### PR TITLE
Increase macos-agent AX coverage and contract test depth

### DIFF
--- a/crates/macos-agent/src/backend/hammerspoon.rs
+++ b/crates/macos-agent/src/backend/hammerspoon.rs
@@ -2576,10 +2576,25 @@ fn output_preview(raw: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use nils_test_support::{EnvGuard, GlobalStateLock};
+    use serde_json::json;
 
-    use crate::backend::hammerspoon::{is_backend_unavailable_error, map_hs_failure};
+    use crate::backend::hammerspoon::{
+        is_backend_unavailable_error, map_hs_failure, output_preview, selector_is_empty,
+    };
     use crate::backend::process::ProcessFailure;
     use crate::backend::AxBackendAdapter;
+    use crate::model::{
+        AxActionPerformRequest, AxAttrGetRequest, AxAttrSetRequest, AxClickRequest, AxSelector,
+        AxSessionStartRequest, AxSessionStopRequest, AxTarget, AxTypeRequest, AxWatchPollRequest,
+        AxWatchStartRequest, AxWatchStopRequest,
+    };
+
+    fn node_selector() -> AxSelector {
+        AxSelector {
+            node_id: Some("1.1".to_string()),
+            ..AxSelector::default()
+        }
+    }
 
     #[test]
     fn message_port_error_is_marked_backend_unavailable() {
@@ -2627,5 +2642,347 @@ mod tests {
             .expect("click should parse test override");
         assert_eq!(result.node_id.as_deref(), Some("1.1"));
         assert_eq!(result.matched_count, 1);
+    }
+
+    #[test]
+    fn default_test_mode_fixtures_cover_all_hammerspoon_ax_operations() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let backend = super::HammerspoonAxBackend;
+        let runner = crate::backend::process::RealProcessRunner;
+
+        let list = backend
+            .list(&runner, &crate::model::AxListRequest::default(), 1000)
+            .expect("list default fixture");
+        assert!(list.nodes.is_empty());
+
+        let click = backend
+            .click(
+                &runner,
+                &AxClickRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    allow_coordinate_fallback: false,
+                },
+                1000,
+            )
+            .expect("click default fixture");
+        assert_eq!(click.matched_count, 1);
+
+        let typ = backend
+            .type_text(
+                &runner,
+                &AxTypeRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    text: "test".to_string(),
+                    clear_first: false,
+                    submit: false,
+                    paste: false,
+                    allow_keyboard_fallback: false,
+                },
+                1000,
+            )
+            .expect("type default fixture");
+        assert_eq!(typ.applied_via, "ax-set-value");
+
+        let attr_get = backend
+            .attr_get(
+                &runner,
+                &AxAttrGetRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    name: "AXRole".to_string(),
+                },
+                1000,
+            )
+            .expect("attr get default fixture");
+        assert_eq!(attr_get.name, "AXRole");
+
+        let attr_set = backend
+            .attr_set(
+                &runner,
+                &AxAttrSetRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    name: "AXValue".to_string(),
+                    value: json!("hello"),
+                },
+                1000,
+            )
+            .expect("attr set default fixture");
+        assert!(attr_set.applied);
+
+        let action = backend
+            .action_perform(
+                &runner,
+                &AxActionPerformRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    name: "AXPress".to_string(),
+                },
+                1000,
+            )
+            .expect("action default fixture");
+        assert!(action.performed);
+
+        let session_start = backend
+            .session_start(
+                &runner,
+                &AxSessionStartRequest {
+                    target: AxTarget::default(),
+                    session_id: Some("axs-test".to_string()),
+                },
+                1000,
+            )
+            .expect("session start default fixture");
+        assert_eq!(session_start.session.session_id, "axs-test");
+
+        let session_list = backend
+            .session_list(&runner, 1000)
+            .expect("session list default fixture");
+        assert!(session_list.sessions.is_empty());
+
+        let session_stop = backend
+            .session_stop(
+                &runner,
+                &AxSessionStopRequest {
+                    session_id: "axs-test".to_string(),
+                },
+                1000,
+            )
+            .expect("session stop default fixture");
+        assert!(session_stop.removed);
+
+        let watch_start = backend
+            .watch_start(
+                &runner,
+                &AxWatchStartRequest {
+                    session_id: "axs-test".to_string(),
+                    events: vec!["AXTitleChanged".to_string()],
+                    max_buffer: 64,
+                    watch_id: Some("axw-test".to_string()),
+                },
+                1000,
+            )
+            .expect("watch start default fixture");
+        assert_eq!(watch_start.watch_id, "axw-test");
+
+        let watch_poll = backend
+            .watch_poll(
+                &runner,
+                &AxWatchPollRequest {
+                    watch_id: "axw-test".to_string(),
+                    limit: 10,
+                    drain: true,
+                },
+                1000,
+            )
+            .expect("watch poll default fixture");
+        assert!(watch_poll.running);
+
+        let watch_stop = backend
+            .watch_stop(
+                &runner,
+                &AxWatchStopRequest {
+                    watch_id: "axw-test".to_string(),
+                },
+                1000,
+            )
+            .expect("watch stop default fixture");
+        assert!(watch_stop.stopped);
+    }
+
+    #[test]
+    fn validation_errors_are_reported_for_empty_hammerspoon_inputs() {
+        let backend = super::HammerspoonAxBackend;
+        let runner = crate::backend::process::RealProcessRunner;
+
+        let click_err = backend
+            .click(
+                &runner,
+                &AxClickRequest {
+                    target: AxTarget::default(),
+                    selector: AxSelector::default(),
+                    allow_coordinate_fallback: false,
+                },
+                1000,
+            )
+            .expect_err("empty click selector should fail");
+        assert!(click_err.to_string().contains("selector is empty"));
+
+        let type_err = backend
+            .type_text(
+                &runner,
+                &AxTypeRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    text: "   ".to_string(),
+                    clear_first: false,
+                    submit: false,
+                    paste: false,
+                    allow_keyboard_fallback: false,
+                },
+                1000,
+            )
+            .expect_err("empty text should fail");
+        assert!(type_err.to_string().contains("--text cannot be empty"));
+
+        let attr_get_err = backend
+            .attr_get(
+                &runner,
+                &AxAttrGetRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    name: " ".to_string(),
+                },
+                1000,
+            )
+            .expect_err("empty attr get name should fail");
+        assert!(attr_get_err.to_string().contains("--name cannot be empty"));
+
+        let attr_set_err = backend
+            .attr_set(
+                &runner,
+                &AxAttrSetRequest {
+                    target: AxTarget::default(),
+                    selector: AxSelector::default(),
+                    name: "AXValue".to_string(),
+                    value: json!("hello"),
+                },
+                1000,
+            )
+            .expect_err("empty attr set selector should fail");
+        assert!(attr_set_err.to_string().contains("selector is empty"));
+
+        let action_err = backend
+            .action_perform(
+                &runner,
+                &AxActionPerformRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    name: " ".to_string(),
+                },
+                1000,
+            )
+            .expect_err("empty action name should fail");
+        assert!(action_err.to_string().contains("--name cannot be empty"));
+
+        let session_stop_err = backend
+            .session_stop(
+                &runner,
+                &AxSessionStopRequest {
+                    session_id: " ".to_string(),
+                },
+                1000,
+            )
+            .expect_err("empty session id should fail");
+        assert!(session_stop_err
+            .to_string()
+            .contains("--session-id cannot be empty"));
+
+        let watch_start_err = backend
+            .watch_start(
+                &runner,
+                &AxWatchStartRequest {
+                    session_id: " ".to_string(),
+                    events: vec![],
+                    max_buffer: 10,
+                    watch_id: None,
+                },
+                1000,
+            )
+            .expect_err("empty watch session should fail");
+        assert!(watch_start_err
+            .to_string()
+            .contains("--session-id cannot be empty"));
+
+        let watch_poll_err = backend
+            .watch_poll(
+                &runner,
+                &AxWatchPollRequest {
+                    watch_id: " ".to_string(),
+                    limit: 10,
+                    drain: true,
+                },
+                1000,
+            )
+            .expect_err("empty watch id should fail");
+        assert!(watch_poll_err
+            .to_string()
+            .contains("--watch-id cannot be empty"));
+
+        let watch_stop_err = backend
+            .watch_stop(
+                &runner,
+                &AxWatchStopRequest {
+                    watch_id: " ".to_string(),
+                },
+                1000,
+            )
+            .expect_err("empty watch id should fail");
+        assert!(watch_stop_err
+            .to_string()
+            .contains("--watch-id cannot be empty"));
+    }
+
+    #[test]
+    fn invalid_override_json_reports_parse_hint() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _override = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_AX_ATTR_GET_JSON", "not-json");
+
+        let backend = super::HammerspoonAxBackend;
+        let runner = crate::backend::process::RealProcessRunner;
+        let err = backend
+            .attr_get(
+                &runner,
+                &AxAttrGetRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    name: "AXRole".to_string(),
+                },
+                1000,
+            )
+            .expect_err("invalid json override should fail");
+        let rendered = err.to_string();
+        assert!(rendered.contains("output preview"));
+    }
+
+    #[test]
+    fn empty_override_value_falls_back_to_default_fixture() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _override = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_AX_SESSION_LIST_JSON", "   ");
+
+        let backend = super::HammerspoonAxBackend;
+        let runner = crate::backend::process::RealProcessRunner;
+        let result = backend
+            .session_list(&runner, 1000)
+            .expect("default fixture should be used");
+        assert!(result.sessions.is_empty());
+    }
+
+    #[test]
+    fn not_found_failure_is_marked_backend_unavailable() {
+        let error = map_hs_failure(
+            "ax.list",
+            ProcessFailure::NotFound {
+                program: "hs".to_string(),
+            },
+        );
+        assert!(is_backend_unavailable_error(&error));
+    }
+
+    #[test]
+    fn selector_and_preview_helpers_cover_expected_cases() {
+        assert!(selector_is_empty(&AxSelector::default()));
+        assert!(!selector_is_empty(&AxSelector {
+            title_contains: Some("Save".to_string()),
+            ..AxSelector::default()
+        }));
+
+        let preview = output_preview("abcdefghijklmnopqrstuvwxyz", 8);
+        assert_eq!(preview, "abcdefgh...");
     }
 }

