### PR TITLE
Fix validate false positives for shell redirect commands

### DIFF
--- a/crates/plan-tooling/src/validate.rs
+++ b/crates/plan-tooling/src/validate.rs
@@ -422,8 +422,14 @@ fn contains_angle_placeholder(value: &str) -> bool {
             if start < bytes.len() {
                 if let Some(end) = bytes[start..].iter().position(|b| *b == b'>') {
                     if end >= 1 {
-                        return true;
+                        let inner = &value[start..start + end];
+                        // Treat only tight `<...>` tokens as placeholders. This avoids
+                        // false positives on shell redirects like `cat < in > out`.
+                        if inner.trim() == inner {
+                            return true;
+                        }
                     }
+                    i = start + end;
                 }
             }
         }
@@ -473,4 +479,19 @@ fn is_task_id(s: &str) -> bool {
         return false;
     }
     a.chars().all(|c| c.is_ascii_digit()) && b.chars().all(|c| c.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contains_angle_placeholder;
+
+    #[test]
+    fn angle_placeholder_detects_tight_token() {
+        assert!(contains_angle_placeholder("needs <TBD>"));
+    }
+
+    #[test]
+    fn angle_placeholder_ignores_shell_redirect_spacing() {
+        assert!(!contains_angle_placeholder("cat < input.txt > output.txt"));
+    }
 }

--- a/crates/plan-tooling/tests/validate.rs
+++ b/crates/plan-tooling/tests/validate.rs
@@ -98,6 +98,21 @@ fn validate_missing_dependencies_is_error() {
 }
 
 #[test]
+fn validate_redirect_command_is_not_placeholder() {
+    let repo = init_repo();
+    write_file(&repo.path().join("redirect.md"), REDIRECT_VALIDATION_PLAN);
+
+    let out = run_plan_tooling(repo.path(), &["validate", "--file", "redirect.md"]);
+    assert_eq!(
+        out.code, 0,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    assert!(out.stdout.is_empty());
+    assert!(out.stderr.is_empty());
+}
+
+#[test]
 fn validate_json_ok_with_explicit_file() {
     let repo = init_repo();
     write_file(&repo.path().join("plan.md"), VALID_PLAN);
@@ -228,4 +243,20 @@ const MISSING_DEPS_PLAN: &str = r#"# Plan: Missing deps
   - A works
 - **Validation**:
   - cargo test -p plan-tooling
+"#;
+
+const REDIRECT_VALIDATION_PLAN: &str = r#"# Plan: Redirect
+
+## Sprint 1: First sprint
+
+### Task 1.1: Validate shell redirect command
+- **Location**:
+  - `src/a.rs`
+- **Description**: Keep redirect-based checks
+- **Dependencies**:
+  - none
+- **Acceptance criteria**:
+  - Redirect command is accepted
+- **Validation**:
+  - cat < input.txt > output.txt
 "#;


### PR DESCRIPTION
# Fix validate false positives for shell redirect commands

## Summary
`plan-tooling validate` incorrectly treated shell redirect syntax as an angle-bracket placeholder, causing valid plan files to fail linting. This change narrows placeholder detection so redirect commands like `cat < input.txt > output.txt` pass validation.

## Problem
- Expected: Validation commands that use shell redirects should be accepted as normal commands.
- Actual: Commands with `< ... >` redirect syntax were flagged as placeholders.
- Impact: Valid plans fail `plan-tooling validate`, creating false CI failures and blocking plan adoption.

## Reproduction
1. Create a plan file whose `Validation` includes `cat < input.txt > output.txt`.
2. Run `cargo run -q -p plan-tooling -- validate --file <plan.md>`.

- Expected result: Exit code `0` and no errors.
- Actual result: Exit code `1` with `Validation contains placeholder`.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-52-BUG-001 | medium | high | crates/plan-tooling/src/validate.rs | Placeholder detection misclassifies shell redirect commands as placeholders | Repro: `cat < input.txt > output.txt` triggered `Validation contains placeholder` | fixed |

## Fix Approach
- Restrict angle placeholder matching to tight `<...>` tokens.
- Ignore angle-bracket segments with surrounding inner whitespace, which captures shell redirect forms.
- Add unit tests for placeholder parsing and an integration test for `validate` command behavior.

## Testing
- `cargo test -p plan-tooling` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Behavior still flags explicit placeholder tokens like `<TBD>`.
- Change scope is limited to placeholder detection and associated tests.
