### PR TITLE
Migrate git-scope completion to clap-first adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,6 +1797,7 @@ version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "nils-common",
  "nils-term",
  "nils-test-support",

--- a/completions/bash/git-scope
+++ b/completions/bash/git-scope
@@ -1,9 +1,4 @@
 # nils-cli bash completion: git-scope (and gs* aliases)
-#
-# Install (example):
-#   mkdir -p ~/.local/share/bash-completion/completions
-#   cp completions/bash/git-scope ~/.local/share/bash-completion/completions/git-scope
-# Or source directly from your shell init.
 
 if [[ -z ${BASH_VERSION-} ]]; then
   return 0 2>/dev/null || exit 0
@@ -11,97 +6,88 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
+_nils_cli_git_scope_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
+
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
+
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
+
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
+}
+
+_NILS_GIT_SCOPE_BASH_GENERATED_STATE=0
+
+_nils_cli_git_scope_load_generated_bash() {
+  _nils_cli_git_scope_source_common_bash || return 1
+
+  # command git-scope completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_GIT_SCOPE_BASH_GENERATED_STATE" \
+    "_nils_cli_git_scope_generated" \
+    "git-scope" \
+    "_git-scope" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
 _nils_cli_git_scope_complete() {
+  if ! _nils_cli_git_scope_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
+      COMPREPLY=()
+    fi
+    return 0
+  fi
+
   local invoked_as="${COMP_WORDS[0]}"
   local -a words=("${COMP_WORDS[@]}")
   local cword="$COMP_CWORD"
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local prev="${COMP_WORDS[COMP_CWORD-1]}"
+  local -a inject=()
 
-  local subcmd_override=''
   case "$invoked_as" in
-    gsc) subcmd_override='commit' ;;
-    gst) subcmd_override='tracked' ;;
-    gss) subcmd_override='staged' ;;
-    gsu) subcmd_override='unstaged' ;;
-    gsa) subcmd_override='all' ;;
-    gsun) subcmd_override='untracked' ;;
-    gsh) subcmd_override='help' ;;
+    gst) inject=(tracked) ;;
+    gss) inject=(staged) ;;
+    gsu) inject=(unstaged) ;;
+    gsa) inject=(all) ;;
+    gsun) inject=(untracked) ;;
+    gsc) inject=(commit) ;;
+    gsh) inject=(help) ;;
   esac
 
