### PR TITLE
Add crates.io status workflow for publish automation

### DIFF
--- a/.codex/skills/publish-crates-io/SKILL.md
+++ b/.codex/skills/publish-crates-io/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: publish-crates-io
+description: Publish one, many, or all workspace crates to crates.io with rate-limit-aware retry and reporting.
+---
+
+# Publish Crates IO
+
+## Contract
+
+Prereqs:
+
+- Run inside the `nils-cli` git work tree.
+- `bash`, `git`, `python3`, and `cargo` available on `PATH`.
+- For real publish mode:
+  - local flow: `cargo login` completed, or
+  - CI flow: `CARGO_REGISTRY_TOKEN` provided by workflow secrets.
+- Workspace publish order file exists:
+  - `release/crates-io-publish-order.txt`
+- crates.io status helper exists for post-run verification:
+  - `scripts/crates-io-status.sh`
+
+Inputs:
+
+- Crate selection (one of):
+  - `--crate <name>` (repeatable),
+  - `--crates "a b,c"`,
+  - `--all` (or omit selectors to use default list file).
+- Optional behavior flags:
+  - `--wait-retry`: rate-limited publish waits and retries until all uploads complete.
+  - default (no `--wait-retry`): stop on first rate-limit error and report next eligible upload time.
+  - `--max-retries <N>`: retry cap per crate in wait mode (`0` = unlimited).
+  - `--default-retry-seconds <N>`: fallback wait if retry hint is missing.
+  - `--dry-run-only`: validate publishability without uploading.
+  - `--report-file <path>`: custom report output path.
+  - `--skip-status-check`: skip post-run crates.io snapshot generation.
+
+Outputs:
+
+- Attempts publish in selected order with dry-run before each upload.
+- Produces a markdown report with:
+  - summary counts (published/skipped/failed/pending),
+  - next eligible publish time when rate-limited,
+  - per-crate record including crate name, version, status, start/end time, attempts, notes,
+  - crates.io status snapshot metadata (json/text path + status).
+- Default report path:
+  - `$CODEX_HOME/out/crates-io-publish-report-<timestamp>.md`
+- Default status snapshot outputs:
+  - `${report_file%.md}.status.json`
+  - `${report_file%.md}.status.md`
+
+Exit codes:
+
+- `0`: all selected crates completed successfully (or dry-run passed)
+- `1`: publish/dry-run failure, halted due rate limit, or pending crates remain
+- `2`: usage error
+
+Failure modes:
+
+- Crate not found in workspace metadata.
+- Selected crate has `publish = false`.
+- Publish order invalid for workspace path dependencies.
+- Dirty worktree in publish mode without `--allow-dirty`.
+- `cargo publish` fails (non-rate-limit error).
+- Rate-limit encountered:
+  - default mode: stop and report retry time,
+  - wait mode: retry until success or `--max-retries` reached.
+
+## Scripts (only entrypoints)
+
+- `<PROJECT_ROOT>/.codex/skills/publish-crates-io/scripts/publish-crates-io.sh`
+
+## Workflow
+
+1. Resolve crate set (single / multi / all) and validate against workspace metadata.
+2. For each selected crate, run `cargo publish --dry-run` first.
+3. In publish mode:
+   - publish sequentially in the selected order,
+   - skip already-published versions on crates.io by default.
+4. Handle rate-limit conditions:
+   - default mode: stop immediately and report next eligible publish time,
+   - `--wait-retry`: sleep/retry and continue until all crates are done.
+5. Run post-run crates.io snapshot using:
+   - `scripts/crates-io-status.sh` (with `--fail-on-missing` when publish run is otherwise successful).
+6. Write a structured report from template:
+   - `.codex/skills/publish-crates-io/references/PUBLISH_REPORT_TEMPLATE.md`

--- a/.codex/skills/publish-crates-io/references/PUBLISH_REPORT_TEMPLATE.md
+++ b/.codex/skills/publish-crates-io/references/PUBLISH_REPORT_TEMPLATE.md
@@ -1,0 +1,37 @@
+# crates.io Publish Report
+
+## Summary
+
+- Mode: `<publish|dry-run-only>`
+- Retry behavior: `<stop-on-rate-limit|wait-and-retry>`
+- Started (UTC): `<YYYY-MM-DDTHH:MM:SSZ>`
+- Ended (UTC): `<YYYY-MM-DDTHH:MM:SSZ>`
+- Selected crates: `<N>`
+- Published: `<N>`
+- Skipped existing: `<N>`
+- Dry-run only: `<N>`
+- Failed: `<N>`
+- Not attempted: `<N>`
+- Next eligible publish time (UTC): `<optional YYYY-MM-DDTHH:MM:SSZ>`
+- Status snapshot: `<ok|failed|skipped>`
+- Status snapshot exit code: `<optional int>`
+- Status JSON: `<optional path>`
+- Status text: `<optional path>`
+
+## Successful Uploads
+
+| Crate | Version | Status | Start (UTC) | End (UTC) | Attempts | Note |
+|---|---:|---|---|---|---:|---|
+| `<crate-name>` | `<x.y.z>` | `published` | `<time>` | `<time>` | `<n>` | `<details>` |
+
+## Failed Uploads
+
+| Crate | Version | Status | Start (UTC) | End (UTC) | Attempts | Note |
+|---|---:|---|---|---|---:|---|
+| `<crate-name>` | `<x.y.z>` | `failed` | `<time>` | `<time>` | `<n>` | `<error or rate-limit details>` |
+
+## Full Attempts
+
+| Crate | Version | Status | Start (UTC) | End (UTC) | Attempts | Note |
+|---|---:|---|---|---|---:|---|
+| `<crate-name>` | `<x.y.z>` | `<published|failed|skipped|pending|dry-run-ok>` | `<time>` | `<time>` | `<n>` | `<details>` |

