### PR TITLE
Add CI-gated fast path for release checks

### DIFF
--- a/.codex/skills/nils-cli-release/SKILL.md
+++ b/.codex/skills/nils-cli-release/SKILL.md
@@ -11,6 +11,7 @@ Prereqs:
 
 - Run inside the `nils-cli` git work tree (the script resolves the repo root via `git`).
 - `git`, `python3`, `cargo`, `semantic-commit`, and `git-scope` available on `PATH`.
+- `gh` available on `PATH` when using `--ci-gate-main`.
 - `cargo-nextest` available on `PATH` when using default release checks (`NILS_CLI_TEST_RUNNER=nextest`).
 - Release checks available at `.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (unless `--skip-checks`).
 
@@ -20,6 +21,7 @@ Inputs:
   - `--version X.Y.Z` (accepts `vX.Y.Z` and normalizes to `X.Y.Z`)
 - Optional:
   - `--skip-checks` (skip full lint/tests; still runs `cargo check --workspace` to refresh `Cargo.lock`)
+  - `--ci-gate-main` (skip full lint/tests only when `origin/main` HEAD matches local `HEAD` and has a successful CI run)
   - `--skip-readme` (do not update README release tag example)
   - `--skip-push` (do not push commit or tag to `origin`)
   - `--allow-dirty` (allow a dirty working tree)
@@ -30,7 +32,7 @@ Outputs:
 
 - Updates workspace version in `Cargo.toml` and any crate `Cargo.toml` files with explicit `version = "..."`.
 - Updates README release tag examples (unless `--skip-readme`).
-- Refreshes `Cargo.lock` via `cargo check` or the full checks script.
+- Refreshes `Cargo.lock` via `cargo check --workspace --locked` or the full checks script.
 - Runs release checks through `nils-cli-checks.sh` with `NILS_CLI_TEST_RUNNER=nextest` by default (unless overridden).
 - Creates a semantic commit for the version bump.
 - Creates an annotated tag `vX.Y.Z` and (unless `--skip-push`) pushes commit + tag to `origin`.
@@ -49,6 +51,8 @@ Failure modes:
 - Tag already exists without `--force-tag`.
 - Required commands missing (`git`, `python3`, `cargo`, `semantic-commit`, `git-scope`).
 - `cargo-nextest` missing while default check path (`nextest`) is active.
+- `--ci-gate-main` used outside `main`, or local `HEAD` does not match `origin/main`.
+- `--ci-gate-main` used but `origin/main` has no successful completed CI run.
 - Release checks or `cargo check` fail.
 - Commit or tag creation fails.
 
@@ -60,5 +64,5 @@ Failure modes:
 
 - Validate inputs and environment.
 - Bump workspace + crate versions and update README.
-- Run checks (defaulting to `nextest`, or `cargo check` with `--skip-checks`) to refresh `Cargo.lock`.
+- Run checks (defaulting to `nextest`, `cargo check --workspace --locked` with `--skip-checks`, or CI-gated `cargo check --workspace --locked` with `--ci-gate-main`) to refresh `Cargo.lock`.
 - Commit with `semantic-commit`, tag `vX.Y.Z`, and push to trigger the release workflow.

--- a/.codex/skills/nils-cli-release/scripts/nils-cli-release.sh
+++ b/.codex/skills/nils-cli-release/scripts/nils-cli-release.sh
@@ -9,6 +9,7 @@ Usage:
 Options:
   --version X.Y.Z   Required. Accepts vX.Y.Z and normalizes to X.Y.Z.
   --skip-checks     Skip full lint/tests; runs cargo check to refresh Cargo.lock.
+  --ci-gate-main    Skip full lint/tests only when origin/main HEAD has a green CI run.
   --skip-readme     Do not update README release tag examples.
   --skip-push       Do not push commit or tag to origin.
   --allow-dirty     Allow a dirty working tree.
@@ -28,6 +29,7 @@ note() {
 
 version=""
 skip_checks=0
+ci_gate_main=0
 skip_readme=0
 skip_push=0
 allow_dirty=0
@@ -44,6 +46,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-checks)
       skip_checks=1
+      shift
+      ;;
+    --ci-gate-main)
+      ci_gate_main=1
       shift
       ;;
     --skip-readme)
@@ -92,6 +98,12 @@ for cmd in git python3 cargo semantic-commit git-scope; do
   fi
 done
 
+if [[ "$ci_gate_main" -eq 1 ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    die "--ci-gate-main requires gh on PATH"
+  fi
+fi
+
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [[ -z "$repo_root" ]]; then
   die "must run inside a git work tree"
@@ -112,6 +124,60 @@ if [[ "$allow_dirty" -eq 0 ]]; then
   if [[ -n "$(git status --porcelain)" ]]; then
     die "working tree is not clean; commit/stash changes or use --allow-dirty"
   fi
+fi
+
+if [[ "$ci_gate_main" -eq 1 ]]; then
+  if [[ -z "$current_branch" || "$current_branch" != "main" ]]; then
+    die "--ci-gate-main requires running on branch 'main'"
+  fi
+
+  note "verifying CI status for origin/main"
+  git fetch origin main --quiet
+
+  head_sha="$(git rev-parse --verify HEAD)"
+  origin_main_sha="$(git rev-parse --verify origin/main)"
+  if [[ "$head_sha" != "$origin_main_sha" ]]; then
+    die "--ci-gate-main requires HEAD to match origin/main (pull/rebase main first)"
+  fi
+
+  ci_run_json="$(gh run list --workflow ci.yml --branch main --event push --commit "$origin_main_sha" --limit 20 --json databaseId,status,conclusion,url,headSha 2>/dev/null)" \
+    || die "failed to query CI runs from GitHub"
+
+  ci_run_result="$(
+    python3 - "$origin_main_sha" "$ci_run_json" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+
+sha = sys.argv[1]
+runs = json.loads(sys.argv[2])
+if not runs:
+    print(f"error:no CI run found for origin/main ({sha})")
+    raise SystemExit(2)
+
+run = runs[0]
+run_head_sha = run.get("headSha")
+status = run.get("status")
+conclusion = run.get("conclusion")
+url = run.get("url", "")
+
+if run_head_sha and run_head_sha != sha:
+    print(f"error:CI run SHA mismatch ({run_head_sha} != {sha}): {url}")
+    raise SystemExit(5)
+if status != "completed":
+    print(f"error:CI run is not completed yet ({status}): {url}")
+    raise SystemExit(3)
+if conclusion != "success":
+    print(f"error:CI run is not green ({conclusion}): {url}")
+    raise SystemExit(4)
+
+print(url)
+PY
+  )" || die "$ci_run_result"
+
+  note "main CI is green: ${ci_run_result}"
+  skip_checks=1
 fi
 
 python3 - "$version" <<'PY'
@@ -218,7 +284,7 @@ if [[ "$skip_checks" -eq 0 ]]; then
   fi
   NILS_CLI_TEST_RUNNER="$checks_runner" "$checks_script"
 else
-  cargo check --workspace
+  cargo check --workspace --locked
 fi
 
 git add -A


### PR DESCRIPTION
# Add CI-gated fast path for release checks

## Summary
Add a CI-gated fast path to `nils-cli-release.sh` so release operators can skip the expensive local lint/test suite when `origin/main` is already green in GitHub Actions. The default behavior is unchanged: full local checks still run unless the new gate is explicitly enabled.

## Changes
- Add `--ci-gate-main` flag to `.codex/skills/nils-cli-release/scripts/nils-cli-release.sh`.
- Require `gh` when CI gating is enabled, enforce branch `main`, and enforce `HEAD == origin/main` before allowing the fast path.
- Query GitHub Actions CI (`ci.yml`) for `origin/main` commit status and fail fast if the run is missing, incomplete, or non-success.
- Keep full checks as default and use `cargo check --workspace --locked` for `--skip-checks`/CI-gated paths.
- Update `.codex/skills/nils-cli-release/SKILL.md` contract/prereqs/failure-modes for the new behavior.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass, rerun after final patch)
- `bash -n .codex/skills/nils-cli-release/scripts/nils-cli-release.sh` (pass)
- `.codex/skills/nils-cli-release/scripts/nils-cli-release.sh --version 9.9.9 --ci-gate-main --skip-push --skip-readme --allow-dirty` on feature branch (expected fail: requires branch `main`)

## Risk / Notes
- CI-gated fast path depends on `gh` auth/network availability at release time.
- Guard is intentionally strict (`main` + exact `origin/main` SHA) to avoid false confidence from stale CI.
