### PR TITLE
Accept common boolean env values

### DIFF
--- a/crates/api-testing-core/src/cli_util.rs
+++ b/crates/api-testing-core/src/cli_util.rs
@@ -37,15 +37,17 @@ pub fn bool_from_env<S: WarnSink + ?Sized>(
         return default;
     }
     match raw.to_ascii_lowercase().as_str() {
-        "true" => true,
-        "false" => false,
+        "true" | "1" | "yes" | "on" => true,
+        "false" | "0" | "no" | "off" => false,
         _ => {
             let label = tool_label.and_then(|l| (!l.trim().is_empty()).then_some(l));
             let msg = match label {
                 Some(label) => format!(
-                    "{label}: warning: {name} must be true|false (got: {raw}); treating as false"
+                    "{label}: warning: {name} must be true|false|1|0|yes|no|on|off (got: {raw}); treating as false"
                 ),
-                None => format!("{name} must be true|false (got: {raw}); treating as false"),
+                None => format!(
+                    "{name} must be true|false|1|0|yes|no|on|off (got: {raw}); treating as false"
+                ),
             };
             warnings.warn(&msg);
             false

--- a/crates/api-testing-core/tests/cli_util.rs
+++ b/crates/api-testing-core/tests/cli_util.rs
@@ -33,7 +33,7 @@ fn bool_from_env_parses_and_warns_with_label() {
     );
     assert_eq!(got, false);
     let msg = String::from_utf8_lossy(&stderr);
-    assert!(msg.contains("api-gql: warning: GQL_FOO must be true|false"));
+    assert!(msg.contains("api-gql: warning: GQL_FOO must be true|false|1|0|yes|no|on|off"));
     assert!(msg.contains("nope"));
 }
 
@@ -49,7 +49,7 @@ fn bool_from_env_parses_and_warns_without_label() {
     );
     assert_eq!(got, false);
     assert_eq!(warnings.len(), 1);
-    assert!(warnings[0].contains("REST_FOO must be true|false"));
+    assert!(warnings[0].contains("REST_FOO must be true|false|1|0|yes|no|on|off"));
     assert!(!warnings[0].contains("warning:"));
 }
 
@@ -66,6 +66,54 @@ fn bool_from_env_uses_default_on_empty() {
     );
     assert_eq!(got, true);
     assert!(stderr.is_empty());
+}
+
+#[test]
+fn bool_from_env_accepts_truthy_and_falsey_aliases() {
+    let mut warnings: Vec<String> = Vec::new();
+    assert!(cli_util::bool_from_env(
+        Some("1".to_string()),
+        "REST_FOO",
+        false,
+        None,
+        &mut warnings,
+    ));
+    assert!(cli_util::bool_from_env(
+        Some("yes".to_string()),
+        "REST_FOO",
+        false,
+        None,
+        &mut warnings,
+    ));
+    assert!(cli_util::bool_from_env(
+        Some("on".to_string()),
+        "REST_FOO",
+        false,
+        None,
+        &mut warnings,
+    ));
+    assert!(!cli_util::bool_from_env(
+        Some("0".to_string()),
+        "REST_FOO",
+        true,
+        None,
+        &mut warnings,
+    ));
+    assert!(!cli_util::bool_from_env(
+        Some("no".to_string()),
+        "REST_FOO",
+        true,
+        None,
+        &mut warnings,
+    ));
+    assert!(!cli_util::bool_from_env(
+        Some("off".to_string()),
+        "REST_FOO",
+        true,
+        None,
+        &mut warnings,
+    ));
+    assert!(warnings.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
# Accept common boolean env values

## Summary
Allow bool env parsing to accept common truthy/falsey values (1/0/yes/no/on/off), update warnings, and add coverage tests.

## Problem
- Expected: env toggles like `GQL_HISTORY_ENABLED=1` or `REST_JWT_VALIDATE_ENABLED=yes` enable the feature without warnings.
- Actual: only `true|false` are accepted; other common values warn and are treated as false.
- Impact: feature flags silently disable behavior with confusing warnings.

## Reproduction
1. Set `GQL_HISTORY_ENABLED=1`.
2. Run `api-gql history` in a repo with a GraphQL setup.

- Expected result: history is enabled without warnings.
- Actual result: warning about `true|false` and history treated as disabled.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-30-BUG-001 | medium | high | crates/api-testing-core/src/cli_util.rs | bool_from_env rejects common boolean aliases (1/0/yes/no/on/off), disabling env toggles | crates/api-testing-core/src/cli_util.rs:39-50 | fixed |

## Fix Approach
- Accept 1/0/yes/no/on/off in bool_from_env parsing.
- Expand warning message and add tests for aliases.

## Testing
- ./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh (pass)

## Risk / Notes
- Low risk: change only broadens accepted input values.
