### PR TITLE
Extract shared repo-root fallback helper for CLI callers

### DIFF
--- a/crates/image-processing/src/util.rs
+++ b/crates/image-processing/src/util.rs
@@ -28,12 +28,7 @@ pub fn now_run_id() -> String {
 }
 
 pub fn find_repo_root() -> PathBuf {
-    if let Ok(Some(root)) = common_git::repo_root() {
-        return normalize_path(&root);
-    }
-    std::env::current_dir()
-        .map(|p| normalize_path(&p))
-        .unwrap_or_else(|_| PathBuf::from("."))
+    normalize_path(&common_git::repo_root_or_cwd())
 }
 
 pub fn expand_user(raw: &str) -> PathBuf {

--- a/crates/nils-common/src/git.rs
+++ b/crates/nils-common/src/git.rs
@@ -159,6 +159,14 @@ pub fn repo_root_in(cwd: &Path) -> io::Result<Option<PathBuf>> {
     Ok(trimmed_stdout_if_success(&output).map(PathBuf::from))
 }
 
+pub fn repo_root_or_cwd() -> PathBuf {
+    repo_root()
+        .ok()
+        .flatten()
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
 pub fn rev_parse(args: &[&str]) -> io::Result<Option<String>> {
     let output = run_output(&rev_parse_args(args))?;
     Ok(trimmed_stdout_if_success(&output))
@@ -334,6 +342,35 @@ mod tests {
         assert_eq!(require_work_tree(), Ok(()));
         assert_eq!(repo_root().expect("repo_root"), Some(root.into()));
         assert_eq!(rev_parse(&["HEAD"]).expect("rev_parse"), Some(head));
+    }
+
+    #[test]
+    fn repo_root_or_cwd_prefers_repo_root_when_available() {
+        let lock = GlobalStateLock::new();
+        let repo = init_repo_with(InitRepoOptions::new().with_initial_commit());
+        let _cwd = CwdGuard::set(&lock, repo.path()).expect("set cwd");
+        let expected_root = run_git(repo.path(), &["rev-parse", "--show-toplevel"])
+            .trim()
+            .to_string();
+
+        assert_eq!(repo_root_or_cwd(), PathBuf::from(expected_root));
+    }
+
+    #[test]
+    fn repo_root_or_cwd_falls_back_to_current_dir_outside_repo() {
+        let lock = GlobalStateLock::new();
+        let outside = TempDir::new().expect("tempdir");
+        let _cwd = CwdGuard::set(&lock, outside.path()).expect("set cwd");
+
+        let resolved = repo_root_or_cwd()
+            .canonicalize()
+            .expect("canonicalize resolved path");
+        let expected = outside
+            .path()
+            .canonicalize()
+            .expect("canonicalize expected path");
+
+        assert_eq!(resolved, expected);
     }
 
     #[test]

--- a/crates/plan-tooling/src/repo_root.rs
+++ b/crates/plan-tooling/src/repo_root.rs
@@ -2,9 +2,5 @@ use nils_common::git as common_git;
 use std::path::PathBuf;
 
 pub fn detect() -> PathBuf {
-    if let Ok(Some(root)) = common_git::repo_root() {
-        return root;
-    }
-
-    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    common_git::repo_root_or_cwd()
 }


### PR DESCRIPTION
# Extract shared repo-root fallback helper for CLI callers

## Summary
Extract a shared `repo_root_or_cwd` helper into `nils-common` and migrate existing callers so repo-root fallback behavior is implemented once and validated centrally.

## Changes
- Added `nils_common::git::repo_root_or_cwd()` and unit tests for both repo and non-repo execution contexts.
- Updated `plan-tooling` repo-root detection to use the shared helper.
- Updated `image-processing` repo-root detection to use the shared helper while preserving its path normalization behavior.

## Testing
- `cargo test -p nils-common` (pass)
- `cargo test -p nils-plan-tooling` (pass)
- `cargo test -p nils-image-processing` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `mkdir -p target/coverage && cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, 85.67%)

## Risk / Notes
- This is behavior-preserving refactor scope; only shared fallback composition changed.
