### PR TITLE
feat(api-websocket): migrate completion to clap-first adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,6 +1699,7 @@ version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "nils-api-testing-core",
  "nils-term",
  "nils-test-support",

--- a/completions/bash/api-websocket
+++ b/completions/bash/api-websocket
@@ -6,105 +6,58 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
+_nils_cli_api_websocket_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
+
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
+
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
+
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
+}
+
+_NILS_API_WEBSOCKET_BASH_GENERATED_STATE=0
+
+_nils_cli_api_websocket_load_generated_bash() {
+  _nils_cli_api_websocket_source_common_bash || return 1
+
+  # command api-websocket completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_API_WEBSOCKET_BASH_GENERATED_STATE" \
+    "_nils_cli_api_websocket_generated" \
+    "api-websocket" \
+    "_api_websocket" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
 _nils_cli_api_websocket_complete() {
-  local -a words=("${COMP_WORDS[@]}")
-  local cword="$COMP_CWORD"
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prev="${COMP_WORDS[COMP_CWORD-1]}"
-
-  local -a subcmds=(call history report report-from-cmd)
-  local -a root_opts=(-h --help -V --version)
-
-  if (( cword == 1 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
-      return 0
+  if ! _nils_cli_api_websocket_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
+      COMPREPLY=()
     fi
-    local -a replies=()
-    replies+=( $(compgen -W "${subcmds[*]}" -- "$cur") )
-    replies+=( $(compgen -f -- "$cur") )
-    COMPREPLY=( "${replies[@]}" )
     return 0
   fi
 
-  local subcmd="${words[1]-}"
-  case "$subcmd" in
-    call|history|report|report-from-cmd) ;;
-    *) subcmd="call" ;;
-  esac
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev=''
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
 
-  case "$subcmd" in
-    call)
-      if [[ "$prev" == "--config-dir" ]]; then
-        COMPREPLY=( $(compgen -d -- "$cur") )
-        return 0
-      fi
-      if [[ "$prev" == "--format" ]]; then
-        COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-        return 0
-      fi
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help -e --env -u --url --token --config-dir --no-history --format" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=( $(compgen -f -- "$cur") )
-      return 0
-      ;;
-    history)
-      if [[ "$prev" == "--config-dir" ]]; then
-        COMPREPLY=( $(compgen -d -- "$cur") )
-        return 0
-      fi
-      if [[ "$prev" == "--file" ]]; then
-        COMPREPLY=( $(compgen -f -- "$cur") )
-        return 0
-      fi
-      if [[ "$prev" == "--format" ]]; then
-        COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-        return 0
-      fi
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --config-dir --file --last --tail --command-only --format" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    report)
-      case "$prev" in
-        --request|--out|--response)
-          COMPREPLY=( $(compgen -f -- "$cur") )
-          return 0
-          ;;
-        --project-root|--config-dir)
-          COMPREPLY=( $(compgen -d -- "$cur") )
-          return 0
-          ;;
-      esac
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --case --request --out -e --env -u --url --token --run --response --no-redact --no-command --no-command-url --project-root --config-dir" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    report-from-cmd)
-      case "$prev" in
-        --out|--response)
-          COMPREPLY=( $(compgen -f -- "$cur") )
-          return 0
-          ;;
-      esac
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --case --out --response --allow-empty --expect-empty --dry-run --stdin" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-  esac
-
-  COMPREPLY=()
+  _nils_cli_api_websocket_generated "api-websocket" "$cur" "$prev"
 }
 
-complete -F _nils_cli_api_websocket_complete api-websocket
+if _nils_cli_api_websocket_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_api_websocket_complete api-websocket
+else
+  complete -F _nils_cli_api_websocket_complete api-websocket
+fi

--- a/completions/zsh/_api-websocket
+++ b/completions/zsh/_api-websocket
@@ -1,126 +1,60 @@
 #compdef api-websocket
 
