### PR TITLE
Standardize CLI version flags and policy across workspace

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,6 +18,12 @@
 - Run CLI template: `cargo run -p nils-cli-template -- --help`
 - Run git-scope: `cargo run -p nils-git-scope -- --help`
 
+## CLI version policy
+
+- Every user-facing CLI must expose a root `-V, --version` flag.
+- For clap-based CLIs, set `#[command(version)]` on the root `Parser`.
+- `--help` output should include `-V, --version` in options/help text (auto-generated or custom).
+
 ## Local install (release)
 
 - Build + install all workspace binaries into `~/.local/nils-cli/`:

--- a/crates/git-lock/src/main.rs
+++ b/crates/git-lock/src/main.rs
@@ -17,6 +17,7 @@ mod unlock;
 #[derive(Parser)]
 #[command(
     name = "git-lock",
+    version,
     disable_help_flag = true,
     disable_help_subcommand = true
 )]
@@ -70,6 +71,11 @@ fn run() -> i32 {
         return 0;
     }
 
+    if args.len() > 1 && is_version(&args[1]) {
+        println!("git-lock {}", env!("CARGO_PKG_VERSION"));
+        return 0;
+    }
+
     if !nils_common::git::is_git_repo().unwrap_or(false) {
         println!("{}", messages::NOT_GIT_REPO);
         return 1;
@@ -115,6 +121,10 @@ fn is_help(arg: &str) -> bool {
     matches!(arg, "help" | "--help" | "-h")
 }
 
+fn is_version(arg: &str) -> bool {
+    matches!(arg, "--version" | "-V")
+}
+
 fn is_known_command(arg: &str) -> bool {
     matches!(
         arg,
@@ -124,7 +134,7 @@ fn is_known_command(arg: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_help, is_known_command};
+    use super::{is_help, is_known_command, is_version};
 
     #[test]
     fn is_help_matches_expected_flags() {
@@ -132,6 +142,13 @@ mod tests {
         assert!(is_help("--help"));
         assert!(is_help("-h"));
         assert!(!is_help("lock"));
+    }
+
+    #[test]
+    fn is_version_matches_expected_flags() {
+        assert!(is_version("--version"));
+        assert!(is_version("-V"));
+        assert!(!is_version("lock"));
     }
 
     #[test]

--- a/crates/git-lock/src/messages.rs
+++ b/crates/git-lock/src/messages.rs
@@ -31,5 +31,6 @@ pub fn print_help() {
         "  {:<16}  Create git tag from a lock",
         "tag <label> <tag> [-m msg]"
     );
+    println!("  {:<16}  Show version", "-V, --version");
     println!();
 }

--- a/crates/git-lock/tests/help_outside_repo.rs
+++ b/crates/git-lock/tests/help_outside_repo.rs
@@ -33,3 +33,19 @@ fn help_subcommand_outside_repo_exits_zero() {
     assert!(stdout.contains("Usage: git-lock"));
     assert!(!stdout.contains("Not a Git repository"));
 }
+
+#[test]
+fn version_flag_outside_repo_exits_zero() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = run_git_lock_output(
+        dir.path(),
+        &["--version"],
+        &[("ZSH_CACHE_DIR", dir.path().to_str().unwrap())],
+        None,
+    );
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("git-lock"));
+    assert!(!stdout.contains("Not a Git repository"));
+}

--- a/crates/git-scope/src/main.rs
+++ b/crates/git-scope/src/main.rs
@@ -15,6 +15,7 @@ mod tree;
 #[derive(Parser)]
 #[command(
     name = "git-scope",
+    version,
     disable_help_flag = true,
     disable_help_subcommand = true
 )]
@@ -107,6 +108,7 @@ fn print_help() {
         "  {:<16}  Disable ANSI colors (also via NO_COLOR)",
         "--no-color"
     );
+    println!("  {:<16}  Show version", "-V, --version");
 }
 
 fn main() {

--- a/crates/git-scope/tests/help_outside_repo.rs
+++ b/crates/git-scope/tests/help_outside_repo.rs
@@ -71,3 +71,30 @@ fn help_subcommand_succeeds_outside_git_repo() {
         "unexpected repo warning: {stdout}"
     );
 }
+
+#[test]
+fn version_flag_succeeds_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(git_scope_bin())
+        .args(["--version"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run git-scope --version");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("git-scope"),
+        "missing binary name: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Not a Git repository"),
+        "unexpected repo warning: {stdout}"
+    );
+}

--- a/crates/image-processing/src/cli.rs
+++ b/crates/image-processing/src/cli.rs
@@ -72,6 +72,7 @@ pub const FROM_SVG_VALIDATION_MATRIX: [FromSvgValidationRule; 6] = [
 #[derive(Debug, Parser)]
 #[command(
     name = "image-processing",
+    version,
     about = "Batch image transformations with svg-source and svg-validation flows.",
     after_help = "Notes:\n  - Output-producing subcommands require exactly one output mode: --out, --out-dir, or --in-place (with --yes).\n  - convert --from-svg uses the Rust SVG backend and requires --out + --to png|webp|svg.\n  - svg-validate sanitizes a single svg input and requires --in + --out.\n  - Use --json for machine-readable output (stdout JSON only; logs go to stderr).\n"
 )]

--- a/crates/image-processing/tests/version.rs
+++ b/crates/image-processing/tests/version.rs
@@ -1,0 +1,14 @@
+mod common;
+
+#[test]
+fn version_flag_exits_zero() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let out = common::run_image_processing(dir.path(), &["--version"], &[]);
+
+    assert_eq!(out.code, 0);
+    assert!(
+        out.stdout.contains("image-processing"),
+        "stdout: {}",
+        out.stdout
+    );
+}

--- a/docs/runbooks/new-cli-crate-development-standard.md
+++ b/docs/runbooks/new-cli-crate-development-standard.md
@@ -86,6 +86,7 @@ Every user-facing CLI command surface must have explicit output behavior.
 
 ## Command and UX Rules
 - Use clap-based parsing with stable help text.
+- Root CLI parser must include `#[command(version)]` so `-V, --version` is always available.
 - Usage errors return `64` unless command-specific legacy contract requires otherwise.
 - Keep warning/error prefix conventions consistent with neighboring crates.
 - If completion aliases are provided, keep `completions/zsh/` and `completions/bash/` synchronized.


### PR DESCRIPTION
# Standardize CLI version flags and policy across workspace

## Summary
Add explicit root `-V, --version` behavior to remaining CLIs and codify it as mandatory development policy so new crates ship with consistent version discovery.

## Changes
- Added `#[command(version)]` to `git-scope`, `git-lock`, and `image-processing` root parsers.
- Updated custom help output and argument gating so `git-lock --version` works even outside a Git repo.
- Added regression coverage for `--version` in `git-scope`/`git-lock` and a new `image-processing` version smoke test.
- Documented the mandatory CLI version policy in `DEVELOPMENT.md` and the new CLI crate runbook.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- `git-lock` keeps custom dispatch behavior; version handling is intentionally pre-parse to preserve existing UX.
