### PR TITLE
feat(agent-docs): migrate completion to clap-first adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,7 @@ version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "directories",
  "serde",
  "serde_json",

--- a/completions/bash/agent-docs
+++ b/completions/bash/agent-docs
@@ -6,146 +6,58 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
+_nils_cli_agent_docs_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
+
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
+
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
+
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
+}
+
+_NILS_AGENT_DOCS_BASH_GENERATED_STATE=0
+
+_nils_cli_agent_docs_load_generated_bash() {
+  _nils_cli_agent_docs_source_common_bash || return 1
+
+  # command agent-docs completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_AGENT_DOCS_BASH_GENERATED_STATE" \
+    "_nils_cli_agent_docs_generated" \
+    "agent-docs" \
+    "_agent_docs" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
 _nils_cli_agent_docs_complete() {
-  local -a words=("${COMP_WORDS[@]}")
-  local cword="$COMP_CWORD"
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prev="${COMP_WORDS[COMP_CWORD-1]}"
-
-  local -a subcmds=(resolve contexts add scaffold-agents baseline scaffold-baseline)
-  local -a root_opts=(-h --help -V --version --agent-home --project-path)
-  local -a contexts=(startup skill-dev task-tools project-dev)
-  local -a scopes=(home project)
-  local -a baseline_targets=(home project all)
-  local -a formats=(text json)
-  local -a resolve_formats=(text json checklist)
-
-  local subcmd=''
-  local i=1
-  while (( i < ${#words[@]} )); do
-    local token="${words[i]}"
-    case "$token" in
-      --agent-home|--project-path)
-        ((i+=2))
-        continue
-        ;;
-      -h|--help|-V|--version)
-        ((i++))
-        continue
-        ;;
-      -*)
-        ((i++))
-        continue
-        ;;
-      *)
-        subcmd="$token"
-        break
-        ;;
-    esac
-  done
-
-  case "$prev" in
-    --agent-home|--project-path|--path|--output)
-      COMPREPLY=( $(compgen -f -- "$cur") )
-      return 0
-      ;;
-    --context)
-      COMPREPLY=( $(compgen -W "${contexts[*]}" -- "$cur") )
-      return 0
-      ;;
-    --scope)
-      COMPREPLY=( $(compgen -W "${scopes[*]}" -- "$cur") )
-      return 0
-      ;;
-    --target)
-      case "$subcmd" in
-        baseline|scaffold-baseline)
-          COMPREPLY=( $(compgen -W "${baseline_targets[*]}" -- "$cur") )
-          return 0
-          ;;
-      esac
-      COMPREPLY=( $(compgen -W "${scopes[*]}" -- "$cur") )
-      return 0
-      ;;
-    --format)
-      if [[ "$subcmd" == "resolve" ]]; then
-        COMPREPLY=( $(compgen -W "${resolve_formats[*]}" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=( $(compgen -W "${formats[*]}" -- "$cur") )
-      return 0
-      ;;
-    --when)
-      COMPREPLY=( $(compgen -W "always" -- "$cur") )
-      return 0
-      ;;
-    --notes)
+  if ! _nils_cli_agent_docs_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
       COMPREPLY=()
-      return 0
-      ;;
-  esac
-
-  if [[ -z "$subcmd" || $cword -le $i ]]; then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
-      return 0
     fi
-    COMPREPLY=( $(compgen -W "${subcmds[*]}" -- "$cur") )
     return 0
   fi
 
-  case "$subcmd" in
-    resolve)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --agent-home --project-path --context --format --strict" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    contexts)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --agent-home --project-path --format" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    add)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --agent-home --project-path --target --context --scope --path --required --when --notes" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    scaffold-agents)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --agent-home --project-path --target --output --force" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    baseline)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --agent-home --project-path --check --target --format --strict" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    scaffold-baseline)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --agent-home --project-path --target --missing-only --force --dry-run --format" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-  esac
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev=''
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
 
-  COMPREPLY=()
+  _nils_cli_agent_docs_generated "agent-docs" "$cur" "$prev"
 }
 
-complete -F _nils_cli_agent_docs_complete agent-docs
+if _nils_cli_agent_docs_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_agent_docs_complete agent-docs
+else
+  complete -F _nils_cli_agent_docs_complete agent-docs
+fi

--- a/completions/zsh/_agent-docs
+++ b/completions/zsh/_agent-docs
@@ -1,117 +1,60 @@
 #compdef agent-docs
 
