### PR TITLE
Extract shared token profile auth resolution across API call CLIs

### DIFF
--- a/crates/api-grpc/src/commands/call.rs
+++ b/crates/api-grpc/src/commands/call.rs
@@ -1,13 +1,12 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use api_testing_core::{Result, auth_env, cli_endpoint, cli_util, config, env_file, history, jwt};
+use api_testing_core::{Result, auth_env, cli_endpoint, cli_util, config, history, jwt};
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 
 use crate::cli::CallArgs;
 use api_testing_core::cli_util::{
-    history_timestamp_now, list_available_suffixes, maybe_relpath, parse_u64_default, shell_quote,
-    to_env_key, trim_non_empty,
+    history_timestamp_now, maybe_relpath, parse_u64_default, shell_quote, trim_non_empty,
 };
 
 #[derive(Debug, Clone)]
@@ -66,68 +65,32 @@ pub(crate) fn resolve_auth_for_call(
     let tokens_env = setup.tokens_env.as_ref().expect("tokens_env");
     let tokens_local = setup.tokens_local_env.as_ref().expect("tokens_local_env");
     let tokens_files = setup.tokens_files();
+    let token_resolution = auth_env::resolve_profile_or_env_fallback(
+        auth_env::ProfileTokenConfig {
+            token_name_arg: args.token.as_deref(),
+            token_name_env_var: "GRPC_TOKEN_NAME",
+            token_name_file_var: "GRPC_TOKEN_NAME",
+            token_var_prefix: "GRPC_TOKEN_",
+            tokens_env,
+            tokens_local,
+            tokens_files: &tokens_files,
+            missing_profile_hint: "Set it in setup/grpc/tokens.local.env or use ACCESS_TOKEN without selecting a token profile.",
+            env_fallback_keys: &["ACCESS_TOKEN", "SERVICE_TOKEN"],
+        },
+    )?;
 
-    let token_name_arg = args.token.as_deref().and_then(trim_non_empty);
-    let token_name_env = std::env::var("GRPC_TOKEN_NAME")
-        .ok()
-        .and_then(|s| trim_non_empty(&s));
-    let token_name_file = if !tokens_files.is_empty() {
-        env_file::read_var_last_wins("GRPC_TOKEN_NAME", &tokens_files)?
-    } else {
-        None
+    let auth_source_used = match token_resolution.source {
+        auth_env::ProfileTokenSource::None => AuthSourceUsed::None,
+        auth_env::ProfileTokenSource::Profile => AuthSourceUsed::TokenProfile,
+        auth_env::ProfileTokenSource::EnvFallback { env_name } => {
+            AuthSourceUsed::EnvFallback { env_name }
+        }
     };
 
-    let token_profile_selected =
-        token_name_arg.is_some() || token_name_env.is_some() || token_name_file.is_some();
-    let token_name = token_name_arg
-        .or(token_name_env)
-        .or(token_name_file)
-        .unwrap_or_else(|| "default".to_string())
-        .to_ascii_lowercase();
-
-    if token_profile_selected {
-        let token_key = to_env_key(&token_name);
-        let token_var = format!("GRPC_TOKEN_{token_key}");
-        let bearer_token = env_file::read_var_last_wins(&token_var, &tokens_files)?;
-        let Some(bearer_token) = bearer_token else {
-            let mut available = list_available_suffixes(tokens_env, "GRPC_TOKEN_");
-            if tokens_local.is_file() {
-                available.extend(list_available_suffixes(tokens_local, "GRPC_TOKEN_"));
-                available.sort();
-                available.dedup();
-            }
-            available.retain(|t| t != "name");
-            let available = if available.is_empty() {
-                "none".to_string()
-            } else {
-                available.join(" ")
-            };
-            anyhow::bail!(
-                "Token profile '{token_name}' is empty/missing (available: {available}). Set it in setup/grpc/tokens.local.env or use ACCESS_TOKEN without selecting a token profile."
-            );
-        };
-
-        return Ok(AuthSelection {
-            bearer_token: Some(bearer_token),
-            token_name: token_name.clone(),
-            auth_source_used: AuthSourceUsed::TokenProfile,
-        });
-    }
-
-    if let Some((token, env_name)) =
-        auth_env::resolve_env_fallback(&["ACCESS_TOKEN", "SERVICE_TOKEN"])
-    {
-        return Ok(AuthSelection {
-            bearer_token: Some(token),
-            token_name,
-            auth_source_used: AuthSourceUsed::EnvFallback { env_name },
-        });
-    }
-
     Ok(AuthSelection {
-        bearer_token: None,
-        token_name,
-        auth_source_used: AuthSourceUsed::None,
+        bearer_token: token_resolution.bearer_token,
+        token_name: token_resolution.token_name,
+        auth_source_used,
     })
 }
 

--- a/crates/api-rest/src/commands/call.rs
+++ b/crates/api-rest/src/commands/call.rs
@@ -1,13 +1,12 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use api_testing_core::{Result, auth_env, cli_endpoint, cli_util, config, env_file, history, jwt};
+use api_testing_core::{Result, auth_env, cli_endpoint, cli_util, config, history, jwt};
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 
 use crate::cli::CallArgs;
 use api_testing_core::cli_util::{
-    history_timestamp_now, list_available_suffixes, maybe_relpath, parse_u64_default, shell_quote,
-    to_env_key, trim_non_empty,
+    history_timestamp_now, maybe_relpath, parse_u64_default, shell_quote, trim_non_empty,
 };
 
 #[derive(Debug, Clone)]
@@ -66,68 +65,32 @@ pub(crate) fn resolve_auth_for_call(
     let tokens_env = setup.tokens_env.as_ref().expect("tokens_env");
     let tokens_local = setup.tokens_local_env.as_ref().expect("tokens_local_env");
     let tokens_files = setup.tokens_files();
+    let token_resolution = auth_env::resolve_profile_or_env_fallback(
+        auth_env::ProfileTokenConfig {
+            token_name_arg: args.token.as_deref(),
+            token_name_env_var: "REST_TOKEN_NAME",
+            token_name_file_var: "REST_TOKEN_NAME",
+            token_var_prefix: "REST_TOKEN_",
+            tokens_env,
+            tokens_local,
+            tokens_files: &tokens_files,
+            missing_profile_hint: "Set it in setup/rest/tokens.local.env or use ACCESS_TOKEN without selecting a token profile.",
+            env_fallback_keys: &["ACCESS_TOKEN", "SERVICE_TOKEN"],
+        },
+    )?;
 
-    let token_name_arg = args.token.as_deref().and_then(trim_non_empty);
-    let token_name_env = std::env::var("REST_TOKEN_NAME")
-        .ok()
-        .and_then(|s| trim_non_empty(&s));
-    let token_name_file = if !tokens_files.is_empty() {
-        env_file::read_var_last_wins("REST_TOKEN_NAME", &tokens_files)?
-    } else {
-        None
+    let auth_source_used = match token_resolution.source {
+        auth_env::ProfileTokenSource::None => AuthSourceUsed::None,
+        auth_env::ProfileTokenSource::Profile => AuthSourceUsed::TokenProfile,
+        auth_env::ProfileTokenSource::EnvFallback { env_name } => {
+            AuthSourceUsed::EnvFallback { env_name }
+        }
     };
 
-    let token_profile_selected =
-        token_name_arg.is_some() || token_name_env.is_some() || token_name_file.is_some();
-    let token_name = token_name_arg
-        .or(token_name_env)
-        .or(token_name_file)
-        .unwrap_or_else(|| "default".to_string())
-        .to_ascii_lowercase();
-
-    if token_profile_selected {
-        let token_key = to_env_key(&token_name);
-        let token_var = format!("REST_TOKEN_{token_key}");
-        let bearer_token = env_file::read_var_last_wins(&token_var, &tokens_files)?;
-        let Some(bearer_token) = bearer_token else {
-            let mut available = list_available_suffixes(tokens_env, "REST_TOKEN_");
-            if tokens_local.is_file() {
-                available.extend(list_available_suffixes(tokens_local, "REST_TOKEN_"));
-                available.sort();
-                available.dedup();
-            }
-            available.retain(|t| t != "name");
-            let available = if available.is_empty() {
-                "none".to_string()
-            } else {
-                available.join(" ")
-            };
-            anyhow::bail!(
-                "Token profile '{token_name}' is empty/missing (available: {available}). Set it in setup/rest/tokens.local.env or use ACCESS_TOKEN without selecting a token profile."
-            );
-        };
-
-        return Ok(AuthSelection {
-            bearer_token: Some(bearer_token),
-            token_name: token_name.clone(),
-            auth_source_used: AuthSourceUsed::TokenProfile,
-        });
-    }
-
-    if let Some((token, env_name)) =
-        auth_env::resolve_env_fallback(&["ACCESS_TOKEN", "SERVICE_TOKEN"])
-    {
-        return Ok(AuthSelection {
-            bearer_token: Some(token),
-            token_name,
-            auth_source_used: AuthSourceUsed::EnvFallback { env_name },
-        });
-    }
-
     Ok(AuthSelection {
-        bearer_token: None,
-        token_name,
-        auth_source_used: AuthSourceUsed::None,
+        bearer_token: token_resolution.bearer_token,
+        token_name: token_resolution.token_name,
+        auth_source_used,
     })
 }
 

--- a/crates/api-testing-core/src/auth_env.rs
+++ b/crates/api-testing-core/src/auth_env.rs
@@ -1,4 +1,114 @@
-use crate::cli_util;
+use std::path::Path;
+
+use crate::{Result, cli_util, env_file};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProfileTokenSource {
+    None,
+    Profile,
+    EnvFallback { env_name: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileTokenResolution {
+    pub bearer_token: Option<String>,
+    pub token_name: String,
+    pub source: ProfileTokenSource,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProfileTokenConfig<'a> {
+    pub token_name_arg: Option<&'a str>,
+    pub token_name_env_var: &'a str,
+    pub token_name_file_var: &'a str,
+    pub token_var_prefix: &'a str,
+    pub tokens_env: &'a Path,
+    pub tokens_local: &'a Path,
+    pub tokens_files: &'a [&'a Path],
+    pub missing_profile_hint: &'a str,
+    pub env_fallback_keys: &'a [&'a str],
+}
+
+pub fn resolve_profile_or_env_fallback(
+    config: ProfileTokenConfig<'_>,
+) -> Result<ProfileTokenResolution> {
+    let token_name_arg = config.token_name_arg.and_then(cli_util::trim_non_empty);
+    let token_name_env = std::env::var(config.token_name_env_var)
+        .ok()
+        .and_then(|s| cli_util::trim_non_empty(&s));
+    let token_name_file = if !config.tokens_files.is_empty() {
+        env_file::read_var_last_wins(config.token_name_file_var, config.tokens_files)?
+    } else {
+        None
+    };
+
+    let token_profile_selected =
+        token_name_arg.is_some() || token_name_env.is_some() || token_name_file.is_some();
+    let token_name = token_name_arg
+        .or(token_name_env)
+        .or(token_name_file)
+        .unwrap_or_else(|| "default".to_string())
+        .to_ascii_lowercase();
+
+    if token_profile_selected {
+        let token_key = cli_util::to_env_key(&token_name);
+        let token_var = format!("{}{}", config.token_var_prefix, token_key);
+        let bearer_token = env_file::read_var_last_wins(&token_var, config.tokens_files)?;
+        let Some(bearer_token) = bearer_token else {
+            let available = available_token_profiles(
+                config.tokens_env,
+                config.tokens_local,
+                config.token_var_prefix,
+            );
+            anyhow::bail!(
+                "Token profile '{token_name}' is empty/missing (available: {available}). {}",
+                config.missing_profile_hint
+            );
+        };
+
+        return Ok(ProfileTokenResolution {
+            bearer_token: Some(bearer_token),
+            token_name,
+            source: ProfileTokenSource::Profile,
+        });
+    }
+
+    if let Some((token, env_name)) = resolve_env_fallback(config.env_fallback_keys) {
+        return Ok(ProfileTokenResolution {
+            bearer_token: Some(token),
+            token_name,
+            source: ProfileTokenSource::EnvFallback { env_name },
+        });
+    }
+
+    Ok(ProfileTokenResolution {
+        bearer_token: None,
+        token_name,
+        source: ProfileTokenSource::None,
+    })
+}
+
+fn available_token_profiles(
+    tokens_env: &Path,
+    tokens_local: &Path,
+    token_var_prefix: &str,
+) -> String {
+    let mut available = cli_util::list_available_suffixes(tokens_env, token_var_prefix);
+    if tokens_local.is_file() {
+        available.extend(cli_util::list_available_suffixes(
+            tokens_local,
+            token_var_prefix,
+        ));
+        available.sort();
+        available.dedup();
+    }
+    available.retain(|name| name != "name");
+    if available.is_empty() {
+        "none".to_string()
+    } else {
+        available.join(" ")
+    }
+}
 
 pub fn resolve_env_fallback(keys: &[&str]) -> Option<(String, String)> {
     for &key in keys {
@@ -16,6 +126,12 @@ pub fn resolve_env_fallback(keys: &[&str]) -> Option<(String, String)> {
 mod tests {
     use super::*;
     use nils_test_support::{EnvGuard, GlobalStateLock};
+    use tempfile::TempDir;
+
+    fn write_file(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(path, contents).expect("write");
+    }
 
     #[test]
     fn resolve_env_fallback_prefers_order() {
@@ -51,5 +167,135 @@ mod tests {
             resolve_env_fallback(&["ACCESS_TOKEN", "SERVICE_TOKEN"]),
             None
         );
+    }
+
+    #[test]
+    fn resolve_profile_or_env_fallback_prefers_selected_profile() {
+        let lock = GlobalStateLock::new();
+        let _access = EnvGuard::set(&lock, "ACCESS_TOKEN", "env-token");
+        let _name = EnvGuard::remove(&lock, "REST_TOKEN_NAME");
+
+        let tmp = TempDir::new().expect("tmp");
+        let tokens_env = tmp.path().join("tokens.env");
+        let tokens_local = tmp.path().join("tokens.local.env");
+        write_file(&tokens_env, "REST_TOKEN_SVC=svc-token\n");
+
+        let files = [&tokens_env as &Path, &tokens_local as &Path];
+        let resolved = resolve_profile_or_env_fallback(ProfileTokenConfig {
+            token_name_arg: Some("svc"),
+            token_name_env_var: "REST_TOKEN_NAME",
+            token_name_file_var: "REST_TOKEN_NAME",
+            token_var_prefix: "REST_TOKEN_",
+            tokens_env: &tokens_env,
+            tokens_local: &tokens_local,
+            tokens_files: &files,
+            missing_profile_hint: "hint",
+            env_fallback_keys: &["ACCESS_TOKEN", "SERVICE_TOKEN"],
+        })
+        .expect("profile token resolution");
+
+        assert_eq!(resolved.bearer_token.as_deref(), Some("svc-token"));
+        assert_eq!(resolved.token_name, "svc");
+        assert_eq!(resolved.source, ProfileTokenSource::Profile);
+    }
+
+    #[test]
+    fn resolve_profile_or_env_fallback_uses_env_fallback_without_profile_selection() {
+        let lock = GlobalStateLock::new();
+        let _access = EnvGuard::set(&lock, "ACCESS_TOKEN", "env-token");
+        let _name = EnvGuard::remove(&lock, "REST_TOKEN_NAME");
+
+        let tmp = TempDir::new().expect("tmp");
+        let tokens_env = tmp.path().join("tokens.env");
+        let tokens_local = tmp.path().join("tokens.local.env");
+        let files = [&tokens_env as &Path, &tokens_local as &Path];
+
+        let resolved = resolve_profile_or_env_fallback(ProfileTokenConfig {
+            token_name_arg: None,
+            token_name_env_var: "REST_TOKEN_NAME",
+            token_name_file_var: "REST_TOKEN_NAME",
+            token_var_prefix: "REST_TOKEN_",
+            tokens_env: &tokens_env,
+            tokens_local: &tokens_local,
+            tokens_files: &files,
+            missing_profile_hint: "hint",
+            env_fallback_keys: &["ACCESS_TOKEN", "SERVICE_TOKEN"],
+        })
+        .expect("fallback resolution");
+
+        assert_eq!(resolved.bearer_token.as_deref(), Some("env-token"));
+        assert_eq!(resolved.token_name, "default");
+        assert_eq!(
+            resolved.source,
+            ProfileTokenSource::EnvFallback {
+                env_name: "ACCESS_TOKEN".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_profile_or_env_fallback_reports_available_profiles_when_missing() {
+        let lock = GlobalStateLock::new();
+        let _name = EnvGuard::set(&lock, "REST_TOKEN_NAME", "missing");
+        let _access = EnvGuard::remove(&lock, "ACCESS_TOKEN");
+
+        let tmp = TempDir::new().expect("tmp");
+        let tokens_env = tmp.path().join("tokens.env");
+        let tokens_local = tmp.path().join("tokens.local.env");
+        write_file(
+            &tokens_env,
+            "REST_TOKEN_SVC=svc-token\nREST_TOKEN_DEV=dev-token\n",
+        );
+        let files = [&tokens_env as &Path, &tokens_local as &Path];
+
+        let err = resolve_profile_or_env_fallback(ProfileTokenConfig {
+            token_name_arg: None,
+            token_name_env_var: "REST_TOKEN_NAME",
+            token_name_file_var: "REST_TOKEN_NAME",
+            token_var_prefix: "REST_TOKEN_",
+            tokens_env: &tokens_env,
+            tokens_local: &tokens_local,
+            tokens_files: &files,
+            missing_profile_hint: "Set it in setup/rest/tokens.local.env.",
+            env_fallback_keys: &["ACCESS_TOKEN", "SERVICE_TOKEN"],
+        })
+        .expect_err("missing profile should error");
+
+        let text = err.to_string();
+        assert!(text.contains("Token profile 'missing' is empty/missing"));
+        assert!(text.contains("svc dev") || text.contains("dev svc"));
+        assert!(text.contains("setup/rest/tokens.local.env"));
+    }
+
+    #[test]
+    fn resolve_profile_or_env_fallback_prefers_env_over_file_for_name() {
+        let lock = GlobalStateLock::new();
+        let _name = EnvGuard::set(&lock, "REST_TOKEN_NAME", "prod");
+
+        let tmp = TempDir::new().expect("tmp");
+        let tokens_env = tmp.path().join("tokens.env");
+        let tokens_local = tmp.path().join("tokens.local.env");
+        write_file(
+            &tokens_env,
+            "REST_TOKEN_NAME=staging\nREST_TOKEN_PROD=prod-token\n",
+        );
+        let files = [&tokens_env as &Path, &tokens_local as &Path];
+
+        let resolved = resolve_profile_or_env_fallback(ProfileTokenConfig {
+            token_name_arg: None,
+            token_name_env_var: "REST_TOKEN_NAME",
+            token_name_file_var: "REST_TOKEN_NAME",
+            token_var_prefix: "REST_TOKEN_",
+            tokens_env: &tokens_env,
+            tokens_local: &tokens_local,
+            tokens_files: &files,
+            missing_profile_hint: "hint",
+            env_fallback_keys: &["ACCESS_TOKEN", "SERVICE_TOKEN"],
+        })
+        .expect("env token name resolution");
+
+        assert_eq!(resolved.bearer_token.as_deref(), Some("prod-token"));
+        assert_eq!(resolved.token_name, "prod");
+        assert_eq!(resolved.source, ProfileTokenSource::Profile);
     }
 }

--- a/crates/api-websocket/src/commands/call.rs
+++ b/crates/api-websocket/src/commands/call.rs
@@ -1,13 +1,12 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use api_testing_core::{Result, auth_env, cli_endpoint, cli_util, config, env_file, history, jwt};
+use api_testing_core::{Result, auth_env, cli_endpoint, cli_util, config, history, jwt};
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 
 use crate::cli::{CallArgs, OutputFormat};
 use api_testing_core::cli_util::{
-    history_timestamp_now, list_available_suffixes, maybe_relpath, parse_u64_default, shell_quote,
-    to_env_key, trim_non_empty,
+    history_timestamp_now, maybe_relpath, parse_u64_default, shell_quote, trim_non_empty,
 };
 
 const CALL_SCHEMA_VERSION: &str = "cli.api-websocket.call.v1";
@@ -84,68 +83,32 @@ pub(crate) fn resolve_auth_for_call(
     let tokens_env = setup.tokens_env.as_ref().expect("tokens_env");
     let tokens_local = setup.tokens_local_env.as_ref().expect("tokens_local_env");
     let tokens_files = setup.tokens_files();
+    let token_resolution = auth_env::resolve_profile_or_env_fallback(
+        auth_env::ProfileTokenConfig {
+            token_name_arg: args.token.as_deref(),
+            token_name_env_var: "WS_TOKEN_NAME",
+            token_name_file_var: "WS_TOKEN_NAME",
+            token_var_prefix: "WS_TOKEN_",
+            tokens_env,
+            tokens_local,
+            tokens_files: &tokens_files,
+            missing_profile_hint: "Set it in setup/websocket/tokens.local.env or use ACCESS_TOKEN without selecting a token profile.",
+            env_fallback_keys: &["ACCESS_TOKEN", "SERVICE_TOKEN"],
+        },
+    )?;
 
-    let token_name_arg = args.token.as_deref().and_then(trim_non_empty);
-    let token_name_env = std::env::var("WS_TOKEN_NAME")
-        .ok()
-        .and_then(|s| trim_non_empty(&s));
-    let token_name_file = if !tokens_files.is_empty() {
-        env_file::read_var_last_wins("WS_TOKEN_NAME", &tokens_files)?
-    } else {
-        None
+    let auth_source_used = match token_resolution.source {
+        auth_env::ProfileTokenSource::None => AuthSourceUsed::None,
+        auth_env::ProfileTokenSource::Profile => AuthSourceUsed::TokenProfile,
+        auth_env::ProfileTokenSource::EnvFallback { env_name } => {
+            AuthSourceUsed::EnvFallback { env_name }
+        }
     };
 
-    let token_profile_selected =
-        token_name_arg.is_some() || token_name_env.is_some() || token_name_file.is_some();
-    let token_name = token_name_arg
-        .or(token_name_env)
-        .or(token_name_file)
-        .unwrap_or_else(|| "default".to_string())
-        .to_ascii_lowercase();
-
-    if token_profile_selected {
-        let token_key = to_env_key(&token_name);
-        let token_var = format!("WS_TOKEN_{token_key}");
-        let bearer_token = env_file::read_var_last_wins(&token_var, &tokens_files)?;
-        let Some(bearer_token) = bearer_token else {
-            let mut available = list_available_suffixes(tokens_env, "WS_TOKEN_");
-            if tokens_local.is_file() {
-                available.extend(list_available_suffixes(tokens_local, "WS_TOKEN_"));
-                available.sort();
-                available.dedup();
-            }
-            available.retain(|t| t != "name");
-            let available = if available.is_empty() {
-                "none".to_string()
-            } else {
-                available.join(" ")
-            };
-            anyhow::bail!(
-                "Token profile '{token_name}' is empty/missing (available: {available}). Set it in setup/websocket/tokens.local.env or use ACCESS_TOKEN without selecting a token profile."
-            );
-        };
-
-        return Ok(AuthSelection {
-            bearer_token: Some(bearer_token),
-            token_name: token_name.clone(),
-            auth_source_used: AuthSourceUsed::TokenProfile,
-        });
-    }
-
-    if let Some((token, env_name)) =
-        auth_env::resolve_env_fallback(&["ACCESS_TOKEN", "SERVICE_TOKEN"])
-    {
-        return Ok(AuthSelection {
-            bearer_token: Some(token),
-            token_name,
-            auth_source_used: AuthSourceUsed::EnvFallback { env_name },
-        });
-    }
-
     Ok(AuthSelection {
-        bearer_token: None,
-        token_name,
-        auth_source_used: AuthSourceUsed::None,
+        bearer_token: token_resolution.bearer_token,
+        token_name: token_resolution.token_name,
+        auth_source_used,
     })
 }
 
@@ -629,8 +592,14 @@ fn maybe_print_failure_body_to_stderr(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nils_test_support::{EnvGuard, GlobalStateLock};
     use std::fs;
     use tempfile::tempdir;
+
+    fn write_file(path: &Path, contents: &str) {
+        fs::create_dir_all(path.parent().expect("parent")).expect("mkdir parent");
+        fs::write(path, contents).expect("write");
+    }
 
     fn test_history_writer(path: &Path) -> history::HistoryWriter {
         history::HistoryWriter::new(
@@ -640,6 +609,51 @@ mod tests {
                 keep: 5,
             },
         )
+    }
+
+    #[test]
+    fn resolve_auth_for_call_prefers_profile_then_env_fallback() {
+        let lock = GlobalStateLock::new();
+        let _access = EnvGuard::set(&lock, "ACCESS_TOKEN", "env-token");
+        let _name = EnvGuard::remove(&lock, "WS_TOKEN_NAME");
+
+        let tmp = tempdir().expect("tempdir");
+        let setup_dir = tmp.path().join("setup/websocket");
+        fs::create_dir_all(&setup_dir).expect("mkdir setup");
+        write_file(&setup_dir.join("tokens.env"), "WS_TOKEN_SVC=svc-token\n");
+        let setup = api_testing_core::config::ResolvedSetup::websocket(setup_dir, None);
+
+        let args = CallArgs {
+            env: None,
+            url: None,
+            token: Some("svc".to_string()),
+            config_dir: None,
+            no_history: false,
+            format: OutputFormat::Text,
+            request: "requests/health.ws.json".to_string(),
+        };
+        let auth = resolve_auth_for_call(&args, &setup).expect("token profile resolution");
+        assert_eq!(auth.bearer_token.as_deref(), Some("svc-token"));
+        assert!(matches!(
+            auth.auth_source_used,
+            AuthSourceUsed::TokenProfile
+        ));
+
+        let args = CallArgs {
+            env: None,
+            url: None,
+            token: None,
+            config_dir: None,
+            no_history: false,
+            format: OutputFormat::Text,
+            request: "requests/health.ws.json".to_string(),
+        };
+        let auth = resolve_auth_for_call(&args, &setup).expect("env fallback resolution");
+        assert_eq!(auth.bearer_token.as_deref(), Some("env-token"));
+        assert!(matches!(
+            auth.auth_source_used,
+            AuthSourceUsed::EnvFallback { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
# Extract shared token profile auth resolution across API call CLIs

## Summary
This change removes duplicated token profile selection logic from REST, gRPC, and WebSocket call commands by introducing a shared resolver in `nils-api-testing-core`, while preserving existing user-facing error and fallback behavior.

## Changes
- Added `ProfileTokenConfig` and `resolve_profile_or_env_fallback` in `crates/api-testing-core/src/auth_env.rs`.
- Refactored `resolve_auth_for_call` in `api-rest`, `api-grpc`, and `api-websocket` to use the shared resolver and map shared source state back to crate-local enums.
- Added new shared helper tests in `auth_env` and added WebSocket auth precedence coverage (`resolve_auth_for_call_prefers_profile_then_env_fallback`).

## Testing
- `cargo test -p nils-api-testing-core auth_env::tests && cargo test -p nils-api-rest resolve_auth_for_call_prefers_profile_then_env_fallback && cargo test -p nils-api-grpc resolve_auth_for_call_prefers_profile_then_env_fallback && cargo test -p nils-api-websocket resolve_auth_for_call_prefers_profile_then_env_fallback` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `mkdir -p target/coverage && cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass)

## Risk / Notes
- Existing CLI output contracts are intentionally preserved (same token-profile missing message shape and env fallback order).
- Coverage gate result: `85.67%` total line coverage.
