### PR TITLE
Add linked-worktree fallback to agent-docs policy resolution

### DIFF
--- a/crates/agent-docs/README.md
+++ b/crates/agent-docs/README.md
@@ -226,6 +226,47 @@ Flags:
 - Evaluates baseline required docs for selected target scope(s).
 - Missing required baseline docs cause exit `1` only when `--strict` is set.
 
+## Worktree fallback
+
+Worktree fallback is deterministic and applies only to project-scope required docs when running
+from a linked worktree in `auto` mode.
+
+### Fallback order (project scope)
+
+`startup` project policy:
+
+1. `<PROJECT_PATH>/AGENTS.override.md`
+2. `<PROJECT_PATH>/AGENTS.md`
+3. `<PRIMARY_WORKTREE_PATH>/AGENTS.override.md` (fallback)
+4. `<PRIMARY_WORKTREE_PATH>/AGENTS.md` (fallback)
+
+`project-dev` required project docs (built-ins and required project-scope extension entries):
+
+1. `<PROJECT_PATH>/<doc-path>`
+2. `<PRIMARY_WORKTREE_PATH>/<doc-path>` (fallback)
+
+### Strict and compatibility semantics
+
+- `--strict` exits `1` only when all candidates in the deterministic order are missing.
+- `local-only` mode disables `<PRIMARY_WORKTREE_PATH>` fallback candidates and enforces local
+  project paths only.
+- Non-worktree repositories are unchanged: only `<PROJECT_PATH>` candidates are evaluated.
+
+### Output disclosure and local-only operation
+
+When fallback is used, output must disclose fallback provenance in addition to required-doc
+presence.
+
+- `text`/`json`: include a fallback source marker and the resolved fallback path.
+- `checklist`: keep required-doc status lines and include fallback provenance in the same report.
+
+To disable fallback, run resolve/baseline in `local-only` mode.
+
+```bash
+agent-docs --worktree-fallback local-only resolve --context startup --strict --format checklist
+agent-docs --worktree-fallback local-only baseline --check --target project --strict --format text
+```
+
 ## Output Contract
 
 ### `resolve` text example

--- a/crates/agent-docs/src/cli.rs
+++ b/crates/agent-docs/src/cli.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
 
-use crate::model::{BaselineTarget, Context, DocumentWhen, OutputFormat, ResolveFormat, Scope};
+use crate::model::{
+    BaselineTarget, Context, DocumentWhen, FallbackMode, OutputFormat, ResolveFormat, Scope,
+};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -17,6 +19,17 @@ pub struct Cli {
 
     #[arg(long, global = true, value_name = "PATH")]
     pub project_path: Option<PathBuf>,
+
+    #[arg(
+        long = "worktree-fallback",
+        global = true,
+        value_enum,
+        default_value_t = FallbackMode::Auto,
+        value_name = "MODE",
+        help = "Project worktree fallback mode",
+        long_help = "Project worktree fallback mode. auto enables linked-worktree fallback to the primary worktree; local-only disables fallback and enforces local project files only."
+    )]
+    pub worktree_fallback: FallbackMode,
 
     #[command(subcommand)]
     pub command: Command,

--- a/crates/agent-docs/src/commands/add.rs
+++ b/crates/agent-docs/src/commands/add.rs
@@ -285,6 +285,9 @@ mod tests {
         ResolvedRoots {
             codex_home: home.path().to_path_buf(),
             project_path: project.path().to_path_buf(),
+            is_linked_worktree: false,
+            git_common_dir: None,
+            primary_worktree_path: None,
         }
     }
 

--- a/crates/agent-docs/src/commands/baseline.rs
+++ b/crates/agent-docs/src/commands/baseline.rs
@@ -5,7 +5,7 @@ use crate::config::load_configs_from_roots;
 use crate::env::ResolvedRoots;
 use crate::model::{
     BaselineCheckItem, BaselineCheckReport, BaselineTarget, ConfigDocumentEntry, ConfigLoadError,
-    ConfigScopeFile, Context, DocumentSource, DocumentStatus, Scope,
+    ConfigScopeFile, Context, DocumentSource, DocumentStatus, FallbackMode, Scope,
 };
 use crate::paths::normalize_path;
 