+_nils_cli_agent_docs_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_agent-docs]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_AGENT_DOCS_ZSH_GENERATED_STATE=0
+
+_nils_cli_agent_docs_load_generated_zsh() {
+  _nils_cli_agent_docs_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_AGENT_DOCS_ZSH_GENERATED_STATE" \
+    "_nils_cli_agent_docs_generated" \
+    "agent-docs" \
+    "_agent-docs" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_agent_docs_generated" \]; then$' \
+    '^fi$'
+}
+
 _agent-docs() {
   emulate -L zsh -o extendedglob
 
-  local context='' state='' state_descr=''
-  local -a line=()
-  typeset -A opt_args=()
+  if ! _nils_cli_agent_docs_load_generated_zsh; then
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
+    fi
+    return 1
+  fi
 
-  local -a subcommands=()
-  subcommands=(
-    'resolve:Resolve required docs for a context'
-    'contexts:List supported contexts'
-    'add:Upsert one AGENT_DOCS.toml entry'
-    'scaffold-agents:Scaffold default AGENTS.md template'
-    'baseline:Check baseline doc coverage'
-    'scaffold-baseline:Scaffold missing baseline docs'
-  )
-
-  local subcmd=''
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[Print help]' \
-    '(-V --version)'{-V,--version}'[Print version]' \
-    '--agent-home=[Override AGENT_HOME root]:path:_files -/' \
-    '--project-path=[Override PROJECT_PATH root]:path:_files -/' \
-    '1:command:->subcmds' \
-    '*::arg:->args'
-
-  case "${state-}" in
-    subcmds)
-      _describe -t commands 'agent-docs command' subcommands && return 0
-      ;;
-    args)
-      subcmd="${line[1]-}"
-      subcmd="${subcmd%%[[:space:]]#}"
-      ;;
-  esac
-
-  case "$subcmd" in
-    resolve)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Print help]' \
-        '--agent-home=[Override AGENT_HOME root]:path:_files -/' \
-        '--project-path=[Override PROJECT_PATH root]:path:_files -/' \
-        '--context=[Context to resolve]:context:(startup skill-dev task-tools project-dev)' \
-        '--format=[Output format]:format:(text json checklist)' \
-        '--strict[Return non-zero when required documents are missing]' \
-        && return 0
-      ;;
-    contexts)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Print help]' \
-        '--agent-home=[Override AGENT_HOME root]:path:_files -/' \
-        '--project-path=[Override PROJECT_PATH root]:path:_files -/' \
-        '--format=[Output format]:format:(text json)' \
-        && return 0
-      ;;
-    add)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Print help]' \
-        '--agent-home=[Override AGENT_HOME root]:path:_files -/' \
-        '--project-path=[Override PROJECT_PATH root]:path:_files -/' \
-        '--target=[Config scope file to update]:target:(home project)' \
-        '--context=[Context key]:context:(startup skill-dev task-tools project-dev)' \
-        '--scope=[Document root scope]:scope:(home project)' \
-        '--path=[Document path]:path:_files -/' \
-        '--required[Set required=true for this entry]' \
-        '--when=[Condition key]:when:(always)' \
-        '--notes=[Optional notes text]:notes:' \
-        && return 0
-      ;;
-    scaffold-agents)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Print help]' \
-        '--agent-home=[Override AGENT_HOME root]:path:_files -/' \
-        '--project-path=[Override PROJECT_PATH root]:path:_files -/' \
-        '--target=[Scope root to scaffold]:target:(home project)' \
-        '--output=[Write to explicit output file path]:path:_files -/' \
-        '--force[Overwrite output file when it exists]' \
-        && return 0
-      ;;
-    baseline)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Print help]' \
-        '--agent-home=[Override AGENT_HOME root]:path:_files -/' \
-        '--project-path=[Override PROJECT_PATH root]:path:_files -/' \
-        '--check[Run baseline coverage checks]' \
-        '--target=[Scope selection]:target:(home project all)' \
-        '--format=[Output format]:format:(text json)' \
-        '--strict[Return non-zero when required documents are missing]' \
-        && return 0
-      ;;
-    scaffold-baseline)
-      _arguments -C \
-        '(-h --help)'{-h,--help}'[Print help]' \
-        '--agent-home=[Override AGENT_HOME root]:path:_files -/' \
-        '--project-path=[Override PROJECT_PATH root]:path:_files -/' \
-        '--target=[Scope selection]:target:(home project all)' \
-        '--missing-only[Create only missing baseline files]' \
-        '--force[Overwrite existing files]' \
-        '--dry-run[Print planned writes without writing files]' \
-        '--format=[Output format]:format:(text json)' \
-        && return 0
-      ;;
-    '')
-      _message 'command (resolve|contexts|add|scaffold-agents|baseline|scaffold-baseline)'
-      return 0
-      ;;
-    *)
-      _message 'unknown command'
-      return 0
-      ;;
-  esac
+  _nils_cli_agent_docs_generated
 }
 
