### PR TITLE
Increase semantic-commit test coverage for validation and staged parsing

### DIFF
--- a/crates/semantic-commit/src/commit.rs
+++ b/crates/semantic-commit/src/commit.rs
@@ -396,3 +396,67 @@ fn print_usage(stderr: bool) {
     let _ = writeln!(out);
     let _ = writeln!(out, "  semantic-commit commit --message-file ./message.txt");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn message_file(contents: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().expect("create temp message file");
+        file.write_all(contents.as_bytes())
+            .expect("write temp message file");
+        file
+    }
+
+    #[test]
+    fn validate_commit_message_accepts_valid_header_without_body() {
+        let file = message_file("feat: add parser coverage\n");
+        assert!(validate_commit_message(file.path()).is_ok());
+    }
+
+    #[test]
+    fn validate_commit_message_accepts_valid_scoped_header_with_body() {
+        let file = message_file("fix(parser-2): handle edge case\n\n- Handle malformed input\n");
+        assert!(validate_commit_message(file.path()).is_ok());
+    }
+
+    #[test]
+    fn validate_commit_message_rejects_header_over_100_chars() {
+        let subject = "a".repeat(95);
+        let file = message_file(&format!("feat: {subject}\n"));
+
+        assert_eq!(validate_commit_message(file.path()), Err(1));
+    }
+
+    #[test]
+    fn validate_commit_message_rejects_uppercase_scope() {
+        let file = message_file("feat(Core): add parser coverage\n");
+        assert_eq!(validate_commit_message(file.path()), Err(1));
+    }
+
+    #[test]
+    fn validate_commit_message_rejects_empty_line_inside_body() {
+        let file = message_file("feat: add parser coverage\n\n- First line\n\n- Second line\n");
+        assert_eq!(validate_commit_message(file.path()), Err(1));
+    }
+
+    #[test]
+    fn validate_commit_message_rejects_body_line_over_100_chars() {
+        let long_line = "A".repeat(99);
+        let file = message_file(&format!("feat: add parser coverage\n\n- {long_line}\n"));
+
+        assert_eq!(validate_commit_message(file.path()), Err(1));
+    }
+
+    #[test]
+    fn is_valid_header_enforces_shape_rules() {
+        assert!(is_valid_header("fix(core_2): handle edge case"));
+        assert!(is_valid_header("chore: update fixtures"));
+        assert!(!is_valid_header("Fix: uppercase type"));
+        assert!(!is_valid_header("fix(core!): invalid scope character"));
+        assert!(!is_valid_header("fix(scope):"));
+        assert!(!is_valid_header("fix(scope): "));
+        assert!(!is_valid_header("fix(scope) missing colon"));
+    }
+}

--- a/crates/semantic-commit/src/staged_context.rs
+++ b/crates/semantic-commit/src/staged_context.rs
@@ -372,3 +372,78 @@ fn print_usage(stderr: bool) {
     let _ = writeln!(out, "Outputs:");
     let _ = writeln!(out, "  - Bundle: commit-context.json + staged.patch");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_name_status_z_parses_basic_entries() {
+        let buf = b"A\0src/main.rs\0M\0README.md\0";
+        let entries = parse_name_status_z(buf).expect("parse name-status output");
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].status, "A");
+        assert_eq!(entries[0].path, "src/main.rs");
+        assert_eq!(entries[0].score, None);
+        assert_eq!(entries[0].old_path, None);
+
+        assert_eq!(entries[1].status, "M");
+        assert_eq!(entries[1].path, "README.md");
+        assert_eq!(entries[1].score, None);
+        assert_eq!(entries[1].old_path, None);
+    }
+
+    #[test]
+    fn parse_name_status_z_parses_renames_and_copies_with_scores() {
+        let buf = b"R087\0old/path.txt\0new/path.txt\0C100\0src/lib.rs\0src/lib_copy.rs\0";
+        let entries = parse_name_status_z(buf).expect("parse rename/copy entries");
+
+        assert_eq!(entries.len(), 2);
+
+        assert_eq!(entries[0].status, "R");
+        assert_eq!(entries[0].score, Some(87));
+        assert_eq!(entries[0].path, "new/path.txt");
+        assert_eq!(entries[0].old_path.as_deref(), Some("old/path.txt"));
+
+        assert_eq!(entries[1].status, "C");
+        assert_eq!(entries[1].score, Some(100));
+        assert_eq!(entries[1].path, "src/lib_copy.rs");
+        assert_eq!(entries[1].old_path.as_deref(), Some("src/lib.rs"));
+    }
+
+    #[test]
+    fn parse_name_status_z_rejects_malformed_rename_entry() {
+        let result = parse_name_status_z(b"R100\0old/path.txt\0");
+        assert!(result.is_err());
+        let err = match result {
+            Ok(_) => panic!("expected malformed name-status output"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("malformed name-status output"));
+    }
+
+    #[test]
+    fn parse_name_status_z_tolerates_invalid_similarity_score() {
+        let entries = parse_name_status_z(b"Rxx\0old/path.txt\0new/path.txt\0")
+            .expect("parse rename with non-numeric score");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].status, "R");
+        assert_eq!(entries[0].score, None);
+        assert_eq!(entries[0].path, "new/path.txt");
+        assert_eq!(entries[0].old_path.as_deref(), Some("old/path.txt"));
+    }
+
+    #[test]
+    fn is_lockfile_matches_known_package_manager_lockfiles() {
+        assert!(is_lockfile("yarn.lock"));
+        assert!(is_lockfile("frontend/package-lock.json"));
+        assert!(is_lockfile("subdir/pnpm-lock.yaml"));
+        assert!(is_lockfile("bun.lockb"));
+        assert!(is_lockfile("bun.lock"));
+        assert!(is_lockfile("npm-shrinkwrap.json"));
+        assert!(!is_lockfile("package-lock.json.bak"));
+        assert!(!is_lockfile("Cargo.lock"));
+    }
+}

