### PR TITLE
Allow env listing from endpoints.local.env

### DIFF
--- a/crates/api-testing-core/src/cli_endpoint.rs
+++ b/crates/api-testing-core/src/cli_endpoint.rs
@@ -116,19 +116,22 @@ pub fn list_available_env_suffixes(
     url_prefix: &str,
     missing_message: &str,
 ) -> Result<Vec<String>> {
-    if !endpoints_env.is_file() {
+    if !endpoints_env.is_file() && !endpoints_local.is_file() {
         anyhow::bail!("{missing_message}");
     }
 
-    let mut out = cli_util::list_available_suffixes(endpoints_env, url_prefix);
+    let mut out = Vec::new();
+    if endpoints_env.is_file() {
+        out.extend(cli_util::list_available_suffixes(endpoints_env, url_prefix));
+    }
     if endpoints_local.is_file() {
         out.extend(cli_util::list_available_suffixes(
             endpoints_local,
             url_prefix,
         ));
-        out.sort();
-        out.dedup();
     }
+    out.sort();
+    out.dedup();
 
     Ok(out)
 }

--- a/crates/api-testing-core/tests/cli_endpoint.rs
+++ b/crates/api-testing-core/tests/cli_endpoint.rs
@@ -182,6 +182,27 @@ fn list_available_env_suffixes_errors_when_missing_endpoints() {
 }
 
 #[test]
+fn list_available_env_suffixes_local_only() {
+    let tmp = TempDir::new().unwrap();
+    let endpoints_env = tmp.path().join("missing.env");
+    let endpoints_local = tmp.path().join("endpoints.local.env");
+    write_file(
+        &endpoints_local,
+        "REST_URL_LOCAL=http://local\nREST_URL_DEV=http://dev\n",
+    );
+
+    let out = list_available_env_suffixes(
+        &endpoints_env,
+        &endpoints_local,
+        "REST_URL_",
+        "endpoints.env not found (expected under setup/rest/)",
+    )
+    .unwrap();
+
+    assert_eq!(out, vec!["dev", "local"]);
+}
+
+#[test]
 fn list_available_env_suffixes_merges_and_sorts() {
     let tmp = TempDir::new().unwrap();
     let endpoints_env = tmp.path().join("endpoints.env");


### PR DESCRIPTION
# Allow env listing from endpoints.local.env

## Summary
Accept endpoints.local.env as a source of env suffixes when endpoints.env is missing, so list-envs works for local-only setups.

## Problem
- Expected: `api-gql call --list-envs` should list envs from `endpoints.local.env` even when `endpoints.env` is absent.
- Actual: listing errors with "endpoints.env not found" when only local file exists.
- Impact: local-only setups cannot list available envs without creating a dummy endpoints.env.

## Reproduction
1. Create `setup/graphql/endpoints.local.env` with `GQL_URL_LOCAL=http://localhost:1234` and do not create `setup/graphql/endpoints.env`.
2. Run `api-gql call --list-envs`.

- Expected result: `local` appears in the list.
- Actual result: error about missing endpoints.env.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-23-BUG-001 | medium | high | crates/api-testing-core/src/cli_endpoint.rs | list_available_env_suffixes errors when only endpoints.local.env exists, blocking env listing | crates/api-testing-core/src/cli_endpoint.rs:116 | fixed |

## Fix Approach
- Treat endpoints.local.env as sufficient for list_available_env_suffixes.
- Add a regression test for local-only env listings.

## Testing
- cargo fmt --all -- --check (pass)
- cargo clippy --all-targets --all-features -- -D warnings (pass)
- cargo test --workspace (pass)
- zsh -f tests/zsh/completion.test.zsh (pass)
- cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 80 (pass)
- scripts/ci/coverage-summary.sh target/coverage/lcov.info (pass)

## Risk / Notes
- Low risk; change is limited to env listing helper logic.
