### PR TITLE
Harden codex auth token fallbacks and parity tests

### DIFF
--- a/crates/codex-core/src/auth.rs
+++ b/crates/codex-core/src/auth.rs
@@ -25,7 +25,15 @@ pub fn email_from_auth_file(path: &Path) -> Result<Option<String>, CoreError> {
 pub fn account_id_from_auth_file(path: &Path) -> Result<Option<String>, CoreError> {
     let value = json::read_json(path)?;
     let account = json::string_at(&value, &["tokens", "account_id"])
-        .or_else(|| json::string_at(&value, &["account_id"]));
+        .or_else(|| json::string_at(&value, &["account_id"]))
+        .or_else(|| {
+            let token = token_from_auth_json(&value)?;
+            let payload = jwt::decode_payload_json(&token)?;
+            payload
+                .get("sub")
+                .and_then(|value| value.as_str())
+                .map(json::strip_newlines)
+        });
     Ok(account)
 }
 
@@ -50,5 +58,7 @@ pub fn identity_key_from_auth_file(path: &Path) -> Result<Option<String>, CoreEr
 
 fn token_from_auth_json(value: &serde_json::Value) -> Option<String> {
     json::string_at(value, &["tokens", "id_token"])
+        .or_else(|| json::string_at(value, &["id_token"]))
         .or_else(|| json::string_at(value, &["tokens", "access_token"]))
+        .or_else(|| json::string_at(value, &["access_token"]))
 }

--- a/crates/codex-core/tests/auth_contract.rs
+++ b/crates/codex-core/tests/auth_contract.rs
@@ -57,6 +57,34 @@ fn auth_contract_identity_precedence_and_account_fallback_are_stable() {
 }
 
 #[test]
+fn auth_contract_top_level_tokens_are_supported_for_identity_and_email() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let path = dir.path().join("auth.json");
+    let content = format!(
+        r#"{{"id_token":"{}","access_token":"{}"}}"#,
+        token(PAYLOAD_ALPHA),
+        token(PAYLOAD_ALPHA)
+    );
+    fs::write(&path, content).expect("write auth json");
+
+    let identity = auth::identity_from_auth_file(&path).expect("identity");
+    let email = auth::email_from_auth_file(&path).expect("email");
+    assert_eq!(identity, Some("user_123".to_string()));
+    assert_eq!(email, Some("alpha@example.com".to_string()));
+}
+
+#[test]
+fn auth_contract_account_id_falls_back_to_sub_claim() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let path = dir.path().join("auth.json");
+    let content = format!(r#"{{"access_token":"{}"}}"#, token(PAYLOAD_ALPHA));
+    fs::write(&path, content).expect("write auth json");
+
+    let account_id = auth::account_id_from_auth_file(&path).expect("account");
+    assert_eq!(account_id, Some("user_123".to_string()));
+}
+
+#[test]
 fn auth_contract_invalid_auth_file_is_deterministic_and_non_secret_leaking() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let path = dir.path().join("broken.json");

--- a/crates/gemini-core/tests/auth_contract.rs
+++ b/crates/gemini-core/tests/auth_contract.rs
@@ -57,6 +57,34 @@ fn auth_contract_identity_precedence_and_account_fallback_are_stable() {
 }
 
 #[test]
+fn auth_contract_top_level_tokens_are_supported_for_identity_and_email() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let path = dir.path().join("auth.json");
+    let content = format!(
+        r#"{{"id_token":"{}","access_token":"{}"}}"#,
+        token(PAYLOAD_ALPHA),
+        token(PAYLOAD_ALPHA)
+    );
+    fs::write(&path, content).expect("write auth json");
+
+    let identity = auth::identity_from_auth_file(&path).expect("identity");
+    let email = auth::email_from_auth_file(&path).expect("email");
+    assert_eq!(identity, Some("user_123".to_string()));
+    assert_eq!(email, Some("alpha@example.com".to_string()));
+}
+
+#[test]
+fn auth_contract_account_id_falls_back_to_sub_claim() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let path = dir.path().join("auth.json");
+    let content = format!(r#"{{"access_token":"{}"}}"#, token(PAYLOAD_ALPHA));
+    fs::write(&path, content).expect("write auth json");
+
+    let account_id = auth::account_id_from_auth_file(&path).expect("account");
+    assert_eq!(account_id, Some("user_123".to_string()));
+}
+
+#[test]
 fn auth_contract_invalid_auth_file_is_deterministic_and_non_secret_leaking() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let path = dir.path().join("broken.json");


### PR DESCRIPTION
## Summary

- Harden `codex-core` auth parsing for legacy/flattened `auth.json` payloads.
- Align `codex-core` `account_id` fallback semantics with `gemini-core`.
- Add codex/gemini contract tests to lock fallback behavior and prevent regressions.

## Changes

- `crates/codex-core/src/auth.rs`
  - `token_from_auth_json` now accepts top-level `id_token` and `access_token` when nested `tokens.*` keys are absent.
  - `account_id_from_auth_file` now falls back to JWT `sub` claim when `account_id` is missing.
- `crates/codex-core/tests/auth_contract.rs`
  - Added coverage for top-level token parsing.
  - Added coverage for `account_id` fallback to `sub`.
- `crates/gemini-core/tests/auth_contract.rs`
  - Added matching contract tests to keep codex/gemini fallback behavior parity under test.

## Testing

- `cargo test -p nils-codex-core auth_contract`
- `cargo test -p nils-gemini-core auth_contract`
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85`
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (85.43%)

## Risk / Notes

- Low risk: this only broadens accepted auth file shapes and keeps existing paths intact.
- Added contract tests in both cores to reduce parity regressions.
