### PR TITLE
Extract shared env default helper into nils-common

### DIFF
--- a/crates/codex-core/src/config.rs
+++ b/crates/codex-core/src/config.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use nils_common::env as shared_env;
+
 use crate::paths;
 
 pub const DEFAULT_MODEL: &str = "gpt-5.1-codex-mini";
@@ -21,24 +23,20 @@ pub struct RuntimeConfig {
 
 pub fn snapshot() -> RuntimeConfig {
     RuntimeConfig {
-        model: env_or_default("CODEX_CLI_MODEL", DEFAULT_MODEL),
-        reasoning: env_or_default("CODEX_CLI_REASONING", DEFAULT_REASONING),
+        model: shared_env::env_or_default("CODEX_CLI_MODEL", DEFAULT_MODEL),
+        reasoning: shared_env::env_or_default("CODEX_CLI_REASONING", DEFAULT_REASONING),
         allow_dangerous_enabled_raw: std::env::var("CODEX_ALLOW_DANGEROUS_ENABLED")
             .unwrap_or_default(),
         secret_dir: paths::resolve_secret_dir(),
         auth_file: paths::resolve_auth_file(),
         secret_cache_dir: paths::resolve_secret_cache_dir(),
-        auto_refresh_enabled: env_or_default(
+        auto_refresh_enabled: shared_env::env_or_default(
             "CODEX_AUTO_REFRESH_ENABLED",
             DEFAULT_AUTO_REFRESH_ENABLED,
         ),
-        auto_refresh_min_days: env_or_default(
+        auto_refresh_min_days: shared_env::env_or_default(
             "CODEX_AUTO_REFRESH_MIN_DAYS",
             DEFAULT_AUTO_REFRESH_MIN_DAYS,
         ),
     }
-}
-
-pub fn env_or_default(key: &str, default: &str) -> String {
-    std::env::var(key).unwrap_or_else(|_| default.to_string())
 }

--- a/crates/codex-core/src/exec.rs
+++ b/crates/codex-core/src/exec.rs
@@ -1,3 +1,4 @@
+use nils_common::env as shared_env;
 use nils_common::process as shared_process;
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -54,8 +55,8 @@ pub fn exec_dangerous(prompt: &str, caller: &str, stderr: &mut impl Write) -> i3
         return 1;
     }
 
-    let model = env_or_default("CODEX_CLI_MODEL", DEFAULT_MODEL);
-    let reasoning = env_or_default("CODEX_CLI_REASONING", DEFAULT_REASONING);
+    let model = shared_env::env_or_default("CODEX_CLI_MODEL", DEFAULT_MODEL);
+    let reasoning = shared_env::env_or_default("CODEX_CLI_REASONING", DEFAULT_REASONING);
     let reasoning_arg = format!("model_reasoning_effort=\"{}\"", reasoning);
     let args = [
         "exec",
@@ -77,10 +78,6 @@ pub fn exec_dangerous(prompt: &str, caller: &str, stderr: &mut impl Write) -> i3
             1
         }
     }
-}
-
-fn env_or_default(key: &str, default: &str) -> String {
-    std::env::var(key).unwrap_or_else(|_| default.to_string())
 }
 
 fn is_true_env(key: &str, stderr: &mut impl Write) -> bool {

--- a/crates/fzf-cli/src/util.rs
+++ b/crates/fzf-cli/src/util.rs
@@ -19,7 +19,7 @@ pub fn join_args(args: &[String]) -> String {
 }
 
 pub fn env_or_default(name: &str, default: &str) -> String {
-    env::var(name).unwrap_or_else(|_| default.to_string())
+    common_env::env_or_default(name, default)
 }
 
 pub fn env_is_true(name: &str) -> bool {

--- a/crates/nils-common/src/env.rs
+++ b/crates/nils-common/src/env.rs
@@ -21,6 +21,10 @@ pub fn env_truthy_or(name: &str, default: bool) -> bool {
     truthy_from_env(name).unwrap_or(default)
 }
 
+pub fn env_or_default(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
 pub fn no_color_enabled() -> bool {
     std::env::var_os("NO_COLOR").is_some()
 }
@@ -82,6 +86,26 @@ mod tests {
         let lock = GlobalStateLock::new();
         let _guard = EnvGuard::set(&lock, "NILS_COMMON_ENV_TRUTHY_OR_VALUE_TEST", " off ");
         assert!(!env_truthy_or("NILS_COMMON_ENV_TRUTHY_OR_VALUE_TEST", true));
+    }
+
+    #[test]
+    fn env_or_default_prefers_present_value() {
+        let lock = GlobalStateLock::new();
+        let _guard = EnvGuard::set(&lock, "NILS_COMMON_ENV_OR_DEFAULT_PRESENT_TEST", "custom");
+        assert_eq!(
+            env_or_default("NILS_COMMON_ENV_OR_DEFAULT_PRESENT_TEST", "fallback"),
+            "custom"
+        );
+    }
+
+    #[test]
+    fn env_or_default_uses_default_when_missing() {
+        let lock = GlobalStateLock::new();
+        let _guard = EnvGuard::remove(&lock, "NILS_COMMON_ENV_OR_DEFAULT_MISSING_TEST");
+        assert_eq!(
+            env_or_default("NILS_COMMON_ENV_OR_DEFAULT_MISSING_TEST", "fallback"),
+            "fallback"
+        );
     }
 
     #[test]

--- a/crates/nils-common/src/lib.rs
+++ b/crates/nils-common/src/lib.rs
@@ -11,6 +11,7 @@
 //! pub fn is_truthy(input: &str) -> bool;
 //! pub fn env_truthy(name: &str) -> bool;
 //! pub fn env_truthy_or(name: &str, default: bool) -> bool;
+//! pub fn env_or_default(name: &str, default: &str) -> String;
 //! pub fn no_color_enabled() -> bool;
 //!
 //! // shell


### PR DESCRIPTION
# Extract shared env default helper into nils-common

## Summary
This change removes duplicated environment default lookup logic by extracting `env_or_default` into `nils-common` and routing existing `codex-core` and `fzf-cli` callers through the shared helper. Behavior is preserved while reducing cross-crate duplication and adding explicit shared tests.

## Changes
- Add `nils_common::env::env_or_default(name, default)`.
- Replace duplicated `env_or_default` logic in `/crates/codex-core/src/config.rs` and `/crates/codex-core/src/exec.rs` with the shared helper.
- Route `/crates/fzf-cli/src/util.rs` `env_or_default` through `nils-common`.
- Add `nils-common` tests covering present and missing env var fallback behavior.
- Update `nils-common` API contract doc comments to include the new helper.

## Testing
- `cargo test -p nils-common -p nils-codex-core -p nils-fzf-cli` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `mkdir -p target/coverage && cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, 85.68%)

## Risk / Notes
- Low risk: call sites now depend on a shared helper with identical fallback semantics.
- Regression protection: new `nils-common` unit tests plus full workspace checks and coverage gate.
