### PR TITLE
Show git-lock help outside repositories

### DIFF
--- a/crates/git-lock/src/main.rs
+++ b/crates/git-lock/src/main.rs
@@ -60,13 +60,19 @@ fn main() {
 }
 
 fn run() -> i32 {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() > 1 && is_help(&args[1]) {
+        print_help();
+        return 0;
+    }
+
     if !git::is_git_repo() {
         println!("❗ Not a Git repository. Run this command inside a Git project.");
         return 1;
     }
 
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() <= 1 || is_help(&args[1]) {
+    if args.len() <= 1 {
         print_help();
         return 0;
     }

--- a/crates/git-lock/tests/help_outside_repo.rs
+++ b/crates/git-lock/tests/help_outside_repo.rs
@@ -1,0 +1,35 @@
+mod common;
+
+use common::run_git_lock_output;
+
+#[test]
+fn help_flag_outside_repo_exits_zero() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = run_git_lock_output(
+        dir.path(),
+        &["--help"],
+        &[("ZSH_CACHE_DIR", dir.path().to_str().unwrap())],
+        None,
+    );
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Usage: git-lock"));
+    assert!(!stdout.contains("Not a Git repository"));
+}
+
+#[test]
+fn help_subcommand_outside_repo_exits_zero() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = run_git_lock_output(
+        dir.path(),
+        &["help"],
+        &[("ZSH_CACHE_DIR", dir.path().to_str().unwrap())],
+        None,
+    );
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Usage: git-lock"));
+    assert!(!stdout.contains("Not a Git repository"));
+}


### PR DESCRIPTION
# Show git-lock help outside repositories

## Summary
`git-lock` previously required being inside a Git repo even to display `--help`/`help`. This change makes help output available anywhere while keeping the repo check for real commands.

## Problem
- Expected: `git-lock --help` and `git-lock help` should succeed regardless of cwd.
- Actual: Outside a repo, help printed the repo error and exited non-zero.
- Impact: Users cannot discover usage unless they first `cd` into a repository.

## Reproduction
1. Create an empty temp directory (not a git repo).
2. Run `git-lock --help` or `git-lock help`.

- Expected result: Usage prints and exit code is 0.
- Actual result: Prints "Not a Git repository" and exits 1.

## Issues Found
Severity: critical | high | medium | low
Confidence: high | medium | low
Status: open | fixed | deferred | needs-info

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-16-BUG-001 | low | high | crates/git-lock/src/main.rs | Help is blocked by repo check | `crates/git-lock/tests/help_outside_repo.rs` | fixed |

## Fix Approach
- Detect `--help` and `help` before `is_git_repo()` gating.
- Add integration coverage for both help entrypoints.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- None; only affects help paths.
