### PR TITLE
Add auth remove command for codex-cli

### DIFF
--- a/completions/zsh/_codex-cli
+++ b/completions/zsh/_codex-cli
@@ -195,6 +195,7 @@ _codex-cli() {
         'login:Login with ChatGPT (browser/device-code) or API key'
         'use:Switch to a secret by name or email'
         'save:Save CODEX_AUTH_FILE into CODEX_SECRET_DIR'
+        'remove:Remove SECRET_JSON from CODEX_SECRET_DIR'
         'refresh:Refresh OAuth tokens'
         'auto-refresh:Refresh stale tokens across auth + secrets'
         'current:Show which secret matches CODEX_AUTH_FILE'
@@ -248,6 +249,16 @@ _codex-cli() {
             '1:secret file name:' \
             && return 0
           ;;
+        remove)
+          _arguments -C \
+            '(-h --help)'{-h,--help}'[Show help]' \
+            '--format=[Output format (text or json)]:format:(text json)' \
+            '--json[Output machine-readable JSON]' \
+            '(-y --yes)--yes[Remove target file without prompt]' \
+            '(--yes -y)-y[Remove target file without prompt]' \
+            '1:secret file name:' \
+            && return 0
+          ;;
         refresh)
           _arguments -C \
             '(-h --help)'{-h,--help}'[Show help]' \
@@ -266,7 +277,7 @@ _codex-cli() {
           return 0
           ;;
         '')
-          _message 'auth command (login|use|save|refresh|auto-refresh|current|sync)'
+          _message 'auth command (login|use|save|remove|refresh|auto-refresh|current|sync)'
           return 0
           ;;
         *)

--- a/crates/codex-cli/README.md
+++ b/crates/codex-cli/README.md
@@ -12,7 +12,7 @@ Usage:
 
 Groups:
   agent    prompt | advice | knowledge | commit
-  auth     login | use | save | refresh | auto-refresh | current | sync
+  auth     login | use | save | remove | refresh | auto-refresh | current | sync
   diag     rate-limits
   config   show | set
   starship (options)
@@ -48,6 +48,7 @@ Help:
 - `login [--api-key|--device-code]`: Login via ChatGPT browser flow (`chatgpt-browser`, default), ChatGPT device-code flow (`chatgpt-device-code`), or API key flow (`api-key`). `--api-key` and `--device-code` are mutually exclusive (`64` on invalid usage).
 - `use <name|email>`: Switch to a secret by name or email.
 - `save [--yes] <secret.json>`: Save active `CODEX_AUTH_FILE` into `CODEX_SECRET_DIR` with an explicit file name. If target exists, interactive mode prompts for overwrite; non-interactive and JSON mode require `--yes` to overwrite.
+- `remove [--yes] <secret.json>`: Remove a secret file from `CODEX_SECRET_DIR`. Interactive mode prompts for confirmation; non-interactive and JSON mode require `--yes`.
 - `refresh [secret.json]`: Refresh OAuth tokens.
 - `auto-refresh`: Refresh stale tokens across auth + secrets.
 - `current`: Show which secret matches `CODEX_AUTH_FILE`.
@@ -59,6 +60,7 @@ Auth examples:
 - `codex-cli auth login --api-key`: OpenAI API key login.
 - `codex-cli auth save team-alpha.json`: Save and prompt before overwrite when applicable.
 - `codex-cli auth save --yes team-alpha.json`: Force overwrite without prompt.
+- `codex-cli auth remove --yes team-alpha.json`: Remove a saved secret file.
 
 ### diag
 - `rate-limits [options] [secret.json]`: Rate-limit diagnostics. Options: `-c`, `-d/--debug`, `--cached`, `--no-refresh-auth`, `--json`, `--one-line`, `--all`, `--async`, `--jobs <n>`.