--- a/crates/macos-agent/src/backend/mod.rs
+++ b/crates/macos-agent/src/backend/mod.rs
@@ -393,8 +393,24 @@ impl AxBackendAdapter for AutoAxBackend {
 mod tests {
     use nils_test_support::{EnvGuard, GlobalStateLock};
     use pretty_assertions::assert_eq;
+    use serde_json::json;
 
-    use crate::backend::AxBackendPreference;
+    use crate::backend::process::RealProcessRunner;
+    use crate::backend::{
+        AppleScriptAxBackend, AutoAxBackend, AxBackendAdapter, AxBackendPreference,
+    };
+    use crate::model::{
+        AxActionPerformRequest, AxAttrGetRequest, AxAttrSetRequest, AxClickRequest, AxListRequest,
+        AxSelector, AxSessionStartRequest, AxSessionStopRequest, AxTarget, AxTypeRequest,
+        AxWatchPollRequest, AxWatchStartRequest, AxWatchStopRequest,
+    };
+
+    fn node_selector() -> AxSelector {
+        AxSelector {
+            node_id: Some("1.1".to_string()),
+            ..AxSelector::default()
+        }
+    }
 
     #[test]
     fn backend_preference_defaults_to_applescript_in_test_mode() {
@@ -416,5 +432,286 @@ mod tests {
             AxBackendPreference::resolve(),
             AxBackendPreference::Hammerspoon
         );
+    }
+
+    #[test]
+    fn applescript_backend_reports_unsupported_for_ax_extension_methods() {
+        let runner = RealProcessRunner;
+        let request_target = AxTarget::default();
+        let selector = node_selector();
+
+        let attr_get = AppleScriptAxBackend.attr_get(
+            &runner,
+            &AxAttrGetRequest {
+                target: request_target.clone(),
+                selector: selector.clone(),
+                name: "AXRole".to_string(),
+            },
+            1000,
+        );
+        assert!(attr_get.is_err());
+
+        let attr_set = AppleScriptAxBackend.attr_set(
+            &runner,
+            &AxAttrSetRequest {
+                target: request_target.clone(),
+                selector: selector.clone(),
+                name: "AXValue".to_string(),
+                value: json!("hello"),
+            },
+            1000,
+        );
+        assert!(attr_set.is_err());
+
+        let action = AppleScriptAxBackend.action_perform(
+            &runner,
+            &AxActionPerformRequest {
+                target: request_target,
+                selector,
+                name: "AXPress".to_string(),
+            },
+            1000,
+        );
+        assert!(action.is_err());
+    }
+
+    #[test]
+    fn auto_backend_hammerspoon_preference_routes_list_click_type() {
+        let lock = GlobalStateLock::new();
+        let _test_mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _backend = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_AX_BACKEND", "hammerspoon");
+        let _list = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_LIST_JSON",
+            r#"{"nodes":[{"node_id":"1.1","role":"AXButton","enabled":true,"focused":false,"actions":[],"path":["1","1"]}],"warnings":[]}"#,
+        );
+        let _click = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_CLICK_JSON",
+            r#"{"node_id":"1.1","matched_count":1,"action":"ax-press","used_coordinate_fallback":false}"#,
+        );
+        let _typ = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_TYPE_JSON",
+            r#"{"node_id":"1.1","matched_count":1,"applied_via":"ax-set-value","text_length":4,"submitted":false,"used_keyboard_fallback":false}"#,
+        );
+
+        let backend = AutoAxBackend::default();
+        let runner = RealProcessRunner;
+        let list = backend
+            .list(&runner, &AxListRequest::default(), 1000)
+            .expect("list should succeed");
+        assert_eq!(list.nodes.len(), 1);
+
+        let click = backend
+            .click(
+                &runner,
+                &AxClickRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    allow_coordinate_fallback: false,
+                },
+                1000,
+            )
+            .expect("click should succeed");
+        assert_eq!(click.matched_count, 1);
+
+        let typ = backend
+            .type_text(
+                &runner,
+                &AxTypeRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    text: "test".to_string(),
+                    clear_first: false,
+                    submit: false,
+                    paste: false,
+                    allow_keyboard_fallback: false,
+                },
+                1000,
+            )
+            .expect("type should succeed");
+        assert_eq!(typ.text_length, 4);
+    }
+
+    #[test]
+    fn auto_backend_auto_preference_uses_hammerspoon_first_when_available() {
+        let lock = GlobalStateLock::new();
+        let _test_mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _backend = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_AX_BACKEND", "auto");
+        let _list = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_LIST_JSON",
+            r#"{"nodes":[{"node_id":"9.9","role":"AXButton","enabled":true,"focused":false,"actions":[],"path":["9","9"]}],"warnings":[]}"#,
+        );
+
+        let backend = AutoAxBackend::default();
+        let runner = RealProcessRunner;
+        let list = backend
+            .list(&runner, &AxListRequest::default(), 1000)
+            .expect("list should succeed");
+        assert_eq!(list.nodes[0].node_id, "9.9");
+    }
+
+    #[test]
+    fn auto_backend_ax_extension_methods_route_through_hammerspoon() {
+        let lock = GlobalStateLock::new();
+        let _test_mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _backend = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_AX_BACKEND", "applescript");
+
+        let _attr_get = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_ATTR_GET_JSON",
+            r#"{"node_id":"1.1","matched_count":1,"name":"AXRole","value":"AXButton"}"#,
+        );
+        let _attr_set = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_ATTR_SET_JSON",
+            r#"{"node_id":"1.1","matched_count":1,"name":"AXValue","applied":true,"value_type":"string"}"#,
+        );
+        let _action = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_ACTION_PERFORM_JSON",
+            r#"{"node_id":"1.1","matched_count":1,"name":"AXPress","performed":true}"#,
+        );
+        let _session_start = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_SESSION_START_JSON",
+            r#"{"session_id":"axs-1","app":"Arc","bundle_id":"company.thebrowser.Browser","pid":1001,"created_at_ms":1700000000000,"created":true}"#,
+        );
+        let _session_list = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_SESSION_LIST_JSON",
+            r#"{"sessions":[{"session_id":"axs-1","app":"Arc","bundle_id":"company.thebrowser.Browser","pid":1001,"created_at_ms":1700000000000}]}"#,
+        );
+        let _session_stop = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_SESSION_STOP_JSON",
+            r#"{"session_id":"axs-1","removed":true}"#,
+        );
+        let _watch_start = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_WATCH_START_JSON",
+            r#"{"watch_id":"axw-1","session_id":"axs-1","events":["AXTitleChanged"],"max_buffer":64,"started":true}"#,
+        );
+        let _watch_poll = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_WATCH_POLL_JSON",
+            r#"{"watch_id":"axw-1","events":[],"dropped":0,"running":true}"#,
+        );
+        let _watch_stop = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_WATCH_STOP_JSON",
+            r#"{"watch_id":"axw-1","stopped":true,"drained":0}"#,
+        );
+
+        let backend = AutoAxBackend::default();
+        let runner = RealProcessRunner;
+
+        let attr_get = backend
+            .attr_get(
+                &runner,
+                &AxAttrGetRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    name: "AXRole".to_string(),
+                },
+                1000,
+            )
+            .expect("attr get should succeed");
+        assert_eq!(attr_get.name, "AXRole");
+
+        let attr_set = backend
+            .attr_set(
+                &runner,
+                &AxAttrSetRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    name: "AXValue".to_string(),
+                    value: json!("hello"),
+                },
+                1000,
+            )
+            .expect("attr set should succeed");
+        assert!(attr_set.applied);
+
+        let action = backend
+            .action_perform(
+                &runner,
+                &AxActionPerformRequest {
+                    target: AxTarget::default(),
+                    selector: node_selector(),
+                    name: "AXPress".to_string(),
+                },
+                1000,
+            )
+            .expect("action should succeed");
+        assert!(action.performed);
+
+        let start = backend
+            .session_start(
+                &runner,
+                &AxSessionStartRequest {
+                    target: AxTarget::default(),
+                    session_id: Some("axs-1".to_string()),
+                },
+                1000,
+            )
+            .expect("session start should succeed");
+        assert_eq!(start.session.session_id, "axs-1");
+
+        let listed = backend
+            .session_list(&runner, 1000)
+            .expect("session list should succeed");
+        assert_eq!(listed.sessions.len(), 1);
+
+        let stop = backend
+            .session_stop(
+                &runner,
+                &AxSessionStopRequest {
+                    session_id: "axs-1".to_string(),
+                },
+                1000,
+            )
+            .expect("session stop should succeed");
+        assert!(stop.removed);
+
+        let watch_start = backend
+            .watch_start(
+                &runner,
+                &AxWatchStartRequest {
+                    session_id: "axs-1".to_string(),
+                    events: vec!["AXTitleChanged".to_string()],
+                    max_buffer: 64,
+                    watch_id: Some("axw-1".to_string()),
+                },
+                1000,
+            )
+            .expect("watch start should succeed");
+        assert_eq!(watch_start.watch_id, "axw-1");
+
+        let watch_poll = backend
+            .watch_poll(
+                &runner,
+                &AxWatchPollRequest {
+                    watch_id: "axw-1".to_string(),
+                    limit: 10,
+                    drain: true,
+                },
+                1000,
+            )
+            .expect("watch poll should succeed");
+        assert!(watch_poll.running);
+
+        let watch_stop = backend
+            .watch_stop(
+                &runner,
+                &AxWatchStopRequest {
+                    watch_id: "axw-1".to_string(),
+                },
+                1000,
+            )
+            .expect("watch stop should succeed");
+        assert!(watch_stop.stopped);
     }
 }

