### PR TITLE
Parse inline comments in env files

### DIFF
--- a/crates/api-testing-core/src/env_file.rs
+++ b/crates/api-testing-core/src/env_file.rs
@@ -35,14 +35,41 @@ fn parse_assignment_line(line: &str) -> Option<(String, String)> {
         return None;
     }
 
-    let mut value = rhs.trim().to_string();
-    if let Some(stripped) = value.strip_prefix('"').and_then(|v| v.strip_suffix('"')) {
-        value = stripped.to_string();
-    } else if let Some(stripped) = value.strip_prefix('\'').and_then(|v| v.strip_suffix('\'')) {
-        value = stripped.to_string();
-    }
+    let raw_value = rhs.trim();
+    let value = if let Some(stripped) = parse_quoted_value(raw_value) {
+        stripped
+    } else {
+        strip_inline_comment(raw_value).to_string()
+    };
 
     Some((key.to_string(), value))
+}
+
+fn parse_quoted_value(value: &str) -> Option<String> {
+    let mut chars = value.chars();
+    let quote = chars.next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+
+    let closing_index = value[1..].find(quote).map(|idx| idx + 1)?;
+    let remainder = value[closing_index + 1..].trim_start();
+    if !remainder.is_empty() && !remainder.starts_with('#') {
+        return None;
+    }
+
+    Some(value[1..closing_index].to_string())
+}
+
+fn strip_inline_comment(value: &str) -> &str {
+    let mut prev_was_space = false;
+    for (idx, ch) in value.char_indices() {
+        if ch == '#' && prev_was_space {
+            return value[..idx].trim_end();
+        }
+        prev_was_space = ch.is_whitespace();
+    }
+    value.trim_end()
 }
 
 /// Read an env var from a list of `.env`-like files using the legacy "last assignment wins" semantics.
@@ -144,5 +171,37 @@ NOPE=   plain
         write(&local, "A=\n");
 
         assert_eq!(read_var_last_wins("A", &[&base, &local]).unwrap(), None);
+    }
+
+    #[test]
+    fn env_file_inline_comments_only_strip_unquoted_values() {
+        let tmp = TempDir::new().expect("tmp");
+        let f = tmp.path().join("inline.env");
+        write(
+            &f,
+            r#"
+FOO=bar # comment
+BAR="baz # keep"
+BAZ='qux # keep'
+QUX=keep#hash
+"#,
+        );
+
+        assert_eq!(
+            read_var_last_wins("FOO", &[&f]).unwrap(),
+            Some("bar".to_string())
+        );
+        assert_eq!(
+            read_var_last_wins("BAR", &[&f]).unwrap(),
+            Some("baz # keep".to_string())
+        );
+        assert_eq!(
+            read_var_last_wins("BAZ", &[&f]).unwrap(),
+            Some("qux # keep".to_string())
+        );
+        assert_eq!(
+            read_var_last_wins("QUX", &[&f]).unwrap(),
+            Some("keep#hash".to_string())
+        );
     }
 }


### PR DESCRIPTION
# Parse inline comments in env files

## Summary
Ignore inline `#` comments for unquoted `.env` values while preserving `#` inside quoted strings.

## Problem
- Expected: `FOO=bar # comment` should parse as `bar`.
- Actual: The parser returned `bar # comment` because inline comments were not stripped.
- Impact: Endpoint/token lookups can include comment text, causing invalid URLs or credentials.

## Reproduction
1. Create an env file containing `FOO=bar # comment`.
2. Call `read_var_last_wins("FOO", ...)`.

- Expected result: `Some("bar")`.
- Actual result: `Some("bar # comment")`.

## Issues Found
Severity: low
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-9-BUG-001 | low | high | crates/api-testing-core/src/env_file.rs | Inline comments were included in unquoted values | read_var_last_wins on `FOO=bar # comment` | fixed |

## Fix Approach
- Strip inline `#` comments only for unquoted values.
- Add tests covering quoted and unquoted inline comment cases.

## Testing
- ./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh (pass)

## Risk / Notes
- Low risk; change is limited to env parsing and has explicit tests.
