### PR TITLE
Improve shared Git preflight checks across CLI crates

### DIFF
--- a/crates/git-cli/src/commit.rs
+++ b/crates/git-cli/src/commit.rs
@@ -7,6 +7,7 @@ use crate::commit_shared::{
 use crate::prompt;
 use crate::util;
 use anyhow::{Result, anyhow};
+use nils_common::git::{self as common_git, GitContextError};
 use nils_common::shell::{AnsiStripMode, strip_ansi as strip_ansi_impl};
 use std::env;
 use std::io::Write;
@@ -61,13 +62,7 @@ fn parse_command(raw: &str) -> Option<CommitCommand> {
 }
 
 fn run_context(args: &[String]) -> i32 {
-    if !util::cmd_exists("git") {
-        eprintln!("❗ git is required but was not found in PATH.");
-        return 1;
-    }
-
-    if !git_status_success(&["rev-parse", "--is-inside-work-tree"]) {
-        eprintln!("❌ Not a git repository.");
+    if !ensure_git_work_tree() {
         return 1;
     }
 
@@ -428,13 +423,7 @@ fn file_probe(blob_ref: &str) -> Option<String> {
 }
 
 fn run_to_stash(args: &[String]) -> i32 {
-    if !util::cmd_exists("git") {
-        eprintln!("❗ git is required but was not found in PATH.");
-        return 1;
-    }
-
-    if !git_status_success(&["rev-parse", "--is-inside-work-tree"]) {
-        eprintln!("❌ Not a git repository.");
+    if !ensure_git_work_tree() {
         return 1;
     }
 
@@ -749,6 +738,20 @@ fn synthesize_stash_object(
 
 fn short_sha(value: &str) -> String {
     value.chars().take(7).collect()
+}
+
+fn ensure_git_work_tree() -> bool {
+    match common_git::require_work_tree() {
+        Ok(()) => true,
+        Err(GitContextError::GitNotFound) => {
+            eprintln!("❗ git is required but was not found in PATH.");
+            false
+        }
+        Err(GitContextError::NotRepository) => {
+            eprintln!("❌ Not a git repository.");
+            false
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/git-cli/src/commit_json.rs
+++ b/crates/git-cli/src/commit_json.rs
@@ -1,10 +1,10 @@
 use crate::clipboard;
 use crate::commit_shared::{
-    DiffNumstat, diff_numstat, git_output, git_status_code, git_status_success,
-    git_stdout_trimmed_optional, is_lockfile, parse_name_status_z,
+    DiffNumstat, diff_numstat, git_output, git_status_code, git_stdout_trimmed_optional,
+    is_lockfile, parse_name_status_z,
 };
-use crate::util;
 use anyhow::{Result, anyhow};
+use nils_common::git::{self as common_git, GitContextError};
 use serde_json::{Map, Number, Value};
 use std::collections::BTreeMap;
 use std::env;
@@ -34,14 +34,16 @@ enum ParseOutcome<T> {
 }
 
 pub fn run(args: &[String]) -> i32 {
-    if !util::cmd_exists("git") {
-        eprintln!("❗ git is required but was not found in PATH.");
-        return 1;
-    }
-
-    if !git_status_success(&["rev-parse", "--is-inside-work-tree"]) {
-        eprintln!("❌ Not a git repository.");
-        return 1;
+    match common_git::require_work_tree() {
+        Ok(()) => {}
+        Err(GitContextError::GitNotFound) => {
+            eprintln!("❗ git is required but was not found in PATH.");
+            return 1;
+        }
+        Err(GitContextError::NotRepository) => {
+            eprintln!("❌ Not a git repository.");
+            return 1;
+        }
     }
 
     let parsed = match parse_args(args) {

--- a/crates/git-summary/src/git.rs
+++ b/crates/git-summary/src/git.rs
@@ -1,18 +1,15 @@
 use anyhow::{Context, Result};
 use nils_common::git as common_git;
+use nils_common::git::GitContextError;
 
 pub fn require_git() -> Result<(), &'static str> {
-    if common_git::run_status_quiet(&["--version"]).is_err() {
-        return Err("❗ git is required but was not found in PATH.");
+    match common_git::require_repo() {
+        Ok(()) => Ok(()),
+        Err(GitContextError::GitNotFound) => Err("❗ git is required but was not found in PATH."),
+        Err(GitContextError::NotRepository) => {
+            Err("⚠️ Not a Git repository. Run this command inside a Git project.")
+        }
     }
-
-    let status = common_git::run_status_quiet(&["rev-parse", "--git-dir"]);
-
-    if !status.map(|s| s.success()).unwrap_or(false) {
-        return Err("⚠️ Not a Git repository. Run this command inside a Git project.");
-    }
-
-    Ok(())
 }
 
 pub fn run_git(args: &[String]) -> Result<String> {

--- a/crates/nils-common/src/git.rs
+++ b/crates/nils-common/src/git.rs
@@ -2,6 +2,12 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Output, Stdio};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitContextError {
+    GitNotFound,
+    NotRepository,
+}
+
 pub fn run_output(args: &[&str]) -> io::Result<Output> {
     run_output_inner(None, args)
 }
@@ -24,6 +30,28 @@ pub fn run_status_inherit(args: &[&str]) -> io::Result<ExitStatus> {
 
 pub fn run_status_inherit_in(cwd: &Path, args: &[&str]) -> io::Result<ExitStatus> {
     run_status_inherit_inner(Some(cwd), args)
+}
+
+pub fn is_git_available() -> bool {
+    run_status_quiet(&["--version"])
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+pub fn require_repo() -> Result<(), GitContextError> {
+    require_context(None, &["rev-parse", "--git-dir"])
+}
+
+pub fn require_repo_in(cwd: &Path) -> Result<(), GitContextError> {
+    require_context(Some(cwd), &["rev-parse", "--git-dir"])
+}
+
+pub fn require_work_tree() -> Result<(), GitContextError> {
+    require_context(None, &["rev-parse", "--is-inside-work-tree"])
+}
+
+pub fn require_work_tree_in(cwd: &Path) -> Result<(), GitContextError> {
+    require_context(Some(cwd), &["rev-parse", "--is-inside-work-tree"])
 }
 
 pub fn is_inside_work_tree() -> io::Result<bool> {
@@ -91,6 +119,25 @@ fn run_status_inherit_inner(cwd: Option<&Path>, args: &[&str]) -> io::Result<Exi
     cmd.status()
 }
 
+fn require_context(cwd: Option<&Path>, probe_args: &[&str]) -> Result<(), GitContextError> {
+    if !is_git_available() {
+        return Err(GitContextError::GitNotFound);
+    }
+
+    let in_context = match cwd {
+        Some(cwd) => run_status_quiet_in(cwd, probe_args),
+        None => run_status_quiet(probe_args),
+    }
+    .map(|status| status.success())
+    .unwrap_or(false);
+
+    if in_context {
+        Ok(())
+    } else {
+        Err(GitContextError::NotRepository)
+    }
+}
+
 fn rev_parse_args<'a>(args: &'a [&'a str]) -> Vec<&'a str> {
     let mut full = Vec::with_capacity(args.len() + 1);
     full.push("rev-parse");
@@ -115,7 +162,7 @@ fn trimmed_stdout_if_success(output: &Output) -> Option<String> {
 mod tests {
     use super::*;
     use nils_test_support::git::{InitRepoOptions, git as run_git, init_repo_with};
-    use nils_test_support::{CwdGuard, GlobalStateLock};
+    use nils_test_support::{CwdGuard, EnvGuard, GlobalStateLock};
     use pretty_assertions::assert_eq;
     use tempfile::TempDir;
 
@@ -204,7 +251,39 @@ mod tests {
 
         assert!(is_git_repo().expect("is_git_repo"));
         assert!(is_inside_work_tree().expect("is_inside_work_tree"));
+        assert_eq!(require_repo(), Ok(()));
+        assert_eq!(require_work_tree(), Ok(()));
         assert_eq!(repo_root().expect("repo_root"), Some(root.into()));
         assert_eq!(rev_parse(&["HEAD"]).expect("rev_parse"), Some(head));
+    }
+
+    #[test]
+    fn require_work_tree_in_reports_missing_git_or_repo_state() {
+        let lock = GlobalStateLock::new();
+        let outside = TempDir::new().expect("tempdir");
+        let empty = TempDir::new().expect("tempdir");
+        let _path = EnvGuard::set(&lock, "PATH", &empty.path().to_string_lossy());
+
+        assert_eq!(
+            require_work_tree_in(outside.path()),
+            Err(GitContextError::GitNotFound)
+        );
+    }
+
+    #[test]
+    fn require_repo_and_work_tree_in_report_context_readiness() {
+        let repo = init_repo_with(InitRepoOptions::new());
+        let outside = TempDir::new().expect("tempdir");
+
+        assert_eq!(require_repo_in(repo.path()), Ok(()));
+        assert_eq!(require_work_tree_in(repo.path()), Ok(()));
+        assert_eq!(
+            require_repo_in(outside.path()),
+            Err(GitContextError::NotRepository)
+        );
+        assert_eq!(
+            require_work_tree_in(outside.path()),
+            Err(GitContextError::NotRepository)
+        );
     }
 }


### PR DESCRIPTION
# Improve shared Git preflight checks across CLI crates

## Summary
Extracted a reusable Git preflight API into `nils-common` and migrated `git-summary` plus `git-cli commit` paths to consume it, reducing duplicated `git exists + repo/worktree` checks while preserving existing user-facing error text.

## Changes
- Added `GitContextError` and shared preflight helpers in `crates/nils-common/src/git.rs` (`is_git_available`, `require_repo*`, `require_work_tree*`).
- Switched `crates/git-summary/src/git.rs` to use shared repo preflight logic with the same warning/error strings.
- Switched `crates/git-cli/src/commit.rs` and `crates/git-cli/src/commit_json.rs` to shared worktree preflight logic.
- Added/updated `nils-common` tests to verify missing-git, repo, and worktree readiness states.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Scope is intentionally limited to preflight checks; command behavior and output wording remain unchanged.
