### PR TITLE
feat(api-test): migrate completion to clap-first adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,6 +1662,7 @@ version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "nils-api-testing-core",
  "nils-term",
  "nils-test-support",

--- a/completions/bash/api-test
+++ b/completions/bash/api-test
@@ -6,63 +6,58 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
+_nils_cli_api_test_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
+
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
+
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
+
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
+}
+
+_NILS_API_TEST_BASH_GENERATED_STATE=0
+
+_nils_cli_api_test_load_generated_bash() {
+  _nils_cli_api_test_source_common_bash || return 1
+
+  # command api-test completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_API_TEST_BASH_GENERATED_STATE" \
+    "_nils_cli_api_test_generated" \
+    "api-test" \
+    "_api_test" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
 _nils_cli_api_test_complete() {
-  local -a words=("${COMP_WORDS[@]}")
-  local cword="$COMP_CWORD"
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prev="${COMP_WORDS[COMP_CWORD-1]}"
-
-  local -a subcmds=(run summary)
-  local -a root_opts=(-h --help -V --version)
-
-  if (( cword == 1 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
-      return 0
+  if ! _nils_cli_api_test_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
+      COMPREPLY=()
     fi
-    COMPREPLY=( $(compgen -W "${subcmds[*]}" -- "$cur") )
     return 0
   fi
 
-  local subcmd="${words[1]-}"
-  case "$subcmd" in
-    run|summary) ;;
-    *) subcmd="run" ;;
-  esac
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev=''
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
 
-  case "$subcmd" in
-    run)
-      case "$prev" in
-        --suite-file|--out|--junit)
-          COMPREPLY=( $(compgen -f -- "$cur") )
-          return 0
-          ;;
-      esac
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --suite --suite-file --out --junit --allow-writes --tag --only --skip --fail-fast --continue" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    summary)
-      case "$prev" in
-        --in|--out)
-          COMPREPLY=( $(compgen -f -- "$cur") )
-          return 0
-          ;;
-      esac
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --in --out --slow --hide-skipped --max-failed --max-skipped --no-github-summary" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-  esac
-
-  COMPREPLY=()
+  _nils_cli_api_test_generated "api-test" "$cur" "$prev"
 }
 
-complete -F _nils_cli_api_test_complete api-test
-
+if _nils_cli_api_test_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_api_test_complete api-test
+else
+  complete -F _nils_cli_api_test_complete api-test
+fi

--- a/completions/zsh/_api-test
+++ b/completions/zsh/_api-test
@@ -1,108 +1,60 @@
 #compdef api-test
 
