### PR TITLE
feat(agentctl): migrate completion to clap-first adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,7 @@ name = "nils-agentctl"
 version = "0.4.4"
 dependencies = [
  "clap",
+ "clap_complete",
  "nils-agent-provider-claude",
  "nils-agent-provider-codex",
  "nils-agent-provider-gemini",
@@ -1608,6 +1609,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/completions/bash/agentctl
+++ b/completions/bash/agentctl
@@ -6,97 +6,58 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
+_nils_cli_agentctl_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
+
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
+
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
+
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
+}
+
+_NILS_AGENTCTL_BASH_GENERATED_STATE=0
+
+_nils_cli_agentctl_load_generated_bash() {
+  _nils_cli_agentctl_source_common_bash || return 1
+
+  # command agentctl completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_AGENTCTL_BASH_GENERATED_STATE" \
+    "_nils_cli_agentctl_generated" \
+    "agentctl" \
+    "_agentctl" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
 _nils_cli_agentctl_complete() {
-  local -a words=("${COMP_WORDS[@]}")
-  local cword="$COMP_CWORD"
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prev="${COMP_WORDS[COMP_CWORD-1]}"
-
-  local -a root_cmds=(provider diag debug workflow automation help)
-  local -a root_opts=(-h --help -V --version)
-
-  if (( cword == 1 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
-      return 0
+  if ! _nils_cli_agentctl_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
+      COMPREPLY=()
     fi
-    COMPREPLY=( $(compgen -W "${root_cmds[*]}" -- "$cur") )
     return 0
   fi
 
-  local cmd="${words[1]-}"
-  case "$cmd" in
-    provider)
-      local -a provider_cmds=(list healthcheck)
-      if (( cword == 2 )); then
-        COMPREPLY=( $(compgen -W "${provider_cmds[*]}" -- "$cur") )
-        return 0
-      fi
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --provider --timeout-ms --format" -- "$cur") )
-      else
-        COMPREPLY=()
-      fi
-      return 0
-      ;;
-    diag)
-      local -a diag_cmds=(doctor capabilities)
-      if (( cword == 2 )); then
-        COMPREPLY=( $(compgen -W "${diag_cmds[*]}" -- "$cur") )
-        return 0
-      fi
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --provider --include-experimental --timeout-ms --format --probe-mode" -- "$cur") )
-      elif [[ "$prev" == "--format" ]]; then
-        COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-      elif [[ "$prev" == "--probe-mode" ]]; then
-        COMPREPLY=( $(compgen -W "auto live test" -- "$cur") )
-      else
-        COMPREPLY=()
-      fi
-      return 0
-      ;;
-    debug)
-      if (( cword == 2 )); then
-        COMPREPLY=( $(compgen -W "bundle" -- "$cur") )
-        return 0
-      fi
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --output-dir --format" -- "$cur") )
-      elif [[ "$prev" == "--format" ]]; then
-        COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-      else
-        COMPREPLY=( $(compgen -d -- "$cur") )
-      fi
-      return 0
-      ;;
-    workflow)
-      if (( cword == 2 )); then
-        COMPREPLY=( $(compgen -W "run" -- "$cur") )
-        return 0
-      fi
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help --file --format" -- "$cur") )
-      elif [[ "$prev" == "--format" ]]; then
-        COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-      elif [[ "$prev" == "--file" ]]; then
-        COMPREPLY=( $(compgen -f -- "$cur") )
-      else
-        COMPREPLY=()
-      fi
-      return 0
-      ;;
-    automation|help)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-h --help" -- "$cur") )
-      else
-        COMPREPLY=()
-      fi
-      return 0
-      ;;
-  esac
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev=''
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
 
-  COMPREPLY=()
+  _nils_cli_agentctl_generated "agentctl" "$cur" "$prev"
 }
 
-complete -F _nils_cli_agentctl_complete agentctl
+if _nils_cli_agentctl_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_agentctl_complete agentctl
+else
+  complete -F _nils_cli_agentctl_complete agentctl
+fi

--- a/completions/zsh/_agentctl
+++ b/completions/zsh/_agentctl
@@ -1,136 +1,60 @@
 #compdef agentctl
 
