### PR TITLE
Redact snake_case token fields

### DIFF
--- a/crates/api-testing-core/src/redact.rs
+++ b/crates/api-testing-core/src/redact.rs
@@ -7,10 +7,13 @@ fn should_redact_key(key: &str) -> bool {
     matches!(
         k.as_str(),
         "accesstoken"
+            | "access_token"
             | "refreshtoken"
+            | "refresh_token"
             | "password"
             | "token"
             | "apikey"
+            | "api_key"
             | "authorization"
             | "cookie"
             | "set-cookie"
@@ -58,10 +61,13 @@ mod tests {
     fn redact_replaces_common_secret_fields_recursively() {
         let mut v = serde_json::json!({
             "accessToken": "a",
+            "access_token": "a2",
             "refreshToken": "b",
+            "refresh_token": "b2",
             "password": "c",
             "token": "d",
             "apiKey": "e",
+            "api_key": "e2",
             "authorization": "Bearer x",
             "cookie": "a=b",
             "set-cookie": "c=d",
@@ -78,10 +84,13 @@ mod tests {
         redact_json(&mut v).unwrap();
 
         assert_eq!(v["accessToken"], REDACTED);
+        assert_eq!(v["access_token"], REDACTED);
         assert_eq!(v["refreshToken"], REDACTED);
+        assert_eq!(v["refresh_token"], REDACTED);
         assert_eq!(v["password"], REDACTED);
         assert_eq!(v["token"], REDACTED);
         assert_eq!(v["apiKey"], REDACTED);
+        assert_eq!(v["api_key"], REDACTED);
         assert_eq!(v["authorization"], REDACTED);
         assert_eq!(v["cookie"], REDACTED);
         assert_eq!(v["set-cookie"], REDACTED);


### PR DESCRIPTION
# Redact snake_case token fields

## Summary
Expand token redaction to include snake_case keys used by OAuth payloads and ensure tests cover them.

## Problem
- Expected: token fields are redacted regardless of camelCase or snake_case key style.
- Actual: snake_case keys like `access_token`, `refresh_token`, and `api_key` are not redacted.
- Impact: secrets can appear in reports/history output.

## Reproduction
1. Call `api_testing_core::redact::redact_json` with JSON containing `access_token` or `refresh_token` keys.
2. Inspect the value after redaction.

- Expected result: values are replaced with `<REDACTED>`.
- Actual result: snake_case token values remain unchanged.

## Issues Found
Severity: critical | high | medium | low
Confidence: high | medium | low
Status: open | fixed | deferred | needs-info

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-6-BUG-001 | high | high | crates/api-testing-core/src/redact.rs | Snake_case token keys are not redacted | crates/api-testing-core/src/redact.rs:5-20 | fixed |

## Fix Approach
- Add snake_case token key variants to the redaction allowlist.
- Extend redaction tests to cover snake_case fields.

## Testing
- ./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh (pass)

## Risk / Notes
- Expands redaction coverage for common OAuth token key styles.
