### PR TITLE
feat(git-cli): clap-first completion adapters for sprint 4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,6 +1768,8 @@ name = "nils-git-cli"
 version = "0.4.4"
 dependencies = [
  "anyhow",
+ "clap",
+ "clap_complete",
  "nils-common",
  "nils-test-support",
  "pretty_assertions",

--- a/completions/bash/git-cli
+++ b/completions/bash/git-cli
@@ -1,9 +1,4 @@
 # nils-cli bash completion: git-cli (and gx* aliases)
-#
-# Install (example):
-#   mkdir -p ~/.local/share/bash-completion/completions
-#   cp completions/bash/git-cli ~/.local/share/bash-completion/completions/git-cli
-# Or source directly from your shell init.
 
 if [[ -z ${BASH_VERSION-} ]]; then
   return 0 2>/dev/null || exit 0
@@ -11,29 +6,52 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli__has_word() {
-  local needle="$1"
-  shift
-  local w=''
-  for w in "$@"; do
-    [[ "$w" == "$needle" ]] && return 0
-  done
-  return 1
+_nils_cli_git_cli_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
+
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
+
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
+
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
 }
 
-_nils_cli_git_cli_hashes() {
-  if command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    command git log --pretty=format:%h -n 20 2>/dev/null || true
-  fi
+_NILS_GIT_CLI_BASH_GENERATED_STATE=0
+
+_nils_cli_git_cli_load_generated_bash() {
+  _nils_cli_git_cli_source_common_bash || return 1
+
+  # command git-cli completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_GIT_CLI_BASH_GENERATED_STATE" \
+    "_nils_cli_git_cli_generated" \
+    "git-cli" \
+    "_git-cli" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
 }
 
 _nils_cli_git_cli_complete() {
+  if ! _nils_cli_git_cli_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
+      COMPREPLY=()
+    fi
+    return 0
+  fi
+
   local invoked_as="${COMP_WORDS[0]}"
   local -a words=("${COMP_WORDS[@]}")
   local cword="$COMP_CWORD"
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local prev="${COMP_WORDS[COMP_CWORD-1]}"
-
   local -a inject=()
 
   case "$invoked_as" in
@@ -76,7 +94,7 @@ _nils_cli_git_cli_complete() {
     gxobl) inject=(open blame) ;;
   esac
 
-  if (( ${#inject[@]} > 0 )); then
+  if [[ "$invoked_as" != "git-cli" ]]; then
     words=( "git-cli" "${inject[@]}" "${words[@]:1}" )
     cword=$((cword + ${#inject[@]}))
     cur="${words[cword]}"
@@ -85,277 +103,29 @@ _nils_cli_git_cli_complete() {
     words[0]="git-cli"
   fi
 
-  local -a root_cmds=(utils reset commit branch ci open help)
-  local -a root_opts=(-h --help -V --version)
+  local -a saved_words=("${COMP_WORDS[@]}")
+  local saved_cword="$COMP_CWORD"
 
-  if (( cword == 1 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
-      return 0
-    fi
-    COMPREPLY=( $(compgen -W "${root_cmds[*]}" -- "$cur") )
-    return 0
-  fi
+  COMP_WORDS=("${words[@]}")
+  COMP_CWORD="$cword"
+  _nils_cli_git_cli_generated "git-cli" "$cur" "$prev"
+  local rc=$?
 
-  local group="${words[1]-}"
-  case "$group" in
-    help|-h|--help|-V|--version)
-      COMPREPLY=()
-      return 0
-      ;;
-  esac
-
-  if (( cword == 2 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
-      return 0
-    fi
-    local -a group_cmds=()
-    case "$group" in
-      utils)
-        group_cmds=(zip copy-staged copy root commit-hash hash help)
-        ;;
-      reset)
-        group_cmds=(soft mixed hard undo back-head back-checkout remote help)
-        ;;
-      commit)
-        group_cmds=(context context-json context_json contextjson json to-stash stash help)
-        ;;
-      branch)
-        group_cmds=(cleanup delete-merged help)
-        ;;
-      ci)
-        group_cmds=(pick help)
-        ;;
-      open)
-        group_cmds=(repo branch default-branch default commit compare pr pull-request mr merge-request pulls prs merge-requests mrs issue issues action actions release releases tag tags commits history file blob blame help)
-        ;;
-    esac
-    COMPREPLY=( $(compgen -W "${group_cmds[*]}" -- "$cur") )
-    return 0
-  fi
-
-  local cmd="${words[2]-}"
-
-  case "$group" in
-    utils)
-      case "$cmd" in
-        copy|copy-staged)
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "--stdout -p --print --both -h --help" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        root)
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "--shell" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        commit-hash|hash)
-          if (( cword == 3 )); then
-            local hashes="$( _nils_cli_git_cli_hashes )"
-            COMPREPLY=( $(compgen -W "HEAD ${hashes}" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        zip|help)
-          COMPREPLY=()
-          return 0
-          ;;
-      esac
-      ;;
-    reset)
-      case "$cmd" in
-        soft|mixed|hard)
-          COMPREPLY=()
-          return 0
-          ;;
-        undo|back-head|back-checkout|help)
-          COMPREPLY=()
-          return 0
-          ;;
-        remote)
-          if [[ "$prev" == "--ref" ]]; then
-            COMPREPLY=()
-            return 0
-          fi
-          if [[ "$prev" == "-r" || "$prev" == "--remote" ]]; then
-            COMPREPLY=()
-            return 0
-          fi
-          if [[ "$prev" == "-b" || "$prev" == "--branch" ]]; then
-            COMPREPLY=()
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "--ref -r --remote -b --branch --no-fetch --prune --clean --set-upstream -y --yes -h --help" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-      esac
-      ;;
-    commit)
-      case "$cmd" in
-        context)
-          if [[ "$prev" == "--include" ]]; then
-            COMPREPLY=( $(compgen -f -- "$cur") )
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "--stdout --both --no-color --include -h --help" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        context-json|context_json|contextjson|json)
-          if [[ "$prev" == "--out-dir" ]]; then
-            COMPREPLY=( $(compgen -f -- "$cur") )
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "--stdout --both --pretty --bundle --out-dir -h --help" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        to-stash|stash)
-          if (( cword == 3 )); then
-            local hashes="$( _nils_cli_git_cli_hashes )"
-            COMPREPLY=( $(compgen -W "HEAD ${hashes}" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        help)
-          COMPREPLY=()
-          return 0
-          ;;
-      esac
-      ;;
-    branch)
-      case "$cmd" in
-        cleanup|delete-merged)
-          if [[ "$prev" == "-b" || "$prev" == "--base" ]]; then
-            COMPREPLY=()
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "-b --base -s --squash -h --help" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        help)
-          COMPREPLY=()
-          return 0
-          ;;
-      esac
-      ;;
-    ci)
-      case "$cmd" in
-        pick)
-          if [[ "$prev" == "-r" || "$prev" == "--remote" ]]; then
-            COMPREPLY=()
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            COMPREPLY=( $(compgen -W "-r --remote --no-fetch -f --force --stay -h --help" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        help)
-          COMPREPLY=()
-          return 0
-          ;;
-      esac
-      ;;
-    open)
-      case "$cmd" in
-        repo|default-branch|default)
-          if (( cword == 3 )); then
-            local remotes
-            remotes="$(command git remote 2>/dev/null || true)"
-            COMPREPLY=( $(compgen -W "${remotes}" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        branch|compare|commits|history|commit)
-          if (( cword == 3 || cword == 4 )); then
-            local refs
-            refs="$(command git for-each-ref --format='%(refname:short)' refs/heads refs/remotes refs/tags 2>/dev/null || true)"
-            COMPREPLY=( $(compgen -W "${refs}" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        pr|pull-request|mr|merge-request|pulls|prs|merge-requests|mrs|issues|issue)
-          COMPREPLY=()
-          return 0
-          ;;
-        actions|action)
-          if (( cword == 3 )); then
-            local workflows
-            workflows="$(command git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml' 2>/dev/null || true)"
-            COMPREPLY=( $(compgen -W "${workflows}" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        releases|release|tags|tag)
-          if (( cword == 3 )); then
-            local tags
-            tags="$(command git tag --sort=-creatordate 2>/dev/null || true)"
-            COMPREPLY=( $(compgen -W "${tags}" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        file|blob|blame)
-          if (( cword == 3 )); then
-            COMPREPLY=( $(compgen -f -- "$cur") )
-            return 0
-          fi
-          if (( cword == 4 )); then
-            local refs
-            refs="$(command git for-each-ref --format='%(refname:short)' refs/heads refs/remotes refs/tags 2>/dev/null || true)"
-            COMPREPLY=( $(compgen -W "${refs}" -- "$cur") )
-            return 0
-          fi
-          COMPREPLY=()
-          return 0
-          ;;
-        help)
-          COMPREPLY=()
-          return 0
-          ;;
-      esac
-      ;;
-  esac
-
-  COMPREPLY=()
+  COMP_WORDS=("${saved_words[@]}")
+  COMP_CWORD="$saved_cword"
+  return $rc
 }
 
-complete -F _nils_cli_git_cli_complete git-cli gx gxh gxu gxr gxc gxb gxi gxo \
-  gxuz gxuc gxur gxuh gxrs gxrm gxrh gxru gxrbh gxrbc gxrr \
-  gxcc gxcj gxcs gxbc gxip \
-  gxor gxob gxod gxoc gxocp gxop gxopl gxoi gxoa gxorl gxot gxocs gxof gxobl
+if _nils_cli_git_cli_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_git_cli_complete \
+    git-cli gx gxh gxu gxr gxc gxb gxi gxo \
+    gxuz gxuc gxur gxuh gxrs gxrm gxrh gxru gxrbh gxrbc gxrr \
+    gxcc gxcj gxcs gxbc gxip \
+    gxor gxob gxod gxoc gxocp gxop gxopl gxoi gxoa gxorl gxot gxocs gxof gxobl
+else
+  complete -F _nils_cli_git_cli_complete \
+    git-cli gx gxh gxu gxr gxc gxb gxi gxo \
+    gxuz gxuc gxur gxuh gxrs gxrm gxrh gxru gxrbh gxrbc gxrr \
+    gxcc gxcj gxcs gxbc gxip \
+    gxor gxob gxod gxoc gxocp gxop gxopl gxoi gxoa gxorl gxot gxocs gxof gxobl
+fi

--- a/completions/zsh/_git-cli
+++ b/completions/zsh/_git-cli
@@ -3,650 +3,143 @@
 #  gxcc gxcj gxcs gxbc gxip \
 #  gxor gxob gxod gxoc gxocp gxop gxopl gxoi gxoa gxorl gxot gxocs gxof gxobl
 
-__git_cli_commit_hashes() {
-  emulate -L zsh -o extendedglob
+_nils_cli_git_cli_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
 
-  local -a commit_hashes=()
+  local source_file="${functions_source[_git-cli]-}"
+  local helper_path=''
 
-  if command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    commit_hashes=(${(f)"$(command git log --pretty=format:'%h:%s' -n 20 2>/dev/null || true)"})
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
   fi
 
-  (( ${#commit_hashes[@]} > 0 )) && print -l -- "${commit_hashes[@]}"
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_GIT_CLI_ZSH_GENERATED_STATE=0
+
+_nils_cli_git_cli_load_generated_zsh() {
+  _nils_cli_git_cli_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_GIT_CLI_ZSH_GENERATED_STATE" \
+    "_nils_cli_git_cli_generated" \
+    "git-cli" \
+    "_git-cli" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_git_cli_generated" \]; then$' \
+    '^fi$'
+}
+
+_nils_cli_git_cli_apply_alias_rewrite_zsh() {
+  local invoked_as="${words[1]-}"
+  local -a inject=()
+
+  case "$invoked_as" in
+    gxh) inject=(help) ;;
+    gxu) inject=(utils) ;;
+    gxr) inject=(reset) ;;
+    gxc) inject=(commit) ;;
+    gxb) inject=(branch) ;;
+    gxi) inject=(ci) ;;
+    gxo) inject=(open) ;;
+    gxuz) inject=(utils zip) ;;
+    gxuc) inject=(utils copy-staged) ;;
+    gxur) inject=(utils root) ;;
+    gxuh) inject=(utils commit-hash) ;;
+    gxrs) inject=(reset soft) ;;
+    gxrm) inject=(reset mixed) ;;
+    gxrh) inject=(reset hard) ;;
+    gxru) inject=(reset undo) ;;
+    gxrbh) inject=(reset back-head) ;;
+    gxrbc) inject=(reset back-checkout) ;;
+    gxrr) inject=(reset remote) ;;
+    gxcc) inject=(commit context) ;;
+    gxcj) inject=(commit context-json) ;;
+    gxcs) inject=(commit to-stash) ;;
+    gxbc) inject=(branch cleanup) ;;
+    gxip) inject=(ci pick) ;;
+    gxor) inject=(open repo) ;;
+    gxob) inject=(open branch) ;;
+    gxod) inject=(open default-branch) ;;
+    gxoc) inject=(open commit) ;;
+    gxocp) inject=(open compare) ;;
+    gxop) inject=(open pr) ;;
+    gxopl) inject=(open pulls) ;;
+    gxoi) inject=(open issues) ;;
+    gxoa) inject=(open actions) ;;
+    gxorl) inject=(open releases) ;;
+    gxot) inject=(open tags) ;;
+    gxocs) inject=(open commits) ;;
+    gxof) inject=(open file) ;;
+    gxobl) inject=(open blame) ;;
+  esac
+
+  if [[ "$invoked_as" != "git-cli" ]]; then
+    local -a rewritten_words=('git-cli')
+    local token=''
+    local -i idx=2
+
+    for token in "${inject[@]}"; do
+      rewritten_words+=("$token")
+    done
+
+    while (( idx <= ${#words[@]} )); do
+      rewritten_words+=("${words[idx]}")
+      (( idx++ ))
+    done
+
+    words=("${rewritten_words[@]}")
+    (( CURRENT += ${#inject[@]} ))
+  fi
 }
 
 _git-cli() {
   emulate -L zsh -o extendedglob
 
-  local context='' state='' state_descr=''
-  local -a line=()
-  typeset -A opt_args=()
+  local -i saved_current="$CURRENT"
+  local -a saved_words=("${words[@]}")
 
-  local -i orig_current="$CURRENT"
-  local -a orig_words=("${words[@]}")
-
-  local invoked_as="${orig_words[1]-}"
-  local group_override=''
-  local cmd_override=''
-
-  case "$invoked_as" in
-    gxh)
-      group_override='help'
-      ;;
-    gxu)
-      group_override='utils'
-      ;;
-    gxr)
-      group_override='reset'
-      ;;
-    gxc)
-      group_override='commit'
-      ;;
-    gxb)
-      group_override='branch'
-      ;;
-    gxi)
-      group_override='ci'
-      ;;
-    gxo)
-      group_override='open'
-      ;;
-    gxuz)
-      group_override='utils'
-      cmd_override='zip'
-      ;;
-    gxuc)
-      group_override='utils'
-      cmd_override='copy-staged'
-      ;;
-    gxur)
-      group_override='utils'
-      cmd_override='root'
-      ;;
-    gxuh)
-      group_override='utils'
-      cmd_override='commit-hash'
-      ;;
-    gxrs)
-      group_override='reset'
-      cmd_override='soft'
-      ;;
-    gxrm)
-      group_override='reset'
-      cmd_override='mixed'
-      ;;
-    gxrh)
-      group_override='reset'
-      cmd_override='hard'
-      ;;
-    gxru)
-      group_override='reset'
-      cmd_override='undo'
-      ;;
-    gxrbh)
-      group_override='reset'
-      cmd_override='back-head'
-      ;;
-    gxrbc)
-      group_override='reset'
-      cmd_override='back-checkout'
-      ;;
-    gxrr)
-      group_override='reset'
-      cmd_override='remote'
-      ;;
-    gxcc)
-      group_override='commit'
-      cmd_override='context'
-      ;;
-    gxcj)
-      group_override='commit'
-      cmd_override='context-json'
-      ;;
-    gxcs)
-      group_override='commit'
-      cmd_override='to-stash'
-      ;;
-    gxbc)
-      group_override='branch'
-      cmd_override='cleanup'
-      ;;
-    gxip)
-      group_override='ci'
-      cmd_override='pick'
-      ;;
-    gxor)
-      group_override='open'
-      cmd_override='repo'
-      ;;
-    gxob)
-      group_override='open'
-      cmd_override='branch'
-      ;;
-    gxod)
-      group_override='open'
-      cmd_override='default-branch'
-      ;;
-    gxoc)
-      group_override='open'
-      cmd_override='commit'
-      ;;
-    gxocp)
-      group_override='open'
-      cmd_override='compare'
-      ;;
-    gxop)
-      group_override='open'
-      cmd_override='pr'
-      ;;
-    gxopl)
-      group_override='open'
-      cmd_override='pulls'
-      ;;
-    gxoi)
-      group_override='open'
-      cmd_override='issues'
-      ;;
-    gxoa)
-      group_override='open'
-      cmd_override='actions'
-      ;;
-    gxorl)
-      group_override='open'
-      cmd_override='releases'
-      ;;
-    gxot)
-      group_override='open'
-      cmd_override='tags'
-      ;;
-    gxocs)
-      group_override='open'
-      cmd_override='commits'
-      ;;
-    gxof)
-      group_override='open'
-      cmd_override='file'
-      ;;
-    gxobl)
-      group_override='open'
-      cmd_override='blame'
-      ;;
-  esac
-
-  local -a groups=()
-  groups=(
-    'utils:Utility helpers'
-    'reset:Reset helpers'
-    'commit:Commit helpers'
-    'branch:Branch helpers'
-    'ci:CI helpers'
-    'open:Open remote pages'
-    'help:Display help message for git-cli'
-  )
-
-  local group=''
-  local cmd=''
-
-  if [[ -n "$group_override" ]]; then
-    group="$group_override"
-    cmd="$cmd_override"
-  else
-    _arguments -C \
-      '(-h --help)'{-h,--help}'[Display help message for git-cli]' \
-      '(-V --version)'{-V,--version}'[Display version for git-cli]' \
-      '1:group:->groups' \
-      '*::arg:->args'
-
-    case "${state-}" in
-      groups)
-        _describe -t groups 'git-cli group' groups && return 0
-        ;;
-      args)
-        group="${line[1]:-${orig_words[2]-}}"
-        group="${group%%[[:space:]]#}"
-        ;;
-    esac
+  if ! _nils_cli_git_cli_load_generated_zsh; then
+    words=("${saved_words[@]}")
+    CURRENT="$saved_current"
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
+    fi
+    return 1
   fi
 
