### PR TITLE
feat(macos-agent): migrate completion to clap-first adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,6 +1859,7 @@ name = "nils-macos-agent"
 version = "0.4.4"
 dependencies = [
  "clap",
+ "clap_complete",
  "image",
  "nils-common",
  "nils-screen-record",

--- a/completions/bash/macos-agent
+++ b/completions/bash/macos-agent
@@ -6,127 +6,58 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_macos_agent_complete() {
-  local -a words=("${COMP_WORDS[@]}")
-  local cword="$COMP_CWORD"
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+_nils_cli_macos_agent_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
-  local -a root_opts=(-h --help -V --version --format --error-format --dry-run --retries --retry-delay-ms --timeout-ms --trace --trace-dir)
-  local -a groups=(preflight windows apps window input input-source ax observe debug wait scenario profile)
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
 
-  if (( cword == 1 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "${root_opts[*]}" -- "$cur") )
-      return 0
-    fi
-    COMPREPLY=( $(compgen -W "${groups[*]}" -- "$cur") )
-    return 0
-  fi
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
 
-  local group="${words[1]-}"
-  case "$group" in
-    windows)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "list" -- "$cur") ); return 0; fi
-      ;;
-    apps)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "list" -- "$cur") ); return 0; fi
-      ;;
-    window)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "activate" -- "$cur") ); return 0; fi
-      ;;
-    input)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "click type hotkey" -- "$cur") ); return 0; fi
-      ;;
-    input-source)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "current switch" -- "$cur") ); return 0; fi
-      ;;
-    ax)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "list click type attr action session watch" -- "$cur") ); return 0; fi
-      ;;
-    observe)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "screenshot" -- "$cur") ); return 0; fi
-      ;;
-    debug)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "bundle" -- "$cur") ); return 0; fi
-      ;;
-    wait)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "sleep app-active window-present ax-present ax-unique" -- "$cur") ); return 0; fi
-      ;;
-    scenario)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "run" -- "$cur") ); return 0; fi
-      ;;
-    profile)
-      if (( cword == 2 )); then COMPREPLY=( $(compgen -W "validate init" -- "$cur") ); return 0; fi
-      ;;
-  esac
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
 
-  case "$prev" in
-    --format)
-      COMPREPLY=( $(compgen -W "text json tsv" -- "$cur") )
-      return 0
-      ;;
-    --error-format)
-      COMPREPLY=( $(compgen -W "text json" -- "$cur") )
-      return 0
-      ;;
-    --button)
-      COMPREPLY=( $(compgen -W "left right middle" -- "$cur") )
-      return 0
-      ;;
-    --image-format)
-      COMPREPLY=( $(compgen -W "png jpg webp" -- "$cur") )
-      return 0
-      ;;
-    --match-strategy)
-      COMPREPLY=( $(compgen -W "contains exact prefix suffix regex" -- "$cur") )
-      return 0
-      ;;
-    --fallback-order)
-      COMPREPLY=( $(compgen -W "ax-press ax-confirm frame-center coordinate" -- "$cur") )
-      return 0
-      ;;
-    --postcondition-focused|--focused|--enabled)
-      COMPREPLY=( $(compgen -W "true false" -- "$cur") )
-      return 0
-      ;;
-    --path|--file|--trace-dir)
-      COMPREPLY=( $(compgen -f -- "$cur") )
-      return 0
-      ;;
-    --output-dir)
-      COMPREPLY=( $(compgen -d -- "$cur") )
-      return 0
-      ;;
-  esac
-
-  if [[ "$cur" == -* ]]; then
-    local -a opts=(
-      --format --error-format --dry-run --retries --retry-delay-ms --timeout-ms --trace --trace-dir
-      --strict --include-probes
-      --app --window-title-contains --window-name --on-screen-only
-      --window-id --active-window --bundle-id --wait-ms
-      --x --y --button --count --pre-wait-ms --post-wait-ms
-      --text --delay-ms --submit --enter --mods --key
-      --id
-      --role --title-contains --max-depth --limit --nth
-      --session-id --identifier-contains --value-contains --subrole --focused --enabled
-      --name --value --value-type --watch-id --events --max-buffer --drain
-      --allow-coordinate-fallback --clear-first --paste --allow-keyboard-fallback
-      --reselect-before-click --fallback-order
-      --match-strategy --selector-explain --selector-padding
-      --gate-app-active --gate-window-present --gate-ax-present --gate-ax-unique
-      --gate-timeout-ms --gate-poll-ms
-      --postcondition-focused --postcondition-attribute --postcondition-attribute-value
-      --postcondition-timeout-ms --postcondition-poll-ms
-      --path --output-dir --image-format --ms --timeout-ms --poll-ms
-      -h --help -V --version
-    )
-    COMPREPLY=( $(compgen -W "${opts[*]}" -- "$cur") )
-    return 0
-  fi
-
-  COMPREPLY=()
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
 }
 
