### PR TITLE
feat(screen-record): migrate completion to clap-first adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "block2",
  "chrono",
  "clap",
+ "clap_complete",
  "ctrlc",
  "dispatch2",
  "libc",

--- a/completions/bash/screen-record
+++ b/completions/bash/screen-record
@@ -6,41 +6,58 @@ fi
 
 shopt -s progcomp 2>/dev/null || true
 
+_nils_cli_screen_record_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
+
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
+
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
+
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
+}
+
+_NILS_SCREEN_RECORD_BASH_GENERATED_STATE=0
+
+_nils_cli_screen_record_load_generated_bash() {
+  _nils_cli_screen_record_source_common_bash || return 1
+
+  # command screen-record completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_SCREEN_RECORD_BASH_GENERATED_STATE" \
+    "_nils_cli_screen_record_generated" \
+    "screen-record" \
+    "_screen-record" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
 _nils_cli_screen_record_complete() {
-  local -a words=(${COMP_WORDS[@]})
-  local cword="$COMP_CWORD"
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prev="${COMP_WORDS[COMP_CWORD-1]}"
-
-  case "$prev" in
-    --path)
-      COMPREPLY=( $(compgen -f -- "$cur") )
-      return 0
-      ;;
-    --dir)
-      COMPREPLY=( $(compgen -d -- "$cur") )
-      return 0
-      ;;
-    --audio)
-      COMPREPLY=( $(compgen -W "off system mic both" -- "$cur") )
-      return 0
-      ;;
-    --format)
-      COMPREPLY=( $(compgen -W "mov mp4" -- "$cur") )
-      return 0
-      ;;
-    --image-format)
-      COMPREPLY=( $(compgen -W "png jpg webp" -- "$cur") )
-      return 0
-      ;;
-  esac
-
-  if [[ "$cur" == -* ]]; then
-    COMPREPLY=( $(compgen -W "-h --help -V --version --screenshot --portal --list-windows --list-displays --list-apps --preflight --request-permission --window-id --app --window-name --active-window --display --display-id --duration --audio --path --format --image-format --dir" -- "$cur") )
+  if ! _nils_cli_screen_record_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_no_legacy_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_no_legacy_bash
+    else
+      COMPREPLY=()
+    fi
     return 0
   fi
 
-  COMPREPLY=()
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev=''
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
+
+  _nils_cli_screen_record_generated "screen-record" "$cur" "$prev"
 }
 
-complete -F _nils_cli_screen_record_complete screen-record
+if _nils_cli_screen_record_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_screen_record_complete screen-record
+else
+  complete -F _nils_cli_screen_record_complete screen-record
+fi

--- a/completions/zsh/_screen-record
+++ b/completions/zsh/_screen-record
@@ -1,31 +1,60 @@
 #compdef screen-record
 
+_nils_cli_screen_record_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_screen-record]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_SCREEN_RECORD_ZSH_GENERATED_STATE=0
+
+_nils_cli_screen_record_load_generated_zsh() {
+  _nils_cli_screen_record_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_SCREEN_RECORD_ZSH_GENERATED_STATE" \
+    "_nils_cli_screen_record_generated" \
+    "screen-record" \
+    "_screen-record" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_screen_record_generated" \]; then$' \
+    '^fi$'
+}
+
 _screen-record() {
   emulate -L zsh -o extendedglob
 
-  _arguments -C \
-    '--screenshot[Capture a single window screenshot and exit]' \
-    '--portal[Use the system portal picker (Linux Wayland) instead of X11 selectors]' \
-    '--list-windows[Print selectable windows as TSV and exit]' \
-    '--list-displays[Print selectable displays as TSV and exit]' \
-    '--list-apps[Print selectable apps as TSV and exit]' \
-    '--preflight[Check macOS permission or Linux prerequisites and exit]' \
-    '--request-permission[Best-effort permission request (macOS) or preflight (Linux), then exit]' \
-    '--window-id=[Record a specific window id]:id:' \
-    '--app=[Select a window by app/owner name]:name:' \
-    '--window-name=[Narrow app selection by window title]:name:' \
-    '--active-window[Record the frontmost window on the current Space]' \
-    '--display[Record the main display]' \
-    '--display-id=[Record a specific display id]:id:' \
-    '--duration=[Record for N seconds]:seconds:' \
-    '--audio=[Audio capture mode]:audio:(off system mic both)' \
-    '--path=[Output file path]:path:_files' \
-    '--format=[Container format]:format:(mov mp4)' \
-    '--image-format=[Screenshot output format]:format:(png jpg webp)' \
-    '--dir=[Output directory for screenshot mode]:path:_files -/' \
-    '(-h --help)'{-h,--help}'[Show help]' \
-    '(-V --version)'{-V,--version}'[Show version]' \
-    && return 0
+  if ! _nils_cli_screen_record_load_generated_zsh; then
+    if (( $+functions[_nils_cli_completion_common_fail_closed_no_legacy_zsh] )); then
+      _nils_cli_completion_common_fail_closed_no_legacy_zsh
+    fi
+    return 1
+  fi
+
+  _nils_cli_screen_record_generated
 }
 