+_nils_cli_agentctl_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_agentctl]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_AGENTCTL_ZSH_GENERATED_STATE=0
+
+_nils_cli_agentctl_load_generated_zsh() {
+  _nils_cli_agentctl_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_AGENTCTL_ZSH_GENERATED_STATE" \
+    "_nils_cli_agentctl_generated" \
+    "agentctl" \
+    "_agentctl" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_agentctl_generated" \]; then$' \
+    '^fi$'
+}
+
 _agentctl() {
   emulate -L zsh -o extendedglob
 
-  local context='' state='' state_descr=''
-  typeset -A opt_args
+  if ! _nils_cli_agentctl_load_generated_zsh; then
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
+    fi
+    return 1
+  fi
 
-  local -a commands=(
-    'provider:Provider registry and selection'
-    'diag:Provider-neutral diagnostics'
-    'debug:Debug bundle and troubleshooting tools'
-    'workflow:Declarative workflow orchestration'
-    'automation:Local automation integrations'
-    'help:Display help message'
-  )
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[Show help]' \
-    '(-V --version)'{-V,--version}'[Show version]' \
-    '1:command:->command' \
-    '*::arg:->args'
-
-  case "$state" in
-    command)
-      _describe -t commands 'agentctl command' commands && return 0
-      ;;
-    args)
-      ;;
-    *)
-      return 0
-      ;;
-  esac
-
-  local cmd="${words[2]-}"
-  case "$cmd" in
-    provider)
-      local -a provider_cmds=(
-        'list:List registered providers and current health status'
-        'healthcheck:Execute healthcheck for one provider'
-      )
-      if (( CURRENT == 3 )); then
-        _describe -t commands 'agentctl provider' provider_cmds && return 0
-      fi
-      case "${words[3]-}" in
-        list|healthcheck)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--provider=[Provider override]:provider id:' \
-            '--timeout-ms=[Healthcheck timeout in milliseconds]:milliseconds:' \
-            '--format=[Output format]:format:(text json)' \
-            && return 0
-          ;;
-        *)
-          _message 'provider command (list|healthcheck)'
-          return 0
-          ;;
-      esac
-      ;;
-    diag)
-      local -a diag_cmds=(
-        'doctor:Run provider and automation readiness diagnostics'
-        'capabilities:Report provider and automation capability inventory'
-      )
-      if (( CURRENT == 3 )); then
-        _describe -t commands 'agentctl diag' diag_cmds && return 0
-      fi
-      case "${words[3]-}" in
-        doctor)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--provider=[Provider filter]:provider id:' \
-            '--timeout-ms=[Healthcheck timeout in milliseconds]:milliseconds:' \
-            '--format=[Output format]:format:(text json)' \
-            '--probe-mode=[Probe execution mode]:mode:(auto live test)' \
-            && return 0
-          ;;
-        capabilities)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--provider=[Provider filter]:provider id:' \
-            '--include-experimental[Include experimental capability flags]' \
-            '--timeout-ms=[Healthcheck timeout in milliseconds]:milliseconds:' \
-            '--format=[Output format]:format:(text json)' \
-            '--probe-mode=[Probe execution mode]:mode:(auto live test)' \
-            && return 0
-          ;;
-        *)
-          _message 'diag command (doctor|capabilities)'
-          return 0
-          ;;
-      esac
-      ;;
-    debug)
-      if (( CURRENT == 3 )); then
-        _describe -t commands 'agentctl debug' \
-          'bundle:Collect one-shot debug artifacts with a versioned manifest' && return 0
-      fi
-      case "${words[3]-}" in
-        bundle)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--output-dir=[Output directory]:directory:_files -/' \
-            '--format=[Output format]:format:(text json)' \
-            && return 0
-          ;;
-        *)
-          _message 'debug command (bundle)'
-          return 0
-          ;;
-      esac
-      ;;
-    workflow)
-      if (( CURRENT == 3 )); then
-        _describe -t commands 'agentctl workflow' \
-          'run:Execute workflow manifest' && return 0
-      fi
-      case "${words[3]-}" in
-        run)
-          _arguments -C \
-            '(-h --help)'{-h,--help}'[Show help]' \
-            '--file=[Path to workflow manifest JSON file]:file:_files' \
-            '--format=[Output format]:format:(text json)' \
-            && return 0
-          ;;
-        *)
-          _message 'workflow command (run)'
-          return 0
-          ;;
-      esac
-      ;;
-    automation|help)
-      _arguments -C '(-h --help)'{-h,--help}'[Show help]' && return 0
-      ;;
-  esac
+  _nils_cli_agentctl_generated
 }
+
+if _nils_cli_agentctl_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _agentctl agentctl
+else
+  compdef _agentctl agentctl
+fi

--- a/crates/agentctl/Cargo.toml
+++ b/crates/agentctl/Cargo.toml
@@ -16,6 +16,7 @@ name = "agentctl"
 path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
+clap_complete = { workspace = true }
 agent-provider-codex = { version = "0.4.4", path = "../agent-provider-codex", package = "nils-agent-provider-codex" }
 agent-provider-claude = { version = "0.4.4", path = "../agent-provider-claude", package = "nils-agent-provider-claude" }
 agent-provider-gemini = { version = "0.4.4", path = "../agent-provider-gemini", package = "nils-agent-provider-gemini" }