+_nils_cli_api_test_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_api-test]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_API_TEST_ZSH_GENERATED_STATE=0
+
+_nils_cli_api_test_load_generated_zsh() {
+  _nils_cli_api_test_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_API_TEST_ZSH_GENERATED_STATE" \
+    "_nils_cli_api_test_generated" \
+    "api-test" \
+    "_api-test" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_api_test_generated" \]; then$' \
+    '^fi$'
+}
+
 _api-test() {
   emulate -L zsh -o extendedglob
 
-  local context='' state='' state_descr=''
-  local -a line=()
-  typeset -A opt_args=()
-
-  local -i orig_current="$CURRENT"
-  local -a orig_words=("${words[@]}")
-
-  local cur="${orig_words[orig_current]-}"
-  cur="${cur%%[[:space:]]#}"
-
-  local -a subcommands=()
-  subcommands=(
-    'run:Run a suite (default)'
-    'summary:Render a Markdown summary from results JSON'
-  )
-
-  if (( orig_current == 2 )); then
-    if [[ "$cur" == -* ]]; then
-      local -a root_opts=(
-        '-h:Show help'
-        '--help:Show help'
-        '-V:Show version'
-        '--version:Show version'
-      )
-      _describe -t options 'option' root_opts && return 0
-      return 0
+  if ! _nils_cli_api_test_load_generated_zsh; then
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
     fi
-
-    _describe -t commands 'api-test command' subcommands && return 0
-    return 0
+    return 1
   fi
 
-  local subcmd="${orig_words[2]-}"
-  subcmd="${subcmd%%[[:space:]]#}"
-
-  case "$subcmd" in
-    run|summary) ;;
-    *) subcmd="run" ;;
-  esac
-
-  case "$subcmd" in
-    run)
-      if [[ "$cur" == -* ]]; then
-        local -a run_opts=(
-          '--suite:Suite name (tests/api/suites/<name>.suite.json)'
-          '--suite-file:Explicit suite file path'
-          '--out:Write results JSON to a file'
-          '--junit:Write JUnit XML to a file'
-          '--allow-writes:Allow write-capable cases'
-          '--tag:Run only cases that include this tag'
-          '--only:Run only listed case IDs (comma-separated)'
-          '--skip:Skip listed case IDs (comma-separated)'
-          '--fail-fast:Stop after the first failed case'
-          '--continue:Continue after failures (default)'
-          '--help:Show help'
-          '-h:Show help'
-        )
-        _describe -t options 'option' run_opts && return 0
-      fi
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Show help]' \
-        '--suite=[Suite name (tests/api/suites/<name>.suite.json)]:suite:' \
-        '--suite-file=[Explicit suite file path]:suite file:_files' \
-        '--out=[Write results JSON to a file]:file:_files' \
-        '--junit=[Write JUnit XML to a file]:file:_files' \
-        '--allow-writes[Allow write-capable cases (still requires allowWrite: true)]' \
-        '--tag=[Run only cases that include this tag (repeatable; AND semantics)]:tag:' \
-        '--only=[Run only listed case IDs (comma-separated)]:ids:' \
-        '--skip=[Skip listed case IDs (comma-separated)]:ids:' \
-        '--fail-fast[Stop after the first failed case]' \
-        '--continue[Continue after failures (default)]' \
-        && return 0
-      ;;
-    summary)
-      if [[ "$cur" == -* ]]; then
-        local -a summary_opts=(
-          '--in:Input results JSON file path (default: stdin)'
-          '--out:Write Markdown summary to a file'
-          '--slow:Show slowest N executed cases'
-          '--hide-skipped:Do not show skipped cases list'
-          '--max-failed:Max failed cases to print'
-          '--max-skipped:Max skipped cases to print'
-          '--no-github-summary:Do not write to $GITHUB_STEP_SUMMARY'
-          '--help:Show help'
-          '-h:Show help'
-        )
-        _describe -t options 'option' summary_opts && return 0
-      fi
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Show help]' \
-        '--in=[Input results JSON file path (default: stdin)]:file:_files' \
-        '--out=[Write Markdown summary to a file]:file:_files' \
-        '--slow=[Show slowest N executed cases]:n:' \
-        '--hide-skipped[Do not show skipped cases list]' \
-        '--max-failed=[Max failed cases to print]:n:' \
-        '--max-skipped=[Max skipped cases to print]:n:' \
-        '--no-github-summary[Do not write to $GITHUB_STEP_SUMMARY]' \
-        && return 0
-      ;;
-  esac
+  _nils_cli_api_test_generated
 }
 
-compdef _api-test api-test
+if _nils_cli_api_test_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _api-test api-test
+else
+  compdef _api-test api-test
+fi