-compdef _screen-record screen-record
+if _nils_cli_screen_record_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _screen-record screen-record
+else
+  compdef _screen-record screen-record
+fi

--- a/crates/screen-record/Cargo.toml
+++ b/crates/screen-record/Cargo.toml
@@ -17,6 +17,7 @@ name = "screen-record"
 path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
+clap_complete = { workspace = true }
 ctrlc = "3.5.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 nils-common = { version = "0.4.4", path = "../nils-common", package = "nils-common" }

--- a/crates/screen-record/src/completion.rs
+++ b/crates/screen-record/src/completion.rs
@@ -1,0 +1,31 @@
+use clap::CommandFactory;
+use clap_complete::{Generator, Shell, generate};
+
+use crate::cli::Cli;
+
+pub fn run(args: &[String]) -> i32 {
+    match args.first().map(String::as_str) {
+        None => {
+            eprintln!("usage: screen-record completion <bash|zsh>");
+            1
+        }
+        Some("bash") if args.len() == 1 => generate_script(Shell::Bash),
+        Some("zsh") if args.len() == 1 => generate_script(Shell::Zsh),
+        Some(shell) if args.len() == 1 => {
+            eprintln!("screen-record: error: unsupported completion shell '{shell}'");
+            eprintln!("usage: screen-record completion <bash|zsh>");
+            1
+        }
+        _ => {
+            eprintln!("screen-record: error: expected `screen-record completion <bash|zsh>`");
+            1
+        }
+    }
+}
+
+fn generate_script<G: Generator>(generator: G) -> i32 {
+    let mut command = Cli::command();
+    let bin_name = command.get_name().to_string();
+    generate(generator, &mut command, bin_name, &mut std::io::stdout());
+    0
+}

--- a/crates/screen-record/src/lib.rs
+++ b/crates/screen-record/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod completion;
 pub mod error;
 pub mod run;
 pub mod select;

--- a/crates/screen-record/src/main.rs
+++ b/crates/screen-record/src/main.rs
@@ -5,6 +5,16 @@ use screen_record::cli::Cli;
 use screen_record::run::run;
 
 fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.get(1).map(String::as_str) == Some("completion") {
+        let code = screen_record::completion::run(&args[2..]);
+        return if code == 0 {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::from(1)
+        };
+    }
+
     let cli = Cli::parse();
     match run(cli) {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/screen-record/tests/completion_outside_repo.rs
+++ b/crates/screen-record/tests/completion_outside_repo.rs
@@ -1,0 +1,24 @@
+mod common;
+
+use tempfile::TempDir;
+
+#[test]
+fn completion_export_succeeds_outside_git_repo() {
+    let harness = common::ScreenRecordHarness::new();
+    let dir = TempDir::new().expect("tempdir");
+    let out = harness.run(dir.path(), &["completion", "zsh"]);
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+    assert!(out.stdout_text().contains("#compdef screen-record"));
+}
+
+#[test]
+fn completion_rejects_unknown_shell_outside_git_repo() {
+    let harness = common::ScreenRecordHarness::new();
+    let dir = TempDir::new().expect("tempdir");
+    let out = harness.run(dir.path(), &["completion", "fish"]);
+
+    assert_ne!(out.code, 0);
+    assert!(out.stderr_text().contains("unsupported completion shell"));
+    assert!(out.stderr_text().contains("fish"));
+}


### PR DESCRIPTION
## Summary
- implement Task 4.17 from `docs/plans/repo-completion-standard-rollout-plan.md`
- add `screen-record completion <bash|zsh>` using clap-generated completion output from `Cli::command()`
- migrate `completions/zsh/_screen-record` and `completions/bash/screen-record` to thin shared-adapter wrappers
- add completion smoke tests for outside-repo execution

## Testing
- cargo fmt --all
- cargo test -p nils-screen-record
- cargo run -p nils-screen-record --bin screen-record -- completion zsh >/dev/null
- cargo run -p nils-screen-record --bin screen-record -- completion bash >/dev/null
- zsh -n completions/zsh/_screen-record
- bash -n completions/bash/screen-record
- zsh -f tests/zsh/completion.test.zsh
