### PR TITLE
Harden async partial-failure and default-all rate-limit contracts

### DIFF
--- a/crates/codex-cli/tests/rate_limits_async.rs
+++ b/crates/codex-cli/tests/rate_limits_async.rs
@@ -1,6 +1,6 @@
 use nils_test_support::bin;
 use nils_test_support::cmd::{self, CmdOptions, CmdOutput};
-use nils_test_support::http::{HttpResponse, LoopbackServer};
+use nils_test_support::http::{HttpResponse, LoopbackServer, TestServer};
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use std::fs;
@@ -360,4 +360,80 @@ fn rate_limits_async_json_falls_back_to_cache_for_missing_access_token() {
     assert_eq!(beta["summary"]["non_weekly_label"], "5h");
     assert_eq!(beta["summary"]["non_weekly_remaining"], 91);
     assert!(beta["raw_usage"].is_null());
+}
+
+#[test]
+fn rate_limits_async_json_partial_failure_keeps_results_array() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secret_dir = dir.path().join("secrets");
+    let cache_root = dir.path().join("cache_root");
+    fs::create_dir_all(&secret_dir).expect("secret dir");
+    fs::create_dir_all(&cache_root).expect("cache root");
+    fs::write(
+        secret_dir.join("alpha.json"),
+        r#"{"tokens":{"access_token":"tok-alpha","account_id":"acct_001"}}"#,
+    )
+    .expect("write alpha");
+    fs::write(
+        secret_dir.join("beta.json"),
+        r#"{"tokens":{"access_token":"tok-beta","account_id":"acct_002"}}"#,
+    )
+    .expect("write beta");
+
+    let server = TestServer::new(|request| {
+        if request
+            .header_value("authorization")
+            .as_deref()
+            .is_some_and(|value| value.contains("tok-beta"))
+        {
+            return HttpResponse::new(500, r#"{"error":"simulated failure"}"#);
+        }
+        HttpResponse::new(
+            200,
+            r#"{
+  "rate_limit": {
+    "primary_window": { "limit_window_seconds": 18000, "used_percent": 6, "reset_at": 1700003600 },
+    "secondary_window": { "limit_window_seconds": 604800, "used_percent": 12, "reset_at": 1700600000 }
+  }
+}"#,
+        )
+    })
+    .expect("server");
+
+    let output = run(
+        &["diag", "rate-limits", "--async", "--json"],
+        &[
+            ("CODEX_SECRET_DIR", &secret_dir),
+            ("ZSH_CACHE_DIR", &cache_root),
+        ],
+        &[
+            ("CODEX_CHATGPT_BASE_URL", &server.url()),
+            ("CODEX_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false"),
+            ("CODEX_RATE_LIMITS_CURL_CONNECT_TIMEOUT_SECONDS", "1"),
+            ("CODEX_RATE_LIMITS_CURL_MAX_TIME_SECONDS", "3"),
+        ],
+    );
+    assert_exit(&output, 1);
+
+    let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
+    assert_eq!(payload["mode"], "async");
+    assert_eq!(payload["ok"], false);
+    let results = payload["results"].as_array().expect("results");
+    assert_eq!(results.len(), 2);
+
+    let alpha = results
+        .iter()
+        .find(|entry| entry["target_file"] == "alpha.json")
+        .expect("alpha result");
+    assert_eq!(alpha["ok"], true);
+    assert_eq!(alpha["source"], "network");
+
+    let beta = results
+        .iter()
+        .find(|entry| entry["target_file"] == "beta.json")
+        .expect("beta result");
+    assert_eq!(beta["ok"], false);
+    assert_eq!(beta["source"], "network");
+    assert_eq!(beta["error"]["code"], "request-failed");
+    assert!(beta["error"]["message"].is_string());
 }

--- a/crates/codex-cli/tests/rate_limits_network.rs
+++ b/crates/codex-cli/tests/rate_limits_network.rs
@@ -259,6 +259,47 @@ fn rate_limits_all_mode_renders_table() {
 }
 
 #[test]
+fn rate_limits_default_all_env_enables_all_mode_without_flag() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    fs::create_dir_all(&secrets).expect("secrets dir");
+    write_secret(&secrets, "alpha.json", Some("tok_alpha"));
+    write_secret(&secrets, "beta.json", Some("tok_beta"));
+
+    let cache_root = dir.path().join("cache_root");
+    fs::create_dir_all(&cache_root).expect("cache root");
+
+    let server = LoopbackServer::new().expect("server");
+    server.add_route(
+        "GET",
+        "/wham/usage",
+        HttpResponse::new(200, wham_usage_ok_body()),
+    );
+
+    let output = run(
+        &["diag", "rate-limits"],
+        &[
+            ("CODEX_SECRET_DIR", &secrets),
+            ("ZSH_CACHE_DIR", &cache_root),
+        ],
+        &[
+            ("CODEX_CHATGPT_BASE_URL", &server.url()),
+            ("CODEX_RATE_LIMITS_DEFAULT_ALL_ENABLED", "true"),
+            ("CODEX_RATE_LIMITS_CURL_CONNECT_TIMEOUT_SECONDS", "1"),
+            ("CODEX_RATE_LIMITS_CURL_MAX_TIME_SECONDS", "3"),
+            ("TZ", "UTC"),
+            ("NO_COLOR", "1"),
+        ],
+    );
+    assert_exit(&output, 0);
+    let out = stdout(&output);
+    assert!(out.contains("🚦 Codex rate limits for all accounts"));
+    assert!(out.contains("alpha"));
+    assert!(out.contains("beta"));
+    assert!(!out.contains("Rate limits remaining"));
+}
+
+#[test]
 fn rate_limits_async_falls_back_to_cache_in_debug_mode() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let secrets = dir.path().join("secrets");


### PR DESCRIPTION
# Harden async partial-failure and default-all rate-limit contracts

## Summary
Strengthen `codex-cli diag rate-limits` behavior contracts by adding targeted integration coverage for async JSON partial failures and the default-all mode toggle, without changing runtime logic.

## Changes
- Add an async JSON test that keeps `results` structured when one account request fails.
- Add a test that validates `CODEX_RATE_LIMITS_DEFAULT_ALL_ENABLED=true` switches bare `diag rate-limits` to all-mode.
- Make async partial-failure fixtures hermetic by forcing an isolated cache root.

## Testing
- `cargo test -p nils-codex-cli --test rate_limits_async --test rate_limits_network` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, 85.42%)

## Risk / Notes
- Scope is test-only and focused on user-visible diagnostics contracts.
- No production code changes or behavior rewrites are included.
