### PR TITLE
Fix nils-term progress writer recovery on poisoned mutex

### DIFF
--- a/crates/nils-term/src/progress.rs
+++ b/crates/nils-term/src/progress.rs
@@ -298,7 +298,10 @@ impl WriterTerm {
     }
 
     fn write_all(&self, bytes: &[u8]) -> io::Result<()> {
-        let mut guard = self.buffer.lock().expect("writer buffer lock");
+        let mut guard = match self.buffer.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         guard.extend_from_slice(bytes);
         Ok(())
     }

--- a/crates/nils-term/tests/progress.rs
+++ b/crates/nils-term/tests/progress.rs
@@ -2,8 +2,15 @@ use std::sync::{Arc, Mutex};
 
 use nils_term::progress::{Progress, ProgressDrawTarget, ProgressEnabled, ProgressOptions};
 
+fn lock_buffer(buffer: &Arc<Mutex<Vec<u8>>>) -> std::sync::MutexGuard<'_, Vec<u8>> {
+    match buffer.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
 fn read_output(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
-    String::from_utf8_lossy(&buffer.lock().expect("buffer lock")).to_string()
+    String::from_utf8_lossy(&lock_buffer(buffer)).to_string()
 }
 
 fn normalize(s: &str) -> String {
@@ -132,4 +139,32 @@ fn suspend_does_not_panic() {
     p.tick();
     p.suspend(|| {});
     p.finish();
+}
+
+#[test]
+fn writer_target_recovers_after_buffer_poisoning() {
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let poison_target = buffer.clone();
+
+    let _ = std::thread::spawn(move || {
+        let _guard = poison_target.lock().expect("buffer lock");
+        panic!("poison writer buffer");
+    })
+    .join();
+
+    assert!(buffer.lock().is_err(), "expected poisoned mutex");
+
+    let opts = ProgressOptions::default()
+        .with_enabled(ProgressEnabled::On)
+        .with_draw_target(ProgressDrawTarget::to_writer(buffer.clone()))
+        .with_width(Some(60))
+        .with_prefix("poison ");
+
+    let p = Progress::new(2, opts);
+    p.inc(1);
+    p.finish();
+
+    let out = normalize(&read_output(&buffer));
+    assert!(out.contains("1/2"), "output was: {out:?}");
+    assert!(out.contains("poison"), "output was: {out:?}");
 }


### PR DESCRIPTION
## Summary
- Avoid panicking in `nils-term` writer-backed progress rendering when the output mutex has been poisoned.
- Preserve behavior by recovering poisoned locks and continuing to append progress output.

## Changes
- Updated `WriterTerm::write_all` in `crates/nils-term/src/progress.rs` to recover from `PoisonError` via `into_inner()`.
- Added a regression test in `crates/nils-term/tests/progress.rs` that poisons the writer buffer mutex and verifies progress rendering still succeeds.
- Updated test helper buffer reads to recover from poisoned locks so assertions remain deterministic.

## Testing
- `cargo test -p nils-term`
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85`
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info`

## Risk / Notes
- Low risk: behavior changes only when the writer mutex is poisoned; normal lock path remains unchanged.
- The refactor keeps output formatting and progress APIs unchanged.