### PR TITLE
Unify test output conversion in shared support

### DIFF
--- a/crates/git-lock/tests/common.rs
+++ b/crates/git-lock/tests/common.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::process::Output;
 
 use nils_test_support::bin::resolve;
-use nils_test_support::cmd::{CmdOptions, CmdOutput, run_with};
+use nils_test_support::cmd::{CmdOptions, run_with};
 use nils_test_support::git::{InitRepoOptions, init_repo_with};
 #[allow(unused_imports)]
 pub use nils_test_support::git::{commit_file, git, repo_id};
@@ -37,7 +37,7 @@ pub fn run_git_lock_output(
     };
 
     let output = run_with(&git_lock_bin(), args, &options);
-    output_from_cmd(output)
+    output.into_output()
 }
 
 pub fn run_git_lock(
@@ -56,26 +56,4 @@ pub fn run_git_lock(
         );
     }
     String::from_utf8_lossy(&output.stdout).to_string()
-}
-
-fn output_from_cmd(output: CmdOutput) -> Output {
-    Output {
-        status: exit_status_from_code(output.code),
-        stdout: output.stdout,
-        stderr: output.stderr,
-    }
-}
-
-#[cfg(unix)]
-fn exit_status_from_code(code: i32) -> std::process::ExitStatus {
-    use std::os::unix::process::ExitStatusExt;
-    let raw = if code >= 0 { code << 8 } else { 1 << 8 };
-    std::process::ExitStatus::from_raw(raw)
-}
-
-#[cfg(windows)]
-fn exit_status_from_code(code: i32) -> std::process::ExitStatus {
-    use std::os::windows::process::ExitStatusExt;
-    let raw = if code >= 0 { code as u32 } else { 1 };
-    std::process::ExitStatus::from_raw(raw)
 }

--- a/crates/git-scope/tests/common.rs
+++ b/crates/git-scope/tests/common.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::process::Output;
 
 use nils_test_support::bin::resolve;
-use nils_test_support::cmd::{CmdOptions, CmdOutput, run_with};
+use nils_test_support::cmd::{CmdOptions, run_with};
 pub use nils_test_support::git::git;
 use nils_test_support::git::{InitRepoOptions, init_repo_with};
 
@@ -33,27 +33,5 @@ pub fn run_git_scope_output(dir: &Path, args: &[&str], envs: &[(&str, &str)]) ->
             output.stdout_text()
         );
     }
-    output_from_cmd(output)
-}
-
-fn output_from_cmd(output: CmdOutput) -> Output {
-    Output {
-        status: exit_status_from_code(output.code),
-        stdout: output.stdout,
-        stderr: output.stderr,
-    }
-}
-
-#[cfg(unix)]
-fn exit_status_from_code(code: i32) -> std::process::ExitStatus {
-    use std::os::unix::process::ExitStatusExt;
-    let raw = if code >= 0 { code << 8 } else { 1 << 8 };
-    std::process::ExitStatus::from_raw(raw)
-}
-
-#[cfg(windows)]
-fn exit_status_from_code(code: i32) -> std::process::ExitStatus {
-    use std::os::windows::process::ExitStatusExt;
-    let raw = if code >= 0 { code as u32 } else { 1 };
-    std::process::ExitStatus::from_raw(raw)
+    output.into_output()
 }

--- a/crates/nils-test-support/src/cmd.rs
+++ b/crates/nils-test-support/src/cmd.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Command, Output, Stdio};
 
 /// Output captured from a command invocation.
 #[derive(Debug)]
@@ -22,6 +22,30 @@ impl CmdOutput {
     pub fn stderr_text(&self) -> String {
         String::from_utf8_lossy(&self.stderr).to_string()
     }
+
+    /// Convert to `std::process::Output` for integration with assertion APIs
+    /// that expect process output semantics.
+    pub fn into_output(self) -> Output {
+        Output {
+            status: exit_status_from_code(self.code),
+            stdout: self.stdout,
+            stderr: self.stderr,
+        }
+    }
+}
+
+#[cfg(unix)]
+fn exit_status_from_code(code: i32) -> std::process::ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    let raw = if code >= 0 { code << 8 } else { 1 << 8 };
+    std::process::ExitStatus::from_raw(raw)
+}
+
+#[cfg(windows)]
+fn exit_status_from_code(code: i32) -> std::process::ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    let raw = if code >= 0 { code as u32 } else { 1 };
+    std::process::ExitStatus::from_raw(raw)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/nils-test-support/tests/bin_cmd.rs
+++ b/crates/nils-test-support/tests/bin_cmd.rs
@@ -30,6 +30,33 @@ fn resolve_prefers_env_var_with_underscore() {
     assert_eq!(bin::resolve("test-bin"), path);
 }
 
