### PR TITLE
Harden agent-docs config validation coverage

### DIFF
--- a/crates/agent-docs/tests/config.rs
+++ b/crates/agent-docs/tests/config.rs
@@ -151,3 +151,206 @@ context = "startup"
     assert!(err.location.is_some());
     assert!(err.message.contains("invalid TOML"));
 }
+
+#[test]
+fn load_scope_config_reports_io_error_when_config_path_is_directory() {
+    let home = TempDir::new().expect("create home dir");
+    fs::create_dir(home.path().join(CONFIG_FILE_NAME)).expect("create config dir");
+
+    let err = load_scope_config(Scope::Home, home.path())
+        .expect_err("directory at config path should be rejected");
+    assert_eq!(err.kind, ConfigErrorKind::Io);
+    assert_eq!(err.file_path, home.path().join(CONFIG_FILE_NAME));
+    assert!(err.message.contains("failed to read AGENT_DOCS.toml"));
+}
+
+#[test]
+fn load_scope_config_rejects_root_literal_with_parse_error() {
+    let home = TempDir::new().expect("create home dir");
+    write_config(home.path(), r#""not-a-table""#);
+
+    let err =
+        load_scope_config(Scope::Home, home.path()).expect_err("root literal should be rejected");
+    assert_eq!(err.kind, ConfigErrorKind::Parse);
+    assert!(err.message.contains("invalid TOML"));
+}
+
+#[test]
+fn load_scope_config_rejects_document_key_that_is_not_array() {
+    let home = TempDir::new().expect("create home dir");
+    write_config(home.path(), r#"document = "oops""#);
+
+    let err =
+        load_scope_config(Scope::Home, home.path()).expect_err("document key type should fail");
+    assert_eq!(err.kind, ConfigErrorKind::Validation);
+    assert_eq!(err.document_index, None);
+    assert_eq!(err.field.as_deref(), Some("document"));
+    assert!(
+        err.message
+            .contains("must be an array of [[document]] tables")
+    );
+}
+
+#[test]
+fn load_scope_config_rejects_document_entry_that_is_not_table() {
+    let home = TempDir::new().expect("create home dir");
+    write_config(home.path(), r#"document = ["oops"]"#);
+
+    let err =
+        load_scope_config(Scope::Home, home.path()).expect_err("document entry type should fail");
+    assert_eq!(err.kind, ConfigErrorKind::Validation);
+    assert_eq!(err.document_index, Some(0));
+    assert_eq!(err.field.as_deref(), Some("document"));
+    assert!(err.message.contains("entry must be a TOML table"));
+}
+
+#[test]
+fn load_scope_config_rejects_unknown_document_field_with_allowed_list() {
+    let home = TempDir::new().expect("create home dir");
+    write_config(
+        home.path(),
+        r#"
+[[document]]
+context = "startup"
+scope = "home"
+path = "AGENTS.md"
+unexpected = true
+"#,
+    );
+
+    let err = load_scope_config(Scope::Home, home.path()).expect_err("unknown field should fail");
+    assert_eq!(err.kind, ConfigErrorKind::Validation);
+    assert_eq!(err.document_index, Some(0));
+    assert_eq!(err.field.as_deref(), Some("unexpected"));
+    assert!(err.message.contains("unsupported field `unexpected`"));
+    assert!(err.message.contains("context"));
+    assert!(err.message.contains("notes"));
+}
+
+#[test]
+fn load_scope_config_rejects_unsupported_scope_with_actionable_error() {
+    let home = TempDir::new().expect("create home dir");
+    write_config(
+        home.path(),
+        r#"
+[[document]]
+context = "startup"
+scope = "workspace"
+path = "AGENTS.md"
+"#,
+    );
+
+    let err = load_scope_config(Scope::Home, home.path()).expect_err("scope should be rejected");
+    assert_eq!(err.kind, ConfigErrorKind::Validation);
+    assert_eq!(err.document_index, Some(0));
+    assert_eq!(err.field.as_deref(), Some("scope"));
+    assert!(err.message.contains("unsupported scope"));
+    assert!(err.message.contains("home"));
+    assert!(err.message.contains("project"));
+}
+
+#[test]
+fn load_scope_config_rejects_path_that_is_only_whitespace() {
+    let home = TempDir::new().expect("create home dir");
+    write_config(
+        home.path(),
+        r#"
+[[document]]
+context = "startup"
+scope = "home"
+path = "   "
+"#,
+    );
+
+    let err = load_scope_config(Scope::Home, home.path()).expect_err("empty path should fail");
+    assert_eq!(err.kind, ConfigErrorKind::Validation);
+    assert_eq!(err.document_index, Some(0));
+    assert_eq!(err.field.as_deref(), Some("path"));
+    assert!(err.message.contains("path cannot be empty"));
+}
+
+#[test]
+fn load_scope_config_reports_type_errors_for_optional_fields() {
+    let home = TempDir::new().expect("create home dir");
+    let cases = [
+        ("required = \"yes\"", "required", "string"),
+        ("when = 123", "when", "integer"),
+        ("notes = []", "notes", "array"),
+    ];
+
+    for (assignment, expected_field, expected_type) in cases {
+        write_config(
+            home.path(),
+            &format!(
+                r#"
+[[document]]
+context = "startup"
+scope = "home"
+path = "AGENTS.md"
+{assignment}
+"#
+            ),
+        );
+
+        let err = load_scope_config(Scope::Home, home.path())
+            .expect_err("optional field type mismatch should fail");
+        assert_eq!(err.kind, ConfigErrorKind::Validation);
+        assert_eq!(err.document_index, Some(0));
+        assert_eq!(err.field.as_deref(), Some(expected_field));
+        assert!(err.message.contains(&format!("found {expected_type}")));
+    }
+}
+
+#[test]
+fn load_scope_config_reports_type_errors_for_required_string_fields() {
+    let home = TempDir::new().expect("create home dir");
+    let cases = [
+        (
+            r#"
+context = 1979-05-27T07:32:00Z
+scope = "home"
+path = "AGENTS.md"
+"#,
+            "context",
+            "datetime",
+        ),
+        (
+            r#"
+context = "startup"
+scope = { kind = "home" }
+path = "AGENTS.md"
+"#,
+            "scope",
+            "table",
+        ),
+        (
+            r#"
+context = "startup"
+scope = "home"
+path = 1.5
+"#,
+            "path",
+            "float",
+        ),
+    ];
+
+    for (body, expected_field, expected_type) in cases {
+        write_config(
+            home.path(),
+            &format!(
+                r#"
+[[document]]
+{body}
+"#
+            ),
+        );
+
+        let err = load_scope_config(Scope::Home, home.path())
+            .expect_err("required string field type mismatch should fail");
+        assert_eq!(err.kind, ConfigErrorKind::Validation);
+        assert_eq!(err.document_index, Some(0));
+        assert_eq!(err.field.as_deref(), Some(expected_field));
+        assert!(err.message.contains("expected string"));
+        assert!(err.message.contains(&format!("found {expected_type}")));
+    }
+}


### PR DESCRIPTION
# Harden agent-docs config validation coverage



## Summary
Improve `nils-agent-docs` configuration contract coverage by adding focused tests for invalid and edge-case `AGENT_DOCS.toml` shapes, emphasizing actionable diagnostics and failure classification.

## Changes
- Add I/O error coverage when the config path resolves to a directory.
- Add validation coverage for non-array `document`, non-table `[[document]]` entries, and unknown fields.
- Add explicit error-path tests for unsupported `scope`, whitespace-only `path`, and top-level literal parse failures.
- Add required/optional field type-mismatch cases to verify detailed, user-facing validation messages.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 85.71%)

## Risk / Notes
- Scope is test-only in `crates/agent-docs/tests/config.rs`; no runtime behavior change.
