### PR TITLE
Unify NO_COLOR handling across CLI crates

### DIFF
--- a/crates/codex-cli/src/rate_limits/ansi.rs
+++ b/crates/codex-cli/src/rate_limits/ansi.rs
@@ -1,9 +1,10 @@
+use nils_common::env as shared_env;
 use std::io::{self, IsTerminal};
 
 const CURRENT_PROFILE_FG: &str = "\x1b[38;2;199;146;234m";
 
 pub fn should_color() -> bool {
-    if std::env::var_os("NO_COLOR").is_some() {
+    if shared_env::no_color_enabled() {
         return false;
     }
     io::stdout().is_terminal()

--- a/crates/git-cli/src/commit.rs
+++ b/crates/git-cli/src/commit.rs
@@ -7,6 +7,7 @@ use crate::commit_shared::{
 use crate::prompt;
 use crate::util;
 use anyhow::{Result, anyhow};
+use nils_common::env as shared_env;
 use nils_common::git::{self as common_git, GitContextError};
 use nils_common::shell::{AnsiStripMode, strip_ansi as strip_ansi_impl};
 use std::env;
@@ -202,7 +203,7 @@ fn git_scope_available() -> bool {
 
 fn git_scope_output(no_color: bool) -> Result<String> {
     let mut args: Vec<&str> = vec!["staged"];
-    if no_color || env::var_os("NO_COLOR").is_some() {
+    if shared_env::no_color_requested(no_color) {
         args.push("--no-color");
     }
 

--- a/crates/git-lock/src/diff.rs
+++ b/crates/git-lock/src/diff.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use nils_common::env as shared_env;
 use std::process::Command;
 
 use crate::messages;
@@ -71,7 +72,7 @@ pub fn run(args: &[String]) -> Result<i32> {
     println!();
 
     let mut log_args = vec!["log", "--oneline", "--graph", "--decorate"];
-    if no_color || std::env::var_os("NO_COLOR").is_some() {
+    if shared_env::no_color_requested(no_color) {
         log_args.push("--color=never");
     }
     let range = format!("{hash1}..{hash2}");

--- a/crates/git-lock/tests/diff_tag.rs
+++ b/crates/git-lock/tests/diff_tag.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{commit_file, init_repo, run_git_lock, run_git_lock_output};
+use common::{commit_file, git, init_repo, run_git_lock, run_git_lock_output};
 use std::path::Path;
 use tempfile::TempDir;
 
@@ -24,6 +24,34 @@ fn diff_no_color() {
         &env,
         None,
     );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("🧮 Comparing commits"));
+    assert!(!stdout.contains("\u{1b}["));
+}
+
+#[test]
+fn diff_no_color_env_overrides_forced_git_color() {
+    let repo = init_repo();
+    let cache = cache_dir();
+    let cache_dir = cache.path().to_str().expect("cache path");
+    let env = [("ZSH_CACHE_DIR", cache_dir)];
+
+    git(repo.path(), &["config", "color.ui", "always"]);
+
+    run_git_lock(repo.path(), &["lock", "base"], &env, None);
+    commit_file(repo.path(), "file.txt", "change", "change");
+    run_git_lock(repo.path(), &["lock", "next"], &env, None);
+
+    let colored_output = run_git_lock_output(repo.path(), &["diff", "base", "next"], &env, None);
+    let colored_stdout = String::from_utf8_lossy(&colored_output.stdout);
+    assert!(
+        colored_stdout.contains("\u{1b}["),
+        "expected ANSI output when git config forces color"
+    );
+
+    let no_color_env = [("ZSH_CACHE_DIR", cache_dir), ("NO_COLOR", "1")];
+    let output = run_git_lock_output(repo.path(), &["diff", "base", "next"], &no_color_env, None);
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("🧮 Comparing commits"));

--- a/crates/nils-common/src/env.rs
+++ b/crates/nils-common/src/env.rs
@@ -25,6 +25,10 @@ pub fn no_color_enabled() -> bool {
     std::env::var_os("NO_COLOR").is_some()
 }
 
+pub fn no_color_requested(explicit_no_color: bool) -> bool {
+    explicit_no_color || no_color_enabled()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -85,5 +89,20 @@ mod tests {
         let lock = GlobalStateLock::new();
         let _guard = EnvGuard::set(&lock, "NO_COLOR", "");
         assert!(no_color_enabled());
+    }
+
+    #[test]
+    fn no_color_requested_respects_explicit_flag() {
+        let lock = GlobalStateLock::new();
+        let _guard = EnvGuard::remove(&lock, "NO_COLOR");
+        assert!(no_color_requested(true));
+        assert!(!no_color_requested(false));
+    }
+
+    #[test]
+    fn no_color_requested_respects_env_presence() {
+        let lock = GlobalStateLock::new();
+        let _guard = EnvGuard::set(&lock, "NO_COLOR", "1");
+        assert!(no_color_requested(false));
     }
 }

--- a/crates/nils-common/src/process.rs
+++ b/crates/nils-common/src/process.rs
@@ -227,6 +227,11 @@ mod tests {
     use nils_test_support::{GlobalStateLock, StubBinDir, prepend_path};
     use std::fs;
 
+    #[cfg(unix)]
+    fn shell_program() -> &'static str {
+        "/bin/sh"
+    }
+
     #[test]
     fn find_in_path_with_explicit_missing_path_returns_none() {
         let dir = tempfile::TempDir::new().expect("tempdir");
@@ -325,8 +330,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn run_output_returns_output_for_nonzero_status() {
-        let output = run_output("sh", &["-c", "printf 'oops' 1>&2; printf 'out'; exit 2"])
-            .expect("run output");
+        let output = run_output(
+            shell_program(),
+            &["-c", "printf 'oops' 1>&2; printf 'out'; exit 2"],
+        )
+        .expect("run output");
 
         assert!(!output.status.success());
         assert_eq!(output.stdout_lossy(), "out");
@@ -336,8 +344,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn run_checked_returns_nonzero_error_with_captured_output() {
-        let err = run_checked("sh", &["-c", "printf 'e' 1>&2; printf 'o'; exit 7"])
-            .expect_err("expected nonzero error");
+        let err = run_checked(
+            shell_program(),
+            &["-c", "printf 'e' 1>&2; printf 'o'; exit 7"],
+        )
+        .expect_err("expected nonzero error");
 
         match err {
             ProcessError::Io(_) => panic!("expected nonzero error"),
@@ -352,7 +363,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn run_stdout_trimmed_trims_trailing_whitespace() {
-        let stdout = run_stdout_trimmed("sh", &["-c", "printf ' hello \\n\\n'"]).expect("stdout");
+        let stdout =
+            run_stdout_trimmed(shell_program(), &["-c", "printf ' hello \\n\\n'"]).expect("stdout");
 
         assert_eq!(stdout, "hello");
     }
@@ -360,10 +372,11 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn run_status_helpers_keep_stdio_contracts() {
-        let quiet = run_status_quiet("sh", &["-c", "exit 0"]).expect("quiet status");
+        let quiet = run_status_quiet(shell_program(), &["-c", "exit 0"]).expect("quiet status");
         assert!(quiet.success());
 
-        let inherit = run_status_inherit("sh", &["-c", "exit 3"]).expect("inherit status");
+        let inherit =
+            run_status_inherit(shell_program(), &["-c", "exit 3"]).expect("inherit status");
         assert_eq!(inherit.code(), Some(3));
     }
 }


### PR DESCRIPTION
## Summary
Centralize NO_COLOR detection in `nils-common` and route multiple CLI call-sites through the shared helper so color behavior stays consistent across commands.

## Changes
- Added `no_color_requested(explicit_no_color: bool)` to `nils-common::env` and covered helper behavior with unit tests.
- Switched NO_COLOR checks in `git-cli`, `git-lock`, and `codex-cli` to the shared helper.
- Added a `git-lock` regression test that forces `git` color and verifies `NO_COLOR=1` still strips ANSI output.
- Hardened `nils-common` process tests to use `/bin/sh` directly so workspace test runs are stable when PATH is mutated by other tests.

## Testing
- `cargo fmt --all && cargo test -p nils-common && cargo test -p nils-git-lock --test diff_tag && cargo test -p nils-git-cli --test commit commit_context_no_color_env_propagates && cargo test -p nils-codex-cli --test rate_limits_ansi rate_limits_ansi_should_color_respects_no_color` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)

## Risk / Notes
- Low risk behavior-preserving refactor with added regression coverage around forced-color behavior.