--- a/.codex/skills/publish-crates-io/scripts/publish-crates-io.sh
+++ b/.codex/skills/publish-crates-io/scripts/publish-crates-io.sh
@@ -1,0 +1,740 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  <ENTRYPOINT> [options]
+
+Options:
+  --crate NAME               Add one crate (repeatable).
+  --crates "A B,C"           Add multiple crates (space/comma separated).
+  --all                      Publish all crates from the list file.
+  --list-file PATH           Crate order file for --all/default.
+  --publish                  Run dry-run + publish (default).
+  --dry-run-only             Only run cargo publish --dry-run.
+  --wait-retry               On rate-limit errors, wait and retry until completion.
+  --max-retries N            Max publish retries per crate in --wait-retry mode (0 = unlimited).
+  --default-retry-seconds N  Fallback wait seconds when retry time cannot be parsed (default: 300).
+  --registry NAME            Optional cargo registry name (blank = crates.io).
+  --skip-existing            Skip already-published versions on crates.io (default for publish mode).
+  --no-skip-existing         Do not skip existing crate versions.
+  --allow-dirty              Allow dirty worktree in publish mode.
+  --skip-status-check        Do not run post-run crates.io status snapshot.
+  --status-script PATH       Override status snapshot script path.
+  --status-json-file PATH    Override status snapshot JSON output path.
+  --status-text-file PATH    Override status snapshot text output path.
+  --report-file PATH         Markdown report output path.
+  -h, --help                 Show help.
+
+Examples:
+  <ENTRYPOINT> --crate nils-codex-cli
+  <ENTRYPOINT> --crates "nils-common nils-term" --wait-retry
+  <ENTRYPOINT> --all --wait-retry --report-file "$CODEX_HOME/out/publish-report.md"
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+note() {
+  echo "info: $*" >&2
+}
+
+warn() {
+  echo "warning: $*" >&2
+}
+
+contains() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    if [[ "$item" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+append_crates_from_words() {
+  local raw="$1"
+  local item
+  raw="${raw//,/ }"
+  for item in $raw; do
+    [[ -n "$item" ]] || continue
+    selected_crates+=("$item")
+  done
+}
+
+append_crates_from_file() {
+  local path="$1"
+  [[ -f "$path" ]] || die "crate list file not found: $path"
+  local line trimmed
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    trimmed="$(printf '%s' "$line" | sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//')"
+    [[ -n "$trimmed" ]] || continue
+    selected_crates+=("$trimmed")
+  done < "$path"
+}
+
+sanitize_field() {
+  printf '%s' "$1" | tr '\n\t' '  '
+}
+
+now_utc() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+add_seconds_utc() {
+  "$python_bin" - "$1" <<'PY'
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import sys
+
+seconds = int(sys.argv[1])
+base = datetime.now(timezone.utc) + timedelta(seconds=seconds)
+print(base.strftime("%Y-%m-%dT%H:%M:%SZ"))
+PY
+}
+
+selected_crate_version() {
+  local metadata_path="$1"
+  local crate="$2"
+  "$python_bin" - "$metadata_path" "$crate" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+
+metadata_path, crate = sys.argv[1], sys.argv[2]
+with open(metadata_path, "r", encoding="utf-8") as fp:
+    metadata = json.load(fp)
+for pkg in metadata["packages"]:
+    if pkg.get("name") == crate:
+        print(pkg["version"])
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+crate_version_exists_on_crates_io() {
+  local crate="$1"
+  local version="$2"
+  "$python_bin" - "$crate" "$version" <<'PY'
+from __future__ import annotations
+
+import sys
+import urllib.error
+import urllib.request
+
+crate, version = sys.argv[1], sys.argv[2]
+url = f"https://crates.io/api/v1/crates/{crate}/{version}"
+try:
+    urllib.request.urlopen(url, timeout=15)
+except urllib.error.HTTPError as exc:
+    if exc.code == 404:
+        raise SystemExit(1)
+    raise
+raise SystemExit(0)
+PY
+}
+
+is_rate_limited_log() {
+  local log_file="$1"
+  "$python_bin" - "$log_file" <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8", errors="replace").read().lower()
+patterns = [
+    r"\b429\b",
+    r"too many requests",
+    r"rate limit",
+    r"retry[- ]?after",
+    r"please wait",
+]
+if any(re.search(p, text) for p in patterns):
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+extract_retry_seconds() {
+  local log_file="$1"
+  local fallback="$2"
+  "$python_bin" - "$log_file" "$fallback" <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8", errors="replace").read().lower()
+fallback = int(sys.argv[2])
+
+patterns = [
+    (r"retry[- ]?after[^0-9]*(\d+)", 1),
+    (r"(\d+)\s*seconds?", 1),
+    (r"(\d+)\s*secs?", 1),
+    (r"(\d+)\s*minutes?", 60),
+    (r"(\d+)\s*mins?", 60),
+    (r"(\d+)\s*hours?", 3600),
+    (r"(\d+)\s*hrs?", 3600),
+]
+for pattern, multiplier in patterns:
+    match = re.search(pattern, text)
+    if match:
+        value = int(match.group(1)) * multiplier
+        print(value)
+        raise SystemExit(0)
+
+print(max(0, fallback))
+PY
+}
+
+extract_error_line() {
+  local log_file="$1"
+  "$python_bin" - "$log_file" <<'PY'
+from __future__ import annotations
+
+import sys
+
+lines = [line.strip() for line in open(sys.argv[1], "r", encoding="utf-8", errors="replace").read().splitlines()]
+for line in lines:
+    if "error:" in line.lower():
+        print(line)
+        raise SystemExit(0)
+for line in reversed(lines):
+    if line:
+        print(line)
+        raise SystemExit(0)
+print("unknown error")
+PY
+}
+
+run_with_log() {
+  local log_file="$1"
+  shift
+  set +e
+  "$@" 2>&1 | tee "$log_file"
+  local rc=${PIPESTATUS[0]}
+  set -e
+  return "$rc"
+}
+
+record_row() {
+  local crate="$1"
+  local version="$2"
+  local status="$3"
+  local started_at="$4"
+  local ended_at="$5"
+  local attempts="$6"
+  local note_msg="$7"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$crate" \
+    "$version" \
+    "$status" \
+    "$started_at" \
+    "$ended_at" \
+    "$attempts" \
+    "$(sanitize_field "$note_msg")" >> "$rows_file"
+}
+
+write_report() {
+  local path="$1"
+  local mode_label="$2"
+  local wait_label="$3"
+  local started="$4"
+  local ended="$5"
+  local selected_total="$6"
+  local next_retry="$7"
+  local status_check_state="$8"
+  local status_check_rc="$9"
+  local status_json_file="${10}"
+  local status_text_file="${11}"
+  "$python_bin" - "$rows_file" "$path" "$mode_label" "$wait_label" "$started" "$ended" "$selected_total" "$next_retry" "$status_check_state" "$status_check_rc" "$status_json_file" "$status_text_file" <<'PY'
+from __future__ import annotations
+
+import csv
+import pathlib
+import sys
+
+rows_file, out_path, mode_label, wait_label, started, ended, selected_total, next_retry, status_check_state, status_check_rc, status_json_file, status_text_file = sys.argv[1:13]
+rows = []
+with open(rows_file, "r", encoding="utf-8") as fp:
+    reader = csv.DictReader(
+        fp,
+        fieldnames=["crate", "version", "status", "started_at", "ended_at", "attempts", "note"],
+        delimiter="\t",
+    )
+    for row in reader:
+        rows.append(row)
+
+counts = {
+    "published": 0,
+    "skipped": 0,
+    "dry-run-ok": 0,
+    "failed": 0,
+    "pending": 0,
+}
+for row in rows:
+    status = row["status"]
+    if status in counts:
+        counts[status] += 1
+
+def table(filter_fn):
+    selected = [r for r in rows if filter_fn(r)]
+    if not selected:
+        return "_None_\n"
+    out = ["| Crate | Version | Status | Start (UTC) | End (UTC) | Attempts | Note |", "|---|---:|---|---|---|---:|---|"]
+    for row in selected:
+        out.append(
+            "| {crate} | {version} | {status} | {started_at} | {ended_at} | {attempts} | {note} |".format(
+                crate=row["crate"] or "-",
+                version=row["version"] or "-",
+                status=row["status"] or "-",
+                started_at=row["started_at"] or "-",
+                ended_at=row["ended_at"] or "-",
+                attempts=row["attempts"] or "0",
+                note=row["note"] or "-",
+            )
+        )
+    return "\n".join(out) + "\n"
+
+content = []
+content.append("# crates.io Publish Report\n")
+content.append("## Summary\n")
+content.append(f"- Mode: `{mode_label}`")
+content.append(f"- Retry behavior: `{wait_label}`")
+content.append(f"- Started (UTC): `{started}`")
+content.append(f"- Ended (UTC): `{ended}`")
+content.append(f"- Selected crates: `{selected_total}`")
+content.append(f"- Published: `{counts['published']}`")
+content.append(f"- Skipped existing: `{counts['skipped']}`")
+content.append(f"- Dry-run only: `{counts['dry-run-ok']}`")
+content.append(f"- Failed: `{counts['failed']}`")
+content.append(f"- Not attempted: `{counts['pending']}`")
+if next_retry:
+    content.append(f"- Next eligible publish time (UTC): `{next_retry}`")
+content.append(f"- Status snapshot: `{status_check_state}`")
+if status_check_rc:
+    content.append(f"- Status snapshot exit code: `{status_check_rc}`")
+if status_json_file:
+    content.append(f"- Status JSON: `{status_json_file}`")
+if status_text_file:
+    content.append(f"- Status text: `{status_text_file}`")
+content.append("")
+content.append("## Successful Uploads\n")
+content.append(table(lambda r: r["status"] == "published"))
+content.append("## Failed Uploads\n")
+content.append(table(lambda r: r["status"] == "failed"))
+content.append("## Full Attempts\n")
+content.append(table(lambda _r: True))
+
+path = pathlib.Path(out_path)
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text("\n".join(content), encoding="utf-8")
+PY
+}
+
+cargo_bin="${PUBLISH_CRATES_IO_CARGO_BIN:-cargo}"
+python_bin="${PUBLISH_CRATES_IO_PYTHON_BIN:-python3}"
+sleep_bin="${PUBLISH_CRATES_IO_SLEEP_BIN:-sleep}"
+
+mode="publish"
+wait_retry=0
+max_retries=0
+default_retry_seconds=300
+list_file="release/crates-io-publish-order.txt"
+registry=""
+skip_existing=1
+allow_dirty=0
+select_all=0
+report_file=""
+skip_status_check=0
+status_script="${PUBLISH_CRATES_IO_STATUS_SCRIPT:-}"
+status_json_file=""
+status_text_file=""
+declare -a selected_crates=()
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --crate)
+      [[ $# -ge 2 ]] || die "--crate requires a value"
+      selected_crates+=("${2:-}")
+      shift 2
+      ;;
+    --crates)
+      [[ $# -ge 2 ]] || die "--crates requires a value"
+      append_crates_from_words "${2:-}"
+      shift 2
+      ;;
+    --all)
+      select_all=1
+      shift
+      ;;
+    --list-file)
+      [[ $# -ge 2 ]] || die "--list-file requires a value"
+      list_file="${2:-}"
+      shift 2
+      ;;
+    --publish)
+      mode="publish"
+      shift
+      ;;
+    --dry-run-only)
+      mode="dry-run-only"
+      shift
+      ;;
+    --wait-retry)
+      wait_retry=1
+      shift
+      ;;
+    --max-retries)
+      [[ $# -ge 2 ]] || die "--max-retries requires a value"
+      max_retries="${2:-}"
+      shift 2
+      ;;
+    --default-retry-seconds)
+      [[ $# -ge 2 ]] || die "--default-retry-seconds requires a value"
+      default_retry_seconds="${2:-}"
+      shift 2
+      ;;
+    --registry)
+      [[ $# -ge 2 ]] || die "--registry requires a value"
+      registry="${2:-}"
+      shift 2
+      ;;
+    --skip-existing)
+      skip_existing=1
+      shift
+      ;;
+    --no-skip-existing)
+      skip_existing=0
+      shift
+      ;;
+    --allow-dirty)
+      allow_dirty=1
+      shift
+      ;;
+    --skip-status-check)
+      skip_status_check=1
+      shift
+      ;;
+    --status-script)
+      [[ $# -ge 2 ]] || die "--status-script requires a value"
+      status_script="${2:-}"
+      shift 2
+      ;;
+    --status-json-file)
+      [[ $# -ge 2 ]] || die "--status-json-file requires a value"
+      status_json_file="${2:-}"
+      shift 2
+      ;;
+    --status-text-file)
+      [[ $# -ge 2 ]] || die "--status-text-file requires a value"
+      status_text_file="${2:-}"
+      shift 2
+      ;;
+    --report-file)
+      [[ $# -ge 2 ]] || die "--report-file requires a value"
+      report_file="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: ${1:-}" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ "$max_retries" =~ ^[0-9]+$ ]] || die "--max-retries must be an integer >= 0"
+[[ "$default_retry_seconds" =~ ^[0-9]+$ ]] || die "--default-retry-seconds must be an integer >= 0"
+
+if [[ "$select_all" -eq 1 && ${#selected_crates[@]} -gt 0 ]]; then
+  die "--all cannot be combined with --crate/--crates"
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -n "$repo_root" ]] || die "must run inside a git work tree"
+cd "$repo_root"
+
+if [[ "$select_all" -eq 1 || ${#selected_crates[@]} -eq 0 ]]; then
+  append_crates_from_file "$list_file"
+fi
+
+declare -a deduped_crates=()
+for crate in "${selected_crates[@]}"; do
+  [[ "$crate" =~ ^[A-Za-z0-9_-]+$ ]] || die "invalid crate name: '$crate'"
+  if ! contains "$crate" "${deduped_crates[@]}"; then
+    deduped_crates+=("$crate")
+  fi
+done
+selected_crates=("${deduped_crates[@]}")
+[[ ${#selected_crates[@]} -gt 0 ]] || die "no crates selected"
+
+metadata_file="$(mktemp)"
+rows_file="$(mktemp)"
+cleanup() {
+  rm -f "$metadata_file" "$rows_file"
+}
+trap cleanup EXIT
+
+"$cargo_bin" metadata --format-version 1 --no-deps > "$metadata_file"
+
+"$python_bin" - "$metadata_file" "${selected_crates[@]}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+
+metadata_path = sys.argv[1]
+selected = sys.argv[2:]
+with open(metadata_path, "r", encoding="utf-8") as fp:
+    metadata = json.load(fp)
+packages = {pkg["name"]: pkg for pkg in metadata["packages"]}
+
+errors: list[str] = []
+order = {name: idx for idx, name in enumerate(selected)}
+
+for name in selected:
+    pkg = packages.get(name)
+    if pkg is None:
+        errors.append(f"selected crate '{name}' is not in this workspace")
+        continue
+    if pkg.get("publish") == []:
+        errors.append(f"selected crate '{name}' has publish=false")
+
+for name in selected:
+    pkg = packages.get(name)
+    if pkg is None:
+        continue
+    for dep in pkg.get("dependencies", []):
+        dep_name = dep.get("name")
+        if dep.get("path") and dep_name in order and order[dep_name] > order[name]:
+            errors.append(
+                f"publish order invalid: '{name}' depends on '{dep_name}', "
+                "so dependency must appear earlier in the crate list"
+            )
+
+if errors:
+    for err in errors:
+        print(f"error: {err}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+
+if [[ "$mode" == "publish" && "$allow_dirty" -eq 0 ]]; then
+  if [[ -n "$(git status --porcelain)" ]]; then
+    die "working tree is not clean; commit/stash changes or use --allow-dirty"
+  fi
+fi
+
+if [[ -z "$report_file" ]]; then
+  codex_home="${CODEX_HOME:-$HOME/.codex}"
+  timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  report_file="${codex_home}/out/crates-io-publish-report-${timestamp}.md"
+fi
+mkdir -p "$(dirname "$report_file")"
+
+if [[ -z "$status_script" ]]; then
+  status_script="${repo_root}/scripts/crates-io-status.sh"
+fi
+if [[ -z "$status_json_file" ]]; then
+  status_json_file="${report_file%.md}.status.json"
+fi
+if [[ -z "$status_text_file" ]]; then
+  status_text_file="${report_file%.md}.status.md"
+fi
+mkdir -p "$(dirname "$status_json_file")" "$(dirname "$status_text_file")"
+
+declare -a cargo_args=(--locked)
+if [[ -n "$registry" ]]; then
+  cargo_args+=(--registry "$registry")
+fi
+if [[ "$allow_dirty" -eq 1 ]]; then
+  cargo_args+=(--allow-dirty)
+fi
+
+if [[ "$mode" == "dry-run-only" ]]; then
+  skip_existing=0
+fi
+
+note "mode: $mode"
+note "crates: ${selected_crates[*]}"
+note "wait retry: $wait_retry"
+note "report: $report_file"
+if [[ "$skip_status_check" -eq 1 ]]; then
+  note "status snapshot: disabled"
+else
+  note "status snapshot script: $status_script"
+fi
+
+run_started_at="$(now_utc)"
+halted=0
+halt_reason=""
+next_retry_at=""
+published_count=0
+skipped_count=0
+dry_run_ok_count=0
+failed_count=0
+pending_count=0
+status_check_state="skipped"
+status_check_rc=""
+
+for ((idx=0; idx<${#selected_crates[@]}; idx++)); do
+  crate="${selected_crates[$idx]}"
+  version="$(selected_crate_version "$metadata_file" "$crate" || true)"
+  [[ -n "$version" ]] || version="unknown"
+  crate_started_at="$(now_utc)"
+
+  if [[ "$halted" -eq 1 ]]; then
+    record_row "$crate" "$version" "pending" "" "" "0" "not attempted due to earlier halt: $halt_reason"
+    pending_count=$((pending_count + 1))
+    continue
+  fi
+
+  if [[ "$mode" == "publish" && "$skip_existing" -eq 1 && -z "$registry" ]]; then
+    if crate_version_exists_on_crates_io "$crate" "$version"; then
+      crate_ended_at="$(now_utc)"
+      note "skip ${crate} v${version} (already published on crates.io)"
+      record_row "$crate" "$version" "skipped" "$crate_started_at" "$crate_ended_at" "0" "already exists on crates.io"
+      skipped_count=$((skipped_count + 1))
+      continue
+    fi
+  fi
+
+  dry_log="$(mktemp)"
+  note "[dry-run] cargo publish -p ${crate} --dry-run ${cargo_args[*]}"
+  if ! run_with_log "$dry_log" "$cargo_bin" publish -p "$crate" --dry-run "${cargo_args[@]}"; then
+    crate_ended_at="$(now_utc)"
+    err_line="$(extract_error_line "$dry_log")"
+    record_row "$crate" "$version" "failed" "$crate_started_at" "$crate_ended_at" "0" "dry-run failed: ${err_line}"
+    rm -f "$dry_log"
+    failed_count=$((failed_count + 1))
+    halted=1
+    halt_reason="dry-run failed on ${crate}"
+    continue
+  fi
+  rm -f "$dry_log"
+
+  if [[ "$mode" == "dry-run-only" ]]; then
+    crate_ended_at="$(now_utc)"
+    record_row "$crate" "$version" "dry-run-ok" "$crate_started_at" "$crate_ended_at" "0" "dry-run passed"
+    dry_run_ok_count=$((dry_run_ok_count + 1))
+    continue
+  fi
+
+  attempts=0
+  while true; do
+    attempts=$((attempts + 1))
+    publish_log="$(mktemp)"
+    note "[publish] cargo publish -p ${crate} ${cargo_args[*]} (attempt ${attempts})"
+    if run_with_log "$publish_log" "$cargo_bin" publish -p "$crate" "${cargo_args[@]}"; then
+      crate_ended_at="$(now_utc)"
+      record_row "$crate" "$version" "published" "$crate_started_at" "$crate_ended_at" "$attempts" "publish succeeded"
+      rm -f "$publish_log"
+      published_count=$((published_count + 1))
+      break
+    fi
+
+    if is_rate_limited_log "$publish_log"; then
+      retry_seconds="$(extract_retry_seconds "$publish_log" "$default_retry_seconds")"
+      retry_at="$(add_seconds_utc "$retry_seconds")"
+      if [[ "$wait_retry" -eq 1 ]]; then
+        if [[ "$max_retries" -gt 0 && "$attempts" -ge "$max_retries" ]]; then
+          crate_ended_at="$(now_utc)"
+          record_row "$crate" "$version" "failed" "$crate_started_at" "$crate_ended_at" "$attempts" "rate-limited and hit max retries (${max_retries}); next retry at ${retry_at}"
+          rm -f "$publish_log"
+          failed_count=$((failed_count + 1))
+          halted=1
+          halt_reason="max retries reached on ${crate}"
+          next_retry_at="$retry_at"
+          break
+        fi
+        warn "rate-limited on ${crate}; waiting ${retry_seconds}s (next retry at ${retry_at})"
+        rm -f "$publish_log"
+        "$sleep_bin" "$retry_seconds"
+        continue
+      fi
+
+      crate_ended_at="$(now_utc)"
+      record_row "$crate" "$version" "failed" "$crate_started_at" "$crate_ended_at" "$attempts" "rate-limited; next eligible publish time: ${retry_at}"
+      rm -f "$publish_log"
+      failed_count=$((failed_count + 1))
+      halted=1
+      halt_reason="rate limit on ${crate}"
+      next_retry_at="$retry_at"
+      break
+    fi
+
+    crate_ended_at="$(now_utc)"
+    err_line="$(extract_error_line "$publish_log")"
+    record_row "$crate" "$version" "failed" "$crate_started_at" "$crate_ended_at" "$attempts" "publish failed: ${err_line}"
+    rm -f "$publish_log"
+    failed_count=$((failed_count + 1))
+    halted=1
+    halt_reason="publish failed on ${crate}"
+    break
+  done
+done
+
+if [[ "$skip_status_check" -eq 0 ]]; then
+  if [[ -x "$status_script" ]]; then
+    declare -a status_cmd=("$status_script" --format both --json-out "$status_json_file" --text-out "$status_text_file")
+    for crate in "${selected_crates[@]}"; do
+      status_cmd+=(--crate "$crate")
+    done
+    if [[ "$mode" == "publish" && "$failed_count" -eq 0 && "$pending_count" -eq 0 ]]; then
+      status_cmd+=(--fail-on-missing)
+    fi
+
+    note "running status snapshot"
+    set +e
+    "${status_cmd[@]}"
+    status_check_rc="$?"
+    set -e
+    if [[ "$status_check_rc" == "0" ]]; then
+      status_check_state="ok"
+    else
+      status_check_state="failed"
+      warn "status snapshot failed with exit code ${status_check_rc}"
+      if [[ "$failed_count" -eq 0 && "$pending_count" -eq 0 ]]; then
+        failed_count=$((failed_count + 1))
+      fi
+    fi
+  else
+    warn "status snapshot script missing or not executable: $status_script"
+    status_check_state="skipped"
+  fi
+fi
+
+run_ended_at="$(now_utc)"
+mode_label="$mode"
+wait_label="stop-on-rate-limit"
+if [[ "$wait_retry" -eq 1 ]]; then
+  wait_label="wait-and-retry"
+fi
+write_report "$report_file" "$mode_label" "$wait_label" "$run_started_at" "$run_ended_at" "${#selected_crates[@]}" "$next_retry_at" "$status_check_state" "$status_check_rc" "$status_json_file" "$status_text_file"
+
+note "report written: $report_file"
+if [[ "$status_check_state" == "ok" ]]; then
+  note "status json: $status_json_file"
+  note "status text: $status_text_file"
+fi
+note "published=${published_count} skipped=${skipped_count} dry-run-ok=${dry_run_ok_count} failed=${failed_count} pending=${pending_count}"
+
+if [[ "$failed_count" -gt 0 || "$pending_count" -gt 0 ]]; then
+  exit 1
+fi
+
+exit 0

--- a/.codex/skills/publish-crates-io/tests/test_crates_io_status.sh
+++ b/.codex/skills/publish-crates-io/tests/test_crates_io_status.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+entrypoint="${repo_root}/scripts/crates-io-status.sh"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! rg -q "$pattern" "$file"; then
+    echo "error: expected pattern '$pattern' in $file" >&2
+    sed -n '1,220p' "$file" >&2 || true
+    exit 1
+  fi
+}
+
+create_mock_cargo() {
+  local dir="$1"
+  cat > "${dir}/cargo" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "metadata" ]]; then
+  echo "unexpected cargo command: $*" >&2
+  exit 1
+fi
+
+cat <<'JSON'
+{
+  "packages": [
+    {
+      "name": "nils-a",
+      "version": "1.2.3",
+      "publish": null,
+      "dependencies": []
+    },
+    {
+      "name": "nils-b",
+      "version": "1.2.4",
+      "publish": null,
+      "dependencies": []
+    }
+  ]
+}
+JSON
+MOCK
+  chmod +x "${dir}/cargo"
+}
+
+create_mock_api_server_script() {
+  local path="$1"
+  cat > "$path" <<'PY'
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+fixture_path, port_file = sys.argv[1], sys.argv[2]
+with open(fixture_path, "r", encoding="utf-8") as fp:
+    fixtures = json.load(fp)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        entry = fixtures.get(self.path)
+        if entry is None:
+            status = 404
+            payload = {"errors": [{"detail": "not found"}]}
+        else:
+            status = int(entry.get("status", 200))
+            payload = entry.get("body", {})
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _fmt: str, *_args: object) -> None:
+        return
+
+
+server = HTTPServer(("127.0.0.1", 0), Handler)
+with open(port_file, "w", encoding="utf-8") as fp:
+    fp.write(str(server.server_port))
+server.serve_forever()
+PY
+  chmod +x "$path"
+}
+
+start_mock_api() {
+  local server_py="$1"
+  local fixture="$2"
+  local port_file="$3"
+  local log_file="$4"
+  python3 "$server_py" "$fixture" "$port_file" >"$log_file" 2>&1 &
+  local pid=$!
+  for _ in $(seq 1 80); do
+    if [[ -s "$port_file" ]]; then
+      break
+    fi
+    sleep 0.05
+  done
+  [[ -s "$port_file" ]] || fail "mock api did not start"
+  echo "$pid"
+}
+
+test_explicit_version_fail_on_missing() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local bin_dir="${tmp}/bin"
+  mkdir -p "$bin_dir"
+  create_mock_cargo "$bin_dir"
+
+  local fixture="${tmp}/fixture.json"
+  cat > "$fixture" <<'JSON'
+{
+  "/api/v1/crates/nils-a": {"status": 200, "body": {"crate": {"name": "nils-a", "newest_version": "1.2.3", "updated_at": "2026-02-11T10:00:00Z"}}},
+  "/api/v1/crates/nils-b": {"status": 200, "body": {"crate": {"name": "nils-b", "newest_version": "1.2.4", "updated_at": "2026-02-11T10:00:00Z"}}},
+  "/api/v1/crates/nils-a/1.2.3": {"status": 200, "body": {"version": {"num": "1.2.3", "created_at": "2026-02-11T10:01:00Z", "yanked": false, "downloads": 5}}},
+  "/api/v1/crates/nils-b/1.2.3": {"status": 404, "body": {"errors": [{"detail": "missing"}]}}
+}
+JSON
+
+  local server_py="${tmp}/mock_api.py"
+  local port_file="${tmp}/port.txt"
+  local api_log="${tmp}/api.log"
+  create_mock_api_server_script "$server_py"
+  local pid
+  pid="$(start_mock_api "$server_py" "$fixture" "$port_file" "$api_log")"
+  trap "kill $pid 2>/dev/null || true" RETURN
+  local port
+  port="$(cat "$port_file")"
+
+  local json_out="${tmp}/status.json"
+  set +e
+  CRATES_IO_STATUS_CARGO_BIN="${bin_dir}/cargo" \
+    CRATES_IO_STATUS_API_BASE="http://127.0.0.1:${port}/api/v1" \
+    "$entrypoint" --crates "nils-a nils-b" --version v1.2.3 --format json --json-out "$json_out" --fail-on-missing \
+    >"${tmp}/stdout.log" 2>"${tmp}/stderr.log"
+  local rc=$?
+  set -e
+
+  [[ "$rc" -eq 1 ]] || fail "expected exit code 1, got $rc"
+  python3 - "$json_out" <<'PY'
+from __future__ import annotations
+import json
+import sys
+
+data = json.load(open(sys.argv[1], "r", encoding="utf-8"))
+assert data["query"]["mode"] == "explicit-version"
+assert data["query"]["target_version"] == "1.2.3"
+by_name = {item["crate"]: item for item in data["results"]}
+assert by_name["nils-a"]["status"] == "published"
+assert by_name["nils-b"]["status"] == "missing"
+assert data["summary"]["missing"] == 1
+print("ok")
+PY
+  trap - RETURN
+}
+
+test_workspace_mode_text_and_json() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local bin_dir="${tmp}/bin"
+  mkdir -p "$bin_dir"
+  create_mock_cargo "$bin_dir"
+
+  local fixture="${tmp}/fixture.json"
+  cat > "$fixture" <<'JSON'
+{
+  "/api/v1/crates/nils-a": {"status": 200, "body": {"crate": {"name": "nils-a", "newest_version": "1.2.3", "updated_at": "2026-02-11T10:00:00Z"}}},
+  "/api/v1/crates/nils-b": {"status": 200, "body": {"crate": {"name": "nils-b", "newest_version": "1.2.4", "updated_at": "2026-02-11T10:00:00Z"}}},
+  "/api/v1/crates/nils-a/1.2.3": {"status": 200, "body": {"version": {"num": "1.2.3", "created_at": "2026-02-11T10:01:00Z", "yanked": false, "downloads": 5}}},
+  "/api/v1/crates/nils-b/1.2.4": {"status": 200, "body": {"version": {"num": "1.2.4", "created_at": "2026-02-11T10:02:00Z", "yanked": false, "downloads": 8}}}
+}
+JSON
+
+  local server_py="${tmp}/mock_api.py"
+  local port_file="${tmp}/port.txt"
+  local api_log="${tmp}/api.log"
+  create_mock_api_server_script "$server_py"
+  local pid
+  pid="$(start_mock_api "$server_py" "$fixture" "$port_file" "$api_log")"
+  trap "kill $pid 2>/dev/null || true" RETURN
+  local port
+  port="$(cat "$port_file")"
+
+  local json_out="${tmp}/status.json"
+  local text_out="${tmp}/status.md"
+  CRATES_IO_STATUS_CARGO_BIN="${bin_dir}/cargo" \
+    CRATES_IO_STATUS_API_BASE="http://127.0.0.1:${port}/api/v1" \
+    "$entrypoint" --crates "nils-a nils-b" --format both --json-out "$json_out" --text-out "$text_out" \
+    >"${tmp}/stdout.log" 2>"${tmp}/stderr.log"
+
+  assert_contains "$text_out" "# crates.io Status Report"
+  assert_contains "$text_out" "\\| nils-a \\| 1.2.3 \\| 1.2.3 \\| published \\|"
+  assert_contains "$text_out" "\\| nils-b \\| 1.2.4 \\| 1.2.4 \\| published \\|"
+  python3 - "$json_out" <<'PY'
+from __future__ import annotations
+import json
+import sys
+
+data = json.load(open(sys.argv[1], "r", encoding="utf-8"))
+assert data["query"]["mode"] == "workspace-version"
+assert data["summary"]["published"] == 2
+assert data["summary"]["missing"] == 0
+print("ok")
+PY
+  trap - RETURN
+}
+
+if [[ ! -x "$entrypoint" ]]; then
+  fail "missing executable: $entrypoint"
+fi
+
+test_explicit_version_fail_on_missing
+test_workspace_mode_text_and_json
+
+echo "ok: crates.io status tests passed"

--- a/.codex/skills/publish-crates-io/tests/test_publish_crates_io.sh
+++ b/.codex/skills/publish-crates-io/tests/test_publish_crates_io.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+skill_root="$(cd "${script_dir}/.." && pwd)"
+entrypoint="${skill_root}/scripts/publish-crates-io.sh"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! rg -q -- "$pattern" "$file"; then
+    echo "error: expected pattern '$pattern' in $file" >&2
+    sed -n '1,220p' "$file" >&2 || true
+    exit 1
+  fi
+}
+
+create_mock_cargo() {
+  local dir="$1"
+  cat > "${dir}/cargo" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+scenario="${MOCK_CARGO_SCENARIO:-success}"
+state_file="${MOCK_CARGO_STATE:-/tmp/mock-cargo-state}"
+
+if [[ "${1:-}" == "metadata" ]]; then
+  cat <<'JSON'
+{
+  "packages": [
+    {
+      "name": "nils-a",
+      "version": "1.2.3",
+      "publish": null,
+      "dependencies": []
+    },
+    {
+      "name": "nils-b",
+      "version": "1.2.4",
+      "publish": null,
+      "dependencies": []
+    }
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" != "publish" ]]; then
+  echo "unexpected cargo command: $*" >&2
+  exit 1
+fi
+
+crate=""
+dry_run=0
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+  arg="${args[$i]}"
+  if [[ "$arg" == "-p" ]]; then
+    crate="${args[$((i+1))]}"
+  elif [[ "$arg" == "--dry-run" ]]; then
+    dry_run=1
+  fi
+done
+
+if [[ -z "$crate" ]]; then
+  echo "missing crate name" >&2
+  exit 1
+fi
+
+if [[ "$dry_run" -eq 1 ]]; then
+  echo "dry-run ok for $crate"
+  exit 0
+fi
+
+case "$scenario" in
+  success)
+    echo "published $crate"
+    exit 0
+    ;;
+  rate-limit-stop)
+    if [[ "$crate" == "nils-a" ]]; then
+      echo "error: too many requests; retry after 120 seconds" >&2
+      exit 1
+    fi
+    echo "published $crate"
+    exit 0
+    ;;
+  rate-limit-once)
+    key="${state_file}.${crate}"
+    attempts=0
+    if [[ -f "$key" ]]; then
+      attempts="$(cat "$key")"
+    fi
+    attempts=$((attempts + 1))
+    echo "$attempts" > "$key"
+    if [[ "$crate" == "nils-a" && "$attempts" -eq 1 ]]; then
+      echo "error: rate limit reached, retry after 0 seconds" >&2
+      exit 1
+    fi
+    echo "published $crate on attempt $attempts"
+    exit 0
+    ;;
+  *)
+    echo "unknown scenario: $scenario" >&2
+    exit 1
+    ;;
+esac
+MOCK
+  chmod +x "${dir}/cargo"
+}
+
+create_mock_status_script() {
+  local dir="$1"
+  cat > "${dir}/crates-io-status.sh" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+scenario="${MOCK_STATUS_SCENARIO:-ok}"
+calls_file="${MOCK_STATUS_CALLS:-/tmp/mock-status-calls}"
+json_out=""
+text_out=""
+
+echo "$*" >> "$calls_file"
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --json-out)
+      json_out="${2:-}"
+      shift 2
+      ;;
+    --text-out)
+      text_out="${2:-}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$json_out" ]]; then
+  mkdir -p "$(dirname "$json_out")"
+  cat > "$json_out" <<'JSON'
+{"summary":{"published":2,"missing":0,"error":0}}
+JSON
+fi
+if [[ -n "$text_out" ]]; then
+  mkdir -p "$(dirname "$text_out")"
+  cat > "$text_out" <<'TEXT'
+# mock status report
+TEXT
+fi
+
+if [[ "$scenario" == "fail" ]]; then
+  exit 1
+fi
+exit 0
+MOCK
+  chmod +x "${dir}/crates-io-status.sh"
+}
+
+create_temp_repo() {
+  local repo_dir="$1"
+  git init "$repo_dir" >/dev/null
+  git -C "$repo_dir" config user.email "test@example.com"
+  git -C "$repo_dir" config user.name "Test User"
+  echo "seed" > "${repo_dir}/README.md"
+  git -C "$repo_dir" add README.md
+  git -C "$repo_dir" commit -m "init" >/dev/null
+}
+
+test_rate_limit_stop_reports_next_time() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local repo="${tmp}/repo"
+  local bin_dir="${tmp}/bin"
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo"
+  create_mock_cargo "$bin_dir"
+
+  local report="${tmp}/report-stop.md"
+  set +e
+  PATH="${bin_dir}:$PATH" MOCK_CARGO_SCENARIO="rate-limit-stop" \
+    "$entrypoint" --crates "nils-a nils-b" --no-skip-existing --report-file "$report" --allow-dirty --skip-status-check \
+    >"${tmp}/stdout.log" 2>"${tmp}/stderr.log"
+  local rc=$?
+  set -e
+
+  [[ "$rc" -eq 1 ]] || fail "expected exit code 1 for default rate-limit stop, got $rc"
+  assert_contains "$report" "Next eligible publish time"
+  assert_contains "$report" "\\| nils-a \\| 1.2.3 \\| failed \\|"
+  assert_contains "$report" "\\| nils-b \\| 1.2.4 \\| pending \\|"
+}
+
+test_wait_retry_finishes_all() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local repo="${tmp}/repo"
+  local bin_dir="${tmp}/bin"
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo"
+  create_mock_cargo "$bin_dir"
+
+  local report="${tmp}/report-wait.md"
+  PATH="${bin_dir}:$PATH" MOCK_CARGO_SCENARIO="rate-limit-once" MOCK_CARGO_STATE="${tmp}/state" \
+    PUBLISH_CRATES_IO_SLEEP_BIN="true" \
+    "$entrypoint" --crates "nils-a nils-b" --wait-retry --no-skip-existing --report-file "$report" --allow-dirty --skip-status-check \
+    >"${tmp}/stdout.log" 2>"${tmp}/stderr.log"
+
+  assert_contains "$report" "\\| nils-a \\| 1.2.3 \\| published \\|"
+  assert_contains "$report" "\\| nils-b \\| 1.2.4 \\| published \\|"
+  assert_contains "$report" 'Failed: `0`'
+}
+
+test_status_snapshot_integration() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local repo="${tmp}/repo"
+  local bin_dir="${tmp}/bin"
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo"
+  create_mock_cargo "$bin_dir"
+  create_mock_status_script "$bin_dir"
+
+  local report="${tmp}/report-status.md"
+  local status_calls="${tmp}/status-calls.log"
+  PATH="${bin_dir}:$PATH" MOCK_CARGO_SCENARIO="success" MOCK_STATUS_CALLS="$status_calls" \
+    PUBLISH_CRATES_IO_STATUS_SCRIPT="${bin_dir}/crates-io-status.sh" \
+    "$entrypoint" --crates "nils-a nils-b" --no-skip-existing --report-file "$report" --allow-dirty \
+    >"${tmp}/stdout.log" 2>"${tmp}/stderr.log"
+
+  assert_contains "$status_calls" "--fail-on-missing"
+  assert_contains "$report" 'Status snapshot: `ok`'
+  assert_contains "$report" 'Status JSON:'
+  assert_contains "$report" 'Status text:'
+  [[ -f "${report%.md}.status.json" ]] || fail "missing status json output"
+  [[ -f "${report%.md}.status.md" ]] || fail "missing status text output"
+}
+
+if [[ ! -f "${skill_root}/SKILL.md" ]]; then
+  echo "error: missing SKILL.md" >&2
+  exit 1
+fi
+if [[ ! -f "$entrypoint" ]]; then
+  echo "error: missing scripts/publish-crates-io.sh" >&2
+  exit 1
+fi
+if [[ ! -f "${skill_root}/references/PUBLISH_REPORT_TEMPLATE.md" ]]; then
+  echo "error: missing references/PUBLISH_REPORT_TEMPLATE.md" >&2
+  exit 1
+fi
+
+test_rate_limit_stop_reports_next_time
+test_wait_retry_finishes_all
+test_status_snapshot_integration
+
+echo "ok: project skill smoke checks passed"