--- a/crates/macos-agent/src/commands/ax_action.rs
+++ b/crates/macos-agent/src/commands/ax_action.rs
@@ -73,3 +73,64 @@ pub fn run_perform(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use nils_test_support::{EnvGuard, GlobalStateLock};
+
+    use super::run_perform;
+    use crate::backend::process::RealProcessRunner;
+    use crate::cli::{AxActionPerformArgs, OutputFormat};
+    use crate::run::ActionPolicy;
+
+    fn policy(dry_run: bool) -> ActionPolicy {
+        ActionPolicy {
+            dry_run,
+            retries: 0,
+            retry_delay_ms: 150,
+            timeout_ms: 1000,
+        }
+    }
+
+    fn sample_args() -> AxActionPerformArgs {
+        AxActionPerformArgs {
+            node_id: Some("1.1".to_string()),
+            role: None,
+            title_contains: None,
+            identifier_contains: None,
+            value_contains: None,
+            subrole: None,
+            focused: None,
+            enabled: None,
+            nth: None,
+            session_id: None,
+            app: None,
+            bundle_id: None,
+            window_title_contains: None,
+            name: "AXPress".to_string(),
+        }
+    }
+
+    #[test]
+    fn run_perform_dry_run_supports_text_and_json() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let runner = RealProcessRunner;
+
+        run_perform(OutputFormat::Text, &sample_args(), policy(true), &runner)
+            .expect("text dry-run should succeed");
+        run_perform(OutputFormat::Json, &sample_args(), policy(true), &runner)
+            .expect("json dry-run should succeed");
+    }
+
+    #[test]
+    fn run_perform_rejects_tsv() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let runner = RealProcessRunner;
+
+        let err = run_perform(OutputFormat::Tsv, &sample_args(), policy(true), &runner)
+            .expect_err("tsv should be rejected");
+        assert!(err.to_string().contains("windows list"));
+    }
+}

