### PR TITLE
Harden agentctl diag coverage parity for Gemini provider

### DIFF
--- a/crates/agentctl/tests/diag_capabilities.rs
+++ b/crates/agentctl/tests/diag_capabilities.rs
@@ -16,6 +16,7 @@ fn run(args: &[&str]) -> CmdOutput {
 
 fn install_stub_tools(stub: &StubBinDir) {
     stub.write_exe("codex", "#!/bin/sh\nexit 0\n");
+    stub.write_exe("gemini", "#!/bin/sh\nexit 0\n");
     stub.write_exe(
         "macos-agent",
         "#!/bin/sh\necho '{\"ok\":true,\"result\":{\"checks\":[{\"id\":\"accessibility\",\"status\":\"ok\",\"blocking\":true}]}}'\n",
@@ -81,6 +82,29 @@ fn diag_capabilities_json_reports_inventory_and_readiness() {
     ));
     assert!(
         capabilities
+            .iter()
+            .any(|capability| capability.get("name").and_then(Value::as_str)
+                == Some("auth.commands"))
+    );
+
+    let gemini_provider = providers
+        .iter()
+        .find(|provider| provider.get("id").and_then(Value::as_str) == Some("gemini"))
+        .expect("gemini provider");
+    let gemini_capabilities = gemini_provider
+        .get("capabilities")
+        .and_then(Value::as_array)
+        .expect("gemini capabilities");
+    assert!(
+        gemini_capabilities
+            .iter()
+            .any(|capability| capability.get("name").and_then(Value::as_str) == Some("execute"))
+    );
+    assert!(gemini_capabilities.iter().any(|capability| {
+        capability.get("name").and_then(Value::as_str) == Some("diag.rate-limits")
+    }));
+    assert!(
+        gemini_capabilities
             .iter()
             .any(|capability| capability.get("name").and_then(Value::as_str)
                 == Some("auth.commands"))

--- a/crates/agentctl/tests/diag_doctor.rs
+++ b/crates/agentctl/tests/diag_doctor.rs
@@ -17,6 +17,7 @@ fn run(args: &[&str]) -> CmdOutput {
 
 fn install_stub_tools(stub: &StubBinDir) {
     stub.write_exe("codex", "#!/bin/sh\nexit 0\n");
+    stub.write_exe("gemini", "#!/bin/sh\nexit 0\n");
     stub.write_exe(
         "macos-agent",
         "#!/bin/sh\necho '{\"ok\":true,\"result\":{\"checks\":[{\"id\":\"accessibility\",\"status\":\"ok\",\"blocking\":true}]}}'\n",
@@ -71,6 +72,7 @@ fn diag_doctor_json_includes_provider_and_automation_readiness() {
         .and_then(Value::as_array)
         .expect("checks array");
     assert!(has_check(checks, "provider", "codex"));
+    assert!(has_check(checks, "provider", "gemini"));
     assert!(has_check(checks, "provider", "claude"));
     for tool in [
         "macos-agent",


### PR DESCRIPTION
# Harden agentctl diag coverage parity for Gemini provider

## Summary
This change tightens `agentctl` diagnostic contract tests to enforce Gemini provider parity in the same readiness and capability surfaces already asserted for other providers.

## Changes
- Stub the `gemini` CLI in diagnostic integration tests so provider readiness checks run through deterministic test fixtures.
- Extend `diag doctor --format json` assertions to require a Gemini provider check entry.
- Extend `diag capabilities --format json` assertions to require Gemini capability inventory (`execute`, `diag.rate-limits`, `auth.commands`).

## Testing
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass: 85.43%)

## Risk / Notes
- Scope is test-only and intentionally locks existing behavior contracts for provider diagnostics.