--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ In `--dry-run` mode, the script runs `cargo publish --dry-run` for every selecte
 In `--publish` mode, the script runs `dry-run -> publish` sequentially per crate (in your specified order).
 By default, `--publish` skips crates that are already published at the same version on crates.io.
 
+To query crates.io publish status (single/multi/all crates), use:
+
+- `scripts/crates-io-status.sh --all --format text`
+- `scripts/crates-io-status.sh --crates "nils-common nils-codex-cli" --version v0.3.1 --format json`
+- `scripts/crates-io-status.sh --crate nils-codex-cli --format both --json-out "$CODEX_HOME/out/codex-status.json"`
+
+`--version` checks that exact version; without `--version` the script checks each crate's current workspace version.
+Use `--fail-on-missing` for CI gates.
+
 GitHub Actions manual flow is also available at `.github/workflows/publish-crates.yml`:
 
 - Trigger via `workflow_dispatch`.

--- a/docs/runbooks/crates-io-status-script-runbook.md
+++ b/docs/runbooks/crates-io-status-script-runbook.md
@@ -1,0 +1,201 @@
+# crates.io Status Script Runbook
+
+## Purpose
+
+This runbook explains how to use `scripts/crates-io-status.sh` to check workspace crates publish status on crates.io.
+
+The script supports:
+
+- single crate, multiple crates, or all crates from `release/crates-io-publish-order.txt`
+- explicit target version query (`--version`)
+- workspace-version query (omit `--version`)
+- CI-friendly JSON output and human-readable text output
+
+## Prerequisites
+
+- run inside this git repo
+- `bash`, `python3`, `cargo` available on `PATH`
+- network access to crates.io API
+
+## Common Usage
+
+```bash
+# 1) single crate, workspace version, text output
+scripts/crates-io-status.sh --crate nils-codex-cli --format text
+
+# 2) multiple crates, explicit version, JSON output
+scripts/crates-io-status.sh \
+  --crates "nils-common nils-codex-cli" \
+  --version v0.3.1 \
+  --format json \
+  --json-out "$CODEX_HOME/out/crates-status-v0.3.1.json"
+
+# 3) all crates from publish-order file, both outputs
+scripts/crates-io-status.sh \
+  --all \
+  --format both \
+  --text-out "$CODEX_HOME/out/crates-status-all.md" \
+  --json-out "$CODEX_HOME/out/crates-status-all.json"
+
+# 4) CI gate: fail when any crate is missing/error
+scripts/crates-io-status.sh \
+  --all \
+  --format json \
+  --json-out "$CODEX_HOME/out/crates-status-ci.json" \
+  --fail-on-missing
+```
+
+## Output Semantics
+
+- `status=published`: version exists and not yanked
+- `status=yanked`: version exists but yanked
+- `status=missing`: queried version not found on crates.io
+- `status=error`: API/network/transient failure after retries
+
+`--fail-on-missing` returns non-zero if any result is not `published`/`yanked`.
+
+## Real Successful Query Results
+
+The following commands were executed successfully on **2026-02-11 (UTC)**.
+
+### A. Explicit Version Query (Success)
+
+Command:
+
+```bash
+scripts/crates-io-status.sh \
+  --crate nils-codex-cli \
+  --version v0.3.1 \
+  --format both \
+  --text-out "$CODEX_HOME/out/crates-io-status-nils-codex-cli-v0.3.1.md" \
+  --json-out "$CODEX_HOME/out/crates-io-status-nils-codex-cli-v0.3.1.json"
+```
+
+Text output snapshot:
+
+```md
+# crates.io Status Report
+
+- Checked at (UTC): `2026-02-11T10:59:48Z`
+- Query mode: `explicit-version`
+- Target version: `0.3.1`
+- Total crates: `1`
+- Published: `1`
+- Yanked: `0`
+- Missing: `0`
+- Error: `0`
+
+| Crate | Workspace | Checked | Status | Latest | Published at (UTC) | Note |
+|---|---:|---:|---|---:|---|---|
+| nils-codex-cli | 0.3.1 | 0.3.1 | published | 0.3.1 | 2026-02-11T10:28:48.326957Z | - |
+```
+
+JSON output snapshot:
+
+```json
+{
+  "checked_at": "2026-02-11T10:59:48Z",
+  "query": {
+    "mode": "explicit-version",
+    "target_version": "0.3.1"
+  },
+  "summary": {
+    "total": 1,
+    "published": 1,
+    "yanked": 0,
+    "missing": 0,
+    "error": 0
+  },
+  "results": [
+    {
+      "crate": "nils-codex-cli",
+      "publishable": true,
+      "workspace_version": "0.3.1",
+      "checked_version": "0.3.1",
+      "status": "published",
+      "published": true,
+      "yanked": false,
+      "published_at": "2026-02-11T10:28:48.326957Z",
+      "latest_version": "0.3.1",
+      "crate_updated_at": "2026-02-11T10:28:48.326957Z",
+      "version_downloads": 0,
+      "crate_exists": true,
+      "error": null
+    }
+  ]
+}
+```
+
+### B. Workspace Version Query (Success)
+
+Command:
+
+```bash
+scripts/crates-io-status.sh \
+  --crate nils-codex-cli \
+  --format both \
+  --text-out "$CODEX_HOME/out/crates-io-status-nils-codex-cli-workspace.md" \
+  --json-out "$CODEX_HOME/out/crates-io-status-nils-codex-cli-workspace.json"
+```
+
+Text output snapshot:
+
+```md
+# crates.io Status Report
+
+- Checked at (UTC): `2026-02-11T10:59:48Z`
+- Query mode: `workspace-version`
+- Total crates: `1`
+- Published: `1`
+- Yanked: `0`
+- Missing: `0`
+- Error: `0`
+
+| Crate | Workspace | Checked | Status | Latest | Published at (UTC) | Note |
+|---|---:|---:|---|---:|---|---|
+| nils-codex-cli | 0.3.1 | 0.3.1 | published | 0.3.1 | 2026-02-11T10:28:48.326957Z | - |
+```
+
+JSON output snapshot:
+
+```json
+{
+  "checked_at": "2026-02-11T10:59:48Z",
+  "query": {
+    "mode": "workspace-version",
+    "target_version": null
+  },
+  "summary": {
+    "total": 1,
+    "published": 1,
+    "yanked": 0,
+    "missing": 0,
+    "error": 0
+  },
+  "results": [
+    {
+      "crate": "nils-codex-cli",
+      "publishable": true,
+      "workspace_version": "0.3.1",
+      "checked_version": "0.3.1",
+      "status": "published",
+      "published": true,
+      "yanked": false,
+      "published_at": "2026-02-11T10:28:48.326957Z",
+      "latest_version": "0.3.1",
+      "crate_updated_at": "2026-02-11T10:28:48.326957Z",
+      "version_downloads": 0,
+      "crate_exists": true,
+      "error": null
+    }
+  ]
+}
+```
+
+## Notes for publish-crates-io Skill Integration
+
+`./.codex/skills/publish-crates-io/scripts/publish-crates-io.sh` already supports post-run snapshot by calling this script.
+
+- Default: generate `${report_file%.md}.status.json` and `${report_file%.md}.status.md`
+- Disable snapshot: `--skip-status-check`
+- Override script/output paths: `--status-script`, `--status-json-file`, `--status-text-file`

