### PR TITLE
Expand nils-common git wrapper characterization coverage

### DIFF
--- a/crates/nils-common/src/git.rs
+++ b/crates/nils-common/src/git.rs
@@ -110,3 +110,101 @@ fn trimmed_stdout_if_success(output: &Output) -> Option<String> {
         Some(trimmed)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nils_test_support::git::{git as run_git, init_repo_with, InitRepoOptions};
+    use nils_test_support::{CwdGuard, GlobalStateLock};
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    #[test]
+    fn run_output_in_preserves_nonzero_status() {
+        let repo = init_repo_with(InitRepoOptions::new());
+
+        let output = run_output_in(repo.path(), &["rev-parse", "--verify", "HEAD"])
+            .expect("run output in repo");
+
+        assert!(!output.status.success());
+        assert!(!output.stderr.is_empty());
+    }
+
+    #[test]
+    fn run_status_quiet_in_returns_success_and_failure_statuses() {
+        let repo = init_repo_with(InitRepoOptions::new());
+
+        let ok =
+            run_status_quiet_in(repo.path(), &["rev-parse", "--git-dir"]).expect("status success");
+        let bad = run_status_quiet_in(repo.path(), &["rev-parse", "--verify", "HEAD"])
+            .expect("status failure");
+
+        assert!(ok.success());
+        assert!(!bad.success());
+    }
+
+    #[test]
+    fn is_git_repo_in_and_is_inside_work_tree_in_match_repo_context() {
+        let repo = init_repo_with(InitRepoOptions::new());
+        let outside = TempDir::new().expect("tempdir");
+
+        assert!(is_git_repo_in(repo.path()).expect("is_git_repo in repo"));
+        assert!(is_inside_work_tree_in(repo.path()).expect("is_inside_work_tree in repo"));
+        assert!(!is_git_repo_in(outside.path()).expect("is_git_repo outside repo"));
+        assert!(!is_inside_work_tree_in(outside.path()).expect("is_inside_work_tree outside repo"));
+    }
+
+    #[test]
+    fn repo_root_in_returns_root_or_none() {
+        let repo = init_repo_with(InitRepoOptions::new());
+        let outside = TempDir::new().expect("tempdir");
+        let expected_root = run_git(repo.path(), &["rev-parse", "--show-toplevel"])
+            .trim()
+            .to_string();
+
+        assert_eq!(
+            repo_root_in(repo.path()).expect("repo_root_in repo"),
+            Some(expected_root.into())
+        );
+        assert_eq!(
+            repo_root_in(outside.path()).expect("repo_root_in outside"),
+            None
+        );
+    }
+
+    #[test]
+    fn rev_parse_in_returns_value_or_none() {
+        let repo = init_repo_with(InitRepoOptions::new().with_initial_commit());
+        let head = run_git(repo.path(), &["rev-parse", "HEAD"])
+            .trim()
+            .to_string();
+
+        assert_eq!(
+            rev_parse_in(repo.path(), &["HEAD"]).expect("rev_parse head"),
+            Some(head)
+        );
+        assert_eq!(
+            rev_parse_in(repo.path(), &["--verify", "refs/heads/does-not-exist"])
+                .expect("rev_parse missing ref"),
+            None
+        );
+    }
+
+    #[test]
+    fn cwd_wrappers_delegate_to_in_variants() {
+        let lock = GlobalStateLock::new();
+        let repo = init_repo_with(InitRepoOptions::new().with_initial_commit());
+        let _cwd = CwdGuard::set(&lock, repo.path()).expect("set cwd");
+        let head = run_git(repo.path(), &["rev-parse", "HEAD"])
+            .trim()
+            .to_string();
+        let root = run_git(repo.path(), &["rev-parse", "--show-toplevel"])
+            .trim()
+            .to_string();
+
+        assert!(is_git_repo().expect("is_git_repo"));
+        assert!(is_inside_work_tree().expect("is_inside_work_tree"));
+        assert_eq!(repo_root().expect("repo_root"), Some(root.into()));
+        assert_eq!(rev_parse(&["HEAD"]).expect("rev_parse"), Some(head));
+    }
+}


### PR DESCRIPTION
# Expand nils-common git wrapper characterization coverage

## Summary
This PR adds characterization tests for the shared `nils-common::git` helper so dependent CLIs keep stable behavior in repo and non-repo contexts, without changing runtime logic.

## Changes
- Add tests for `run_output_in` and `run_status_quiet_in` success and nonzero status semantics.
- Add tests for `is_git_repo(_in)`, `is_inside_work_tree(_in)`, `repo_root(_in)`, and `rev_parse(_in)` across repo and non-repo cases.
- Add cwd-based wrapper tests using `GlobalStateLock` and `CwdGuard` to verify delegation parity with `_in` variants.

## Testing
- `cargo test -p nils-common` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Test-only change in `crates/nils-common/src/git.rs`; no production behavior changes.
