### PR TITLE
Honor FZF_FILE_MAX_DEPTH in fzf-cli

### DIFF
--- a/crates/fzf-cli/src/directory.rs
+++ b/crates/fzf-cli/src/directory.rs
@@ -184,7 +184,7 @@ fn list_files_in_dir(dir: &Path, max_depth: usize) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let walker = WalkDir::new(dir)
         .follow_links(true)
-        .max_depth(max_depth.saturating_add(1))
+        .max_depth(max_depth)
         .into_iter()
         .filter_entry(|e| e.file_name() != ".git");
 
@@ -217,4 +217,21 @@ fn list_files_in_dir(dir: &Path, max_depth: usize) -> Vec<String> {
 
 fn canonicalize_or_fallback(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn list_files_in_dir_respects_max_depth() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("root.txt"), "x").unwrap();
+        std::fs::create_dir_all(dir.path().join("nested")).unwrap();
+        std::fs::write(dir.path().join("nested/deeper.txt"), "x").unwrap();
+
+        let files = list_files_in_dir(dir.path(), 1);
+        assert_eq!(files, vec!["root.txt"]);
+    }
 }

--- a/crates/fzf-cli/src/file.rs
+++ b/crates/fzf-cli/src/file.rs
@@ -58,7 +58,7 @@ fn list_files(max_depth: usize) -> Vec<String> {
 
     let walker = WalkDir::new(".")
         .follow_links(true)
-        .max_depth(max_depth.saturating_add(1))
+        .max_depth(max_depth)
         .into_iter()
         .filter_entry(|e| e.file_name() != ".git");
 
@@ -132,5 +132,22 @@ mod tests {
 
         let files = list_files(5);
         assert_eq!(files, vec!["a.txt", "b.txt", "nested/c.txt"]);
+    }
+
+    #[test]
+    fn list_files_respects_max_depth() {
+        let _lock = CWD_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+
+        std::fs::write(dir.path().join("root.txt"), "x").unwrap();
+        std::fs::create_dir_all(dir.path().join("nested")).unwrap();
+        std::fs::write(dir.path().join("nested/deeper.txt"), "x").unwrap();
+
+        let original = std::env::current_dir().unwrap();
+        let _guard = CwdGuard::new(original);
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let files = list_files(1);
+        assert_eq!(files, vec!["root.txt"]);
     }
 }


### PR DESCRIPTION
# Honor FZF_FILE_MAX_DEPTH in fzf-cli

## Summary
Fixes an off-by-one depth limit in fzf-cli file/directory scans and adds tests to keep the max-depth
behavior stable.

## Problem
- Expected: `FZF_FILE_MAX_DEPTH` limits file discovery to the configured depth.
- Actual: file discovery scanned one extra level because the WalkDir depth was incremented.
- Impact: deeper-than-requested scans return extra entries and add unnecessary traversal cost.

## Reproduction
1. Create a repo with a nested file two levels deep (for example `nested/deeper.txt`).
2. Run `FZF_FILE_MAX_DEPTH=1 fzf-cli file` (or `fzf-cli directory` after selecting a folder).

- Expected result: only root-level files are listed.
- Actual result: nested files at depth 2 appear.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-22-BUG-001 | medium | high | crates/fzf-cli/src/file.rs, crates/fzf-cli/src/directory.rs | Max depth scans one level deeper than configured | crates/fzf-cli/src/file.rs, crates/fzf-cli/src/directory.rs | fixed |

## Fix Approach
- Use the configured max depth directly for WalkDir traversal.
- Add unit coverage for file and directory depth limits.

## Testing
- ./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh (pass)

## Risk / Notes
- Low risk; change is limited to depth handling and adds tests.
