### PR TITLE
Fix git-cli open warning in headless Linux environments

### DIFF
--- a/crates/git-cli/src/open.rs
+++ b/crates/git-cli/src/open.rs
@@ -931,12 +931,36 @@ fn open_url(url: &str, label: &str) -> i32 {
         }
     };
     if !output.status.success() {
+        if is_headless_open_failure(&output) {
+            println!("🔗 URL: {url}");
+            eprintln!("⚠️  Could not launch a browser in this environment; open the URL manually.");
+            return 0;
+        }
         emit_output(&output);
         return exit_code(&output);
     }
 
     println!("{label}: {url}");
     0
+}
+
+fn is_headless_open_failure(output: &Output) -> bool {
+    let mut message = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+    if !output.stdout.is_empty() {
+        message.push('\n');
+        message.push_str(&String::from_utf8_lossy(&output.stdout).to_ascii_lowercase());
+    }
+
+    if message.contains("no method available for opening")
+        || message.contains("couldn't find a suitable web browser")
+    {
+        return true;
+    }
+
+    message.contains("not found")
+        && ["www-browser", "links2", "elinks", "links", "lynx", "w3m"]
+            .iter()
+            .any(|candidate| message.contains(candidate))
 }
 
 fn is_help_token(raw: &str) -> bool {
@@ -1018,9 +1042,23 @@ fn emit_output(output: &Output) {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt as _;
+    #[cfg(windows)]
+    use std::os::windows::process::ExitStatusExt as _;
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[cfg(unix)]
+    fn test_exit_status(code: i32) -> std::process::ExitStatus {
+        std::process::ExitStatus::from_raw(code << 8)
+    }
+
+    #[cfg(windows)]
+    fn test_exit_status(code: i32) -> std::process::ExitStatus {
+        std::process::ExitStatus::from_raw(code as u32)
     }
 
     #[test]
@@ -1244,5 +1282,25 @@ mod tests {
             commits_url(Provider::Gitlab, "https://gitlab.com/acme/repo", "main"),
             "https://gitlab.com/acme/repo/-/commits/main"
         );
+    }
+
+    #[test]
+    fn headless_open_failure_detection_matches_xdg_open_signals() {
+        let output = Output {
+            status: test_exit_status(3),
+            stdout: Vec::new(),
+            stderr: b"/usr/bin/open: 882: www-browser: not found\nxdg-open: no method available for opening 'https://example.com'\n".to_vec(),
+        };
+        assert!(is_headless_open_failure(&output));
+    }
+
+    #[test]
+    fn headless_open_failure_detection_does_not_mask_other_errors() {
+        let output = Output {
+            status: test_exit_status(126),
+            stdout: Vec::new(),
+            stderr: b"open: permission denied\n".to_vec(),
+        };
+        assert!(!is_headless_open_failure(&output));
     }
 }

--- a/crates/git-cli/tests/open.rs
+++ b/crates/git-cli/tests/open.rs
@@ -5,17 +5,28 @@ use nils_test_support::StubBinDir;
 use nils_test_support::cmd::{CmdOutput, run_with};
 use std::path::Path;
 
-fn run_with_open_stub(harness: &GitCliHarness, cwd: &Path, args: &[&str]) -> CmdOutput {
+fn run_with_open_script(
+    harness: &GitCliHarness,
+    cwd: &Path,
+    args: &[&str],
+    open_script: &str,
+) -> CmdOutput {
     let stubs = StubBinDir::new();
-    stubs.write_exe(
-        "open",
+    stubs.write_exe("open", open_script);
+    let options = harness.cmd_options(cwd).with_path_prepend(stubs.path());
+    run_with(&harness.git_cli_bin(), args, &options)
+}
+
+fn run_with_open_stub(harness: &GitCliHarness, cwd: &Path, args: &[&str]) -> CmdOutput {
+    run_with_open_script(
+        harness,
+        cwd,
+        args,
         r#"#!/bin/bash
 set -euo pipefail
 exit 0
 "#,
-    );
-    let options = harness.cmd_options(cwd).with_path_prepend(stubs.path());
-    run_with(&harness.git_cli_bin(), args, &options)
+    )
 }
 
 #[test]
@@ -99,4 +110,61 @@ fn open_actions_rejects_non_github_provider() {
         output.stderr_text(),
         "❗ actions is only supported for GitHub remotes.\n"
     );
+}
+
+#[test]
+fn open_repo_headless_environment_prints_clear_manual_open_warning() {
+    let harness = GitCliHarness::new();
+    let dir = init_repo();
+    git(
+        dir.path(),
+        &["remote", "add", "origin", "git@github.com:acme/repo.git"],
+    );
+
+    let output = run_with_open_script(
+        &harness,
+        dir.path(),
+        &["open", "repo"],
+        r#"#!/bin/bash
+set -euo pipefail
+echo "/usr/bin/open: 882: www-browser: not found" >&2
+echo "xdg-open: no method available for opening '$1'" >&2
+exit 3
+"#,
+    );
+
+    assert_eq!(output.code, 0);
+    assert_eq!(
+        output.stdout_text(),
+        "🔗 URL: https://github.com/acme/repo\n"
+    );
+    assert_eq!(
+        output.stderr_text(),
+        "⚠️  Could not launch a browser in this environment; open the URL manually.\n"
+    );
+}
+
+#[test]
+fn open_repo_non_headless_open_error_still_fails() {
+    let harness = GitCliHarness::new();
+    let dir = init_repo();
+    git(
+        dir.path(),
+        &["remote", "add", "origin", "git@github.com:acme/repo.git"],
+    );
+
+    let output = run_with_open_script(
+        &harness,
+        dir.path(),
+        &["open", "repo"],
+        r#"#!/bin/bash
+set -euo pipefail
+echo "open: permission denied" >&2
+exit 126
+"#,
+    );
+
+    assert_eq!(output.code, 126);
+    assert_eq!(output.stdout_text(), "");
+    assert_eq!(output.stderr_text(), "open: permission denied\n");
 }


### PR DESCRIPTION
## Summary
- Improve `git-cli open` behavior in headless Linux environments where `open`/`xdg-open` cannot launch a browser.
- Replace noisy system error output with a clear warning and a manual URL fallback.

## Changes
- Add headless failure detection in `open_url` for common `xdg-open`/`open` “no browser available” signals.
- On detected headless failure, print:
  - `🔗 URL: <url>`
  - `⚠️  Could not launch a browser in this environment; open the URL manually.`
  and return success.
- Keep existing non-headless open failures unchanged (still propagate stderr + non-zero exit).
- Add coverage for:
  - detection of headless vs non-headless failure signals
  - `open repo` headless fallback output/exit behavior
  - passthrough behavior for non-headless opener failures

## Testing
- `cargo test -p nils-git-cli open_repo_ && cargo test -p nils-git-cli headless_open_failure_`
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
- `mkdir -p target/coverage && cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info`

## Risk / Notes
- This intentionally changes headless fallback semantics for `open` commands from error to warning + success.
- Non-headless opener failures remain unchanged to avoid masking real errors.