@@ -27,3 +28,4 @@ serde_json = { workspace = true }
 [dev-dependencies]
 nils-test-support = { version = "0.4.4", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
+tempfile = "3"

--- a/crates/agentctl/src/cli.rs
+++ b/crates/agentctl/src/cli.rs
@@ -2,7 +2,7 @@ use crate::debug::DebugArgs;
 use crate::diag::DiagArgs;
 use crate::provider::commands::ProviderArgs;
 use crate::workflow::WorkflowArgs;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(
@@ -28,4 +28,12 @@ pub enum Command {
     Workflow(WorkflowArgs),
     /// Local automation integrations
     Automation,
+    /// Print shell completion script
+    Completion(CompletionArgs),
+}
+
+#[derive(Args)]
+pub struct CompletionArgs {
+    #[arg(value_enum)]
+    pub shell: crate::completion::CompletionShell,
 }

--- a/crates/agentctl/src/completion.rs
+++ b/crates/agentctl/src/completion.rs
@@ -1,0 +1,26 @@
+use clap::{CommandFactory, ValueEnum};
+use clap_complete::{Generator, Shell, generate};
+
+use crate::cli::Cli;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum CompletionShell {
+    Bash,
+    Zsh,
+}
+
+pub fn run(shell: CompletionShell) -> i32 {
+    let mut command = Cli::command();
+    let bin_name = command.get_name().to_string();
+
+    match shell {
+        CompletionShell::Bash => print_completion(Shell::Bash, &mut command, &bin_name),
+        CompletionShell::Zsh => print_completion(Shell::Zsh, &mut command, &bin_name),
+    }
+
+    0
+}
+
+fn print_completion<G: Generator>(generator: G, command: &mut clap::Command, bin_name: &str) {
+    generate(generator, command, bin_name, &mut std::io::stdout());
+}

--- a/crates/agentctl/src/lib.rs
+++ b/crates/agentctl/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod completion;
 pub mod debug;
 pub mod diag;
 pub mod provider;
@@ -46,6 +47,7 @@ where
             None => print_group_help("workflow"),
         },
         Some(cli::Command::Automation) => print_group_help("automation"),
+        Some(cli::Command::Completion(args)) => completion::run(args.shell),
         None => print_root_help(),
     }
 }

--- a/crates/agentctl/tests/completion_outside_repo.rs
+++ b/crates/agentctl/tests/completion_outside_repo.rs
@@ -1,0 +1,40 @@
+use nils_test_support::bin;
+use nils_test_support::cmd;
+use std::path::PathBuf;
+
+fn agentctl_bin() -> PathBuf {
+    bin::resolve("agentctl")
+}
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = cmd::run_in_dir(
+        dir.path(),
+        &agentctl_bin(),
+        &["completion", "zsh"],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.code, 0);
+    let stdout = output.stdout_text();
+    assert!(stdout.contains("#compdef agentctl"), "stdout={stdout}");
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = cmd::run_in_dir(
+        dir.path(),
+        &agentctl_bin(),
+        &["completion", "fish"],
+        &[],
+        None,
+    );
+
+    assert_ne!(output.code, 0);
+    let stderr = output.stderr_text();
+    assert!(stderr.contains("invalid value"), "stderr={stderr}");
+    assert!(stderr.contains("fish"), "stderr={stderr}");
+}

--- a/crates/agentctl/tests/run_from_dispatch.rs
+++ b/crates/agentctl/tests/run_from_dispatch.rs
@@ -6,6 +6,7 @@ use nils_test_support::{CwdGuard, EnvGuard, GlobalStateLock, StubBinDir, prepend
 fn run_from_group_help_and_parse_errors_return_expected_exit_codes() {
     assert_eq!(agentctl::run_from(["agentctl"]), 0);
     assert_eq!(agentctl::run_from(["agentctl", "--help"]), 0);
+    assert_eq!(agentctl::run_from(["agentctl", "completion", "zsh"]), 0);
     assert_eq!(agentctl::run_from(["agentctl", "provider"]), 0);
     assert_eq!(agentctl::run_from(["agentctl", "diag"]), 0);
     assert_eq!(agentctl::run_from(["agentctl", "debug"]), 0);


### PR DESCRIPTION
## Summary
- add clap-first completion export via `agentctl completion <bash|zsh>`
- migrate zsh/bash completion assets to thin adapters backed by generated completion scripts
- add completion outside-repo tests and cover run_from dispatch path for completion subcommand

## Validation
- cargo test -p nils-agentctl
- zsh -n completions/zsh/_agentctl
- bash -n completions/bash/agentctl
- zsh -f tests/zsh/completion.test.zsh
