### PR TITLE
Rename ff* aliases to fx*

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Then download the matching `nils-cli-<tag>-<target>.tar.gz` asset, extract it, a
 `<extract_dir>/bin` to your `PATH`.
 
 For zsh completions, add `<extract_dir>/completions/zsh` to your `fpath` and run `compinit`.
-Optional: source `<extract_dir>/completions/zsh/aliases.zsh` to enable `gs*`/`cx*`/`ff*` aliases.
+Optional: source `<extract_dir>/completions/zsh/aliases.zsh` to enable `gs*`/`cx*`/`fx*` aliases.
 
 For bash completions, copy `<extract_dir>/completions/bash/<command>` into your bash-completion directory
 (example: `~/.local/share/bash-completion/completions/`) or source it from your shell init.
-Optional: source `<extract_dir>/completions/bash/aliases.bash` to enable `gs*`/`cx*`/`ff*` aliases.
+Optional: source `<extract_dir>/completions/bash/aliases.bash` to enable `gs*`/`cx*`/`fx*` aliases.
 
 ## git-scope
 - Example usage: `git-scope staged`, `git-scope all -p`, `git-scope commit HEAD -p`
@@ -73,7 +73,7 @@ Optional: source `<extract_dir>/completions/bash/aliases.bash` to enable `gs*`/`
 ## fzf-cli
 - Example usage: `fzf-cli file`, `fzf-cli directory`, `fzf-cli history`, `fzf-cli port`, `fzf-cli process`
 - Note: some subcommands print shell commands for `eval` (e.g. `fzf-cli directory` prints a `cd ...`), see [crates/fzf-cli/README.md](crates/fzf-cli/README.md).
-- Optional aliases (opt-in): `ff*` (Zsh: [completions/zsh/aliases.zsh](completions/zsh/aliases.zsh), Bash: [completions/bash/aliases.bash](completions/bash/aliases.bash)); `ffd` and `ffh` are functions that `eval` the emitted command.
+- Optional aliases (opt-in): `fx*` (Zsh: [completions/zsh/aliases.zsh](completions/zsh/aliases.zsh), Bash: [completions/bash/aliases.bash](completions/bash/aliases.bash)); `fxd` and `fxh` are functions that `eval` the emitted command.
 
 ## codex-cli
 - Docs: [crates/codex-cli/README.md](crates/codex-cli/README.md)

--- a/completions/bash/aliases.bash
+++ b/completions/bash/aliases.bash
@@ -55,24 +55,23 @@ _nils_cli__has_alias cxgc || alias cxgc='codex-cli agent commit'
 _nils_cli__has_alias cxst || alias cxst='codex-cli starship'
 
 # ---------------------------------------------------------------------------
-# fzf-cli (ff*)
+# fzf-cli (fx*)
 # ---------------------------------------------------------------------------
-_nils_cli__has_alias ff || alias ff='fzf-cli'
-_nils_cli__has_alias fff || alias fff='fzf-cli file'
+_nils_cli__has_alias fx || alias fx='fzf-cli'
+_nils_cli__has_alias fxf || alias fxf='fzf-cli file'
 
 # These use eval to preserve parent-shell effects:
-_nils_cli__has_function ffd || ffd() { eval "$(fzf-cli directory -- "$@")"; }
-_nils_cli__has_function ffh || ffh() { eval "$(fzf-cli history -- "$@")"; }
+_nils_cli__has_function fxd || fxd() { eval "$(fzf-cli directory -- "$@")"; }
+_nils_cli__has_function fxh || fxh() { eval "$(fzf-cli history -- "$@")"; }
 
-_nils_cli__has_alias ffgs || alias ffgs='fzf-cli git-status'
-_nils_cli__has_alias ffgc || alias ffgc='fzf-cli git-commit'
-_nils_cli__has_alias ffgco || alias ffgco='fzf-cli git-checkout'
-_nils_cli__has_alias ffgb || alias ffgb='fzf-cli git-branch'
-_nils_cli__has_alias ffgt || alias ffgt='fzf-cli git-tag'
-_nils_cli__has_alias ffp || alias ffp='fzf-cli process'
-_nils_cli__has_alias ffpo || alias ffpo='fzf-cli port'
-_nils_cli__has_alias ffenv || alias ffenv='fzf-cli env'
-_nils_cli__has_alias ffal || alias ffal='fzf-cli alias'
-_nils_cli__has_alias fffn || alias fffn='fzf-cli function'
-_nils_cli__has_alias ffdef || alias ffdef='fzf-cli def'
-
+_nils_cli__has_alias fxgs || alias fxgs='fzf-cli git-status'
+_nils_cli__has_alias fxgc || alias fxgc='fzf-cli git-commit'
+_nils_cli__has_alias fxgco || alias fxgco='fzf-cli git-checkout'
+_nils_cli__has_alias fxgb || alias fxgb='fzf-cli git-branch'
+_nils_cli__has_alias fxgt || alias fxgt='fzf-cli git-tag'
+_nils_cli__has_alias fxp || alias fxp='fzf-cli process'
+_nils_cli__has_alias fxpo || alias fxpo='fzf-cli port'
+_nils_cli__has_alias fxenv || alias fxenv='fzf-cli env'
+_nils_cli__has_alias fxal || alias fxal='fzf-cli alias'
+_nils_cli__has_alias fxfn || alias fxfn='fzf-cli function'
+_nils_cli__has_alias fxdef || alias fxdef='fzf-cli def'

--- a/completions/bash/fzf-cli
+++ b/completions/bash/fzf-cli
@@ -1,4 +1,4 @@
-# nils-cli bash completion: fzf-cli (and ff* aliases)
+# nils-cli bash completion: fzf-cli (and fx* aliases)
 
 if [[ -z ${BASH_VERSION-} ]]; then
   return 0 2>/dev/null || exit 0
@@ -14,20 +14,20 @@ _nils_cli_fzf_cli_complete() {
 
   local subcmd_override=''
   case "$invoked_as" in
-    fff) subcmd_override='file' ;;
-    ffd) subcmd_override='directory' ;;
-    ffgs) subcmd_override='git-status' ;;
-    ffgc) subcmd_override='git-commit' ;;
-    ffgco) subcmd_override='git-checkout' ;;
-    ffgb) subcmd_override='git-branch' ;;
-    ffgt) subcmd_override='git-tag' ;;
-    ffp) subcmd_override='process' ;;
-    ffpo) subcmd_override='port' ;;
-    ffh) subcmd_override='history' ;;
-    ffenv) subcmd_override='env' ;;
-    ffal) subcmd_override='alias' ;;
-    fffn) subcmd_override='function' ;;
-    ffdef) subcmd_override='def' ;;
+    fxf) subcmd_override='file' ;;
+    fxd) subcmd_override='directory' ;;
+    fxgs) subcmd_override='git-status' ;;
+    fxgc) subcmd_override='git-commit' ;;
+    fxgco) subcmd_override='git-checkout' ;;
+    fxgb) subcmd_override='git-branch' ;;
+    fxgt) subcmd_override='git-tag' ;;
+    fxp) subcmd_override='process' ;;
+    fxpo) subcmd_override='port' ;;
+    fxh) subcmd_override='history' ;;
+    fxenv) subcmd_override='env' ;;
+    fxal) subcmd_override='alias' ;;
+    fxfn) subcmd_override='function' ;;
+    fxdef) subcmd_override='def' ;;
   esac
 
   if [[ -n "$subcmd_override" ]]; then
@@ -100,5 +100,4 @@ _nils_cli_fzf_cli_complete() {
   COMPREPLY=( $(compgen -W "${root_subcmds[*]}" -- "$cur") )
 }
 
-complete -F _nils_cli_fzf_cli_complete fzf-cli ff fff ffd ffgs ffgc ffgco ffgb ffgt ffp ffpo ffh ffenv ffal fffn ffdef
-
+complete -F _nils_cli_fzf_cli_complete fzf-cli fx fxf fxd fxgs fxgc fxgco fxgb fxgt fxp fxpo fxh fxenv fxal fxfn fxdef

--- a/completions/zsh/_fzf-cli
+++ b/completions/zsh/_fzf-cli
@@ -1,4 +1,4 @@
-#compdef fzf-cli ff fff ffd ffgs ffgc ffgco ffgb ffgt ffp ffpo ffh ffenv ffal fffn ffdef
+#compdef fzf-cli fx fxf fxd fxgs fxgc fxgco fxgb fxgt fxp fxpo fxh fxenv fxal fxfn fxdef
 
 __fzf_cli_query() {
   emulate -L zsh -o extendedglob
@@ -18,20 +18,20 @@ _fzf-cli() {
   local subcmd_override=''
 
   case "$invoked_as" in
-    fff) subcmd_override='file' ;;
-    ffd) subcmd_override='directory' ;;
-    ffgs) subcmd_override='git-status' ;;
-    ffgc) subcmd_override='git-commit' ;;
-    ffgco) subcmd_override='git-checkout' ;;
-    ffgb) subcmd_override='git-branch' ;;
-    ffgt) subcmd_override='git-tag' ;;
-    ffp) subcmd_override='process' ;;
-    ffpo) subcmd_override='port' ;;
-    ffh) subcmd_override='history' ;;
-    ffenv) subcmd_override='env' ;;
-    ffal) subcmd_override='alias' ;;
-    fffn) subcmd_override='function' ;;
-    ffdef) subcmd_override='def' ;;
+    fxf) subcmd_override='file' ;;
+    fxd) subcmd_override='directory' ;;
+    fxgs) subcmd_override='git-status' ;;
+    fxgc) subcmd_override='git-commit' ;;
+    fxgco) subcmd_override='git-checkout' ;;
+    fxgb) subcmd_override='git-branch' ;;
+    fxgt) subcmd_override='git-tag' ;;
+    fxp) subcmd_override='process' ;;
+    fxpo) subcmd_override='port' ;;
+    fxh) subcmd_override='history' ;;
+    fxenv) subcmd_override='env' ;;
+    fxal) subcmd_override='alias' ;;
+    fxfn) subcmd_override='function' ;;
+    fxdef) subcmd_override='def' ;;
   esac
 
   local -a subcommands=()
@@ -128,4 +128,4 @@ _fzf-cli() {
   esac
 }
 
-compdef _fzf-cli fzf-cli ff fff ffd ffgs ffgc ffgco ffgb ffgt ffp ffpo ffh ffenv ffal fffn ffdef
+compdef _fzf-cli fzf-cli fx fxf fxd fxgs fxgc fxgco fxgb fxgt fxp fxpo fxh fxenv fxal fxfn fxdef

--- a/completions/zsh/aliases.zsh
+++ b/completions/zsh/aliases.zsh
@@ -45,27 +45,27 @@ fi
 (( $+aliases[cxst] )) || alias cxst='codex-cli starship'
 
 # ---------------------------------------------------------------------------
-# fzf-cli (ff*)
+# fzf-cli (fx*)
 # ---------------------------------------------------------------------------
-(( $+aliases[ff] )) || alias ff='fzf-cli'
-(( $+aliases[fff] )) || alias fff='fzf-cli file'
+(( $+aliases[fx] )) || alias fx='fzf-cli'
+(( $+aliases[fxf] )) || alias fxf='fzf-cli file'
 
 # These use eval to preserve parent-shell effects:
-if (( ! $+functions[ffd] )); then
-  ffd() { eval "$(fzf-cli directory -- "$@")"; }
+if (( ! $+functions[fxd] )); then
+  fxd() { eval "$(fzf-cli directory -- "$@")"; }
 fi
-if (( ! $+functions[ffh] )); then
-  ffh() { eval "$(fzf-cli history -- "$@")"; }
+if (( ! $+functions[fxh] )); then
+  fxh() { eval "$(fzf-cli history -- "$@")"; }
 fi
 
-(( $+aliases[ffgs] )) || alias ffgs='fzf-cli git-status'
-(( $+aliases[ffgc] )) || alias ffgc='fzf-cli git-commit'
-(( $+aliases[ffgco] )) || alias ffgco='fzf-cli git-checkout'
-(( $+aliases[ffgb] )) || alias ffgb='fzf-cli git-branch'
-(( $+aliases[ffgt] )) || alias ffgt='fzf-cli git-tag'
-(( $+aliases[ffp] )) || alias ffp='fzf-cli process'
-(( $+aliases[ffpo] )) || alias ffpo='fzf-cli port'
-(( $+aliases[ffenv] )) || alias ffenv='fzf-cli env'
-(( $+aliases[ffal] )) || alias ffal='fzf-cli alias'
-(( $+aliases[fffn] )) || alias fffn='fzf-cli function'
-(( $+aliases[ffdef] )) || alias ffdef='fzf-cli def'
+(( $+aliases[fxgs] )) || alias fxgs='fzf-cli git-status'
+(( $+aliases[fxgc] )) || alias fxgc='fzf-cli git-commit'
+(( $+aliases[fxgco] )) || alias fxgco='fzf-cli git-checkout'
+(( $+aliases[fxgb] )) || alias fxgb='fzf-cli git-branch'
+(( $+aliases[fxgt] )) || alias fxgt='fzf-cli git-tag'
+(( $+aliases[fxp] )) || alias fxp='fzf-cli process'
+(( $+aliases[fxpo] )) || alias fxpo='fzf-cli port'
+(( $+aliases[fxenv] )) || alias fxenv='fzf-cli env'
+(( $+aliases[fxal] )) || alias fxal='fzf-cli alias'
+(( $+aliases[fxfn] )) || alias fxfn='fzf-cli function'
+(( $+aliases[fxdef] )) || alias fxdef='fzf-cli def'

--- a/docs/plans/zsh-wrappers-to-aliases-plan.md
+++ b/docs/plans/zsh-wrappers-to-aliases-plan.md
@@ -6,14 +6,14 @@ where required) so that, after `brew install`, users can enable short commands w
 line and still get completion via the existing `compdef` mappings in `completions/zsh/`.
 
 Initial scope: `git-scope` (`gs*` aliases for all subcommands), `codex-cli` (`cx*` only), and `fzf-cli`
-(`ff*` naming scheme).
+(`fx*` naming scheme).
 
 ## Scope
 - In scope:
   - Add a Zsh aliases snippet (opt-in via `source`) providing aliases for:
     - `git-scope` (`gs*` aliases for all subcommands)
     - `codex-cli` (`cx*` only; drop legacy `codex-*` and `crl/crla`)
-    - `fzf-cli` (`ff*` aliases, with function wrappers only where needed for parent-shell effects)
+    - `fzf-cli` (`fx*` aliases, with function wrappers only where needed for parent-shell effects)
   - Remove wrapper scripts that exist solely to provide these alias entrypoints.
   - Update Zsh completion registrations so alias names trigger the same completion as the underlying binary.
   - Update docs to describe the new setup for Homebrew and release tarball installs.
@@ -44,10 +44,10 @@ Initial scope: `git-scope` (`gs*` aliases for all subcommands), `codex-cli` (`cx
 - Do not support legacy long names (e.g. `codex-use`) or `crl/crla`; keep `cx*` only.
 
 ### fzf-cli
