### PR TITLE
Support raster sizing for convert --from-svg output

### DIFF
--- a/crates/image-processing/README.md
+++ b/crates/image-processing/README.md
@@ -27,7 +27,7 @@ Help:
 - `svg-validate`: Validate + sanitize one SVG input into one SVG output.
 - `convert`: Convert image formats.
   - Legacy mode: `--in ... --to png|jpg|webp`.
-  - SVG mode: `--from-svg <path> --to png|webp|svg --out <file>`.
+  - SVG mode: `--from-svg <path> --to png|webp|svg --out <file>` (optional `--width`/`--height` for raster outputs).
 - `resize`: Resize by `--scale`, `--width`/`--height`, or `--aspect` + `--fit` (`contain|cover|stretch`).
 - `rotate`: Rotate by degrees; requires `--degrees`.
 - `crop`: Crop by `--rect`, `--size`, or `--aspect` (exactly one).
@@ -48,6 +48,8 @@ Help:
 - Required: `--to png|webp|svg`, `--out <file>`.
 - Forbidden with `--from-svg`: `--in`, `--recursive`, `--glob`, `--out-dir`, `--in-place`.
 - `--out` extension must match `--to`.
+- Optional: `--width`/`--height` for raster output sizing (`png`/`webp`); a single side keeps aspect ratio.
+- `--to svg` does not support `--width`/`--height`.
 - This path is Rust-backed (`usvg`/`resvg`) and does not require ImageMagick.
 
 ## `svg-validate` contract
@@ -79,6 +81,7 @@ cargo run -p nils-image-processing -- convert \
   --from-svg crates/image-processing/tests/fixtures/sample-icon.svg \
   --to webp \
   --out out/plan-doc-examples/sample.webp \
