### PR TITLE
Fix history auth source label

### DIFF
--- a/crates/api-rest/src/commands/call.rs
+++ b/crates/api-rest/src/commands/call.rs
@@ -430,8 +430,10 @@ fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32) {
                 record.push_str(&format!(" token={}", ctx.token_name_for_log));
             }
         }
-        AuthSourceUsed::EnvFallback { .. } => {
-            record.push_str(" auth=ACCESS_TOKEN");
+        AuthSourceUsed::EnvFallback { env_name } => {
+            if !env_name.is_empty() {
+                record.push_str(&format!(" auth={env_name}"));
+            }
         }
         AuthSourceUsed::None => {}
     }

--- a/crates/api-rest/tests/history.rs
+++ b/crates/api-rest/tests/history.rs
@@ -167,6 +167,37 @@ fn history_url_omitted_when_log_disabled() {
 }
 
 #[test]
+fn history_records_service_token_env_source() {
+    let tmp = TempDir::new().expect("tmp");
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("setup/rest")).expect("mkdir setup");
+    write_health_request(root);
+
+    let server = start_server();
+    let out = run_api_rest(
+        root,
+        &[
+            "call",
+            "--config-dir",
+            "setup/rest",
+            "--url",
+            &server.url(),
+            "requests/health.request.json",
+        ],
+        &[
+            ("REST_HISTORY_ENABLED", "true"),
+            ("SERVICE_TOKEN", "svc-token"),
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+
+    let history_file = root.join("setup/rest/.rest_history");
+    let content = std::fs::read_to_string(&history_file).expect("read history");
+    assert!(content.contains("auth=SERVICE_TOKEN"));
+    assert!(!content.contains("auth=ACCESS_TOKEN"));
+}
+
+#[test]
 fn history_file_override_writes_to_custom_path() {
     let tmp = TempDir::new().expect("tmp");
     let root = tmp.path();


### PR DESCRIPTION
# Fix history auth source label

## Summary
Ensure api-rest history records the correct auth source when falling back to env tokens, and add coverage for the SERVICE_TOKEN path.

## Problem
- Expected: history entries should record the actual env source used (e.g., SERVICE_TOKEN).
- Actual: env fallback always logs `auth=ACCESS_TOKEN`, even when SERVICE_TOKEN is used.
- Impact: misleading history output when SERVICE_TOKEN is the active auth source.

## Reproduction
1. Set `SERVICE_TOKEN=...` with no token profile selected.
2. Run `api-rest call --config-dir setup/rest --url <url> requests/health.request.json`.

- Expected result: history entry contains `auth=SERVICE_TOKEN`.
- Actual result: history entry contains `auth=ACCESS_TOKEN`.

## Issues Found
Severity: critical | high | medium | low
Confidence: high | medium | low
Status: open | fixed | deferred | needs-info

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-31-BUG-001 | low | high | crates/api-rest/src/commands/call.rs | History logging hardcodes ACCESS_TOKEN for env fallback auth source | crates/api-rest/src/commands/call.rs:430-436 | fixed |

## Fix Approach
- Emit the actual env name when recording env fallback auth sources.
- Add a history test that exercises the SERVICE_TOKEN path.

## Testing
- ./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh (pass)

## Risk / Notes
- Low risk: change only affects history labeling.