--- a/scripts/crates-io-status.sh
+++ b/scripts/crates-io-status.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/crates-io-status.sh [options]
+
+Options:
+  --crate NAME            Add one crate (repeatable).
+  --crates "A B,C"        Add multiple crates (space/comma separated).
+  --all                   Query all crates from the list file.
+  --list-file PATH        Default crate list file (default: release/crates-io-publish-order.txt).
+  --version X.Y.Z         Check a specific version (accepts vX.Y.Z).
+  --format MODE           text|json|both (default: text).
+  --json-out PATH         Write JSON output to file.
+  --text-out PATH         Write human-readable output to file.
+  --fail-on-missing       Exit with non-zero when any crate is missing/error.
+  --max-attempts N        HTTP retry attempts for transient errors (default: 3).
+  --timeout-seconds N     HTTP timeout seconds per request (default: 15).
+  -h, --help              Show help.
+
+Environment:
+  CRATES_IO_STATUS_CARGO_BIN      Override cargo executable (default: cargo)
+  CRATES_IO_STATUS_PYTHON_BIN     Override python executable (default: python3)
+  CRATES_IO_STATUS_API_BASE       Override crates.io API base
+                                  (default: https://crates.io/api/v1)
+USAGE
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+note() {
+  echo "info: $*" >&2
+}
+
+contains() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    if [[ "$item" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+append_crates_from_words() {
+  local raw="$1"
+  local item
+  raw="${raw//,/ }"
+  for item in $raw; do
+    [[ -n "$item" ]] || continue
+    selected_crates+=("$item")
+  done
+}
+
+append_crates_from_file() {
+  local path="$1"
+  [[ -f "$path" ]] || die "crate list file not found: $path"
+  local line trimmed
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    trimmed="$(printf '%s' "$line" | sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//')"
+    [[ -n "$trimmed" ]] || continue
+    selected_crates+=("$trimmed")
+  done < "$path"
+}
+
+cargo_bin="${CRATES_IO_STATUS_CARGO_BIN:-cargo}"
+python_bin="${CRATES_IO_STATUS_PYTHON_BIN:-python3}"
+api_base="${CRATES_IO_STATUS_API_BASE:-https://crates.io/api/v1}"
+
+format="text"
+version=""
+list_file="release/crates-io-publish-order.txt"
+fail_on_missing=0
+select_all=0
+max_attempts=3
+timeout_seconds=15
+json_out=""
+text_out=""
+declare -a selected_crates=()
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --crate)
+      [[ $# -ge 2 ]] || die "--crate requires a value"
+      selected_crates+=("${2:-}")
+      shift 2
+      ;;
+    --crates)
+      [[ $# -ge 2 ]] || die "--crates requires a value"
+      append_crates_from_words "${2:-}"
+      shift 2
+      ;;
+    --all)
+      select_all=1
+      shift
+      ;;
+    --list-file)
+      [[ $# -ge 2 ]] || die "--list-file requires a value"
+      list_file="${2:-}"
+      shift 2
+      ;;
+    --version)
+      [[ $# -ge 2 ]] || die "--version requires a value"
+      version="${2:-}"
+      shift 2
+      ;;
+    --format)
+      [[ $# -ge 2 ]] || die "--format requires a value"
+      format="${2:-}"
+      shift 2
+      ;;
+    --json-out)
+      [[ $# -ge 2 ]] || die "--json-out requires a value"
+      json_out="${2:-}"
+      shift 2
+      ;;
+    --text-out)
+      [[ $# -ge 2 ]] || die "--text-out requires a value"
+      text_out="${2:-}"
+      shift 2
+      ;;
+    --fail-on-missing)
+      fail_on_missing=1
+      shift
+      ;;
+    --max-attempts)
+      [[ $# -ge 2 ]] || die "--max-attempts requires a value"
+      max_attempts="${2:-}"
+      shift 2
+      ;;
+    --timeout-seconds)
+      [[ $# -ge 2 ]] || die "--timeout-seconds requires a value"
+      timeout_seconds="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: ${1:-}" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$format" in
+  text|json|both) ;;
+  *) die "--format must be one of: text, json, both" ;;
+esac
+
+[[ "$max_attempts" =~ ^[0-9]+$ ]] || die "--max-attempts must be an integer >= 0"
+[[ "$timeout_seconds" =~ ^[0-9]+$ ]] || die "--timeout-seconds must be an integer >= 0"
+if [[ "$max_attempts" -lt 1 ]]; then
+  die "--max-attempts must be >= 1"
+fi
+
+if [[ "$select_all" -eq 1 && ${#selected_crates[@]} -gt 0 ]]; then
+  die "--all cannot be combined with --crate/--crates"
+fi
+
+version="${version#v}"
+if [[ -n "$version" ]]; then
+  if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+    die "invalid --version: $version"
+  fi
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -n "$repo_root" ]] || die "must run inside a git work tree"
+cd "$repo_root"
+
+if [[ "$select_all" -eq 1 || ${#selected_crates[@]} -eq 0 ]]; then
+  append_crates_from_file "$list_file"
+fi
+
+declare -a deduped_crates=()
+for crate in "${selected_crates[@]}"; do
+  [[ "$crate" =~ ^[A-Za-z0-9_-]+$ ]] || die "invalid crate name: '$crate'"
+  if ! contains "$crate" "${deduped_crates[@]}"; then
+    deduped_crates+=("$crate")
+  fi
+done
+selected_crates=("${deduped_crates[@]}")
+[[ ${#selected_crates[@]} -gt 0 ]] || die "no crates selected"
+
+if [[ "$format" == "both" && -z "$json_out" ]]; then
+  codex_home="${CODEX_HOME:-$HOME/.codex}"
+  timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  json_out="${codex_home}/out/crates-io-status-${timestamp}.json"
+fi
+if [[ -n "$json_out" ]]; then
+  mkdir -p "$(dirname "$json_out")"
+fi
+if [[ -n "$text_out" ]]; then
+  mkdir -p "$(dirname "$text_out")"
+fi
+
+metadata_file="$(mktemp)"
+trap 'rm -f "$metadata_file"' EXIT
+"$cargo_bin" metadata --format-version 1 --no-deps > "$metadata_file"
+
+"$python_bin" - "$metadata_file" "$format" "$json_out" "$text_out" "$version" "$fail_on_missing" "$api_base" "$max_attempts" "$timeout_seconds" "${selected_crates[@]}" <<'PY'
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import pathlib
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+metadata_path = sys.argv[1]
+fmt = sys.argv[2]
+json_out = sys.argv[3]
+text_out = sys.argv[4]
+version_arg = sys.argv[5]
+fail_on_missing = sys.argv[6] == "1"
+api_base = sys.argv[7].rstrip("/")
+max_attempts = int(sys.argv[8])
+timeout_seconds = int(sys.argv[9])
+selected = sys.argv[10:]
+
+with open(metadata_path, "r", encoding="utf-8") as fp:
+    metadata = json.load(fp)
+packages = {pkg["name"]: pkg for pkg in metadata["packages"]}
+
+errors: list[str] = []
+for name in selected:
+    if name not in packages:
+        errors.append(f"selected crate '{name}' is not in this workspace")
+if errors:
+    for err in errors:
+        print(f"error: {err}", file=sys.stderr)
+    raise SystemExit(1)
+
+checked_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+mode = "explicit-version" if version_arg else "workspace-version"
+user_agent = "nils-cli-crates-io-status/1.0"
+
+def parse_retry_after(headers: dict[str, str], attempt: int) -> float:
+    retry_after = headers.get("Retry-After", "").strip()
+    if retry_after.isdigit():
+        return float(max(0, int(retry_after)))
+    return float(min(30, 2 ** max(0, attempt - 1)))
+
+def parse_error_message(raw: str) -> str:
+    raw = raw.strip()
+    if not raw:
+        return ""
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        payload = None
+    if isinstance(payload, dict):
+        errors = payload.get("errors")
+        if isinstance(errors, list) and errors:
+            first = errors[0]
+            if isinstance(first, dict):
+                detail = first.get("detail")
+                if isinstance(detail, str):
+                    return detail
+            if isinstance(first, str):
+                return first
+        message = payload.get("error")
+        if isinstance(message, str):
+            return message
+    return raw.splitlines()[0][:200]
+
+def fetch_json(path: str) -> dict[str, object]:
+    url = f"{api_base}{path}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": user_agent,
+        },
+    )
+    last_error = ""
+    for attempt in range(1, max_attempts + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+                text = response.read().decode("utf-8", errors="replace")
+                return {
+                    "ok": True,
+                    "status": response.status,
+                    "json": json.loads(text),
+                    "error": "",
+                }
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 404:
+                return {"ok": False, "status": 404, "json": None, "error": "not found"}
+            message = parse_error_message(body)
+            last_error = f"http {exc.code}: {message}" if message else f"http {exc.code}"
+            if exc.code in (429, 500, 502, 503, 504) and attempt < max_attempts:
+                headers = {k: v for k, v in exc.headers.items()}
+                time.sleep(parse_retry_after(headers, attempt))
+                continue
+            return {"ok": False, "status": exc.code, "json": None, "error": last_error}
+        except urllib.error.URLError as exc:
+            reason = str(exc.reason)
+            last_error = f"url error: {reason}"
+            if attempt < max_attempts:
+                time.sleep(parse_retry_after({}, attempt))
+                continue
+            return {"ok": False, "status": None, "json": None, "error": last_error}
+        except json.JSONDecodeError:
+            last_error = "invalid json response"
+            return {"ok": False, "status": None, "json": None, "error": last_error}
+    return {"ok": False, "status": None, "json": None, "error": last_error or "request failed"}
+
+results: list[dict[str, object]] = []
+summary = {
+    "total": len(selected),
+    "published": 0,
+    "yanked": 0,
+    "missing": 0,
+    "error": 0,
+}
+
+for crate in selected:
+    pkg = packages[crate]
+    publish_field = pkg.get("publish")
+    publishable = publish_field != []
+    workspace_version = pkg.get("version") or ""
+    checked_version = version_arg if version_arg else workspace_version
+
+    encoded_crate = urllib.parse.quote(crate, safe="")
+    crate_resp = fetch_json(f"/crates/{encoded_crate}")
+    version_resp = fetch_json(f"/crates/{encoded_crate}/{urllib.parse.quote(checked_version, safe='')}")
+
+    latest_version = None
+    crate_updated_at = None
+    if crate_resp["ok"]:
+        crate_payload = crate_resp["json"].get("crate", {})
+        latest_version = crate_payload.get("newest_version")
+        crate_updated_at = crate_payload.get("updated_at")
+
+    status = "missing"
+    published = False
+    yanked = None
+    published_at = None
+    version_downloads = None
+    error_message = ""
+
+    if version_resp["ok"]:
+        version_payload = version_resp["json"].get("version", {})
+        published = True
+        yanked = bool(version_payload.get("yanked", False))
+        status = "yanked" if yanked else "published"
+        published_at = version_payload.get("created_at")
+        version_downloads = version_payload.get("downloads")
+    elif version_resp["status"] == 404:
+        status = "missing"
+    else:
+        status = "error"
+        error_message = str(version_resp["error"] or "")
+
+    if not crate_resp["ok"] and crate_resp["status"] not in (None, 404) and not error_message:
+        error_message = str(crate_resp["error"] or "")
+        status = "error"
+    if crate_resp["status"] == 404 and status == "missing":
+        error_message = "crate not found on crates.io"
+
+    summary_key = "published"
+    if status == "yanked":
+        summary_key = "yanked"
+    elif status == "missing":
+        summary_key = "missing"
+    elif status == "error":
+        summary_key = "error"
+    summary[summary_key] += 1
+
+    results.append(
+        {
+            "crate": crate,
+            "publishable": publishable,
+            "workspace_version": workspace_version,
+            "checked_version": checked_version,
+            "status": status,
+            "published": published,
+            "yanked": yanked,
+            "published_at": published_at,
+            "latest_version": latest_version,
+            "crate_updated_at": crate_updated_at,
+            "version_downloads": version_downloads,
+            "crate_exists": crate_resp["status"] != 404,
+            "error": error_message or None,
+        }
+    )
+
+payload = {
+    "checked_at": checked_at,
+    "query": {
+        "mode": mode,
+        "target_version": version_arg or None,
+    },
+    "summary": summary,
+    "results": results,
+}
+
+def render_text(data: dict[str, object]) -> str:
+    lines: list[str] = []
+    query = data["query"]
+    summary = data["summary"]
+    rows = data["results"]
+    lines.append("# crates.io Status Report")
+    lines.append("")
+    lines.append(f"- Checked at (UTC): `{data['checked_at']}`")
+    lines.append(f"- Query mode: `{query['mode']}`")
+    if query["target_version"]:
+        lines.append(f"- Target version: `{query['target_version']}`")
+    lines.append(f"- Total crates: `{summary['total']}`")
+    lines.append(f"- Published: `{summary['published']}`")
+    lines.append(f"- Yanked: `{summary['yanked']}`")
+    lines.append(f"- Missing: `{summary['missing']}`")
+    lines.append(f"- Error: `{summary['error']}`")
+    lines.append("")
+    lines.append("| Crate | Workspace | Checked | Status | Latest | Published at (UTC) | Note |")
+    lines.append("|---|---:|---:|---|---:|---|---|")
+    for row in rows:
+        note = row["error"] or "-"
+        lines.append(
+            "| {crate} | {workspace_version} | {checked_version} | {status} | {latest_version} | {published_at} | {note} |".format(
+                crate=row["crate"],
+                workspace_version=row["workspace_version"] or "-",
+                checked_version=row["checked_version"] or "-",
+                status=row["status"],
+                latest_version=row["latest_version"] or "-",
+                published_at=row["published_at"] or "-",
+                note=re.sub(r"[\r\n\t]+", " ", str(note)),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+json_text = json.dumps(payload, ensure_ascii=False, indent=2)
+text_report = render_text(payload)
+
+if fmt == "json":
+    if json_out:
+        path = pathlib.Path(json_out)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json_text + "\n", encoding="utf-8")
+    else:
+        sys.stdout.write(json_text + "\n")
+elif fmt == "text":
+    if text_out:
+        path = pathlib.Path(text_out)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text_report, encoding="utf-8")
+    else:
+        sys.stdout.write(text_report)
+else:
+    if text_out:
+        path = pathlib.Path(text_out)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text_report, encoding="utf-8")
+    else:
+        sys.stdout.write(text_report)
+    if json_out:
+        path = pathlib.Path(json_out)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json_text + "\n", encoding="utf-8")
+    else:
+        sys.stdout.write(json_text + "\n")
+
+if fail_on_missing and any(r["status"] not in {"published", "yanked"} for r in results):
+    raise SystemExit(1)
+PY
+
+if [[ -n "$json_out" ]]; then
+  note "json output: $json_out"
+fi
+if [[ -n "$text_out" ]]; then
+  note "text output: $text_out"
+fi


### PR DESCRIPTION
# Add crates.io status workflow for publish automation

## Summary
This PR adds an end-to-end crates.io publish status workflow for this repository. It introduces a reusable status query script with machine-readable and human-readable outputs, integrates that status verification into the `publish-crates-io` project skill, and documents operational usage in a runbook with real successful query results.

## Changes
- Add `scripts/crates-io-status.sh` with single/multi/all crate selectors, optional explicit version checks, `text|json|both` output modes, and `--fail-on-missing` for CI gates.
- Add project skill `.codex/skills/publish-crates-io/` with crates publish orchestration, rate-limit handling (`stop-on-rate-limit` and `wait-and-retry`), and report template.
- Integrate post-run status snapshots in `publish-crates-io.sh` (default status JSON/text artifacts + optional skip/override flags).
- Add tests for both scripts including mock crates.io API behavior and publish/status integration scenarios.
- Add runbook `docs/runbooks/crates-io-status-script-runbook.md` with concrete usage and real successful output samples.
- Update `README.md` crates.io section with status-script examples.

## Testing
- `bash .codex/skills/publish-crates-io/tests/test_crates_io_status.sh` (pass)
- `bash .codex/skills/publish-crates-io/tests/test_publish_crates_io.sh` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- crates.io API responses can be eventually consistent immediately after publish; the status script retries transient failures, but callers should still allow short propagation windows.
- The new publish skill defaults to running status snapshot after each run; this can be disabled with `--skip-status-check` when needed.