@@ -77,7 +79,7 @@ Auth examples:
 - Contract spec: `docs/specs/codex-cli-diag-auth-json-contract-v1.md`
 - Consumer runbook: `docs/runbooks/json-consumers.md`
 - Covered surfaces: `diag rate-limits` (single/all/async) and
-  `auth login|use|save|refresh|auto-refresh|current|sync`.
+  `auth login|use|save|remove|refresh|auto-refresh|current|sync`.
 
 ## Environment
 - `CODEX_ALLOW_DANGEROUS_ENABLED=true` is required for `agent` commands.

--- a/crates/codex-cli/docs/runbooks/json-consumers.md
+++ b/crates/codex-cli/docs/runbooks/json-consumers.md
@@ -3,7 +3,7 @@
 ## Scope
 This runbook is for frontend/service callers that consume `codex-cli` machine output for:
 - `diag rate-limits` (single/all/async)
-- `auth login|use|save|refresh|auto-refresh|current|sync`
+- `auth login|use|save|remove|refresh|auto-refresh|current|sync`
 
 Contract source of truth:
 - `crates/codex-cli/docs/specs/codex-cli-diag-auth-json-contract-v1.md`
@@ -16,8 +16,9 @@ Contract source of truth:
 2. Parse JSON `stdout` only; do not parse prose `stderr`.
 3. Validate stable envelope keys first: `schema_version`, `command`, `ok`.
 4. Parse `result` for single-entity responses and `results` for collection responses.
-5. Route by `command` (`diag rate-limits`, `auth login`, `auth use`, `auth save`, `auth refresh`,
-   `auth auto-refresh`, `auth current`, `auth sync`) and ignore unknown additive fields.
+5. Route by `command` (`diag rate-limits`, `auth login`, `auth use`, `auth save`, `auth remove`,
+   `auth refresh`, `auth auto-refresh`, `auth current`, `auth sync`) and ignore unknown additive
+   fields.
 6. Enforce schema routing:
    - `diag rate-limits` => `schema_version=codex-cli.diag.rate-limits.v1`
    - `auth *` => `schema_version=codex-cli.auth.v1`
@@ -34,6 +35,9 @@ Contract source of truth:
 - `auth save` overwrite handling:
   - success path: check `result.overwritten` (`false` = new file, `true` = replaced existing file)
   - confirmation-required path: `ok=false`, `error.code=overwrite-confirmation-required`
+- `auth remove` confirmation handling:
+  - success path: check `result.removed=true`
+  - confirmation-required path: `ok=false`, `error.code=remove-confirmation-required`
 - `auth current` secret directory resolution errors are command-level failures:
   - `error.code=secret-dir-not-configured|secret-dir-not-found|secret-dir-read-failed`
   - treat these as configuration/operational errors, not as `secret-not-matched`.
@@ -48,6 +52,7 @@ codex-cli auth login --format json --device-code
 codex-cli auth login --format json --api-key
 codex-cli auth save --format json team-alpha.json
 codex-cli auth save --format json --yes team-alpha.json
+codex-cli auth remove --format json --yes team-alpha.json
 codex-cli auth auto-refresh --format json
 codex-cli auth current --format json
 ```

--- a/crates/codex-cli/docs/specs/codex-cli-diag-auth-json-contract-v1.md
+++ b/crates/codex-cli/docs/specs/codex-cli-diag-auth-json-contract-v1.md
@@ -4,7 +4,7 @@
 This document extends `docs/specs/cli-service-json-contract-guideline-v1.md` for service-consumed
 JSON output from:
 - `codex-cli diag rate-limits` (single/all/async)
-- `codex-cli auth login|use|save|refresh|auto-refresh|current|sync`
+- `codex-cli auth login|use|save|remove|refresh|auto-refresh|current|sync`
 
 Human-readable output remains the default UX. JSON mode must be explicit (`--format json` or
 `--json` where supported for compatibility).
@@ -18,6 +18,7 @@ Human-readable output remains the default UX. JSON mode must be explicit (`--for
 | auth login | `auth login` | `codex-cli.auth.v1` | `result` |
 | auth use | `auth use` | `codex-cli.auth.v1` | `result` |
 | auth save | `auth save` | `codex-cli.auth.v1` | `result` |