--- a/crates/macos-agent/src/commands/ax_attr.rs
+++ b/crates/macos-agent/src/commands/ax_attr.rs
@@ -186,3 +186,133 @@ fn print_set_result(format: OutputFormat, result: AxAttrSetResult) -> Result<(),
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use nils_test_support::{EnvGuard, GlobalStateLock};
+    use serde_json::json;
+
+    use super::{parse_value, run_get, run_set, value_type_name};
+    use crate::backend::process::RealProcessRunner;
+    use crate::cli::{AxAttrGetArgs, AxAttrSetArgs, AxValueType, OutputFormat};
+    use crate::run::ActionPolicy;
+
+    fn policy(dry_run: bool) -> ActionPolicy {
+        ActionPolicy {
+            dry_run,
+            retries: 0,
+            retry_delay_ms: 150,
+            timeout_ms: 1000,
+        }
+    }
+
+    fn sample_get_args() -> AxAttrGetArgs {
+        AxAttrGetArgs {
+            node_id: Some("1.1".to_string()),
+            role: None,
+            title_contains: None,
+            identifier_contains: None,
+            value_contains: None,
+            subrole: None,
+            focused: None,
+            enabled: None,
+            nth: None,
+            session_id: None,
+            app: None,
+            bundle_id: None,
+            window_title_contains: None,
+            name: "AXRole".to_string(),
+        }
+    }
+
+    fn sample_set_args(value_type: AxValueType, value: &str) -> AxAttrSetArgs {
+        AxAttrSetArgs {
+            node_id: Some("1.1".to_string()),
+            role: None,
+            title_contains: None,
+            identifier_contains: None,
+            value_contains: None,
+            subrole: None,
+            focused: None,
+            enabled: None,
+            nth: None,
+            session_id: None,
+            app: None,
+            bundle_id: None,
+            window_title_contains: None,
+            name: "AXValue".to_string(),
+            value: value.to_string(),
+            value_type,
+        }
+    }
+
+    #[test]
+    fn parse_value_covers_supported_types() {
+        assert_eq!(
+            parse_value(AxValueType::String, "hello").expect("string"),
+            json!("hello")
+        );
+        assert_eq!(
+            parse_value(AxValueType::Number, "42").expect("integer"),
+            json!(42)
+        );
+        assert_eq!(
+            parse_value(AxValueType::Bool, "true").expect("bool"),
+            json!(true)
+        );
+        assert_eq!(
+            parse_value(AxValueType::Json, "{\"k\":1}").expect("json"),
+            json!({"k": 1})
+        );
+        assert_eq!(
+            parse_value(AxValueType::Null, "ignored").expect("null"),
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn parse_value_reports_expected_usage_errors() {
+        let bool_err = parse_value(AxValueType::Bool, "maybe").expect_err("invalid bool");
+        assert!(bool_err.to_string().contains("true or false"));
+
+        let number_err = parse_value(AxValueType::Number, "NaN").expect_err("invalid number");
+        assert!(number_err.to_string().contains("finite number"));
+
+        let json_err = parse_value(AxValueType::Json, "{invalid json").expect_err("invalid json");
+        assert!(json_err.to_string().contains("valid json"));
+    }
+
+    #[test]
+    fn value_type_name_matches_cli_values() {
+        assert_eq!(value_type_name(AxValueType::String), "string");
+        assert_eq!(value_type_name(AxValueType::Number), "number");
+        assert_eq!(value_type_name(AxValueType::Bool), "bool");
+        assert_eq!(value_type_name(AxValueType::Json), "json");
+        assert_eq!(value_type_name(AxValueType::Null), "null");
+    }
+
+    #[test]
+    fn run_get_and_set_return_usage_error_for_tsv_format() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let runner = RealProcessRunner;
+
+        let get_err = run_get(
+            OutputFormat::Tsv,
+            &sample_get_args(),
+            policy(false),
+            &runner,
+        )
+        .expect_err("tsv should be rejected");
+        assert!(get_err.to_string().contains("windows list"));
+
+        let set_err = run_set(
+            OutputFormat::Tsv,
+            &sample_set_args(AxValueType::String, "hello"),
+            policy(true),
+            &runner,
+        )
+        .expect_err("tsv should be rejected");
+        assert!(set_err.to_string().contains("windows list"));
+    }
+}

