### PR TITLE
Add Bash completions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -72,7 +72,9 @@
   - `target/coverage/html/index.html`
 - Note: doctests are **not included** in coverage initially; still run doctests for correctness: `cargo test --workspace --doc`
 
-## Shell completions (zsh)
+## Shell completions
+
+### Zsh
 
 - Completion files:
   - `completions/zsh/_git-scope`
@@ -91,3 +93,22 @@
   - Add `wrappers/` to `PATH`.
   - Add `completions/zsh/` to `fpath` and run `compinit`.
   - Optional: `source completions/zsh/aliases.zsh`
+
+### Bash
+
+- Completion files:
+  - `completions/bash/git-scope`
+  - `completions/bash/git-summary`
+  - `completions/bash/git-lock`
+  - `completions/bash/fzf-cli`
+  - `completions/bash/codex-cli`
+  - `completions/bash/semantic-commit`
+  - `completions/bash/plan-tooling`
+  - `completions/bash/api-rest`
+  - `completions/bash/api-gql`
+  - `completions/bash/api-test`
+- Optional aliases (Bash): `completions/bash/aliases.bash`
+- Setup:
+  - Install `bash-completion` (recommended), then copy `completions/bash/<command>` into your completions directory (example: `~/.local/share/bash-completion/completions/`).
+  - Or: source the desired files from your `~/.bashrc`.
+  - Optional: `source completions/bash/aliases.bash`

--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ Then download the matching `nils-cli-<tag>-<target>.tar.gz` asset, extract it, a
 For zsh completions, add `<extract_dir>/completions/zsh` to your `fpath` and run `compinit`.
 Optional: source `<extract_dir>/completions/zsh/aliases.zsh` to enable `gs*`/`cx*`/`ff*` aliases.
 
+For bash completions, copy `<extract_dir>/completions/bash/<command>` into your bash-completion directory
+(example: `~/.local/share/bash-completion/completions/`) or source it from your shell init.
+Optional: source `<extract_dir>/completions/bash/aliases.bash` to enable `gs*`/`cx*`/`ff*` aliases.
+
 ## git-scope
 - Example usage: `git-scope staged`, `git-scope all -p`, `git-scope commit HEAD -p`
-- Optional Zsh aliases (opt-in):
+- Optional aliases (opt-in; Zsh: `completions/zsh/aliases.zsh`, Bash: `completions/bash/aliases.bash`):
   - `gs` → `git-scope`
   - `gst` → `git-scope tracked`
   - `gss` → `git-scope staged`