+| auth remove | `auth remove` | `codex-cli.auth.v1` | `result` |
 | auth refresh | `auth refresh` | `codex-cli.auth.v1` | `result` |
 | auth auto-refresh | `auth auto-refresh` | `codex-cli.auth.v1` | `result` |
 | auth current | `auth current` | `codex-cli.auth.v1` | `result` |
@@ -75,6 +76,7 @@ Stable (safe for strict parsing):
   - `auth use`: `target`, `matched_secret`, `applied`, `auth_file`
   - `auth save`: `auth_file`, `target_file`, `saved`, `overwritten`
     (`true` when an existing target file is replaced)
+  - `auth remove`: `target_file`, `removed`
   - `auth refresh`: `target_file`, `refreshed`, `synced`, `refreshed_at`
   - `auth auto-refresh`: `refreshed`, `skipped`, `failed`, `min_age_days`, `targets[*]`
   - `auth current`: `auth_file`, `matched`, `matched_secret`, `match_mode`
@@ -240,6 +242,36 @@ Informational (do not hard-depend for schema validation):
     "details": {
       "target_file": "/home/user/.codex/secrets/team-alpha.json",
       "overwritten": false
+    }
+  }
+}
+```
+
+### auth remove (success)
+```json
+{
+  "schema_version": "codex-cli.auth.v1",
+  "command": "auth remove",
+  "ok": true,
+  "result": {
+    "target_file": "/home/user/.codex/secrets/team-alpha.json",
+    "removed": true
+  }
+}
+```
+
+### auth remove (confirmation required, failure)
+```json
+{
+  "schema_version": "codex-cli.auth.v1",
+  "command": "auth remove",
+  "ok": false,
+  "error": {
+    "code": "remove-confirmation-required",
+    "message": "codex-remove: /home/user/.codex/secrets/team-alpha.json exists; rerun with --yes to remove",
+    "details": {
+      "target_file": "/home/user/.codex/secrets/team-alpha.json",
+      "removed": false
     }
   }
 }

--- a/crates/codex-cli/src/auth/mod.rs
+++ b/crates/codex-cli/src/auth/mod.rs
@@ -3,6 +3,7 @@ pub mod current;
 pub mod login;
 pub mod output;
 pub mod refresh;
+pub mod remove;
 pub mod save;
 pub mod sync;
 pub mod use_secret;

