### PR TITLE
Treat empty Dependencies as missing in plan validation

### DIFF
--- a/crates/plan-tooling/src/parse.rs
+++ b/crates/plan-tooling/src/parse.rs
@@ -208,11 +208,13 @@ pub fn parse_plan_with_display(
             };
 
             let mut normalized: Vec<String> = Vec::new();
+            let mut saw_value = false;
             for d in deps {
                 let trimmed = d.trim();
                 if trimmed.is_empty() {
                     continue;
                 }
+                saw_value = true;
                 if trimmed.eq_ignore_ascii_case("none") {
                     continue;
                 }
@@ -223,7 +225,11 @@ pub fn parse_plan_with_display(
                     }
                 }
             }
-            task.dependencies = Some(normalized);
+            if !saw_value {
+                task.dependencies = None;
+            } else {
+                task.dependencies = Some(normalized);
+            }
         }
     }
 

--- a/crates/plan-tooling/tests/validate.rs
+++ b/crates/plan-tooling/tests/validate.rs
@@ -86,6 +86,17 @@ fn validate_repo_relative_file_works_from_nested_dir() {
     assert!(out.stderr.is_empty());
 }
 
+#[test]
+fn validate_missing_dependencies_is_error() {
+    let repo = init_repo();
+    write_file(&repo.path().join("missing-deps.md"), MISSING_DEPS_PLAN);
+
+    let out = run_plan_tooling(repo.path(), &["validate", "--file", "missing-deps.md"]);
+    assert_eq!(out.code, 1);
+    assert!(out.stdout.is_empty());
+    assert!(out.stderr.contains("missing Dependencies"));
+}
+
 const VALID_PLAN: &str = r#"# Plan: Example
 
 ## Sprint 1: First sprint
@@ -116,4 +127,19 @@ const INVALID_PLAN: &str = r#"# Plan: Bad
   - <TBD>
 - **Validation**:
   - TBD
+"#;
+
+const MISSING_DEPS_PLAN: &str = r#"# Plan: Missing deps
+
+## Sprint 1: First sprint
+
+### Task 1.1: Do thing
+- **Location**:
+  - `src/a.rs`
+- **Description**: Do A
+- **Dependencies**:
+- **Acceptance criteria**:
+  - A works
+- **Validation**:
+  - cargo test -p plan-tooling
 "#;


### PR DESCRIPTION
# Treat empty Dependencies as missing in plan validation

## Summary
Ensure an empty **Dependencies** section is treated as missing so `plan-tooling validate` reports the error instead of silently passing.

## Problem
- Expected: A task with an empty `Dependencies` list should fail validation as “missing Dependencies”.
- Actual: Validation passes when `Dependencies` is present but has no values.
- Impact: Plans can ship with incomplete dependency metadata without any validation signal.

## Reproduction
1. Create a plan task with `- **Dependencies**:` but no list items.
2. Run `plan-tooling validate --file <plan>`.

- Expected result: Non‑zero exit with “missing Dependencies”.
- Actual result: Exit 0, no error reported.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-11-BUG-001 | medium | high | crates/plan-tooling/src/parse.rs | Empty Dependencies treated as present | plan-tooling validate passes with empty list | fixed |

## Fix Approach
- Track whether any non-empty dependency values were provided; if none, keep `dependencies = None` so validation flags the missing field.
- Add a regression test for the empty Dependencies case.

## Testing
- ./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh (pass)

## Risk / Notes
- Low risk; change only affects validation behavior for empty lists.
