### PR TITLE
Use local time for starship reset output

### DIFF
--- a/completions/bash/codex-cli
+++ b/completions/bash/codex-cli
@@ -210,7 +210,7 @@ _nils_cli_codex_cli_complete() {
         return 0
       fi
       if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --no-5h --ttl --time-format --refresh --is-enabled" -- "$cur") )
+        COMPREPLY=( $(compgen -W "-h --help --no-5h --ttl --time-format --show-timezone --refresh --is-enabled" -- "$cur") )
         return 0
       fi
       COMPREPLY=()
@@ -229,4 +229,3 @@ complete -F _nils_cli_codex_cli_complete \
   codex-cli cx \
   cxgp cxga cxgk cxgc cxau cxar cxaa cxac cxas cxst cxdr cxdra \
   cxcs cxct
-

--- a/completions/zsh/_codex-cli
+++ b/completions/zsh/_codex-cli
@@ -378,7 +378,8 @@ _codex-cli() {
         '(-h --help)'{-h,--help}'[Show help]' \
         '--no-5h[Hide the 5h window output]' \
         '--ttl=[Cache TTL]:duration:' \
-        '--time-format=[Reset time format (UTC)]:strftime:' \
+        '--time-format=[Reset time format (local time)]:strftime:' \
+        '--show-timezone[Show timezone offset in default reset time display]' \
         '--refresh[Force a blocking refresh]' \
         '--is-enabled[Exit 0 if starship is enabled]' \
         && return 0

--- a/crates/codex-cli/README.md
+++ b/crates/codex-cli/README.md
@@ -45,7 +45,7 @@ Help:
 - `set <key> <value>`: Emit a shell snippet for the current shell.
 
 ### starship
-- `starship [--no-5h] [--ttl <duration>] [--time-format <strftime>] [--refresh] [--is-enabled]`: Render or refresh the Starship line.
+- `starship [--no-5h] [--ttl <duration>] [--time-format <strftime>] [--show-timezone] [--refresh] [--is-enabled]`: Render or refresh the Starship line. Default reset time uses local time without timezone; `--show-timezone` adds the local offset.
 
 ## Environment
 - `CODEX_ALLOW_DANGEROUS_ENABLED=true` is required for `agent` commands.

--- a/crates/codex-cli/src/cli.rs
+++ b/crates/codex-cli/src/cli.rs
@@ -155,9 +155,12 @@ pub struct StarshipArgs {
     /// Cache TTL
     #[arg(long = "ttl")]
     pub ttl: Option<String>,
-    /// Reset time format (UTC)
+    /// Reset time format (local time)
     #[arg(long = "time-format")]
     pub time_format: Option<String>,
+    /// Show timezone offset in the default reset time display
+    #[arg(long = "show-timezone")]
+    pub show_timezone: bool,
     /// Force a blocking refresh
     #[arg(long = "refresh")]
     pub refresh: bool,

--- a/crates/codex-cli/src/main.rs
+++ b/crates/codex-cli/src/main.rs
@@ -133,6 +133,7 @@ fn handle_starship(args: &cli::StarshipArgs) -> i32 {
         no_5h: args.no_5h,
         ttl: args.ttl.clone(),
         time_format: args.time_format.clone(),
+        show_timezone: args.show_timezone,
         refresh: args.refresh,
         is_enabled: args.is_enabled,
     };

--- a/crates/codex-cli/src/starship/mod.rs
+++ b/crates/codex-cli/src/starship/mod.rs
@@ -15,12 +15,14 @@ pub struct StarshipOptions {
     pub no_5h: bool,
     pub ttl: Option<String>,
     pub time_format: Option<String>,
+    pub show_timezone: bool,
     pub refresh: bool,
     pub is_enabled: bool,
 }
 
 const DEFAULT_TTL_SECONDS: u64 = 300;
 const DEFAULT_TIME_FORMAT: &str = "%m-%d %H:%M";
+const DEFAULT_TIME_FORMAT_WITH_TIMEZONE: &str = "%m-%d %H:%M %:z";
 
 pub fn run(options: &StarshipOptions) -> i32 {
     if options.is_enabled {
@@ -46,10 +48,11 @@ pub fn run(options: &StarshipOptions) -> i32 {
 
     let show_5h =
         shared_env::env_truthy_or("CODEX_STARSHIP_SHOW_5H_ENABLED", true) && !options.no_5h;
-    let time_format = options
-        .time_format
-        .as_deref()
-        .unwrap_or(DEFAULT_TIME_FORMAT);
+    let time_format = match options.time_format.as_deref() {
+        Some(value) => value,
+        None if options.show_timezone => DEFAULT_TIME_FORMAT_WITH_TIMEZONE,
+        None => DEFAULT_TIME_FORMAT,
+    };
     let stale_suffix =
         std::env::var("CODEX_STARSHIP_STALE_SUFFIX").unwrap_or_else(|_| " (stale)".to_string());
 
@@ -135,7 +138,9 @@ fn parse_duration_seconds(raw: &str) -> Option<u64> {
 
 fn print_ttl_usage() {
     eprintln!("codex-cli starship: invalid --ttl");
-    eprintln!("usage: codex-cli starship [--no-5h] [--ttl <duration>] [--time-format <strftime>] [--refresh] [--is-enabled]");
+    eprintln!(
+        "usage: codex-cli starship [--no-5h] [--ttl <duration>] [--time-format <strftime>] [--show-timezone] [--refresh] [--is-enabled]"
+    );
 }
 
 fn read_cached_entry(target_file: &Path, ttl_seconds: u64) -> (Option<CacheEntry>, bool) {

--- a/crates/codex-cli/src/starship/render.rs
+++ b/crates/codex-cli/src/starship/render.rs
@@ -1,4 +1,4 @@
-use chrono::{TimeZone, Utc};
+use chrono::{Local, TimeZone};
 use nils_common::env as shared_env;
 use std::io::{self, IsTerminal};
 use std::path::Path;
@@ -69,7 +69,7 @@ pub fn render_line(
     show_5h: bool,
     weekly_reset_time_format: &str,
 ) -> Option<String> {
-    let weekly_reset_time = format_epoch_utc(entry.weekly_reset_epoch, weekly_reset_time_format)
+    let weekly_reset_time = format_epoch_local(entry.weekly_reset_epoch, weekly_reset_time_format)
         .unwrap_or_else(|| "?".to_string());
 
     let color_enabled = should_color();
@@ -91,8 +91,8 @@ pub fn render_line(
     Some(format!("{prefix}{weekly_token} {weekly_reset_time}"))
 }
 
-fn format_epoch_utc(epoch: i64, fmt: &str) -> Option<String> {
-    let dt = Utc.timestamp_opt(epoch, 0).single()?;
+fn format_epoch_local(epoch: i64, fmt: &str) -> Option<String> {
+    let dt = Local.timestamp_opt(epoch, 0).single()?;
     Some(dt.format(fmt).to_string())
 }
 

--- a/crates/codex-cli/tests/starship_cached.rs
+++ b/crates/codex-cli/tests/starship_cached.rs
@@ -13,6 +13,7 @@ fn run(args: &[&str], envs: &[(&str, &Path)], vars: &[(&str, &str)]) -> CmdOutpu
     let mut options = CmdOptions::default()
         // Stabilize output for tests regardless of user shell/starship environment.
         .with_env("NO_COLOR", "1")
+        .with_env("TZ", "UTC")
         .with_env_remove("STARSHIP_SESSION_KEY")
         .with_env_remove("STARSHIP_SHELL");
     for (key, path) in envs {
@@ -178,6 +179,45 @@ fn starship_cached_output_formats_and_supports_no_5h() {
     );
     assert_exit(&output, 0);
     assert_eq!(stdout(&output), "alpha W:88% 2023-11-21T20:53Z\n");
+}
+
+#[test]
+fn starship_default_time_uses_local_format_and_show_timezone_flag() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let (auth_file, secrets, cache_root) = write_auth_and_secret(&dir);
+
+    let fetched_at = now_epoch().saturating_sub(1).max(1);
+    write_starship_cache_kv(
+        &cache_root,
+        "alpha",
+        &format!(
+            "fetched_at={fetched_at}\nnon_weekly_label=5h\nnon_weekly_remaining=94\nweekly_remaining=88\nweekly_reset_epoch=1700600000\n"
+        ),
+    );
+
+    let output = run(
+        &["starship"],
+        &[
+            ("CODEX_AUTH_FILE", &auth_file),
+            ("CODEX_SECRET_DIR", &secrets),
+            ("ZSH_CACHE_DIR", &cache_root),
+        ],
+        &[("CODEX_STARSHIP_ENABLED", "true")],
+    );
+    assert_exit(&output, 0);
+    assert_eq!(stdout(&output), "alpha 5h:94% W:88% 11-21 20:53\n");
+
+    let output = run(
+        &["starship", "--show-timezone"],
+        &[
+            ("CODEX_AUTH_FILE", &auth_file),
+            ("CODEX_SECRET_DIR", &secrets),
+            ("ZSH_CACHE_DIR", &cache_root),
+        ],
+        &[("CODEX_STARSHIP_ENABLED", "true")],
+    );
+    assert_exit(&output, 0);
+    assert_eq!(stdout(&output), "alpha 5h:94% W:88% 11-21 20:53 +00:00\n");
 }
 
 #[test]

--- a/crates/codex-cli/tests/starship_refresh.rs
+++ b/crates/codex-cli/tests/starship_refresh.rs
@@ -15,6 +15,7 @@ fn run(args: &[&str], envs: &[(&str, &Path)], vars: &[(&str, &str)]) -> CmdOutpu
     let mut options = CmdOptions::default()
         // Stabilize output for tests regardless of user shell/starship environment.
         .with_env("NO_COLOR", "1")
+        .with_env("TZ", "UTC")
         .with_env_remove("STARSHIP_SESSION_KEY")
         .with_env_remove("STARSHIP_SHELL");
     for (key, path) in envs {


### PR DESCRIPTION
# Use local time for starship reset output

## Summary
This change updates `codex-cli starship` so reset timestamps are rendered in local time by default, keeps the default output compact by omitting timezone text, and adds an explicit flag to show timezone when needed.

## Changes
- Switch Starship reset-time rendering from UTC to local time.
- Add `--show-timezone` to append local offset in the default reset-time display.
- Wire the new flag through CLI parsing and runtime options.
- Update Zsh/Bash completions and codex-cli README for the new flag and behavior.
- Add/update integration tests to cover default local-time formatting and timezone display.

## Testing
- `cargo test -p codex-cli` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Existing users who expected UTC in default starship output will now see local time instead.
- `--time-format` remains available and still overrides the default format behavior.