-complete -F _nils_cli_macos_agent_complete macos-agent
+_NILS_MACOS_AGENT_BASH_GENERATED_STATE=0
+
+_nils_cli_macos_agent_load_generated_bash() {
+  _nils_cli_macos_agent_source_common_bash || return 1
+
+  # command macos-agent completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_MACOS_AGENT_BASH_GENERATED_STATE" \
+    "_nils_cli_macos_agent_generated" \
+    "macos-agent" \
+    "_macos_agent" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
+_nils_cli_macos_agent_complete() {
+  if ! _nils_cli_macos_agent_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
+      COMPREPLY=()
+    fi
+    return 0
+  fi
+
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev=''
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
+
+  _nils_cli_macos_agent_generated "macos-agent" "$cur" "$prev"
+}
+
+if _nils_cli_macos_agent_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_macos_agent_complete macos-agent
+else
+  complete -F _nils_cli_macos_agent_complete macos-agent
+fi

--- a/completions/zsh/_macos-agent
+++ b/completions/zsh/_macos-agent
@@ -1,515 +1,60 @@
 #compdef macos-agent
 
+_nils_cli_macos_agent_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_macos-agent]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_MACOS_AGENT_ZSH_GENERATED_STATE=0
+
+_nils_cli_macos_agent_load_generated_zsh() {
+  _nils_cli_macos_agent_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_MACOS_AGENT_ZSH_GENERATED_STATE" \
+    "_nils_cli_macos_agent_generated" \
+    "macos-agent" \
+    "_macos-agent" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_macos_agent_generated" \]; then$' \
+    '^fi$'
+}
+
 _macos-agent() {
   emulate -L zsh -o extendedglob
 
-  local context state state_descr
-  typeset -A opt_args
-
-  local -a global_opts
-  global_opts=(
-    '--format=[Output format]:format:(text json tsv)'
-    '--error-format=[Error output format]:format:(text json)'
-    '--dry-run[Print planned actions without mutating desktop state]'
-    '--retries=[Retry count for mutating actions]:count:'
-    '--retry-delay-ms=[Delay between retries in milliseconds]:ms:'
-    '--timeout-ms=[Per-action timeout in milliseconds]:ms:'
-    '--trace[Emit per-command trace artifacts under AGENT_HOME/out]'
-    '--trace-dir=[Override trace output directory]:path:_files'
-    '(-h --help)'{-h,--help}'[Show help]'
-    '(-V --version)'{-V,--version}'[Show version]'
-  )
-
-  if (( CURRENT == 2 )); then
-    _describe -t commands 'macos-agent command' \
-      'preflight:Check runtime dependencies and permissions' \
-      'windows:List windows' \
-      'apps:List apps' \
-      'window:Activate app/window target' \
-      'input:Pointer and keyboard actions' \
-      'input-source:Inspect and switch keyboard input sources' \
-      'ax:Accessibility node operations' \
-      'observe:Capture screenshot artifacts' \
-      'debug:Capture deterministic triage bundles' \
-      'wait:UI stabilization wait primitives' \
-      'scenario:Run declarative scenario files' \
-      'profile:Validate/init coordinate profiles'
-    return 0
+  if ! _nils_cli_macos_agent_load_generated_zsh; then
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
+    fi
+    return 1
   fi
 
-  local group="${words[2]}"
-  case "$group" in
-    preflight)
-      _arguments -C $global_opts \
-        '--strict[Treat advisory warnings as readiness failures]' \
-        '--include-probes[Run actionable probes in addition to static checks]' \
-        && return 0
-      ;;
-
-    windows)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'windows command' 'list:List windows'
-        return 0
-      fi
-      _arguments -C $global_opts \
-        '3:windows command:(list)' \
-        '--app=[Filter by app/owner name]:name:' \
-        '--window-title-contains=[Narrow app selection by window title]:name:' \
-        '--window-name=[Deprecated alias of --window-title-contains]:name:' \
-        '--on-screen-only[Include only on-screen windows]' \
-        && return 0
-      ;;
-
-    apps)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'apps command' 'list:List apps'
-        return 0
-      fi
-      _arguments -C $global_opts '3:apps command:(list)' && return 0
-      ;;
-
-    window)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'window command' 'activate:Activate app/window target'
-        return 0
-      fi
-      _arguments -C $global_opts \
-        '3:window command:(activate)' \
-        '--window-id=[Select by window id]:id:' \
-        '--active-window[Select frontmost active window]' \
-        '--app=[Select by app name]:name:' \
-        '--window-title-contains=[Narrow app selection by window title]:name:' \
-        '--window-name=[Deprecated alias of --window-title-contains]:name:' \
-        '--bundle-id=[Select by bundle id]:bundle:' \
-        '--wait-ms=[Wait up to this many milliseconds for active confirmation]:ms:' \
-        && return 0
-      ;;
-
-    input)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'input command' \
-          'click:Click at x/y coordinates' \
-          'type:Type text' \
-          'hotkey:Send hotkey chord'
-        return 0
-      fi
-
-      local input_cmd="${words[3]}"
-      case "$input_cmd" in
-        click)
-          _arguments -C $global_opts \
-            '--x=[X coordinate in pixels]:x:' \
-            '--y=[Y coordinate in pixels]:y:' \
-            '--button=[Mouse button]:button:(left right middle)' \
-            '--count=[Number of clicks]:count:' \
-            '--pre-wait-ms=[Wait before clicking]:ms:' \
-            '--post-wait-ms=[Wait after clicking]:ms:' \
-            && return 0
-          ;;
-        type)
-          _arguments -C $global_opts \
-            '--text=[Text to type]:text:' \
-            '--delay-ms=[Delay between key events]:ms:' \
-            '--submit[Press Enter after typing]' \
-            '--enter[Deprecated alias of --submit]' \
-            && return 0
-          ;;
-        hotkey)
-          _arguments -C $global_opts \
-            '--mods=[Modifier keys, comma-separated]:mods:' \
-            '--key=[Main key]:key:' \
-            && return 0
-          ;;
-      esac
-      ;;
-
-    input-source)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'input-source command' \
-          'current:Show current input source id' \
-          'switch:Switch input source id'
-        return 0
-      fi
-
-      local input_source_cmd="${words[3]}"
-      case "$input_source_cmd" in
-        current)
-          _arguments -C $global_opts && return 0
-          ;;
-        switch)
-          _arguments -C $global_opts \
-            '--id=[Input source id or alias (abc/us)]:id:' \
-            && return 0
-          ;;
-      esac
-      ;;
-
-    ax)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'ax command' \
-          'list:List AX nodes' \
-          'click:Click AX node' \
-          'type:Type into AX node' \
-          'attr:Read or set AX attributes' \
-          'action:Perform AX actions' \
-          'session:Manage AX sessions' \
-          'watch:Manage AX watchers'
-        return 0
-      fi
-
-      local ax_cmd="${words[3]}"
-      case "$ax_cmd" in
-        list)
-          _arguments -C $global_opts \
-            '--session-id=[Target session id]:id:' \
-            '--app=[Target app name]:name:' \
-            '--bundle-id=[Target bundle id]:bundle:' \
-            '--window-title-contains=[Narrow to windows by title]:text:' \
-            '--role=[Filter by AX role]:role:' \
-            '--title-contains=[Filter by title substring]:text:' \
-            '--identifier-contains=[Filter by identifier substring]:text:' \
-            '--value-contains=[Filter by value substring]:text:' \
-            '--subrole=[Filter by AX subrole]:subrole:' \
-            '--focused=[Filter by focused state]:bool:(true false)' \
-            '--enabled=[Filter by enabled state]:bool:(true false)' \
-            '--max-depth=[Limit traversal depth]:depth:' \
-            '--limit=[Limit number of returned nodes]:count:' \
-            && return 0
-          ;;
-        click)
-          _arguments -C $global_opts \
-            '--node-id=[Select by node id]:id:' \
-            '--role=[Select by AX role]:role:' \
-            '--title-contains=[Select by title substring]:text:' \
-            '--identifier-contains=[Select by identifier substring]:text:' \
-            '--value-contains=[Select by value substring]:text:' \
-            '--subrole=[Select by AX subrole]:subrole:' \
-            '--focused=[Select by focused state]:bool:(true false)' \
-            '--enabled=[Select by enabled state]:bool:(true false)' \
-            '--nth=[Select nth match from role/title selector]:n:' \
-            '--match-strategy=[Text match strategy]:strategy:(contains exact prefix suffix regex)' \
-            '--selector-explain[Emit selector explain diagnostics in JSON output]' \
-            '--session-id=[Target session id]:id:' \
-            '--app=[Target app name]:name:' \
-            '--bundle-id=[Target bundle id]:bundle:' \
-            '--window-title-contains=[Narrow to windows by title]:text:' \
-            '--reselect-before-click[Re-resolve selector immediately before click]' \
-            '--allow-coordinate-fallback[Allow coordinate fallback when AXPress is unavailable]' \
-            '--fallback-order=[Fallback stage order]:stages:' \
-            '--gate-app-active[Require app-active gate before mutation]' \
-            '--gate-window-present[Require window-present gate before mutation]' \
-            '--gate-ax-present[Require selector gate with >= 1 match]' \
-            '--gate-ax-unique[Require selector gate with exactly one match]' \
-            '--gate-timeout-ms=[Timeout for gate checks in milliseconds]:ms:' \
-            '--gate-poll-ms=[Poll interval for gate checks in milliseconds]:ms:' \
-            '--postcondition-focused=[Expected focused state after mutation]:bool:(true false)' \
-            '--postcondition-attribute=[Expected AX attribute name after mutation]:name:' \
-            '--postcondition-attribute-value=[Expected AX attribute value after mutation]:value:' \
-            '--postcondition-timeout-ms=[Timeout for postcondition checks in milliseconds]:ms:' \
-            '--postcondition-poll-ms=[Poll interval for postcondition checks in milliseconds]:ms:' \
-            && return 0
-          ;;
-        type)
-          _arguments -C $global_opts \
-            '--node-id=[Select by node id]:id:' \
-            '--role=[Select by AX role]:role:' \
-            '--title-contains=[Select by title substring]:text:' \
-            '--identifier-contains=[Select by identifier substring]:text:' \
-            '--value-contains=[Select by value substring]:text:' \
-            '--subrole=[Select by AX subrole]:subrole:' \
-            '--focused=[Select by focused state]:bool:(true false)' \
-            '--enabled=[Select by enabled state]:bool:(true false)' \
-            '--nth=[Select nth match from role/title selector]:n:' \
-            '--match-strategy=[Text match strategy]:strategy:(contains exact prefix suffix regex)' \
-            '--selector-explain[Emit selector explain diagnostics in JSON output]' \
-            '--session-id=[Target session id]:id:' \
-            '--app=[Target app name]:name:' \
-            '--bundle-id=[Target bundle id]:bundle:' \
-            '--window-title-contains=[Narrow to windows by title]:text:' \
-            '--text=[Text to type]:text:' \
-            '--clear-first[Clear field before typing]' \
-            '--submit[Press Enter after typing]' \
-            '--paste[Use clipboard paste strategy]' \
-            '--allow-keyboard-fallback[Allow keyboard fallback when AX value set is unavailable]' \
-            '--gate-app-active[Require app-active gate before mutation]' \
-            '--gate-window-present[Require window-present gate before mutation]' \
-            '--gate-ax-present[Require selector gate with >= 1 match]' \
-            '--gate-ax-unique[Require selector gate with exactly one match]' \
-            '--gate-timeout-ms=[Timeout for gate checks in milliseconds]:ms:' \
-            '--gate-poll-ms=[Poll interval for gate checks in milliseconds]:ms:' \
-            '--postcondition-focused=[Expected focused state after mutation]:bool:(true false)' \
-            '--postcondition-attribute=[Expected AX attribute name after mutation]:name:' \
-            '--postcondition-attribute-value=[Expected AX attribute value after mutation]:value:' \
-            '--postcondition-timeout-ms=[Timeout for postcondition checks in milliseconds]:ms:' \
-            '--postcondition-poll-ms=[Poll interval for postcondition checks in milliseconds]:ms:' \
-            && return 0
-          ;;
-        attr)
-          if (( CURRENT == 4 )); then
-            _describe -t subcommands 'ax attr command' \
-              'get:Read AX attribute value' \
-              'set:Set AX attribute value'
-            return 0
-          fi
-          local ax_attr_cmd="${words[4]}"
-          case "$ax_attr_cmd" in
-            get)
-              _arguments -C $global_opts \
-                '--node-id=[Select by node id]:id:' \
-                '--role=[Select by AX role]:role:' \
-                '--title-contains=[Select by title substring]:text:' \
-                '--identifier-contains=[Select by identifier substring]:text:' \
-                '--value-contains=[Select by value substring]:text:' \
-                '--subrole=[Select by AX subrole]:subrole:' \
-                '--focused=[Select by focused state]:bool:(true false)' \
-                '--enabled=[Select by enabled state]:bool:(true false)' \
-                '--nth=[Select nth match]:n:' \
-                '--session-id=[Target session id]:id:' \
-                '--app=[Target app name]:name:' \
-                '--bundle-id=[Target bundle id]:bundle:' \
-                '--window-title-contains=[Narrow to windows by title]:text:' \
-                '--name=[AX attribute name]:name:' \
-                && return 0
-              ;;
-            set)
-              _arguments -C $global_opts \
-                '--node-id=[Select by node id]:id:' \
-                '--role=[Select by AX role]:role:' \
-                '--title-contains=[Select by title substring]:text:' \
-                '--identifier-contains=[Select by identifier substring]:text:' \
-                '--value-contains=[Select by value substring]:text:' \
-                '--subrole=[Select by AX subrole]:subrole:' \
-                '--focused=[Select by focused state]:bool:(true false)' \
-                '--enabled=[Select by enabled state]:bool:(true false)' \
-                '--nth=[Select nth match]:n:' \
-                '--session-id=[Target session id]:id:' \
-                '--app=[Target app name]:name:' \
-                '--bundle-id=[Target bundle id]:bundle:' \
-                '--window-title-contains=[Narrow to windows by title]:text:' \
-                '--name=[AX attribute name]:name:' \
-                '--value=[AX attribute value]:value:' \
-                '--value-type=[Parse type for --value]:type:(string number bool json null)' \
-                && return 0
-              ;;
-          esac
-          ;;
-        action)
-          if (( CURRENT == 4 )); then
-            _describe -t subcommands 'ax action command' 'perform:Perform AX action'
-            return 0
-          fi
-          _arguments -C $global_opts \
-            '--node-id=[Select by node id]:id:' \
-            '--role=[Select by AX role]:role:' \
-            '--title-contains=[Select by title substring]:text:' \
-            '--identifier-contains=[Select by identifier substring]:text:' \
-            '--value-contains=[Select by value substring]:text:' \
-            '--subrole=[Select by AX subrole]:subrole:' \
-            '--focused=[Select by focused state]:bool:(true false)' \
-            '--enabled=[Select by enabled state]:bool:(true false)' \
-            '--nth=[Select nth match]:n:' \
-            '--session-id=[Target session id]:id:' \
-            '--app=[Target app name]:name:' \
-            '--bundle-id=[Target bundle id]:bundle:' \
-            '--window-title-contains=[Narrow to windows by title]:text:' \
-            '--name=[AX action name]:name:' \
-            && return 0
-          ;;
-        session)
-          if (( CURRENT == 4 )); then
-            _describe -t subcommands 'ax session command' \
-              'start:Create or update AX session' \
-              'list:List AX sessions' \
-              'stop:Stop AX session'
-            return 0
-          fi
-          local ax_session_cmd="${words[4]}"
-          case "$ax_session_cmd" in
-            start)
-              _arguments -C $global_opts \
-                '--app=[Target app name]:name:' \
-                '--bundle-id=[Target bundle id]:bundle:' \
-                '--session-id=[Session id]:id:' \
-                '--window-title-contains=[Persist window title filter]:text:' \
-                && return 0
-              ;;
-            list)
-              _arguments -C $global_opts && return 0
-              ;;
-            stop)
-              _arguments -C $global_opts '--session-id=[Session id to remove]:id:' && return 0
-              ;;
-          esac
-          ;;
-        watch)
-          if (( CURRENT == 4 )); then
-            _describe -t subcommands 'ax watch command' \
-              'start:Start AX watcher' \
-              'poll:Poll AX watcher events' \
-              'stop:Stop AX watcher'
-            return 0
-          fi
-          local ax_watch_cmd="${words[4]}"
-          case "$ax_watch_cmd" in
-            start)
-              _arguments -C $global_opts \
-                '--session-id=[Session id to bind watcher]:id:' \
-                '--watch-id=[Optional watcher id]:id:' \
-                '--events=[Comma-separated AX notifications]:events:' \
-                '--max-buffer=[Maximum in-memory event buffer size]:count:' \
-                && return 0
-              ;;
-            poll)
-              _arguments -C $global_opts \
-                '--watch-id=[Watch id to poll]:id:' \
-                '--limit=[Max events to return]:count:' \
-                '--drain=[Drain returned events]:bool:(true false)' \
-                && return 0
-              ;;
-            stop)
-              _arguments -C $global_opts '--watch-id=[Watch id to stop]:id:' && return 0
-              ;;
-          esac
-          ;;
-      esac
-      ;;
-
-    observe)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'observe command' 'screenshot:Capture screenshot'
-        return 0
-      fi
-      _arguments -C $global_opts \
-        '3:observe command:(screenshot)' \
-        '--window-id=[Select by window id]:id:' \
-        '--active-window[Select frontmost active window]' \
-        '--app=[Select by app name]:name:' \
-        '--window-title-contains=[Narrow app selection by window title]:name:' \
-        '--window-name=[Deprecated alias of --window-title-contains]:name:' \
-        '--path=[Output path]:path:_files' \
-        '--image-format=[Output image format]:format:(png jpg webp)' \
-        '--node-id=[Select AX node by node id]:id:' \
-        '--role=[Select AX node by role]:role:' \
-        '--title-contains=[Select AX node by title substring]:text:' \
-        '--identifier-contains=[Select AX node by identifier substring]:text:' \
-        '--value-contains=[Select AX node by value substring]:text:' \
-        '--subrole=[Select AX node by subrole]:subrole:' \
-        '--focused=[Select AX node by focused state]:bool:(true false)' \
-        '--enabled=[Select AX node by enabled state]:bool:(true false)' \
-        '--nth=[Select nth AX node match]:n:' \
-        '--match-strategy=[Text match strategy]:strategy:(contains exact prefix suffix regex)' \
-        '--selector-explain[Emit selector explain diagnostics in JSON output]' \
-        '--selector-padding=[Expand selector frame by N pixels]:px:' \
-        && return 0
-      ;;
-
-    debug)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'debug command' 'bundle:Capture deterministic triage artifact bundle'
-        return 0
-      fi
-      _arguments -C $global_opts \
-        '3:debug command:(bundle)' \
-        '--window-id=[Select by window id]:id:' \
-        '--active-window[Select frontmost active window]' \
-        '--app=[Select by app name]:name:' \
-        '--window-title-contains=[Narrow app selection by window title]:name:' \
-        '--window-name=[Deprecated alias of --window-title-contains]:name:' \
-        '--output-dir=[Output directory for debug artifacts]:path:_files -/' \
-        && return 0
-      ;;
-
-    wait)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'wait command' \
-          'sleep:Sleep for a fixed duration' \
-          'app-active:Wait for app to become active' \
-          'window-present:Wait for target window to appear' \
-          'ax-present:Wait until AX selector resolves to at least one node' \
-          'ax-unique:Wait until AX selector resolves to exactly one node'
-        return 0
-      fi
-
-      local wait_cmd="${words[3]}"
-      case "$wait_cmd" in
-        sleep)
-          _arguments -C $global_opts '--ms=[Sleep duration in milliseconds]:ms:' && return 0
-          ;;
-        app-active)
-          _arguments -C $global_opts \
-            '--app=[App name]:name:' \
-            '--bundle-id=[Bundle id]:bundle:' \
-            '--timeout-ms=[Timeout in milliseconds]:ms:' \
-            '--poll-ms=[Poll interval in milliseconds]:ms:' \
-            && return 0
-          ;;
-        window-present)
-          _arguments -C $global_opts \
-            '--window-id=[Select by window id]:id:' \
-            '--active-window[Select frontmost active window]' \
-            '--app=[Select by app name]:name:' \
-            '--window-title-contains=[Narrow app selection by window title]:name:' \
-            '--window-name=[Deprecated alias of --window-title-contains]:name:' \
-            '--timeout-ms=[Timeout in milliseconds]:ms:' \
-            '--poll-ms=[Poll interval in milliseconds]:ms:' \
-            && return 0
-          ;;
-        ax-present|ax-unique)
-          _arguments -C $global_opts \
-            '--node-id=[Select by node id]:id:' \
-            '--role=[Select by AX role]:role:' \
-            '--title-contains=[Select by title substring]:text:' \
-            '--identifier-contains=[Select by identifier substring]:text:' \
-            '--value-contains=[Select by value substring]:text:' \
-            '--subrole=[Select by AX subrole]:subrole:' \
-            '--focused=[Select by focused state]:bool:(true false)' \
-            '--enabled=[Select by enabled state]:bool:(true false)' \
-            '--nth=[Select nth match from selector]:n:' \
-            '--match-strategy=[Text match strategy]:strategy:(contains exact prefix suffix regex)' \
-            '--selector-explain[Emit selector explain diagnostics in JSON output]' \
-            '--session-id=[Target session id]:id:' \
-            '--app=[Target app name]:name:' \
-            '--bundle-id=[Target bundle id]:bundle:' \
-            '--window-title-contains=[Narrow to windows by title]:text:' \
-            '--timeout-ms=[Timeout in milliseconds]:ms:' \
-            '--poll-ms=[Poll interval in milliseconds]:ms:' \
-            && return 0
-          ;;
-      esac
-      ;;
-
-    scenario)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'scenario command' 'run:Run scenario JSON file'
-        return 0
-      fi
-      _arguments -C $global_opts \
-        '3:scenario command:(run)' \
-        '--file=[Scenario JSON file]:path:_files' \
-        && return 0
-      ;;
-
-    profile)
-      if (( CURRENT == 3 )); then
-        _describe -t subcommands 'profile command' \
-          'validate:Validate profile schema and coordinate bounds' \
-          'init:Write profile scaffold template'
-        return 0
-      fi
-      local profile_cmd="${words[3]}"
-      case "$profile_cmd" in
-        validate)
-          _arguments -C $global_opts '--file=[Profile JSON file]:path:_files' && return 0
-          ;;
-        init)
-          _arguments -C $global_opts \
-            '--name=[Profile name]:name:' \
-            '--path=[Output path]:path:_files' \
-            && return 0
-          ;;
-      esac
-      ;;
-  esac
+  _nils_cli_macos_agent_generated
 }
 
