### PR TITLE
Normalize REST token profile leading separators

### DIFF
--- a/crates/api-testing-core/src/suite/cleanup.rs
+++ b/crates/api-testing-core/src/suite/cleanup.rs
@@ -171,11 +171,14 @@ fn resolve_rest_token_profile(setup_dir: &Path, profile: &str) -> Result<String>
 
     let key = profile.trim().to_ascii_uppercase();
     let mut env_key = String::new();
+    let mut prev_us = false;
     for c in key.chars() {
         if c.is_ascii_alphanumeric() {
             env_key.push(c);
-        } else if !env_key.ends_with('_') {
+            prev_us = false;
+        } else if !env_key.is_empty() && !prev_us {
             env_key.push('_');
+            prev_us = true;
         }
     }
     while env_key.ends_with('_') {

--- a/crates/api-testing-core/src/suite/runner.rs
+++ b/crates/api-testing-core/src/suite/runner.rs
@@ -187,11 +187,14 @@ fn resolve_rest_token_profile(setup_dir: &Path, profile: &str) -> Result<String>
 
     let key = profile.trim().to_ascii_uppercase();
     let mut env_key = String::new();
+    let mut prev_us = false;
     for c in key.chars() {
         if c.is_ascii_alphanumeric() {
             env_key.push(c);
-        } else if !env_key.ends_with('_') {
+            prev_us = false;
+        } else if !env_key.is_empty() && !prev_us {
             env_key.push('_');
+            prev_us = true;
         }
     }
     while env_key.ends_with('_') {
@@ -1575,6 +1578,15 @@ mod tests {
 
         let token = resolve_rest_token_profile(&fixture.setup_dir, "team alpha").unwrap();
         assert_eq!(token, "local");
+    }
+
+    #[test]
+    fn suite_runner_token_profile_ignores_leading_separators() {
+        let fixture = RestSetupFixture::new();
+        fixture.write_tokens_env("REST_TOKEN_TEAM_ALPHA=base\n");
+
+        let token = resolve_rest_token_profile(&fixture.setup_dir, "-team alpha").unwrap();
+        assert_eq!(token, "base");
     }
 
     #[test]


### PR DESCRIPTION
# Normalize REST token profile leading separators

## Summary
Fix REST token profile normalization so leading separators don't introduce a leading underscore and break env lookups.

## Problem
- Expected: A profile like "-team alpha" resolves `REST_TOKEN_TEAM_ALPHA`.
- Actual: Normalization produces `REST_TOKEN__TEAM_ALPHA`, failing to find the token.
- Impact: REST auth can fail when profile names start with non-alphanumeric characters.

## Reproduction
1. Set `REST_TOKEN_TEAM_ALPHA=...` in tokens env.
2. Invoke REST auth with profile `-team alpha`.

- Expected result: Token resolves successfully.
- Actual result: Lookup fails due to `REST_TOKEN__TEAM_ALPHA`.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-13-BUG-001 | medium | high | crates/api-testing-core/src/suite/runner.rs | Leading separator adds extra underscore in token key | profile "-team alpha" -> `REST_TOKEN__TEAM_ALPHA` | fixed |

## Fix Approach
- Track separator emission to avoid leading underscores during normalization.
- Apply fix in runner + cleanup token resolution paths.
- Add regression test for a profile with a leading separator.

## Testing
- ./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh (pass)

## Risk / Notes
- Low risk; only affects token profile normalization.
