### PR TITLE
Harden completion audit and release readiness gates

### DIFF
--- a/.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
+++ b/.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
@@ -8,6 +8,7 @@ Usage:
 
 Runs the required pre-delivery checks from DEVELOPMENT.md:
   - bash scripts/ci/docs-placement-audit.sh --strict
+  - bash scripts/ci/completion-asset-audit.sh --strict
   - cargo fmt --all -- --check
   - cargo clippy --all-targets --all-features -- -D warnings
   - cargo test --workspace
@@ -112,6 +113,7 @@ fi
 
 coverage_dir="${NILS_CLI_COVERAGE_DIR:-target/coverage}"
 run mkdir -p "$coverage_dir"
+run bash scripts/ci/completion-asset-audit.sh --strict
 run cargo fmt --all -- --check
 run cargo clippy --all-targets --all-features -- -D warnings
 if [[ "$test_runner" == "nextest" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           tool: cargo-nextest
 
+      - name: Completion asset audit
+        run: bash scripts/ci/completion-asset-audit.sh --strict
+
       - name: Nils CLI checks (includes docs-placement-audit)
         env:
           NILS_CLI_TEST_RUNNER: nextest

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,13 +53,16 @@
 
 - Canonical completion governance runbook: `docs/runbooks/cli-completion-development-standard.md`.
 - When completion/alias code changes, follow that runbook for clap-first/no-legacy policy and completion-focused validation.
+- Completion mode policy is `clap-first` with no legacy completion mode.
+- `*_COMPLETION_MODE` toggles are forbidden (including `<CLI_NAME_UPPER>_COMPLETION_MODE`).
+- Release packaging must ship both `completions/zsh/` and `completions/bash/`, including alias files `completions/zsh/aliases.zsh` and `completions/bash/aliases.bash`.
 
 ### Required before committing
 
 - All commands in **Formatting and linting** must pass.
 - `cargo test --workspace`
-- `zsh -f tests/zsh/completion.test.zsh`
-- If completion/alias files changed, also run:
+- Completion verification commands from `docs/runbooks/cli-completion-development-standard.md`:
+  - `zsh -f tests/zsh/completion.test.zsh`
   - `zsh -n completions/zsh/_<cli>`
   - `bash -n completions/bash/<cli>`
 - Documentation placement for changed Markdown files MUST comply with

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Detailed scope, API examples, migration conventions, and non-goals are documente
 This repo keeps optional wrapper scripts and completion assets in-repo.
 Contributor completion governance (architecture, no-legacy policy, alias sync, and completion-focused checks) is defined in
 [docs/runbooks/cli-completion-development-standard.md](docs/runbooks/cli-completion-development-standard.md).
+Completion mode policy is clap-first/no-legacy; legacy completion mode toggles (including `*_COMPLETION_MODE`) are forbidden.
 
 Location:
 
@@ -119,6 +120,9 @@ To trigger a release build, push a tag like `v0.4.4`:
 
 Then download the matching `nils-cli-<tag>-<target>.tar.gz` asset, extract it, and add
 `<extract_dir>/bin` to your `PATH`.
+
+Release packaging contract: shipped artifacts must include `completions/zsh/`, `completions/bash/`,
+`completions/zsh/aliases.zsh`, and `completions/bash/aliases.bash`.
 
 For zsh completions, add `<extract_dir>/completions/zsh` to your `fpath` and run `compinit`.
 Optional: source `<extract_dir>/completions/zsh/aliases.zsh` to enable `gs*`/`cx*`/`fx*` aliases.

--- a/docs/runbooks/INTEGRATION_TEST.md
+++ b/docs/runbooks/INTEGRATION_TEST.md
@@ -1,0 +1,29 @@
+# Integration Test Runbook
+
+## Purpose
+
+- Define completion-focused integration verification for contributors.
+- Keep policy aligned with `docs/runbooks/cli-completion-development-standard.md`.
+
+## Completion mode policy
+
+- Completion mode is clap-first (`clap_complete`) and no-legacy.
+- Legacy completion mode is forbidden.
+- `*_COMPLETION_MODE` toggles are forbidden, including `<CLI_NAME_UPPER>_COMPLETION_MODE`.
+
+## Completion verification commands
+
+- Runbook reference: `docs/runbooks/cli-completion-development-standard.md`.
+- Run these commands when completion/alias assets change:
+  - `zsh -f tests/zsh/completion.test.zsh`
+  - `zsh -n completions/zsh/_<cli>`
+  - `bash -n completions/bash/<cli>`
+
+## Release packaging expectations
+
+- Shipped artifacts must include both completion trees:
+  - `completions/zsh/`
+  - `completions/bash/`
+- Shipped artifacts must include both alias files:
+  - `completions/zsh/aliases.zsh`
+  - `completions/bash/aliases.bash`

--- a/scripts/ci/completion-asset-audit.sh
+++ b/scripts/ci/completion-asset-audit.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ci/completion-asset-audit.sh [--strict]
+
+Checks completion-asset matrix coverage for workspace binaries:
+  - required binaries must have both zsh/bash completion assets present
+  - every workspace binary must be represented in the matrix
+  - matrix rows must align with workspace binaries and policy fields
+
+Options:
+  --strict   Treat policy warnings as hard failures
+  -h, --help Show this help
+USAGE
+}
+
+strict=0
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --strict)
+      strict=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: ${1:-}" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
+  echo "error: must run inside a git work tree" >&2
+  exit 2
+fi
+cd "$repo_root"
+
+matrix_path="docs/reports/completion-coverage-matrix.md"
+workspace_bins_script="scripts/workspace-bins.py"
+
+if [[ ! -f "$matrix_path" ]]; then
+  echo "error: missing matrix file: $matrix_path" >&2
+  exit 2
+fi
+
+if [[ ! -f "$workspace_bins_script" ]]; then
+  echo "error: missing workspace inventory script: $workspace_bins_script" >&2
+  exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required to run $workspace_bins_script" >&2
+  exit 2
+fi
+
+declare -a errors=()
+declare -a warnings=()
+declare -A matrix_obligation=()
+declare -A matrix_zsh_cell=()
+declare -A matrix_bash_cell=()
+declare -A workspace_set=()
+
+escalate_or_warn() {
+  local message="$1"
+  if [[ $strict -eq 1 ]]; then
+    errors+=("$message")
+  else
+    warnings+=("$message")
+  fi
+}
+
+matrix_rows=0
+while IFS=$'\t' read -r bin obligation zsh_cell bash_cell; do
+  matrix_rows=$((matrix_rows + 1))
+  if [[ -n "${matrix_obligation[$bin]+x}" ]]; then
+    errors+=("duplicate matrix row for binary: $bin")
+    continue
+  fi
+  matrix_obligation["$bin"]="$obligation"
+  matrix_zsh_cell["$bin"]="$zsh_cell"
+  matrix_bash_cell["$bin"]="$bash_cell"
+done < <(
+  awk -F'|' '
+    function trim(s) {
+      gsub(/^[ \t]+|[ \t]+$/, "", s)
+      return s
+    }
+    {
+      bin = trim($2)
+      obligation = trim($3)
+      zsh = trim($4)
+      bash = trim($5)
+      if (bin ~ /^`[^`]+`$/ && obligation ~ /^`(required|excluded)`$/) {
+        gsub(/`/, "", bin)
+        gsub(/`/, "", obligation)
+        print bin "\t" obligation "\t" zsh "\t" bash
+      }
+    }
+  ' "$matrix_path"
+)
+
+if [[ $matrix_rows -eq 0 ]]; then
+  echo "error: no matrix rows found in $matrix_path" >&2
+  exit 2
+fi
+
+mapfile -t workspace_bins < <(python3 "$workspace_bins_script")
+if [[ ${#workspace_bins[@]} -eq 0 ]]; then
+  echo "error: no workspace binaries found via $workspace_bins_script" >&2
+  exit 2
+fi
+
+for bin in "${workspace_bins[@]}"; do
+  workspace_set["$bin"]=1
+done
+
+for bin in "${workspace_bins[@]}"; do
+  if [[ -z "${matrix_obligation[$bin]+x}" ]]; then
+    errors+=("undeclared exclusion: workspace binary missing from matrix: $bin")
+  fi
+done
+
+mapfile -t matrix_bins_sorted < <(printf '%s\n' "${!matrix_obligation[@]}" | sort)
+for bin in "${matrix_bins_sorted[@]}"; do
+  if [[ -z "${workspace_set[$bin]+x}" ]]; then
+    errors+=("matrix drift: matrix row does not match workspace inventory: $bin")
+  fi
+done
+
+required_count=0
+excluded_count=0
+for bin in "${matrix_bins_sorted[@]}"; do
+  if [[ -z "${workspace_set[$bin]+x}" ]]; then
+    continue
+  fi
+
+  obligation="${matrix_obligation[$bin]}"
+  zsh_cell="${matrix_zsh_cell[$bin]}"
+  bash_cell="${matrix_bash_cell[$bin]}"
+
+  case "$obligation" in
+    required)
+      required_count=$((required_count + 1))
+      expected_zsh="\`present\` (\`_${bin}\`)"
+      expected_bash="\`present\` (\`${bin}\`)"
+      if [[ "$zsh_cell" != "$expected_zsh" ]]; then
+        errors+=("matrix drift: required binary $bin zsh column expected '$expected_zsh' but found '$zsh_cell'")
+      fi
+      if [[ "$bash_cell" != "$expected_bash" ]]; then
+        errors+=("matrix drift: required binary $bin bash column expected '$expected_bash' but found '$bash_cell'")
+      fi
+      if [[ ! -f "completions/zsh/_$bin" ]]; then
+        errors+=("missing completion asset: completions/zsh/_$bin (required binary: $bin)")
+      fi
+      if [[ ! -f "completions/bash/$bin" ]]; then
+        errors+=("missing completion asset: completions/bash/$bin (required binary: $bin)")
+      fi
+      ;;
+    excluded)
+      excluded_count=$((excluded_count + 1))
+      if [[ "$zsh_cell" != "\`missing\`" ]]; then
+        errors+=("matrix drift: excluded binary $bin zsh column expected '\`missing\`' but found '$zsh_cell'")
+      fi
+      if [[ "$bash_cell" != "\`missing\`" ]]; then
+        errors+=("matrix drift: excluded binary $bin bash column expected '\`missing\`' but found '$bash_cell'")
+      fi
+      if [[ -f "completions/zsh/_$bin" ]]; then
+        escalate_or_warn "excluded binary has zsh completion asset: completions/zsh/_$bin"
+      fi
+      if [[ -f "completions/bash/$bin" ]]; then
+        escalate_or_warn "excluded binary has bash completion asset: completions/bash/$bin"
+      fi
+      ;;
+    *)
+      errors+=("matrix drift: unsupported obligation '$obligation' for binary $bin")
+      ;;
+  esac
+done
+
+for warn in "${warnings[@]}"; do
+  echo "WARN: $warn"
+done
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  for err in "${errors[@]}"; do
+    echo "FAIL: $err"
+  done
+  echo "FAIL: completion asset audit (strict=$strict, workspace_bins=${#workspace_bins[@]}, matrix_rows=$matrix_rows, required=$required_count, excluded=$excluded_count, errors=${#errors[@]}, warnings=${#warnings[@]})"
+  exit 1
+fi
+
+echo "PASS: completion asset audit (strict=$strict, workspace_bins=${#workspace_bins[@]}, matrix_rows=$matrix_rows, required=$required_count, excluded=$excluded_count, warnings=${#warnings[@]})"

--- a/scripts/ci/docs-placement-audit.sh
+++ b/scripts/ci/docs-placement-audit.sh
@@ -77,7 +77,7 @@ done
 runbook_is_approved_workspace_file() {
   local base="$1"
   case "$base" in
-    cli-completion-development-standard.md|crates-io-status-script-runbook.md|new-cli-crate-development-standard.md|provider-onboarding.md|wrappers-mode-usage.md)
+    INTEGRATION_TEST.md|cli-completion-development-standard.md|crates-io-status-script-runbook.md|new-cli-crate-development-standard.md|provider-onboarding.md|wrappers-mode-usage.md)
       return 0
       ;;
     *)


### PR DESCRIPTION
## Summary
Sprint 5 hardening is now enforced by default: completion-asset policy is audited in CI and required checks, and contributor/release docs now codify clap-first no-legacy completion governance.

## Changes
- Add `scripts/ci/completion-asset-audit.sh` to validate matrix alignment, required/excluded obligations, and zsh/bash asset presence.
- Wire completion-asset audit into required local checks and GitHub Actions CI workflow.
- Add `docs/runbooks/INTEGRATION_TEST.md` with completion verification, no-legacy policy, and release packaging expectations.
- Update `DEVELOPMENT.md` and `README.md` with explicit no-legacy completion policy and packaging contract.
- Extend docs placement allowlist to permit the new integration runbook.

## Testing
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `mkdir -p target/coverage` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass; 85.88%)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass)
- `bash scripts/ci/completion-asset-audit.sh --strict` (pass)
- `zsh -f tests/zsh/completion.test.zsh` (pass)

## Risk / Notes
- `docs/runbooks/INTEGRATION_TEST.md` is now an approved workspace runbook in `scripts/ci/docs-placement-audit.sh`.
