### PR TITLE
feat(memo-cli): migrate completion to clap-first adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,6 +1878,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "clap_complete",
  "pretty_assertions",
  "rusqlite",
  "serde",

--- a/completions/bash/memo-cli
+++ b/completions/bash/memo-cli
@@ -6,103 +6,58 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_memo_cli_complete() {
-  local -a words=("${COMP_WORDS[@]}")
-  local cword="$COMP_CWORD"
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+_nils_cli_memo_cli_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
-  local -a subcmds=(add update delete list search report fetch apply help)
-  local -a global_opts=(-h --help -V --version --db --json --format)
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
 
-  if (( cword == 1 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "${global_opts[*]}" -- "$cur") )
-      return 0
-    fi
-    COMPREPLY=( $(compgen -W "${subcmds[*]}" -- "$cur") )
-    return 0
-  fi
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
 
-  local subcmd="${words[1]-}"
-  if [[ "$cur" == -* ]]; then
-    case "$subcmd" in
-      add)
-        COMPREPLY=( $(compgen -W "${global_opts[*]} --source" -- "$cur") )
-        return 0
-        ;;
-      update)
-        COMPREPLY=( $(compgen -W "${global_opts[*]}" -- "$cur") )
-        return 0
-        ;;
-      delete)
-        COMPREPLY=( $(compgen -W "${global_opts[*]} --hard" -- "$cur") )
-        return 0
-        ;;
-      list)
-        COMPREPLY=( $(compgen -W "${global_opts[*]} --limit --offset --state" -- "$cur") )
-        return 0
-        ;;
-      search)
-        COMPREPLY=( $(compgen -W "${global_opts[*]} --limit --state --field --match" -- "$cur") )
-        return 0
-        ;;
-      report)
-        COMPREPLY=( $(compgen -W "${global_opts[*]}" -- "$cur") )
-        return 0
-        ;;
-      fetch)
-        COMPREPLY=( $(compgen -W "${global_opts[*]} --limit --cursor --state" -- "$cur") )
-        return 0
-        ;;
-      apply)
-        COMPREPLY=( $(compgen -W "${global_opts[*]} --input --stdin --dry-run" -- "$cur") )
-        return 0
-        ;;
-      *)
-        COMPREPLY=( $(compgen -W "${global_opts[*]}" -- "$cur") )
-        return 0
-        ;;
-    esac
-  fi
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
 
-  case "$prev" in
-    --db|--input)
-      COMPREPLY=( $(compgen -f -- "$cur") )
-      return 0
-      ;;
-    --format)
-      COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-      return 0
-      ;;
-    --state)
-      case "$subcmd" in
-        list|search)
-          COMPREPLY=( $(compgen -W "all pending enriched" -- "$cur") )
-          return 0
-          ;;
-        fetch)
-          COMPREPLY=( $(compgen -W "pending" -- "$cur") )
-          return 0
-          ;;
-      esac
-      ;;
-    --field)
-      COMPREPLY=( $(compgen -W "raw derived tags" -- "$cur") )
-      return 0
-      ;;
-    --match)
-      COMPREPLY=( $(compgen -W "fts prefix contains" -- "$cur") )
-      return 0
-      ;;
-  esac
-
-  if [[ "$subcmd" == "report" && "$cword" -eq 2 ]]; then
-    COMPREPLY=( $(compgen -W "week month" -- "$cur") )
-    return 0
-  fi
-
-  COMPREPLY=()
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
 }
 
