### PR TITLE
Add Hammerspoon-backed AX object APIs, sessions, and observers

### DIFF
--- a/BINARY_DEPENDENCIES.md
+++ b/BINARY_DEPENDENCIES.md
@@ -39,6 +39,7 @@ These tools enable richer behavior. Missing tools typically trigger fallback beh
 | `pactl` | Linux audio source discovery for `screen-record --audio ...` | `brew install pulseaudio` |
 | `xdg-desktop-portal` + backend + PipeWire | Wayland portal capture path (`screen-record --portal`) | Prefer distro packages |
 | `open-changed-files` | Optional helper used by `fzf-cli git-commit` | Project-specific optional tool |
+| `hs` (Hammerspoon CLI) | Preferred AX backend path for `macos-agent ax *` (fallback to JXA when unavailable) | `brew install --cask hammerspoon` |
 
 ## 3. Development and Validation Toolchain
 

--- a/crates/macos-agent/README.md
+++ b/crates/macos-agent/README.md
@@ -26,6 +26,10 @@ macos-agent input-source switch --id abc
 macos-agent ax list --app Arc --role AXButton --title-contains "New"
 macos-agent ax click --app Arc --role AXLink --title-contains "YouTube" --nth 1 --allow-coordinate-fallback
 macos-agent ax type --app Arc --role AXTextField --title-contains "Search" --text "lofi" --submit --allow-keyboard-fallback
+macos-agent ax attr get --app Arc --role AXTextField --name AXValue
+macos-agent ax action perform --app Arc --role AXButton --title-contains "Submit" --name AXPress
+macos-agent ax session start --app Arc --session-id arc-main
+macos-agent ax watch start --session-id arc-main --events AXTitleChanged,AXFocusedUIElementChanged
 
 # observation
 macos-agent observe screenshot --active-window --path ./tmp/macos-agent.png
@@ -53,9 +57,18 @@ macos-agent wait window-present --app Terminal --window-name Inbox --timeout-ms 
   - `macos-agent input-source current`
   - `macos-agent input-source switch --id <source_id|abc|us>`
 - `ax`
-  - `macos-agent ax list [--app <name> | --bundle-id <bundle_id>] [--role <AXRole>] [--title-contains <text>] [--max-depth <n>] [--limit <n>]`
-  - `macos-agent ax click (--node-id <id> | --role <AXRole> --title-contains <text> [--nth <n>]) [--app <name> | --bundle-id <bundle_id>] [--allow-coordinate-fallback]`
-  - `macos-agent ax type (--node-id <id> | --role <AXRole> --title-contains <text> [--nth <n>]) --text <text> [--clear-first] [--submit] [--paste] [--allow-keyboard-fallback]`
+  - `macos-agent ax list [--session-id <id> | --app <name> | --bundle-id <bundle_id>] [--window-title-contains <text>] [--role <AXRole>] [--title-contains <text>] [--identifier-contains <text>] [--value-contains <text>] [--subrole <AXSubrole>] [--focused <bool>] [--enabled <bool>] [--max-depth <n>] [--limit <n>]`
+  - `macos-agent ax click [--node-id <id> | --role <AXRole> | --title-contains <text> | --identifier-contains <text> | --value-contains <text> | --subrole <AXSubrole> | --focused <bool> | --enabled <bool>] [--nth <n>] [--session-id <id> | --app <name> | --bundle-id <bundle_id>] [--window-title-contains <text>] [--allow-coordinate-fallback]`
+  - `macos-agent ax type [--node-id <id> | --role <AXRole> | --title-contains <text> | --identifier-contains <text> | --value-contains <text> | --subrole <AXSubrole> | --focused <bool> | --enabled <bool>] [--nth <n>] [--session-id <id> | --app <name> | --bundle-id <bundle_id>] [--window-title-contains <text>] --text <text> [--clear-first] [--submit] [--paste] [--allow-keyboard-fallback]`
+  - `macos-agent ax attr get [selector flags...] [target flags...] --name <AXAttribute>`
+  - `macos-agent ax attr set [selector flags...] [target flags...] --name <AXAttribute> --value <value> [--value-type <string|number|bool|json|null>]`
+  - `macos-agent ax action perform [selector flags...] [target flags...] --name <AXAction>`
+  - `macos-agent ax session start [--session-id <id>] [--app <name> | --bundle-id <bundle_id>] [--window-title-contains <text>]`
+  - `macos-agent ax session list`
+  - `macos-agent ax session stop --session-id <id>`
+  - `macos-agent ax watch start --session-id <id> [--watch-id <id>] [--events <comma-separated-AX-notifications>] [--max-buffer <n>]`
+  - `macos-agent ax watch poll --watch-id <id> [--limit <n>] [--drain|--no-drain]`
+  - `macos-agent ax watch stop --watch-id <id>`
 - `observe`
   - `macos-agent observe screenshot (--window-id <id> | --active-window | --app <name> [--window-name <name>]) [--path <file>] [--image-format <png|jpg|webp>]`
 - `wait`
@@ -170,6 +183,8 @@ Use these defaults for better stability:
   - `--timeout-ms 5000`
 - Use `wait app-active` / `wait window-present` before mutating actions.
 - Prefer `ax click/type` first, then opt in to fallback flags when app AX trees are unstable.
+- AX backend selection defaults to `auto` (Hammerspoon first, JXA fallback).
+  - Override with `CODEX_MACOS_AGENT_AX_BACKEND=hammerspoon|applescript|auto`.
 
 ## Deterministic Test Mode
 
@@ -257,6 +272,7 @@ macos-agent profile init --name local-1440p --path "$CODEX_HOME/out/local-profil
 | Flaky click/input behavior | `macos-agent --trace --error-format json input click ...` | latest trace JSON (`attempts_used`, timeout/retry policy) |
 | AX selector no match / ambiguous match | `macos-agent --format json ax list --app <name> --role <AXRole> --title-contains <text>` | node candidates (`node_id`, `role`, `title`, `identifier`) and refine selector / `--nth` |
 | AX press/type fails but coordinate/keyboard path should continue | rerun with `ax click --allow-coordinate-fallback` or `ax type --allow-keyboard-fallback` | whether `used_coordinate_fallback` / `used_keyboard_fallback` is true in JSON result |
+| Hammerspoon AX backend unavailable | `hs -t 1 -q -c 'return \"ok\"'` | ensure Hammerspoon is running and `require('hs.ipc')` is enabled, or keep backend `auto` for JXA fallback |
 | Input source mismatch before typing | `macos-agent --format json input-source current` then `... switch --id abc` | current source id and switch result (`switched=true`) |
 | Trace enabled but command does not start | `macos-agent --trace --trace-dir <path> --error-format json preflight` | `trace.write` error and writable-path hint |
 | Real-app scenario failed mid-flow | run target `e2e_real_apps` command with `--nocapture` | `steps.jsonl`, `step-summary.json`, `artifact-index.json` |

