### PR TITLE
Add a gated refactor skill for shared foundations and stability

### DIFF
--- a/.codex/skills/nils-cli-refactor-foundations/SKILL.md
+++ b/.codex/skills/nils-cli-refactor-foundations/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: nils-cli-refactor-foundations
+description: Find and implement high-value test/stability/shared-foundation refactors across crates, then deliver via create-feature-pr.
+---
+
+# Nils CLI Refactor Foundations
+
+## Contract
+
+Prereqs:
+
+- Run inside the `nils-cli` git work tree.
+- Rust toolchain available on `PATH` (`cargo`, `rustfmt`, `clippy`).
+- `git`, `gh`, `semantic-commit`, and `git-scope` available when creating the delivery PR.
+- Use this skill together with:
+  - `$create-feature-pr` for branch/commit/PR delivery.
+
+Inputs:
+
+- Optional scope hints:
+  - target crate(s) to prioritize
+  - constraints (time, risk tolerance, out-of-scope areas)
+- Optional quality priorities:
+  - `coverage-first`, `stability-first`, `shared-extraction-first`
+
+Outputs:
+
+- One of two outcomes:
+  - `Implement`: at least one high-value refactor is implemented with tests and validation evidence.
+  - `No Action`: no high-value target found; return concrete recommendations and potential issue list.
+- Standardized report formatted from:
+  - `.codex/skills/nils-cli-refactor-foundations/references/IMPLEMENTATION_RESPONSE_TEMPLATE.md`
+  - `.codex/skills/nils-cli-refactor-foundations/references/NO_ACTION_RESPONSE_TEMPLATE.md`
+- Delivery via `$create-feature-pr` when code changes are implemented.
+
+Exit codes:
+
+- `0`: completed workflow (implemented changes or no-action report)
+- `1`: command/runtime failure while executing workflow
+- `2`: usage/scope ambiguity that blocks safe execution
+
+Failure modes:
+
+- No candidate passes the value gate (avoid refactor-for-refactor).
+- Candidate requires behavior changes that break parity expectations.
+- Shared extraction crosses crate boundaries with unclear ownership or high regression risk.
+- Unable to run required validation commands in the current environment.
+
+## Scripts (only entrypoints)
+
+- `.codex/skills/nils-cli-refactor-foundations/scripts/render-refactor-response-template.sh`
+
+## Workflow
+
+1. Build candidate inventory (all crates, evidence-first)
+
+- Review each crate for:
+  - missing tests around observable behavior, edge cases, and error paths
+  - flaky or brittle logic (implicit assumptions, weak error handling, unstable output contracts)
+  - duplicated domain-neutral helpers that could move into shared foundations crates:
+    - `crates/nils-common`
+    - `crates/nils-term`
+    - `crates/nils-test-support`
+- Capture each candidate with concrete evidence (file path + why it matters).
+
+2. Apply the value gate (must pass before any refactor)
+
+- A candidate is implementable only if it satisfies at least one:
+  - improves correctness/stability for user-visible behavior
+  - adds meaningful coverage for uncovered critical paths
+  - removes duplicated logic used by 2+ crates via shared foundations extraction
+- Reject candidates that are style-only, cosmetic-only, or low-impact churn.
+
+3. Decide branch
+
+- If one or more candidates pass:
+  - choose smallest high-value slice
+  - implement with behavior parity preserved
+  - add/expand tests first or alongside code changes
+- If none pass:
+  - do not refactor
+  - produce a no-action recommendations report using the no-action template
+
+4. Implementation rules (when branch is `Implement`)
+
+- Prefer characterization tests before moving logic.
+- Keep crate-local adapters for user-facing messages/exit-code policy when extracting shared helpers.
+- Extract only domain-neutral primitives into shared foundations crates.
+- Avoid bundling unrelated cleanup in the same change set.
+
+5. Validation
+
+- Run targeted tests for touched crates first.
+- If scope is broad or cross-crate, run:
+  - `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh`
+- Report exact commands and pass/fail status.
+
+6. Delivery (required for implemented changes)
+
+- Use `$create-feature-pr` to:
+  - create feature branch
+  - commit with semantic commit policy
+  - push and open PR with summary, changes, testing, and risk notes
+
+7. Response contract (always required)
+
+- `Implement` path: use the implementation template.
+- `No Action` path: use the no-action template with concrete recommendation list and potential issues.
+- Render helpers:
+  - `./.codex/skills/nils-cli-refactor-foundations/scripts/render-refactor-response-template.sh --mode implement`
+  - `./.codex/skills/nils-cli-refactor-foundations/scripts/render-refactor-response-template.sh --mode no-action`

--- a/.codex/skills/nils-cli-refactor-foundations/references/IMPLEMENTATION_RESPONSE_TEMPLATE.md
+++ b/.codex/skills/nils-cli-refactor-foundations/references/IMPLEMENTATION_RESPONSE_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Decision
+- Implement
+
+## Scope
+- Goal:
+- Selected candidate(s):
+- Why this is high-value:
+
+## Candidate Assessment
+| Candidate | Crate(s) | Type (coverage/stability/shared) | Evidence (path + issue) | Decision |
+| --- | --- | --- | --- | --- |
+| C1 |  |  |  | Implement |
+
+## Changes Implemented
+- Code:
+- Shared extraction (if any):
+- Behavior parity considerations:
+
+## Tests and Validation
+- `<command>` (pass/fail):
+- `<command>` (pass/fail):
+- Coverage/stability impact:
+
+## Risks and Follow-ups
+- Residual risks:
+- Deferred opportunities:
+
+## Delivery
+- Branch:
+- PR:

