### PR TITLE
Prevent escape leakage when Arc cleanup loses focus

### DIFF
--- a/crates/macos-agent/tests/real_common.rs
+++ b/crates/macos-agent/tests/real_common.rs
@@ -925,7 +925,11 @@ fn best_effort_arc_reset_to_blank() {
         }
     }
 
-    let _ = run_osascript_script(r#"tell application "System Events" to key code 53"#);
+    // Guard escape dispatch so we do not leak control glyphs to terminal when Arc
+    // activation loses focus unexpectedly in real E2E runs.
+    if frontmost_app_is("Arc") {
+        let _ = run_osascript_script(r#"tell application "System Events" to key code 53"#);
+    }
 }
 
 fn best_effort_close_active_finder_window() {
@@ -940,6 +944,13 @@ fn try_activate_app(app_name: &str) -> bool {
         escape_applescript(app_name)
     );
     run_osascript_script(&script).is_some()
+}
+
+fn frontmost_app_is(app_name: &str) -> bool {
+    let script = r#"tell application "System Events" to get name of first application process whose frontmost is true"#;
+    run_osascript_script(script)
+        .map(|name| name.trim().eq_ignore_ascii_case(app_name))
+        .unwrap_or(false)
 }
 
 fn try_set_clipboard_text(text: &str) -> bool {


### PR DESCRIPTION
# Prevent escape leakage when Arc cleanup loses focus

## Summary
This PR hardens the real E2E Arc cleanup helper in `macos-agent` so it only sends `Esc` when Arc is still the frontmost app. This prevents accidental control-glyph injection into a foreground terminal when focus shifts between activation and teardown.

## Problem
- Expected: Arc teardown should not send keys to unrelated foreground apps.
- Actual: Cleanup unconditionally dispatched `key code 53` (`Esc`) after best-effort Arc reset.
- Impact: In interactive terminals, focus drift can surface control glyphs (for example `^[`) and pollute command output during real E2E runs.

## Reproduction
1. Run real E2E Arc flows with cleanup enabled (for example `cargo test -p macos-agent --test e2e_real_apps -- --nocapture`) on macOS.
2. Force focus away from Arc before teardown `Esc` dispatch (for example quickly focus Terminal).

- Expected result: no stray control key is sent to non-Arc frontmost apps.
- Actual result: teardown may emit `Esc` to whichever app is frontmost.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-61-BUG-001 | medium | high | crates/macos-agent/tests/real_common.rs | Arc cleanup sends unconditional Esc without frontmost-app guard | crates/macos-agent/tests/real_common.rs:928 | fixed |

## Fix Approach
- Add `frontmost_app_is("Arc")` helper based on System Events frontmost process query.
- Gate cleanup `key code 53` dispatch behind frontmost-app verification.
- Keep existing cleanup behavior unchanged when Arc remains frontmost.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Change is limited to real E2E test helper teardown path; production command behavior is unchanged.