-  if [[ -n "$subcmd_override" ]]; then
-    words=( "git-scope" "$subcmd_override" "${words[@]:1}" )
-    cword=$((cword + 1))
+  if [[ "$invoked_as" != "git-scope" ]]; then
+    words=( "git-scope" "${inject[@]}" "${words[@]:1}" )
+    cword=$((cword + ${#inject[@]}))
     cur="${words[cword]}"
     prev="${words[cword-1]}"
-  else
-    words[0]="git-scope"
   fi
 
-  local -a root_subcmds=(
-    tracked
-    staged
-    unstaged
-    all
-    untracked
-    commit
-    help
-  )
-  local -a root_opts=(-h --help --no-color)
+  local -a saved_words=("${COMP_WORDS[@]}")
+  local saved_cword="$COMP_CWORD"
 
-  if (( cword == 1 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
-      return 0
-    fi
-    COMPREPLY=( $(compgen -W "${root_subcmds[*]}" -- "$cur") )
-    return 0
-  fi
+  COMP_WORDS=("${words[@]}")
+  COMP_CWORD="$cword"
+  _nils_cli_git_scope_generated "git-scope" "$cur" "$prev"
+  local rc=$?
 
-  local subcmd="${words[1]-}"
-
-  case "$subcmd" in
-    tracked)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --no-color -p --print" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=( $(compgen -f -- "$cur") )
-      return 0
-      ;;
-    staged|unstaged|all|untracked)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --no-color -p --print" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    commit)
-      if [[ "$prev" == "--parent" || "$prev" == "-P" ]]; then
-        COMPREPLY=( $(compgen -W "1 2" -- "$cur") )
-        return 0
-      fi
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --no-color -p --print --parent -P" -- "$cur") )
-        return 0
-      fi
-
-      local hashes=''
-      if command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        hashes="$(command git log --pretty=format:%h -n 20 2>/dev/null || true)"
-      fi
-      COMPREPLY=( $(compgen -W "HEAD ${hashes}" -- "$cur") )
-      return 0
-      ;;
-    help)
-      COMPREPLY=()
-      return 0
-      ;;
-  esac
-
-  COMPREPLY=( $(compgen -W "${root_subcmds[*]}" -- "$cur") )
+  COMP_WORDS=("${saved_words[@]}")
+  COMP_CWORD="$saved_cword"
+  return $rc
 }
 
-complete -F _nils_cli_git_scope_complete git-scope gs gst gss gsu gsa gsun gsc gsh
-
+if _nils_cli_git_scope_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_git_scope_complete \
+    git-scope gs gst gss gsu gsa gsun gsc gsh
+else
+  complete -F _nils_cli_git_scope_complete \
+    git-scope gs gst gss gsu gsa gsun gsc gsh
+fi

--- a/completions/zsh/_git-scope
+++ b/completions/zsh/_git-scope
@@ -1,123 +1,105 @@
 #compdef git-scope gs gst gss gsu gsa gsun gsc gsh
 
+_nils_cli_git_scope_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_git-scope]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_GIT_SCOPE_ZSH_GENERATED_STATE=0
+
+_nils_cli_git_scope_load_generated_zsh() {
+  _nils_cli_git_scope_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_GIT_SCOPE_ZSH_GENERATED_STATE" \
+    "_nils_cli_git_scope_generated" \
+    "git-scope" \
+    "_git-scope" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_git_scope_generated" \]; then$' \
+    '^fi$'
+}
+
+_nils_cli_git_scope_apply_alias_rewrite_zsh() {
+  local invoked_as="${words[1]-}"
+  local -a inject=()
+
+  case "$invoked_as" in
+    gst) inject=(tracked) ;;
+    gss) inject=(staged) ;;
+    gsu) inject=(unstaged) ;;
+    gsa) inject=(all) ;;
+    gsun) inject=(untracked) ;;
+    gsc) inject=(commit) ;;
+    gsh) inject=(help) ;;
+  esac
+
+  if [[ "$invoked_as" != "git-scope" ]]; then
+    local -a rewritten_words=('git-scope')
+    local token=''
+    local -i idx=2
+
+    for token in "${inject[@]}"; do
+      rewritten_words+=("$token")
+    done
+
+    while (( idx <= ${#words[@]} )); do
+      rewritten_words+=("${words[idx]}")
+      (( idx++ ))
+    done
+
+    words=("${rewritten_words[@]}")
+    (( CURRENT += ${#inject[@]} ))
+  fi
+}
+
 _git-scope() {
   emulate -L zsh -o extendedglob
 
-  local context='' state='' state_descr=''
-  local -a line=()
-  typeset -A opt_args=()
+  local -i saved_current="$CURRENT"
+  local -a saved_words=("${words[@]}")
 
-  local -i orig_current="$CURRENT"
-  local -a orig_words=("${words[@]}")
-
-  local invoked_as="${orig_words[1]-}"
-  local subcmd_override=''
-
-  case "$invoked_as" in
-    gsc)
-      subcmd_override='commit'
-      ;;
-    gst)
-      subcmd_override='tracked'
-      ;;
-    gss)
-      subcmd_override='staged'
-      ;;
-    gsu)
-      subcmd_override='unstaged'
-      ;;
-    gsa)
-      subcmd_override='all'
-      ;;
-    gsun)
-      subcmd_override='untracked'
-      ;;
-    gsh)
-      subcmd_override='help'
-      ;;
-  esac
-
-  typeset -a subcommands=()
-  subcommands=(
-    'tracked:Show tracked files (optional path prefix filter)'
-    'staged:Show staged changes'
-    'unstaged:Show unstaged changes'
-    'all:Show staged + unstaged changes'
-    'untracked:Show untracked files'
-    'commit:Inspect a commit (supports --parent for merges)'
-    'help:Display help message for git-scope'
-  )
-
-  local subcmd=''
-
-  if [[ -n "$subcmd_override" ]]; then
-    subcmd="$subcmd_override"
-  else
-    _arguments -C \
-      '(-h --help)'{-h,--help}'[Display help message for git-scope]' \
-      '--no-color[Disable ANSI colors (also via NO_COLOR)]' \
-      '1:command:->subcmds' \
-      '*::arg:->args'
-
-    case "${state-}" in
-      subcmds)
-        _describe -t commands 'git-scope subcommand' subcommands && return 0
-        ;;
-      args)
-        subcmd="${line[1]:-${orig_words[2]-}}"
-        subcmd="${subcmd%%[[:space:]]#}"
-        ;;
-    esac
+  if ! _nils_cli_git_scope_load_generated_zsh; then
+    words=("${saved_words[@]}")
+    CURRENT="$saved_current"
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
+    fi
+    return 1
   fi
 
