### PR TITLE
Update README badges for CI, coverage, release, and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nils-cli
 
-[![Coverage](https://raw.githubusercontent.com/graysurf/nils-cli/coverage-badge/badges/coverage.svg)](https://github.com/graysurf/nils-cli/actions/workflows/ci.yml)
+[![CI](https://github.com/graysurf/nils-cli/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/graysurf/nils-cli/actions/workflows/ci.yml) [![Coverage](https://raw.githubusercontent.com/graysurf/nils-cli/coverage-badge/badges/coverage.svg)](https://github.com/graysurf/nils-cli/actions/workflows/ci.yml) [![Release](https://img.shields.io/github/v/release/graysurf/nils-cli?sort=semver)](https://github.com/graysurf/nils-cli/releases) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Rust CLI workspace scaffold for building multiple independently packaged binaries.
 
@@ -100,9 +100,3 @@ Optional: source `<extract_dir>/completions/bash/aliases.bash` to enable `gs*`/`
 4. Build or run the new CLI with `cargo build -p <cli-name>` or `cargo run -p <cli-name> -- ...`.
 5. Verify packaging picks it up (both local install + GitHub Releases use the same discovery):
    - `python3 scripts/workspace-bins.py | rg "^<cli-name>$"` (see [scripts/workspace-bins.py](scripts/workspace-bins.py))
-
-## License
-
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-
-This project is licensed under the MIT License. See [LICENSE](LICENSE).


### PR DESCRIPTION
# Update README badges for CI, coverage, release, and license

## Summary
This updates the top README badge row to show the most useful project signals in a common order. CI and release badges are added, and coverage plus license badges are grouped in the same row.

## Changes
- Add a CI workflow status badge linked to the CI workflow.
- Add a latest GitHub release badge linked to Releases.
- Move the license badge into the top badge row beside coverage.
- Remove the redundant `## License` section from the bottom of README.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- README-only change with no runtime behavior impact.