--- a/crates/api-test/Cargo.toml
+++ b/crates/api-test/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 api-testing-core = { version = "0.4.4", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 nils-term = { version = "0.4.4", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/api-test/src/completion.rs
+++ b/crates/api-test/src/completion.rs
@@ -1,0 +1,26 @@
+use clap::{CommandFactory, ValueEnum};
+use clap_complete::{Generator, Shell, generate};
+
+use crate::Cli;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum CompletionShell {
+    Bash,
+    Zsh,
+}
+
+pub(crate) fn run(shell: CompletionShell) -> i32 {
+    let mut command = Cli::command();
+    let bin_name = command.get_name().to_string();
+
+    match shell {
+        CompletionShell::Bash => print_completion(Shell::Bash, &mut command, &bin_name),
+        CompletionShell::Zsh => print_completion(Shell::Zsh, &mut command, &bin_name),
+    }
+
+    0
+}
+
+fn print_completion<G: Generator>(generator: G, command: &mut clap::Command, bin_name: &str) {
+    generate(generator, command, bin_name, &mut std::io::stdout());
+}

--- a/crates/api-test/src/main.rs
+++ b/crates/api-test/src/main.rs
@@ -13,6 +13,8 @@ use api_testing_core::suite::schema::load_and_validate_suite;
 use api_testing_core::suite::summary::{SummaryOptions, render_summary_from_json_str};
 use nils_term::progress::{Progress, ProgressOptions};
 
+mod completion;
+
 #[derive(Parser)]
 #[command(
     name = "api-test",
@@ -31,6 +33,15 @@ enum Command {
     Run(RunArgs),
     /// Render a Markdown summary from results JSON
     Summary(SummaryArgs),
+    /// Print shell completion script
+    Completion(CompletionArgs),
+}
+
+#[derive(Args)]
+struct CompletionArgs {
+    /// Shell to generate completion for
+    #[arg(value_enum)]
+    shell: completion::CompletionShell,
 }
 
 #[derive(Args)]
@@ -125,7 +136,7 @@ fn argv_with_default_command(raw_args: &[String]) -> Vec<String> {
     let is_root_help = first == "-h" || first == "--help";
     let is_root_version = first == "-V" || first == "--version";
 
-    let is_explicit_command = matches!(first, "run" | "summary");
+    let is_explicit_command = matches!(first, "run" | "summary" | "completion");
     if !is_explicit_command && !is_root_help && !is_root_version {
         argv.push("run".to_string());
     }
@@ -140,6 +151,7 @@ fn print_root_help() {
     println!("Commands:");
     println!("  run      Run a suite (default)");
     println!("  summary  Render a Markdown summary from results JSON");
+    println!("  completion  Print shell completion script");
     println!();
     println!("Common options (run; see `api-test run --help` for full details):");
     println!("  --suite <name>        Resolve suite under tests/api/suites/<name>.suite.json");
@@ -156,6 +168,7 @@ fn print_root_help() {
     println!("  api-test --help");
     println!("  api-test --suite smoke --help");
     println!("  api-test run --suite smoke --out results.json");
+    println!("  api-test completion zsh");
 }
 
 fn main() {
@@ -195,6 +208,7 @@ fn run() -> i32 {
         }
         Some(Command::Run(args)) => cmd_run(&args),
         Some(Command::Summary(args)) => cmd_summary(&args),
+        Some(Command::Completion(args)) => completion::run(args.shell),
     }
 }
 
@@ -383,4 +397,43 @@ fn cmd_summary(args: &SummaryArgs) -> i32 {
 
     print!("{md}");
     0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::argv_with_default_command;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn argv_with_default_command_inserts_run_except_for_explicit_commands() {
+        let argv = argv_with_default_command(&[]);
+        assert_eq!(argv, vec!["api-test".to_string()]);
+
+        let argv = argv_with_default_command(&["--help".to_string()]);
+        assert_eq!(argv, vec!["api-test".to_string(), "--help".to_string()]);
+
+        let argv = argv_with_default_command(&["summary".to_string()]);
+        assert_eq!(argv, vec!["api-test".to_string(), "summary".to_string()]);
+
+        let argv = argv_with_default_command(&["completion".to_string(), "zsh".to_string()]);
+        assert_eq!(
+            argv,
+            vec![
+                "api-test".to_string(),
+                "completion".to_string(),
+                "zsh".to_string()
+            ]
+        );
+
+        let argv = argv_with_default_command(&["--suite".to_string(), "smoke".to_string()]);
+        assert_eq!(
+            argv,
+            vec![
+                "api-test".to_string(),
+                "run".to_string(),
+                "--suite".to_string(),
+                "smoke".to_string()
+            ]
+        );
+    }
 }

--- a/crates/api-test/tests/cli_smoke.rs
+++ b/crates/api-test/tests/cli_smoke.rs
@@ -18,6 +18,7 @@ fn help_includes_key_flags() {
     assert_eq!(out.code, 0);
     let text = format!("{}{}", out.stdout_text(), out.stderr_text());
     assert!(text.contains("summary"));
+    assert!(text.contains("completion"));
     assert!(text.contains("--suite"));
     assert!(text.contains("--suite-file"));
 }

--- a/crates/api-test/tests/completion_outside_repo.rs
+++ b/crates/api-test/tests/completion_outside_repo.rs
@@ -1,0 +1,54 @@
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use nils_test_support::bin::resolve;
+
+fn api_test_bin() -> PathBuf {
+    resolve("api-test")
+}
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(api_test_bin())
+        .args(["completion", "zsh"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run api-test completion zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef api-test"),
+        "missing zsh completion header: {stdout}"
+    );
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(api_test_bin())
+        .args(["completion", "fish"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run api-test completion fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid value") && stderr.contains("fish"),
+        "missing invalid shell error: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- migrate `api-test` to a clap-first completion export path via `api-test completion <bash|zsh>` while preserving default `run` behavior
- replace static zsh/bash completion scripts with thin adapters that load generated completion from the binary
- add completion-specific tests (outside-repo export + invalid shell) and update root help smoke assertions

## Validation
- cargo test -p nils-api-test
- zsh -n completions/zsh/_api-test
- bash -n completions/bash/api-test
- zsh -f tests/zsh/completion.test.zsh
