### PR TITLE
Fix codex-cli auth current default secret directory resolution

### DIFF
--- a/crates/codex-cli/README.md
+++ b/crates/codex-cli/README.md
@@ -82,7 +82,11 @@ Auth examples:
 ## Environment
 - `CODEX_ALLOW_DANGEROUS_ENABLED=true` is required for `agent` commands.
 - `CODEX_CLI_MODEL` and `CODEX_CLI_REASONING` set `codex exec` defaults.
-- `CODEX_SECRET_DIR`, `CODEX_AUTH_FILE`, `CODEX_SECRET_CACHE_DIR` control auth/secret paths.
+- `CODEX_SECRET_DIR` controls the secret directory path. When unset, it defaults to
+  `~/.config/codex_secrets`.
+- `CODEX_AUTH_FILE` controls the active auth file path. When unset, it defaults to
+  `~/.codex/auth.json`.
+- `CODEX_SECRET_CACHE_DIR` controls secret cache timestamps.
 - `CODEX_STARSHIP_ENABLED=true` enables Starship output.
 - `CODEX_STARSHIP_TTL` overrides the cache TTL.
 

--- a/crates/codex-cli/docs/specs/codex-cli-diag-auth-json-contract-v1.md
+++ b/crates/codex-cli/docs/specs/codex-cli-diag-auth-json-contract-v1.md
@@ -286,7 +286,7 @@ Informational (do not hard-depend for schema validation):
 }
 ```
 
-### auth current (failure)
+### auth current (failure: secret-not-matched)
 ```json
 {
   "schema_version": "codex-cli.auth.v1",
@@ -298,6 +298,22 @@ Informational (do not hard-depend for schema validation):
     "details": {
       "auth_file": "/home/user/.codex/auth.json",
       "matched": false
+    }
+  }
+}
+```
+
+### auth current (failure: secret-dir-not-found)
+```json
+{
+  "schema_version": "codex-cli.auth.v1",
+  "command": "auth current",
+  "ok": false,
+  "error": {
+    "code": "secret-dir-not-found",
+    "message": "/home/user/.config/codex_secrets not found",
+    "details": {
+      "secret_dir": "/home/user/.config/codex_secrets"
     }
   }
 }

--- a/crates/codex-cli/src/auth/current.rs
+++ b/crates/codex-cli/src/auth/current.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde_json::json;
+use std::io::ErrorKind;
 use std::path::Path;
 
 use crate::auth;
@@ -52,49 +53,56 @@ pub fn run_with_json(output_json: bool) -> Result<i32> {
         }
     };
 
-    let secret_dir = paths::resolve_secret_dir();
+    let secret_dir = match paths::resolve_secret_dir() {
+        Some(path) => path,
+        None => {
+            emit_secret_dir_error(
+                output_json,
+                "secret-dir-not-configured",
+                "CODEX_SECRET_DIR is not configured".to_string(),
+                None,
+            )?;
+            return Ok(1);
+        }
+    };
+    let entries = match std::fs::read_dir(&secret_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            emit_secret_dir_error(
+                output_json,
+                "secret-dir-not-found",
+                format!("{} not found", secret_dir.display()),
+                Some(json!({
+                    "secret_dir": secret_dir.display().to_string(),
+                })),
+            )?;
+            return Ok(1);
+        }
+        Err(err) => {
+            emit_secret_dir_error(
+                output_json,
+                "secret-dir-read-failed",
+                format!("failed to read {}: {err}", secret_dir.display()),
+                Some(json!({
+                    "secret_dir": secret_dir.display().to_string(),
+                    "error": err.to_string(),
+                })),
+            )?;
+            return Ok(1);
+        }
+    };
     let mut matched: Option<(String, MatchMode)> = None;
 
-    if let Some(secret_dir) = secret_dir
-        && let Ok(entries) = std::fs::read_dir(&secret_dir)
-    {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|s| s.to_str()) != Some("json") {
-                continue;
-            }
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
 
