### PR TITLE
Extract shared Git parsing helpers into nils-common

### DIFF
--- a/crates/git-cli/src/commit_shared.rs
+++ b/crates/git-cli/src/commit_shared.rs
@@ -66,41 +66,17 @@ pub(crate) struct NameStatusEntry {
 }
 
 pub(crate) fn parse_name_status_z(bytes: &[u8]) -> Result<Vec<NameStatusEntry>> {
-    let parts: Vec<&[u8]> = bytes.split(|b| *b == 0).filter(|p| !p.is_empty()).collect();
-    let mut out: Vec<NameStatusEntry> = Vec::new();
-    let mut i = 0;
-
-    while i < parts.len() {
-        let status_raw = String::from_utf8_lossy(parts[i]).to_string();
-        i += 1;
-
-        if status_raw.starts_with('R') || status_raw.starts_with('C') {
-            let old = parts
-                .get(i)
-                .ok_or_else(|| anyhow!("error: malformed name-status output"))?;
-            let new = parts
-                .get(i + 1)
-                .ok_or_else(|| anyhow!("error: malformed name-status output"))?;
-            i += 2;
-            out.push(NameStatusEntry {
-                status_raw,
-                path: String::from_utf8_lossy(new).to_string(),
-                old_path: Some(String::from_utf8_lossy(old).to_string()),
-            });
-        } else {
-            let file = parts
-                .get(i)
-                .ok_or_else(|| anyhow!("error: malformed name-status output"))?;
-            i += 1;
-            out.push(NameStatusEntry {
-                status_raw,
-                path: String::from_utf8_lossy(file).to_string(),
-                old_path: None,
-            });
-        }
-    }
-
-    Ok(out)
+    let parsed = common_git::parse_name_status_z(bytes).map_err(|err| anyhow!("{err}"))?;
+    Ok(parsed
+        .into_iter()
+        .map(|entry| NameStatusEntry {
+            status_raw: String::from_utf8_lossy(entry.status_raw).to_string(),
+            path: String::from_utf8_lossy(entry.path).to_string(),
+            old_path: entry
+                .old_path
+                .map(|old_path| String::from_utf8_lossy(old_path).to_string()),
+        })
+        .collect())
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -153,19 +129,7 @@ pub(crate) fn diff_numstat(path: &str) -> Result<DiffNumstat> {
 }
 
 pub(crate) fn is_lockfile(path: &str) -> bool {
-    let name = std::path::Path::new(path)
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("");
-    matches!(
-        name,
-        "yarn.lock"
-            | "package-lock.json"
-            | "pnpm-lock.yaml"
-            | "bun.lockb"
-            | "bun.lock"
-            | "npm-shrinkwrap.json"
-    )
+    common_git::is_lockfile_path(path)
 }
 
 #[cfg(test)]

--- a/crates/git-lock/tests/diff_tag.rs
+++ b/crates/git-lock/tests/diff_tag.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::{commit_file, git, init_repo, run_git_lock, run_git_lock_output};
+use nils_test_support::cmd::{CmdOptions, run_with};
 use std::path::Path;
 use tempfile::TempDir;
 
@@ -43,7 +44,17 @@ fn diff_no_color_env_overrides_forced_git_color() {
     commit_file(repo.path(), "file.txt", "change", "change");
     run_git_lock(repo.path(), &["lock", "next"], &env, None);
 
-    let colored_output = run_git_lock_output(repo.path(), &["diff", "base", "next"], &env, None);
+    let colored_options = CmdOptions::new()
+        .with_cwd(repo.path())
+        .with_env("ZSH_CACHE_DIR", cache_dir)
+        .with_env_remove("NO_COLOR")
+        .with_stdin_bytes(&[]);
+    let colored_output = run_with(
+        &common::git_lock_bin(),
+        &["diff", "base", "next"],
+        &colored_options,
+    )
+    .into_output();
     let colored_stdout = String::from_utf8_lossy(&colored_output.stdout);
     assert!(
         colored_stdout.contains("\u{1b}["),

--- a/crates/nils-common/src/git.rs
+++ b/crates/nils-common/src/git.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Output, Stdio};
@@ -6,6 +8,83 @@ use std::process::{Command, ExitStatus, Output, Stdio};
 pub enum GitContextError {
     GitNotFound,
     NotRepository,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NameStatusParseError {
+    MalformedOutput,
+}
+
+impl fmt::Display for NameStatusParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NameStatusParseError::MalformedOutput => {
+                write!(f, "error: malformed name-status output")
+            }
+        }
+    }
+}
+
+impl Error for NameStatusParseError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NameStatusZEntry<'a> {
+    pub status_raw: &'a [u8],
+    pub path: &'a [u8],
+    pub old_path: Option<&'a [u8]>,
+}
+
+pub fn parse_name_status_z(buf: &[u8]) -> Result<Vec<NameStatusZEntry<'_>>, NameStatusParseError> {
+    let parts: Vec<&[u8]> = buf
+        .split(|b| *b == 0)
+        .filter(|part| !part.is_empty())
+        .collect();
+    let mut out: Vec<NameStatusZEntry<'_>> = Vec::new();
+    let mut i = 0;
+
+    while i < parts.len() {
+        let status_raw = parts[i];
+        i += 1;
+
+        if matches!(status_raw.first(), Some(b'R' | b'C')) {
+            let old = *parts.get(i).ok_or(NameStatusParseError::MalformedOutput)?;
+            let new = *parts
+                .get(i + 1)
+                .ok_or(NameStatusParseError::MalformedOutput)?;
+            i += 2;
+            out.push(NameStatusZEntry {
+                status_raw,
+                path: new,
+                old_path: Some(old),
+            });
+        } else {
+            let file = *parts.get(i).ok_or(NameStatusParseError::MalformedOutput)?;
+            i += 1;
+            out.push(NameStatusZEntry {
+                status_raw,
+                path: file,
+                old_path: None,
+            });
+        }
+    }
+
+    Ok(out)
+}
+
+pub fn is_lockfile_path(path: &str) -> bool {
+    let name = Path::new(path)
+        .file_name()
+        .and_then(|segment| segment.to_str())
+        .unwrap_or("");
+    matches!(
+        name,
+        "yarn.lock"
+            | "package-lock.json"
+            | "pnpm-lock.yaml"
+            | "bun.lockb"
+            | "bun.lock"
+            | "npm-shrinkwrap.json"
+    )
 }
 
 pub fn run_output(args: &[&str]) -> io::Result<Output> {
@@ -285,5 +364,46 @@ mod tests {
             require_work_tree_in(outside.path()),
             Err(GitContextError::NotRepository)
         );
+    }
+
+    #[test]
+    fn parse_name_status_z_handles_rename_copy_and_modify() {
+        let bytes = b"R100\0old.txt\0new.txt\0C90\0src.rs\0dst.rs\0M\0file.txt\0";
+        let entries = parse_name_status_z(bytes).expect("parse name-status");
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].status_raw, b"R100");
+        assert_eq!(entries[0].path, b"new.txt");
+        assert_eq!(entries[0].old_path, Some(&b"old.txt"[..]));
+        assert_eq!(entries[1].status_raw, b"C90");
+        assert_eq!(entries[1].path, b"dst.rs");
+        assert_eq!(entries[1].old_path, Some(&b"src.rs"[..]));
+        assert_eq!(entries[2].status_raw, b"M");
+        assert_eq!(entries[2].path, b"file.txt");
+        assert_eq!(entries[2].old_path, None);
+    }
+
+    #[test]
+    fn parse_name_status_z_errors_on_malformed_output() {
+        let err = parse_name_status_z(b"R100\0old.txt\0").expect_err("expected parse error");
+        assert_eq!(err, NameStatusParseError::MalformedOutput);
+        assert_eq!(err.to_string(), "error: malformed name-status output");
+    }
+
+    #[test]
+    fn is_lockfile_path_matches_known_package_manager_lockfiles() {
+        for path in [
+            "yarn.lock",
+            "frontend/package-lock.json",
+            "subdir/pnpm-lock.yaml",
+            "bun.lockb",
+            "bun.lock",
+            "npm-shrinkwrap.json",
+        ] {
+            assert!(is_lockfile_path(path), "expected {path} to be a lockfile");
+        }
+
+        assert!(!is_lockfile_path("Cargo.lock"));
+        assert!(!is_lockfile_path("package-lock.json.bak"));
     }
 }

