### PR TITLE
Improve semantic-commit automation ergonomics and safety

### DIFF
--- a/completions/bash/semantic-commit
+++ b/completions/bash/semantic-commit
@@ -26,17 +26,41 @@ _nils_cli_semantic_commit_complete() {
 
   local subcmd="${words[1]-}"
   case "$subcmd" in
-    staged-context|help)
+    staged-context)
+      if [[ "$prev" == "--format" ]]; then
+        COMPREPLY=( $(compgen -W "bundle json patch" -- "$cur") )
+        return 0
+      fi
+      if [[ "$prev" == "--repo" ]]; then
+        COMPREPLY=( $(compgen -d -- "$cur") )
+        return 0
+      fi
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "-h --help --format --json --repo" -- "$cur") )
+        return 0
+      fi
+      COMPREPLY=()
+      return 0
+      ;;
+    help)
       COMPREPLY=()
       return 0
       ;;
     commit)
-      if [[ "$prev" == "--message-file" ]]; then
+      if [[ "$prev" == "--message-file" || "$prev" == "-F" || "$prev" == "--message-out" ]]; then
         COMPREPLY=( $(compgen -f -- "$cur") )
         return 0
       fi
+      if [[ "$prev" == "--repo" ]]; then
+        COMPREPLY=( $(compgen -d -- "$cur") )
+        return 0
+      fi
+      if [[ "$prev" == "--summary" ]]; then
+        COMPREPLY=( $(compgen -W "git-scope git-show none" -- "$cur") )
+        return 0
+      fi
       if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --message --message-file" -- "$cur") )
+        COMPREPLY=( $(compgen -W "-h --help -m --message -F --message-file --message-out --summary --no-summary --repo --automation --non-interactive --validate-only --dry-run --no-progress --quiet" -- "$cur") )
         return 0
       fi
       COMPREPLY=()
@@ -48,4 +72,3 @@ _nils_cli_semantic_commit_complete() {
 }
 
 complete -F _nils_cli_semantic_commit_complete semantic-commit
-

--- a/completions/zsh/_semantic-commit
+++ b/completions/zsh/_semantic-commit
@@ -34,18 +34,29 @@ _semantic-commit() {
         staged-context)
           _arguments -C \
             '(-h --help)'{-h,--help}'[Show help message]' \
+            '--format=[Output format]:format:(bundle json patch)' \
+            '--json[Equivalent to --format json]' \
+            '--repo=[Path to git repository]:repository:_files -/' \
             && return 0
-          _message 'no additional arguments'
-          return 0
           ;;
         commit)
           _arguments -C \
             '(-h --help)'{-h,--help}'[Show help message]' \
+            '-m+[Commit message text]:message:' \
             '--message=[Commit message text]:message:' \
+            '-F+[Path to commit message file]:file:_files' \
             '--message-file=[Path to commit message file]:file:_files' \
+            '--message-out=[Write prepared message to path]:file:_files' \
+            '--summary=[Summary output mode]:mode:(git-scope git-show none)' \
+            '--no-summary[Do not print summary after commit]' \
+            '--repo=[Path to git repository]:repository:_files -/' \
+            '--automation[Disable stdin fallback and require --message/--message-file]' \
+            '--non-interactive[Alias of --automation]' \
+            '--validate-only[Validate message format and exit]' \
+            '--dry-run[Validate and staged-check without creating a commit]' \
+            '--no-progress[Disable progress spinner]' \
+            '--quiet[Suppress progress and summary output]' \
             && return 0
-          _message 'commit message'
-          return 0
           ;;
         help)
           _message 'no additional arguments'

--- a/crates/semantic-commit/README.md
+++ b/crates/semantic-commit/README.md
@@ -22,11 +22,28 @@ Help:
 ## Commands
 
 ### staged-context
-- `staged-context`: Emit a bundle to stdout containing `commit-context.json` and `staged.patch`.
+- `staged-context [--format <bundle|json|patch>] [--json] [--repo <path>]`
+- Output formats:
+  - `bundle` (default): `commit-context.json` + `staged.patch`
+  - `json`: only `commit-context.json`
+  - `patch`: only `staged.patch`
+- `--repo <path>` runs against a repository path without changing shell cwd.
 
 ### commit
-- `commit [--message <text> | --message-file <path>]`: Validate and commit staged changes. When no
-  flags are provided, the message is read from stdin.
+- `commit [options]`
+- Message sources:
+  - `-m, --message <text>`
+  - `-F, --message-file <path>`
+  - stdin (disabled with `--automation`)
+- Useful options:
+  - `--summary <git-scope|git-show|none>` (default: `git-scope` with fallback to `git-show`)
+  - `--no-summary`
+  - `--validate-only`
+  - `--dry-run`
+  - `--message-out <path>`
+  - `--repo <path>`
+  - `--no-progress`
+  - `--quiet`
 
 ## Commit Message Validation
 - Header must be non-empty, `<= 100` characters, and use a lowercase type.
@@ -36,9 +53,12 @@ Help:
 
 ## Exit codes
 - `0`: success and help output.
-- `1`: usage errors, validation failures, or operational errors.
+- `1`: usage errors or operational errors.
 - `2`: no staged changes.
+- `3`: commit message missing/empty.
+- `4`: commit message validation failed.
+- `5`: required dependency missing (for example, `git`).
 
 ## Dependencies
 - `git` is required.
-- `git-scope` is required to print the commit summary after a successful commit.
+- `git-scope` is optional; when unavailable, commit summary falls back to `git show -1`.