-            if let Some(key) = auth_key.as_deref()
-                && let Ok(Some(candidate_key)) = auth::identity_key_from_auth_file(&path)
-                && candidate_key == key
-            {
-                let candidate_hash = match fs::sha256_file(&path) {
-                    Ok(hash) => hash,
-                    Err(_) => {
-                        if output_json {
-                            output::emit_error(
-                                "auth current",
-                                "hash-failed",
-                                format!("failed to hash {}", path.display()),
-                                Some(json!({
-                                    "path": path.display().to_string(),
-                                })),
-                            )?;
-                        } else {
-                            eprintln!("codex: failed to hash {}", path.display());
-                        }
-                        return Ok(1);
-                    }
-                };
-                let mode = if candidate_hash == auth_hash {
-                    MatchMode::Exact
-                } else {
-                    MatchMode::Identity
-                };
-                matched = Some((file_name(&path), mode));
-                break;
-            }
-
+        if let Some(key) = auth_key.as_deref()
+            && let Ok(Some(candidate_key)) = auth::identity_key_from_auth_file(&path)
+            && candidate_key == key
+        {
             let candidate_hash = match fs::sha256_file(&path) {
                 Ok(hash) => hash,
                 Err(_) => {
@@ -113,10 +121,36 @@ pub fn run_with_json(output_json: bool) -> Result<i32> {
                     return Ok(1);
                 }
             };
-            if candidate_hash == auth_hash {
-                matched = Some((file_name(&path), MatchMode::Exact));
-                break;
+            let mode = if candidate_hash == auth_hash {
+                MatchMode::Exact
+            } else {
+                MatchMode::Identity
+            };
+            matched = Some((file_name(&path), mode));
+            break;
+        }
+
+        let candidate_hash = match fs::sha256_file(&path) {
+            Ok(hash) => hash,
+            Err(_) => {
+                if output_json {
+                    output::emit_error(
+                        "auth current",
+                        "hash-failed",
+                        format!("failed to hash {}", path.display()),
+                        Some(json!({
+                            "path": path.display().to_string(),
+                        })),
+                    )?;
+                } else {
+                    eprintln!("codex: failed to hash {}", path.display());
+                }
+                return Ok(1);
             }
+        };
+        if candidate_hash == auth_hash {
+            matched = Some((file_name(&path), MatchMode::Exact));
+            break;
         }
     }
 
@@ -182,4 +216,18 @@ fn file_name(path: &Path) -> String {
         .and_then(|name| name.to_str())
         .unwrap_or_default()
         .to_string()
+}
+
+fn emit_secret_dir_error(
+    output_json: bool,
+    code: &str,
+    message: String,
+    details: Option<serde_json::Value>,
+) -> Result<()> {
+    if output_json {
+        output::emit_error("auth current", code, message, details)?;
+    } else {
+        eprintln!("codex: {message}");
+    }
+    Ok(())
 }

--- a/crates/codex-cli/src/paths.rs
+++ b/crates/codex-cli/src/paths.rs
@@ -6,6 +6,10 @@ pub fn resolve_secret_dir() -> Option<PathBuf> {
         return Some(dir);
     }
 
+    if let Some(home) = home_dir() {
+        return Some(home.join(".config").join("codex_secrets"));
+    }
+
     let feature_dir = resolve_feature_dir()?;
     if feature_dir.join("init.zsh").is_file() || feature_dir.join("codex-tools.zsh").is_file() {
         return Some(feature_dir.join("secrets"));

--- a/crates/codex-cli/tests/auth_json_contract.rs
+++ b/crates/codex-cli/tests/auth_json_contract.rs
@@ -180,6 +180,94 @@ fn auth_json_contract_current_missing_auth_file_is_structured() {
 }
 
 #[test]
+fn auth_json_contract_current_defaults_to_home_secret_dir_when_env_unset() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let home = dir.path().join("home");
+    let auth_dir = home.join(".codex");
+    let secret_dir = home.join(".config").join("codex_secrets");
+    fs::create_dir_all(&auth_dir).expect("auth dir");
+    fs::create_dir_all(&secret_dir).expect("secret dir");
+
+    let auth_file = auth_dir.join("auth.json");
+    let content = auth_json(
+        PAYLOAD_ALPHA,
+        "acct_001",
+        "refresh_a",
+        "2025-01-20T12:34:56Z",
+    );
+    fs::write(&auth_file, &content).expect("write auth");
+    fs::write(secret_dir.join("alpha.json"), &content).expect("write secret");
+
+    let home_str = home.to_string_lossy().to_string();
+    let output = run_with(
+        &["auth", "current", "--json"],
+        &[],
+        &[
+            ("HOME", home_str.as_str()),
+            ("CODEX_AUTH_FILE", ""),
+            ("CODEX_SECRET_DIR", ""),
+        ],
+    );
+    assert_eq!(output.code, 0);
+
+    let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
+    assert_eq!(payload["schema_version"], "codex-cli.auth.v1");
+    assert_eq!(payload["command"], "auth current");
+    assert_eq!(payload["ok"], true);
+    assert_eq!(
+        payload["result"]["auth_file"],
+        auth_file.display().to_string()
+    );
+    assert_eq!(payload["result"]["matched"], true);
+    assert_eq!(payload["result"]["matched_secret"], "alpha.json");
+}
+
+#[test]
+fn auth_json_contract_current_missing_default_secret_dir_is_structured() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let home = dir.path().join("home");
+    let auth_dir = home.join(".codex");
+    fs::create_dir_all(&auth_dir).expect("auth dir");
+
+    let auth_file = auth_dir.join("auth.json");
+    fs::write(
+        &auth_file,
+        auth_json(
+            PAYLOAD_ALPHA,
+            "acct_001",
+            "refresh_a",
+            "2025-01-20T12:34:56Z",
+        ),
+    )
+    .expect("write auth");
+
+    let home_str = home.to_string_lossy().to_string();
+    let output = run_with(
+        &["auth", "current", "--json"],
+        &[],
+        &[
+            ("HOME", home_str.as_str()),
+            ("CODEX_AUTH_FILE", ""),
+            ("CODEX_SECRET_DIR", ""),
+        ],
+    );
+    assert_eq!(output.code, 1);
+
+    let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
+    assert_eq!(payload["schema_version"], "codex-cli.auth.v1");
+    assert_eq!(payload["command"], "auth current");
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"]["code"], "secret-dir-not-found");
+    assert_eq!(
+        payload["error"]["details"]["secret_dir"],
+        home.join(".config")
+            .join("codex_secrets")
+            .display()
+            .to_string()
+    );
+}
+
+#[test]
 fn auth_json_contract_current_no_match_is_structured() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let secrets = dir.path().join("secrets");