@@ -64,12 +68,12 @@ Optional: source `<extract_dir>/completions/zsh/aliases.zsh` to enable `gs*`/`cx
 ## fzf-cli
 - Example usage: `fzf-cli file`, `fzf-cli directory`, `fzf-cli history`, `fzf-cli port`, `fzf-cli process`
 - Note: some subcommands print shell commands for `eval` (e.g. `fzf-cli directory` prints a `cd ...`), see `crates/fzf-cli/README.md`.
-- Optional Zsh aliases (opt-in): `ff*` (see `completions/zsh/aliases.zsh`); `ffd` and `ffh` are functions that `eval` the emitted command.
+- Optional aliases (opt-in): `ff*` (Zsh: `completions/zsh/aliases.zsh`, Bash: `completions/bash/aliases.bash`); `ffd` and `ffh` are functions that `eval` the emitted command.
 
 ## codex-cli
 - Docs: `crates/codex-cli/README.md`
 - Example usage: `codex-cli auth current`, `codex-cli diag rate-limits --one-line`
-- Optional Zsh aliases (opt-in): `cx*` (see `completions/zsh/aliases.zsh`).
+- Optional aliases (opt-in): `cx*` (Zsh: `completions/zsh/aliases.zsh`, Bash: `completions/bash/aliases.bash`).
 
 ## semantic-commit
 - Example usage:
@@ -116,11 +120,11 @@ See `crates/api-testing-core/README.md` for the recommended repo layout and end-
 5. Verify packaging picks it up (both local install + GitHub Releases use the same discovery):
    - `python3 scripts/workspace-bins.py | rg "^<cli-name>$"`
 
-## Zsh wrappers and completions
-This repo keeps optional zsh wrapper scripts and completion assets in-repo.
+## Shell wrappers and completions
+This repo keeps optional wrapper scripts and completion assets in-repo.
 
 Decision:
-- Keep zsh completion and wrapper assets under `completions/zsh/` and `wrappers/`.
+- Keep completion and wrapper assets under `completions/` and `wrappers/`.
 
 Rationale:
 - Keeps shell UX assets versioned alongside the Rust CLIs they accompany.
@@ -140,13 +144,27 @@ Location:
   - `completions/zsh/_codex-cli`
   - `completions/zsh/_semantic-commit`
   - `completions/zsh/_plan-tooling`
+- `completions/bash/`: bash completion files
+  - `completions/bash/aliases.bash`
+  - `completions/bash/api-rest`
+  - `completions/bash/api-gql`
+  - `completions/bash/api-test`
+  - `completions/bash/git-scope`
+  - `completions/bash/git-summary`
+  - `completions/bash/git-lock`
+  - `completions/bash/fzf-cli`
+  - `completions/bash/codex-cli`
+  - `completions/bash/semantic-commit`
+  - `completions/bash/plan-tooling`
 - `wrappers/`: wrapper scripts for invoking CLI binaries or enforcing env setup
 
 Integration steps:
-1. Add `completions/zsh/` to your `fpath`, then run `compinit` in your shell init.
-2. Optional: `source completions/zsh/aliases.zsh`
-3. Dev-only: add `wrappers/` to your PATH (or symlink wrapper scripts into a bin directory).
-4. Regenerate completions when CLIs change, and commit updates alongside code.
+1. Zsh: add `completions/zsh/` to your `fpath`, then run `compinit` in your shell init.
+2. Zsh (optional): `source completions/zsh/aliases.zsh`
+3. Bash: copy `completions/bash/<command>` into your bash-completion directory, or source them from your shell init.
+4. Bash (optional): `source completions/bash/aliases.bash`
+5. Dev-only: add `wrappers/` to your PATH (or symlink wrapper scripts into a bin directory).
+6. Regenerate completions when CLIs change, and commit updates alongside code.
 
 ## License
 

--- a/completions/bash/aliases.bash
+++ b/completions/bash/aliases.bash
@@ -1,0 +1,78 @@
+# nils-cli aliases (Bash)
+#
+# Opt-in: source this file from your ~/.bashrc after installing nils-cli.
+# Designed to avoid clobbering user-defined aliases/functions.
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s expand_aliases 2>/dev/null || true
+
+_nils_cli__has_alias() {
+  alias "$1" >/dev/null 2>&1
+}
+
+_nils_cli__has_function() {
+  declare -F "$1" >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# git-scope (gs*)
+# ---------------------------------------------------------------------------
+_nils_cli__has_alias gs || alias gs='git-scope'
+
+_nils_cli__has_alias gst || alias gst='git-scope tracked'
+_nils_cli__has_alias gss || alias gss='git-scope staged'
+_nils_cli__has_alias gsu || alias gsu='git-scope unstaged'
+_nils_cli__has_alias gsa || alias gsa='git-scope all'
+_nils_cli__has_alias gsun || alias gsun='git-scope untracked'
+_nils_cli__has_alias gsc || alias gsc='git-scope commit'
+_nils_cli__has_alias gsh || alias gsh='git-scope help'
+
+# ---------------------------------------------------------------------------
+# codex-cli (cx*)
+# ---------------------------------------------------------------------------
+_nils_cli__has_alias cx || alias cx='codex-cli'
+
+_nils_cli__has_alias cxau || alias cxau='codex-cli auth use'
+_nils_cli__has_alias cxar || alias cxar='codex-cli auth refresh'
+_nils_cli__has_alias cxaa || alias cxaa='codex-cli auth auto-refresh'
+_nils_cli__has_alias cxac || alias cxac='codex-cli auth current'
+_nils_cli__has_alias cxas || alias cxas='codex-cli auth sync'
+
+_nils_cli__has_alias cxdr || alias cxdr='codex-cli diag rate-limits'
+_nils_cli__has_alias cxdra || alias cxdra='codex-cli diag rate-limits --async'
+
+_nils_cli__has_alias cxcs || alias cxcs='codex-cli config show'
+_nils_cli__has_alias cxct || alias cxct='codex-cli config set'
+
+_nils_cli__has_alias cxgp || alias cxgp='codex-cli agent prompt'
+_nils_cli__has_alias cxga || alias cxga='codex-cli agent advice'
+_nils_cli__has_alias cxgk || alias cxgk='codex-cli agent knowledge'
+_nils_cli__has_alias cxgc || alias cxgc='codex-cli agent commit'
+
+_nils_cli__has_alias cxst || alias cxst='codex-cli starship'
+
+# ---------------------------------------------------------------------------
+# fzf-cli (ff*)
+# ---------------------------------------------------------------------------
+_nils_cli__has_alias ff || alias ff='fzf-cli'
+_nils_cli__has_alias fff || alias fff='fzf-cli file'
+
+# These use eval to preserve parent-shell effects:
+_nils_cli__has_function ffd || ffd() { eval "$(fzf-cli directory -- "$@")"; }
+_nils_cli__has_function ffh || ffh() { eval "$(fzf-cli history -- "$@")"; }
+
+_nils_cli__has_alias ffgs || alias ffgs='fzf-cli git-status'
+_nils_cli__has_alias ffgc || alias ffgc='fzf-cli git-commit'
+_nils_cli__has_alias ffgco || alias ffgco='fzf-cli git-checkout'
+_nils_cli__has_alias ffgb || alias ffgb='fzf-cli git-branch'
+_nils_cli__has_alias ffgt || alias ffgt='fzf-cli git-tag'
+_nils_cli__has_alias ffp || alias ffp='fzf-cli process'
+_nils_cli__has_alias ffpo || alias ffpo='fzf-cli port'
+_nils_cli__has_alias ffenv || alias ffenv='fzf-cli env'
+_nils_cli__has_alias ffal || alias ffal='fzf-cli alias'
+_nils_cli__has_alias fffn || alias fffn='fzf-cli function'
+_nils_cli__has_alias ffdef || alias ffdef='fzf-cli def'
+

--- a/completions/bash/api-gql
+++ b/completions/bash/api-gql
@@ -1,0 +1,121 @@
+# nils-cli bash completion: api-gql
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_api_gql_complete() {
+  local -a words=("${COMP_WORDS[@]}")
+  local cword="$COMP_CWORD"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  local -a subcmds=(call history report report-from-cmd schema)
+  local -a root_opts=(-h --help -V --version)
+
+  if (( cword == 1 )); then
+    if [[ "$cur" == -* ]]; then
+      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
+      return 0
+    fi
+    local -a replies=()
+    replies+=( $(compgen -W "${subcmds[*]}" -- "$cur") )
+    replies+=( $(compgen -f -- "$cur") )
+    COMPREPLY=( "${replies[@]}" )
+    return 0
+  fi
+
+  local subcmd="${words[1]-}"
+  case "$subcmd" in
+    call|history|report|report-from-cmd|schema) ;;
+    *) subcmd="call" ;;
+  esac
+
+  case "$subcmd" in
+    call)
+      if [[ "$prev" == "--config-dir" ]]; then
+        COMPREPLY=( $(compgen -d -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help -e --env -u --url --jwt --config-dir --list-envs --list-jwts --no-history" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=( $(compgen -f -- "$cur") )
+      return 0
+      ;;
+    history)
+      if [[ "$prev" == "--config-dir" ]]; then
+        COMPREPLY=( $(compgen -d -- "$cur") )
+        return 0
+      fi
+      if [[ "$prev" == "--file" ]]; then
+        COMPREPLY=( $(compgen -f -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --config-dir --file --last --tail --command-only" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    report)
+      case "$prev" in
+        --op|--operation|--vars|--variables|--out|--response)
+          COMPREPLY=( $(compgen -f -- "$cur") )
+          return 0
+          ;;
+        --project-root|--config-dir)
+          COMPREPLY=( $(compgen -d -- "$cur") )
+          return 0
+          ;;
+      esac
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --case --op --operation --vars --variables --out -e --env -u --url --jwt --run --response --allow-empty --expect-empty --no-redact --no-command --no-command-url --project-root --config-dir" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    report-from-cmd)
+      case "$prev" in
+        --out|--response)
+          COMPREPLY=( $(compgen -f -- "$cur") )
+          return 0
+          ;;
+      esac
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --case --out --response --allow-empty --expect-empty --dry-run --stdin" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    schema)
+      case "$prev" in
+        --config-dir)
+          COMPREPLY=( $(compgen -d -- "$cur") )
+          return 0
+          ;;
+        --file)
+          COMPREPLY=( $(compgen -f -- "$cur") )
+          return 0
+          ;;
+      esac
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --config-dir --file --cat" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+
+  COMPREPLY=()
+}
+
+complete -F _nils_cli_api_gql_complete api-gql
+

--- a/completions/bash/api-rest
+++ b/completions/bash/api-rest
@@ -1,0 +1,103 @@
+# nils-cli bash completion: api-rest
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_api_rest_complete() {
+  local -a words=("${COMP_WORDS[@]}")
+  local cword="$COMP_CWORD"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  local -a subcmds=(call history report report-from-cmd)
+  local -a root_opts=(-h --help -V --version)
+
+  if (( cword == 1 )); then
+    if [[ "$cur" == -* ]]; then
+      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
+      return 0
+    fi
+    local -a replies=()
+    replies+=( $(compgen -W "${subcmds[*]}" -- "$cur") )
+    replies+=( $(compgen -f -- "$cur") )
+    COMPREPLY=( "${replies[@]}" )
+    return 0
+  fi
+
+  local subcmd="${words[1]-}"
+  case "$subcmd" in
+    call|history|report|report-from-cmd) ;;
+    *) subcmd="call" ;;
+  esac
+
+  case "$subcmd" in
+    call)
+      if [[ "$prev" == "--config-dir" ]]; then
+        COMPREPLY=( $(compgen -d -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help -e --env -u --url --token --config-dir --no-history" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=( $(compgen -f -- "$cur") )
+      return 0
+      ;;
+    history)
+      if [[ "$prev" == "--config-dir" ]]; then
+        COMPREPLY=( $(compgen -d -- "$cur") )
+        return 0
+      fi
+      if [[ "$prev" == "--file" ]]; then
+        COMPREPLY=( $(compgen -f -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --config-dir --file --last --tail --command-only" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    report)
+      case "$prev" in
+        --request|--out|--response)
+          COMPREPLY=( $(compgen -f -- "$cur") )
+          return 0
+          ;;
+        --project-root|--config-dir)
+          COMPREPLY=( $(compgen -d -- "$cur") )
+          return 0
+          ;;
+      esac
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --case --request --out -e --env -u --url --token --run --response --no-redact --no-command --no-command-url --project-root --config-dir" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    report-from-cmd)
+      case "$prev" in
+        --out|--response)
+          COMPREPLY=( $(compgen -f -- "$cur") )
+          return 0
+          ;;
+      esac
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --case --out --response --allow-empty --expect-empty --dry-run --stdin" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+
+  COMPREPLY=()
+}
+
+complete -F _nils_cli_api_rest_complete api-rest
+

--- a/completions/bash/api-test
+++ b/completions/bash/api-test
@@ -1,0 +1,68 @@
+# nils-cli bash completion: api-test
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_api_test_complete() {
+  local -a words=("${COMP_WORDS[@]}")
+  local cword="$COMP_CWORD"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  local -a subcmds=(run summary)
+  local -a root_opts=(-h --help -V --version)
+
+  if (( cword == 1 )); then
+    if [[ "$cur" == -* ]]; then
+      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
+      return 0
+    fi
+    COMPREPLY=( $(compgen -W "${subcmds[*]}" -- "$cur") )
+    return 0
+  fi
+
+  local subcmd="${words[1]-}"
+  case "$subcmd" in
+    run|summary) ;;
+    *) subcmd="run" ;;
+  esac
+
+  case "$subcmd" in
+    run)
+      case "$prev" in
+        --suite-file|--out|--junit)
+          COMPREPLY=( $(compgen -f -- "$cur") )
+          return 0
+          ;;
+      esac
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --suite --suite-file --out --junit --allow-writes --tag --only --skip --fail-fast --continue" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    summary)
+      case "$prev" in
+        --in|--out)
+          COMPREPLY=( $(compgen -f -- "$cur") )
+          return 0
+          ;;
+      esac
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --in --out --slow --hide-skipped --max-failed --max-skipped --no-github-summary" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+
+  COMPREPLY=()
+}
+
+complete -F _nils_cli_api_test_complete api-test
+

--- a/completions/bash/codex-cli
+++ b/completions/bash/codex-cli
@@ -1,0 +1,232 @@
+# nils-cli bash completion: codex-cli (and cx* aliases)
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli__has_word() {
+  local needle="$1"
+  shift
+  local w=''
+  for w in "$@"; do
+    [[ "$w" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+_nils_cli_codex_cli_complete() {
+  local invoked_as="${COMP_WORDS[0]}"
+  local -a words=("${COMP_WORDS[@]}")
+  local cword="$COMP_CWORD"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  local -a inject=()
+  local implied_async=''
+
+  case "$invoked_as" in
+    cxau) inject=(auth use) ;;
+    cxar) inject=(auth refresh) ;;
+    cxaa) inject=(auth auto-refresh) ;;
+    cxdr) inject=(diag rate-limits) ;;
+    cxdra) inject=(diag rate-limits); implied_async='1' ;;
+    cxst) inject=(starship) ;;
+    cxgp) inject=(agent prompt) ;;
+    cxga) inject=(agent advice) ;;
+    cxgk) inject=(agent knowledge) ;;
+    cxgc) inject=(agent commit) ;;
+    cxac) inject=(auth current) ;;
+    cxas) inject=(auth sync) ;;
+    cxcs) inject=(config show) ;;
+    cxct) inject=(config set) ;;
+  esac
+
+  if [[ -n "$implied_async" ]] && ! _nils_cli__has_word --async "${words[@]}"; then
+    inject+=(--async)
+  fi
+
+  if (( ${#inject[@]} > 0 )); then
+    words=( "codex-cli" "${inject[@]}" "${words[@]:1}" )
+    cword=$((cword + ${#inject[@]}))
+    cur="${words[cword]}"
+    prev="${words[cword-1]}"
+  else
+    words[0]="codex-cli"
+  fi
+
+  local -a root_cmds=(agent auth diag config starship help)
+  local -a root_opts=(-h --help -V --version)
+
+  if (( cword == 1 )); then
+    if [[ "$cur" == -* ]]; then
+      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
+      return 0
+    fi
+    COMPREPLY=( $(compgen -W "${root_cmds[*]}" -- "$cur") )
+    return 0
+  fi
+
+  local cmd="${words[1]-}"
+
+  case "$cmd" in
+    agent)
+      local -a agent_cmds=(prompt advice knowledge commit)
+      if (( cword == 2 )); then
+        if [[ "$cur" == -* ]]; then
+          COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
+          return 0
+        fi
+        COMPREPLY=( $(compgen -W "${agent_cmds[*]}" -- "$cur") )
+        return 0
+      fi
+      local agent_cmd="${words[2]-}"
+      case "$agent_cmd" in
+        commit)
+          if [[ "$cur" == -* ]]; then
+            COMPREPLY=( $(compgen -W "-h --help -p --push -a --auto-stage" -- "$cur") )
+            return 0
+          fi
+          COMPREPLY=()
+          return 0
+          ;;
+        prompt|advice|knowledge)
+          COMPREPLY=()
+          return 0
+          ;;
+      esac
+      ;;
+    auth)
+      local -a auth_cmds=(use refresh auto-refresh current sync)
+      if (( cword == 2 )); then
+        if [[ "$cur" == -* ]]; then
+          COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
+          return 0
+        fi
+        COMPREPLY=( $(compgen -W "${auth_cmds[*]}" -- "$cur") )
+        return 0
+      fi
+      local auth_cmd="${words[2]-}"
+      case "$auth_cmd" in
+        refresh)
+          if [[ "$cur" == -* ]]; then
+            COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
+            return 0
+          fi
+          COMPREPLY=( $(compgen -f -- "$cur") )
+          return 0
+          ;;
+        use)
+          if [[ "$cur" == -* ]]; then
+            COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
+            return 0
+          fi
+          COMPREPLY=()
+          return 0
+          ;;
+        auto-refresh|current|sync)
+          COMPREPLY=()
+          return 0
+          ;;
+      esac
+      ;;
+    diag)
+      local -a diag_cmds=(rate-limits)
+      if (( cword == 2 )); then
+        if [[ "$cur" == -* ]]; then
+          COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
+          return 0
+        fi
+        COMPREPLY=( $(compgen -W "${diag_cmds[*]}" -- "$cur") )
+        return 0
+      fi
+      local diag_cmd="${words[2]-}"
+      case "$diag_cmd" in
+        rate-limits)
+          if [[ "$prev" == "--jobs" ]]; then
+            COMPREPLY=()
+            return 0
+          fi
+          if [[ "$cur" == -* ]]; then
+            COMPREPLY=( $(compgen -W "-h --help -c -d --debug --cached --async --all --json --one-line --no-refresh-auth --jobs" -- "$cur") )
+            return 0
+          fi
+          COMPREPLY=( $(compgen -f -- "$cur") )
+          return 0
+          ;;
+      esac
+      ;;
+    config)
+      local -a config_cmds=(show set)
+      if (( cword == 2 )); then
+        if [[ "$cur" == -* ]]; then
+          COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
+          return 0
+        fi
+        COMPREPLY=( $(compgen -W "${config_cmds[*]}" -- "$cur") )
+        return 0
+      fi
+      local config_cmd="${words[2]-}"
+      case "$config_cmd" in
+        show)
+          COMPREPLY=()
+          return 0
+          ;;
+        set)
+          local -a config_keys=(
+            model
+            reasoning
+            reason
+            dangerous
+            allow-dangerous
+            CODEX_CLI_MODEL
+            CODEX_CLI_REASONING
+            CODEX_ALLOW_DANGEROUS_ENABLED
+          )
+          if (( cword == 3 )); then
+            COMPREPLY=( $(compgen -W "${config_keys[*]}" -- "$cur") )
+            return 0
+          fi
+          if (( cword == 4 )); then
+            local key="${words[3]-}"
+            case "$key" in
+              dangerous|allow-dangerous|CODEX_ALLOW_DANGEROUS_ENABLED)
+                COMPREPLY=( $(compgen -W "true false" -- "$cur") )
+                return 0
+                ;;
+            esac
+            COMPREPLY=()
+            return 0
+          fi
+          COMPREPLY=()
+          return 0
+          ;;
+      esac
+      ;;
+    starship)
+      if [[ "$prev" == "--ttl" || "$prev" == "--time-format" ]]; then
+        COMPREPLY=()
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --no-5h --ttl --time-format --refresh --is-enabled" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    help)
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+
+  COMPREPLY=()
+}
+
+complete -F _nils_cli_codex_cli_complete \
+  codex-cli cx \
+  cxgp cxga cxgk cxgc cxau cxar cxaa cxac cxas cxst cxdr cxdra \
+  cxcs cxct
+

--- a/completions/bash/fzf-cli
+++ b/completions/bash/fzf-cli
@@ -1,0 +1,104 @@
+# nils-cli bash completion: fzf-cli (and ff* aliases)
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_fzf_cli_complete() {
+  local invoked_as="${COMP_WORDS[0]}"
+  local -a words=("${COMP_WORDS[@]}")
+  local cword="$COMP_CWORD"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+
+  local subcmd_override=''
+  case "$invoked_as" in
+    fff) subcmd_override='file' ;;
+    ffd) subcmd_override='directory' ;;
+    ffgs) subcmd_override='git-status' ;;
+    ffgc) subcmd_override='git-commit' ;;
+    ffgco) subcmd_override='git-checkout' ;;
+    ffgb) subcmd_override='git-branch' ;;
+    ffgt) subcmd_override='git-tag' ;;
+    ffp) subcmd_override='process' ;;
+    ffpo) subcmd_override='port' ;;
+    ffh) subcmd_override='history' ;;
+    ffenv) subcmd_override='env' ;;
+    ffal) subcmd_override='alias' ;;
+    fffn) subcmd_override='function' ;;
+    ffdef) subcmd_override='def' ;;
+  esac
+
+  if [[ -n "$subcmd_override" ]]; then
+    words=( "fzf-cli" "$subcmd_override" "${words[@]:1}" )
+    cword=$((cword + 1))
+    cur="${words[cword]}"
+  else
+    words[0]="fzf-cli"
+  fi
+
+  local -a root_subcmds=(
+    file
+    directory
+    git-status
+    git-commit
+    git-checkout
+    git-branch
+    git-tag
+    process
+    port
+    history
+    env
+    alias
+    function
+    def
+    help
+  )
+
+  if (( cword == 1 )); then
+    if [[ "$cur" == -* ]]; then
+      COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
+      return 0
+    fi
+    COMPREPLY=( $(compgen -W "${root_subcmds[*]}" -- "$cur") )
+    return 0
+  fi
+
+  local subcmd="${words[1]-}"
+  case "$subcmd" in
+    file|directory)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "--vi --vscode --" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    git-commit)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "--snapshot" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    process|port)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-k --kill -9 --force" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    git-status|git-checkout|git-branch|git-tag|history|env|alias|function|def|help)
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+
+  COMPREPLY=( $(compgen -W "${root_subcmds[*]}" -- "$cur") )
+}
+
+complete -F _nils_cli_fzf_cli_complete fzf-cli ff fff ffd ffgs ffgc ffgco ffgb ffgt ffp ffpo ffh ffenv ffal fffn ffdef
+

--- a/completions/bash/git-lock
+++ b/completions/bash/git-lock
@@ -1,0 +1,113 @@
+# nils-cli bash completion: git-lock
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_git_lock_labels() {
+  local lock_base="${ZSH_CACHE_DIR:-}"
+  local lock_dir=''
+  if [[ -z "$lock_base" ]]; then
+    lock_dir="/git-locks"
+  else
+    lock_dir="${lock_base%/}/git-locks"
+  fi
+
+  local toplevel=''
+  toplevel="$(command git rev-parse --show-toplevel 2>/dev/null)" || return 0
+  local repo_id="${toplevel##*/}"
+
+  [[ -d "$lock_dir" ]] || return 0
+
+  local file=''
+  while IFS= read -r file; do
+    [[ -f "$file" ]] || continue
+    local base="${file##*/}"
+    base="${base#${repo_id}-}"
+    base="${base%.lock}"
+    printf '%s\n' "$base"
+  done < <(compgen -G "$lock_dir/${repo_id}-"*.lock)
+}
+
+_nils_cli_git_lock_complete() {
+  local -a words=("${COMP_WORDS[@]}")
+  local cword="$COMP_CWORD"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  local -a subcmds=(lock unlock list copy delete diff tag help)
+  local -a root_opts=(-h --help)
+
+  if (( cword == 1 )); then
+    if [[ "$cur" == -* ]]; then
+      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
+      return 0
+    fi
+    COMPREPLY=( $(compgen -W "${subcmds[*]}" -- "$cur") )
+    return 0
+  fi
+
+  local subcmd="${words[1]-}"
+  case "$subcmd" in
+    -h|--help|help)
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+
+  local labels="$(_nils_cli_git_lock_labels)"
+
+  case "$subcmd" in
+    unlock|delete)
+      if (( cword == 2 )); then
+        COMPREPLY=( $(compgen -W "$labels" -- "$cur") )
+        return 0
+      fi
+      ;;
+    copy)
+      if (( cword == 2 )); then
+        COMPREPLY=( $(compgen -W "$labels" -- "$cur") )
+        return 0
+      fi
+      ;;
+    diff)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "--no-color no-color -h --help" -- "$cur") )
+        return 0
+      fi
+      if (( cword == 2 || cword == 3 )); then
+        COMPREPLY=( $(compgen -W "$labels" -- "$cur") )
+        return 0
+      fi
+      ;;
+    tag)
+      if [[ "$prev" == "-m" ]]; then
+        COMPREPLY=()
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "--push -m" -- "$cur") )
+        return 0
+      fi
+      if (( cword == 2 )); then
+        COMPREPLY=( $(compgen -W "$labels" -- "$cur") )
+        return 0
+      fi
+      ;;
+    lock)
+      COMPREPLY=()
+      return 0
+      ;;
+    list)
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+
+  COMPREPLY=()
+}
+
+complete -F _nils_cli_git_lock_complete git-lock
+

--- a/completions/bash/git-scope
+++ b/completions/bash/git-scope
@@ -1,0 +1,107 @@
+# nils-cli bash completion: git-scope (and gs* aliases)
+#
+# Install (example):
+#   mkdir -p ~/.local/share/bash-completion/completions
+#   cp completions/bash/git-scope ~/.local/share/bash-completion/completions/git-scope
+# Or source directly from your shell init.
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_git_scope_complete() {
+  local invoked_as="${COMP_WORDS[0]}"
+  local -a words=("${COMP_WORDS[@]}")
+  local cword="$COMP_CWORD"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  local subcmd_override=''
+  case "$invoked_as" in
+    gsc) subcmd_override='commit' ;;
+    gst) subcmd_override='tracked' ;;
+    gss) subcmd_override='staged' ;;
+    gsu) subcmd_override='unstaged' ;;
+    gsa) subcmd_override='all' ;;
+    gsun) subcmd_override='untracked' ;;
+    gsh) subcmd_override='help' ;;
+  esac
+
+  if [[ -n "$subcmd_override" ]]; then
+    words=( "git-scope" "$subcmd_override" "${words[@]:1}" )
+    cword=$((cword + 1))
+    cur="${words[cword]}"
+    prev="${words[cword-1]}"
+  else
+    words[0]="git-scope"
+  fi
+
+  local -a root_subcmds=(
+    tracked
+    staged
+    unstaged
+    all
+    untracked
+    commit
+    help
+  )
+  local -a root_opts=(-h --help --no-color)
+
+  if (( cword == 1 )); then
+    if [[ "$cur" == -* ]]; then
+      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
+      return 0
+    fi
+    COMPREPLY=( $(compgen -W "${root_subcmds[*]}" -- "$cur") )
+    return 0
+  fi
+
+  local subcmd="${words[1]-}"
+
+  case "$subcmd" in
+    tracked)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --no-color -p --print" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=( $(compgen -f -- "$cur") )
+      return 0
+      ;;
+    staged|unstaged|all|untracked)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --no-color -p --print" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    commit)
+      if [[ "$prev" == "--parent" || "$prev" == "-P" ]]; then
+        COMPREPLY=( $(compgen -W "1 2" -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --no-color -p --print --parent -P" -- "$cur") )
+        return 0
+      fi
+
+      local hashes=''
+      if command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        hashes="$(command git log --pretty=format:%h -n 20 2>/dev/null || true)"
+      fi
+      COMPREPLY=( $(compgen -W "HEAD ${hashes}" -- "$cur") )
+      return 0
+      ;;
+    help)
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+
+  COMPREPLY=( $(compgen -W "${root_subcmds[*]}" -- "$cur") )
+}
+
+complete -F _nils_cli_git_scope_complete git-scope gs gst gss gsu gsa gsun gsc gsh
+

--- a/completions/bash/git-summary
+++ b/completions/bash/git-summary
@@ -1,0 +1,37 @@
+# nils-cli bash completion: git-summary
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_git_summary_complete() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+
+  local -a subcmds=(
+    today
+    yesterday
+    this-month
+    last-month
+    this-week
+    last-week
+    all
+    help
+  )
+  local -a opts=(-h --help)
+
+  if (( COMP_CWORD == 1 )); then
+    if [[ "$cur" == -* ]]; then
+      COMPREPLY=( $(compgen -W "${opts[*]}" -- "$cur") )
+      return 0
+    fi
+    COMPREPLY=( $(compgen -W "${subcmds[*]}" -- "$cur") )
+    return 0
+  fi
+
+  COMPREPLY=()
+}
+
+complete -F _nils_cli_git_summary_complete git-summary
+

--- a/completions/bash/plan-tooling
+++ b/completions/bash/plan-tooling
@@ -1,0 +1,91 @@
+# nils-cli bash completion: plan-tooling
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_plan_tooling_complete() {
+  local -a words=("${COMP_WORDS[@]}")
+  local cword="$COMP_CWORD"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  local -a subcmds=(to-json validate batches scaffold help)
+  local -a opts=(-h --help)
+
+  if (( cword == 1 )); then
+    if [[ "$cur" == -* ]]; then
+      COMPREPLY=( $(compgen -W "${opts[*]}" -- "$cur") )
+      return 0
+    fi
+    COMPREPLY=( $(compgen -W "${subcmds[*]}" -- "$cur") )
+    return 0
+  fi
+
+  local subcmd="${words[1]-}"
+  case "$subcmd" in
+    -h|--help|help)
+      COMPREPLY=()
+      return 0
+      ;;
+    to-json)
+      if [[ "$prev" == "--file" ]]; then
+        COMPREPLY=( $(compgen -f -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --file --sprint --pretty" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    validate)
+      if [[ "$prev" == "--file" ]]; then
+        COMPREPLY=( $(compgen -f -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --file" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    batches)
+      if [[ "$prev" == "--file" ]]; then
+        COMPREPLY=( $(compgen -f -- "$cur") )
+        return 0
+      fi
+      if [[ "$prev" == "--format" ]]; then
+        COMPREPLY=( $(compgen -W "json text" -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --file --sprint --format" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    scaffold)
+      if [[ "$prev" == "--file" ]]; then
+        COMPREPLY=( $(compgen -f -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --slug --file --title --force" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+
+  COMPREPLY=()
+}
+
+complete -F _nils_cli_plan_tooling_complete plan-tooling
+

--- a/completions/bash/semantic-commit
+++ b/completions/bash/semantic-commit
@@ -1,0 +1,51 @@
+# nils-cli bash completion: semantic-commit
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_semantic_commit_complete() {
+  local -a words=("${COMP_WORDS[@]}")
+  local cword="$COMP_CWORD"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  local -a root_subcmds=(staged-context commit help)
+  local -a root_opts=(-h --help)
+
+  if (( cword == 1 )); then
+    if [[ "$cur" == -* ]]; then
+      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
+      return 0
+    fi
+    COMPREPLY=( $(compgen -W "${root_subcmds[*]}" -- "$cur") )
+    return 0
+  fi
+
+  local subcmd="${words[1]-}"
+  case "$subcmd" in
+    staged-context|help)
+      COMPREPLY=()
+      return 0
+      ;;
+    commit)
+      if [[ "$prev" == "--message-file" ]]; then
+        COMPREPLY=( $(compgen -f -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --message --message-file" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+  esac
+
+  COMPREPLY=()
+}
+
+complete -F _nils_cli_semantic_commit_complete semantic-commit
+

--- a/tests/zsh/completion.test.zsh
+++ b/tests/zsh/completion.test.zsh
@@ -16,6 +16,18 @@ COMP_PLAN_TOOLING_FILE="$REPO_ROOT/completions/zsh/_plan-tooling"
 COMP_CODEX_CLI_FILE="$REPO_ROOT/completions/zsh/_codex-cli"
 ALIASES_FILE="$REPO_ROOT/completions/zsh/aliases.zsh"
 
+BASH_GIT_SCOPE_FILE="$REPO_ROOT/completions/bash/git-scope"
+BASH_SUMMARY_FILE="$REPO_ROOT/completions/bash/git-summary"
+BASH_LOCK_FILE="$REPO_ROOT/completions/bash/git-lock"
+BASH_FZF_CLI_FILE="$REPO_ROOT/completions/bash/fzf-cli"
+BASH_SEMANTIC_COMMIT_FILE="$REPO_ROOT/completions/bash/semantic-commit"
+BASH_API_REST_FILE="$REPO_ROOT/completions/bash/api-rest"
+BASH_API_GQL_FILE="$REPO_ROOT/completions/bash/api-gql"
+BASH_API_TEST_FILE="$REPO_ROOT/completions/bash/api-test"
+BASH_PLAN_TOOLING_FILE="$REPO_ROOT/completions/bash/plan-tooling"
+BASH_CODEX_CLI_FILE="$REPO_ROOT/completions/bash/codex-cli"
+BASH_ALIASES_FILE="$REPO_ROOT/completions/bash/aliases.bash"
+
 if [[ ! -f "$COMP_FILE" ]]; then
   print -u2 -r -- "FAIL: missing completion file"
   exit 1
@@ -68,6 +80,61 @@ fi
 
 if [[ ! -f "$ALIASES_FILE" ]]; then
   print -u2 -r -- "FAIL: missing nils-cli aliases file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_GIT_SCOPE_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash git-scope completion file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_SUMMARY_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash git-summary completion file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_LOCK_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash git-lock completion file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_FZF_CLI_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash fzf-cli completion file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_SEMANTIC_COMMIT_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash semantic-commit completion file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_API_REST_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash api-rest completion file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_API_GQL_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash api-gql completion file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_API_TEST_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash api-test completion file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_PLAN_TOOLING_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash plan-tooling completion file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_CODEX_CLI_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash codex-cli completion file"
+  exit 1
+fi
+
+if [[ ! -f "$BASH_ALIASES_FILE" ]]; then
+  print -u2 -r -- "FAIL: missing bash nils-cli aliases file"
   exit 1
 fi
 
@@ -366,6 +433,61 @@ grep -q -- "--async\\[" "$COMP_CODEX_CLI_FILE" || {
 
 grep -q -- "--cached\\[" "$COMP_CODEX_CLI_FILE" || {
   print -u2 -r -- "FAIL: codex-cli completion missing --cached"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_GIT_SCOPE_FILE\"; complete -p git-scope | grep -q _nils_cli_git_scope_complete" || {
+  print -u2 -r -- "FAIL: failed to source bash git-scope completion file"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_SUMMARY_FILE\"; complete -p git-summary | grep -q _nils_cli_git_summary_complete" || {
+  print -u2 -r -- "FAIL: failed to source bash git-summary completion file"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_LOCK_FILE\"; complete -p git-lock | grep -q _nils_cli_git_lock_complete" || {
+  print -u2 -r -- "FAIL: failed to source bash git-lock completion file"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_FZF_CLI_FILE\"; complete -p fzf-cli | grep -q _nils_cli_fzf_cli_complete; complete -p ff | grep -q _nils_cli_fzf_cli_complete" || {
+  print -u2 -r -- "FAIL: failed to source bash fzf-cli completion file"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_SEMANTIC_COMMIT_FILE\"; complete -p semantic-commit | grep -q _nils_cli_semantic_commit_complete" || {
+  print -u2 -r -- "FAIL: failed to source bash semantic-commit completion file"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_PLAN_TOOLING_FILE\"; complete -p plan-tooling | grep -q _nils_cli_plan_tooling_complete" || {
+  print -u2 -r -- "FAIL: failed to source bash plan-tooling completion file"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_API_REST_FILE\"; complete -p api-rest | grep -q _nils_cli_api_rest_complete" || {
+  print -u2 -r -- "FAIL: failed to source bash api-rest completion file"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_API_GQL_FILE\"; complete -p api-gql | grep -q _nils_cli_api_gql_complete" || {
+  print -u2 -r -- "FAIL: failed to source bash api-gql completion file"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_API_TEST_FILE\"; complete -p api-test | grep -q _nils_cli_api_test_complete" || {
+  print -u2 -r -- "FAIL: failed to source bash api-test completion file"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_CODEX_CLI_FILE\"; complete -p codex-cli | grep -q _nils_cli_codex_cli_complete; complete -p cx | grep -q _nils_cli_codex_cli_complete" || {
+  print -u2 -r -- "FAIL: failed to source bash codex-cli completion file"
+  exit 1
+}
+
+bash -c "set -euo pipefail; source \"$BASH_ALIASES_FILE\"; alias gs >/dev/null; alias cx >/dev/null; alias ff >/dev/null; declare -F ffd >/dev/null; declare -F ffh >/dev/null" || {
+  print -u2 -r -- "FAIL: failed to source bash nils-cli aliases file"
   exit 1
 }
 


### PR DESCRIPTION
# Add Bash completions

## Summary
Add first-party Bash completion scripts for the shipped nils-cli binaries, plus an opt-in Bash aliases snippet, matching the existing Zsh completions/aliases layout.

## Changes
- Add Bash completions under `completions/bash/` for the shipped CLIs
- Add opt-in Bash aliases snippet (`completions/bash/aliases.bash`) for `gs*`/`cx*`/`ff*`
- Update docs and extend completion smoke test to source the Bash assets

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- None