-complete -F _nils_cli_memo_cli_complete memo-cli
+_NILS_MEMO_CLI_BASH_GENERATED_STATE=0
+
+_nils_cli_memo_cli_load_generated_bash() {
+  _nils_cli_memo_cli_source_common_bash || return 1
+
+  # command memo-cli completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_MEMO_CLI_BASH_GENERATED_STATE" \
+    "_nils_cli_memo_cli_generated" \
+    "memo-cli" \
+    "_memo_cli" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
+_nils_cli_memo_cli_complete() {
+  if ! _nils_cli_memo_cli_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
+      COMPREPLY=()
+    fi
+    return 0
+  fi
+
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev=''
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
+
+  _nils_cli_memo_cli_generated "memo-cli" "$cur" "$prev"
+}
+
+if _nils_cli_memo_cli_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_memo_cli_complete memo-cli
+else
+  complete -F _nils_cli_memo_cli_complete memo-cli
+fi

--- a/completions/zsh/_memo-cli
+++ b/completions/zsh/_memo-cli
@@ -1,108 +1,60 @@
 #compdef memo-cli
 
+_nils_cli_memo_cli_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_memo-cli]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_MEMO_CLI_ZSH_GENERATED_STATE=0
+
+_nils_cli_memo_cli_load_generated_zsh() {
+  _nils_cli_memo_cli_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_MEMO_CLI_ZSH_GENERATED_STATE" \
+    "_nils_cli_memo_cli_generated" \
+    "memo-cli" \
+    "_memo-cli" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_memo_cli_generated" \]; then$' \
+    '^fi$'
+}
+
 _memo-cli() {
   emulate -L zsh -o extendedglob
 
-  local curcontext="$curcontext" state line
-  typeset -A opt_args
-
-  local -a subcommands=(
-    'add:Capture one raw memo entry'
-    'update:Update one memo entry and reset derived workflow state'
-    'delete:Hard-delete one memo entry and dependent data'
-    'list:List memo entries in deterministic order'
-    'search:Search memo entries with selectable match mode'
-    'report:Show weekly or monthly summary report'
-    'fetch:Fetch pending items for agent enrichment'
-    'apply:Apply enrichment payloads'
-    'help:Show help'
-  )
-
-  local -a global_opts=(
-    '--db=[SQLite file path]:path:_files'
-    '--json[Output JSON]'
-    '--format=[Output format]:format:(text json)'
-    '(-h --help)'{-h,--help}'[Show help]'
-    '(-V --version)'{-V,--version}'[Show version]'
-  )
-
-  if (( CURRENT == 2 )); then
-    _describe -t commands 'memo-cli command' subcommands && return 0
-    _message 'command (add|update|delete|list|search|report|fetch|apply)'
-    return 0
+  if ! _nils_cli_memo_cli_load_generated_zsh; then
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
+    fi
+    return 1
   fi
 
-  local cmd="${words[2]-}"
-  case "$cmd" in
-    add)
-      _arguments -C \
-        $global_opts \
-        '--source=[Capture source label]:source:' \
-        '*:memo text:' \
-        && return 0
-      ;;
-    update)
-      _arguments -C \
-        $global_opts \
-        '1:item id:' \
-        '*:updated memo text:' \
-        && return 0
-      ;;
-    delete)
-      _arguments -C \
-        $global_opts \
-        '--hard[Confirm hard delete behavior]' \
-        '1:item id:' \
-        && return 0
-      ;;
-    list)
-      _arguments -C \
-        $global_opts \
-        '--limit=[Max rows to return]:limit:' \
-        '--offset=[Row offset for paging]:offset:' \
-        '--state=[Row selection mode]:state:(all pending enriched)' \
-        && return 0
-      ;;
-    search)
-      _arguments -C \
-        $global_opts \
-        '--limit=[Max rows to return]:limit:' \
-        '--state=[Row selection mode]:state:(all pending enriched)' \
-        '--field=[Search fields (comma-separated)]:field:(raw derived tags)' \
-        '--match=[Search match mode]:match:(fts prefix contains)' \
-        '*:query:' \
-        && return 0
-      ;;
-    report)
-      _arguments -C \
-        $global_opts \
-        '1:period:(week month)' \
-        && return 0
-      ;;
-    fetch)
-      _arguments -C \
-        $global_opts \
-        '--limit=[Max rows to return]:limit:' \
-        '--cursor=[Opaque cursor for pagination]:cursor:' \
-        '--state=[Fetch selection mode]:state:(pending)' \
-        && return 0
-      ;;
-    apply)
-      _arguments -C \
-        $global_opts \
-        '--input=[JSON file containing apply payload]:file:_files' \
-        '--stdin[Read payload JSON from stdin]' \
-        '--dry-run[Validate payload without write-back]' \
-        && return 0
-      ;;
-    help|-h|--help)
-      _message 'no additional arguments'
-      return 0
-      ;;
-    *)
-      _arguments -C $global_opts && return 0
-      ;;
-  esac
+  _nils_cli_memo_cli_generated
 }
 
-compdef _memo-cli memo-cli
+if _nils_cli_memo_cli_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _memo-cli memo-cli
+else
+  compdef _memo-cli memo-cli
+fi

--- a/crates/memo-cli/Cargo.toml
+++ b/crates/memo-cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 chrono-tz = "0.10"
 rusqlite = { version = "0.38.0", features = ["bundled"] }

--- a/crates/memo-cli/src/app.rs
+++ b/crates/memo-cli/src/app.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 
 use clap::{Parser, error::ErrorKind};
 
-use crate::cli::{Cli, OutputMode};
+use crate::cli::{Cli, MemoCommand, OutputMode};
 use crate::errors::AppError;
 
 pub fn run() -> i32 {
@@ -30,6 +30,10 @@ where
             }
         }
     };
