### PR TITLE
Strengthen nils-test-support cmd option coverage

### DIFF
--- a/crates/nils-test-support/tests/bin_cmd.rs
+++ b/crates/nils-test-support/tests/bin_cmd.rs
@@ -68,3 +68,118 @@ pwd
     let expected = expected.to_string_lossy();
     assert_eq!(stdout, expected);
 }
+
+#[cfg(unix)]
+#[test]
+fn run_with_env_remove_prefix_clears_matching_variables() {
+    let lock = GlobalStateLock::new();
+    let temp = TempDir::new().expect("tempdir");
+    let script = r#"#!/bin/sh
+printf "%s|%s" "${NTS_REMOVE_ME-unset}" "${NTS_KEEP_ME-unset}"
+"#;
+    write_exe(temp.path(), "env-prefix-test", script);
+    let bin = temp.path().join("env-prefix-test");
+
+    let _remove_guard = EnvGuard::set(&lock, "NTS_REMOVE_ME", "present");
+    let _keep_guard = EnvGuard::set(&lock, "NTS_KEEP_ME", "present");
+
+    let options = cmd::CmdOptions::new().with_env_remove_prefix("NTS_REMOVE_");
+    let output = cmd::run_with(&bin, &[], &options);
+
+    assert_eq!(output.code, 0);
+    assert_eq!(output.stdout_text(), "unset|present");
+}
+
+#[cfg(unix)]
+#[test]
+fn run_with_env_set_wins_after_env_remove() {
+    let lock = GlobalStateLock::new();
+    let temp = TempDir::new().expect("tempdir");
+    let script = r#"#!/bin/sh
+printf "%s" "${NTS_VALUE-unset}"
+"#;
+    write_exe(temp.path(), "env-override-test", script);
+    let bin = temp.path().join("env-override-test");
+
+    let _guard = EnvGuard::set(&lock, "NTS_VALUE", "parent");
+    let options = cmd::CmdOptions::new()
+        .with_env_remove("NTS_VALUE")
+        .with_env("NTS_VALUE", "child");
+    let output = cmd::run_with(&bin, &[], &options);
+
+    assert_eq!(output.code, 0);
+    assert_eq!(output.stdout_text(), "child");
+}
+
+#[cfg(unix)]
+#[test]
+fn with_path_prepend_places_directory_before_existing_path() {
+    let temp = TempDir::new().expect("tempdir");
+    let first_dir = temp.path().join("first");
+    let second_dir = temp.path().join("second");
+    std::fs::create_dir_all(&first_dir).expect("create first dir");
+    std::fs::create_dir_all(&second_dir).expect("create second dir");
+
+    write_exe(
+        &first_dir,
+        "path-pick",
+        r#"#!/bin/sh
+printf "first"
+"#,
+    );
+    write_exe(
+        &second_dir,
+        "path-pick",
+        r#"#!/bin/sh
+printf "second"
+"#,
+    );
+    write_exe(
+        temp.path(),
+        "path-runner",
+        r#"#!/bin/sh
+path-pick
+"#,
+    );
+
+    let bin = temp.path().join("path-runner");
+    let base_path = second_dir.to_string_lossy().to_string();
+    let base_options = cmd::CmdOptions::new().with_env("PATH", &base_path);
+    let base = cmd::run_with(&bin, &[], &base_options);
+    assert_eq!(base.code, 0);
+    assert_eq!(base.stdout_text(), "second");
+
+    let prefixed_options = base_options.with_path_prepend(&first_dir);
+    let prefixed = cmd::run_with(&bin, &[], &prefixed_options);
+    assert_eq!(prefixed.code, 0);
+    assert_eq!(prefixed.stdout_text(), "first");
+}
+
+#[cfg(unix)]
+#[test]
+fn run_in_dir_with_overrides_options_cwd() {
+    let temp = TempDir::new().expect("tempdir");
+    let dir_arg = temp.path().join("arg-dir");
+    let option_dir = temp.path().join("option-dir");
+    std::fs::create_dir_all(&dir_arg).expect("create arg dir");
+    std::fs::create_dir_all(&option_dir).expect("create option dir");
+
+    write_exe(
+        temp.path(),
+        "pwd-override-test",
+        r#"#!/bin/sh
+pwd
+"#,
+    );
+    let bin = temp.path().join("pwd-override-test");
+    let options = cmd::CmdOptions::new().with_cwd(&option_dir);
+
+    let output = cmd::run_in_dir_with(&dir_arg, &bin, &[], &options);
+    let stdout = output.stdout_text();
+    let stdout = stdout.trim_end();
+    let expected = std::fs::canonicalize(&dir_arg).expect("canonical");
+    let expected = expected.to_string_lossy();
+
+    assert_eq!(output.code, 0);
+    assert_eq!(stdout, expected);
+}


### PR DESCRIPTION
# Strengthen nils-test-support cmd option coverage

## Summary
This PR adds characterization tests for `nils-test-support::cmd` option behavior so shared test helpers stay stable across crates that rely on command execution wrappers.

## Changes
- Add coverage for `CmdOptions::with_env_remove_prefix` to confirm targeted environment removal without touching unrelated variables.
- Add coverage for env remove + env set precedence, and for `with_path_prepend` command resolution ordering.
- Add coverage for `run_in_dir_with` precedence to verify explicit `dir` argument overrides `options.cwd`.

## Testing
- `cargo test -p nils-test-support` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Test-only change in `crates/nils-test-support/tests/bin_cmd.rs`; no runtime logic changes.