--- a/crates/semantic-commit/tests/commit.rs
+++ b/crates/semantic-commit/tests/commit.rs
@@ -29,6 +29,45 @@ fn commit_outside_git_repo_errors() {
 }
 
 #[test]
+fn commit_help_flag_prints_usage() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(dir.path(), &["commit", "--help"], &[], None);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(as_str(&output.stdout)
+        .contains("semantic-commit commit [--message <text> | --message-file <path>]"));
+}
+
+#[test]
+fn commit_unknown_argument_errors_before_git_checks() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(dir.path(), &["commit", "--bogus"], &[], None);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("error: unknown argument: --bogus"));
+}
+
+#[test]
+fn commit_message_flag_requires_value() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output =
+        common::run_semantic_commit_output(dir.path(), &["commit", "--message"], &[], None);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("error: --message requires a value"));
+}
+
+#[test]
+fn commit_message_file_flag_requires_path() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output =
+        common::run_semantic_commit_output(dir.path(), &["commit", "--message-file"], &[], None);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("error: --message-file requires a path"));
+}
+
+#[test]
 fn commit_no_staged_changes_exits_2() {
     let repo = common::init_repo();
     let output = common::run_semantic_commit_output(
@@ -128,6 +167,17 @@ fn commit_message_file_missing_errors() {
 }
 
 #[test]
+fn commit_empty_stdin_message_errors() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output = common::run_semantic_commit_output(repo.path(), &["commit"], &[], Some(""));
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("error: commit message is empty"));
+}
+
+#[test]
 fn commit_fails_when_git_scope_missing() {
     let repo = common::init_repo();
     stage_file(repo.path(), "a.txt", "hello\n");
@@ -151,6 +201,51 @@ fn commit_fails_when_git_scope_missing() {
         !head.status.success(),
         "expected no commit to have been created"
     );
+}
+
+#[test]
+fn commit_message_file_successfully_commits() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+    common::write_file(
+        repo.path(),
+        "message.txt",
+        "feat(core): add thing\n\n- Add thing\n",
+    );
+
+    let tool_dir = tempfile::TempDir::new().expect("tempdir");
+    common::write_executable(
+        tool_dir.path(),
+        "git-scope",
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1-}" == "help" ]]; then
+  exit 0
+fi
+if [[ "${1-}" != "commit" || "${2-}" != "HEAD" || "${3-}" != "--no-color" ]]; then
+  echo "unexpected args: $*" >&2
+  exit 2
+fi
+echo "GIT_SCOPE_OK"
+"#,
+    );
+
+    let tool_dir = tool_dir.path().to_str().expect("tool dir str");
+    let path_env = format!("{tool_dir}:/usr/bin:/bin:/usr/sbin:/sbin");
+    let envs = vec![
+        ("PATH", path_env.as_str()),
+        ("GIT_AUTHOR_DATE", "Thu, 01 Jan 1970 00:00:00 +0000"),
+        ("GIT_COMMITTER_DATE", "Thu, 01 Jan 1970 00:00:00 +0000"),
+    ];
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &["commit", "--message-file", "message.txt"],
+        &envs,
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(as_str(&output.stdout).contains("GIT_SCOPE_OK"));
 }
 
 #[test]

--- a/crates/semantic-commit/tests/staged_context.rs
+++ b/crates/semantic-commit/tests/staged_context.rs
@@ -43,6 +43,26 @@ fn staged_context_outside_git_repo_errors() {
 }
 
 #[test]
+fn staged_context_help_flag_prints_usage() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output =
+        common::run_semantic_commit_output(dir.path(), &["staged-context", "--help"], &[], None);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(as_str(&output.stdout).contains("Usage: semantic-commit staged-context"));
+}
+
+#[test]
+fn staged_context_unknown_argument_errors_before_git_checks() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output =
+        common::run_semantic_commit_output(dir.path(), &["staged-context", "--bogus"], &[], None);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("error: unknown argument: --bogus"));
+}
+
+#[test]
 fn staged_context_no_staged_changes_exits_2() {
     let repo = common::init_repo();
     let output = common::run_semantic_commit_output(repo.path(), &["staged-context"], &[], None);


### PR DESCRIPTION
# Increase semantic-commit test coverage for validation and staged parsing

## Progress
- None

## Planning PR
- None

## Summary
This PR strengthens semantic-commit correctness by covering previously untested validation and staged-context parsing branches that can break automation workflows.

## Changes
- Added unit tests in commit module for header length, scope validity, body formatting, and accepted header forms.
- Added unit tests in staged_context module for name-status parsing (basic, rename/copy with score, malformed entries) and lockfile detection.
- Added integration tests for commit and staged-context help/unknown-arg behavior, missing flag value errors, empty stdin message, and message-file success path.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `cargo test -p semantic-commit` (pass)

## Risk / Notes
- Tests invoke help dispatch paths that print usage text during unit runs; runtime behavior is unchanged.
