### PR TITLE
Share API CLI auth source enum across crates

### DIFF
--- a/crates/api-grpc/src/commands/call.rs
+++ b/crates/api-grpc/src/commands/call.rs
@@ -16,12 +16,7 @@ pub(crate) struct EndpointSelection {
     pub(crate) endpoint_value_used: String,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) enum AuthSourceUsed {
-    None,
-    TokenProfile,
-    EnvFallback { env_name: String },
-}
+pub(crate) type AuthSourceUsed = auth_env::CliAuthSource;
 
 #[derive(Debug, Clone)]
 pub(crate) struct AuthSelection {
@@ -79,18 +74,10 @@ pub(crate) fn resolve_auth_for_call(
         },
     )?;
 
-    let auth_source_used = match token_resolution.source {
-        auth_env::ProfileTokenSource::None => AuthSourceUsed::None,
-        auth_env::ProfileTokenSource::Profile => AuthSourceUsed::TokenProfile,
-        auth_env::ProfileTokenSource::EnvFallback { env_name } => {
-            AuthSourceUsed::EnvFallback { env_name }
-        }
-    };
-
     Ok(AuthSelection {
         bearer_token: token_resolution.bearer_token,
         token_name: token_resolution.token_name,
-        auth_source_used,
+        auth_source_used: token_resolution.source.into(),
     })
 }
 

--- a/crates/api-rest/src/commands/call.rs
+++ b/crates/api-rest/src/commands/call.rs
@@ -16,12 +16,7 @@ pub(crate) struct EndpointSelection {
     pub(crate) endpoint_value_used: String,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) enum AuthSourceUsed {
-    None,
-    TokenProfile,
-    EnvFallback { env_name: String },
-}
+pub(crate) type AuthSourceUsed = auth_env::CliAuthSource;
 
 #[derive(Debug, Clone)]
 pub(crate) struct AuthSelection {
@@ -79,18 +74,10 @@ pub(crate) fn resolve_auth_for_call(
         },
     )?;
 
-    let auth_source_used = match token_resolution.source {
-        auth_env::ProfileTokenSource::None => AuthSourceUsed::None,
-        auth_env::ProfileTokenSource::Profile => AuthSourceUsed::TokenProfile,
-        auth_env::ProfileTokenSource::EnvFallback { env_name } => {
-            AuthSourceUsed::EnvFallback { env_name }
-        }
-    };
-
     Ok(AuthSelection {
         bearer_token: token_resolution.bearer_token,
         token_name: token_resolution.token_name,
-        auth_source_used,
+        auth_source_used: token_resolution.source.into(),
     })
 }
 

--- a/crates/api-testing-core/src/auth_env.rs
+++ b/crates/api-testing-core/src/auth_env.rs
@@ -10,6 +10,23 @@ pub enum ProfileTokenSource {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CliAuthSource {
+    None,
+    TokenProfile,
+    EnvFallback { env_name: String },
+}
+
+impl From<ProfileTokenSource> for CliAuthSource {
+    fn from(value: ProfileTokenSource) -> Self {
+        match value {
+            ProfileTokenSource::None => Self::None,
+            ProfileTokenSource::Profile => Self::TokenProfile,
+            ProfileTokenSource::EnvFallback { env_name } => Self::EnvFallback { env_name },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProfileTokenResolution {
     pub bearer_token: Option<String>,
     pub token_name: String,
@@ -142,6 +159,26 @@ mod tests {
         assert_eq!(
             resolve_env_fallback(&["ACCESS_TOKEN", "SERVICE_TOKEN"]),
             Some(("access".to_string(), "ACCESS_TOKEN".to_string()))
+        );
+    }
+
+    #[test]
+    fn cli_auth_source_maps_profile_source_variants() {
+        assert_eq!(
+            CliAuthSource::from(ProfileTokenSource::None),
+            CliAuthSource::None
+        );
+        assert_eq!(
+            CliAuthSource::from(ProfileTokenSource::Profile),
+            CliAuthSource::TokenProfile
+        );
+        assert_eq!(
+            CliAuthSource::from(ProfileTokenSource::EnvFallback {
+                env_name: "ACCESS_TOKEN".to_string()
+            }),
+            CliAuthSource::EnvFallback {
+                env_name: "ACCESS_TOKEN".to_string()
+            }
         );
     }
 

--- a/crates/api-websocket/src/commands/call.rs
+++ b/crates/api-websocket/src/commands/call.rs
@@ -18,12 +18,7 @@ pub(crate) struct EndpointSelection {
     pub(crate) endpoint_value_used: String,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) enum AuthSourceUsed {
-    None,
-    TokenProfile,
-    EnvFallback { env_name: String },
-}
+pub(crate) type AuthSourceUsed = auth_env::CliAuthSource;
 
 #[derive(Debug, Clone)]
 pub(crate) struct AuthSelection {
@@ -97,18 +92,10 @@ pub(crate) fn resolve_auth_for_call(
         },
     )?;
 
-    let auth_source_used = match token_resolution.source {
-        auth_env::ProfileTokenSource::None => AuthSourceUsed::None,
-        auth_env::ProfileTokenSource::Profile => AuthSourceUsed::TokenProfile,
-        auth_env::ProfileTokenSource::EnvFallback { env_name } => {
-            AuthSourceUsed::EnvFallback { env_name }
-        }
-    };
-
     Ok(AuthSelection {
         bearer_token: token_resolution.bearer_token,
         token_name: token_resolution.token_name,
-        auth_source_used,
+        auth_source_used: token_resolution.source.into(),
     })
 }
 


### PR DESCRIPTION
## Summary
- Extract shared CLI auth-source representation into `nils-api-testing-core`.
- Remove duplicated `AuthSourceUsed` enum definitions and conversion matches from `api-rest`, `api-grpc`, and `api-websocket` call paths.
- Preserve existing output/error behavior by keeping `TokenProfile`/`EnvFallback` semantics unchanged via shared conversion.

## Changes
- Added `auth_env::CliAuthSource` and `From<ProfileTokenSource>` conversion in `crates/api-testing-core/src/auth_env.rs`.
- Added a conversion characterization test in `crates/api-testing-core/src/auth_env.rs`.
- Replaced local enums with `type AuthSourceUsed = auth_env::CliAuthSource` in:
  - `crates/api-rest/src/commands/call.rs`
  - `crates/api-grpc/src/commands/call.rs`
  - `crates/api-websocket/src/commands/call.rs`
- Simplified auth selection mapping to `token_resolution.source.into()` in all three call flows.

## Testing
- `cargo test -p nils-api-testing-core -p nils-api-rest -p nils-api-grpc -p nils-api-websocket`
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85`
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info`

## Risk / Notes
- Low risk: type-sharing refactor only; no user-facing text/exit-code changes intended.
- Coverage gate remains above threshold (`85.68%`).
