### PR TITLE
Prevent git-scope -p from failing without file

### DIFF
--- a/crates/git-scope/src/print.rs
+++ b/crates/git-scope/src/print.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::process::{Command, Stdio};
 
 pub fn print_file_content(path: &str) -> Result<()> {
@@ -121,17 +121,30 @@ fn git_show_to_file(spec: &str, dest: &str) -> Result<()> {
 }
 
 fn is_binary_file(path: &str) -> Result<bool> {
-    let output = Command::new("file")
-        .arg("--mime")
-        .arg(path)
-        .output()
-        .with_context(|| format!("file --mime {path}"))?;
-
-    if !output.status.success() {
-        return Ok(false);
+    match Command::new("file").arg("--mime").arg(path).output() {
+        Ok(output) => {
+            if output.status.success() {
+                let text = String::from_utf8_lossy(&output.stdout);
+                return Ok(text.contains("charset=binary"));
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return is_binary_file_fallback(path);
+        }
+        Err(err) => return Err(err).with_context(|| format!("file --mime {path}")),
     }
-    let text = String::from_utf8_lossy(&output.stdout);
-    Ok(text.contains("charset=binary"))
+
+    is_binary_file_fallback(path)
+}
+
+fn is_binary_file_fallback(path: &str) -> Result<bool> {
+    const CHUNK_SIZE: usize = 8192;
+    let mut file = fs::File::open(path).with_context(|| format!("open {path}"))?;
+    let mut buf = [0u8; CHUNK_SIZE];
+    let n = file
+        .read(&mut buf)
+        .with_context(|| format!("read {path}"))?;
+    Ok(buf[..n].contains(&0))
 }
 
 fn mktemp_path() -> Result<String> {

--- a/crates/git-scope/tests/tool_degradation.rs
+++ b/crates/git-scope/tests/tool_degradation.rs
@@ -27,12 +27,58 @@ fn tracked_warns_when_tree_missing() {
     assert!(output.contains("tree is not installed"));
 }
 
+#[test]
+fn tracked_print_works_when_file_missing() {
+    let repo = common::init_repo();
+    let root = repo.path();
+
+    fs::write(root.join("tracked.txt"), "HELLO_FROM_TEXT").unwrap();
+    let bytes = [0u8, 159u8, 146u8, 150u8];
+    fs::write(root.join("bin.dat"), bytes).unwrap();
+    common::git(root, &["add", "."]);
+    common::git(root, &["commit", "-m", "add files"]);
+
+    let stub = tempfile::TempDir::new().unwrap();
+    let git_path = which_cmd("git");
+    let mktemp_path = which_cmd("mktemp");
+    symlink(&git_path, stub.path().join("git")).unwrap();
+    symlink(&mktemp_path, stub.path().join("mktemp")).unwrap();
+
+    let path_env = stub.path().to_string_lossy().to_string();
+    let output = common::run_git_scope(
+        root,
+        &["tracked", "-p"],
+        &[("NO_COLOR", "1"), ("PATH", path_env.as_str())],
+    );
+
+    assert!(
+        output.contains("📄 tracked.txt (working tree)"),
+        "text label missing: {output}"
+    );
+    assert!(
+        output.contains("HELLO_FROM_TEXT"),
+        "text content missing: {output}"
+    );
+    assert!(
+        output.contains("📄 bin.dat (binary file in working tree)"),
+        "binary label missing: {output}"
+    );
+    assert!(
+        output.contains("[Binary file content omitted]"),
+        "binary placeholder missing: {output}"
+    );
+}
+
 fn which_git() -> String {
+    which_cmd("git")
+}
+
+fn which_cmd(cmd: &str) -> String {
     let output = std::process::Command::new("which")
-        .arg("git")
+        .arg(cmd)
         .output()
-        .expect("which git");
+        .unwrap_or_else(|_| panic!("which {cmd}"));
     let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    assert!(!path.is_empty(), "git not found in PATH for tests");
+    assert!(!path.is_empty(), "{cmd} not found in PATH for tests");
     path
 }


### PR DESCRIPTION
# Prevent git-scope -p from failing without file

## Summary
`git-scope` previously errored in `-p/--print` mode when the optional `file(1)` tool was missing. This change adds a small Rust fallback binary detector so printing works in minimal environments.

## Problem
- Expected: `git-scope tracked -p` prints text files and omits binary contents, even if `file(1)` is not installed.
- Actual: `git-scope tracked -p` failed with an error when `file(1)` was missing.
- Impact: In environments without `file(1)` (or restricted PATH), `-p/--print` was unusable.

## Reproduction
1. Create a repo with a text file and a binary file (contains a NUL byte).
2. Run `git-scope tracked -p` with `PATH` that contains `git` + `mktemp` but not `file`.

- Expected result: Text file content prints; binary file prints `[Binary file content omitted]`.
- Actual result: Command failed with a `file --mime ...` error.

## Issues Found
Severity: critical | high | medium | low
Confidence: high | medium | low
Status: open | fixed | deferred | needs-info

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-14-BUG-001 | medium | high | crates/git-scope/src/print.rs | `-p/--print` fails when `file(1)` is missing | `crates/git-scope/tests/tool_degradation.rs` | fixed |

## Fix Approach
- Use `file --mime` when available.
- If `file(1)` is missing (or fails), fall back to a simple NUL-byte scan of the first 8KB.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- The fallback detector is intentionally conservative/simple; it may not match `file(1)` for all edge cases, but avoids hard failure and still prevents obvious binary spew.
