### PR TITLE
Add memo-cli search field selection and multi-field filtering

### DIFF
--- a/completions/bash/memo-cli
+++ b/completions/bash/memo-cli
@@ -44,7 +44,7 @@ _nils_cli_memo_cli_complete() {
         return 0
         ;;
       search)
-        COMPREPLY=( $(compgen -W "${global_opts[*]} --limit --state" -- "$cur") )
+        COMPREPLY=( $(compgen -W "${global_opts[*]} --limit --state --field" -- "$cur") )
         return 0
         ;;
       report)
@@ -86,6 +86,10 @@ _nils_cli_memo_cli_complete() {
           return 0
           ;;
       esac
+      ;;
+    --field)
+      COMPREPLY=( $(compgen -W "raw derived tags" -- "$cur") )
+      return 0
       ;;
   esac
 

--- a/completions/zsh/_memo-cli
+++ b/completions/zsh/_memo-cli
@@ -68,6 +68,7 @@ _memo-cli() {
         $global_opts \
         '--limit=[Max rows to return]:limit:' \
         '--state=[Row selection mode]:state:(all pending enriched)' \
+        '--field=[Search fields (comma-separated)]:field:(raw derived tags)' \
         '*:query:' \
         && return 0
       ;;

--- a/crates/memo-cli/README.md
+++ b/crates/memo-cli/README.md
@@ -16,7 +16,8 @@ Commands:
   update <item_id> <text>                    Update a memo and reset downstream derived data
   delete <item_id> --hard                    Hard-delete a memo and all dependent data
   list [--limit <n>] [--offset <n>]         List entries (default: newest first)
-  search <query> [--limit <n>]              Search raw + active derived text
+  search <query> [--limit <n>]              Search raw/derived/tags text
+         [--field <raw|derived|tags>[,...]]
   report <week|month> [--tz <iana-tz>]      Build period summaries
          [--from <rfc3339>] [--to <rfc3339>]
   fetch [--limit <n>] [--cursor <opaque>]   Pull records for enrichment workers
@@ -32,6 +33,7 @@ Commands:
 - `add --at`: optional explicit capture time (RFC3339). Without `--at`, system time is used.
 - `list`: show records with deterministic ordering and optional state filters.
 - `search`: run keyword/prefix search across capture and active enrichment.
+- `search --field`: optional field scope, supports multi-select (example: `--field raw,tags`).
 - `report`: render weekly/monthly summaries with capture fallback when enrichment is missing.
 - `report --from/--to`: optional explicit range (RFC3339). Use both together.
 - `fetch`: machine-facing pull for pending enrichment work.

--- a/crates/memo-cli/docs/runbooks/memo-cli-agent-workflow.md
+++ b/crates/memo-cli/docs/runbooks/memo-cli-agent-workflow.md
@@ -69,6 +69,7 @@ Notes:
 ## 4. Validate with search and report
 ```bash
 memo-cli search "ssd" --json
+memo-cli search "sharedterm" --field raw,tags --json
 memo-cli report week
 memo-cli report month --json
 memo-cli report week --tz Asia/Taipei

--- a/crates/memo-cli/docs/runbooks/memo-cli-rollout.md
+++ b/crates/memo-cli/docs/runbooks/memo-cli-rollout.md
@@ -17,6 +17,7 @@ from pre-consolidation builds are not guaranteed to auto-upgrade.
 4. Validate list/search/report basics:
    - `memo-cli list --limit 5`
    - `memo-cli search "rollout"`
+   - `memo-cli search "rollout" --field raw,tags`
    - `memo-cli update itm_00000001 "rollout updated capture"`
    - `memo-cli delete itm_00000002 --hard`
    - `memo-cli report week`

--- a/crates/memo-cli/docs/specs/memo-cli-command-contract-v1.md
+++ b/crates/memo-cli/docs/specs/memo-cli-command-contract-v1.md
@@ -193,11 +193,14 @@ JSON output:
 Search inbox and active derived fields.
 
 ```text
-memo-cli search <query> [--limit <n>] [--state <all|pending|enriched>] [--json|--format json]
+memo-cli search <query> [--limit <n>] [--state <all|pending|enriched>]
+                [--field <raw|derived|tags>[,<raw|derived|tags>...]] [--json|--format json]
 ```
 
 Behavior:
 - Uses SQLite FTS-backed matching for raw capture and active enrichment text.
+- `--field` narrows the FTS search surface; default is all fields (`raw,derived,tags`).
+- `--field` accepts comma-separated multi-select (for example: `--field raw,tags`).
 - Ranking is deterministic for score ties (`created_at DESC`, `item_id DESC`).
 
 Text output (`stdout`):
@@ -208,6 +211,7 @@ JSON output:
   fields when available:
   - `content_type`
   - `validation_status`
+- JSON `meta` includes `fields[]` reflecting the effective field scope.
 
 ### `report`
 Generate period summaries from capture + enrichment data.

--- a/crates/memo-cli/docs/specs/memo-cli-json-contract-v1.md
+++ b/crates/memo-cli/docs/specs/memo-cli-json-contract-v1.md
@@ -120,12 +120,12 @@ Semantics:
 - `results[]` item fields:
   - `item_id`, `created_at`
   - `score` (number)
-  - `matched_fields` (array of strings; example: `raw_text`, `category`)
+  - `matched_fields` (array of strings; values: `raw_text`, `derived_text`, `tags_text`)
   - `preview` (string)
   - optional `content_type`
   - optional `validation_status`
 - optional `meta`:
-  - `query`, `limit`, `state`
+  - `query`, `limit`, `state`, `fields`
 
 ### `report` (`result`)
 - `result.period`: `week` or `month`

--- a/crates/memo-cli/src/cli.rs
+++ b/crates/memo-cli/src/cli.rs
@@ -31,6 +31,13 @@ pub enum ItemState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum SearchField {
+    Raw,
+    Derived,
+    Tags,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum ReportPeriod {
     Week,
     Month,
@@ -144,6 +151,15 @@ pub struct SearchArgs {
     /// Row selection mode
     #[arg(long, value_enum, default_value_t = ItemState::All)]
     pub state: ItemState,
+
+    /// Search fields (comma-separated): raw, derived, tags
+    #[arg(
+        long = "field",
+        value_enum,
+        value_delimiter = ',',
+        default_values_t = [SearchField::Raw, SearchField::Derived, SearchField::Tags]
+    )]
+    pub fields: Vec<SearchField>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -256,7 +272,7 @@ fn default_db_path() -> PathBuf {
 pub(crate) mod tests {
     use clap::{CommandFactory, Parser};
 
-    use super::{Cli, OutputMode};
+    use super::{Cli, MemoCommand, OutputMode, SearchField};
 
     #[test]
     fn output_mode_defaults_to_text() {
@@ -301,5 +317,28 @@ pub(crate) mod tests {
         assert!(subcommands.contains(&"report".to_string()));
         assert!(subcommands.contains(&"fetch".to_string()));
         assert!(subcommands.contains(&"apply".to_string()));
+    }
+
+    #[test]
+    fn search_fields_supports_comma_separated_values() {
+        let cli = Cli::parse_from(["memo-cli", "search", "ssd", "--field", "raw,tags"]);
+        let MemoCommand::Search(args) = cli.command else {
+            panic!("expected search command");
+        };
+
+        assert_eq!(args.fields, vec![SearchField::Raw, SearchField::Tags]);
+    }
+
+    #[test]
+    fn search_fields_default_to_all_fields() {
+        let cli = Cli::parse_from(["memo-cli", "search", "ssd"]);
+        let MemoCommand::Search(args) = cli.command else {
+            panic!("expected search command");
+        };
+
+        assert_eq!(
+            args.fields,
+            vec![SearchField::Raw, SearchField::Derived, SearchField::Tags]
+        );
     }
 }

--- a/crates/memo-cli/src/commands/mod.rs
+++ b/crates/memo-cli/src/commands/mod.rs
@@ -32,6 +32,7 @@ pub fn run(cli: &Cli, output_mode: OutputMode) -> Result<(), AppError> {
             output_mode,
             to_query_state(args.state),
             &args.query,
+            &args.fields,
             args.limit,
         ),
         MemoCommand::Report(args) => report::run(&storage, output_mode, args),

--- a/crates/memo-cli/src/commands/search.rs
+++ b/crates/memo-cli/src/commands/search.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use crate::cli::OutputMode;
+use crate::cli::{OutputMode, SearchField as CliSearchField};
 use crate::errors::AppError;
 use crate::output::{emit_json_results_with_meta, format_item_id, text};
 use crate::storage::Storage;
@@ -12,6 +12,7 @@ pub fn run(
     output_mode: OutputMode,
     state: QueryState,
     query: &str,
+    fields: &[CliSearchField],
     limit: usize,
 ) -> Result<(), AppError> {
     let query = query.trim();
@@ -19,7 +20,9 @@ pub fn run(
         return Err(AppError::usage("search requires a non-empty query"));
     }
 
-    let rows = storage.with_connection(|conn| search::search_items(conn, query, state, limit))?;
+    let search_fields = map_search_fields(fields);
+    let rows = storage
+        .with_connection(|conn| search::search_items(conn, query, state, &search_fields, limit))?;
 
     if output_mode.is_json() {
         let results = rows
@@ -45,6 +48,7 @@ pub fn run(
                 "query": query,
                 "limit": limit,
                 "state": query_state_label(state),
+                "fields": search_field_labels(&search_fields),
             })),
         );
     }
@@ -60,4 +64,34 @@ fn query_state_label(state: QueryState) -> &'static str {
         QueryState::Pending => "pending",
         QueryState::Enriched => "enriched",
     }
+}
+
+fn map_search_fields(fields: &[CliSearchField]) -> Vec<search::SearchField> {
+    let mut out = Vec::new();
+    let source = if fields.is_empty() {
+        &[
+            CliSearchField::Raw,
+            CliSearchField::Derived,
+            CliSearchField::Tags,
+        ][..]
+    } else {
+        fields
+    };
+
+    for field in source {
+        let mapped = match field {
+            CliSearchField::Raw => search::SearchField::Raw,
+            CliSearchField::Derived => search::SearchField::Derived,
+            CliSearchField::Tags => search::SearchField::Tags,
+        };
+        if !out.contains(&mapped) {
+            out.push(mapped);
+        }
+    }
+
+    out
+}
+
+fn search_field_labels(fields: &[search::SearchField]) -> Vec<&'static str> {
+    fields.iter().map(|field| field.label()).collect()
 }

--- a/crates/memo-cli/src/storage/search.rs
+++ b/crates/memo-cli/src/storage/search.rs
@@ -5,6 +5,27 @@ use crate::errors::AppError;
 
 use super::repository::QueryState;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchField {
+    Raw,
+    Derived,
+    Tags,
+}
+
+impl SearchField {
+    fn fts_column(self) -> &'static str {
+        match self {
+            Self::Raw => "raw_text",
+            Self::Derived => "derived_text",
+            Self::Tags => "tags_text",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        self.fts_column()
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct SearchItem {
     pub item_id: i64,
@@ -65,8 +86,16 @@ pub fn search_items(
     conn: &Connection,
     query: &str,
     state: QueryState,
+    fields: &[SearchField],
     limit: usize,
 ) -> Result<Vec<SearchItem>, AppError> {
+    let fields = normalize_search_fields(fields);
+    let scoped_query = build_scoped_query(query, &fields);
+    let matched_fields = fields
+        .iter()
+        .map(|field| field.label().to_string())
+        .collect::<Vec<_>>();
+
     let state_filter = match state {
         QueryState::All => "1 = 1",
         QueryState::Pending => {
@@ -112,12 +141,12 @@ pub fn search_items(
 
     let mut stmt = conn.prepare(&sql).map_err(AppError::db_query)?;
     let rows = stmt
-        .query_map(params![query, limit as i64], |row| {
+        .query_map(params![scoped_query, limit as i64], |row| {
             Ok(SearchItem {
                 item_id: row.get(0)?,
                 created_at: row.get(1)?,
                 score: row.get(2)?,
-                matched_fields: vec!["raw_text".to_string()],
+                matched_fields: matched_fields.clone(),
                 preview: row.get(3)?,
                 content_type: row.get(4)?,
                 validation_status: row.get(5)?,
@@ -127,6 +156,32 @@ pub fn search_items(
 
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(AppError::db_query)
+}
+
+fn normalize_search_fields(fields: &[SearchField]) -> Vec<SearchField> {
+    let mut out = Vec::new();
+    let source = if fields.is_empty() {
+        &[SearchField::Raw, SearchField::Derived, SearchField::Tags][..]
+    } else {
+        fields
+    };
+
+    for field in source {
+        if !out.contains(field) {
+            out.push(*field);
+        }
+    }
+
+    out
+}
+
+fn build_scoped_query(query: &str, fields: &[SearchField]) -> String {
+    let columns = fields
+        .iter()
+        .map(|field| field.fts_column())
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("{{{columns}}}: ({query})")
 }
 
 pub fn report_summary(conn: &Connection, period: ReportPeriod) -> Result<ReportSummary, AppError> {

--- a/crates/memo-cli/tests/json_contract.rs
+++ b/crates/memo-cli/tests/json_contract.rs
@@ -101,6 +101,10 @@ fn json_contract() {
     assert_eq!(search_json["meta"]["query"], "ssd");
     assert_eq!(search_json["meta"]["limit"], 5);
     assert_eq!(search_json["meta"]["state"], "all");
+    assert_eq!(
+        search_json["meta"]["fields"],
+        json!(["raw_text", "derived_text", "tags_text"])
+    );
 
     let fetch_output = run_memo_cli(&db_path, &["--json", "fetch", "--limit", "1"], None);
     assert_eq!(

--- a/crates/memo-cli/tests/search_and_report.rs
+++ b/crates/memo-cli/tests/search_and_report.rs
@@ -83,7 +83,19 @@ fn search_and_report() {
         .expect("seed should succeed");
 
     let search_rows = storage
-        .with_connection(|conn| search::search_items(conn, "tokyo", QueryState::All, 20))
+        .with_connection(|conn| {
+            search::search_items(
+                conn,
+                "tokyo",
+                QueryState::All,
+                &[
+                    search::SearchField::Raw,
+                    search::SearchField::Derived,
+                    search::SearchField::Tags,
+                ],
+                20,
+            )
+        })
         .expect("search should succeed");
 
     assert!(!search_rows.is_empty());
@@ -99,4 +111,119 @@ fn search_and_report() {
 
     assert_eq!(report.period, "week");
     assert!(report.totals.captured >= 2);
+}
+
+#[test]
+fn search_supports_field_filters() {
+    let db_path = test_db_path("search_supports_field_filters");
+    let storage = Storage::new(db_path);
+
+    let (raw_item_id, tagged_item_id) = storage
+        .with_transaction(|tx| {
+            let raw_item = repository::add_item(tx, "sharedterm appears in raw text", "cli", None)?;
+            let tagged_item = repository::add_item(tx, "this row has no shared term in raw text", "cli", None)?;
+
+            tx.execute(
+                "insert into item_derivations(
+                    item_id,
+                    derivation_version,
+                    status,
+                    is_active,
+                    base_derivation_id,
+                    derivation_hash,
+                    agent_run_id,
+                    summary,
+                    category,
+                    priority,
+                    due_at,
+                    normalized_text,
+                    confidence,
+                    payload_json,
+                    conflict_reason
+                ) values (?1, 1, 'accepted', 1, null, ?2, 'agent-run-tag', 'nohit', 'misc', null, null, 'nohit', 0.7, ?3, null)",
+                rusqlite::params![
+                    tagged_item.item_id,
+                    format!("hash-{}", tagged_item.item_id),
+                    "{\"ok\":true}"
+                ],
+            )
+            .map_err(memo_cli::errors::AppError::db)?;
+
+            let derivation_id: i64 = tx
+                .query_row(
+                    "select derivation_id from item_derivations where item_id = ?1 and derivation_version = 1",
+                    rusqlite::params![tagged_item.item_id],
+                    |row| row.get(0),
+                )
+                .map_err(memo_cli::errors::AppError::db_query)?;
+
+            tx.execute(
+                "insert into tags(tag_name, tag_name_norm) values ('sharedterm', 'sharedterm')",
+                [],
+            )
+            .map_err(memo_cli::errors::AppError::db)?;
+            let tag_id: i64 = tx
+                .query_row(
+                    "select tag_id from tags where tag_name_norm = 'sharedterm'",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(memo_cli::errors::AppError::db_query)?;
+
+            tx.execute(
+                "insert into item_tags(derivation_id, tag_id) values (?1, ?2)",
+                rusqlite::params![derivation_id, tag_id],
+            )
+            .map_err(memo_cli::errors::AppError::db)?;
+
+            Ok((raw_item.item_id, tagged_item.item_id))
+        })
+        .expect("seed should succeed");
+
+    let raw_rows = storage
+        .with_connection(|conn| {
+            search::search_items(
+                conn,
+                "sharedterm",
+                QueryState::All,
+                &[search::SearchField::Raw],
+                20,
+            )
+        })
+        .expect("raw field search should succeed");
+    assert_eq!(raw_rows.len(), 1);
+    assert_eq!(raw_rows[0].item_id, raw_item_id);
+
+    let tag_rows = storage
+        .with_connection(|conn| {
+            search::search_items(
+                conn,
+                "sharedterm",
+                QueryState::All,
+                &[search::SearchField::Tags],
+                20,
+            )
+        })
+        .expect("tags field search should succeed");
+    assert_eq!(tag_rows.len(), 1);
+    assert_eq!(tag_rows[0].item_id, tagged_item_id);
+
+    let raw_and_tag_rows = storage
+        .with_connection(|conn| {
+            search::search_items(
+                conn,
+                "sharedterm",
+                QueryState::All,
+                &[search::SearchField::Raw, search::SearchField::Tags],
+                20,
+            )
+        })
+        .expect("raw+tags field search should succeed");
+    let matched_ids = raw_and_tag_rows
+        .iter()
+        .map(|row| row.item_id)
+        .collect::<Vec<_>>();
+
+    assert!(matched_ids.contains(&raw_item_id));
+    assert!(matched_ids.contains(&tagged_item_id));
 }

--- a/tests/zsh/completion.test.zsh
+++ b/tests/zsh/completion.test.zsh
@@ -726,6 +726,11 @@ grep -q -- "--dry-run\\[Validate payload without write-back\\]" "$COMP_MEMO_CLI_
   exit 1
 }
 
+grep -q -- "--field=\\[Search fields (comma-separated)\\]" "$COMP_MEMO_CLI_FILE" || {
+  print -u2 -r -- "FAIL: memo-cli completion missing --field"
+  exit 1
+}
+
 grep -q -- "--window-title-contains" "$BASH_MACOS_AGENT_FILE" || {
   print -u2 -r -- "FAIL: bash macos-agent completion missing canonical --window-title-contains"
   exit 1
@@ -758,6 +763,11 @@ grep -q -- "--include-experimental" "$BASH_AGENTCTL_FILE" || {
 
 grep -q -- "--probe-mode" "$BASH_AGENTCTL_FILE" || {
   print -u2 -r -- "FAIL: bash agentctl completion missing --probe-mode"
+  exit 1
+}
+
+grep -q -- "--field" "$BASH_MEMO_CLI_FILE" || {
+  print -u2 -r -- "FAIL: bash memo-cli completion missing --field"
   exit 1
 }
 


### PR DESCRIPTION
# Add memo-cli search field selection and multi-field filtering

## Summary
Adds field-scoped search for `memo-cli search` so users can limit matches to `raw`, `derived`, and/or `tags`, while keeping a default search scope across all fields when `--field` is omitted.

## Changes
- Add `--field` to `memo-cli search` with comma-separated multi-select parsing.
- Scope FTS search to selected columns and expose effective fields in JSON `meta.fields`.
- Add and update tests for default/all-fields behavior and raw/tags filter behavior.
- Update memo-cli command/json specs, runbooks, README, and bash/zsh completions.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Existing memo SQLite databases are intentionally not backward-compatible after schema consolidation.
- Search result `matched_fields` now reflects selected effective fields (`raw_text`, `derived_text`, `tags_text`).