-  case "$subcmd" in
-    commit)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Display help message for git-scope]' \
-        '--no-color[Disable ANSI colors (also via NO_COLOR)]' \
-        '(-p --print)'{-p,--print}'[Print contents of each file in the commit (from HEAD or working tree)]' \
-        '--parent=[For merge commits: show diff against parent <n>]:parent index:' \
-        '-P+[For merge commits: show diff against parent <n>]:parent index:' \
-        '1:commit-ish:->commit_hashes'
+  _nils_cli_git_scope_apply_alias_rewrite_zsh
+  _nils_cli_git_scope_generated
+  local rc=$?
 
-      case "${state-}" in
-        commit_hashes)
-          local -a commit_hashes=()
-
-          if command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-            commit_hashes=(${(f)"$(command git log --pretty=format:'%h:%s' -n 20 2>/dev/null || true)"})
-          fi
-
-          if (( ${#commit_hashes[@]} > 0 )); then
-            _describe -t commits 'commit hash' commit_hashes && return 0
-          fi
-
-          _message 'commit hash'
-          return 0
-          ;;
-      esac
-
-      return 0
-      ;;
-    tracked)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Display help message for git-scope]' \
-        '--no-color[Disable ANSI colors (also via NO_COLOR)]' \
-        '(-p --print)'{-p,--print}'[Print the contents of each file]' \
-        '*:prefix:_files -/' \
-        && return 0
-      _message 'prefix'
-      return 0
-      ;;
-    staged|unstaged|all|untracked)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Display help message for git-scope]' \
-        '--no-color[Disable ANSI colors (also via NO_COLOR)]' \
-        '(-p --print)'{-p,--print}'[Print the contents of each file]' \
-        && return 0
-      return 0
-      ;;
-  esac
+  words=("${saved_words[@]}")
+  CURRENT="$saved_current"
+  return $rc
 }
 
-compdef _git-scope git-scope gs gst gss gsu gsa gsun gsc gsh
+if _nils_cli_git_scope_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _git-scope \
+    git-scope gs gst gss gsu gsa gsun gsc gsh
+else
+  compdef _git-scope git-scope gs gst gss gsu gsa gsun gsc gsh
+fi

--- a/crates/git-scope/Cargo.toml
+++ b/crates/git-scope/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 nils-term = { version = "0.4.4", path = "../nils-term", package = "nils-term" }
 nils-common = { version = "0.4.4", path = "../nils-common", package = "nils-common" }
 tempfile = "3"

--- a/crates/git-scope/src/completion.rs
+++ b/crates/git-scope/src/completion.rs
@@ -1,0 +1,17 @@
+use clap::CommandFactory;
+use clap_complete::{Generator, Shell, generate};
+use std::io;
+
+pub fn run(shell: crate::CompletionShell) -> i32 {
+    match shell {
+        crate::CompletionShell::Bash => generate_script(Shell::Bash),
+        crate::CompletionShell::Zsh => generate_script(Shell::Zsh),
+    }
+}
+
+fn generate_script<G: Generator>(generator: G) -> i32 {
+    let mut command = crate::Cli::command();
+    let bin_name = command.get_name().to_string();
+    generate(generator, &mut command, bin_name, &mut io::stdout());
+    0
+}

