### PR TITLE
Restore validate --format completion for plan-tooling

### DIFF
--- a/completions/bash/plan-tooling
+++ b/completions/bash/plan-tooling
@@ -47,8 +47,12 @@ _nils_cli_plan_tooling_complete() {
         COMPREPLY=( $(compgen -f -- "$cur") )
         return 0
       fi
+      if [[ "$prev" == "--format" ]]; then
+        COMPREPLY=( $(compgen -W "json text" -- "$cur") )
+        return 0
+      fi
       if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --file" -- "$cur") )
+        COMPREPLY=( $(compgen -W "-h --help --file --format" -- "$cur") )
         return 0
       fi
       COMPREPLY=()
@@ -88,4 +92,3 @@ _nils_cli_plan_tooling_complete() {
 }
 
 complete -F _nils_cli_plan_tooling_complete plan-tooling
-

--- a/completions/zsh/_plan-tooling
+++ b/completions/zsh/_plan-tooling
@@ -60,6 +60,7 @@ _plan-tooling() {
       _arguments -C \
         '(-h --help)'{-h,--help}'[Show help]' \
         '--file=[Validate a specific plan file (repeatable)]:file:_files' \
+        '--format=[Output format]:format:(json text)' \
         && return 0
       ;;
     batches)
@@ -87,4 +88,3 @@ _plan-tooling() {
 }
 
 compdef _plan-tooling plan-tooling
-


### PR DESCRIPTION
# Restore validate --format completion for plan-tooling

## Summary
Adds `--format` and its `json`/`text` value suggestions to the `plan-tooling validate` completion for both bash and zsh to match the new CLI flag.

## Problem
- Expected: `plan-tooling validate` completion suggests `--format` and its values in bash and zsh.
- Actual: only `--file` (and help flags) are suggested; `--format` is missing.
- Impact: users do not discover the new flag via tab completion.

## Reproduction
1. Load the `plan-tooling` completion for bash or zsh.
2. Type `plan-tooling validate --` and press Tab.

- Expected result: `--format` appears with `json`/`text` values.
- Actual result: `--format` is not suggested.

## Issues Found
Severity: low
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-26-BUG-001 | low | high | completions/bash/plan-tooling | validate missing --format completion | completions/bash/plan-tooling:45-55 | fixed |
| PR-26-BUG-002 | low | high | completions/zsh/_plan-tooling | validate missing --format completion | completions/zsh/_plan-tooling:59-64 | fixed |

## Fix Approach
- Add `--format` and `json`/`text` value completion for `validate` in bash.
- Add `--format` completion for `validate` in zsh.

## Testing
- `cargo fmt --all -- --check` (pass)
- `cargo clippy --all-targets --all-features -- -D warnings` (pass)
- `cargo test --workspace` (pass)
- `zsh -f tests/zsh/completion.test.zsh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 80` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 83.81%)

## Risk / Notes
- None.