--- a/crates/codex-cli/src/auth/output.rs
+++ b/crates/codex-cli/src/auth/output.rs
@@ -30,6 +30,12 @@ pub struct AuthSaveResult {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct AuthRemoveResult {
+    pub target_file: String,
+    pub removed: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct AuthRefreshResult {
     pub target_file: String,
     pub refreshed: bool,

--- a/crates/codex-cli/src/auth/remove.rs
+++ b/crates/codex-cli/src/auth/remove.rs
@@ -1,0 +1,233 @@
+use anyhow::Result;
+use serde_json::json;
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+use crate::auth::output::{self, AuthRemoveResult};
+use crate::paths;
+
+pub fn run(target: &str, yes: bool) -> Result<i32> {
+    run_with_json(target, yes, false)
+}
+
+pub fn run_with_json(target: &str, yes: bool, output_json: bool) -> Result<i32> {
+    if target.is_empty() {
+        return usage_error(
+            output_json,
+            "codex-remove: usage: codex-remove [--yes] <secret.json>",
+        );
+    }
+
+    if is_invalid_target(target) {
+        if output_json {
+            output::emit_error(
+                "auth remove",
+                "invalid-secret-file-name",
+                format!("codex-remove: invalid secret file name: {target}"),
+                Some(json!({ "target": target })),
+            )?;
+        } else {
+            eprintln!("codex-remove: invalid secret file name: {target}");
+        }
+        return Ok(64);
+    }
+
+    let secret_dir = match resolve_secret_dir_from_env() {
+        Some(path) => path,
+        None => {
+            if output_json {
+                output::emit_error(
+                    "auth remove",
+                    "secret-dir-not-configured",
+                    "codex-remove: CODEX_SECRET_DIR is not configured",
+                    None,
+                )?;
+            } else {
+                eprintln!("codex-remove: CODEX_SECRET_DIR is not configured");
+            }
+            return Ok(1);
+        }
+    };
+
+    if !secret_dir.is_dir() {
+        if output_json {
+            output::emit_error(
+                "auth remove",
+                "secret-dir-not-found",
+                format!(
+                    "codex-remove: CODEX_SECRET_DIR not found: {}",
+                    secret_dir.display()
+                ),
+                Some(json!({
+                    "secret_dir": secret_dir.display().to_string(),
+                })),
+            )?;
+        } else {
+            eprintln!(
+                "codex-remove: CODEX_SECRET_DIR not found: {}",
+                secret_dir.display()
+            );
+        }
+        return Ok(1);
+    }
+
+    let target_file = secret_dir.join(target);
+    if !target_file.is_file() {
+        if output_json {
+            output::emit_error(
+                "auth remove",
+                "target-not-found",
+                format!(
+                    "codex-remove: secret file not found: {}",
+                    target_file.display()
+                ),
+                Some(json!({
+                    "target_file": target_file.display().to_string(),
+                })),
+            )?;
+        } else {
+            eprintln!(
+                "codex-remove: secret file not found: {}",
+                target_file.display()
+            );
+        }
+        return Ok(1);
+    }
+
+    if !yes {
+        if output_json {
+            output::emit_error(
+                "auth remove",
+                "remove-confirmation-required",
+                format!(
+                    "codex-remove: {} exists; rerun with --yes to remove",
+                    target_file.display()
+                ),
+                Some(json!({
+                    "target_file": target_file.display().to_string(),
+                    "removed": false,
+                })),
+            )?;
+            return Ok(1);
+        }
+
+        if !interactive_io_available() {
+            eprintln!(
+                "codex-remove: {} exists; rerun with --yes to remove",
+                target_file.display()
+            );
+            return Ok(1);
+        }
+
+        if !confirm_remove(&target_file)? {
+            eprintln!(
+                "codex-remove: removal declined for {}",
+                target_file.display()
+            );
+            return Ok(1);
+        }
+    }
+
+    if let Err(err) = std::fs::remove_file(&target_file) {
+        if output_json {
+            output::emit_error(
+                "auth remove",
+                "remove-failed",
+                format!("codex-remove: failed to remove {}", target_file.display()),
+                Some(json!({
+                    "target_file": target_file.display().to_string(),
+                    "error": err.to_string(),
+                })),
+            )?;
+        } else {
+            eprintln!("codex-remove: failed to remove {}", target_file.display());
+        }
+        return Ok(1);
+    }
+
+    remove_target_timestamp(&target_file);
+
+    if output_json {
+        output::emit_result(
+            "auth remove",
+            AuthRemoveResult {
+                target_file: target_file.display().to_string(),
+                removed: true,
+            },
+        )?;
+    } else {
+        println!("codex: removed {}", target_file.display());
+    }
+    Ok(0)
+}
+
+fn usage_error(output_json: bool, message: &str) -> Result<i32> {
+    if output_json {
+        output::emit_error("auth remove", "invalid-usage", message, None)?;
+    } else {
+        eprintln!("{message}");
+    }
+    Ok(64)
+}
+
+fn resolve_secret_dir_from_env() -> Option<PathBuf> {
+    let raw = std::env::var_os("CODEX_SECRET_DIR")?;
+    if raw.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(raw))
+}
+
+fn is_invalid_target(target: &str) -> bool {
+    target.contains('/') || target.contains('\\') || target.contains("..")
+}
+
+fn interactive_io_available() -> bool {
+    io::stdin().is_terminal() && io::stdout().is_terminal()
+}
+
+fn confirm_remove(target: &Path) -> Result<bool> {
+    eprint!("codex-remove: remove {}? [y/N]: ", target.display());
+    io::stderr().flush()?;
+
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    let normalized = line.trim().to_ascii_lowercase();
+    Ok(matches!(normalized.as_str(), "y" | "yes"))
+}
+
+fn remove_target_timestamp(target_file: &Path) {
+    let Some(cache_dir) = paths::resolve_secret_cache_dir() else {
+        return;
+    };
+    let file_name = target_file
+        .file_name()
+        .and_then(|v| v.to_str())
+        .unwrap_or("auth.json");
+    let timestamp_file = cache_dir.join(format!("{file_name}.timestamp"));
+    let _ = std::fs::remove_file(timestamp_file);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_invalid_target, resolve_secret_dir_from_env};
+    use nils_test_support::{EnvGuard, GlobalStateLock};
+
+    #[test]
+    fn invalid_target_rejects_paths_and_traversal() {
+        assert!(is_invalid_target("../a.json"));
+        assert!(is_invalid_target("a/b.json"));
+        assert!(is_invalid_target(r"a\b.json"));
+        assert!(!is_invalid_target("alpha.json"));
+    }
+
+    #[test]
+    fn resolve_secret_dir_uses_codex_secret_dir_only() {
+        let lock = GlobalStateLock::new();
+        let _set = EnvGuard::set(&lock, "CODEX_SECRET_DIR", "/tmp/secrets");
+        assert_eq!(
+            resolve_secret_dir_from_env().expect("secret dir"),
+            std::path::PathBuf::from("/tmp/secrets")
+        );
+    }
+}

--- a/crates/codex-cli/src/cli.rs
+++ b/crates/codex-cli/src/cli.rs
@@ -120,6 +120,16 @@ pub enum AuthCommand {
         #[arg(value_name = "secret", num_args = 0..)]
         args: Vec<String>,
     },
+    /// Remove SECRET_JSON from CODEX_SECRET_DIR
+    Remove {
+        #[command(flatten)]
+        output: OutputModeArgs,
+        /// Remove target file without prompt (non-interactive)
+        #[arg(short = 'y', long = "yes")]
+        yes: bool,
+        #[arg(value_name = "secret", num_args = 0..)]
+        args: Vec<String>,
+    },
     /// Refresh OAuth tokens
     Refresh {
         #[command(flatten)]

--- a/crates/codex-cli/src/main.rs
+++ b/crates/codex-cli/src/main.rs
@@ -97,6 +97,13 @@ fn handle_auth(args: &cli::AuthArgs) -> i32 {
             }
             auth::save::run_with_json(&args[0], *yes, output.is_json()).unwrap_or(1)
         }
+        Some(cli::AuthCommand::Remove { output, yes, args }) => {
+            if args.len() != 1 || args[0].is_empty() {
+                eprintln!("codex-remove: usage: codex-remove [--yes] <secret.json>");
+                return 64;
+            }
+            auth::remove::run_with_json(&args[0], *yes, output.is_json()).unwrap_or(1)
+        }
         Some(cli::AuthCommand::Refresh { output, args }) => {
             if args.len() > 1 {
                 eprintln!("codex-refresh: usage: codex-refresh-auth [secret.json]");

--- a/crates/codex-cli/tests/auth_json_contract.rs
+++ b/crates/codex-cli/tests/auth_json_contract.rs
@@ -526,6 +526,58 @@ fn auth_json_contract_save_overwrite_requires_confirmation() {
 }
 
 #[test]
+fn auth_json_contract_remove_success_includes_stable_fields() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    fs::create_dir_all(&secrets).expect("secrets");
+    fs::write(
+        secrets.join("alpha.json"),
+        r#"{"tokens":{"access_token":"tok-old"}}"#,
+    )
+    .expect("write target");
+
+    let output = run(
+        &["auth", "remove", "--json", "--yes", "alpha.json"],
+        &[("CODEX_SECRET_DIR", &secrets)],
+    );
+    assert_eq!(output.code, 0);
+
+    let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
+    assert_eq!(payload["schema_version"], "codex-cli.auth.v1");
+    assert_eq!(payload["command"], "auth remove");
+    assert_eq!(payload["ok"], true);
+    assert_eq!(payload["result"]["removed"], true);
+    assert_eq!(
+        payload["result"]["target_file"],
+        secrets.join("alpha.json").display().to_string()
+    );
+}
+
+#[test]
+fn auth_json_contract_remove_requires_confirmation() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    fs::create_dir_all(&secrets).expect("secrets");
+    fs::write(
+        secrets.join("alpha.json"),
+        r#"{"tokens":{"access_token":"tok-old"}}"#,
+    )
+    .expect("write target");
+
+    let output = run(
+        &["auth", "remove", "--json", "alpha.json"],
+        &[("CODEX_SECRET_DIR", &secrets)],
+    );
+    assert_eq!(output.code, 1);
+
+    let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
+    assert_eq!(payload["schema_version"], "codex-cli.auth.v1");
+    assert_eq!(payload["command"], "auth remove");
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"]["code"], "remove-confirmation-required");
+}
+
+#[test]
 fn auth_json_contract_auto_refresh_invalid_min_days_is_structured() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let auth_file = dir.path().join("auth.json");

--- a/crates/codex-cli/tests/auth_remove.rs
+++ b/crates/codex-cli/tests/auth_remove.rs
@@ -1,0 +1,133 @@
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOptions, CmdOutput};
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn codex_cli_bin() -> PathBuf {
+    bin::resolve("codex-cli")
+}
+
+fn run_with(args: &[&str], envs: &[(&str, &Path)], vars: &[(&str, &str)]) -> CmdOutput {
+    let mut options = CmdOptions::default();
+    for (key, path) in envs {
+        options = options.with_env(key, path.to_string_lossy().as_ref());
+    }
+    for (key, value) in vars {
+        options = options.with_env(key, value);
+    }
+    let bin = codex_cli_bin();
+    cmd::run_with(&bin, args, &options)
+}
+
+fn stdout(output: &CmdOutput) -> String {
+    output.stdout_text()
+}
+
+fn stderr(output: &CmdOutput) -> String {
+    output.stderr_text()
+}
+
+#[test]
+fn auth_remove_requires_file_name() {
+    let output = run_with(&["auth", "remove"], &[], &[]);
+    assert_eq!(output.code, 64);
+    assert!(stderr(&output).contains("usage"));
+}
+
+#[test]
+fn auth_remove_rejects_path_traversal() {
+    let output = run_with(&["auth", "remove", "../bad.json"], &[], &[]);
+    assert_eq!(output.code, 64);
+    assert!(stderr(&output).contains("invalid secret file name"));
+}
+
+#[test]
+fn auth_remove_errors_when_secret_dir_missing() {
+    let output = run_with(
+        &["auth", "remove", "alpha.json"],
+        &[],
+        &[("CODEX_SECRET_DIR", "")],
+    );
+    assert_eq!(output.code, 1);
+    assert!(stderr(&output).contains("CODEX_SECRET_DIR is not configured"));
+}
+
+#[test]
+fn auth_remove_errors_when_target_missing() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    fs::create_dir_all(&secrets).expect("secrets");
+
+    let output = run_with(
+        &["auth", "remove", "alpha.json"],
+        &[("CODEX_SECRET_DIR", &secrets)],
+        &[],
+    );
+    assert_eq!(output.code, 1);
+    assert!(stderr(&output).contains("secret file not found"));
+}
+
+#[test]
+fn auth_remove_requires_yes_in_non_tty_mode() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    let target = secrets.join("alpha.json");
+    fs::create_dir_all(&secrets).expect("secrets");
+    fs::write(&target, r#"{"tokens":{"access_token":"tok"}}"#).expect("target");
+
+    let output = run_with(
+        &["auth", "remove", "alpha.json"],
+        &[("CODEX_SECRET_DIR", &secrets)],
+        &[],
+    );
+    assert_eq!(output.code, 1);
+    assert!(stderr(&output).contains("rerun with --yes"));
+    assert!(target.exists(), "target should still exist");
+}
+
+#[test]
+fn auth_remove_yes_deletes_file_and_timestamp() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    let cache = dir.path().join("cache");
+    let target = secrets.join("alpha.json");
+    let timestamp = cache.join("alpha.json.timestamp");
+    fs::create_dir_all(&secrets).expect("secrets");
+    fs::create_dir_all(&cache).expect("cache");
+    fs::write(&target, r#"{"tokens":{"access_token":"tok"}}"#).expect("target");
+    fs::write(&timestamp, "2025-01-20T00:00:00Z").expect("timestamp");
+
+    let output = run_with(
+        &["auth", "remove", "--yes", "alpha.json"],
+        &[
+            ("CODEX_SECRET_DIR", &secrets),
+            ("CODEX_SECRET_CACHE_DIR", &cache),
+        ],
+        &[],
+    );
+    assert_eq!(output.code, 0);
+    assert!(stdout(&output).contains("codex: removed"));
+    assert!(!target.exists(), "target should be removed");
+    assert!(!timestamp.exists(), "timestamp should be removed");
+}
+
+#[test]
+fn auth_remove_json_requires_confirmation() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    let target = secrets.join("alpha.json");
+    fs::create_dir_all(&secrets).expect("secrets");
+    fs::write(&target, r#"{"tokens":{"access_token":"tok"}}"#).expect("target");
+
+    let output = run_with(
+        &["auth", "remove", "--json", "alpha.json"],
+        &[("CODEX_SECRET_DIR", &secrets)],
+        &[],
+    );
+    assert_eq!(output.code, 1);
+    let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["error"]["code"], "remove-confirmation-required");
+}