--- a/crates/git-scope/src/main.rs
+++ b/crates/git-scope/src/main.rs
@@ -1,10 +1,11 @@
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use nils_common::env as shared_env;
 use std::process;
 
 mod change;
 mod commit;
+mod completion;
 mod git;
 mod git_cmd;
 mod print;
@@ -80,6 +81,18 @@ enum Command {
     },
     /// Display help message for git-scope
     Help,
+    /// Export shell completion script
+    Completion {
+        /// Shell to generate completion script for
+        #[arg(value_enum, value_name = "shell")]
+        shell: CompletionShell,
+    },
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+enum CompletionShell {
+    Bash,
+    Zsh,
 }
 
 fn print_help() {
@@ -97,6 +110,10 @@ fn print_help() {
     println!(
         "  {:<16}  Show commit details (use -p to print content)",
         "commit <id>"
+    );
+    println!(
+        "  {:<16}  Export shell completion script",
+        "completion <shell>"
     );
     println!();
     println!("Options:");
@@ -121,10 +138,21 @@ fn main() {
 fn run() -> Result<()> {
     let cli = Cli::parse();
 
-    let help_requested = cli.help || matches!(cli.command, Some(Command::Help));
-    if help_requested {
+    if cli.help {
         print_help();
         return Ok(());
+    }
+
+    let command = cli.command.unwrap_or(Command::Help);
+    match command {
+        Command::Help => {
+            print_help();
+            return Ok(());
+        }
+        Command::Completion { shell } => {
+            process::exit(completion::run(shell));
+        }
+        _ => {}
     }
 
     if !git::is_git_repo() {
@@ -135,7 +163,7 @@ fn run() -> Result<()> {
     let no_color = cli.no_color || shared_env::no_color_enabled();
     let progress_opt_in = git_scope_progress_opt_in();
 
-    match cli.command.unwrap_or(Command::Help) {
+    match command {
         Command::Tracked { print, prefixes } => {
             let lines = git::collect_tracked(&prefixes)?;
             render::render_with_type(
@@ -197,9 +225,7 @@ fn run() -> Result<()> {
             commit::render_commit(&commit, parent.as_deref(), no_color, print, progress_opt_in)
                 .with_context(|| format!("git-scope commit {commit}"))?;
         }
-        Command::Help => {
-            print_help();
-        }
+        Command::Help | Command::Completion { .. } => unreachable!(),
     }
 
     Ok(())

--- a/crates/git-scope/tests/help_outside_repo.rs
+++ b/crates/git-scope/tests/help_outside_repo.rs
@@ -98,3 +98,53 @@ fn version_flag_succeeds_outside_git_repo() {
         "unexpected repo warning: {stdout}"
     );
 }
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(git_scope_bin())
+        .args(["completion", "zsh"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run git-scope completion zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef git-scope"),
+        "missing zsh completion header: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Not a Git repository"),
+        "unexpected repo warning: {stdout}"
+    );
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(git_scope_bin())
+        .args(["completion", "fish"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run git-scope completion fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Not a Git repository"),
+        "unexpected repo warning: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
Migrates `git-scope` to a clap-first completion export contract and replaces legacy hand-written zsh/bash completion logic with thin adapters backed by generated scripts while preserving `gs*` alias behavior.

## Changes
- Added `git-scope completion <bash|zsh>` using `clap_complete` and wired it to run outside git repositories.
- Replaced `completions/zsh/_git-scope` and `completions/bash/git-scope` with common-helper-based thin adapters, including alias rewrite mapping for `gs*` shortcuts.
- Added integration coverage for completion export behavior outside repos and unknown shell rejection paths.

## Testing
- `cargo test -p nils-git-scope` (pass)
- `zsh -f tests/zsh/completion.test.zsh` (pass)
- `zsh -n completions/zsh/_git-scope` (pass)
- `bash -n completions/bash/git-scope` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass)

## Risk / Notes
- Adapter loading is fail-closed by design: if generated completion load fails, no legacy fallback path is used.
