### PR TITLE
Fix numstat output for filenames containing =>

### DIFF
--- a/crates/git-scope/src/change.rs
+++ b/crates/git-scope/src/change.rs
@@ -42,26 +42,24 @@ pub fn parse_name_status_output(output: &str) -> Vec<ChangeEntry> {
 }
 
 pub fn canonical_path(raw: &str) -> String {
-    if raw.contains("=>") {
-        if raw.contains('{') && raw.contains('}') {
-            let (prefix, after_open) = raw.split_once('{').unwrap_or((raw, ""));
-            let (inside, suffix) = after_open.split_once('}').unwrap_or((after_open, ""));
-
-            let mut new_part = inside.split("=>").last().unwrap_or(inside).trim();
-            if new_part.starts_with(' ') {
-                new_part = new_part.trim_start();
-            }
-
-            format!("{prefix}{new_part}{suffix}")
-        } else {
-            let mut new_part = raw.split("=>").last().unwrap_or(raw).trim();
-            if new_part.starts_with(' ') {
-                new_part = new_part.trim_start();
-            }
-            new_part.to_string()
-        }
-    } else {
+    if !raw.contains(" => ") {
         raw.to_string()
+    } else if raw.contains('{') && raw.contains('}') {
+        let (prefix, after_open) = raw.split_once('{').unwrap_or((raw, ""));
+        let (inside, suffix) = after_open.split_once('}').unwrap_or((after_open, ""));
+
+        let mut new_part = inside.split(" => ").last().unwrap_or(inside).trim();
+        if new_part.starts_with(' ') {
+            new_part = new_part.trim_start();
+        }
+
+        format!("{prefix}{new_part}{suffix}")
+    } else {
+        let mut new_part = raw.split(" => ").last().unwrap_or(raw).trim();
+        if new_part.starts_with(' ') {
+            new_part = new_part.trim_start();
+        }
+        new_part.to_string()
     }
 }
 
@@ -99,6 +97,18 @@ mod tests {
     fn canonical_path_brace_syntax() {
         let raw = "src/{old => new}/file.txt";
         assert_eq!(canonical_path(raw), "src/new/file.txt");
+    }
+
+    #[test]
+    fn canonical_path_plain_rename_syntax() {
+        let raw = "old/path.txt => new/path.txt";
+        assert_eq!(canonical_path(raw), "new/path.txt");
+    }
+
+    #[test]
+    fn canonical_path_keeps_literal_arrow_filename() {
+        let raw = "a=>b.txt";
+        assert_eq!(canonical_path(raw), "a=>b.txt");
     }
 
     #[test]


### PR DESCRIPTION
# Fix numstat output for filenames containing =>

## Summary
This fixes a `git-scope commit` parsing bug where filenames that literally contain `=>` were treated like rename syntax, causing line stats to be dropped (`+ - / -`) even when the file was a normal modified path.

## Problem
- Expected: A modified file named like `a=>b.txt` should keep its full path key and show correct `+/-` totals.
- Actual: `canonical_path` rewrote any path containing `=>`, so `a=>b.txt` became `b.txt` and no numstat match was found.
- Impact: Incorrect per-file and total diff stats in commit view for a valid filename pattern.

## Reproduction
1. Create a repo and commit a file literally named `a=>b.txt`.
2. Modify it and commit again.
3. Run `git show --pretty=format: --name-status HEAD` and `git show --pretty=format: --numstat HEAD`.
4. Observe `name-status` uses `a=>b.txt` while old parser canonicalized the numstat path as `b.txt`.

- Expected result: `a=>b.txt` maps correctly and prints numeric `+/-` stats.
- Actual result: mapping misses, so stats degrade to `-/-`.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-51-BUG-001 | medium | high | crates/git-scope/src/change.rs | Literal `=>` filenames are misparsed as rename markers | `canonical_path` matched raw `=>` and stripped prefix; repro with `a=>b.txt` | fixed |

## Fix Approach
- Restrict rename normalization to true rename marker token `" => "`.
- Preserve literal arrow filenames unchanged.
- Add regression tests for plain rename syntax and literal `a=>b.txt` paths.

## Testing
- `cargo test -p git-scope canonical_path` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Low risk: change is isolated to path canonicalization for commit numstat mapping.
