### PR TITLE
Refactor browser-open fallback for headless Ubuntu environments

### DIFF
--- a/crates/git-cli/src/open.rs
+++ b/crates/git-cli/src/open.rs
@@ -1,4 +1,5 @@
 use crate::util;
+use nils_common::process;
 use std::io::{self, Write};
 use std::process::Output;
 
@@ -914,11 +915,7 @@ fn open_url(url: &str, label: &str) -> i32 {
         return 1;
     }
 
-    let opener = if util::cmd_exists("open") {
-        "open"
-    } else if util::cmd_exists("xdg-open") {
-        "xdg-open"
-    } else {
+    let Some(opener) = process::browser_open_command() else {
         eprintln!("❌ Cannot open URL (no open/xdg-open)");
         return 1;
     };
@@ -931,7 +928,7 @@ fn open_url(url: &str, label: &str) -> i32 {
         }
     };
     if !output.status.success() {
-        if is_headless_open_failure(&output) {
+        if process::is_headless_browser_launch_failure(&output.stdout, &output.stderr) {
             println!("🔗 URL: {url}");
             eprintln!("⚠️  Could not launch a browser in this environment; open the URL manually.");
             return 0;
@@ -942,25 +939,6 @@ fn open_url(url: &str, label: &str) -> i32 {
 
     println!("{label}: {url}");
     0
-}
-
-fn is_headless_open_failure(output: &Output) -> bool {
-    let mut message = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
-    if !output.stdout.is_empty() {
-        message.push('\n');
-        message.push_str(&String::from_utf8_lossy(&output.stdout).to_ascii_lowercase());
-    }
-
-    if message.contains("no method available for opening")
-        || message.contains("couldn't find a suitable web browser")
-    {
-        return true;
-    }
-
-    message.contains("not found")
-        && ["www-browser", "links2", "elinks", "links", "lynx", "w3m"]
-            .iter()
-            .any(|candidate| message.contains(candidate))
 }
 
 fn is_help_token(raw: &str) -> bool {
@@ -1042,23 +1020,9 @@ fn emit_output(output: &Output) {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
-    #[cfg(unix)]
-    use std::os::unix::process::ExitStatusExt as _;
-    #[cfg(windows)]
-    use std::os::windows::process::ExitStatusExt as _;
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_string()).collect()
-    }
-
-    #[cfg(unix)]
-    fn test_exit_status(code: i32) -> std::process::ExitStatus {
-        std::process::ExitStatus::from_raw(code << 8)
-    }
-
-    #[cfg(windows)]
-    fn test_exit_status(code: i32) -> std::process::ExitStatus {
-        std::process::ExitStatus::from_raw(code as u32)
     }
 
     #[test]
@@ -1282,25 +1246,5 @@ mod tests {
             commits_url(Provider::Gitlab, "https://gitlab.com/acme/repo", "main"),
             "https://gitlab.com/acme/repo/-/commits/main"
         );
-    }
-
-    #[test]
-    fn headless_open_failure_detection_matches_xdg_open_signals() {
-        let output = Output {
-            status: test_exit_status(3),
-            stdout: Vec::new(),
-            stderr: b"/usr/bin/open: 882: www-browser: not found\nxdg-open: no method available for opening 'https://example.com'\n".to_vec(),
-        };
-        assert!(is_headless_open_failure(&output));
-    }
-
-    #[test]
-    fn headless_open_failure_detection_does_not_mask_other_errors() {
-        let output = Output {
-            status: test_exit_status(126),
-            stdout: Vec::new(),
-            stderr: b"open: permission denied\n".to_vec(),
-        };
-        assert!(!is_headless_open_failure(&output));
     }
 }

--- a/crates/nils-common/src/process.rs
+++ b/crates/nils-common/src/process.rs
@@ -121,6 +121,35 @@ pub fn cmd_exists(program: &str) -> bool {
     find_in_path(program).is_some()
 }
 
+pub fn browser_open_command() -> Option<&'static str> {
+    if cmd_exists("open") {
+        Some("open")
+    } else if cmd_exists("xdg-open") {
+        Some("xdg-open")
+    } else {
+        None
+    }
+}
+
+pub fn is_headless_browser_launch_failure(stdout: &[u8], stderr: &[u8]) -> bool {
+    let mut message = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    if !stdout.is_empty() {
+        message.push('\n');
+        message.push_str(&String::from_utf8_lossy(stdout).to_ascii_lowercase());
+    }
+
+    if message.contains("no method available for opening")
+        || message.contains("couldn't find a suitable web browser")
+    {
+        return true;
+    }
+
+    message.contains("not found")
+        && ["www-browser", "links2", "elinks", "links", "lynx", "w3m"]
+            .iter()
+            .any(|candidate| message.contains(candidate))
+}
+
 pub fn find_in_path(program: &str) -> Option<PathBuf> {
     if looks_like_path(program) {
         let p = PathBuf::from(program);
@@ -224,7 +253,7 @@ fn is_executable_file(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nils_test_support::{GlobalStateLock, StubBinDir, prepend_path};
+    use nils_test_support::{EnvGuard, GlobalStateLock, StubBinDir, prepend_path};
     use std::fs;
 
     #[cfg(unix)]
@@ -378,5 +407,43 @@ mod tests {
         let inherit =
             run_status_inherit(shell_program(), &["-c", "exit 3"]).expect("inherit status");
         assert_eq!(inherit.code(), Some(3));
+    }
+
+    #[test]
+    fn browser_open_command_prefers_open_then_xdg_open() {
+        let lock = GlobalStateLock::new();
+
+        let both = StubBinDir::new();
+        both.write_exe("open", "#!/bin/sh\nexit 0\n");
+        both.write_exe("xdg-open", "#!/bin/sh\nexit 0\n");
+        let _both_path_guard = EnvGuard::set(&lock, "PATH", &both.path_str());
+        assert_eq!(browser_open_command(), Some("open"));
+        drop(_both_path_guard);
+
+        let xdg_only = StubBinDir::new();
+        xdg_only.write_exe("xdg-open", "#!/bin/sh\nexit 0\n");
+        let _xdg_path_guard = EnvGuard::set(&lock, "PATH", &xdg_only.path_str());
+        assert_eq!(browser_open_command(), Some("xdg-open"));
+        drop(_xdg_path_guard);
+
+        let empty = tempfile::TempDir::new().expect("tempdir");
+        let empty_path = empty.path().to_string_lossy().to_string();
+        let _empty_path_guard = EnvGuard::set(&lock, "PATH", &empty_path);
+        assert_eq!(browser_open_command(), None);
+    }
+
+    #[test]
+    fn headless_browser_launch_failure_detection_matches_xdg_open_signals() {
+        let stderr =
+            b"/usr/bin/open: 882: www-browser: not found\nxdg-open: no method available for opening 'https://example.com'\n";
+        assert!(is_headless_browser_launch_failure(&[], stderr));
+    }
+
+    #[test]
+    fn headless_browser_launch_failure_detection_does_not_mask_other_errors() {
+        assert!(!is_headless_browser_launch_failure(
+            &[],
+            b"open: permission denied\n"
+        ));
     }
 }


### PR DESCRIPTION
# Refactor browser-open fallback for headless Ubuntu environments

## Summary
Extract browser-launch command selection and headless-launch failure detection into shared `nils-common` helpers, then reuse them in `git-cli open` so Ubuntu headless behavior is consistent and warning text remains clear.

## Changes
- Add `browser_open_command` and `is_headless_browser_launch_failure` to `crates/nils-common/src/process.rs` with focused unit coverage.
- Replace duplicated open/xdg-open + headless detection logic in `crates/git-cli/src/open.rs` with shared helper calls.
- Keep existing user-facing fallback behavior for headless environments (`🔗 URL` + clear manual-open warning).

## Testing
- `cargo test -p nils-common browser_open_command_prefers_open_then_xdg_open` (pass)
- `cargo test -p nils-common headless_browser_launch_failure_detection_` (pass)
- `cargo test -p nils-git-cli open_repo_` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `awk '/^LF:/{lf+=$2}/^LH:/{lh+=$2} END {cov=(lh/lf*100); printf "coverage=%.2f%% (%d/%d)\n",cov,lh,lf; exit(cov<85)}' target/coverage/lcov.info` (pass)

## Risk / Notes
- Scope is intentionally limited to shared command/error detection extraction; URL construction and provider-specific behavior are unchanged.
