### PR TITLE
Add wrapper execution mode controls and safety guards

### DIFF
--- a/docs/runbooks/wrappers-mode-usage.md
+++ b/docs/runbooks/wrappers-mode-usage.md
@@ -1,0 +1,154 @@
+# Wrapper Execution Mode Runbook
+
+## Purpose
+
+This runbook defines how `wrappers/*` choose between:
+- a locally installed binary, and
+- workspace debug execution (`cargo run -q -p ...`).
+
+It also documents the safety rules added to prevent wrapper self-recursion and ambiguous fallback behavior.
+
+## Scope
+
+This applies to all current wrappers under `wrappers/`:
+- `agent-docs`
+- `agentctl`
+- `api-gql`
+- `api-rest`
+- `api-test`
+- `cli-template`
+- `codex-cli`
+- `fzf-cli`
+- `git-cli`
+- `git-lock`
+- `git-scope`
+- `git-summary`
+- `image-processing`
+- `macos-agent`
+- `plan-tooling`
+- `screen-record`
+- `semantic-commit`
+
+## Environment Contract
+
+### `NILS_WRAPPER_MODE`
+
+Supported values:
+- `auto` (default)
+- `debug`
+- `installed`
+
+Behavior summary:
+
+| Mode | Resolution behavior |
+|---|---|
+| `auto` | Try installed binary first; if not found, fallback to `cargo run -q -p <package> -- ...`. |
+| `debug` | Force `cargo run -q -p <package> -- ...`; fail if `cargo` is unavailable. |
+| `installed` | Force installed binary lookup only; do not fallback to `cargo`. |
+
+Invalid mode value exits with code `64` and an explicit error.
+
+Note: debug mode uses Cargo package names (for example `nils-git-scope`, `nils-codex-cli`), not
+necessarily the binary name.
+
+### `NILS_WRAPPER_INSTALL_PREFIX`
+
+Optional install prefix for installed binary lookup.
+
+Default:
+- `~/.local/nils-cli`
+
+Lookup order for installed mode resolution:
+1. `${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}/<bin>`
+2. `command -v <bin>`
+
+Both `~` and `~/...` forms are expanded.
+
+## Safety Guarantees
+
+All wrappers enforce:
+- self-recursion guard: candidate binary path must not resolve to the wrapper itself (`-ef` check)
+- explicit mode validation (`auto|debug|installed` only)
+- deterministic fallback and error messages by mode
+
+This prevents infinite recursion when `wrappers/` appears before real binaries in `PATH`.
+
+## `codex-cli` Special Behavior
+
+`codex-cli` preserves migrated command routing:
+- `provider`
+- `debug`
+- `workflow`
+- `automation`
+
+These commands are executed via `agentctl` using the selected wrapper mode.
+
+If routing cannot execute, wrapper prints:
+- `codex-cli: use \`agentctl <cmd>\` for provider-neutral orchestration`
+- exits `64`
+
+## `git-cli` Compatibility Behavior
+
+`git-cli` wrapper preserves the existing compatibility rule:
+- when called as `git-cli -- help ...`, arguments are normalized to `git-cli help ...` before
+  resolution/execution.
+
+## Usage Examples
+
+Set globally (for current shell):
+
+```bash
+export NILS_WRAPPER_MODE=debug
+```
+
+Force installed binary usage:
+
+```bash
+export NILS_WRAPPER_MODE=installed
+export NILS_WRAPPER_INSTALL_PREFIX="$HOME/.local/nils-cli"
+```
+
+One-shot override for a single command:
+
+```bash
+NILS_WRAPPER_MODE=auto ./wrappers/git-scope tracked
+NILS_WRAPPER_MODE=debug ./wrappers/codex-cli auth current
+NILS_WRAPPER_MODE=installed ./wrappers/semantic-commit --help
+```
+
+`.env` example:
+
+```dotenv
+NILS_WRAPPER_MODE=debug
+# NILS_WRAPPER_MODE=auto
+# NILS_WRAPPER_MODE=installed
+```
+
+## Troubleshooting
+
+### `... invalid NILS_WRAPPER_MODE=...`
+- Cause: unsupported mode string
+- Fix: use one of `auto`, `debug`, `installed`
+
+### `... cargo not found (required when NILS_WRAPPER_MODE=debug)`
+- Cause: debug mode without Cargo on `PATH`
+- Fix: install Rust/Cargo, or switch mode to `auto`/`installed`
+
+### `... installed binary not found (NILS_WRAPPER_MODE=installed)`
+- Cause: installed mode cannot find target binary in prefix or `PATH`
+- Fix:
+  1. run install flow (`./.codex/skills/nils-cli-install/scripts/nils-cli-install.sh`)
+  2. confirm `NILS_WRAPPER_INSTALL_PREFIX` and `PATH`
+
+### `... binary not found (install via cargo install or build the workspace)`
+- Cause: `auto` mode could not find installed binary and cannot run cargo fallback
+- Fix: install binary or ensure Cargo is available
+
+## Verification Quick Checks
+
+```bash
+NILS_WRAPPER_MODE=debug ./wrappers/cli-template --help
+NILS_WRAPPER_MODE=auto ./wrappers/cli-template --help
+NILS_WRAPPER_MODE=installed NILS_WRAPPER_INSTALL_PREFIX="$HOME/.local/nils-cli" ./wrappers/cli-template --help
+scripts/ci/wrapper-mode-smoke.sh
+```