-- Use the `ff` prefix:
-  - `ff` maps to `fzf-cli`.
-  - `ff*` maps to a specific `fzf-cli <subcommand>` dispatcher command.
-  - Prefer readable abbreviations that avoid collisions (`ffdef`, `fffn`, `ffal`, etc.).
+- Use the `fx` prefix:
+  - `fx` maps to `fzf-cli`.
+  - `fx*` maps to a specific `fzf-cli <subcommand>` dispatcher command.
+  - Prefer readable abbreviations that avoid collisions (`fxdef`, `fxfn`, `fxal`, etc.).
 
 ## Alias inventory
 ### git-scope
@@ -78,21 +78,21 @@ Initial scope: `git-scope` (`gs*` aliases for all subcommands), `codex-cli` (`cx
 - `cxgc` → `codex-cli agent commit`
 
 ### fzf-cli
-- `ff` → `fzf-cli`
-- `fff` → `fzf-cli file`
-- `ffd` → `fzf-cli directory` (prefer a function wrapper to support `cd` via `eval`)
-- `ffgs` → `fzf-cli git-status`
-- `ffgc` → `fzf-cli git-commit`
-- `ffgco` → `fzf-cli git-checkout`
-- `ffgb` → `fzf-cli git-branch`
-- `ffgt` → `fzf-cli git-tag`
-- `ffp` → `fzf-cli process`
-- `ffpo` → `fzf-cli port`
-- `ffh` → `fzf-cli history` (prefer a function wrapper to support `eval`)
-- `ffenv` → `fzf-cli env`
-- `ffal` → `fzf-cli alias`
-- `fffn` → `fzf-cli function`
-- `ffdef` → `fzf-cli def`
+- `fx` → `fzf-cli`
+- `fxf` → `fzf-cli file`
+- `fxd` → `fzf-cli directory` (prefer a function wrapper to support `cd` via `eval`)
+- `fxgs` → `fzf-cli git-status`
+- `fxgc` → `fzf-cli git-commit`
+- `fxgco` → `fzf-cli git-checkout`
+- `fxgb` → `fzf-cli git-branch`
+- `fxgt` → `fzf-cli git-tag`
+- `fxp` → `fzf-cli process`
+- `fxpo` → `fzf-cli port`
+- `fxh` → `fzf-cli history` (prefer a function wrapper to support `eval`)
+- `fxenv` → `fzf-cli env`
+- `fxal` → `fzf-cli alias`
+- `fxfn` → `fzf-cli function`
+- `fxdef` → `fzf-cli def`
 
 ## Sprint 1: Add aliases + completion support
 **Goal**: Land an opt-in aliases file for the full inventory and ensure completion works for all alias names.
@@ -167,7 +167,7 @@ Initial scope: `git-scope` (`gs*` aliases for all subcommands), `codex-cli` (`cx
   - Sourcing the file in `zsh -f` does not error.
   - Aliases/functions are not redefined if the user already has them defined.
 - **Validation**:
-  - `zsh -f -c 'source completions/zsh/aliases.zsh && alias gs && alias cx && alias ff'`
+  - `zsh -f -c 'source completions/zsh/aliases.zsh && alias gs && alias cx && alias fx'`
 
 ### Task 1.3: Update `git-scope` completion registration for `gs*`
 - **Location**:
@@ -185,20 +185,20 @@ Initial scope: `git-scope` (`gs*` aliases for all subcommands), `codex-cli` (`cx
   - `rg -n \"#compdef git-scope\" completions/zsh/_git-scope`
   - `rg -n \"compdef _git-scope\" completions/zsh/_git-scope`
 
-### Task 1.4: Update `fzf-cli` completion registration for `ff*`
+### Task 1.4: Update `fzf-cli` completion registration for `fx*`
 - **Location**:
   - `completions/zsh/_fzf-cli`
-- **Description**: Register completion for `ff*` alias names by adding them to the `#compdef` header and
+- **Description**: Register completion for `fx*` alias names by adding them to the `#compdef` header and
   the explicit `compdef` call, so completion triggers for aliases without requiring
-  `setopt complete_aliases`. Add `invoked_as` override handling so `ff*` aliases that map to a fixed
-  dispatcher subcommand complete as if that subcommand were already selected (e.g., `fff` behaves like
+  `setopt complete_aliases`. Add `invoked_as` override handling so `fx*` aliases that map to a fixed
+  dispatcher subcommand complete as if that subcommand were already selected (e.g., `fxf` behaves like
   `fzf-cli file` completion).
 - **Dependencies**:
   - Task 1.2
 - **Complexity**: 2
 - **Acceptance criteria**:
-  - `completions/zsh/_fzf-cli` registers `compdef _fzf-cli` for every `ff*` name in the alias inventory.
-  - `invoked_as` overrides cover `ff*` aliases that map to a fixed dispatcher subcommand.
+  - `completions/zsh/_fzf-cli` registers `compdef _fzf-cli` for every `fx*` name in the alias inventory.
+  - `invoked_as` overrides cover `fx*` aliases that map to a fixed dispatcher subcommand.
 - **Validation**:
   - `rg -n \"#compdef fzf-cli\" completions/zsh/_fzf-cli`
   - `rg -n \"compdef _fzf-cli\" completions/zsh/_fzf-cli`
@@ -235,7 +235,7 @@ Initial scope: `git-scope` (`gs*` aliases for all subcommands), `codex-cli` (`cx
   - CI runs a Zsh test that sources the aliases snippet and asserts representative names exist:
     - `gs/gst/gss/gsu/gsa/gsun/gsc/gsh`
     - `cx/cxau/cxst/cxdr/cxdra`
-    - `ff/fff/ffgs/ffdef`
+    - `fx/fxf/fxgs/fxdef`
 - **Validation**:
   - `zsh -f tests/zsh/completion.test.zsh`
 
@@ -377,29 +377,29 @@ Initial scope: `git-scope` (`gs*` aliases for all subcommands), `codex-cli` (`cx
   - `cxau --help` behaves like `codex-cli auth use --help`.
   - `cxst --help` behaves like `codex-cli starship --help`.
   - `cxdra --help` behaves like `codex-cli diag rate-limits --help` (with `--async` implied by alias).
-  - `ff --help` behaves like `fzf-cli --help`.
-  - Tab completion works for representative codex aliases (`cx`, `cxau`, `cxst`) and fzf aliases (`ff`, `fff`, `ffgs`).
+  - `fx --help` behaves like `fzf-cli --help`.
+  - Tab completion works for representative codex aliases (`cx`, `cxau`, `cxst`) and fzf aliases (`fx`, `fxf`, `fxgs`).
 - **Validation**:
   - New zsh session:
     - Ensure `compinit` is enabled and `_git-scope` is installed.
     - `source \"$(brew --prefix nils-cli)/share/nils-cli/aliases.zsh\"`.
     - Type `gs ` then press Tab; repeat for `gss ` and `gsc `.
     - Type `cx ` then press Tab; repeat for `cxst ` and `cxdra `.
-    - Type `ff ` then press Tab; repeat for `fff ` and `ffgs `.
+    - Type `fx ` then press Tab; repeat for `fxf ` and `fxgs `.
 
 ## Testing Strategy
 - Unit: none (no Rust behavior changes).
 - Integration:
   - `zsh -f tests/zsh/completion.test.zsh` (and/or new alias-focused test) ensures Zsh assets are sourceable.
 - E2E/manual:
-  - In a clean Zsh session: source the aliases file, then verify completion works for `gs`, `cx`, and `ff`.
+  - In a clean Zsh session: source the aliases file, then verify completion works for `gs`, `cx`, and `fx`.
 
 ## Risks & gotchas
 - **Alias conflicts**: `gs` is a common alias name; the snippet should avoid overwriting existing aliases.
 - **Non-interactive shells**: aliases are not available unless sourced; wrapper removal may affect scripts.
 - **Completion ordering**: completion requires `compinit` and completion files in `completions/zsh/` installed/available.
 - **Homebrew caveats**: brew can install files but cannot auto-edit `~/.zshrc`; the formula must print instructions.
-- **Parent-shell effects**: `fzf-cli directory` and `fzf-cli history` require `eval` to fully match the original UX; prefer function wrappers for `ffd` and `ffh`.
+- **Parent-shell effects**: `fzf-cli directory` and `fzf-cli history` require `eval` to fully match the original UX; prefer function wrappers for `fxd` and `fxh`.
 
 ## Rollback plan
 - Reintroduce `wrappers/gs`, `wrappers/gsc`, `wrappers/gst` as scripts if alias-only proves too limiting.

--- a/tests/zsh/completion.test.zsh
+++ b/tests/zsh/completion.test.zsh
@@ -311,33 +311,33 @@ if (( ! $+aliases[cxdra] )); then
   exit 1
 fi
 
-if (( ! $+aliases[ff] )); then
-  print -u2 -r -- "FAIL: ff alias not defined"
+if (( ! $+aliases[fx] )); then
+  print -u2 -r -- "FAIL: fx alias not defined"
   exit 1
 fi
 
-if (( ! $+aliases[fff] )); then
-  print -u2 -r -- "FAIL: fff alias not defined"
+if (( ! $+aliases[fxf] )); then
+  print -u2 -r -- "FAIL: fxf alias not defined"
   exit 1
 fi
 
-if (( ! $+aliases[ffgs] )); then
-  print -u2 -r -- "FAIL: ffgs alias not defined"
+if (( ! $+aliases[fxgs] )); then
+  print -u2 -r -- "FAIL: fxgs alias not defined"
   exit 1
 fi
 
-if (( ! $+aliases[ffdef] )); then
-  print -u2 -r -- "FAIL: ffdef alias not defined"
+if (( ! $+aliases[fxdef] )); then
+  print -u2 -r -- "FAIL: fxdef alias not defined"
   exit 1
 fi
 
-if (( ! $+functions[ffd] )); then
-  print -u2 -r -- "FAIL: ffd function not defined"
+if (( ! $+functions[fxd] )); then
+  print -u2 -r -- "FAIL: fxd function not defined"
   exit 1
 fi
 
-if (( ! $+functions[ffh] )); then
-  print -u2 -r -- "FAIL: ffh function not defined"
+if (( ! $+functions[fxh] )); then
+  print -u2 -r -- "FAIL: fxh function not defined"
   exit 1
 fi
 
@@ -451,7 +451,7 @@ bash -c "set -euo pipefail; source \"$BASH_LOCK_FILE\"; complete -p git-lock | g
   exit 1
 }
 
-bash -c "set -euo pipefail; source \"$BASH_FZF_CLI_FILE\"; complete -p fzf-cli | grep -q _nils_cli_fzf_cli_complete; complete -p ff | grep -q _nils_cli_fzf_cli_complete" || {
+bash -c "set -euo pipefail; source \"$BASH_FZF_CLI_FILE\"; complete -p fzf-cli | grep -q _nils_cli_fzf_cli_complete; complete -p fx | grep -q _nils_cli_fzf_cli_complete" || {
   print -u2 -r -- "FAIL: failed to source bash fzf-cli completion file"
   exit 1
 }
@@ -486,7 +486,7 @@ bash -c "set -euo pipefail; source \"$BASH_CODEX_CLI_FILE\"; complete -p codex-c
   exit 1
 }
 
-bash -c "set -euo pipefail; source \"$BASH_ALIASES_FILE\"; alias gs >/dev/null; alias cx >/dev/null; alias ff >/dev/null; declare -F ffd >/dev/null; declare -F ffh >/dev/null" || {
+bash -c "set -euo pipefail; source \"$BASH_ALIASES_FILE\"; alias gs >/dev/null; alias cx >/dev/null; alias fx >/dev/null; declare -F fxd >/dev/null; declare -F fxh >/dev/null" || {
   print -u2 -r -- "FAIL: failed to source bash nils-cli aliases file"
   exit 1
 }


### PR DESCRIPTION
# Rename ff* aliases to fx*

## Summary
Rename the opt-in fzf-cli short aliases from ff* to fx* across Zsh/Bash aliases and completions.

## Changes
- Rename alias and function entrypoints: ff* -> fx* (including eval wrappers)
- Update zsh/bash completion registration to include fx* names
- Update docs and completion tests to reflect new names

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 80` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass; 83.75%)

## Risk / Notes
- Breaking change for users who source the aliases files: update `ff*` usage to `fx*`.
