### PR TITLE
Make macos-agent subcommands consistent and ax-first

### DIFF
--- a/completions/bash/macos-agent
+++ b/completions/bash/macos-agent
@@ -42,7 +42,7 @@ _nils_cli_macos_agent_complete() {
       if (( cword == 2 )); then COMPREPLY=( $(compgen -W "current switch" -- "$cur") ); return 0; fi
       ;;
     ax)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "list click type" -- "$cur") ); return 0; fi
+      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "list click type attr action session watch" -- "$cur") ); return 0; fi
       ;;
     observe)
       if (( cword == 2 )); then COMPREPLY=( $(compgen -W "screenshot" -- "$cur") ); return 0; fi
@@ -85,15 +85,16 @@ _nils_cli_macos_agent_complete() {
     local -a opts=(
       --format --error-format --dry-run --retries --retry-delay-ms --timeout-ms --trace --trace-dir
       --strict --include-probes
-      --app --window-name --on-screen-only
+      --app --window-title-contains --window-name --on-screen-only
       --window-id --active-window --bundle-id --wait-ms
       --x --y --button --count --pre-wait-ms --post-wait-ms
-      --text --delay-ms --enter --mods --key
+      --text --delay-ms --submit --enter --mods --key
       --id
       --role --title-contains --max-depth --limit --nth
-      --allow-coordinate-fallback --clear-first --submit --paste --allow-keyboard-fallback
+      --session-id --identifier-contains --value-contains --subrole --focused --enabled
+      --name --value --value-type --watch-id --events --max-buffer --drain
+      --allow-coordinate-fallback --clear-first --paste --allow-keyboard-fallback
       --path --image-format --ms --timeout-ms --poll-ms
-      --name
       -h --help -V --version
     )
     COMPREPLY=( $(compgen -W "${opts[*]}" -- "$cur") )

--- a/completions/zsh/_macos-agent
+++ b/completions/zsh/_macos-agent
@@ -53,7 +53,8 @@ _macos-agent() {
       _arguments -C $global_opts \
         '3:windows command:(list)' \
         '--app=[Filter by app/owner name]:name:' \
-        '--window-name=[Narrow app selection by window title]:name:' \
+        '--window-title-contains=[Narrow app selection by window title]:name:' \
+        '--window-name=[Deprecated alias of --window-title-contains]:name:' \
         '--on-screen-only[Include only on-screen windows]' \
         && return 0
       ;;
@@ -76,7 +77,8 @@ _macos-agent() {
         '--window-id=[Select by window id]:id:' \
         '--active-window[Select frontmost active window]' \
         '--app=[Select by app name]:name:' \
-        '--window-name=[Narrow app selection by window title]:name:' \
+        '--window-title-contains=[Narrow app selection by window title]:name:' \
+        '--window-name=[Deprecated alias of --window-title-contains]:name:' \
         '--bundle-id=[Select by bundle id]:bundle:' \
         '--wait-ms=[Wait up to this many milliseconds for active confirmation]:ms:' \
         && return 0
@@ -107,7 +109,8 @@ _macos-agent() {
           _arguments -C $global_opts \
             '--text=[Text to type]:text:' \
             '--delay-ms=[Delay between key events]:ms:' \
-            '--enter[Press Enter after typing]' \
+            '--submit[Press Enter after typing]' \
+            '--enter[Deprecated alias of --submit]' \
             && return 0
           ;;
         hotkey)
@@ -145,7 +148,11 @@ _macos-agent() {
         _describe -t subcommands 'ax command' \
           'list:List AX nodes' \
           'click:Click AX node' \
-          'type:Type into AX node'
+          'type:Type into AX node' \
+          'attr:Read or set AX attributes' \
+          'action:Perform AX actions' \
+          'session:Manage AX sessions' \
+          'watch:Manage AX watchers'
         return 0
       fi
 
@@ -153,10 +160,17 @@ _macos-agent() {
       case "$ax_cmd" in
         list)
           _arguments -C $global_opts \
+            '--session-id=[Target session id]:id:' \
             '--app=[Target app name]:name:' \
             '--bundle-id=[Target bundle id]:bundle:' \
+            '--window-title-contains=[Narrow to windows by title]:text:' \
             '--role=[Filter by AX role]:role:' \
             '--title-contains=[Filter by title substring]:text:' \
+            '--identifier-contains=[Filter by identifier substring]:text:' \
+            '--value-contains=[Filter by value substring]:text:' \
+            '--subrole=[Filter by AX subrole]:subrole:' \
+            '--focused=[Filter by focused state]:bool:(true false)' \
+            '--enabled=[Filter by enabled state]:bool:(true false)' \
             '--max-depth=[Limit traversal depth]:depth:' \
             '--limit=[Limit number of returned nodes]:count:' \
             && return 0
@@ -166,9 +180,16 @@ _macos-agent() {
             '--node-id=[Select by node id]:id:' \
             '--role=[Select by AX role]:role:' \
             '--title-contains=[Select by title substring]:text:' \
+            '--identifier-contains=[Select by identifier substring]:text:' \
+            '--value-contains=[Select by value substring]:text:' \
+            '--subrole=[Select by AX subrole]:subrole:' \
+            '--focused=[Select by focused state]:bool:(true false)' \
+            '--enabled=[Select by enabled state]:bool:(true false)' \
             '--nth=[Select nth match from role/title selector]:n:' \
+            '--session-id=[Target session id]:id:' \
             '--app=[Target app name]:name:' \
             '--bundle-id=[Target bundle id]:bundle:' \
+            '--window-title-contains=[Narrow to windows by title]:text:' \
             '--allow-coordinate-fallback[Allow coordinate fallback when AXPress is unavailable]' \
             && return 0
           ;;
@@ -177,15 +198,149 @@ _macos-agent() {
             '--node-id=[Select by node id]:id:' \
             '--role=[Select by AX role]:role:' \
             '--title-contains=[Select by title substring]:text:' \
+            '--identifier-contains=[Select by identifier substring]:text:' \
+            '--value-contains=[Select by value substring]:text:' \
+            '--subrole=[Select by AX subrole]:subrole:' \
+            '--focused=[Select by focused state]:bool:(true false)' \
+            '--enabled=[Select by enabled state]:bool:(true false)' \
             '--nth=[Select nth match from role/title selector]:n:' \
+            '--session-id=[Target session id]:id:' \
             '--app=[Target app name]:name:' \
             '--bundle-id=[Target bundle id]:bundle:' \
+            '--window-title-contains=[Narrow to windows by title]:text:' \
             '--text=[Text to type]:text:' \
             '--clear-first[Clear field before typing]' \
             '--submit[Press Enter after typing]' \
             '--paste[Use clipboard paste strategy]' \
             '--allow-keyboard-fallback[Allow keyboard fallback when AX value set is unavailable]' \
             && return 0
+          ;;
+        attr)
+          if (( CURRENT == 4 )); then
+            _describe -t subcommands 'ax attr command' \
+              'get:Read AX attribute value' \
+              'set:Set AX attribute value'
+            return 0
+          fi
+          local ax_attr_cmd="${words[4]}"
+          case "$ax_attr_cmd" in
+            get)
+              _arguments -C $global_opts \
+                '--node-id=[Select by node id]:id:' \
+                '--role=[Select by AX role]:role:' \
+                '--title-contains=[Select by title substring]:text:' \
+                '--identifier-contains=[Select by identifier substring]:text:' \
+                '--value-contains=[Select by value substring]:text:' \
+                '--subrole=[Select by AX subrole]:subrole:' \
+                '--focused=[Select by focused state]:bool:(true false)' \
+                '--enabled=[Select by enabled state]:bool:(true false)' \
+                '--nth=[Select nth match]:n:' \
+                '--session-id=[Target session id]:id:' \
+                '--app=[Target app name]:name:' \
+                '--bundle-id=[Target bundle id]:bundle:' \
+                '--window-title-contains=[Narrow to windows by title]:text:' \
+                '--name=[AX attribute name]:name:' \
+                && return 0
+              ;;
+            set)
+              _arguments -C $global_opts \
+                '--node-id=[Select by node id]:id:' \
+                '--role=[Select by AX role]:role:' \
+                '--title-contains=[Select by title substring]:text:' \
+                '--identifier-contains=[Select by identifier substring]:text:' \
+                '--value-contains=[Select by value substring]:text:' \
+                '--subrole=[Select by AX subrole]:subrole:' \
+                '--focused=[Select by focused state]:bool:(true false)' \
+                '--enabled=[Select by enabled state]:bool:(true false)' \
+                '--nth=[Select nth match]:n:' \
+                '--session-id=[Target session id]:id:' \
+                '--app=[Target app name]:name:' \
+                '--bundle-id=[Target bundle id]:bundle:' \
+                '--window-title-contains=[Narrow to windows by title]:text:' \
+                '--name=[AX attribute name]:name:' \
+                '--value=[AX attribute value]:value:' \
+                '--value-type=[Parse type for --value]:type:(string number bool json null)' \
+                && return 0
+              ;;
+          esac
+          ;;
+        action)
+          if (( CURRENT == 4 )); then
+            _describe -t subcommands 'ax action command' 'perform:Perform AX action'
+            return 0
+          fi
+          _arguments -C $global_opts \
+            '--node-id=[Select by node id]:id:' \
+            '--role=[Select by AX role]:role:' \
+            '--title-contains=[Select by title substring]:text:' \
+            '--identifier-contains=[Select by identifier substring]:text:' \
+            '--value-contains=[Select by value substring]:text:' \
+            '--subrole=[Select by AX subrole]:subrole:' \
+            '--focused=[Select by focused state]:bool:(true false)' \
+            '--enabled=[Select by enabled state]:bool:(true false)' \
+            '--nth=[Select nth match]:n:' \
+            '--session-id=[Target session id]:id:' \
+            '--app=[Target app name]:name:' \
+            '--bundle-id=[Target bundle id]:bundle:' \
+            '--window-title-contains=[Narrow to windows by title]:text:' \
+            '--name=[AX action name]:name:' \
+            && return 0
+          ;;
+        session)
+          if (( CURRENT == 4 )); then
+            _describe -t subcommands 'ax session command' \
+              'start:Create or update AX session' \
+              'list:List AX sessions' \
+              'stop:Stop AX session'
+            return 0
+          fi
+          local ax_session_cmd="${words[4]}"
+          case "$ax_session_cmd" in
+            start)
+              _arguments -C $global_opts \
+                '--app=[Target app name]:name:' \
+                '--bundle-id=[Target bundle id]:bundle:' \
+                '--session-id=[Session id]:id:' \
+                '--window-title-contains=[Persist window title filter]:text:' \
+                && return 0
+              ;;
+            list)
+              _arguments -C $global_opts && return 0
+              ;;
+            stop)
+              _arguments -C $global_opts '--session-id=[Session id to remove]:id:' && return 0
+              ;;
+          esac
+          ;;
+        watch)
+          if (( CURRENT == 4 )); then
+            _describe -t subcommands 'ax watch command' \
+              'start:Start AX watcher' \
+              'poll:Poll AX watcher events' \
+              'stop:Stop AX watcher'
+            return 0
+          fi
+          local ax_watch_cmd="${words[4]}"
+          case "$ax_watch_cmd" in
+            start)
+              _arguments -C $global_opts \
+                '--session-id=[Session id to bind watcher]:id:' \
+                '--watch-id=[Optional watcher id]:id:' \
+                '--events=[Comma-separated AX notifications]:events:' \
+                '--max-buffer=[Maximum in-memory event buffer size]:count:' \
+                && return 0
+              ;;
+            poll)
+              _arguments -C $global_opts \
+                '--watch-id=[Watch id to poll]:id:' \
+                '--limit=[Max events to return]:count:' \
+                '--drain=[Drain returned events]:bool:(true false)' \
+                && return 0
+              ;;
+            stop)
+              _arguments -C $global_opts '--watch-id=[Watch id to stop]:id:' && return 0
+              ;;
+          esac
           ;;
       esac
       ;;
