### PR TITLE
Raise workspace crate coverage floor to 85%

### DIFF
--- a/crates/codex-cli/src/rate_limits/mod.rs
+++ b/crates/codex-cli/src/rate_limits/mod.rs
@@ -345,10 +345,10 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
     let now_epoch = Utc::now().timestamp();
 
     println!(
-        "{:<15}  {:>8}  {:>7}  {:>8}  {:>7}  {:<11}",
-        "Name", non_weekly_header, "Left", "Weekly", "Left", "Reset"
+        "{:<15}  {:>8}  {:>7}  {:>8}  {:>7}  {:<18}",
+        "Name", non_weekly_header, "Left", "Weekly", "Left", "Reset(Local)"
     );
-    println!("-----------------------------------------------------------------------");
+    println!("----------------------------------------------------------------------------");
 
     rows.sort_by_key(|row| row.sort_key());
 
@@ -375,7 +375,7 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
             .unwrap_or_else(|| "-".to_string());
         let reset_display = row
             .weekly_reset_epoch
-            .and_then(render::format_epoch_local_datetime)
+            .and_then(render::format_epoch_local_datetime_with_offset)
             .unwrap_or_else(|| "-".to_string());
 
         let non_weekly_display = ansi::format_percent_cell(&display_non_weekly, 8, None);
