### PR TITLE
Migrate git-lock completion to clap-first adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,6 +1784,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "nils-common",
  "nils-term",
  "nils-test-support",

--- a/completions/bash/git-lock
+++ b/completions/bash/git-lock
@@ -6,108 +6,58 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_git_lock_labels() {
-  local lock_base="${ZSH_CACHE_DIR:-}"
-  local lock_dir=''
-  if [[ -z "$lock_base" ]]; then
-    lock_dir="/git-locks"
-  else
-    lock_dir="${lock_base%/}/git-locks"
-  fi
+_nils_cli_git_lock_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
-  local toplevel=''
-  toplevel="$(command git rev-parse --show-toplevel 2>/dev/null)" || return 0
-  local repo_id="${toplevel##*/}"
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
 
-  [[ -d "$lock_dir" ]] || return 0
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
 
-  local file=''
-  while IFS= read -r file; do
-    [[ -f "$file" ]] || continue
-    local base="${file##*/}"
-    base="${base#${repo_id}-}"
-    base="${base%.lock}"
-    printf '%s\n' "$base"
-  done < <(compgen -G "$lock_dir/${repo_id}-"*.lock)
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
+}
+
+_NILS_GIT_LOCK_BASH_GENERATED_STATE=0
+
+_nils_cli_git_lock_load_generated_bash() {
+  _nils_cli_git_lock_source_common_bash || return 1
+
+  # command git-lock completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_GIT_LOCK_BASH_GENERATED_STATE" \
+    "_nils_cli_git_lock_generated" \
+    "git-lock" \
+    "_git-lock" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
 }
 
 _nils_cli_git_lock_complete() {
-  local -a words=("${COMP_WORDS[@]}")
-  local cword="$COMP_CWORD"
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prev="${COMP_WORDS[COMP_CWORD-1]}"
-
-  local -a subcmds=(lock unlock list copy delete diff tag help)
-  local -a root_opts=(-h --help)
-
-  if (( cword == 1 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
-      return 0
+  if ! _nils_cli_git_lock_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
+      COMPREPLY=()
     fi
-    COMPREPLY=( $(compgen -W "${subcmds[*]}" -- "$cur") )
     return 0
   fi
 
-  local subcmd="${words[1]-}"
-  case "$subcmd" in
-    -h|--help|help)
-      COMPREPLY=()
-      return 0
-      ;;
-  esac
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev=''
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
 
-  local labels="$(_nils_cli_git_lock_labels)"
-
-  case "$subcmd" in
-    unlock|delete)
-      if (( cword == 2 )); then
-        COMPREPLY=( $(compgen -W "$labels" -- "$cur") )
-        return 0
-      fi
-      ;;
-    copy)
-      if (( cword == 2 )); then
-        COMPREPLY=( $(compgen -W "$labels" -- "$cur") )
-        return 0
-      fi
-      ;;
-    diff)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "--no-color no-color -h --help" -- "$cur") )
-        return 0
-      fi
-      if (( cword == 2 || cword == 3 )); then
-        COMPREPLY=( $(compgen -W "$labels" -- "$cur") )
-        return 0
-      fi
-      ;;
-    tag)
-      if [[ "$prev" == "-m" ]]; then
-        COMPREPLY=()
-        return 0
-      fi
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "--push -m" -- "$cur") )
-        return 0
-      fi
-      if (( cword == 2 )); then
-        COMPREPLY=( $(compgen -W "$labels" -- "$cur") )
-        return 0
-      fi
-      ;;
-    lock)
-      COMPREPLY=()
-      return 0
-      ;;
-    list)
-      COMPREPLY=()
-      return 0
-      ;;
-  esac
-
-  COMPREPLY=()
+  _nils_cli_git_lock_generated "git-lock" "$cur" "$prev"
 }
 
-complete -F _nils_cli_git_lock_complete git-lock
-
+if _nils_cli_git_lock_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_git_lock_complete git-lock
+else
+  complete -F _nils_cli_git_lock_complete git-lock
+fi

--- a/completions/zsh/_git-lock
+++ b/completions/zsh/_git-lock
@@ -1,155 +1,60 @@
 #compdef git-lock
 
-__git_lock_labels() {
-  emulate -L zsh -o extendedglob
+_nils_cli_git_lock_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
 
-  local toplevel='' repo_id='' lock_dir='' file=''
-  lock_dir="$ZSH_CACHE_DIR/git-locks"
+  local source_file="${functions_source[_git-lock]-}"
+  local helper_path=''
 
-  toplevel="$(command git rev-parse --show-toplevel 2>/dev/null)" || return 0
-  repo_id="${toplevel:t}"
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
 
-  [[ -d "$lock_dir" ]] || return 0
-
-  for file in "$lock_dir/${repo_id}-"*.lock(N); do
-    [[ -f "$file" ]] || continue
-    local label="${file:t}"
-    label="${label#${repo_id}-}"
-    label="${label%.lock}"
-    print -r -- "$label"
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
   done
 
-  return 0
+  return 1
 }
 
