### PR TITLE
Remove codex-cli legacy completion mode and enforce clap-only policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1727,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "clap_complete",
  "nils-common",
  "nils-term",
  "nils-test-support",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,7 +52,7 @@
 ## Completion governance
 
 - Canonical completion governance runbook: `docs/runbooks/cli-completion-development-standard.md`.
-- When completion/alias code changes, follow that runbook for architecture/fallback policy and completion-focused validation.
+- When completion/alias code changes, follow that runbook for clap-first/no-legacy policy and completion-focused validation.
 
 ### Required before committing
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Detailed scope, API examples, migration conventions, and non-goals are documente
 ## Shell wrappers and completions
 
 This repo keeps optional wrapper scripts and completion assets in-repo.
-Contributor completion governance (architecture, fallback, alias sync, and completion-focused checks) is defined in
+Contributor completion governance (architecture, no-legacy policy, alias sync, and completion-focused checks) is defined in
 [docs/runbooks/cli-completion-development-standard.md](docs/runbooks/cli-completion-development-standard.md).
 
 Location:

--- a/completions/bash/codex-cli
+++ b/completions/bash/codex-cli
@@ -16,13 +16,53 @@ _nils_cli__has_word() {
   return 1
 }
 
+_NILS_CODEX_CLI_BASH_GENERATED_STATE=0
+
+_nils_cli_codex_cli_load_generated_bash() {
+  if [[ "${_NILS_CODEX_CLI_BASH_GENERATED_STATE}" == "1" ]]; then
+    declare -F _nils_cli_codex_cli_generated >/dev/null 2>&1 && return 0
+    _NILS_CODEX_CLI_BASH_GENERATED_STATE=0
+  elif [[ "${_NILS_CODEX_CLI_BASH_GENERATED_STATE}" == "-1" ]]; then
+    return 1
+  fi
+
+  local script=''
+  script="$(command codex-cli completion bash 2>/dev/null)" || {
+    _NILS_CODEX_CLI_BASH_GENERATED_STATE=-1
+    return 1
+  }
+
+  script="${script//_codex-cli/_nils_cli_codex_cli_generated}"
+  script="$(printf '%s\n' "$script" | sed '/^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 /,/^fi$/d')" || {
+    _NILS_CODEX_CLI_BASH_GENERATED_STATE=-1
+    return 1
+  }
+
+  eval "$script" || {
+    _NILS_CODEX_CLI_BASH_GENERATED_STATE=-1
+    return 1
+  }
+
+  declare -F _nils_cli_codex_cli_generated >/dev/null 2>&1 || {
+    _NILS_CODEX_CLI_BASH_GENERATED_STATE=-1
+    return 1
+  }
+
+  _NILS_CODEX_CLI_BASH_GENERATED_STATE=1
+  return 0
+}
+
 _nils_cli_codex_cli_complete() {
+  if ! _nils_cli_codex_cli_load_generated_bash; then
+    COMPREPLY=()
+    return 0
+  fi
+
   local invoked_as="${COMP_WORDS[0]}"
   local -a words=("${COMP_WORDS[@]}")
   local cword="$COMP_CWORD"
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local prev="${COMP_WORDS[COMP_CWORD-1]}"
-
   local -a inject=()
   local implied_async=''
 
@@ -43,240 +83,32 @@ _nils_cli_codex_cli_complete() {
     cxct) inject=(config set) ;;
   esac
 
-  if [[ -n "$implied_async" ]] && ! _nils_cli__has_word --async "${words[@]}"; then
-    inject+=(--async)
-  fi
-
-  if (( ${#inject[@]} > 0 )); then
+  if [[ "$invoked_as" != "codex-cli" ]]; then
     words=( "codex-cli" "${inject[@]}" "${words[@]:1}" )
     cword=$((cword + ${#inject[@]}))
     cur="${words[cword]}"
     prev="${words[cword-1]}"
-  else
-    words[0]="codex-cli"
   fi
 
-  local -a root_cmds=(agent auth diag config starship help)
-  # Compatibility shim: provider-neutral groups move to agentctl.
-  local -a migrated_cmds=(provider debug workflow automation)
-  local -a root_opts=(-h --help -V --version)
-
-  if (( cword == 1 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
-      return 0
-    fi
-    COMPREPLY=( $(compgen -W "${root_cmds[*]} ${migrated_cmds[*]}" -- "$cur") )
-    return 0
+  if [[ -n "$implied_async" ]] && ! _nils_cli__has_word --async "${words[@]}"; then
+    local -a with_async=( "${words[@]:0:$cword}" "--async" "${words[@]:$cword}" )
+    words=( "${with_async[@]}" )
+    cword=$((cword + 1))
+    cur="${words[cword]}"
+    prev="${words[cword-1]}"
   fi
 
-  local cmd="${words[1]-}"
+  local -a saved_words=("${COMP_WORDS[@]}")
+  local saved_cword="$COMP_CWORD"
 
-  case "$cmd" in
-    agent)
-      local -a agent_cmds=(prompt advice knowledge commit)
-      if (( cword == 2 )); then
-        if [[ "$cur" == -* ]]; then
-          COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
-          return 0
-        fi
-        COMPREPLY=( $(compgen -W "${agent_cmds[*]}" -- "$cur") )
-        return 0
-      fi
-      local agent_cmd="${words[2]-}"
-      case "$agent_cmd" in
-        commit)
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "-h --help -p --push -a --auto-stage" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        prompt|advice|knowledge)
-          COMPREPLY=()
-          return 0
-          ;;
-      esac
-      ;;
-    auth)
-      local -a auth_cmds=(login use save refresh auto-refresh current sync)
-      if (( cword == 2 )); then
-        if [[ "$cur" == -* ]]; then
-          COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
-          return 0
-        fi
-        COMPREPLY=( $(compgen -W "${auth_cmds[*]}" -- "$cur") )
-        return 0
-      fi
-      local auth_cmd="${words[2]-}"
-      case "$auth_cmd" in
-        login)
-          if [[ "$prev" == "--format" ]]; then
-            COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "-h --help --format --json --api-key --device-code" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        refresh)
-          if [[ "$prev" == "--format" ]]; then
-            COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "-h --help --format --json" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=( $(compgen -f -- "$cur") )
-          return 0
-          ;;
-        save)
-          if [[ "$prev" == "--format" ]]; then
-            COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "-h --help --format --json -y --yes" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=( $(compgen -f -- "$cur") )
-          return 0
-          ;;
-        use)
-          if [[ "$prev" == "--format" ]]; then
-            COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "-h --help --format --json" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        auto-refresh|current|sync)
-          if [[ "$prev" == "--format" ]]; then
-            COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "-h --help --format --json" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-      esac
-      ;;
-    diag)
-      local -a diag_cmds=(rate-limits)
-      if (( cword == 2 )); then
-        if [[ "$cur" == -* ]]; then
-          COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
-          return 0
-        fi
-        COMPREPLY=( $(compgen -W "${diag_cmds[*]}" -- "$cur") )
-        return 0
-      fi
-      local diag_cmd="${words[2]-}"
-      case "$diag_cmd" in
-        rate-limits)
-          if [[ "$prev" == "--jobs" ]]; then
-            COMPREPLY=()
-            return 0
-          fi
-          if [[ "$prev" == "--format" ]]; then
-            COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "-h --help -c -d --debug --cached --async --all --format --json --one-line --no-refresh-auth --jobs" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=( $(compgen -f -- "$cur") )
-          return 0
-          ;;
-      esac
-      ;;
-    config)
-      local -a config_cmds=(show set)
-      if (( cword == 2 )); then
-        if [[ "$cur" == -* ]]; then
-          COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
-          return 0
-        fi
-        COMPREPLY=( $(compgen -W "${config_cmds[*]}" -- "$cur") )
-        return 0
-      fi
-      local config_cmd="${words[2]-}"
-      case "$config_cmd" in
-        show)
-          COMPREPLY=()
-          return 0
-          ;;
-        set)
-          local -a config_keys=(
-            model
-            reasoning
-            reason
-            dangerous
-            allow-dangerous
-            CODEX_CLI_MODEL
-            CODEX_CLI_REASONING
-            CODEX_ALLOW_DANGEROUS_ENABLED
-          )
-          if (( cword == 3 )); then
-            COMPREPLY=( $(compgen -W "${config_keys[*]}" -- "$cur") )
-            return 0
-          fi
-          if (( cword == 4 )); then
-            local key="${words[3]-}"
-            case "$key" in
-              dangerous|allow-dangerous|CODEX_ALLOW_DANGEROUS_ENABLED)
-                COMPREPLY=( $(compgen -W "true false" -- "$cur") )
-                return 0
-                ;;
-            esac
-            COMPREPLY=()
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-      esac
-      ;;
-    starship)
-      if [[ "$prev" == "--ttl" || "$prev" == "--time-format" ]]; then
-        COMPREPLY=()
-        return 0
-      fi
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --no-5h --ttl --time-format --show-timezone --refresh --is-enabled" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    provider|debug|workflow|automation)
-      if (( cword == 2 )); then
-        COMPREPLY=( $(compgen -W "agentctl" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    help)
-      COMPREPLY=()
-      return 0
-      ;;
-  esac
+  COMP_WORDS=("${words[@]}")
+  COMP_CWORD="$cword"
+  _nils_cli_codex_cli_generated "codex-cli" "$cur" "$prev"
+  local rc=$?
 
-  COMPREPLY=()
+  COMP_WORDS=("${saved_words[@]}")
+  COMP_CWORD="$saved_cword"
+  return $rc
 }
 
 complete -F _nils_cli_codex_cli_complete \