-compdef _macos-agent macos-agent
+if _nils_cli_macos_agent_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _macos-agent macos-agent
+else
+  compdef _macos-agent macos-agent
+fi

--- a/crates/macos-agent/Cargo.toml
+++ b/crates/macos-agent/Cargo.toml
@@ -16,6 +16,7 @@ name = "macos-agent"
 path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
+clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 regex = "1"

--- a/crates/macos-agent/src/cli.rs
+++ b/crates/macos-agent/src/cli.rs
@@ -152,6 +152,16 @@ pub enum CommandGroup {
         #[command(subcommand)]
         command: ProfileCommand,
     },
+
+    /// Print shell completion script.
+    Completion(CompletionArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct CompletionArgs {
+    /// Shell to generate completion for.
+    #[arg(value_enum)]
+    pub shell: crate::completion::CompletionShell,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/crates/macos-agent/src/completion.rs
+++ b/crates/macos-agent/src/completion.rs
@@ -1,0 +1,26 @@
+use clap::{CommandFactory, ValueEnum};
+use clap_complete::{Generator, Shell, generate};
+
+use crate::cli::Cli;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CompletionShell {
+    Bash,
+    Zsh,
+}
+
+pub fn run(shell: CompletionShell) -> i32 {
+    let mut command = Cli::command();
+    let bin_name = command.get_name().to_string();
+
+    match shell {
+        CompletionShell::Bash => print_completion(Shell::Bash, &mut command, &bin_name),
+        CompletionShell::Zsh => print_completion(Shell::Zsh, &mut command, &bin_name),
+    }
+
+    0
+}
+
+fn print_completion<G: Generator>(generator: G, command: &mut clap::Command, bin_name: &str) {
+    generate(generator, command, bin_name, &mut std::io::stdout());
+}

--- a/crates/macos-agent/src/lib.rs
+++ b/crates/macos-agent/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod backend;
 pub mod cli;
 pub mod commands;
+pub mod completion;
 pub mod error;
 pub mod model;
 pub mod preflight;

--- a/crates/macos-agent/src/main.rs
+++ b/crates/macos-agent/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use clap::{Parser, error::ErrorKind};
-use macos_agent::cli::{Cli, ErrorFormat};
+use macos_agent::cli::{Cli, CommandGroup, ErrorFormat};
 use macos_agent::error::CliError;
 use macos_agent::model::ErrorEnvelope;
 use macos_agent::run::{command_label, run};
@@ -48,6 +48,11 @@ fn main() -> ExitCode {
             return ExitCode::from(code as u8);
         }
     };
+
+    if let CommandGroup::Completion(args) = &cli.command {
+        let code = macos_agent::completion::run(args.shell);
+        return ExitCode::from(code as u8);
+    }
 
     let trace_enabled = cli.trace || cli.trace_dir.is_some();
     if trace_enabled && let Err(error) = ensure_trace_dir_writable(&cli) {
@@ -287,5 +292,9 @@ mod tests {
         let switch = Cli::try_parse_from(["macos-agent", "input-source", "switch", "--id", "abc"])
             .expect("input-source switch parse");
         assert_eq!(command_label(&switch), "input-source.switch");
+
+        let completion =
+            Cli::try_parse_from(["macos-agent", "completion", "zsh"]).expect("completion parse");
+        assert_eq!(command_label(&completion), "completion");
     }
 }

--- a/crates/macos-agent/src/run.rs
+++ b/crates/macos-agent/src/run.rs
@@ -97,6 +97,7 @@ pub fn command_group_label(command: &CommandGroup) -> &'static str {
             ProfileCommand::Validate(_) => "profile.validate",
             ProfileCommand::Init(_) => "profile.init",
         },
