### PR TITLE
Prevent panic when auth env setup is partially configured

### DIFF
--- a/crates/api-testing-core/src/config.rs
+++ b/crates/api-testing-core/src/config.rs
@@ -311,24 +311,32 @@ impl ResolvedSetup {
     }
 
     pub fn tokens_files(&self) -> Vec<&Path> {
-        let Some(tokens_env) = self.tokens_env.as_ref() else {
-            return Vec::new();
-        };
-        let tokens_local = self.tokens_local_env.as_ref().expect("tokens_local_env");
-        if tokens_env.is_file() || tokens_local.is_file() {
-            vec![tokens_env, tokens_local]
+        let mut files: Vec<&Path> = Vec::new();
+        if let Some(tokens_env) = self.tokens_env.as_deref() {
+            files.push(tokens_env);
+        }
+        if let Some(tokens_local) = self.tokens_local_env.as_deref() {
+            files.push(tokens_local);
+        }
+
+        if files.iter().any(|path| path.is_file()) {
+            files
         } else {
             Vec::new()
         }
     }
 
     pub fn jwts_files(&self) -> Vec<&Path> {
-        let Some(jwts_env) = self.jwts_env.as_ref() else {
-            return Vec::new();
-        };
-        let jwts_local = self.jwts_local_env.as_ref().expect("jwts_local_env");
-        if jwts_env.is_file() || jwts_local.is_file() {
-            vec![jwts_env, jwts_local]
+        let mut files: Vec<&Path> = Vec::new();
+        if let Some(jwts_env) = self.jwts_env.as_deref() {
+            files.push(jwts_env);
+        }
+        if let Some(jwts_local) = self.jwts_local_env.as_deref() {
+            files.push(jwts_local);
+        }
+
+        if files.iter().any(|path| path.is_file()) {
+            files
         } else {
             Vec::new()
         }
@@ -418,6 +426,46 @@ mod tests {
                 resolved.endpoints_local_env.as_path()
             ]
         );
+    }
+
+    #[test]
+    fn tokens_files_handles_missing_local_path_without_panicking() {
+        let tmp = TempDir::new().expect("tmp");
+        let root = std::fs::canonicalize(tmp.path()).expect("root abs");
+        let setup = root.join("setup/rest");
+
+        let mut resolved = ResolvedSetup::rest(setup, None);
+        let tokens_env = resolved.tokens_env.as_ref().expect("tokens env").clone();
+        write_file(&tokens_env, "REST_TOKEN_DEFAULT=abc\n");
+        resolved.tokens_local_env = None;
+
+        let files: Vec<PathBuf> = resolved
+            .tokens_files()
+            .into_iter()
+            .map(Path::to_path_buf)
+            .collect();
+
+        assert_eq!(files, vec![tokens_env]);
+    }
+
+    #[test]
+    fn jwts_files_handles_missing_local_path_without_panicking() {
+        let tmp = TempDir::new().expect("tmp");
+        let root = std::fs::canonicalize(tmp.path()).expect("root abs");
+        let setup = root.join("setup/graphql");
+
+        let mut resolved = ResolvedSetup::graphql(setup, None);
+        let jwts_env = resolved.jwts_env.as_ref().expect("jwts env").clone();
+        write_file(&jwts_env, "GQL_JWT_DEFAULT=abc\n");
+        resolved.jwts_local_env = None;
+
+        let files: Vec<PathBuf> = resolved
+            .jwts_files()
+            .into_iter()
+            .map(Path::to_path_buf)
+            .collect();
+
+        assert_eq!(files, vec![jwts_env]);
     }
 
     #[test]


### PR DESCRIPTION
# Prevent panic when auth env setup is partially configured

## Summary
This fix removes panic paths in `ResolvedSetup::tokens_files()` and `ResolvedSetup::jwts_files()` when only one optional auth env path is present. The methods now collect whichever optional paths exist and return them only when at least one real file exists.

## Problem
- Expected: optional setup path combinations should return a stable result or empty list, never panic.
- Actual: `tokens_files()` and `jwts_files()` used `expect()` on `*_local_env`, which panicked if those optional fields were `None`.
- Impact: consumers can crash at runtime when `ResolvedSetup` is partially configured (direct construction or mutation).

## Reproduction
1. Create a `ResolvedSetup::rest(...)` (or `ResolvedSetup::graphql(...)`).
2. Set `tokens_local_env` (or `jwts_local_env`) to `None` while keeping the corresponding `*_env` path.
3. Call `tokens_files()` (or `jwts_files()`).

- Expected result: method returns available files (or empty list), no panic.
- Actual result (before fix): panic at `expect("tokens_local_env")` / `expect("jwts_local_env")`.

## Issues Found
Severity: medium
Confidence: high
Status: fixed

| ID | Severity | Confidence | Area | Summary | Evidence | Status |
| --- | --- | --- | --- | --- | --- | --- |
| PR-121-BUG-001 | medium | high | crates/api-testing-core/src/config.rs | Optional local auth env path missing caused panic in setup file resolution. | `crates/api-testing-core/src/config.rs` (`tokens_files` / `jwts_files` prior `expect`) | fixed |

## Fix Approach
- Replace `expect()`-based optional path handling with defensive collection of present optional paths.
- Preserve existing behavior of returning no files when no auth env file exists on disk.
- Add regression tests:
  - `tokens_files_handles_missing_local_path_without_panicking`
  - `jwts_files_handles_missing_local_path_without_panicking`

## Testing
- `cargo test -p nils-api-testing-core` (pass)
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)

## Risk / Notes
- Low risk: changes are scoped to optional path aggregation logic in one file.
- Existing behavior for fully configured setups remains unchanged.