+
+    if let MemoCommand::Completion(args) = cli.command {
+        return crate::completion::run(args.shell);
+    }
 
     let output_mode = match cli.resolve_output_mode() {
         Ok(mode) => mode,

--- a/crates/memo-cli/src/cli.rs
+++ b/crates/memo-cli/src/cli.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use crate::errors::AppError;
 
@@ -96,6 +96,14 @@ pub enum MemoCommand {
     Fetch(FetchArgs),
     /// Apply enrichment payloads
     Apply(ApplyArgs),
+    /// Print shell completion script
+    Completion(CompletionArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct CompletionArgs {
+    #[arg(value_enum)]
+    pub shell: crate::completion::CompletionShell,
 }
 
 #[derive(Debug, clap::Args)]
@@ -246,6 +254,7 @@ impl Cli {
             MemoCommand::Report(_) => "memo-cli report",
             MemoCommand::Fetch(_) => "memo-cli fetch",
             MemoCommand::Apply(_) => "memo-cli apply",
+            MemoCommand::Completion(_) => "memo-cli completion",
         }
     }
 
@@ -259,6 +268,7 @@ impl Cli {
             MemoCommand::Report(_) => "memo-cli.report.v1",
             MemoCommand::Fetch(_) => "memo-cli.fetch.v1",
             MemoCommand::Apply(_) => "memo-cli.apply.v1",
+            MemoCommand::Completion(_) => "memo-cli.completion.v1",
         }
     }
 }
@@ -328,6 +338,7 @@ pub(crate) mod tests {
         assert!(subcommands.contains(&"report".to_string()));
         assert!(subcommands.contains(&"fetch".to_string()));
         assert!(subcommands.contains(&"apply".to_string()));
+        assert!(subcommands.contains(&"completion".to_string()));
     }
 
     #[test]

--- a/crates/memo-cli/src/commands/mod.rs
+++ b/crates/memo-cli/src/commands/mod.rs
@@ -41,6 +41,7 @@ pub fn run(cli: &Cli, output_mode: OutputMode) -> Result<(), AppError> {
             fetch::run(&storage, output_mode, args.limit, args.cursor.as_deref())
         }
         MemoCommand::Apply(args) => apply::run(&storage, output_mode, args),
+        MemoCommand::Completion(_) => Ok(()),
     }
 }
 

--- a/crates/memo-cli/src/completion.rs
+++ b/crates/memo-cli/src/completion.rs
@@ -1,0 +1,26 @@
+use clap::{CommandFactory, ValueEnum};
+use clap_complete::{Generator, Shell, generate};
+
+use crate::cli::Cli;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CompletionShell {
+    Bash,
+    Zsh,
+}
+
+pub fn run(shell: CompletionShell) -> i32 {
+    let mut command = Cli::command();
+    let bin_name = command.get_name().to_string();
+
+    match shell {
+        CompletionShell::Bash => print_completion(Shell::Bash, &mut command, &bin_name),
+        CompletionShell::Zsh => print_completion(Shell::Zsh, &mut command, &bin_name),
+    }
+
+    0
+}
+
+fn print_completion<G: Generator>(generator: G, command: &mut clap::Command, bin_name: &str) {
+    generate(generator, command, bin_name, &mut std::io::stdout());
+}

--- a/crates/memo-cli/src/lib.rs
+++ b/crates/memo-cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod cli;
 pub mod commands;
+pub mod completion;
 pub mod errors;
 pub mod output;
 pub mod preprocess;

--- a/crates/memo-cli/tests/completion_outside_repo.rs
+++ b/crates/memo-cli/tests/completion_outside_repo.rs
@@ -1,0 +1,69 @@
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn memo_cli_bin() -> PathBuf {
+    for env_name in ["CARGO_BIN_EXE_memo-cli", "CARGO_BIN_EXE_memo_cli"] {
+        if let Some(path) = std::env::var_os(env_name) {
+            return PathBuf::from(path);
+        }
+    }
+
+    let current = std::env::current_exe().expect("current test executable");
+    let target_profile_dir = current
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("target profile dir");
+    let candidate = target_profile_dir.join(format!("memo-cli{}", std::env::consts::EXE_SUFFIX));
+    assert!(
+        candidate.exists(),
+        "memo-cli binary path not found via env vars or fallback candidate {}",
+        candidate.display()
+    );
+    candidate
+}
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(memo_cli_bin())
+        .args(["completion", "zsh"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run memo-cli completion zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef memo-cli"),
+        "missing zsh completion header: {stdout}"
+    );
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(memo_cli_bin())
+        .args(["completion", "fish"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run memo-cli completion fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid value") && stderr.contains("fish"),
+        "missing invalid shell error: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- add clap-first completion export via `memo-cli completion <bash|zsh>`
- route completion subcommand before output-mode/storage flows to keep completion deterministic
- migrate zsh/bash completion assets to thin adapters backed by generated completion scripts
- add completion outside-repo tests and extend parser subcommand coverage

## Validation
- cargo test -p nils-memo-cli
- zsh -n completions/zsh/_memo-cli
- bash -n completions/bash/memo-cli
- zsh -f tests/zsh/completion.test.zsh