--- a/scripts/ci/wrapper-mode-smoke.sh
+++ b/scripts/ci/wrapper-mode-smoke.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ci/wrapper-mode-smoke.sh [--wrapper PATH] [--help]
+
+Description:
+  Runs an isolated smoke test for wrapper execution modes:
+  - NILS_WRAPPER_MODE=debug
+  - NILS_WRAPPER_MODE=installed
+  - NILS_WRAPPER_MODE=auto (prefer installed + fallback to cargo)
+
+Options:
+  --wrapper PATH   Wrapper script to test (default: wrappers/cli-template)
+  -h, --help       Show help
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+assert_file_has_content() {
+  local file="$1"
+  local label="$2"
+  if [[ ! -s "$file" ]]; then
+    die "$label expected content in $file"
+  fi
+}
+
+assert_file_empty() {
+  local file="$1"
+  local label="$2"
+  if [[ -s "$file" ]]; then
+    die "$label expected empty file: $file"
+  fi
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+wrapper="$repo_root/wrappers/cli-template"
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --wrapper)
+      [[ $# -ge 2 ]] || die "--wrapper requires a path"
+      wrapper="${2}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: ${1:-}"
+      ;;
+  esac
+done
+
+if [[ "$wrapper" != /* ]]; then
+  wrapper="$repo_root/$wrapper"
+fi
+
+[[ -f "$wrapper" ]] || die "wrapper not found: $wrapper"
+[[ -x "$wrapper" ]] || die "wrapper is not executable: $wrapper"
+
+bin_name="$(basename "$wrapper")"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fake_path="$tmp_dir/path"
+install_prefix="$tmp_dir/install"
+mkdir -p "$fake_path" "$install_prefix"
+
+cargo_log="$tmp_dir/cargo.log"
+installed_log="$tmp_dir/installed.log"
+
+touch "$cargo_log" "$installed_log"
+
+cat > "$fake_path/cargo" <<'FAKE_CARGO'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${WRAPPER_TEST_CARGO_LOG:?}"
+printf 'fake-cargo\n'
+FAKE_CARGO
+chmod +x "$fake_path/cargo"
+
+cat > "$install_prefix/$bin_name" <<'FAKE_INSTALLED'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${WRAPPER_TEST_INSTALLED_LOG:?}"
+printf 'fake-installed\n'
+FAKE_INSTALLED
+chmod +x "$install_prefix/$bin_name"
+
+run_wrapper() {
+  local mode="$1"
+  local out_file="$2"
+  local err_file="$3"
+  shift 3
+
+  WRAPPER_TEST_CARGO_LOG="$cargo_log" \
+  WRAPPER_TEST_INSTALLED_LOG="$installed_log" \
+  PATH="$fake_path:/usr/bin:/bin" \
+  NILS_WRAPPER_MODE="$mode" \
+  NILS_WRAPPER_INSTALL_PREFIX="$install_prefix" \
+  "$wrapper" "$@" >"$out_file" 2>"$err_file"
+}
+
+reset_logs() {
+  : > "$cargo_log"
+  : > "$installed_log"
+}
+
+# 1) debug mode: force cargo path.
+reset_logs
+run_wrapper debug "$tmp_dir/debug.out" "$tmp_dir/debug.err" smoke-debug
+assert_file_has_content "$cargo_log" "debug mode"
+assert_file_empty "$installed_log" "debug mode"
+
+# 2) installed mode: force installed binary path.
+reset_logs
+run_wrapper installed "$tmp_dir/installed.out" "$tmp_dir/installed.err" smoke-installed
+assert_file_has_content "$installed_log" "installed mode"
+assert_file_empty "$cargo_log" "installed mode"
+
+# 3) auto mode: prefer installed binary when present.
+reset_logs
+run_wrapper auto "$tmp_dir/auto-prefer.out" "$tmp_dir/auto-prefer.err" smoke-auto-prefer
+assert_file_has_content "$installed_log" "auto mode (prefer installed)"
+assert_file_empty "$cargo_log" "auto mode (prefer installed)"
+
+# 4) auto mode fallback: if installed missing, fallback to cargo.
+rm -f "$install_prefix/$bin_name"
+reset_logs
+run_wrapper auto "$tmp_dir/auto-fallback.out" "$tmp_dir/auto-fallback.err" smoke-auto-fallback
+assert_file_has_content "$cargo_log" "auto mode (fallback cargo)"
+assert_file_empty "$installed_log" "auto mode (fallback cargo)"
+
+echo "ok: wrapper mode smoke tests passed for $wrapper"

--- a/wrappers/agent-docs
+++ b/wrappers/agent-docs
@@ -1,13 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v agent-docs >/dev/null 2>&1; then
-  exec agent-docs "$@"
+bin_name="agent-docs"
+crate_name="nils-agent-docs"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p agent-docs -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "agent-docs: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1

--- a/wrappers/agentctl
+++ b/wrappers/agentctl
@@ -1,13 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v agentctl >/dev/null 2>&1; then
-  exec agentctl "$@"
+bin_name="agentctl"
+crate_name="nils-agentctl"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p agentctl -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "agentctl: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1

--- a/wrappers/api-gql
+++ b/wrappers/api-gql
@@ -1,14 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v api-gql >/dev/null 2>&1; then
-  exec api-gql "$@"
+bin_name="api-gql"
+crate_name="nils-api-gql"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p api-gql -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "api-gql: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1
-

--- a/wrappers/api-rest
+++ b/wrappers/api-rest
@@ -1,14 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v api-rest >/dev/null 2>&1; then
-  exec api-rest "$@"
+bin_name="api-rest"
+crate_name="nils-api-rest"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p api-rest -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "api-rest: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1
-

--- a/wrappers/api-test
+++ b/wrappers/api-test
@@ -1,14 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v api-test >/dev/null 2>&1; then
-  exec api-test "$@"
+bin_name="api-test"
+crate_name="nils-api-test"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p api-test -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "api-test: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1
-

--- a/wrappers/cli-template
+++ b/wrappers/cli-template
@@ -1,13 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v cli-template >/dev/null 2>&1; then
-  exec cli-template "$@"
+bin_name="cli-template"
+crate_name="nils-cli-template"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p cli-template -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "cli-template: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1

--- a/wrappers/codex-cli
+++ b/wrappers/codex-cli
@@ -1,9 +1,84 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+args=("$@")
+
 self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
-args=("$@")
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "codex-cli: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed_for() {
+  local target_bin="$1"
+  local candidate=""
+
+  candidate="${install_prefix}/${target_bin}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$target_bin" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug_for() {
+  local target_crate="$1"
+
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$target_crate" -- "${args[@]}"
+  fi
+
+  return 1
+}
+
+run_installed_for() {
+  local target_bin="$1"
+  local installed=""
+
+  if installed="$(resolve_installed_for "$target_bin")"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  return 1
+}
+
+run_auto_for() {
+  local target_bin="$1"
+  local target_crate="$2"
+
+  if run_installed_for "$target_bin"; then
+    return 0
+  fi
+
+  if run_debug_for "$target_crate"; then
+    return 0
+  fi
+
+  return 1
+}
 
 migrated_cmd=''
 if [[ ${#args[@]} -gt 0 ]]; then
@@ -14,23 +89,45 @@ if [[ ${#args[@]} -gt 0 ]]; then
   esac
 fi
 
-if [[ -n "${migrated_cmd}" ]] && command -v agentctl >/dev/null 2>&1; then
-  exec agentctl "${args[@]}"
-fi
+if [[ -n "$migrated_cmd" ]]; then
+  case "$mode" in
+    debug)
+      run_debug_for "nils-agentctl" || true
+      ;;
+    installed)
+      run_installed_for "agentctl" || true
+      ;;
+    auto)
+      run_auto_for "agentctl" "nils-agentctl" || true
+      ;;
+  esac
 
-if [[ -n "${migrated_cmd}" ]]; then
   echo "codex-cli: use \`agentctl ${migrated_cmd}\` for provider-neutral orchestration" >&2
   exit 64
 fi
 
-installed="$(command -v codex-cli || true)"
-if [[ -n "${installed}" && "${installed}" != "${self_path}" ]]; then
-  exec "${installed}" "${args[@]}"
-fi
-
-if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p codex-cli -- "${args[@]}"
-fi
+case "$mode" in
+  debug)
+    if run_debug_for "nils-codex-cli"; then
+      exit 0
+    fi
+    echo "codex-cli: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+    exit 1
+    ;;
+  installed)
+    if run_installed_for "codex-cli"; then
+      exit 0
+    fi
+    echo "codex-cli: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+    echo "codex-cli: expected ${install_prefix}/codex-cli or a PATH entry" >&2
+    exit 1
+    ;;
+  auto)
+    if run_auto_for "codex-cli" "nils-codex-cli"; then
+      exit 0
+    fi
+    ;;
+esac
 
 echo "codex-cli: binary not found (install via cargo install or build the workspace)" >&2
 exit 1

--- a/wrappers/fzf-cli
+++ b/wrappers/fzf-cli
@@ -1,14 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v fzf-cli >/dev/null 2>&1; then
-  exec fzf-cli "$@"
+bin_name="fzf-cli"
+crate_name="nils-fzf-cli"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p fzf-cli -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "fzf-cli: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1
-

--- a/wrappers/git-cli
+++ b/wrappers/git-cli
@@ -1,17 +1,89 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+bin_name="git-cli"
+crate_name="nils-git-cli"
 args=("$@")
 if [[ ${#args[@]} -ge 2 && ${args[0]} == "--" && ${args[1]} == "help" ]]; then
   args=("help" "${args[@]:2}")
 fi
 
-if command -v git-cli >/dev/null 2>&1; then
-  exec git-cli "${args[@]}"
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p git-cli -- "${args[@]}"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
 echo "git-cli: binary not found (install via cargo install or build the workspace)" >&2

--- a/wrappers/git-lock
+++ b/wrappers/git-lock
@@ -1,13 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v git-lock >/dev/null 2>&1; then
-  exec git-lock "$@"
+bin_name="git-lock"
+crate_name="nils-git-lock"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p git-lock -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "git-lock: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1

--- a/wrappers/git-scope
+++ b/wrappers/git-scope
@@ -1,13 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v git-scope >/dev/null 2>&1; then
-  exec git-scope "$@"
+bin_name="git-scope"
+crate_name="nils-git-scope"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p git-scope -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "git-scope: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1

--- a/wrappers/git-summary
+++ b/wrappers/git-summary
@@ -1,13 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v git-summary >/dev/null 2>&1; then
-  exec git-summary "$@"
+bin_name="git-summary"
+crate_name="nils-git-summary"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p git-summary -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "git-summary: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1

--- a/wrappers/image-processing
+++ b/wrappers/image-processing
@@ -1,13 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v image-processing >/dev/null 2>&1; then
-  exec image-processing "$@"
+bin_name="image-processing"
+crate_name="nils-image-processing"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p image-processing -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "image-processing: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1

--- a/wrappers/macos-agent
+++ b/wrappers/macos-agent
@@ -1,13 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v macos-agent >/dev/null 2>&1; then
-  exec macos-agent "$@"
+bin_name="macos-agent"
+crate_name="nils-macos-agent"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p macos-agent -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "macos-agent: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1

--- a/wrappers/plan-tooling
+++ b/wrappers/plan-tooling
@@ -1,14 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v plan-tooling >/dev/null 2>&1; then
-  exec plan-tooling "$@"
+bin_name="plan-tooling"
+crate_name="nils-plan-tooling"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p plan-tooling -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "plan-tooling: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1
-

--- a/wrappers/screen-record
+++ b/wrappers/screen-record
@@ -1,13 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v screen-record >/dev/null 2>&1; then
-  exec screen-record "$@"
+bin_name="screen-record"
+crate_name="nils-screen-record"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p screen-record -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "screen-record: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1

--- a/wrappers/semantic-commit
+++ b/wrappers/semantic-commit
@@ -1,13 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v semantic-commit >/dev/null 2>&1; then
-  exec semantic-commit "$@"
+bin_name="semantic-commit"
+crate_name="nils-semantic-commit"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
-  exec cargo run -q -p semantic-commit -- "$@"
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 
-echo "semantic-commit: binary not found (install via cargo install or build the workspace)" >&2
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
 exit 1


### PR DESCRIPTION
# Add wrapper execution mode controls and safety guards

## Summary
This change standardizes wrapper execution behavior across the repository by adding explicit mode control (`auto`, `debug`, `installed`), preventing wrapper self-recursion, and documenting deterministic fallback/error semantics. It also adds a focused smoke-test script to verify mode resolution behavior in isolation.

## Changes
- Added `NILS_WRAPPER_MODE` and `NILS_WRAPPER_INSTALL_PREFIX` handling to all wrapper scripts under `wrappers/`.
- Added self-recursion guards and strict mode validation with deterministic error exits/messages.
- Preserved wrapper-specific behavior for `codex-cli` migrated command routing and `git-cli -- help` normalization.
- Added `/docs/runbooks/wrappers-mode-usage.md` to document mode contract, troubleshooting, and usage examples.
- Added `/scripts/ci/wrapper-mode-smoke.sh` to verify `debug`/`installed`/`auto` mode behavior (including auto fallback).

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `scripts/ci/wrapper-mode-smoke.sh` (pass)

## Risk / Notes
- Wrapper behavior is now environment-driven; callers relying on implicit fallback should keep `NILS_WRAPPER_MODE=auto` (default) or set mode explicitly.