+  --width 512 \
   --json
 ```
 

--- a/crates/image-processing/src/cli.rs
+++ b/crates/image-processing/src/cli.rs
@@ -42,7 +42,7 @@ pub struct FromSvgValidationRule {
 }
 
 #[allow(dead_code)]
-pub const FROM_SVG_VALIDATION_MATRIX: [FromSvgValidationRule; 6] = [
+pub const FROM_SVG_VALIDATION_MATRIX: [FromSvgValidationRule; 7] = [
     FromSvgValidationRule {
         when: "subcommand=convert && --from-svg",
         expect: "requires --out and forbids --out-dir/--in-place",
@@ -54,6 +54,10 @@ pub const FROM_SVG_VALIDATION_MATRIX: [FromSvgValidationRule; 6] = [
     FromSvgValidationRule {
         when: "subcommand=convert && --from-svg",
         expect: "requires --to and supports only png|webp|svg",
+    },
+    FromSvgValidationRule {
+        when: "subcommand=convert && --from-svg",
+        expect: "accepts optional --width/--height for png|webp outputs",
     },
     FromSvgValidationRule {
         when: "subcommand=svg-validate",
@@ -74,7 +78,7 @@ pub const FROM_SVG_VALIDATION_MATRIX: [FromSvgValidationRule; 6] = [
     name = "image-processing",
     version,
     about = "Batch image transformations with svg-source and svg-validation flows.",
-    after_help = "Notes:\n  - Output-producing subcommands require exactly one output mode: --out, --out-dir, or --in-place (with --yes).\n  - convert --from-svg uses the Rust SVG backend and requires --out + --to png|webp|svg.\n  - svg-validate sanitizes a single svg input and requires --in + --out.\n  - Use --json for machine-readable output (stdout JSON only; logs go to stderr).\n"
+    after_help = "Notes:\n  - Output-producing subcommands require exactly one output mode: --out, --out-dir, or --in-place (with --yes).\n  - convert --from-svg uses the Rust SVG backend and requires --out + --to png|webp|svg.\n  - convert --from-svg optionally supports --width/--height for png|webp raster size.\n  - svg-validate sanitizes a single svg input and requires --in + --out.\n  - Use --json for machine-readable output (stdout JSON only; logs go to stderr).\n"
 )]
 pub struct Cli {
     #[arg(value_enum)]
@@ -125,7 +129,7 @@ pub struct Cli {
     #[arg(long)]
     pub quality: Option<i32>,
 
-    // resize / pad
+    // resize / pad / convert --from-svg
     #[arg(long)]
     pub scale: Option<f64>,
     #[arg(long)]

--- a/crates/image-processing/src/main.rs
+++ b/crates/image-processing/src/main.rs
@@ -194,6 +194,8 @@ fn run() -> i32 {
         report_enabled: cli.report,
         json_enabled: cli.json,
         convert_to: cli.to.as_deref(),
+        from_svg_width: if from_svg_mode { cli.width } else { None },
+        from_svg_height: if from_svg_mode { cli.height } else { None },
         quality: cli.quality,
         resize_scale: cli.scale,
         resize_width: if cli.subcommand == Operation::Resize {
@@ -309,6 +311,20 @@ fn validate(cli: &Cli) -> Result<(), util::UsageError> {
                 message: "convert --from-svg requires --out".to_string(),
             });
         }
+        if let Some(width) = cli.width
+            && width <= 0
+        {
+            return Err(util::UsageError {
+                message: "convert --from-svg --width must be > 0".to_string(),
+            });
+        }
+        if let Some(height) = cli.height
+            && height <= 0
+        {
+            return Err(util::UsageError {
+                message: "convert --from-svg --height must be > 0".to_string(),
+            });
+        }
     }
 
     if cli.subcommand == Operation::SvgValidate {
@@ -369,7 +385,9 @@ fn validate(cli: &Cli) -> Result<(), util::UsageError> {
         }
     }
 
-    if !matches!(cli.subcommand, Operation::Resize | Operation::Pad) {
+    let allows_shared_width_height = matches!(cli.subcommand, Operation::Resize | Operation::Pad)
+        || (cli.subcommand == Operation::Convert && from_svg_mode);
+    if !allows_shared_width_height {
         if cli.width.is_some() {
             forbid("--width")?;
         }
@@ -424,6 +442,12 @@ fn validate(cli: &Cli) -> Result<(), util::UsageError> {
                 if !svg_validate::SUPPORTED_FROM_SVG_TARGETS.contains(&to) {
                     return Err(util::UsageError {
                         message: "convert --from-svg --to must be one of: png|webp|svg".to_string(),
+                    });
+                }
+                if to == "svg" && (cli.width.is_some() || cli.height.is_some()) {
+                    return Err(util::UsageError {
+                        message: "convert --from-svg --to svg does not support --width/--height"
+                            .to_string(),
                     });
                 }
             } else if !model::SUPPORTED_CONVERT_TARGETS.contains(&to) {
@@ -563,6 +587,31 @@ mod tests {
 
         cli.to = Some("svg".to_string());
         assert!(validate(&cli).is_ok());
+    }
+
+    #[test]
+    fn validate_from_svg_dimensions_contract() {
+        let mut cli = base_cli(Operation::Convert);
+        cli.to = Some("png".to_string());
+        cli.width = Some(128);
+        let err = validate(&cli).expect_err("legacy convert should reject --width");
+        assert!(err.to_string().contains("convert does not support --width"));
+
+        cli.from_svg = Some("icon.svg".to_string());
+        cli.inputs.clear();
+        assert!(validate(&cli).is_ok());
+
+        cli.width = Some(0);
+        let err = validate(&cli).expect_err("from-svg width must be positive");
+        assert!(err.to_string().contains("--width must be > 0"));
+
+        cli.width = Some(128);
+        cli.to = Some("svg".to_string());
+        let err = validate(&cli).expect_err("svg output should reject resize dimensions");
+        assert!(
+            err.to_string()
+                .contains("does not support --width/--height")
+        );
     }
 
     #[test]

--- a/crates/image-processing/src/processing.rs
+++ b/crates/image-processing/src/processing.rs
@@ -188,6 +188,8 @@ pub struct ProcessArgs<'a> {
     pub report_enabled: bool,
     pub json_enabled: bool,
     pub convert_to: Option<&'a str>,
+    pub from_svg_width: Option<i32>,
+    pub from_svg_height: Option<i32>,
     pub quality: Option<i32>,
     pub resize_scale: Option<f64>,
     pub resize_width: Option<i32>,
@@ -226,6 +228,8 @@ pub fn process_items(args: ProcessArgs<'_>) -> anyhow::Result<Summary> {
         report_enabled,
         json_enabled,
         convert_to,
+        from_svg_width,
+        from_svg_height,
         quality,
         resize_scale,
         resize_width,
@@ -512,6 +516,14 @@ pub fn process_items(args: ProcessArgs<'_>) -> anyhow::Result<Summary> {
                     .as_deref()
                     .ok_or_else(|| util::usage_err("internal error: missing output path"))?;
                 let target = svg_validate::parse_from_svg_target(convert_to)?;
+                let raster_size_hint = from_svg_raster_size_hint(from_svg_width, from_svg_height)?;
+                if target == "svg"
+                    && (raster_size_hint.width.is_some() || raster_size_hint.height.is_some())
+                {
+                    return Err(util::usage_err(
+                        "convert --from-svg --to svg does not support --width/--height",
+                    ));
+                }
                 let mut cmd = vec![
                     "image-processing".to_string(),
                     "convert".to_string(),
@@ -522,13 +534,25 @@ pub fn process_items(args: ProcessArgs<'_>) -> anyhow::Result<Summary> {
                     "--out".to_string(),
                     output_path.to_string_lossy().to_string(),
                 ];
+                if let Some(width) = raster_size_hint.width {
+                    cmd.extend(["--width".to_string(), width.to_string()]);
+                }
+                if let Some(height) = raster_size_hint.height {
+                    cmd.extend(["--height".to_string(), height.to_string()]);
+                }
                 if dry_run {
                     cmd.push("--dry-run".to_string());
                 }
                 item_cmds.push(util::command_str(&cmd));
 
                 let doc = from_svg_doc.as_ref().expect("from_svg_doc");
-                let info = svg_validate::render_svg_to_output(doc, target, output_path, dry_run)?;
+                let info = svg_validate::render_svg_to_output(
+                    doc,
+                    target,
+                    output_path,
+                    raster_size_hint,
+                    dry_run,
+                )?;
                 if !dry_run {
                     output_info = Some(info);
                 }
@@ -1316,6 +1340,26 @@ fn ext_normalize(path: &Path) -> String {
         return "jpg".to_string();
     }
     ext
+}
+
+fn from_svg_raster_size_hint(
+    width: Option<i32>,
+    height: Option<i32>,
+) -> anyhow::Result<svg_validate::RasterSizeHint> {
+    Ok(svg_validate::RasterSizeHint {
+        width: parse_positive_dimension(width, "--width")?,
+        height: parse_positive_dimension(height, "--height")?,
+    })
+}
+
+fn parse_positive_dimension(value: Option<i32>, flag: &str) -> anyhow::Result<Option<u32>> {
+    match value {
+        Some(v) if v > 0 => Ok(Some(v as u32)),
+        Some(_) => Err(util::usage_err(format!(
+            "convert --from-svg {flag} must be > 0"
+        ))),
+        None => Ok(None),
+    }
 }
 
 fn output_supports_alpha(ext: &str) -> bool {

--- a/crates/image-processing/src/svg_validate.rs
+++ b/crates/image-processing/src/svg_validate.rs
@@ -27,6 +27,12 @@ pub struct SanitizedSvgDocument {
     pub uses_alpha: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RasterSizeHint {
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub struct SvgValidateCommandResult {
     pub input_path: String,
@@ -234,10 +240,16 @@ pub fn render_svg_to_output(
     doc: &SanitizedSvgDocument,
     output_format: &str,
     output_path: &Path,
+    raster_size_hint: RasterSizeHint,
     dry_run: bool,
 ) -> anyhow::Result<ImageInfo> {
     match output_format {
         "svg" => {
+            if raster_size_hint.width.is_some() || raster_size_hint.height.is_some() {
+                return Err(util::usage_err(
+                    "convert --from-svg --to svg does not support --width/--height",
+                ));
+            }
             if !dry_run {
                 util::ensure_parent_dir(output_path, false)?;
                 std::fs::write(output_path, doc.content.as_bytes())?;
@@ -252,19 +264,24 @@ pub fn render_svg_to_output(
             )
         }
         "png" | "webp" => {
+            let tree = resvg::usvg::Tree::from_str(&doc.content, &resvg::usvg::Options::default())
+                .map_err(|err| anyhow::anyhow!("failed to parse sanitized svg: {err}"))?;
+            let size = tree.size().to_int_size();
+            let base_width = size.width();
+            let base_height = size.height();
+            let (width, height) =
+                resolve_raster_dimensions(base_width, base_height, raster_size_hint)?;
+
             if !dry_run {
                 util::ensure_parent_dir(output_path, false)?;
-                let tree =
-                    resvg::usvg::Tree::from_str(&doc.content, &resvg::usvg::Options::default())
-                        .map_err(|err| anyhow::anyhow!("failed to parse sanitized svg: {err}"))?;
-                let size = tree.size().to_int_size();
-                let width = size.width();
-                let height = size.height();
                 let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height)
                     .ok_or_else(|| anyhow::anyhow!("failed to allocate raster surface"))?;
                 resvg::render(
                     &tree,
-                    resvg::tiny_skia::Transform::identity(),
+                    resvg::tiny_skia::Transform::from_scale(
+                        width as f32 / base_width as f32,
+                        height as f32 / base_height as f32,
+                    ),
                     &mut pixmap.as_mut(),
                 );
 
@@ -277,8 +294,8 @@ pub fn render_svg_to_output(
             }
             output_info(
                 output_format,
-                doc.width,
-                doc.height,
+                width,
+                height,
                 doc.uses_alpha,
                 output_path,
                 dry_run,
@@ -340,6 +357,33 @@ fn output_info(
         exif_orientation: None,
         size_bytes,
     })
+}
+
+fn resolve_raster_dimensions(
+    base_width: u32,
+    base_height: u32,
+    hint: RasterSizeHint,
+) -> anyhow::Result<(u32, u32)> {
+    if base_width == 0 || base_height == 0 {
+        return Err(anyhow::anyhow!("sanitized svg has invalid dimensions"));
+    }
+    let dims = match (hint.width, hint.height) {
+        (Some(width), Some(height)) => (width, height),
+        (Some(width), None) => {
+            let height = ((width as f64 * base_height as f64) / base_width as f64)
+                .round()
+                .max(1.0) as u32;
+            (width, height)
+        }
+        (None, Some(height)) => {
+            let width = ((height as f64 * base_width as f64) / base_height as f64)
+                .round()
+                .max(1.0) as u32;
+            (width, height)
+        }
+        (None, None) => (base_width, base_height),
+    };
+    Ok((dims.0.max(1), dims.1.max(1)))
 }
 
 fn parse_view_box(raw: &str) -> Result<(u32, u32), String> {
@@ -464,5 +508,30 @@ mod tests {
                 .iter()
                 .any(|d| d.code == "disallowed_tag" || d.code == "unsafe_tag")
         );
+    }
+
+    #[test]
+    fn resolve_raster_dimensions_preserves_aspect_when_single_dimension_is_set() {
+        let by_width = resolve_raster_dimensions(
+            80,
+            40,
+            RasterSizeHint {
+                width: Some(200),
+                height: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(by_width, (200, 100));
+
+        let by_height = resolve_raster_dimensions(
+            80,
+            40,
+            RasterSizeHint {
+                width: None,
+                height: Some(120),
+            },
+        )
+        .unwrap();
+        assert_eq!(by_height, (240, 120));
     }
 }

--- a/crates/image-processing/tests/core_flows.rs
+++ b/crates/image-processing/tests/core_flows.rs
@@ -308,6 +308,66 @@ fn from_svg_supports_png_webp_svg_outputs_without_imagemagick() {
 }
 
 #[test]
+fn from_svg_supports_explicit_raster_dimensions() {
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("icon.svg"),
+        r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 60" width="80" height="60">
+<rect x="4" y="4" width="72" height="52" rx="8" fill="#0f62fe"/>
+</svg>"##,
+    )
+    .unwrap();
+
+    let stub = common::make_stub_dir();
+    let path_s = stub.path().to_string_lossy().to_string();
+    let envs = [("PATH", path_s.as_str())];
+
+    let width_only = common::run_image_processing(
+        dir.path(),
+        &[
+            "convert",
+            "--from-svg",
+            "icon.svg",
+            "--to",
+            "png",
+            "--out",
+            "out/icon-width.png",
+            "--width",
+            "512",
+            "--json",
+        ],
+        &envs,
+    );
+    assert_eq!(width_only.code, 0, "stderr: {}", width_only.stderr);
+    let width_only_json: serde_json::Value = serde_json::from_str(&width_only.stdout).unwrap();
+    assert_eq!(width_only_json["items"][0]["output_info"]["width"], 512);
+    assert_eq!(width_only_json["items"][0]["output_info"]["height"], 384);
+
+    let exact_box = common::run_image_processing(
+        dir.path(),
+        &[
+            "convert",
+            "--from-svg",
+            "icon.svg",
+            "--to",
+            "png",
+            "--out",
+            "out/icon-box.png",
+            "--width",
+            "512",
+            "--height",
+            "512",
+            "--json",
+        ],
+        &envs,
+    );
+    assert_eq!(exact_box.code, 0, "stderr: {}", exact_box.stderr);
+    let exact_box_json: serde_json::Value = serde_json::from_str(&exact_box.stdout).unwrap();
+    assert_eq!(exact_box_json["items"][0]["output_info"]["width"], 512);
+    assert_eq!(exact_box_json["items"][0]["output_info"]["height"], 512);
+}
+
+#[test]
 fn from_svg_still_runs_when_legacy_operations_lack_imagemagick() {
     let dir = tempfile::TempDir::new().unwrap();
     fs::write(dir.path().join("a.png"), "img").unwrap();

--- a/crates/image-processing/tests/edge_cases.rs
+++ b/crates/image-processing/tests/edge_cases.rs
@@ -461,6 +461,70 @@ fn from_svg_rejects_output_mode_mismatches() {
 }
 
 #[test]
+fn from_svg_rejects_invalid_dimension_contracts() {
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("icon.svg"),
+        r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+<rect x="2" y="2" width="28" height="28" fill="#0f62fe"/>
+</svg>"##,
+    )
+    .unwrap();
+
+    let stub = common::make_stub_dir();
+    let path_s = stub.path().to_string_lossy().to_string();
+    let envs = [("PATH", path_s.as_str())];
+
+    let with_svg_target = common::run_image_processing(
+        dir.path(),
+        &[
+            "convert",
+            "--from-svg",
+            "icon.svg",
+            "--to",
+            "svg",
+            "--out",
+            "out/icon.svg",
+            "--width",
+            "256",
+            "--json",
+        ],
+        &envs,
+    );
+    assert_eq!(with_svg_target.code, 2);
+    assert!(
+        with_svg_target
+            .stderr
+            .contains("does not support --width/--height"),
+        "stderr: {}",
+        with_svg_target.stderr
+    );
+
+    let with_zero_width = common::run_image_processing(
+        dir.path(),
+        &[
+            "convert",
+            "--from-svg",
+            "icon.svg",
+            "--to",
+            "png",
+            "--out",
+            "out/icon.png",
+            "--width",
+            "0",
+            "--json",
+        ],
+        &envs,
+    );
+    assert_eq!(with_zero_width.code, 2);
+    assert!(
+        with_zero_width.stderr.contains("--width must be > 0"),
+        "stderr: {}",
+        with_zero_width.stderr
+    );
+}
+
+#[test]
 fn svg_validate_invalid_svg_returns_actionable_error() {
     let dir = tempfile::TempDir::new().unwrap();
     fs::write(


### PR DESCRIPTION
# Support raster sizing for convert --from-svg output

## Summary
Add first-class raster sizing support to `image-processing convert --from-svg` so callers can generate sharp PNG/WebP outputs at requested dimensions instead of being locked to the SVG viewBox raster size.

## Changes
- Allow `--width` and `--height` for `convert --from-svg` in CLI validation and route the values through processing.
- Update Rust SVG renderer to scale the vector tree into requested raster dimensions, with single-dimension aspect-ratio preservation.
- Add contract tests for valid sizing and invalid combinations (`--to svg` + size flags, zero dimension), and document the new flags in README.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- `--width/--height` are only valid for `--to png|webp`; `--to svg` still rejects sizing flags by design.