--- a/crates/macos-agent/src/commands/ax_session.rs
+++ b/crates/macos-agent/src/commands/ax_session.rs
@@ -170,3 +170,150 @@ fn print_start(format: OutputFormat, result: AxSessionStartResult) -> Result<(),
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use nils_test_support::{EnvGuard, GlobalStateLock};
+
+    use super::{run_list, run_start, run_stop};
+    use crate::backend::process::RealProcessRunner;
+    use crate::cli::{AxSessionListArgs, AxSessionStartArgs, AxSessionStopArgs, OutputFormat};
+    use crate::run::ActionPolicy;
+
+    fn policy(dry_run: bool) -> ActionPolicy {
+        ActionPolicy {
+            dry_run,
+            retries: 0,
+            retry_delay_ms: 150,
+            timeout_ms: 1000,
+        }
+    }
+
+    fn sample_start_args() -> AxSessionStartArgs {
+        AxSessionStartArgs {
+            app: Some("Arc".to_string()),
+            bundle_id: None,
+            session_id: Some("axs-unit".to_string()),
+            window_title_contains: Some("Inbox".to_string()),
+        }
+    }
+
+    fn sample_stop_args() -> AxSessionStopArgs {
+        AxSessionStopArgs {
+            session_id: "axs-unit".to_string(),
+        }
+    }
+
+    #[test]
+    fn run_start_and_stop_dry_run_support_text_and_json() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let runner = RealProcessRunner;
+
+        run_start(
+            OutputFormat::Text,
+            &sample_start_args(),
+            policy(true),
+            &runner,
+        )
+        .expect("start text dry-run should succeed");
+        run_start(
+            OutputFormat::Json,
+            &sample_start_args(),
+            policy(true),
+            &runner,
+        )
+        .expect("start json dry-run should succeed");
+
+        run_stop(
+            OutputFormat::Text,
+            &sample_stop_args(),
+            policy(true),
+            &runner,
+        )
+        .expect("stop text dry-run should succeed");
+        run_stop(
+            OutputFormat::Json,
+            &sample_stop_args(),
+            policy(true),
+            &runner,
+        )
+        .expect("stop json dry-run should succeed");
+    }
+
+    #[test]
+    fn run_start_and_stop_reject_tsv_in_dry_run() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let runner = RealProcessRunner;
+
+        let start_err = run_start(
+            OutputFormat::Tsv,
+            &sample_start_args(),
+            policy(true),
+            &runner,
+        )
+        .expect_err("start tsv should be rejected");
+        assert!(start_err.to_string().contains("windows list"));
+
+        let stop_err = run_stop(
+            OutputFormat::Tsv,
+            &sample_stop_args(),
+            policy(true),
+            &runner,
+        )
+        .expect_err("stop tsv should be rejected");
+        assert!(stop_err.to_string().contains("windows list"));
+    }
+
+    #[test]
+    fn run_list_covers_non_empty_text_and_tsv_rejection() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _backend = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_AX_BACKEND", "hammerspoon");
+        let _list_override = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_SESSION_LIST_JSON",
+            r#"{"sessions":[{"session_id":"axs-unit","app":"Arc","bundle_id":"company.thebrowser.Browser","pid":4242,"window_title_contains":"Inbox","created_at_ms":1700000001000}]}"#,
+        );
+        let runner = RealProcessRunner;
+
+        run_list(
+            OutputFormat::Text,
+            &AxSessionListArgs::default(),
+            policy(false),
+            &runner,
+        )
+        .expect("list text should succeed");
+
+        let err = run_list(
+            OutputFormat::Tsv,
+            &AxSessionListArgs::default(),
+            policy(false),
+            &runner,
+        )
+        .expect_err("list tsv should be rejected");
+        assert!(err.to_string().contains("windows list"));
+    }
+
+    #[test]
+    fn run_list_text_supports_empty_sessions_branch() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _backend = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_AX_BACKEND", "hammerspoon");
+        let _list_override = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_SESSION_LIST_JSON",
+            r#"{"sessions":[]}"#,
+        );
+        let runner = RealProcessRunner;
+
+        run_list(
+            OutputFormat::Text,
+            &AxSessionListArgs::default(),
+            policy(false),
+            &runner,
+        )
+        .expect("list text should succeed with empty sessions");
+    }
+}

