### PR TITLE
Allow validate to run without git worktree

### DIFF
--- a/crates/plan-tooling/src/validate.rs
+++ b/crates/plan-tooling/src/validate.rs
@@ -60,16 +60,6 @@ pub fn run(args: &[String]) -> i32 {
 
     let repo_root = crate::repo_root::detect();
 
-    if !has_git() {
-        eprintln!("validate_plans: error: git is required");
-        return 1;
-    }
-
-    if !is_git_worktree(&repo_root) {
-        eprintln!("validate_plans: error: must run inside a git work tree");
-        return 1;
-    }
-
     let discovered = if files.is_empty() {
         discover_default_plan_files(&repo_root)
     } else {
@@ -110,26 +100,6 @@ pub fn run(args: &[String]) -> i32 {
         eprintln!("error: {err}");
     }
     1
-}
-
-fn has_git() -> bool {
-    Command::new("git")
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .is_ok()
-}
-
-fn is_git_worktree(repo_root: &Path) -> bool {
-    Command::new("git")
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .current_dir(repo_root)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
 }
 
 fn discover_default_plan_files(repo_root: &Path) -> Vec<String> {

--- a/crates/plan-tooling/tests/validate.rs
+++ b/crates/plan-tooling/tests/validate.rs
@@ -3,6 +3,7 @@ mod common;
 use common::{git, init_repo, run_plan_tooling, write_file};
 
 use pretty_assertions::assert_eq;
+use tempfile::TempDir;
 
 #[test]
 fn validate_ok_with_explicit_file() {
@@ -10,6 +11,21 @@ fn validate_ok_with_explicit_file() {
     write_file(&repo.path().join("plan.md"), VALID_PLAN);
 
     let out = run_plan_tooling(repo.path(), &["validate", "--file", "plan.md"]);
+    assert_eq!(
+        out.code, 0,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    assert!(out.stdout.is_empty());
+    assert!(out.stderr.is_empty());
+}
+
+#[test]
+fn validate_explicit_file_without_git_repo() {
+    let dir = TempDir::new().expect("tempdir");
+    write_file(&dir.path().join("plan.md"), VALID_PLAN);
+
+    let out = run_plan_tooling(dir.path(), &["validate", "--file", "plan.md"]);
     assert_eq!(
         out.code, 0,
         "stdout: {}\nstderr: {}",


### PR DESCRIPTION
# Allow validate to run without git worktree

## Summary
Remove the hard git/worktree requirement from `plan-tooling validate` so explicit file validation works outside a repo, and add a regression test for the non-git case.

## Problem
- Expected: `plan-tooling validate --file <plan.md>` works even outside a git repo and uses filesystem fallback.
- Actual: `validate` exits early with "git is required" / "must run inside a git work tree".
- Impact: explicit file validation fails in temp dirs or non-repo contexts, unlike other subcommands.

## Reproduction
1. `tmpdir=$(mktemp -d)`
2. `printf '%s\n' '# Plan: Example' '## Sprint 1: First sprint' '### Task 1.1: Do thing' '- **Location**:' '  - `src/a.rs`' '- **Description**: Do A' '- **Dependencies**:' '  - none' '- **Acceptance criteria**:' '  - A works' '- **Validation**:' '  - cargo test -p plan-tooling' > "$tmpdir/plan.md"`
3. `(cd "$tmpdir" && plan-tooling validate --file plan.md)`

- Expected result: exit 0 with no stderr output.
- Actual result: exit 1 with git/worktree error.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-7-BUG-001 | medium | high | crates/plan-tooling/src/validate.rs | validate requires git even for explicit files | `plan-tooling validate --file plan.md` outside git repo | fixed |

## Fix Approach
- Drop the early git/worktree gate in `validate` and rely on git only for tracked-file discovery.
- Add a non-git regression test for `validate --file`.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- None.