--- a/crates/semantic-commit/src/commit.rs
+++ b/crates/semantic-commit/src/commit.rs
@@ -2,210 +2,418 @@ use crate::git;
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 use std::fs::File;
 use std::io::{BufRead, BufReader, IsTerminal, Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+const EXIT_ERROR: i32 = 1;
+const EXIT_NO_STAGED_CHANGES: i32 = 2;
+const EXIT_MESSAGE_REQUIRED: i32 = 3;
+const EXIT_VALIDATION_FAILED: i32 = 4;
+const EXIT_DEPENDENCY_ERROR: i32 = 5;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SummaryMode {
+    GitScope,
+    GitShow,
+    None,
+}
+
+impl SummaryMode {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "git-scope" => Some(Self::GitScope),
+            "git-show" => Some(Self::GitShow),
+            "none" => Some(Self::None),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CommitOptions {
+    message: Option<String>,
+    message_file: Option<String>,
+    message_out: Option<PathBuf>,
+    summary_mode: SummaryMode,
+    no_progress: bool,
+    quiet: bool,
+    automation: bool,
+    validate_only: bool,
+    dry_run: bool,
+    repo: Option<PathBuf>,
+}
+
+impl Default for CommitOptions {
+    fn default() -> Self {
+        Self {
+            message: None,
+            message_file: None,
+            message_out: None,
+            summary_mode: SummaryMode::GitScope,
+            no_progress: false,
+            quiet: false,
+            automation: false,
+            validate_only: false,
+            dry_run: false,
+            repo: None,
+        }
+    }
+}
+
 pub fn run(args: &[String]) -> i32 {
-    let mut message: Option<String> = None;
-    let mut message_file: Option<String> = None;
+    let mut options = match parse_args(args) {
+        Ok(options) => options,
+        Err(code) => return code,
+    };
+
+    if !git::command_exists("git") {
+        eprintln!("error: git is required (ensure it is installed and on PATH)");
+        return EXIT_DEPENDENCY_ERROR;
+    }
+
+    if options.quiet {
+        options.no_progress = true;
+        options.summary_mode = SummaryMode::None;
+    }
+
+    let message_contents = match read_message_contents(&options) {
+        Ok(contents) => contents,
+        Err(code) => return code,
+    };
+
+    if let Some(path) = options.message_out.as_deref() {
+        if let Err(err) = write_message_file(path, &message_contents) {
+            eprintln!("error: failed to write --message-out file: {err}");
+            return EXIT_ERROR;
+        }
+    }
+
+    let tmpfile = match tempfile::NamedTempFile::new() {
+        Ok(file) => file,
+        Err(_) => {
+            eprintln!("error: failed to create temp file for commit message");
+            return EXIT_ERROR;
+        }
+    };
+
+    if let Err(err) = write_message_file(tmpfile.path(), &message_contents) {
+        eprintln!("{err:#}");
+        return EXIT_ERROR;
+    }
+
+    if let Err(code) = validate_commit_message(tmpfile.path()) {
+        return code;
+    }
+
+    if options.validate_only {
+        return 0;
+    }
+
+    if !git::is_inside_work_tree(options.repo.as_deref()) {
+        eprintln!("error: must run inside a git work tree");
+        return EXIT_ERROR;
+    }
+
+    match git::has_staged_changes(options.repo.as_deref()) {
+        Ok(true) => {}
+        Ok(false) => {
+            eprintln!("error: no staged changes (stage files with git add first)");
+            return EXIT_NO_STAGED_CHANGES;
+        }
+        Err(err) => {
+            eprintln!("{err:#}");
+            return EXIT_ERROR;
+        }
+    }
+
+    if options.dry_run {
+        return 0;
+    }
+
+    let show_progress = !options.no_progress && std::io::stderr().is_terminal();
+    let progress = if show_progress {
+        Some(Progress::spinner(
+            ProgressOptions::default()
+                .with_prefix("semantic-commit ")
+                .with_finish(ProgressFinish::Clear),
+        ))
+    } else {
+        None
+    };
+
+    if let Some(progress) = &progress {
+        progress.set_message("git commit");
+        progress.tick();
+    }
+
+    let status = git_commit(tmpfile.path(), options.repo.as_deref());
+
+    if let Some(progress) = &progress {
+        progress.finish_and_clear();
+    }
+
+    match status {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            let rc = status.code().unwrap_or(EXIT_ERROR);
+            eprintln!("error: git commit failed (exit code: {rc})");
+            return rc;
+        }
+        Err(err) => {
+            eprintln!("{err:#}");
+            return EXIT_ERROR;
+        }
+    }
+
+    print_summary(options.summary_mode, options.repo.as_deref())
+}
+
+fn parse_args(args: &[String]) -> Result<CommitOptions, i32> {
+    let mut options = CommitOptions::default();
 
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
             "-h" | "--help" => {
                 print_usage_stdout();
-                return 0;
+                return Err(0);
             }
-            "--message" => {
+            "--message" | "-m" => {
                 let value = match args.get(i + 1) {
                     Some(value) => value.clone(),
                     None => {
-                        eprintln!("error: --message requires a value");
+                        eprintln!("error: {} requires a value", args[i]);
                         print_usage_stderr();
-                        return 1;
+                        return Err(EXIT_ERROR);
                     }
                 };
-                message = Some(value);
+                options.message = Some(value);
                 i += 2;
             }
-            "--message-file" => {
+            "--message-file" | "-F" => {
                 let value = match args.get(i + 1) {
                     Some(value) => value.clone(),
                     None => {
-                        eprintln!("error: --message-file requires a path");
+                        eprintln!("error: {} requires a path", args[i]);
                         print_usage_stderr();
-                        return 1;
+                        return Err(EXIT_ERROR);
                     }
                 };
-                message_file = Some(value);
+                options.message_file = Some(value);
+                i += 2;
+            }
+            "--message-out" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --message-out requires a path");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.message_out = Some(PathBuf::from(value));
+                i += 2;
+            }
+            "--summary" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value,
+                    None => {
+                        eprintln!("error: --summary requires a value");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+
+                let Some(mode) = SummaryMode::parse(value) else {
+                    eprintln!(
+                        "error: invalid --summary value: {value} (expected: git-scope, git-show, none)"
+                    );
+                    print_usage_stderr();
+                    return Err(EXIT_ERROR);
+                };
+
+                options.summary_mode = mode;
+                i += 2;
+            }
+            "--no-summary" => {
+                options.summary_mode = SummaryMode::None;
+                i += 1;
+            }
+            "--no-progress" => {
+                options.no_progress = true;
+                i += 1;
+            }
+            "--quiet" => {
+                options.quiet = true;
+                i += 1;
+            }
+            "--automation" | "--non-interactive" => {
+                options.automation = true;
+                i += 1;
+            }
+            "--validate-only" => {
+                options.validate_only = true;
+                i += 1;
+            }
+            "--dry-run" => {
+                options.dry_run = true;
+                i += 1;
+            }
+            "--repo" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --repo requires a path");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.repo = Some(PathBuf::from(value));
                 i += 2;
             }
             other => {
                 eprintln!("error: unknown argument: {other}");
                 print_usage_stderr();
-                return 1;
+                return Err(EXIT_ERROR);
             }
         }
     }
 
-    if message.is_some() && message_file.is_some() {
+    if options.message.is_some() && options.message_file.is_some() {
         eprintln!("error: use only one of --message or --message-file");
-        return 1;
+        return Err(EXIT_ERROR);
     }
 
-    if !git::is_inside_work_tree() {
-        eprintln!("error: must run inside a git work tree");
-        return 1;
-    }
+    Ok(options)
+}
 
