### PR TITLE
Count numstat entries with spaced paths

### DIFF
--- a/crates/git-summary/src/main.rs
+++ b/crates/git-summary/src/main.rs
@@ -373,14 +373,26 @@ fn parse_numstat_totals(log: &str) -> (i64, i64) {
     let mut deleted = 0i64;
 
     for line in log.lines() {
-        if is_lockfile_line(line) {
+        let mut parts = line.splitn(3, '\t');
+        let added_part = match parts.next() {
+            Some(part) => part,
+            None => continue,
+        };
+        let deleted_part = match parts.next() {
+            Some(part) => part,
+            None => continue,
+        };
+        let path = match parts.next() {
+            Some(part) => part,
+            None => continue,
+        };
+
+        if is_lockfile_line(path) {
             continue;
         }
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() == 3 {
-            added += parts[0].parse::<i64>().unwrap_or(0);
-            deleted += parts[1].parse::<i64>().unwrap_or(0);
-        }
+
+        added += added_part.parse::<i64>().unwrap_or(0);
+        deleted += deleted_part.parse::<i64>().unwrap_or(0);
     }
 
     (added, deleted)
@@ -417,4 +429,30 @@ struct Row {
 
 fn format_date(date: NaiveDate) -> String {
     date.format("%Y-%m-%d").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_numstat_totals;
+
+    #[test]
+    fn parse_numstat_totals_counts_paths_with_spaces() {
+        let log = "\
+2024-01-01
+1\t2\tpath/with space.txt
+3\t4\tpath/with space/another file.md
+";
+        let (added, deleted) = parse_numstat_totals(log);
+        assert_eq!((added, deleted), (4, 6));
+    }
+
+    #[test]
+    fn parse_numstat_totals_skips_lockfiles_with_spaces() {
+        let log = "\
+1\t1\tpath/with space/yarn.lock
+2\t3\tpath/with space/src/lib.rs
+";
+        let (added, deleted) = parse_numstat_totals(log);
+        assert_eq!((added, deleted), (2, 3));
+    }
 }

--- a/crates/git-summary/tests/edge_cases.rs
+++ b/crates/git-summary/tests/edge_cases.rs
@@ -157,7 +157,7 @@ fn filenames_with_spaces_are_counted() {
     let output = run_git_summary(root, &["2024-01-01", "2024-01-31"], &[]);
     let line = format!(
         "{:<25} {:<40} {:>8} {:>8} {:>8} {:>8} {:>12} {:>12}",
-        "Space", "space@example.com", 0, 0, 0, 1, "2024-01-12", "2024-01-12"
+        "Space", "space@example.com", 2, 0, 2, 1, "2024-01-12", "2024-01-12"
     );
     assert!(
         output.contains(&line),


### PR DESCRIPTION
# Count numstat entries with spaced paths

## Summary
Fix git-summary numstat parsing to handle tab-delimited lines so files with spaces are counted.

## Problem
- Expected: Files with spaces in their paths should contribute to added/deleted totals.
- Actual: `parse_numstat_totals` used whitespace splitting and skipped lines with spaced paths.
- Impact: Summary totals undercount changes when a repo includes files with spaces.

## Reproduction
1. Commit a file named `file with spaces.txt`.
2. Run `git-summary 2024-01-01 2024-01-31`.

- Expected result: Added/deleted totals include the file.
- Actual result: Totals remain 0 for that author.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-10-BUG-001 | medium | high | crates/git-summary/src/main.rs | Numstat parsing ignores paths with spaces | parse_numstat_totals on tab-delimited lines | fixed |

## Fix Approach
- Parse numstat lines using tab separation to keep spaced paths intact.
- Add unit tests plus update edge-case expectation for spaced filenames.

## Testing
- ./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh (pass)

## Risk / Notes
- Low risk; change only affects parsing of numstat output.
