### PR TITLE
Consolidate shared env truthy helpers for diagnostics and preflight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "agent-provider-gemini",
  "agent-runtime-core",
  "clap",
+ "nils-common",
  "nils-test-support",
  "pretty_assertions",
  "serde",
@@ -1524,6 +1525,7 @@ version = "0.3.0"
 dependencies = [
  "clap",
  "image",
+ "nils-common",
  "nils-test-support",
  "pretty_assertions",
  "regex",

--- a/crates/agentctl/Cargo.toml
+++ b/crates/agentctl/Cargo.toml
@@ -10,6 +10,7 @@ agent-provider-codex = { path = "../agent-provider-codex" }
 agent-provider-claude = { path = "../agent-provider-claude" }
 agent-provider-gemini = { path = "../agent-provider-gemini" }
 agent-runtime-core = { path = "../agent-runtime-core" }
+nils-common = { path = "../nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/agentctl/src/diag/mod.rs
+++ b/crates/agentctl/src/diag/mod.rs
@@ -2,6 +2,7 @@ pub mod capabilities;
 pub mod doctor;
 
 use clap::{Args, Subcommand, ValueEnum};
+use nils_common::env as shared_env;
 use serde::Serialize;
 
 pub const DIAG_SCHEMA_VERSION: &str = "agentctl.diag.v1";
@@ -67,7 +68,9 @@ impl ProbeMode {
 pub fn resolve_probe_mode(mode: ProbeModeArg) -> ProbeMode {
     match mode {
         ProbeModeArg::Auto => {
-            if env_truthy(MACOS_AGENT_TEST_MODE_ENV) || env_truthy(SCREEN_RECORD_TEST_MODE_ENV) {
+            if shared_env::env_truthy(MACOS_AGENT_TEST_MODE_ENV)
+                || shared_env::env_truthy(SCREEN_RECORD_TEST_MODE_ENV)
+            {
                 ProbeMode::Test
             } else {
                 ProbeMode::Live
@@ -235,15 +238,6 @@ pub fn emit_json<T: Serialize>(value: &T) -> i32 {
             EXIT_RUNTIME_ERROR
         }
     }
-}
-
-pub fn env_truthy(name: &str) -> bool {
-    let raw =
-        std::env::var_os(name).map(|value| value.to_string_lossy().trim().to_ascii_lowercase());
-    matches!(
-        raw.as_deref(),
-        Some("1") | Some("true") | Some("yes") | Some("on")
-    )
 }
 
 pub fn classify_hint_category(text: &str) -> FailureHintCategory {

--- a/crates/macos-agent/Cargo.toml
+++ b/crates/macos-agent/Cargo.toml
@@ -9,6 +9,7 @@ clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 regex = "1"
+nils-common = { path = "../nils-common" }
 screen-record = { path = "../screen-record" }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 

--- a/crates/macos-agent/src/preflight.rs
+++ b/crates/macos-agent/src/preflight.rs
@@ -1,7 +1,6 @@
-use std::env;
-use std::path::PathBuf;
 use std::process::Command;
 
+use nils_common::{env as shared_env, process as shared_process};
 use screen_record::types::PermissionStatusSchema;
 use serde_json::{Value, json};
 
@@ -488,7 +487,7 @@ fn probe_input_hotkey() -> CheckReport {
 }
 
 fn probe_screenshot() -> CheckReport {
-    if env_truthy("CODEX_MACOS_AGENT_TEST_MODE") {
+    if shared_env::env_truthy("CODEX_MACOS_AGENT_TEST_MODE") {
         return CheckReport {
             id: "probe_screenshot",
             label: "Probe: observe screenshot",
@@ -540,28 +539,8 @@ fn probe_screenshot() -> CheckReport {
     }
 }
 
-fn env_truthy(name: &str) -> bool {
-    let raw = env::var_os(name).map(|value| value.to_string_lossy().trim().to_ascii_lowercase());
-    matches!(
-        raw.as_deref(),
-        Some("1") | Some("true") | Some("yes") | Some("on")
-    )
-}
-
 fn find_in_path(bin: &str) -> Option<String> {
-    if bin.contains(std::path::MAIN_SEPARATOR) {
-        let path = PathBuf::from(bin);
-        if path.is_file() {
-            return Some(path.display().to_string());
-        }
-        return None;
-    }
-
-    let path_var = env::var_os("PATH")?;
-    env::split_paths(&path_var)
-        .map(|dir| dir.join(bin))
-        .find(|candidate| candidate.is_file())
-        .map(|candidate| candidate.display().to_string())
+    shared_process::find_in_path(bin).map(|path| path.display().to_string())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/macos-agent/src/test_mode.rs
+++ b/crates/macos-agent/src/test_mode.rs
@@ -1,7 +1,8 @@
+use nils_common::env as shared_env;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn enabled() -> bool {
-    env_truthy("CODEX_MACOS_AGENT_TEST_MODE")
+    shared_env::env_truthy("CODEX_MACOS_AGENT_TEST_MODE")
 }
 
 pub fn timestamp_token() -> String {
@@ -17,15 +18,6 @@ pub fn timestamp_token() -> String {
         .map(|d| d.as_secs())
         .unwrap_or(0);
     secs.to_string()
-}
-
-pub fn env_truthy(name: &str) -> bool {
-    let raw =
-        std::env::var_os(name).map(|value| value.to_string_lossy().trim().to_ascii_lowercase());
-    matches!(
-        raw.as_deref(),
-        Some("1") | Some("true") | Some("yes") | Some("on")
-    )
 }
 
 #[cfg(test)]

--- a/crates/nils-common/src/env.rs
+++ b/crates/nils-common/src/env.rs
@@ -6,18 +6,19 @@ pub fn is_truthy_or(input: Option<&str>, default: bool) -> bool {
     input.map(is_truthy).unwrap_or(default)
 }
 
+fn truthy_from_env(name: &str) -> Option<bool> {
+    std::env::var_os(name).map(|value| {
+        let value = value.to_string_lossy();
+        is_truthy(value.trim())
+    })
+}
+
 pub fn env_truthy(name: &str) -> bool {
-    std::env::var(name)
-        .ok()
-        .map(|value| is_truthy(value.as_str()))
-        .unwrap_or(false)
+    truthy_from_env(name).unwrap_or(false)
 }
 
 pub fn env_truthy_or(name: &str, default: bool) -> bool {
-    match std::env::var(name) {
-        Ok(value) => is_truthy(value.as_str()),
-        Err(_) => default,
-    }
+    truthy_from_env(name).unwrap_or(default)
 }
 
 pub fn no_color_enabled() -> bool {
@@ -58,11 +59,25 @@ mod tests {
     }
 
     #[test]
+    fn env_truthy_trims_whitespace() {
+        let lock = GlobalStateLock::new();
+        let _guard = EnvGuard::set(&lock, "NILS_COMMON_ENV_TRUTHY_TRIM_TEST", " yes ");
+        assert!(env_truthy("NILS_COMMON_ENV_TRUTHY_TRIM_TEST"));
+    }
+
+    #[test]
     fn env_truthy_or_falls_back_to_default() {
         let lock = GlobalStateLock::new();
         let _guard = EnvGuard::remove(&lock, "NILS_COMMON_ENV_TRUTHY_OR_TEST");
         assert!(env_truthy_or("NILS_COMMON_ENV_TRUTHY_OR_TEST", true));
         assert!(!env_truthy_or("NILS_COMMON_ENV_TRUTHY_OR_TEST", false));
+    }
+
+    #[test]
+    fn env_truthy_or_prefers_present_trimmed_values() {
+        let lock = GlobalStateLock::new();
+        let _guard = EnvGuard::set(&lock, "NILS_COMMON_ENV_TRUTHY_OR_VALUE_TEST", " off ");
+        assert!(!env_truthy_or("NILS_COMMON_ENV_TRUTHY_OR_VALUE_TEST", true));
     }
 
     #[test]


### PR DESCRIPTION
# Consolidate shared env truthy parsing across agent CLIs

## Summary
This change removes duplicated environment truthy parsing and PATH lookup logic from `macos-agent` and `agentctl` by routing both through `nils-common`, while preserving existing CLI behavior and tightening shared test coverage for trimmed environment values.

## Changes
- Added shared `truthy_from_env` handling in `nils-common` and updated `env_truthy`/`env_truthy_or` to parse trimmed `var_os` values.
- Replaced local `env_truthy` implementations in `crates/macos-agent/src/test_mode.rs`, `crates/macos-agent/src/preflight.rs`, and `crates/agentctl/src/diag/mod.rs` with `nils-common` helpers.
- Routed `macos-agent` preflight PATH discovery through `nils-common::process::find_in_path`.
- Added `nils-common` dependency wiring to `macos-agent` and `agentctl` and refreshed `Cargo.lock`.
- Added regression tests in `crates/nils-common/src/env.rs` for whitespace-trimmed env parsing behavior.

## Testing
- `cargo test -p nils-common` (pass)
- `cargo test -p macos-agent` (pass)
- `cargo test -p agentctl` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- `env_truthy` now trims whitespace for environment values, which intentionally broadens acceptance for values like `" yes "`.
