### PR TITLE
Make git-scope print flows independent of mktemp

### DIFF
--- a/BINARY_DEPENDENCIES.md
+++ b/BINARY_DEPENDENCIES.md
@@ -17,7 +17,6 @@ These tools are required for common command paths.
 |---|---|---|---|
 | `git` | `git-scope`, `git-cli`, `git-summary`, `git-lock`, `semantic-commit`, `fzf-cli git-*` | Required | `brew install git` |
 | `fzf` | `fzf-cli` interactive commands | Required (for `fzf-cli`) | `brew install fzf` |
-| `mktemp` | `git-scope` print flows (`-p`, commit print modes) | Required for those modes | Usually preinstalled (verify with `command -v mktemp`) |
 | `magick` (or `convert` + `identify`) | `image-processing` | Required (for `image-processing`) | `brew install imagemagick` |
 | `ffmpeg` | `screen-record` on Linux | Required on Linux | `brew install ffmpeg` |
 | `codex` | `codex-cli agent *` flows | Required for agent commands | Install from official Codex distribution |
@@ -136,7 +135,7 @@ eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 ## 8. Quick Environment Verification
 
 ```bash
-for c in git gh fzf mktemp tree file magick ffmpeg bat im-select; do
+for c in git gh fzf tree file magick ffmpeg bat im-select; do
   if command -v "$c" >/dev/null 2>&1; then
     echo "[OK]   $c -> $(command -v "$c")"
   else

--- a/crates/git-scope/Cargo.toml
+++ b/crates/git-scope/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 nils-term = { path = "../nils-term" }
 nils-common = { path = "../nils-common" }
+tempfile = "3"
 
 [dev-dependencies]
 nils-test-support = { path = "../nils-test-support" }
-tempfile = "3"

--- a/crates/git-scope/README.md
+++ b/crates/git-scope/README.md
@@ -43,7 +43,6 @@ Options:
 - `git` is required for all commands.
 - `tree` is optional; missing or unsupported versions emit a warning and skip tree output.
 - `file` is optional; when unavailable, binary detection falls back to content inspection.
-- `mktemp` is required for printing contents from the index or commit history.
 
 ## Environment
 - `NO_COLOR`: Disable ANSI colors.

--- a/crates/git-scope/src/print.rs
+++ b/crates/git-scope/src/print.rs
@@ -4,6 +4,7 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
+use tempfile::NamedTempFile;
 
 #[derive(Debug, Clone, Copy)]
 pub enum PrintSource {
@@ -53,31 +54,29 @@ pub fn emit_file_from_commit(commit: &str, path: &str) -> Result<()> {
         return Ok(());
     }
 
-    let tmp = mktemp_path()?;
-    if git_show_to_file(&format!("{commit}:{path}"), &tmp).is_err() {
-        let _ = fs::remove_file(&tmp);
+    let tmp = new_temp_file()?;
+    if git_show_to_file(&format!("{commit}:{path}"), tmp.path()).is_err() {
         println!("❗ File not found in commit {commit}: {path}");
         return Ok(());
     }
 
-    if is_binary_file(&tmp)? {
+    if is_binary_file(tmp.path())? {
         println!("📄 {path} (binary file in {commit})");
         println!("🔹 [Binary file content omitted]");
     } else {
         println!("📄 {path} (from {commit})");
         println!("```");
-        let content = fs::read(&tmp)?;
+        let content = fs::read(tmp.path())?;
         std::io::stdout().write_all(&content)?;
         println!();
         println!("```");
     }
 