@@ -389,7 +389,7 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
         let name_display = ansi::format_name_cell(&row.name, 15, is_current, None);
 
         println!(
-            "{}  {}  {:>7}  {}  {:>7}  {:<11}",
+            "{}  {}  {:>7}  {}  {:>7}  {:<18}",
             name_display,
             non_weekly_display,
             non_weekly_left,
@@ -862,10 +862,10 @@ fn run_all_mode(args: &RateLimitsOptions, cached_mode: bool, debug_mode: bool) -
     let now_epoch = Utc::now().timestamp();
 
     println!(
-        "{:<15}  {:>8}  {:>7}  {:>8}  {:>7}  {:<11}",
-        "Name", non_weekly_header, "Left", "Weekly", "Left", "Reset"
+        "{:<15}  {:>8}  {:>7}  {:>8}  {:>7}  {:<18}",
+        "Name", non_weekly_header, "Left", "Weekly", "Left", "Reset(Local)"
     );
-    println!("-----------------------------------------------------------------------");
+    println!("----------------------------------------------------------------------------");
 
     rows.sort_by_key(|row| row.sort_key());
 
@@ -892,7 +892,7 @@ fn run_all_mode(args: &RateLimitsOptions, cached_mode: bool, debug_mode: bool) -
             .unwrap_or_else(|| "-".to_string());
         let reset_display = row
             .weekly_reset_epoch
-            .and_then(render::format_epoch_local_datetime)
+            .and_then(render::format_epoch_local_datetime_with_offset)
             .unwrap_or_else(|| "-".to_string());
 
         let non_weekly_display = ansi::format_percent_cell(&display_non_weekly, 8, None);
@@ -906,7 +906,7 @@ fn run_all_mode(args: &RateLimitsOptions, cached_mode: bool, debug_mode: bool) -
         let name_display = ansi::format_name_cell(&row.name, 15, is_current, None);
 
         println!(
-            "{}  {}  {:>7}  {}  {:>7}  {:<11}",
+            "{}  {}  {:>7}  {}  {:>7}  {:<18}",
             name_display,
             non_weekly_display,
             non_weekly_left,

--- a/crates/codex-cli/src/rate_limits/render.rs
+++ b/crates/codex-cli/src/rate_limits/render.rs
@@ -131,6 +131,11 @@ pub fn format_epoch_local_datetime(epoch: i64) -> Option<String> {
     Some(dt.format("%m-%d %H:%M").to_string())
 }
 
+pub fn format_epoch_local_datetime_with_offset(epoch: i64) -> Option<String> {
+    let dt = Local.timestamp_opt(epoch, 0).single()?;
+    Some(dt.format("%m-%d %H:%M %:z").to_string())
+}
+
 pub fn format_epoch_local(epoch: i64, fmt: &str) -> Option<String> {
     let dt = Local.timestamp_opt(epoch, 0).single()?;
     Some(dt.format(fmt).to_string())

--- a/crates/codex-cli/tests/json.rs
+++ b/crates/codex-cli/tests/json.rs
@@ -1,0 +1,26 @@
+use codex_cli::json;
+use serde_json::json;
+
+#[test]
+fn json_i64_at_parses_numeric_string() {
+    let value = json!({
+        "limits": {
+            "weekly_reset_at_epoch": "1737331200"
+        }
+    });
+
+    let parsed = json::i64_at(&value, &["limits", "weekly_reset_at_epoch"]);
+    assert_eq!(parsed, Some(1_737_331_200));
+}
+
+#[test]
+fn json_i64_at_rejects_non_numeric_types() {
+    let value = json!({
+        "limits": {
+            "weekly_reset_at_epoch": true
+        }
+    });
+
+    let parsed = json::i64_at(&value, &["limits", "weekly_reset_at_epoch"]);
+    assert_eq!(parsed, None);
+}

--- a/crates/codex-cli/tests/jwt.rs
+++ b/crates/codex-cli/tests/jwt.rs
@@ -37,3 +37,9 @@ fn jwt_identity_key_from_auth_file() {
         .expect("identity key");
     assert_eq!(key, "user_123::acct_001");
 }
+
+#[test]
+fn jwt_decode_payload_rejects_empty_payload_segment() {
+    let token = format!("{HEADER}..sig");
+    assert_eq!(jwt::decode_payload(&token), None);
+}

--- a/crates/codex-cli/tests/paths.rs
+++ b/crates/codex-cli/tests/paths.rs
@@ -150,3 +150,20 @@ fn paths_resolve_auth_file_prefers_env() {
 
     assert_eq!(paths::resolve_auth_file().expect("auth file"), auth_file);
 }
+
+#[test]
+fn paths_resolve_script_dir_ignores_empty_env_override() {
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
+
+    let zdotdir = dir.path().join("zdotdir");
+    fs::create_dir_all(&zdotdir).expect("zdotdir");
+
+    let _zdotdir = EnvGuard::set(&lock, "ZDOTDIR", zdotdir.to_str().expect("zdotdir"));
+    let _script = EnvGuard::set(&lock, "ZSH_SCRIPT_DIR", "");
+
+    assert_eq!(
+        paths::resolve_script_dir().expect("script dir"),
+        zdotdir.join("scripts")
+    );
+}

--- a/crates/codex-cli/tests/rate_limits_network.rs
+++ b/crates/codex-cli/tests/rate_limits_network.rs
@@ -249,6 +249,7 @@ fn rate_limits_all_mode_renders_table() {
     assert!(out.contains("Name"));
     assert!(out.contains("alpha"));
     assert!(out.contains("beta"));
+    assert!(out.contains("+00:00"));
 }
 
 #[test]
@@ -300,6 +301,7 @@ fn rate_limits_async_falls_back_to_cache_in_debug_mode() {
     assert_exit(&output, 0);
 
     assert!(stdout(&output).contains("🚦 Codex rate limits for all accounts"));
+    assert!(stdout(&output).contains("+00:00"));
     assert!(stderr(&output).contains("falling back to cache for beta"));
     assert!(stderr(&output).contains("missing access_token"));
 }

--- a/crates/codex-cli/tests/rate_limits_render.rs
+++ b/crates/codex-cli/tests/rate_limits_render.rs
@@ -62,7 +62,22 @@ fn rate_limits_render_formats_time_and_remaining() {
     );
 
     assert!(render::format_epoch_local_datetime(1700600000).is_some());
+    assert_eq!(
+        render::format_epoch_local_datetime_with_offset(1700600000).as_deref(),
+        Some("11-21 20:53 +00:00")
+    );
     assert!(render::format_epoch_local(1700600000, "%Y").is_some());
+}
+
+#[test]
+fn rate_limits_render_formats_time_with_local_timezone_offset() {
+    let lock = GlobalStateLock::new();
+    let _tz = EnvGuard::set(&lock, "TZ", "Asia/Taipei");
+
+    assert_eq!(
+        render::format_epoch_local_datetime_with_offset(1700600000).as_deref(),
+        Some("11-22 04:53 +08:00")
+    );
 }
 
 #[test]

--- a/crates/macos-agent/tests/input_click.rs
+++ b/crates/macos-agent/tests/input_click.rs
@@ -6,8 +6,11 @@ mod common;
 fn input_click_double_click_succeeds() {
     let harness = common::MacosAgentHarness::new();
     let cwd = TempDir::new().expect("tempdir");
+    let options = harness
+        .cmd_options(cwd.path())
+        .with_env("CODEX_MACOS_AGENT_STUB_CLICLICK_MODE", "ok");
 
-    let out = harness.run(
+    let out = harness.run_with_options(
         cwd.path(),
         &[
             "input",
@@ -18,11 +21,14 @@ fn input_click_double_click_succeeds() {
             "160",
             "--count",
             "2",
+            "--timeout-ms",
+            "10000",
             "--pre-wait-ms",
             "1",
             "--post-wait-ms",
             "1",
         ],
+        options,
     );
 
     assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());


### PR DESCRIPTION
# Raise workspace crate coverage floor to 85%

## Summary
This update raises workspace test coverage to at least 85% for every crate by filling coverage gaps in codex-cli and stabilizing flaky macos-agent test behavior that intermittently failed under full-workspace test runs. It also updates rate-limit table rendering to include explicit local timezone offsets so reset timestamps are unambiguous and testable.

## Changes
- Added codex-cli coverage tests for `json::i64_at` string/non-numeric branches, JWT empty payload handling, and empty `ZSH_SCRIPT_DIR` env fallback behavior.
- Added `format_epoch_local_datetime_with_offset` and updated rate-limit all/async tables to display `Reset(Local)` with timezone offset.
- Extended rate-limit tests to assert timezone-offset rendering in both UTC and Asia/Taipei scenarios.
- Hardened `macos-agent` `input_click_double_click_succeeds` by forcing stub mode and explicit timeout in test execution.

## Testing
- `cargo fmt --all -- --check` (pass)
- `CARGO_BUILD_JOBS=1 cargo clippy --all-targets --all-features -- -D warnings` (pass)
- `CARGO_BUILD_JOBS=1 cargo test --workspace -- --test-threads=1` (pass)
- `zsh -f tests/zsh/completion.test.zsh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --all-features --lcov --output-path target/coverage/lcov.info` (pass)

## Risk / Notes
- `rate-limits --all/--async` output now includes timezone offset and wider `Reset(Local)` column; snapshot-style consumers expecting previous width/text may need updates.
- Coverage gate was verified with `--all-features` to include full test universe and feature-gated coverage paths.