--- a/crates/macos-agent/src/commands/ax_watch.rs
+++ b/crates/macos-agent/src/commands/ax_watch.rs
@@ -167,3 +167,140 @@ pub fn run_stop(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use nils_test_support::{EnvGuard, GlobalStateLock};
+
+    use super::{run_poll, run_start, run_stop};
+    use crate::backend::process::RealProcessRunner;
+    use crate::cli::{AxWatchPollArgs, AxWatchStartArgs, AxWatchStopArgs, OutputFormat};
+    use crate::run::ActionPolicy;
+
+    fn policy(dry_run: bool) -> ActionPolicy {
+        ActionPolicy {
+            dry_run,
+            retries: 0,
+            retry_delay_ms: 150,
+            timeout_ms: 1000,
+        }
+    }
+
+    fn sample_start_args() -> AxWatchStartArgs {
+        AxWatchStartArgs {
+            session_id: "axs-unit".to_string(),
+            watch_id: Some("axw-unit".to_string()),
+            events: vec![
+                "AXFocusedUIElementChanged".to_string(),
+                "AXTitleChanged".to_string(),
+            ],
+            max_buffer: 64,
+        }
+    }
+
+    fn sample_poll_args() -> AxWatchPollArgs {
+        AxWatchPollArgs {
+            watch_id: "axw-unit".to_string(),
+            limit: 10,
+            drain: true,
+        }
+    }
+
+    fn sample_stop_args() -> AxWatchStopArgs {
+        AxWatchStopArgs {
+            watch_id: "axw-unit".to_string(),
+        }
+    }
+
+    #[test]
+    fn run_start_and_stop_dry_run_support_text_and_json() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let runner = RealProcessRunner;
+
+        run_start(
+            OutputFormat::Text,
+            &sample_start_args(),
+            policy(true),
+            &runner,
+        )
+        .expect("start text dry-run should succeed");
+        run_start(
+            OutputFormat::Json,
+            &sample_start_args(),
+            policy(true),
+            &runner,
+        )
+        .expect("start json dry-run should succeed");
+
+        run_stop(
+            OutputFormat::Text,
+            &sample_stop_args(),
+            policy(true),
+            &runner,
+        )
+        .expect("stop text dry-run should succeed");
+        run_stop(
+            OutputFormat::Json,
+            &sample_stop_args(),
+            policy(true),
+            &runner,
+        )
+        .expect("stop json dry-run should succeed");
+    }
+
+    #[test]
+    fn run_start_and_stop_reject_tsv_in_dry_run() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let runner = RealProcessRunner;
+
+        let start_err = run_start(
+            OutputFormat::Tsv,
+            &sample_start_args(),
+            policy(true),
+            &runner,
+        )
+        .expect_err("start tsv should be rejected");
+        assert!(start_err.to_string().contains("windows list"));
+
+        let stop_err = run_stop(
+            OutputFormat::Tsv,
+            &sample_stop_args(),
+            policy(true),
+            &runner,
+        )
+        .expect_err("stop tsv should be rejected");
+        assert!(stop_err.to_string().contains("windows list"));
+    }
+
+    #[test]
+    fn run_poll_covers_event_text_and_tsv_rejection() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_TEST_MODE", "1");
+        let _backend = EnvGuard::set(&lock, "CODEX_MACOS_AGENT_AX_BACKEND", "hammerspoon");
+        let _poll_override = EnvGuard::set(
+            &lock,
+            "CODEX_MACOS_AGENT_AX_WATCH_POLL_JSON",
+            r#"{"watch_id":"axw-unit","events":[{"watch_id":"axw-unit","event":"AXTitleChanged","at_ms":1700000002222,"role":"AXButton","title":"Save","identifier":"save-btn","pid":2001}],"dropped":0,"running":true}"#,
+        );
+        let runner = RealProcessRunner;
+
+        run_poll(
+            OutputFormat::Text,
+            &sample_poll_args(),
+            policy(false),
+            &runner,
+        )
+        .expect("poll text should succeed");
+
+        let err = run_poll(
+            OutputFormat::Tsv,
+            &sample_poll_args(),
+            policy(false),
+            &runner,
+        )
+        .expect_err("poll tsv should be rejected");
+        assert!(err.to_string().contains("windows list"));
+    }
+}