--- a/completions/zsh/_codex-cli
+++ b/completions/zsh/_codex-cli
@@ -2,450 +2,122 @@
 #  cxgp cxga cxgk cxgc cxau cxar cxaa cxac cxas cxst cxdr cxdra \
 #  cxcs cxct
 
-_codex-cli() {
-  emulate -L zsh -o extendedglob
+typeset -gi _NILS_CODEX_CLI_ZSH_GENERATED_STATE=0
 
-  local context='' state='' state_descr=''
-  local -a line=()
-  typeset -A opt_args=()
+_nils_cli_codex_cli_load_generated_zsh() {
+  if [[ "${_NILS_CODEX_CLI_ZSH_GENERATED_STATE}" == "1" ]]; then
+    (( $+functions[_nils_cli_codex_cli_generated] )) && return 0
+    _NILS_CODEX_CLI_ZSH_GENERATED_STATE=0
+  elif [[ "${_NILS_CODEX_CLI_ZSH_GENERATED_STATE}" == "-1" ]]; then
+    return 1
+  fi
 
-  local -i orig_current="$CURRENT"
-  local -a orig_words=("${words[@]}")
+  local script=''
+  script="$(command codex-cli completion zsh 2>/dev/null)" || {
+    _NILS_CODEX_CLI_ZSH_GENERATED_STATE=-1
+    return 1
+  }
 
-  local invoked_as="${orig_words[1]-}"
-  local subcmd_override=''
-  local subcmd2_override=''
+  script="${script//_codex-cli/_nils_cli_codex_cli_generated}"
+  script="$(printf '%s\n' "$script" | sed '/^if \[ "\$funcstack\[1\]" = "_nils_cli_codex_cli_generated" \]; then$/,/^fi$/d')" || {
+    _NILS_CODEX_CLI_ZSH_GENERATED_STATE=-1
+    return 1
+  }
+
+  eval "$script" || {
+    _NILS_CODEX_CLI_ZSH_GENERATED_STATE=-1
+    return 1
+  }
+
+  if (( ! $+functions[_nils_cli_codex_cli_generated] )); then
+    _NILS_CODEX_CLI_ZSH_GENERATED_STATE=-1
+    return 1
+  fi
+
+  _NILS_CODEX_CLI_ZSH_GENERATED_STATE=1
+  return 0
+}
+
+_nils_cli_codex_cli_apply_alias_rewrite_zsh() {
+  local invoked_as="${words[1]-}"
+  local -a inject=()
   local implied_async=''
 
   case "$invoked_as" in
-    cxau)
-      subcmd_override='auth'
-      subcmd2_override='use'
-      ;;
-    cxar)
-      subcmd_override='auth'
-      subcmd2_override='refresh'
-      ;;
-    cxaa)
-      subcmd_override='auth'
-      subcmd2_override='auto-refresh'
-      ;;
-    cxdr)
-      subcmd_override='diag'
-      subcmd2_override='rate-limits'
-      ;;
-    cxdra)
-      subcmd_override='diag'
-      subcmd2_override='rate-limits'
-      implied_async='1'
-      ;;
-    cxst)
-      subcmd_override='starship'
-      ;;
-    cxgp)
-      subcmd_override='agent'
-      subcmd2_override='prompt'
-      ;;
-    cxga)
-      subcmd_override='agent'
-      subcmd2_override='advice'
-      ;;
-    cxgk)
-      subcmd_override='agent'
-      subcmd2_override='knowledge'
-      ;;
-    cxgc)
-      subcmd_override='agent'
-      subcmd2_override='commit'
-      ;;
-    cxac)
-      subcmd_override='auth'
-      subcmd2_override='current'
-      ;;
-    cxas)
-      subcmd_override='auth'
-      subcmd2_override='sync'
-      ;;
-    cxcs)
-      subcmd_override='config'
-      subcmd2_override='show'
-      ;;
-    cxct)
-      subcmd_override='config'
-      subcmd2_override='set'
-      ;;
+    cxau) inject=(auth use) ;;
+    cxar) inject=(auth refresh) ;;
+    cxaa) inject=(auth auto-refresh) ;;
+    cxdr) inject=(diag rate-limits) ;;
+    cxdra) inject=(diag rate-limits); implied_async='1' ;;
+    cxst) inject=(starship) ;;
+    cxgp) inject=(agent prompt) ;;
+    cxga) inject=(agent advice) ;;
+    cxgk) inject=(agent knowledge) ;;
+    cxgc) inject=(agent commit) ;;
+    cxac) inject=(auth current) ;;
+    cxas) inject=(auth sync) ;;
+    cxcs) inject=(config show) ;;
+    cxct) inject=(config set) ;;
   esac