+_nils_cli_api_websocket_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_api-websocket]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_API_WEBSOCKET_ZSH_GENERATED_STATE=0
+
+_nils_cli_api_websocket_load_generated_zsh() {
+  _nils_cli_api_websocket_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_API_WEBSOCKET_ZSH_GENERATED_STATE" \
+    "_nils_cli_api_websocket_generated" \
+    "api-websocket" \
+    "_api-websocket" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_api_websocket_generated" \]; then$' \
+    '^fi$'
+}
+
 _api-websocket() {
   emulate -L zsh -o extendedglob
 
-  local context='' state='' state_descr=''
-  local -a line=()
-  typeset -A opt_args=()
-
-  local -i orig_current="$CURRENT"
-  local -a orig_words=("${words[@]}")
-
-  local cur="${orig_words[orig_current]-}"
-  cur="${cur%%[[:space:]]#}"
-
-  local -a subcommands=()
-  subcommands=(
-    'call:Execute a request file and print the response body to stdout (default)'
-    'history:Print the last (or last N) history entries'
-    'report:Generate a Markdown API test report'
-    'report-from-cmd:Generate a report from a saved `call` snippet'
-  )
-
-  if (( orig_current == 2 )); then
-    if [[ "$cur" == -* ]]; then
-      local -a root_opts=(
-        '-h:Show help'
-        '--help:Show help'
-        '-V:Show version'
-        '--version:Show version'
-      )
-      _describe -t options 'option' root_opts && return 0
-      return 0
+  if ! _nils_cli_api_websocket_load_generated_zsh; then
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
     fi
-
-    _describe -t commands 'api-websocket command' subcommands
-    _files
-    return 0
+    return 1
   fi
 
-  local subcmd="${orig_words[2]-}"
-  subcmd="${subcmd%%[[:space:]]#}"
-
-  case "$subcmd" in
-    call|history|report|report-from-cmd) ;;
-    *) subcmd="call" ;;
-  esac
-
-  case "$subcmd" in
-    call)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Show help]' \
-        '(-e --env)'{-e,--env}'[Endpoint preset name]:env:' \
-        '(-u --url)'{-u,--url}'[Explicit WebSocket URL]:url:' \
-        '--token=[Token profile name]:token:' \
-        '--config-dir=[WebSocket setup dir (discovery seed)]:dir:_files -/' \
-        '--no-history[Disable history writing]' \
-        '--format=[Output format]:format:(text json)' \
-        '1:request file:_files' \
-        && return 0
-      ;;
-    history)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Show help]' \
-        '--config-dir=[WebSocket setup dir (discovery seed)]:dir:_files -/' \
-        '--file=[Explicit history file path]:file:_files' \
-        '--last[Print the last entry (default)]' \
-        '--tail=[Print the last N entries]:n:' \
-        '--command-only[Omit metadata lines (starting with "#")]' \
-        '--format=[Output format]:format:(text json)' \
-        && return 0
-      ;;
-    report)
-      if [[ "$cur" == -* ]]; then
-        local -a report_opts=(
-          '--case:Report case name'
-          '--request:Request file path (*.ws.json or *.websocket.json)'
-          '--out:Output report path'
-          '--env:Endpoint preset name (passed through)'
-          '--url:Explicit WebSocket URL (passed through)'
-          '--token:Token profile name (passed through)'
-          '--run:Execute the request and embed the response'
-          '--response:Use an existing response file (or "-" for stdin)'
-          '--no-redact:Do not redact secrets in request/response JSON blocks'
-          '--no-command:Omit the command snippet section'
-          '--no-command-url:Omit URL value in command snippet'
-          '--project-root:Override project root (default: git root or CWD)'
-          '--config-dir:WebSocket setup dir (passed through)'
-          '--help:Show help'
-        )
-        _describe -t options 'option' report_opts && return 0
-      fi
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Show help]' \
-        '--case=[Report case name]:case:' \
-        '--request=[Request file path (*.ws.json or *.websocket.json)]:request file:_files' \
-        '--out=[Output report path]:file:_files' \
-        '(-e --env)'{-e,--env}'[Endpoint preset name (passed through)]:env:' \
-        '(-u --url)'{-u,--url}'[Explicit WebSocket URL (passed through)]:url:' \
-        '--token=[Token profile name (passed through)]:token:' \
-        '--run[Execute the request and embed the response]' \
-        '--response=[Use an existing response file (or "-" for stdin)]:response file:_files' \
-        '--no-redact[Do not redact secrets in request/response JSON blocks]' \
-        '--no-command[Omit the command snippet section]' \
-        '--no-command-url[When using --url, omit the URL value in the command snippet]' \
-        '--project-root=[Override project root (default: git root or CWD)]:dir:_files -/' \
-        '--config-dir=[WebSocket setup dir (passed through)]:dir:_files -/' \
-        && return 0
-      ;;
-    report-from-cmd)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Show help]' \
-        '--case=[Override report case name (default: derived from snippet)]:case:' \
-        '--out=[Output report path]:file:_files' \
-        '--response=[Use an existing response file (or "-" for stdin)]:response file:_files' \
-        '(--allow-empty --expect-empty)--allow-empty[Allow generating a report with empty/no-data response]' \
-        '(--allow-empty --expect-empty)--expect-empty[Alias of --allow-empty]' \
-        '--dry-run[Print equivalent `api-websocket report ...` command and exit 0]' \
-        '--stdin[Read the command snippet from stdin]' \
-        '1::snippet:' \
-        && return 0
-      ;;
-  esac
+  _nils_cli_api_websocket_generated
 }
 