--- a/.codex/skills/nils-cli-refactor-foundations/references/NO_ACTION_RESPONSE_TEMPLATE.md
+++ b/.codex/skills/nils-cli-refactor-foundations/references/NO_ACTION_RESPONSE_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Decision
+- No Action
+
+## Why No Refactor Was Implemented
+- Summary:
+- Gate result:
+
+## Candidate Assessment
+| Candidate | Crate(s) | Type (coverage/stability/shared) | Evidence (path + issue) | Rejection reason |
+| --- | --- | --- | --- | --- |
+| C1 |  |  |  |  |
+
+## Recommendations (Actionable)
+1. `<recommendation with concrete file/command>`
+2. `<recommendation with concrete file/command>`
+3. `<recommendation with concrete file/command>`
+
+## Potential Issue List
+- P1:
+- P2:
+- P3:
+
+## Validation Notes
+- What was checked:
+- What could not be verified:
+
+## Delivery
+- Branch:
+- PR:

--- a/.codex/skills/nils-cli-refactor-foundations/scripts/render-refactor-response-template.sh
+++ b/.codex/skills/nils-cli-refactor-foundations/scripts/render-refactor-response-template.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_dir="$(cd "${script_dir}/.." && pwd)"
+ref_dir="${skill_dir}/references"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  render-refactor-response-template.sh --mode <implement|no-action|both>
+
+Modes:
+  implement   Print implementation response template
+  no-action   Print no-action response template
+  both        Print implementation template, then no-action template
+USAGE
+}
+
+mode=""
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --mode)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --mode requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      mode="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: ${1:-}" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$mode" ]]; then
+  echo "error: --mode is required" >&2
+  usage >&2
+  exit 2
+fi
+
+impl="${ref_dir}/IMPLEMENTATION_RESPONSE_TEMPLATE.md"
+no_action="${ref_dir}/NO_ACTION_RESPONSE_TEMPLATE.md"
+
+if [[ ! -f "$impl" ]]; then
+  echo "error: missing template: $impl" >&2
+  exit 1
+fi
+if [[ ! -f "$no_action" ]]; then
+  echo "error: missing template: $no_action" >&2
+  exit 1
+fi
+
+case "$mode" in
+  implement)
+    cat "$impl"
+    ;;
+  no-action)
+    cat "$no_action"
+    ;;
+  both)
+    cat "$impl"
+    echo
+    cat "$no_action"
+    ;;
+  *)
+    echo "error: invalid --mode '${mode}' (expected implement|no-action|both)" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/.codex/skills/nils-cli-refactor-foundations/tests/README.md
+++ b/.codex/skills/nils-cli-refactor-foundations/tests/README.md
@@ -1,0 +1,7 @@
+# nils-cli-refactor-foundations tests
+
+Run:
+
+```bash
+bash .codex/skills/nils-cli-refactor-foundations/tests/test_render_refactor_response_template.sh
+```

--- a/.codex/skills/nils-cli-refactor-foundations/tests/test_render_refactor_response_template.sh
+++ b/.codex/skills/nils-cli-refactor-foundations/tests/test_render_refactor_response_template.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_dir="$(cd "${script_dir}/.." && pwd)"
+script="${skill_dir}/scripts/render-refactor-response-template.sh"
+
+assert_contains() {
+  local haystack="${1:-}"
+  local needle="${2:-}"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "expected output to contain: $needle" >&2
+    exit 1
+  fi
+}
+
+run_mode() {
+  local mode="${1:-}"
+  "$script" --mode "$mode"
+}
+
+impl_output="$(run_mode implement)"
+assert_contains "$impl_output" "## Decision"
+assert_contains "$impl_output" "- Implement"
+
+no_action_output="$(run_mode no-action)"
+assert_contains "$no_action_output" "## Decision"
+assert_contains "$no_action_output" "- No Action"
+
+both_output="$(run_mode both)"
+assert_contains "$both_output" "## Changes Implemented"
+assert_contains "$both_output" "## Recommendations (Actionable)"
+
+set +e
+"$script" --mode invalid >/dev/null 2>&1
+rc=$?
+set -e
+if [[ "$rc" -ne 2 ]]; then
+  echo "expected invalid mode exit code 2, got $rc" >&2
+  exit 1
+fi
+
+echo "ok: render-refactor-response-template tests passed"


### PR DESCRIPTION
# Add a gated refactor skill for shared foundations and stability



## Summary
This PR adds a local Codex skill that targets high-value refactors in this workspace: it first gates candidates by impact (coverage, stability, shared extraction), then either implements a minimal worthwhile slice with validation or returns a structured no-action report when no refactor is justified.

## Changes
- Add `.codex/skills/nils-cli-refactor-foundations/SKILL.md` with value-gated workflow and delivery rules
- Add standardized implementation/no-action response templates under `references/`
- Add `render-refactor-response-template.sh` and smoke tests for template mode handling

## Testing
- `/Users/terry/.config/codex-kit/skills/tools/skill-management/skill-governance/scripts/validate_skill_contracts.sh --file .codex/skills/nils-cli-refactor-foundations/SKILL.md` (pass)
- `bash .codex/skills/nils-cli-refactor-foundations/tests/test_render_refactor_response_template.sh` (pass)

## Risk / Notes
- The upstream create-skill scaffold only supports `skills/...`, so this repo-local `.codex/skills/...` skill was scaffolded with equivalent structure manually