-    match git::has_staged_changes() {
-        Ok(true) => {}
-        Ok(false) => {
-            eprintln!("error: no staged changes (stage files with git add first)");
-            return 2;
-        }
-        Err(err) => {
-            eprintln!("{err:#}");
-            return 1;
-        }
-    }
-
-    let message_contents = match (message, message_file) {
-        (Some(text), None) => text,
-        (None, Some(path)) => match std::fs::read_to_string(&path) {
+fn read_message_contents(options: &CommitOptions) -> Result<String, i32> {
+    let message_contents = match (&options.message, &options.message_file) {
+        (Some(text), None) => text.clone(),
+        (None, Some(path)) => match std::fs::read_to_string(path) {
             Ok(contents) => contents,
             Err(_) => {
                 eprintln!("error: message file not found: {path}");
-                return 1;
+                return Err(EXIT_ERROR);
             }
         },
         (None, None) => {
+            if options.automation {
+                eprintln!(
+                    "error: no commit message provided in automation mode (use --message or --message-file)"
+                );
+                return Err(EXIT_MESSAGE_REQUIRED);
+            }
+
             if std::io::stdin().is_terminal() {
                 eprintln!(
                     "error: no commit message provided (use stdin, --message, or --message-file)"
                 );
                 print_usage_stderr();
-                return 1;
+                return Err(EXIT_MESSAGE_REQUIRED);
             }
 
             let mut buf = String::new();
             if let Err(err) = std::io::stdin().read_to_string(&mut buf) {
                 eprintln!("{err:#}");
-                return 1;
+                return Err(EXIT_ERROR);
             }
             buf
         }
         (Some(_), Some(_)) => unreachable!("validated above"),
     };
 
-    if message_contents.is_empty() {
+    if message_contents.trim().is_empty() {
         eprintln!("error: commit message is empty");
-        return 1;
+        return Err(EXIT_MESSAGE_REQUIRED);
     }
 
-    let progress = Progress::spinner(
-        ProgressOptions::default()
-            .with_prefix("semantic-commit ")
-            .with_finish(ProgressFinish::Clear),
-    );
+    Ok(message_contents)
+}
 
-    progress.set_message("prepare message");
-    progress.tick();
-
-    let tmpfile = match tempfile::NamedTempFile::new() {
-        Ok(file) => file,
-        Err(_) => {
-            progress.finish_and_clear();
-            eprintln!("error: failed to create temp file for commit message");
-            return 1;
-        }
-    };
-
-    if let Err(err) = write_message_file(tmpfile.path(), &message_contents) {
-        progress.finish_and_clear();
-        eprintln!("{err:#}");
-        return 1;
+fn git_commit(
+    message_path: &Path,
+    repo: Option<&Path>,
+) -> anyhow::Result<std::process::ExitStatus> {
+    let mut command = Command::new("git");
+    if let Some(repo) = repo {
+        command.arg("-C").arg(repo);
     }
 
-    progress.set_message("validate message");
-    progress.tick();
-    if let Err(code) = progress.suspend(|| validate_commit_message(tmpfile.path())) {
-        progress.finish_and_clear();
-        return code;
-    }
-
-    progress.set_message("check git-scope");
-    progress.tick();
-    if let Err(code) = progress.suspend(ensure_git_scope_available) {
-        progress.finish_and_clear();
-        return code;
-    }
-
-    progress.set_message("git commit");
-    progress.tick();
-    progress.finish_and_clear();
-
-    let status = Command::new("git")
+    command
         .args(["commit", "-F"])
-        .arg(tmpfile.path())
+        .arg(message_path)
         .env("GIT_PAGER", "cat")
         .env("PAGER", "cat")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::inherit())
-        .status();
-
-    match status {
-        Ok(status) if status.success() => {}
-        Ok(status) => {
-            let rc = status.code().unwrap_or(1);
-            eprintln!("error: git commit failed (exit code: {rc})");
-            return rc;
-        }
-        Err(err) => {
-            eprintln!("{err:#}");
-            return 1;
-        }
-    }
-
-    print_summary()
+        .status()
+        .map_err(Into::into)
 }
 
-fn ensure_git_scope_available() -> Result<(), i32> {
-    let status = Command::new("git-scope")
-        .arg("help")
+fn print_summary(summary_mode: SummaryMode, repo: Option<&Path>) -> i32 {
+    match summary_mode {
+        SummaryMode::None => 0,
+        SummaryMode::GitShow => print_git_show_summary(repo),
+        SummaryMode::GitScope => {
+            if run_git_scope_summary(repo) {
+                0
+            } else {
+                eprintln!(
+                    "warning: git-scope summary unavailable; falling back to git show --name-status"
+                );
+                print_git_show_summary(repo)
+            }
+        }
+    }
+}
+
+fn run_git_scope_summary(repo: Option<&Path>) -> bool {
+    let mut command = Command::new("git-scope");
+    if let Some(repo) = repo {
+        command.current_dir(repo);
+    }
+
+    let status = command
+        .args(["commit", "HEAD", "--no-color"])
         .env("GIT_PAGER", "cat")
         .env("PAGER", "cat")
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
         .status();
 
     match status {
-        Ok(status) if status.success() => Ok(()),
+        Ok(status) if status.success() => true,
         Ok(status) => {
-            let rc = status.code().unwrap_or(1);
-            eprintln!("error: git-scope failed (exit code: {rc})");
-            Err(1)
+            let rc = status.code().unwrap_or(EXIT_ERROR);
+            eprintln!("warning: git-scope commit failed (exit code: {rc})");
+            false
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            eprintln!("error: git-scope is required (ensure it is installed and on PATH)");
-            Err(1)
+            eprintln!("warning: git-scope not found on PATH");
+            false
         }
         Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
-            eprintln!("error: git-scope is required (ensure it is executable and on PATH)");
-            Err(1)
+            eprintln!("warning: git-scope is not executable");
+            false
         }
         Err(err) => {
-            eprintln!("error: git-scope is required (failed to run git-scope: {err})");
-            Err(1)
+            eprintln!("warning: git-scope commit failed: {err}");
+            false
         }
     }
 }
 
-fn print_summary() -> i32 {
-    let status = Command::new("git-scope")
-        .args(["commit", "HEAD", "--no-color"])
+fn print_git_show_summary(repo: Option<&Path>) -> i32 {
+    let mut command = Command::new("git");
+    if let Some(repo) = repo {
+        command.arg("-C").arg(repo);
+    }
+
+    let status = command
+        .args(["show", "-1", "--name-status", "--oneline", "--no-color"])
         .env("GIT_PAGER", "cat")
         .env("PAGER", "cat")
         .stdin(Stdio::null())
@@ -216,21 +424,13 @@ fn print_summary() -> i32 {
     match status {
         Ok(status) if status.success() => 0,
         Ok(status) => {
-            let rc = status.code().unwrap_or(1);
-            eprintln!("error: git-scope commit failed (exit code: {rc})");
+            let rc = status.code().unwrap_or(EXIT_ERROR);
+            eprintln!("error: git show summary failed (exit code: {rc})");
             rc
         }
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            eprintln!("error: git-scope is required (ensure it is installed and on PATH)");
-            1
-        }
-        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
-            eprintln!("error: git-scope is required (ensure it is executable and on PATH)");
-            1
-        }
         Err(err) => {
-            eprintln!("error: git-scope commit failed: {err}");
-            1
+            eprintln!("error: git show summary failed: {err}");
+            EXIT_ERROR
         }
     }
 }
@@ -244,7 +444,7 @@ fn write_message_file(path: &Path, contents: &str) -> anyhow::Result<()> {
 fn validate_commit_message(path: &Path) -> Result<(), i32> {
     let file = File::open(path).map_err(|_| {
         eprintln!("error: commit message validation failed");
-        1
+        EXIT_VALIDATION_FAILED
     })?;
 
     let reader = BufReader::new(file);
@@ -312,7 +512,7 @@ fn validate_commit_message(path: &Path) -> Result<(), i32> {
 
 fn fail_validation(message: &str) -> Result<(), i32> {
     eprintln!("error: {message}");
-    Err(1)
+    Err(EXIT_VALIDATION_FAILED)
 }
 
 fn is_valid_header(header: &str) -> bool {
@@ -376,16 +576,51 @@ fn print_usage(stderr: bool) {
     let _ = writeln!(out, "Usage:");
     let _ = writeln!(
         out,
-        "  semantic-commit commit [--message <text> | --message-file <path>]"
+        "  semantic-commit commit [--message <text>|--message-file <path>] [options]"
     );
     let _ = writeln!(out);
+    let _ = writeln!(out, "Options:");
+    let _ = writeln!(out, "  -m, --message <text>         Commit message text");
     let _ = writeln!(
         out,
-        "Reads a prepared commit message (prefer stdin for multi-line messages), runs:"
+        "  -F, --message-file <path>    Read commit message from file"
     );
-    let _ = writeln!(out, "  git commit -F <temp-file>");
-    let _ = writeln!(out, "Then prints:");
-    let _ = writeln!(out, "  git-scope commit HEAD --no-color");
+    let _ = writeln!(
+        out,
+        "      --message-out <path>     Save prepared message for recovery"
+    );
+    let _ = writeln!(
+        out,
+        "      --summary <mode>         Summary mode: git-scope | git-show | none"
+    );
+    let _ = writeln!(
+        out,
+        "      --no-summary             Equivalent to --summary none"
+    );
+    let _ = writeln!(
+        out,
+        "      --repo <path>            Run git commands against repo path"
+    );
+    let _ = writeln!(
+        out,
+        "      --automation             Disallow stdin message fallback"
+    );
+    let _ = writeln!(
+        out,
+        "      --validate-only          Validate message format only"
+    );
+    let _ = writeln!(
+        out,
+        "      --dry-run                Validate + staged checks, skip git commit"
+    );
+    let _ = writeln!(
+        out,
+        "      --no-progress            Disable progress spinner"
+    );
+    let _ = writeln!(
+        out,
+        "      --quiet                  Suppress progress and summary output"
+    );
     let _ = writeln!(out);
     let _ = writeln!(out, "Examples:");
     let _ = writeln!(out, "  cat <<'MSG' | semantic-commit commit");
@@ -394,7 +629,10 @@ fn print_usage(stderr: bool) {
     let _ = writeln!(out, "  - Add thing");
     let _ = writeln!(out, "  MSG");
     let _ = writeln!(out);
-    let _ = writeln!(out, "  semantic-commit commit --message-file ./message.txt");
+    let _ = writeln!(
+        out,
+        "  semantic-commit commit -F ./message.txt --summary git-show"
+    );
 }
 
 #[cfg(test)]
@@ -407,6 +645,14 @@ mod tests {
         file.write_all(contents.as_bytes())
             .expect("write temp message file");
         file
+    }
+
+    #[test]
+    fn summary_mode_parse_supports_known_values() {
+        assert_eq!(SummaryMode::parse("git-scope"), Some(SummaryMode::GitScope));
+        assert_eq!(SummaryMode::parse("git-show"), Some(SummaryMode::GitShow));
+        assert_eq!(SummaryMode::parse("none"), Some(SummaryMode::None));
+        assert_eq!(SummaryMode::parse("other"), None);
     }
 
     #[test]
@@ -426,19 +672,28 @@ mod tests {
         let subject = "a".repeat(95);
         let file = message_file(&format!("feat: {subject}\n"));
 
-        assert_eq!(validate_commit_message(file.path()), Err(1));
+        assert_eq!(
+            validate_commit_message(file.path()),
+            Err(EXIT_VALIDATION_FAILED)
+        );
     }
 
     #[test]
     fn validate_commit_message_rejects_uppercase_scope() {
         let file = message_file("feat(Core): add parser coverage\n");
-        assert_eq!(validate_commit_message(file.path()), Err(1));
+        assert_eq!(
+            validate_commit_message(file.path()),
+            Err(EXIT_VALIDATION_FAILED)
+        );
     }
 
     #[test]
     fn validate_commit_message_rejects_empty_line_inside_body() {
         let file = message_file("feat: add parser coverage\n\n- First line\n\n- Second line\n");
-        assert_eq!(validate_commit_message(file.path()), Err(1));
+        assert_eq!(
+            validate_commit_message(file.path()),
+            Err(EXIT_VALIDATION_FAILED)
+        );
     }
 
     #[test]
@@ -446,7 +701,10 @@ mod tests {
         let long_line = "A".repeat(99);
         let file = message_file(&format!("feat: add parser coverage\n\n- {long_line}\n"));
 
-        assert_eq!(validate_commit_message(file.path()), Err(1));
+        assert_eq!(
+            validate_commit_message(file.path()),
+            Err(EXIT_VALIDATION_FAILED)
+        );
     }
 
     #[test]

--- a/crates/semantic-commit/src/git.rs
+++ b/crates/semantic-commit/src/git.rs
@@ -1,15 +1,51 @@
-use nils_common::git as common_git;
+use std::path::Path;
+use std::process::{Command, Stdio};
 
-pub fn is_inside_work_tree() -> bool {
-    common_git::is_inside_work_tree().unwrap_or(false)
+pub fn command_exists(program: &str) -> bool {
+    Command::new(program)
+        .arg("--help")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
 }
 
-pub fn has_staged_changes() -> anyhow::Result<bool> {
-    let status = common_git::run_status_quiet(&["diff", "--cached", "--quiet", "--"])?;
+pub fn is_inside_work_tree(repo: Option<&Path>) -> bool {
+    let output = git_command(repo)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim() == "true"
+        }
+        _ => false,
+    }
+}
+
+pub fn has_staged_changes(repo: Option<&Path>) -> anyhow::Result<bool> {
+    let status = git_command(repo)
+        .args(["diff", "--cached", "--quiet", "--"])
+        .status()?;
 
     match status.code() {
         Some(0) => Ok(false),
         Some(1) => Ok(true),
         _ => Ok(!status.success()),
     }
+}
+
+fn git_command(repo: Option<&Path>) -> Command {
+    let mut command = Command::new("git");
+    if let Some(repo) = repo {
+        command.arg("-C").arg(repo);
+    }
+
+    command
+        .env("GIT_PAGER", "cat")
+        .env("PAGER", "cat")
+        .stdin(Stdio::null());
+
+    command
 }

--- a/crates/semantic-commit/src/staged_context.rs
+++ b/crates/semantic-commit/src/staged_context.rs
@@ -2,83 +2,207 @@ use crate::git;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
+const EXIT_ERROR: i32 = 1;
+const EXIT_NO_STAGED_CHANGES: i32 = 2;
+const EXIT_DEPENDENCY_ERROR: i32 = 5;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OutputFormat {
+    Bundle,
+    Json,
+    Patch,
+}
+
+impl OutputFormat {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "bundle" => Some(Self::Bundle),
+            "json" => Some(Self::Json),
+            "patch" => Some(Self::Patch),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StagedContextOptions {
+    format: OutputFormat,
+    repo: Option<PathBuf>,
+}
+
+impl Default for StagedContextOptions {
+    fn default() -> Self {
+        Self {
+            format: OutputFormat::Bundle,
+            repo: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Bundle {
+    context_json: String,
+    patch: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct NumstatEntry {
+    insertions: Option<i64>,
+    deletions: Option<i64>,
+    binary: bool,
+}
+
 pub fn run(args: &[String]) -> i32 {
-    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
-        print_usage_stdout();
-        return 0;
+    let options = match parse_args(args) {
+        Ok(options) => options,
+        Err(code) => return code,
+    };
+
+    if !git::command_exists("git") {
+        eprintln!("error: git is required (ensure it is installed and on PATH)");
+        return EXIT_DEPENDENCY_ERROR;
     }
 
-    if let Some(arg) = args.first() {
-        eprintln!("error: unknown argument: {arg}");
-        print_usage_stderr();
-        return 1;
-    }
-
-    if !git::is_inside_work_tree() {
+    if !git::is_inside_work_tree(options.repo.as_deref()) {
         eprintln!("error: must run inside a git work tree");
-        return 1;
+        return EXIT_ERROR;
     }
 
-    match git::has_staged_changes() {
+    match git::has_staged_changes(options.repo.as_deref()) {
         Ok(true) => {}
         Ok(false) => {
             eprintln!("error: no staged changes (stage files with git add first)");
-            return 2;
+            return EXIT_NO_STAGED_CHANGES;
         }
         Err(err) => {
             eprintln!("{err:#}");
-            return 1;
+            return EXIT_ERROR;
         }
     }
 
-    let (context_json, patch) = match build_bundle() {
+    let bundle = match build_bundle(options.repo.as_deref()) {
         Ok(bundle) => bundle,
         Err(err) => {
             eprintln!("{err:#}");
-            return 1;
+            return EXIT_ERROR;
         }
     };
 
-    println!("===== commit-context.json =====");
-    println!("{context_json}");
-    println!();
-    println!("===== staged.patch =====");
-    if let Err(err) = std::io::stdout().write_all(&patch) {
-        eprintln!("{err:#}");
-        return 1;
+    match options.format {
+        OutputFormat::Bundle => {
+            println!("===== commit-context.json =====");
+            println!("{}", bundle.context_json);
+            println!();
+            println!("===== staged.patch =====");
+            if let Err(err) = std::io::stdout().write_all(&bundle.patch) {
+                eprintln!("{err:#}");
+                return EXIT_ERROR;
+            }
+        }
+        OutputFormat::Json => {
+            println!("{}", bundle.context_json);
+        }
+        OutputFormat::Patch => {
+            if let Err(err) = std::io::stdout().write_all(&bundle.patch) {
+                eprintln!("{err:#}");
+                return EXIT_ERROR;
+            }
+        }
     }
 
     0
 }
 
-fn build_bundle() -> anyhow::Result<(String, Vec<u8>)> {
+fn parse_args(args: &[String]) -> Result<StagedContextOptions, i32> {
+    let mut options = StagedContextOptions::default();
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-h" | "--help" => {
+                print_usage_stdout();
+                return Err(0);
+            }
+            "--format" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value,
+                    None => {
+                        eprintln!("error: --format requires a value");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+
+                let Some(format) = OutputFormat::parse(value) else {
+                    eprintln!(
+                        "error: invalid --format value: {value} (expected: bundle, json, patch)"
+                    );
+                    print_usage_stderr();
+                    return Err(EXIT_ERROR);
+                };
+
+                options.format = format;
+                i += 2;
+            }
+            "--json" => {
+                options.format = OutputFormat::Json;
+                i += 1;
+            }
+            "--repo" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --repo requires a path");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.repo = Some(PathBuf::from(value));
+                i += 2;
+            }
+            other => {
+                eprintln!("error: unknown argument: {other}");
+                print_usage_stderr();
+                return Err(EXIT_ERROR);
+            }
+        }
+    }
+
+    Ok(options)
+}
+
+fn build_bundle(repo: Option<&Path>) -> anyhow::Result<Bundle> {
     let generated_at = OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .ok()
         .map(|s| s.to_string());
 
-    let repo_root = git_string(&["rev-parse", "--show-toplevel"])?;
+    let repo_root = git_string(repo, &["rev-parse", "--show-toplevel"])?;
     let repo_name = Path::new(&repo_root)
         .file_name()
         .and_then(|name| name.to_str())
         .map(|s| s.to_string());
 
-    let branch = git_string_ok(&["symbolic-ref", "--quiet", "--short", "HEAD"]);
-    let head = git_string_ok(&["rev-parse", "--short", "HEAD"]);
+    let branch = git_string_ok(repo, &["symbolic-ref", "--quiet", "--short", "HEAD"]);
+    let head = git_string_ok(repo, &["rev-parse", "--short", "HEAD"]);
 
-    let name_status = git_bytes(&[
-        "-c",
-        "core.quotepath=false",
-        "diff",
-        "--cached",
-        "--name-status",
-        "-z",
-    ])?;
+    let name_status = git_bytes(
+        repo,
+        &[
+            "-c",
+            "core.quotepath=false",
+            "diff",
+            "--cached",
+            "--name-status",
+            "-z",
+        ],
+    )?;
+    let numstats = diff_numstat_map(repo)?;
 
     let mut status_counts: BTreeMap<String, u32> = BTreeMap::new();
     let mut top_dir_counts: BTreeMap<String, u32> = BTreeMap::new();
@@ -106,14 +230,14 @@ fn build_bundle() -> anyhow::Result<(String, Vec<u8>)> {
             lockfile_count += 1;
         }
 
-        let (file_insertions, file_deletions, binary) = diff_numstat(&entry.path)?;
-        if binary {
+        let file_stats = numstats.get(&entry.path).copied().unwrap_or_default();
+        if file_stats.binary {
             binary_file_count += 1;
         } else {
-            if let Some(n) = file_insertions {
+            if let Some(n) = file_stats.insertions {
                 insertions += n;
             }
-            if let Some(n) = file_deletions {
+            if let Some(n) = file_stats.deletions {
                 deletions += n;
             }
         }
@@ -129,13 +253,13 @@ fn build_bundle() -> anyhow::Result<(String, Vec<u8>)> {
         }
         obj.insert(
             "insertions".to_string(),
-            file_insertions.map_or(Value::Null, |n| json!(n)),
+            file_stats.insertions.map_or(Value::Null, |n| json!(n)),
         );
         obj.insert(
             "deletions".to_string(),
-            file_deletions.map_or(Value::Null, |n| json!(n)),
+            file_stats.deletions.map_or(Value::Null, |n| json!(n)),
         );
-        obj.insert("binary".to_string(), json!(binary));
+        obj.insert("binary".to_string(), json!(file_stats.binary));
         obj.insert("lockfile".to_string(), json!(lockfile));
         files.push(Value::Object(obj));
     }
@@ -175,15 +299,21 @@ fn build_bundle() -> anyhow::Result<(String, Vec<u8>)> {
     });
 
     let context_json = serde_json::to_string(&context)?;
-    let patch = git_bytes(&[
-        "-c",
-        "core.quotepath=false",
-        "diff",
-        "--cached",
-        "--no-color",
-    ])?;
+    let patch = git_bytes(
+        repo,
+        &[
+            "-c",
+            "core.quotepath=false",
+            "diff",
+            "--cached",
+            "--no-color",
+        ],
+    )?;
 
-    Ok((context_json, patch))
+    Ok(Bundle {
+        context_json,
+        patch,
+    })
 }
 
 struct NameStatusEntry {
@@ -241,33 +371,78 @@ fn parse_name_status_z(buf: &[u8]) -> anyhow::Result<Vec<NameStatusEntry>> {
     Ok(out)
 }
 
-fn diff_numstat(path: &str) -> anyhow::Result<(Option<i64>, Option<i64>, bool)> {
-    let stdout = git_string(&[
-        "-c",
-        "core.quotepath=false",
-        "diff",
-        "--cached",
-        "--numstat",
-        "--",
-        path,
-    ])?;
+fn diff_numstat_map(repo: Option<&Path>) -> anyhow::Result<BTreeMap<String, NumstatEntry>> {
+    let stdout = git_bytes(
+        repo,
+        &[
+            "-c",
+            "core.quotepath=false",
+            "diff",
+            "--cached",
+            "--numstat",
+            "-z",
+        ],
+    )?;
 
-    let line = stdout.lines().next().unwrap_or("").to_string();
-    if line.trim().is_empty() {
-        return Ok((None, None, false));
+    parse_numstat_z(&stdout)
+}
+
+fn parse_numstat_z(buf: &[u8]) -> anyhow::Result<BTreeMap<String, NumstatEntry>> {
+    let mut map: BTreeMap<String, NumstatEntry> = BTreeMap::new();
+
+    let mut i = 0;
+    while i < buf.len() {
+        let added = read_field(buf, &mut i, b'\t')?;
+        let deleted = read_field(buf, &mut i, b'\t')?;
+
+        let path = if i < buf.len() && buf[i] == 0 {
+            i += 1;
+            let _old_path = read_field(buf, &mut i, b'\0')?;
+            read_field(buf, &mut i, b'\0')?
+        } else {
+            read_field(buf, &mut i, b'\0')?
+        };
+
+        let (insertions, deletions, binary) = if added == "-" || deleted == "-" {
+            (None, None, true)
+        } else {
+            (parse_i64_opt(&added), parse_i64_opt(&deleted), false)
+        };
+
+        map.insert(
+            path,
+            NumstatEntry {
+                insertions,
+                deletions,
+                binary,
+            },
+        );
     }
 
-    let mut parts = line.split('\t');
-    let added = parts.next().unwrap_or("");
-    let deleted = parts.next().unwrap_or("");
+    Ok(map)
+}
 
-    if added == "-" || deleted == "-" {
-        return Ok((None, None, true));
+fn parse_i64_opt(value: &str) -> Option<i64> {
+    value.parse::<i64>().ok()
+}
+
+fn read_field(buf: &[u8], index: &mut usize, delimiter: u8) -> anyhow::Result<String> {
+    if *index > buf.len() {
+        return Err(anyhow::anyhow!("error: malformed numstat output"));
     }
 
-    let ins = added.parse::<i64>().ok();
-    let del = deleted.parse::<i64>().ok();
-    Ok((ins, del, false))
+    let start = *index;
+    while *index < buf.len() && buf[*index] != delimiter {
+        *index += 1;
+    }
+
+    if *index >= buf.len() {
+        return Err(anyhow::anyhow!("error: malformed numstat output"));
+    }
+
+    let field = std::str::from_utf8(&buf[start..*index])?.to_string();
+    *index += 1;
+    Ok(field)
 }
 
 fn is_lockfile(path: &str) -> bool {
@@ -286,13 +461,8 @@ fn is_lockfile(path: &str) -> bool {
     )
 }
 
-fn git_string(args: &[&str]) -> anyhow::Result<String> {
-    let output = Command::new("git")
-        .args(args)
-        .env("GIT_PAGER", "cat")
-        .env("PAGER", "cat")
-        .stdin(Stdio::null())
-        .output()?;
+fn git_string(repo: Option<&Path>, args: &[&str]) -> anyhow::Result<String> {
+    let output = git_output(repo, args)?;
 
     if !output.status.success() {
         return Err(anyhow::anyhow!(
@@ -306,14 +476,8 @@ fn git_string(args: &[&str]) -> anyhow::Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-fn git_string_ok(args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .args(args)
-        .env("GIT_PAGER", "cat")
-        .env("PAGER", "cat")
-        .stdin(Stdio::null())
-        .output()
-        .ok()?;
+fn git_string_ok(repo: Option<&Path>, args: &[&str]) -> Option<String> {
+    let output = git_output(repo, args).ok()?;
 
     if !output.status.success() {
         return None;
@@ -327,13 +491,8 @@ fn git_string_ok(args: &[&str]) -> Option<String> {
     }
 }
 
-fn git_bytes(args: &[&str]) -> anyhow::Result<Vec<u8>> {
-    let output = Command::new("git")
-        .args(args)
-        .env("GIT_PAGER", "cat")
-        .env("PAGER", "cat")
-        .stdin(Stdio::null())
-        .output()?;
+fn git_bytes(repo: Option<&Path>, args: &[&str]) -> anyhow::Result<Vec<u8>> {
+    let output = git_output(repo, args)?;
 
     if !output.status.success() {
         return Err(anyhow::anyhow!(
@@ -345,6 +504,21 @@ fn git_bytes(args: &[&str]) -> anyhow::Result<Vec<u8>> {
     }
 
     Ok(output.stdout)
+}
+
+fn git_output(repo: Option<&Path>, args: &[&str]) -> anyhow::Result<std::process::Output> {
+    let mut command = Command::new("git");
+    if let Some(repo) = repo {
+        command.arg("-C").arg(repo);
+    }
+
+    command
+        .args(args)
+        .env("GIT_PAGER", "cat")
+        .env("PAGER", "cat")
+        .stdin(Stdio::null())
+        .output()
+        .map_err(Into::into)
 }
 
 fn print_usage_stdout() {
@@ -362,20 +536,89 @@ fn print_usage(stderr: bool) {
         &mut std::io::stdout()
     };
 
-    let _ = writeln!(out, "Usage: semantic-commit staged-context");
+    let _ = writeln!(
+        out,
+        "Usage: semantic-commit staged-context [--format <bundle|json|patch>] [--repo <path>]"
+    );
     let _ = writeln!(out);
     let _ = writeln!(
         out,
         "Print staged change context for commit message generation."
     );
     let _ = writeln!(out);
+    let _ = writeln!(out, "Options:");
+    let _ = writeln!(
+        out,
+        "  --format <mode>  Output format: bundle (default), json, patch"
+    );
+    let _ = writeln!(out, "  --json           Equivalent to --format json");
+    let _ = writeln!(out, "  --repo <path>    Run git commands against repo path");
+    let _ = writeln!(out);
     let _ = writeln!(out, "Outputs:");
-    let _ = writeln!(out, "  - Bundle: commit-context.json + staged.patch");
+    let _ = writeln!(out, "  - bundle: commit-context.json + staged.patch");
+    let _ = writeln!(out, "  - json: commit-context.json only");
+    let _ = writeln!(out, "  - patch: staged.patch only");
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn output_format_parse_supports_known_values() {
+        assert_eq!(OutputFormat::parse("bundle"), Some(OutputFormat::Bundle));
+        assert_eq!(OutputFormat::parse("json"), Some(OutputFormat::Json));
+        assert_eq!(OutputFormat::parse("patch"), Some(OutputFormat::Patch));
+        assert_eq!(OutputFormat::parse("other"), None);
+    }
+
+    #[test]
+    fn parse_numstat_z_parses_standard_rows() {
+        let map = parse_numstat_z(b"12\t3\tsrc/main.rs\0").expect("parse numstat");
+        let value = map.get("src/main.rs").expect("missing numstat entry");
+        assert_eq!(
+            *value,
+            NumstatEntry {
+                insertions: Some(12),
+                deletions: Some(3),
+                binary: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_numstat_z_parses_binary_rows() {
+        let map = parse_numstat_z(b"-\t-\tassets/logo.bin\0").expect("parse binary numstat");
+        let value = map.get("assets/logo.bin").expect("missing numstat entry");
+        assert_eq!(
+            *value,
+            NumstatEntry {
+                insertions: None,
+                deletions: None,
+                binary: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_numstat_z_parses_rename_rows() {
+        let map = parse_numstat_z(b"3\t1\t\0old.txt\0new.txt\0").expect("parse rename numstat");
+        let value = map.get("new.txt").expect("missing numstat entry");
+        assert_eq!(
+            *value,
+            NumstatEntry {
+                insertions: Some(3),
+                deletions: Some(1),
+                binary: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_numstat_z_rejects_malformed_rows() {
+        let result = parse_numstat_z(b"12\t3\tno-null-terminator");
+        assert!(result.is_err());
+    }
 
     #[test]
     fn parse_name_status_z_parses_basic_entries() {

--- a/crates/semantic-commit/tests/commit.rs
+++ b/crates/semantic-commit/tests/commit.rs
@@ -14,6 +14,26 @@ fn stage_file(repo: &Path, name: &str, contents: &str) {
     common::git(repo, &["add", name]);
 }
 
+fn deterministic_env(path: &str) -> Vec<(&'static str, String)> {
+    vec![
+        ("PATH", path.to_string()),
+        (
+            "GIT_AUTHOR_DATE",
+            "Thu, 01 Jan 1970 00:00:00 +0000".to_string(),
+        ),
+        (
+            "GIT_COMMITTER_DATE",
+            "Thu, 01 Jan 1970 00:00:00 +0000".to_string(),
+        ),
+    ]
+}
+
+fn env_refs<'a>(envs: &'a [(&'static str, String)]) -> Vec<(&'static str, &'a str)> {
+    envs.iter()
+        .map(|(key, value)| (*key, value.as_str()))
+        .collect()
+}
+
 #[test]
 fn commit_outside_git_repo_errors() {
     let dir = tempfile::TempDir::new().expect("tempdir");
@@ -35,7 +55,7 @@ fn commit_help_flag_prints_usage() {
 
     assert_eq!(output.status.code(), Some(0));
     assert!(as_str(&output.stdout)
-        .contains("semantic-commit commit [--message <text> | --message-file <path>]"));
+        .contains("semantic-commit commit [--message <text>|--message-file <path>] [options]"));
 }
 
 #[test]
@@ -55,6 +75,15 @@ fn commit_message_flag_requires_value() {
 
     assert_eq!(output.status.code(), Some(1));
     assert!(as_str(&output.stderr).contains("error: --message requires a value"));
+}
+
+#[test]
+fn commit_short_message_flag_requires_value() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(dir.path(), &["commit", "-m"], &[], None);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("error: -m requires a value"));
 }
 
 #[test]
@@ -94,7 +123,7 @@ fn commit_invalid_header_format_is_hard_fail() {
         None,
     );
 
-    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(output.status.code(), Some(4));
     assert!(as_str(&output.stderr).contains("error: invalid header format"));
 
     let head = common::git_output(repo.path(), &["rev-parse", "--verify", "HEAD"]);
@@ -112,7 +141,7 @@ fn commit_body_requires_blank_line() {
     let message = "feat: test\n- Bad body without blank line\n";
     let output = common::run_semantic_commit_output(repo.path(), &["commit"], &[], Some(message));
 
-    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(output.status.code(), Some(4));
     assert!(as_str(&output.stderr)
         .contains("error: commit body must be separated from header by a blank line"));
 }
@@ -125,7 +154,7 @@ fn commit_body_line_requires_capitalized_bullet() {
     let message = "feat: test\n\n- bad\n";
     let output = common::run_semantic_commit_output(repo.path(), &["commit"], &[], Some(message));
 
-    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(output.status.code(), Some(4));
     assert!(as_str(&output.stderr)
         .contains("error: commit body line 3 must start with '- ' followed by uppercase letter"));
 }
@@ -167,44 +196,193 @@ fn commit_message_file_missing_errors() {
 }
 
 #[test]
-fn commit_empty_stdin_message_errors() {
+fn commit_empty_stdin_message_errors_with_exit_3() {
     let repo = common::init_repo();
     stage_file(repo.path(), "a.txt", "hello\n");
 
     let output = common::run_semantic_commit_output(repo.path(), &["commit"], &[], Some(""));
 
-    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(output.status.code(), Some(3));
     assert!(as_str(&output.stderr).contains("error: commit message is empty"));
 }
 
 #[test]
-fn commit_fails_when_git_scope_missing() {
+fn commit_whitespace_stdin_message_errors_with_exit_3() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output = common::run_semantic_commit_output(repo.path(), &["commit"], &[], Some(" \n\t\n"));
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(as_str(&output.stderr).contains("error: commit message is empty"));
+}
+
+#[test]
+fn commit_automation_requires_message_flag_or_file() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output =
+        common::run_semantic_commit_output(repo.path(), &["commit", "--automation"], &[], Some(""));
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(as_str(&output.stderr).contains("error: no commit message provided in automation mode"));
+}
+
+#[test]
+fn commit_validate_only_allows_outside_repo() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
+fn commit_validate_only_invalid_message_returns_4() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "Feat(core): add thing",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+}
+
+#[test]
+fn commit_dry_run_validates_and_checks_staged_without_committing() {
     let repo = common::init_repo();
     stage_file(repo.path(), "a.txt", "hello\n");
 
     let output = common::run_semantic_commit_output(
         repo.path(),
-        &["commit"],
-        &[
-            ("PATH", "/usr/bin:/bin:/usr/sbin:/sbin"),
-            ("GIT_AUTHOR_DATE", "Thu, 01 Jan 1970 00:00:00 +0000"),
-            ("GIT_COMMITTER_DATE", "Thu, 01 Jan 1970 00:00:00 +0000"),
-        ],
-        Some("feat(core): add thing\n\n- Add thing\n"),
+        &["commit", "--dry-run", "--message", "feat(core): add thing"],
+        &[],
+        None,
     );
 
-    assert_eq!(output.status.code(), Some(1));
-    assert!(as_str(&output.stderr).contains("error: git-scope is required"));
+    assert_eq!(output.status.code(), Some(0));
 
     let head = common::git_output(repo.path(), &["rev-parse", "--verify", "HEAD"]);
-    assert!(
-        !head.status.success(),
-        "expected no commit to have been created"
-    );
+    assert!(!head.status.success(), "expected no commit during dry-run");
 }
 
 #[test]
-fn commit_message_file_successfully_commits() {
+fn commit_default_summary_falls_back_to_git_show_when_git_scope_missing() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let envs_owned = deterministic_env("/usr/bin:/bin:/usr/sbin:/sbin");
+    let envs = env_refs(&envs_owned);
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): add thing",
+            "--no-progress",
+        ],
+        &envs,
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(as_str(&output.stderr).contains("warning: git-scope summary unavailable"));
+    assert!(as_str(&output.stdout).contains("feat(core): add thing"));
+}
+
+#[test]
+fn commit_no_summary_suppresses_summary_output() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let envs_owned = deterministic_env("/usr/bin:/bin:/usr/sbin:/sbin");
+    let envs = env_refs(&envs_owned);
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "-m",
+            "feat(core): add thing",
+            "--no-summary",
+            "--no-progress",
+        ],
+        &envs,
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(as_str(&output.stdout).trim().is_empty());
+}
+
+#[test]
+fn commit_git_show_summary_mode_works_without_git_scope() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let envs_owned = deterministic_env("/usr/bin:/bin:/usr/sbin:/sbin");
+    let envs = env_refs(&envs_owned);
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): add thing",
+            "--summary",
+            "git-show",
+            "--no-progress",
+        ],
+        &envs,
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(as_str(&output.stdout).contains("feat(core): add thing"));
+    assert!(!as_str(&output.stderr).contains("warning: git-scope"));
+}
+
+#[test]
+fn commit_message_out_writes_recovery_message() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+    let out_path = repo.path().join("commit-message.txt");
+
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "Feat(core): bad",
+            "--message-out",
+            "commit-message.txt",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    let saved = fs::read_to_string(out_path).expect("read message-out file");
+    assert_eq!(saved, "Feat(core): bad");
+}
+
+#[test]
+fn commit_message_file_successfully_commits_with_git_scope() {
     let repo = common::init_repo();
     stage_file(repo.path(), "a.txt", "hello\n");
     common::write_file(
@@ -219,9 +397,6 @@ fn commit_message_file_successfully_commits() {
         "git-scope",
         r#"#!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1-}" == "help" ]]; then
-  exit 0
-fi
 if [[ "${1-}" != "commit" || "${2-}" != "HEAD" || "${3-}" != "--no-color" ]]; then
   echo "unexpected args: $*" >&2
   exit 2
@@ -232,66 +407,22 @@ echo "GIT_SCOPE_OK"
 
     let tool_dir = tool_dir.path().to_str().expect("tool dir str");
     let path_env = format!("{tool_dir}:/usr/bin:/bin:/usr/sbin:/sbin");
-    let envs = vec![
-        ("PATH", path_env.as_str()),
-        ("GIT_AUTHOR_DATE", "Thu, 01 Jan 1970 00:00:00 +0000"),
-        ("GIT_COMMITTER_DATE", "Thu, 01 Jan 1970 00:00:00 +0000"),
-    ];
+    let envs_owned = deterministic_env(&path_env);
+    let envs = env_refs(&envs_owned);
     let output = common::run_semantic_commit_output(
         repo.path(),
-        &["commit", "--message-file", "message.txt"],
+        &["commit", "-F", "message.txt", "--no-progress"],
         &envs,
         None,
     );
 
     assert_eq!(output.status.code(), Some(0));
     assert!(as_str(&output.stdout).contains("GIT_SCOPE_OK"));
-}
-
-#[test]
-fn commit_success_uses_git_scope_when_available() {
-    let repo = common::init_repo();
-    stage_file(repo.path(), "a.txt", "hello\n");
-
-    let tool_dir = tempfile::TempDir::new().expect("tempdir");
-    common::write_executable(
-        tool_dir.path(),
-        "git-scope",
-        r#"#!/usr/bin/env bash
-set -euo pipefail
-if [[ "${1-}" == "help" ]]; then
-  exit 0
-fi
-if [[ "${1-}" != "commit" || "${2-}" != "HEAD" || "${3-}" != "--no-color" ]]; then
-  echo "unexpected args: $*" >&2
-  exit 2
-fi
-echo "GIT_SCOPE_OK"
-"#,
-    );
-
-    let tool_dir = tool_dir.path().to_str().unwrap();
-    let path_env = format!("{tool_dir}:/usr/bin:/bin:/usr/sbin:/sbin");
-    let envs = vec![
-        ("PATH", path_env.as_str()),
-        ("GIT_AUTHOR_DATE", "Thu, 01 Jan 1970 00:00:00 +0000"),
-        ("GIT_COMMITTER_DATE", "Thu, 01 Jan 1970 00:00:00 +0000"),
-    ];
-    let output = common::run_semantic_commit_output(
-        repo.path(),
-        &["commit", "--message", "feat(core): add thing"],
-        &envs,
-        None,
-    );
-
-    assert_eq!(output.status.code(), Some(0));
-    assert!(as_str(&output.stdout).contains("GIT_SCOPE_OK"));
-    assert!(!as_str(&output.stderr).contains("warning:"));
 }
 
 #[cfg(unix)]
 #[test]
-fn commit_fails_when_git_scope_is_not_executable() {
+fn commit_falls_back_when_git_scope_is_not_executable() {
     use std::os::unix::fs::PermissionsExt;
 
     let repo = common::init_repo();
@@ -306,24 +437,54 @@ fn commit_fails_when_git_scope_is_not_executable() {
 
     let tool_dir = tool_dir.path().to_str().unwrap();
     let path_env = format!("{tool_dir}:/usr/bin:/bin:/usr/sbin:/sbin");
-    let envs = vec![
-        ("PATH", path_env.as_str()),
-        ("GIT_AUTHOR_DATE", "Thu, 01 Jan 1970 00:00:00 +0000"),
-        ("GIT_COMMITTER_DATE", "Thu, 01 Jan 1970 00:00:00 +0000"),
-    ];
+    let envs_owned = deterministic_env(&path_env);
+    let envs = env_refs(&envs_owned);
     let output = common::run_semantic_commit_output(
         repo.path(),
-        &["commit", "--message", "feat(core): add thing"],
+        &[
+            "commit",
+            "--message",
+            "feat(core): add thing",
+            "--no-progress",
+        ],
         &envs,
         None,
     );
 
-    assert_eq!(output.status.code(), Some(1));
-    assert!(as_str(&output.stderr).contains("error: git-scope is required"));
+    assert_eq!(output.status.code(), Some(0));
+    assert!(as_str(&output.stderr).contains("warning: git-scope summary unavailable"));
+    assert!(as_str(&output.stdout).contains("feat(core): add thing"));
+}
 
+#[test]
+fn commit_repo_flag_commits_from_external_cwd() {
+    let outer = tempfile::TempDir::new().expect("tempdir");
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let envs_owned = deterministic_env("/usr/bin:/bin:/usr/sbin:/sbin");
+    let envs = env_refs(&envs_owned);
+    let repo_path = repo.path().to_str().expect("repo path");
+    let output = common::run_semantic_commit_output(
+        outer.path(),
+        &[
+            "commit",
+            "--repo",
+            repo_path,
+            "--message",
+            "feat(core): add thing",
+            "--summary",
+            "none",
+            "--no-progress",
+        ],
+        &envs,
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
     let head = common::git_output(repo.path(), &["rev-parse", "--verify", "HEAD"]);
     assert!(
-        !head.status.success(),
-        "expected no commit to have been created"
+        head.status.success(),
+        "expected commit to be created in --repo target"
     );
 }

--- a/crates/semantic-commit/tests/staged_context.rs
+++ b/crates/semantic-commit/tests/staged_context.rs
@@ -26,6 +26,10 @@ fn extract_context_json(stdout: &str) -> Value {
     serde_json::from_str(json_part.trim()).expect("parse commit-context.json")
 }
 
+fn parse_json(stdout: &str) -> Value {
+    serde_json::from_str(stdout.trim()).expect("parse json output")
+}
+
 fn find_file<'a>(files: &'a [Value], path: &str) -> &'a Value {
     files
         .iter()
@@ -49,7 +53,8 @@ fn staged_context_help_flag_prints_usage() {
         common::run_semantic_commit_output(dir.path(), &["staged-context", "--help"], &[], None);
 
     assert_eq!(output.status.code(), Some(0));
-    assert!(as_str(&output.stdout).contains("Usage: semantic-commit staged-context"));
+    assert!(as_str(&output.stdout)
+        .contains("semantic-commit staged-context [--format <bundle|json|patch>]"));
 }
 
 #[test]
@@ -63,6 +68,22 @@ fn staged_context_unknown_argument_errors_before_git_checks() {
 }
 
 #[test]
+fn staged_context_invalid_format_value_errors() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &["staged-context", "--format", "yaml"],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("error: invalid --format value: yaml"));
+}
+
+#[test]
 fn staged_context_no_staged_changes_exits_2() {
     let repo = common::init_repo();
     let output = common::run_semantic_commit_output(repo.path(), &["staged-context"], &[], None);
@@ -73,7 +94,7 @@ fn staged_context_no_staged_changes_exits_2() {
 }
 
 #[test]
-fn staged_context_fallback_prints_diff() {
+fn staged_context_bundle_format_prints_json_and_patch() {
     let repo = common::init_repo();
     stage_file(repo.path(), "a.txt", "hello\n");
 
@@ -85,6 +106,63 @@ fn staged_context_fallback_prints_diff() {
     assert!(stdout.contains("===== commit-context.json ====="));
     assert!(stdout.contains("\"schemaVersion\":1"));
     assert!(stdout.contains("===== staged.patch ====="));
+    assert!(stdout.contains("diff --git a/a.txt b/a.txt"));
+}
+
+#[test]
+fn staged_context_json_format_outputs_single_json_document() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &["staged-context", "--format", "json"],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = as_str(&output.stdout);
+    assert!(!stdout.contains("===== commit-context.json ====="));
+    assert!(!stdout.contains("===== staged.patch ====="));
+
+    let context = parse_json(&stdout);
+    assert_eq!(context["schemaVersion"].as_i64(), Some(1));
+    assert_eq!(
+        context["staged"]["patch"]["path"].as_str(),
+        Some("staged.patch")
+    );
+}
+
+#[test]
+fn staged_context_json_flag_alias_outputs_json() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output =
+        common::run_semantic_commit_output(repo.path(), &["staged-context", "--json"], &[], None);
+
+    assert_eq!(output.status.code(), Some(0));
+    let context = parse_json(&as_str(&output.stdout));
+    assert_eq!(context["schemaVersion"].as_i64(), Some(1));
+}
+
+#[test]
+fn staged_context_patch_format_outputs_patch_only() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &["staged-context", "--format", "patch"],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = as_str(&output.stdout);
+    assert!(!stdout.contains("===== commit-context.json ====="));
+    assert!(!stdout.contains("===== staged.patch ====="));
     assert!(stdout.contains("diff --git a/a.txt b/a.txt"));
 }
 
@@ -185,4 +263,23 @@ fn staged_context_records_renames() {
     assert!(status_counts
         .iter()
         .any(|item| item["status"].as_str() == Some("R")));
+}
+
+#[test]
+fn staged_context_repo_flag_runs_from_external_cwd() {
+    let outer = tempfile::TempDir::new().expect("tempdir");
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let repo_path = repo.path().to_str().expect("repo path");
+    let output = common::run_semantic_commit_output(
+        outer.path(),
+        &["staged-context", "--repo", repo_path, "--json"],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    let context = parse_json(&as_str(&output.stdout));
+    assert_eq!(context["schemaVersion"].as_i64(), Some(1));
 }


### PR DESCRIPTION
## Summary
- Implemented all planned `semantic-commit` CLI ergonomics improvements for agent workflows.
- Added safer automation paths, deterministic CLI options, and richer output controls.
- Preserved existing behavior where possible while reducing hard-fail paths.

## Changes
- `commit` command:
  - Added `-m/--message`, `-F/--message-file`, `--message-out`, `--summary`, `--no-summary`, `--repo`, `--automation`, `--non-interactive`, `--validate-only`, `--dry-run`, `--no-progress`, `--quiet`.
  - Added summary fallback from `git-scope` to `git show` instead of hard-failing.
  - Added explicit exit codes for message-required (`3`), validation (`4`), and dependency (`5`).
  - Enforced whitespace-only message as empty.
- `staged-context` command:
  - Added `--format <bundle|json|patch>`, `--json`, and `--repo`.
  - Replaced per-file `numstat` calls with a single-pass `--numstat -z` parser.
- Shared git behavior:
  - Added repo-targeted git helpers and dependency checks.
- Updated shell completions:
  - `completions/zsh/_semantic-commit`
  - `completions/bash/semantic-commit`
- Updated docs:
  - `crates/semantic-commit/README.md`
- Expanded tests:
  - `crates/semantic-commit/tests/commit.rs`
  - `crates/semantic-commit/tests/staged_context.rs`
  - plus new unit coverage in source modules.

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `zsh -f tests/zsh/completion.test.zsh`
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85`
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info`
  - Total line coverage: **85.46%**

## Risk/Notes
- `semantic-commit commit` now degrades gracefully when `git-scope` is unavailable.
- New CLI options are additive; existing usage still works.