+        CommandGroup::Completion(_) => "completion",
     }
 }
 
@@ -150,6 +151,7 @@ pub fn run(cli: Cli) -> Result<(), CliError> {
         CommandGroup::Profile {
             command: ProfileCommand::Init(args),
         } => commands::profile::run_init(cli.format, &args),
+        CommandGroup::Completion(_) => Ok(()),
         CommandGroup::Window {
             command: WindowCommand::Activate(args),
         } => commands::window_activate::run(cli.format, &args, policy, &runner),

--- a/crates/macos-agent/tests/cli_smoke.rs
+++ b/crates/macos-agent/tests/cli_smoke.rs
@@ -23,6 +23,7 @@ fn help_lists_command_groups() {
         "wait",
         "scenario",
         "profile",
+        "completion",
     ] {
         assert!(text.contains(token), "missing token in help: {token}");
     }

--- a/crates/macos-agent/tests/completion_outside_repo.rs
+++ b/crates/macos-agent/tests/completion_outside_repo.rs
@@ -1,0 +1,27 @@
+use tempfile::TempDir;
+
+mod common;
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+
+    let out = harness.run(cwd.path(), &["completion", "zsh"]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+
+    let stdout = out.stdout_text();
+    assert!(stdout.contains("#compdef macos-agent"), "stdout: {stdout}");
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let harness = common::MacosAgentHarness::new();
+    let cwd = TempDir::new().expect("tempdir");
+
+    let out = harness.run(cwd.path(), &["completion", "fish"]);
+    assert_ne!(out.code, 0);
+    let stderr = out.stderr_text();
+    assert!(stderr.contains("invalid value"), "stderr: {stderr}");
+    assert!(stderr.contains("fish"), "stderr: {stderr}");
+}


### PR DESCRIPTION
## Summary
- add clap-first completion export via `macos-agent completion <bash|zsh>`
- handle completion before runtime/trace execution path to keep generation deterministic
- migrate zsh/bash completion assets to thin adapters backed by generated completion scripts
- add completion outside-repo test coverage and include completion in root help smoke checks

## Validation
- cargo test -p nils-macos-agent
- zsh -n completions/zsh/_macos-agent
- bash -n completions/bash/macos-agent
- zsh -f tests/zsh/completion.test.zsh