-    let _ = fs::remove_file(&tmp);
     Ok(())
 }
 
 fn emit_from_worktree(path: &str) -> Result<()> {
-    if is_binary_file(path)? {
+    if is_binary_file(Path::new(path))? {
         println!("📄 {path} (binary file in working tree)");
         println!("🔹 [Binary file content omitted]");
     } else {
@@ -92,34 +91,32 @@ fn emit_from_worktree(path: &str) -> Result<()> {
 }
 
 fn emit_from_index(path: &str) -> Result<()> {
-    let tmp = mktemp_path()?;
-    if git_show_to_file(&format!(":{path}"), &tmp).is_err() {
-        let _ = fs::remove_file(&tmp);
+    let tmp = new_temp_file()?;
+    if git_show_to_file(&format!(":{path}"), tmp.path()).is_err() {
         println!("❗ Failed to read file from index: {path}");
         return Ok(());
     }
 
-    if is_binary_file(&tmp)? {
+    if is_binary_file(tmp.path())? {
         println!("📄 {path} (binary file in index)");
         println!("🔹 [Binary file content omitted]");
     } else {
         println!("📄 {path} (index)");
         println!("```");
-        let content = fs::read(&tmp)?;
+        let content = fs::read(tmp.path())?;
         std::io::stdout().write_all(&content)?;
         println!();
         println!("```");
     }
 
-    let _ = fs::remove_file(&tmp);
     Ok(())
 }
 
 fn emit_from_head(path: &str, fallback: HeadFallback) -> Result<()> {
-    let tmp = mktemp_path()?;
-    git_show_to_file(&format!("HEAD:{path}"), &tmp)?;
+    let tmp = new_temp_file()?;
+    git_show_to_file(&format!("HEAD:{path}"), tmp.path())?;
 
-    if is_binary_file(&tmp)? {
+    if is_binary_file(tmp.path())? {
         match fallback {
             HeadFallback::DeletedInIndex => {
                 println!("📄 {path} (deleted in index; binary file in HEAD)");
@@ -139,13 +136,12 @@ fn emit_from_head(path: &str, fallback: HeadFallback) -> Result<()> {
             }
         }
         println!("```");
-        let content = fs::read(&tmp)?;
+        let content = fs::read(tmp.path())?;
         std::io::stdout().write_all(&content)?;
         println!();
         println!("```");
     }
 
-    let _ = fs::remove_file(&tmp);
     Ok(())
 }
 
@@ -158,7 +154,7 @@ fn git_has_object(spec: &str) -> Result<bool> {
     Ok(status.success())
 }
 
-fn git_show_to_file(spec: &str, dest: &str) -> Result<()> {
+fn git_show_to_file(spec: &str, dest: &Path) -> Result<()> {
     let output = Command::new("git")
         .args(["show", spec])
         .output()
@@ -171,7 +167,9 @@ fn git_show_to_file(spec: &str, dest: &str) -> Result<()> {
     Ok(())
 }
 
-fn is_binary_file(path: &str) -> Result<bool> {
+fn is_binary_file(path: &Path) -> Result<bool> {
+    let path_display = path.display();
+
     if let Some(false) = file_mime_available().get() {
         return is_binary_file_fallback(path);
     }
@@ -188,7 +186,7 @@ fn is_binary_file(path: &str) -> Result<bool> {
             file_mime_available().get_or_init(|| false);
             return is_binary_file_fallback(path);
         }
-        Err(err) => return Err(err).with_context(|| format!("file --mime {path}")),
+        Err(err) => return Err(err).with_context(|| format!("file --mime {path_display}")),
     }
 
     is_binary_file_fallback(path)
@@ -199,38 +197,17 @@ fn file_mime_available() -> &'static OnceLock<bool> {
     &FILE_MIME_AVAILABLE
 }
 
-fn is_binary_file_fallback(path: &str) -> Result<bool> {
+fn is_binary_file_fallback(path: &Path) -> Result<bool> {
+    let path_display = path.display();
     const CHUNK_SIZE: usize = 8192;
-    let mut file = fs::File::open(path).with_context(|| format!("open {path}"))?;
+    let mut file = fs::File::open(path).with_context(|| format!("open {path_display}"))?;
     let mut buf = [0u8; CHUNK_SIZE];
     let n = file
         .read(&mut buf)
-        .with_context(|| format!("read {path}"))?;
+        .with_context(|| format!("read {path_display}"))?;
     Ok(buf[..n].contains(&0))
 }
 
-fn mktemp_path() -> Result<String> {
-    if let Ok(path) = run_mktemp(&["mktemp"]) {
-        return Ok(path);
-    }
-
-    if let Ok(path) = run_mktemp(&["mktemp", "-t", "git-scope.XXXXXX"]) {
-        return Ok(path);
-    }
-
-    println!("❗ Failed to create temp file");
-    anyhow::bail!("mktemp failed")
-}
-
-fn run_mktemp(args: &[&str]) -> Result<String> {
-    let output = Command::new(args[0]).args(&args[1..]).output()?;
-    if !output.status.success() {
-        anyhow::bail!("mktemp failed")
-    }
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if path.is_empty() {
-        anyhow::bail!("mktemp produced empty output")
-    } else {
-        Ok(path)
-    }
+fn new_temp_file() -> Result<NamedTempFile> {
+    NamedTempFile::new().context("create temp file")
 }

--- a/crates/git-scope/tests/tool_degradation.rs
+++ b/crates/git-scope/tests/tool_degradation.rs
@@ -40,9 +40,7 @@ fn tracked_print_works_when_file_missing() {
 
     let stub = tempfile::TempDir::new().unwrap();
     let git_path = which_cmd("git");
-    let mktemp_path = which_cmd("mktemp");
     symlink(&git_path, stub.path().join("git")).unwrap();
-    symlink(&mktemp_path, stub.path().join("mktemp")).unwrap();
 
     let path_env = stub.path().to_string_lossy().to_string();
     let output = common::run_git_scope(
@@ -66,6 +64,39 @@ fn tracked_print_works_when_file_missing() {
     assert!(
         output.contains("[Binary file content omitted]"),
         "binary placeholder missing: {output}"
+    );
+}
+
+#[test]
+fn staged_print_works_without_mktemp_or_file() {
+    let repo = common::init_repo();
+    let root = repo.path();
+
+    fs::write(root.join("tracked.txt"), "base line\n").unwrap();
+    common::git(root, &["add", "tracked.txt"]);
+    common::git(root, &["commit", "-m", "base"]);
+
+    fs::write(root.join("tracked.txt"), "STAGED_LINE\n").unwrap();
+    common::git(root, &["add", "tracked.txt"]);
+
+    let stub = tempfile::TempDir::new().unwrap();
+    let git_path = which_cmd("git");
+    symlink(&git_path, stub.path().join("git")).unwrap();
+
+    let path_env = stub.path().to_string_lossy().to_string();
+    let output = common::run_git_scope(
+        root,
+        &["staged", "-p"],
+        &[("NO_COLOR", "1"), ("PATH", path_env.as_str())],
+    );
+
+    assert!(
+        output.contains("📄 tracked.txt (index)"),
+        "index label missing: {output}"
+    );
+    assert!(
+        output.contains("STAGED_LINE"),
+        "staged content missing: {output}"
     );
 }
 


### PR DESCRIPTION
# Make git-scope print flows independent of mktemp

## Summary
This PR removes the runtime dependency on the external `mktemp` command for `git-scope` print flows. `-p` output for staged and commit paths now uses Rust-managed temporary files, so the command keeps working when only `git` is present on `PATH`.

## Changes
- Replaced shell `mktemp` invocations in `crates/git-scope/src/print.rs` with `tempfile::NamedTempFile`.
- Added regression coverage in `crates/git-scope/tests/tool_degradation.rs` for `staged -p` without `mktemp` or `file` in `PATH`.
- Updated dependency docs (`crates/git-scope/README.md`, `BINARY_DEPENDENCIES.md`) and moved `tempfile` to a runtime dependency in `crates/git-scope/Cargo.toml`.

## Testing
- `cargo test -p git-scope` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Low risk: output format and user-facing messages are unchanged; only temp-file lifecycle and tooling dependency were adjusted.
