### PR TITLE
Raise per-crate coverage to at least 80%

### DIFF
--- a/crates/cli-template/tests/cli.rs
+++ b/crates/cli-template/tests/cli.rs
@@ -1,5 +1,5 @@
 use nils_test_support::bin;
-use nils_test_support::cmd::{self, CmdOutput};
+use nils_test_support::cmd::{self, run_with, CmdOptions, CmdOutput};
 use std::path::PathBuf;
 
 fn cli_template_bin() -> PathBuf {
@@ -9,6 +9,12 @@ fn cli_template_bin() -> PathBuf {
 fn run(args: &[&str]) -> CmdOutput {
     let bin = cli_template_bin();
     cmd::run(&bin, args, &[], None)
+}
+
+fn run_without_rust_log(args: &[&str]) -> CmdOutput {
+    let bin = cli_template_bin();
+    let options = CmdOptions::new().with_env_remove("RUST_LOG");
+    run_with(&bin, args, &options)
 }
 
 #[test]
@@ -28,6 +34,22 @@ fn cli_template_hello_defaults_to_world() {
 #[test]
 fn cli_template_hello_accepts_name() {
     let output = run(&["hello", "Nils"]);
+    assert_eq!(output.code, 0);
+    let stdout = output.stdout_text();
+    assert!(stdout.contains("Hello, Nils!"), "stdout={stdout}");
+}
+
+#[test]
+fn cli_template_progress_demo_prints_done() {
+    let output = run(&["progress-demo"]);
+    assert_eq!(output.code, 0);
+    let stdout = output.stdout_text();
+    assert_eq!(stdout.trim(), "done", "stdout={stdout}");
+}
+
+#[test]
+fn cli_template_invalid_log_level_still_prints_greeting() {
+    let output = run_without_rust_log(&["--log-level", "not-a-level", "hello", "Nils"]);
     assert_eq!(output.code, 0);
     let stdout = output.stdout_text();
     assert!(stdout.contains("Hello, Nils!"), "stdout={stdout}");

--- a/crates/git-summary/tests/cli_paths.rs
+++ b/crates/git-summary/tests/cli_paths.rs
@@ -1,6 +1,75 @@
 mod common;
 
+use common::{git, init_repo, run_git_summary};
 use std::fs;
+use std::path::Path;
+
+const SEPARATOR: &str =
+    "----------------------------------------------------------------------------------------------------------------------------------------";
+
+fn summary_table_header() -> String {
+    format!(
+        "{:<25} {:<40} {:>8} {:>8} {:>8} {:>8} {:>12} {:>12}",
+        "Name", "Email", "Added", "Deleted", "Net", "Commits", "First", "Last"
+    )
+}
+
+fn seed_single_commit(root: &Path) {
+    fs::write(root.join("seed.txt"), "seed\n").expect("write seed file");
+    git(root, &["add", "seed.txt"]);
+    git(root, &["commit", "-m", "seed"]);
+}
+
+#[test]
+fn no_args_and_help_aliases_print_usage() {
+    let temp = tempfile::TempDir::new().unwrap();
+
+    let no_args_output = run_git_summary(temp.path(), &[], &[]);
+    assert!(no_args_output.contains("Usage: git-summary <command> [args]"));
+    assert!(no_args_output.contains("Commands:"));
+    assert!(no_args_output.contains("Entire history"));
+
+    for args in [&["help"][..], &["--help"][..], &["-h"][..]] {
+        let output = run_git_summary(temp.path(), args, &[]);
+        assert!(output.contains("Usage: git-summary <command> [args]"));
+        assert!(output.contains("Commands:"));
+        assert!(output.contains("Custom date range (YYYY-MM-DD)"));
+    }
+}
+
+#[test]
+fn shortcut_commands_print_stable_headers() {
+    let repo = init_repo();
+    let root = repo.path();
+    seed_single_commit(root);
+
+    let table_header = summary_table_header();
+    let cases = [
+        ("all", "Git summary for all commits"),
+        ("today", "Git summary for today:"),
+        ("yesterday", "Git summary for yesterday:"),
+        ("this-month", "Git summary for this month:"),
+        ("last-month", "Git summary for last month:"),
+        ("this-week", "Git summary for this week:"),
+        ("last-week", "Git summary for last week:"),
+    ];
+
+    for (cmd, expected_header) in cases {
+        let output = run_git_summary(root, &[cmd], &[]);
+        assert!(
+            output.contains(expected_header),
+            "missing header for `{cmd}`: {output}"
+        );
+        assert!(
+            output.contains(&table_header),
+            "missing table header for `{cmd}`: {output}"
+        );
+        assert!(
+            output.contains(SEPARATOR),
+            "missing separator for `{cmd}`: {output}"
+        );
+    }
+}
 
 #[test]
 fn reports_missing_git_in_path() {

--- a/crates/plan-tooling/tests/to_json.rs
+++ b/crates/plan-tooling/tests/to_json.rs
@@ -63,6 +63,53 @@ fn to_json_invalid_sprint_is_usage_error() {
 }
 
 #[test]
+fn to_json_help_prints_usage_and_exits_zero() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+
+    let out = run_plan_tooling(dir.path(), &["to-json", "--help"]);
+    assert_eq!(out.code, 0);
+    assert!(out.stdout.is_empty());
+    assert!(out.stderr.contains("Usage:"));
+    assert!(out.stderr.contains("plan_to_json.sh"));
+}
+
+#[test]
+fn to_json_unknown_argument_is_usage_error() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+
+    let out = run_plan_tooling(dir.path(), &["to-json", "--wat"]);
+    assert_eq!(out.code, 2);
+    assert!(out.stdout.is_empty());
+    assert!(out.stderr.contains("plan_to_json: unknown argument: --wat"));
+}
+
+#[test]
+fn to_json_missing_value_for_file_is_usage_error() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+
+    let out = run_plan_tooling(dir.path(), &["to-json", "--file"]);
+    assert_eq!(out.code, 2);
+    assert!(out.stdout.is_empty());
+    assert!(out
+        .stderr
+        .contains("plan_to_json: missing value for --file"));
+}
+
+#[test]
+fn to_json_missing_value_for_sprint_is_usage_error() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let plan_path = dir.path().join("plan.md");
+    write_file(&plan_path, VALID_PLAN);
+
+    let out = run_plan_tooling(dir.path(), &["to-json", "--file", "plan.md", "--sprint"]);
+    assert_eq!(out.code, 2);
+    assert!(out.stdout.is_empty());
+    assert!(out
+        .stderr
+        .contains("plan_to_json: missing value for --sprint"));
+}
+
+#[test]
 fn to_json_missing_file_is_parse_error() {
     let dir = tempfile::TempDir::new().expect("tempdir");
 

--- a/docs/plans/all-crates-coverage-80-plan.md
+++ b/docs/plans/all-crates-coverage-80-plan.md
@@ -1,0 +1,126 @@
+# Plan: Raise every crate to at least 80% line coverage
+
+## Overview
+This plan raises per-crate line coverage so every crate in the workspace is at or above 80.00%. The current coverage snapshot shows three crates below the threshold: `cli-template` (62.07%), `git-summary` (72.73%), and `plan-tooling` (79.76%). The implementation strategy is test-first and behavior-preserving: add deterministic tests for untested CLI paths and validation branches, then rerun workspace coverage and gate checks.
+
+## Scope
+- In scope:
+  - Add/extend tests in `cli-template`, `git-summary`, and `plan-tooling` only.
+  - Keep runtime behavior unchanged (no feature changes).
+  - Validate with crate tests, required repo checks, and workspace coverage.
+- Out of scope:
+  - Refactoring unrelated crates.
+  - Changing CLI output contracts for existing commands.
+  - Modifying CI workflow definitions.
+
+## Assumptions (if any)
+1. Coverage is measured via `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info`.
+2. Per-crate line coverage is computed from `target/coverage/lcov.info` grouped by `crates/<name>/` paths.
+3. Existing tests and fixtures in each target crate can be reused without adding new external dependencies.
+
+## Sprint 1: Lift low-coverage crates with targeted tests
+**Goal**: Raise `cli-template`, `git-summary`, and `plan-tooling` to >= 80% line coverage.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p cli-template -p git-summary -p plan-tooling`
+- Verify:
+  - New tests pass and cover previously unexecuted command branches.
+
+### Task 1.1: Cover `cli-template` progress and logging fallback paths
+- **Location**:
+  - `crates/cli-template/tests/cli.rs`
+- **Description**: Add integration tests to exercise `progress-demo` execution and invalid `--log-level` fallback while preserving current user-facing output behavior.
+- **Dependencies**:
+  - none
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - `progress-demo` test asserts successful exit and expected `done` output.
+  - Invalid `--log-level` test confirms command still succeeds and returns expected greeting output.
+- **Validation**:
+  - `cargo test -p cli-template`
+
+### Task 1.2: Cover `git-summary` help and date-shortcut command branches
+- **Location**:
+  - `crates/git-summary/tests/cli_paths.rs`
+  - `crates/git-summary/tests/edge_cases.rs`
+- **Description**: Add integration tests for no-arg/help output and each date shortcut command branch (`today`, `yesterday`, `this-month`, `last-month`, `this-week`, `last-week`, plus `all`) using deterministic assertions on header/usage text.
+- **Dependencies**:
+  - none
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Help/no-arg invocations return success and print usage sections.
+  - Shortcut commands execute successfully in a temp git repo and emit expected `Git summary` headers.
+- **Validation**:
+  - `cargo test -p git-summary`
+
+### Task 1.3: Cover `plan-tooling` `to-json` usage/error branches
+- **Location**:
+  - `crates/plan-tooling/tests/to_json.rs`
+- **Description**: Add focused CLI tests for `to-json` usage paths (for example `--help`, unknown flags, and missing option values) so parser entrypoints and usage rendering are exercised.
+- **Dependencies**:
+  - none
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - New tests assert expected exit codes for usage errors.
+  - `--help` path is validated for expected usage text.
+- **Validation**:
+  - `cargo test -p plan-tooling`
+
+## Sprint 2: Validate workspace gates and publish feature PR
+**Goal**: Prove all crates are >= 80% and publish changes as a feature PR.
+**Demo/Validation**:
+- Command(s):
+  - `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh`
+  - `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info`
+  - `scripts/ci/coverage-summary.sh target/coverage/lcov.info`
+- Verify:
+  - All mandatory checks pass.
+  - Per-crate coverage report shows no crate below 80%.
+
+### Task 2.1: Run required checks and verify per-crate coverage thresholds
+- **Location**:
+  - `target/coverage/lcov.info`
+- **Description**: Execute required repo checks and recompute per-crate coverage percentages from lcov output to confirm threshold compliance.
+- **Dependencies**:
+  - Task 1.1
+  - Task 1.2
+  - Task 1.3
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - Required checks are green.
+  - Coverage summary confirms all crates >= 80.00%.
+- **Validation**:
+  - `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh`
+  - `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info`
+
+### Task 2.2: Commit and open feature PR
+- **Location**:
+  - `references/PR_TEMPLATE.md`
+- **Description**: Create a feature branch, commit with `semantic-commit-autostage`, push, and open a PR with testing evidence and coverage results.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - Commit message follows semantic commit format.
+  - PR is created with summary, changes, testing, and risk sections.
+- **Validation**:
+  - `gh pr view --json number,title,url`
+
+## Testing Strategy
+- Unit/integration:
+  - Crate-specific tests for `cli-template`, `git-summary`, `plan-tooling`.
+- Workspace checks:
+  - Run required fmt/clippy/test/zsh checks via `nils-cli-checks`.
+- Coverage:
+  - Re-generate lcov and verify both total and per-crate thresholds.
+
+## Risks & gotchas
+- Date-based commands in `git-summary` can be flaky if assertions depend on exact dates; tests must assert stable labels/prefixes only.
+- CLI help formatting can shift with clap updates; assertions should target durable substrings rather than full snapshots.
+- `progress-demo` includes sleep calls; avoid overly strict timing assertions.
+- `gh pr create` may fail in environments without GitHub auth; if so, retain branch/commit and report exact blocker.
+
+## Rollback plan
+- Revert only newly added test files/blocks if they introduce flakiness.
+- Keep functional code unchanged; rollback scope should be test-only.
+- If coverage remains below target, split additional test-only follow-up tasks per crate instead of broad refactors.


### PR DESCRIPTION
# Raise per-crate coverage to at least 80%

## Summary
This PR raises per-crate test coverage so every crate in the workspace meets or exceeds 80% line coverage. It adds deterministic integration tests for low-coverage command paths in `cli-template`, `git-summary`, and `plan-tooling`, and includes a validated execution plan used to drive and verify the implementation.

## Changes
- Add `cli-template` integration tests for `progress-demo` and invalid `--log-level` fallback behavior.
- Add `git-summary` integration tests covering usage/help paths and date shortcut command branches.
- Add `plan-tooling` `to-json` tests for help and usage-error branches (unknown args and missing values).
- Add plan document `docs/plans/all-crates-coverage-80-plan.md` and validate it with `plan-tooling`.

## Testing
- `cargo test -p cli-template -p git-summary -p plan-tooling` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total 85.25%)
- Per-crate lcov aggregation check (pass, all crates >= 80.00%)

## Risk / Notes
- Assertions for date-based paths intentionally use stable prefixes to avoid date flakiness.
- Changes are test-only; no runtime behavior was modified.