--- a/crates/macos-agent/tests/ax_extended.rs
+++ b/crates/macos-agent/tests/ax_extended.rs
@@ -1,0 +1,386 @@
+use serde_json::json;
+use tempfile::TempDir;
+
+mod common;
+
+#[test]
+fn ax_attr_get_json_supports_override_payload() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+    let options = harness.cmd_options(cwd.path()).with_env(
+        "CODEX_MACOS_AGENT_AX_ATTR_GET_JSON",
+        r#"{"node_id":"2.1","matched_count":1,"name":"AXRole","value":{"role":"AXButton"}}"#,
+    );
+
+    let out = harness.run_with_options(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "ax",
+            "attr",
+            "get",
+            "--node-id",
+            "2.1",
+            "--name",
+            "AXRole",
+        ],
+        options,
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+    let payload: serde_json::Value = serde_json::from_str(&out.stdout_text()).expect("stdout json");
+    assert_eq!(payload["command"], json!("ax.attr.get"));
+    assert_eq!(payload["result"]["name"], json!("AXRole"));
+    assert_eq!(payload["result"]["value"]["role"], json!("AXButton"));
+}
+
+#[test]
+fn ax_attr_set_dry_run_bool_value_type_is_reported() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+
+    let out = harness.run(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "ax",
+            "attr",
+            "set",
+            "--node-id",
+            "1.2",
+            "--name",
+            "AXEnabled",
+            "--value",
+            "true",
+            "--value-type",
+            "bool",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+    let payload: serde_json::Value = serde_json::from_str(&out.stdout_text()).expect("stdout json");
+    assert_eq!(payload["command"], json!("ax.attr.set"));
+    assert_eq!(payload["result"]["applied"], json!(false));
+    assert_eq!(payload["result"]["value_type"], json!("bool"));
+}
+
+#[test]
+fn ax_attr_set_rejects_invalid_bool_value() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+
+    let out = harness.run(
+        cwd.path(),
+        &[
+            "ax",
+            "attr",
+            "set",
+            "--node-id",
+            "1.2",
+            "--name",
+            "AXEnabled",
+            "--value",
+            "maybe",
+            "--value-type",
+            "bool",
+        ],
+    );
+
+    assert_eq!(out.code, 2);
+    assert_eq!(out.stdout_text(), "");
+    assert!(out.stderr_text().contains("true or false"));
+}
+
+#[test]
+fn ax_attr_set_rejects_non_finite_number_value() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+
+    let out = harness.run(
+        cwd.path(),
+        &[
+            "ax",
+            "attr",
+            "set",
+            "--node-id",
+            "1.2",
+            "--name",
+            "AXValue",
+            "--value",
+            "NaN",
+            "--value-type",
+            "number",
+        ],
+    );
+
+    assert_eq!(out.code, 2);
+    assert_eq!(out.stdout_text(), "");
+    assert!(out.stderr_text().contains("finite number"));
+}
+
+#[test]
+fn ax_action_perform_text_output_is_emitted() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+
+    let out = harness.run(
+        cwd.path(),
+        &[
+            "ax",
+            "action",
+            "perform",
+            "--node-id",
+            "1.1",
+            "--name",
+            "AXPress",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+    assert!(out.stdout_text().contains("ax.action.perform"));
+    assert!(out.stdout_text().contains("performed=true"));
+}
+
+#[test]
+fn ax_session_start_list_stop_json_contracts() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+    let options = harness
+        .cmd_options(cwd.path())
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_SESSION_START_JSON",
+            r#"{"session_id":"axs-demo","app":"Arc","bundle_id":"company.thebrowser.Browser","pid":2001,"window_title_contains":"Inbox","created_at_ms":1700000001111,"created":true}"#,
+        )
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_SESSION_LIST_JSON",
+            r#"{"sessions":[{"session_id":"axs-demo","app":"Arc","bundle_id":"company.thebrowser.Browser","pid":2001,"window_title_contains":"Inbox","created_at_ms":1700000001111}]}"#,
+        )
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_SESSION_STOP_JSON",
+            r#"{"session_id":"axs-demo","removed":true}"#,
+        );
+
+    let start_out = harness.run_with_options(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "ax",
+            "session",
+            "start",
+            "--app",
+            "Arc",
+            "--session-id",
+            "axs-demo",
+            "--window-title-contains",
+            "Inbox",
+        ],
+        options.clone(),
+    );
+    assert_eq!(start_out.code, 0, "stderr: {}", start_out.stderr_text());
+    let start_payload: serde_json::Value =
+        serde_json::from_str(&start_out.stdout_text()).expect("stdout json");
+    assert_eq!(start_payload["command"], json!("ax.session.start"));
+    assert_eq!(start_payload["result"]["session_id"], json!("axs-demo"));
+    assert_eq!(start_payload["result"]["created"], json!(true));
+
+    let list_out = harness.run_with_options(
+        cwd.path(),
+        &["--format", "json", "ax", "session", "list"],
+        options.clone(),
+    );
+    assert_eq!(list_out.code, 0, "stderr: {}", list_out.stderr_text());
+    let list_payload: serde_json::Value =
+        serde_json::from_str(&list_out.stdout_text()).expect("stdout json");
+    assert_eq!(list_payload["command"], json!("ax.session.list"));
+    assert_eq!(
+        list_payload["result"]["sessions"][0]["session_id"],
+        json!("axs-demo")
+    );
+
+    let stop_out = harness.run_with_options(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "ax",
+            "session",
+            "stop",
+            "--session-id",
+            "axs-demo",
+        ],
+        options,
+    );
+    assert_eq!(stop_out.code, 0, "stderr: {}", stop_out.stderr_text());
+    let stop_payload: serde_json::Value =
+        serde_json::from_str(&stop_out.stdout_text()).expect("stdout json");
+    assert_eq!(stop_payload["command"], json!("ax.session.stop"));
+    assert_eq!(stop_payload["result"]["removed"], json!(true));
+}
+
+#[test]
+fn ax_watch_start_poll_stop_json_contracts() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+    let options = harness
+        .cmd_options(cwd.path())
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_WATCH_START_JSON",
+            r#"{"watch_id":"axw-demo","session_id":"axs-demo","events":["AXTitleChanged","AXFocusedUIElementChanged"],"max_buffer":64,"started":true}"#,
+        )
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_WATCH_POLL_JSON",
+            r#"{"watch_id":"axw-demo","events":[{"watch_id":"axw-demo","event":"AXTitleChanged","at_ms":1700000002222,"role":"AXButton","title":"Save","identifier":"save-btn","pid":2001}],"dropped":0,"running":true}"#,
+        )
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_WATCH_STOP_JSON",
+            r#"{"watch_id":"axw-demo","stopped":true,"drained":1}"#,
+        );
+
+    let start_out = harness.run_with_options(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "ax",
+            "watch",
+            "start",
+            "--session-id",
+            "axs-demo",
+            "--watch-id",
+            "axw-demo",
+            "--events",
+            "AXTitleChanged,AXFocusedUIElementChanged",
+            "--max-buffer",
+            "64",
+        ],
+        options.clone(),
+    );
+    assert_eq!(start_out.code, 0, "stderr: {}", start_out.stderr_text());
+    let start_payload: serde_json::Value =
+        serde_json::from_str(&start_out.stdout_text()).expect("stdout json");
+    assert_eq!(start_payload["command"], json!("ax.watch.start"));
+    assert_eq!(start_payload["result"]["watch_id"], json!("axw-demo"));
+    assert_eq!(start_payload["result"]["started"], json!(true));
+
+    let poll_out = harness.run_with_options(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "ax",
+            "watch",
+            "poll",
+            "--watch-id",
+            "axw-demo",
+            "--limit",
+            "10",
+        ],
+        options.clone(),
+    );
+    assert_eq!(poll_out.code, 0, "stderr: {}", poll_out.stderr_text());
+    let poll_payload: serde_json::Value =
+        serde_json::from_str(&poll_out.stdout_text()).expect("stdout json");
+    assert_eq!(poll_payload["command"], json!("ax.watch.poll"));
+    assert_eq!(
+        poll_payload["result"]["events"][0]["event"],
+        json!("AXTitleChanged")
+    );
+
+    let stop_out = harness.run_with_options(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "ax",
+            "watch",
+            "stop",
+            "--watch-id",
+            "axw-demo",
+        ],
+        options,
+    );
+    assert_eq!(stop_out.code, 0, "stderr: {}", stop_out.stderr_text());
+    let stop_payload: serde_json::Value =
+        serde_json::from_str(&stop_out.stdout_text()).expect("stdout json");
+    assert_eq!(stop_payload["command"], json!("ax.watch.stop"));
+    assert_eq!(stop_payload["result"]["drained"], json!(1));
+}
+
+#[test]
+fn ax_commands_can_force_hammerspoon_backend_for_list_click_type() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+    let options = harness
+        .cmd_options(cwd.path())
+        .with_env("CODEX_MACOS_AGENT_AX_BACKEND", "hammerspoon")
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_LIST_JSON",
+            r#"{"nodes":[{"node_id":"1.1","role":"AXButton","title":"Run","identifier":"run-btn","enabled":true,"focused":false,"actions":["AXPress"],"path":["1","1"]}],"warnings":[]}"#,
+        )
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_CLICK_JSON",
+            r#"{"node_id":"1.1","matched_count":1,"action":"ax-press","used_coordinate_fallback":false}"#,
+        )
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_TYPE_JSON",
+            r#"{"node_id":"1.2","matched_count":1,"applied_via":"ax-set-value","text_length":4,"submitted":true,"used_keyboard_fallback":false}"#,
+        );
+
+    let list_out = harness.run_with_options(
+        cwd.path(),
+        &["--format", "json", "ax", "list", "--role", "AXButton"],
+        options.clone(),
+    );
+    assert_eq!(list_out.code, 0, "stderr: {}", list_out.stderr_text());
+    let list_payload: serde_json::Value =
+        serde_json::from_str(&list_out.stdout_text()).expect("stdout json");
+    assert_eq!(list_payload["command"], json!("ax.list"));
+    assert_eq!(
+        list_payload["result"]["nodes"][0]["identifier"],
+        json!("run-btn")
+    );
+
+    let click_out = harness.run_with_options(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "ax",
+            "click",
+            "--node-id",
+            "1.1",
+            "--allow-coordinate-fallback",
+        ],
+        options.clone(),
+    );
+    assert_eq!(click_out.code, 0, "stderr: {}", click_out.stderr_text());
+    let click_payload: serde_json::Value =
+        serde_json::from_str(&click_out.stdout_text()).expect("stdout json");
+    assert_eq!(click_payload["command"], json!("ax.click"));
+    assert_eq!(click_payload["result"]["action"], json!("ax-press"));
+
+    let type_out = harness.run_with_options(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "ax",
+            "type",
+            "--node-id",
+            "1.2",
+            "--text",
+            "test",
+            "--submit",
+        ],
+        options,
+    );
+    assert_eq!(type_out.code, 0, "stderr: {}", type_out.stderr_text());
+    let type_payload: serde_json::Value =
+        serde_json::from_str(&type_out.stdout_text()).expect("stdout json");
+    assert_eq!(type_payload["command"], json!("ax.type"));
+    assert_eq!(type_payload["result"]["submitted"], json!(true));
+}