+
+  if [[ "$invoked_as" != "codex-cli" ]]; then
+    local -a rewritten_words=('codex-cli')
+    local token=''
+    local -i idx=2
+
+    for token in "${inject[@]}"; do
+      rewritten_words+=("$token")
+    done
+
+    while (( idx <= ${#words[@]} )); do
+      rewritten_words+=("${words[idx]}")
+      (( idx++ ))
+    done
+
+    words=("${rewritten_words[@]}")
+    (( CURRENT += ${#inject[@]} ))
+  fi
 
   if [[ -n "$implied_async" && " ${words[*]-} " != *" --async "* ]]; then
-    local -a injected_words=()
-    injected_words=(
-      "${words[@]:0:$((CURRENT-1))}"
-      "--async"
-      "${words[@]:$((CURRENT-1))}"
-    )
-    words=("${injected_words[@]}")
+    local -a async_words=()
+    local -i idx=1
+
+    while (( idx < CURRENT )); do
+      async_words+=("${words[idx]}")
+      (( idx++ ))
+    done
+
+    async_words+=("--async")
+
+    while (( idx <= ${#words[@]} )); do
+      async_words+=("${words[idx]}")
+      (( idx++ ))
+    done
+
+    words=("${async_words[@]}")
     (( CURRENT++ ))
   fi
+}
 
-  local -a subcommands=()
-  subcommands=(
-    'agent:Prompts and skill wrappers'
-    'auth:Auth and secrets'
-    'diag:Diagnostics'
-    'config:Configuration'
-    'starship:Starship integration'
-    'provider:Provider-neutral migration (use agentctl provider)'
-    'debug:Provider-neutral migration (use agentctl debug)'
-    'workflow:Provider-neutral migration (use agentctl workflow)'
-    'automation:Provider-neutral migration (use agentctl automation)'
-    'help:Display help message'
-  )
+_codex-cli() {
+  emulate -L zsh -o extendedglob
 
-  local subcmd=''
-  local subcmd2=''
+  local -i saved_current="$CURRENT"
+  local -a saved_words=("${words[@]}")
 
-  if [[ -n "$subcmd_override" ]]; then
-    subcmd="$subcmd_override"
-    subcmd2="$subcmd2_override"
-  else
-    _arguments -C \
-      '(-h --help)'{-h,--help}'[Show help]' \
-      '(-V --version)'{-V,--version}'[Show version]' \
-      '1:command:->subcmds' \
-      '*::arg:->args'
-
-    case "${state-}" in
-      subcmds)
-        _describe -t commands 'codex-cli subcommand' subcommands && return 0
-        ;;
-      args)
-        subcmd="${line[1]:-${orig_words[2]-}}"
-        subcmd="${subcmd%%[[:space:]]#}"
-        ;;
-    esac
+  if ! _nils_cli_codex_cli_load_generated_zsh; then
+    words=("${saved_words[@]}")
+    CURRENT="$saved_current"
+    return 1
   fi
 
-  case "$subcmd" in
-    agent)
-      local -a agent_cmds=()
-      agent_cmds=(
-        'prompt:Run a raw prompt'
-        'advice:Get actionable engineering advice'
-        'knowledge:Get an explanation for a concept'
-        'commit:Run the semantic-commit workflow'
-      )
+  _nils_cli_codex_cli_apply_alias_rewrite_zsh
+  _nils_cli_codex_cli_generated
+  local rc=$?
 
-      if [[ -z "$subcmd2" ]]; then
-        _arguments -C \
-          '(-h --help)'{-h,--help}'[Show help]' \
-          '1:agent command:->agent_subcmds' \
-          '*::arg:->agent_args'
-
-        case "${state-}" in
-          agent_subcmds)
-            _describe -t commands 'codex-cli agent' agent_cmds && return 0
-            ;;
-          agent_args)
-            subcmd2="${line[1]:-${orig_words[3]-}}"
-            subcmd2="${subcmd2%%[[:space:]]#}"
-            ;;
-        esac
-      fi
-
-      case "$subcmd2" in
-        prompt)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '*:prompt text:' \
-            && return 0
-          ;;
-        advice)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '*:question:' \
-            && return 0
-          ;;
-        knowledge)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '*:concept:' \
-            && return 0
-          ;;
-        commit)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '(-p --push)'{-p,--push}'[Push after committing]' \
-            '(-a --auto-stage)'{-a,--auto-stage}'[Autostage changes before committing]' \
-            '*:extra prompt:' \
-            && return 0
-          ;;
-        '')
-          _message 'agent command (prompt|advice|knowledge|commit)'
-          return 0
-          ;;
-        *)
-          _message 'unknown agent command'
-          return 0
-          ;;
-      esac
-      ;;
-    auth)
-      local -a auth_cmds=()
-      auth_cmds=(
-        'login:Login with ChatGPT (browser/device-code) or API key'
-        'use:Switch to a secret by name or email'
-        'save:Save CODEX_AUTH_FILE into CODEX_SECRET_DIR'
-        'remove:Remove SECRET_JSON from CODEX_SECRET_DIR'
-        'refresh:Refresh OAuth tokens'
-        'auto-refresh:Refresh stale tokens across auth + secrets'
-        'current:Show which secret matches CODEX_AUTH_FILE'
-        'sync:Sync CODEX_AUTH_FILE back into matching secrets'
-      )
-
-      if [[ -z "$subcmd2" ]]; then
-        _arguments -C \
-          '(-h --help)'{-h,--help}'[Show help]' \
-          '1:auth command:->auth_subcmds' \
-          '*::arg:->auth_args'
-
-        case "${state-}" in
-          auth_subcmds)
-            _describe -t commands 'codex-cli auth' auth_cmds && return 0
-            ;;
-          auth_args)
-            subcmd2="${line[1]:-${orig_words[3]-}}"
-            subcmd2="${subcmd2%%[[:space:]]#}"
-            ;;
-        esac
-      fi
-
-      case "$subcmd2" in
-        login)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--format=[Output format (text or json)]:format:(text json)' \
-            '--json[Output machine-readable JSON]' \
-            '--api-key[Use API key login flow]' \
-            '--device-code[Use ChatGPT device-code login flow]' \
-            && return 0
-          _message 'no additional arguments'
-          return 0
-          ;;
-        use)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--format=[Output format (text or json)]:format:(text json)' \
-            '--json[Output machine-readable JSON]' \
-            '1:profile or email:' \
-            && return 0
-          ;;
-        save)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--format=[Output format (text or json)]:format:(text json)' \
-            '--json[Output machine-readable JSON]' \
-            '(-y --yes)--yes[Overwrite target file without prompt]' \
-            '(--yes -y)-y[Overwrite target file without prompt]' \
-            '1:secret file name:' \
-            && return 0
-          ;;
-        remove)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--format=[Output format (text or json)]:format:(text json)' \
-            '--json[Output machine-readable JSON]' \
-            '(-y --yes)--yes[Remove target file without prompt]' \
-            '(--yes -y)-y[Remove target file without prompt]' \
-            '1:secret file name:' \
-            && return 0
-          ;;
-        refresh)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--format=[Output format (text or json)]:format:(text json)' \
-            '--json[Output machine-readable JSON]' \
-            '*:secret file:_files' \
-            && return 0
-          ;;
-        auto-refresh|current|sync)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--format=[Output format (text or json)]:format:(text json)' \
-            '--json[Output machine-readable JSON]' \
-            && return 0
-          _message 'no additional arguments'
-          return 0
-          ;;
-        '')
-          _message 'auth command (login|use|save|remove|refresh|auto-refresh|current|sync)'
-          return 0
-          ;;
-        *)
-          _message 'unknown auth command'
-          return 0
-          ;;
-      esac
-      ;;
-    diag)
-      local -a diag_cmds=()
-      diag_cmds=(
-        'rate-limits:Rate-limits diagnostics'
-      )
-
-      if [[ -z "$subcmd2" ]]; then
-        _arguments -C \
-          '(-h --help)'{-h,--help}'[Show help]' \
-          '1:diag command:->diag_subcmds' \
-          '*::arg:->diag_args'
-
-        case "${state-}" in
-          diag_subcmds)
-            _describe -t commands 'codex-cli diag' diag_cmds && return 0
-            ;;
-          diag_args)
-            subcmd2="${line[1]:-${orig_words[3]-}}"
-            subcmd2="${subcmd2%%[[:space:]]#}"
-            ;;
-        esac
-      fi
-
-      case "$subcmd2" in
-        rate-limits)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '(-c)-c[Clear starship cache before querying]' \
-            '(-d --debug)'{-d,--debug}'[Debug output]' \
-            '--cached[Cached mode (no network)]' \
-            '--async[Concurrent all-secrets mode]' \
-            '--all[Query all secrets under CODEX_SECRET_DIR]' \
-            '--format=[Output format (text or json)]:format:(text json)' \
-            '--json[Output raw JSON]' \
-            '--one-line[Output a one-line summary]' \
-            '--no-refresh-auth[Disable refresh-on-401 behavior]' \
-            '--jobs=[Max concurrent jobs (async mode)]:jobs:' \
-            '1::secret.json:' \
-            && return 0
-          ;;
-        '')
-          _message 'diag command (rate-limits)'
-          return 0
-          ;;
-        *)
-          _message 'unknown diag command'
-          return 0
-          ;;
-      esac
-      ;;
-    config)
-      local -a config_cmds=()
-      config_cmds=(
-        'show:Show current configuration'
-        'set:Set configuration value (current shell only)'
-      )
-
-      if [[ -z "$subcmd2" ]]; then
-        _arguments -C \
-          '(-h --help)'{-h,--help}'[Show help]' \
-          '1:config command:->config_subcmds' \
-          '*::arg:->config_args'
-
-        case "${state-}" in
-          config_subcmds)
-            _describe -t commands 'codex-cli config' config_cmds && return 0
-            ;;
-          config_args)
-            subcmd2="${line[1]:-${orig_words[3]-}}"
-            subcmd2="${subcmd2%%[[:space:]]#}"
-            ;;
-        esac
-      fi
-
-      case "$subcmd2" in
-        show)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            && return 0
-          _message 'no additional arguments'
-          return 0
-          ;;
-        set)
-          local -a config_keys=()
-          config_keys=(
-            'model:Alias for CODEX_CLI_MODEL'
-            'reasoning:Alias for CODEX_CLI_REASONING'
-            'reason:Alias for CODEX_CLI_REASONING'
-            'dangerous:Alias for CODEX_ALLOW_DANGEROUS_ENABLED'
-            'allow-dangerous:Alias for CODEX_ALLOW_DANGEROUS_ENABLED'
-            'CODEX_CLI_MODEL:Model env var'
-            'CODEX_CLI_REASONING:Reasoning env var'
-            'CODEX_ALLOW_DANGEROUS_ENABLED:Dangerous-mode env var'
-          )
-
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '1:key:->config_keys' \
-            '2:value:->config_values'
-
-          case "${state-}" in
-            config_keys)
-              _describe -t values 'config key' config_keys && return 0
-              ;;
-            config_values)
-              local key="${line[1]:-${orig_words[4]-}}"
-              if [[ -z "$key" ]]; then
-                key="${orig_words[2]-}"
-              fi
-              case "$key" in
-                dangerous|allow-dangerous|CODEX_ALLOW_DANGEROUS_ENABLED)
-                  _describe -t values 'value' \
-                    'true:Enable dangerous mode' \
-                    'false:Disable dangerous mode' \
-                    && return 0
-                  ;;
-              esac
-              _message 'value'
-              return 0
-              ;;
-          esac
-          ;;
-        '')
-          _message 'config command (show|set)'
-          return 0
-          ;;
-        *)
-          _message 'unknown config command'
-          return 0
-          ;;
-      esac
-      ;;
-    starship)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Show help]' \
-        '--no-5h[Hide the 5h window output]' \
-        '--ttl=[Cache TTL]:duration:' \
-        '--time-format=[Reset time format (local time)]:strftime:' \
-        '--show-timezone[Show timezone offset in default reset time display]' \
-        '--refresh[Force a blocking refresh]' \
-        '--is-enabled[Exit 0 if starship is enabled]' \
-        && return 0
-      ;;
-    provider|debug|workflow|automation)
-      _message "codex-cli migration: use agentctl $subcmd for provider-neutral orchestration"
-      return 0
-      ;;
-    help)
-      _message 'no additional arguments'
-      return 0
-      ;;
-    '')
-      _message 'command (agent|auth|diag|config|starship|help; provider/debug/workflow/automation -> agentctl)'
-      return 0
-      ;;
-    *)
-      _message 'unknown command'
-      return 0
-      ;;
-  esac
+  words=("${saved_words[@]}")
+  CURRENT="$saved_current"
+  return $rc
 }
 
 compdef _codex-cli \

--- a/crates/codex-cli/Cargo.toml
+++ b/crates/codex-cli/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = { workspace = true }
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/codex-cli/src/cli.rs
+++ b/crates/codex-cli/src/cli.rs
@@ -23,6 +23,8 @@ pub enum Command {
     Config(ConfigArgs),
     /// Starship integration command group
     Starship(StarshipArgs),
+    /// Export shell completion script
+    Completion(CompletionArgs),
 }
 
 #[derive(Args)]