@@ -200,7 +355,8 @@ _macos-agent() {
         '--window-id=[Select by window id]:id:' \
         '--active-window[Select frontmost active window]' \
         '--app=[Select by app name]:name:' \
-        '--window-name=[Narrow app selection by window title]:name:' \
+        '--window-title-contains=[Narrow app selection by window title]:name:' \
+        '--window-name=[Deprecated alias of --window-title-contains]:name:' \
         '--path=[Output path]:path:_files' \
         '--image-format=[Output image format]:format:(png jpg webp)' \
         && return 0
@@ -233,7 +389,8 @@ _macos-agent() {
             '--window-id=[Select by window id]:id:' \
             '--active-window[Select frontmost active window]' \
             '--app=[Select by app name]:name:' \
-            '--window-name=[Narrow app selection by window title]:name:' \
+            '--window-title-contains=[Narrow app selection by window title]:name:' \
+            '--window-name=[Deprecated alias of --window-title-contains]:name:' \
             '--timeout-ms=[Timeout in milliseconds]:ms:' \
             '--poll-ms=[Poll interval in milliseconds]:ms:' \
             && return 0

--- a/crates/macos-agent/README.md
+++ b/crates/macos-agent/README.md
@@ -36,7 +36,7 @@ macos-agent observe screenshot --active-window --path ./tmp/macos-agent.png
 
 # stabilization waits
 macos-agent wait app-active --app Terminal --timeout-ms 1500
-macos-agent wait window-present --app Terminal --window-name Inbox --timeout-ms 1500
+macos-agent wait window-present --app Terminal --window-title-contains Inbox --timeout-ms 1500
 ```
 
 ## Command Surface
@@ -44,14 +44,14 @@ macos-agent wait window-present --app Terminal --window-name Inbox --timeout-ms 
 - `preflight`
   - `macos-agent preflight [--strict] [--include-probes]`
 - `windows`
-  - `macos-agent windows list [--app <name>] [--window-name <name>] [--on-screen-only]`
+  - `macos-agent windows list [--app <name>] [--window-title-contains <name>] [--on-screen-only]`
 - `apps`
   - `macos-agent apps list`
 - `window`
-  - `macos-agent window activate (--window-id <id> | --active-window | --app <name> [--window-name <name>] | --bundle-id <bundle_id>) [--wait-ms <ms>]`
+  - `macos-agent window activate (--window-id <id> | --active-window | --app <name> [--window-title-contains <name>] | --bundle-id <bundle_id>) [--wait-ms <ms>]`
 - `input`
   - `macos-agent input click --x <px> --y <px> [--button <left|right|middle>] [--count <n>] [--pre-wait-ms <ms>] [--post-wait-ms <ms>]`
-  - `macos-agent input type --text <text> [--delay-ms <ms>] [--enter]`
+  - `macos-agent input type --text <text> [--delay-ms <ms>] [--submit]`
   - `macos-agent input hotkey --mods <cmd,ctrl,alt,shift,fn> --key <key>`
 - `input-source`
   - `macos-agent input-source current`
@@ -70,11 +70,11 @@ macos-agent wait window-present --app Terminal --window-name Inbox --timeout-ms 
   - `macos-agent ax watch poll --watch-id <id> [--limit <n>] [--drain|--no-drain]`
   - `macos-agent ax watch stop --watch-id <id>`
 - `observe`
-  - `macos-agent observe screenshot (--window-id <id> | --active-window | --app <name> [--window-name <name>]) [--path <file>] [--image-format <png|jpg|webp>]`
+  - `macos-agent observe screenshot (--window-id <id> | --active-window | --app <name> [--window-title-contains <name>]) [--path <file>] [--image-format <png|jpg|webp>]`
 - `wait`
   - `macos-agent wait sleep --ms <ms>`
   - `macos-agent wait app-active (--app <name> | --bundle-id <bundle_id>) [--timeout-ms <ms>] [--poll-ms <ms>]`
-  - `macos-agent wait window-present (--window-id <id> | --active-window | --app <name> [--window-name <name>]) [--timeout-ms <ms>] [--poll-ms <ms>]`
+  - `macos-agent wait window-present (--window-id <id> | --active-window | --app <name> [--window-title-contains <name>]) [--timeout-ms <ms>] [--poll-ms <ms>]`
 - `scenario`
   - `macos-agent scenario run --file <scenario.json>`
 - `profile`
@@ -94,11 +94,27 @@ macos-agent wait window-present --app Terminal --window-name Inbox --timeout-ms 
 
 Notes:
 - `--format tsv` is only supported by `windows list` and `apps list`.
+- Canonical flags: use `--window-title-contains` and `input type --submit`.
+- Backward-compatible aliases are still accepted: `--window-name`, `input type --enter`.
 - `--dry-run` guarantees no OS automation command execution for mutating actions.
 - `--error-format json` emits machine-parseable error payloads on `stderr`.
 - `--trace` writes per-command trace artifacts to `CODEX_HOME/out/macos-agent-trace/`.
 - `--trace-dir` overrides trace artifact output directory.
 - When trace mode is enabled, `macos-agent` verifies trace directory writability before running actions.
+
+## Migration Guide: Legacy aliases to canonical flags
+
+Use canonical flags in all new scripts, fixtures, and runbooks.
+
+| Legacy alias | Canonical form | Migration action | Compatibility policy |
+| --- | --- | --- | --- |
+| `--window-name <text>` | `--window-title-contains <text>` | Replace in command invocations and saved recipes. | Accepted during the current `0.x` rollout window; removal requires an explicit future breaking-change release note. |
+| `input type --enter` | `input type --submit` | Replace alias flags in test fixtures and automation scripts. | Accepted during the current `0.x` rollout window with equivalent behavior. |
+
+Migration checklist:
+- `rg -n -- "--window-name|input type --enter" crates/macos-agent docs`
+- Convert results to canonical flags and keep command behavior unchanged.
+- If a migrated command fails, choose the command path from `Command Decision Matrix` first, then jump to the mapped row in `Troubleshooting matrix`.
 
 ## Output Contract
 
@@ -168,6 +184,16 @@ Error envelope (`--error-format json`):
 | Screen Recording | Terminal host allowed in **System Settings > Privacy & Security > Screen Recording** | observe screenshot fails | Enable Screen Recording for terminal host |
 | `cliclick` binary | Installed and on `PATH` | preflight reports missing `cliclick` | `brew install cliclick` |
 
+## AX Backend Capability Matrix
+
+| Backend preference | `ax list/click/type` | `ax attr/action/session/watch` | Notes |
+| --- | --- | --- | --- |
+| `auto` (default) | Hammerspoon first, fallback to AppleScript (JXA) when Hammerspoon is unavailable | Hammerspoon-only | Best default for resilience; fallback does not apply to extended AX commands |
+| `hammerspoon` | Supported | Supported | Full AX surface; requires `hs` CLI and `hs.ipc` enabled |
+| `applescript` | Supported (JXA) | Not supported directly | Extended AX commands still depend on Hammerspoon runtime |
+
+Preflight now emits an `ax_backend_capabilities` row so operators can verify backend mode and fallback expectations before failures.
+
 ## Reliability Boundaries and Practices
 
 Desktop UI automation is inherently brittle due to animation timing, focus drift, and app responsiveness.
@@ -185,6 +211,20 @@ Use these defaults for better stability:
 - Prefer `ax click/type` first, then opt in to fallback flags when app AX trees are unstable.
 - AX backend selection defaults to `auto` (Hammerspoon first, JXA fallback).
   - Override with `CODEX_MACOS_AGENT_AX_BACKEND=hammerspoon|applescript|auto`.
+
+## Command Decision Matrix (AX/Input/Wait/Fallback/Backend)
+
+Use this matrix to pick commands consistently. Start from the decision row, then use the mapped troubleshooting row on failure.
+
+| Decision ID | When | Command choice (`ax`/`input`/`wait`) | Fallback policy | Backend policy | Troubleshooting row |
+| --- | --- | --- | --- | --- | --- |
+| `D1` | Target element is discoverable in AX tree | `ax list` -> `ax click` / `ax type`; gate with `wait app-active` and (if needed) `wait window-present` | Keep fallback flags off first | `auto` default is preferred; see `AX Backend Capability Matrix` | `T3`, `T5` |
+| `D2` | AX selector exists but can be unstable across reruns | Same as `D1`, plus `--allow-coordinate-fallback` or `--allow-keyboard-fallback`; keep wait gates explicit | Opt in per command (`ax click/type` only) | Keep `auto` so `ax click/type` can fall back to JXA when Hammerspoon is unavailable | `T4`, `T5` |
+| `D3` | AX path is unavailable for the target app | `window activate` + `input click` / `input type` / `input hotkey`; use `wait app-active/window-present` before mutation | No AX fallback path; use coordinate/keyboard input directly | Backend-independent for pure `input` flow | `T1`, `T2` |
+| `D4` | Need extended AX operations (`attr`, `action`, `session`, `watch`) | Use `ax attr/action/session/watch` commands; add wait gate before mutating action | No fallback support for extended AX commands | Requires Hammerspoon runtime support (see `AX Backend Capability Matrix`) | `T5` |
+| `D5` | Text entry depends on deterministic keyboard layout | `input-source current` -> `input-source switch --id <id>` -> `ax type` or `input type` | Prefer paste/submit flow when IME variance is high | Backend-independent for `input-source`; AX typing still follows `D1`/`D2` backend rules | `T6` |
+
+This AX-first + fallback policy avoids brittle coordinate-only flows while keeping a reliable escape hatch.
 
 ## Deterministic Test Mode
 
@@ -266,14 +306,16 @@ macos-agent profile init --name local-1440p --path "$CODEX_HOME/out/local-profil
 
 ## Troubleshooting matrix
 
-| Symptom | Next command | What to inspect |
-| --- | --- | --- |
-| `not authorized` or Apple Events failures | `macos-agent --format json preflight --include-probes` | `error.hints`, Automation/Accessibility rows |
-| Flaky click/input behavior | `macos-agent --trace --error-format json input click ...` | latest trace JSON (`attempts_used`, timeout/retry policy) |
-| AX selector no match / ambiguous match | `macos-agent --format json ax list --app <name> --role <AXRole> --title-contains <text>` | node candidates (`node_id`, `role`, `title`, `identifier`) and refine selector / `--nth` |
-| AX press/type fails but coordinate/keyboard path should continue | rerun with `ax click --allow-coordinate-fallback` or `ax type --allow-keyboard-fallback` | whether `used_coordinate_fallback` / `used_keyboard_fallback` is true in JSON result |
-| Hammerspoon AX backend unavailable | `hs -t 1 -q -c 'return \"ok\"'` | ensure Hammerspoon is running and `require('hs.ipc')` is enabled, or keep backend `auto` for JXA fallback |
-| Input source mismatch before typing | `macos-agent --format json input-source current` then `... switch --id abc` | current source id and switch result (`switched=true`) |
-| Trace enabled but command does not start | `macos-agent --trace --trace-dir <path> --error-format json preflight` | `trace.write` error and writable-path hint |
-| Real-app scenario failed mid-flow | run target `e2e_real_apps` command with `--nocapture` | `steps.jsonl`, `step-summary.json`, `artifact-index.json` |
-| Profile coordinate drift | `macos-agent profile validate --file <profile.json>` | key-path validation errors and bounds issues |
+Use the `Decision ID` from `Command Decision Matrix` to choose the row quickly.
+
+| ID | Symptom | Next command | What to inspect | Decision row |
+| --- | --- | --- | --- | --- |
+| `T1` | `not authorized` or Apple Events failures | `macos-agent --format json preflight --include-probes` | `error.hints`, Automation/Accessibility rows | `D3` |
+| `T2` | Flaky click/input behavior | `macos-agent --trace --error-format json input click ...` | latest trace JSON (`attempts_used`, timeout/retry policy) | `D3` |
+| `T3` | AX selector no match / ambiguous match | `macos-agent --format json ax list --app <name> --role <AXRole> --title-contains <text>` | node candidates (`node_id`, `role`, `title`, `identifier`) and refine selector / `--nth` | `D1` |
+| `T4` | AX press/type fails but coordinate/keyboard path should continue | rerun with `ax click --allow-coordinate-fallback` or `ax type --allow-keyboard-fallback` | whether `used_coordinate_fallback` / `used_keyboard_fallback` is true in JSON result | `D2` |
+| `T5` | Hammerspoon AX backend unavailable | `hs -t 1 -q -c 'return \"ok\"'` | ensure Hammerspoon is running and `require('hs.ipc')` is enabled, or keep backend `auto` for JXA fallback | `D1`, `D2`, `D4` |
+| `T6` | Input source mismatch before typing | `macos-agent --format json input-source current` then `... switch --id abc` | current source id and switch result (`switched=true`) | `D5` |
+| `T7` | Trace enabled but command does not start | `macos-agent --trace --trace-dir <path> --error-format json preflight` | `trace.write` error and writable-path hint | `D3` |
+| `T8` | Real-app scenario failed mid-flow | run target `e2e_real_apps` command with `--nocapture` | `steps.jsonl`, `step-summary.json`, `artifact-index.json` | `D1`, `D2`, `D3` |
+| `T9` | Profile coordinate drift | `macos-agent profile validate --file <profile.json>` | key-path validation errors and bounds issues | `D3` |

--- a/crates/macos-agent/src/backend/applescript.rs
+++ b/crates/macos-agent/src/backend/applescript.rs
@@ -1,5 +1,6 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde_json::{Map, Value};
 
 use crate::backend::process::{map_failure, ProcessFailure, ProcessRequest, ProcessRunner};
 use crate::error::CliError;
@@ -213,24 +214,6 @@ const AX_CLICK_JXA_SCRIPT: &str = r#"function run(argv) {
     return { element: element, node: nodeFrom(element, path) };
   }
 
-  function resolveByNodeId(roots, nodeId) {
-    var segments = String(nodeId).split(".");
-    if (segments.length === 0) { return null; }
-    var rootIndex = Number(segments[0]);
-    if (!rootIndex || rootIndex < 1 || rootIndex > roots.length) { return null; }
-    var element = roots[rootIndex - 1];
-    var path = [String(rootIndex)];
-    for (var i = 1; i < segments.length; i += 1) {
-      var index = Number(segments[i]);
-      if (!index || index < 1) { return null; }
-      var children = safe(function () { return element.uiElements(); }, []);
-      if (!children || index > children.length) { return null; }
-      element = children[index - 1];
-      path.push(String(index));
-    }
-    return { element: element, node: nodeFrom(element, path) };
-  }
-
   var payload = {};
   if (argv.length > 0 && argv[0]) { payload = JSON.parse(argv[0]); }
   var selector = payload.selector || {};
@@ -365,6 +348,24 @@ const AX_TYPE_JXA_SCRIPT: &str = r#"function run(argv) {
       title: title,
       identifier: identifier
     };
+  }
+
+  function resolveByNodeId(roots, nodeId) {
+    var segments = String(nodeId).split(".");
+    if (segments.length === 0) { return null; }
+    var rootIndex = Number(segments[0]);
+    if (!rootIndex || rootIndex < 1 || rootIndex > roots.length) { return null; }
+    var element = roots[rootIndex - 1];
+    var path = [String(rootIndex)];
+    for (var i = 1; i < segments.length; i += 1) {
+      var index = Number(segments[i]);
+      if (!index || index < 1) { return null; }
+      var children = safe(function () { return element.uiElements(); }, []);
+      if (!children || index > children.length) { return null; }
+      element = children[index - 1];
+      path.push(String(index));
+    }
+    return { element: element, node: nodeFrom(element, path) };
   }
 
   var payload = {};
@@ -764,11 +765,20 @@ where
 {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
-        return Err(CliError::ax_parse_failure(operation, "stdout was empty"));
+        return Err(ax_parse_error(operation, "stdout was empty"));
     }
 
-    serde_json::from_str(trimmed).map_err(|err| {
-        CliError::ax_parse_failure(
+    let value: Value = serde_json::from_str(trimmed).map_err(|err| {
+        ax_parse_error(
+            operation,
+            format!("{err}; stdout preview=`{}`", output_preview(trimmed, 120)),
+        )
+    })?;
+
+    validate_jxa_contract(operation, &value)?;
+
+    serde_json::from_value(value).map_err(|err| {
+        ax_parse_error(
             operation,
             format!("{err}; stdout preview=`{}`", output_preview(trimmed, 120)),
         )
@@ -785,6 +795,285 @@ fn map_ax_failure(operation: &str, failure: ProcessFailure) -> CliError {
 
 fn selector_is_empty(selector: &AxSelector) -> bool {
     selector.node_id.is_none() && selector.role.is_none() && selector.title_contains.is_none()
+}
+
+fn ax_parse_error(operation: &str, detail: impl Into<String>) -> CliError {
+    let mut err = CliError::ax_parse_failure(operation, detail);
+    if let Some(hint) = ax_contract_hint(operation) {
+        err = err.with_hint(hint);
+    }
+    err
+}
+
+fn ax_contract_error(operation: &str, detail: impl Into<String>) -> CliError {
+    let mut err = CliError::runtime(format!(
+        "{operation} failed: AX backend contract violation ({})",
+        detail.into().trim()
+    ))
+    .with_operation(operation)
+    .with_hint("Run `macos-agent preflight --include-probes --strict` to verify Accessibility/Automation access.")
+    .with_hint("Use --trace to capture raw backend output for diagnosis.");
+    if let Some(hint) = ax_contract_hint(operation) {
+        err = err.with_hint(hint);
+    }
+    err
+}
+
+fn ax_contract_hint(operation: &str) -> Option<&'static str> {
+    match operation {
+        "ax.list" => {
+            Some("Expected object contract: { nodes: [...], warnings: [...] } (warnings optional).")
+        }
+        "ax.click" => Some(
+            "Expected object contract: { matched_count, action, node_id?, used_coordinate_fallback?, fallback_x?, fallback_y? }.",
+        ),
+        "ax.type" => Some(
+            "Expected object contract: { matched_count, applied_via, text_length, node_id?, submitted?, used_keyboard_fallback? }.",
+        ),
+        _ => None,
+    }
+}
+
+fn validate_jxa_contract(operation: &str, value: &Value) -> Result<(), CliError> {
+    match operation {
+        "ax.list" => validate_ax_list_contract(operation, value),
+        "ax.click" => validate_ax_click_contract(operation, value),
+        "ax.type" => validate_ax_type_contract(operation, value),
+        _ => Ok(()),
+    }
+}
+
+fn expect_object<'a>(
+    operation: &str,
+    value: &'a Value,
+) -> Result<&'a Map<String, Value>, CliError> {
+    value
+        .as_object()
+        .ok_or_else(|| ax_contract_error(operation, "top-level payload must be a JSON object"))
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn ensure_required_array<'a>(
+    operation: &str,
+    object: &'a Map<String, Value>,
+    field: &str,
+) -> Result<&'a Vec<Value>, CliError> {
+    let value = object
+        .get(field)
+        .ok_or_else(|| ax_contract_error(operation, format!("missing required `{field}` array")))?;
+    value.as_array().ok_or_else(|| {
+        ax_contract_error(
+            operation,
+            format!(
+                "`{field}` must be an array (received {})",
+                json_type_name(value)
+            ),
+        )
+    })
+}
+
+fn ensure_optional_array<'a>(
+    operation: &str,
+    object: &'a Map<String, Value>,
+    field: &str,
+) -> Result<Option<&'a Vec<Value>>, CliError> {
+    match object.get(field) {
+        None => Ok(None),
+        Some(value) => value.as_array().map(Some).ok_or_else(|| {
+            ax_contract_error(
+                operation,
+                format!(
+                    "`{field}` must be an array when present (received {})",
+                    json_type_name(value)
+                ),
+            )
+        }),
+    }
+}
+
+fn ensure_required_u64(
+    operation: &str,
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<u64, CliError> {
+    let value = object.get(field).ok_or_else(|| {
+        ax_contract_error(operation, format!("missing required `{field}` number"))
+    })?;
+    value.as_u64().ok_or_else(|| {
+        ax_contract_error(
+            operation,
+            format!(
+                "`{field}` must be a non-negative integer (received {})",
+                json_type_name(value)
+            ),
+        )
+    })
+}
+
+fn ensure_required_non_empty_string(
+    operation: &str,
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<(), CliError> {
+    let value = object.get(field).ok_or_else(|| {
+        ax_contract_error(operation, format!("missing required `{field}` string"))
+    })?;
+    let text = value.as_str().ok_or_else(|| {
+        ax_contract_error(
+            operation,
+            format!(
+                "`{field}` must be a string (received {})",
+                json_type_name(value)
+            ),
+        )
+    })?;
+    if text.trim().is_empty() {
+        return Err(ax_contract_error(
+            operation,
+            format!("`{field}` must be a non-empty string"),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_optional_bool(
+    operation: &str,
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<(), CliError> {
+    if let Some(value) = object.get(field) {
+        if !value.is_boolean() {
+            return Err(ax_contract_error(
+                operation,
+                format!(
+                    "`{field}` must be a boolean when present (received {})",
+                    json_type_name(value)
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn ensure_optional_string_or_null(
+    operation: &str,
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<(), CliError> {
+    if let Some(value) = object.get(field) {
+        if !value.is_null() && !value.is_string() {
+            return Err(ax_contract_error(
+                operation,
+                format!(
+                    "`{field}` must be a string or null when present (received {})",
+                    json_type_name(value)
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn ensure_optional_i64(
+    operation: &str,
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<Option<i64>, CliError> {
+    match object.get(field) {
+        None => Ok(None),
+        Some(value) => value.as_i64().map(Some).ok_or_else(|| {
+            ax_contract_error(
+                operation,
+                format!(
+                    "`{field}` must be an integer when present (received {})",
+                    json_type_name(value)
+                ),
+            )
+        }),
+    }
+}
+
+fn validate_ax_list_contract(operation: &str, value: &Value) -> Result<(), CliError> {
+    let object = expect_object(operation, value)?;
+    let nodes = ensure_required_array(operation, object, "nodes")?;
+    for (index, node) in nodes.iter().enumerate() {
+        if !node.is_object() {
+            return Err(ax_contract_error(
+                operation,
+                format!(
+                    "`nodes[{index}]` must be an object (received {})",
+                    json_type_name(node)
+                ),
+            ));
+        }
+    }
+
+    if let Some(warnings) = ensure_optional_array(operation, object, "warnings")? {
+        for (index, warning) in warnings.iter().enumerate() {
+            if !warning.is_string() {
+                return Err(ax_contract_error(
+                    operation,
+                    format!(
+                        "`warnings[{index}]` must be a string (received {})",
+                        json_type_name(warning)
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_ax_click_contract(operation: &str, value: &Value) -> Result<(), CliError> {
+    let object = expect_object(operation, value)?;
+    ensure_required_u64(operation, object, "matched_count")?;
+    ensure_required_non_empty_string(operation, object, "action")?;
+    ensure_optional_bool(operation, object, "used_coordinate_fallback")?;
+    ensure_optional_string_or_null(operation, object, "node_id")?;
+    let fallback_x = ensure_optional_i64(operation, object, "fallback_x")?;
+    let fallback_y = ensure_optional_i64(operation, object, "fallback_y")?;
+
+    let used_coordinate_fallback = object
+        .get("used_coordinate_fallback")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    if fallback_x.is_some() ^ fallback_y.is_some() {
+        return Err(ax_contract_error(
+            operation,
+            "`fallback_x` and `fallback_y` must either both be present or both be omitted",
+        ));
+    }
+
+    if used_coordinate_fallback && (fallback_x.is_none() || fallback_y.is_none()) {
+        return Err(ax_contract_error(
+            operation,
+            "`fallback_x` and `fallback_y` are required when `used_coordinate_fallback` is true",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_ax_type_contract(operation: &str, value: &Value) -> Result<(), CliError> {
+    let object = expect_object(operation, value)?;
+    ensure_required_u64(operation, object, "matched_count")?;
+    ensure_required_u64(operation, object, "text_length")?;
+    ensure_required_non_empty_string(operation, object, "applied_via")?;
+    ensure_optional_bool(operation, object, "submitted")?;
+    ensure_optional_bool(operation, object, "used_keyboard_fallback")?;
+    ensure_optional_string_or_null(operation, object, "node_id")?;
+    Ok(())
 }
 
 fn test_mode_override_json(operation: &str) -> Option<String> {
@@ -842,7 +1131,10 @@ mod tests {
     use crate::backend::process::{ProcessFailure, ProcessOutput, ProcessRequest, ProcessRunner};
     use crate::model::{AxClickRequest, AxListRequest, AxSelector, AxTypeRequest};
 
-    use super::{ax_click, ax_list, ax_type, escape_applescript, parse_modifiers, Modifier};
+    use super::{
+        ax_click, ax_list, ax_type, escape_applescript, parse_modifiers, Modifier,
+        AX_CLICK_JXA_SCRIPT, AX_TYPE_JXA_SCRIPT,
+    };
 
     struct FixedOutputRunner {
         stdout: String,
@@ -929,6 +1221,88 @@ mod tests {
             .hints()
             .iter()
             .any(|hint| hint.contains("preflight") || hint.contains("--trace")));
+    }
+
+    #[test]
+    fn ax_click_script_declares_node_id_helper_once() {
+        assert_eq!(
+            AX_CLICK_JXA_SCRIPT
+                .matches("function resolveByNodeId")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn ax_type_script_declares_node_id_helper_once() {
+        assert_eq!(
+            AX_TYPE_JXA_SCRIPT
+                .matches("function resolveByNodeId")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn ax_list_contract_failure_reports_missing_nodes_array() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::remove(&lock, "CODEX_MACOS_AGENT_TEST_MODE");
+        let _override = EnvGuard::remove(&lock, "CODEX_MACOS_AGENT_AX_LIST_JSON");
+        let runner = FixedOutputRunner::new(r#"{"warnings":[]}"#);
+
+        let err = ax_list(&runner, &AxListRequest::default(), 250)
+            .expect_err("missing nodes contract field should fail");
+        assert_eq!(err.operation(), Some("ax.list"));
+        assert!(err.message().contains("AX backend contract violation"));
+        assert!(err.message().contains("nodes"));
+        assert!(err.hints().iter().any(|hint| hint.contains("nodes")));
+    }
+
+    #[test]
+    fn ax_click_contract_failure_requires_fallback_coordinate_pair() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::remove(&lock, "CODEX_MACOS_AGENT_TEST_MODE");
+        let _override = EnvGuard::remove(&lock, "CODEX_MACOS_AGENT_AX_CLICK_JSON");
+        let runner = FixedOutputRunner::new(
+            r#"{"node_id":"1.1","matched_count":1,"action":"ax-press-fallback","used_coordinate_fallback":true,"fallback_x":42}"#,
+        );
+        let request = AxClickRequest {
+            selector: AxSelector {
+                node_id: Some("1.1".to_string()),
+                ..AxSelector::default()
+            },
+            ..AxClickRequest::default()
+        };
+
+        let err = ax_click(&runner, &request, 250)
+            .expect_err("fallback coordinates without pair should fail");
+        assert_eq!(err.operation(), Some("ax.click"));
+        assert!(err.message().contains("AX backend contract violation"));
+        assert!(err.message().contains("fallback_x"));
+        assert!(err.message().contains("fallback_y"));
+    }
+
+    #[test]
+    fn ax_type_contract_failure_requires_text_length() {
+        let lock = GlobalStateLock::new();
+        let _mode = EnvGuard::remove(&lock, "CODEX_MACOS_AGENT_TEST_MODE");
+        let _override = EnvGuard::remove(&lock, "CODEX_MACOS_AGENT_AX_TYPE_JSON");
+        let runner = FixedOutputRunner::new(
+            r#"{"node_id":"1.2","matched_count":1,"applied_via":"ax-set-value"}"#,
+        );
+        let request = AxTypeRequest {
+            selector: AxSelector {
+                node_id: Some("1.2".to_string()),
+                ..AxSelector::default()
+            },
+            text: "hello".to_string(),
+            ..AxTypeRequest::default()
+        };
+
+        let err = ax_type(&runner, &request, 250).expect_err("missing text_length should fail");
+        assert_eq!(err.operation(), Some("ax.type"));
+        assert!(err.message().contains("AX backend contract violation"));
+        assert!(err.message().contains("text_length"));
     }
 
     #[test]

--- a/crates/macos-agent/src/backend/hammerspoon.rs
+++ b/crates/macos-agent/src/backend/hammerspoon.rs
@@ -29,7 +29,10 @@ const AX_WATCH_POLL_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_WATCH_POLL_JSON"
 const AX_WATCH_STOP_TEST_MODE_ENV: &str = "CODEX_MACOS_AGENT_AX_WATCH_STOP_JSON";
 const BACKEND_UNAVAILABLE_HINT_PREFIX: &str = "Hammerspoon backend unavailable";
 
-const AX_LIST_HS_SCRIPT: &str = r#"
+macro_rules! hs_ax_script_with_targeting_prelude {
+    ($operation:literal, $body:literal) => {
+        concat!(
+            r#"
 local json = hs.json
 local appmod = hs.application
 local ax = hs.axuielement
@@ -91,6 +94,77 @@ local function boolAttr(element, name, fallback)
   return tostring(value):lower() == "true"
 end
 
+local function children(element)
+  return asTable(attr(element, "AXChildren", {}))
+end
+
+local function resolveApp(target)
+  target = resolveTarget(target)
+
+  if target.pid then
+    local byPid = appmod.applicationForPID(tonumber(target.pid))
+    if byPid then return byPid, target end
+  end
+
+  if target.app and tostring(target.app) ~= "" then
+    local found = appmod.find(tostring(target.app))
+    if found then return found, target end
+  end
+
+  if target.bundle_id and tostring(target.bundle_id) ~= "" then
+    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
+    if type(apps) == "table" and #apps > 0 then
+      return apps[1], target
+    end
+  end
+
+  return appmod.frontmostApplication(), target
+end
+
+local function rootsForApp(app, target)
+  local appElement = ax.applicationElement(app)
+  if not appElement then
+    fail("unable to resolve target app process for "#,
+            $operation,
+            r#")
+  end
+
+  local roots = asTable(attr(appElement, "AXWindows", {}))
+  if #roots == 0 then
+    roots = children(appElement)
+  end
+  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
+  if not windowFilter then
+    return roots
+  end
+
+  local filtered = {}
+  for _, root in ipairs(roots) do
+    local title = string.lower(normalize(attr(root, "AXTitle", "")))
+    if string.find(title, windowFilter, 1, true) then
+      table.insert(filtered, root)
+    end
+  end
+  return filtered
+end
+
+local function copyPath(path)
+  local out = {}
+  for i, value in ipairs(path) do
+    out[i] = value
+  end
+  return out
+end
+
+"#,
+            $body
+        )
+    };
+}
+
+const AX_LIST_HS_SCRIPT: &str = hs_ax_script_with_targeting_prelude!(
+    "ax.list",
+    r#"
 local function frameFor(element)
   local pos = attr(element, "AXPosition", nil)
   local size = attr(element, "AXSize", nil)
@@ -124,66 +198,6 @@ local function valuePreview(element)
     text = string.sub(text, 1, 160) .. "..."
   end
   return text
-end
-
-local function children(element)
-  return asTable(attr(element, "AXChildren", {}))
-end
-
-local function resolveApp(target)
-  target = resolveTarget(target)
-
-  if target.pid then
-    local byPid = appmod.applicationForPID(tonumber(target.pid))
-    if byPid then return byPid, target end
-  end
-
-  if target.app and tostring(target.app) ~= "" then
-    local found = appmod.find(tostring(target.app))
-    if found then return found, target end
-  end
-
-  if target.bundle_id and tostring(target.bundle_id) ~= "" then
-    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
-    if type(apps) == "table" and #apps > 0 then
-      return apps[1], target
-    end
-  end
-
-  return appmod.frontmostApplication(), target
-end
-
-local function rootsForApp(app, target)
-  local appElement = ax.applicationElement(app)
-  if not appElement then
-    fail("unable to resolve target app process for ax.list")
-  end
-
-  local roots = asTable(attr(appElement, "AXWindows", {}))
-  if #roots == 0 then
-    roots = children(appElement)
-  end
-  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
-  if not windowFilter then
-    return roots
-  end
-
-  local filtered = {}
-  for _, root in ipairs(roots) do
-    local title = string.lower(normalize(attr(root, "AXTitle", "")))
-    if string.find(title, windowFilter, 1, true) then
-      table.insert(filtered, root)
-    end
-  end
-  return filtered
-end
-
-local function copyPath(path)
-  local out = {}
-  for i, value in ipairs(path) do
-    out[i] = value
-  end
-  return out
 end
 
 local function parsePayload()
@@ -305,123 +319,12 @@ for rootIndex, root in ipairs(roots) do
 end
 
 return json.encode({ nodes = nodes, warnings = {} })
-"#;
+"#
+);
 
-const AX_CLICK_HS_SCRIPT: &str = r#"
-local json = hs.json
-local appmod = hs.application
-local ax = hs.axuielement
-
-local function fail(message)
-  error(message, 0)
-end
-
-local function safe(callable, fallback)
-  local ok, value = pcall(callable)
-  if ok then return value end
-  return fallback
-end
-
-local function normalize(value)
-  if value == nil then return "" end
-  return tostring(value)
-end
-
-local function asTable(value)
-  if type(value) == "table" then return value end
-  return {}
-end
-
-local function ensureState()
-  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
-  return _G.__codex_macos_agent_ax
-end
-
-local function resolveTarget(rawTarget)
-  local target = rawTarget or {}
-  local state = ensureState()
-  if target.session_id and tostring(target.session_id) ~= "" then
-    local session = state.sessions[tostring(target.session_id)]
-    if not session then
-      fail("session_id does not exist")
-    end
-    return {
-      session_id = tostring(target.session_id),
-      app = target.app or session.app,
-      bundle_id = target.bundle_id or session.bundle_id,
-      pid = session.pid,
-      window_title_contains = target.window_title_contains or session.window_title_contains,
-    }
-  end
-  return target
-end
-
-local function attr(element, name, fallback)
-  local value = safe(function() return element:attributeValue(name) end, fallback)
-  if value == nil then return fallback end
-  return value
-end
-
-local function children(element)
-  return asTable(attr(element, "AXChildren", {}))
-end
-
-local function resolveApp(target)
-  target = resolveTarget(target)
-
-  if target.pid then
-    local byPid = appmod.applicationForPID(tonumber(target.pid))
-    if byPid then return byPid, target end
-  end
-
-  if target.app and tostring(target.app) ~= "" then
-    local found = appmod.find(tostring(target.app))
-    if found then return found, target end
-  end
-
-  if target.bundle_id and tostring(target.bundle_id) ~= "" then
-    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
-    if type(apps) == "table" and #apps > 0 then
-      return apps[1], target
-    end
-  end
-
-  return appmod.frontmostApplication(), target
-end
-
-local function rootsForApp(app, target)
-  local appElement = ax.applicationElement(app)
-  if not appElement then
-    fail("unable to resolve target app process for ax.click")
-  end
-
-  local roots = asTable(attr(appElement, "AXWindows", {}))
-  if #roots == 0 then
-    roots = children(appElement)
-  end
-  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
-  if not windowFilter then
-    return roots
-  end
-
-  local filtered = {}
-  for _, root in ipairs(roots) do
-    local title = string.lower(normalize(attr(root, "AXTitle", "")))
-    if string.find(title, windowFilter, 1, true) then
-      table.insert(filtered, root)
-    end
-  end
-  return filtered
-end
-
-local function copyPath(path)
-  local out = {}
-  for i, value in ipairs(path) do
-    out[i] = value
-  end
-  return out
-end
-
+const AX_CLICK_HS_SCRIPT: &str = hs_ax_script_with_targeting_prelude!(
+    "ax.click",
+    r#"
 local function nodeFrom(element, path)
   local role = normalize(attr(element, "AXRole", ""))
   local title = normalize(attr(element, "AXTitle", ""))
@@ -613,132 +516,14 @@ if not performOk then
 end
 
 return json.encode(result)
-"#;
+"#
+);
 
-const AX_TYPE_HS_SCRIPT: &str = r#"
-local json = hs.json
-local appmod = hs.application
-local ax = hs.axuielement
+const AX_TYPE_HS_SCRIPT: &str = hs_ax_script_with_targeting_prelude!(
+    "ax.type",
+    r#"
 local eventtap = hs.eventtap
 local pasteboard = hs.pasteboard
-
-local function fail(message)
-  error(message, 0)
-end
-
-local function safe(callable, fallback)
-  local ok, value = pcall(callable)
-  if ok then return value end
-  return fallback
-end
-
-local function normalize(value)
-  if value == nil then return "" end
-  return tostring(value)
-end
-
-local function asTable(value)
-  if type(value) == "table" then return value end
-  return {}
-end
-
-local function ensureState()
-  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
-  return _G.__codex_macos_agent_ax
-end
-
-local function attr(element, name, fallback)
-  local value = safe(function() return element:attributeValue(name) end, fallback)
-  if value == nil then return fallback end
-  return value
-end
-
-local function boolAttr(element, name, fallback)
-  local value = attr(element, name, fallback)
-  if type(value) == "boolean" then return value end
-  if value == nil then return fallback end
-  return tostring(value):lower() == "true"
-end
-
-local function children(element)
-  return asTable(attr(element, "AXChildren", {}))
-end
-
-local function resolveTarget(rawTarget)
-  local target = rawTarget or {}
-  local state = ensureState()
-  if target.session_id and tostring(target.session_id) ~= "" then
-    local session = state.sessions[tostring(target.session_id)]
-    if not session then
-      fail("session_id does not exist")
-    end
-    return {
-      session_id = tostring(target.session_id),
-      app = target.app or session.app,
-      bundle_id = target.bundle_id or session.bundle_id,
-      pid = session.pid,
-      window_title_contains = target.window_title_contains or session.window_title_contains,
-    }
-  end
-  return target
-end
-
-local function resolveApp(target)
-  target = resolveTarget(target)
-
-  if target.pid then
-    local byPid = appmod.applicationForPID(tonumber(target.pid))
-    if byPid then return byPid, target end
-  end
-
-  if target.app and tostring(target.app) ~= "" then
-    local found = appmod.find(tostring(target.app))
-    if found then return found, target end
-  end
-
-  if target.bundle_id and tostring(target.bundle_id) ~= "" then
-    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
-    if type(apps) == "table" and #apps > 0 then
-      return apps[1], target
-    end
-  end
-
-  return appmod.frontmostApplication(), target
-end
-
-local function rootsForApp(app, target)
-  local appElement = ax.applicationElement(app)
-  if not appElement then
-    fail("unable to resolve target app process for ax.type")
-  end
-
-  local roots = asTable(attr(appElement, "AXWindows", {}))
-  if #roots == 0 then
-    roots = children(appElement)
-  end
-
-  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
-  if not windowFilter then
-    return roots
-  end
-
-  local filtered = {}
-  for _, root in ipairs(roots) do
-    local title = string.lower(normalize(attr(root, "AXTitle", "")))
-    if string.find(title, windowFilter, 1, true) then
-      table.insert(filtered, root)
-    end
-  end
-  return filtered
-end
-
-local function copyPath(path)
-  local out = {}
-  for i, value in ipairs(path) do
-    out[i] = value
-  end
-  return out
-end
 
 local function nodeFrom(element, path)
   local role = normalize(attr(element, "AXRole", ""))
@@ -931,76 +716,12 @@ return json.encode({
   submitted = submit,
   used_keyboard_fallback = usedKeyboardFallback,
 })
-"#;
+"#
+);
 
-const AX_ATTR_GET_HS_SCRIPT: &str = r#"
-local json = hs.json
-local appmod = hs.application
-local ax = hs.axuielement
-
-local function fail(message)
-  error(message, 0)
-end
-
-local function safe(callable, fallback)
-  local ok, value = pcall(callable)
-  if ok then return value end
-  return fallback
-end
-
-local function normalize(value)
-  if value == nil then return "" end
-  return tostring(value)
-end
-
-local function asTable(value)
-  if type(value) == "table" then return value end
-  return {}
-end
-
-local function ensureState()
-  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
-  return _G.__codex_macos_agent_ax
-end
-
-local function attr(element, name, fallback)
-  local value = safe(function() return element:attributeValue(name) end, fallback)
-  if value == nil then return fallback end
-  return value
-end
-
-local function boolAttr(element, name, fallback)
-  local value = attr(element, name, fallback)
-  if type(value) == "boolean" then return value end
-  if value == nil then return fallback end
-  return tostring(value):lower() == "true"
-end
-
-local function children(element)
-  return asTable(attr(element, "AXChildren", {}))
-end
-
-local function resolveTarget(rawTarget)
-  local target = rawTarget or {}
-  local state = ensureState()
-
-  if target.session_id and tostring(target.session_id) ~= "" then
-    local session = state.sessions[tostring(target.session_id)]
-    if not session then
-      fail("session_id does not exist")
-    end
-    return {
-      session_id = tostring(target.session_id),
-      app = target.app or session.app,
-      bundle_id = target.bundle_id or session.bundle_id,
-      pid = session.pid,
-      window_title_contains = target.window_title_contains or session.window_title_contains,
-    }
-  end
-
-  return target
-end
-
+const AX_ATTR_GET_HS_SCRIPT: &str = hs_ax_script_with_targeting_prelude!(
+    "ax.attr.get",
+    r#"
 local function resolveApp(target)
   target = resolveTarget(target)
 
@@ -1022,40 +743,6 @@ local function resolveApp(target)
   end
 
   return appmod.frontmostApplication(), target
-end
-
-local function rootsForApp(app, target)
-  local appElement = ax.applicationElement(app)
-  if not appElement then
-    fail("unable to resolve target app process for ax.attr.get")
-  end
-
-  local roots = asTable(attr(appElement, "AXWindows", {}))
-  if #roots == 0 then
-    roots = children(appElement)
-  end
-
-  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
-  if not windowFilter then
-    return roots
-  end
-
-  local filtered = {}
-  for _, root in ipairs(roots) do
-    local title = string.lower(normalize(attr(root, "AXTitle", "")))
-    if string.find(title, windowFilter, 1, true) then
-      table.insert(filtered, root)
-    end
-  end
-  return filtered
-end
-
-local function copyPath(path)
-  local out = {}
-  for i, value in ipairs(path) do
-    out[i] = value
-  end
-  return out
 end
 
 local function nodeFrom(element, path)
@@ -1256,121 +943,12 @@ return json.encode({
   name = name,
   value = value,
 })
-"#;
+"#
+);
 
-const AX_ATTR_SET_HS_SCRIPT: &str = r#"
-local json = hs.json
-local appmod = hs.application
-local ax = hs.axuielement
-
-local function fail(message)
-  error(message, 0)
-end
-
-local function safe(callable, fallback)
-  local ok, value = pcall(callable)
-  if ok then return value end
-  return fallback
-end
-
-local function normalize(value)
-  if value == nil then return "" end
-  return tostring(value)
-end
-
-local function asTable(value)
-  if type(value) == "table" then return value end
-  return {}
-end
-
-local function ensureState()
-  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
-  return _G.__codex_macos_agent_ax
-end
-
-local function attr(element, name, fallback)
-  local value = safe(function() return element:attributeValue(name) end, fallback)
-  if value == nil then return fallback end
-  return value
-end
-
-local function boolAttr(element, name, fallback)
-  local value = attr(element, name, fallback)
-  if type(value) == "boolean" then return value end
-  if value == nil then return fallback end
-  return tostring(value):lower() == "true"
-end
-
-local function children(element)
-  return asTable(attr(element, "AXChildren", {}))
-end
-
-local function resolveTarget(rawTarget)
-  local target = rawTarget or {}
-  local state = ensureState()
-  if target.session_id and tostring(target.session_id) ~= "" then
-    local session = state.sessions[tostring(target.session_id)]
-    if not session then fail("session_id does not exist") end
-    return {
-      session_id = tostring(target.session_id),
-      app = target.app or session.app,
-      bundle_id = target.bundle_id or session.bundle_id,
-      pid = session.pid,
-      window_title_contains = target.window_title_contains or session.window_title_contains,
-    }
-  end
-  return target
-end
-
-local function resolveApp(target)
-  target = resolveTarget(target)
-
-  if target.pid then
-    local byPid = appmod.applicationForPID(tonumber(target.pid))
-    if byPid then return byPid, target end
-  end
-
-  if target.app and tostring(target.app) ~= "" then
-    local found = appmod.find(tostring(target.app))
-    if found then return found, target end
-  end
-
-  if target.bundle_id and tostring(target.bundle_id) ~= "" then
-    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
-    if type(apps) == "table" and #apps > 0 then
-      return apps[1], target
-    end
-  end
-
-  return appmod.frontmostApplication(), target
-end
-
-local function rootsForApp(app, target)
-  local appElement = ax.applicationElement(app)
-  if not appElement then fail("unable to resolve target app process for ax.attr.set") end
-
-  local roots = asTable(attr(appElement, "AXWindows", {}))
-  if #roots == 0 then roots = children(appElement) end
-
-  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
-  if not windowFilter then return roots end
-
-  local filtered = {}
-  for _, root in ipairs(roots) do
-    local title = string.lower(normalize(attr(root, "AXTitle", "")))
-    if string.find(title, windowFilter, 1, true) then
-      table.insert(filtered, root)
-    end
-  end
-  return filtered
-end
-
-local function copyPath(path)
-  local out = {}
-  for i, value in ipairs(path) do out[i] = value end
-  return out
-end
-
+const AX_ATTR_SET_HS_SCRIPT: &str = hs_ax_script_with_targeting_prelude!(
+    "ax.attr.set",
+    r#"
 local function nodeFrom(element, path)
   return {
     node_id = table.concat(path, "."),
@@ -1492,96 +1070,12 @@ return json.encode({
   applied = true,
   value_type = valueType,
 })
-"#;
+"#
+);
 
-const AX_ACTION_PERFORM_HS_SCRIPT: &str = r#"
-local json = hs.json
-local appmod = hs.application
-local ax = hs.axuielement
-
-local function fail(message) error(message, 0) end
-local function safe(callable, fallback)
-  local ok, value = pcall(callable)
-  if ok then return value end
-  return fallback
-end
-local function normalize(value)
-  if value == nil then return "" end
-  return tostring(value)
-end
-local function asTable(value)
-  if type(value) == "table" then return value end
-  return {}
-end
-local function ensureState()
-  _G.__codex_macos_agent_ax = _G.__codex_macos_agent_ax or { sessions = {}, watchers = {} }
-  return _G.__codex_macos_agent_ax
-end
-local function attr(element, name, fallback)
-  local value = safe(function() return element:attributeValue(name) end, fallback)
-  if value == nil then return fallback end
-  return value
-end
-local function boolAttr(element, name, fallback)
-  local value = attr(element, name, fallback)
-  if type(value) == "boolean" then return value end
-  if value == nil then return fallback end
-  return tostring(value):lower() == "true"
-end
-local function children(element)
-  return asTable(attr(element, "AXChildren", {}))
-end
-local function resolveTarget(rawTarget)
-  local target = rawTarget or {}
-  local state = ensureState()
-  if target.session_id and tostring(target.session_id) ~= "" then
-    local session = state.sessions[tostring(target.session_id)]
-    if not session then fail("session_id does not exist") end
-    return {
-      session_id = tostring(target.session_id),
-      app = target.app or session.app,
-      bundle_id = target.bundle_id or session.bundle_id,
-      pid = session.pid,
-      window_title_contains = target.window_title_contains or session.window_title_contains,
-    }
-  end
-  return target
-end
-local function resolveApp(target)
-  target = resolveTarget(target)
-  if target.pid then
-    local byPid = appmod.applicationForPID(tonumber(target.pid))
-    if byPid then return byPid, target end
-  end
-  if target.app and tostring(target.app) ~= "" then
-    local found = appmod.find(tostring(target.app))
-    if found then return found, target end
-  end
-  if target.bundle_id and tostring(target.bundle_id) ~= "" then
-    local apps = appmod.applicationsForBundleID(tostring(target.bundle_id))
-    if type(apps) == "table" and #apps > 0 then return apps[1], target end
-  end
-  return appmod.frontmostApplication(), target
-end
-local function rootsForApp(app, target)
-  local appElement = ax.applicationElement(app)
-  if not appElement then fail("unable to resolve target app process for ax.action.perform") end
-  local roots = asTable(attr(appElement, "AXWindows", {}))
-  if #roots == 0 then roots = children(appElement) end
-  local windowFilter = target and target.window_title_contains and string.lower(tostring(target.window_title_contains)) or nil
-  if not windowFilter then return roots end
-  local filtered = {}
-  for _, root in ipairs(roots) do
-    local title = string.lower(normalize(attr(root, "AXTitle", "")))
-    if string.find(title, windowFilter, 1, true) then table.insert(filtered, root) end
-  end
-  return filtered
-end
-local function copyPath(path)
-  local out = {}
-  for i, value in ipairs(path) do out[i] = value end
-  return out
-end
+const AX_ACTION_PERFORM_HS_SCRIPT: &str = hs_ax_script_with_targeting_prelude!(
+    "ax.action.perform",
+    r#"
 local function nodeFrom(element, path)
   return {
     node_id = table.concat(path, "."),
@@ -1681,7 +1175,8 @@ return json.encode({
   name = name,
   performed = true,
 })
-"#;
+"#
+);
 
 const AX_SESSION_START_HS_SCRIPT: &str = r#"
 local json = hs.json

--- a/crates/macos-agent/src/backend/mod.rs
+++ b/crates/macos-agent/src/backend/mod.rs
@@ -16,6 +16,11 @@ use crate::model::{
 };
 use crate::test_mode;
 
+const AX_EXTENDED_CAPABILITY_HINT: &str =
+    "AX attr/action/session/watch commands require Hammerspoon backend (`hs`).";
+const AX_EXTENDED_CAPABILITY_ACTION_HINT: &str =
+    "Use `CODEX_MACOS_AGENT_AX_BACKEND=hammerspoon|auto` and run `macos-agent preflight --include-probes` to verify readiness.";
+
 pub trait AxBackendAdapter {
     fn list(
         &self,
@@ -44,9 +49,12 @@ pub trait AxBackendAdapter {
         _request: &AxAttrGetRequest,
         _timeout_ms: u64,
     ) -> Result<AxAttrGetResult, CliError> {
-        Err(CliError::runtime(
-            "AX attribute get is not supported by this backend",
-        ))
+        Err(
+            CliError::runtime("AX attribute get is not supported by this backend")
+                .with_operation("ax.attr.get")
+                .with_hint(AX_EXTENDED_CAPABILITY_HINT)
+                .with_hint(AX_EXTENDED_CAPABILITY_ACTION_HINT),
+        )
     }
 
     fn attr_set(
@@ -55,9 +63,12 @@ pub trait AxBackendAdapter {
         _request: &AxAttrSetRequest,
         _timeout_ms: u64,
     ) -> Result<AxAttrSetResult, CliError> {
-        Err(CliError::runtime(
-            "AX attribute set is not supported by this backend",
-        ))
+        Err(
+            CliError::runtime("AX attribute set is not supported by this backend")
+                .with_operation("ax.attr.set")
+                .with_hint(AX_EXTENDED_CAPABILITY_HINT)
+                .with_hint(AX_EXTENDED_CAPABILITY_ACTION_HINT),
+        )
     }
 
     fn action_perform(
@@ -66,9 +77,12 @@ pub trait AxBackendAdapter {
         _request: &AxActionPerformRequest,
         _timeout_ms: u64,
     ) -> Result<AxActionPerformResult, CliError> {
-        Err(CliError::runtime(
-            "AX action perform is not supported by this backend",
-        ))
+        Err(
+            CliError::runtime("AX action perform is not supported by this backend")
+                .with_operation("ax.action.perform")
+                .with_hint(AX_EXTENDED_CAPABILITY_HINT)
+                .with_hint(AX_EXTENDED_CAPABILITY_ACTION_HINT),
+        )
     }
 
     fn session_start(
@@ -77,9 +91,12 @@ pub trait AxBackendAdapter {
         _request: &AxSessionStartRequest,
         _timeout_ms: u64,
     ) -> Result<AxSessionStartResult, CliError> {
-        Err(CliError::runtime(
-            "AX session start is not supported by this backend",
-        ))
+        Err(
+            CliError::runtime("AX session start is not supported by this backend")
+                .with_operation("ax.session.start")
+                .with_hint(AX_EXTENDED_CAPABILITY_HINT)
+                .with_hint(AX_EXTENDED_CAPABILITY_ACTION_HINT),
+        )
     }
 
     fn session_list(
@@ -87,9 +104,12 @@ pub trait AxBackendAdapter {
         _runner: &dyn ProcessRunner,
         _timeout_ms: u64,
     ) -> Result<AxSessionListResult, CliError> {
-        Err(CliError::runtime(
-            "AX session list is not supported by this backend",
-        ))
+        Err(
+            CliError::runtime("AX session list is not supported by this backend")
+                .with_operation("ax.session.list")
+                .with_hint(AX_EXTENDED_CAPABILITY_HINT)
+                .with_hint(AX_EXTENDED_CAPABILITY_ACTION_HINT),
+        )
     }
 
     fn session_stop(
@@ -98,9 +118,12 @@ pub trait AxBackendAdapter {
         _request: &AxSessionStopRequest,
         _timeout_ms: u64,
     ) -> Result<AxSessionStopResult, CliError> {
-        Err(CliError::runtime(
-            "AX session stop is not supported by this backend",
-        ))
+        Err(
+            CliError::runtime("AX session stop is not supported by this backend")
+                .with_operation("ax.session.stop")
+                .with_hint(AX_EXTENDED_CAPABILITY_HINT)
+                .with_hint(AX_EXTENDED_CAPABILITY_ACTION_HINT),
+        )
     }
 
     fn watch_start(
@@ -109,9 +132,12 @@ pub trait AxBackendAdapter {
         _request: &AxWatchStartRequest,
         _timeout_ms: u64,
     ) -> Result<AxWatchStartResult, CliError> {
-        Err(CliError::runtime(
-            "AX watch start is not supported by this backend",
-        ))
+        Err(
+            CliError::runtime("AX watch start is not supported by this backend")
+                .with_operation("ax.watch.start")
+                .with_hint(AX_EXTENDED_CAPABILITY_HINT)
+                .with_hint(AX_EXTENDED_CAPABILITY_ACTION_HINT),
+        )
     }
 
     fn watch_poll(
@@ -120,9 +146,12 @@ pub trait AxBackendAdapter {
         _request: &AxWatchPollRequest,
         _timeout_ms: u64,
     ) -> Result<AxWatchPollResult, CliError> {
-        Err(CliError::runtime(
-            "AX watch poll is not supported by this backend",
-        ))
+        Err(
+            CliError::runtime("AX watch poll is not supported by this backend")
+                .with_operation("ax.watch.poll")
+                .with_hint(AX_EXTENDED_CAPABILITY_HINT)
+                .with_hint(AX_EXTENDED_CAPABILITY_ACTION_HINT),
+        )
     }
 
     fn watch_stop(
@@ -131,9 +160,12 @@ pub trait AxBackendAdapter {
         _request: &AxWatchStopRequest,
         _timeout_ms: u64,
     ) -> Result<AxWatchStopResult, CliError> {
-        Err(CliError::runtime(
-            "AX watch stop is not supported by this backend",
-        ))
+        Err(
+            CliError::runtime("AX watch stop is not supported by this backend")
+                .with_operation("ax.watch.stop")
+                .with_hint(AX_EXTENDED_CAPABILITY_HINT)
+                .with_hint(AX_EXTENDED_CAPABILITY_ACTION_HINT),
+        )
     }
 }
 
@@ -176,7 +208,21 @@ pub enum AxBackendPreference {
     AppleScript,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxBackendCapabilityCheck {
+    pub message: String,
+    pub hint: Option<String>,
+}
+
 impl AxBackendPreference {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Hammerspoon => "hammerspoon",
+            Self::AppleScript => "applescript",
+        }
+    }
+
     pub fn resolve() -> Self {
         if let Ok(raw) = std::env::var("CODEX_MACOS_AGENT_AX_BACKEND") {
             match raw.trim().to_ascii_lowercase().as_str() {
@@ -193,6 +239,33 @@ impl AxBackendPreference {
         } else {
             Self::Auto
         }
+    }
+
+    fn capability_message(self) -> &'static str {
+        match self {
+            Self::Auto => {
+                "AX backend preference=auto; list/click/type use Hammerspoon first and may fallback to AppleScript (JXA). attr/action/session/watch remain Hammerspoon-only."
+            }
+            Self::Hammerspoon => {
+                "AX backend preference=hammerspoon; list/click/type and attr/action/session/watch all use Hammerspoon."
+            }
+            Self::AppleScript => {
+                "AX backend preference=applescript; list/click/type use AppleScript (JXA), while attr/action/session/watch still require Hammerspoon."
+            }
+        }
+    }
+}
+
+pub fn preflight_capability_check() -> AxBackendCapabilityCheck {
+    let preference = AxBackendPreference::resolve();
+    let hint = if preference == AxBackendPreference::Hammerspoon {
+        None
+    } else {
+        Some(AX_EXTENDED_CAPABILITY_ACTION_HINT.to_string())
+    };
+    AxBackendCapabilityCheck {
+        message: preference.capability_message().to_string(),
+        hint,
     }
 }
 

--- a/crates/macos-agent/src/cli.rs
+++ b/crates/macos-agent/src/cli.rs
@@ -35,6 +35,11 @@ pub enum ImageFormat {
     name = "macos-agent",
     version,
     about = "Automate macOS desktop actions for agent workflows.",
+    after_help = "Decision guide (AX-first):\n\
+1) Prefer `ax` commands for element-targeted interaction.\n\
+2) If AX is flaky, enable fallback flags (`--allow-coordinate-fallback`, `--allow-keyboard-fallback`).\n\
+3) If AX is unavailable, use `window activate` + `input` commands.\n\
+4) Add `wait` commands around mutating steps for stability.",
     disable_help_subcommand = true
 )]
 pub struct Cli {
@@ -75,6 +80,7 @@ pub struct Cli {
 }
 
 #[derive(Debug, Clone, Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum CommandGroup {
     /// Check runtime dependencies and permissions.
     Preflight(PreflightArgs),
@@ -164,7 +170,11 @@ pub struct ListWindowsArgs {
     pub app: Option<String>,
 
     /// Narrow app selection by window title substring.
-    #[arg(long, requires = "app")]
+    #[arg(
+        long = "window-title-contains",
+        visible_alias = "window-name",
+        requires = "app"
+    )]
     pub window_name: Option<String>,
 
     /// Include only on-screen windows.
@@ -210,7 +220,11 @@ pub struct WindowActivateArgs {
     pub app: Option<String>,
 
     /// Narrow app selection by window title substring.
-    #[arg(long, requires = "app")]
+    #[arg(
+        long = "window-title-contains",
+        visible_alias = "window-name",
+        requires = "app"
+    )]
     pub window_name: Option<String>,
 
     /// Select by bundle id.
@@ -328,16 +342,8 @@ pub enum AxWatchCommand {
     Stop(AxWatchStopArgs),
 }
 
-#[derive(Debug, Clone, Args)]
-#[command(
-    group(
-        ArgGroup::new("target")
-            .required(false)
-            .multiple(false)
-            .args(["session_id", "app", "bundle_id"])
-    )
-)]
-pub struct AxListArgs {
+#[derive(Debug, Clone, Args, Default)]
+pub struct AxTargetArgs {
     /// Select target by existing session id.
     #[arg(long)]
     pub session_id: Option<String>,
@@ -353,34 +359,80 @@ pub struct AxListArgs {
     /// Filter roots by window title substring.
     #[arg(long)]
     pub window_title_contains: Option<String>,
+}
 
-    /// Filter by AX role.
+#[derive(Debug, Clone, Args, Default)]
+pub struct AxMatchFiltersArgs {
+    /// Select by AX role.
     #[arg(long)]
     pub role: Option<String>,
 
-    /// Filter by title substring.
+    /// Select by title substring.
     #[arg(long)]
     pub title_contains: Option<String>,
 
-    /// Filter by identifier substring.
+    /// Select by identifier substring.
     #[arg(long)]
     pub identifier_contains: Option<String>,
 
-    /// Filter by value substring.
+    /// Select by value substring.
     #[arg(long)]
     pub value_contains: Option<String>,
 
-    /// Filter by subrole.
+    /// Select by AX subrole.
     #[arg(long)]
     pub subrole: Option<String>,
 
-    /// Filter by focused flag.
+    /// Select by focused state.
     #[arg(long)]
     pub focused: Option<bool>,
 
-    /// Filter by enabled flag.
+    /// Select by enabled state.
     #[arg(long)]
     pub enabled: Option<bool>,
+}
+
+#[derive(Debug, Clone, Args, Default)]
+pub struct AxSelectorArgs {
+    /// Select by node id from `ax list`.
+    #[arg(
+        long,
+        conflicts_with_all = [
+            "role",
+            "title_contains",
+            "identifier_contains",
+            "value_contains",
+            "subrole",
+            "focused",
+            "enabled",
+            "nth"
+        ]
+    )]
+    pub node_id: Option<String>,
+
+    #[command(flatten)]
+    pub filters: AxMatchFiltersArgs,
+
+    /// Select the nth match from compound selector results.
+    #[arg(long)]
+    pub nth: Option<u32>,
+}
+
+#[derive(Debug, Clone, Args)]
+#[command(
+    group(
+        ArgGroup::new("target")
+            .required(false)
+            .multiple(false)
+            .args(["session_id", "app", "bundle_id"])
+    )
+)]
+pub struct AxListArgs {
+    #[command(flatten)]
+    pub target: AxTargetArgs,
+
+    #[command(flatten)]
+    pub filters: AxMatchFiltersArgs,
 
     /// Limit traversal depth.
     #[arg(long)]
@@ -416,69 +468,11 @@ pub struct AxListArgs {
     )
 )]
 pub struct AxClickArgs {
-    /// Select by node id from `ax list`.
-    #[arg(
-        long,
-        conflicts_with_all = [
-            "role",
-            "title_contains",
-            "identifier_contains",
-            "value_contains",
-            "subrole",
-            "focused",
-            "enabled",
-            "nth"
-        ]
-    )]
-    pub node_id: Option<String>,
+    #[command(flatten)]
+    pub selector: AxSelectorArgs,
 
-    /// Select by AX role.
-    #[arg(long)]
-    pub role: Option<String>,
-
-    /// Select by title substring.
-    #[arg(long)]
-    pub title_contains: Option<String>,
-
-    /// Select by identifier substring.
-    #[arg(long)]
-    pub identifier_contains: Option<String>,
-
-    /// Select by value substring.
-    #[arg(long)]
-    pub value_contains: Option<String>,
-
-    /// Select by AX subrole.
-    #[arg(long)]
-    pub subrole: Option<String>,
-
-    /// Select by focused state.
-    #[arg(long)]
-    pub focused: Option<bool>,
-
-    /// Select by enabled state.
-    #[arg(long)]
-    pub enabled: Option<bool>,
-
-    /// Select the nth match from compound selector results.
-    #[arg(long)]
-    pub nth: Option<u32>,
-
-    /// Select target by existing session id.
-    #[arg(long)]
-    pub session_id: Option<String>,
-
-    /// Narrow selector to app name.
-    #[arg(long)]
-    pub app: Option<String>,
-
-    /// Narrow selector to bundle id.
-    #[arg(long)]
-    pub bundle_id: Option<String>,
-
-    /// Narrow to windows whose title contains this value.
-    #[arg(long)]
-    pub window_title_contains: Option<String>,
+    #[command(flatten)]
+    pub target: AxTargetArgs,
 
     /// Allow coordinate fallback when AX press is unavailable.
     #[arg(long)]
@@ -510,69 +504,11 @@ pub struct AxClickArgs {
     )
 )]
 pub struct AxTypeArgs {
-    /// Select by node id from `ax list`.
-    #[arg(
-        long,
-        conflicts_with_all = [
-            "role",
-            "title_contains",
-            "identifier_contains",
-            "value_contains",
-            "subrole",
-            "focused",
-            "enabled",
-            "nth"
-        ]
-    )]
-    pub node_id: Option<String>,
+    #[command(flatten)]
+    pub selector: AxSelectorArgs,
 
-    /// Select by AX role.
-    #[arg(long)]
-    pub role: Option<String>,
-
-    /// Select by title substring.
-    #[arg(long)]
-    pub title_contains: Option<String>,
-
-    /// Select by identifier substring.
-    #[arg(long)]
-    pub identifier_contains: Option<String>,
-
-    /// Select by value substring.
-    #[arg(long)]
-    pub value_contains: Option<String>,
-
-    /// Select by AX subrole.
-    #[arg(long)]
-    pub subrole: Option<String>,
-
-    /// Select by focused state.
-    #[arg(long)]
-    pub focused: Option<bool>,
-
-    /// Select by enabled state.
-    #[arg(long)]
-    pub enabled: Option<bool>,
-
-    /// Select the nth match from compound selector results.
-    #[arg(long)]
-    pub nth: Option<u32>,
-
-    /// Select target by existing session id.
-    #[arg(long)]
-    pub session_id: Option<String>,
-
-    /// Narrow selector to app name.
-    #[arg(long)]
-    pub app: Option<String>,
-
-    /// Narrow selector to bundle id.
-    #[arg(long)]
-    pub bundle_id: Option<String>,
-
-    /// Narrow to windows whose title contains this value.
-    #[arg(long)]
-    pub window_title_contains: Option<String>,
+    #[command(flatten)]
+    pub target: AxTargetArgs,
 
     /// Text to type.
     #[arg(long, value_parser = clap::builder::NonEmptyStringValueParser::new())]
@@ -620,69 +556,11 @@ pub struct AxTypeArgs {
     )
 )]
 pub struct AxAttrGetArgs {
-    /// Select by node id from `ax list`.
-    #[arg(
-        long,
-        conflicts_with_all = [
-            "role",
-            "title_contains",
-            "identifier_contains",
-            "value_contains",
-            "subrole",
-            "focused",
-            "enabled",
-            "nth"
-        ]
-    )]
-    pub node_id: Option<String>,
+    #[command(flatten)]
+    pub selector: AxSelectorArgs,
 
-    /// Select by AX role.
-    #[arg(long)]
-    pub role: Option<String>,
-
-    /// Select by title substring.
-    #[arg(long)]
-    pub title_contains: Option<String>,
-
-    /// Select by identifier substring.
-    #[arg(long)]
-    pub identifier_contains: Option<String>,
-
-    /// Select by value substring.
-    #[arg(long)]
-    pub value_contains: Option<String>,
-
-    /// Select by AX subrole.
-    #[arg(long)]
-    pub subrole: Option<String>,
-
-    /// Select by focused state.
-    #[arg(long)]
-    pub focused: Option<bool>,
-
-    /// Select by enabled state.
-    #[arg(long)]
-    pub enabled: Option<bool>,
-
-    /// Select the nth match from compound selector results.
-    #[arg(long)]
-    pub nth: Option<u32>,
-
-    /// Select target by existing session id.
-    #[arg(long)]
-    pub session_id: Option<String>,
-
-    /// Narrow selector to app name.
-    #[arg(long)]
-    pub app: Option<String>,
-
-    /// Narrow selector to bundle id.
-    #[arg(long)]
-    pub bundle_id: Option<String>,
-
-    /// Narrow to windows whose title contains this value.
-    #[arg(long)]
-    pub window_title_contains: Option<String>,
+    #[command(flatten)]
+    pub target: AxTargetArgs,
 
     /// AX attribute name.
     #[arg(long)]
@@ -723,69 +601,11 @@ pub enum AxValueType {
     )
 )]
 pub struct AxAttrSetArgs {
-    /// Select by node id from `ax list`.
-    #[arg(
-        long,
-        conflicts_with_all = [
-            "role",
-            "title_contains",
-            "identifier_contains",
-            "value_contains",
-            "subrole",
-            "focused",
-            "enabled",
-            "nth"
-        ]
-    )]
-    pub node_id: Option<String>,
+    #[command(flatten)]
+    pub selector: AxSelectorArgs,
 
-    /// Select by AX role.
-    #[arg(long)]
-    pub role: Option<String>,
-
-    /// Select by title substring.
-    #[arg(long)]
-    pub title_contains: Option<String>,
-
-    /// Select by identifier substring.
-    #[arg(long)]
-    pub identifier_contains: Option<String>,
-
-    /// Select by value substring.
-    #[arg(long)]
-    pub value_contains: Option<String>,
-
-    /// Select by AX subrole.
-    #[arg(long)]
-    pub subrole: Option<String>,
-
-    /// Select by focused state.
-    #[arg(long)]
-    pub focused: Option<bool>,
-
-    /// Select by enabled state.
-    #[arg(long)]
-    pub enabled: Option<bool>,
-
-    /// Select the nth match from compound selector results.
-    #[arg(long)]
-    pub nth: Option<u32>,
-
-    /// Select target by existing session id.
-    #[arg(long)]
-    pub session_id: Option<String>,
-
-    /// Narrow selector to app name.
-    #[arg(long)]
-    pub app: Option<String>,
-
-    /// Narrow selector to bundle id.
-    #[arg(long)]
-    pub bundle_id: Option<String>,
-
-    /// Narrow to windows whose title contains this value.
-    #[arg(long)]
-    pub window_title_contains: Option<String>,
+    #[command(flatten)]
+    pub target: AxTargetArgs,
 
     /// AX attribute name.
     #[arg(long)]
@@ -825,69 +645,11 @@ pub struct AxAttrSetArgs {
     )
 )]
 pub struct AxActionPerformArgs {
-    /// Select by node id from `ax list`.
-    #[arg(
-        long,
-        conflicts_with_all = [
-            "role",
-            "title_contains",
-            "identifier_contains",
-            "value_contains",
-            "subrole",
-            "focused",
-            "enabled",
-            "nth"
-        ]
-    )]
-    pub node_id: Option<String>,
+    #[command(flatten)]
+    pub selector: AxSelectorArgs,
 
-    /// Select by AX role.
-    #[arg(long)]
-    pub role: Option<String>,
-
-    /// Select by title substring.
-    #[arg(long)]
-    pub title_contains: Option<String>,
-
-    /// Select by identifier substring.
-    #[arg(long)]
-    pub identifier_contains: Option<String>,
-
-    /// Select by value substring.
-    #[arg(long)]
-    pub value_contains: Option<String>,
-
-    /// Select by AX subrole.
-    #[arg(long)]
-    pub subrole: Option<String>,
-
-    /// Select by focused state.
-    #[arg(long)]
-    pub focused: Option<bool>,
-
-    /// Select by enabled state.
-    #[arg(long)]
-    pub enabled: Option<bool>,
-
-    /// Select the nth match from compound selector results.
-    #[arg(long)]
-    pub nth: Option<u32>,
-
-    /// Select target by existing session id.
-    #[arg(long)]
-    pub session_id: Option<String>,
-
-    /// Narrow selector to app name.
-    #[arg(long)]
-    pub app: Option<String>,
-
-    /// Narrow selector to bundle id.
-    #[arg(long)]
-    pub bundle_id: Option<String>,
-
-    /// Narrow to windows whose title contains this value.
-    #[arg(long)]
-    pub window_title_contains: Option<String>,
+    #[command(flatten)]
+    pub target: AxTargetArgs,
 
     /// AX action name.
     #[arg(long)]
@@ -1014,7 +776,7 @@ pub struct InputTypeArgs {
     pub delay_ms: Option<u64>,
 
     /// Press Enter after typing.
-    #[arg(long)]
+    #[arg(long = "submit", visible_alias = "enter")]
     pub enter: bool,
 }
 
@@ -1058,7 +820,11 @@ pub struct ObserveScreenshotArgs {
     pub app: Option<String>,
 
     /// Narrow app selection by window title substring.
-    #[arg(long, requires = "app")]
+    #[arg(
+        long = "window-title-contains",
+        visible_alias = "window-name",
+        requires = "app"
+    )]
     pub window_name: Option<String>,
 
     /// Output path.
@@ -1178,7 +944,11 @@ pub struct WaitWindowPresentArgs {
     pub app: Option<String>,
 
     /// Narrow app selection by window title substring.
-    #[arg(long, requires = "app")]
+    #[arg(
+        long = "window-title-contains",
+        visible_alias = "window-name",
+        requires = "app"
+    )]
     pub window_name: Option<String>,
 
     /// Timeout in milliseconds.
@@ -1239,7 +1009,7 @@ mod tests {
             "window-present",
             "--app",
             "Terminal",
-            "--window-name",
+            "--window-title-contains",
             "Inbox",
             "--timeout-ms",
             "2000",
@@ -1281,20 +1051,43 @@ mod tests {
     }
 
     #[test]
-    fn rejects_window_name_without_app() {
+    fn rejects_window_title_contains_without_app() {
         let err = Cli::try_parse_from([
             "macos-agent",
             "wait",
             "window-present",
-            "--window-name",
+            "--window-title-contains",
             "Inbox",
         ])
-        .expect_err("window-name requires app");
+        .expect_err("window-title-contains requires app");
         let rendered = err.to_string();
         assert!(
             rendered.contains("requires")
                 || rendered.contains("required arguments were not provided")
         );
+    }
+
+    #[test]
+    fn supports_window_name_alias_for_backward_compatibility() {
+        let cli = Cli::try_parse_from([
+            "macos-agent",
+            "wait",
+            "window-present",
+            "--app",
+            "Terminal",
+            "--window-name",
+            "Inbox",
+        ])
+        .expect("legacy --window-name alias should parse");
+
+        match cli.command {
+            CommandGroup::Wait {
+                command: WaitCommand::WindowPresent(args),
+            } => {
+                assert_eq!(args.window_name.as_deref(), Some("Inbox"));
+            }
+            other => panic!("unexpected command variant: {other:?}"),
+        }
     }
 
     #[test]
@@ -1308,6 +1101,35 @@ mod tests {
             } => {
                 assert_eq!(args.id, "abc".to_string());
             }
+            other => panic!("unexpected command variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_input_type_submit_and_enter_alias() {
+        let canonical = Cli::try_parse_from([
+            "macos-agent",
+            "input",
+            "type",
+            "--text",
+            "hello",
+            "--submit",
+        ])
+        .expect("input type --submit should parse");
+        match canonical.command {
+            CommandGroup::Input {
+                command: super::InputCommand::Type(args),
+            } => assert!(args.enter),
+            other => panic!("unexpected command variant: {other:?}"),
+        }
+
+        let alias =
+            Cli::try_parse_from(["macos-agent", "input", "type", "--text", "hello", "--enter"])
+                .expect("input type --enter alias should parse");
+        match alias.command {
+            CommandGroup::Input {
+                command: super::InputCommand::Type(args),
+            } => assert!(args.enter),
             other => panic!("unexpected command variant: {other:?}"),
         }
     }
@@ -1335,9 +1157,9 @@ mod tests {
             CommandGroup::Ax {
                 command: AxCommand::List(args),
             } => {
-                assert_eq!(args.app.as_deref(), Some("Arc"));
-                assert_eq!(args.role.as_deref(), Some("AXButton"));
-                assert_eq!(args.title_contains.as_deref(), Some("New tab"));
+                assert_eq!(args.target.app.as_deref(), Some("Arc"));
+                assert_eq!(args.filters.role.as_deref(), Some("AXButton"));
+                assert_eq!(args.filters.title_contains.as_deref(), Some("New tab"));
                 assert_eq!(args.max_depth, Some(4));
                 assert_eq!(args.limit, Some(20));
             }
@@ -1362,7 +1184,7 @@ mod tests {
             CommandGroup::Ax {
                 command: AxCommand::Click(args),
             } => {
-                assert_eq!(args.node_id.as_deref(), Some("node-17"));
+                assert_eq!(args.selector.node_id.as_deref(), Some("node-17"));
                 assert!(args.allow_coordinate_fallback);
             }
             other => panic!("unexpected command variant: {other:?}"),
@@ -1394,9 +1216,12 @@ mod tests {
             CommandGroup::Ax {
                 command: AxCommand::Type(args),
             } => {
-                assert_eq!(args.role.as_deref(), Some("AXTextField"));
-                assert_eq!(args.title_contains.as_deref(), Some("Search"));
-                assert_eq!(args.nth, Some(2));
+                assert_eq!(args.selector.filters.role.as_deref(), Some("AXTextField"));
+                assert_eq!(
+                    args.selector.filters.title_contains.as_deref(),
+                    Some("Search")
+                );
+                assert_eq!(args.selector.nth, Some(2));
                 assert_eq!(args.text, "hello");
                 assert!(args.clear_first);
                 assert!(args.submit);
@@ -1444,8 +1269,8 @@ mod tests {
             CommandGroup::Ax {
                 command: AxCommand::Type(args),
             } => {
-                assert_eq!(args.role.as_deref(), Some("AXTextField"));
-                assert!(args.title_contains.is_none());
+                assert_eq!(args.selector.filters.role.as_deref(), Some("AXTextField"));
+                assert!(args.selector.filters.title_contains.is_none());
             }
             other => panic!("unexpected command variant: {other:?}"),
         }
@@ -1496,7 +1321,7 @@ mod tests {
                         command: AxAttrCommand::Get(args),
                     },
             } => {
-                assert_eq!(args.node_id.as_deref(), Some("1.2"));
+                assert_eq!(args.selector.node_id.as_deref(), Some("1.2"));
                 assert_eq!(args.name, "AXRole");
             }
             other => panic!("unexpected command variant: {other:?}"),
@@ -1526,8 +1351,11 @@ mod tests {
                         command: AxAttrCommand::Set(args),
                     },
             } => {
-                assert_eq!(args.role.as_deref(), Some("AXTextField"));
-                assert_eq!(args.title_contains.as_deref(), Some("Search"));
+                assert_eq!(args.selector.filters.role.as_deref(), Some("AXTextField"));
+                assert_eq!(
+                    args.selector.filters.title_contains.as_deref(),
+                    Some("Search")
+                );
                 assert_eq!(args.name, "AXValue");
                 assert_eq!(args.value, "hello");
             }
@@ -1555,7 +1383,7 @@ mod tests {
                         command: AxActionCommand::Perform(args),
                     },
             } => {
-                assert_eq!(args.node_id.as_deref(), Some("1.1"));
+                assert_eq!(args.selector.node_id.as_deref(), Some("1.1"));
                 assert_eq!(args.name, "AXPress");
             }
             other => panic!("unexpected command variant: {other:?}"),

--- a/crates/macos-agent/src/commands/ax_action.rs
+++ b/crates/macos-agent/src/commands/ax_action.rs
@@ -1,10 +1,16 @@
+use std::time::Instant;
+
 use crate::backend::process::ProcessRunner;
 use crate::backend::{AutoAxBackend, AxBackendAdapter};
 use crate::cli::{AxActionPerformArgs, OutputFormat};
-use crate::commands::ax_common::{build_selector, build_target, AxSelectorInput};
+use crate::commands::ax_common::{build_selector_from_args, build_target_from_args};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{AxActionPerformRequest, AxActionPerformResult, SuccessEnvelope};
-use crate::run::ActionPolicy;
+use crate::model::{AxActionPerformCommandResult, AxActionPerformRequest, AxActionPerformResult};
+use crate::retry::run_with_retry;
+use crate::run::{
+    action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
+};
 
 pub fn run_perform(
     format: OutputFormat,
@@ -13,61 +19,54 @@ pub fn run_perform(
     runner: &dyn ProcessRunner,
 ) -> Result<(), CliError> {
     let request = AxActionPerformRequest {
-        target: build_target(
-            args.session_id.clone(),
-            args.app.clone(),
-            args.bundle_id.clone(),
-            args.window_title_contains.clone(),
-        )?,
-        selector: build_selector(AxSelectorInput {
-            node_id: args.node_id.clone(),
-            role: args.role.clone(),
-            title_contains: args.title_contains.clone(),
-            identifier_contains: args.identifier_contains.clone(),
-            value_contains: args.value_contains.clone(),
-            subrole: args.subrole.clone(),
-            focused: args.focused,
-            enabled: args.enabled,
-            nth: args.nth,
-        })?,
+        target: build_target_from_args(&args.target)?,
+        selector: build_selector_from_args(&args.selector)?,
         name: args.name.clone(),
     };
 
-    let result = if policy.dry_run {
-        AxActionPerformResult {
-            node_id: request.selector.node_id.clone(),
-            matched_count: 0,
-            name: request.name.clone(),
-            performed: false,
-        }
-    } else {
+    let action_id = next_action_id("ax.action.perform");
+    let started = Instant::now();
+    let mut attempts_used = 0u8;
+    let mut detail = AxActionPerformResult {
+        node_id: request.selector.node_id.clone(),
+        matched_count: 0,
+        name: request.name.clone(),
+        performed: false,
+    };
+
+    if !policy.dry_run {
         let backend = AutoAxBackend::default();
-        backend.action_perform(runner, &request, policy.timeout_ms)?
+        let retry = policy.retry_policy();
+        let (backend_result, attempts) = run_with_retry(retry, || {
+            backend.action_perform(runner, &request, policy.timeout_ms)
+        })?;
+        attempts_used = attempts;
+        detail = backend_result;
+    }
+
+    let result = AxActionPerformCommandResult {
+        detail,
+        policy: action_policy_result(policy),
+        meta: build_action_meta_with_attempts(action_id, started, policy, attempts_used),
     };
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.action.perform", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.action.perform", result)?;
         }
         OutputFormat::Text => {
             println!(
-                "ax.action.perform\tnode_id={}\tname={}\tmatched_count={}\tperformed={}",
-                result.node_id.unwrap_or_default(),
-                result.name,
-                result.matched_count,
-                result.performed
+                "ax.action.perform\tnode_id={}\tname={}\tmatched_count={}\tperformed={}\taction_id={}\telapsed_ms={}",
+                result.detail.node_id.clone().unwrap_or_default(),
+                result.detail.name,
+                result.detail.matched_count,
+                result.detail.performed,
+                result.meta.action_id,
+                result.meta.elapsed_ms,
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
@@ -94,19 +93,11 @@ mod tests {
 
     fn sample_args() -> AxActionPerformArgs {
         AxActionPerformArgs {
-            node_id: Some("1.1".to_string()),
-            role: None,
-            title_contains: None,
-            identifier_contains: None,
-            value_contains: None,
-            subrole: None,
-            focused: None,
-            enabled: None,
-            nth: None,
-            session_id: None,
-            app: None,
-            bundle_id: None,
-            window_title_contains: None,
+            selector: crate::cli::AxSelectorArgs {
+                node_id: Some("1.1".to_string()),
+                ..crate::cli::AxSelectorArgs::default()
+            },
+            target: crate::cli::AxTargetArgs::default(),
             name: "AXPress".to_string(),
         }
     }

--- a/crates/macos-agent/src/commands/ax_attr.rs
+++ b/crates/macos-agent/src/commands/ax_attr.rs
@@ -1,14 +1,20 @@
+use std::time::Instant;
+
 use serde_json::Value;
 
 use crate::backend::process::ProcessRunner;
 use crate::backend::{AutoAxBackend, AxBackendAdapter};
 use crate::cli::{AxAttrGetArgs, AxAttrSetArgs, AxValueType, OutputFormat};
-use crate::commands::ax_common::{build_selector, build_target, AxSelectorInput};
+use crate::commands::ax_common::{build_selector_from_args, build_target_from_args};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
 use crate::model::{
-    AxAttrGetRequest, AxAttrGetResult, AxAttrSetRequest, AxAttrSetResult, SuccessEnvelope,
+    AxAttrGetRequest, AxAttrGetResult, AxAttrSetCommandResult, AxAttrSetRequest, AxAttrSetResult,
 };
-use crate::run::ActionPolicy;
+use crate::retry::run_with_retry;
+use crate::run::{
+    action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
+};
 
 pub fn run_get(
     format: OutputFormat,
@@ -17,23 +23,8 @@ pub fn run_get(
     runner: &dyn ProcessRunner,
 ) -> Result<(), CliError> {
     let request = AxAttrGetRequest {
-        target: build_target(
-            args.session_id.clone(),
-            args.app.clone(),
-            args.bundle_id.clone(),
-            args.window_title_contains.clone(),
-        )?,
-        selector: build_selector(AxSelectorInput {
-            node_id: args.node_id.clone(),
-            role: args.role.clone(),
-            title_contains: args.title_contains.clone(),
-            identifier_contains: args.identifier_contains.clone(),
-            value_contains: args.value_contains.clone(),
-            subrole: args.subrole.clone(),
-            focused: args.focused,
-            enabled: args.enabled,
-            nth: args.nth,
-        })?,
+        target: build_target_from_args(&args.target)?,
+        selector: build_selector_from_args(&args.selector)?,
         name: args.name.clone(),
     };
 
@@ -49,38 +40,37 @@ pub fn run_set(
     runner: &dyn ProcessRunner,
 ) -> Result<(), CliError> {
     let request = AxAttrSetRequest {
-        target: build_target(
-            args.session_id.clone(),
-            args.app.clone(),
-            args.bundle_id.clone(),
-            args.window_title_contains.clone(),
-        )?,
-        selector: build_selector(AxSelectorInput {
-            node_id: args.node_id.clone(),
-            role: args.role.clone(),
-            title_contains: args.title_contains.clone(),
-            identifier_contains: args.identifier_contains.clone(),
-            value_contains: args.value_contains.clone(),
-            subrole: args.subrole.clone(),
-            focused: args.focused,
-            enabled: args.enabled,
-            nth: args.nth,
-        })?,
+        target: build_target_from_args(&args.target)?,
+        selector: build_selector_from_args(&args.selector)?,
         name: args.name.clone(),
         value: parse_value(args.value_type, &args.value)?,
     };
 
-    let result = if policy.dry_run {
-        AxAttrSetResult {
-            node_id: request.selector.node_id.clone(),
-            matched_count: 0,
-            name: request.name.clone(),
-            applied: false,
-            value_type: value_type_name(args.value_type).to_string(),
-        }
-    } else {
+    let action_id = next_action_id("ax.attr.set");
+    let started = Instant::now();
+    let mut attempts_used = 0u8;
+    let mut detail = AxAttrSetResult {
+        node_id: request.selector.node_id.clone(),
+        matched_count: 0,
+        name: request.name.clone(),
+        applied: false,
+        value_type: value_type_name(args.value_type).to_string(),
+    };
+
+    if !policy.dry_run {
         let backend = AutoAxBackend::default();
-        backend.attr_set(runner, &request, policy.timeout_ms)?
+        let retry = policy.retry_policy();
+        let (backend_result, attempts) = run_with_retry(retry, || {
+            backend.attr_set(runner, &request, policy.timeout_ms)
+        })?;
+        attempts_used = attempts;
+        detail = backend_result;
+    }
+
+    let result = AxAttrSetCommandResult {
+        detail,
+        policy: action_policy_result(policy),
+        meta: build_action_meta_with_attempts(action_id, started, policy, attempts_used),
     };
 
     print_set_result(format, result)
@@ -129,13 +119,7 @@ fn parse_value(value_type: AxValueType, raw: &str) -> Result<Value, CliError> {
 fn print_get_result(format: OutputFormat, result: AxAttrGetResult) -> Result<(), CliError> {
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.attr.get", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.attr.get", result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -147,40 +131,32 @@ fn print_get_result(format: OutputFormat, result: AxAttrGetResult) -> Result<(),
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
     Ok(())
 }
 
-fn print_set_result(format: OutputFormat, result: AxAttrSetResult) -> Result<(), CliError> {
+fn print_set_result(format: OutputFormat, result: AxAttrSetCommandResult) -> Result<(), CliError> {
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.attr.set", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.attr.set", result)?;
         }
         OutputFormat::Text => {
             println!(
-                "ax.attr.set\tnode_id={}\tname={}\tmatched_count={}\tapplied={}\tvalue_type={}",
-                result.node_id.unwrap_or_default(),
-                result.name,
-                result.matched_count,
-                result.applied,
-                result.value_type
+                "ax.attr.set\tnode_id={}\tname={}\tmatched_count={}\tapplied={}\tvalue_type={}\taction_id={}\telapsed_ms={}",
+                result.detail.node_id.clone().unwrap_or_default(),
+                result.detail.name,
+                result.detail.matched_count,
+                result.detail.applied,
+                result.detail.value_type,
+                result.meta.action_id,
+                result.meta.elapsed_ms
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
@@ -208,38 +184,22 @@ mod tests {
 
     fn sample_get_args() -> AxAttrGetArgs {
         AxAttrGetArgs {
-            node_id: Some("1.1".to_string()),
-            role: None,
-            title_contains: None,
-            identifier_contains: None,
-            value_contains: None,
-            subrole: None,
-            focused: None,
-            enabled: None,
-            nth: None,
-            session_id: None,
-            app: None,
-            bundle_id: None,
-            window_title_contains: None,
+            selector: crate::cli::AxSelectorArgs {
+                node_id: Some("1.1".to_string()),
+                ..crate::cli::AxSelectorArgs::default()
+            },
+            target: crate::cli::AxTargetArgs::default(),
             name: "AXRole".to_string(),
         }
     }
 
     fn sample_set_args(value_type: AxValueType, value: &str) -> AxAttrSetArgs {
         AxAttrSetArgs {
-            node_id: Some("1.1".to_string()),
-            role: None,
-            title_contains: None,
-            identifier_contains: None,
-            value_contains: None,
-            subrole: None,
-            focused: None,
-            enabled: None,
-            nth: None,
-            session_id: None,
-            app: None,
-            bundle_id: None,
-            window_title_contains: None,
+            selector: crate::cli::AxSelectorArgs {
+                node_id: Some("1.1".to_string()),
+                ..crate::cli::AxSelectorArgs::default()
+            },
+            target: crate::cli::AxTargetArgs::default(),
             name: "AXValue".to_string(),
             value: value.to_string(),
             value_type,

--- a/crates/macos-agent/src/commands/ax_click.rs
+++ b/crates/macos-agent/src/commands/ax_click.rs
@@ -4,9 +4,10 @@ use crate::backend::cliclick;
 use crate::backend::process::ProcessRunner;
 use crate::backend::{AutoAxBackend, AxBackendAdapter};
 use crate::cli::{AxClickArgs, MouseButton, OutputFormat};
-use crate::commands::ax_common::{build_selector, build_target, AxSelectorInput};
+use crate::commands::ax_common::{build_selector_from_args, build_target_from_args};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{AxClickCommandResult, AxClickRequest, AxClickResult, SuccessEnvelope};
+use crate::model::{AxClickCommandResult, AxClickRequest, AxClickResult};
 use crate::retry::run_with_retry;
 use crate::run::{
     action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
@@ -64,13 +65,7 @@ pub fn run(
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.click", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.click", result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -83,9 +78,7 @@ pub fn run(
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
@@ -93,23 +86,8 @@ pub fn run(
 }
 
 fn build_request(args: &AxClickArgs) -> Result<AxClickRequest, CliError> {
-    let target = build_target(
-        args.session_id.clone(),
-        args.app.clone(),
-        args.bundle_id.clone(),
-        args.window_title_contains.clone(),
-    )?;
-    let selector = build_selector(AxSelectorInput {
-        node_id: args.node_id.clone(),
-        role: args.role.clone(),
-        title_contains: args.title_contains.clone(),
-        identifier_contains: args.identifier_contains.clone(),
-        value_contains: args.value_contains.clone(),
-        subrole: args.subrole.clone(),
-        focused: args.focused,
-        enabled: args.enabled,
-        nth: args.nth,
-    })?;
+    let target = build_target_from_args(&args.target)?;
+    let selector = build_selector_from_args(&args.selector)?;
     Ok(AxClickRequest {
         target,
         selector,

--- a/crates/macos-agent/src/commands/ax_common.rs
+++ b/crates/macos-agent/src/commands/ax_common.rs
@@ -1,3 +1,4 @@
+use crate::cli::{AxSelectorArgs, AxTargetArgs};
 use crate::error::CliError;
 use crate::model::{AxSelector, AxTarget};
 
@@ -45,6 +46,29 @@ pub fn build_target(
     })
 }
 
+pub fn build_target_from_args(args: &AxTargetArgs) -> Result<AxTarget, CliError> {
+    build_target(
+        args.session_id.clone(),
+        args.app.clone(),
+        args.bundle_id.clone(),
+        args.window_title_contains.clone(),
+    )
+}
+
+pub fn selector_input_from_args(args: &AxSelectorArgs) -> AxSelectorInput {
+    AxSelectorInput {
+        node_id: args.node_id.clone(),
+        role: args.filters.role.clone(),
+        title_contains: args.filters.title_contains.clone(),
+        identifier_contains: args.filters.identifier_contains.clone(),
+        value_contains: args.filters.value_contains.clone(),
+        subrole: args.filters.subrole.clone(),
+        focused: args.filters.focused,
+        enabled: args.filters.enabled,
+        nth: args.nth,
+    }
+}
+
 pub fn build_selector(input: AxSelectorInput) -> Result<AxSelector, CliError> {
     if input.nth == Some(0) {
         return Err(CliError::usage("--nth must be at least 1"));
@@ -87,4 +111,8 @@ pub fn build_selector(input: AxSelectorInput) -> Result<AxSelector, CliError> {
         enabled: input.enabled,
         nth: input.nth.map(|value| value as usize),
     })
+}
+
+pub fn build_selector_from_args(args: &AxSelectorArgs) -> Result<AxSelector, CliError> {
+    build_selector(selector_input_from_args(args))
 }

--- a/crates/macos-agent/src/commands/ax_list.rs
+++ b/crates/macos-agent/src/commands/ax_list.rs
@@ -1,9 +1,10 @@
 use crate::backend::process::ProcessRunner;
 use crate::backend::{AutoAxBackend, AxBackendAdapter};
 use crate::cli::{AxListArgs, OutputFormat};
-use crate::commands::ax_common::build_target;
+use crate::commands::ax_common::build_target_from_args;
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{AxListRequest, SuccessEnvelope};
+use crate::model::AxListRequest;
 use crate::run::ActionPolicy;
 
 pub fn run(
@@ -12,22 +13,17 @@ pub fn run(
     policy: ActionPolicy,
     runner: &dyn ProcessRunner,
 ) -> Result<(), CliError> {
-    let target = build_target(
-        args.session_id.clone(),
-        args.app.clone(),
-        args.bundle_id.clone(),
-        args.window_title_contains.clone(),
-    )?;
+    let target = build_target_from_args(&args.target)?;
 
     let request = AxListRequest {
         target,
-        role: args.role.clone(),
-        title_contains: args.title_contains.clone(),
-        identifier_contains: args.identifier_contains.clone(),
-        value_contains: args.value_contains.clone(),
-        subrole: args.subrole.clone(),
-        focused: args.focused,
-        enabled: args.enabled,
+        role: args.filters.role.clone(),
+        title_contains: args.filters.title_contains.clone(),
+        identifier_contains: args.filters.identifier_contains.clone(),
+        value_contains: args.filters.value_contains.clone(),
+        subrole: args.filters.subrole.clone(),
+        focused: args.filters.focused,
+        enabled: args.filters.enabled,
         max_depth: args.max_depth,
         limit: args.limit.map(|value| value as usize),
     };
@@ -36,13 +32,7 @@ pub fn run(
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.list", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.list", result)?;
         }
         OutputFormat::Text => {
             if result.nodes.is_empty() {
@@ -60,9 +50,7 @@ pub fn run(
             }
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/ax_session.rs
+++ b/crates/macos-agent/src/commands/ax_session.rs
@@ -1,13 +1,19 @@
+use std::time::Instant;
+
 use crate::backend::process::ProcessRunner;
 use crate::backend::{AutoAxBackend, AxBackendAdapter};
 use crate::cli::{AxSessionListArgs, AxSessionStartArgs, AxSessionStopArgs, OutputFormat};
 use crate::commands::ax_common::build_target;
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
 use crate::model::{
-    AxSessionListResult, AxSessionStartRequest, AxSessionStartResult, AxSessionStopRequest,
-    AxSessionStopResult, SuccessEnvelope,
+    AxSessionListResult, AxSessionStartCommandResult, AxSessionStartRequest, AxSessionStartResult,
+    AxSessionStopCommandResult, AxSessionStopRequest, AxSessionStopResult,
 };
-use crate::run::ActionPolicy;
+use crate::retry::run_with_retry;
+use crate::run::{
+    action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
+};
 
 pub fn run_start(
     format: OutputFormat,
@@ -25,24 +31,38 @@ pub fn run_start(
         session_id: args.session_id.clone(),
     };
 
-    let result = if policy.dry_run {
-        AxSessionStartResult {
-            session: crate::model::AxSessionInfo {
-                session_id: request
-                    .session_id
-                    .clone()
-                    .unwrap_or_else(|| "axs-dry-run".to_string()),
-                app: request.target.app.clone(),
-                bundle_id: request.target.bundle_id.clone(),
-                pid: None,
-                window_title_contains: request.target.window_title_contains.clone(),
-                created_at_ms: 0,
-            },
-            created: false,
-        }
-    } else {
+    let action_id = next_action_id("ax.session.start");
+    let started = Instant::now();
+    let mut attempts_used = 0u8;
+    let mut detail = AxSessionStartResult {
+        session: crate::model::AxSessionInfo {
+            session_id: request
+                .session_id
+                .clone()
+                .unwrap_or_else(|| "axs-dry-run".to_string()),
+            app: request.target.app.clone(),
+            bundle_id: request.target.bundle_id.clone(),
+            pid: None,
+            window_title_contains: request.target.window_title_contains.clone(),
+            created_at_ms: 0,
+        },
+        created: false,
+    };
+
+    if !policy.dry_run {
         let backend = AutoAxBackend::default();
-        backend.session_start(runner, &request, policy.timeout_ms)?
+        let retry = policy.retry_policy();
+        let (backend_result, attempts) = run_with_retry(retry, || {
+            backend.session_start(runner, &request, policy.timeout_ms)
+        })?;
+        attempts_used = attempts;
+        detail = backend_result;
+    }
+
+    let result = AxSessionStartCommandResult {
+        detail,
+        policy: action_policy_result(policy),
+        meta: build_action_meta_with_attempts(action_id, started, policy, attempts_used),
     };
 
     print_start(format, result)
@@ -59,13 +79,7 @@ pub fn run_list(
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.session.list", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.session.list", result)?;
         }
         OutputFormat::Text => {
             if result.sessions.is_empty() {
@@ -84,9 +98,7 @@ pub fn run_list(
             }
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
@@ -103,68 +115,75 @@ pub fn run_stop(
         session_id: args.session_id.clone(),
     };
 
-    let result = if policy.dry_run {
-        AxSessionStopResult {
-            session_id: request.session_id,
-            removed: false,
-        }
-    } else {
-        let backend = AutoAxBackend::default();
-        backend.session_stop(runner, &request, policy.timeout_ms)?
+    let action_id = next_action_id("ax.session.stop");
+    let started = Instant::now();
+    let mut attempts_used = 0u8;
+    let mut detail = AxSessionStopResult {
+        session_id: request.session_id.clone(),
+        removed: false,
     };
 
+    if !policy.dry_run {
+        let backend = AutoAxBackend::default();
+        let retry = policy.retry_policy();
+        let (backend_result, attempts) = run_with_retry(retry, || {
+            backend.session_stop(runner, &request, policy.timeout_ms)
+        })?;
+        attempts_used = attempts;
+        detail = backend_result;
+    }
+
+    let result = AxSessionStopCommandResult {
+        detail,
+        policy: action_policy_result(policy),
+        meta: build_action_meta_with_attempts(action_id, started, policy, attempts_used),
+    };
+
+    print_stop(format, result)
+}
+
+fn print_start(format: OutputFormat, result: AxSessionStartCommandResult) -> Result<(), CliError> {
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.session.stop", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.session.start", result)?;
         }
         OutputFormat::Text => {
             println!(
-                "ax.session.stop\tsession_id={}\tremoved={}",
-                result.session_id, result.removed
+                "ax.session.start\tsession_id={}\tapp={}\tbundle_id={}\tpid={}\tcreated={}\tcreated_at_ms={}\taction_id={}\telapsed_ms={}",
+                result.detail.session.session_id,
+                result.detail.session.app.unwrap_or_default(),
+                result.detail.session.bundle_id.unwrap_or_default(),
+                result.detail.session.pid.unwrap_or_default(),
+                result.detail.created,
+                result.detail.session.created_at_ms,
+                result.meta.action_id,
+                result.meta.elapsed_ms,
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
     Ok(())
 }
 
-fn print_start(format: OutputFormat, result: AxSessionStartResult) -> Result<(), CliError> {
+fn print_stop(format: OutputFormat, result: AxSessionStopCommandResult) -> Result<(), CliError> {
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.session.start", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.session.stop", result)?;
         }
         OutputFormat::Text => {
             println!(
-                "ax.session.start\tsession_id={}\tapp={}\tbundle_id={}\tpid={}\tcreated={}\tcreated_at_ms={}",
-                result.session.session_id,
-                result.session.app.unwrap_or_default(),
-                result.session.bundle_id.unwrap_or_default(),
-                result.session.pid.unwrap_or_default(),
-                result.created,
-                result.session.created_at_ms,
+                "ax.session.stop\tsession_id={}\tremoved={}\taction_id={}\telapsed_ms={}",
+                result.detail.session_id,
+                result.detail.removed,
+                result.meta.action_id,
+                result.meta.elapsed_ms,
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/ax_type.rs
+++ b/crates/macos-agent/src/commands/ax_type.rs
@@ -3,9 +3,10 @@ use std::time::Instant;
 use crate::backend::process::ProcessRunner;
 use crate::backend::{AutoAxBackend, AxBackendAdapter};
 use crate::cli::{AxTypeArgs, OutputFormat};
-use crate::commands::ax_common::{build_selector, build_target, AxSelectorInput};
+use crate::commands::ax_common::{build_selector_from_args, build_target_from_args};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{AxTypeCommandResult, AxTypeRequest, AxTypeResult, SuccessEnvelope};
+use crate::model::{AxTypeCommandResult, AxTypeRequest, AxTypeResult};
 use crate::retry::run_with_retry;
 use crate::run::{
     action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
@@ -48,13 +49,7 @@ pub fn run(
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.type", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.type", result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -67,9 +62,7 @@ pub fn run(
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
@@ -77,23 +70,8 @@ pub fn run(
 }
 
 fn build_request(args: &AxTypeArgs) -> Result<AxTypeRequest, CliError> {
-    let target = build_target(
-        args.session_id.clone(),
-        args.app.clone(),
-        args.bundle_id.clone(),
-        args.window_title_contains.clone(),
-    )?;
-    let selector = build_selector(AxSelectorInput {
-        node_id: args.node_id.clone(),
-        role: args.role.clone(),
-        title_contains: args.title_contains.clone(),
-        identifier_contains: args.identifier_contains.clone(),
-        value_contains: args.value_contains.clone(),
-        subrole: args.subrole.clone(),
-        focused: args.focused,
-        enabled: args.enabled,
-        nth: args.nth,
-    })?;
+    let target = build_target_from_args(&args.target)?;
+    let selector = build_selector_from_args(&args.selector)?;
     Ok(AxTypeRequest {
         target,
         selector,

--- a/crates/macos-agent/src/commands/ax_watch.rs
+++ b/crates/macos-agent/src/commands/ax_watch.rs
@@ -1,12 +1,18 @@
+use std::time::Instant;
+
 use crate::backend::process::ProcessRunner;
 use crate::backend::{AutoAxBackend, AxBackendAdapter};
 use crate::cli::{AxWatchPollArgs, AxWatchStartArgs, AxWatchStopArgs, OutputFormat};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
 use crate::model::{
-    AxWatchPollRequest, AxWatchPollResult, AxWatchStartRequest, AxWatchStartResult,
-    AxWatchStopRequest, AxWatchStopResult, SuccessEnvelope,
+    AxWatchPollRequest, AxWatchPollResult, AxWatchStartCommandResult, AxWatchStartRequest,
+    AxWatchStartResult, AxWatchStopCommandResult, AxWatchStopRequest, AxWatchStopResult,
 };
-use crate::run::ActionPolicy;
+use crate::retry::run_with_retry;
+use crate::run::{
+    action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
+};
 
 pub fn run_start(
     format: OutputFormat,
@@ -21,50 +27,37 @@ pub fn run_start(
         watch_id: args.watch_id.clone(),
     };
 
-    let result = if policy.dry_run {
-        AxWatchStartResult {
-            watch_id: request
-                .watch_id
-                .clone()
-                .unwrap_or_else(|| "axw-dry-run".to_string()),
-            session_id: request.session_id,
-            events: request.events,
-            max_buffer: request.max_buffer,
-            started: false,
-        }
-    } else {
-        let backend = AutoAxBackend::default();
-        backend.watch_start(runner, &request, policy.timeout_ms)?
+    let action_id = next_action_id("ax.watch.start");
+    let started = Instant::now();
+    let mut attempts_used = 0u8;
+    let mut detail = AxWatchStartResult {
+        watch_id: request
+            .watch_id
+            .clone()
+            .unwrap_or_else(|| "axw-dry-run".to_string()),
+        session_id: request.session_id.clone(),
+        events: request.events.clone(),
+        max_buffer: request.max_buffer,
+        started: false,
     };
 
-    match format {
-        OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.watch.start", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
-        }
-        OutputFormat::Text => {
-            println!(
-                "ax.watch.start\twatch_id={}\tsession_id={}\tstarted={}\tevents={}\tmax_buffer={}",
-                result.watch_id,
-                result.session_id,
-                result.started,
-                result.events.join(","),
-                result.max_buffer
-            );
-        }
-        OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
-        }
+    if !policy.dry_run {
+        let backend = AutoAxBackend::default();
+        let retry = policy.retry_policy();
+        let (backend_result, attempts) = run_with_retry(retry, || {
+            backend.watch_start(runner, &request, policy.timeout_ms)
+        })?;
+        attempts_used = attempts;
+        detail = backend_result;
     }
 
-    Ok(())
+    let result = AxWatchStartCommandResult {
+        detail,
+        policy: action_policy_result(policy),
+        meta: build_action_meta_with_attempts(action_id, started, policy, attempts_used),
+    };
+
+    print_start(format, result)
 }
 
 pub fn run_poll(
@@ -84,13 +77,7 @@ pub fn run_poll(
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.watch.poll", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.watch.poll", result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -112,9 +99,7 @@ pub fn run_poll(
             }
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
@@ -131,37 +116,76 @@ pub fn run_stop(
         watch_id: args.watch_id.clone(),
     };
 
-    let result = if policy.dry_run {
-        AxWatchStopResult {
-            watch_id: request.watch_id,
-            stopped: false,
-            drained: 0,
-        }
-    } else {
-        let backend = AutoAxBackend::default();
-        backend.watch_stop(runner, &request, policy.timeout_ms)?
+    let action_id = next_action_id("ax.watch.stop");
+    let started = Instant::now();
+    let mut attempts_used = 0u8;
+    let mut detail = AxWatchStopResult {
+        watch_id: request.watch_id.clone(),
+        stopped: false,
+        drained: 0,
     };
 
+    if !policy.dry_run {
+        let backend = AutoAxBackend::default();
+        let retry = policy.retry_policy();
+        let (backend_result, attempts) = run_with_retry(retry, || {
+            backend.watch_stop(runner, &request, policy.timeout_ms)
+        })?;
+        attempts_used = attempts;
+        detail = backend_result;
+    }
+
+    let result = AxWatchStopCommandResult {
+        detail,
+        policy: action_policy_result(policy),
+        meta: build_action_meta_with_attempts(action_id, started, policy, attempts_used),
+    };
+
+    print_stop(format, result)
+}
+
+fn print_start(format: OutputFormat, result: AxWatchStartCommandResult) -> Result<(), CliError> {
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("ax.watch.stop", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("ax.watch.start", result)?;
         }
         OutputFormat::Text => {
             println!(
-                "ax.watch.stop\twatch_id={}\tstopped={}\tdrained={}",
-                result.watch_id, result.stopped, result.drained
+                "ax.watch.start\twatch_id={}\tsession_id={}\tstarted={}\tevents={}\tmax_buffer={}\taction_id={}\telapsed_ms={}",
+                result.detail.watch_id,
+                result.detail.session_id,
+                result.detail.started,
+                result.detail.events.join(","),
+                result.detail.max_buffer,
+                result.meta.action_id,
+                result.meta.elapsed_ms,
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
+        }
+    }
+
+    Ok(())
+}
+
+fn print_stop(format: OutputFormat, result: AxWatchStopCommandResult) -> Result<(), CliError> {
+    match format {
+        OutputFormat::Json => {
+            emit_json_success("ax.watch.stop", result)?;
+        }
+        OutputFormat::Text => {
+            println!(
+                "ax.watch.stop\twatch_id={}\tstopped={}\tdrained={}\taction_id={}\telapsed_ms={}",
+                result.detail.watch_id,
+                result.detail.stopped,
+                result.detail.drained,
+                result.meta.action_id,
+                result.meta.elapsed_ms,
+            );
+        }
+        OutputFormat::Tsv => {
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/input_click.rs
+++ b/crates/macos-agent/src/commands/input_click.rs
@@ -3,8 +3,9 @@ use std::time::Instant;
 use crate::backend::cliclick;
 use crate::backend::process::ProcessRunner;
 use crate::cli::{InputClickArgs, OutputFormat};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{InputClickResult, SuccessEnvelope};
+use crate::model::InputClickResult;
 use crate::retry::run_with_retry;
 use crate::run::{
     action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
@@ -53,13 +54,7 @@ pub fn run(
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("input.click", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("input.click", result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -73,9 +68,7 @@ pub fn run(
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/input_hotkey.rs
+++ b/crates/macos-agent/src/commands/input_hotkey.rs
@@ -3,8 +3,9 @@ use std::time::Instant;
 use crate::backend::applescript;
 use crate::backend::process::ProcessRunner;
 use crate::cli::{InputHotkeyArgs, OutputFormat};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{InputHotkeyResult, SuccessEnvelope};
+use crate::model::InputHotkeyResult;
 use crate::retry::run_with_retry;
 use crate::run::{
     action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
@@ -49,13 +50,7 @@ pub fn run(
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("input.hotkey", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("input.hotkey", result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -67,9 +62,7 @@ pub fn run(
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/input_source.rs
+++ b/crates/macos-agent/src/commands/input_source.rs
@@ -1,8 +1,9 @@
 use crate::backend::input_source;
 use crate::backend::process::ProcessRunner;
 use crate::cli::{InputSourceCurrentArgs, InputSourceSwitchArgs, OutputFormat};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{InputSourceCurrentResult, InputSourceSwitchResult, SuccessEnvelope};
+use crate::model::{InputSourceCurrentResult, InputSourceSwitchResult};
 use crate::run::ActionPolicy;
 
 pub fn run_current(
@@ -16,21 +17,13 @@ pub fn run_current(
     };
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("input-source.current", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("input-source.current", result)?;
         }
         OutputFormat::Text => {
             println!("input-source.current\tcurrent={}", result.current);
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
@@ -51,13 +44,7 @@ pub fn run_switch(
     };
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("input-source.switch", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("input-source.switch", result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -66,9 +53,7 @@ pub fn run_switch(
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/input_type.rs
+++ b/crates/macos-agent/src/commands/input_type.rs
@@ -3,8 +3,9 @@ use std::time::Instant;
 use crate::backend::applescript;
 use crate::backend::process::ProcessRunner;
 use crate::cli::{InputTypeArgs, OutputFormat};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{InputTypeResult, SuccessEnvelope};
+use crate::model::InputTypeResult;
 use crate::retry::run_with_retry;
 use crate::run::{
     action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
@@ -48,13 +49,7 @@ pub fn run(
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("input.type", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("input.type", result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -63,9 +58,7 @@ pub fn run(
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/list.rs
+++ b/crates/macos-agent/src/commands/list.rs
@@ -1,19 +1,14 @@
 use crate::cli::{ListAppsArgs, ListWindowsArgs, OutputFormat};
+use crate::commands::emit_json_success;
 use crate::error::CliError;
-use crate::model::{ListAppsResult, ListWindowsResult, SuccessEnvelope};
+use crate::model::{ListAppsResult, ListWindowsResult};
 use crate::targets;
 
 pub fn run_windows_list(format: OutputFormat, args: &ListWindowsArgs) -> Result<(), CliError> {
     let windows = targets::list_windows(args)?;
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("windows.list", ListWindowsResult { windows });
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("windows.list", ListWindowsResult { windows })?;
         }
         OutputFormat::Text | OutputFormat::Tsv => {
             for row in windows {
@@ -29,13 +24,7 @@ pub fn run_apps_list(format: OutputFormat, _args: &ListAppsArgs) -> Result<(), C
     let apps = targets::list_apps()?;
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("apps.list", ListAppsResult { apps });
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("apps.list", ListAppsResult { apps })?;
         }
         OutputFormat::Text | OutputFormat::Tsv => {
             for row in apps {

--- a/crates/macos-agent/src/commands/mod.rs
+++ b/crates/macos-agent/src/commands/mod.rs
@@ -1,3 +1,8 @@
+use serde::Serialize;
+
+use crate::error::CliError;
+use crate::model::SuccessEnvelope;
+
 pub mod ax_action;
 pub mod ax_attr;
 pub mod ax_click;
@@ -16,3 +21,23 @@ pub mod profile;
 pub mod scenario;
 pub mod wait;
 pub mod window_activate;
+
+const TSV_LIST_ONLY_FORMAT_MESSAGE: &str =
+    "--format tsv is only supported for `windows list` and `apps list`";
+
+pub(crate) fn emit_json_success<T>(command: &'static str, result: T) -> Result<(), CliError>
+where
+    T: Serialize,
+{
+    let payload = SuccessEnvelope::new(command, result);
+    println!(
+        "{}",
+        serde_json::to_string(&payload)
+            .map_err(|err| CliError::runtime(format!("failed to serialize json output: {err}")))?
+    );
+    Ok(())
+}
+
+pub(crate) fn reject_tsv_for_list_only() -> Result<(), CliError> {
+    Err(CliError::usage(TSV_LIST_ONLY_FORMAT_MESSAGE))
+}

--- a/crates/macos-agent/src/commands/observe.rs
+++ b/crates/macos-agent/src/commands/observe.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 use crate::cli::{ObserveScreenshotArgs, OutputFormat};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{ScreenshotResult, SuccessEnvelope, WindowRow};
+use crate::model::{ScreenshotResult, WindowRow};
 use crate::targets::{self, TargetSelector};
 use crate::test_mode;
 
@@ -29,21 +30,13 @@ pub fn run_screenshot(format: OutputFormat, args: &ObserveScreenshotArgs) -> Res
                 path: output_path.display().to_string(),
                 target: WindowRow::from(&window),
             };
-            let payload = SuccessEnvelope::new("observe.screenshot", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("observe.screenshot", result)?;
         }
         OutputFormat::Text => {
             println!("{}", output_path.display());
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/profile.rs
+++ b/crates/macos-agent/src/commands/profile.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 use crate::cli::{OutputFormat, ProfileInitArgs, ProfileValidateArgs};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{ProfileInitResult, ProfileValidateResult, SuccessEnvelope};
+use crate::model::{ProfileInitResult, ProfileValidateResult};
 use crate::test_mode;
 
 pub fn run_validate(format: OutputFormat, args: &ProfileValidateArgs) -> Result<(), CliError> {
@@ -42,21 +43,13 @@ pub fn run_validate(format: OutputFormat, args: &ProfileValidateArgs) -> Result<
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("profile.validate", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("profile.validate", result)?;
         }
         OutputFormat::Text => {
             println!("profile.validate\tfile={}\tvalid=true", result.file);
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
@@ -118,21 +111,13 @@ pub fn run_init(format: OutputFormat, args: &ProfileInitArgs) -> Result<(), CliE
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("profile.init", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("profile.init", result)?;
         }
         OutputFormat::Text => {
             println!("{}", output_path.display());
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/scenario.rs
+++ b/crates/macos-agent/src/commands/scenario.rs
@@ -5,8 +5,9 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::cli::{OutputFormat, ScenarioRunArgs};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{ScenarioRunResult, ScenarioStepResult, SuccessEnvelope};
+use crate::model::{ScenarioRunResult, ScenarioStepResult};
 
 #[derive(Debug, Deserialize)]
 struct ScenarioFile {
@@ -131,13 +132,7 @@ pub fn run(format: OutputFormat, args: &ScenarioRunArgs) -> Result<(), CliError>
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("scenario.run", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("scenario.run", result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -146,9 +141,7 @@ pub fn run(format: OutputFormat, args: &ScenarioRunArgs) -> Result<(), CliError>
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/wait.rs
+++ b/crates/macos-agent/src/commands/wait.rs
@@ -1,8 +1,9 @@
 use std::time::Instant;
 
 use crate::cli::{OutputFormat, WaitAppActiveArgs, WaitSleepArgs, WaitWindowPresentArgs};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{SuccessEnvelope, WaitResult};
+use crate::model::WaitResult;
 use crate::targets::{self, TargetSelector};
 use crate::wait;
 
@@ -66,13 +67,7 @@ fn emit_wait_result(
 ) -> Result<(), CliError> {
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new(command, result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success(command, result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -81,9 +76,7 @@ fn emit_wait_result(
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 

--- a/crates/macos-agent/src/commands/window_activate.rs
+++ b/crates/macos-agent/src/commands/window_activate.rs
@@ -3,8 +3,9 @@ use std::time::Instant;
 use crate::backend::applescript::{self, ActivationTarget};
 use crate::backend::process::ProcessRunner;
 use crate::cli::{OutputFormat, WindowActivateArgs};
+use crate::commands::{emit_json_success, reject_tsv_for_list_only};
 use crate::error::CliError;
-use crate::model::{SuccessEnvelope, WindowActivateResult};
+use crate::model::WindowActivateResult;
 use crate::retry::run_with_retry;
 use crate::run::{
     action_policy_result, build_action_meta_with_attempts, next_action_id, ActionPolicy,
@@ -46,13 +47,7 @@ pub fn run(
 
     match format {
         OutputFormat::Json => {
-            let payload = SuccessEnvelope::new("window.activate", result);
-            println!(
-                "{}",
-                serde_json::to_string(&payload).map_err(|err| CliError::runtime(format!(
-                    "failed to serialize json output: {err}"
-                )))?
-            );
+            emit_json_success("window.activate", result)?;
         }
         OutputFormat::Text => {
             println!(
@@ -67,9 +62,7 @@ pub fn run(
             );
         }
         OutputFormat::Tsv => {
-            return Err(CliError::usage(
-                "--format tsv is only supported for `windows list` and `apps list`",
-            ));
+            return reject_tsv_for_list_only();
         }
     }
 
@@ -100,7 +93,7 @@ fn resolve_target(
 
     let window = targets::resolve_window(&selector).map_err(|err| {
         CliError::runtime(format!(
-            "window activate failed for selector `{}`: {}; try --window-id <id> or --app <name> --window-name <title>",
+            "window activate failed for selector `{}`: {}; try --window-id <id> or --app <name> --window-title-contains <title>",
             selector_label(args),
             err
         ))
@@ -122,7 +115,7 @@ fn selector_label(args: &WindowActivateArgs) -> String {
     }
     if let Some(app) = args.app.as_deref() {
         if let Some(window_name) = args.window_name.as_deref() {
-            return format!("--app {app} --window-name {window_name}");
+            return format!("--app {app} --window-title-contains {window_name}");
         }
         return format!("--app {app}");
     }
@@ -207,7 +200,7 @@ mod tests {
         };
         assert_eq!(
             selector_label(&app_window),
-            "--app Terminal --window-name Inbox"
+            "--app Terminal --window-title-contains Inbox"
         );
 
         let bundle = WindowActivateArgs {

--- a/crates/macos-agent/src/error.rs
+++ b/crates/macos-agent/src/error.rs
@@ -67,6 +67,7 @@ impl CliError {
         ))
         .with_operation(operation)
         .with_hint("Run `macos-agent preflight --include-probes --strict` to verify Accessibility/Automation access.")
+        .with_hint("Review preflight `ax_backend_capabilities` to confirm backend support and fallback behavior.")
         .with_hint("Use --trace to capture raw backend output for diagnosis.")
     }
 
@@ -77,6 +78,7 @@ impl CliError {
         ))
         .with_operation(operation)
         .with_hint("Adjust AX selector filters so exactly one element is targeted.")
+        .with_hint("For attr/action/session/watch flows, ensure Hammerspoon backend is available.")
     }
 
     pub fn exit_code(&self) -> u8 {

--- a/crates/macos-agent/src/main.rs
+++ b/crates/macos-agent/src/main.rs
@@ -4,14 +4,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use clap::{error::ErrorKind, Parser};
-use macos_agent::cli::{
-    AxActionCommand, AxAttrCommand, AxCommand, AxSessionCommand, AxWatchCommand, Cli, CommandGroup,
-    ErrorFormat, InputCommand, InputSourceCommand, ObserveCommand, ProfileCommand, ScenarioCommand,
-    WaitCommand, WindowCommand,
-};
+use macos_agent::cli::{Cli, ErrorFormat};
 use macos_agent::error::CliError;
 use macos_agent::model::ErrorEnvelope;
-use macos_agent::run::run;
+use macos_agent::run::{command_label, run};
 use macos_agent::test_mode;
 
 static TRACE_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -176,7 +172,7 @@ fn write_trace(
         "schema_version": 1,
         "ok": ok,
         "elapsed_ms": elapsed_ms,
-        "command": cli.map(command_label).unwrap_or_else(|| "<parse-error>".to_string()),
+        "command": cli.map(command_label).unwrap_or("<parse-error>").to_string(),
         "args": raw_args,
         "error": err.map(|value| ErrorEnvelope::from_error(value).error),
         "policy": cli.map(|value| serde_json::json!({
@@ -223,69 +219,12 @@ fn codex_out_dir() -> PathBuf {
     PathBuf::from(".codex").join("out")
 }
 
-fn command_label(cli: &Cli) -> String {
-    match &cli.command {
-        CommandGroup::Preflight(_) => "preflight".to_string(),
-        CommandGroup::Windows { .. } => "windows.list".to_string(),
-        CommandGroup::Apps { .. } => "apps.list".to_string(),
-        CommandGroup::Window { command } => match command {
-            WindowCommand::Activate(_) => "window.activate".to_string(),
-        },
-        CommandGroup::Input { command } => match command {
-            InputCommand::Click(_) => "input.click".to_string(),
-            InputCommand::Type(_) => "input.type".to_string(),
-            InputCommand::Hotkey(_) => "input.hotkey".to_string(),
-        },
-        CommandGroup::InputSource { command } => match command {
-            InputSourceCommand::Current(_) => "input-source.current".to_string(),
-            InputSourceCommand::Switch(_) => "input-source.switch".to_string(),
-        },
-        CommandGroup::Ax { command } => match command {
-            AxCommand::List(_) => "ax.list".to_string(),
-            AxCommand::Click(_) => "ax.click".to_string(),
-            AxCommand::Type(_) => "ax.type".to_string(),
-            AxCommand::Attr { command } => match command {
-                AxAttrCommand::Get(_) => "ax.attr.get".to_string(),
-                AxAttrCommand::Set(_) => "ax.attr.set".to_string(),
-            },
-            AxCommand::Action { command } => match command {
-                AxActionCommand::Perform(_) => "ax.action.perform".to_string(),
-            },
-            AxCommand::Session { command } => match command {
-                AxSessionCommand::Start(_) => "ax.session.start".to_string(),
-                AxSessionCommand::List(_) => "ax.session.list".to_string(),
-                AxSessionCommand::Stop(_) => "ax.session.stop".to_string(),
-            },
-            AxCommand::Watch { command } => match command {
-                AxWatchCommand::Start(_) => "ax.watch.start".to_string(),
-                AxWatchCommand::Poll(_) => "ax.watch.poll".to_string(),
-                AxWatchCommand::Stop(_) => "ax.watch.stop".to_string(),
-            },
-        },
-        CommandGroup::Observe { command } => match command {
-            ObserveCommand::Screenshot(_) => "observe.screenshot".to_string(),
-        },
-        CommandGroup::Wait { command } => match command {
-            WaitCommand::Sleep(_) => "wait.sleep".to_string(),
-            WaitCommand::AppActive(_) => "wait.app-active".to_string(),
-            WaitCommand::WindowPresent(_) => "wait.window-present".to_string(),
-        },
-        CommandGroup::Scenario { command } => match command {
-            ScenarioCommand::Run(_) => "scenario.run".to_string(),
-        },
-        CommandGroup::Profile { command } => match command {
-            ProfileCommand::Validate(_) => "profile.validate".to_string(),
-            ProfileCommand::Init(_) => "profile.init".to_string(),
-        },
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use clap::Parser;
 
-    use super::command_label;
     use macos_agent::cli::Cli;
+    use macos_agent::run::command_label;
 
     #[test]
     fn command_label_maps_ax_subcommands() {

--- a/crates/macos-agent/src/model.rs
+++ b/crates/macos-agent/src/model.rs
@@ -423,6 +423,14 @@ pub struct AxAttrSetResult {
     pub value_type: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct AxAttrSetCommandResult {
+    #[serde(flatten)]
+    pub detail: AxAttrSetResult,
+    pub policy: ActionPolicyResult,
+    pub meta: ActionMeta,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AxActionPerformResult {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -430,6 +438,14 @@ pub struct AxActionPerformResult {
     pub matched_count: usize,
     pub name: String,
     pub performed: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AxActionPerformCommandResult {
+    #[serde(flatten)]
+    pub detail: AxActionPerformResult,
+    pub policy: ActionPolicyResult,
+    pub meta: ActionMeta,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -466,6 +482,14 @@ pub struct AxSessionStartResult {
     pub created: bool,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct AxSessionStartCommandResult {
+    #[serde(flatten)]
+    pub detail: AxSessionStartResult,
+    pub policy: ActionPolicyResult,
+    pub meta: ActionMeta,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AxSessionListResult {
     pub sessions: Vec<AxSessionInfo>,
@@ -475,6 +499,14 @@ pub struct AxSessionListResult {
 pub struct AxSessionStopResult {
     pub session_id: String,
     pub removed: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AxSessionStopCommandResult {
+    #[serde(flatten)]
+    pub detail: AxSessionStopResult,
+    pub policy: ActionPolicyResult,
+    pub meta: ActionMeta,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -526,6 +558,14 @@ pub struct AxWatchStartResult {
     pub started: bool,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct AxWatchStartCommandResult {
+    #[serde(flatten)]
+    pub detail: AxWatchStartResult,
+    pub policy: ActionPolicyResult,
+    pub meta: ActionMeta,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct AxWatchPollResult {
     pub watch_id: String,
@@ -539,6 +579,14 @@ pub struct AxWatchStopResult {
     pub watch_id: String,
     pub stopped: bool,
     pub drained: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AxWatchStopCommandResult {
+    #[serde(flatten)]
+    pub detail: AxWatchStopResult,
+    pub policy: ActionPolicyResult,
+    pub meta: ActionMeta,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/macos-agent/src/run.rs
+++ b/crates/macos-agent/src/run.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
+use crate::backend;
 use crate::backend::process::RealProcessRunner;
 use crate::cli::{
     AppsCommand, AxActionCommand, AxAttrCommand, AxCommand, AxSessionCommand, AxWatchCommand, Cli,
@@ -30,6 +31,67 @@ impl ActionPolicy {
             retries: self.retries,
             retry_delay_ms: self.retry_delay_ms,
         }
+    }
+}
+
+pub fn command_label(cli: &Cli) -> &'static str {
+    command_group_label(&cli.command)
+}
+
+pub fn command_group_label(command: &CommandGroup) -> &'static str {
+    match command {
+        CommandGroup::Preflight(_) => "preflight",
+        CommandGroup::Windows { .. } => "windows.list",
+        CommandGroup::Apps { .. } => "apps.list",
+        CommandGroup::Window { command } => match command {
+            WindowCommand::Activate(_) => "window.activate",
+        },
+        CommandGroup::Input { command } => match command {
+            InputCommand::Click(_) => "input.click",
+            InputCommand::Type(_) => "input.type",
+            InputCommand::Hotkey(_) => "input.hotkey",
+        },
+        CommandGroup::InputSource { command } => match command {
+            InputSourceCommand::Current(_) => "input-source.current",
+            InputSourceCommand::Switch(_) => "input-source.switch",
+        },
+        CommandGroup::Ax { command } => match command {
+            AxCommand::List(_) => "ax.list",
+            AxCommand::Click(_) => "ax.click",
+            AxCommand::Type(_) => "ax.type",
+            AxCommand::Attr { command } => match command {
+                AxAttrCommand::Get(_) => "ax.attr.get",
+                AxAttrCommand::Set(_) => "ax.attr.set",
+            },
+            AxCommand::Action { command } => match command {
+                AxActionCommand::Perform(_) => "ax.action.perform",
+            },
+            AxCommand::Session { command } => match command {
+                AxSessionCommand::Start(_) => "ax.session.start",
+                AxSessionCommand::List(_) => "ax.session.list",
+                AxSessionCommand::Stop(_) => "ax.session.stop",
+            },
+            AxCommand::Watch { command } => match command {
+                AxWatchCommand::Start(_) => "ax.watch.start",
+                AxWatchCommand::Poll(_) => "ax.watch.poll",
+                AxWatchCommand::Stop(_) => "ax.watch.stop",
+            },
+        },
+        CommandGroup::Observe { command } => match command {
+            ObserveCommand::Screenshot(_) => "observe.screenshot",
+        },
+        CommandGroup::Wait { command } => match command {
+            WaitCommand::Sleep(_) => "wait.sleep",
+            WaitCommand::AppActive(_) => "wait.app-active",
+            WaitCommand::WindowPresent(_) => "wait.window-present",
+        },
+        CommandGroup::Scenario { command } => match command {
+            ScenarioCommand::Run(_) => "scenario.run",
+        },
+        CommandGroup::Profile { command } => match command {
+            ProfileCommand::Validate(_) => "profile.validate",
+            ProfileCommand::Init(_) => "profile.init",
+        },
     }
 }
 
@@ -175,7 +237,16 @@ fn run_preflight(format: OutputFormat, args: PreflightArgs) -> Result<(), CliErr
     } else {
         Vec::new()
     };
-    let report = preflight::build_report_with_probes(snapshot, args.strict, probes);
+    let mut report = preflight::build_report_with_probes(snapshot, args.strict, probes);
+    let backend_capability = backend::preflight_capability_check();
+    report.checks.push(preflight::CheckReport {
+        id: "ax_backend_capabilities",
+        label: "AX backend capabilities",
+        status: preflight::CheckStatus::Ok,
+        blocking: false,
+        message: backend_capability.message,
+        hint: backend_capability.hint,
+    });
 
     match format {
         OutputFormat::Text => println!("{}", preflight::render_text(&report)),

--- a/crates/macos-agent/tests/cli_smoke.rs
+++ b/crates/macos-agent/tests/cli_smoke.rs
@@ -119,6 +119,132 @@ fn input_source_current_and_switch_emit_json_payloads() {
 }
 
 #[test]
+fn windows_list_window_name_alias_matches_canonical_behavior() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+
+    let canonical = harness.run(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "windows",
+            "list",
+            "--app",
+            "Terminal",
+            "--window-title-contains",
+            "Docs",
+        ],
+    );
+    assert_eq!(canonical.code, 0, "stderr: {}", canonical.stderr_text());
+
+    let alias = harness.run(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "windows",
+            "list",
+            "--app",
+            "Terminal",
+            "--window-name",
+            "Docs",
+        ],
+    );
+    assert_eq!(alias.code, 0, "stderr: {}", alias.stderr_text());
+
+    let canonical_payload: serde_json::Value =
+        serde_json::from_str(&canonical.stdout_text()).expect("canonical windows json");
+    let alias_payload: serde_json::Value =
+        serde_json::from_str(&alias.stdout_text()).expect("alias windows json");
+
+    assert_eq!(
+        canonical_payload["command"],
+        serde_json::json!("windows.list")
+    );
+    assert_eq!(alias_payload["command"], serde_json::json!("windows.list"));
+    assert_eq!(
+        canonical_payload["result"]["windows"],
+        alias_payload["result"]["windows"]
+    );
+}
+
+#[test]
+fn input_type_enter_alias_matches_submit_behavior() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+
+    let canonical = harness.run(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--retries",
+            "2",
+            "--retry-delay-ms",
+            "9",
+            "--timeout-ms",
+            "1234",
+            "input",
+            "type",
+            "--text",
+            "hello",
+            "--submit",
+        ],
+    );
+    assert_eq!(canonical.code, 0, "stderr: {}", canonical.stderr_text());
+    let canonical_payload: serde_json::Value =
+        serde_json::from_str(&canonical.stdout_text()).expect("submit payload json");
+
+    let alias = harness.run(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--retries",
+            "2",
+            "--retry-delay-ms",
+            "9",
+            "--timeout-ms",
+            "1234",
+            "input",
+            "type",
+            "--text",
+            "hello",
+            "--enter",
+        ],
+    );
+    assert_eq!(alias.code, 0, "stderr: {}", alias.stderr_text());
+    let alias_payload: serde_json::Value =
+        serde_json::from_str(&alias.stdout_text()).expect("enter payload json");
+
+    for payload in [&canonical_payload, &alias_payload] {
+        assert_eq!(payload["command"], serde_json::json!("input.type"));
+        assert_eq!(payload["result"]["text_length"], serde_json::json!(5));
+        assert_eq!(payload["result"]["enter"], serde_json::json!(true));
+        assert_eq!(
+            payload["result"]["meta"]["dry_run"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            payload["result"]["meta"]["attempts_used"],
+            serde_json::json!(0)
+        );
+    }
+
+    assert_eq!(
+        canonical_payload["result"]["policy"],
+        alias_payload["result"]["policy"]
+    );
+    assert_eq!(
+        normalize_action_result(&canonical_payload)["result"],
+        normalize_action_result(&alias_payload)["result"]
+    );
+}
+
+#[test]
 fn preflight_json_smoke() {
     let harness = common::MacosAgentHarness::new();
     let cwd = TempDir::new().expect("tempdir");
@@ -131,6 +257,15 @@ fn preflight_json_smoke() {
         serde_json::from_str(&out.stdout_text()).expect("stdout should be json");
     assert_eq!(payload["schema_version"], serde_json::json!(1));
     assert_eq!(payload["command"], serde_json::json!("preflight"));
+    let checks = payload["result"]["checks"]
+        .as_array()
+        .expect("preflight checks should be an array");
+    assert!(
+        checks
+            .iter()
+            .any(|check| check["id"] == serde_json::json!("ax_backend_capabilities")),
+        "preflight checks should include ax_backend_capabilities row"
+    );
 }
 
 #[test]
@@ -148,4 +283,50 @@ fn tsv_mode_is_rejected_for_input_commands() {
     assert!(out
         .stderr_text()
         .contains("only supported for `windows list` and `apps list`"));
+}
+
+#[test]
+fn trace_command_label_stays_in_sync_with_runtime_mapping() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+    let trace_dir = cwd.path().join("trace-sync");
+    let trace_dir_text = trace_dir.to_string_lossy().to_string();
+
+    let out = harness.run(
+        cwd.path(),
+        &[
+            "--trace",
+            "--trace-dir",
+            &trace_dir_text,
+            "--format",
+            "json",
+            "input-source",
+            "switch",
+            "--id",
+            "abc",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+
+    let trace_path = std::fs::read_dir(&trace_dir)
+        .expect("trace dir should exist")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.extension().map(|ext| ext == "json").unwrap_or(false))
+        .expect("trace file should be created");
+    let raw = std::fs::read_to_string(trace_path).expect("trace payload should be readable");
+    let payload: serde_json::Value = serde_json::from_str(&raw).expect("trace payload is json");
+    assert_eq!(payload["command"], serde_json::json!("input-source.switch"));
+}
+
+fn normalize_action_result(payload: &serde_json::Value) -> serde_json::Value {
+    let mut normalized = payload.clone();
+    if let Some(meta) = normalized
+        .pointer_mut("/result/meta")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        meta.remove("action_id");
+        meta.remove("elapsed_ms");
+    }
+    normalized
 }

--- a/crates/macos-agent/tests/contracts.rs
+++ b/crates/macos-agent/tests/contracts.rs
@@ -75,6 +75,140 @@ fn success_commands_write_stdout_only() {
 }
 
 #[test]
+fn mutating_commands_emit_unified_json_envelope_schema() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+
+    let cases: Vec<(&str, Vec<&str>)> = vec![
+        (
+            "window.activate",
+            vec![
+                "--format",
+                "json",
+                "--dry-run",
+                "--retries",
+                "2",
+                "--retry-delay-ms",
+                "9",
+                "--timeout-ms",
+                "1234",
+                "window",
+                "activate",
+                "--app",
+                "Terminal",
+            ],
+        ),
+        (
+            "input.click",
+            vec![
+                "--format",
+                "json",
+                "--dry-run",
+                "--retries",
+                "2",
+                "--retry-delay-ms",
+                "9",
+                "--timeout-ms",
+                "1234",
+                "input",
+                "click",
+                "--x",
+                "10",
+                "--y",
+                "10",
+            ],
+        ),
+        (
+            "input.type",
+            vec![
+                "--format",
+                "json",
+                "--dry-run",
+                "--retries",
+                "2",
+                "--retry-delay-ms",
+                "9",
+                "--timeout-ms",
+                "1234",
+                "input",
+                "type",
+                "--text",
+                "hello",
+                "--submit",
+            ],
+        ),
+        (
+            "input.hotkey",
+            vec![
+                "--format",
+                "json",
+                "--dry-run",
+                "--retries",
+                "2",
+                "--retry-delay-ms",
+                "9",
+                "--timeout-ms",
+                "1234",
+                "input",
+                "hotkey",
+                "--mods",
+                "cmd",
+                "--key",
+                "4",
+            ],
+        ),
+        (
+            "ax.click",
+            vec![
+                "--format",
+                "json",
+                "--dry-run",
+                "--retries",
+                "2",
+                "--retry-delay-ms",
+                "9",
+                "--timeout-ms",
+                "1234",
+                "ax",
+                "click",
+                "--node-id",
+                "1.1",
+            ],
+        ),
+        (
+            "ax.type",
+            vec![
+                "--format",
+                "json",
+                "--dry-run",
+                "--retries",
+                "2",
+                "--retry-delay-ms",
+                "9",
+                "--timeout-ms",
+                "1234",
+                "ax",
+                "type",
+                "--node-id",
+                "1.1",
+                "--text",
+                "hello",
+            ],
+        ),
+    ];
+
+    for (command, args) in cases {
+        let out = harness.run(cwd.path(), &args);
+        assert_eq!(out.code, 0, "args={args:?}, stderr={}", out.stderr_text());
+        assert_eq!(out.stderr_text(), "", "args={args:?}");
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&out.stdout_text()).expect("mutating command should emit json");
+        assert_action_envelope_contract(&payload, command);
+    }
+}
+
+#[test]
 fn error_commands_write_stderr_only_with_error_prefix() {
     let harness = common::MacosAgentHarness::new();
     let cwd = TempDir::new().expect("tempdir");
@@ -183,12 +317,48 @@ fn trace_writes_artifacts_for_success_and_failure() {
                 .map(|ext| ext == "json")
                 .unwrap_or(false)
         })
+        .map(|entry| {
+            let path = entry.path();
+            let raw = std::fs::read_to_string(path).expect("trace payload should be readable");
+            serde_json::from_str::<serde_json::Value>(&raw).expect("trace payload should be json")
+        })
         .collect::<Vec<_>>();
     assert!(
         entries.len() >= 2,
         "expected at least two trace files, got {}",
         entries.len()
     );
+
+    let success = entries
+        .iter()
+        .find(|payload| {
+            payload["command"] == serde_json::json!("input.click")
+                && payload["ok"] == serde_json::json!(true)
+        })
+        .expect("success trace payload should exist");
+    assert_eq!(success["schema_version"], serde_json::json!(1));
+    assert!(success["elapsed_ms"].as_u64().is_some());
+    assert!(success["args"].is_array());
+    assert_eq!(success["error"], serde_json::Value::Null);
+    assert_eq!(success["policy"]["dry_run"], serde_json::json!(true));
+    assert_eq!(success["policy"]["retries"], serde_json::json!(0));
+
+    let failure = entries
+        .iter()
+        .find(|payload| {
+            payload["command"] == serde_json::json!("input.hotkey")
+                && payload["ok"] == serde_json::json!(false)
+        })
+        .expect("failure trace payload should exist");
+    assert_eq!(failure["schema_version"], serde_json::json!(1));
+    assert!(failure["elapsed_ms"].as_u64().is_some());
+    assert!(failure["args"].is_array());
+    assert_eq!(failure["policy"]["dry_run"], serde_json::json!(false));
+    assert_eq!(failure["error"]["category"], serde_json::json!("usage"));
+    assert!(failure["error"]["message"]
+        .as_str()
+        .unwrap_or("")
+        .contains("invalid modifier"));
 }
 
 #[test]
@@ -316,4 +486,38 @@ fn trace_command_labels_include_ax_commands() {
     assert!(commands.iter().any(|command| command == "ax.list"));
     assert!(commands.iter().any(|command| command == "ax.click"));
     assert!(commands.iter().any(|command| command == "ax.type"));
+}
+
+fn assert_action_envelope_contract(payload: &serde_json::Value, expected_command: &str) {
+    assert_eq!(payload["schema_version"], serde_json::json!(1));
+    assert_eq!(payload["ok"], serde_json::json!(true));
+    assert_eq!(payload["command"], serde_json::json!(expected_command));
+
+    let result = payload["result"]
+        .as_object()
+        .expect("result should be object");
+    assert!(result.contains_key("policy"), "missing policy block");
+    assert!(result.contains_key("meta"), "missing meta block");
+
+    let policy = result["policy"]
+        .as_object()
+        .expect("policy should be object");
+    assert_eq!(policy["dry_run"], serde_json::json!(true));
+    assert_eq!(policy["retries"], serde_json::json!(2));
+    assert_eq!(policy["retry_delay_ms"], serde_json::json!(9));
+    assert_eq!(policy["timeout_ms"], serde_json::json!(1234));
+
+    let meta = result["meta"].as_object().expect("meta should be object");
+    let action_id = meta["action_id"]
+        .as_str()
+        .expect("meta.action_id should be string");
+    assert!(
+        action_id.starts_with(expected_command),
+        "action_id `{action_id}` should start with `{expected_command}`"
+    );
+    assert!(meta["elapsed_ms"].as_u64().is_some());
+    assert_eq!(meta["dry_run"], policy["dry_run"]);
+    assert_eq!(meta["retries"], policy["retries"]);
+    assert_eq!(meta["attempts_used"], serde_json::json!(0));
+    assert_eq!(meta["timeout_ms"], policy["timeout_ms"]);
 }

--- a/crates/macos-agent/tests/input_keyboard.rs
+++ b/crates/macos-agent/tests/input_keyboard.rs
@@ -16,7 +16,7 @@ fn input_type_accepts_whitespace_and_punctuation() {
             "type",
             "--text",
             "hello, world!",
-            "--enter",
+            "--submit",
         ],
     );
 

--- a/crates/macos-agent/tests/scenario_chain.rs
+++ b/crates/macos-agent/tests/scenario_chain.rs
@@ -162,8 +162,36 @@ fn scenario_run_executes_fixture_steps() {
     let payload: serde_json::Value =
         serde_json::from_str(&out.stdout_text()).expect("scenario run json");
     assert_eq!(payload["command"], serde_json::json!("scenario.run"));
+    assert_eq!(payload["result"]["total_steps"], serde_json::json!(3));
+    assert_eq!(payload["result"]["passed_steps"], serde_json::json!(3));
     assert_eq!(payload["result"]["failed_steps"], serde_json::json!(0));
-    assert!(payload["result"]["passed_steps"].as_u64().unwrap_or(0) >= 3);
+    let steps = payload["result"]["steps"]
+        .as_array()
+        .expect("steps should be an array");
+
+    let preflight = steps
+        .iter()
+        .find(|step| step["step_id"] == serde_json::json!("preflight"))
+        .expect("preflight step should exist");
+    assert_eq!(preflight["operation"], serde_json::json!("preflight"));
+    assert_eq!(preflight["ax_path"], serde_json::Value::Null);
+    assert_eq!(preflight["fallback_used"], serde_json::Value::Null);
+
+    let activate = steps
+        .iter()
+        .find(|step| step["step_id"] == serde_json::json!("activate"))
+        .expect("activate step should exist");
+    assert_eq!(activate["operation"], serde_json::json!("window.activate"));
+    assert_eq!(activate["ax_path"], serde_json::Value::Null);
+    assert_eq!(activate["fallback_used"], serde_json::Value::Null);
+
+    let click = steps
+        .iter()
+        .find(|step| step["step_id"] == serde_json::json!("click-dry-run"))
+        .expect("click step should exist");
+    assert_eq!(click["operation"], serde_json::json!("input.click"));
+    assert_eq!(click["ax_path"], serde_json::Value::Null);
+    assert_eq!(click["fallback_used"], serde_json::Value::Null);
 }
 
 #[test]
@@ -225,4 +253,73 @@ fn scenario_steps_report_ax_path_and_fallback_state() {
     assert_eq!(typ["operation"], serde_json::json!("ax.type"));
     assert_eq!(typ["ax_path"], serde_json::json!("keyboard-fallback"));
     assert_eq!(typ["fallback_used"], serde_json::json!(true));
+}
+
+#[test]
+fn scenario_steps_report_ax_native_path_when_fallback_not_used() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("scenario-ax.json");
+
+    let options = harness
+        .cmd_options(cwd.path())
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_LIST_JSON",
+            r#"{"nodes":[{"node_id":"1.1","role":"AXButton","enabled":true,"focused":false,"actions":["AXPress"],"path":["1","1"]}],"warnings":[]}"#,
+        )
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_CLICK_JSON",
+            r#"{"node_id":"1.1","matched_count":1,"action":"ax-press","used_coordinate_fallback":false}"#,
+        )
+        .with_env(
+            "CODEX_MACOS_AGENT_AX_TYPE_JSON",
+            r#"{"node_id":"1.1","matched_count":1,"applied_via":"ax-set-value","text_length":11,"submitted":false,"used_keyboard_fallback":false}"#,
+        );
+
+    let out = harness.run_with_options(
+        cwd.path(),
+        &[
+            "--format",
+            "json",
+            "scenario",
+            "run",
+            "--file",
+            fixture.to_str().unwrap(),
+        ],
+        options,
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+    let payload: serde_json::Value =
+        serde_json::from_str(&out.stdout_text()).expect("scenario run json");
+    let steps = payload["result"]["steps"]
+        .as_array()
+        .expect("steps should be an array");
+
+    let ax_list = steps
+        .iter()
+        .find(|step| step["step_id"] == serde_json::json!("ax-list"))
+        .expect("ax-list step should exist");
+    assert_eq!(ax_list["operation"], serde_json::json!("ax.list"));
+    assert_eq!(ax_list["ax_path"], serde_json::Value::Null);
+    assert_eq!(ax_list["fallback_used"], serde_json::Value::Null);
+
+    let click = steps
+        .iter()
+        .find(|step| step["step_id"] == serde_json::json!("ax-click"))
+        .expect("ax-click step should exist");
+    assert_eq!(click["operation"], serde_json::json!("ax.click"));
+    assert_eq!(click["ax_path"], serde_json::json!("ax-native"));
+    assert_eq!(click["fallback_used"], serde_json::json!(false));
+
+    let typ = steps
+        .iter()
+        .find(|step| step["step_id"] == serde_json::json!("ax-type"))
+        .expect("ax-type step should exist");
+    assert_eq!(typ["operation"], serde_json::json!("ax.type"));
+    assert_eq!(typ["ax_path"], serde_json::json!("ax-native"));
+    assert_eq!(typ["fallback_used"], serde_json::json!(false));
 }

--- a/crates/macos-agent/tests/wait.rs
+++ b/crates/macos-agent/tests/wait.rs
@@ -74,6 +74,31 @@ fn wait_window_present_succeeds_for_terminal() {
             "window-present",
             "--app",
             "Terminal",
+            "--window-title-contains",
+            "Docs",
+            "--timeout-ms",
+            "50",
+            "--poll-ms",
+            "5",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+    assert_eq!(out.stderr_text(), "");
+}
+
+#[test]
+fn wait_window_present_supports_window_name_alias() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+
+    let out = harness.run(
+        cwd.path(),
+        &[
+            "wait",
+            "window-present",
+            "--app",
+            "Terminal",
             "--window-name",
             "Docs",
             "--timeout-ms",

--- a/crates/macos-agent/tests/window_activate.rs
+++ b/crates/macos-agent/tests/window_activate.rs
@@ -73,5 +73,5 @@ fn window_activate_error_includes_selector_and_fallback_hint() {
     assert_eq!(out.stdout_text(), "");
     let stderr = out.stderr_text();
     assert!(stderr.contains("--window-id 999"));
-    assert!(stderr.contains("try --window-id <id> or --app <name> --window-name <title>"));
+    assert!(stderr.contains("try --window-id <id> or --app <name> --window-title-contains <title>"));
 }

--- a/docs/plans/macos-agent-realtime-feedback-usability-hardening-plan.md
+++ b/docs/plans/macos-agent-realtime-feedback-usability-hardening-plan.md
@@ -339,6 +339,14 @@ This plan hardens `macos-agent` for real-world agent development loops where com
   - `MACOS_AGENT_REAL_E2E=1 MACOS_AGENT_REAL_E2E_MUTATING=1 MACOS_AGENT_REAL_E2E_APPS=arc MACOS_AGENT_REAL_E2E_PROFILE=default-1440p cargo test -p macos-agent --test e2e_real_apps -- matrix_runner_supports_app_subset_selection_real -- --nocapture --test-threads=1`
   - `echo "manual-only real-app validation; do not include in CI default test jobs"`
 
+### Sprint 4 migration and rollout notes (Task 4.2 publish)
+- Publish a README command decision matrix that explicitly maps `ax`/`input`/`wait` choices, fallback usage, and backend expectations.
+- Set canonical invocation baseline for docs/examples: `--window-title-contains` and `input type --submit`.
+- Keep compatibility aliases (`--window-name`, `input type --enter`) accepted during the current `0.x` rollout window; do not change default text output/error contracts in Sprint 4.
+- Link decision matrix rows to troubleshooting and backend capability sections so fallback/backend incidents are diagnosable without changing command contracts.
+- Verification command:
+  - `rg -n "decision matrix|migration|alias|fallback|backend" crates/macos-agent/README.md`
+
 ### Task 4.3: Final compatibility checks and release guardrails
 - **Location**:
   - `crates/macos-agent/README.md`

--- a/docs/plans/macos-agent-subcommand-consistency-usability-execution-plan.md
+++ b/docs/plans/macos-agent-subcommand-consistency-usability-execution-plan.md
@@ -1,0 +1,370 @@
+# Plan: macos-agent subcommand consistency and usability execution plan
+
+## Overview
+This plan operationalizes `docs/plans/macos-agent-subcommand-consistency-usability-refactor-plan.md` into an executable sprint schedule with lane ownership, effort estimates, dependency gates, and rollout controls. The primary goal is user-friendly, clear, and easy-to-use CLI behavior; the secondary goal is maintainability through lower duplication, higher test coverage, and stronger stability guarantees. The plan is designed for incremental delivery with compatibility-preserving checkpoints after every sprint. Default capacity is two engineers plus shared documentation/testing support.
+
+## Scope
+- In scope:
+  - Convert strategy tasks into sequenced execution tasks with estimated effort and lane ownership.
+  - Define critical path, parallelizable work, and integration checkpoints.
+  - Add explicit sprint Go/No-Go criteria and validation commands.
+  - Provide dual capacity guidance (2-engineer default, 1-engineer fallback).
+- Out of scope:
+  - Implementing the refactor itself in this plan document.
+  - Changing release branching policy beyond this refactor.
+
+## Assumptions (if any)
+1. Default staffing model: 2 engineers (Lane A + Lane B) with shared support for docs/completions/tests.
+2. If only 1 engineer is available, the same task order applies but parallel tasks become sequential.
+3. Backward compatibility remains mandatory: canonical naming introduced via aliases first, removals deferred.
+4. Mandatory quality gates from `DEVELOPMENT.md` must pass before completion.
+
+## Execution lanes and estimation model
+- Lane A (CLI/contract): `cli.rs`, `commands/*`, `run.rs`, `main.rs`, `model.rs`, contract tests.
+- Lane B (backend): `backend/hammerspoon.rs`, `backend/applescript.rs`, `backend/mod.rs`, `preflight.rs`.
+- Lane C (docs/completion/test hardening): `README.md`, shell completions, scenario/docs/testing glue.
+
+Estimate mapping (used below):
+- Complexity 4-5: 0.5-1.0 engineer-day.
+- Complexity 6-7: 1.0-2.0 engineer-days.
+- Complexity 8: 2.0-3.0 engineer-days.
+- Complexity 9: 3.0-4.0 engineer-days.
+
+## Sprint 1: Contract and output foundation (Week 1)
+**Goal**: Ship shared output helpers and unified mutating envelope without breaking existing behavior.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p macos-agent --test contracts`
+  - `cargo test -p macos-agent --test cli_smoke`
+- Verify:
+  - Output/error handling is centralized and consistent.
+  - Mutating commands expose uniform `policy` and `meta` contract.
+
+**Parallelization notes**:
+- `Task 1.1` (Lane A) and `Task 1.2` (Lane B/A integration) run in parallel.
+- `Task 1.3` is integration and starts only after 1.1 + 1.2.
+
+### Task 1.1: Centralize command emit/reject helpers
+- **Location**:
+  - `crates/macos-agent/src/commands/mod.rs`
+  - `crates/macos-agent/src/commands/ax_click.rs`
+  - `crates/macos-agent/src/commands/ax_type.rs`
+  - `crates/macos-agent/src/commands/ax_attr.rs`
+  - `crates/macos-agent/src/commands/ax_action.rs`
+  - `crates/macos-agent/src/commands/ax_session.rs`
+  - `crates/macos-agent/src/commands/ax_watch.rs`
+  - `crates/macos-agent/src/commands/input_click.rs`
+  - `crates/macos-agent/src/commands/input_type.rs`
+  - `crates/macos-agent/src/commands/input_hotkey.rs`
+  - `crates/macos-agent/src/commands/input_source.rs`
+  - `crates/macos-agent/src/commands/window_activate.rs`
+  - `crates/macos-agent/src/commands/observe.rs`
+  - `crates/macos-agent/src/commands/wait.rs`
+  - `crates/macos-agent/src/commands/scenario.rs`
+  - `crates/macos-agent/src/commands/profile.rs`
+  - `crates/macos-agent/src/commands/list.rs`
+- **Description**: Replace repeated JSON serialization and TSV rejection branches with shared helper functions. Lane: A. Estimated effort: 1.5-2.0 days.
+- **Dependencies**:
+  - none
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Shared helper is used across command handlers.
+  - Command payload shape and behavior remain backward compatible.
+  - Error messages remain operation-aware.
+- **Validation**:
+  - `cargo test -p macos-agent --test contracts`
+  - `cargo test -p macos-agent --test cli_smoke`
+
+### Task 1.2: Unify mutating envelope for AX mutators missing policy/meta
+- **Location**:
+  - `crates/macos-agent/src/model.rs`
+  - `crates/macos-agent/src/run.rs`
+  - `crates/macos-agent/src/commands/ax_attr.rs`
+  - `crates/macos-agent/src/commands/ax_action.rs`
+  - `crates/macos-agent/src/commands/ax_session.rs`
+  - `crates/macos-agent/src/commands/ax_watch.rs`
+- **Description**: Add consistent `policy` and `meta` payload blocks to mutating AX commands that currently diverge. Lane: B with A review. Estimated effort: 2.0-3.0 days.
+- **Dependencies**:
+  - none
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - All mutating command responses follow one documented contract.
+  - Dry-run responses preserve contract shape.
+  - Existing JSON consumers can parse one common envelope.
+- **Validation**:
+  - `cargo test -p macos-agent --test contracts`
+  - `cargo test -p macos-agent --test scenario_chain`
+
+### Task 1.3: Consolidate command identity mapping (dispatch + trace)
+- **Location**:
+  - `crates/macos-agent/src/run.rs`
+  - `crates/macos-agent/src/main.rs`
+  - `crates/macos-agent/tests/cli_smoke.rs`
+- **Description**: Introduce single source for command labels used by trace and runtime identity to prevent drift. Lane: A. Estimated effort: 1.0 day.
+- **Dependencies**:
+  - Task 1.1
+  - Task 1.2
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Label mapping changes in one place.
+  - Trace and runtime command identity are consistent.
+- **Validation**:
+  - `cargo test -p macos-agent --test cli_smoke`
+  - `cargo test -p macos-agent --test contracts`
+
+## Sprint 2: UX normalization and discoverability (Week 2)
+**Goal**: Make command usage more intuitive via shared AX args, canonical naming, and explicit decision guidance.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p macos-agent --lib cli::tests`
+  - `zsh -f tests/zsh/completion.test.zsh`
+- Verify:
+  - AX selectors/targets are centrally defined.
+  - Canonical naming is visible in help/completions while aliases preserve compatibility.
+
+**Parallelization notes**:
+- `Task 2.1` (Lane A) and `Task 2.2` (Lane C+A) run in parallel.
+- `Task 2.3` starts after 2.1 + 2.2.
+
+### Task 2.1: Flatten reusable AX target/selector args
+- **Location**:
+  - `crates/macos-agent/src/cli.rs`
+  - `crates/macos-agent/src/commands/ax_common.rs`
+  - `crates/macos-agent/src/commands/ax_click.rs`
+  - `crates/macos-agent/src/commands/ax_type.rs`
+  - `crates/macos-agent/src/commands/ax_attr.rs`
+  - `crates/macos-agent/src/commands/ax_action.rs`
+  - `crates/macos-agent/src/commands/ax_session.rs`
+  - `crates/macos-agent/src/commands/ax_watch.rs`
+  - `crates/macos-agent/src/commands/ax_list.rs`
+- **Description**: Introduce shared `clap` fragments and centralized validation for AX selector/target constraints. Lane: A. Estimated effort: 1.5-2.0 days.
+- **Dependencies**:
+  - none
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - AX arg definitions are reusable and not duplicated.
+  - Selector/target error semantics are consistent across AX subcommands.
+- **Validation**:
+  - `cargo test -p macos-agent --lib cli::tests`
+  - `cargo test -p macos-agent --test cli_smoke`
+
+### Task 2.2: Canonical flag naming + alias migration layer
+- **Location**:
+  - `crates/macos-agent/src/cli.rs`
+  - `crates/macos-agent/src/commands/input_type.rs`
+  - `crates/macos-agent/src/commands/wait.rs`
+  - `crates/macos-agent/src/commands/observe.rs`
+  - `completions/zsh/_macos-agent`
+  - `completions/bash/macos-agent`
+- **Description**: Define canonical names for overlapping concepts and keep old forms as aliases. Lane: C with A review. Estimated effort: 2.0-2.5 days.
+- **Dependencies**:
+  - none
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - Help text and completions prioritize canonical names.
+  - Legacy names remain functional through alias compatibility.
+  - Behavior parity holds between canonical and alias paths.
+- **Validation**:
+  - `cargo test -p macos-agent --lib cli::tests`
+  - `zsh -f tests/zsh/completion.test.zsh`
+  - `rg -n "window_title_contains|window-name|window_title" completions/bash/macos-agent`
+
+### Task 2.3: Add explicit user decision guidance in docs/help
+- **Location**:
+  - `crates/macos-agent/README.md`
+  - `crates/macos-agent/src/cli.rs`
+- **Description**: Add AX-first vs fallback decision path with clear examples and troubleshooting entry points. Lane: C. Estimated effort: 0.5-1.0 day.
+- **Dependencies**:
+  - Task 2.1
+  - Task 2.2
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - Users can choose `ax` vs `input` vs `wait` quickly from docs/help.
+  - Guidance remains consistent with actual command behavior.
+- **Validation**:
+  - `rg -n "ax-first|fallback|input\\.|decision" crates/macos-agent/README.md`
+  - `cargo run -p macos-agent -- --help | rg -i "ax|fallback|input"`
+  - `cargo run -p macos-agent -- --help`
+
+## Sprint 3: Backend dedup and capability transparency (Weeks 3-4)
+**Goal**: Reduce backend maintenance overhead while making backend capability limits explicit and debuggable.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p macos-agent --lib backend::tests`
+  - `cargo test -p macos-agent --test ax_extended`
+- Verify:
+  - Repeated backend helper logic is centralized.
+  - Backend capability constraints are visible to users before failure surprises.
+
+**Parallelization notes**:
+- In 2-engineer mode, `Task 3.1` and `Task 3.2` can run concurrently with file partitioning.
+- In 1-engineer mode, do `3.2` first (lower risk), then `3.1`, then `3.3`.
+
+### Task 3.1: Deduplicate Hammerspoon helper prelude blocks
+- **Location**:
+  - `crates/macos-agent/src/backend/hammerspoon.rs`
+  - `crates/macos-agent/src/backend/mod.rs`
+- **Description**: Build shared Lua prelude fragments and operation-specific assembly to remove repeated helper definitions. Lane: B. Estimated effort: 3.0-4.0 days.
+- **Dependencies**:
+  - none
+- **Complexity**: 9
+- **Acceptance criteria**:
+  - Shared helpers are not copied per operation.
+  - AX behavior parity remains intact under existing tests.
+- **Validation**:
+  - `cargo test -p macos-agent --lib backend::tests`
+  - `cargo test -p macos-agent --test ax_extended`
+
+### Task 3.2: Remove duplicated JXA helper definitions and tighten parser checks
+- **Location**:
+  - `crates/macos-agent/src/backend/applescript.rs`
+  - `crates/macos-agent/src/backend/mod.rs`
+- **Description**: Eliminate duplicated JXA functions and improve JSON parse/contract guards. Lane: B. Estimated effort: 1.5-2.0 days.
+- **Dependencies**:
+  - none
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Duplicate helper definitions are removed.
+  - Parse failures remain operation-specific and actionable.
+- **Validation**:
+  - `cargo test -p macos-agent --lib backend::tests`
+  - `cargo test -p macos-agent --test ax_extended`
+
+### Task 3.3: Surface backend capability matrix in diagnostics and preflight
+- **Location**:
+  - `crates/macos-agent/src/backend/mod.rs`
+  - `crates/macos-agent/src/preflight.rs`
+  - `crates/macos-agent/src/error.rs`
+  - `crates/macos-agent/README.md`
+- **Description**: Document and expose capability boundaries for `auto/hammerspoon/applescript`, especially Hammerspoon-only AX features. Lane: A+C. Estimated effort: 1.0-1.5 days.
+- **Dependencies**:
+  - Task 3.1
+  - Task 3.2
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Unsupported backend paths provide capability-aware hints.
+  - Preflight/docs communicate readiness and likely fallback behavior.
+- **Validation**:
+  - `cargo test -p macos-agent --test preflight`
+  - `cargo test -p macos-agent --test contracts`
+
+## Sprint 4: Stability hardening and rollout gate (Week 5)
+**Goal**: Increase confidence with compatibility-focused coverage and ship a rollback-safe handoff.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p macos-agent --test cli_smoke`
+  - `cargo test -p macos-agent --test contracts`
+  - `cargo test -p macos-agent --test scenario_chain`
+  - `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh`
+- Verify:
+  - Alias compatibility and unified contract are enforced by tests.
+  - Docs/completions/release notes align with final behavior.
+
+**Parallelization notes**:
+- `Task 4.1` and `Task 4.2` parallel.
+- `Task 4.3` final integration gate.
+
+### Task 4.1: Add compatibility and regression tests
+- **Location**:
+  - `crates/macos-agent/tests/cli_smoke.rs`
+  - `crates/macos-agent/tests/contracts.rs`
+  - `crates/macos-agent/tests/scenario_chain.rs`
+  - `tests/zsh/completion.test.zsh`
+- **Description**: Add assertions for alias/canonical parity, unified mutating envelope, and fallback telemetry stability. Lane: A+C. Estimated effort: 2.0-2.5 days.
+- **Dependencies**:
+  - Task 1.2
+  - Task 2.2
+  - Task 3.3
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - Alias and canonical paths are behaviorally equivalent.
+  - Contracts enforce unified schema and telemetry semantics.
+- **Validation**:
+  - `cargo test -p macos-agent --test cli_smoke`
+  - `cargo test -p macos-agent --test contracts`
+  - `cargo test -p macos-agent --test scenario_chain`
+  - `zsh -f tests/zsh/completion.test.zsh`
+
+### Task 4.2: Publish user matrix and migration guidance
+- **Location**:
+  - `crates/macos-agent/README.md`
+  - `docs/plans/macos-agent-realtime-feedback-usability-hardening-plan.md`
+- **Description**: Publish command decision matrix and migration notes for canonical naming with alias window. Lane: C. Estimated effort: 1.0 day.
+- **Dependencies**:
+  - Task 2.3
+  - Task 3.3
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - README includes matrix + migration notes + troubleshooting linkage.
+- **Validation**:
+  - `rg -n "decision matrix|migration|alias|fallback|backend" crates/macos-agent/README.md`
+
+### Task 4.3: Run mandatory gate + release handoff
+- **Location**:
+  - `DEVELOPMENT.md`
+  - `crates/macos-agent/README.md`
+  - `crates/macos-agent/tests/cli_smoke.rs`
+  - `crates/macos-agent/tests/contracts.rs`
+  - `crates/macos-agent/tests/scenario_chain.rs`
+  - `crates/macos-agent/tests/ax_extended.rs`
+  - `crates/macos-agent/tests/preflight.rs`
+- **Description**: Execute full required checks, write residual-risk summary, and finalize rollback trigger checklist for rollout. Lane: A+B+C final pass. Estimated effort: 1.0-1.5 days.
+- **Dependencies**:
+  - Task 4.1
+  - Task 4.2
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Mandatory checks pass (or failures are explicitly documented with remediation).
+  - Release handoff includes risk and rollback trigger list.
+- **Validation**:
+  - `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh`
+
+## Timeline and critical path
+- 2-engineer model (recommended): ~5 weeks calendar time.
+  - Critical path: `1.2 -> 1.3 -> 2.2 -> 2.3 -> 3.1 -> 3.3 -> 4.1 -> 4.3`.
+- 1-engineer model (fallback): ~7-8 weeks calendar time.
+  - Execute strictly by dependency order, no parallel lanes.
+
+## Daily execution rhythm
+- Daily start:
+  - Pick highest-priority unblocked task on critical path.
+  - Reconfirm local baseline with task-specific validation command.
+- Daily end:
+  - Run task validation commands.
+  - Record pass/fail and unresolved risks in PR notes.
+- Sprint close:
+  - Run sprint demo commands.
+  - Apply Go/No-Go gate before moving forward.
+
+## Go/No-Go gates
+- Sprint 1 gate:
+  - `contracts` and `cli_smoke` green, no schema drift for existing consumers.
+- Sprint 2 gate:
+  - CLI alias compatibility confirmed by tests and completion checks.
+- Sprint 3 gate:
+  - Backend dedup tests green and capability diagnostics clear.
+- Sprint 4 gate:
+  - Full required checks pass and release handoff complete.
+
+## Testing Strategy
+- Unit:
+  - `cli::tests` for parsing/alias/selector normalization.
+  - backend parser and capability-path unit tests.
+- Integration:
+  - `contracts`, `scenario_chain`, `cli_smoke` for end-to-end command contract stability.
+- E2E/manual:
+  - AX-first local smoke flow plus fallback path verification using documented examples.
+
+## Risks & gotchas
+- Large file overlap risk (`cli.rs`, `backend/hammerspoon.rs`) can create merge conflicts if lanes are not strictly scoped.
+- Alias migration risk if help/completion/docs are not updated in same sprint as parsing changes.
+- Backend dedup risk can cause subtle selector regressions without targeted AX regression tests.
+
+## Rollback plan
+- Keep one PR per task or tightly related pair to allow surgical revert.
+- For compatibility regressions, keep aliases active and revert canonical-help promotion first.
+- For backend regressions, revert `hammerspoon.rs`/`applescript.rs` dedup commits independently while preserving CLI/documentation gains.
+- Trigger rollback when any of the following occurs:
+  - `contracts` or `scenario_chain` regressions.
+  - Reproducible AX behavior drift from pre-refactor baseline.
+  - External user script breakage on legacy flags.

--- a/docs/plans/macos-agent-subcommand-consistency-usability-refactor-plan.md
+++ b/docs/plans/macos-agent-subcommand-consistency-usability-refactor-plan.md
@@ -1,0 +1,351 @@
+# Plan: macos-agent subcommand consistency and usability refactor
+
+## Overview
+This plan refactors `macos-agent` subcommands to make the CLI more user friendly, easier to discover, and more predictable in day-to-day agent workflows. The primary outcome is a clearer usage model (AX-first with explicit fallback boundaries) and consistent command contracts across output, retries, and metadata. The secondary outcome is maintainability: reducing duplicated CLI/backend logic, expanding coverage for compatibility-sensitive changes, and hardening stability through deterministic validation paths. The plan evaluates and implements all seven identified refactor directions, with backward-compatible rollout steps.
+
+## Scope
+- In scope:
+  - Unify repeated output/format handling (`json` serialization branches, TSV rejection handling, text envelope patterns).
+  - Standardize mutating command contract (`policy`, `meta`, retry/attempt telemetry) across AX and non-AX mutating commands.
+  - Consolidate AX selector/target argument definitions into reusable `clap` structs.
+  - Normalize naming and mental model for overlapping flags (`window_name` vs `window_title_contains`, `enter` vs `submit`) using compatibility aliases.
+  - Clarify backend capability boundaries (`auto` vs Hammerspoon-only features) in runtime errors, preflight, and docs.
+  - Deduplicate backend script helper logic in both `hammerspoon.rs` and `applescript.rs`.
+  - Publish a usage decision matrix that makes command choice clear (`ax` vs `input`, fallback rules, troubleshooting path).
+  - Add targeted tests to preserve backward compatibility and improve stability.
+- Out of scope:
+  - New automation domains outside current command families.
+  - Non-macOS support.
+  - Replacing AppleScript/Hammerspoon stacks with a new runtime.
+  - Changing existing success/error exit code semantics.
+
+## Assumptions (if any)
+1. Backward compatibility for existing scripts is required; breaking flag/output changes must be migrated with aliases and explicit deprecation messaging.
+2. The current AX-first direction remains the product strategy, while `input.*` stays as low-level fallback primitives.
+3. `plan-tooling`, Rust toolchain, and required local test dependencies are available in contributor environments.
+4. Mutating action telemetry should remain machine-parseable and stable for scenario/test harness consumers.
+
+## Sprint 1: Contract and output consistency foundation
+**Goal**: Remove repeated output/format boilerplate and make mutating command responses consistently parseable.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p macos-agent --test contracts`
+  - `cargo test -p macos-agent --test cli_smoke`
+- Verify:
+  - Command outputs follow shared emit path with consistent error handling.
+  - Mutating commands expose a uniform policy/meta contract.
+
+**Parallelization notes**:
+- `Task 1.1` and `Task 1.2` can run in parallel.
+- `Task 1.3` depends on `Task 1.1` and `Task 1.2`.
+
+### Task 1.1: Extract shared command output helpers
+- **Location**:
+  - `crates/macos-agent/src/commands/mod.rs`
+  - `crates/macos-agent/src/commands/ax_click.rs`
+  - `crates/macos-agent/src/commands/ax_type.rs`
+  - `crates/macos-agent/src/commands/ax_attr.rs`
+  - `crates/macos-agent/src/commands/ax_action.rs`
+  - `crates/macos-agent/src/commands/ax_session.rs`
+  - `crates/macos-agent/src/commands/ax_watch.rs`
+  - `crates/macos-agent/src/commands/input_click.rs`
+  - `crates/macos-agent/src/commands/input_type.rs`
+  - `crates/macos-agent/src/commands/input_hotkey.rs`
+  - `crates/macos-agent/src/commands/input_source.rs`
+  - `crates/macos-agent/src/commands/window_activate.rs`
+  - `crates/macos-agent/src/commands/observe.rs`
+  - `crates/macos-agent/src/commands/wait.rs`
+  - `crates/macos-agent/src/commands/scenario.rs`
+  - `crates/macos-agent/src/commands/profile.rs`
+  - `crates/macos-agent/src/commands/list.rs`
+  - `crates/macos-agent/src/error.rs`
+- **Description**: Add shared helpers for JSON success emission, serialization error mapping, and unsupported TSV rejection. Replace per-command duplicated branches with helper calls while preserving current wire format.
+- **Dependencies**:
+  - none
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Per-command repeated JSON serialization and TSV rejection branches are removed from handlers and replaced with shared helper usage.
+  - CLI behavior and payload schema remain unchanged for existing commands.
+  - Serialization and format errors remain operation-aware and actionable.
+- **Validation**:
+  - `cargo test -p macos-agent --test contracts`
+  - `cargo test -p macos-agent --test cli_smoke`
+
+### Task 1.2: Unify mutating action envelope across command families
+- **Location**:
+  - `crates/macos-agent/src/model.rs`
+  - `crates/macos-agent/src/run.rs`
+  - `crates/macos-agent/src/commands/ax_attr.rs`
+  - `crates/macos-agent/src/commands/ax_action.rs`
+  - `crates/macos-agent/src/commands/ax_session.rs`
+  - `crates/macos-agent/src/commands/ax_watch.rs`
+- **Description**: Extend mutating AX commands that currently lack full action metadata to include consistent `policy` and `meta` blocks (including attempt semantics where relevant), matching existing `window.activate`, `input.*`, `ax.click`, `ax.type` behavior.
+- **Dependencies**:
+  - none
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - All mutating commands expose a documented, consistent policy/meta schema in JSON mode.
+  - Dry-run responses preserve contract shape and explicit non-mutating semantics.
+  - Existing consumers can parse mutating responses via one stable contract.
+- **Validation**:
+  - `cargo test -p macos-agent --test contracts`
+  - `cargo test -p macos-agent --test scenario_chain`
+
+### Task 1.3: Consolidate command identity mapping used by dispatch and trace
+- **Location**:
+  - `crates/macos-agent/src/run.rs`
+  - `crates/macos-agent/src/main.rs`
+  - `crates/macos-agent/tests/cli_smoke.rs`
+- **Description**: Introduce a shared command identity resolver used by runtime dispatch metadata and trace labeling to prevent drift between command routing and command label strings.
+- **Dependencies**:
+  - Task 1.1
+  - Task 1.2
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Command labels for tracing and JSON envelopes derive from a single source of truth.
+  - New subcommands require changes in one mapping location only.
+  - Existing trace/tests continue to pass without command label regressions.
+- **Validation**:
+  - `cargo test -p macos-agent --test cli_smoke`
+  - `cargo test -p macos-agent --test contracts`
+
+## Sprint 2: CLI UX normalization and discoverability
+**Goal**: Make command usage rules easier to learn by reducing argument drift and harmonizing overlapping flag semantics.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p macos-agent --lib cli::tests`
+  - `zsh -f tests/zsh/completion.test.zsh`
+- Verify:
+  - AX selector/target arguments are defined once and reused consistently.
+  - Overlapping flags expose a clear canonical form plus compatibility aliases.
+
+**Parallelization notes**:
+- `Task 2.1` and `Task 2.2` can run in parallel.
+- `Task 2.3` depends on `Task 2.1` and `Task 2.2`.
+
+### Task 2.1: Introduce reusable AX `clap` argument fragments
+- **Location**:
+  - `crates/macos-agent/src/cli.rs`
+  - `crates/macos-agent/src/commands/ax_common.rs`
+  - `crates/macos-agent/src/commands/ax_click.rs`
+  - `crates/macos-agent/src/commands/ax_type.rs`
+  - `crates/macos-agent/src/commands/ax_attr.rs`
+  - `crates/macos-agent/src/commands/ax_action.rs`
+  - `crates/macos-agent/src/commands/ax_session.rs`
+  - `crates/macos-agent/src/commands/ax_watch.rs`
+  - `crates/macos-agent/src/commands/ax_list.rs`
+- **Description**: Create reusable `AxTargetArgs` and `AxSelectorArgs` (or equivalent flattened structs), enforce shared validation constraints centrally, and apply them across `ax click/type/attr/action`.
+- **Dependencies**:
+  - none
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - AX command parsing logic no longer duplicates selector/target field declarations.
+  - Selector and target validation errors are consistent across AX subcommands.
+  - Existing valid CLI invocations remain accepted.
+- **Validation**:
+  - `cargo test -p macos-agent --lib cli::tests`
+  - `cargo test -p macos-agent --test cli_smoke`
+
+### Task 2.2: Normalize user-facing flag vocabulary with backward-compatible aliases
+- **Location**:
+  - `crates/macos-agent/src/cli.rs`
+  - `crates/macos-agent/src/commands/input_type.rs`
+  - `crates/macos-agent/src/commands/wait.rs`
+  - `crates/macos-agent/src/commands/observe.rs`
+  - `completions/zsh/_macos-agent`
+  - `completions/bash/macos-agent`
+- **Description**: Define canonical naming for overlapping concepts (`window_title_contains`, submit/enter semantics) and keep old names as aliases during migration. Update help/completions so users see one preferred mental model.
+- **Dependencies**:
+  - none
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - Canonical flags are clearly documented in `--help` and completions.
+  - Legacy flag forms continue to work and emit compatibility-safe messaging when appropriate.
+  - Command behavior remains unchanged across alias and canonical paths.
+- **Validation**:
+  - `cargo test -p macos-agent --lib cli::tests`
+  - `zsh -f tests/zsh/completion.test.zsh`
+  - `rg -n "window_title_contains|window-name|window_title" completions/bash/macos-agent`
+
+### Task 2.3: Add explicit usage decision path to command help and docs
+- **Location**:
+  - `crates/macos-agent/README.md`
+  - `crates/macos-agent/src/cli.rs`
+- **Description**: Add concise decision guidance in CLI descriptions and README: when to start with `ax`, when to use fallback flags, and when to intentionally use `input.*` primitives.
+- **Dependencies**:
+  - Task 2.1
+  - Task 2.2
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - Users can identify preferred command path without reading source code.
+  - README and help text present consistent vocabulary and ordering.
+  - Guidance covers stability-oriented flows (`activate` + `wait` + `ax` + fallback).
+- **Validation**:
+  - `rg -n "ax-first|fallback|input\.|decision" crates/macos-agent/README.md`
+  - `cargo run -p macos-agent -- --help | rg -i "ax|fallback|input"`
+  - `cargo run -p macos-agent -- --help`
+
+## Sprint 3: Backend consistency and capability transparency
+**Goal**: Reduce backend script duplication and make capability boundaries explicit to operators and tooling.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p macos-agent --lib backend::tests`
+  - `cargo test -p macos-agent --test ax_extended`
+- Verify:
+  - Backend helper logic is centralized and easier to maintain.
+  - Unsupported capability paths fail with explicit, actionable guidance.
+
+**Parallelization notes**:
+- `Task 3.1` can run in parallel with `Task 3.2`.
+- `Task 3.3` depends on `Task 3.1` and `Task 3.2`.
+
+### Task 3.1: Deduplicate Hammerspoon script helper blocks
+- **Location**:
+  - `crates/macos-agent/src/backend/hammerspoon.rs`
+  - `crates/macos-agent/src/backend/mod.rs`
+- **Description**: Factor repeated Lua helper fragments (`ensureState`, target/session resolution, selector walk utilities) into shared script prelude builders and operation-specific sections.
+- **Dependencies**:
+  - none
+- **Complexity**: 9
+- **Acceptance criteria**:
+  - Shared helper logic is defined once and reused by AX operations.
+  - Script behavior/output parity for all AX operations is preserved.
+  - Existing backend tests remain green.
+- **Validation**:
+  - `cargo test -p macos-agent --lib backend::tests`
+  - `cargo test -p macos-agent --test ax_extended`
+
+### Task 3.2: Remove AppleScript/JXA helper duplication and tighten parser contracts
+- **Location**:
+  - `crates/macos-agent/src/backend/applescript.rs`
+  - `crates/macos-agent/src/backend/mod.rs`
+- **Description**: Eliminate duplicated JXA helper definitions (including repeated `resolveByNodeId`) and formalize parse/contract checks for backend JSON decoding.
+- **Dependencies**:
+  - none
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Duplicated JXA helper definitions are removed.
+  - Parse failure messages remain operation-specific and actionable.
+  - AX click/type/list behavior in test mode remains deterministic.
+- **Validation**:
+  - `cargo test -p macos-agent --lib backend::tests`
+  - `cargo test -p macos-agent --test ax_extended`
+
+### Task 3.3: Expose backend capability matrix in runtime diagnostics and preflight
+- **Location**:
+  - `crates/macos-agent/src/backend/mod.rs`
+  - `crates/macos-agent/src/preflight.rs`
+  - `crates/macos-agent/src/error.rs`
+  - `crates/macos-agent/README.md`
+- **Description**: Surface which AX features are available per backend preference (`auto`, `hammerspoon`, `applescript`) and provide explicit remediation for Hammerspoon-only commands (`attr/action/session/watch`).
+- **Dependencies**:
+  - Task 3.1
+  - Task 3.2
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Unsupported backend command paths produce clear capability-specific hints.
+  - Preflight (or documented diagnostics) can reveal backend readiness and likely fallback behavior.
+  - README troubleshooting aligns with runtime diagnostics.
+- **Validation**:
+  - `cargo test -p macos-agent --test preflight`
+  - `cargo test -p macos-agent --test contracts`
+
+## Sprint 4: Stability hardening, test expansion, and rollout safety
+**Goal**: Lock in usability and maintainability gains with focused coverage and operational rollout controls.
+**Demo/Validation**:
+- Command(s):
+  - `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh`
+  - `cargo test -p macos-agent --test scenario_chain`
+- Verify:
+  - Refactor remains backward compatible and stable.
+  - Documentation, completions, and test suites reflect the new unified model.
+
+**Parallelization notes**:
+- `Task 4.1` and `Task 4.2` can run in parallel.
+- `Task 4.3` depends on `Task 4.1` and `Task 4.2`.
+
+### Task 4.1: Expand compatibility-focused test coverage
+- **Location**:
+  - `crates/macos-agent/tests/cli_smoke.rs`
+  - `crates/macos-agent/tests/contracts.rs`
+  - `crates/macos-agent/tests/scenario_chain.rs`
+  - `tests/zsh/completion.test.zsh`
+- **Description**: Add tests for canonical-vs-alias flag parity, unified mutating envelope assertions, and scenario telemetry consistency for AX fallback paths.
+- **Dependencies**:
+  - Task 1.2
+  - Task 2.2
+  - Task 3.3
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - Alias and canonical flags are behaviorally equivalent.
+  - Contract tests enforce unified mutating output schema.
+  - Scenario telemetry continues to encode fallback path details reliably.
+- **Validation**:
+  - `cargo test -p macos-agent --test cli_smoke`
+  - `cargo test -p macos-agent --test contracts`
+  - `cargo test -p macos-agent --test scenario_chain`
+  - `zsh -f tests/zsh/completion.test.zsh`
+
+### Task 4.2: Publish user-facing command matrix and migration notes
+- **Location**:
+  - `crates/macos-agent/README.md`
+  - `docs/plans/macos-agent-realtime-feedback-usability-hardening-plan.md`
+- **Description**: Document a concrete command selection matrix (`ax`/`input`/`wait`/`window`) and migration notes for renamed canonical flags with alias compatibility windows.
+- **Dependencies**:
+  - Task 2.3
+  - Task 3.3
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - README contains an actionable matrix and copy-paste workflow examples.
+  - Migration notes explain compatibility guarantees and deprecation timeline.
+  - Troubleshooting references updated backend capability guidance.
+- **Validation**:
+  - `rg -n "decision matrix|migration|alias|fallback|backend" crates/macos-agent/README.md`
+
+### Task 4.3: Run full quality gate and prepare rollback-safe release handoff
+- **Location**:
+  - `DEVELOPMENT.md`
+  - `crates/macos-agent/README.md`
+  - `crates/macos-agent/tests/cli_smoke.rs`
+  - `crates/macos-agent/tests/contracts.rs`
+  - `crates/macos-agent/tests/scenario_chain.rs`
+  - `crates/macos-agent/tests/ax_extended.rs`
+  - `crates/macos-agent/tests/preflight.rs`
+- **Description**: Execute mandatory checks, collect residual risk notes, and prepare rollback procedure references so refactor rollout can be safely reverted without user disruption.
+- **Dependencies**:
+  - Task 4.1
+  - Task 4.2
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Required project checks pass or are explicitly documented with remediation.
+  - Release handoff includes known-risk list and rollback trigger criteria.
+  - No unresolved placeholder markers remain in command docs or plan artifacts.
+- **Validation**:
+  - `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh`
+
+## Testing Strategy
+- Unit:
+  - CLI parse/alias tests for selector/target normalization and backward compatibility.
+  - Backend parser/contract tests for AX response decoding and capability errors.
+- Integration:
+  - Command contract tests for stdout/stderr discipline and JSON schema consistency.
+  - Scenario chain tests for telemetry and fallback path integrity.
+- E2E/manual:
+  - Preflight + AX-first workflow smoke checks on local macOS hosts.
+  - Manual verification of fallback behavior and troubleshooting clarity in README examples.
+
+## Risks & gotchas
+- Backward compatibility risk: scripts may rely on legacy flag names and current text output nuances.
+- Refactor coupling risk: output/contract changes can affect scenario and external parsers simultaneously.
+- Backend dedup risk: script refactors can silently alter AX resolution edge cases if not tightly tested.
+- Usability drift risk: docs/help/completions can diverge unless updated in the same sprint as CLI changes.
+
+## Rollback plan
+- Keep refactor changes grouped by sprint and merge in small PRs so any regression can be reverted by sprint-level rollback.
+- Preserve legacy flag aliases during rollout; if regressions appear, demote new canonical flags in docs/help and keep aliases as primary until fixed.
+- If backend dedup introduces behavior regressions, revert backend script refactor commits first while retaining command-surface improvements.
+- If mutating contract unification breaks consumers, temporarily restore previous JSON fields in compatibility mode and gate strict schema under opt-in until migration completes.
+- Rollback trigger criteria:
+  - Contract test regressions in `contracts` or `scenario_chain`.
+  - Reproducible failures in AX command parity against pre-refactor baseline.
+  - User-reported breakage in legacy flag paths.

--- a/tests/zsh/completion.test.zsh
+++ b/tests/zsh/completion.test.zsh
@@ -597,6 +597,46 @@ grep -q -- "--dry-run\\[" "$COMP_MACOS_AGENT_FILE" || {
   exit 1
 }
 
+grep -q -- "--window-title-contains=\\[Narrow app selection by window title\\]" "$COMP_MACOS_AGENT_FILE" || {
+  print -u2 -r -- "FAIL: macos-agent completion missing canonical --window-title-contains"
+  exit 1
+}
+
+grep -q -- "--window-name=\\[Deprecated alias of --window-title-contains\\]" "$COMP_MACOS_AGENT_FILE" || {
+  print -u2 -r -- "FAIL: macos-agent completion missing --window-name alias contract"
+  exit 1
+}
+
+grep -q -- "--submit\\[Press Enter after typing\\]" "$COMP_MACOS_AGENT_FILE" || {
+  print -u2 -r -- "FAIL: macos-agent completion missing canonical --submit"
+  exit 1
+}
+
+grep -q -- "--enter\\[Deprecated alias of --submit\\]" "$COMP_MACOS_AGENT_FILE" || {
+  print -u2 -r -- "FAIL: macos-agent completion missing --enter alias contract"
+  exit 1
+}
+
+grep -q -- "--window-title-contains" "$BASH_MACOS_AGENT_FILE" || {
+  print -u2 -r -- "FAIL: bash macos-agent completion missing canonical --window-title-contains"
+  exit 1
+}
+
+grep -q -- "--window-name" "$BASH_MACOS_AGENT_FILE" || {
+  print -u2 -r -- "FAIL: bash macos-agent completion missing --window-name alias"
+  exit 1
+}
+
+grep -q -- "--submit" "$BASH_MACOS_AGENT_FILE" || {
+  print -u2 -r -- "FAIL: bash macos-agent completion missing canonical --submit"
+  exit 1
+}
+
+grep -q -- "--enter" "$BASH_MACOS_AGENT_FILE" || {
+  print -u2 -r -- "FAIL: bash macos-agent completion missing --enter alias"
+  exit 1
+}
+
 bash -c "set -euo pipefail; source \"$BASH_GIT_SCOPE_FILE\"; complete -p git-scope | grep -q _nils_cli_git_scope_complete" || {
   print -u2 -r -- "FAIL: failed to source bash git-scope completion file"
   exit 1


### PR DESCRIPTION
# Make macos-agent subcommands consistent and ax-first

## Summary
This PR unifies `macos-agent` command behavior around an AX-first model with clearer fallbacks, consistent mutating JSON contracts, and stronger discoverability via canonical flags/completions/docs while keeping backward-compatible aliases for existing scripts.

## Changes
- Consolidate command output/error helpers and standardize mutating `policy`/`meta` envelopes across AX and input/window commands.
- Normalize flag vocabulary to canonical `--window-title-contains` and `--submit`, while preserving `--window-name` and `--enter` aliases.
- Expand AX command surface (`attr`/`action`/`session`/`watch`) and keep command label/trace mapping in sync.
- Deduplicate Hammerspoon/AppleScript AX script helpers and add backend capability diagnostics in preflight and error hints.
- Add compatibility-focused tests (alias parity, contract schema, scenario telemetry, completion coverage) and sprint plan artifacts.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Legacy aliases remain supported in the current `0.x` rollout window; follow-up can remove aliases after migration confidence.
- Alias parity coverage currently focuses on `window-name` and `enter/submit`; additional alias pairs can be extended later.