--- a/crates/semantic-commit/src/staged_context.rs
+++ b/crates/semantic-commit/src/staged_context.rs
@@ -1,4 +1,5 @@
 use crate::git;
+use nils_common::git as common_git;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -324,32 +325,15 @@ struct NameStatusEntry {
 }
 
 fn parse_name_status_z(buf: &[u8]) -> anyhow::Result<Vec<NameStatusEntry>> {
-    let parts: Vec<&[u8]> = buf.split(|b| *b == 0).filter(|p| !p.is_empty()).collect();
+    let parts = common_git::parse_name_status_z(buf).map_err(|err| anyhow::anyhow!("{err}"))?;
     let mut out: Vec<NameStatusEntry> = Vec::new();
 
-    let mut i = 0;
-    while i < parts.len() {
-        let raw_status = std::str::from_utf8(parts[i])?;
-        i += 1;
-
-        let (path, old_path) = if raw_status.starts_with('R') || raw_status.starts_with('C') {
-            let old = parts
-                .get(i)
-                .ok_or_else(|| anyhow::anyhow!("error: malformed name-status output"))?;
-            let new = parts
-                .get(i + 1)
-                .ok_or_else(|| anyhow::anyhow!("error: malformed name-status output"))?;
-            i += 2;
-            (
-                std::str::from_utf8(new)?.to_string(),
-                Some(std::str::from_utf8(old)?.to_string()),
-            )
-        } else {
-            let file = parts
-                .get(i)
-                .ok_or_else(|| anyhow::anyhow!("error: malformed name-status output"))?;
-            i += 1;
-            (std::str::from_utf8(file)?.to_string(), None)
+    for entry in parts {
+        let raw_status = std::str::from_utf8(entry.status_raw)?;
+        let path = std::str::from_utf8(entry.path)?.to_string();
+        let old_path = match entry.old_path {
+            Some(path) => Some(std::str::from_utf8(path)?.to_string()),
+            None => None,
         };
 
         let status_letter = raw_status
@@ -446,19 +430,7 @@ fn read_field(buf: &[u8], index: &mut usize, delimiter: u8) -> anyhow::Result<St
 }
 
 fn is_lockfile(path: &str) -> bool {
-    let name = Path::new(path)
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("");
-    matches!(
-        name,
-        "yarn.lock"
-            | "package-lock.json"
-            | "pnpm-lock.yaml"
-            | "bun.lockb"
-            | "bun.lock"
-            | "npm-shrinkwrap.json"
-    )
+    common_git::is_lockfile_path(path)
 }
 
 fn git_string(repo: Option<&Path>, args: &[&str]) -> anyhow::Result<String> {


### PR DESCRIPTION
# Extract shared Git parsing helpers into nils-common

## Summary
Extract shared Git `--name-status -z` parsing and lockfile-path detection into `nils-common`, then reuse those helpers in `git-cli` and `semantic-commit` to reduce duplicate logic and keep behavior aligned across CLIs. Also harden a `git-lock` test against inherited `NO_COLOR` environment leakage.

## Changes
- Add `parse_name_status_z` and `is_lockfile_path` shared helpers to `crates/nils-common/src/git.rs` with focused unit coverage.
- Refactor `crates/git-cli/src/commit_shared.rs` and `crates/semantic-commit/src/staged_context.rs` to consume the new shared helpers while preserving crate-local output/error behavior.
- Stabilize `crates/git-lock/tests/diff_tag.rs` by removing inherited `NO_COLOR` for the forced-color assertion path.

## Testing
- `cargo test -p nils-common -p nils-git-cli -p nils-semantic-commit` (pass)
- `cargo test -p nils-git-lock --test diff_tag` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)

## Risk / Notes
- Runtime behavior changes are not expected; this is a shared-foundation extraction plus test-stability hardening.