@@ -70,7 +72,9 @@ pub struct AuthArgs {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub enum OutputFormat {
+    #[value(name = "text")]
     Text,
+    #[value(name = "json")]
     Json,
 }
 
@@ -107,7 +111,7 @@ pub enum AuthCommand {
     Use {
         #[command(flatten)]
         output: OutputModeArgs,
-        #[arg(value_name = "target", num_args = 0..)]
+        #[arg(id = "target", value_name = "target", num_args = 0..)]
         args: Vec<String>,
     },
     /// Save active CODEX_AUTH_FILE into CODEX_SECRET_DIR as SECRET_JSON
@@ -117,7 +121,7 @@ pub enum AuthCommand {
         /// Overwrite target file if it already exists (non-interactive)
         #[arg(short = 'y', long = "yes")]
         yes: bool,
-        #[arg(value_name = "secret", num_args = 0..)]
+        #[arg(id = "secret", value_name = "secret", num_args = 0..)]
         args: Vec<String>,
     },
     /// Remove SECRET_JSON from CODEX_SECRET_DIR
@@ -127,14 +131,14 @@ pub enum AuthCommand {
         /// Remove target file without prompt (non-interactive)
         #[arg(short = 'y', long = "yes")]
         yes: bool,
-        #[arg(value_name = "secret", num_args = 0..)]
+        #[arg(id = "secret", value_name = "secret", num_args = 0..)]
         args: Vec<String>,
     },
     /// Refresh OAuth tokens
     Refresh {
         #[command(flatten)]
         output: OutputModeArgs,
-        #[arg(value_name = "secret", num_args = 0..)]
+        #[arg(id = "secret", value_name = "secret", num_args = 0..)]
         args: Vec<String>,
     },
     /// Refresh stale tokens across auth + secrets
@@ -236,4 +240,17 @@ pub struct StarshipArgs {
     /// Exit 0 if starship is enabled
     #[arg(long = "is-enabled")]
     pub is_enabled: bool,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum CompletionShell {
+    Bash,
+    Zsh,
+}
+
+#[derive(Args)]
+pub struct CompletionArgs {
+    /// Shell to generate completion script for
+    #[arg(value_enum, value_name = "shell")]
+    pub shell: CompletionShell,
 }

--- a/crates/codex-cli/src/completion/mod.rs
+++ b/crates/codex-cli/src/completion/mod.rs
@@ -1,0 +1,17 @@
+use clap::CommandFactory;
+use clap_complete::{Generator, Shell, generate};
+use std::io;
+
+pub fn run(shell: crate::cli::CompletionShell) -> i32 {
+    match shell {
+        crate::cli::CompletionShell::Bash => generate_script(Shell::Bash),
+        crate::cli::CompletionShell::Zsh => generate_script(Shell::Zsh),
+    }
+}
+
+fn generate_script<G: Generator>(generator: G) -> i32 {
+    let mut command = crate::cli::Cli::command();
+    let bin_name = command.get_name().to_string();
+    generate(generator, &mut command, bin_name, &mut io::stdout());
+    0
+}

--- a/crates/codex-cli/src/main.rs
+++ b/crates/codex-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod completion;
 
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser};
@@ -43,6 +44,7 @@ fn run() -> i32 {
             cli::Command::Diag(args) => handle_diag(&args),
             cli::Command::Config(args) => handle_config(&args),
             cli::Command::Starship(args) => handle_starship(&args),
+            cli::Command::Completion(args) => handle_completion(&args),
         },
         None => {
             let mut cmd = cli::Cli::command();
@@ -165,6 +167,10 @@ fn handle_starship(args: &cli::StarshipArgs) -> i32 {
         is_enabled: args.is_enabled,
     };
     codex_cli::starship::run(&options)
+}
+
+fn handle_completion(args: &cli::CompletionArgs) -> i32 {
+    completion::run(args.shell)
 }
 
 fn print_subcommand_help(name: &str) -> i32 {

--- a/crates/codex-cli/tests/completion_contract.rs
+++ b/crates/codex-cli/tests/completion_contract.rs
@@ -1,0 +1,88 @@
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use pretty_assertions::assert_eq;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+fn codex_cli_bin() -> PathBuf {
+    bin::resolve("codex-cli")
+}
+
+fn run(args: &[&str]) -> CmdOutput {
+    let bin = codex_cli_bin();
+    cmd::run(&bin, args, &[], None)
+}
+
+fn completion_zsh() -> &'static str {
+    static OUTPUT: OnceLock<String> = OnceLock::new();
+    OUTPUT
+        .get_or_init(|| {
+            let output = run(&["completion", "zsh"]);
+            assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+            output.stdout_text()
+        })
+        .as_str()
+}
+
+fn assert_contains_all(haystack: &str, needles: &[&str]) {
+    for needle in needles {
+        assert!(
+            haystack.contains(needle),
+            "missing completion contract token: {needle}"
+        );
+    }
+}
+
+#[test]
+fn completion_contract_includes_top_level_command_families() {
+    let script = completion_zsh();
+    assert_contains_all(
+        script,
+        &[
+            "'agent:Agent command group' \\",
+            "'auth:Authentication command group' \\",
+            "'diag:Diagnostics command group' \\",
+            "'config:Configuration command group' \\",
+            "'starship:Starship integration command group' \\",
+        ],
+    );
+}
+
+#[test]
+fn completion_contract_is_context_aware_across_command_families() {
+    let script = completion_zsh();
+    assert_contains_all(
+        script,
+        &[
+            "curcontext=\"${curcontext%:*:*}:codex-cli-agent-command-$line[1]:\"",
+            "curcontext=\"${curcontext%:*:*}:codex-cli-auth-command-$line[1]:\"",
+            "curcontext=\"${curcontext%:*:*}:codex-cli-diag-command-$line[1]:\"",
+            "curcontext=\"${curcontext%:*:*}:codex-cli-config-command-$line[1]:\"",
+            "'--api-key[Use API key login flow]' \\",
+            "'--cached[Cached mode (no network)]' \\",
+            "':key:_default' \\",
+            "':value:_default' \\",
+            "'--time-format=[Reset time format (local time)]:TIME_FORMAT:_default' \\",
+            "'*::target:_default' \\",
+            "'*::secret:_default' \\",
+        ],
+    );
+}
+
+#[test]
+fn completion_contract_format_values_include_text_and_json() {
+    let script = completion_zsh();
+    let format_candidates = script.match_indices(":format:(text json)'").count();
+    assert!(
+        format_candidates >= 2,
+        "expected at least 2 format candidate entries, got {format_candidates}"
+    );
+    assert_contains_all(
+        script,
+        &[
+            "'--format=[Output format (\\`text\\` or \\`json\\`)]:format:(text json)' \\",
+            "'(--format)--json[Output machine-readable JSON]' \\",
+            "'(--format)--json[Output raw JSON]' \\",
+        ],
+    );
+}

--- a/crates/codex-cli/tests/completion_smoke.rs
+++ b/crates/codex-cli/tests/completion_smoke.rs
@@ -1,0 +1,147 @@
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use pretty_assertions::assert_eq;
+use std::path::PathBuf;
+
+fn codex_cli_bin() -> PathBuf {
+    bin::resolve("codex-cli")
+}
+
+fn run(args: &[&str]) -> CmdOutput {
+    let bin = codex_cli_bin();
+    cmd::run(&bin, args, &[], None)
+}
+
+fn stdout(output: &CmdOutput) -> String {
+    output.stdout_text()
+}
+
+fn assert_exit(output: &CmdOutput, code: i32) {
+    assert_eq!(output.code, code, "stderr: {}", output.stderr_text());
+}
+
+fn contains_token(space_delimited: &str, token: &str) -> bool {
+    space_delimited
+        .split_whitespace()
+        .any(|candidate| candidate == token)
+}
+
+fn bash_case_opts(script: &str, label: &str) -> String {
+    let case_marker = format!("{label})");
+    let mut in_case = false;
+
+    for line in script.lines() {
+        let trimmed = line.trim();
+        if trimmed == case_marker {
+            in_case = true;
+            continue;
+        }
+
+        if !in_case {
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("opts=\"") {
+            let end = rest
+                .find('"')
+                .unwrap_or_else(|| panic!("missing closing quote for opts in case {label}"));
+            return rest[..end].to_string();
+        }
+
+        if trimmed.ends_with(")") {
+            break;
+        }
+    }
+
+    panic!("missing bash opts case: {label}");
+}
+
+#[test]
+fn completion_export_is_stable_across_repeated_runs() {
+    let zsh_first = run(&["completion", "zsh"]);
+    assert_exit(&zsh_first, 0);
+    let zsh_second = run(&["completion", "zsh"]);
+    assert_exit(&zsh_second, 0);
+    assert_eq!(zsh_first.stdout, zsh_second.stdout);
+    assert_eq!(zsh_first.stderr, zsh_second.stderr);
+
+    let bash_first = run(&["completion", "bash"]);
+    assert_exit(&bash_first, 0);
+    let bash_second = run(&["completion", "bash"]);
+    assert_exit(&bash_second, 0);
+    assert_eq!(bash_first.stdout, bash_second.stdout);
+    assert_eq!(bash_first.stderr, bash_second.stderr);
+}
+
+#[test]
+fn completion_bash_candidates_remain_context_aware() {
+    let output = run(&["completion", "bash"]);
+    assert_exit(&output, 0);
+    let script = stdout(&output);
+
+    let root_opts = bash_case_opts(&script, "codex__cli");
+    for token in [
+        "agent",
+        "auth",
+        "diag",
+        "config",
+        "starship",
+        "completion",
+        "help",
+    ] {
+        assert!(
+            contains_token(&root_opts, token),
+            "missing root token: {token}"
+        );
+    }
+    for token in [
+        "login",
+        "rate-limits",
+        "--api-key",
+        "--cached",
+        "provider",
+        "workflow",
+    ] {
+        assert!(
+            !contains_token(&root_opts, token),
+            "unexpected root token: {token}"
+        );
+    }
+
+    let completion_opts = bash_case_opts(&script, "codex__cli__completion");
+    assert_eq!(completion_opts, "-h --help bash zsh");
+    for token in ["agent", "auth", "--api-key", "--cached"] {
+        assert!(
+            !contains_token(&completion_opts, token),
+            "completion command should not include token: {token}"
+        );
+    }
+
+    let auth_login_opts = bash_case_opts(&script, "codex__cli__auth__login");
+    for token in ["--format", "--json", "--api-key", "--device-code"] {
+        assert!(
+            contains_token(&auth_login_opts, token),
+            "missing auth login token: {token}"
+        );
+    }
+    for token in ["--cached", "--jobs", "--all"] {
+        assert!(
+            !contains_token(&auth_login_opts, token),
+            "unexpected auth login token: {token}"
+        );
+    }
+
+    let diag_rate_limits_opts = bash_case_opts(&script, "codex__cli__diag__rate__limits");
+    for token in ["--cached", "--async", "--jobs", "--format", "--json"] {
+        assert!(
+            contains_token(&diag_rate_limits_opts, token),
+            "missing diag token: {token}"
+        );
+    }
+    for token in ["--api-key", "--device-code"] {
+        assert!(
+            !contains_token(&diag_rate_limits_opts, token),
+            "unexpected diag token: {token}"
+        );
+    }
+}

--- a/crates/codex-cli/tests/main_entrypoint.rs
+++ b/crates/codex-cli/tests/main_entrypoint.rs
@@ -108,3 +108,39 @@ fn main_help_includes_json_output_modes_for_diag_and_auth() {
     assert!(auth_text.contains("--json"));
     assert!(auth_text.contains("--format"));
 }
+
+#[test]
+fn main_help_includes_completion_export_entrypoint() {
+    let output = run(&["--help"]);
+    assert_exit(&output, 0);
+    let help = stdout(&output);
+    assert!(help.contains("completion"));
+    assert!(help.contains("Export shell completion script"));
+}
+
+#[test]
+fn main_completion_exports_bash_and_zsh_scripts() {
+    let zsh = run(&["completion", "zsh"]);
+    assert_exit(&zsh, 0);
+    let zsh_text = stdout(&zsh);
+    assert!(zsh_text.contains("#compdef codex-cli"));
+    assert!(zsh_text.contains("completion:Export shell completion script"));
+    assert!(zsh_text.contains(":shell -- Shell to generate completion script for:(bash zsh)"));
+
+    let bash = run(&["completion", "bash"]);
+    assert_exit(&bash, 0);
+    let bash_text = stdout(&bash);
+    assert!(bash_text.contains("_codex-cli()"));
+    assert!(bash_text.contains("complete -F _codex-cli"));
+    assert!(bash_text.contains("opts=\"-h --help bash zsh\""));
+}
+
+#[test]
+fn main_completion_rejects_unknown_shell_with_usage_error() {
+    let output = run(&["completion", "fish"]);
+    assert_exit(&output, 64);
+    let err = stderr(&output);
+    assert!(err.contains("invalid value"));
+    assert!(err.contains("bash"));
+    assert!(err.contains("zsh"));
+}

--- a/docs/plans/repo-completion-standard-rollout-plan.md
+++ b/docs/plans/repo-completion-standard-rollout-plan.md
@@ -8,7 +8,7 @@ This plan establishes a workspace-wide completion development standard, register
 - In scope: Implement `codex-cli` clap-first completion export flow and migrate its zsh/bash completion adapters.
 - In scope: Complete the same completion architecture for all remaining user-facing CLIs that require shipped completions.
 - In scope: Add missing `image-processing` completion assets and tests if classified as completion-required.
-- In scope: Expand completion validation, rollout runbooks, and rollback controls.
+- In scope: Expand completion validation, rollout runbooks, and no-legacy enforcement controls.
 - Out of scope: Fish/PowerShell completion support.
 - Out of scope: Behavioral changes to command execution semantics, output schemas, or exit-code contracts.
 - Out of scope: Migrating `cli-template` into a user-facing release contract.
@@ -16,7 +16,7 @@ This plan establishes a workspace-wide completion development standard, register
 ## Assumptions (if any)
 1. Completion-required binaries are all workspace binaries except explicitly internal/example binaries (initially `cli-template`).
 2. Each completion-required CLI can expose a user-facing completion export command (for example `completion <shell>`).
-3. Per-CLI legacy fallback gates (for emergency rollback) are acceptable during staged migration.
+3. Completion adapters remain thin and completion behavior is clap-generated (no legacy completion-mode switch).
 4. Completion files remain distributed under `completions/zsh/` and `completions/bash/`, with aliases synchronized in both shells.
 
 ## Sprint 1: Governance and Coverage Baseline
@@ -49,15 +49,15 @@ This plan establishes a workspace-wide completion development standard, register
 - **Location**:
   - `docs/runbooks/cli-completion-development-standard.md` (new)
   - `docs/runbooks/new-cli-crate-development-standard.md`
-- **Description**: Define canonical completion architecture and rules: clap-first completion contract, shell adapter responsibilities, alias sync policy, fallback controls, context-aware candidate requirements, test gates, and release expectations.
+- **Description**: Define canonical completion architecture and rules: clap-first completion contract, shell adapter responsibilities, alias sync policy, no-legacy enforcement controls, context-aware candidate requirements, test gates, and release expectations.
 - **Dependencies**:
   - Task 1.1
 - **Complexity**: 6
 - **Acceptance criteria**:
-  - Runbook includes required sections: architecture, contract boundaries, fallback policy, testing requirements, and rollout checklist.
+  - Runbook includes required sections: architecture, contract boundaries, no-legacy policy, testing requirements, and rollout checklist.
   - New-CLI runbook references the completion standard as required guidance for future crates.
 - **Validation**:
-  - `rg -n "clap|clap_complete|adapter|fallback|aliases|context|testing|rollback" docs/runbooks/cli-completion-development-standard.md`
+  - `rg -n "clap|clap_complete|adapter|no-legacy|aliases|context|testing" docs/runbooks/cli-completion-development-standard.md`
   - `rg -n "cli-completion-development-standard" docs/runbooks/new-cli-crate-development-standard.md`
 
 ### Task 1.3: Register completion standard in project agent-docs policy
@@ -95,7 +95,7 @@ This plan establishes a workspace-wide completion development standard, register
 **Demo/Validation**:
 - Command(s): `cargo test -p nils-codex-cli`
 - Command(s): `zsh -f tests/zsh/completion.test.zsh`
-- Verify: `codex-cli` completion is clap-first, context-aware (not global candidate dumps), aliases preserve behavior, and fallback mode is testable.
+- Verify: `codex-cli` completion is clap-first, context-aware (not global candidate dumps), aliases preserve behavior, and no legacy-mode gate remains.
 
 ### Task 2.1: Add `completion <shell>` export path for codex-cli
 - **Location**:
@@ -133,33 +133,33 @@ This plan establishes a workspace-wide completion development standard, register
   - `cargo test -p nils-codex-cli completion_contract`
   - `cargo run -p nils-codex-cli --bin codex-cli -- completion zsh | rg -q -- "--format"`
 
-### Task 2.3: Convert codex-cli zsh/bash files to thin adapters with rollback gate
+### Task 2.3: Convert codex-cli zsh/bash files to thin adapters (no legacy gate)
 - **Location**:
   - `completions/zsh/_codex-cli`
   - `completions/bash/codex-cli`
   - `completions/zsh/aliases.zsh`
   - `completions/bash/aliases.bash`
-- **Description**: Replace hardcoded completion matrices with clap-generated assets, preserve alias injection semantics (`cx*`, `cxdra`), and keep `CODEX_CLI_COMPLETION_MODE=legacy` rollback path available.
+- **Description**: Replace hardcoded completion matrices with clap-generated assets, preserve alias injection semantics (`cx*`, `cxdra`), and remove `CODEX_CLI_COMPLETION_MODE=legacy` rollback path.
 - **Dependencies**:
   - Task 2.2
 - **Complexity**: 8
 - **Acceptance criteria**:
   - Shell completions are generated from `codex-cli completion zsh|bash`, not manually curated flag lists.
   - Alias/wrapper invocation behavior remains compatible with current `cx*` UX.
-  - Legacy mode bypass is available and documented.
+  - No `CODEX_CLI_COMPLETION_MODE` gate or legacy completion function remains in codex adapters.
   - Shell files keep only adapter-specific logic and alias wiring.
 - **Validation**:
   - `zsh -n completions/zsh/_codex-cli`
   - `bash -n completions/bash/codex-cli`
   - `zsh -f tests/zsh/completion.test.zsh`
-  - `bash -lc 'CODEX_CLI_COMPLETION_MODE=legacy source completions/bash/codex-cli; complete -p codex-cli >/dev/null'`
+  - `rg -n "CODEX_CLI_COMPLETION_MODE|_nils_cli_codex_cli_complete_legacy" completions/zsh/_codex-cli completions/bash/codex-cli`
 
 ### Task 2.4: Add pilot-specific completion regression tests
 - **Location**:
   - `tests/zsh/completion.test.zsh`
   - `crates/codex-cli/tests/main_entrypoint.rs`
   - `crates/codex-cli/tests/completion_smoke.rs` (new)
-- **Description**: Add regression checks for export-command stability, adapter wiring, alias mapping, fallback mode, and context-aware candidate filtering.
+- **Description**: Add regression checks for export-command stability, adapter wiring, alias mapping, no-legacy enforcement, and context-aware candidate filtering.
 - **Dependencies**:
   - Task 2.3
 - **Complexity**: 6
@@ -182,7 +182,7 @@ This plan establishes a workspace-wide completion development standard, register
   - `completions/zsh/_completion-adapter-common.zsh` (new)
   - `completions/bash/completion-adapter-common.bash` (new)
   - `docs/runbooks/cli-completion-development-standard.md`
-- **Description**: Create shared helper functions for loading clap-generated completion assets, handling shell quoting/registration, applying fallback mode, and reducing per-file duplication across CLI completion adapters.
+- **Description**: Create shared helper functions for loading clap-generated completion assets, handling shell quoting/registration, enforcing no-legacy adapter behavior, and reducing per-file duplication across CLI completion adapters.
 - **Dependencies**:
   - Task 2.4
 - **Complexity**: 7
@@ -197,7 +197,7 @@ This plan establishes a workspace-wide completion development standard, register
 - **Location**:
   - `docs/runbooks/cli-completion-development-standard.md`
   - `docs/specs/completion-contract-template.md` (new)
-- **Description**: Define a repeatable per-CLI contract template (command graph, value providers, alias map, fallback env var, tests) to keep all migrations consistent.
+- **Description**: Define a repeatable per-CLI contract template (command graph, value providers, alias map, no-legacy invariants, tests) to keep all migrations consistent.
 - **Dependencies**:
   - Task 1.2
   - Task 3.1
@@ -206,7 +206,7 @@ This plan establishes a workspace-wide completion development standard, register
   - Template includes required fields for implementation and test coverage.
   - Migration checklist is actionable without undocumented steps.
 - **Validation**:
-  - `rg -n "alias map|fallback|validation|acceptance" docs/specs/completion-contract-template.md docs/runbooks/cli-completion-development-standard.md`
+  - `rg -n "alias map|no-legacy|validation|acceptance" docs/specs/completion-contract-template.md docs/runbooks/cli-completion-development-standard.md`
 
 ### Task 3.3: Expand completion test harness to be coverage-driven
 - **Location**:
@@ -225,21 +225,21 @@ This plan establishes a workspace-wide completion development standard, register
   - `zsh -f tests/zsh/completion.test.zsh`
   - `bash tests/completion/coverage_matrix.sh`
 
-### Task 3.4: Standardize and test per-CLI rollback toggle contract
+### Task 3.4: Standardize and test no-legacy completion enforcement contract
 - **Location**:
   - `docs/reports/completion-coverage-matrix.md`
   - `docs/runbooks/cli-completion-development-standard.md`
   - `tests/completion/coverage_matrix.sh`
-- **Description**: Define per-CLI fallback env var naming and require each completion-required CLI to declare its rollback toggle and legacy behavior test expectation in the matrix.
+- **Description**: Define no-legacy completion enforcement metadata and require each completion-required CLI migration to declare how adapters stay clap-first without completion mode toggles.
 - **Dependencies**:
   - Task 1.1
   - Task 3.2
 - **Complexity**: 4
 - **Acceptance criteria**:
-  - Every completion-required CLI has an explicit fallback env var entry in the matrix.
-  - Matrix-driven checks fail if fallback metadata is missing.
+  - Every completion-required CLI has explicit no-legacy completion enforcement metadata in the matrix/template.
+  - Matrix-driven checks fail if no-legacy metadata is missing.
 - **Validation**:
-  - `rg -n "COMPLETION_MODE|fallback|legacy" docs/reports/completion-coverage-matrix.md`
+  - `rg -n "no-legacy|COMPLETION_MODE|legacy completion mode" docs/reports/completion-coverage-matrix.md docs/specs/completion-contract-template.md`
   - `bash tests/completion/coverage_matrix.sh`
 
 ## Sprint 4: Full Migration for Remaining Completion-Required CLIs
@@ -553,18 +553,18 @@ This plan establishes a workspace-wide completion development standard, register
   - `rg -n "image-processing" docs/reports/completion-coverage-matrix.md tests/completion/coverage_matrix.sh`
 
 ## Sprint 5: Hardening, CI Gates, and Release Readiness
-**Goal**: Lock in migration with reproducible checks, contributor guidance, and operational rollback readiness.
+**Goal**: Lock in migration with reproducible checks, contributor guidance, and no-legacy completion governance.
 **Demo/Validation**:
 - Command(s): `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
 - Command(s): `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85`
-- Verify: required checks, completion coverage, and rollback controls are release-ready.
+- Verify: required checks, completion coverage, and no-legacy controls are release-ready.
 
 ### Task 5.1: Update release/integration runbooks for new completion architecture
 - **Location**:
   - `DEVELOPMENT.md`
   - `docs/runbooks/INTEGRATION_TEST.md`
   - `README.md`
-- **Description**: Document completion verification commands, per-CLI fallback env toggles, and release packaging expectations for completion assets.
+- **Description**: Document completion verification commands, no-legacy completion policy, and release packaging expectations for completion assets.
 - **Dependencies**:
   - Task 4.1
   - Task 4.2
@@ -572,10 +572,10 @@ This plan establishes a workspace-wide completion development standard, register
   - Task 4.4
 - **Complexity**: 5
 - **Acceptance criteria**:
-  - Contributor docs include explicit completion verification and rollback instructions.
+  - Contributor docs include explicit completion verification and no-legacy instructions.
   - Release documentation reflects final completion asset layout.
 - **Validation**:
-  - `rg -n "completion|clap_complete|fallback|legacy" DEVELOPMENT.md docs/runbooks/INTEGRATION_TEST.md README.md`
+  - `rg -n "completion|clap_complete|no-legacy|legacy completion mode" DEVELOPMENT.md docs/runbooks/INTEGRATION_TEST.md README.md`
 
 ### Task 5.2: Execute required checks and workspace coverage gate
 - **Location**:
@@ -637,13 +637,13 @@ This plan establishes a workspace-wide completion development standard, register
 ## Testing Strategy
 - Unit:
   - Per-crate completion contract tests (clap command model, exported script smoke, candidate/value routing).
-  - Alias injection and fallback-mode tests where alias semantics are non-trivial.
+  - Alias injection and no-legacy enforcement tests where alias semantics are non-trivial.
 - Integration:
   - `tests/zsh/completion.test.zsh` matrix-driven completion asset and registration checks.
   - Crate integration tests for completion export-command stability and context-aware candidate behavior.
 - E2E/manual:
   - Spot-check tab completion for nested commands and value flags across representative CLI families.
-  - Rollback drill: enable per-CLI legacy mode env var and verify adapter fallback behavior.
+  - No-legacy drill: verify adapters contain no completion-mode switches and generated path remains context-aware.
 
 ## Risks & gotchas
 - Per-CLI migration scope is large; drift between matrix policy and implemented adapters can regress silently without strict audit.
@@ -652,9 +652,8 @@ This plan establishes a workspace-wide completion development standard, register
 - Completion latency may regress if optional runtime value providers do expensive checks on every tab press.
 - Alias-heavy CLIs (`git-cli`, `codex-cli`, `fzf-cli`) are prone to behavioral regressions if injection semantics diverge from current contracts.
 
-## Rollback plan
-- Keep per-CLI legacy completion mode toggles during rollout (for example `CODEX_CLI_COMPLETION_MODE=legacy`) and enforce toggle inventory in `docs/reports/completion-coverage-matrix.md`.
-- If a migrated CLI regresses, switch that CLI to legacy adapter mode and ship a focused hotfix while retaining clap-based completion generation internals for debugging.
+## Regression response plan
+- Do not reintroduce legacy completion mode toggles (`*_COMPLETION_MODE`) during rollout.
+- If a migrated CLI regresses, patch clap metadata and/or thin adapter wiring directly, then ship a focused hotfix.
 - If a family-wide regression appears, revert only the affected completion family files plus related crate completion module changes, then rerun required checks.
-- Require fallback-mode regression tests for each migrated CLI so rollback controls are continuously validated.
-- Preserve `docs/reports/completion-coverage-matrix.md` as rollback source-of-truth so temporary exclusions are explicit and auditable.
+- Keep matrix/test metadata as the enforcement source-of-truth so no-legacy invariants remain auditable.

--- a/docs/reports/completion-coverage-matrix.md
+++ b/docs/reports/completion-coverage-matrix.md
@@ -10,6 +10,7 @@
 - Completion quality baseline for every `required` binary: subcommands + long/short flags + declared value candidates.
 - Completion quality baseline for every `required` binary also requires context-aware filtering by cursor position (not global candidate dumps).
 - Preferred implementation mode for every `required` binary: clap-first (`clap` + `clap_complete`) generated baseline completions, with thin shell adapters and optional dynamic value extensions only when needed.
+- Legacy completion-mode toggles (`*_COMPLETION_MODE`) are not supported; adapters must stay clap-first and fail closed when generated completion cannot be loaded.
 - This matrix currently tracks asset coverage and obligation decisions; deeper quality/export-command conformance is validated in rollout sprints and completion tests.
 
 ## Matrix

--- a/docs/runbooks/cli-completion-development-standard.md
+++ b/docs/runbooks/cli-completion-development-standard.md
@@ -63,12 +63,12 @@ Shell adapters may only:
 
 - register completion for canonical command names and required aliases
 - apply minor shell-specific formatting/wiring
-- apply per-CLI fallback mode dispatch
+- apply deterministic fail-closed behavior when generated completion cannot be loaded
 
 Dynamic/runtime value completion is optional and must extend (not replace) clap-generated baseline:
 
 - preferred dynamic path: `clap_complete::env::CompleteEnv`
-- fallback dynamic path (when needed): crate-local hidden completion command (e.g., `__complete`)
+- alternative dynamic path (when needed): crate-local hidden completion command (e.g., `__complete`)
 
 ## Contract Boundaries: Rust vs Shell
 Rust responsibilities:
@@ -82,7 +82,7 @@ Shell responsibilities:
 
 - completion hook registration (`compdef` / `complete`)
 - alias registration and alias-to-command mapping
-- fallback mode dispatch
+- generated-script loading and thin adapter wiring only
 
 Any logic that can drift from clap parsing belongs in Rust, not shell adapters.
 
@@ -102,19 +102,15 @@ Rules:
   - `fx*` for `fzf-cli`
 - ensure completion registration covers aliases that require command completion behavior
 
-## Fallback and Rollback Policy
-Each completion-required CLI must support a per-CLI fallback switch:
+## No Legacy Completion Mode Policy
+Completion implementations must not maintain dual completion stacks (`clap` + legacy shell tree).
 
-- env var: `<CLI_NAME_UPPER>_COMPLETION_MODE`
-- values:
-  - `clap` (default): clap-generated baseline (+ optional dynamic extensions)
-  - `legacy`: legacy shell path for emergency rollback
+Rules:
 
-Rollback requirements:
-
-- fallback must be per-CLI, never global
-- rollback must not alter command execution semantics
-- runbook/README for affected CLI must document enable/disable steps
+- do not add `<CLI_NAME_UPPER>_COMPLETION_MODE` toggles for completion behavior
+- do not keep legacy completion dispatch functions alongside clap-generated completion paths
+- if generated completion quality is wrong, fix clap metadata and/or thin adapter logic in-place
+- generated-load failure must fail closed (empty/no candidates) rather than routing to a legacy path
 
 ## Testing Requirements and Required Checks Linkage
 Completion work must satisfy completion-specific checks and repository gates.
@@ -146,6 +142,6 @@ Use this checklist for every existing CLI migration:
 4. generate/update `completions/zsh/_<cli>` and `completions/bash/<cli>`
 5. keep shell adapters thin (alias wiring and optional dynamic hooks only)
 6. if dynamic values are needed, add `CompleteEnv` (or crate-local `__complete` only where justified)
-7. define and document `<CLI_NAME_UPPER>_COMPLETION_MODE`
+7. enforce no-legacy completion policy (no `COMPLETION_MODE` gates or legacy completion functions)
 8. sync aliases in both alias files when alias-bearing CLIs are touched
-9. run completion checks + required repo checks; record rollout/fallback status in PR notes
+9. run completion checks + required repo checks; record rollout status in PR notes

--- a/docs/runbooks/new-cli-crate-development-standard.md
+++ b/docs/runbooks/new-cli-crate-development-standard.md
@@ -16,7 +16,7 @@ Use these as the source of truth to avoid policy drift:
 - Required checks and coverage policy:
   - `DEVELOPMENT.md`
   - `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
-- Workspace completion architecture and migration/rollback rules:
+- Workspace completion architecture and migration rules:
   - `docs/runbooks/cli-completion-development-standard.md`
 - Publishing workflow and order:
   - `scripts/publish-crates.sh`
@@ -118,7 +118,7 @@ Every user-facing CLI command surface must have explicit output behavior.
 - Keep warning/error prefix conventions consistent with neighboring crates.
 - For completion-required CLIs, implement clap-first completion generation via `clap_complete` so baseline completion covers subcommands, long/short flags, declared value candidates, and context-aware filtering (not global candidate dumps).
 - If completions or completion aliases are provided, implement them per
-  `docs/runbooks/cli-completion-development-standard.md` (clap-first generation, thin shell adapters, alias sync, and per-CLI fallback mode).
+  `docs/runbooks/cli-completion-development-standard.md` (clap-first generation, thin shell adapters, alias sync, and no-legacy completion mode).
 
 ## Testing and Validation Rules
 Minimum testing for new CLI crates:

--- a/tests/zsh/completion.test.zsh
+++ b/tests/zsh/completion.test.zsh
@@ -486,25 +486,71 @@ if (( ! $+aliases[cx] )); then
   exit 1
 fi
 
-if (( ! $+aliases[cxau] )); then
-  print -u2 -r -- "FAIL: cxau alias not defined"
+for codex_alias in cxau cxar cxaa cxac cxas cxdr cxdra cxcs cxct cxgp cxga cxgk cxgc cxst; do
+  if (( ! $+aliases[$codex_alias] )); then
+    print -u2 -r -- "FAIL: $codex_alias alias not defined"
+    exit 1
+  fi
+done
+
+grep -q "_nils_cli_codex_cli_load_generated_zsh()" "$COMP_CODEX_CLI_FILE" || {
+  print -u2 -r -- "FAIL: codex-cli zsh adapter missing generated-loader wiring"
+  exit 1
+}
+
+grep -q "_nils_cli_codex_cli_apply_alias_rewrite_zsh()" "$COMP_CODEX_CLI_FILE" || {
+  print -u2 -r -- "FAIL: codex-cli zsh adapter missing alias rewrite hook"
+  exit 1
+}
+
+if grep -q "CODEX_CLI_COMPLETION_MODE" "$COMP_CODEX_CLI_FILE"; then
+  print -u2 -r -- "FAIL: codex-cli zsh adapter must not include legacy completion mode gate"
   exit 1
 fi
 
-if (( ! $+aliases[cxst] )); then
-  print -u2 -r -- "FAIL: cxst alias not defined"
+if grep -q "CODEX_CLI_COMPLETION_MODE" "$BASH_CODEX_CLI_FILE"; then
+  print -u2 -r -- "FAIL: codex-cli bash adapter must not include legacy completion mode gate"
   exit 1
 fi
 
-if (( ! $+aliases[cxdr] )); then
-  print -u2 -r -- "FAIL: cxdr alias not defined"
+if grep -q "_nils_cli_codex_cli_complete_legacy" "$COMP_CODEX_CLI_FILE"; then
+  print -u2 -r -- "FAIL: codex-cli zsh adapter still contains legacy completion function"
   exit 1
 fi
 
-if (( ! $+aliases[cxdra] )); then
-  print -u2 -r -- "FAIL: cxdra alias not defined"
+if grep -q "_nils_cli_codex_cli_complete_legacy" "$BASH_CODEX_CLI_FILE"; then
+  print -u2 -r -- "FAIL: codex-cli bash adapter still contains legacy completion function"
   exit 1
 fi
+
+codex_cli_compdef_tail="$(tail -n 4 "$COMP_CODEX_CLI_FILE" | tr '\n' ' ')"
+for codex_alias in cx cxgp cxga cxgk cxgc cxau cxar cxaa cxac cxas cxst cxdr cxdra cxcs cxct; do
+  if [[ " $codex_cli_compdef_tail " != *" $codex_alias "* ]]; then
+    print -u2 -r -- "FAIL: codex-cli zsh compdef missing alias mapping for $codex_alias"
+    exit 1
+  fi
+done
+
+for case_expect in \
+  "cxau) inject=(auth use)" \
+  "cxar) inject=(auth refresh)" \
+  "cxaa) inject=(auth auto-refresh)" \
+  "cxac) inject=(auth current)" \
+  "cxas) inject=(auth sync)" \
+  "cxdr) inject=(diag rate-limits)" \
+  "cxdra) inject=(diag rate-limits); implied_async='1'" \
+  "cxcs) inject=(config show)" \
+  "cxct) inject=(config set)" \
+  "cxgp) inject=(agent prompt)" \
+  "cxga) inject=(agent advice)" \
+  "cxgk) inject=(agent knowledge)" \
+  "cxgc) inject=(agent commit)" \
+  "cxst) inject=(starship)"; do
+  grep -q "$case_expect" "$COMP_CODEX_CLI_FILE" || {
+    print -u2 -r -- "FAIL: codex-cli zsh adapter missing alias rewrite case: $case_expect"
+    exit 1
+  }
+done
 
 if (( ! $+aliases[fx] )); then
   print -u2 -r -- "FAIL: fx alias not defined"
@@ -606,63 +652,68 @@ grep -q "to-json:Parse a plan markdown file" "$COMP_PLAN_TOOLING_FILE" || {
   exit 1
 }
 
-grep -q "agent:Prompts and skill wrappers" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing agent command"
+if ! CODEX_ZSH_GENERATED="$(cargo run -q -p nils-codex-cli --bin codex-cli -- completion zsh)"; then
+  print -u2 -r -- "FAIL: unable to export codex-cli zsh completion from clap"
+  exit 1
+fi
+
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q "agent:Agent command group" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing agent command"
   exit 1
 }
 
-grep -q "auth:Auth and secrets" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing auth command"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q "auth:Authentication command group" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing auth command"
   exit 1
 }
 
-grep -q "login:Login with ChatGPT" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing auth login command"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q "login:Login to Codex" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing auth login command"
   exit 1
 }
 
