### PR TITLE
Fix commit print to use commit snapshots

### DIFF
--- a/crates/git-scope/README.md
+++ b/crates/git-scope/README.md
@@ -91,7 +91,7 @@ Output is emoji-heavy and colorized unless `--no-color` or `NO_COLOR` is set.
 ## commit with print
 - Setup: commit with text file in history.
 - Command: `git-scope commit HEAD -p`.
-- Expect: `📦 Printing file contents` and `📄 <file> (from HEAD)` or `(working tree)`.
+- Expect: `📦 Printing file contents` and `📄 <file> (from <commit-ish>)`.
 
 ## merge parent selection
 - Setup: create merge commit with two parents and divergent changes.

--- a/crates/git-scope/src/commit.rs
+++ b/crates/git-scope/src/commit.rs
@@ -1,6 +1,6 @@
 use crate::change::{canonical_path, parse_name_status_output};
 use crate::git_cmd::run_git;
-use crate::print::{emit_file, HeadFallback, PrintSource};
+use crate::print::emit_file_from_commit;
 use crate::progress::ProgressRunner;
 use crate::render::{color_reset_for_commit, kind_color_for_commit, render_tree_for_commit};
 use anyhow::Result;
@@ -26,7 +26,7 @@ pub fn render_commit(
 
         for file in files {
             progress.run(&file, || -> Result<()> {
-                emit_file(PrintSource::Worktree, &file, HeadFallback::FromHead)?;
+                emit_file_from_commit(commit, &file)?;
                 println!();
                 Ok(())
             })?;

--- a/crates/git-scope/src/print.rs
+++ b/crates/git-scope/src/print.rs
@@ -47,6 +47,35 @@ pub fn emit_file(source: PrintSource, path: &str, fallback: HeadFallback) -> Res
     }
 }
 
+pub fn emit_file_from_commit(commit: &str, path: &str) -> Result<()> {
+    if path.is_empty() {
+        println!("❗ Missing file path");
+        return Ok(());
+    }
+
+    let tmp = mktemp_path()?;
+    if git_show_to_file(&format!("{commit}:{path}"), &tmp).is_err() {
+        let _ = fs::remove_file(&tmp);
+        println!("❗ File not found in commit {commit}: {path}");
+        return Ok(());
+    }
+
+    if is_binary_file(&tmp)? {
+        println!("📄 {path} (binary file in {commit})");
+        println!("🔹 [Binary file content omitted]");
+    } else {
+        println!("📄 {path} (from {commit})");
+        println!("```");
+        let content = fs::read(&tmp)?;
+        std::io::stdout().write_all(&content)?;
+        println!();
+        println!("```");
+    }
+
+    let _ = fs::remove_file(&tmp);
+    Ok(())
+}
+
 fn emit_from_worktree(path: &str) -> Result<()> {
     if is_binary_file(path)? {
         println!("📄 {path} (binary file in working tree)");

--- a/crates/git-scope/tests/characterization_warnings.rs
+++ b/crates/git-scope/tests/characterization_warnings.rs
@@ -85,8 +85,8 @@ fn missing_file_warning_is_stable() {
     let output = common::run_git_scope(root, &["commit", &old_commit, "-p"], &[("NO_COLOR", "1")]);
 
     assert!(
-        output.contains("❗ File not found: vanish.txt"),
-        "missing file warning not found: {output}"
+        output.contains(&format!("📄 vanish.txt (from {old_commit})")),
+        "commit snapshot header missing: {output}"
     );
 }
 


### PR DESCRIPTION
# Fix commit print to use commit snapshots

## Summary
Ensure `git-scope commit -p` prints file contents from the target commit snapshot (not the working tree/HEAD), and update characterization coverage + docs to reflect commit-snapshot output.

## Problem
- Expected: commit-mode printing shows file content from the specified commit.
- Actual: commit-mode printing reads the working tree/HEAD, so historical commits show missing or incorrect content.
- Impact: commit inspection is misleading for older commits and deleted files.

## Reproduction
1. Create a repo, commit `vanish.txt`, capture the commit hash.
2. Delete `vanish.txt` in a later commit.
3. Run: `git-scope commit <old_commit> -p`.

- Expected result: `vanish.txt` prints from `<old_commit>`.
- Actual result: `vanish.txt` reports "File not found" (or shows current worktree content).

## Issues Found
Severity: critical | high | medium | low
Confidence: high | medium | low
Status: open | fixed | deferred | needs-info

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-17-BUG-001 | medium | high | crates/git-scope/src/commit.rs | Commit print uses worktree/HEAD instead of commit snapshot | crates/git-scope/src/commit.rs:28 | fixed |

## Fix Approach
- Route commit printing through a commit-snapshot reader that shells `git show <commit>:<path>`.
- Update the characterization test and README expectations to match commit snapshot output.

## Testing
- ./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh (pass)

## Risk / Notes
- Commit labels in print headers use the provided commit-ish (may be full hash).
