### PR TITLE
Allow endpoints.local.env without endpoints.env

### DIFF
--- a/crates/api-testing-core/src/config.rs
+++ b/crates/api-testing-core/src/config.rs
@@ -303,7 +303,7 @@ impl ResolvedSetup {
     }
 
     pub fn endpoints_files(&self) -> Vec<&Path> {
-        if self.endpoints_env.is_file() {
+        if self.endpoints_env.is_file() || self.endpoints_local_env.is_file() {
             vec![&self.endpoints_env, &self.endpoints_local_env]
         } else {
             Vec::new()
@@ -395,6 +395,29 @@ mod tests {
         .expect("resolve");
 
         assert_eq!(setup_dir, cfg_root.join("custom/rest"));
+    }
+
+    #[test]
+    fn endpoints_files_includes_local_when_env_missing() {
+        let tmp = TempDir::new().expect("tmp");
+        let root = std::fs::canonicalize(tmp.path()).expect("root abs");
+        let setup = root.join("setup/rest");
+
+        write_file(
+            &setup.join("endpoints.local.env"),
+            "export REST_URL_LOCAL=http://localhost:1234\n",
+        );
+
+        let resolved = ResolvedSetup::rest(setup, None);
+        let files = resolved.endpoints_files();
+
+        assert_eq!(
+            files,
+            vec![
+                resolved.endpoints_env.as_path(),
+                resolved.endpoints_local_env.as_path()
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Allow endpoints.local.env without endpoints.env

## Summary
Ensure endpoint resolution recognizes local-only endpoint files by treating endpoints.local.env as sufficient for endpoints discovery and add a regression test.

## Problem
- Expected: local-only endpoint configs in `setup/rest/endpoints.local.env` should be read when `endpoints.env` is absent.
- Actual: endpoint discovery treats endpoints files as missing when `endpoints.env` is absent, so local-only configs are ignored.
- Impact: users with only `endpoints.local.env` see default URL usage or errors for named envs unless they add a dummy `endpoints.env`.

## Reproduction
1. Create `setup/rest/endpoints.local.env` with `REST_URL_LOCAL=http://localhost:1234` and do not create `setup/rest/endpoints.env`.
2. Run `api-rest call --env local <request.json>` (or set `REST_ENV_DEFAULT=local` in the endpoints.local.env).

- Expected result: endpoint resolution uses `http://localhost:1234`.
- Actual result: endpoint discovery treats endpoints as missing and falls back to default or errors.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-21-BUG-001 | medium | high | crates/api-testing-core/src/config.rs | endpoints.local.env is ignored when endpoints.env is missing, so local-only endpoint configs are skipped | crates/api-testing-core/src/config.rs:303 | fixed |

## Fix Approach
- Treat endpoints.local.env as sufficient for endpoints discovery.
- Add a regression test for local-only endpoints files.

## Testing
- cargo fmt --all -- --check (pass)
- cargo clippy --all-targets --all-features -- -D warnings (pass)
- cargo test --workspace (pass)
- zsh -f tests/zsh/completion.test.zsh (pass)
- cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 80 (pass)
- scripts/ci/coverage-summary.sh target/coverage/lcov.info (pass)

## Risk / Notes
- Low risk; change only affects endpoints file discovery.