-grep -q "save:Save CODEX_AUTH_FILE" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing auth save command"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q "save:Save active CODEX_AUTH_FILE" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing auth save command"
   exit 1
 }
 
-grep -q "remove:Remove SECRET_JSON" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing auth remove command"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q "remove:Remove SECRET_JSON" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing auth remove command"
   exit 1
 }
 
-grep -q -- "--api-key\\[" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing --api-key"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q -- "--api-key\\[" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing --api-key"
   exit 1
 }
 
-grep -q -- "--device-code\\[" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing --device-code"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q -- "--device-code\\[" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing --device-code"
   exit 1
 }
 
-grep -q -- "--yes\\[" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing --yes"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q -- "--yes\\[" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing --yes"
   exit 1
 }
 
-grep -q "diag:Diagnostics" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing diag command"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q "diag:Diagnostics command group" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing diag command"
   exit 1
 }
 
-grep -q -- "--all\\[" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing --all"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q -- "--all\\[" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing --all"
   exit 1
 }
 
-grep -q -- "--async\\[" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing --async"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q -- "--async\\[" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing --async"
   exit 1
 }
 
-grep -q -- "--cached\\[" "$COMP_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: codex-cli completion missing --cached"
+print -r -- "$CODEX_ZSH_GENERATED" | grep -q -- "--cached\\[" || {
+  print -u2 -r -- "FAIL: codex-cli generated completion missing --cached"
   exit 1
 }
 