@@ -14,7 +14,16 @@ pub fn check_builtin_baseline(
     roots: &ResolvedRoots,
     strict: bool,
 ) -> Result<BaselineCheckReport, ConfigLoadError> {
-    let mut items = builtin_items_for_target(target, roots);
+    check_builtin_baseline_with_mode(target, roots, strict, FallbackMode::Auto)
+}
+
+pub fn check_builtin_baseline_with_mode(
+    target: BaselineTarget,
+    roots: &ResolvedRoots,
+    strict: bool,
+    fallback_mode: FallbackMode,
+) -> Result<BaselineCheckReport, ConfigLoadError> {
+    let mut items = builtin_items_for_target(target, roots, fallback_mode);
     let builtin_keys: HashSet<BaselineKey> = items.iter().map(BaselineKey::from_item).collect();
 
     let configs = load_configs_from_roots(roots)?;
@@ -22,6 +31,7 @@ pub fn check_builtin_baseline(
     items.extend(required_extension_items(
         target,
         roots,
+        fallback_mode,
         &configs_in_load_order,
         &builtin_keys,
     ));
@@ -41,14 +51,15 @@ pub fn check_builtin_baseline(
 fn builtin_items_for_target(
     target: BaselineTarget,
     roots: &ResolvedRoots,
+    fallback_mode: FallbackMode,
 ) -> Vec<BaselineCheckItem> {
     let mut items = Vec::new();
     match target {
         BaselineTarget::Home => items.extend(home_items(roots)),
-        BaselineTarget::Project => items.extend(project_items(roots)),
+        BaselineTarget::Project => items.extend(project_items(roots, fallback_mode)),
         BaselineTarget::All => {
             items.extend(home_items(roots));
-            items.extend(project_items(roots));
+            items.extend(project_items(roots, fallback_mode));
         }
     }
     items
@@ -56,7 +67,7 @@ fn builtin_items_for_target(
 
 fn home_items(roots: &ResolvedRoots) -> Vec<BaselineCheckItem> {
     vec![
-        startup_policy_item(Scope::Home, &roots.codex_home),
+        startup_policy_item(Scope::Home, &roots.codex_home, None),
         required_item(
             Scope::Home,
             Context::SkillDev,
@@ -78,22 +89,19 @@ fn home_items(roots: &ResolvedRoots) -> Vec<BaselineCheckItem> {
     ]
 }
 
-fn project_items(roots: &ResolvedRoots) -> Vec<BaselineCheckItem> {
+fn project_items(roots: &ResolvedRoots, fallback_mode: FallbackMode) -> Vec<BaselineCheckItem> {
+    let project_fallback_root = project_fallback_root(roots, fallback_mode);
     vec![
-        startup_policy_item(Scope::Project, &roots.project_path),
-        required_item(
-            Scope::Project,
-            Context::ProjectDev,
-            "project-dev",
-            &roots.project_path,
-            "DEVELOPMENT.md",
-            "project development guidance from PROJECT_PATH/DEVELOPMENT.md",
-            DocumentSource::Builtin,
-        ),
+        startup_policy_item(Scope::Project, &roots.project_path, project_fallback_root),
+        project_dev_item(&roots.project_path, project_fallback_root),
     ]
 }
 
-fn startup_policy_item(scope: Scope, root: &Path) -> BaselineCheckItem {
+fn startup_policy_item(
+    scope: Scope,
+    root: &Path,
+    fallback_root: Option<&Path>,
+) -> BaselineCheckItem {
     let override_path = normalize_path(&root.join("AGENTS.override.md"));
     if override_path.exists() {
         return BaselineCheckItem {
@@ -111,20 +119,66 @@ fn startup_policy_item(scope: Scope, root: &Path) -> BaselineCheckItem {
         };
     }
 
-    let fallback_path = normalize_path(&root.join("AGENTS.md"));
-    let status = if fallback_path.exists() {
-        DocumentStatus::Present
-    } else {
-        DocumentStatus::Missing
-    };
+    let local_agents = normalize_path(&root.join("AGENTS.md"));
+    if local_agents.exists() {
+        return BaselineCheckItem {
+            scope,
+            context: Context::Startup,
+            label: "startup policy".to_string(),
+            path: local_agents,
+            required: true,
+            status: DocumentStatus::Present,
+            source: DocumentSource::BuiltinFallback,
+            why: format!(
+                "startup {} policy (AGENTS.override.md missing, fallback AGENTS.md)",
+                scope
+            ),
+        };
+    }
+
+    if let Some(fallback_root) = fallback_root {
+        let fallback_override = normalize_path(&fallback_root.join("AGENTS.override.md"));
+        if fallback_override.exists() {
+            return BaselineCheckItem {
+                scope,
+                context: Context::Startup,
+                label: "startup policy".to_string(),
+                path: fallback_override,
+                required: true,
+                status: DocumentStatus::Present,
+                source: DocumentSource::Builtin,
+                why: format!(
+                    "startup {} policy (local missing, fallback to primary AGENTS.override.md)",
+                    scope
+                ),
+            };
+        }
+
+        let fallback_agents = normalize_path(&fallback_root.join("AGENTS.md"));
+        if fallback_agents.exists() {
+            return BaselineCheckItem {
+                scope,
+                context: Context::Startup,
+                label: "startup policy".to_string(),
+                path: fallback_agents,
+                required: true,
+                status: DocumentStatus::Present,
+                source: DocumentSource::BuiltinFallback,
+                why: format!(
+                    "startup {} policy (local missing, fallback to primary AGENTS.md)",
+                    scope
+                ),
+            };
+        }
+    }
 
     BaselineCheckItem {
         scope,
         context: Context::Startup,
         label: "startup policy".to_string(),
-        path: fallback_path,
+        path: local_agents,
         required: true,
-        status,
+        status: DocumentStatus::Missing,
         source: DocumentSource::BuiltinFallback,
         why: format!(
             "startup {} policy (AGENTS.override.md missing, fallback AGENTS.md)",
@@ -161,9 +215,53 @@ fn required_item(
     }
 }
 
+fn project_dev_item(root: &Path, fallback_root: Option<&Path>) -> BaselineCheckItem {
+    let local_path = normalize_path(&root.join("DEVELOPMENT.md"));
+    if local_path.exists() {
+        return BaselineCheckItem {
+            scope: Scope::Project,
+            context: Context::ProjectDev,
+            label: "project-dev".to_string(),
+            path: local_path,
+            required: true,
+            status: DocumentStatus::Present,
+            source: DocumentSource::Builtin,
+            why: "project development guidance from PROJECT_PATH/DEVELOPMENT.md".to_string(),
+        };
+    }
+
+    if let Some(fallback_root) = fallback_root {
+        let fallback_path = normalize_path(&fallback_root.join("DEVELOPMENT.md"));
+        if fallback_path.exists() {
+            return BaselineCheckItem {
+                scope: Scope::Project,
+                context: Context::ProjectDev,
+                label: "project-dev".to_string(),
+                path: fallback_path,
+                required: true,
+                status: DocumentStatus::Present,
+                source: DocumentSource::Builtin,
+                why: "project development guidance from PROJECT_PATH/DEVELOPMENT.md (fallback to primary worktree)".to_string(),
+            };
+        }
+    }
+
+    BaselineCheckItem {
+        scope: Scope::Project,
+        context: Context::ProjectDev,
+        label: "project-dev".to_string(),
+        path: local_path,
+        required: true,
+        status: DocumentStatus::Missing,
+        source: DocumentSource::Builtin,
+        why: "project development guidance from PROJECT_PATH/DEVELOPMENT.md".to_string(),
+    }
+}
+
 fn required_extension_items(
     target: BaselineTarget,
     roots: &ResolvedRoots,
+    fallback_mode: FallbackMode,
     configs_in_load_order: &[&ConfigScopeFile],
     builtin_keys: &HashSet<BaselineKey>,
 ) -> Vec<BaselineCheckItem> {
@@ -174,6 +272,7 @@ fn required_extension_items(
         merge_required_extension_items(
             target,
             roots,
+            fallback_mode,
             config,
             builtin_keys,
             &mut extension_items,
@@ -187,6 +286,7 @@ fn required_extension_items(
 fn merge_required_extension_items(
     target: BaselineTarget,
     roots: &ResolvedRoots,
+    fallback_mode: FallbackMode,
     config: &ConfigScopeFile,
     builtin_keys: &HashSet<BaselineKey>,
     extension_items: &mut Vec<BaselineCheckItem>,
@@ -197,7 +297,7 @@ fn merge_required_extension_items(
             continue;
         }
 
-        let path = resolve_extension_path(entry, roots);
+        let path = resolve_extension_path_with_project_fallback(entry, roots, fallback_mode);
         let key = BaselineKey::new(entry.context, entry.scope, path.clone());
         if builtin_keys.contains(&key) {
             continue;
@@ -249,6 +349,30 @@ fn resolve_extension_path(entry: &ConfigDocumentEntry, roots: &ResolvedRoots) ->
         Scope::Project => &roots.project_path,
     };
     normalize_path(&root.join(&entry.path))
+}
+
+fn resolve_extension_path_with_project_fallback(
+    entry: &ConfigDocumentEntry,
+    roots: &ResolvedRoots,
+    fallback_mode: FallbackMode,
+) -> PathBuf {
+    let local_path = resolve_extension_path(entry, roots);
+    if local_path.exists()
+        || !should_use_project_fallback(entry.scope, entry.required, fallback_mode)
+    {
+        return local_path;
+    }
+
+    let Some(primary_root) = project_fallback_root(roots, fallback_mode) else {
+        return local_path;
+    };
+
+    let fallback_path = normalize_path(&primary_root.join(&entry.path));
+    if fallback_path.exists() {
+        fallback_path
+    } else {
+        local_path
+    }
 }
 
 fn extension_why(config: &ConfigScopeFile, index: usize, entry: &ConfigDocumentEntry) -> String {
@@ -309,4 +433,16 @@ fn suggested_actions(items: &[BaselineCheckItem]) -> Vec<String> {
     }
 
     actions
+}
+
+fn project_fallback_root(roots: &ResolvedRoots, fallback_mode: FallbackMode) -> Option<&Path> {
+    if fallback_mode == FallbackMode::Auto && roots.is_linked_worktree {
+        roots.primary_worktree_path.as_deref()
+    } else {
+        None
+    }
+}
+
+fn should_use_project_fallback(scope: Scope, required: bool, fallback_mode: FallbackMode) -> bool {
+    scope == Scope::Project && required && fallback_mode == FallbackMode::Auto
 }

--- a/crates/agent-docs/src/commands/scaffold_agents.rs
+++ b/crates/agent-docs/src/commands/scaffold_agents.rs
@@ -184,6 +184,9 @@ mod tests {
         ResolvedRoots {
             codex_home: home.path().to_path_buf(),
             project_path: project.path().to_path_buf(),
+            is_linked_worktree: false,
+            git_common_dir: None,
+            primary_worktree_path: None,
         }
     }
 

--- a/crates/agent-docs/src/commands/scaffold_baseline.rs
+++ b/crates/agent-docs/src/commands/scaffold_baseline.rs
@@ -469,6 +469,9 @@ mod tests {
         ResolvedRoots {
             codex_home: home.path().to_path_buf(),
             project_path: project.path().to_path_buf(),
+            is_linked_worktree: false,
+            git_common_dir: None,
+            primary_worktree_path: None,
         }
     }
 

--- a/crates/agent-docs/src/env.rs
+++ b/crates/agent-docs/src/env.rs
@@ -17,16 +17,23 @@ pub struct PathOverrides {
 pub struct ResolvedRoots {
     pub codex_home: PathBuf,
     pub project_path: PathBuf,
+    pub is_linked_worktree: bool,
+    pub git_common_dir: Option<PathBuf>,
+    pub primary_worktree_path: Option<PathBuf>,
 }
 
 pub fn resolve_roots(overrides: &PathOverrides) -> Result<ResolvedRoots> {
     let cwd = env::current_dir().context("failed to read current directory")?;
     let codex_home = resolve_codex_home(overrides.codex_home.as_deref(), &cwd);
     let project_path = resolve_project_path(overrides.project_path.as_deref(), &cwd);
+    let metadata = resolve_linked_worktree_metadata(&project_path);
 
     Ok(ResolvedRoots {
         codex_home,
         project_path,
+        is_linked_worktree: metadata.is_linked_worktree,
+        git_common_dir: metadata.git_common_dir,
+        primary_worktree_path: metadata.primary_worktree_path,
     })
 }
 
@@ -73,8 +80,43 @@ fn read_env_path(name: &str) -> Option<PathBuf> {
 }
 
 fn git_top_level(cwd: &Path) -> Option<PathBuf> {
+    git_rev_parse_path(cwd, "--show-toplevel")
+}
+
+#[derive(Debug, Default)]
+struct LinkedWorktreeMetadata {
+    is_linked_worktree: bool,
+    git_common_dir: Option<PathBuf>,
+    primary_worktree_path: Option<PathBuf>,
+}
+
+fn resolve_linked_worktree_metadata(cwd: &Path) -> LinkedWorktreeMetadata {
+    let absolute_git_dir = git_rev_parse_path(cwd, "--absolute-git-dir");
+    let git_common_dir = git_rev_parse_path(cwd, "--git-common-dir");
+
+    let Some(git_common_dir) = git_common_dir else {
+        return LinkedWorktreeMetadata::default();
+    };
+
+    let is_linked_worktree = absolute_git_dir
+        .as_ref()
+        .is_some_and(|git_dir| git_dir != &git_common_dir);
+    let primary_worktree_path = if is_linked_worktree {
+        git_common_dir.parent().map(Path::to_path_buf)
+    } else {
+        None
+    };
+
+    LinkedWorktreeMetadata {
+        is_linked_worktree,
+        git_common_dir: Some(git_common_dir),
+        primary_worktree_path,
+    }
+}
+
+fn git_rev_parse_path(cwd: &Path, arg: &str) -> Option<PathBuf> {
     let output = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
+        .args(["rev-parse", arg])
         .current_dir(cwd)
         .output()
         .ok()?;
@@ -88,6 +130,6 @@ fn git_top_level(cwd: &Path) -> Option<PathBuf> {
     if trimmed.is_empty() {
         None
     } else {
-        Some(PathBuf::from(trimmed))
+        Some(normalize_root_path(Path::new(trimmed), cwd))
     }
 }

--- a/crates/agent-docs/src/lib.rs
+++ b/crates/agent-docs/src/lib.rs
@@ -44,6 +44,7 @@ where
 }
 
 fn dispatch(cli: Cli) -> i32 {
+    let fallback_mode = cli.worktree_fallback;
     let overrides = PathOverrides {
         codex_home: cli.codex_home,
         project_path: cli.project_path,
@@ -60,13 +61,15 @@ fn dispatch(cli: Cli) -> i32 {
                 Err(code) => return code,
             };
 
-            let report = match resolver::resolve(args.context, &roots, args.strict) {
-                Ok(report) => report,
-                Err(err) => {
-                    eprintln!("error: {err}");
-                    return config_error_exit_code(&err);
-                }
-            };
+            let report =
+                match resolver::resolve_with_mode(args.context, &roots, args.strict, fallback_mode)
+                {
+                    Ok(report) => report,
+                    Err(err) => {
+                        eprintln!("error: {err}");
+                        return config_error_exit_code(&err);
+                    }
+                };
             let exit_code = if args.strict && report.has_missing_required() {
                 EXIT_STRICT_MISSING_REQUIRED
             } else {
@@ -151,10 +154,11 @@ fn dispatch(cli: Cli) -> i32 {
                 Ok(roots) => roots,
                 Err(code) => return code,
             };
-            let report = match commands::baseline::check_builtin_baseline(
+            let report = match commands::baseline::check_builtin_baseline_with_mode(
                 args.target,
                 &roots,
                 args.strict,
+                fallback_mode,
             ) {
                 Ok(report) => report,
                 Err(err) => {

--- a/crates/agent-docs/src/model.rs
+++ b/crates/agent-docs/src/model.rs
@@ -110,6 +110,29 @@ impl fmt::Display for OutputFormat {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum, Default)]
 #[serde(rename_all = "kebab-case")]
+pub enum FallbackMode {
+    #[default]
+    Auto,
+    LocalOnly,
+}
+
+impl FallbackMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::LocalOnly => "local-only",
+        }
+    }
+}
+
+impl fmt::Display for FallbackMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum, Default)]
+#[serde(rename_all = "kebab-case")]
 pub enum ResolveFormat {
     #[default]
     Text,
@@ -247,6 +270,9 @@ pub struct ResolveReport {
     pub strict: bool,
     pub codex_home: PathBuf,
     pub project_path: PathBuf,
+    pub is_linked_worktree: bool,
+    pub git_common_dir: Option<PathBuf>,
+    pub primary_worktree_path: Option<PathBuf>,
     pub documents: Vec<ResolvedDocument>,
     pub summary: ResolveSummary,
 }

--- a/crates/agent-docs/src/resolver.rs
+++ b/crates/agent-docs/src/resolver.rs
@@ -5,7 +5,8 @@ use crate::config::load_configs_from_roots;
 use crate::env::ResolvedRoots;
 use crate::model::{
     ConfigDocumentEntry, ConfigLoadError, ConfigScopeFile, Context, DocumentSource, DocumentStatus,
-    LoadedConfigs, ResolveReport, ResolveSummary, ResolvedDocument, Scope, SUPPORTED_CONTEXTS,
+    FallbackMode, LoadedConfigs, ResolveReport, ResolveSummary, ResolvedDocument, Scope,
+    SUPPORTED_CONTEXTS,
 };
 use crate::paths::normalize_path;
 
@@ -18,14 +19,38 @@ pub fn resolve(
     roots: &ResolvedRoots,
     strict: bool,
 ) -> Result<ResolveReport, ConfigLoadError> {
+    resolve_with_mode(context, roots, strict, FallbackMode::Auto)
+}
+
+pub fn resolve_with_mode(
+    context: Context,
+    roots: &ResolvedRoots,
+    strict: bool,
+    fallback_mode: FallbackMode,
+) -> Result<ResolveReport, ConfigLoadError> {
     let configs = load_configs_from_roots(roots)?;
-    Ok(resolve_with_configs(context, roots, strict, &configs))
+    Ok(resolve_with_configs_with_mode(
+        context,
+        roots,
+        strict,
+        fallback_mode,
+        &configs,
+    ))
 }
 
 pub fn resolve_builtin(context: Context, roots: &ResolvedRoots, strict: bool) -> ResolveReport {
-    match resolve(context, roots, strict) {
+    resolve_builtin_with_mode(context, roots, strict, FallbackMode::Auto)
+}
+
+pub fn resolve_builtin_with_mode(
+    context: Context,
+    roots: &ResolvedRoots,
+    strict: bool,
+    fallback_mode: FallbackMode,
+) -> ResolveReport {
+    match resolve_with_mode(context, roots, strict, fallback_mode) {
         Ok(report) => report,
-        Err(_) => resolve_builtin_only(context, roots, strict),
+        Err(_) => resolve_builtin_only_with_mode(context, roots, strict, fallback_mode),
     }
 }
 
@@ -34,8 +59,18 @@ pub fn resolve_builtin_only(
     roots: &ResolvedRoots,
     strict: bool,
 ) -> ResolveReport {
+    resolve_builtin_only_with_mode(context, roots, strict, FallbackMode::Auto)
+}
+
+pub fn resolve_builtin_only_with_mode(
+    context: Context,
+    roots: &ResolvedRoots,
+    strict: bool,
+    fallback_mode: FallbackMode,
+) -> ResolveReport {
+    let project_fallback_root = project_fallback_root(roots, fallback_mode);
     let documents = match context {
-        Context::Startup => resolve_startup(roots),
+        Context::Startup => resolve_startup(roots, fallback_mode),
         Context::SkillDev => vec![resolve_required_doc(
             Context::SkillDev,
             Scope::Home,
@@ -52,13 +87,14 @@ pub fn resolve_builtin_only(
             "tool-selection guidance from CODEX_HOME/CLI_TOOLS.md",
             DocumentSource::Builtin,
         )],
-        Context::ProjectDev => vec![resolve_required_doc(
+        Context::ProjectDev => vec![resolve_required_doc_with_project_fallback(
             Context::ProjectDev,
             Scope::Project,
             &roots.project_path,
             "DEVELOPMENT.md",
             "project development guidance from PROJECT_PATH/DEVELOPMENT.md",
             DocumentSource::Builtin,
+            project_fallback_root,
         )],
     };
 
@@ -69,6 +105,9 @@ pub fn resolve_builtin_only(
         strict,
         codex_home: roots.codex_home.clone(),
         project_path: roots.project_path.clone(),
+        is_linked_worktree: roots.is_linked_worktree,
+        git_common_dir: roots.git_common_dir.clone(),
+        primary_worktree_path: roots.primary_worktree_path.clone(),
         documents,
         summary,
     }
@@ -80,7 +119,18 @@ pub fn resolve_with_configs(
     strict: bool,
     configs: &LoadedConfigs,
 ) -> ResolveReport {
-    let mut documents = resolve_builtin_only(context, roots, strict).documents;
+    resolve_with_configs_with_mode(context, roots, strict, FallbackMode::Auto, configs)
+}
+
+pub fn resolve_with_configs_with_mode(
+    context: Context,
+    roots: &ResolvedRoots,
+    strict: bool,
+    fallback_mode: FallbackMode,
+    configs: &LoadedConfigs,
+) -> ResolveReport {
+    let mut documents =
+        resolve_builtin_only_with_mode(context, roots, strict, fallback_mode).documents;
     let builtin_keys: HashSet<ResolveKey> =
         documents.iter().map(ResolveKey::from_document).collect();
 
@@ -91,6 +141,7 @@ pub fn resolve_with_configs(
         merge_extension_documents(
             context,
             roots,
+            fallback_mode,
             config,
             &builtin_keys,
             &mut extension_documents,
@@ -106,6 +157,9 @@ pub fn resolve_with_configs(
         strict,
         codex_home: roots.codex_home.clone(),
         project_path: roots.project_path.clone(),
+        is_linked_worktree: roots.is_linked_worktree,
+        git_common_dir: roots.git_common_dir.clone(),
+        primary_worktree_path: roots.primary_worktree_path.clone(),
         documents,
         summary,
     }
@@ -114,6 +168,7 @@ pub fn resolve_with_configs(
 fn merge_extension_documents(
     context: Context,
     roots: &ResolvedRoots,
+    fallback_mode: FallbackMode,
     config: &ConfigScopeFile,
     builtin_keys: &HashSet<ResolveKey>,
     extension_documents: &mut Vec<ResolvedDocument>,
@@ -124,7 +179,8 @@ fn merge_extension_documents(
             continue;
         }
 
-        let resolved_path = resolve_extension_path(entry, roots);
+        let resolved_path =
+            resolve_extension_path_with_project_fallback(entry, roots, fallback_mode);
         let key = ResolveKey::new(context, entry.scope, resolved_path.clone());
         if builtin_keys.contains(&key) {
             continue;
@@ -169,6 +225,30 @@ fn resolve_extension_path(entry: &ConfigDocumentEntry, roots: &ResolvedRoots) ->
     normalize_path(&root.join(&entry.path))
 }
 
+fn resolve_extension_path_with_project_fallback(
+    entry: &ConfigDocumentEntry,
+    roots: &ResolvedRoots,
+    fallback_mode: FallbackMode,
+) -> PathBuf {
+    let local_path = resolve_extension_path(entry, roots);
+    if local_path.exists()
+        || !should_use_project_fallback(entry.scope, entry.required, fallback_mode)
+    {
+        return local_path;
+    }
+
+    let Some(primary_root) = project_fallback_root(roots, fallback_mode) else {
+        return local_path;
+    };
+
+    let fallback_path = normalize_path(&primary_root.join(&entry.path));
+    if fallback_path.exists() {
+        fallback_path
+    } else {
+        local_path
+    }
+}
+
 fn extension_why(config: &ConfigScopeFile, index: usize, entry: &ConfigDocumentEntry) -> String {
     match entry
         .notes
@@ -208,14 +288,22 @@ impl ResolveKey {
     }
 }
 
-fn resolve_startup(roots: &ResolvedRoots) -> Vec<ResolvedDocument> {
+fn resolve_startup(roots: &ResolvedRoots, fallback_mode: FallbackMode) -> Vec<ResolvedDocument> {
     vec![
-        resolve_startup_scope(Scope::Home, &roots.codex_home),
-        resolve_startup_scope(Scope::Project, &roots.project_path),
+        resolve_startup_scope(Scope::Home, &roots.codex_home, None),
+        resolve_startup_scope(
+            Scope::Project,
+            &roots.project_path,
+            project_fallback_root(roots, fallback_mode),
+        ),
     ]
 }
 
-fn resolve_startup_scope(scope: Scope, root: &Path) -> ResolvedDocument {
+fn resolve_startup_scope(
+    scope: Scope,
+    root: &Path,
+    fallback_root: Option<&Path>,
+) -> ResolvedDocument {
     let override_path = normalize_path(&root.join("AGENTS.override.md"));
     if override_path.exists() {
         return ResolvedDocument {
@@ -232,6 +320,56 @@ fn resolve_startup_scope(scope: Scope, root: &Path) -> ResolvedDocument {
         };
     }
 
+    let local_agents_path = normalize_path(&root.join("AGENTS.md"));
+    if local_agents_path.exists() {
+        return ResolvedDocument {
+            context: Context::Startup,
+            scope,
+            path: local_agents_path,
+            required: true,
+            status: DocumentStatus::Present,
+            source: DocumentSource::BuiltinFallback,
+            why: format!(
+                "startup {} policy (AGENTS.override.md missing, fallback AGENTS.md)",
+                scope
+            ),
+        };
+    }
+
+    if let Some(fallback_root) = fallback_root {
+        let fallback_override = normalize_path(&fallback_root.join("AGENTS.override.md"));
+        if fallback_override.exists() {
+            return ResolvedDocument {
+                context: Context::Startup,
+                scope,
+                path: fallback_override,
+                required: true,
+                status: DocumentStatus::Present,
+                source: DocumentSource::Builtin,
+                why: format!(
+                    "startup {} policy (local missing, fallback to primary AGENTS.override.md)",
+                    scope
+                ),
+            };
+        }
+
+        let fallback_agents = normalize_path(&fallback_root.join("AGENTS.md"));
+        if fallback_agents.exists() {
+            return ResolvedDocument {
+                context: Context::Startup,
+                scope,
+                path: fallback_agents,
+                required: true,
+                status: DocumentStatus::Present,
+                source: DocumentSource::BuiltinFallback,
+                why: format!(
+                    "startup {} policy (local missing, fallback to primary AGENTS.md)",
+                    scope
+                ),
+            };
+        }
+    }
+
     resolve_required_doc(
         Context::Startup,
         scope,
@@ -243,6 +381,68 @@ fn resolve_startup_scope(scope: Scope, root: &Path) -> ResolvedDocument {
         ),
         DocumentSource::BuiltinFallback,
     )
+}
+
+fn resolve_required_doc_with_project_fallback(
+    context: Context,
+    scope: Scope,
+    root: &Path,
+    file_name: &str,
+    why: &str,
+    source: DocumentSource,
+    fallback_root: Option<&Path>,
+) -> ResolvedDocument {
+    let local_path = normalize_path(&root.join(file_name));
+    if local_path.exists() {
+        return ResolvedDocument {
+            context,
+            scope,
+            path: local_path,
+            required: true,
+            status: DocumentStatus::Present,
+            source,
+            why: why.to_string(),
+        };
+    }
+
+    if scope == Scope::Project {
+        if let Some(fallback_root) = fallback_root {
+            let fallback_path = normalize_path(&fallback_root.join(file_name));
+            if fallback_path.exists() {
+                return ResolvedDocument {
+                    context,
+                    scope,
+                    path: fallback_path,
+                    required: true,
+                    status: DocumentStatus::Present,
+                    source,
+                    why: format!("{why} (fallback to primary worktree)"),
+                };
+            }
+        }
+    }
+
+    ResolvedDocument {
+        context,
+        scope,
+        path: local_path,
+        required: true,
+        status: DocumentStatus::Missing,
+        source,
+        why: why.to_string(),
+    }
+}
+
+fn project_fallback_root(roots: &ResolvedRoots, fallback_mode: FallbackMode) -> Option<&Path> {
+    if fallback_mode == FallbackMode::Auto && roots.is_linked_worktree {
+        roots.primary_worktree_path.as_deref()
+    } else {
+        None
+    }
+}
+
+fn should_use_project_fallback(scope: Scope, required: bool, fallback_mode: FallbackMode) -> bool {
+    scope == Scope::Project && required && fallback_mode == FallbackMode::Auto
 }
 
 fn resolve_required_doc(

--- a/crates/agent-docs/tests/baseline.rs
+++ b/crates/agent-docs/tests/baseline.rs
@@ -25,6 +25,9 @@ fn roots(home: &TempDir, project: &TempDir) -> ResolvedRoots {
     ResolvedRoots {
         codex_home: home.path().to_path_buf(),
         project_path: project.path().to_path_buf(),
+        is_linked_worktree: false,
+        git_common_dir: None,
+        primary_worktree_path: None,
     }
 }
 

--- a/crates/agent-docs/tests/common.rs
+++ b/crates/agent-docs/tests/common.rs
@@ -42,6 +42,9 @@ impl FixtureWorkspace {
         ResolvedRoots {
             codex_home: self.codex_home.clone(),
             project_path: self.project_path.clone(),
+            is_linked_worktree: false,
+            git_common_dir: None,
+            primary_worktree_path: None,
         }
     }
 }

--- a/crates/agent-docs/tests/env_paths.rs
+++ b/crates/agent-docs/tests/env_paths.rs
@@ -57,6 +57,10 @@ fn json_path(value: &Value, key: &str) -> PathBuf {
     PathBuf::from(raw)
 }
 
+fn json_optional_path(value: &Value, key: &str) -> Option<PathBuf> {
+    value[key].as_str().map(PathBuf::from)
+}
+
 #[test]
 fn resolve_uses_env_overrides_for_codex_home_and_project_path() {
     let home = TempDir::new().expect("create home");
@@ -88,14 +92,15 @@ fn resolve_uses_env_overrides_for_codex_home_and_project_path() {
 }
 
 #[test]
-fn resolve_falls_back_to_git_toplevel_when_project_path_not_set() {
+fn resolve_detects_linked_worktree_metadata_when_project_path_not_set() {
     let home = TempDir::new().expect("create home");
-    let repo = TempDir::new().expect("create repo");
-    let nested = repo.path().join("nested/work");
-    fs::create_dir_all(&nested).expect("create nested directory");
+    let workspace = TempDir::new().expect("create workspace");
+    let repo = workspace.path().join("repo");
+    let linked_worktree = workspace.path().join("linked");
+    fs::create_dir_all(&repo).expect("create repo directory");
 
     let git_init = Command::new("git")
-        .current_dir(repo.path())
+        .current_dir(&repo)
         .args(["init"]) // NOPMD
         .output()
         .expect("run git init");
@@ -105,8 +110,76 @@ fn resolve_falls_back_to_git_toplevel_when_project_path_not_set() {
         String::from_utf8_lossy(&git_init.stderr)
     );
 
+    let git_user_name = Command::new("git")
+        .current_dir(&repo)
+        .args(["config", "user.name", "Agent Docs Tests"])
+        .output()
+        .expect("set git user.name");
+    assert!(
+        git_user_name.status.success(),
+        "git config user.name failed: {}",
+        String::from_utf8_lossy(&git_user_name.stderr)
+    );
+
+    let git_user_email = Command::new("git")
+        .current_dir(&repo)
+        .args(["config", "user.email", "agent-docs@example.test"])
+        .output()
+        .expect("set git user.email");
+    assert!(
+        git_user_email.status.success(),
+        "git config user.email failed: {}",
+        String::from_utf8_lossy(&git_user_email.stderr)
+    );
+
+    fs::write(repo.join("README.md"), "seed\n").expect("write initial commit file");
+    let git_add = Command::new("git")
+        .current_dir(&repo)
+        .args(["add", "."])
+        .output()
+        .expect("run git add");
+    assert!(
+        git_add.status.success(),
+        "git add failed: {}",
+        String::from_utf8_lossy(&git_add.stderr)
+    );
+
+    let git_commit = Command::new("git")
+        .current_dir(&repo)
+        .args(["commit", "-m", "seed"])
+        .output()
+        .expect("run git commit");
+    assert!(
+        git_commit.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&git_commit.stderr)
+    );
+
+    let linked_worktree_arg = linked_worktree
+        .to_str()
+        .expect("linked worktree path should be utf-8");
+    let git_worktree_add = Command::new("git")
+        .current_dir(&repo)
+        .args([
+            "worktree",
+            "add",
+            linked_worktree_arg,
+            "-b",
+            "linked-worktree",
+        ])
+        .output()
+        .expect("run git worktree add");
+    assert!(
+        git_worktree_add.status.success(),
+        "git worktree add failed: {}",
+        String::from_utf8_lossy(&git_worktree_add.stderr)
+    );
+
+    let nested = linked_worktree.join("nested/work");
+    fs::create_dir_all(&nested).expect("create nested directory");
+
     write_markdown(&home.path().join("DEVELOPMENT.md"));
-    write_markdown(&repo.path().join("DEVELOPMENT.md"));
+    write_markdown(&linked_worktree.join("DEVELOPMENT.md"));
 
     let output = run_agent_docs(
         &nested,
@@ -118,7 +191,23 @@ fn resolve_falls_back_to_git_toplevel_when_project_path_not_set() {
     let json = parse_json_stdout(&output);
     assert_eq!(
         canonical_string(&json_path(&json, "project_path")),
-        canonical_string(repo.path())
+        canonical_string(&linked_worktree)
+    );
+    assert!(json["is_linked_worktree"]
+        .as_bool()
+        .expect("json[is_linked_worktree] should be bool"));
+    assert_eq!(
+        canonical_string(
+            &json_optional_path(&json, "git_common_dir").expect("git_common_dir should be present")
+        ),
+        canonical_string(&repo.join(".git"))
+    );
+    assert_eq!(
+        canonical_string(
+            &json_optional_path(&json, "primary_worktree_path")
+                .expect("primary_worktree_path should be present")
+        ),
+        canonical_string(&repo)
     );
 }
 
@@ -141,6 +230,239 @@ fn resolve_falls_back_to_cwd_when_not_git_repo_and_no_project_path() {
     assert_eq!(
         canonical_string(&json_path(&json, "project_path")),
         canonical_string(cwd.path())
+    );
+    assert!(!json["is_linked_worktree"]
+        .as_bool()
+        .expect("json[is_linked_worktree] should be bool"));
+    assert!(json["git_common_dir"].is_null());
+    assert!(json["primary_worktree_path"].is_null());
+}
+
+#[test]
+fn cli_help_documents_worktree_mode_values() {
+    let cwd = TempDir::new().expect("create cwd");
+    let output = run_agent_docs(cwd.path(), &["--help"], &[], &[]);
+
+    assert_eq!(
+        output.code, 0,
+        "--help should succeed: stderr={}",
+        output.stderr
+    );
+    assert!(
+        output.stdout.contains("worktree"),
+        "--help should mention worktree fallback mode:\n{}",
+        output.stdout
+    );
+    assert!(
+        output.stdout.contains("auto"),
+        "--help should include auto mode:\n{}",
+        output.stdout
+    );
+    assert!(
+        output.stdout.contains("local-only"),
+        "--help should include local-only mode:\n{}",
+        output.stdout
+    );
+}
+
+#[test]
+fn resolve_strict_auto_uses_primary_worktree_fallback_but_local_only_keeps_local_strict_behavior() {
+    let home = TempDir::new().expect("create home");
+    let workspace = TempDir::new().expect("create workspace");
+    let repo = workspace.path().join("repo");
+    let linked_worktree = workspace.path().join("linked");
+    fs::create_dir_all(&repo).expect("create repo directory");
+
+    let git_init = Command::new("git")
+        .current_dir(&repo)
+        .args(["init"]) // NOPMD
+        .output()
+        .expect("run git init");
+    assert!(
+        git_init.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&git_init.stderr)
+    );
+
+    let git_user_name = Command::new("git")
+        .current_dir(&repo)
+        .args(["config", "user.name", "Agent Docs Tests"])
+        .output()
+        .expect("set git user.name");
+    assert!(
+        git_user_name.status.success(),
+        "git config user.name failed: {}",
+        String::from_utf8_lossy(&git_user_name.stderr)
+    );
+
+    let git_user_email = Command::new("git")
+        .current_dir(&repo)
+        .args(["config", "user.email", "agent-docs@example.test"])
+        .output()
+        .expect("set git user.email");
+    assert!(
+        git_user_email.status.success(),
+        "git config user.email failed: {}",
+        String::from_utf8_lossy(&git_user_email.stderr)
+    );
+
+    fs::write(repo.join("README.md"), "seed\n").expect("write initial commit file");
+    let git_add = Command::new("git")
+        .current_dir(&repo)
+        .args(["add", "."])
+        .output()
+        .expect("run git add");
+    assert!(
+        git_add.status.success(),
+        "git add failed: {}",
+        String::from_utf8_lossy(&git_add.stderr)
+    );
+
+    let git_commit = Command::new("git")
+        .current_dir(&repo)
+        .args(["commit", "-m", "seed"])
+        .output()
+        .expect("run git commit");
+    assert!(
+        git_commit.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&git_commit.stderr)
+    );
+
+    let linked_worktree_arg = linked_worktree
+        .to_str()
+        .expect("linked worktree path should be utf-8");
+    let git_worktree_add = Command::new("git")
+        .current_dir(&repo)
+        .args([
+            "worktree",
+            "add",
+            linked_worktree_arg,
+            "-b",
+            "linked-worktree",
+        ])
+        .output()
+        .expect("run git worktree add");
+    assert!(
+        git_worktree_add.status.success(),
+        "git worktree add failed: {}",
+        String::from_utf8_lossy(&git_worktree_add.stderr)
+    );
+
+    write_markdown(&home.path().join("DEVELOPMENT.md"));
+    write_markdown(&repo.join("AGENTS.md"));
+    write_markdown(&repo.join("DEVELOPMENT.md"));
+    let local_development = linked_worktree.join("DEVELOPMENT.md");
+    if local_development.exists() {
+        fs::remove_file(&local_development).expect("remove local linked-worktree development");
+    }
+    let local_agents = linked_worktree.join("AGENTS.md");
+    if local_agents.exists() {
+        fs::remove_file(&local_agents).expect("remove local linked-worktree agents");
+    }
+
+    let auto_output = run_agent_docs(
+        &linked_worktree,
+        &[
+            "resolve",
+            "--context",
+            "project-dev",
+            "--format",
+            "checklist",
+            "--strict",
+        ],
+        &[("CODEX_HOME", home.path())],
+        &["PROJECT_PATH"],
+    );
+    assert_eq!(
+        auto_output.code, 0,
+        "auto mode should pass when fallback doc exists in primary worktree: stdout=\n{}\nstderr=\n{}",
+        auto_output.stdout, auto_output.stderr
+    );
+    assert!(
+        auto_output
+            .stdout
+            .contains("DEVELOPMENT.md status=present path="),
+        "auto mode checklist should mark DEVELOPMENT.md as present:\n{}",
+        auto_output.stdout
+    );
+    assert!(
+        auto_output
+            .stdout
+            .contains(&repo.join("DEVELOPMENT.md").display().to_string()),
+        "auto mode should resolve from primary worktree path:\n{}",
+        auto_output.stdout
+    );
+
+    let local_only_output = run_agent_docs(
+        &linked_worktree,
+        &[
+            "--worktree-fallback",
+            "local-only",
+            "resolve",
+            "--context",
+            "project-dev",
+            "--format",
+            "checklist",
+            "--strict",
+        ],
+        &[("CODEX_HOME", home.path())],
+        &["PROJECT_PATH"],
+    );
+    assert_eq!(
+        local_only_output.code, 1,
+        "local-only mode should keep strict local behavior: stdout=\n{}\nstderr=\n{}",
+        local_only_output.stdout, local_only_output.stderr
+    );
+    assert!(
+        local_only_output
+            .stdout
+            .contains("DEVELOPMENT.md status=missing path="),
+        "local-only mode checklist should keep DEVELOPMENT.md missing:\n{}",
+        local_only_output.stdout
+    );
+    assert!(
+        local_only_output
+            .stdout
+            .contains(&linked_worktree.join("DEVELOPMENT.md").display().to_string()),
+        "local-only mode should report local project path:\n{}",
+        local_only_output.stdout
+    );
+
+    let baseline_auto_output = run_agent_docs(
+        &linked_worktree,
+        &[
+            "baseline", "--check", "--target", "project", "--strict", "--format", "text",
+        ],
+        &[("CODEX_HOME", home.path())],
+        &["PROJECT_PATH"],
+    );
+    assert_eq!(
+        baseline_auto_output.code, 0,
+        "auto baseline strict should pass with primary-worktree fallback: stdout=\n{}\nstderr=\n{}",
+        baseline_auto_output.stdout, baseline_auto_output.stderr
+    );
+
+    let baseline_local_only_output = run_agent_docs(
+        &linked_worktree,
+        &[
+            "--worktree-fallback",
+            "local-only",
+            "baseline",
+            "--check",
+            "--target",
+            "project",
+            "--strict",
+            "--format",
+            "text",
+        ],
+        &[("CODEX_HOME", home.path())],
+        &["PROJECT_PATH"],
+    );
+    assert_eq!(
+        baseline_local_only_output.code, 1,
+        "local-only baseline strict should keep local-only failure semantics: stdout=\n{}\nstderr=\n{}",
+        baseline_local_only_output.stdout, baseline_local_only_output.stderr
     );
 }
 

--- a/docs/plans/agent-docs-worktree-policy-fallback-plan.md
+++ b/docs/plans/agent-docs-worktree-policy-fallback-plan.md
@@ -1,0 +1,266 @@
+# Plan: agent-docs worktree policy fallback support
+
+## Overview
+This plan adds first-class linked-worktree support to `agent-docs` so required policy documents can still resolve when they are intentionally not committed and only exist in the primary worktree. The core behavior is: resolve from the current project path first, then fallback to the primary worktree for equivalent project-scope files when running inside a linked worktree. The plan keeps strict mode meaningful, preserves non-worktree behavior, and adds explicit output metadata so users can see when fallback was used.
+
+## Scope
+- In scope:
+  - Detect linked-worktree metadata (`is_worktree`, `git_common_dir`, `primary_worktree_path`) during root resolution.
+  - Add deterministic fallback for project-scope required docs (`startup`, `project-dev`, and required `AGENT_DOCS.toml` project entries).
+  - Surface fallback provenance in `resolve`/`baseline` output.
+  - Add integration tests that reproduce "doc exists only in primary worktree".
+  - Improve scaffold behavior so project baseline docs can be copied from primary worktree content instead of generic templates when available.
+- Out of scope:
+  - Remote/shared sync of policy files outside local Git metadata.
+  - Cross-repository fallback (only current Git repository worktrees are considered).
+  - Automatic commits/staging for copied baseline docs.
+
+## Assumptions (if any)
+1. Teams using worktrees may keep `AGENTS.md` (and similar policy docs) untracked by design.
+2. In standard non-bare repositories, `git rev-parse --git-common-dir` points to `<primary>/.git` and can be used to infer the primary worktree root.
+3. `git` is available at runtime (already required by existing `PROJECT_PATH` fallback logic).
+4. If multiple linked worktrees exist, the primary worktree is the authoritative fallback source.
+
+## Success Criteria
+1. `agent-docs resolve --context startup --strict --format checklist` passes in a linked worktree when `AGENTS.md` is missing locally but present in the primary worktree.
+2. `agent-docs baseline --check --target project --strict` reports no missing required project docs under the same scenario.
+3. Output clearly discloses fallback usage (source + fallback path) to avoid hidden behavior.
+4. Existing non-worktree behavior and tests remain unchanged.
+
+## Sprint 1: Worktree detection + contract
+**Goal**: Introduce explicit linked-worktree metadata and freeze fallback precedence/compatibility contract before resolver changes.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p agent-docs env_paths`
+  - `cargo run -q -p agent-docs -- resolve --context startup --format json`
+- Verify:
+  - Runtime metadata can distinguish non-worktree vs linked-worktree execution.
+  - Contract docs describe exact precedence and compatibility behavior.
+
+### Task 1.1: Document worktree fallback contract and precedence
+- **Location**:
+  - `crates/agent-docs/README.md`
+- **Description**: Add a new "Worktree fallback" section defining precedence for project-scope docs: local override/default first, then primary-worktree equivalent path; include strict-mode semantics and an explicit compatibility note that non-worktree repos are unchanged.
+- **Dependencies**:
+  - none
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - README includes a deterministic fallback order for `startup` and `project-dev` project-scope docs.
+  - README documents how fallback appears in output and how to disable fallback if needed.
+- **Validation**:
+  - `rg -n "^## Worktree fallback$|fallback order|local-only|linked worktree" crates/agent-docs/README.md`
+  - `rg -n "resolve --context startup --strict|baseline --check --target project --strict" crates/agent-docs/README.md`
+
+### Task 1.2: Extend root resolution with linked-worktree metadata
+- **Location**:
+  - `crates/agent-docs/src/env.rs`
+  - `crates/agent-docs/src/model.rs`
+  - `crates/agent-docs/tests/env_paths.rs`
+- **Description**: Extend resolved environment/root model to capture linked-worktree metadata (`is_linked_worktree`, `git_common_dir`, `primary_worktree_path`). Implement detection using `git rev-parse --absolute-git-dir` + `--git-common-dir`, with robust fallback to `None` when unavailable.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Metadata is populated for linked worktrees and absent for regular repos/non-git directories.
+  - Detection tolerates command failures without panicking and preserves existing root resolution behavior.
+- **Validation**:
+  - `cargo test -p agent-docs env_paths`
+
+### Task 1.3: Add explicit fallback mode toggle
+- **Location**:
+  - `crates/agent-docs/src/cli.rs`
+  - `crates/agent-docs/src/model.rs`
+  - `crates/agent-docs/src/lib.rs`
+- **Description**: Add a global mode switch for project fallback behavior (`auto` default, `local-only` opt-out) so teams can keep deterministic local-only enforcement if desired.
+- **Dependencies**:
+  - Task 1.2
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Default mode enables worktree fallback when metadata is available.
+  - `local-only` mode disables fallback and restores current strict local behavior.
+  - `--help` documents the new switch clearly.
+- **Validation**:
+  - `cargo run -q -p agent-docs -- --help | rg -n "worktree|local-only|auto"`
+  - `cargo test -p agent-docs`
+
+## Sprint 2: Resolver + baseline fallback implementation
+**Goal**: Apply fallback resolution to project-scope required docs and make fallback provenance explicit in machine/human outputs.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p agent-docs resolve_builtin baseline`
+  - `cargo run -q -p agent-docs -- resolve --context startup --format checklist --strict`
+- Verify:
+  - Strict resolve/baseline pass when required files exist in primary worktree fallback path.
+  - Output identifies fallback source path.
+
+### Task 2.1: Extend document model/output for fallback provenance
+- **Location**:
+  - `crates/agent-docs/src/model.rs`
+  - `crates/agent-docs/src/output.rs`
+- **Description**: Add explicit provenance fields for resolved docs (e.g., `resolved_from` or `source_path`) and a new source type for worktree fallback to avoid ambiguous "present" status.
+- **Dependencies**:
+  - Task 1.3
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Output can represent both logical target path and actual fallback source path.
+  - Existing text/checklist/json output remains parseable; new fields are additive.
+- **Validation**:
+  - `cargo test -p agent-docs resolve_builtin`
+
+### Task 2.2: Implement project-scope fallback chain in resolver
+- **Location**:
+  - `crates/agent-docs/src/resolver.rs`
+  - `crates/agent-docs/src/paths.rs`
+- **Description**: Implement fallback lookup chain for project-scope docs when in `auto` mode: (1) current worktree path, (2) primary worktree equivalent path. Apply to startup project policy (`AGENTS.override.md` then `AGENTS.md`), built-in `project-dev` docs, and required project-scope extension docs (including `AGENT_DOCS.toml` required entries whose local file is missing but primary equivalent exists).
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - `startup` project policy resolves `AGENTS.override.md`/`AGENTS.md` from primary worktree when missing locally.
+  - `project-dev` required docs and required extension docs can resolve via equivalent primary worktree paths.
+  - Required project-scope `AGENT_DOCS.toml` entries are considered present when their equivalent primary-worktree path exists.
+  - Home-scope docs never use project worktree fallback.
+- **Validation**:
+  - `cargo test -p agent-docs resolve_builtin`
+  - `cargo test -p agent-docs resolve_toml`
+  - `cargo test -p agent-docs worktree_fallback -- --nocapture`
+
+### Task 2.3: Align baseline check with resolver fallback semantics
+- **Location**:
+  - `crates/agent-docs/src/commands/baseline.rs`
+  - `crates/agent-docs/src/output.rs`
+- **Description**: Reuse the same fallback chain in baseline checks so strict baseline behaves consistently with strict resolve. Include fallback provenance in baseline text/json output.
+- **Dependencies**:
+  - Task 2.2
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - `baseline --strict` no longer fails for project-scope docs when fallback source exists.
+  - Suggested actions still appear only when neither local nor fallback source exists.
+- **Validation**:
+  - `cargo test -p agent-docs baseline`
+
+### Task 2.4: Add linked-worktree integration tests (real Git worktree)
+- **Location**:
+  - `crates/agent-docs/tests/worktree_fallback.rs`
+  - `crates/agent-docs/tests/common.rs`
+- **Description**: Add end-to-end tests that create a temp repo, add a linked worktree, place `AGENTS.md` only in primary worktree, then execute `agent-docs` from linked worktree to validate strict resolve/baseline behavior under `auto` and `local-only` modes.
+- **Dependencies**:
+  - Task 1.2
+  - Task 2.3
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - Test reproduces current failure mode and verifies fallback fix.
+  - Tests cover both startup policy and at least one project-dev required doc/extension path.
+- **Validation**:
+  - `cargo test -p agent-docs worktree_fallback -- --nocapture`
+
+## Sprint 3: Scaffold UX + migration safety
+**Goal**: Ensure remediation commands produce expected project-specific content in worktrees and reduce accidental template overwrite drift.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p agent-docs scaffold_baseline`
+  - `agent-docs scaffold-baseline --target project --missing-only --dry-run --format text`
+- Verify:
+  - Scaffold reports when content is sourced from primary worktree fallback.
+  - Existing template-based behavior remains available when no fallback source exists.
+
+### Task 3.1: Teach scaffold-baseline to copy from primary fallback when available
+- **Location**:
+  - `crates/agent-docs/src/commands/scaffold_baseline.rs`
+  - `crates/agent-docs/tests/scaffold_baseline.rs`
+- **Description**: For missing project baseline docs in linked worktrees, prefer copying actual file contents from primary worktree equivalent paths (if present) before falling back to default templates. Keep `--force`/`--missing-only` semantics unchanged.
+- **Dependencies**:
+  - Task 2.2
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - `--missing-only` creates missing project docs from primary content when available.
+  - Action reason/output clearly states "created from primary worktree fallback".
+  - No behavior change for non-worktree repos.
+- **Validation**:
+  - `cargo test -p agent-docs scaffold_baseline`
+
+### Task 3.2: Add migration guidance and troubleshooting
+- **Location**:
+  - `crates/agent-docs/README.md`
+  - `docs/plans/agent-docs-worktree-policy-fallback-plan.md`
+- **Description**: Document operator guidance for teams currently relying on local-only behavior: when to use `local-only`, how to hydrate missing docs into worktrees, and how to interpret fallback paths in checklist/baseline output.
+- **Dependencies**:
+  - Task 3.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - README includes migration examples for both fallback-enabled and local-only flows.
+  - Troubleshooting section covers detached worktree + missing primary file scenarios.
+- **Validation**:
+  - `rg -n "^## Migration|^## Troubleshooting|local-only|fallback-enabled|hydrate" crates/agent-docs/README.md`
+  - `rg -n "detached|primary worktree|local-only" crates/agent-docs/README.md`
+
+## Sprint 4: Regression hardening + rollout
+**Goal**: Verify end-to-end safety across worktree/non-worktree paths and keep release risk low.
+**Demo/Validation**:
+- Command(s):
+  - `cargo test -p agent-docs`
+  - `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh`
+- Verify:
+  - All existing checks pass.
+  - No regressions in CLI output contracts consumed by automation.
+
+### Task 4.1: Add compatibility regression tests for non-worktree behavior
+- **Location**:
+  - `crates/agent-docs/tests/resolve_builtin.rs`
+  - `crates/agent-docs/tests/baseline.rs`
+- **Description**: Add assertions that behavior in normal repos remains unchanged (source/status/order) and that `local-only` mode preserves current strict failure semantics when project docs are missing locally.
+- **Dependencies**:
+  - Task 2.4
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Existing snapshots/expectations remain stable or are intentionally updated with documented rationale.
+  - `local-only` mode reproduces pre-feature missing-doc failures in linked worktree tests.
+- **Validation**:
+  - `cargo test -p agent-docs resolve_builtin baseline`
+
+### Task 4.2: Final contract pass for release readiness
+- **Location**:
+  - `crates/agent-docs/README.md`
+  - `BINARY_DEPENDENCIES.md`
+- **Description**: Ensure CLI contract docs, examples, and dependency expectations align with the new worktree behavior and flags.
+- **Dependencies**:
+  - Task 4.1
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - README command examples compile with implemented flags/outputs.
+  - No conflicting statements about project-path-only resolution remain.
+- **Validation**:
+  - `rg -n "PROJECT_PATH|worktree|fallback|local-only" crates/agent-docs/README.md BINARY_DEPENDENCIES.md`
+
+## Dependency and Parallelization Map
+- Critical path:
+  - Task 1.1 -> Task 1.2 -> Task 1.3 -> Task 2.1 -> Task 2.2 -> Task 2.3 -> Task 2.4 -> Task 4.1 -> Task 4.2
+- Parallelizable groups:
+  - Task 2.4 can begin once Task 2.3 API shape is stable; test fixture scaffolding can start in parallel with Task 3.1.
+  - Task 3.2 can run in parallel with Task 4.1 once fallback output strings are finalized.
+
+## Testing Strategy
+- Unit:
+  - Root/worktree metadata detection in `env` tests.
+  - Resolver candidate-chain tests for startup/project-dev and extension docs.
+  - Baseline fallback-specific status/source assertions.
+- Integration:
+  - Real `git worktree` fixture tests for `resolve --strict` and `baseline --strict`.
+  - Scaffold tests verifying copy-from-primary fallback and fallback-to-template behavior.
+- E2E/manual:
+  - In a linked worktree where `AGENTS.md` exists only in primary, run:
+    - `agent-docs resolve --context startup --strict --format checklist`
+    - `agent-docs baseline --check --target project --strict --format text`
+    - `agent-docs scaffold-baseline --target project --missing-only --dry-run --format text`
+
+## Risks & gotchas
+- Fallback can hide local drift if users expect every worktree to have explicit copies. Mitigation: output provenance + `local-only` mode.
+- Inferring primary worktree path from Git metadata can fail in unusual repository layouts. Mitigation: fail closed to local-only behavior when metadata is incomplete.
+- Output schema changes can break downstream parsers. Mitigation: additive fields only and compatibility tests for text/checklist formats.
+- Worktree tests can be flaky on constrained CI environments. Mitigation: keep fixture setup deterministic and isolate `git` command assumptions.
+
+## Rollback plan
+- Add an emergency release toggle that defaults to `local-only` (or hard-disable fallback path) without removing new CLI fields.
+- Revert resolver/baseline fallback logic to local-path-only while keeping metadata detection inert.
+- Keep integration tests but mark fallback-specific ones ignored until re-enabled; retain non-worktree regression coverage.
+- If scaffold copy-from-primary introduces risk, revert only `scaffold_baseline` changes and keep read-only resolve/baseline fallback.


### PR DESCRIPTION
# Add linked-worktree fallback to agent-docs policy resolution

## Summary
Implement linked-worktree aware policy resolution in `agent-docs` so strict startup/project checks can pass when required project docs only exist in the primary worktree, while preserving opt-out local-only behavior.

## Changes
- Add linked-worktree metadata to root resolution (`is_linked_worktree`, `git_common_dir`, `primary_worktree_path`).
- Add global `--worktree-fallback <auto|local-only>` flag (default `auto`) and wire it through `resolve` and `baseline`.
- Apply fallback chain for project-scope required docs (startup policy files, project-dev built-ins, required project extension docs).
- Add integration coverage for linked-worktree fallback vs local-only strict behavior and document the new contract in `crates/agent-docs/README.md`.
- Add execution plan artifact: `docs/plans/agent-docs-worktree-policy-fallback-plan.md`.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 85.75%)

## Risk / Notes
- Fallback provenance currently relies on resolved path + reason text; explicit source-path fields can be expanded in follow-up work.