+#[test]
+fn cmd_output_into_output_preserves_fields_and_exit_code() {
+    let output = cmd::CmdOutput {
+        code: 7,
+        stdout: b"stdout bytes".to_vec(),
+        stderr: b"stderr bytes".to_vec(),
+    };
+
+    let output = output.into_output();
+    assert_eq!(output.status.code(), Some(7));
+    assert_eq!(output.stdout, b"stdout bytes");
+    assert_eq!(output.stderr, b"stderr bytes");
+}
+
+#[test]
+fn cmd_output_into_output_maps_negative_code_to_failure() {
+    let output = cmd::CmdOutput {
+        code: -1,
+        stdout: Vec::new(),
+        stderr: Vec::new(),
+    };
+
+    let output = output.into_output();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!output.status.success());
+}
+
 #[cfg(unix)]
 #[test]
 fn run_captures_exit_code_stdout_stderr_and_env() {

--- a/crates/semantic-commit/tests/common.rs
+++ b/crates/semantic-commit/tests/common.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::process::Output;
 
 use nils_test_support::bin::resolve;
-use nils_test_support::cmd::{CmdOptions, CmdOutput, run_with};
+use nils_test_support::cmd::{CmdOptions, run_with};
 use nils_test_support::fs::{write_executable as write_executable_file, write_text};
 use nils_test_support::git::{InitRepoOptions, init_repo_with};
 #[allow(unused_imports)]
@@ -38,32 +38,10 @@ pub fn run_semantic_commit_output(
         None => options.with_stdin_bytes(&[]),
     };
     let output = run_with(&semantic_commit_bin(), args, &options);
-    output_from_cmd(output)
+    output.into_output()
 }
 
 pub fn write_executable(dir: &Path, rel: &str, contents: &str) {
     let path = dir.join(rel);
     write_executable_file(&path, contents);
-}
-
-fn output_from_cmd(output: CmdOutput) -> Output {
-    Output {
-        status: exit_status_from_code(output.code),
-        stdout: output.stdout,
-        stderr: output.stderr,
-    }
-}
-
-#[cfg(unix)]
-fn exit_status_from_code(code: i32) -> std::process::ExitStatus {
-    use std::os::unix::process::ExitStatusExt;
-    let raw = if code >= 0 { code << 8 } else { 1 << 8 };
-    std::process::ExitStatus::from_raw(raw)
-}
-
-#[cfg(windows)]
-fn exit_status_from_code(code: i32) -> std::process::ExitStatus {
-    use std::os::windows::process::ExitStatusExt;
-    let raw = if code >= 0 { code as u32 } else { 1 };
-    std::process::ExitStatus::from_raw(raw)
 }


### PR DESCRIPTION
# Unify test output conversion in shared support

## Summary
Extract duplicated test-only `CmdOutput -> std::process::Output` conversion logic into `nils-test-support` so multiple CLI crates can reuse one cross-platform implementation and keep behavior consistent.

## Changes
- Added `CmdOutput::into_output()` in `crates/nils-test-support/src/cmd.rs` with shared exit-status mapping.
- Added characterization tests in `crates/nils-test-support/tests/bin_cmd.rs` for stream preservation, exit code mapping, and negative-code fallback.
- Removed duplicated conversion helpers from `crates/git-scope/tests/common.rs`, `crates/git-lock/tests/common.rs`, and `crates/semantic-commit/tests/common.rs` and switched them to the shared API.

## Testing
- `cargo test -p nils-test-support -p git-scope -p git-lock -p semantic-commit` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Scope is limited to test harness plumbing; no production CLI behavior changed.
- Existing crate-level tests plus workspace checks validate parity after extraction.