--- a/tests/zsh/completion.test.zsh
+++ b/tests/zsh/completion.test.zsh
@@ -576,6 +576,11 @@ grep -q "save:Save CODEX_AUTH_FILE" "$COMP_CODEX_CLI_FILE" || {
   exit 1
 }
 
+grep -q "remove:Remove SECRET_JSON" "$COMP_CODEX_CLI_FILE" || {
+  print -u2 -r -- "FAIL: codex-cli completion missing auth remove command"
+  exit 1
+}
+
 grep -q -- "--api-key\\[" "$COMP_CODEX_CLI_FILE" || {
   print -u2 -r -- "FAIL: codex-cli completion missing --api-key"
   exit 1


### PR DESCRIPTION
# Add auth remove command for codex-cli

## Summary
Add a new `codex-cli auth remove` command to complete auth secret lifecycle management alongside `auth save`, with explicit confirmation semantics for destructive operations and machine-readable JSON output parity.

## Changes
- Add `auth remove [--yes] <secret.json>` command wiring in CLI parsing and runtime dispatch.
- Implement remove flow with filename validation, `CODEX_SECRET_DIR` checks, confirmation gate behavior, timestamp cleanup, and structured JSON/text responses.
- Add integration coverage for remove success/error paths, extend JSON contract tests, and update zsh completion checks.
- Update codex-cli README and JSON contract/runbook docs to include `auth remove`.

## Testing
- `./.codex/skills/nils-cli-checks/scripts/nils-cli-checks.sh` (pass)
- `cargo test -p nils-codex-cli --tests` (pass)

## Risk / Notes
- `auth remove` intentionally mirrors `auth save` safety posture by requiring `--yes` in non-interactive and JSON modes.
- Command removes only explicit `<secret.json>` targets and rejects path/traversal input.