--- a/crates/macos-agent/src/backend/hammerspoon.rs
+++ b/crates/macos-agent/src/backend/hammerspoon.rs
@@ -1,0 +1,2631 @@
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::backend::process::{ProcessFailure, ProcessRequest, ProcessRunner};
+use crate::error::CliError;
+use crate::model::{
+    AxActionPerformRequest, AxActionPerformResult, AxAttrGetRequest, AxAttrGetResult,
+    AxAttrSetRequest, AxAttrSetResult, AxClickRequest, AxClickResult, AxListRequest, AxListResult,
+    AxSelector, AxSessionListResult, AxSessionStartRequest, AxSessionStartResult,
+    AxSessionStopRequest, AxSessionStopResult, AxTypeRequest, AxTypeResult, AxWatchPollRequest,
+    AxWatchPollResult, AxWatchStartRequest, AxWatchStartResult, AxWatchStopRequest,
+    AxWatchStopResult,
+};
+use crate::test_mode;
+
+use super::AxBackendAdapter;
+
+const AX_LIST_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_LIST_JSON";
+const AX_CLICK_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_CLICK_JSON";
+const AX_TYPE_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_TYPE_JSON";
+const AX_ATTR_GET_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_ATTR_GET_JSON";
+const AX_ATTR_SET_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_ATTR_SET_JSON";
+const AX_ACTION_PERFORM_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_ACTION_PERFORM_JSON";
+const AX_SESSION_START_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_SESSION_START_JSON";
+const AX_SESSION_LIST_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_SESSION_LIST_JSON";
+const AX_SESSION_STOP_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_SESSION_STOP_JSON";
+const AX_WATCH_START_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_WATCH_START_JSON";
+const AX_WATCH_POLL_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_WATCH_POLL_JSON";
+const AX_WATCH_STOP_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_WATCH_STOP_JSON";
+const BACKEND_UNAVAILABLE_HINT_PREFIX: &str = "Hammerspoon backend unavailable";
+
+const AX_LIST_HS_SCRIPT: &str = r#"
+local json = hs.json
+local appmod = hs.application
+local ax = hs.axuielement
+
+local function fail(message)
+  error(message, 0)
+end
+
+local function safe(callable, fallback)
+  local ok, value = pcall(callable)
+  if ok then return value end
+  return fallback
+end
+
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+
+local function asTable(value)
+  if type(value) == "table" then return value end
+  return {}
+end
+
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+
+local function resolveTarget(rawTarget)
+  local target = rawTarget or {}
+  local state = ensureState()
+  if target.session_id and tostring(target.session_id) ~= "" then
+    local session = state.sessions[tostring(target.session_id)]
+    if not session then
+      fail("session_id does not exist")
+    end
+    return {
+      session_id = tostring(target.session_id),
+      app = target.app or session.app,
+      bundle_id = target.bundle_id or session.bundle_id,
+      pid = session.pid,
+      window_title_contains = target.window_title_contains or session.window_title_contains,
+    }
+  end
+  return target
+end
+
+local function attr(element, name, fallback)
+  local value = safe(function() return element:attributeValue(name) end, fallback)
+  if value == nil then return fallback end
+  return value
+end
+
+local function boolAttr(element, name, fallback)
+  local value = attr(element, name, fallback)
+  if type(value) == "boolean" then return value end
+  if value == nil then return fallback end
+  return tostring(value):lower() == "true"
+end
+
+local function frameFor(element)
+  local pos = attr(element, "AXPosition", nil)
+  local size = attr(element, "AXSize", nil)
+  if type(pos) ~= "table" or type(size) ~= "table" then return nil end
+
+  local x = tonumber(pos.x or pos[1])
+  local y = tonumber(pos.y or pos[2])
+  local width = tonumber(size.w or size.width or size[1])
+  local height = tonumber(size.h or size.height or size[2])
+
+  if not x or not y or not width or not height then return nil end
+  return { x = x, y = y, width = width, height = height }
+end
+
+local function actionNames(element)
+  local raw = safe(function() return element:actionNames() end, nil)
+  if type(raw) ~= "table" then return {} end
+  local out = {}
+  for _, name in ipairs(raw) do
+    local text = normalize(name)
+    if text ~= "" then table.insert(out, text) end
+  end
+  return out
+end
+
+local function valuePreview(element)
+  local value = attr(element, "AXValue", nil)
+  if value == nil then return nil end
+  local text = normalize(value)
+  if #text > 160 then
+    text = string.sub(text, 1, 160) .. "..."
+  end
+  return text
+end
+
+local function children(element)
+  return asTable(attr(element, "AXChildren", {}))
+end
+
+local function resolveApp(target)
+  target = resolveTarget(target)
+
+  if target.pid then
+    local byPid = appmod.applicationForPID(tonumber(target.pid))
+    if byPid then return byPid, target end
+  end
+
+  if target.app and tostring(target.app) ~= "" then
+    local found = appmod.find(tostring(target.app))
+    if found then return found, target end
+  end
+
+  if target.bundle_id and tostring(target.bundle_id) ~= "" then
+    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
+    if type(apps) == "table" and #apps > 0 then
+      return apps[1], target
+    end
+  end
+
+  return appmod.frontmostApplication(), target
+end
+
+local function rootsForApp(app, target)
+  local appElement = ax.applicationElement(app)
+  if not appElement then
+    fail("unable to resolve target app process for ax.list")
+  end
+
+  local roots = asTable(attr(appElement, "AXWindows", {}))
+  if #roots == 0 then
+    roots = children(appElement)
+  end
+  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
+  if not windowFilter then
+    return roots
+  end
+
+  local filtered = {}
+  for _, root in ipairs(roots) do
+    local title = string.lower(normalize(attr(root, "AXTitle", "")))
+    if string.find(title, windowFilter, 1, true) then
+      table.insert(filtered, root)
+    end
+  end
+  return filtered
+end
+
+local function copyPath(path)
+  local out = {}
+  for i, value in ipairs(path) do
+    out[i] = value
+  end
+  return out
+end
+
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then
+    fail("invalid payload JSON")
+  end
+  return payload
+end
+
+local payload = parsePayload()
+local roleFilter = payload.role and string.lower(tostring(payload.role)) or nil
+local titleFilter = payload.title_contains and string.lower(tostring(payload.title_contains)) or nil
+local identifierFilter = payload.identifier_contains and string.lower(tostring(payload.identifier_contains)) or nil
+local valueFilter = payload.value_contains and string.lower(tostring(payload.value_contains)) or nil
+local subroleFilter = payload.subrole and string.lower(tostring(payload.subrole)) or nil
+local maxDepth = payload.max_depth and tonumber(payload.max_depth) or nil
+local limit = payload.limit and tonumber(payload.limit) or nil
+local focusedFilter = payload.focused
+local enabledFilter = payload.enabled
+
+local app, resolvedTarget = resolveApp(payload.target)
+if not app then
+  fail("unable to resolve target app process for ax.list")
+end
+
+local roots = rootsForApp(app, resolvedTarget)
+local nodes = {}
+
+local function nodeFrom(element, path)
+  local role = normalize(attr(element, "AXRole", ""))
+  local title = normalize(attr(element, "AXTitle", ""))
+  local identifier = normalize(attr(element, "AXIdentifier", ""))
+  local subrole = normalize(attr(element, "AXSubrole", ""))
+
+  local node = {
+    node_id = table.concat(path, "."),
+    role = role,
+    subrole = subrole ~= "" and subrole or nil,
+    title = title ~= "" and title or nil,
+    identifier = identifier ~= "" and identifier or nil,
+    value_preview = valuePreview(element),
+    enabled = boolAttr(element, "AXEnabled", true),
+    focused = boolAttr(element, "AXFocused", false),
+    frame = frameFor(element),
+    actions = actionNames(element),
+    path = copyPath(path),
+  }
+
+  return node
+end
+
+local function matches(node)
+  if roleFilter and string.lower(node.role or "") ~= roleFilter then
+    return false
+  end
+
+  if titleFilter then
+    local title = string.lower(node.title or "")
+    local identifier = string.lower(node.identifier or "")
+    if not string.find(title, titleFilter, 1, true) and not string.find(identifier, titleFilter, 1, true) then
+      return false
+    end
+  end
+
+  if identifierFilter and not string.find(string.lower(node.identifier or ""), identifierFilter, 1, true) then
+    return false
+  end
+
+  if valueFilter and not string.find(string.lower(node.value_preview or ""), valueFilter, 1, true) then
+    return false
+  end
+
+  if subroleFilter and string.lower(node.subrole or "") ~= subroleFilter then
+    return false
+  end
+
+  if focusedFilter ~= nil and node.focused ~= focusedFilter then
+    return false
+  end
+
+  if enabledFilter ~= nil and node.enabled ~= enabledFilter then
+    return false
+  end
+
+  return true
+end
+
+local function visit(element, path, depth)
+  if limit and #nodes >= limit then
+    return
+  end
+
+  local node = nodeFrom(element, path)
+  if matches(node) then
+    table.insert(nodes, node)
+  end
+
+  if maxDepth and depth >= maxDepth then
+    return
+  end
+
+  for index, child in ipairs(children(element)) do
+    local childPath = copyPath(path)
+    table.insert(childPath, tostring(index))
+    visit(child, childPath, depth + 1)
+    if limit and #nodes >= limit then
+      return
+    end
+  end
+end
+
+for rootIndex, root in ipairs(roots) do
+  visit(root, { tostring(rootIndex) }, 0)
+  if limit and #nodes >= limit then
+    break
+  end
+end
+
+return json.encode({ nodes = nodes, warnings = {} })
+"#;
+
+const AX_CLICK_HS_SCRIPT: &str = r#"
+local json = hs.json
+local appmod = hs.application
+local ax = hs.axuielement
+
+local function fail(message)
+  error(message, 0)
+end
+
+local function safe(callable, fallback)
+  local ok, value = pcall(callable)
+  if ok then return value end
+  return fallback
+end
+
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+
+local function asTable(value)
+  if type(value) == "table" then return value end
+  return {}
+end
+
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+
+local function resolveTarget(rawTarget)
+  local target = rawTarget or {}
+  local state = ensureState()
+  if target.session_id and tostring(target.session_id) ~= "" then
+    local session = state.sessions[tostring(target.session_id)]
+    if not session then
+      fail("session_id does not exist")
+    end
+    return {
+      session_id = tostring(target.session_id),
+      app = target.app or session.app,
+      bundle_id = target.bundle_id or session.bundle_id,
+      pid = session.pid,
+      window_title_contains = target.window_title_contains or session.window_title_contains,
+    }
+  end
+  return target
+end
+
+local function attr(element, name, fallback)
+  local value = safe(function() return element:attributeValue(name) end, fallback)
+  if value == nil then return fallback end
+  return value
+end
+
+local function children(element)
+  return asTable(attr(element, "AXChildren", {}))
+end
+
+local function resolveApp(target)
+  target = resolveTarget(target)
+
+  if target.pid then
+    local byPid = appmod.applicationForPID(tonumber(target.pid))
+    if byPid then return byPid, target end
+  end
+
+  if target.app and tostring(target.app) ~= "" then
+    local found = appmod.find(tostring(target.app))
+    if found then return found, target end
+  end
+
+  if target.bundle_id and tostring(target.bundle_id) ~= "" then
+    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
+    if type(apps) == "table" and #apps > 0 then
+      return apps[1], target
+    end
+  end
+
+  return appmod.frontmostApplication(), target
+end
+
+local function rootsForApp(app, target)
+  local appElement = ax.applicationElement(app)
+  if not appElement then
+    fail("unable to resolve target app process for ax.click")
+  end
+
+  local roots = asTable(attr(appElement, "AXWindows", {}))
+  if #roots == 0 then
+    roots = children(appElement)
+  end
+  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
+  if not windowFilter then
+    return roots
+  end
+
+  local filtered = {}
+  for _, root in ipairs(roots) do
+    local title = string.lower(normalize(attr(root, "AXTitle", "")))
+    if string.find(title, windowFilter, 1, true) then
+      table.insert(filtered, root)
+    end
+  end
+  return filtered
+end
+
+local function copyPath(path)
+  local out = {}
+  for i, value in ipairs(path) do
+    out[i] = value
+  end
+  return out
+end
+
+local function nodeFrom(element, path)
+  local role = normalize(attr(element, "AXRole", ""))
+  local title = normalize(attr(element, "AXTitle", ""))
+  local identifier = normalize(attr(element, "AXIdentifier", ""))
+  local subrole = normalize(attr(element, "AXSubrole", ""))
+  local value = normalize(attr(element, "AXValue", ""))
+  local focused = normalize(attr(element, "AXFocused", "false"))
+  local enabled = normalize(attr(element, "AXEnabled", "true"))
+  return {
+    node_id = table.concat(path, "."),
+    role = role,
+    title = title,
+    identifier = identifier,
+    subrole = subrole,
+    value_preview = value,
+    focused = string.lower(focused) == "true",
+    enabled = string.lower(enabled) == "true",
+  }
+end
+
+local function frameCenter(element)
+  local pos = attr(element, "AXPosition", nil)
+  local size = attr(element, "AXSize", nil)
+  if type(pos) ~= "table" or type(size) ~= "table" then return nil end
+
+  local x = tonumber(pos.x or pos[1])
+  local y = tonumber(pos.y or pos[2])
+  local width = tonumber(size.w or size.width or size[1])
+  local height = tonumber(size.h or size.height or size[2])
+
+  if not x or not y or not width or not height then return nil end
+  return {
+    x = math.floor(x + width / 2),
+    y = math.floor(y + height / 2),
+  }
+end
+
+local function resolveByNodeId(roots, nodeId)
+  local parts = {}
+  for segment in string.gmatch(tostring(nodeId), "[^.]+") do
+    table.insert(parts, tonumber(segment))
+  end
+  if #parts == 0 then return nil end
+
+  local rootIndex = parts[1]
+  if not rootIndex or rootIndex < 1 or rootIndex > #roots then
+    return nil
+  end
+
+  local element = roots[rootIndex]
+  local path = { tostring(rootIndex) }
+
+  for i = 2, #parts do
+    local childIndex = parts[i]
+    local directChildren = children(element)
+    if not childIndex or childIndex < 1 or childIndex > #directChildren then
+      return nil
+    end
+    element = directChildren[childIndex]
+    table.insert(path, tostring(childIndex))
+  end
+
+  return {
+    element = element,
+    node = nodeFrom(element, path),
+  }
+end
+
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then
+    fail("invalid payload JSON")
+  end
+  return payload
+end
+
+local payload = parsePayload()
+local selector = payload.selector or {}
+local roleFilter = selector.role and string.lower(tostring(selector.role)) or nil
+local titleFilter = selector.title_contains and string.lower(tostring(selector.title_contains)) or nil
+local identifierFilter = selector.identifier_contains and string.lower(tostring(selector.identifier_contains)) or nil
+local valueFilter = selector.value_contains and string.lower(tostring(selector.value_contains)) or nil
+local subroleFilter = selector.subrole and string.lower(tostring(selector.subrole)) or nil
+local focusedFilter = selector.focused
+local enabledFilter = selector.enabled
+local nth = selector.nth and tonumber(selector.nth) or nil
+local allowCoordinateFallback = payload.allow_coordinate_fallback and true or false
+
+local app, resolvedTarget = resolveApp(payload.target)
+if not app then
+  fail("unable to resolve target app process for ax.click")
+end
+
+local roots = rootsForApp(app, resolvedTarget)
+local matches = {}
+
+if selector.node_id then
+  local byId = resolveByNodeId(roots, selector.node_id)
+  if byId then
+    table.insert(matches, byId)
+  end
+else
+  local function walk(element, path)
+    local node = nodeFrom(element, path)
+    local roleMatch = (not roleFilter) or (string.lower(node.role or "") == roleFilter)
+    local title = string.lower(node.title or "")
+    local identifier = string.lower(node.identifier or "")
+    local value = string.lower(node.value_preview or "")
+    local subrole = string.lower(node.subrole or "")
+    local titleMatch = (not titleFilter) or string.find(title, titleFilter, 1, true) or string.find(identifier, titleFilter, 1, true)
+    local identifierMatch = (not identifierFilter) or string.find(identifier, identifierFilter, 1, true)
+    local valueMatch = (not valueFilter) or string.find(value, valueFilter, 1, true)
+    local subroleMatch = (not subroleFilter) or subrole == subroleFilter
+    local focusedMatch = (focusedFilter == nil) or (node.focused == focusedFilter)
+    local enabledMatch = (enabledFilter == nil) or (node.enabled == enabledFilter)
+    if roleMatch and titleMatch and identifierMatch and valueMatch and subroleMatch and focusedMatch and enabledMatch then
+      table.insert(matches, { element = element, node = node })
+    end
+
+    for index, child in ipairs(children(element)) do
+      local childPath = copyPath(path)
+      table.insert(childPath, tostring(index))
+      walk(child, childPath)
+    end
+  end
+
+  for rootIndex, root in ipairs(roots) do
+    walk(root, { tostring(rootIndex) })
+  end
+end
+
+if #matches == 0 then
+  fail("selector returned zero AX matches")
+end
+
+local selected
+if selector.node_id then
+  selected = matches[1]
+elseif nth then
+  if nth < 1 or nth > #matches then
+    fail("selector nth is out of range")
+  end
+  selected = matches[nth]
+else
+  if #matches ~= 1 then
+    fail("selector is ambiguous; add --nth or narrow role/title filters")
+  end
+  selected = matches[1]
+end
+
+local actions = asTable(safe(function() return selected.element:actionNames() end, {}))
+local actionToRun = nil
+for _, name in ipairs(actions) do
+  local value = normalize(name)
+  if value == "AXPress" or value == "AXConfirm" then
+    actionToRun = value
+    break
+  end
+end
+
+local result = {
+  node_id = selected.node.node_id,
+  matched_count = #matches,
+  action = "ax-press",
+  used_coordinate_fallback = false,
+}
+
+local performOk = false
+if actionToRun then
+  performOk = safe(function()
+    selected.element:performAction(actionToRun)
+    return true
+  end, false)
+end
+
+if not performOk then
+  if not allowCoordinateFallback then
+    fail("AXPress action unavailable")
+  end
+  local center = frameCenter(selected.element)
+  if not center then
+    fail("coordinate fallback requested but AXPosition/AXSize unavailable")
+  end
+  result.action = "ax-press-fallback"
+  result.used_coordinate_fallback = true
+  result.fallback_x = center.x
+  result.fallback_y = center.y
+end
+
+return json.encode(result)
+"#;
+
+const AX_TYPE_HS_SCRIPT: &str = r#"
+local json = hs.json
+local appmod = hs.application
+local ax = hs.axuielement
+local eventtap = hs.eventtap
+local pasteboard = hs.pasteboard
+
+local function fail(message)
+  error(message, 0)
+end
+
+local function safe(callable, fallback)
+  local ok, value = pcall(callable)
+  if ok then return value end
+  return fallback
+end
+
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+
+local function asTable(value)
+  if type(value) == "table" then return value end
+  return {}
+end
+
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+
+local function attr(element, name, fallback)
+  local value = safe(function() return element:attributeValue(name) end, fallback)
+  if value == nil then return fallback end
+  return value
+end
+
+local function boolAttr(element, name, fallback)
+  local value = attr(element, name, fallback)
+  if type(value) == "boolean" then return value end
+  if value == nil then return fallback end
+  return tostring(value):lower() == "true"
+end
+
+local function children(element)
+  return asTable(attr(element, "AXChildren", {}))
+end
+
+local function resolveTarget(rawTarget)
+  local target = rawTarget or {}
+  local state = ensureState()
+  if target.session_id and tostring(target.session_id) ~= "" then
+    local session = state.sessions[tostring(target.session_id)]
+    if not session then
+      fail("session_id does not exist")
+    end
+    return {
+      session_id = tostring(target.session_id),
+      app = target.app or session.app,
+      bundle_id = target.bundle_id or session.bundle_id,
+      pid = session.pid,
+      window_title_contains = target.window_title_contains or session.window_title_contains,
+    }
+  end
+  return target
+end
+
+local function resolveApp(target)
+  target = resolveTarget(target)
+
+  if target.pid then
+    local byPid = appmod.applicationForPID(tonumber(target.pid))
+    if byPid then return byPid, target end
+  end
+
+  if target.app and tostring(target.app) ~= "" then
+    local found = appmod.find(tostring(target.app))
+    if found then return found, target end
+  end
+
+  if target.bundle_id and tostring(target.bundle_id) ~= "" then
+    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
+    if type(apps) == "table" and #apps > 0 then
+      return apps[1], target
+    end
+  end
+
+  return appmod.frontmostApplication(), target
+end
+
+local function rootsForApp(app, target)
+  local appElement = ax.applicationElement(app)
+  if not appElement then
+    fail("unable to resolve target app process for ax.type")
+  end
+
+  local roots = asTable(attr(appElement, "AXWindows", {}))
+  if #roots == 0 then
+    roots = children(appElement)
+  end
+
+  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
+  if not windowFilter then
+    return roots
+  end
+
+  local filtered = {}
+  for _, root in ipairs(roots) do
+    local title = string.lower(normalize(attr(root, "AXTitle", "")))
+    if string.find(title, windowFilter, 1, true) then
+      table.insert(filtered, root)
+    end
+  end
+  return filtered
+end
+
+local function copyPath(path)
+  local out = {}
+  for i, value in ipairs(path) do
+    out[i] = value
+  end
+  return out
+end
+
+local function nodeFrom(element, path)
+  local role = normalize(attr(element, "AXRole", ""))
+  local title = normalize(attr(element, "AXTitle", ""))
+  local identifier = normalize(attr(element, "AXIdentifier", ""))
+  local subrole = normalize(attr(element, "AXSubrole", ""))
+  local value = normalize(attr(element, "AXValue", ""))
+  return {
+    node_id = table.concat(path, "."),
+    role = role,
+    title = title,
+    identifier = identifier,
+    subrole = subrole,
+    value_preview = value,
+    focused = boolAttr(element, "AXFocused", false),
+    enabled = boolAttr(element, "AXEnabled", true),
+  }
+end
+
+local function resolveByNodeId(roots, nodeId)
+  local parts = {}
+  for segment in string.gmatch(tostring(nodeId), "[^.]+") do
+    table.insert(parts, tonumber(segment))
+  end
+  if #parts == 0 then return nil end
+
+  local rootIndex = parts[1]
+  if not rootIndex or rootIndex < 1 or rootIndex > #roots then
+    return nil
+  end
+
+  local element = roots[rootIndex]
+  local path = { tostring(rootIndex) }
+
+  for i = 2, #parts do
+    local childIndex = parts[i]
+    local directChildren = children(element)
+    if not childIndex or childIndex < 1 or childIndex > #directChildren then
+      return nil
+    end
+    element = directChildren[childIndex]
+    table.insert(path, tostring(childIndex))
+  end
+
+  return {
+    element = element,
+    node = nodeFrom(element, path),
+  }
+end
+
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then
+    fail("invalid payload JSON")
+  end
+  return payload
+end
+
+local payload = parsePayload()
+local selector = payload.selector or {}
+local roleFilter = selector.role and string.lower(tostring(selector.role)) or nil
+local titleFilter = selector.title_contains and string.lower(tostring(selector.title_contains)) or nil
+local identifierFilter = selector.identifier_contains and string.lower(tostring(selector.identifier_contains)) or nil
+local valueFilter = selector.value_contains and string.lower(tostring(selector.value_contains)) or nil
+local subroleFilter = selector.subrole and string.lower(tostring(selector.subrole)) or nil
+local focusedFilter = selector.focused
+local enabledFilter = selector.enabled
+local nth = selector.nth and tonumber(selector.nth) or nil
+local text = payload.text and tostring(payload.text) or ""
+local allowKeyboardFallback = payload.allow_keyboard_fallback and true or false
+local clearFirst = payload.clear_first and true or false
+local submit = payload.submit and true or false
+local paste = payload.paste and true or false
+
+if text == "" then
+  fail("text cannot be empty")
+end
+
+local app, resolvedTarget = resolveApp(payload.target)
+if not app then
+  fail("unable to resolve target app process for ax.type")
+end
+safe(function() app:activate() end, nil)
+
+local roots = rootsForApp(app, resolvedTarget)
+local matches = {}
+
+if selector.node_id then
+  local byId = resolveByNodeId(roots, selector.node_id)
+  if byId then
+    table.insert(matches, byId)
+  end
+else
+  local function walk(element, path)
+    local node = nodeFrom(element, path)
+    local roleMatch = (not roleFilter) or (string.lower(node.role or "") == roleFilter)
+    local title = string.lower(node.title or "")
+    local identifier = string.lower(node.identifier or "")
+    local value = string.lower(node.value_preview or "")
+    local subrole = string.lower(node.subrole or "")
+    local titleMatch = (not titleFilter) or string.find(title, titleFilter, 1, true) or string.find(identifier, titleFilter, 1, true)
+    local identifierMatch = (not identifierFilter) or string.find(identifier, identifierFilter, 1, true)
+    local valueMatch = (not valueFilter) or string.find(value, valueFilter, 1, true)
+    local subroleMatch = (not subroleFilter) or subrole == subroleFilter
+    local focusedMatch = (focusedFilter == nil) or (node.focused == focusedFilter)
+    local enabledMatch = (enabledFilter == nil) or (node.enabled == enabledFilter)
+    if roleMatch and titleMatch and identifierMatch and valueMatch and subroleMatch and focusedMatch and enabledMatch then
+      table.insert(matches, { element = element, node = node })
+    end
+
+    for index, child in ipairs(children(element)) do
+      local childPath = copyPath(path)
+      table.insert(childPath, tostring(index))
+      walk(child, childPath)
+    end
+  end
+
+  for rootIndex, root in ipairs(roots) do
+    walk(root, { tostring(rootIndex) })
+  end
+end
+
+if #matches == 0 then
+  fail("selector returned zero AX matches")
+end
+
+local selected
+if selector.node_id then
+  selected = matches[1]
+elseif nth then
+  if nth < 1 or nth > #matches then
+    fail("selector nth is out of range")
+  end
+  selected = matches[nth]
+else
+  if #matches ~= 1 then
+    fail("selector is ambiguous; add --nth or narrow selector filters")
+  end
+  selected = matches[1]
+end
+
+local appliedVia = "ax-set-value"
+local usedKeyboardFallback = false
+
+local function applyPaste()
+  pasteboard.setContents(text)
+  eventtap.keyStroke({"cmd"}, "v", 0)
+end
+
+local appliedOk = safe(function()
+  safe(function() selected.element:setAttributeValue("AXFocused", true) end, nil)
+  if clearFirst then
+    safe(function() selected.element:setAttributeValue("AXValue", "") end, nil)
+  end
+  if paste then
+    applyPaste()
+    appliedVia = "ax-paste"
+  else
+    selected.element:setAttributeValue("AXValue", text)
+    appliedVia = "ax-set-value"
+  end
+  return true
+end, false)
+
+if not appliedOk then
+  if not allowKeyboardFallback then
+    fail("AX value set failed")
+  end
+
+  usedKeyboardFallback = true
+  if paste then
+    applyPaste()
+    appliedVia = "keyboard-paste-fallback"
+  else
+    eventtap.keyStrokes(text)
+    appliedVia = "keyboard-keystroke-fallback"
+  end
+end
+
+if submit then
+  eventtap.keyStroke({}, "return", 0)
+end
+
+return json.encode({
+  node_id = selected.node.node_id,
+  matched_count = #matches,
+  applied_via = appliedVia,
+  text_length = string.len(text),
+  submitted = submit,
+  used_keyboard_fallback = usedKeyboardFallback,
+})
+"#;
+
+const AX_ATTR_GET_HS_SCRIPT: &str = r#"
+local json = hs.json
+local appmod = hs.application
+local ax = hs.axuielement
+
+local function fail(message)
+  error(message, 0)
+end
+
+local function safe(callable, fallback)
+  local ok, value = pcall(callable)
+  if ok then return value end
+  return fallback
+end
+
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+
+local function asTable(value)
+  if type(value) == "table" then return value end
+  return {}
+end
+
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+
+local function attr(element, name, fallback)
+  local value = safe(function() return element:attributeValue(name) end, fallback)
+  if value == nil then return fallback end
+  return value
+end
+
+local function boolAttr(element, name, fallback)
+  local value = attr(element, name, fallback)
+  if type(value) == "boolean" then return value end
+  if value == nil then return fallback end
+  return tostring(value):lower() == "true"
+end
+
+local function children(element)
+  return asTable(attr(element, "AXChildren", {}))
+end
+
+local function resolveTarget(rawTarget)
+  local target = rawTarget or {}
+  local state = ensureState()
+
+  if target.session_id and tostring(target.session_id) ~= "" then
+    local session = state.sessions[tostring(target.session_id)]
+    if not session then
+      fail("session_id does not exist")
+    end
+    return {
+      session_id = tostring(target.session_id),
+      app = target.app or session.app,
+      bundle_id = target.bundle_id or session.bundle_id,
+      pid = session.pid,
+      window_title_contains = target.window_title_contains or session.window_title_contains,
+    }
+  end
+
+  return target
+end
+
+local function resolveApp(target)
+  target = resolveTarget(target)
+
+  if target.pid then
+    local byPid = appmod.applicationForPID(tonumber(target.pid))
+    if byPid then return byPid end
+  end
+
+  if target.app and tostring(target.app) ~= "" then
+    local found = appmod.find(tostring(target.app))
+    if found then return found, target end
+  end
+
+  if target.bundle_id and tostring(target.bundle_id) ~= "" then
+    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
+    if type(apps) == "table" and #apps > 0 then
+      return apps[1], target
+    end
+  end
+
+  return appmod.frontmostApplication(), target
+end
+
+local function rootsForApp(app, target)
+  local appElement = ax.applicationElement(app)
+  if not appElement then
+    fail("unable to resolve target app process for ax.attr.get")
+  end
+
+  local roots = asTable(attr(appElement, "AXWindows", {}))
+  if #roots == 0 then
+    roots = children(appElement)
+  end
+
+  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
+  if not windowFilter then
+    return roots
+  end
+
+  local filtered = {}
+  for _, root in ipairs(roots) do
+    local title = string.lower(normalize(attr(root, "AXTitle", "")))
+    if string.find(title, windowFilter, 1, true) then
+      table.insert(filtered, root)
+    end
+  end
+  return filtered
+end
+
+local function copyPath(path)
+  local out = {}
+  for i, value in ipairs(path) do
+    out[i] = value
+  end
+  return out
+end
+
+local function nodeFrom(element, path)
+  local role = normalize(attr(element, "AXRole", ""))
+  local title = normalize(attr(element, "AXTitle", ""))
+  local identifier = normalize(attr(element, "AXIdentifier", ""))
+  local subrole = normalize(attr(element, "AXSubrole", ""))
+  local value = normalize(attr(element, "AXValue", ""))
+  return {
+    node_id = table.concat(path, "."),
+    role = role,
+    title = title,
+    identifier = identifier,
+    subrole = subrole,
+    value_preview = value,
+    focused = boolAttr(element, "AXFocused", false),
+    enabled = boolAttr(element, "AXEnabled", true),
+  }
+end
+
+local function matches(node, selector)
+  selector = selector or {}
+
+  if selector.role and string.lower(node.role or "") ~= string.lower(tostring(selector.role)) then
+    return false
+  end
+  if selector.title_contains and not string.find(string.lower(node.title or ""), string.lower(tostring(selector.title_contains)), 1, true) then
+    return false
+  end
+  if selector.identifier_contains and not string.find(string.lower(node.identifier or ""), string.lower(tostring(selector.identifier_contains)), 1, true) then
+    return false
+  end
+  if selector.value_contains and not string.find(string.lower(node.value_preview or ""), string.lower(tostring(selector.value_contains)), 1, true) then
+    return false
+  end
+  if selector.subrole and string.lower(node.subrole or "") ~= string.lower(tostring(selector.subrole)) then
+    return false
+  end
+  if selector.focused ~= nil and node.focused ~= selector.focused then
+    return false
+  end
+  if selector.enabled ~= nil and node.enabled ~= selector.enabled then
+    return false
+  end
+  return true
+end
+
+local function resolveByNodeId(roots, nodeId)
+  local parts = {}
+  for segment in string.gmatch(tostring(nodeId), "[^.]+") do
+    table.insert(parts, tonumber(segment))
+  end
+  if #parts == 0 then return nil end
+
+  local rootIndex = parts[1]
+  if not rootIndex or rootIndex < 1 or rootIndex > #roots then
+    return nil
+  end
+
+  local element = roots[rootIndex]
+  local path = { tostring(rootIndex) }
+  for i = 2, #parts do
+    local childIndex = parts[i]
+    local directChildren = children(element)
+    if not childIndex or childIndex < 1 or childIndex > #directChildren then
+      return nil
+    end
+    element = directChildren[childIndex]
+    table.insert(path, tostring(childIndex))
+  end
+  return { element = element, node = nodeFrom(element, path) }
+end
+
+local function collectMatches(roots, selector)
+  local matchesOut = {}
+
+  if selector.node_id then
+    local byId = resolveByNodeId(roots, selector.node_id)
+    if byId then
+      table.insert(matchesOut, byId)
+    end
+    return matchesOut
+  end
+
+  local function walk(element, path)
+    local node = nodeFrom(element, path)
+    if matches(node, selector) then
+      table.insert(matchesOut, { element = element, node = node })
+    end
+    for index, child in ipairs(children(element)) do
+      local childPath = copyPath(path)
+      table.insert(childPath, tostring(index))
+      walk(child, childPath)
+    end
+  end
+
+  for rootIndex, root in ipairs(roots) do
+    walk(root, { tostring(rootIndex) })
+  end
+  return matchesOut
+end
+
+local function selectOne(matchesOut, selector)
+  if #matchesOut == 0 then
+    fail("selector returned zero AX matches")
+  end
+
+  if selector.node_id then
+    return matchesOut[1], #matchesOut
+  end
+
+  local nth = selector.nth and tonumber(selector.nth) or nil
+  if nth then
+    if nth < 1 or nth > #matchesOut then
+      fail("selector nth is out of range")
+    end
+    return matchesOut[nth], #matchesOut
+  end
+
+  if #matchesOut ~= 1 then
+    fail("selector is ambiguous; add --nth or narrow selector filters")
+  end
+
+  return matchesOut[1], #matchesOut
+end
+
+local function sanitize(value, depth)
+  depth = depth or 0
+  if depth > 6 then
+    return tostring(value)
+  end
+
+  local kind = type(value)
+  if kind == "nil" then
+    return json.null
+  end
+  if kind == "string" or kind == "number" or kind == "boolean" then
+    return value
+  end
+  if kind == "table" then
+    local out = {}
+    local count = 0
+    local maxIndex = 0
+    local isArray = true
+    for key, _ in pairs(value) do
+      count = count + 1
+      if type(key) ~= "number" or key < 1 or key % 1 ~= 0 then
+        isArray = false
+        break
+      end
+      if key > maxIndex then maxIndex = key end
+    end
+    if isArray and maxIndex ~= count then
+      isArray = false
+    end
+    if isArray then
+      for i = 1, maxIndex do
+        out[i] = sanitize(value[i], depth + 1)
+      end
+    else
+      for key, child in pairs(value) do
+        out[tostring(key)] = sanitize(child, depth + 1)
+      end
+    end
+    return out
+  end
+  return tostring(value)
+end
+
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then
+    fail("invalid payload JSON")
+  end
+  return payload
+end
+
+local payload = parsePayload()
+local selector = payload.selector or {}
+local app, target = resolveApp(payload.target)
+if not app then
+  fail("unable to resolve target app process for ax.attr.get")
+end
+
+local roots = rootsForApp(app, target)
+local matchesOut = collectMatches(roots, selector)
+local selected, matchedCount = selectOne(matchesOut, selector)
+local name = normalize(payload.name)
+if name == "" then
+  fail("attribute name cannot be empty")
+end
+local value = sanitize(attr(selected.element, name, nil), 0)
+
+return json.encode({
+  node_id = selected.node.node_id,
+  matched_count = matchedCount,
+  name = name,
+  value = value,
+})
+"#;
+
+const AX_ATTR_SET_HS_SCRIPT: &str = r#"
+local json = hs.json
+local appmod = hs.application
+local ax = hs.axuielement
+
+local function fail(message)
+  error(message, 0)
+end
+
+local function safe(callable, fallback)
+  local ok, value = pcall(callable)
+  if ok then return value end
+  return fallback
+end
+
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+
+local function asTable(value)
+  if type(value) == "table" then return value end
+  return {}
+end
+
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+
+local function attr(element, name, fallback)
+  local value = safe(function() return element:attributeValue(name) end, fallback)
+  if value == nil then return fallback end
+  return value
+end
+
+local function boolAttr(element, name, fallback)
+  local value = attr(element, name, fallback)
+  if type(value) == "boolean" then return value end
+  if value == nil then return fallback end
+  return tostring(value):lower() == "true"
+end
+
+local function children(element)
+  return asTable(attr(element, "AXChildren", {}))
+end
+
+local function resolveTarget(rawTarget)
+  local target = rawTarget or {}
+  local state = ensureState()
+  if target.session_id and tostring(target.session_id) ~= "" then
+    local session = state.sessions[tostring(target.session_id)]
+    if not session then fail("session_id does not exist") end
+    return {
+      session_id = tostring(target.session_id),
+      app = target.app or session.app,
+      bundle_id = target.bundle_id or session.bundle_id,
+      pid = session.pid,
+      window_title_contains = target.window_title_contains or session.window_title_contains,
+    }
+  end
+  return target
+end
+
+local function resolveApp(target)
+  target = resolveTarget(target)
+
+  if target.pid then
+    local byPid = appmod.applicationForPID(tonumber(target.pid))
+    if byPid then return byPid, target end
+  end
+
+  if target.app and tostring(target.app) ~= "" then
+    local found = appmod.find(tostring(target.app))
+    if found then return found, target end
+  end
+
+  if target.bundle_id and tostring(target.bundle_id) ~= "" then
+    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
+    if type(apps) == "table" and #apps > 0 then
+      return apps[1], target
+    end
+  end
+
+  return appmod.frontmostApplication(), target
+end
+
+local function rootsForApp(app, target)
+  local appElement = ax.applicationElement(app)
+  if not appElement then fail("unable to resolve target app process for ax.attr.set") end
+
+  local roots = asTable(attr(appElement, "AXWindows", {}))
+  if #roots == 0 then roots = children(appElement) end
+
+  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
+  if not windowFilter then return roots end
+
+  local filtered = {}
+  for _, root in ipairs(roots) do
+    local title = string.lower(normalize(attr(root, "AXTitle", "")))
+    if string.find(title, windowFilter, 1, true) then
+      table.insert(filtered, root)
+    end
+  end
+  return filtered
+end
+
+local function copyPath(path)
+  local out = {}
+  for i, value in ipairs(path) do out[i] = value end
+  return out
+end
+
+local function nodeFrom(element, path)
+  return {
+    node_id = table.concat(path, "."),
+    role = normalize(attr(element, "AXRole", "")),
+    title = normalize(attr(element, "AXTitle", "")),
+    identifier = normalize(attr(element, "AXIdentifier", "")),
+    subrole = normalize(attr(element, "AXSubrole", "")),
+    value_preview = normalize(attr(element, "AXValue", "")),
+    focused = boolAttr(element, "AXFocused", false),
+    enabled = boolAttr(element, "AXEnabled", true),
+  }
+end
+
+local function matches(node, selector)
+  selector = selector or {}
+  if selector.role and string.lower(node.role or "") ~= string.lower(tostring(selector.role)) then return false end
+  if selector.title_contains and not string.find(string.lower(node.title or ""), string.lower(tostring(selector.title_contains)), 1, true) then return false end
+  if selector.identifier_contains and not string.find(string.lower(node.identifier or ""), string.lower(tostring(selector.identifier_contains)), 1, true) then return false end
+  if selector.value_contains and not string.find(string.lower(node.value_preview or ""), string.lower(tostring(selector.value_contains)), 1, true) then return false end
+  if selector.subrole and string.lower(node.subrole or "") ~= string.lower(tostring(selector.subrole)) then return false end
+  if selector.focused ~= nil and node.focused ~= selector.focused then return false end
+  if selector.enabled ~= nil and node.enabled ~= selector.enabled then return false end
+  return true
+end
+
+local function resolveByNodeId(roots, nodeId)
+  local parts = {}
+  for segment in string.gmatch(tostring(nodeId), "[^.]+") do table.insert(parts, tonumber(segment)) end
+  if #parts == 0 then return nil end
+
+  local rootIndex = parts[1]
+  if not rootIndex or rootIndex < 1 or rootIndex > #roots then return nil end
+
+  local element = roots[rootIndex]
+  local path = { tostring(rootIndex) }
+  for i = 2, #parts do
+    local childIndex = parts[i]
+    local directChildren = children(element)
+    if not childIndex or childIndex < 1 or childIndex > #directChildren then return nil end
+    element = directChildren[childIndex]
+    table.insert(path, tostring(childIndex))
+  end
+  return { element = element, node = nodeFrom(element, path) }
+end
+
+local function collectMatches(roots, selector)
+  local matchesOut = {}
+
+  if selector.node_id then
+    local byId = resolveByNodeId(roots, selector.node_id)
+    if byId then table.insert(matchesOut, byId) end
+    return matchesOut
+  end
+
+  local function walk(element, path)
+    local node = nodeFrom(element, path)
+    if matches(node, selector) then table.insert(matchesOut, { element = element, node = node }) end
+    for index, child in ipairs(children(element)) do
+      local childPath = copyPath(path)
+      table.insert(childPath, tostring(index))
+      walk(child, childPath)
+    end
+  end
+
+  for rootIndex, root in ipairs(roots) do
+    walk(root, { tostring(rootIndex) })
+  end
+  return matchesOut
+end
+
+local function selectOne(matchesOut, selector)
+  if #matchesOut == 0 then fail("selector returned zero AX matches") end
+  if selector.node_id then return matchesOut[1], #matchesOut end
+
+  local nth = selector.nth and tonumber(selector.nth) or nil
+  if nth then
+    if nth < 1 or nth > #matchesOut then fail("selector nth is out of range") end
+    return matchesOut[nth], #matchesOut
+  end
+  if #matchesOut ~= 1 then fail("selector is ambiguous; add --nth or narrow selector filters") end
+  return matchesOut[1], #matchesOut
+end
+
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then fail("invalid payload JSON") end
+  return payload
+end
+
+local payload = parsePayload()
+local name = normalize(payload.name)
+if name == "" then fail("attribute name cannot be empty") end
+
+local app, target = resolveApp(payload.target)
+if not app then fail("unable to resolve target app process for ax.attr.set") end
+
+local roots = rootsForApp(app, target)
+local matchesOut = collectMatches(roots, payload.selector or {})
+local selected, matchedCount = selectOne(matchesOut, payload.selector or {})
+
+local applied = safe(function()
+  selected.element:setAttributeValue(name, payload.value)
+  return true
+end, false)
+if not applied then
+  fail("failed to set AX attribute value")
+end
+
+local valueType = type(payload.value)
+if payload.value == json.null then
+  valueType = "null"
+end
+
+return json.encode({
+  node_id = selected.node.node_id,
+  matched_count = matchedCount,
+  name = name,
+  applied = true,
+  value_type = valueType,
+})
+"#;
+
+const AX_ACTION_PERFORM_HS_SCRIPT: &str = r#"
+local json = hs.json
+local appmod = hs.application
+local ax = hs.axuielement
+
+local function fail(message) error(message, 0) end
+local function safe(callable, fallback)
+  local ok, value = pcall(callable)
+  if ok then return value end
+  return fallback
+end
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+local function asTable(value)
+  if type(value) == "table" then return value end
+  return {}
+end
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+local function attr(element, name, fallback)
+  local value = safe(function() return element:attributeValue(name) end, fallback)
+  if value == nil then return fallback end
+  return value
+end
+local function boolAttr(element, name, fallback)
+  local value = attr(element, name, fallback)
+  if type(value) == "boolean" then return value end
+  if value == nil then return fallback end
+  return tostring(value):lower() == "true"
+end
+local function children(element)
+  return asTable(attr(element, "AXChildren", {}))
+end
+local function resolveTarget(rawTarget)
+  local target = rawTarget or {}
+  local state = ensureState()
+  if target.session_id and tostring(target.session_id) ~= "" then
+    local session = state.sessions[tostring(target.session_id)]
+    if not session then fail("session_id does not exist") end
+    return {
+      session_id = tostring(target.session_id),
+      app = target.app or session.app,
+      bundle_id = target.bundle_id or session.bundle_id,
+      pid = session.pid,
+      window_title_contains = target.window_title_contains or session.window_title_contains,
+    }
+  end
+  return target
+end
+local function resolveApp(target)
+  target = resolveTarget(target)
+  if target.pid then
+    local byPid = appmod.applicationForPID(tonumber(target.pid))
+    if byPid then return byPid, target end
+  end
+  if target.app and tostring(target.app) ~= "" then
+    local found = appmod.find(tostring(target.app))
+    if found then return found, target end
+  end
+  if target.bundle_id and tostring(target.bundle_id) ~= "" then
+    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
+    if type(apps) == "table" and #apps > 0 then return apps[1], target end
+  end
+  return appmod.frontmostApplication(), target
+end
+local function rootsForApp(app, target)
+  local appElement = ax.applicationElement(app)
+  if not appElement then fail("unable to resolve target app process for ax.action.perform") end
+  local roots = asTable(attr(appElement, "AXWindows", {}))
+  if #roots == 0 then roots = children(appElement) end
+  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
+  if not windowFilter then return roots end
+  local filtered = {}
+  for _, root in ipairs(roots) do
+    local title = string.lower(normalize(attr(root, "AXTitle", "")))
+    if string.find(title, windowFilter, 1, true) then table.insert(filtered, root) end
+  end
+  return filtered
+end
+local function copyPath(path)
+  local out = {}
+  for i, value in ipairs(path) do out[i] = value end
+  return out
+end
+local function nodeFrom(element, path)
+  return {
+    node_id = table.concat(path, "."),
+    role = normalize(attr(element, "AXRole", "")),
+    title = normalize(attr(element, "AXTitle", "")),
+    identifier = normalize(attr(element, "AXIdentifier", "")),
+    subrole = normalize(attr(element, "AXSubrole", "")),
+    value_preview = normalize(attr(element, "AXValue", "")),
+    focused = boolAttr(element, "AXFocused", false),
+    enabled = boolAttr(element, "AXEnabled", true),
+  }
+end
+local function matches(node, selector)
+  selector = selector or {}
+  if selector.role and string.lower(node.role or "") ~= string.lower(tostring(selector.role)) then return false end
+  if selector.title_contains and not string.find(string.lower(node.title or ""), string.lower(tostring(selector.title_contains)), 1, true) then return false end
+  if selector.identifier_contains and not string.find(string.lower(node.identifier or ""), string.lower(tostring(selector.identifier_contains)), 1, true) then return false end
+  if selector.value_contains and not string.find(string.lower(node.value_preview or ""), string.lower(tostring(selector.value_contains)), 1, true) then return false end
+  if selector.subrole and string.lower(node.subrole or "") ~= string.lower(tostring(selector.subrole)) then return false end
+  if selector.focused ~= nil and node.focused ~= selector.focused then return false end
+  if selector.enabled ~= nil and node.enabled ~= selector.enabled then return false end
+  return true
+end
+local function resolveByNodeId(roots, nodeId)
+  local parts = {}
+  for segment in string.gmatch(tostring(nodeId), "[^.]+") do table.insert(parts, tonumber(segment)) end
+  if #parts == 0 then return nil end
+  local rootIndex = parts[1]
+  if not rootIndex or rootIndex < 1 or rootIndex > #roots then return nil end
+  local element = roots[rootIndex]
+  local path = { tostring(rootIndex) }
+  for i = 2, #parts do
+    local childIndex = parts[i]
+    local directChildren = children(element)
+    if not childIndex or childIndex < 1 or childIndex > #directChildren then return nil end
+    element = directChildren[childIndex]
+    table.insert(path, tostring(childIndex))
+  end
+  return { element = element, node = nodeFrom(element, path) }
+end
+local function collectMatches(roots, selector)
+  local matchesOut = {}
+  if selector.node_id then
+    local byId = resolveByNodeId(roots, selector.node_id)
+    if byId then table.insert(matchesOut, byId) end
+    return matchesOut
+  end
+  local function walk(element, path)
+    local node = nodeFrom(element, path)
+    if matches(node, selector) then table.insert(matchesOut, { element = element, node = node }) end
+    for index, child in ipairs(children(element)) do
+      local childPath = copyPath(path)
+      table.insert(childPath, tostring(index))
+      walk(child, childPath)
+    end
+  end
+  for rootIndex, root in ipairs(roots) do walk(root, { tostring(rootIndex) }) end
+  return matchesOut
+end
+local function selectOne(matchesOut, selector)
+  if #matchesOut == 0 then fail("selector returned zero AX matches") end
+  if selector.node_id then return matchesOut[1], #matchesOut end
+  local nth = selector.nth and tonumber(selector.nth) or nil
+  if nth then
+    if nth < 1 or nth > #matchesOut then fail("selector nth is out of range") end
+    return matchesOut[nth], #matchesOut
+  end
+  if #matchesOut ~= 1 then fail("selector is ambiguous; add --nth or narrow selector filters") end
+  return matchesOut[1], #matchesOut
+end
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then fail("invalid payload JSON") end
+  return payload
+end
+
+local payload = parsePayload()
+local name = normalize(payload.name)
+if name == "" then fail("action name cannot be empty") end
+
+local app, target = resolveApp(payload.target)
+if not app then fail("unable to resolve target app process for ax.action.perform") end
+
+local roots = rootsForApp(app, target)
+local matchesOut = collectMatches(roots, payload.selector or {})
+local selected, matchedCount = selectOne(matchesOut, payload.selector or {})
+local performed = safe(function()
+  selected.element:performAction(name)
+  return true
+end, false)
+if not performed then fail("failed to perform AX action") end
+
+return json.encode({
+  node_id = selected.node.node_id,
+  matched_count = matchedCount,
+  name = name,
+  performed = true,
+})
+"#;
+
+const AX_SESSION_START_HS_SCRIPT: &str = r#"
+local json = hs.json
+local appmod = hs.application
+local timer = hs.timer
+
+local function fail(message) error(message, 0) end
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+local function nowMs()
+  return math.floor((timer.secondsSinceEpoch and timer.secondsSinceEpoch() or os.time()) * 1000)
+end
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then fail("invalid payload JSON") end
+  return payload
+end
+local function resolveApp(target)
+  target = target or {}
+  if target.app and normalize(target.app) ~= "" then
+    local found = appmod.find(normalize(target.app))
+    if found then return found end
+  end
+  if target.bundle_id and normalize(target.bundle_id) ~= "" then
+    local apps = appmod.applicationsForBundleID(normalize(target.bundle_id))
+    if type(apps) == "table" and #apps > 0 then return apps[1] end
+  end
+  return appmod.frontmostApplication()
+end
+local function generateSessionId()
+  return string.format("axs-%d-%d", os.time(), math.random(1000, 999999))
+end
+
+local payload = parsePayload()
+local target = payload.target or {}
+local app = resolveApp(target)
+if not app then fail("unable to resolve target app process for ax.session.start") end
+
+local state = ensureState()
+local requestedId = normalize(payload.session_id)
+if requestedId == "" then requestedId = normalize(target.session_id) end
+if requestedId == "" then requestedId = generateSessionId() end
+local existing = state.sessions[requestedId]
+
+local createdAt = existing and existing.created_at_ms or nowMs()
+local info = {
+  session_id = requestedId,
+  app = normalize(target.app) ~= "" and normalize(target.app) or app:name(),
+  bundle_id = normalize(target.bundle_id) ~= "" and normalize(target.bundle_id) or app:bundleID(),
+  pid = app:pid(),
+  window_title_contains = target.window_title_contains and tostring(target.window_title_contains) or nil,
+  created_at_ms = createdAt,
+}
+state.sessions[requestedId] = info
+
+return json.encode({
+  session_id = info.session_id,
+  app = info.app,
+  bundle_id = info.bundle_id,
+  pid = info.pid,
+  window_title_contains = info.window_title_contains,
+  created_at_ms = info.created_at_ms,
+  created = existing == nil,
+})
+"#;
+
+const AX_SESSION_LIST_HS_SCRIPT: &str = r#"
+local json = hs.json
+
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+
+local state = ensureState()
+local sessions = {}
+for _, session in pairs(state.sessions) do
+  table.insert(sessions, {
+    session_id = session.session_id,
+    app = session.app,
+    bundle_id = session.bundle_id,
+    pid = session.pid,
+    window_title_contains = session.window_title_contains,
+    created_at_ms = session.created_at_ms or 0,
+  })
+end
+table.sort(sessions, function(a, b) return (a.session_id or "") < (b.session_id or "") end)
+return json.encode({ sessions = sessions })
+"#;
+
+const AX_SESSION_STOP_HS_SCRIPT: &str = r#"
+local json = hs.json
+
+local function fail(message) error(message, 0) end
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then fail("invalid payload JSON") end
+  return payload
+end
+
+local payload = parsePayload()
+local sessionId = normalize(payload.session_id)
+if sessionId == "" then fail("session_id cannot be empty") end
+
+local state = ensureState()
+local removed = state.sessions[sessionId] ~= nil
+state.sessions[sessionId] = nil
+
+for watchId, slot in pairs(state.watchers) do
+  if slot and slot.session_id == sessionId then
+    if slot.observer and slot.observer.stop then pcall(function() slot.observer:stop() end) end
+    state.watchers[watchId] = nil
+  end
+end
+
+return json.encode({
+  session_id = sessionId,
+  removed = removed,
+})
+"#;
+
+const AX_WATCH_START_HS_SCRIPT: &str = r#"
+local json = hs.json
+local appmod = hs.application
+local ax = hs.axuielement
+local observermod = hs.axuielement and hs.axuielement.observer or nil
+local timer = hs.timer
+
+local function fail(message) error(message, 0) end
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+local function asTable(value)
+  if type(value) == "table" then return value end
+  return {}
+end
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+local function nowMs()
+  return math.floor((timer.secondsSinceEpoch and timer.secondsSinceEpoch() or os.time()) * 1000)
+end
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then fail("invalid payload JSON") end
+  return payload
+end
+local function generateWatchId()
+  return string.format("axw-%d-%d", os.time(), math.random(1000, 999999))
+end
+local function resolveAppFromSession(session)
+  if session.pid then
+    local byPid = appmod.applicationForPID(tonumber(session.pid))
+    if byPid then return byPid end
+  end
+  if session.app and normalize(session.app) ~= "" then
+    local byName = appmod.find(normalize(session.app))
+    if byName then return byName end
+  end
+  if session.bundle_id and normalize(session.bundle_id) ~= "" then
+    local apps = appmod.applicationsForBundleID(normalize(session.bundle_id))
+    if type(apps) == "table" and #apps > 0 then return apps[1] end
+  end
+  return nil
+end
+
+local payload = parsePayload()
+local sessionId = normalize(payload.session_id)
+if sessionId == "" then fail("session_id cannot be empty") end
+local state = ensureState()
+local session = state.sessions[sessionId]
+if not session then fail("session_id does not exist") end
+
+local app = resolveAppFromSession(session)
+if not app then fail("unable to resolve app from session") end
+if not observermod or not observermod.new then
+  fail("AX observer backend unavailable in Hammerspoon runtime")
+end
+
+local watchId = normalize(payload.watch_id)
+if watchId == "" then watchId = generateWatchId() end
+
+local events = asTable(payload.events)
+if #events == 0 then
+  events = { "AXFocusedUIElementChanged", "AXTitleChanged" }
+end
+local normalizedEvents = {}
+for _, eventName in ipairs(events) do
+  local value = normalize(eventName)
+  if value ~= "" then
+    table.insert(normalizedEvents, value)
+  end
+end
+if #normalizedEvents == 0 then
+  normalizedEvents = { "AXFocusedUIElementChanged", "AXTitleChanged" }
+end
+
+local maxBuffer = tonumber(payload.max_buffer) or 256
+if maxBuffer < 1 then maxBuffer = 1 end
+
+local slot = state.watchers[watchId]
+if slot and slot.observer and slot.observer.stop then
+  pcall(function() slot.observer:stop() end)
+end
+
+local appElement = ax.applicationElement(app)
+if not appElement then fail("unable to resolve AX application element from session") end
+local pid = tonumber(session.pid) or app:pid()
+if not pid then fail("unable to resolve app pid from session") end
+
+slot = {
+  watch_id = watchId,
+  session_id = sessionId,
+  events = normalizedEvents,
+  max_buffer = maxBuffer,
+  dropped = 0,
+  buffer = {},
+  observed_pid = pid,
+}
+
+local function safeAttr(element, name)
+  local ok, value = pcall(function() return element:attributeValue(name) end)
+  if ok then return value end
+  return nil
+end
+
+local function callback(_, element, eventName, details)
+  local current = state.watchers[watchId]
+  if not current then return end
+  local evt = {
+    watch_id = watchId,
+    event = tostring(eventName),
+    at_ms = nowMs(),
+    pid = current.observed_pid,
+  }
+  if element then
+    local role = safeAttr(element, "AXRole")
+    local title = safeAttr(element, "AXTitle")
+    local identifier = safeAttr(element, "AXIdentifier")
+    evt.role = role and tostring(role) or nil
+    evt.title = title and tostring(title) or nil
+    evt.identifier = identifier and tostring(identifier) or nil
+  end
+  table.insert(current.buffer, evt)
+  while #current.buffer > current.max_buffer do
+    table.remove(current.buffer, 1)
+    current.dropped = (current.dropped or 0) + 1
+  end
+end
+
+local observer = observermod.new(pid)
+if not observer then fail("failed to create AX observer") end
+observer:callback(callback)
+
+local registered = {}
+for _, eventName in ipairs(normalizedEvents) do
+  local ok = pcall(function()
+    observer:addWatcher(appElement, eventName)
+  end)
+  if ok then
+    table.insert(registered, eventName)
+  end
+end
+if #registered == 0 then
+  fail("failed to register AX notifications for observer")
+end
+
+local started = pcall(function()
+  observer:start()
+end)
+if not started then
+  fail("failed to start AX observer")
+end
+
+slot.observer = observer
+slot.events = registered
+state.watchers[watchId] = slot
+
+return json.encode({
+  watch_id = watchId,
+  session_id = sessionId,
+  events = registered,
+  max_buffer = maxBuffer,
+  started = true,
+})
+"#;
+
+const AX_WATCH_POLL_HS_SCRIPT: &str = r#"
+local json = hs.json
+
+local function fail(message) error(message, 0) end
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then fail("invalid payload JSON") end
+  return payload
+end
+
+local payload = parsePayload()
+local watchId = normalize(payload.watch_id)
+if watchId == "" then fail("watch_id cannot be empty") end
+local limit = tonumber(payload.limit) or 50
+if limit < 1 then limit = 1 end
+local drain = payload.drain
+if drain == nil then drain = true end
+
+local state = ensureState()
+local slot = state.watchers[watchId]
+if not slot then fail("watch_id does not exist") end
+
+local events = {}
+local available = #slot.buffer
+local take = math.min(available, limit)
+for i = 1, take do
+  table.insert(events, slot.buffer[i])
+end
+
+if drain then
+  for _ = 1, take do
+    table.remove(slot.buffer, 1)
+  end
+end
+
+local running = false
+if slot.observer and slot.observer.isRunning then
+  local ok, value = pcall(function() return slot.observer:isRunning() end)
+  if ok then running = value and true or false end
+end
+
+return json.encode({
+  watch_id = watchId,
+  events = events,
+  dropped = slot.dropped or 0,
+  running = running,
+})
+"#;
+
+const AX_WATCH_STOP_HS_SCRIPT: &str = r#"
+local json = hs.json
+
+local function fail(message) error(message, 0) end
+local function normalize(value)
+  if value == nil then return "" end
+  return tostring(value)
+end
+local function ensureState()
+  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
+  return _G.__codex_macos_agent_ax
+end
+local function parsePayload()
+  local raw = (_cli and _cli.args and _cli.args[1]) or "{}"
+  local payload = json.decode(raw)
+  if type(payload) ~= "table" then fail("invalid payload JSON") end
+  return payload
+end
+
+local payload = parsePayload()
+local watchId = normalize(payload.watch_id)
+if watchId == "" then fail("watch_id cannot be empty") end
+local state = ensureState()
+local slot = state.watchers[watchId]
+if not slot then
+  return json.encode({ watch_id = watchId, stopped = false, drained = 0 })
+end
+
+local drained = #(slot.buffer or {})
+if slot.observer and slot.observer.stop then
+  pcall(function() slot.observer:stop() end)
+end
+state.watchers[watchId] = nil
+return json.encode({
+  watch_id = watchId,
+  stopped = true,
+  drained = drained,
+})
+"#;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct HammerspoonAxBackend;
+
+impl AxBackendAdapter for HammerspoonAxBackend {
+    fn list(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxListRequest,
+        timeout_ms: u64,
+    ) -> Result<AxListResult, CliError> {
+        run_hs_json(
+            runner,
+            "ax.list",
+            request,
+            AX_LIST_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn click(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxClickRequest,
+        timeout_ms: u64,
+    ) -> Result<AxClickResult, CliError> {
+        if selector_is_empty(&request.selector) {
+            return Err(
+                CliError::ax_contract_failure("ax.click", "selector is empty")
+                    .with_operation("ax.click.hammerspoon")
+                    .with_hint("Provide --node-id or selector filters (--role/--title-contains)."),
+            );
+        }
+
+        run_hs_json(
+            runner,
+            "ax.click",
+            request,
+            AX_CLICK_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn type_text(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxTypeRequest,
+        timeout_ms: u64,
+    ) -> Result<AxTypeResult, CliError> {
+        if request.text.trim().is_empty() {
+            return Err(
+                CliError::usage("--text cannot be empty").with_operation("ax.type.hammerspoon")
+            );
+        }
+        if selector_is_empty(&request.selector) {
+            return Err(
+                CliError::ax_contract_failure("ax.type", "selector is empty")
+                    .with_operation("ax.type.hammerspoon")
+                    .with_hint("Provide --node-id or selector filters (--role/--title-contains)."),
+            );
+        }
+
+        run_hs_json(
+            runner,
+            "ax.type",
+            request,
+            AX_TYPE_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn attr_get(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxAttrGetRequest,
+        timeout_ms: u64,
+    ) -> Result<AxAttrGetResult, CliError> {
+        if request.name.trim().is_empty() {
+            return Err(
+                CliError::usage("--name cannot be empty").with_operation("ax.attr.get.hammerspoon")
+            );
+        }
+        if selector_is_empty(&request.selector) {
+            return Err(
+                CliError::ax_contract_failure("ax.attr.get", "selector is empty")
+                    .with_operation("ax.attr.get.hammerspoon")
+                    .with_hint("Provide --node-id or selector filters."),
+            );
+        }
+
+        run_hs_json(
+            runner,
+            "ax.attr.get",
+            request,
+            AX_ATTR_GET_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn attr_set(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxAttrSetRequest,
+        timeout_ms: u64,
+    ) -> Result<AxAttrSetResult, CliError> {
+        if request.name.trim().is_empty() {
+            return Err(
+                CliError::usage("--name cannot be empty").with_operation("ax.attr.set.hammerspoon")
+            );
+        }
+        if selector_is_empty(&request.selector) {
+            return Err(
+                CliError::ax_contract_failure("ax.attr.set", "selector is empty")
+                    .with_operation("ax.attr.set.hammerspoon")
+                    .with_hint("Provide --node-id or selector filters."),
+            );
+        }
+
+        run_hs_json(
+            runner,
+            "ax.attr.set",
+            request,
+            AX_ATTR_SET_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn action_perform(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxActionPerformRequest,
+        timeout_ms: u64,
+    ) -> Result<AxActionPerformResult, CliError> {
+        if request.name.trim().is_empty() {
+            return Err(CliError::usage("--name cannot be empty")
+                .with_operation("ax.action.perform.hammerspoon"));
+        }
+        if selector_is_empty(&request.selector) {
+            return Err(
+                CliError::ax_contract_failure("ax.action.perform", "selector is empty")
+                    .with_operation("ax.action.perform.hammerspoon")
+                    .with_hint("Provide --node-id or selector filters."),
+            );
+        }
+
+        run_hs_json(
+            runner,
+            "ax.action.perform",
+            request,
+            AX_ACTION_PERFORM_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn session_start(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxSessionStartRequest,
+        timeout_ms: u64,
+    ) -> Result<AxSessionStartResult, CliError> {
+        run_hs_json(
+            runner,
+            "ax.session.start",
+            request,
+            AX_SESSION_START_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn session_list(
+        &self,
+        runner: &dyn ProcessRunner,
+        timeout_ms: u64,
+    ) -> Result<AxSessionListResult, CliError> {
+        run_hs_json(
+            runner,
+            "ax.session.list",
+            &serde_json::json!({}),
+            AX_SESSION_LIST_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn session_stop(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxSessionStopRequest,
+        timeout_ms: u64,
+    ) -> Result<AxSessionStopResult, CliError> {
+        if request.session_id.trim().is_empty() {
+            return Err(CliError::usage("--session-id cannot be empty")
+                .with_operation("ax.session.stop.hammerspoon"));
+        }
+
+        run_hs_json(
+            runner,
+            "ax.session.stop",
+            request,
+            AX_SESSION_STOP_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn watch_start(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxWatchStartRequest,
+        timeout_ms: u64,
+    ) -> Result<AxWatchStartResult, CliError> {
+        if request.session_id.trim().is_empty() {
+            return Err(CliError::usage("--session-id cannot be empty")
+                .with_operation("ax.watch.start.hammerspoon"));
+        }
+        run_hs_json(
+            runner,
+            "ax.watch.start",
+            request,
+            AX_WATCH_START_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn watch_poll(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxWatchPollRequest,
+        timeout_ms: u64,
+    ) -> Result<AxWatchPollResult, CliError> {
+        if request.watch_id.trim().is_empty() {
+            return Err(CliError::usage("--watch-id cannot be empty")
+                .with_operation("ax.watch.poll.hammerspoon"));
+        }
+        run_hs_json(
+            runner,
+            "ax.watch.poll",
+            request,
+            AX_WATCH_POLL_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+
+    fn watch_stop(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxWatchStopRequest,
+        timeout_ms: u64,
+    ) -> Result<AxWatchStopResult, CliError> {
+        if request.watch_id.trim().is_empty() {
+            return Err(CliError::usage("--watch-id cannot be empty")
+                .with_operation("ax.watch.stop.hammerspoon"));
+        }
+        run_hs_json(
+            runner,
+            "ax.watch.stop",
+            request,
+            AX_WATCH_STOP_HS_SCRIPT,
+            timeout_ms.max(1),
+        )
+    }
+}
+
+pub fn is_backend_unavailable_error(error: &CliError) -> bool {
+    if !error
+        .operation()
+        .map(|operation| operation.ends_with(".hammerspoon"))
+        .unwrap_or(false)
+    {
+        return false;
+    }
+
+    error
+        .hints()
+        .iter()
+        .any(|hint| hint.starts_with(BACKEND_UNAVAILABLE_HINT_PREFIX))
+}
+
+fn run_hs_json<Request, Response>(
+    runner: &dyn ProcessRunner,
+    operation: &'static str,
+    payload: &Request,
+    script: &'static str,
+    timeout_ms: u64,
+) -> Result<Response, CliError>
+where
+    Request: Serialize,
+    Response: DeserializeOwned,
+{
+    if let Some(override_json) = test_mode_override_json(operation) {
+        return parse_hs_output(operation, &override_json);
+    }
+
+    if test_mode::enabled() {
+        if let Some(default_json) = test_mode_default_json(operation) {
+            return parse_hs_output(operation, default_json);
+        }
+    }
+
+    let payload_json = serde_json::to_string(payload).map_err(|err| {
+        CliError::ax_payload_encode(&format!("{operation}.hammerspoon"), err.to_string())
+    })?;
+    let timeout_seconds = format!("{:.3}", (timeout_ms.max(1) as f64) / 1000.0);
+
+    let request = ProcessRequest::new(
+        "hs",
+        vec![
+            "-q".to_string(),
+            "-t".to_string(),
+            timeout_seconds,
+            "-c".to_string(),
+            script.to_string(),
+            "--".to_string(),
+            payload_json,
+        ],
+        timeout_ms.max(1),
+    );
+
+    let stdout = runner
+        .run(&request)
+        .map(|output| output.stdout)
+        .map_err(|failure| map_hs_failure(operation, failure))?;
+
+    parse_hs_output(operation, &stdout)
+}
+
+fn parse_hs_output<Response>(operation: &str, raw: &str) -> Result<Response, CliError>
+where
+    Response: DeserializeOwned,
+{
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(CliError::ax_parse_failure(
+            &format!("{operation}.hammerspoon"),
+            "empty stdout",
+        )
+        .with_hint(
+            "Ensure Hammerspoon is running and `hs.ipc` is enabled in ~/.hammerspoon/init.lua.",
+        ));
+    }
+
+    serde_json::from_str(trimmed).map_err(|err| {
+        CliError::ax_parse_failure(
+            &format!("{operation}.hammerspoon"),
+            format!("{err}; output preview: {}", output_preview(trimmed, 240)),
+        )
+        .with_hint("If backend mode is `auto`, macos-agent may fall back to JXA for AX commands.")
+    })
+}
+
+fn map_hs_failure(operation: &str, failure: ProcessFailure) -> CliError {
+    let operation_label = format!("{operation}.hammerspoon");
+
+    match failure {
+        ProcessFailure::NotFound { .. } => CliError::runtime(
+            "hammerspoon AX backend is unavailable: missing dependency `hs` in PATH",
+        )
+        .with_operation(operation_label)
+        .with_hint(
+            "Hammerspoon backend unavailable; install Hammerspoon and ensure `hs` is in PATH.",
+        )
+        .with_hint("Auto mode will fall back to JXA AX backend."),
+        ProcessFailure::Timeout { timeout_ms, .. } => CliError::timeout(
+            &operation_label,
+            timeout_ms,
+        )
+        .with_operation(operation_label)
+        .with_hint("Hammerspoon backend unavailable; command timed out while connecting to hs IPC.")
+        .with_hint(
+            "Enable `require('hs.ipc')` in ~/.hammerspoon/init.lua and keep Hammerspoon running.",
+        ),
+        ProcessFailure::NonZero { code, stderr, .. } => {
+            let lower = stderr.to_ascii_lowercase();
+            let unavailable = lower.contains("message port")
+                || lower.contains("ipc module")
+                || lower.contains("is it running")
+                || lower.contains("connection refused");
+
+            let mut error = CliError::runtime(format!(
+                "{operation_label} failed via `hs` (exit {code}): {stderr}"
+            ))
+            .with_operation(operation_label);
+
+            if unavailable {
+                error = error
+                    .with_hint(
+                        "Hammerspoon backend unavailable; hs cannot connect to Hammerspoon IPC.",
+                    )
+                    .with_hint(
+                        "Enable `require('hs.ipc')` in ~/.hammerspoon/init.lua and reload config.",
+                    )
+                    .with_hint("Auto mode will fall back to JXA AX backend.");
+            }
+
+            error
+        }
+        ProcessFailure::Io { message, .. } => {
+            CliError::runtime(format!("{operation_label} failed to run `hs`: {message}"))
+                .with_operation(operation_label)
+                .with_hint(
+                    "Hammerspoon backend unavailable; check hs executable and local IPC state.",
+                )
+        }
+    }
+}
+
+fn test_mode_override_json(operation: &str) -> Option<String> {
+    if !test_mode::enabled() {
+        return None;
+    }
+
+    let env_name = match operation {
+        "ax.list" => AX_LIST_TEST_MODE_ENV,
+        "ax.click" => AX_CLICK_TEST_MODE_ENV,
+        "ax.type" => AX_TYPE_TEST_MODE_ENV,
+        "ax.attr.get" => AX_ATTR_GET_TEST_MODE_ENV,
+        "ax.attr.set" => AX_ATTR_SET_TEST_MODE_ENV,
+        "ax.action.perform" => AX_ACTION_PERFORM_TEST_MODE_ENV,
+        "ax.session.start" => AX_SESSION_START_TEST_MODE_ENV,
+        "ax.session.list" => AX_SESSION_LIST_TEST_MODE_ENV,
+        "ax.session.stop" => AX_SESSION_STOP_TEST_MODE_ENV,
+        "ax.watch.start" => AX_WATCH_START_TEST_MODE_ENV,
+        "ax.watch.poll" => AX_WATCH_POLL_TEST_MODE_ENV,
+        "ax.watch.stop" => AX_WATCH_STOP_TEST_MODE_ENV,
+        _ => return None,
+    };
+
+    std::env::var(env_name).ok().and_then(|raw| {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn test_mode_default_json(operation: &str) -> Option<&'static str> {
+    match operation {
+        "ax.list" => Some(r#"{"nodes":[],"warnings":[]}"#),
+        "ax.click" => Some(
+            r#"{"node_id":"test-node","matched_count":1,"action":"ax-press","used_coordinate_fallback":false}"#,
+        ),
+        "ax.type" => Some(
+            r#"{"node_id":"test-node","matched_count":1,"applied_via":"ax-set-value","text_length":0,"submitted":false,"used_keyboard_fallback":false}"#,
+        ),
+        "ax.attr.get" => {
+            Some(r#"{"node_id":"test-node","matched_count":1,"name":"AXRole","value":"AXButton"}"#)
+        }
+        "ax.attr.set" => Some(
+            r#"{"node_id":"test-node","matched_count":1,"name":"AXValue","applied":true,"value_type":"string"}"#,
+        ),
+        "ax.action.perform" => {
+            Some(r#"{"node_id":"test-node","matched_count":1,"name":"AXPress","performed":true}"#)
+        }
+        "ax.session.start" => Some(
+            r#"{"session_id":"axs-test","app":"Arc","bundle_id":"company.thebrowser.Browser","pid":1001,"created_at_ms":1700000000000,"created":true}"#,
+        ),
+        "ax.session.list" => Some(r#"{"sessions":[]}"#),
+        "ax.session.stop" => Some(r#"{"session_id":"axs-test","removed":true}"#),
+        "ax.watch.start" => Some(
+            r#"{"watch_id":"axw-test","session_id":"axs-test","events":["AXTitleChanged"],"max_buffer":64,"started":true}"#,
+        ),
+        "ax.watch.poll" => {
+            Some(r#"{"watch_id":"axw-test","events":[],"dropped":0,"running":true}"#)
+        }
+        "ax.watch.stop" => Some(r#"{"watch_id":"axw-test","stopped":true,"drained":0}"#),
+        _ => None,
+    }
+}
+
+fn selector_is_empty(selector: &AxSelector) -> bool {
+    selector.node_id.is_none()
+        && selector.role.is_none()
+        && selector.title_contains.is_none()
+        && selector.identifier_contains.is_none()
+        && selector.value_contains.is_none()
+        && selector.subrole.is_none()
+        && selector.focused.is_none()
+        && selector.enabled.is_none()
+}
+
+fn output_preview(raw: &str, max_chars: usize) -> String {
+    let mut preview = raw.chars().take(max_chars).collect::<String>();
+    if raw.chars().count() > max_chars {
+        preview.push_str("...");
+    }
+    preview
+}
+
+#[cfg(test)]
+mod tests {
+    use nils_test_support::{EnvGuard, GlobalStateLock};
+
+    use crate::backend::hammerspoon::{is_backend_unavailable_error, map_hs_failure};
+    use crate::backend::process::ProcessFailure;
+    use crate::backend::AxBackendAdapter;
+
+    #[test]
+    fn message_port_error_is_marked_backend_unavailable() {
+        let error = map_hs_failure(
+            "ax.list",
+            ProcessFailure::NonZero {
+                program: "hs".to_string(),
+                code: 69,
+                stderr: "can't access Hammerspoon message port Hammerspoon; is it running with the ipc module loaded?".to_string(),
+            },
+        );
+
+        assert!(is_backend_unavailable_error(&error));
+    }
+
+    #[test]
+    fn test_mode_override_is_honored_for_click() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _override = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_CLICK_JSON",
+            r#"{"node_id":"1.1","matched_count":1,"action":"ax-press","used_coordinate_fallback":false}"#,
+        );
+
+        let runner = crate::backend::process::RealProcessRunner;
+        let request = crate::model::AxClickRequest {
+            target: crate::model::AxTarget::default(),
+            selector: crate::model::AxSelector {
+                node_id: Some("1.1".to_string()),
+                role: None,
+                title_contains: None,
+                identifier_contains: None,
+                value_contains: None,
+                subrole: None,
+                focused: None,
+                enabled: None,
+                nth: None,
+            },
+            allow_coordinate_fallback: false,
+        };
+
+        let result = super::HammerspoonAxBackend
+            .click(&runner, &request, 1000)
+            .expect("click should parse test override");
+        assert_eq!(result.node_id.as_deref(), Some("1.1"));
+        assert_eq!(result.matched_count, 1);
+    }
+}

--- a/crates/macos-agent/src/backend/mod.rs
+++ b/crates/macos-agent/src/backend/mod.rs
@@ -1,13 +1,20 @@
 pub mod applescript;
 pub mod cliclick;
+pub mod hammerspoon;
 pub mod input_source;
 pub mod process;
 
+use crate::backend::hammerspoon::HammerspoonAxBackend;
 use crate::backend::process::ProcessRunner;
 use crate::error::CliError;
 use crate::model::{
-    AxClickRequest, AxClickResult, AxListRequest, AxListResult, AxTypeRequest, AxTypeResult,
+    AxActionPerformRequest, AxActionPerformResult, AxAttrGetRequest, AxAttrGetResult,
+    AxAttrSetRequest, AxAttrSetResult, AxClickRequest, AxClickResult, AxListRequest, AxListResult,
+    AxSessionListResult, AxSessionStartRequest, AxSessionStartResult, AxSessionStopRequest,
+    AxSessionStopResult, AxTypeRequest, AxTypeResult, AxWatchPollRequest, AxWatchPollResult,
+    AxWatchStartRequest, AxWatchStartResult, AxWatchStopRequest, AxWatchStopResult,
 };
+use crate::test_mode;
 
 pub trait AxBackendAdapter {
     fn list(
@@ -30,6 +37,104 @@ pub trait AxBackendAdapter {
         request: &AxTypeRequest,
         timeout_ms: u64,
     ) -> Result<AxTypeResult, CliError>;
+
+    fn attr_get(
+        &self,
+        _runner: &dyn ProcessRunner,
+        _request: &AxAttrGetRequest,
+        _timeout_ms: u64,
+    ) -> Result<AxAttrGetResult, CliError> {
+        Err(CliError::runtime(
+            "AX attribute get is not supported by this backend",
+        ))
+    }
+
+    fn attr_set(
+        &self,
+        _runner: &dyn ProcessRunner,
+        _request: &AxAttrSetRequest,
+        _timeout_ms: u64,
+    ) -> Result<AxAttrSetResult, CliError> {
+        Err(CliError::runtime(
+            "AX attribute set is not supported by this backend",
+        ))
+    }
+
+    fn action_perform(
+        &self,
+        _runner: &dyn ProcessRunner,
+        _request: &AxActionPerformRequest,
+        _timeout_ms: u64,
+    ) -> Result<AxActionPerformResult, CliError> {
+        Err(CliError::runtime(
+            "AX action perform is not supported by this backend",
+        ))
+    }
+
+    fn session_start(
+        &self,
+        _runner: &dyn ProcessRunner,
+        _request: &AxSessionStartRequest,
+        _timeout_ms: u64,
+    ) -> Result<AxSessionStartResult, CliError> {
+        Err(CliError::runtime(
+            "AX session start is not supported by this backend",
+        ))
+    }
+
+    fn session_list(
+        &self,
+        _runner: &dyn ProcessRunner,
+        _timeout_ms: u64,
+    ) -> Result<AxSessionListResult, CliError> {
+        Err(CliError::runtime(
+            "AX session list is not supported by this backend",
+        ))
+    }
+
+    fn session_stop(
+        &self,
+        _runner: &dyn ProcessRunner,
+        _request: &AxSessionStopRequest,
+        _timeout_ms: u64,
+    ) -> Result<AxSessionStopResult, CliError> {
+        Err(CliError::runtime(
+            "AX session stop is not supported by this backend",
+        ))
+    }
+
+    fn watch_start(
+        &self,
+        _runner: &dyn ProcessRunner,
+        _request: &AxWatchStartRequest,
+        _timeout_ms: u64,
+    ) -> Result<AxWatchStartResult, CliError> {
+        Err(CliError::runtime(
+            "AX watch start is not supported by this backend",
+        ))
+    }
+
+    fn watch_poll(
+        &self,
+        _runner: &dyn ProcessRunner,
+        _request: &AxWatchPollRequest,
+        _timeout_ms: u64,
+    ) -> Result<AxWatchPollResult, CliError> {
+        Err(CliError::runtime(
+            "AX watch poll is not supported by this backend",
+        ))
+    }
+
+    fn watch_stop(
+        &self,
+        _runner: &dyn ProcessRunner,
+        _request: &AxWatchStopRequest,
+        _timeout_ms: u64,
+    ) -> Result<AxWatchStopResult, CliError> {
+        Err(CliError::runtime(
+            "AX watch stop is not supported by this backend",
+        ))
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -61,5 +166,255 @@ impl AxBackendAdapter for AppleScriptAxBackend {
         timeout_ms: u64,
     ) -> Result<AxTypeResult, CliError> {
         applescript::ax_type(runner, request, timeout_ms)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AxBackendPreference {
+    Auto,
+    Hammerspoon,
+    AppleScript,
+}
+
+impl AxBackendPreference {
+    pub fn resolve() -> Self {
+        if let Ok(raw) = std::env::var("CODEX_MACOS_AGENT_AX_BACKEND") {
+            match raw.trim().to_ascii_lowercase().as_str() {
+                "hammerspoon" | "hs" => return Self::Hammerspoon,
+                "applescript" | "jxa" => return Self::AppleScript,
+                "auto" => return Self::Auto,
+                _ => {}
+            }
+        }
+
+        if test_mode::enabled() {
+            // Tests rely on deterministic osascript stubs.
+            Self::AppleScript
+        } else {
+            Self::Auto
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AutoAxBackend {
+    preference: AxBackendPreference,
+}
+
+impl Default for AutoAxBackend {
+    fn default() -> Self {
+        Self {
+            preference: AxBackendPreference::resolve(),
+        }
+    }
+}
+
+impl AutoAxBackend {
+    fn fallback_with_hint(primary_error: CliError, fallback_error: CliError) -> CliError {
+        fallback_error.with_hint(format!(
+            "Hammerspoon backend failed first: {}",
+            primary_error.message()
+        ))
+    }
+}
+
+impl AxBackendAdapter for AutoAxBackend {
+    fn list(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxListRequest,
+        timeout_ms: u64,
+    ) -> Result<AxListResult, CliError> {
+        match self.preference {
+            AxBackendPreference::Hammerspoon => {
+                HammerspoonAxBackend.list(runner, request, timeout_ms)
+            }
+            AxBackendPreference::AppleScript => {
+                AppleScriptAxBackend.list(runner, request, timeout_ms)
+            }
+            AxBackendPreference::Auto => match HammerspoonAxBackend
+                .list(runner, request, timeout_ms)
+            {
+                Ok(result) => Ok(result),
+                Err(primary_error) if hammerspoon::is_backend_unavailable_error(&primary_error) => {
+                    AppleScriptAxBackend
+                        .list(runner, request, timeout_ms)
+                        .map_err(|fallback_error| {
+                            Self::fallback_with_hint(primary_error, fallback_error)
+                        })
+                }
+                Err(error) => Err(error),
+            },
+        }
+    }
+
+    fn click(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxClickRequest,
+        timeout_ms: u64,
+    ) -> Result<AxClickResult, CliError> {
+        match self.preference {
+            AxBackendPreference::Hammerspoon => {
+                HammerspoonAxBackend.click(runner, request, timeout_ms)
+            }
+            AxBackendPreference::AppleScript => {
+                AppleScriptAxBackend.click(runner, request, timeout_ms)
+            }
+            AxBackendPreference::Auto => match HammerspoonAxBackend
+                .click(runner, request, timeout_ms)
+            {
+                Ok(result) => Ok(result),
+                Err(primary_error) if hammerspoon::is_backend_unavailable_error(&primary_error) => {
+                    AppleScriptAxBackend
+                        .click(runner, request, timeout_ms)
+                        .map_err(|fallback_error| {
+                            Self::fallback_with_hint(primary_error, fallback_error)
+                        })
+                }
+                Err(error) => Err(error),
+            },
+        }
+    }
+
+    fn type_text(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxTypeRequest,
+        timeout_ms: u64,
+    ) -> Result<AxTypeResult, CliError> {
+        match self.preference {
+            AxBackendPreference::Hammerspoon => {
+                HammerspoonAxBackend.type_text(runner, request, timeout_ms)
+            }
+            AxBackendPreference::AppleScript => {
+                AppleScriptAxBackend.type_text(runner, request, timeout_ms)
+            }
+            AxBackendPreference::Auto => {
+                match HammerspoonAxBackend.type_text(runner, request, timeout_ms) {
+                    Ok(result) => Ok(result),
+                    Err(primary_error)
+                        if hammerspoon::is_backend_unavailable_error(&primary_error) =>
+                    {
+                        AppleScriptAxBackend
+                            .type_text(runner, request, timeout_ms)
+                            .map_err(|fallback_error| {
+                                Self::fallback_with_hint(primary_error, fallback_error)
+                            })
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+        }
+    }
+
+    fn attr_get(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxAttrGetRequest,
+        timeout_ms: u64,
+    ) -> Result<AxAttrGetResult, CliError> {
+        HammerspoonAxBackend.attr_get(runner, request, timeout_ms)
+    }
+
+    fn attr_set(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxAttrSetRequest,
+        timeout_ms: u64,
+    ) -> Result<AxAttrSetResult, CliError> {
+        HammerspoonAxBackend.attr_set(runner, request, timeout_ms)
+    }
+
+    fn action_perform(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxActionPerformRequest,
+        timeout_ms: u64,
+    ) -> Result<AxActionPerformResult, CliError> {
+        HammerspoonAxBackend.action_perform(runner, request, timeout_ms)
+    }
+
+    fn session_start(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxSessionStartRequest,
+        timeout_ms: u64,
+    ) -> Result<AxSessionStartResult, CliError> {
+        HammerspoonAxBackend.session_start(runner, request, timeout_ms)
+    }
+
+    fn session_list(
+        &self,
+        runner: &dyn ProcessRunner,
+        timeout_ms: u64,
+    ) -> Result<AxSessionListResult, CliError> {
+        HammerspoonAxBackend.session_list(runner, timeout_ms)
+    }
+
+    fn session_stop(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxSessionStopRequest,
+        timeout_ms: u64,
+    ) -> Result<AxSessionStopResult, CliError> {
+        HammerspoonAxBackend.session_stop(runner, request, timeout_ms)
+    }
+
+    fn watch_start(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxWatchStartRequest,
+        timeout_ms: u64,
+    ) -> Result<AxWatchStartResult, CliError> {
+        HammerspoonAxBackend.watch_start(runner, request, timeout_ms)
+    }
+
+    fn watch_poll(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxWatchPollRequest,
+        timeout_ms: u64,
+    ) -> Result<AxWatchPollResult, CliError> {
+        HammerspoonAxBackend.watch_poll(runner, request, timeout_ms)
+    }
+
+    fn watch_stop(
+        &self,
+        runner: &dyn ProcessRunner,
+        request: &AxWatchStopRequest,
+        timeout_ms: u64,
+    ) -> Result<AxWatchStopResult, CliError> {
+        HammerspoonAxBackend.watch_stop(runner, request, timeout_ms)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nils_test_support::{EnvGuard, GlobalStateLock};
+    use pretty_assertions::assert_eq;
+
+    use crate::backend::AxBackendPreference;
+
+    #[test]
+    fn backend_preference_defaults_to_applescript_in_test_mode() {
+        let lock = GlobalStateLock::new();
+        let _test_mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _backend = EnvGuard::remove(&lock, "CODEX_MACOS_AGENT_AX_BACKEND");
+        assert_eq!(
+            AxBackendPreference::resolve(),
+            AxBackendPreference::AppleScript
+        );
+    }
+
+    #[test]
+    fn backend_preference_env_overrides_test_mode_default() {
+        let lock = GlobalStateLock::new();
+        let _test_mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _backend = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_AX_BACKEND", "hammerspoon");
+        assert_eq!(
+            AxBackendPreference::resolve(),
+            AxBackendPreference::Hammerspoon
+        );
     }
 }

--- a/crates/macos-agent/src/cli.rs
+++ b/crates/macos-agent/src/cli.rs
@@ -263,6 +263,69 @@ pub enum AxCommand {
 
     /// Type text into an AX node.
     Type(AxTypeArgs),
+
+    /// Read or set arbitrary AX attributes.
+    Attr {
+        #[command(subcommand)]
+        command: AxAttrCommand,
+    },
+
+    /// Perform arbitrary AX actions.
+    Action {
+        #[command(subcommand)]
+        command: AxActionCommand,
+    },
+
+    /// Manage long-lived AX sessions.
+    Session {
+        #[command(subcommand)]
+        command: AxSessionCommand,
+    },
+
+    /// Start/poll/stop AX notification watchers.
+    Watch {
+        #[command(subcommand)]
+        command: AxWatchCommand,
+    },
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum AxAttrCommand {
+    /// Read an AX attribute value.
+    Get(AxAttrGetArgs),
+
+    /// Set an AX attribute value.
+    Set(AxAttrSetArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum AxActionCommand {
+    /// Perform an AX action.
+    Perform(AxActionPerformArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum AxSessionCommand {
+    /// Create or update an AX session.
+    Start(AxSessionStartArgs),
+
+    /// List active AX sessions.
+    List(AxSessionListArgs),
+
+    /// Stop an AX session.
+    Stop(AxSessionStopArgs),
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum AxWatchCommand {
+    /// Start a watcher bound to an AX session.
+    Start(AxWatchStartArgs),
+
+    /// Poll buffered watcher events.
+    Poll(AxWatchPollArgs),
+
+    /// Stop a watcher.
+    Stop(AxWatchStopArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -271,10 +334,14 @@ pub enum AxCommand {
         ArgGroup::new("target")
             .required(false)
             .multiple(false)
-            .args(["app", "bundle_id"])
+            .args(["session_id", "app", "bundle_id"])
     )
 )]
 pub struct AxListArgs {
+    /// Select target by existing session id.
+    #[arg(long)]
+    pub session_id: Option<String>,
+
     /// Select target app by name.
     #[arg(long)]
     pub app: Option<String>,
@@ -283,6 +350,10 @@ pub struct AxListArgs {
     #[arg(long)]
     pub bundle_id: Option<String>,
 
+    /// Filter roots by window title substring.
+    #[arg(long)]
+    pub window_title_contains: Option<String>,
+
     /// Filter by AX role.
     #[arg(long)]
     pub role: Option<String>,
@@ -290,6 +361,26 @@ pub struct AxListArgs {
     /// Filter by title substring.
     #[arg(long)]
     pub title_contains: Option<String>,
+
+    /// Filter by identifier substring.
+    #[arg(long)]
+    pub identifier_contains: Option<String>,
+
+    /// Filter by value substring.
+    #[arg(long)]
+    pub value_contains: Option<String>,
+
+    /// Filter by subrole.
+    #[arg(long)]
+    pub subrole: Option<String>,
+
+    /// Filter by focused flag.
+    #[arg(long)]
+    pub focused: Option<bool>,
+
+    /// Filter by enabled flag.
+    #[arg(long)]
+    pub enabled: Option<bool>,
 
     /// Limit traversal depth.
     #[arg(long)]
@@ -305,32 +396,77 @@ pub struct AxListArgs {
     group(
         ArgGroup::new("selector")
             .required(true)
-            .multiple(false)
-            .args(["node_id", "role"])
+            .multiple(true)
+            .args([
+                "node_id",
+                "role",
+                "title_contains",
+                "identifier_contains",
+                "value_contains",
+                "subrole",
+                "focused",
+                "enabled",
+            ])
     ),
     group(
         ArgGroup::new("target")
             .required(false)
             .multiple(false)
-            .args(["app", "bundle_id"])
+            .args(["session_id", "app", "bundle_id"])
     )
 )]
 pub struct AxClickArgs {
     /// Select by node id from `ax list`.
-    #[arg(long)]
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "role",
+            "title_contains",
+            "identifier_contains",
+            "value_contains",
+            "subrole",
+            "focused",
+            "enabled",
+            "nth"
+        ]
+    )]
     pub node_id: Option<String>,
 
-    /// Select by AX role (requires --title-contains).
-    #[arg(long, requires = "title_contains")]
+    /// Select by AX role.
+    #[arg(long)]
     pub role: Option<String>,
 
-    /// Select by title substring (requires --role).
-    #[arg(long, requires = "role")]
+    /// Select by title substring.
+    #[arg(long)]
     pub title_contains: Option<String>,
 
+    /// Select by identifier substring.
+    #[arg(long)]
+    pub identifier_contains: Option<String>,
+
+    /// Select by value substring.
+    #[arg(long)]
+    pub value_contains: Option<String>,
+
+    /// Select by AX subrole.
+    #[arg(long)]
+    pub subrole: Option<String>,
+
+    /// Select by focused state.
+    #[arg(long)]
+    pub focused: Option<bool>,
+
+    /// Select by enabled state.
+    #[arg(long)]
+    pub enabled: Option<bool>,
+
     /// Select the nth match from compound selector results.
-    #[arg(long, requires = "role")]
+    #[arg(long)]
     pub nth: Option<u32>,
+
+    /// Select target by existing session id.
+    #[arg(long)]
+    pub session_id: Option<String>,
 
     /// Narrow selector to app name.
     #[arg(long)]
@@ -339,6 +475,10 @@ pub struct AxClickArgs {
     /// Narrow selector to bundle id.
     #[arg(long)]
     pub bundle_id: Option<String>,
+
+    /// Narrow to windows whose title contains this value.
+    #[arg(long)]
+    pub window_title_contains: Option<String>,
 
     /// Allow coordinate fallback when AX press is unavailable.
     #[arg(long)]
@@ -350,32 +490,77 @@ pub struct AxClickArgs {
     group(
         ArgGroup::new("selector")
             .required(true)
-            .multiple(false)
-            .args(["node_id", "role"])
+            .multiple(true)
+            .args([
+                "node_id",
+                "role",
+                "title_contains",
+                "identifier_contains",
+                "value_contains",
+                "subrole",
+                "focused",
+                "enabled",
+            ])
     ),
     group(
         ArgGroup::new("target")
             .required(false)
             .multiple(false)
-            .args(["app", "bundle_id"])
+            .args(["session_id", "app", "bundle_id"])
     )
 )]
 pub struct AxTypeArgs {
     /// Select by node id from `ax list`.
-    #[arg(long)]
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "role",
+            "title_contains",
+            "identifier_contains",
+            "value_contains",
+            "subrole",
+            "focused",
+            "enabled",
+            "nth"
+        ]
+    )]
     pub node_id: Option<String>,
 
-    /// Select by AX role (requires --title-contains).
-    #[arg(long, requires = "title_contains")]
+    /// Select by AX role.
+    #[arg(long)]
     pub role: Option<String>,
 
-    /// Select by title substring (requires --role).
-    #[arg(long, requires = "role")]
+    /// Select by title substring.
+    #[arg(long)]
     pub title_contains: Option<String>,
 
+    /// Select by identifier substring.
+    #[arg(long)]
+    pub identifier_contains: Option<String>,
+
+    /// Select by value substring.
+    #[arg(long)]
+    pub value_contains: Option<String>,
+
+    /// Select by AX subrole.
+    #[arg(long)]
+    pub subrole: Option<String>,
+
+    /// Select by focused state.
+    #[arg(long)]
+    pub focused: Option<bool>,
+
+    /// Select by enabled state.
+    #[arg(long)]
+    pub enabled: Option<bool>,
+
     /// Select the nth match from compound selector results.
-    #[arg(long, requires = "role")]
+    #[arg(long)]
     pub nth: Option<u32>,
+
+    /// Select target by existing session id.
+    #[arg(long)]
+    pub session_id: Option<String>,
 
     /// Narrow selector to app name.
     #[arg(long)]
@@ -384,6 +569,10 @@ pub struct AxTypeArgs {
     /// Narrow selector to bundle id.
     #[arg(long)]
     pub bundle_id: Option<String>,
+
+    /// Narrow to windows whose title contains this value.
+    #[arg(long)]
+    pub window_title_contains: Option<String>,
 
     /// Text to type.
     #[arg(long, value_parser = clap::builder::NonEmptyStringValueParser::new())]
@@ -404,6 +593,387 @@ pub struct AxTypeArgs {
     /// Allow keyboard fallback when AX value set/focus is unavailable.
     #[arg(long)]
     pub allow_keyboard_fallback: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+#[command(
+    group(
+        ArgGroup::new("selector")
+            .required(true)
+            .multiple(true)
+            .args([
+                "node_id",
+                "role",
+                "title_contains",
+                "identifier_contains",
+                "value_contains",
+                "subrole",
+                "focused",
+                "enabled",
+            ])
+    ),
+    group(
+        ArgGroup::new("target")
+            .required(false)
+            .multiple(false)
+            .args(["session_id", "app", "bundle_id"])
+    )
+)]
+pub struct AxAttrGetArgs {
+    /// Select by node id from `ax list`.
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "role",
+            "title_contains",
+            "identifier_contains",
+            "value_contains",
+            "subrole",
+            "focused",
+            "enabled",
+            "nth"
+        ]
+    )]
+    pub node_id: Option<String>,
+
+    /// Select by AX role.
+    #[arg(long)]
+    pub role: Option<String>,
+
+    /// Select by title substring.
+    #[arg(long)]
+    pub title_contains: Option<String>,
+
+    /// Select by identifier substring.
+    #[arg(long)]
+    pub identifier_contains: Option<String>,
+
+    /// Select by value substring.
+    #[arg(long)]
+    pub value_contains: Option<String>,
+
+    /// Select by AX subrole.
+    #[arg(long)]
+    pub subrole: Option<String>,
+
+    /// Select by focused state.
+    #[arg(long)]
+    pub focused: Option<bool>,
+
+    /// Select by enabled state.
+    #[arg(long)]
+    pub enabled: Option<bool>,
+
+    /// Select the nth match from compound selector results.
+    #[arg(long)]
+    pub nth: Option<u32>,
+
+    /// Select target by existing session id.
+    #[arg(long)]
+    pub session_id: Option<String>,
+
+    /// Narrow selector to app name.
+    #[arg(long)]
+    pub app: Option<String>,
+
+    /// Narrow selector to bundle id.
+    #[arg(long)]
+    pub bundle_id: Option<String>,
+
+    /// Narrow to windows whose title contains this value.
+    #[arg(long)]
+    pub window_title_contains: Option<String>,
+
+    /// AX attribute name.
+    #[arg(long)]
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum AxValueType {
+    String,
+    Number,
+    Bool,
+    Json,
+    Null,
+}
+
+#[derive(Debug, Clone, Args)]
+#[command(
+    group(
+        ArgGroup::new("selector")
+            .required(true)
+            .multiple(true)
+            .args([
+                "node_id",
+                "role",
+                "title_contains",
+                "identifier_contains",
+                "value_contains",
+                "subrole",
+                "focused",
+                "enabled",
+            ])
+    ),
+    group(
+        ArgGroup::new("target")
+            .required(false)
+            .multiple(false)
+            .args(["session_id", "app", "bundle_id"])
+    )
+)]
+pub struct AxAttrSetArgs {
+    /// Select by node id from `ax list`.
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "role",
+            "title_contains",
+            "identifier_contains",
+            "value_contains",
+            "subrole",
+            "focused",
+            "enabled",
+            "nth"
+        ]
+    )]
+    pub node_id: Option<String>,
+
+    /// Select by AX role.
+    #[arg(long)]
+    pub role: Option<String>,
+
+    /// Select by title substring.
+    #[arg(long)]
+    pub title_contains: Option<String>,
+
+    /// Select by identifier substring.
+    #[arg(long)]
+    pub identifier_contains: Option<String>,
+
+    /// Select by value substring.
+    #[arg(long)]
+    pub value_contains: Option<String>,
+
+    /// Select by AX subrole.
+    #[arg(long)]
+    pub subrole: Option<String>,
+
+    /// Select by focused state.
+    #[arg(long)]
+    pub focused: Option<bool>,
+
+    /// Select by enabled state.
+    #[arg(long)]
+    pub enabled: Option<bool>,
+
+    /// Select the nth match from compound selector results.
+    #[arg(long)]
+    pub nth: Option<u32>,
+
+    /// Select target by existing session id.
+    #[arg(long)]
+    pub session_id: Option<String>,
+
+    /// Narrow selector to app name.
+    #[arg(long)]
+    pub app: Option<String>,
+
+    /// Narrow selector to bundle id.
+    #[arg(long)]
+    pub bundle_id: Option<String>,
+
+    /// Narrow to windows whose title contains this value.
+    #[arg(long)]
+    pub window_title_contains: Option<String>,
+
+    /// AX attribute name.
+    #[arg(long)]
+    pub name: String,
+
+    /// AX attribute value.
+    #[arg(long)]
+    pub value: String,
+
+    /// Parse type for --value.
+    #[arg(long, value_enum, default_value_t = AxValueType::String)]
+    pub value_type: AxValueType,
+}
+
+#[derive(Debug, Clone, Args)]
+#[command(
+    group(
+        ArgGroup::new("selector")
+            .required(true)
+            .multiple(true)
+            .args([
+                "node_id",
+                "role",
+                "title_contains",
+                "identifier_contains",
+                "value_contains",
+                "subrole",
+                "focused",
+                "enabled",
+            ])
+    ),
+    group(
+        ArgGroup::new("target")
+            .required(false)
+            .multiple(false)
+            .args(["session_id", "app", "bundle_id"])
+    )
+)]
+pub struct AxActionPerformArgs {
+    /// Select by node id from `ax list`.
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "role",
+            "title_contains",
+            "identifier_contains",
+            "value_contains",
+            "subrole",
+            "focused",
+            "enabled",
+            "nth"
+        ]
+    )]
+    pub node_id: Option<String>,
+
+    /// Select by AX role.
+    #[arg(long)]
+    pub role: Option<String>,
+
+    /// Select by title substring.
+    #[arg(long)]
+    pub title_contains: Option<String>,
+
+    /// Select by identifier substring.
+    #[arg(long)]
+    pub identifier_contains: Option<String>,
+
+    /// Select by value substring.
+    #[arg(long)]
+    pub value_contains: Option<String>,
+
+    /// Select by AX subrole.
+    #[arg(long)]
+    pub subrole: Option<String>,
+
+    /// Select by focused state.
+    #[arg(long)]
+    pub focused: Option<bool>,
+
+    /// Select by enabled state.
+    #[arg(long)]
+    pub enabled: Option<bool>,
+
+    /// Select the nth match from compound selector results.
+    #[arg(long)]
+    pub nth: Option<u32>,
+
+    /// Select target by existing session id.
+    #[arg(long)]
+    pub session_id: Option<String>,
+
+    /// Narrow selector to app name.
+    #[arg(long)]
+    pub app: Option<String>,
+
+    /// Narrow selector to bundle id.
+    #[arg(long)]
+    pub bundle_id: Option<String>,
+
+    /// Narrow to windows whose title contains this value.
+    #[arg(long)]
+    pub window_title_contains: Option<String>,
+
+    /// AX action name.
+    #[arg(long)]
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Args)]
+#[command(
+    group(
+        ArgGroup::new("target")
+            .required(false)
+            .multiple(false)
+            .args(["app", "bundle_id"])
+    )
+)]
+pub struct AxSessionStartArgs {
+    /// Select target app by name.
+    #[arg(long)]
+    pub app: Option<String>,
+
+    /// Select target app by bundle id.
+    #[arg(long)]
+    pub bundle_id: Option<String>,
+
+    /// Optionally name the session id.
+    #[arg(long)]
+    pub session_id: Option<String>,
+
+    /// Persist window title root filter in this session.
+    #[arg(long)]
+    pub window_title_contains: Option<String>,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct AxSessionListArgs {}
+
+#[derive(Debug, Clone, Args)]
+pub struct AxSessionStopArgs {
+    /// Session id to remove.
+    #[arg(long)]
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct AxWatchStartArgs {
+    /// Session id to bind watcher to.
+    #[arg(long)]
+    pub session_id: String,
+
+    /// Optional watcher id.
+    #[arg(long)]
+    pub watch_id: Option<String>,
+
+    /// Comma-separated AX notification names.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        default_value = "AXFocusedUIElementChanged,AXTitleChanged"
+    )]
+    pub events: Vec<String>,
+
+    /// Maximum in-memory event buffer size.
+    #[arg(long, default_value_t = 256)]
+    pub max_buffer: usize,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct AxWatchPollArgs {
+    /// Watch id to poll.
+    #[arg(long)]
+    pub watch_id: String,
+
+    /// Max events to return.
+    #[arg(long, default_value_t = 50)]
+    pub limit: usize,
+
+    /// Drain returned events from watcher buffer.
+    #[arg(long, default_value_t = true)]
+    pub drain: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct AxWatchStopArgs {
+    /// Watch id to stop.
+    #[arg(long)]
+    pub watch_id: String,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -626,8 +1196,8 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::{
-        AxCommand, Cli, CommandGroup, ErrorFormat, InputSourceCommand, OutputFormat, WaitCommand,
-        WindowCommand,
+        AxActionCommand, AxAttrCommand, AxCommand, AxSessionCommand, AxWatchCommand, Cli,
+        CommandGroup, ErrorFormat, InputSourceCommand, OutputFormat, WaitCommand, WindowCommand,
     };
 
     #[test]
@@ -859,8 +1429,8 @@ mod tests {
     }
 
     #[test]
-    fn rejects_ax_type_role_without_title_contains() {
-        let err = Cli::try_parse_from([
+    fn parses_ax_type_role_without_title_contains() {
+        let cli = Cli::try_parse_from([
             "macos-agent",
             "ax",
             "type",
@@ -869,12 +1439,25 @@ mod tests {
             "--text",
             "hello",
         ])
-        .expect_err("role requires title-contains");
+        .expect("role-only selector should parse");
+        match cli.command {
+            CommandGroup::Ax {
+                command: AxCommand::Type(args),
+            } => {
+                assert_eq!(args.role.as_deref(), Some("AXTextField"));
+                assert!(args.title_contains.is_none());
+            }
+            other => panic!("unexpected command variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_ax_type_nth_without_selector_filter() {
+        let err =
+            Cli::try_parse_from(["macos-agent", "ax", "type", "--nth", "2", "--text", "hello"])
+                .expect_err("nth alone should be rejected by selector group");
         let rendered = err.to_string();
-        assert!(
-            rendered.contains("requires")
-                || rendered.contains("required arguments were not provided")
-        );
+        assert!(rendered.contains("required arguments were not provided"));
     }
 
     #[test]
@@ -891,5 +1474,139 @@ mod tests {
         .expect_err("app and bundle-id should be mutually exclusive");
         let rendered = err.to_string();
         assert!(rendered.contains("cannot be used with"));
+    }
+
+    #[test]
+    fn parses_ax_attr_get_and_set_commands() {
+        let get_cli = Cli::try_parse_from([
+            "macos-agent",
+            "ax",
+            "attr",
+            "get",
+            "--node-id",
+            "1.2",
+            "--name",
+            "AXRole",
+        ])
+        .expect("ax attr get should parse");
+        match get_cli.command {
+            CommandGroup::Ax {
+                command:
+                    AxCommand::Attr {
+                        command: AxAttrCommand::Get(args),
+                    },
+            } => {
+                assert_eq!(args.node_id.as_deref(), Some("1.2"));
+                assert_eq!(args.name, "AXRole");
+            }
+            other => panic!("unexpected command variant: {other:?}"),
+        }
+
+        let set_cli = Cli::try_parse_from([
+            "macos-agent",
+            "ax",
+            "attr",
+            "set",
+            "--role",
+            "AXTextField",
+            "--title-contains",
+            "Search",
+            "--name",
+            "AXValue",
+            "--value",
+            "hello",
+            "--value-type",
+            "string",
+        ])
+        .expect("ax attr set should parse");
+        match set_cli.command {
+            CommandGroup::Ax {
+                command:
+                    AxCommand::Attr {
+                        command: AxAttrCommand::Set(args),
+                    },
+            } => {
+                assert_eq!(args.role.as_deref(), Some("AXTextField"));
+                assert_eq!(args.title_contains.as_deref(), Some("Search"));
+                assert_eq!(args.name, "AXValue");
+                assert_eq!(args.value, "hello");
+            }
+            other => panic!("unexpected command variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_ax_action_session_and_watch_commands() {
+        let action_cli = Cli::try_parse_from([
+            "macos-agent",
+            "ax",
+            "action",
+            "perform",
+            "--node-id",
+            "1.1",
+            "--name",
+            "AXPress",
+        ])
+        .expect("ax action perform should parse");
+        match action_cli.command {
+            CommandGroup::Ax {
+                command:
+                    AxCommand::Action {
+                        command: AxActionCommand::Perform(args),
+                    },
+            } => {
+                assert_eq!(args.node_id.as_deref(), Some("1.1"));
+                assert_eq!(args.name, "AXPress");
+            }
+            other => panic!("unexpected command variant: {other:?}"),
+        }
+
+        let session_cli = Cli::try_parse_from([
+            "macos-agent",
+            "ax",
+            "session",
+            "start",
+            "--app",
+            "Arc",
+            "--session-id",
+            "axs-demo",
+        ])
+        .expect("ax session start should parse");
+        match session_cli.command {
+            CommandGroup::Ax {
+                command:
+                    AxCommand::Session {
+                        command: AxSessionCommand::Start(args),
+                    },
+            } => {
+                assert_eq!(args.app.as_deref(), Some("Arc"));
+                assert_eq!(args.session_id.as_deref(), Some("axs-demo"));
+            }
+            other => panic!("unexpected command variant: {other:?}"),
+        }
+
+        let watch_cli = Cli::try_parse_from([
+            "macos-agent",
+            "ax",
+            "watch",
+            "start",
+            "--session-id",
+            "axs-demo",
+            "--events",
+            "AXTitleChanged,AXFocusedUIElementChanged",
+        ])
+        .expect("ax watch start should parse");
+        match watch_cli.command {
+            CommandGroup::Ax {
+                command:
+                    AxCommand::Watch {
+                        command: AxWatchCommand::Start(args),
+                    },
+            } => {
+                assert_eq!(args.session_id, "axs-demo");
+                assert_eq!(args.events.len(), 2);
+            }
+            other => panic!("unexpected command variant: {other:?}"),
+        }
     }
 }

--- a/crates/macos-agent/src/commands/ax_action.rs
+++ b/crates/macos-agent/src/commands/ax_action.rs
@@ -1,0 +1,75 @@
+use crate::backend::process::ProcessRunner;
+use crate::backend::{AutoAxBackend, AxBackendAdapter};
+use crate::cli::{AxActionPerformArgs, OutputFormat};
+use crate::commands::ax_common::{build_selector, build_target, AxSelectorInput};
+use crate::error::CliError;
+use crate::model::{AxActionPerformRequest, AxActionPerformResult, SuccessEnvelope};
+use crate::run::ActionPolicy;
+
+pub fn run_perform(
+    format: OutputFormat,
+    args: &AxActionPerformArgs,
+    policy: ActionPolicy,
+    runner: &dyn ProcessRunner,
+) -> Result<(), CliError> {
+    let request = AxActionPerformRequest {
+        target: build_target(
+            args.session_id.clone(),
+            args.app.clone(),
+            args.bundle_id.clone(),
+            args.window_title_contains.clone(),
+        )?,
+        selector: build_selector(AxSelectorInput {
+            node_id: args.node_id.clone(),
+            role: args.role.clone(),
+            title_contains: args.title_contains.clone(),
+            identifier_contains: args.identifier_contains.clone(),
+            value_contains: args.value_contains.clone(),
+            subrole: args.subrole.clone(),
+            focused: args.focused,
+            enabled: args.enabled,
+            nth: args.nth,
+        })?,
+        name: args.name.clone(),
+    };
+
+    let result = if policy.dry_run {
+        AxActionPerformResult {
+            node_id: request.selector.node_id.clone(),
+            matched_count: 0,
+            name: request.name.clone(),
+            performed: false,
+        }
+    } else {
+        let backend = AutoAxBackend::default();
+        backend.action_perform(runner, &request, policy.timeout_ms)?
+    };
+
+    match format {
+        OutputFormat::Json => {
+            let payload = SuccessEnvelope::new("ax.action.perform", result);
+            println!(
+                "{}",
+                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
+                    "failed to serialize json output: {err}"
+                )))?
+            );
+        }
+        OutputFormat::Text => {
+            println!(
+                "ax.action.perform\tnode_id={}\tname={}\tmatched_count={}\tperformed={}",
+                result.node_id.unwrap_or_default(),
+                result.name,
+                result.matched_count,
+                result.performed
+            );
+        }
+        OutputFormat::Tsv => {
+            return Err(CliError::usage(
+                "--format tsv is only supported for `windows list` and `apps list`",
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/macos-agent/src/commands/ax_attr.rs
+++ b/crates/macos-agent/src/commands/ax_attr.rs
@@ -1,0 +1,188 @@
+use serde_json::Value;
+
+use crate::backend::process::ProcessRunner;
+use crate::backend::{AutoAxBackend, AxBackendAdapter};
+use crate::cli::{AxAttrGetArgs, AxAttrSetArgs, AxValueType, OutputFormat};
+use crate::commands::ax_common::{build_selector, build_target, AxSelectorInput};
+use crate::error::CliError;
+use crate::model::{
+    AxAttrGetRequest, AxAttrGetResult, AxAttrSetRequest, AxAttrSetResult, SuccessEnvelope,
+};
+use crate::run::ActionPolicy;
+
+pub fn run_get(
+    format: OutputFormat,
+    args: &AxAttrGetArgs,
+    policy: ActionPolicy,
+    runner: &dyn ProcessRunner,
+) -> Result<(), CliError> {
+    let request = AxAttrGetRequest {
+        target: build_target(
+            args.session_id.clone(),
+            args.app.clone(),
+            args.bundle_id.clone(),
+            args.window_title_contains.clone(),
+        )?,
+        selector: build_selector(AxSelectorInput {
+            node_id: args.node_id.clone(),
+            role: args.role.clone(),
+            title_contains: args.title_contains.clone(),
+            identifier_contains: args.identifier_contains.clone(),
+            value_contains: args.value_contains.clone(),
+            subrole: args.subrole.clone(),
+            focused: args.focused,
+            enabled: args.enabled,
+            nth: args.nth,
+        })?,
+        name: args.name.clone(),
+    };
+
+    let backend = AutoAxBackend::default();
+    let result = backend.attr_get(runner, &request, policy.timeout_ms)?;
+    print_get_result(format, result)
+}
+
+pub fn run_set(
+    format: OutputFormat,
+    args: &AxAttrSetArgs,
+    policy: ActionPolicy,
+    runner: &dyn ProcessRunner,
+) -> Result<(), CliError> {
+    let request = AxAttrSetRequest {
+        target: build_target(
+            args.session_id.clone(),
+            args.app.clone(),
+            args.bundle_id.clone(),
+            args.window_title_contains.clone(),
+        )?,
+        selector: build_selector(AxSelectorInput {
+            node_id: args.node_id.clone(),
+            role: args.role.clone(),
+            title_contains: args.title_contains.clone(),
+            identifier_contains: args.identifier_contains.clone(),
+            value_contains: args.value_contains.clone(),
+            subrole: args.subrole.clone(),
+            focused: args.focused,
+            enabled: args.enabled,
+            nth: args.nth,
+        })?,
+        name: args.name.clone(),
+        value: parse_value(args.value_type, &args.value)?,
+    };
+
+    let result = if policy.dry_run {
+        AxAttrSetResult {
+            node_id: request.selector.node_id.clone(),
+            matched_count: 0,
+            name: request.name.clone(),
+            applied: false,
+            value_type: value_type_name(args.value_type).to_string(),
+        }
+    } else {
+        let backend = AutoAxBackend::default();
+        backend.attr_set(runner, &request, policy.timeout_ms)?
+    };
+
+    print_set_result(format, result)
+}
+
+fn value_type_name(value_type: AxValueType) -> &'static str {
+    match value_type {
+        AxValueType::String => "string",
+        AxValueType::Number => "number",
+        AxValueType::Bool => "bool",
+        AxValueType::Json => "json",
+        AxValueType::Null => "null",
+    }
+}
+
+fn parse_value(value_type: AxValueType, raw: &str) -> Result<Value, CliError> {
+    match value_type {
+        AxValueType::String => Ok(Value::String(raw.to_string())),
+        AxValueType::Number => {
+            if let Ok(integer) = raw.parse::<i64>() {
+                return Ok(Value::Number(integer.into()));
+            }
+            let float = raw
+                .parse::<f64>()
+                .map_err(|_| CliError::usage("--value is not a valid number"))?;
+            let number = serde_json::Number::from_f64(float)
+                .ok_or_else(|| CliError::usage("--value is not a finite number"))?;
+            Ok(Value::Number(number))
+        }
+        AxValueType::Bool => {
+            let normalized = raw.trim().to_ascii_lowercase();
+            match normalized.as_str() {
+                "true" => Ok(Value::Bool(true)),
+                "false" => Ok(Value::Bool(false)),
+                _ => Err(CliError::usage(
+                    "--value must be true or false for --value-type bool",
+                )),
+            }
+        }
+        AxValueType::Json => serde_json::from_str(raw)
+            .map_err(|err| CliError::usage(format!("--value is not valid json: {err}"))),
+        AxValueType::Null => Ok(Value::Null),
+    }
+}
+
+fn print_get_result(format: OutputFormat, result: AxAttrGetResult) -> Result<(), CliError> {
+    match format {
+        OutputFormat::Json => {
+            let payload = SuccessEnvelope::new("ax.attr.get", result);
+            println!(
+                "{}",
+                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
+                    "failed to serialize json output: {err}"
+                )))?
+            );
+        }
+        OutputFormat::Text => {
+            println!(
+                "ax.attr.get\tnode_id={}\tname={}\tmatched_count={}\tvalue={}",
+                result.node_id.unwrap_or_default(),
+                result.name,
+                result.matched_count,
+                result.value
+            );
+        }
+        OutputFormat::Tsv => {
+            return Err(CliError::usage(
+                "--format tsv is only supported for `windows list` and `apps list`",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn print_set_result(format: OutputFormat, result: AxAttrSetResult) -> Result<(), CliError> {
+    match format {
+        OutputFormat::Json => {
+            let payload = SuccessEnvelope::new("ax.attr.set", result);
+            println!(
+                "{}",
+                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
+                    "failed to serialize json output: {err}"
+                )))?
+            );
+        }
+        OutputFormat::Text => {
+            println!(
+                "ax.attr.set\tnode_id={}\tname={}\tmatched_count={}\tapplied={}\tvalue_type={}",
+                result.node_id.unwrap_or_default(),
+                result.name,
+                result.matched_count,
+                result.applied,
+                result.value_type
+            );
+        }
+        OutputFormat::Tsv => {
+            return Err(CliError::usage(
+                "--format tsv is only supported for `windows list` and `apps list`",
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/macos-agent/src/commands/ax_click.rs
+++ b/crates/macos-agent/src/commands/ax_click.rs
@@ -2,12 +2,11 @@ use std::time::Instant;
 
 use crate::backend::cliclick;
 use crate::backend::process::ProcessRunner;
-use crate::backend::{AppleScriptAxBackend, AxBackendAdapter};
+use crate::backend::{AutoAxBackend, AxBackendAdapter};
 use crate::cli::{AxClickArgs, MouseButton, OutputFormat};
+use crate::commands::ax_common::{build_selector, build_target, AxSelectorInput};
 use crate::error::CliError;
-use crate::model::{
-    AxClickCommandResult, AxClickRequest, AxClickResult, AxSelector, AxTarget, SuccessEnvelope,
-};
+use crate::model::{AxClickCommandResult, AxClickRequest, AxClickResult, SuccessEnvelope};
 use crate::retry::run_with_retry;
 use crate::run::{
     action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
@@ -33,7 +32,7 @@ pub fn run(
     };
 
     if !policy.dry_run {
-        let backend = AppleScriptAxBackend;
+        let backend = AutoAxBackend::default();
         let retry = policy.retry_policy();
         let (mut backend_result, attempts) =
             run_with_retry(retry, || backend.click(runner, &request, policy.timeout_ms))?;
@@ -94,20 +93,26 @@ pub fn run(
 }
 
 fn build_request(args: &AxClickArgs) -> Result<AxClickRequest, CliError> {
-    if args.nth == Some(0) {
-        return Err(CliError::usage("--nth must be at least 1"));
-    }
+    let target = build_target(
+        args.session_id.clone(),
+        args.app.clone(),
+        args.bundle_id.clone(),
+        args.window_title_contains.clone(),
+    )?;
+    let selector = build_selector(AxSelectorInput {
+        node_id: args.node_id.clone(),
+        role: args.role.clone(),
+        title_contains: args.title_contains.clone(),
+        identifier_contains: args.identifier_contains.clone(),
+        value_contains: args.value_contains.clone(),
+        subrole: args.subrole.clone(),
+        focused: args.focused,
+        enabled: args.enabled,
+        nth: args.nth,
+    })?;
     Ok(AxClickRequest {
-        target: AxTarget {
-            app: args.app.clone(),
-            bundle_id: args.bundle_id.clone(),
-        },
-        selector: AxSelector {
-            node_id: args.node_id.clone(),
-            role: args.role.clone(),
-            title_contains: args.title_contains.clone(),
-            nth: args.nth.map(|value| value as usize),
-        },
+        target,
+        selector,
         allow_coordinate_fallback: args.allow_coordinate_fallback,
     })
 }

--- a/crates/macos-agent/src/commands/ax_common.rs
+++ b/crates/macos-agent/src/commands/ax_common.rs
@@ -1,0 +1,90 @@
+use crate::error::CliError;
+use crate::model::{AxSelector, AxTarget};
+
+#[derive(Debug, Clone, Default)]
+pub struct AxSelectorInput {
+    pub node_id: Option<String>,
+    pub role: Option<String>,
+    pub title_contains: Option<String>,
+    pub identifier_contains: Option<String>,
+    pub value_contains: Option<String>,
+    pub subrole: Option<String>,
+    pub focused: Option<bool>,
+    pub enabled: Option<bool>,
+    pub nth: Option<u32>,
+}
+
+pub fn build_target(
+    session_id: Option<String>,
+    app: Option<String>,
+    bundle_id: Option<String>,
+    window_title_contains: Option<String>,
+) -> Result<AxTarget, CliError> {
+    let mut target_count = 0;
+    if session_id.is_some() {
+        target_count += 1;
+    }
+    if app.is_some() {
+        target_count += 1;
+    }
+    if bundle_id.is_some() {
+        target_count += 1;
+    }
+
+    if target_count > 1 {
+        return Err(CliError::usage(
+            "--session-id cannot be combined with --app/--bundle-id",
+        ));
+    }
+
+    Ok(AxTarget {
+        session_id,
+        app,
+        bundle_id,
+        window_title_contains,
+    })
+}
+
+pub fn build_selector(input: AxSelectorInput) -> Result<AxSelector, CliError> {
+    if input.nth == Some(0) {
+        return Err(CliError::usage("--nth must be at least 1"));
+    }
+
+    let has_primary_filters = input.role.is_some()
+        || input.title_contains.is_some()
+        || input.identifier_contains.is_some()
+        || input.value_contains.is_some()
+        || input.subrole.is_some()
+        || input.focused.is_some()
+        || input.enabled.is_some();
+    let has_non_node_filters = has_primary_filters || input.nth.is_some();
+
+    if input.node_id.is_some() && has_non_node_filters {
+        return Err(CliError::usage(
+            "--node-id cannot be combined with role/title/identifier/value/subrole/focused/enabled/nth selectors",
+        ));
+    }
+
+    if input.node_id.is_none() && !has_primary_filters {
+        if input.nth.is_some() {
+            return Err(CliError::usage(
+                "--nth requires at least one selector filter when --node-id is not set",
+            ));
+        }
+        return Err(CliError::usage(
+            "provide --node-id or at least one selector filter (--role/--title-contains/--identifier-contains/--value-contains/--subrole/--focused/--enabled)",
+        ));
+    }
+
+    Ok(AxSelector {
+        node_id: input.node_id,
+        role: input.role,
+        title_contains: input.title_contains,
+        identifier_contains: input.identifier_contains,
+        value_contains: input.value_contains,
+        subrole: input.subrole,
+        focused: input.focused,
+        enabled: input.enabled,
+        nth: input.nth.map(|value| value as usize),
+    })
+}

--- a/crates/macos-agent/src/commands/ax_list.rs
+++ b/crates/macos-agent/src/commands/ax_list.rs
@@ -1,8 +1,9 @@
 use crate::backend::process::ProcessRunner;
-use crate::backend::{AppleScriptAxBackend, AxBackendAdapter};
+use crate::backend::{AutoAxBackend, AxBackendAdapter};
 use crate::cli::{AxListArgs, OutputFormat};
+use crate::commands::ax_common::build_target;
 use crate::error::CliError;
-use crate::model::{AxListRequest, AxTarget, SuccessEnvelope};
+use crate::model::{AxListRequest, SuccessEnvelope};
 use crate::run::ActionPolicy;
 
 pub fn run(
@@ -11,17 +12,26 @@ pub fn run(
     policy: ActionPolicy,
     runner: &dyn ProcessRunner,
 ) -> Result<(), CliError> {
+    let target = build_target(
+        args.session_id.clone(),
+        args.app.clone(),
+        args.bundle_id.clone(),
+        args.window_title_contains.clone(),
+    )?;
+
     let request = AxListRequest {
-        target: AxTarget {
-            app: args.app.clone(),
-            bundle_id: args.bundle_id.clone(),
-        },
+        target,
         role: args.role.clone(),
         title_contains: args.title_contains.clone(),
+        identifier_contains: args.identifier_contains.clone(),
+        value_contains: args.value_contains.clone(),
+        subrole: args.subrole.clone(),
+        focused: args.focused,
+        enabled: args.enabled,
         max_depth: args.max_depth,
         limit: args.limit.map(|value| value as usize),
     };
-    let backend = AppleScriptAxBackend;
+    let backend = AutoAxBackend::default();
     let result = backend.list(runner, &request, policy.timeout_ms)?;
 
     match format {

--- a/crates/macos-agent/src/commands/ax_session.rs
+++ b/crates/macos-agent/src/commands/ax_session.rs
@@ -1,0 +1,172 @@
+use crate::backend::process::ProcessRunner;
+use crate::backend::{AutoAxBackend, AxBackendAdapter};
+use crate::cli::{AxSessionListArgs, AxSessionStartArgs, AxSessionStopArgs, OutputFormat};
+use crate::commands::ax_common::build_target;
+use crate::error::CliError;
+use crate::model::{
+    AxSessionListResult, AxSessionStartRequest, AxSessionStartResult, AxSessionStopRequest,
+    AxSessionStopResult, SuccessEnvelope,
+};
+use crate::run::ActionPolicy;
+
+pub fn run_start(
+    format: OutputFormat,
+    args: &AxSessionStartArgs,
+    policy: ActionPolicy,
+    runner: &dyn ProcessRunner,
+) -> Result<(), CliError> {
+    let request = AxSessionStartRequest {
+        target: build_target(
+            None,
+            args.app.clone(),
+            args.bundle_id.clone(),
+            args.window_title_contains.clone(),
+        )?,
+        session_id: args.session_id.clone(),
+    };
+
+    let result = if policy.dry_run {
+        AxSessionStartResult {
+            session: crate::model::AxSessionInfo {
+                session_id: request
+                    .session_id
+                    .clone()
+                    .unwrap_or_else(|| "axs-dry-run".to_string()),
+                app: request.target.app.clone(),
+                bundle_id: request.target.bundle_id.clone(),
+                pid: None,
+                window_title_contains: request.target.window_title_contains.clone(),
+                created_at_ms: 0,
+            },
+            created: false,
+        }
+    } else {
+        let backend = AutoAxBackend::default();
+        backend.session_start(runner, &request, policy.timeout_ms)?
+    };
+
+    print_start(format, result)
+}
+
+pub fn run_list(
+    format: OutputFormat,
+    _args: &AxSessionListArgs,
+    policy: ActionPolicy,
+    runner: &dyn ProcessRunner,
+) -> Result<(), CliError> {
+    let backend = AutoAxBackend::default();
+    let result: AxSessionListResult = backend.session_list(runner, policy.timeout_ms)?;
+
+    match format {
+        OutputFormat::Json => {
+            let payload = SuccessEnvelope::new("ax.session.list", result);
+            println!(
+                "{}",
+                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
+                    "failed to serialize json output: {err}"
+                )))?
+            );
+        }
+        OutputFormat::Text => {
+            if result.sessions.is_empty() {
+                println!("ax.session.list\tsessions=0");
+            } else {
+                for session in result.sessions {
+                    println!(
+                        "ax.session.list\tsession_id={}\tapp={}\tbundle_id={}\tpid={}\tcreated_at_ms={}",
+                        session.session_id,
+                        session.app.unwrap_or_default(),
+                        session.bundle_id.unwrap_or_default(),
+                        session.pid.unwrap_or_default(),
+                        session.created_at_ms,
+                    );
+                }
+            }
+        }
+        OutputFormat::Tsv => {
+            return Err(CliError::usage(
+                "--format tsv is only supported for `windows list` and `apps list`",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn run_stop(
+    format: OutputFormat,
+    args: &AxSessionStopArgs,
+    policy: ActionPolicy,
+    runner: &dyn ProcessRunner,
+) -> Result<(), CliError> {
+    let request = AxSessionStopRequest {
+        session_id: args.session_id.clone(),
+    };
+
+    let result = if policy.dry_run {
+        AxSessionStopResult {
+            session_id: request.session_id,
+            removed: false,
+        }
+    } else {
+        let backend = AutoAxBackend::default();
+        backend.session_stop(runner, &request, policy.timeout_ms)?
+    };
+
+    match format {
+        OutputFormat::Json => {
+            let payload = SuccessEnvelope::new("ax.session.stop", result);
+            println!(
+                "{}",
+                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
+                    "failed to serialize json output: {err}"
+                )))?
+            );
+        }
+        OutputFormat::Text => {
+            println!(
+                "ax.session.stop\tsession_id={}\tremoved={}",
+                result.session_id, result.removed
+            );
+        }
+        OutputFormat::Tsv => {
+            return Err(CliError::usage(
+                "--format tsv is only supported for `windows list` and `apps list`",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn print_start(format: OutputFormat, result: AxSessionStartResult) -> Result<(), CliError> {
+    match format {
+        OutputFormat::Json => {
+            let payload = SuccessEnvelope::new("ax.session.start", result);
+            println!(
+                "{}",
+                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
+                    "failed to serialize json output: {err}"
+                )))?
+            );
+        }
+        OutputFormat::Text => {
+            println!(
+                "ax.session.start\tsession_id={}\tapp={}\tbundle_id={}\tpid={}\tcreated={}\tcreated_at_ms={}",
+                result.session.session_id,
+                result.session.app.unwrap_or_default(),
+                result.session.bundle_id.unwrap_or_default(),
+                result.session.pid.unwrap_or_default(),
+                result.created,
+                result.session.created_at_ms,
+            );
+        }
+        OutputFormat::Tsv => {
+            return Err(CliError::usage(
+                "--format tsv is only supported for `windows list` and `apps list`",
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/macos-agent/src/commands/ax_type.rs
+++ b/crates/macos-agent/src/commands/ax_type.rs
@@ -1,12 +1,11 @@
 use std::time::Instant;
 
 use crate::backend::process::ProcessRunner;
-use crate::backend::{AppleScriptAxBackend, AxBackendAdapter};
+use crate::backend::{AutoAxBackend, AxBackendAdapter};
 use crate::cli::{AxTypeArgs, OutputFormat};
+use crate::commands::ax_common::{build_selector, build_target, AxSelectorInput};
 use crate::error::CliError;
-use crate::model::{
-    AxSelector, AxTarget, AxTypeCommandResult, AxTypeRequest, AxTypeResult, SuccessEnvelope,
-};
+use crate::model::{AxTypeCommandResult, AxTypeRequest, AxTypeResult, SuccessEnvelope};
 use crate::retry::run_with_retry;
 use crate::run::{
     action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
@@ -32,7 +31,7 @@ pub fn run(
     };
 
     if !policy.dry_run {
-        let backend = AppleScriptAxBackend;
+        let backend = AutoAxBackend::default();
         let retry = policy.retry_policy();
         let (backend_result, attempts) = run_with_retry(retry, || {
             backend.type_text(runner, &request, policy.timeout_ms)
@@ -78,20 +77,26 @@ pub fn run(
 }
 
 fn build_request(args: &AxTypeArgs) -> Result<AxTypeRequest, CliError> {
-    if args.nth == Some(0) {
-        return Err(CliError::usage("--nth must be at least 1"));
-    }
+    let target = build_target(
+        args.session_id.clone(),
+        args.app.clone(),
+        args.bundle_id.clone(),
+        args.window_title_contains.clone(),
+    )?;
+    let selector = build_selector(AxSelectorInput {
+        node_id: args.node_id.clone(),
+        role: args.role.clone(),
+        title_contains: args.title_contains.clone(),
+        identifier_contains: args.identifier_contains.clone(),
+        value_contains: args.value_contains.clone(),
+        subrole: args.subrole.clone(),
+        focused: args.focused,
+        enabled: args.enabled,
+        nth: args.nth,
+    })?;
     Ok(AxTypeRequest {
-        target: AxTarget {
-            app: args.app.clone(),
-            bundle_id: args.bundle_id.clone(),
-        },
-        selector: AxSelector {
-            node_id: args.node_id.clone(),
-            role: args.role.clone(),
-            title_contains: args.title_contains.clone(),
-            nth: args.nth.map(|value| value as usize),
-        },
+        target,
+        selector,
         text: args.text.clone(),
         clear_first: args.clear_first,
         submit: args.submit,

--- a/crates/macos-agent/src/commands/ax_watch.rs
+++ b/crates/macos-agent/src/commands/ax_watch.rs
@@ -1,0 +1,169 @@
+use crate::backend::process::ProcessRunner;
+use crate::backend::{AutoAxBackend, AxBackendAdapter};
+use crate::cli::{AxWatchPollArgs, AxWatchStartArgs, AxWatchStopArgs, OutputFormat};
+use crate::error::CliError;
+use crate::model::{
+    AxWatchPollRequest, AxWatchPollResult, AxWatchStartRequest, AxWatchStartResult,
+    AxWatchStopRequest, AxWatchStopResult, SuccessEnvelope,
+};
+use crate::run::ActionPolicy;
+
+pub fn run_start(
+    format: OutputFormat,
+    args: &AxWatchStartArgs,
+    policy: ActionPolicy,
+    runner: &dyn ProcessRunner,
+) -> Result<(), CliError> {
+    let request = AxWatchStartRequest {
+        session_id: args.session_id.clone(),
+        events: args.events.clone(),
+        max_buffer: args.max_buffer,
+        watch_id: args.watch_id.clone(),
+    };
+
+    let result = if policy.dry_run {
+        AxWatchStartResult {
+            watch_id: request
+                .watch_id
+                .clone()
+                .unwrap_or_else(|| "axw-dry-run".to_string()),
+            session_id: request.session_id,
+            events: request.events,
+            max_buffer: request.max_buffer,
+            started: false,
+        }
+    } else {
+        let backend = AutoAxBackend::default();
+        backend.watch_start(runner, &request, policy.timeout_ms)?
+    };
+
+    match format {
+        OutputFormat::Json => {
+            let payload = SuccessEnvelope::new("ax.watch.start", result);
+            println!(
+                "{}",
+                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
+                    "failed to serialize json output: {err}"
+                )))?
+            );
+        }
+        OutputFormat::Text => {
+            println!(
+                "ax.watch.start\twatch_id={}\tsession_id={}\tstarted={}\tevents={}\tmax_buffer={}",
+                result.watch_id,
+                result.session_id,
+                result.started,
+                result.events.join(","),
+                result.max_buffer
+            );
+        }
+        OutputFormat::Tsv => {
+            return Err(CliError::usage(
+                "--format tsv is only supported for `windows list` and `apps list`",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn run_poll(
+    format: OutputFormat,
+    args: &AxWatchPollArgs,
+    policy: ActionPolicy,
+    runner: &dyn ProcessRunner,
+) -> Result<(), CliError> {
+    let request = AxWatchPollRequest {
+        watch_id: args.watch_id.clone(),
+        limit: args.limit,
+        drain: args.drain,
+    };
+
+    let backend = AutoAxBackend::default();
+    let result: AxWatchPollResult = backend.watch_poll(runner, &request, policy.timeout_ms)?;
+
+    match format {
+        OutputFormat::Json => {
+            let payload = SuccessEnvelope::new("ax.watch.poll", result);
+            println!(
+                "{}",
+                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
+                    "failed to serialize json output: {err}"
+                )))?
+            );
+        }
+        OutputFormat::Text => {
+            println!(
+                "ax.watch.poll\twatch_id={}\tevents={}\tdropped={}\trunning={}",
+                result.watch_id,
+                result.events.len(),
+                result.dropped,
+                result.running,
+            );
+            for event in result.events {
+                println!(
+                    "ax.watch.event\twatch_id={}\tevent={}\tat_ms={}\trole={}\ttitle={}",
+                    event.watch_id,
+                    event.event,
+                    event.at_ms,
+                    event.role.unwrap_or_default(),
+                    event.title.unwrap_or_default()
+                );
+            }
+        }
+        OutputFormat::Tsv => {
+            return Err(CliError::usage(
+                "--format tsv is only supported for `windows list` and `apps list`",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn run_stop(
+    format: OutputFormat,
+    args: &AxWatchStopArgs,
+    policy: ActionPolicy,
+    runner: &dyn ProcessRunner,
+) -> Result<(), CliError> {
+    let request = AxWatchStopRequest {
+        watch_id: args.watch_id.clone(),
+    };
+
+    let result = if policy.dry_run {
+        AxWatchStopResult {
+            watch_id: request.watch_id,
+            stopped: false,
+            drained: 0,
+        }
+    } else {
+        let backend = AutoAxBackend::default();
+        backend.watch_stop(runner, &request, policy.timeout_ms)?
+    };
+
+    match format {
+        OutputFormat::Json => {
+            let payload = SuccessEnvelope::new("ax.watch.stop", result);
+            println!(
+                "{}",
+                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
+                    "failed to serialize json output: {err}"
+                )))?
+            );
+        }
+        OutputFormat::Text => {
+            println!(
+                "ax.watch.stop\twatch_id={}\tstopped={}\tdrained={}",
+                result.watch_id, result.stopped, result.drained
+            );
+        }
+        OutputFormat::Tsv => {
+            return Err(CliError::usage(
+                "--format tsv is only supported for `windows list` and `apps list`",
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/macos-agent/src/commands/mod.rs
+++ b/crates/macos-agent/src/commands/mod.rs
@@ -1,6 +1,11 @@
+pub mod ax_action;
+pub mod ax_attr;
 pub mod ax_click;
+pub mod ax_common;
 pub mod ax_list;
+pub mod ax_session;
 pub mod ax_type;
+pub mod ax_watch;
 pub mod input_click;
 pub mod input_hotkey;
 pub mod input_source;

--- a/crates/macos-agent/src/main.rs
+++ b/crates/macos-agent/src/main.rs
@@ -5,8 +5,9 @@ use std::time::Instant;
 
 use clap::{error::ErrorKind, Parser};
 use macos_agent::cli::{
-    AxCommand, Cli, CommandGroup, ErrorFormat, InputCommand, InputSourceCommand, ObserveCommand,
-    ProfileCommand, ScenarioCommand, WaitCommand, WindowCommand,
+    AxActionCommand, AxAttrCommand, AxCommand, AxSessionCommand, AxWatchCommand, Cli, CommandGroup,
+    ErrorFormat, InputCommand, InputSourceCommand, ObserveCommand, ProfileCommand, ScenarioCommand,
+    WaitCommand, WindowCommand,
 };
 use macos_agent::error::CliError;
 use macos_agent::model::ErrorEnvelope;
@@ -243,6 +244,23 @@ fn command_label(cli: &Cli) -> String {
             AxCommand::List(_) => "ax.list".to_string(),
             AxCommand::Click(_) => "ax.click".to_string(),
             AxCommand::Type(_) => "ax.type".to_string(),
+            AxCommand::Attr { command } => match command {
+                AxAttrCommand::Get(_) => "ax.attr.get".to_string(),
+                AxAttrCommand::Set(_) => "ax.attr.set".to_string(),
+            },
+            AxCommand::Action { command } => match command {
+                AxActionCommand::Perform(_) => "ax.action.perform".to_string(),
+            },
+            AxCommand::Session { command } => match command {
+                AxSessionCommand::Start(_) => "ax.session.start".to_string(),
+                AxSessionCommand::List(_) => "ax.session.list".to_string(),
+                AxSessionCommand::Stop(_) => "ax.session.stop".to_string(),
+            },
+            AxCommand::Watch { command } => match command {
+                AxWatchCommand::Start(_) => "ax.watch.start".to_string(),
+                AxWatchCommand::Poll(_) => "ax.watch.poll".to_string(),
+                AxWatchCommand::Stop(_) => "ax.watch.stop".to_string(),
+            },
         },
         CommandGroup::Observe { command } => match command {
             ObserveCommand::Screenshot(_) => "observe.screenshot".to_string(),
@@ -289,6 +307,41 @@ mod tests {
         ])
         .expect("ax type parse");
         assert_eq!(command_label(&typ), "ax.type");
+
+        let attr_get = Cli::try_parse_from([
+            "macos-agent",
+            "ax",
+            "attr",
+            "get",
+            "--node-id",
+            "1.1",
+            "--name",
+            "AXRole",
+        ])
+        .expect("ax attr get parse");
+        assert_eq!(command_label(&attr_get), "ax.attr.get");
+
+        let action = Cli::try_parse_from([
+            "macos-agent",
+            "ax",
+            "action",
+            "perform",
+            "--node-id",
+            "1.1",
+            "--name",
+            "AXPress",
+        ])
+        .expect("ax action perform parse");
+        assert_eq!(command_label(&action), "ax.action.perform");
+
+        let session_start = Cli::try_parse_from(["macos-agent", "ax", "session", "start"])
+            .expect("ax session start parse");
+        assert_eq!(command_label(&session_start), "ax.session.start");
+
+        let watch_poll =
+            Cli::try_parse_from(["macos-agent", "ax", "watch", "poll", "--watch-id", "axw-1"])
+                .expect("ax watch poll parse");
+        assert_eq!(command_label(&watch_poll), "ax.watch.poll");
 
         let current = Cli::try_parse_from(["macos-agent", "input-source", "current"])
             .expect("input-source current parse");

--- a/crates/macos-agent/src/model.rs
+++ b/crates/macos-agent/src/model.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::error::{CliError, ErrorCategory};
 use crate::screen_record_adapter::{AppInfo, WindowInfo};
@@ -259,9 +260,13 @@ pub struct AxNode {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AxTarget {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub app: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bundle_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window_title_contains: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -272,6 +277,16 @@ pub struct AxSelector {
     pub role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title_contains: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identifier_contains: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value_contains: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subrole: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub focused: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nth: Option<usize>,
 }
@@ -284,6 +299,16 @@ pub struct AxListRequest {
     pub role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title_contains: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identifier_contains: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value_contains: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subrole: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub focused: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_depth: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -349,6 +374,171 @@ pub struct AxTypeResult {
     pub submitted: bool,
     #[serde(default)]
     pub used_keyboard_fallback: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AxAttrGetRequest {
+    #[serde(default)]
+    pub target: AxTarget,
+    #[serde(default)]
+    pub selector: AxSelector,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AxAttrSetRequest {
+    #[serde(default)]
+    pub target: AxTarget,
+    #[serde(default)]
+    pub selector: AxSelector,
+    pub name: String,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AxActionPerformRequest {
+    #[serde(default)]
+    pub target: AxTarget,
+    #[serde(default)]
+    pub selector: AxSelector,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AxAttrGetResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    pub matched_count: usize,
+    pub name: String,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AxAttrSetResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    pub matched_count: usize,
+    pub name: String,
+    pub applied: bool,
+    pub value_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AxActionPerformResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    pub matched_count: usize,
+    pub name: String,
+    pub performed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxSessionStartRequest {
+    #[serde(default)]
+    pub target: AxTarget,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxSessionStopRequest {
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxSessionInfo {
+    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bundle_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window_title_contains: Option<String>,
+    pub created_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxSessionStartResult {
+    #[serde(flatten)]
+    pub session: AxSessionInfo,
+    pub created: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxSessionListResult {
+    pub sessions: Vec<AxSessionInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxSessionStopResult {
+    pub session_id: String,
+    pub removed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxWatchStartRequest {
+    pub session_id: String,
+    #[serde(default)]
+    pub events: Vec<String>,
+    #[serde(default)]
+    pub max_buffer: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watch_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxWatchPollRequest {
+    pub watch_id: String,
+    #[serde(default)]
+    pub limit: usize,
+    #[serde(default)]
+    pub drain: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxWatchStopRequest {
+    pub watch_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxWatchEvent {
+    pub watch_id: String,
+    pub event: String,
+    pub at_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identifier: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxWatchStartResult {
+    pub watch_id: String,
+    pub session_id: String,
+    pub events: Vec<String>,
+    pub max_buffer: usize,
+    pub started: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxWatchPollResult {
+    pub watch_id: String,
+    pub events: Vec<AxWatchEvent>,
+    pub dropped: usize,
+    pub running: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AxWatchStopResult {
+    pub watch_id: String,
+    pub stopped: bool,
+    pub drained: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/macos-agent/src/run.rs
+++ b/crates/macos-agent/src/run.rs
@@ -3,9 +3,9 @@ use std::time::Instant;
 
 use crate::backend::process::RealProcessRunner;
 use crate::cli::{
-    AppsCommand, AxCommand, Cli, CommandGroup, InputCommand, InputSourceCommand, ObserveCommand,
-    OutputFormat, PreflightArgs, ProfileCommand, ScenarioCommand, WaitCommand, WindowCommand,
-    WindowsCommand,
+    AppsCommand, AxActionCommand, AxAttrCommand, AxCommand, AxSessionCommand, AxWatchCommand, Cli,
+    CommandGroup, InputCommand, InputSourceCommand, ObserveCommand, OutputFormat, PreflightArgs,
+    ProfileCommand, ScenarioCommand, WaitCommand, WindowCommand, WindowsCommand,
 };
 use crate::commands;
 use crate::error::CliError;
@@ -98,6 +98,41 @@ pub fn run(cli: Cli) -> Result<(), CliError> {
             AxCommand::List(args) => commands::ax_list::run(cli.format, &args, policy, &runner),
             AxCommand::Click(args) => commands::ax_click::run(cli.format, &args, policy, &runner),
             AxCommand::Type(args) => commands::ax_type::run(cli.format, &args, policy, &runner),
+            AxCommand::Attr { command } => match command {
+                AxAttrCommand::Get(args) => {
+                    commands::ax_attr::run_get(cli.format, &args, policy, &runner)
+                }
+                AxAttrCommand::Set(args) => {
+                    commands::ax_attr::run_set(cli.format, &args, policy, &runner)
+                }
+            },
+            AxCommand::Action { command } => match command {
+                AxActionCommand::Perform(args) => {
+                    commands::ax_action::run_perform(cli.format, &args, policy, &runner)
+                }
+            },
+            AxCommand::Session { command } => match command {
+                AxSessionCommand::Start(args) => {
+                    commands::ax_session::run_start(cli.format, &args, policy, &runner)
+                }
+                AxSessionCommand::List(args) => {
+                    commands::ax_session::run_list(cli.format, &args, policy, &runner)
+                }
+                AxSessionCommand::Stop(args) => {
+                    commands::ax_session::run_stop(cli.format, &args, policy, &runner)
+                }
+            },
+            AxCommand::Watch { command } => match command {
+                AxWatchCommand::Start(args) => {
+                    commands::ax_watch::run_start(cli.format, &args, policy, &runner)
+                }
+                AxWatchCommand::Poll(args) => {
+                    commands::ax_watch::run_poll(cli.format, &args, policy, &runner)
+                }
+                AxWatchCommand::Stop(args) => {
+                    commands::ax_watch::run_stop(cli.format, &args, policy, &runner)
+                }
+            },
         },
     }
 }


### PR DESCRIPTION
# Add Hammerspoon-backed AX object APIs, sessions, and observers

## Summary
Implement a full AX runtime surface in `macos-agent` by keeping the existing CLI façade while adding Hammerspoon-backed object operations, session lifecycle, and observer-driven event streaming, plus expanded selector/target capabilities and dispatch wiring.

## Changes
- Add Hammerspoon AX backend support for `ax attr get/set`, `ax action perform`, `ax session start/list/stop`, and `ax watch start/poll/stop`.
- Add AX observer event stream support via `hs.axuielement.observer` with buffered poll/drain semantics.
- Extend AX selector/target contracts with `session_id`, `window_title_contains`, and advanced filters (`identifier`, `value`, `subrole`, `focused`, `enabled`, `nth`).
- Wire new command groups through CLI parsing, runtime dispatch, models, command modules, and command label tracing.
- Update `macos-agent` README command surface and add Hammerspoon CLI dependency notes.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- AX observer features require a running Hammerspoon with `hs.ipc` enabled.
- Backend default remains `auto` so environments without Hammerspoon can fall back to AppleScript/JXA.
