### PR TITLE
Unify command-existence checks and stabilize coverage mode

### DIFF
--- a/crates/codex-cli/src/agent/commit.rs
+++ b/crates/codex-cli/src/agent/commit.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use nils_common::process;
 use std::collections::BTreeSet;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -315,31 +316,7 @@ fn semantic_commit_prompt(mode: &str) -> Option<String> {
 }
 
 fn command_exists(name: &str) -> bool {
-    let Ok(path) = std::env::var("PATH") else {
-        return false;
-    };
-
-    for dir in std::env::split_paths(&path) {
-        let full = dir.join(name);
-        if !full.is_file() {
-            continue;
-        }
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            if let Ok(meta) = std::fs::metadata(&full)
-                && meta.permissions().mode() & 0o111 != 0
-            {
-                return true;
-            }
-        }
-        #[cfg(not(unix))]
-        {
-            return true;
-        }
-    }
-
-    false
+    process::cmd_exists(name)
 }
 
 #[cfg(test)]

--- a/crates/screen-record/tests/writer.rs
+++ b/crates/screen-record/tests/writer.rs
@@ -3,7 +3,7 @@ use tempfile::TempDir;
 use screen_record::cli::ContainerFormat;
 use screen_record::test_mode::TestWriter;
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(coverage)))]
 use screen_record::macos::writer::{
     write_diagnostics_contact_sheet, write_diagnostics_motion_intervals,
 };
@@ -34,7 +34,7 @@ fn test_writer_finish_without_frame_returns_error() {
     assert!(err.to_string().contains("no frames appended"));
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(coverage)))]
 #[test]
 fn diagnostics_artifact_writers_create_readable_files() {
     let dir = TempDir::new().expect("tempdir");

--- a/crates/semantic-commit/src/git.rs
+++ b/crates/semantic-commit/src/git.rs
@@ -1,14 +1,9 @@
+use nils_common::process;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
 pub fn command_exists(program: &str) -> bool {
-    Command::new(program)
-        .arg("--help")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok()
+    process::cmd_exists(program)
 }
 
 pub fn is_inside_work_tree(repo: Option<&Path>) -> bool {

--- a/crates/semantic-commit/tests/commit.rs
+++ b/crates/semantic-commit/tests/commit.rs
@@ -49,6 +49,25 @@ fn commit_outside_git_repo_errors() {
 }
 
 #[test]
+fn commit_missing_git_dependency_exits_5() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let tool_dir = tempfile::TempDir::new().expect("tempdir");
+    let path_env = tool_dir.path().to_str().expect("tool dir path");
+    let envs_owned = deterministic_env(path_env);
+    let envs = env_refs(&envs_owned);
+
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &["commit", "--message", "chore: test"],
+        &envs,
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(5));
+    assert!(as_str(&output.stderr).contains("error: git is required"));
+}
+
+#[test]
 fn commit_help_flag_prints_usage() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let output = common::run_semantic_commit_output(dir.path(), &["commit", "--help"], &[], None);

--- a/crates/semantic-commit/tests/staged_context.rs
+++ b/crates/semantic-commit/tests/staged_context.rs
@@ -11,6 +11,12 @@ fn as_str(output: &[u8]) -> String {
     String::from_utf8_lossy(output).to_string()
 }
 
+fn env_refs<'a>(envs: &'a [(&'static str, String)]) -> Vec<(&'static str, &'a str)> {
+    envs.iter()
+        .map(|(key, value)| (*key, value.as_str()))
+        .collect()
+}
+
 fn stage_file(repo: &Path, name: &str, contents: &str) {
     common::write_file(repo, name, contents);
     common::git(repo, &["add", name]);
@@ -44,6 +50,21 @@ fn staged_context_outside_git_repo_errors() {
 
     assert_eq!(output.status.code(), Some(1));
     assert!(as_str(&output.stderr).contains("error: must run inside a git work tree"));
+}
+
+#[test]
+fn staged_context_missing_git_dependency_exits_5() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let tool_dir = tempfile::TempDir::new().expect("tempdir");
+    let path_env = tool_dir.path().to_str().expect("tool dir path");
+    let envs_owned = vec![("PATH", path_env.to_string())];
+    let envs = env_refs(&envs_owned);
+
+    let output =
+        common::run_semantic_commit_output(dir.path(), &["staged-context", "--json"], &envs, None);
+
+    assert_eq!(output.status.code(), Some(5));
+    assert!(as_str(&output.stderr).contains("error: git is required"));
 }
 
 #[test]


### PR DESCRIPTION
# Unify command lookup foundations and coverage gating

## Summary
This PR consolidates command-existence detection into the shared `nils-common::process::cmd_exists` helper for both `codex-cli` and `semantic-commit`, and adds regression coverage for semantic-commit's missing-`git` dependency path. It also fixes a coverage-mode compile break in `screen-record` by gating writer diagnostics tests behind `not(coverage)` so workspace llvm-cov runs can complete reliably.

## Changes
- Replaced duplicated command lookup logic in `crates/codex-cli/src/agent/commit.rs` with `nils_common::process::cmd_exists`.
- Replaced `semantic-commit`'s `Command::new("<bin>").arg("--help")` probe with shared `cmd_exists` in `crates/semantic-commit/src/git.rs`.
- Added dependency-missing tests to enforce exit code/message behavior:
  - `commit_missing_git_dependency_exits_5`
  - `staged_context_missing_git_dependency_exits_5`
- Fixed coverage-mode test compilation in `crates/screen-record/tests/writer.rs` by using `#[cfg(all(target_os = "macos", not(coverage)))]` for writer-specific diagnostics tests.

## Testing
- `cargo test -p semantic-commit` (pass)
- `cargo test -p codex-cli --test agent_commit` (pass)
- `cargo test -p screen-record --test writer` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 85.54%)

## Risk / Notes
- `screen-record` writer diagnostics tests are intentionally skipped in coverage mode; this matches existing `macos` module stubbing design under `cfg(coverage)` and unblocks workspace coverage runs.
- Behavioral output for user-facing commands is preserved; changes are limited to dependency probing implementation and test coverage.