-  case "$group" in
-    '')
-      _message 'group (utils|reset|commit|branch|ci|open)'
-      return 0
-      ;;
-    help|-h|--help|-V|--version)
-      _message 'no more arguments'
-      return 0
-      ;;
-  esac
+  _nils_cli_git_cli_apply_alias_rewrite_zsh
+  _nils_cli_git_cli_generated
+  local rc=$?
 
-  local cmd_fallback=''
-  if [[ -n "$group_override" ]]; then
-    cmd_fallback="${orig_words[2]-}"
-  else
-    cmd_fallback="${orig_words[3]-}"
-  fi
-
-  if [[ -z "$cmd" ]]; then
-    local -a cmds=()
-    case "$group" in
-      utils)
-        cmds=(
-          'zip:Create zip archive from HEAD'
-          'copy-staged:Copy staged diff to clipboard'
-          'copy:Alias for copy-staged'
-          'root:Jump to git root'
-          'commit-hash:Resolve commit hash'
-          'hash:Alias for commit-hash'
-          'help:Display help message for utils'
-        )
-        ;;
-      reset)
-        cmds=(
-          'soft:Reset to HEAD~N (soft)'
-          'mixed:Reset to HEAD~N (mixed)'
-          'hard:Reset to HEAD~N (hard)'
-          'undo:Undo last reset'
-          'back-head:Checkout HEAD@{1}'
-          'back-checkout:Return to previous branch'
-          'remote:Reset to remote branch'
-          'help:Display help message for reset'
-        )
-        ;;
-      commit)
-        cmds=(
-          'context:Print commit context'
-          'context-json:Print commit context as JSON'
-          'context_json:Alias for context-json'
-          'contextjson:Alias for context-json'
-          'json:Alias for context-json'
-          'to-stash:Create stash from commit'
-          'stash:Alias for to-stash'
-          'help:Display help message for commit'
-        )
-        ;;
-      branch)
-        cmds=(
-          'cleanup:Delete merged branches'
-          'delete-merged:Alias for cleanup'
-          'help:Display help message for branch'
-        )
-        ;;
-      ci)
-        cmds=(
-          'pick:Cherry-pick into CI branch'
-          'help:Display help message for ci'
-        )
-        ;;
-      open)
-        cmds=(
-          'repo:Open repository page'
-          'branch:Open branch tree page'
-          'default-branch:Open default branch tree page'
-          'default:Alias for default-branch'
-          'commit:Open commit page'
-          'compare:Open compare page'
-          'pr:Open pull or merge request page'
-          'pull-request:Alias for pr'
-          'mr:Alias for pr'
-          'merge-request:Alias for pr'
-          'pulls:Open pull or merge request list'
-          'prs:Alias for pulls'
-          'merge-requests:Alias for pulls'
-          'mrs:Alias for pulls'
-          'issue:Alias for issues'
-          'issues:Open issues list/page'
-          'action:Alias for actions'
-          'actions:Open actions page'
-          'release:Alias for releases'
-          'releases:Open releases list/page'
-          'tag:Alias for tags'
-          'tags:Open tags list/page'
-          'commits:Open commit history page'
-          'history:Alias for commits'
-          'file:Open file page'
-          'blob:Alias for file'
-          'blame:Open blame page'
-          'help:Display help message for open'
-        )
-        ;;
-    esac
-
-    _arguments -C \
-      '(-h --help)'{-h,--help}'[Display help message for git-cli]' \
-      '1:command:->cmds' \
-      '*::arg:->args'
-
-    case "${state-}" in
-      cmds)
-        _describe -t commands "git-cli $group command" cmds && return 0
-        ;;
-      args)
-        cmd="${line[1]:-$cmd_fallback}"
-        cmd="${cmd%%[[:space:]]#}"
-        ;;
-    esac
-  fi
-
-  local -i arg_start=4
-  if [[ -n "$group_override" ]]; then
-    arg_start=3
-  fi
-  if [[ -n "$cmd_override" ]]; then
-    (( arg_start-- ))
-  fi
-
-  local cur="${orig_words[orig_current]-}"
-  cur="${cur%%[[:space:]]#}"
-  local prev="${orig_words[orig_current-1]-}"
-
-  case "$group" in
-    utils)
-      case "$cmd" in
-        copy|copy-staged)
-          if [[ "$cur" == -* ]]; then
-            local -a opts=(
-              '--stdout:Print staged diff to stdout'
-              '-p:Print staged diff to stdout'
-              '--print:Print staged diff to stdout'
-              '--both:Print to stdout and copy to clipboard'
-              '-h:Show help'
-              '--help:Show help'
-            )
-            _describe -t options 'option' opts && return 0
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        root)
-          if [[ "$cur" == -* ]]; then
-            local -a opts=(
-              '--shell:Print cd command for eval'
-            )
-            _describe -t options 'option' opts && return 0
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        commit-hash|hash)
-          if (( orig_current == arg_start )); then
-            local -a commit_hashes=()
-            commit_hashes=(${(f)"$(__git_cli_commit_hashes)"})
-            if (( ${#commit_hashes[@]} > 0 )); then
-              _describe -t commits 'commit hash' commit_hashes && return 0
-            fi
-            _message 'git ref'
-            return 0
-          fi
-          return 0
-          ;;
-        zip|help)
-          _message 'no more arguments'
-          return 0
-          ;;
-      esac
-      ;;
-    reset)
-      case "$cmd" in
-        soft|mixed|hard)
-          if (( orig_current == arg_start )); then
-            _message 'commit count (default: 1)'
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        undo|back-head|back-checkout|help)
-          _message 'no more arguments'
-          return 0
-          ;;
-        remote)
-          if [[ "$prev" == "--ref" ]]; then
-            _message 'remote/branch'
-            return 0
-          fi
-          if [[ "$prev" == "-r" || "$prev" == "--remote" ]]; then
-            _message 'remote name'
-            return 0
-          fi
-          if [[ "$prev" == "-b" || "$prev" == "--branch" ]]; then
-            _message 'branch name'
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            local -a opts=(
-              '--ref:Remote/branch ref'
-              '-r:Remote name'
-              '--remote:Remote name'
-              '-b:Branch name'
-              '--branch:Branch name'
-              '--no-fetch:Skip fetch'
-              '--prune:Prune remote refs'
-              '--clean:Run git clean -fd'
-              '--set-upstream:Set upstream'
-              '-y:Skip confirmations'
-              '--yes:Skip confirmations'
-              '-h:Show help'
-              '--help:Show help'
-            )
-            _describe -t options 'option' opts && return 0
-            return 0
-          fi
-          return 0
-          ;;
-      esac
-      ;;
-    commit)
-      case "$cmd" in
-        context)
-          if [[ "$prev" == "--include" ]]; then
-            _files -/ && return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            local -a opts=(
-              '--stdout:Print to stdout'
-              '--both:Print to stdout and copy to clipboard'
-              '--no-color:Disable ANSI colors'
-              '--include:Include path or glob'
-              '-h:Show help'
-              '--help:Show help'
-            )
-            _describe -t options 'option' opts && return 0
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        context-json|context_json|contextjson|json)
-          if [[ "$prev" == "--out-dir" ]]; then
-            _files -/ && return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            local -a opts=(
-              '--stdout:Print to stdout'
-              '--both:Print to stdout and copy to clipboard'
-              '--pretty:Pretty-print JSON'
-              '--bundle:Print bundle output'
-              '--out-dir:Output directory'
-              '-h:Show help'
-              '--help:Show help'
-            )
-            _describe -t options 'option' opts && return 0
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        to-stash|stash)
-          if (( orig_current == arg_start )); then
-            local -a commit_hashes=()
-            commit_hashes=(${(f)"$(__git_cli_commit_hashes)"})
-            if (( ${#commit_hashes[@]} > 0 )); then
-              _describe -t commits 'commit hash' commit_hashes && return 0
-            fi
-            _message 'commit (optional)'
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        help)
-          _message 'no more arguments'
-          return 0
-          ;;
-      esac
-      ;;
-    branch)
-      case "$cmd" in
-        cleanup|delete-merged)
-          if [[ "$prev" == "-b" || "$prev" == "--base" ]]; then
-            _message 'base ref'
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            local -a opts=(
-              '-b:Base branch'
-              '--base:Base branch'
-              '-s:Squash mode'
-              '--squash:Squash mode'
-              '-h:Show help'
-              '--help:Show help'
-            )
-            _describe -t options 'option' opts && return 0
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        help)
-          _message 'no more arguments'
-          return 0
-          ;;
-      esac
-      ;;
-    ci)
-      case "$cmd" in
-        pick)
-          if [[ "$prev" == "-r" || "$prev" == "--remote" ]]; then
-            _message 'remote name'
-            return 0
-          fi
-          if [[ "$cur" == -* ]]; then
-            local -a opts=(
-              '-r:Remote name'
-              '--remote:Remote name'
-              '--no-fetch:Skip fetch'
-              '-f:Force push'
-              '--force:Force push'
-              '--stay:Stay on CI branch'
-              '-h:Show help'
-              '--help:Show help'
-            )
-            _describe -t options 'option' opts && return 0
-            return 0
-          fi
-
-          if (( orig_current == arg_start )); then
-            _message 'target'
-            return 0
-          fi
-          if (( orig_current == arg_start + 1 )); then
-            _message 'commit or range'
-            return 0
-          fi
-          if (( orig_current == arg_start + 2 )); then
-            _message 'name'
-            return 0
-          fi
-          return 0
-          ;;
-        help)
-          _message 'no more arguments'
-          return 0
-          ;;
-      esac
-      ;;
-    open)
-      case "$cmd" in
-        repo|default-branch|default)
-          if (( orig_current == arg_start )); then
-            local -a remotes=()
-            remotes=(${(f)"$(command git remote 2>/dev/null || true)"})
-            (( ${#remotes[@]} > 0 )) && _describe -t remotes 'remote' remotes
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        branch|compare|commits|history|commit)
-          if (( orig_current == arg_start || orig_current == arg_start + 1 )); then
-            local -a refs=()
-            refs=(${(f)"$(command git for-each-ref --format='%(refname:short)' refs/heads refs/remotes refs/tags 2>/dev/null || true)"})
-            (( ${#refs[@]} > 0 )) && _describe -t refs 'ref' refs
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        pr|pull-request|mr|merge-request|pulls|prs|merge-requests|mrs|issues|issue)
-          if (( orig_current == arg_start )); then
-            _message 'number'
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        actions|action)
-          if (( orig_current == arg_start )); then
-            local -a workflows=()
-            workflows=(${(f)"$(command git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml' 2>/dev/null || true)"})
-            (( ${#workflows[@]} > 0 )) && _describe -t workflows 'workflow' workflows
-            _message 'workflow'
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        releases|release|tags|tag)
-          if (( orig_current == arg_start )); then
-            local -a tags=()
-            tags=(${(f)"$(command git tag --sort=-creatordate 2>/dev/null || true)"})
-            (( ${#tags[@]} > 0 )) && _describe -t tags 'tag' tags
-            _message 'tag'
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        file|blob|blame)
-          if (( orig_current == arg_start )); then
-            _files && return 0
-            _message 'path'
-            return 0
-          fi
-          if (( orig_current == arg_start + 1 )); then
-            local -a refs=()
-            refs=(${(f)"$(command git for-each-ref --format='%(refname:short)' refs/heads refs/remotes refs/tags 2>/dev/null || true)"})
-            (( ${#refs[@]} > 0 )) && _describe -t refs 'ref' refs
-            _message 'ref'
-            return 0
-          fi
-          _message 'no more arguments'
-          return 0
-          ;;
-        help)
-          _message 'no more arguments'
-          return 0
-          ;;
-      esac
-      ;;
-  esac
-
-  _message 'git-cli <group> <command> [args]'
+  words=("${saved_words[@]}")
+  CURRENT="$saved_current"
+  return $rc
 }
 
-compdef _git-cli git-cli gx gxh gxu gxr gxc gxb gxi gxo \
-  gxuz gxuc gxur gxuh gxrs gxrm gxrh gxru gxrbh gxrbc gxrr \
-  gxcc gxcj gxcs gxbc gxip \
-  gxor gxob gxod gxoc gxocp gxop gxopl gxoi gxoa gxorl gxot gxocs gxof gxobl
+if _nils_cli_git_cli_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _git-cli \
+    git-cli gx gxh gxu gxr gxc gxb gxi gxo \
+    gxuz gxuc gxur gxuh gxrs gxrm gxrh gxru gxrbh gxrbc gxrr \
+    gxcc gxcj gxcs gxbc gxip \
+    gxor gxob gxod gxoc gxocp gxop gxopl gxoi gxoa gxorl gxot gxocs gxof gxobl
+else
+  compdef _git-cli \
+    git-cli gx gxh gxu gxr gxc gxb gxi gxo \
+    gxuz gxuc gxur gxuh gxrs gxrm gxrh gxru gxrbh gxrbc gxrr \
+    gxcc gxcj gxcs gxbc gxip \
+    gxor gxob gxod gxoc gxocp gxop gxopl gxoi gxoa gxorl gxot gxocs gxof gxobl
+fi

--- a/crates/git-cli/Cargo.toml
+++ b/crates/git-cli/Cargo.toml
@@ -16,6 +16,8 @@ name = "git-cli"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
+clap = { workspace = true }
+clap_complete = { workspace = true }
 nils-common = { version = "0.4.4", path = "../nils-common", package = "nils-common" }
 serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror = { workspace = true }

--- a/crates/git-cli/src/completion.rs
+++ b/crates/git-cli/src/completion.rs
@@ -1,0 +1,327 @@
+use clap::{Arg, ArgAction, Command, ValueHint};
+use clap_complete::{Generator, Shell, generate};
+use std::io;
+
+pub fn dispatch(shell_raw: &str, extra: &[String]) -> i32 {
+    if !extra.is_empty() {
+        eprintln!("git-cli: error: expected `git-cli completion <bash|zsh>`");
+        return 1;
+    }
+
+    match shell_raw {
+        "bash" => generate_script(Shell::Bash),
+        "zsh" => generate_script(Shell::Zsh),
+        other => {
+            eprintln!("git-cli: error: unsupported completion shell '{other}'");
+            eprintln!("usage: git-cli completion <bash|zsh>");
+            1
+        }
+    }
+}
+
+fn generate_script<G: Generator>(generator: G) -> i32 {
+    let mut command = build_command_model();
+    let bin_name = command.get_name().to_string();
+    generate(generator, &mut command, bin_name, &mut io::stdout());
+    0
+}
+
+fn build_command_model() -> Command {
+    Command::new("git-cli")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("Git helper CLI")
+        .disable_help_subcommand(true)
+        .subcommand(build_utils_group())
+        .subcommand(build_reset_group())
+        .subcommand(build_commit_group())
+        .subcommand(build_branch_group())
+        .subcommand(build_ci_group())
+        .subcommand(build_open_group())
+        .subcommand(Command::new("help").about("Display help message for git-cli"))
+        .subcommand(
+            Command::new("completion")
+                .about("Export shell completion script")
+                .arg(
+                    Arg::new("shell")
+                        .value_name("shell")
+                        .value_parser(["bash", "zsh"])
+                        .required(true),
+                ),
+        )
+}
+
+fn build_utils_group() -> Command {
+    Command::new("utils")
+        .about("Utility helpers")
+        .subcommand(Command::new("zip").about("Create zip archive from HEAD"))
+        .subcommand(
+            Command::new("copy-staged")
+                .visible_alias("copy")
+                .about("Copy staged diff to clipboard")
+                .arg(Arg::new("stdout").long("stdout").action(ArgAction::SetTrue))
+                .arg(
+                    Arg::new("print")
+                        .short('p')
+                        .long("print")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(Arg::new("both").long("both").action(ArgAction::SetTrue)),
+        )
+        .subcommand(
+            Command::new("root")
+                .about("Jump to git root")
+                .arg(Arg::new("shell").long("shell").action(ArgAction::SetTrue)),
+        )
+        .subcommand(
+            Command::new("commit-hash")
+                .visible_alias("hash")
+                .about("Resolve commit hash")
+                .arg(Arg::new("ref").value_name("ref")),
+        )
+        .subcommand(Command::new("help").about("Display help message for utils"))
+}
+
+fn build_reset_group() -> Command {
+    let count_arg = || Arg::new("count").value_name("count");
+
+    Command::new("reset")
+        .about("Reset helpers")
+        .subcommand(
+            Command::new("soft")
+                .about("Reset to HEAD~N (soft)")
+                .arg(count_arg()),
+        )
+        .subcommand(
+            Command::new("mixed")
+                .about("Reset to HEAD~N (mixed)")
+                .arg(count_arg()),
+        )
+        .subcommand(
+            Command::new("hard")
+                .about("Reset to HEAD~N (hard)")
+                .arg(count_arg()),
+        )
+        .subcommand(Command::new("undo").about("Undo last reset"))
+        .subcommand(Command::new("back-head").about("Checkout HEAD@{1}"))
+        .subcommand(Command::new("back-checkout").about("Return to previous branch"))
+        .subcommand(
+            Command::new("remote")
+                .about("Reset to remote branch")
+                .arg(Arg::new("ref").long("ref").value_name("ref"))
+                .arg(
+                    Arg::new("remote")
+                        .short('r')
+                        .long("remote")
+                        .value_name("remote"),
+                )
+                .arg(
+                    Arg::new("branch")
+                        .short('b')
+                        .long("branch")
+                        .value_name("branch"),
+                )
+                .arg(
+                    Arg::new("no-fetch")
+                        .long("no-fetch")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(Arg::new("prune").long("prune").action(ArgAction::SetTrue))
+                .arg(Arg::new("clean").long("clean").action(ArgAction::SetTrue))
+                .arg(
+                    Arg::new("set-upstream")
+                        .long("set-upstream")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("yes")
+                        .short('y')
+                        .long("yes")
+                        .action(ArgAction::SetTrue),
+                ),
+        )
+        .subcommand(Command::new("help").about("Display help message for reset"))
+}
+
+fn build_commit_group() -> Command {
+    Command::new("commit")
+        .about("Commit helpers")
+        .subcommand(
+            Command::new("context")
+                .about("Print commit context")
+                .arg(Arg::new("stdout").long("stdout").action(ArgAction::SetTrue))
+                .arg(Arg::new("both").long("both").action(ArgAction::SetTrue))
+                .arg(
+                    Arg::new("no-color")
+                        .long("no-color")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("include")
+                        .long("include")
+                        .value_name("glob")
+                        .num_args(1..),
+                ),
+        )
+        .subcommand(
+            Command::new("context-json")
+                .visible_aliases(["context_json", "contextjson", "json"])
+                .about("Print commit context as JSON")
+                .arg(Arg::new("stdout").long("stdout").action(ArgAction::SetTrue))
+                .arg(Arg::new("both").long("both").action(ArgAction::SetTrue))
+                .arg(Arg::new("pretty").long("pretty").action(ArgAction::SetTrue))
+                .arg(Arg::new("bundle").long("bundle").action(ArgAction::SetTrue))
+                .arg(Arg::new("out-dir").long("out-dir").value_name("path")),
+        )
+        .subcommand(
+            Command::new("to-stash")
+                .visible_alias("stash")
+                .about("Create stash from commit")
+                .arg(Arg::new("ref").value_name("ref")),
+        )
+        .subcommand(Command::new("help").about("Display help message for commit"))
+}
+
+fn build_branch_group() -> Command {
+    Command::new("branch")
+        .about("Branch helpers")
+        .subcommand(
+            Command::new("cleanup")
+                .visible_alias("delete-merged")
+                .about("Delete merged branches")
+                .arg(Arg::new("base").short('b').long("base").value_name("base"))
+                .arg(
+                    Arg::new("squash")
+                        .short('s')
+                        .long("squash")
+                        .action(ArgAction::SetTrue),
+                ),
+        )
+        .subcommand(Command::new("help").about("Display help message for branch"))
+}
+
+fn build_ci_group() -> Command {
+    Command::new("ci")
+        .about("CI helpers")
+        .subcommand(
+            Command::new("pick")
+                .about("Cherry-pick into CI branch")
+                .arg(
+                    Arg::new("remote")
+                        .short('r')
+                        .long("remote")
+                        .value_name("name"),
+                )
+                .arg(
+                    Arg::new("no-fetch")
+                        .long("no-fetch")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("force")
+                        .short('f')
+                        .long("force")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(Arg::new("stay").long("stay").action(ArgAction::SetTrue)),
+        )
+        .subcommand(Command::new("help").about("Display help message for ci"))
+}
+
+fn build_open_group() -> Command {
+    Command::new("open")
+        .about("Open remote pages")
+        .subcommand(
+            Command::new("repo")
+                .about("Open repository page")
+                .arg(remotes_arg()),
+        )
+        .subcommand(
+            Command::new("branch")
+                .about("Open branch tree page")
+                .arg(Arg::new("ref").value_name("ref")),
+        )
+        .subcommand(
+            Command::new("default-branch")
+                .visible_alias("default")
+                .about("Open default branch tree page")
+                .arg(remotes_arg()),
+        )
+        .subcommand(
+            Command::new("commit")
+                .about("Open commit page")
+                .arg(Arg::new("ref").value_name("ref")),
+        )
+        .subcommand(
+            Command::new("compare")
+                .about("Open compare page")
+                .arg(Arg::new("from").value_name("from"))
+                .arg(Arg::new("to").value_name("to")),
+        )
+        .subcommand(
+            Command::new("pr")
+                .visible_aliases(["pull-request", "mr", "merge-request"])
+                .about("Open pull or merge request page")
+                .arg(Arg::new("id").value_name("id")),
+        )
+        .subcommand(
+            Command::new("pulls")
+                .visible_aliases(["prs", "merge-requests", "mrs"])
+                .about("Open pull or merge request list"),
+        )
+        .subcommand(
+            Command::new("issues")
+                .visible_alias("issue")
+                .about("Open issues list/page")
+                .arg(Arg::new("id").value_name("id")),
+        )
+        .subcommand(
+            Command::new("actions")
+                .visible_alias("action")
+                .about("Open actions page")
+                .arg(Arg::new("workflow").value_name("workflow")),
+        )
+        .subcommand(
+            Command::new("releases")
+                .visible_alias("release")
+                .about("Open releases list/page")
+                .arg(Arg::new("tag").value_name("tag")),
+        )
+        .subcommand(
+            Command::new("tags")
+                .visible_alias("tag")
+                .about("Open tags list/page")
+                .arg(Arg::new("tag").value_name("tag")),
+        )
+        .subcommand(
+            Command::new("commits")
+                .visible_alias("history")
+                .about("Open commit history page")
+                .arg(Arg::new("ref").value_name("ref")),
+        )
+        .subcommand(
+            Command::new("file")
+                .visible_alias("blob")
+                .about("Open file page")
+                .arg(
+                    Arg::new("path")
+                        .value_name("path")
+                        .value_hint(ValueHint::FilePath),
+                )
+                .arg(Arg::new("ref").value_name("ref")),
+        )
+        .subcommand(
+            Command::new("blame")
+                .about("Open blame page")
+                .arg(
+                    Arg::new("path")
+                        .value_name("path")
+                        .value_hint(ValueHint::FilePath),
+                )
+                .arg(Arg::new("ref").value_name("ref")),
+        )
+        .subcommand(Command::new("help").about("Display help message for open"))
+}
+
+fn remotes_arg() -> Arg {
+    Arg::new("remote").value_name("remote")
+}

--- a/crates/git-cli/src/lib.rs
+++ b/crates/git-cli/src/lib.rs
@@ -4,6 +4,7 @@ pub mod clipboard;
 pub mod commit;
 pub mod commit_json;
 pub mod commit_shared;
+pub mod completion;
 pub mod open;
 pub mod prompt;
 pub mod reset;

--- a/crates/git-cli/src/usage.rs
+++ b/crates/git-cli/src/usage.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 use std::io::{self, Write};
 
 use crate::commit;
-use crate::{branch, ci, open, reset, utils};
+use crate::{branch, ci, completion, open, reset, utils};
 
 #[derive(Debug, Clone, Copy)]
 enum Group {
@@ -12,6 +12,7 @@ enum Group {
     Branch,
     Ci,
     Open,
+    Completion,
 }
 
 impl Group {
@@ -23,6 +24,7 @@ impl Group {
             "branch" => Some(Self::Branch),
             "ci" => Some(Self::Ci),
             "open" => Some(Self::Open),
+            "completion" => Some(Self::Completion),
             _ => None,
         }
     }
@@ -113,6 +115,7 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
                 2
             }
         },
+        Some(Group::Completion) => completion::dispatch(cmd_raw, &args[2..]),
         None => {
             eprintln!("Unknown group: {group_raw}");
             print_top_level_usage(&mut io::stdout());
@@ -175,6 +178,11 @@ fn print_group_usage(group_raw: &str) -> i32 {
             .ok();
             0
         }
+        Some(Group::Completion) => {
+            writeln!(out, "Usage: git-cli completion <shell>").ok();
+            writeln!(out, "  bash | zsh").ok();
+            0
+        }
         None => {
             eprintln!("Unknown group: {group_raw}");
             print_top_level_usage(&mut out);
@@ -202,6 +210,7 @@ fn print_top_level_usage(out: &mut dyn Write) {
         "  open     repo | branch | default-branch | commit | compare | pr | pulls | issues | actions | releases | tags | commits | file | blame"
     )
     .ok();
+    writeln!(out, "  completion  bash | zsh").ok();
     writeln!(out).ok();
     writeln!(out, "Help:").ok();
     writeln!(out, "  git-cli help").ok();
@@ -231,6 +240,10 @@ mod tests {
         assert!(matches!(Group::parse("branch"), Some(Group::Branch)));
         assert!(matches!(Group::parse("ci"), Some(Group::Ci)));
         assert!(matches!(Group::parse("open"), Some(Group::Open)));
+        assert!(matches!(
+            Group::parse("completion"),
+            Some(Group::Completion)
+        ));
         assert!(Group::parse("unknown").is_none());
     }
 
@@ -256,6 +269,7 @@ mod tests {
         assert_eq!(dispatch(to_args(&["branch", "unknown"])), 2);
         assert_eq!(dispatch(to_args(&["ci", "unknown"])), 2);
         assert_eq!(dispatch(to_args(&["open", "unknown"])), 2);
+        assert_eq!(dispatch(to_args(&["completion", "fish"])), 1);
     }
 
     #[test]
@@ -277,6 +291,7 @@ mod tests {
         assert_eq!(print_group_usage("branch"), 0);
         assert_eq!(print_group_usage("ci"), 0);
         assert_eq!(print_group_usage("open"), 0);
+        assert_eq!(print_group_usage("completion"), 0);
         assert_eq!(print_group_usage("unknown"), 2);
     }
 
@@ -290,5 +305,6 @@ mod tests {
         assert!(text.contains("Groups:"));
         assert!(text.contains("Examples:"));
         assert!(text.contains("git-cli reset hard 3"));
+        assert!(text.contains("completion  bash | zsh"));
     }
 }

--- a/crates/git-cli/tests/completion_outside_repo.rs
+++ b/crates/git-cli/tests/completion_outside_repo.rs
@@ -1,0 +1,33 @@
+mod common;
+
+use common::GitCliHarness;
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let harness = GitCliHarness::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
+
+    let output = harness.run(dir.path(), &["completion", "zsh"]);
+
+    assert_eq!(output.code, 0);
+    assert_eq!(output.stderr_text(), "");
+    let stdout = output.stdout_text();
+    assert!(stdout.contains("#compdef git-cli"));
+    assert!(!stdout.contains("Not a git repository"));
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let harness = GitCliHarness::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
+
+    let output = harness.run(dir.path(), &["completion", "fish"]);
+
+    assert_eq!(output.code, 1);
+    assert!(
+        output
+            .stderr_text()
+            .contains("unsupported completion shell")
+    );
+    assert!(!output.stderr_text().contains("Not a git repository"));
+}

--- a/crates/git-cli/tests/dispatcher.rs
+++ b/crates/git-cli/tests/dispatcher.rs
@@ -15,6 +15,7 @@ Groups:
   branch   cleanup
   ci       pick
   open     repo | branch | default-branch | commit | compare | pr | pulls | issues | actions | releases | tags | commits | file | blame
+  completion  bash | zsh
 
 Help:
   git-cli help

--- a/crates/macos-agent/tests/input_keyboard.rs
+++ b/crates/macos-agent/tests/input_keyboard.rs
@@ -12,6 +12,8 @@ fn input_type_accepts_whitespace_and_punctuation() {
         &[
             "--format",
             "json",
+            "--timeout-ms",
+            "15000",
             "input",
             "type",
             "--text",
@@ -37,7 +39,7 @@ fn input_type_accepts_whitespace_and_punctuation() {
     );
     assert_eq!(
         payload["result"]["policy"]["timeout_ms"],
-        serde_json::json!(4000)
+        serde_json::json!(15000)
     );
 }
 
@@ -51,6 +53,8 @@ fn input_hotkey_json_reports_modifiers() {
         &[
             "--format",
             "json",
+            "--timeout-ms",
+            "15000",
             "input",
             "hotkey",
             "--mods",
@@ -81,7 +85,7 @@ fn input_hotkey_json_reports_modifiers() {
     );
     assert_eq!(
         payload["result"]["policy"]["timeout_ms"],
-        serde_json::json!(4000)
+        serde_json::json!(15000)
     );
 }
 

--- a/crates/macos-agent/tests/retry.rs
+++ b/crates/macos-agent/tests/retry.rs
@@ -21,6 +21,8 @@ fn click_retries_then_succeeds_when_policy_allows() {
         &[
             "--format",
             "json",
+            "--timeout-ms",
+            "15000",
             "--retries",
             "1",
             "--retry-delay-ms",
@@ -69,6 +71,8 @@ fn click_without_retries_fails_on_first_transient_error() {
         &[
             "--error-format",
             "json",
+            "--timeout-ms",
+            "15000",
             "input",
             "click",
             "--x",

--- a/crates/macos-agent/tests/scenario_chain.rs
+++ b/crates/macos-agent/tests/scenario_chain.rs
@@ -335,6 +335,7 @@ fn scenario_ax_step_supports_gate_and_postcondition_flags() {
                 "id": "ax-click-gated",
                 "args": [
                     "--format", "json",
+                    "--timeout-ms", "15000",
                     "ax", "click",
                     "--app", "Terminal",
                     "--node-id", "1.1",


### PR DESCRIPTION
## Summary
- add `git-cli completion <bash|zsh>` via clap + clap_complete
- migrate `completions/zsh/_git-cli` and `completions/bash/git-cli` to thin adapter wrappers
- add git-cli completion regression coverage (`completion_outside_repo`, usage/dispatcher expectations)
- stabilize macos-agent coverage flakes by setting explicit timeout in affected integration tests

## Validation
- `cargo test -p nils-git-cli`
- `zsh -f tests/zsh/completion.test.zsh`
- `zsh -n completions/zsh/_git-cli`
- `bash -n completions/bash/git-cli`
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85`
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info`