+typeset -gi _NILS_GIT_LOCK_ZSH_GENERATED_STATE=0
+
+_nils_cli_git_lock_load_generated_zsh() {
+  _nils_cli_git_lock_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_GIT_LOCK_ZSH_GENERATED_STATE" \
+    "_nils_cli_git_lock_generated" \
+    "git-lock" \
+    "_git-lock" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_git_lock_generated" \]; then$' \
+    '^fi$'
+}
 
 _git-lock() {
   emulate -L zsh -o extendedglob
 
-  local context='' state='' state_descr=''
-  local -a line=()
-  typeset -A opt_args=()
-
-  local -i orig_current="$CURRENT"
-  local -a orig_words=("${words[@]}")
-
-  local cur="${orig_words[orig_current]-}"
-  cur="${cur%%[[:space:]]#}"
-
-  typeset -a subcmds=() opts=() labels=()
-  subcmds=(
-    'lock:Save commit hash to lock'
-    'unlock:Reset to a saved commit'
-    'list:Show all locks'
-    'copy:Duplicate a lock label'
-    'delete:Remove a lock'
-    'diff:Compare commits between two locks'
-    'tag:Create a git tag from a lock'
-    'help:Show usage'
-  )
-  opts=(
-    '-h:Show help'
-    '--help:Show help'
-  )
-
-  if (( orig_current == 2 )); then
-    if [[ "$cur" == -* ]]; then
-      _describe -t options 'option' opts && return 0
-      return 0
+  if ! _nils_cli_git_lock_load_generated_zsh; then
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
     fi
-    _describe -t commands 'git-lock command' subcmds && return 0
-    _message 'command (lock|unlock|list|copy|delete|diff|tag)'
-    return 0
+    return 1
   fi
 
-  local subcmd="${orig_words[2]-}"
-  subcmd="${subcmd%%[[:space:]]#}"
-
-  case "$subcmd" in
-    -h|--help|help)
-      return 0
-      ;;
-  esac
-
-  labels=(${(f)"$(__git_lock_labels)"})
-
-  case "$subcmd" in
-    unlock|delete)
-      if (( orig_current == 3 )); then
-        (( ${#labels[@]} > 0 )) && _values 'label' "${labels[@]}" && return 0
-        _message 'label'
-        return 0
-      fi
-      ;;
-    copy)
-      if (( orig_current == 3 )); then
-        (( ${#labels[@]} > 0 )) && _values 'source label' "${labels[@]}" && return 0
-        _message 'source label'
-        return 0
-      elif (( orig_current == 4 )); then
-        _message 'target label'
-        return 0
-      fi
-      ;;
-    diff)
-      if [[ "$cur" == -* ]]; then
-        typeset -a diff_opts=(
-          '--no-color:Disable ANSI colors'
-          'no-color:Disable ANSI colors'
-          '-h:Show diff help'
-          '--help:Show diff help'
-        )
-        _describe -t options 'option' diff_opts && return 0
-        return 0
-      fi
-
-      if (( orig_current == 3 || orig_current == 4 )); then
-        (( ${#labels[@]} > 0 )) && _values 'label' "${labels[@]}" && return 0
-        _message 'label'
-        return 0
-      fi
-      ;;
-    tag)
-      if [[ "${orig_words[orig_current-1]-}" == "-m" ]]; then
-        _message 'tag message'
-        return 0
-      fi
-
-      if [[ "$cur" == -* ]]; then
-        typeset -a tag_opts=(
-          '--push:Push the tag to origin'
-          '-m:Tag message'
-        )
-        _describe -t options 'option' tag_opts && return 0
-        return 0
-      fi
-
-      if (( orig_current == 3 )); then
-        (( ${#labels[@]} > 0 )) && _values 'git-lock label' "${labels[@]}" && return 0
-        _message 'git-lock label'
-        return 0
-      elif (( orig_current == 4 )); then
-        _message 'git tag name'
-        return 0
-      fi
-      ;;
-    lock)
-      if (( orig_current == 3 )); then
-        _message 'label (default: default)'
-        return 0
-      elif (( orig_current == 4 )); then
-        _message 'note (optional)'
-        return 0
-      elif (( orig_current == 5 )); then
-        _message 'commit (default: HEAD)'
-        return 0
-      fi
-      ;;
-    list)
-      _message 'no more arguments'
-      return 0
-      ;;
-  esac
+  _nils_cli_git_lock_generated
 }
 
-compdef _git-lock git-lock
+if _nils_cli_git_lock_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _git-lock git-lock
+else
+  compdef _git-lock git-lock
+fi

--- a/crates/git-lock/Cargo.toml
+++ b/crates/git-lock/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 chrono = { version = "0.4", features = ["clock"] }
 nils-term = { version = "0.4.4", path = "../nils-term", package = "nils-term" }
 nils-common = { version = "0.4.4", path = "../nils-common", package = "nils-common" }

--- a/crates/git-lock/src/completion.rs
+++ b/crates/git-lock/src/completion.rs
@@ -1,0 +1,17 @@
+use clap::CommandFactory;
+use clap_complete::{Generator, Shell, generate};
+use std::io;
+
+pub fn run(shell: crate::CompletionShell) -> i32 {
+    match shell {
+        crate::CompletionShell::Bash => generate_script(Shell::Bash),
+        crate::CompletionShell::Zsh => generate_script(Shell::Zsh),
+    }
+}
+
+fn generate_script<G: Generator>(generator: G) -> i32 {
+    let mut command = crate::Cli::command();
+    let bin_name = command.get_name().to_string();
+    generate(generator, &mut command, bin_name, &mut io::stdout());
+    0
+}

--- a/crates/git-lock/src/main.rs
+++ b/crates/git-lock/src/main.rs
@@ -1,5 +1,6 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
+mod completion;
 mod copy;
 mod delete;
 mod diff;
@@ -56,7 +57,18 @@ enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    Completion {
+        /// Shell to generate completion script for
+        #[arg(value_enum, value_name = "shell")]
+        shell: CompletionShell,
+    },
     Help,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+enum CompletionShell {
+    Bash,
+    Zsh,
 }
 
 fn main() {
@@ -74,6 +86,18 @@ fn run() -> i32 {
     if args.len() > 1 && is_version(&args[1]) {
         println!("git-lock {}", env!("CARGO_PKG_VERSION"));
         return 0;
+    }
+
+    if args.len() > 1 && args[1] == "completion" {
+        let cli = Cli::parse_from(&args);
+        let command = cli.command.unwrap_or(Command::Help);
+        return match command {
+            Command::Completion { shell } => completion::run(shell),
+            _ => {
+                messages::print_help();
+                1
+            }
+        };
     }
 
     if !nils_common::git::is_git_repo().unwrap_or(false) {
@@ -102,6 +126,7 @@ fn run() -> i32 {
         Command::Delete { args } => delete::run(&args),
         Command::Diff { args } => diff::run(&args),
         Command::Tag { args } => tag::run(&args),
+        Command::Completion { shell } => Ok(completion::run(shell)),
         Command::Help => {
             messages::print_help();
             Ok(0)
@@ -128,7 +153,7 @@ fn is_version(arg: &str) -> bool {
 fn is_known_command(arg: &str) -> bool {
     matches!(
         arg,
-        "lock" | "unlock" | "list" | "copy" | "delete" | "diff" | "tag" | "help"
+        "lock" | "unlock" | "list" | "copy" | "delete" | "diff" | "tag" | "completion" | "help"
     )
 }
 
@@ -160,6 +185,7 @@ mod tests {
         assert!(is_known_command("delete"));
         assert!(is_known_command("diff"));
         assert!(is_known_command("tag"));
+        assert!(is_known_command("completion"));
         assert!(is_known_command("help"));
         assert!(!is_known_command("nope"));
     }

--- a/crates/git-lock/src/messages.rs
+++ b/crates/git-lock/src/messages.rs
@@ -31,6 +31,10 @@ pub fn print_help() {
         "  {:<16}  Create git tag from a lock",
         "tag <label> <tag> [-m msg]"
     );
+    println!(
+        "  {:<16}  Export shell completion script",
+        "completion <shell>"
+    );
     println!("  {:<16}  Show version", "-V, --version");
     println!();
 }

--- a/crates/git-lock/tests/completion_outside_repo.rs
+++ b/crates/git-lock/tests/completion_outside_repo.rs
@@ -1,0 +1,53 @@
+mod common;
+
+use std::process::{Command, Stdio};
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(common::git_lock_bin())
+        .args(["completion", "zsh"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run git-lock completion zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef git-lock"),
+        "missing zsh completion header: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Not a Git repository"),
+        "unexpected repo warning: {stdout}"
+    );
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(common::git_lock_bin())
+        .args(["completion", "fish"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run git-lock completion fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Not a Git repository"),
+        "unexpected repo warning: {stderr}"
+    );
+}


### PR DESCRIPTION
# Migrate git-lock completion to clap-first adapters

## Summary
Migrate `git-lock` completion to a clap-generated export path and convert shell completion assets into thin adapters so completion behavior stays deterministic and aligned with CLI command metadata.

## Changes
- Added `git-lock completion <shell>` via clap + `clap_complete` and wired it before git-repo checks.
- Added a completion exporter module and updated help text to document the completion command.
- Replaced `completions/zsh/_git-lock` and `completions/bash/git-lock` with thin adapter loaders that use shared no-legacy helpers.
- Added outside-repo integration tests for completion export success and unsupported-shell rejection.

## Testing
- `cargo test -p nils-git-lock` (pass)
- `zsh -f tests/zsh/completion.test.zsh` (pass)
- `zsh -n completions/zsh/_git-lock` (pass)
- `bash -n completions/bash/git-lock` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)

## Risk / Notes
- Legacy dynamic label completion paths were removed to enforce clap-first/no-legacy policy; runtime completion now follows generated clap contract.