### PR DESCRIPTION
# Increase macos-agent AX coverage and contract test depth

## Summary
This PR expands automated coverage for the macos-agent AX stack, including Hammerspoon backend behavior, AutoAxBackend routing, and the new ax attr/action/session/watch command surfaces. It adds both unit and integration coverage to harden JSON/text contracts, dry-run behavior, and TSV guardrails while keeping existing CLI output contracts unchanged.

## Changes
- Added broad Hammerspoon backend tests for default fixtures, validation errors, override parsing, and helper behavior.
- Added AutoAxBackend/AppleScript routing tests for AX extension operations (attr/action/session/watch).
- Added command-level unit tests in `ax_action`, `ax_attr`, `ax_session`, and `ax_watch` for dry-run, text/json output, and TSV rejection paths.
- Added integration suite `crates/macos-agent/tests/ax_extended.rs` to validate end-to-end JSON contracts and backend override env behavior.
- Increased `cargo llvm-cov -p macos-agent --summary-only` coverage to `TOTAL Regions 86.01%` and `TOTAL Lines 85.07%`.

## Testing
- `cargo llvm-cov -p macos-agent --summary-only` (pass)
- `cargo test -p macos-agent` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Tests rely on deterministic test-mode env fixtures; no runtime behavior changes were introduced for non-test execution paths.