@@ -921,23 +972,39 @@ bash -c "set -euo pipefail; source \"$BASH_API_TEST_FILE\"; complete -p api-test
   exit 1
 }
 
-bash -c "set -euo pipefail; source \"$BASH_CODEX_CLI_FILE\"; complete -p codex-cli | grep -q _nils_cli_codex_cli_complete; complete -p cx | grep -q _nils_cli_codex_cli_complete" || {
+bash -c "set -euo pipefail; source \"$BASH_CODEX_CLI_FILE\"; complete -p codex-cli | grep -q _nils_cli_codex_cli_complete; complete -p cx | grep -q _nils_cli_codex_cli_complete; complete -p cxgp | grep -q _nils_cli_codex_cli_complete; complete -p cxga | grep -q _nils_cli_codex_cli_complete; complete -p cxgk | grep -q _nils_cli_codex_cli_complete; complete -p cxgc | grep -q _nils_cli_codex_cli_complete; complete -p cxau | grep -q _nils_cli_codex_cli_complete; complete -p cxar | grep -q _nils_cli_codex_cli_complete; complete -p cxaa | grep -q _nils_cli_codex_cli_complete; complete -p cxac | grep -q _nils_cli_codex_cli_complete; complete -p cxas | grep -q _nils_cli_codex_cli_complete; complete -p cxst | grep -q _nils_cli_codex_cli_complete; complete -p cxdr | grep -q _nils_cli_codex_cli_complete; complete -p cxdra | grep -q _nils_cli_codex_cli_complete; complete -p cxcs | grep -q _nils_cli_codex_cli_complete; complete -p cxct | grep -q _nils_cli_codex_cli_complete" || {
   print -u2 -r -- "FAIL: failed to source bash codex-cli completion file"
   exit 1
 }
 
-grep -q "auth_cmds=(login use save refresh auto-refresh current sync)" "$BASH_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: bash codex-cli completion missing auth login/save command set"
+for case_expect in \
+  "cxau) inject=(auth use)" \
+  "cxar) inject=(auth refresh)" \
+  "cxaa) inject=(auth auto-refresh)" \
+  "cxac) inject=(auth current)" \
+  "cxas) inject=(auth sync)" \
+  "cxdr) inject=(diag rate-limits)" \
+  "cxdra) inject=(diag rate-limits); implied_async='1'" \
+  "cxcs) inject=(config show)" \
+  "cxct) inject=(config set)" \
+  "cxgp) inject=(agent prompt)" \
+  "cxga) inject=(agent advice)" \
+  "cxgk) inject=(agent knowledge)" \
+  "cxgc) inject=(agent commit)" \
+  "cxst) inject=(starship)"; do
+  grep -q "$case_expect" "$BASH_CODEX_CLI_FILE" || {
+    print -u2 -r -- "FAIL: bash codex-cli completion missing invoked_as mapping: $case_expect"
+    exit 1
+  }
+done
+
+grep -q "command codex-cli completion bash" "$BASH_CODEX_CLI_FILE" || {
+  print -u2 -r -- "FAIL: bash codex-cli adapter missing clap completion export hook"
   exit 1
 }
 
-grep -q -- "--api-key --device-code" "$BASH_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: bash codex-cli completion missing login mode flags"
-  exit 1
-}
-
-grep -q -- "-y --yes" "$BASH_CODEX_CLI_FILE" || {
-  print -u2 -r -- "FAIL: bash codex-cli completion missing save overwrite flags"
+bash -c "set -euo pipefail; PATH=\"$REPO_ROOT/wrappers:\$PATH\"; export NILS_WRAPPER_MODE=debug; source \"$BASH_CODEX_CLI_FILE\"; _NILS_CODEX_CLI_BASH_GENERATED_STATE=0; COMP_WORDS=(codex-cli auth login --); COMP_CWORD=3; COMPREPLY=(); _nils_cli_codex_cli_complete; [[ \" \${COMPREPLY[*]} \" == *\" --api-key \"* ]]; [[ \" \${COMPREPLY[*]} \" == *\" --device-code \"* ]]; [[ \" \${COMPREPLY[*]} \" != *\" --cached \"* ]]; [[ \" \${COMPREPLY[*]} \" != *\" --jobs \"* ]]" || {
+  print -u2 -r -- "FAIL: bash codex-cli generated completion is not context-aware for auth login"
   exit 1
 }
 


### PR DESCRIPTION
# Remove codex-cli legacy completion mode and enforce clap-only completion policy

## Summary
This PR removes `CODEX_CLI_COMPLETION_MODE=legacy` from `codex-cli` completions and standardizes completion behavior to a single clap-generated path. It keeps alias rewrite behavior (`cx*`, including `cxdra --async` injection), enforces no-legacy completion governance in repo runbooks/plans, and tightens tests so completion quality remains context-aware instead of global candidate dumps.

## Changes
- Removed legacy completion functions and mode gates from `completions/bash/codex-cli` and `completions/zsh/_codex-cli`.
- Kept only clap-generated completion loading + thin alias rewrite adapters; generated-load failure now fail-closed.
- Added/updated codex-cli completion implementation + tests (`completion` module, contract/smoke tests, entrypoint tests).
- Updated completion governance docs and rollout plan to enforce no-legacy completion policy for future CLI completion work.
- Updated `tests/zsh/completion.test.zsh` to reject legacy mode/function reintroduction and verify generated completion context behavior.

## Testing
- `bash -n completions/bash/codex-cli` (pass)
- `zsh -n completions/zsh/_codex-cli` (pass)
- `cargo test -p nils-codex-cli` (pass)
- `zsh -f tests/zsh/completion.test.zsh` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `mkdir -p target/coverage && cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 85.72%)

## Risk / Notes
- This is an intentional behavioral tightening: completion rollback via `*_COMPLETION_MODE=legacy` is no longer supported.
- If completion regressions appear, fixes must be made in clap metadata/adapters directly rather than reintroducing dual completion stacks.