--- a/crates/codex-cli/tests/paths.rs
+++ b/crates/codex-cli/tests/paths.rs
@@ -73,24 +73,38 @@ fn paths_resolve_secret_dir_from_feature_dir() {
     let feature_dir = script_dir.join("_features").join("codex");
     fs::create_dir_all(&feature_dir).expect("feature dir");
 
-    let _secret = EnvGuard::remove(&lock, "CODEX_SECRET_DIR");
-    let _script_dir = EnvGuard::set(
-        &lock,
-        "ZSH_SCRIPT_DIR",
-        script_dir.to_str().expect("script dir"),
-    );
+    {
+        let home = dir.path().join("home");
+        fs::create_dir_all(&home).expect("home");
+        let _secret = EnvGuard::remove(&lock, "CODEX_SECRET_DIR");
+        let _home = EnvGuard::set(&lock, "HOME", home.to_str().expect("home"));
+        assert_eq!(
+            paths::resolve_secret_dir().expect("secret dir"),
+            home.join(".config").join("codex_secrets")
+        );
+    }
 
-    fs::write(feature_dir.join("init.zsh"), "#").expect("init.zsh");
-    assert_eq!(
-        paths::resolve_secret_dir().expect("secret dir"),
-        feature_dir.join("secrets")
-    );
+    {
+        let _secret = EnvGuard::remove(&lock, "CODEX_SECRET_DIR");
+        let _home = EnvGuard::remove(&lock, "HOME");
+        let _script_dir = EnvGuard::set(
+            &lock,
+            "ZSH_SCRIPT_DIR",
+            script_dir.to_str().expect("script dir"),
+        );
 
-    fs::remove_file(feature_dir.join("init.zsh")).expect("remove init.zsh");
-    assert_eq!(
-        paths::resolve_secret_dir().expect("secret dir"),
-        feature_dir
-    );
+        fs::write(feature_dir.join("init.zsh"), "#").expect("init.zsh");
+        assert_eq!(
+            paths::resolve_secret_dir().expect("secret dir"),
+            feature_dir.join("secrets")
+        );
+
+        fs::remove_file(feature_dir.join("init.zsh")).expect("remove init.zsh");
+        assert_eq!(
+            paths::resolve_secret_dir().expect("secret dir"),
+            feature_dir
+        );
+    }
 }
 
 #[test]