-compdef _agent-docs agent-docs
+if _nils_cli_agent_docs_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _agent-docs agent-docs
+else
+  compdef _agent-docs agent-docs
+fi

--- a/crates/agent-docs/Cargo.toml
+++ b/crates/agent-docs/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 directories = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/agent-docs/src/cli.rs
+++ b/crates/agent-docs/src/cli.rs
@@ -43,6 +43,7 @@ pub enum Command {
     ScaffoldAgents(ScaffoldAgentsArgs),
     Baseline(BaselineArgs),
     ScaffoldBaseline(ScaffoldBaselineArgs),
+    Completion(CompletionArgs),
 }
 
 #[derive(Debug, Args)]
@@ -130,4 +131,10 @@ pub struct ScaffoldBaselineArgs {
 
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     pub format: OutputFormat,
+}
+
+#[derive(Debug, Args)]
+pub struct CompletionArgs {
+    #[arg(value_enum)]
+    pub shell: crate::completion::CompletionShell,
 }

--- a/crates/agent-docs/src/completion.rs
+++ b/crates/agent-docs/src/completion.rs
@@ -1,0 +1,26 @@
+use clap::{CommandFactory, ValueEnum};
+use clap_complete::{Generator, Shell, generate};
+
+use crate::cli::Cli;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum CompletionShell {
+    Bash,
+    Zsh,
+}
+
+pub(crate) fn run(shell: CompletionShell) -> i32 {
+    let mut command = Cli::command();
+    let bin_name = command.get_name().to_string();
+
+    match shell {
+        CompletionShell::Bash => print_completion(Shell::Bash, &mut command, &bin_name),
+        CompletionShell::Zsh => print_completion(Shell::Zsh, &mut command, &bin_name),
+    }
+
+    0
+}
+
+fn print_completion<G: Generator>(generator: G, command: &mut clap::Command, bin_name: &str) {
+    generate(generator, command, bin_name, &mut std::io::stdout());
+}

--- a/crates/agent-docs/src/lib.rs
+++ b/crates/agent-docs/src/lib.rs
@@ -1,5 +1,6 @@
 mod cli;
 pub mod commands;
+mod completion;
 pub mod config;
 pub mod env;
 pub mod model;
@@ -195,6 +196,7 @@ fn dispatch(cli: Cli) -> i32 {
                 }
             }
         }
+        Command::Completion(args) => completion::run(args.shell),
     }
 }
 

--- a/crates/agent-docs/tests/completion_outside_repo.rs
+++ b/crates/agent-docs/tests/completion_outside_repo.rs
@@ -1,0 +1,69 @@
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn agent_docs_bin() -> PathBuf {
+    for env_name in ["CARGO_BIN_EXE_agent-docs", "CARGO_BIN_EXE_agent_docs"] {
+        if let Some(path) = std::env::var_os(env_name) {
+            return PathBuf::from(path);
+        }
+    }
+
+    let current = std::env::current_exe().expect("current test executable");
+    let target_profile_dir = current
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("target profile dir");
+    let candidate = target_profile_dir.join(format!("agent-docs{}", std::env::consts::EXE_SUFFIX));
+    assert!(
+        candidate.exists(),
+        "agent-docs binary path not found via env vars or fallback candidate {}",
+        candidate.display()
+    );
+    candidate
+}
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(agent_docs_bin())
+        .args(["completion", "zsh"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run agent-docs completion zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef agent-docs"),
+        "missing zsh completion header: {stdout}"
+    );
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(agent_docs_bin())
+        .args(["completion", "fish"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run agent-docs completion fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid value") && stderr.contains("fish"),
+        "missing invalid shell error: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- add clap-first completion export via `agent-docs completion <bash|zsh>`
- migrate zsh/bash completion assets to thin adapters backed by generated completion scripts
- add completion outside-repo tests for export and invalid-shell rejection

## Validation
- cargo test -p nils-agent-docs
- zsh -n completions/zsh/_agent-docs
- bash -n completions/bash/agent-docs
- zsh -f tests/zsh/completion.test.zsh
