### PR TITLE
feat(fzf-cli): migrate completion and fix bash adapter symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,8 @@ name = "nils-fzf-cli"
 version = "0.4.4"
 dependencies = [
  "anyhow",
+ "clap",
+ "clap_complete",
  "nils-common",
  "nils-term",
  "nils-test-support",

--- a/completions/bash/agent-docs
+++ b/completions/bash/agent-docs
@@ -6,7 +6,7 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_agent_docs_source_common_bash() {
+_nils_cli_agent-docs_source_common_bash() {
   declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
   local source_file="${BASH_SOURCE[0]}"
@@ -24,21 +24,21 @@ _nils_cli_agent_docs_source_common_bash() {
 
 _NILS_AGENT_DOCS_BASH_GENERATED_STATE=0
 
-_nils_cli_agent_docs_load_generated_bash() {
-  _nils_cli_agent_docs_source_common_bash || return 1
+_nils_cli_agent-docs_load_generated_bash() {
+  _nils_cli_agent-docs_source_common_bash || return 1
 
   # command agent-docs completion bash
   _nils_cli_completion_common_load_generated_bash \
     "_NILS_AGENT_DOCS_BASH_GENERATED_STATE" \
     "_nils_cli_agent_docs_generated" \
     "agent-docs" \
-    "_agent_docs" \
+    "_agent-docs" \
     '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
     '^fi$'
 }
 
-_nils_cli_agent_docs_complete() {
-  if ! _nils_cli_agent_docs_load_generated_bash; then
+_nils_cli_agent-docs_complete() {
+  if ! _nils_cli_agent-docs_load_generated_bash; then
     if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
       _nils_cli_completion_common_fail_closed_no_legacy_bash
     else
@@ -56,8 +56,8 @@ _nils_cli_agent_docs_complete() {
   _nils_cli_agent_docs_generated "agent-docs" "$cur" "$prev"
 }
 
-if _nils_cli_agent_docs_source_common_bash; then
-  _nils_cli_completion_common_register_bash _nils_cli_agent_docs_complete agent-docs
+if _nils_cli_agent-docs_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_agent-docs_complete agent-docs
 else
-  complete -F _nils_cli_agent_docs_complete agent-docs
+  complete -F _nils_cli_agent-docs_complete agent-docs
 fi

--- a/completions/bash/api-gql
+++ b/completions/bash/api-gql
@@ -6,7 +6,7 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_api_gql_source_common_bash() {
+_nils_cli_api-gql_source_common_bash() {
   declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
   local source_file="${BASH_SOURCE[0]}"
@@ -24,21 +24,21 @@ _nils_cli_api_gql_source_common_bash() {
 
 _NILS_API_GQL_BASH_GENERATED_STATE=0
 
-_nils_cli_api_gql_load_generated_bash() {
-  _nils_cli_api_gql_source_common_bash || return 1
+_nils_cli_api-gql_load_generated_bash() {
+  _nils_cli_api-gql_source_common_bash || return 1
 
   # command api-gql completion bash
   _nils_cli_completion_common_load_generated_bash \
     "_NILS_API_GQL_BASH_GENERATED_STATE" \
     "_nils_cli_api_gql_generated" \
     "api-gql" \
-    "_api_gql" \
+    "_api-gql" \
     '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
     '^fi$'
 }
 
-_nils_cli_api_gql_complete() {
-  if ! _nils_cli_api_gql_load_generated_bash; then
+_nils_cli_api-gql_complete() {
+  if ! _nils_cli_api-gql_load_generated_bash; then
     if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
       _nils_cli_completion_common_fail_closed_no_legacy_bash
     else
@@ -56,8 +56,8 @@ _nils_cli_api_gql_complete() {
   _nils_cli_api_gql_generated "api-gql" "$cur" "$prev"
 }
 
-if _nils_cli_api_gql_source_common_bash; then
-  _nils_cli_completion_common_register_bash _nils_cli_api_gql_complete api-gql
+if _nils_cli_api-gql_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_api-gql_complete api-gql
 else
-  complete -F _nils_cli_api_gql_complete api-gql
+  complete -F _nils_cli_api-gql_complete api-gql
 fi

--- a/completions/bash/api-grpc
+++ b/completions/bash/api-grpc
@@ -6,7 +6,7 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_api_grpc_source_common_bash() {
+_nils_cli_api-grpc_source_common_bash() {
   declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
   local source_file="${BASH_SOURCE[0]}"
@@ -24,21 +24,21 @@ _nils_cli_api_grpc_source_common_bash() {
 
 _NILS_API_GRPC_BASH_GENERATED_STATE=0
 
-_nils_cli_api_grpc_load_generated_bash() {
-  _nils_cli_api_grpc_source_common_bash || return 1
+_nils_cli_api-grpc_load_generated_bash() {
+  _nils_cli_api-grpc_source_common_bash || return 1
 
   # command api-grpc completion bash
   _nils_cli_completion_common_load_generated_bash \
     "_NILS_API_GRPC_BASH_GENERATED_STATE" \
     "_nils_cli_api_grpc_generated" \
     "api-grpc" \
-    "_api_grpc" \
+    "_api-grpc" \
     '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
     '^fi$'
 }
 
-_nils_cli_api_grpc_complete() {
-  if ! _nils_cli_api_grpc_load_generated_bash; then
+_nils_cli_api-grpc_complete() {
+  if ! _nils_cli_api-grpc_load_generated_bash; then
     if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
       _nils_cli_completion_common_fail_closed_no_legacy_bash
     else
@@ -56,8 +56,8 @@ _nils_cli_api_grpc_complete() {
   _nils_cli_api_grpc_generated "api-grpc" "$cur" "$prev"
 }
 
-if _nils_cli_api_grpc_source_common_bash; then
-  _nils_cli_completion_common_register_bash _nils_cli_api_grpc_complete api-grpc
+if _nils_cli_api-grpc_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_api-grpc_complete api-grpc
 else
-  complete -F _nils_cli_api_grpc_complete api-grpc
+  complete -F _nils_cli_api-grpc_complete api-grpc
 fi

--- a/completions/bash/api-rest
+++ b/completions/bash/api-rest
@@ -6,7 +6,7 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_api_rest_source_common_bash() {
+_nils_cli_api-rest_source_common_bash() {
   declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
   local source_file="${BASH_SOURCE[0]}"
@@ -24,21 +24,21 @@ _nils_cli_api_rest_source_common_bash() {
 
 _NILS_API_REST_BASH_GENERATED_STATE=0
 
-_nils_cli_api_rest_load_generated_bash() {
-  _nils_cli_api_rest_source_common_bash || return 1
+_nils_cli_api-rest_load_generated_bash() {
+  _nils_cli_api-rest_source_common_bash || return 1
 
   # command api-rest completion bash
   _nils_cli_completion_common_load_generated_bash \
     "_NILS_API_REST_BASH_GENERATED_STATE" \
     "_nils_cli_api_rest_generated" \
     "api-rest" \
-    "_api_rest" \
+    "_api-rest" \
     '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
     '^fi$'
 }
 
-_nils_cli_api_rest_complete() {
-  if ! _nils_cli_api_rest_load_generated_bash; then
+_nils_cli_api-rest_complete() {
+  if ! _nils_cli_api-rest_load_generated_bash; then
     if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
       _nils_cli_completion_common_fail_closed_no_legacy_bash
     else
@@ -56,8 +56,8 @@ _nils_cli_api_rest_complete() {
   _nils_cli_api_rest_generated "api-rest" "$cur" "$prev"
 }
 
-if _nils_cli_api_rest_source_common_bash; then
-  _nils_cli_completion_common_register_bash _nils_cli_api_rest_complete api-rest
+if _nils_cli_api-rest_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_api-rest_complete api-rest
 else
-  complete -F _nils_cli_api_rest_complete api-rest
+  complete -F _nils_cli_api-rest_complete api-rest
 fi

--- a/completions/bash/api-test
+++ b/completions/bash/api-test
@@ -6,7 +6,7 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_api_test_source_common_bash() {
+_nils_cli_api-test_source_common_bash() {
   declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
   local source_file="${BASH_SOURCE[0]}"
@@ -24,21 +24,21 @@ _nils_cli_api_test_source_common_bash() {
 
 _NILS_API_TEST_BASH_GENERATED_STATE=0
 
-_nils_cli_api_test_load_generated_bash() {
-  _nils_cli_api_test_source_common_bash || return 1
+_nils_cli_api-test_load_generated_bash() {
+  _nils_cli_api-test_source_common_bash || return 1
 
   # command api-test completion bash
   _nils_cli_completion_common_load_generated_bash \
     "_NILS_API_TEST_BASH_GENERATED_STATE" \
     "_nils_cli_api_test_generated" \
     "api-test" \
-    "_api_test" \
+    "_api-test" \
     '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
     '^fi$'
 }
 
-_nils_cli_api_test_complete() {
-  if ! _nils_cli_api_test_load_generated_bash; then
+_nils_cli_api-test_complete() {
+  if ! _nils_cli_api-test_load_generated_bash; then
     if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
       _nils_cli_completion_common_fail_closed_no_legacy_bash
     else
@@ -56,8 +56,8 @@ _nils_cli_api_test_complete() {
   _nils_cli_api_test_generated "api-test" "$cur" "$prev"
 }
 
-if _nils_cli_api_test_source_common_bash; then
-  _nils_cli_completion_common_register_bash _nils_cli_api_test_complete api-test
+if _nils_cli_api-test_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_api-test_complete api-test
 else
-  complete -F _nils_cli_api_test_complete api-test
+  complete -F _nils_cli_api-test_complete api-test
 fi

--- a/completions/bash/api-websocket
+++ b/completions/bash/api-websocket
@@ -6,7 +6,7 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_api_websocket_source_common_bash() {
+_nils_cli_api-websocket_source_common_bash() {
   declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
   local source_file="${BASH_SOURCE[0]}"
@@ -24,21 +24,21 @@ _nils_cli_api_websocket_source_common_bash() {
 
 _NILS_API_WEBSOCKET_BASH_GENERATED_STATE=0
 
-_nils_cli_api_websocket_load_generated_bash() {
-  _nils_cli_api_websocket_source_common_bash || return 1
+_nils_cli_api-websocket_load_generated_bash() {
+  _nils_cli_api-websocket_source_common_bash || return 1
 
   # command api-websocket completion bash
   _nils_cli_completion_common_load_generated_bash \
     "_NILS_API_WEBSOCKET_BASH_GENERATED_STATE" \
     "_nils_cli_api_websocket_generated" \
     "api-websocket" \
-    "_api_websocket" \
+    "_api-websocket" \
     '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
     '^fi$'
 }
 
-_nils_cli_api_websocket_complete() {
-  if ! _nils_cli_api_websocket_load_generated_bash; then
+_nils_cli_api-websocket_complete() {
+  if ! _nils_cli_api-websocket_load_generated_bash; then
     if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
       _nils_cli_completion_common_fail_closed_no_legacy_bash
     else
@@ -56,8 +56,8 @@ _nils_cli_api_websocket_complete() {
   _nils_cli_api_websocket_generated "api-websocket" "$cur" "$prev"
 }
 
-if _nils_cli_api_websocket_source_common_bash; then
-  _nils_cli_completion_common_register_bash _nils_cli_api_websocket_complete api-websocket
+if _nils_cli_api-websocket_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_api-websocket_complete api-websocket
 else
-  complete -F _nils_cli_api_websocket_complete api-websocket
+  complete -F _nils_cli_api-websocket_complete api-websocket
 fi

--- a/completions/bash/fzf-cli
+++ b/completions/bash/fzf-cli
@@ -6,102 +6,97 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
+_nils_cli_fzf_cli_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
+
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
+
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
+
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
+}
+
+_NILS_FZF_CLI_BASH_GENERATED_STATE=0
+
+_nils_cli_fzf_cli_load_generated_bash() {
+  _nils_cli_fzf_cli_source_common_bash || return 1
+
+  # command fzf-cli completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_FZF_CLI_BASH_GENERATED_STATE" \
+    "_nils_cli_fzf_cli_generated" \
+    "fzf-cli" \
+    "_fzf-cli" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
 _nils_cli_fzf_cli_complete() {
+  if ! _nils_cli_fzf_cli_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
+      COMPREPLY=()
+    fi
+    return 0
+  fi
+
   local invoked_as="${COMP_WORDS[0]}"
   local -a words=("${COMP_WORDS[@]}")
   local cword="$COMP_CWORD"
   local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+  local -a inject=()
 
-  local subcmd_override=''
   case "$invoked_as" in
-    fxf) subcmd_override='file' ;;
-    fxd) subcmd_override='directory' ;;
-    fxgs) subcmd_override='git-status' ;;
-    fxgc) subcmd_override='git-commit' ;;
-    fxgco) subcmd_override='git-checkout' ;;
-    fxgb) subcmd_override='git-branch' ;;
-    fxgt) subcmd_override='git-tag' ;;
-    fxp) subcmd_override='process' ;;
-    fxpo) subcmd_override='port' ;;
-    fxh) subcmd_override='history' ;;
-    fxenv) subcmd_override='env' ;;
-    fxal) subcmd_override='alias' ;;
-    fxfn) subcmd_override='function' ;;
-    fxdef) subcmd_override='def' ;;
+    fxf) inject=(file) ;;
+    fxd) inject=(directory) ;;
+    fxgs) inject=(git-status) ;;
+    fxgc) inject=(git-commit) ;;
+    fxgco) inject=(git-checkout) ;;
+    fxgb) inject=(git-branch) ;;
+    fxgt) inject=(git-tag) ;;
+    fxp) inject=(process) ;;
+    fxpo) inject=(port) ;;
+    fxh) inject=(history) ;;
+    fxenv) inject=(env) ;;
+    fxal) inject=(alias) ;;
+    fxfn) inject=(function) ;;
+    fxdef) inject=(def) ;;
   esac
 
-  if [[ -n "$subcmd_override" ]]; then
-    words=( "fzf-cli" "$subcmd_override" "${words[@]:1}" )
-    cword=$((cword + 1))
+  if [[ "$invoked_as" != "fzf-cli" ]]; then
+    words=( "fzf-cli" "${inject[@]}" "${words[@]:1}" )
+    cword=$((cword + ${#inject[@]}))
     cur="${words[cword]}"
+    prev="${words[cword-1]}"
   else
     words[0]="fzf-cli"
   fi
 
-  local -a root_subcmds=(
-    file
-    directory
-    git-status
-    git-commit
-    git-checkout
-    git-branch
-    git-tag
-    process
-    port
-    history
-    env
-    alias
-    function
-    def
-    help
-  )
+  local -a saved_words=("${COMP_WORDS[@]}")
+  local saved_cword="$COMP_CWORD"
 
-  if (( cword == 1 )); then
-    if [[ "$cur" == -* ]]; then
-      COMPREPLY=( $(compgen -W "-h --help -V --version" -- "$cur") )
-      return 0
-    fi
-    COMPREPLY=( $(compgen -W "${root_subcmds[*]}" -- "$cur") )
-    return 0
-  fi
+  COMP_WORDS=("${words[@]}")
+  COMP_CWORD="$cword"
+  _nils_cli_fzf_cli_generated "fzf-cli" "$cur" "$prev"
+  local rc=$?
 
-  local subcmd="${words[1]-}"
-  case "$subcmd" in
-    -V|--version)
-      COMPREPLY=()
-      return 0
-      ;;
-    file|directory)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "--vi --vscode --" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    git-commit)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "--snapshot" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    process|port)
-      if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-k --kill -9 --force" -- "$cur") )
-        return 0
-      fi
-      COMPREPLY=()
-      return 0
-      ;;
-    git-status|git-checkout|git-branch|git-tag|history|env|alias|function|def|help)
-      COMPREPLY=()
-      return 0
-      ;;
-  esac
-
-  COMPREPLY=( $(compgen -W "${root_subcmds[*]}" -- "$cur") )
+  COMP_WORDS=("${saved_words[@]}")
+  COMP_CWORD="$saved_cword"
+  return $rc
 }
 
-complete -F _nils_cli_fzf_cli_complete fzf-cli fx fxf fxd fxgs fxgc fxgco fxgb fxgt fxp fxpo fxh fxenv fxal fxfn fxdef
+if _nils_cli_fzf_cli_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_fzf_cli_complete \
+    fzf-cli fx fxf fxd fxgs fxgc fxgco fxgb fxgt fxp fxpo fxh fxenv fxal fxfn fxdef
+else
+  complete -F _nils_cli_fzf_cli_complete \
+    fzf-cli fx fxf fxd fxgs fxgc fxgco fxgb fxgt fxp fxpo fxh fxenv fxal fxfn fxdef
+fi

--- a/completions/bash/macos-agent
+++ b/completions/bash/macos-agent
@@ -6,7 +6,7 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_macos_agent_source_common_bash() {
+_nils_cli_macos-agent_source_common_bash() {
   declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
   local source_file="${BASH_SOURCE[0]}"
@@ -24,21 +24,21 @@ _nils_cli_macos_agent_source_common_bash() {
 
 _NILS_MACOS_AGENT_BASH_GENERATED_STATE=0
 
-_nils_cli_macos_agent_load_generated_bash() {
-  _nils_cli_macos_agent_source_common_bash || return 1
+_nils_cli_macos-agent_load_generated_bash() {
+  _nils_cli_macos-agent_source_common_bash || return 1
 
   # command macos-agent completion bash
   _nils_cli_completion_common_load_generated_bash \
     "_NILS_MACOS_AGENT_BASH_GENERATED_STATE" \
     "_nils_cli_macos_agent_generated" \
     "macos-agent" \
-    "_macos_agent" \
+    "_macos-agent" \
     '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
     '^fi$'
 }
 
-_nils_cli_macos_agent_complete() {
-  if ! _nils_cli_macos_agent_load_generated_bash; then
+_nils_cli_macos-agent_complete() {
+  if ! _nils_cli_macos-agent_load_generated_bash; then
     if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
       _nils_cli_completion_common_fail_closed_no_legacy_bash
     else
@@ -56,8 +56,8 @@ _nils_cli_macos_agent_complete() {
   _nils_cli_macos_agent_generated "macos-agent" "$cur" "$prev"
 }
 
-if _nils_cli_macos_agent_source_common_bash; then
-  _nils_cli_completion_common_register_bash _nils_cli_macos_agent_complete macos-agent
+if _nils_cli_macos-agent_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_macos-agent_complete macos-agent
 else
-  complete -F _nils_cli_macos_agent_complete macos-agent
+  complete -F _nils_cli_macos-agent_complete macos-agent
 fi

--- a/completions/bash/memo-cli
+++ b/completions/bash/memo-cli
@@ -6,7 +6,7 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_memo_cli_source_common_bash() {
+_nils_cli_memo-cli_source_common_bash() {
   declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
   local source_file="${BASH_SOURCE[0]}"
@@ -24,21 +24,21 @@ _nils_cli_memo_cli_source_common_bash() {
 
 _NILS_MEMO_CLI_BASH_GENERATED_STATE=0
 
-_nils_cli_memo_cli_load_generated_bash() {
-  _nils_cli_memo_cli_source_common_bash || return 1
+_nils_cli_memo-cli_load_generated_bash() {
+  _nils_cli_memo-cli_source_common_bash || return 1
 
   # command memo-cli completion bash
   _nils_cli_completion_common_load_generated_bash \
     "_NILS_MEMO_CLI_BASH_GENERATED_STATE" \
     "_nils_cli_memo_cli_generated" \
     "memo-cli" \
-    "_memo_cli" \
+    "_memo-cli" \
     '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
     '^fi$'
 }
 
-_nils_cli_memo_cli_complete() {
-  if ! _nils_cli_memo_cli_load_generated_bash; then
+_nils_cli_memo-cli_complete() {
+  if ! _nils_cli_memo-cli_load_generated_bash; then
     if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
       _nils_cli_completion_common_fail_closed_no_legacy_bash
     else
@@ -56,8 +56,8 @@ _nils_cli_memo_cli_complete() {
   _nils_cli_memo_cli_generated "memo-cli" "$cur" "$prev"
 }
 
-if _nils_cli_memo_cli_source_common_bash; then
-  _nils_cli_completion_common_register_bash _nils_cli_memo_cli_complete memo-cli
+if _nils_cli_memo-cli_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_memo-cli_complete memo-cli
 else
-  complete -F _nils_cli_memo_cli_complete memo-cli
+  complete -F _nils_cli_memo-cli_complete memo-cli
 fi

--- a/completions/bash/plan-tooling
+++ b/completions/bash/plan-tooling
@@ -6,7 +6,7 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_plan_tooling_source_common_bash() {
+_nils_cli_plan-tooling_source_common_bash() {
   declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
   local source_file="${BASH_SOURCE[0]}"
@@ -24,21 +24,21 @@ _nils_cli_plan_tooling_source_common_bash() {
 
 _NILS_PLAN_TOOLING_BASH_GENERATED_STATE=0
 
-_nils_cli_plan_tooling_load_generated_bash() {
-  _nils_cli_plan_tooling_source_common_bash || return 1
+_nils_cli_plan-tooling_load_generated_bash() {
+  _nils_cli_plan-tooling_source_common_bash || return 1
 
   # command plan-tooling completion bash
   _nils_cli_completion_common_load_generated_bash \
     "_NILS_PLAN_TOOLING_BASH_GENERATED_STATE" \
     "_nils_cli_plan_tooling_generated" \
     "plan-tooling" \
-    "_plan_tooling" \
+    "_plan-tooling" \
     '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
     '^fi$'
 }
 
-_nils_cli_plan_tooling_complete() {
-  if ! _nils_cli_plan_tooling_load_generated_bash; then
+_nils_cli_plan-tooling_complete() {
+  if ! _nils_cli_plan-tooling_load_generated_bash; then
     if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
       _nils_cli_completion_common_fail_closed_no_legacy_bash
     else
@@ -56,8 +56,8 @@ _nils_cli_plan_tooling_complete() {
   _nils_cli_plan_tooling_generated "plan-tooling" "$cur" "$prev"
 }
 
-if _nils_cli_plan_tooling_source_common_bash; then
-  _nils_cli_completion_common_register_bash _nils_cli_plan_tooling_complete plan-tooling
+if _nils_cli_plan-tooling_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_plan-tooling_complete plan-tooling
 else
-  complete -F _nils_cli_plan_tooling_complete plan-tooling
+  complete -F _nils_cli_plan-tooling_complete plan-tooling
 fi

--- a/completions/bash/semantic-commit
+++ b/completions/bash/semantic-commit
@@ -6,7 +6,7 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
-_nils_cli_semantic_commit_source_common_bash() {
+_nils_cli_semantic-commit_source_common_bash() {
   declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
 
   local source_file="${BASH_SOURCE[0]}"
@@ -24,21 +24,21 @@ _nils_cli_semantic_commit_source_common_bash() {
 
 _NILS_SEMANTIC_COMMIT_BASH_GENERATED_STATE=0
 
-_nils_cli_semantic_commit_load_generated_bash() {
-  _nils_cli_semantic_commit_source_common_bash || return 1
+_nils_cli_semantic-commit_load_generated_bash() {
+  _nils_cli_semantic-commit_source_common_bash || return 1
 
   # command semantic-commit completion bash
   _nils_cli_completion_common_load_generated_bash \
     "_NILS_SEMANTIC_COMMIT_BASH_GENERATED_STATE" \
     "_nils_cli_semantic_commit_generated" \
     "semantic-commit" \
-    "_semantic_commit" \
+    "_semantic-commit" \
     '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
     '^fi$'
 }
 
-_nils_cli_semantic_commit_complete() {
-  if ! _nils_cli_semantic_commit_load_generated_bash; then
+_nils_cli_semantic-commit_complete() {
+  if ! _nils_cli_semantic-commit_load_generated_bash; then
     if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
       _nils_cli_completion_common_fail_closed_no_legacy_bash
     else
@@ -56,8 +56,8 @@ _nils_cli_semantic_commit_complete() {
   _nils_cli_semantic_commit_generated "semantic-commit" "$cur" "$prev"
 }
 
-if _nils_cli_semantic_commit_source_common_bash; then
-  _nils_cli_completion_common_register_bash _nils_cli_semantic_commit_complete semantic-commit
+if _nils_cli_semantic-commit_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_semantic-commit_complete semantic-commit
 else
-  complete -F _nils_cli_semantic_commit_complete semantic-commit
+  complete -F _nils_cli_semantic-commit_complete semantic-commit
 fi

--- a/completions/zsh/_fzf-cli
+++ b/completions/zsh/_fzf-cli
@@ -1,137 +1,113 @@
 #compdef fzf-cli fx fxf fxd fxgs fxgc fxgco fxgb fxgt fxp fxpo fxh fxenv fxal fxfn fxdef
 
-__fzf_cli_query() {
-  emulate -L zsh -o extendedglob
-  builtin compadd -x 'query'
+_nils_cli_fzf_cli_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_fzf-cli]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_FZF_CLI_ZSH_GENERATED_STATE=0
+
+_nils_cli_fzf_cli_load_generated_zsh() {
+  _nils_cli_fzf_cli_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_FZF_CLI_ZSH_GENERATED_STATE" \
+    "_nils_cli_fzf_cli_generated" \
+    "fzf-cli" \
+    "_fzf-cli" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_fzf_cli_generated" \]; then$' \
+    '^fi$'
+}
+
+_nils_cli_fzf_cli_apply_alias_rewrite_zsh() {
+  local invoked_as="${words[1]-}"
+  local -a inject=()
+
+  case "$invoked_as" in
+    fxf) inject=(file) ;;
+    fxd) inject=(directory) ;;
+    fxgs) inject=(git-status) ;;
+    fxgc) inject=(git-commit) ;;
+    fxgco) inject=(git-checkout) ;;
+    fxgb) inject=(git-branch) ;;
+    fxgt) inject=(git-tag) ;;
+    fxp) inject=(process) ;;
+    fxpo) inject=(port) ;;
+    fxh) inject=(history) ;;
+    fxenv) inject=(env) ;;
+    fxal) inject=(alias) ;;
+    fxfn) inject=(function) ;;
+    fxdef) inject=(def) ;;
+  esac
+
+  if [[ "$invoked_as" != "fzf-cli" ]]; then
+    local -a rewritten_words=('fzf-cli')
+    local token=''
+    local -i idx=2
+
+    for token in "${inject[@]}"; do
+      rewritten_words+=("$token")
+    done
+
+    while (( idx <= ${#words[@]} )); do
+      rewritten_words+=("${words[idx]}")
+      (( idx++ ))
+    done
+
+    words=("${rewritten_words[@]}")
+    (( CURRENT += ${#inject[@]} ))
+  fi
 }
 
 _fzf-cli() {
   emulate -L zsh -o extendedglob
 
-  local context='' state='' state_descr=''
-  local -a line=()
-  typeset -A opt_args=()
+  local -i saved_current="$CURRENT"
+  local -a saved_words=("${words[@]}")
 
-  local -i orig_current="$CURRENT"
-  local -a orig_words=("${words[@]}")
-  local invoked_as="${orig_words[1]-}"
-  local subcmd_override=''
-
-  case "$invoked_as" in
-    fxf) subcmd_override='file' ;;
-    fxd) subcmd_override='directory' ;;
-    fxgs) subcmd_override='git-status' ;;
-    fxgc) subcmd_override='git-commit' ;;
-    fxgco) subcmd_override='git-checkout' ;;
-    fxgb) subcmd_override='git-branch' ;;
-    fxgt) subcmd_override='git-tag' ;;
-    fxp) subcmd_override='process' ;;
-    fxpo) subcmd_override='port' ;;
-    fxh) subcmd_override='history' ;;
-    fxenv) subcmd_override='env' ;;
-    fxal) subcmd_override='alias' ;;
-    fxfn) subcmd_override='function' ;;
-    fxdef) subcmd_override='def' ;;
-  esac
-
-  local -a subcommands=()
-  subcommands=(
-    'file:Search and preview text files'
-    'directory:Search directories and cd into selection'
-    'git-status:Interactive git status viewer'
-    'git-commit:Browse commits and open changed files in editor'
-    'git-checkout:Pick and checkout a previous commit'
-    'git-branch:Browse and checkout branches interactively'
-    'git-tag:Browse and checkout tags interactively'
-    'process:Browse and kill running processes'
-    'port:Browse listening ports and owners'
-    'history:Search and execute command history'
-    'env:Browse environment variables'
-    'alias:Browse shell aliases'
-    'function:Browse defined shell functions'
-    'def:Browse all definitions (env, alias, functions)'
-    'help:Display help message for fzf-cli'
-  )
-
-  if [[ -n "$subcmd_override" ]]; then
-    _arguments -C \
-      '(-h --help)'{-h,--help}'[Display help message for fzf-cli]' \
-      '(-V --version)'{-V,--version}'[Display version for fzf-cli]' \
-      '*::arg:->args'
-  else
-    _arguments -C \
-      '(-h --help)'{-h,--help}'[Display help message for fzf-cli]' \
-      '(-V --version)'{-V,--version}'[Display version for fzf-cli]' \
-      '1:command:->subcmds' \
-      '*::arg:->args'
+  if ! _nils_cli_fzf_cli_load_generated_zsh; then
+    words=("${saved_words[@]}")
+    CURRENT="$saved_current"
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
+    fi
+    return 1
   fi
 
-  case "${state-}" in
-    subcmds)
-      _describe -t commands 'fzf-cli command' subcommands && return 0
-      ;;
-    args)
-      local cur="${orig_words[orig_current]-}"
-      cur="${cur%%[[:space:]]#}"
+  _nils_cli_fzf_cli_apply_alias_rewrite_zsh
+  _nils_cli_fzf_cli_generated
+  local rc=$?
 
-      local subcmd=''
-      if [[ -n "$subcmd_override" ]]; then
-        subcmd="$subcmd_override"
-      else
-        subcmd="${line[1]:-${orig_words[2]-}}"
-        subcmd="${subcmd%%[[:space:]]#}"
-      fi
-
-      case "$subcmd" in
-        -V|--version)
-          _message 'no additional arguments'
-          return 0
-          ;;
-        file|directory)
-          if [[ "$cur" == -* ]]; then
-            local -a opts=(
-              '--vi:Open files with vi'
-              '--vscode:Open files with VSCode'
-              '--:End of options'
-            )
-            _describe -t options 'option' opts && return 0
-            return 0
-          fi
-          __fzf_cli_query
-          return 0
-          ;;
-        git-commit)
-          if [[ "$cur" == -* ]]; then
-            local -a opts=(
-              '--snapshot:Open snapshot from selected commit by default'
-            )
-            _describe -t options 'option' opts && return 0
-            return 0
-          fi
-          __fzf_cli_query
-          return 0
-          ;;
-        process|port)
-          if [[ "$cur" == -* ]]; then
-            local -a opts=(
-              '-k:Kill without interactive confirmation'
-              '--kill:Kill without interactive confirmation'
-              '-9:Force SIGKILL (-9)'
-              '--force:Force SIGKILL (-9)'
-            )
-            _describe -t options 'option' opts && return 0
-            return 0
-          fi
-          __fzf_cli_query
-          return 0
-          ;;
-        git-status|git-checkout|git-branch|git-tag|history|env|alias|function|def|help)
-          builtin compadd -x 'query (optional)'
-          return 0
-          ;;
-      esac
-      ;;
-  esac
+  words=("${saved_words[@]}")
+  CURRENT="$saved_current"
+  return $rc
 }
 
-compdef _fzf-cli fzf-cli fx fxf fxd fxgs fxgc fxgco fxgb fxgt fxp fxpo fxh fxenv fxal fxfn fxdef
+if _nils_cli_fzf_cli_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _fzf-cli \
+    fzf-cli fx fxf fxd fxgs fxgc fxgco fxgb fxgt fxp fxpo fxh fxenv fxal fxfn fxdef
+else
+  compdef _fzf-cli \
+    fzf-cli fx fxf fxd fxgs fxgc fxgco fxgb fxgt fxp fxpo fxh fxenv fxal fxfn fxdef
+fi

--- a/crates/fzf-cli/Cargo.toml
+++ b/crates/fzf-cli/Cargo.toml
@@ -12,6 +12,8 @@ name = "fzf-cli"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
+clap = { workspace = true }
+clap_complete = { workspace = true }
 nils-term = { version = "0.4.4", path = "../nils-term", package = "nils-term" }
 nils-common = { version = "0.4.4", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }

--- a/crates/fzf-cli/src/completion.rs
+++ b/crates/fzf-cli/src/completion.rs
@@ -1,0 +1,158 @@
+use clap::{Arg, ArgAction, Command};
+use clap_complete::{Generator, Shell, generate};
+use std::io;
+
+pub fn run(args: &[String]) -> i32 {
+    match args.first().map(String::as_str) {
+        None => {
+            eprintln!("usage: fzf-cli completion <bash|zsh>");
+            1
+        }
+        Some("bash") if args.len() == 1 => generate_script(Shell::Bash),
+        Some("zsh") if args.len() == 1 => generate_script(Shell::Zsh),
+        Some(shell) if args.len() == 1 => {
+            eprintln!("fzf-cli: error: unsupported completion shell '{shell}'");
+            eprintln!("usage: fzf-cli completion <bash|zsh>");
+            1
+        }
+        _ => {
+            eprintln!("fzf-cli: error: expected `fzf-cli completion <bash|zsh>`");
+            1
+        }
+    }
+}
+
+fn generate_script<G: Generator>(generator: G) -> i32 {
+    let mut command = build_completion_command();
+    let bin_name = command.get_name().to_string();
+    generate(generator, &mut command, bin_name, &mut io::stdout());
+    0
+}
+
+fn query_arg() -> Arg {
+    Arg::new("query")
+        .value_name("query")
+        .num_args(0..)
+        .allow_hyphen_values(true)
+}
+
+fn build_completion_command() -> Command {
+    Command::new("fzf-cli")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("Fuzzy workflow helper CLI")
+        .disable_help_subcommand(true)
+        .subcommand(
+            Command::new("file")
+                .about("Search and preview text files")
+                .arg(Arg::new("vi").long("vi").action(ArgAction::SetTrue))
+                .arg(Arg::new("vscode").long("vscode").action(ArgAction::SetTrue))
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("directory")
+                .about("Search directories and cd into selection")
+                .arg(Arg::new("vi").long("vi").action(ArgAction::SetTrue))
+                .arg(Arg::new("vscode").long("vscode").action(ArgAction::SetTrue))
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("git-status")
+                .about("Interactive git status viewer")
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("git-commit")
+                .about("Browse commits and open changed files in editor")
+                .arg(
+                    Arg::new("snapshot")
+                        .long("snapshot")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("git-checkout")
+                .about("Pick and checkout a previous commit")
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("git-branch")
+                .about("Browse and checkout branches interactively")
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("git-tag")
+                .about("Browse and checkout tags interactively")
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("process")
+                .about("Browse and kill running processes")
+                .arg(
+                    Arg::new("kill")
+                        .short('k')
+                        .long("kill")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("force")
+                        .short('9')
+                        .long("force")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("port")
+                .about("Browse listening ports and owners")
+                .arg(
+                    Arg::new("kill")
+                        .short('k')
+                        .long("kill")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("force")
+                        .short('9')
+                        .long("force")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("history")
+                .about("Search and execute command history")
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("env")
+                .about("Browse environment variables")
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("alias")
+                .about("Browse shell aliases")
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("function")
+                .about("Browse defined shell functions")
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("def")
+                .about("Browse all definitions (env, alias, functions)")
+                .arg(query_arg()),
+        )
+        .subcommand(
+            Command::new("completion")
+                .about("Export shell completion script")
+                .arg(
+                    Arg::new("shell")
+                        .value_name("shell")
+                        .value_parser(["bash", "zsh"])
+                        .required(true),
+                ),
+        )
+        .subcommand(Command::new("help").about("Display help message for fzf-cli"))
+}

--- a/crates/fzf-cli/src/main.rs
+++ b/crates/fzf-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod completion;
 mod confirm;
 mod defs;
 mod directory;
@@ -53,6 +54,7 @@ fn run() -> i32 {
         "alias" => defs::run_alias(rest),
         "function" => defs::run_function(rest),
         "def" => defs::run_def(rest),
+        "completion" => completion::run(rest),
         _ => {
             println!("❗ Unknown command: {cmd}");
             println!("Run 'fzf-cli help' for usage.");
@@ -103,5 +105,6 @@ fn print_help() {
         "  {:<16}  Browse all definitions (env, alias, functions)",
         "def"
     );
+    println!("  {:<16}  Export shell completion script", "completion");
     println!();
 }

--- a/crates/fzf-cli/tests/completion_outside_repo.rs
+++ b/crates/fzf-cli/tests/completion_outside_repo.rs
@@ -1,0 +1,20 @@
+mod common;
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let out = common::run_fzf_cli(temp.path(), &["completion", "zsh"], &[], None);
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("#compdef fzf-cli"), "{}", out.stdout);
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let out = common::run_fzf_cli(temp.path(), &["completion", "fish"], &[], None);
+
+    assert_ne!(out.code, 0);
+    assert!(out.stderr.contains("unsupported completion shell"));
+    assert!(out.stderr.contains("fish"));
+}


### PR DESCRIPTION
## Summary
- implement Task 4.16 from `docs/plans/repo-completion-standard-rollout-plan.md`
- add `fzf-cli completion <bash|zsh>` powered by clap-generated command graph
- migrate `completions/zsh/_fzf-cli` and `completions/bash/fzf-cli` to thin shared adapters with `fx*` alias rewrite support
- add completion smoke tests outside git repo for `fzf-cli`
- fix bash generated-symbol mapping in existing thin adapters so clap bash completion loading does not fail closed (`agent-docs`, `api-*`, `memo-cli`, `macos-agent`, `plan-tooling`, `semantic-commit`)

## Testing
- cargo fmt --all
- cargo test -p nils-fzf-cli
- cargo run -p nils-fzf-cli --bin fzf-cli -- completion zsh >/dev/null
- cargo run -p nils-fzf-cli --bin fzf-cli -- completion bash >/dev/null
- zsh -n completions/zsh/_fzf-cli
- bash -n completions/bash/fzf-cli
- bash -n completions/bash/semantic-commit
- bash -n completions/bash/plan-tooling
- bash -n completions/bash/agent-docs
- bash -n completions/bash/memo-cli
- bash -n completions/bash/macos-agent
- bash -n completions/bash/api-rest
- bash -n completions/bash/api-test
- bash -n completions/bash/api-gql
- bash -n completions/bash/api-grpc
- bash -n completions/bash/api-websocket
- zsh -f tests/zsh/completion.test.zsh
