### PR TITLE
Introduce nils-term progress utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "nils-term",
  "tempfile",
 ]
 
@@ -1517,6 +1518,7 @@ name = "semantic-commit"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "nils-term",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/crates/git-scope/Cargo.toml
+++ b/crates/git-scope/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+nils-term = { path = "../nils-term" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/git-scope/src/commit.rs
+++ b/crates/git-scope/src/commit.rs
@@ -1,6 +1,7 @@
 use crate::print::print_file_content;
 use crate::render::{color_reset_for_commit, kind_color_for_commit, render_tree_for_commit};
 use anyhow::{Context, Result};
+use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 use std::collections::HashMap;
 use std::process::{Command, Stdio};
 
@@ -9,6 +10,7 @@ pub fn render_commit(
     parent_selector: Option<&str>,
     no_color: bool,
     print: bool,
+    progress_opt_in: bool,
 ) -> Result<()> {
     print_commit_metadata(commit, no_color)?;
     print_commit_message(commit)?;
@@ -18,9 +20,38 @@ pub fn render_commit(
     if print && !files.is_empty() {
         println!();
         println!("📦 Printing file contents:");
+
+        let progress = if progress_opt_in {
+            Some(Progress::new(
+                files.len() as u64,
+                ProgressOptions::default()
+                    .with_prefix("git-scope ")
+                    .with_finish(ProgressFinish::Clear),
+            ))
+        } else {
+            None
+        };
+
         for file in files {
-            print_file_content(&file)?;
-            println!();
+            match &progress {
+                Some(progress) => {
+                    progress.set_message(&file);
+                    progress.suspend(|| -> Result<()> {
+                        print_file_content(&file)?;
+                        println!();
+                        Ok(())
+                    })?;
+                    progress.inc(1);
+                }
+                None => {
+                    print_file_content(&file)?;
+                    println!();
+                }
+            }
+        }
+
+        if let Some(progress) = progress {
+            progress.finish_and_clear();
         }
     }
 

--- a/crates/git-scope/src/main.rs
+++ b/crates/git-scope/src/main.rs
@@ -120,6 +120,7 @@ fn run() -> Result<()> {
     }
 
     let no_color = cli.no_color || std::env::var_os("NO_COLOR").is_some();
+    let progress_opt_in = git_scope_progress_opt_in();
 
     if cli.help {
         print_help();
@@ -129,34 +130,63 @@ fn run() -> Result<()> {
     match cli.command.unwrap_or(Command::Help) {
         Command::Tracked { print, prefixes } => {
             let lines = git::collect_tracked(&prefixes)?;
-            render::render_with_type(&lines, no_color, render::PrintMode::Worktree, print)?;
+            render::render_with_type(
+                &lines,
+                no_color,
+                render::PrintMode::Worktree,
+                print,
+                progress_opt_in,
+            )?;
         }
         Command::Staged { print } => {
             let lines = git::collect_staged()?;
-            render::render_with_type(&lines, no_color, render::PrintMode::Index, print)?;
+            render::render_with_type(
+                &lines,
+                no_color,
+                render::PrintMode::Index,
+                print,
+                progress_opt_in,
+            )?;
         }
         Command::Unstaged { print } => {
             let lines = git::collect_unstaged()?;
-            render::render_with_type(&lines, no_color, render::PrintMode::Worktree, print)?;
+            render::render_with_type(
+                &lines,
+                no_color,
+                render::PrintMode::Worktree,
+                print,
+                progress_opt_in,
+            )?;
         }
         Command::All { print } => {
             let (combined, staged, unstaged) = git::collect_all()?;
-            let files =
-                render::render_with_type(&combined, no_color, render::PrintMode::Worktree, false)?;
+            let files = render::render_with_type(
+                &combined,
+                no_color,
+                render::PrintMode::Worktree,
+                false,
+                progress_opt_in,
+            )?;
             if print {
-                render::print_all_files(&files, &staged, &unstaged)?;
+                render::print_all_files(&files, &staged, &unstaged, progress_opt_in)?;
             }
         }
         Command::Untracked { print } => {
             let lines = git::collect_untracked()?;
-            render::render_with_type(&lines, no_color, render::PrintMode::Worktree, print)?;
+            render::render_with_type(
+                &lines,
+                no_color,
+                render::PrintMode::Worktree,
+                print,
+                progress_opt_in,
+            )?;
         }
         Command::Commit {
             print,
             parent,
             commit,
         } => {
-            commit::render_commit(&commit, parent.as_deref(), no_color, print)
+            commit::render_commit(&commit, parent.as_deref(), no_color, print, progress_opt_in)
                 .with_context(|| format!("git-scope commit {commit}"))?;
         }
         Command::Help => {
@@ -165,4 +195,13 @@ fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn git_scope_progress_opt_in() -> bool {
+    let Some(value) = std::env::var_os("GIT_SCOPE_PROGRESS") else {
+        return false;
+    };
+    let value = value.to_string_lossy();
+    let normalized = value.trim().to_ascii_lowercase();
+    matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
 }

--- a/crates/git-scope/src/render.rs
+++ b/crates/git-scope/src/render.rs
@@ -1,5 +1,6 @@
 use crate::print::{print_file_content, print_file_content_index};
 use anyhow::Result;
+use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 use std::collections::BTreeSet;
 use std::process::Command;
 
@@ -21,6 +22,7 @@ pub fn render_with_type(
     no_color: bool,
     print_mode: PrintMode,
     print: bool,
+    progress_opt_in: bool,
 ) -> Result<Vec<String>> {
     if lines.is_empty() {
         println!("⚠️  No matching files");
@@ -64,12 +66,51 @@ pub fn render_with_type(
     if print {
         println!();
         println!("📦 Printing file contents:");
+
+        let progress = if progress_opt_in && !files.is_empty() {
+            Some(Progress::new(
+                files.len() as u64,
+                ProgressOptions::default()
+                    .with_prefix("git-scope ")
+                    .with_finish(ProgressFinish::Clear),
+            ))
+        } else {
+            None
+        };
+
         for file in &files {
-            match print_mode {
-                PrintMode::Index => print_file_content_index(file)?,
-                PrintMode::Worktree => print_file_content(file)?,
+            match (print_mode, &progress) {
+                (PrintMode::Index, Some(progress)) => {
+                    progress.set_message(file);
+                    progress.suspend(|| -> Result<()> {
+                        print_file_content_index(file)?;
+                        println!();
+                        Ok(())
+                    })?;
+                    progress.inc(1);
+                }
+                (PrintMode::Worktree, Some(progress)) => {
+                    progress.set_message(file);
+                    progress.suspend(|| -> Result<()> {
+                        print_file_content(file)?;
+                        println!();
+                        Ok(())
+                    })?;
+                    progress.inc(1);
+                }
+                (PrintMode::Index, None) => {
+                    print_file_content_index(file)?;
+                    println!();
+                }
+                (PrintMode::Worktree, None) => {
+                    print_file_content(file)?;
+                    println!();
+                }
             }
-            println!();
+        }
+
+        if let Some(progress) = progress {
+            progress.finish_and_clear();
         }
     }
 
@@ -80,6 +121,7 @@ pub fn print_all_files(
     files: &[String],
     staged_lines: &[String],
     unstaged_lines: &[String],
+    progress_opt_in: bool,
 ) -> Result<()> {
     println!();
     println!("📦 Printing file contents:");
@@ -87,25 +129,93 @@ pub fn print_all_files(
     let staged_paths = collect_paths(staged_lines);
     let unstaged_paths = collect_paths(unstaged_lines);
 
+    let total_ops = files
+        .iter()
+        .map(|file| {
+            let staged = staged_paths.contains(file) as u64;
+            let unstaged = unstaged_paths.contains(file) as u64;
+            let ops = staged + unstaged;
+            if ops == 0 {
+                1
+            } else {
+                ops
+            }
+        })
+        .sum::<u64>();
+
+    let progress = if progress_opt_in && total_ops > 0 {
+        Some(Progress::new(
+            total_ops,
+            ProgressOptions::default()
+                .with_prefix("git-scope ")
+                .with_finish(ProgressFinish::Clear),
+        ))
+    } else {
+        None
+    };
+
     for file in files {
         let mut printed = false;
 
         if staged_paths.contains(file) {
-            print_file_content_index(file)?;
+            match &progress {
+                Some(progress) => {
+                    progress.set_message(format!("{file} (index)"));
+                    progress.suspend(|| -> Result<()> {
+                        print_file_content_index(file)?;
+                        println!();
+                        Ok(())
+                    })?;
+                    progress.inc(1);
+                }
+                None => {
+                    print_file_content_index(file)?;
+                    println!();
+                }
+            }
             printed = true;
-            println!();
         }
 
         if unstaged_paths.contains(file) {
-            print_file_content(file)?;
+            match &progress {
+                Some(progress) => {
+                    progress.set_message(format!("{file} (working tree)"));
+                    progress.suspend(|| -> Result<()> {
+                        print_file_content(file)?;
+                        println!();
+                        Ok(())
+                    })?;
+                    progress.inc(1);
+                }
+                None => {
+                    print_file_content(file)?;
+                    println!();
+                }
+            }
             printed = true;
-            println!();
         }
 
         if !printed {
-            print_file_content(file)?;
-            println!();
+            match &progress {
+                Some(progress) => {
+                    progress.set_message(file.to_string());
+                    progress.suspend(|| -> Result<()> {
+                        print_file_content(file)?;
+                        println!();
+                        Ok(())
+                    })?;
+                    progress.inc(1);
+                }
+                None => {
+                    print_file_content(file)?;
+                    println!();
+                }
+            }
         }
+    }
+
+    if let Some(progress) = progress {
+        progress.finish_and_clear();
     }
 
     Ok(())

--- a/crates/git-scope/tests/common.rs
+++ b/crates/git-scope/tests/common.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Command, Output, Stdio};
 
 pub fn git(dir: &Path, args: &[&str]) -> String {
     let output = Command::new("git")
@@ -50,8 +50,17 @@ pub fn git_scope_bin() -> PathBuf {
 }
 
 pub fn run_git_scope(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> String {
+    let output = run_git_scope_output(dir, args, envs);
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+pub fn run_git_scope_output(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
     let mut cmd = Command::new(git_scope_bin());
-    cmd.args(args).current_dir(dir).stdout(Stdio::piped());
+    cmd.args(args)
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
     for (k, v) in envs {
         cmd.env(k, v);
     }
@@ -64,5 +73,5 @@ pub fn run_git_scope(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> String
             String::from_utf8_lossy(&output.stdout)
         );
     }
-    String::from_utf8_lossy(&output.stdout).to_string()
+    output
 }

--- a/crates/git-scope/tests/progress_opt_in.rs
+++ b/crates/git-scope/tests/progress_opt_in.rs
@@ -1,0 +1,75 @@
+mod common;
+
+use std::fs;
+
+#[test]
+fn progress_opt_in_preserves_stdout_and_is_silent_in_non_tty() {
+    let repo = common::init_repo();
+    let root = repo.path();
+
+    fs::write(root.join("a.txt"), "BASE").unwrap();
+    fs::write(root.join("b.txt"), "BASE").unwrap();
+    common::git(root, &["add", "."]);
+    common::git(root, &["commit", "-m", "init"]);
+
+    fs::write(root.join("a.txt"), "STAGED").unwrap();
+    common::git(root, &["add", "a.txt"]);
+    fs::write(root.join("b.txt"), "UNSTAGED").unwrap();
+
+    {
+        let baseline = common::run_git_scope(root, &["staged", "-p"], &[("NO_COLOR", "1")]);
+        let output = common::run_git_scope_output(
+            root,
+            &["staged", "-p"],
+            &[("NO_COLOR", "1"), ("GIT_SCOPE_PROGRESS", "1")],
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        assert_eq!(
+            stdout, baseline,
+            "stdout changed under GIT_SCOPE_PROGRESS=1"
+        );
+        assert!(
+            stderr.trim().is_empty(),
+            "expected no stderr output in non-TTY tests: {stderr}"
+        );
+    }
+
+    {
+        let baseline = common::run_git_scope(root, &["all", "-p"], &[("NO_COLOR", "1")]);
+        let output = common::run_git_scope_output(
+            root,
+            &["all", "-p"],
+            &[("NO_COLOR", "1"), ("GIT_SCOPE_PROGRESS", "1")],
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        assert_eq!(
+            stdout, baseline,
+            "stdout changed under GIT_SCOPE_PROGRESS=1"
+        );
+        assert!(
+            stderr.trim().is_empty(),
+            "expected no stderr output in non-TTY tests: {stderr}"
+        );
+    }
+
+    {
+        let baseline = common::run_git_scope(root, &["commit", "HEAD", "-p"], &[("NO_COLOR", "1")]);
+        let output = common::run_git_scope_output(
+            root,
+            &["commit", "HEAD", "-p"],
+            &[("NO_COLOR", "1"), ("GIT_SCOPE_PROGRESS", "1")],
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        assert_eq!(
+            stdout, baseline,
+            "stdout changed under GIT_SCOPE_PROGRESS=1"
+        );
+        assert!(
+            stderr.trim().is_empty(),
+            "expected no stderr output in non-TTY tests: {stderr}"
+        );
+    }
+}

--- a/crates/semantic-commit/Cargo.toml
+++ b/crates/semantic-commit/Cargo.toml
@@ -10,6 +10,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
 time = { version = "0.3", features = ["formatting"] }
+nils-term = { path = "../nils-term" }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/semantic-commit/src/commit.rs
+++ b/crates/semantic-commit/src/commit.rs
@@ -1,4 +1,5 @@
 use crate::git;
+use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 use std::fs::File;
 use std::io::{BufRead, BufReader, IsTerminal, Read, Write};
 use std::path::Path;
@@ -102,26 +103,47 @@ pub fn run(args: &[String]) -> i32 {
         return 1;
     }
 
+    let progress = Progress::spinner(
+        ProgressOptions::default()
+            .with_prefix("semantic-commit ")
+            .with_finish(ProgressFinish::Clear),
+    );
+
+    progress.set_message("prepare message");
+    progress.tick();
+
     let tmpfile = match tempfile::NamedTempFile::new() {
         Ok(file) => file,
         Err(_) => {
+            progress.finish_and_clear();
             eprintln!("error: failed to create temp file for commit message");
             return 1;
         }
     };
 
     if let Err(err) = write_message_file(tmpfile.path(), &message_contents) {
+        progress.finish_and_clear();
         eprintln!("{err:#}");
         return 1;
     }
 
-    if let Err(code) = validate_commit_message(tmpfile.path()) {
+    progress.set_message("validate message");
+    progress.tick();
+    if let Err(code) = progress.suspend(|| validate_commit_message(tmpfile.path())) {
+        progress.finish_and_clear();
         return code;
     }
 
-    if let Err(code) = ensure_git_scope_available() {
+    progress.set_message("check git-scope");
+    progress.tick();
+    if let Err(code) = progress.suspend(ensure_git_scope_available) {
+        progress.finish_and_clear();
         return code;
     }
+
+    progress.set_message("git commit");
+    progress.tick();
+    progress.finish_and_clear();
 
     let status = Command::new("git")
         .args(["commit", "-F"])


### PR DESCRIPTION
# Introduce nils-term progress utilities

## Plan
- [docs/plans/nils-term-progress-plan.md](https://github.com/graysurf/nils-cli/blob/main/docs/plans/nils-term-progress-plan.md)

## Summary
Introduce a small `nils-term` workspace crate that wraps `indicatif` to provide RAII-friendly determinate/spinner progress APIs. Progress draws to stderr by default and auto-disables when stderr is not a TTY to keep stdout safe for piping and machine-readable output.

## Changes
- Add `crates/nils-term` progress abstraction with deterministic writer-based tests + rustdoc examples
- Add `cli-template progress-demo` consumer
- Thread progress into `api-testing-core` / `api-test run` (stdout JSON unchanged)
- Add progress to `api-rest` / `api-gql` call/report run paths (spinners)
- Add batch progress to `image-processing`, indexing spinners to `fzf-cli`
- Add progress to `git-summary`, `git-lock list`, and `plan-tooling validate`
- Add preflight progress to `semantic-commit commit` (clears before invoking `git commit`)
- Add opt-in progress to `git-scope` print modes via `GIT_SCOPE_PROGRESS=1` (stderr-only; stdout unchanged)

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --fail-under-lines 80` (pass)

## Risk / Notes
- Progress is stderr-only and uses Auto TTY enablement; non-TTY runs stay silent.
- `git-scope` progress is opt-in to preserve parity by default.