--- a/docs/runbooks/codex-cli-json-consumers.md
+++ b/docs/runbooks/codex-cli-json-consumers.md
@@ -34,6 +34,9 @@ Contract source of truth:
 - `auth save` overwrite handling:
   - success path: check `result.overwritten` (`false` = new file, `true` = replaced existing file)
   - confirmation-required path: `ok=false`, `error.code=overwrite-confirmation-required`
+- `auth current` secret directory resolution errors are command-level failures:
+  - `error.code=secret-dir-not-configured|secret-dir-not-found|secret-dir-read-failed`
+  - treat these as configuration/operational errors, not as `secret-not-matched`.
 - Treat `raw_usage` and other informational metadata as optional and unstable for strict parsing.
 
 Example commands:


### PR DESCRIPTION
# Fix codex-cli auth current default secret directory resolution

## Summary
Align `codex-cli auth current` with expected defaults by resolving secrets from `~/.config/codex_secrets` when `CODEX_SECRET_DIR` is unset, and returning explicit JSON/text errors when the secret directory is missing or unreadable instead of reporting a misleading match failure.

## Problem
- Expected: `auth current` should locate secrets via default secret directory when env vars are unset.
- Actual: without `CODEX_SECRET_DIR`, matching depended on legacy feature-path discovery and often returned `secret-not-matched`.
- Impact: valid auth setups were reported as unmatched; service consumers could misclassify configuration failures as identity/hash mismatches.

## Reproduction
1. Run with a clean env using only `HOME`/`PATH`: `env -i HOME="$HOME" PATH="$PATH" codex-cli auth current --json`.
2. Observe behavior before fix:
   - if `CODEX_SECRET_DIR` unset, return `ok=false` and `error.code=secret-not-matched` despite a valid `~/.config/codex_secrets`.

- Expected result: default secret path is used and matching succeeds when secrets exist, otherwise a directory-specific error is returned.
- Actual result: fallback path did not target `~/.config/codex_secrets` and errors could be ambiguous.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-114-BUG-001 | medium | high | crates/codex-cli auth path resolution | `auth current` did not use `~/.config/codex_secrets` when `CODEX_SECRET_DIR` was unset and could return misleading `secret-not-matched`. | `crates/codex-cli/src/paths.rs:4`, `crates/codex-cli/src/auth/current.rs:56` | fixed |

## Fix Approach
- Update `resolve_secret_dir()` fallback order to use `$HOME/.config/codex_secrets` when env override is absent.
- In `auth current`, treat secret directory resolution/read failures as command-level errors with stable codes:
  - `secret-dir-not-configured`
  - `secret-dir-not-found`
  - `secret-dir-read-failed`
- Add contract tests for unset env fallback and missing default secret dir.
- Update README + JSON contract spec + consumer runbook to document new default and error semantics.

## Testing
- `cargo test -p nils-codex-cli --test paths --test auth_json_contract --test config` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `zsh -f tests/zsh/completion.test.zsh` (pass)

## Risk / Notes
- Low behavior risk for existing setups that already export `CODEX_SECRET_DIR`; env override still wins.
- Consumer behavior change: some failures previously surfaced as `secret-not-matched` now return explicit `secret-dir-*` errors.
