### PR TITLE
feat(plan-tooling): add JSON output mode to validate command

### DIFF
--- a/crates/plan-tooling/README.md
+++ b/crates/plan-tooling/README.md
@@ -19,6 +19,7 @@ It is used to:
 ## Examples
 ```bash
 plan-tooling validate
+plan-tooling validate --format json | jq .
 plan-tooling to-json --file docs/plans/plan-tooling-cli-consolidation-plan.md --pretty | jq .
 plan-tooling batches --file docs/plans/plan-tooling-cli-consolidation-plan.md --sprint 1 --format text
 plan-tooling scaffold --slug my-new-cli --title "My new CLI plan"

--- a/crates/plan-tooling/src/validate.rs
+++ b/crates/plan-tooling/src/validate.rs
@@ -4,17 +4,19 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
+use serde::Serialize;
 
 use crate::parse::{parse_plan_with_display, Plan, Task};
 
 const USAGE: &str = r#"Usage:
-  validate_plans.sh [--file <path>]...
+  validate_plans.sh [--file <path>]... [--format text|json]
 
 Purpose:
   Lint plan markdown files under docs/plans/ against Plan Format v1.
 
 Options:
   --file <path>  Validate a specific plan file (may be repeated)
+  --format <fmt> text (default) or json
   -h, --help     Show help
 
 Defaults:
@@ -35,8 +37,16 @@ fn die(msg: &str) -> i32 {
     2
 }
 
+#[derive(Debug, Serialize)]
+struct ValidateOutput {
+    ok: bool,
+    files: Vec<String>,
+    errors: Vec<String>,
+}
+
 pub fn run(args: &[String]) -> i32 {
     let mut files: Vec<String> = Vec::new();
+    let mut format = "text".to_string();
 
     let mut i = 0;
     while i < args.len() {
@@ -46,6 +56,13 @@ pub fn run(args: &[String]) -> i32 {
                     return die("--file requires a path");
                 }
                 files.push(args[i + 1].to_string());
+                i += 2;
+            }
+            "--format" => {
+                if args.get(i + 1).is_none() {
+                    return die("--format requires a value");
+                }
+                format = args[i + 1].to_string();
                 i += 2;
             }
             "-h" | "--help" => {
@@ -58,6 +75,10 @@ pub fn run(args: &[String]) -> i32 {
         }
     }
 
+    if format != "text" && format != "json" {
+        return die(&format!("invalid --format (expected text|json): {format}"));
+    }
+
     let repo_root = crate::repo_root::detect();
 
     let discovered = if files.is_empty() {
@@ -65,32 +86,63 @@ pub fn run(args: &[String]) -> i32 {
     } else {
         files
     };
+    let discovered_for_output = discovered.clone();
 
     if discovered.is_empty() {
+        if format == "json" {
+            let output = ValidateOutput {
+                ok: true,
+                files: Vec::new(),
+                errors: Vec::new(),
+            };
+            return print_json_output(output, 0);
+        }
         return 0;
     }
 
-    let progress = Progress::new(
-        discovered.len() as u64,
-        ProgressOptions::default().with_finish(ProgressFinish::Clear),
-    );
+    let progress = if format == "text" {
+        Some(Progress::new(
+            discovered.len() as u64,
+            ProgressOptions::default().with_finish(ProgressFinish::Clear),
+        ))
+    } else {
+        None
+    };
 
     let mut errors: Vec<String> = Vec::new();
     for (idx, display_path) in discovered.into_iter().enumerate() {
-        progress.set_message(display_path.clone());
+        if let Some(p) = progress.as_ref() {
+            p.set_message(display_path.clone());
+        }
 
         let read_path = resolve_repo_relative(&repo_root, Path::new(&display_path));
         if !read_path.is_file() {
             errors.push(format!("{display_path}: file not found"));
-            progress.set_position((idx + 1) as u64);
+            if let Some(p) = progress.as_ref() {
+                p.set_position((idx + 1) as u64);
+            }
             continue;
         }
         errors.extend(validate_plan(&display_path, &read_path));
 
-        progress.set_position((idx + 1) as u64);
+        if let Some(p) = progress.as_ref() {
+            p.set_position((idx + 1) as u64);
+        }
     }
 
-    progress.finish_and_clear();
+    if let Some(p) = progress.as_ref() {
+        p.finish_and_clear();
+    }
+
+    if format == "json" {
+        let code = if errors.is_empty() { 0 } else { 1 };
+        let output = ValidateOutput {
+            ok: errors.is_empty(),
+            files: discovered_for_output,
+            errors,
+        };
+        return print_json_output(output, code);
+    }
 
     if errors.is_empty() {
         return 0;
@@ -100,6 +152,19 @@ pub fn run(args: &[String]) -> i32 {
         eprintln!("error: {err}");
     }
     1
+}
+
+fn print_json_output(output: ValidateOutput, code: i32) -> i32 {
+    match serde_json::to_string(&output) {
+        Ok(s) => {
+            println!("{s}");
+            code
+        }
+        Err(err) => {
+            eprintln!("error: failed to encode JSON: {err}");
+            1
+        }
+    }
 }
 
 fn discover_default_plan_files(repo_root: &Path) -> Vec<String> {

--- a/crates/plan-tooling/tests/validate.rs
+++ b/crates/plan-tooling/tests/validate.rs
@@ -97,6 +97,84 @@ fn validate_missing_dependencies_is_error() {
     assert!(out.stderr.contains("missing Dependencies"));
 }
 
+#[test]
+fn validate_json_ok_with_explicit_file() {
+    let repo = init_repo();
+    write_file(&repo.path().join("plan.md"), VALID_PLAN);
+
+    let out = run_plan_tooling(
+        repo.path(),
+        &["validate", "--file", "plan.md", "--format", "json"],
+    );
+    assert_eq!(
+        out.code, 0,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    assert!(out.stderr.is_empty());
+
+    let v: serde_json::Value = serde_json::from_str(&out.stdout).expect("json");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["files"], serde_json::json!(["plan.md"]));
+    assert_eq!(v["errors"], serde_json::json!([]));
+}
+
+#[test]
+fn validate_json_returns_errors_and_exit_one() {
+    let repo = init_repo();
+    write_file(&repo.path().join("bad.md"), INVALID_PLAN);
+
+    let out = run_plan_tooling(
+        repo.path(),
+        &["validate", "--file", "bad.md", "--format", "json"],
+    );
+    assert_eq!(out.code, 1, "stdout: {}\nstderr: {}", out.stdout, out.stderr);
+    assert!(out.stderr.is_empty());
+
+    let v: serde_json::Value = serde_json::from_str(&out.stdout).expect("json");
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["files"], serde_json::json!(["bad.md"]));
+    let errs = v["errors"].as_array().expect("errors array");
+    assert!(!errs.is_empty());
+    assert!(errs.iter().any(|e| {
+        e.as_str()
+            .is_some_and(|s| s.contains("Location must be repo-relative"))
+    }));
+}
+
+#[test]
+fn validate_json_no_files_emits_empty_payload() {
+    let dir = TempDir::new().expect("tempdir");
+
+    let out = run_plan_tooling(dir.path(), &["validate", "--format", "json"]);
+    assert_eq!(out.code, 0, "stdout: {}\nstderr: {}", out.stdout, out.stderr);
+    assert!(out.stderr.is_empty());
+
+    let v: serde_json::Value = serde_json::from_str(&out.stdout).expect("json");
+    assert_eq!(
+        v,
+        serde_json::json!({
+            "ok": true,
+            "files": [],
+            "errors": []
+        })
+    );
+}
+
+#[test]
+fn validate_invalid_format_is_usage_error() {
+    let repo = init_repo();
+    write_file(&repo.path().join("plan.md"), VALID_PLAN);
+
+    let out = run_plan_tooling(
+        repo.path(),
+        &["validate", "--file", "plan.md", "--format", "yaml"],
+    );
+    assert_eq!(out.code, 2);
+    assert!(out.stdout.is_empty());
+    assert!(out.stderr.contains("invalid --format"));
+}
+
 const VALID_PLAN: &str = r#"# Plan: Example
 
 ## Sprint 1: First sprint


### PR DESCRIPTION
- add `--format <text|json>` to `plan-tooling validate` (default: text)
- preserve existing text-mode behavior and exit codes for backward compatibility
- emit structured JSON payload in json mode: { ok, files, errors }
- return exit code 1 on validation failures in both text and json modes
- add integration tests for json success/failure/empty-file-set and invalid format usage
- update plan-tooling README examples with `validate --format json`