### PR TITLE
Add memo-cli search match modes for fts, prefix, and contains

### DIFF
--- a/completions/bash/memo-cli
+++ b/completions/bash/memo-cli
@@ -44,7 +44,7 @@ _nils_cli_memo_cli_complete() {
         return 0
         ;;
       search)
-        COMPREPLY=( $(compgen -W "${global_opts[*]} --limit --state --field" -- "$cur") )
+        COMPREPLY=( $(compgen -W "${global_opts[*]} --limit --state --field --match" -- "$cur") )
         return 0
         ;;
       report)
@@ -89,6 +89,10 @@ _nils_cli_memo_cli_complete() {
       ;;
     --field)
       COMPREPLY=( $(compgen -W "raw derived tags" -- "$cur") )
+      return 0
+      ;;
+    --match)
+      COMPREPLY=( $(compgen -W "fts prefix contains" -- "$cur") )
       return 0
       ;;
   esac

--- a/completions/zsh/_memo-cli
+++ b/completions/zsh/_memo-cli
@@ -11,7 +11,7 @@ _memo-cli() {
     'update:Update one memo entry and reset derived workflow state'
     'delete:Hard-delete one memo entry and dependent data'
     'list:List memo entries in deterministic order'
-    'search:Search memo entries with FTS-backed query'
+    'search:Search memo entries with selectable match mode'
     'report:Show weekly or monthly summary report'
     'fetch:Fetch pending items for agent enrichment'
     'apply:Apply enrichment payloads'
@@ -69,6 +69,7 @@ _memo-cli() {
         '--limit=[Max rows to return]:limit:' \
         '--state=[Row selection mode]:state:(all pending enriched)' \
         '--field=[Search fields (comma-separated)]:field:(raw derived tags)' \
+        '--match=[Search match mode]:match:(fts prefix contains)' \
         '*:query:' \
         && return 0
       ;;

--- a/crates/memo-cli/README.md
+++ b/crates/memo-cli/README.md
@@ -18,6 +18,7 @@ Commands:
   list [--limit <n>] [--offset <n>]         List entries (default: newest first)
   search <query> [--limit <n>]              Search raw/derived/tags text
          [--field <raw|derived|tags>[,...]]
+         [--match <fts|prefix|contains>]
   report <week|month> [--tz <iana-tz>]      Build period summaries
          [--from <rfc3339>] [--to <rfc3339>]
   fetch [--limit <n>] [--cursor <opaque>]   Pull records for enrichment workers
@@ -34,6 +35,7 @@ Commands:
 - `list`: show records with deterministic ordering and optional state filters.
 - `search`: run keyword/prefix search across capture and active enrichment.
 - `search --field`: optional field scope, supports multi-select (example: `--field raw,tags`).
+- `search --match`: matching mode (`fts`, `prefix`, `contains`), default `fts`.
 - `report`: render weekly/monthly summaries with capture fallback when enrichment is missing.
 - `report --from/--to`: optional explicit range (RFC3339). Use both together.
 - `fetch`: machine-facing pull for pending enrichment work.

--- a/crates/memo-cli/docs/specs/memo-cli-command-contract-v1.md
+++ b/crates/memo-cli/docs/specs/memo-cli-command-contract-v1.md
@@ -194,13 +194,18 @@ Search inbox and active derived fields.
 
 ```text
 memo-cli search <query> [--limit <n>] [--state <all|pending|enriched>]
-                [--field <raw|derived|tags>[,<raw|derived|tags>...]] [--json|--format json]
+                [--field <raw|derived|tags>[,<raw|derived|tags>...]]
+                [--match <fts|prefix|contains>] [--json|--format json]
 ```
 
 Behavior:
 - Uses SQLite FTS-backed matching for raw capture and active enrichment text.
 - `--field` narrows the FTS search surface; default is all fields (`raw,derived,tags`).
 - `--field` accepts comma-separated multi-select (for example: `--field raw,tags`).
+- `--match` controls query semantics:
+  - `fts` (default): pass query as FTS syntax.
+  - `prefix`: convert whitespace-separated terms to FTS prefix tokens (`term*`).
+  - `contains`: perform case-insensitive substring contains matching.
 - Ranking is deterministic for score ties (`created_at DESC`, `item_id DESC`).
 
 Text output (`stdout`):
@@ -212,6 +217,7 @@ JSON output:
   - `content_type`
   - `validation_status`
 - JSON `meta` includes `fields[]` reflecting the effective field scope.
+- JSON `meta` includes `match` reflecting the effective match mode.
 
 ### `report`
 Generate period summaries from capture + enrichment data.

--- a/crates/memo-cli/docs/specs/memo-cli-json-contract-v1.md
+++ b/crates/memo-cli/docs/specs/memo-cli-json-contract-v1.md
@@ -125,7 +125,7 @@ Semantics:
   - optional `content_type`
   - optional `validation_status`
 - optional `meta`:
-  - `query`, `limit`, `state`, `fields`
+  - `query`, `limit`, `state`, `fields`, `match`
 
 ### `report` (`result`)
 - `result.period`: `week` or `month`
@@ -280,7 +280,9 @@ Redaction example (conceptual):
   "meta": {
     "query": "ssd",
     "limit": 20,
-    "state": "all"
+    "state": "all",
+    "fields": ["raw_text", "derived_text", "tags_text"],
+    "match": "fts"
   }
 }
 ```

--- a/crates/memo-cli/src/cli.rs
+++ b/crates/memo-cli/src/cli.rs
@@ -38,6 +38,13 @@ pub enum SearchField {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum SearchMatch {
+    Fts,
+    Prefix,
+    Contains,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum ReportPeriod {
     Week,
     Month,
@@ -81,7 +88,7 @@ pub enum MemoCommand {
     Delete(DeleteArgs),
     /// List memo entries in deterministic order
     List(ListArgs),
-    /// Search memo entries with FTS-backed query
+    /// Search memo entries with selectable match mode
     Search(SearchArgs),
     /// Show weekly or monthly summary report
     Report(ReportArgs),
@@ -141,7 +148,7 @@ pub struct ListArgs {
 
 #[derive(Debug, clap::Args)]
 pub struct SearchArgs {
-    /// Search query text (FTS syntax)
+    /// Search query text
     pub query: String,
 
     /// Max rows to return
@@ -160,6 +167,10 @@ pub struct SearchArgs {
         default_values_t = [SearchField::Raw, SearchField::Derived, SearchField::Tags]
     )]
     pub fields: Vec<SearchField>,
+
+    /// Search match mode: fts, prefix, contains
+    #[arg(long = "match", value_enum, default_value_t = SearchMatch::Fts)]
+    pub match_mode: SearchMatch,
 }
 
 #[derive(Debug, clap::Args)]
@@ -272,7 +283,7 @@ fn default_db_path() -> PathBuf {
 pub(crate) mod tests {
     use clap::{CommandFactory, Parser};
 
-    use super::{Cli, MemoCommand, OutputMode, SearchField};
+    use super::{Cli, MemoCommand, OutputMode, SearchField, SearchMatch};
 
     #[test]
     fn output_mode_defaults_to_text() {
@@ -340,5 +351,25 @@ pub(crate) mod tests {
             args.fields,
             vec![SearchField::Raw, SearchField::Derived, SearchField::Tags]
         );
+    }
+
+    #[test]
+    fn search_match_mode_defaults_to_fts() {
+        let cli = Cli::parse_from(["memo-cli", "search", "ssd"]);
+        let MemoCommand::Search(args) = cli.command else {
+            panic!("expected search command");
+        };
+
+        assert_eq!(args.match_mode, SearchMatch::Fts);
+    }
+
+    #[test]
+    fn search_match_mode_accepts_explicit_value() {
+        let cli = Cli::parse_from(["memo-cli", "search", "ssd", "--match", "contains"]);
+        let MemoCommand::Search(args) = cli.command else {
+            panic!("expected search command");
+        };
+
+        assert_eq!(args.match_mode, SearchMatch::Contains);
     }
 }

--- a/crates/memo-cli/src/commands/mod.rs
+++ b/crates/memo-cli/src/commands/mod.rs
@@ -7,7 +7,7 @@ mod report;
 mod search;
 mod update;
 
-use crate::cli::{Cli, ItemState, MemoCommand, OutputMode};
+use crate::cli::{Cli, ItemState, MemoCommand, OutputMode, SearchMatch};
 use crate::errors::AppError;
 use crate::storage::Storage;
 use crate::storage::repository::QueryState;
@@ -33,6 +33,7 @@ pub fn run(cli: &Cli, output_mode: OutputMode) -> Result<(), AppError> {
             to_query_state(args.state),
             &args.query,
             &args.fields,
+            to_search_match_mode(args.match_mode),
             args.limit,
         ),
         MemoCommand::Report(args) => report::run(&storage, output_mode, args),
@@ -48,5 +49,13 @@ fn to_query_state(state: ItemState) -> QueryState {
         ItemState::All => QueryState::All,
         ItemState::Pending => QueryState::Pending,
         ItemState::Enriched => QueryState::Enriched,
+    }
+}
+
+fn to_search_match_mode(mode: SearchMatch) -> crate::storage::search::SearchMatchMode {
+    match mode {
+        SearchMatch::Fts => crate::storage::search::SearchMatchMode::Fts,
+        SearchMatch::Prefix => crate::storage::search::SearchMatchMode::Prefix,
+        SearchMatch::Contains => crate::storage::search::SearchMatchMode::Contains,
     }
 }

--- a/crates/memo-cli/src/commands/search.rs
+++ b/crates/memo-cli/src/commands/search.rs
@@ -13,6 +13,7 @@ pub fn run(
     state: QueryState,
     query: &str,
     fields: &[CliSearchField],
+    match_mode: search::SearchMatchMode,
     limit: usize,
 ) -> Result<(), AppError> {
     let query = query.trim();
@@ -21,8 +22,9 @@ pub fn run(
     }
 
     let search_fields = map_search_fields(fields);
-    let rows = storage
-        .with_connection(|conn| search::search_items(conn, query, state, &search_fields, limit))?;
+    let rows = storage.with_connection(|conn| {
+        search::search_items(conn, query, state, &search_fields, match_mode, limit)
+    })?;
 
     if output_mode.is_json() {
         let results = rows
@@ -49,6 +51,7 @@ pub fn run(
                 "limit": limit,
                 "state": query_state_label(state),
                 "fields": search_field_labels(&search_fields),
+                "match": search_match_mode_label(match_mode),
             })),
         );
     }
@@ -94,4 +97,12 @@ fn map_search_fields(fields: &[CliSearchField]) -> Vec<search::SearchField> {
 
 fn search_field_labels(fields: &[search::SearchField]) -> Vec<&'static str> {
     fields.iter().map(|field| field.label()).collect()
+}
+
+fn search_match_mode_label(mode: search::SearchMatchMode) -> &'static str {
+    match mode {
+        search::SearchMatchMode::Fts => "fts",
+        search::SearchMatchMode::Prefix => "prefix",
+        search::SearchMatchMode::Contains => "contains",
+    }
 }

--- a/crates/memo-cli/src/storage/search.rs
+++ b/crates/memo-cli/src/storage/search.rs
@@ -12,6 +12,13 @@ pub enum SearchField {
     Tags,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchMatchMode {
+    Fts,
+    Prefix,
+    Contains,
+}
+
 impl SearchField {
     fn fts_column(self) -> &'static str {
         match self {
@@ -87,75 +94,35 @@ pub fn search_items(
     query: &str,
     state: QueryState,
     fields: &[SearchField],
+    match_mode: SearchMatchMode,
     limit: usize,
 ) -> Result<Vec<SearchItem>, AppError> {
     let fields = normalize_search_fields(fields);
-    let scoped_query = build_scoped_query(query, &fields);
+    let state_filter = state_filter_sql(state);
     let matched_fields = fields
         .iter()
         .map(|field| field.label().to_string())
         .collect::<Vec<_>>();
 
-    let state_filter = match state {
-        QueryState::All => "1 = 1",
-        QueryState::Pending => {
-            "not exists (
-                select 1 from item_derivations d
-                where d.item_id = i.item_id and d.is_active = 1 and d.status = 'accepted'
-            )"
+    match match_mode {
+        SearchMatchMode::Fts => {
+            search_items_fts(conn, query, &fields, state_filter, &matched_fields, limit)
         }
-        QueryState::Enriched => {
-            "exists (
-                select 1 from item_derivations d
-                where d.item_id = i.item_id and d.is_active = 1 and d.status = 'accepted'
-            )"
+        SearchMatchMode::Prefix => {
+            let prefix_query = build_prefix_query(query);
+            search_items_fts(
+                conn,
+                &prefix_query,
+                &fields,
+                state_filter,
+                &matched_fields,
+                limit,
+            )
         }
-    };
-
-    let sql = format!(
-        "select
-            i.item_id,
-            i.created_at,
-            bm25(item_search_fts) as score,
-            substr(coalesce(doc.derived_text, i.raw_text), 1, 120) as preview,
-            json_extract(ad.payload_json, '$.content_type') as content_type,
-            json_extract(ad.payload_json, '$.validation_status') as validation_status
-        from item_search_fts
-        join item_search_documents doc on doc.item_id = item_search_fts.rowid
-        join inbox_items i on i.item_id = doc.item_id
-        left join item_derivations ad
-          on ad.derivation_id = (
-            select d.derivation_id
-            from item_derivations d
-            where d.item_id = i.item_id
-              and d.is_active = 1
-              and d.status = 'accepted'
-            order by d.derivation_version desc, d.derivation_id desc
-            limit 1
-          )
-        where item_search_fts match ?1
-          and {state_filter}
-        order by score asc, i.created_at desc, i.item_id desc
-        limit ?2"
-    );
-
-    let mut stmt = conn.prepare(&sql).map_err(AppError::db_query)?;
-    let rows = stmt
-        .query_map(params![scoped_query, limit as i64], |row| {
-            Ok(SearchItem {
-                item_id: row.get(0)?,
-                created_at: row.get(1)?,
-                score: row.get(2)?,
-                matched_fields: matched_fields.clone(),
-                preview: row.get(3)?,
-                content_type: row.get(4)?,
-                validation_status: row.get(5)?,
-            })
-        })
-        .map_err(AppError::db_query)?;
-
-    rows.collect::<Result<Vec<_>, _>>()
-        .map_err(AppError::db_query)
+        SearchMatchMode::Contains => {
+            search_items_contains(conn, query, &fields, state_filter, &matched_fields, limit)
+        }
+    }
 }
 
 fn normalize_search_fields(fields: &[SearchField]) -> Vec<SearchField> {
@@ -182,6 +149,165 @@ fn build_scoped_query(query: &str, fields: &[SearchField]) -> String {
         .collect::<Vec<_>>()
         .join(" ");
     format!("{{{columns}}}: ({query})")
+}
+
+fn state_filter_sql(state: QueryState) -> &'static str {
+    match state {
+        QueryState::All => "1 = 1",
+        QueryState::Pending => {
+            "not exists (
+                select 1 from item_derivations d
+                where d.item_id = i.item_id and d.is_active = 1 and d.status = 'accepted'
+            )"
+        }
+        QueryState::Enriched => {
+            "exists (
+                select 1 from item_derivations d
+                where d.item_id = i.item_id and d.is_active = 1 and d.status = 'accepted'
+            )"
+        }
+    }
+}
+
+fn search_items_fts(
+    conn: &Connection,
+    query: &str,
+    fields: &[SearchField],
+    state_filter: &str,
+    matched_fields: &[String],
+    limit: usize,
+) -> Result<Vec<SearchItem>, AppError> {
+    let scoped_query = build_scoped_query(query, fields);
+    let sql = format!(
+        "select
+            i.item_id,
+            i.created_at,
+            bm25(item_search_fts) as score,
+            substr(coalesce(doc.derived_text, i.raw_text), 1, 120) as preview,
+            json_extract(ad.payload_json, '$.content_type') as content_type,
+            json_extract(ad.payload_json, '$.validation_status') as validation_status
+        from item_search_fts
+        join item_search_documents doc on doc.item_id = item_search_fts.rowid
+        join inbox_items i on i.item_id = doc.item_id
+        left join item_derivations ad
+          on ad.derivation_id = (
+            select d.derivation_id
+            from item_derivations d
+            where d.item_id = i.item_id
+              and d.is_active = 1
+              and d.status = 'accepted'
+            order by d.derivation_version desc, d.derivation_id desc
+            limit 1
+          )
+        where item_search_fts match ?1
+          and {state_filter}
+        order by score asc, i.created_at desc, i.item_id desc
+        limit ?2"
+    );
+    let mut stmt = conn.prepare(&sql).map_err(AppError::db_query)?;
+    let rows = stmt
+        .query_map(params![scoped_query, limit as i64], |row| {
+            Ok(SearchItem {
+                item_id: row.get(0)?,
+                created_at: row.get(1)?,
+                score: row.get(2)?,
+                matched_fields: matched_fields.to_vec(),
+                preview: row.get(3)?,
+                content_type: row.get(4)?,
+                validation_status: row.get(5)?,
+            })
+        })
+        .map_err(AppError::db_query)?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(AppError::db_query)
+}
+
+fn search_items_contains(
+    conn: &Connection,
+    query: &str,
+    fields: &[SearchField],
+    state_filter: &str,
+    matched_fields: &[String],
+    limit: usize,
+) -> Result<Vec<SearchItem>, AppError> {
+    let contains_filter = build_contains_filter(fields);
+    let sql = format!(
+        "select
+            i.item_id,
+            i.created_at,
+            0.0 as score,
+            substr(coalesce(doc.derived_text, i.raw_text), 1, 120) as preview,
+            json_extract(ad.payload_json, '$.content_type') as content_type,
+            json_extract(ad.payload_json, '$.validation_status') as validation_status
+        from item_search_documents doc
+        join inbox_items i on i.item_id = doc.item_id
+        left join item_derivations ad
+          on ad.derivation_id = (
+            select d.derivation_id
+            from item_derivations d
+            where d.item_id = i.item_id
+              and d.is_active = 1
+              and d.status = 'accepted'
+            order by d.derivation_version desc, d.derivation_id desc
+            limit 1
+          )
+        where ({contains_filter})
+          and {state_filter}
+        order by i.created_at desc, i.item_id desc
+        limit ?2"
+    );
+    let mut stmt = conn.prepare(&sql).map_err(AppError::db_query)?;
+    let rows = stmt
+        .query_map(params![query, limit as i64], |row| {
+            Ok(SearchItem {
+                item_id: row.get(0)?,
+                created_at: row.get(1)?,
+                score: row.get(2)?,
+                matched_fields: matched_fields.to_vec(),
+                preview: row.get(3)?,
+                content_type: row.get(4)?,
+                validation_status: row.get(5)?,
+            })
+        })
+        .map_err(AppError::db_query)?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(AppError::db_query)
+}
+
+fn build_contains_filter(fields: &[SearchField]) -> String {
+    fields
+        .iter()
+        .map(|field| {
+            format!(
+                "instr(lower(coalesce(doc.{column}, '')), lower(?1)) > 0",
+                column = field.fts_column()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" or ")
+}
+
+fn build_prefix_query(query: &str) -> String {
+    let tokens = query
+        .split_whitespace()
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(prefix_token)
+        .collect::<Vec<_>>();
+
+    if tokens.is_empty() {
+        query.to_string()
+    } else {
+        tokens.join(" ")
+    }
+}
+
+fn prefix_token(token: &str) -> String {
+    let token = token.trim_end_matches('*');
+    let escaped = token.replace('"', "\"\"");
+    format!("\"{escaped}\"*")
 }
 
 pub fn report_summary(conn: &Connection, period: ReportPeriod) -> Result<ReportSummary, AppError> {

--- a/crates/memo-cli/tests/json_contract.rs
+++ b/crates/memo-cli/tests/json_contract.rs
@@ -101,6 +101,7 @@ fn json_contract() {
     assert_eq!(search_json["meta"]["query"], "ssd");
     assert_eq!(search_json["meta"]["limit"], 5);
     assert_eq!(search_json["meta"]["state"], "all");
+    assert_eq!(search_json["meta"]["match"], "fts");
     assert_eq!(
         search_json["meta"]["fields"],
         json!(["raw_text", "derived_text", "tags_text"])

--- a/crates/memo-cli/tests/search_and_report.rs
+++ b/crates/memo-cli/tests/search_and_report.rs
@@ -93,6 +93,7 @@ fn search_and_report() {
                     search::SearchField::Derived,
                     search::SearchField::Tags,
                 ],
+                search::SearchMatchMode::Fts,
                 20,
             )
         })
@@ -187,6 +188,7 @@ fn search_supports_field_filters() {
                 "sharedterm",
                 QueryState::All,
                 &[search::SearchField::Raw],
+                search::SearchMatchMode::Fts,
                 20,
             )
         })
@@ -201,6 +203,7 @@ fn search_supports_field_filters() {
                 "sharedterm",
                 QueryState::All,
                 &[search::SearchField::Tags],
+                search::SearchMatchMode::Fts,
                 20,
             )
         })
@@ -215,6 +218,7 @@ fn search_supports_field_filters() {
                 "sharedterm",
                 QueryState::All,
                 &[search::SearchField::Raw, search::SearchField::Tags],
+                search::SearchMatchMode::Fts,
                 20,
             )
         })
@@ -226,4 +230,61 @@ fn search_supports_field_filters() {
 
     assert!(matched_ids.contains(&raw_item_id));
     assert!(matched_ids.contains(&tagged_item_id));
+}
+
+#[test]
+fn search_match_modes_support_prefix_and_contains() {
+    let db_path = test_db_path("search_match_modes_support_prefix_and_contains");
+    let storage = Storage::new(db_path);
+
+    let item_id = storage
+        .with_transaction(|tx| {
+            let item = repository::add_item(tx, "123 target", "cli", None)?;
+            Ok(item.item_id)
+        })
+        .expect("seed should succeed");
+
+    let fts_rows = storage
+        .with_connection(|conn| {
+            search::search_items(
+                conn,
+                "12",
+                QueryState::All,
+                &[search::SearchField::Raw],
+                search::SearchMatchMode::Fts,
+                20,
+            )
+        })
+        .expect("fts search should succeed");
+    assert!(fts_rows.is_empty());
+
+    let prefix_rows = storage
+        .with_connection(|conn| {
+            search::search_items(
+                conn,
+                "12",
+                QueryState::All,
+                &[search::SearchField::Raw],
+                search::SearchMatchMode::Prefix,
+                20,
+            )
+        })
+        .expect("prefix search should succeed");
+    assert_eq!(prefix_rows.len(), 1);
+    assert_eq!(prefix_rows[0].item_id, item_id);
+
+    let contains_rows = storage
+        .with_connection(|conn| {
+            search::search_items(
+                conn,
+                "23",
+                QueryState::All,
+                &[search::SearchField::Raw],
+                search::SearchMatchMode::Contains,
+                20,
+            )
+        })
+        .expect("contains search should succeed");
+    assert_eq!(contains_rows.len(), 1);
+    assert_eq!(contains_rows[0].item_id, item_id);
 }

--- a/tests/zsh/completion.test.zsh
+++ b/tests/zsh/completion.test.zsh
@@ -731,6 +731,11 @@ grep -q -- "--field=\\[Search fields (comma-separated)\\]" "$COMP_MEMO_CLI_FILE"
   exit 1
 }
 
+grep -q -- "--match=\\[Search match mode\\]" "$COMP_MEMO_CLI_FILE" || {
+  print -u2 -r -- "FAIL: memo-cli completion missing --match"
+  exit 1
+}
+
 grep -q -- "--window-title-contains" "$BASH_MACOS_AGENT_FILE" || {
   print -u2 -r -- "FAIL: bash macos-agent completion missing canonical --window-title-contains"
   exit 1
@@ -768,6 +773,11 @@ grep -q -- "--probe-mode" "$BASH_AGENTCTL_FILE" || {
 
 grep -q -- "--field" "$BASH_MEMO_CLI_FILE" || {
   print -u2 -r -- "FAIL: bash memo-cli completion missing --field"
+  exit 1
+}
+
+grep -q -- "--match" "$BASH_MEMO_CLI_FILE" || {
+  print -u2 -r -- "FAIL: bash memo-cli completion missing --match"
   exit 1
 }
 


### PR DESCRIPTION
# Add memo-cli search match modes for fts, prefix, and contains

## Summary
This PR adds configurable search matching semantics to `memo-cli search` so callers can choose between raw FTS syntax, token prefix expansion, and case-insensitive substring contains matching while keeping the existing command shape and JSON contract stable.

## Changes
- Added `--match <fts|prefix|contains>` to `memo-cli search` with default `fts`.
- Routed match mode through CLI parsing, command dispatch, search execution, and JSON `meta.match` output.
- Implemented `prefix` mode by converting whitespace-separated terms to FTS prefix tokens.
- Implemented `contains` mode with case-insensitive substring matching over selected fields (`raw`, `derived`, `tags`).
- Updated memo-cli docs/specs and bash/zsh completion scripts, plus completion contract tests.
- Added/updated tests for parser defaults, JSON contract metadata, and search-mode behavior parity.

## Testing
- `cargo test -p nils-memo-cli` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- `contains` mode does not use FTS index scoring and can be slower on larger datasets.
- Existing `fts` behavior remains the default to preserve current semantics for automation callers.
