### PR TITLE
Fix Windows absolute path handling in suite resolution

### DIFF
--- a/crates/api-testing-core/src/suite/resolve.rs
+++ b/crates/api-testing-core/src/suite/resolve.rs
@@ -19,10 +19,11 @@ pub fn find_repo_root(start_dir: &Path) -> Result<PathBuf> {
 
 pub fn resolve_path_from_repo_root(repo_root: &Path, raw: &str) -> PathBuf {
     let raw = raw.trim();
-    if raw.starts_with('/') {
-        PathBuf::from(raw)
+    let path = Path::new(raw);
+    if path.is_absolute() {
+        path.to_path_buf()
     } else {
-        repo_root.join(raw)
+        repo_root.join(path)
     }
 }
 
@@ -235,6 +236,25 @@ mod tests {
         assert_eq!(
             resolve_path_from_repo_root(root, "/abs/path"),
             PathBuf::from("/abs/path")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn suite_resolve_path_from_repo_root_handles_windows_absolute_paths() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        let drive_abs = r"C:\abs\path";
+        assert_eq!(
+            resolve_path_from_repo_root(root, drive_abs),
+            PathBuf::from(drive_abs)
+        );
+
+        let unc_abs = r"\\server\share\suite.yaml";
+        assert_eq!(
+            resolve_path_from_repo_root(root, unc_abs),
+            PathBuf::from(unc_abs)
         );
     }
 


### PR DESCRIPTION
# Fix Windows absolute path handling in suite resolution

## Summary
This PR fixes incorrect path resolution in api-testing-core when callers pass Windows absolute paths (drive-letter or UNC) for suite/config/request locations. The resolver now uses platform-aware absolute-path detection and keeps absolute inputs unchanged.

## Problem
- Expected: Absolute paths should be used as-is on every platform.
- Actual: `resolve_path_from_repo_root` only checked for `/` prefix, so `C:\...` and `\\server\...` were treated as repo-relative.
- Impact: On Windows, commands can fail by resolving to non-existent nested paths under the repo root; severity medium.

## Reproduction
1. On Windows, run an API test command with an absolute suite/config/request path like `C:\work\repo\setup\rest\requests\health.request.json`.
2. The command path resolution calls `resolve_path_from_repo_root(repo_root, raw)` with that absolute input.
3. Before this fix, the resolver joins `repo_root` with the absolute string and points to a wrong path.

- Expected result: The absolute path remains unchanged.
- Actual result: The path is incorrectly resolved under the repo root.

## Issues Found
Severity: critical | high | medium | low
Confidence: high | medium | low
Status: open | fixed | deferred | needs-info

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-53-BUG-001 | medium | high | crates/api-testing-core/src/suite/resolve.rs | Windows absolute paths are misclassified as relative by string-prefix checks | crates/api-testing-core/src/suite/resolve.rs:21 | fixed |

## Fix Approach
- Replace string-prefix absolute path detection with `Path::is_absolute()`.
- Keep joining with `repo_root` only for relative inputs.
- Add Windows-only regression tests for drive-letter and UNC absolute paths.

## Testing
- `cargo test -p api-testing-core suite_resolve_path_from_repo_root_handles_absolute_and_relative` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Scope is limited to one helper used by suite path resolution.
- New Windows regression test is `#[cfg(windows)]`; it will run on Windows CI/hosts.