-compdef _api-websocket api-websocket
+if _nils_cli_api_websocket_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _api-websocket api-websocket
+else
+  compdef _api-websocket api-websocket
+fi

--- a/crates/api-websocket/Cargo.toml
+++ b/crates/api-websocket/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 api-testing-core = { version = "0.4.4", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 nils-term = { version = "0.4.4", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 

--- a/crates/api-websocket/src/cli.rs
+++ b/crates/api-websocket/src/cli.rs
@@ -22,6 +22,15 @@ pub(crate) enum Command {
     Report(ReportArgs),
     /// Generate a Markdown API test report from a saved `call` command snippet
     ReportFromCmd(ReportFromCmdArgs),
+    /// Print shell completion script
+    Completion(CompletionArgs),
+}
+
+#[derive(Args)]
+pub(crate) struct CompletionArgs {
+    /// Shell to generate completion for
+    #[arg(value_enum)]
+    pub(crate) shell: crate::completion::CompletionShell,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]

--- a/crates/api-websocket/src/completion.rs
+++ b/crates/api-websocket/src/completion.rs
@@ -1,0 +1,26 @@
+use clap::{CommandFactory, ValueEnum};
+use clap_complete::{Generator, Shell, generate};
+
+use crate::cli::Cli;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum CompletionShell {
+    Bash,
+    Zsh,
+}
+
+pub(crate) fn run(shell: CompletionShell) -> i32 {
+    let mut command = Cli::command();
+    let bin_name = command.get_name().to_string();
+
+    match shell {
+        CompletionShell::Bash => print_completion(Shell::Bash, &mut command, &bin_name),
+        CompletionShell::Zsh => print_completion(Shell::Zsh, &mut command, &bin_name),
+    }
+
+    0
+}
+
+fn print_completion<G: Generator>(generator: G, command: &mut clap::Command, bin_name: &str) {
+    generate(generator, command, bin_name, &mut std::io::stdout());
+}

--- a/crates/api-websocket/src/main.rs
+++ b/crates/api-websocket/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod commands;
+mod completion;
 
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -9,6 +10,7 @@ use clap::error::ErrorKind;
 
 use crate::cli::{Cli, Command};
 use crate::commands::{cmd_call, cmd_history, cmd_report, cmd_report_from_cmd};
+use crate::completion::run as run_completion;
 
 fn argv_with_default_command(raw_args: &[String]) -> Vec<String> {
     let mut argv = vec!["api-websocket".to_string()];
@@ -20,7 +22,10 @@ fn argv_with_default_command(raw_args: &[String]) -> Vec<String> {
     let is_root_help = first == "-h" || first == "--help";
     let is_root_version = first == "-V" || first == "--version";
 
-    let is_explicit_command = matches!(first, "call" | "history" | "report" | "report-from-cmd");
+    let is_explicit_command = matches!(
+        first,
+        "call" | "history" | "report" | "report-from-cmd" | "completion"
+    );
     if !is_explicit_command && !is_root_help && !is_root_version {
         argv.push("call".to_string());
     }
@@ -39,6 +44,7 @@ fn print_root_help() {
     println!("  history   Print the last (or last N) history entries");
     println!("  report    Generate a Markdown API test report");
     println!("  report-from-cmd  Generate a report from a saved `call` snippet");
+    println!("  completion      Print shell completion script");
     println!();
     println!("Common options (see subcommand help for full details):");
     println!("  --config-dir <dir>   Seed setup/websocket discovery (call/history/report)");
@@ -50,6 +56,7 @@ fn print_root_help() {
     println!("  api-websocket call --help");
     println!("  api-websocket report --help");
     println!("  api-websocket report-from-cmd --help");
+    println!("  api-websocket completion zsh");
 }
 
 fn main() {
@@ -108,6 +115,7 @@ fn run() -> i32 {
         Some(Command::ReportFromCmd(args)) => {
             cmd_report_from_cmd(&args, &invocation_dir, &mut stdout, &mut stderr)
         }
+        Some(Command::Completion(args)) => run_completion(args.shell),
     }
 }
 
@@ -131,6 +139,16 @@ mod tests {
         assert_eq!(
             argv,
             vec!["api-websocket".to_string(), "history".to_string()]
+        );
+
+        let argv = argv_with_default_command(&["completion".to_string(), "zsh".to_string()]);
+        assert_eq!(
+            argv,
+            vec![
+                "api-websocket".to_string(),
+                "completion".to_string(),
+                "zsh".to_string()
+            ]
         );
 
         let argv = argv_with_default_command(&["requests/health.ws.json".to_string()]);

--- a/crates/api-websocket/tests/cli_smoke.rs
+++ b/crates/api-websocket/tests/cli_smoke.rs
@@ -19,6 +19,7 @@ fn help_includes_key_flags() {
     let text = format!("{}{}", out.stdout_text(), out.stderr_text());
     assert!(text.contains("history"));
     assert!(text.contains("report-from-cmd"));
+    assert!(text.contains("completion"));
     assert!(text.contains("--config-dir"));
     assert!(text.contains("--format"));
 }

--- a/crates/api-websocket/tests/completion_outside_repo.rs
+++ b/crates/api-websocket/tests/completion_outside_repo.rs
@@ -1,0 +1,54 @@
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use nils_test_support::bin::resolve;
+
+fn api_websocket_bin() -> PathBuf {
+    resolve("api-websocket")
+}
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(api_websocket_bin())
+        .args(["completion", "zsh"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run api-websocket completion zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef api-websocket"),
+        "missing zsh completion header: {stdout}"
+    );
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(api_websocket_bin())
+        .args(["completion", "fish"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run api-websocket completion fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid value") && stderr.contains("fish"),
+        "missing invalid shell error: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- migrate `api-websocket` to a clap-first completion export path via `api-websocket completion <bash|zsh>`
- replace static zsh/bash completion scripts with thin adapters that load generated completion from the binary
- add completion-specific tests (outside-repo export + invalid shell) and update CLI smoke help assertions

## Validation
- cargo test -p nils-api-websocket
- zsh -n completions/zsh/_api-websocket
- bash -n completions/bash/api-websocket
- zsh -f tests/zsh/completion.test.zsh
