### PR TITLE
Show git-scope help outside repositories

### DIFF
--- a/crates/git-scope/src/main.rs
+++ b/crates/git-scope/src/main.rs
@@ -114,6 +114,12 @@ fn main() {
 fn run() -> Result<()> {
     let cli = Cli::parse();
 
+    let help_requested = cli.help || matches!(cli.command, Some(Command::Help));
+    if help_requested {
+        print_help();
+        return Ok(());
+    }
+
     if !git::is_git_repo() {
         println!("⚠️ Not a Git repository. Run this command inside a Git project.");
         process::exit(1);
@@ -121,11 +127,6 @@ fn run() -> Result<()> {
 
     let no_color = cli.no_color || std::env::var_os("NO_COLOR").is_some();
     let progress_opt_in = git_scope_progress_opt_in();
-
-    if cli.help {
-        print_help();
-        return Ok(());
-    }
 
     match cli.command.unwrap_or(Command::Help) {
         Command::Tracked { print, prefixes } => {

--- a/crates/git-scope/tests/help_outside_repo.rs
+++ b/crates/git-scope/tests/help_outside_repo.rs
@@ -1,0 +1,73 @@
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn git_scope_bin() -> PathBuf {
+    if let Ok(bin) = std::env::var("CARGO_BIN_EXE_git-scope")
+        .or_else(|_| std::env::var("CARGO_BIN_EXE_git_scope"))
+    {
+        return PathBuf::from(bin);
+    }
+
+    let exe = std::env::current_exe().expect("current exe");
+    let target_dir = exe.parent().and_then(|p| p.parent()).expect("target dir");
+    let bin = target_dir.join("git-scope");
+    if bin.exists() {
+        return bin;
+    }
+
+    panic!("git-scope binary path: NotPresent");
+}
+
+#[test]
+fn help_flag_succeeds_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(git_scope_bin())
+        .args(["--help"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run git-scope --help");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Usage: git-scope"),
+        "missing Usage: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Not a Git repository"),
+        "unexpected repo warning: {stdout}"
+    );
+}
+
+#[test]
+fn help_subcommand_succeeds_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(git_scope_bin())
+        .args(["help"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run git-scope help");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Usage: git-scope"),
+        "missing Usage: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Not a Git repository"),
+        "unexpected repo warning: {stdout}"
+    );
+}


### PR DESCRIPTION
# Show git-scope help outside repositories

## Summary
`git-scope --help` and `git-scope help` previously required running inside a Git repository. This change makes help/usage available anywhere while preserving the existing repo check for real commands.

## Problem
- Expected: Help output should be available regardless of the current directory.
- Actual: Outside a Git repo, `git-scope --help` printed the repo warning and exited non-zero.
- Impact: Poor UX; users cannot discover usage unless they `cd` into a repo.

## Reproduction
1. Create an empty temp directory (not a git repo).
2. Run `git-scope --help` or `git-scope help`.

- Expected result: Usage prints and exit code is 0.
- Actual result: Prints "Not a Git repository" and exits 1.

## Issues Found
Severity: critical | high | medium | low
Confidence: high | medium | low
Status: open | fixed | deferred | needs-info

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-15-BUG-001 | low | high | crates/git-scope/src/main.rs | Help is blocked by repo check | `crates/git-scope/tests/help_outside_repo.rs` | fixed |

## Fix Approach
- Detect `--help` and `help` before `is_git_repo()` gating.
- Add integration coverage for both help entrypoints.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- None; only affects help paths.
