### PR TITLE
Fix screen-record screenshot crash on macOS 26

### DIFF
--- a/crates/screen-record/src/macos/screenshot.rs
+++ b/crates/screen-record/src/macos/screenshot.rs
@@ -15,7 +15,7 @@ use objc2::{define_class, msg_send, AnyThread, DefinedClass, MainThreadMarker, M
 use objc2_core_foundation::{CFData, CFDictionary, CFNumber, CFRetained, CFString, CFType, CFURL};
 use objc2_core_graphics::{
     kCGColorSpaceSRGB, CGBitmapInfo, CGColorRenderingIntent, CGColorSpace, CGDataProvider, CGImage,
-    CGImageAlphaInfo, CGImageByteOrderInfo,
+    CGImageAlphaInfo, CGImageByteOrderInfo, CGMainDisplayID,
 };
 use objc2_core_media::CMSampleBuffer;
 use objc2_core_video::{
@@ -41,6 +41,9 @@ pub fn screenshot_window(
     format: ImageFormat,
 ) -> Result<(), CliError> {
     autoreleasepool(|_| {
+        // macOS 26+ may abort inside CoreGraphics (CGS_REQUIRE_INIT) unless CG is initialized first.
+        let _ = CGMainDisplayID();
+
         let shareable = fetch_shareable_content()?;
         let sc_window = find_window(&shareable, window.id)?;
 
@@ -53,6 +56,7 @@ pub fn screenshot_window(
         unsafe {
             config.setWidth(width as usize);
             config.setHeight(height as usize);
+            config.setPixelFormat(kCVPixelFormatType_32BGRA);
             config.setScalesToFit(true);
             config.setPreservesAspectRatio(true);
             config.setShowsCursor(true);

--- a/crates/screen-record/src/macos/stream.rs
+++ b/crates/screen-record/src/macos/stream.rs
@@ -14,6 +14,7 @@ use objc2_av_foundation::{
     AVCaptureConnection, AVCaptureDevice, AVCaptureDeviceInput, AVCaptureOutput, AVCaptureSession,
     AVMediaTypeAudio,
 };
+use objc2_core_graphics::CGMainDisplayID;
 use objc2_core_media::{CMSampleBuffer, CMTime};
 use objc2_foundation::{NSDate, NSError, NSRunLoop};
 use objc2_screen_capture_kit::{
@@ -34,6 +35,9 @@ pub fn record_window(
     format: ContainerFormat,
 ) -> Result<(), CliError> {
     autoreleasepool(|_| {
+        // macOS 26+ may abort inside CoreGraphics (CGS_REQUIRE_INIT) unless CG is initialized first.
+        let _ = CGMainDisplayID();
+
         let shareable = fetch_shareable_content()?;
         let sc_window = find_window(&shareable, window.id)?;
         let captures_system_audio = matches!(audio, AudioMode::System | AudioMode::Both);


### PR DESCRIPTION
# Fix screen-record screenshot crash on macOS 26

## Summary
Fixes a SIGABRT in `screen-record --screenshot` on macOS 26.2 by forcing early CoreGraphics initialization and explicitly requesting a BGRA pixel format for screenshot frames.

## Problem
- Expected: `screen-record --screenshot ...` exits `0` and writes an image to `--path`.
- Actual: On macOS 26.2 (25C56) Apple Silicon, `screen-record 0.2.4` aborts with:
  - `Assertion failed: (did_initialize), function CGS_REQUIRE_INIT, file CGInitialization.c, line 44.`
- Impact: Screenshot mode is unusable (exit 134, no output file).

## Reproduction
1. Ensure Screen Recording permission is granted.
2. Run:

   ```bash
   screen-record --screenshot --active-window --path /tmp/screen-record.png
   ```

- Expected result: exit `0`, `/tmp/screen-record.png` is created.
- Actual result: exit `134` (SIGABRT) with `CGS_REQUIRE_INIT` assertion.

## Issues Found
Severity: critical | high | medium | low
Confidence: high | medium | low
Status: open | fixed | deferred | needs-info

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-41-BUG-001 | high | high | `crates/screen-record/src/macos/screenshot.rs` | `--screenshot` aborts with `CGS_REQUIRE_INIT` on macOS 26.2 | Repro above; crash report frames include `SLSGetDisplaysWithRect` during `SCContentFilter` init | fixed |

## Fix Approach
- Call `CGMainDisplayID()` before constructing `SCContentFilter` to force CoreGraphics initialization (prevents `CGS_REQUIRE_INIT` abort on macOS 26+).
- Set `SCStreamConfiguration` pixel format to `kCVPixelFormatType_32BGRA` for screenshot captures to avoid receiving YUV (`420v`) frames.
- Apply the same CoreGraphics init guard to the recording path as a safety net.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- Manual: `cargo run -p screen-record -- --screenshot --active-window --path /tmp/screen-record-local.png` (pass)

## Risk / Notes
- Low risk: changes are macOS-only and limited to initialization + configuration.
