### PR TITLE
Highlight current auth profile in rate-limits table

### DIFF
--- a/crates/codex-cli/src/rate_limits/ansi.rs
+++ b/crates/codex-cli/src/rate_limits/ansi.rs
@@ -1,10 +1,28 @@
 use std::io::{self, IsTerminal};
 
+const CURRENT_PROFILE_FG: &str = "\x1b[38;2;199;146;234m";
+
 pub fn should_color() -> bool {
     if std::env::var_os("NO_COLOR").is_some() {
         return false;
     }
     io::stdout().is_terminal()
+}
+
+pub fn format_name_cell(
+    raw: &str,
+    width: usize,
+    is_current: bool,
+    color_enabled: Option<bool>,
+) -> String {
+    let padded = format!("{:<width$}", raw, width = width);
+
+    let enabled = color_enabled.unwrap_or_else(should_color);
+    if !enabled || !is_current {
+        return padded;
+    }
+
+    format!("{CURRENT_PROFILE_FG}{padded}{}", reset())
 }
 
 pub fn format_percent_cell(raw: &str, width: usize, color_enabled: Option<bool>) -> String {

--- a/crates/codex-cli/src/rate_limits/mod.rs
+++ b/crates/codex-cli/src/rate_limits/mod.rs
@@ -346,6 +346,8 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
         }
     }
 
+    let current_name = current_secret_basename(&secret_files);
+
     let now_epoch = Utc::now().timestamp();
 
     println!(
@@ -389,9 +391,12 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
             ansi::format_percent_cell("-", 8, None)
         };
 
+        let is_current = current_name.as_deref() == Some(row.name.as_str());
+        let name_display = ansi::format_name_cell(&row.name, 15, is_current, None);
+
         println!(
-            "{:<15}  {}  {:>7}  {}  {:>7}  {:<11}",
-            row.name,
+            "{}  {}  {:>7}  {}  {:>7}  {:<11}",
+            name_display,
             non_weekly_display,
             non_weekly_left,
             weekly_display,
@@ -763,6 +768,8 @@ fn run_all_mode(args: &RateLimitsOptions, cached_mode: bool, debug_mode: bool) -
 
     secret_files.sort();
 
+    let current_name = current_secret_basename(&secret_files);
+
     let total = secret_files.len();
     let progress = if total > 1 {
         Some(Progress::new(
@@ -901,9 +908,12 @@ fn run_all_mode(args: &RateLimitsOptions, cached_mode: bool, debug_mode: bool) -
             ansi::format_percent_cell("-", 8, None)
         };
 
+        let is_current = current_name.as_deref() == Some(row.name.as_str());
+        let name_display = ansi::format_name_cell(&row.name, 15, is_current, None);
+
         println!(
-            "{:<15}  {}  {:>7}  {}  {:>7}  {:<11}",
-            row.name,
+            "{}  {}  {:>7}  {}  {:>7}  {:<11}",
+            name_display,
             non_weekly_display,
             non_weekly_left,
             weekly_display,
@@ -913,6 +923,42 @@ fn run_all_mode(args: &RateLimitsOptions, cached_mode: bool, debug_mode: bool) -
     }
 
     Ok(rc)
+}
+
+fn current_secret_basename(secret_files: &[PathBuf]) -> Option<String> {
+    let auth_file = crate::paths::resolve_auth_file()?;
+    if !auth_file.is_file() {
+        return None;
+    }
+
+    let auth_key = auth::identity_key_from_auth_file(&auth_file).ok().flatten();
+    let auth_hash = crate::fs::sha256_file(&auth_file).ok();
+
+    if let Some(auth_hash) = auth_hash.as_deref() {
+        for secret_file in secret_files {
+            if let Ok(secret_hash) = crate::fs::sha256_file(secret_file) {
+                if secret_hash == auth_hash {
+                    if let Some(name) = secret_file.file_name().and_then(|name| name.to_str()) {
+                        return Some(name.trim_end_matches(".json").to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(auth_key) = auth_key.as_deref() {
+        for secret_file in secret_files {
+            if let Ok(Some(candidate_key)) = auth::identity_key_from_auth_file(secret_file) {
+                if candidate_key == auth_key {
+                    if let Some(name) = secret_file.file_name().and_then(|name| name.to_str()) {
+                        return Some(name.trim_end_matches(".json").to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    None
 }
 
 fn run_single_mode(

--- a/crates/codex-cli/tests/rate_limits_ansi.rs
+++ b/crates/codex-cli/tests/rate_limits_ansi.rs
@@ -28,3 +28,20 @@ fn rate_limits_ansi_format_percent_cell_and_token() {
 
     assert_eq!(ansi::format_percent_token("", Some(true)), "");
 }
+
+#[test]
+fn rate_limits_ansi_format_name_cell() {
+    assert_eq!(
+        ansi::format_name_cell("work", 15, true, Some(false)),
+        "work           "
+    );
+    assert_eq!(
+        ansi::format_name_cell("work", 15, false, Some(true)),
+        "work           "
+    );
+
+    let rendered = ansi::format_name_cell("work", 15, true, Some(true));
+    assert!(rendered.starts_with("\x1b[38;2;199;146;234m"));
+    assert!(rendered.ends_with("\x1b[0m"));
+    assert!(rendered.contains("work"));
+}


### PR DESCRIPTION
# Highlight current auth profile in rate-limits table

## Summary
Highlight the currently active Codex auth profile (the secret that matches `CODEX_AUTH_FILE`) in the `codex-cli diag rate-limits` table output so it's easy to spot which account is in use.

## Changes
- Color the current profile in the Name column using truecolor `#c792ea`.
- Detect the current profile via auth-file hash match, with an identity-key fallback.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Respects `NO_COLOR` and non-TTY stdout; alignment remains stable.
