### PR TITLE
List deleted files in git-scope output

### DIFF
--- a/crates/git-scope/src/git.rs
+++ b/crates/git-scope/src/git.rs
@@ -33,7 +33,7 @@ pub fn collect_staged() -> Result<Vec<String>> {
         "diff",
         "--cached",
         "--name-status",
-        "--diff-filter=ACMRTUXB",
+        "--diff-filter=ACMRTUXBD",
     ])?;
     Ok(lines(output))
 }
@@ -44,7 +44,7 @@ pub fn collect_unstaged() -> Result<Vec<String>> {
         "core.quotepath=false",
         "diff",
         "--name-status",
-        "--diff-filter=ACMRTUXB",
+        "--diff-filter=ACMRTUXBD",
     ])?;
     Ok(lines(output))
 }

--- a/crates/git-scope/tests/edge_cases.rs
+++ b/crates/git-scope/tests/edge_cases.rs
@@ -59,6 +59,24 @@ fn rename_shows_arrow() {
 }
 
 #[test]
+fn staged_deletion_is_listed() {
+    let repo = common::init_repo();
+    let root = repo.path();
+
+    fs::write(root.join("gone.txt"), "gone").unwrap();
+    common::git(root, &["add", "gone.txt"]);
+    common::git(root, &["commit", "-m", "add gone"]);
+
+    common::git(root, &["rm", "gone.txt"]);
+
+    let output = common::run_git_scope(root, &["staged"], &[("NO_COLOR", "1")]);
+    assert!(
+        output.contains("➔ [D] gone.txt"),
+        "staged deletion missing: {output}"
+    );
+}
+
+#[test]
 fn outside_repo_prints_warning() {
     let temp = tempfile::TempDir::new().unwrap();
     let (code, output) = run_git_scope_allow_fail(temp.path(), &["staged"], &[("NO_COLOR", "1")]);


### PR DESCRIPTION
# List deleted files in git-scope output

## Summary
Include deleted entries in staged/unstaged collection so `git-scope` reports `[D]` changes.

## Problem
- Expected: Deleting a tracked file and staging it should show `[D] <file>` in `git-scope staged`.
- Actual: Deleted files are omitted from output.
- Impact: `git-scope` hides a real change type, breaking parity with `git status` style output.

## Reproduction
1. Create and commit a file.
2. `git rm <file>`.
3. Run `git-scope staged`.

- Expected result: Output includes `➔ [D] <file>`.
- Actual result: No deletion entry is listed.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-12-BUG-001 | medium | high | crates/git-scope/src/git.rs | Deleted files excluded from diff filter | `git-scope staged` omits [D] | fixed |

## Fix Approach
- Add `D` to the diff-filter used for staged and unstaged collection.
- Add a regression test covering staged deletions.

## Testing
- ./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh (pass)

## Risk / Notes
- Low risk; expands diff-filter to include deletions.
