### PR TITLE
Add completion flag help text and zsh description audit

### DIFF
--- a/crates/agent-docs/src/cli.rs
+++ b/crates/agent-docs/src/cli.rs
@@ -14,10 +14,20 @@ use crate::model::{
     disable_help_subcommand = true
 )]
 pub struct Cli {
-    #[arg(long, global = true, value_name = "PATH")]
+    #[arg(
+        long,
+        global = true,
+        value_name = "PATH",
+        help = "Override AGENT_HOME root path"
+    )]
     pub agent_home: Option<PathBuf>,
 
-    #[arg(long, global = true, value_name = "PATH")]
+    #[arg(
+        long,
+        global = true,
+        value_name = "PATH",
+        help = "Override project root path"
+    )]
     pub project_path: Option<PathBuf>,
 
     #[arg(
@@ -48,88 +58,123 @@ pub enum Command {
 
 #[derive(Debug, Args)]
 pub struct ResolveArgs {
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, help = "Context to resolve")]
     pub context: Context,
 
-    #[arg(long, value_enum, default_value_t = ResolveFormat::Text)]
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = ResolveFormat::Text,
+        help = "Output format"
+    )]
     pub format: ResolveFormat,
 
-    #[arg(long)]
+    #[arg(long, help = "Fail when required docs are missing")]
     pub strict: bool,
 }
 
 #[derive(Debug, Args)]
 pub struct ContextsArgs {
-    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = OutputFormat::Text,
+        help = "Output format"
+    )]
     pub format: OutputFormat,
 }
 
 #[derive(Debug, Args)]
 pub struct AddArgs {
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, help = "Config target to update")]
     pub target: Scope,
 
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, help = "Context that uses this document")]
     pub context: Context,
 
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, help = "Scope used to resolve relative paths")]
     pub scope: Scope,
 
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", help = "Document path to register")]
     pub path: PathBuf,
 
-    #[arg(long)]
+    #[arg(long, help = "Mark this document as required")]
     pub required: bool,
 
-    #[arg(long, value_enum, default_value_t = DocumentWhen::Always)]
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = DocumentWhen::Always,
+        help = "Condition for when the document is required"
+    )]
     pub when: DocumentWhen,
 
-    #[arg(long)]
+    #[arg(long, help = "Optional notes for the document entry")]
     pub notes: Option<String>,
 }
 
 #[derive(Debug, Args)]
 pub struct ScaffoldAgentsArgs {
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, help = "Scaffold target scope")]
     pub target: Scope,
 
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", help = "Explicit output path")]
     pub output: Option<PathBuf>,
 
-    #[arg(long)]
+    #[arg(long, help = "Overwrite an existing output file")]
     pub force: bool,
 }
 
 #[derive(Debug, Args)]
 pub struct BaselineArgs {
-    #[arg(long)]
+    #[arg(long, help = "Run baseline check mode")]
     pub check: bool,
 
-    #[arg(long, value_enum, default_value_t = BaselineTarget::All)]
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = BaselineTarget::All,
+        help = "Baseline scope target"
+    )]
     pub target: BaselineTarget,
 
-    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = OutputFormat::Text,
+        help = "Output format"
+    )]
     pub format: OutputFormat,
 
-    #[arg(long)]
+    #[arg(long, help = "Fail when required baseline docs are missing")]
     pub strict: bool,
 }
 
 #[derive(Debug, Args)]
 pub struct ScaffoldBaselineArgs {
-    #[arg(long, value_enum, default_value_t = BaselineTarget::All)]
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = BaselineTarget::All,
+        help = "Baseline scope target"
+    )]
     pub target: BaselineTarget,
 
-    #[arg(long)]
+    #[arg(long, help = "Create only missing baseline files")]
     pub missing_only: bool,
 
-    #[arg(long)]
+    #[arg(long, help = "Overwrite existing baseline files")]
     pub force: bool,
 
-    #[arg(long)]
+    #[arg(long, help = "Preview planned changes without writing files")]
     pub dry_run: bool,
 
-    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = OutputFormat::Text,
+        help = "Output format"
+    )]
     pub format: OutputFormat,
 }
 

--- a/crates/fzf-cli/src/completion.rs
+++ b/crates/fzf-cli/src/completion.rs
@@ -56,15 +56,35 @@ pub(crate) fn build_completion_command() -> Command {
         .subcommand(
             Command::new("file")
                 .about("Search and preview text files")
-                .arg(Arg::new("vi").long("vi").action(ArgAction::SetTrue))
-                .arg(Arg::new("vscode").long("vscode").action(ArgAction::SetTrue))
+                .arg(
+                    Arg::new("vi")
+                        .long("vi")
+                        .help("Open selection with vi")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("vscode")
+                        .long("vscode")
+                        .help("Open selection with VS Code")
+                        .action(ArgAction::SetTrue),
+                )
                 .arg(query_arg()),
         )
         .subcommand(
             Command::new("directory")
                 .about("Search directories and cd into selection")
-                .arg(Arg::new("vi").long("vi").action(ArgAction::SetTrue))
-                .arg(Arg::new("vscode").long("vscode").action(ArgAction::SetTrue))
+                .arg(
+                    Arg::new("vi")
+                        .long("vi")
+                        .help("Open selection with vi")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("vscode")
+                        .long("vscode")
+                        .help("Open selection with VS Code")
+                        .action(ArgAction::SetTrue),
+                )
                 .arg(query_arg()),
         )
         .subcommand(
@@ -78,6 +98,7 @@ pub(crate) fn build_completion_command() -> Command {
                 .arg(
                     Arg::new("snapshot")
                         .long("snapshot")
+                        .help("Preview file snapshots from selected commit")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(query_arg()),
@@ -104,12 +125,14 @@ pub(crate) fn build_completion_command() -> Command {
                     Arg::new("kill")
                         .short('k')
                         .long("kill")
+                        .help("Kill selected process")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("force")
                         .short('9')
                         .long("force")
+                        .help("Use SIGKILL when killing")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(query_arg()),
@@ -121,12 +144,14 @@ pub(crate) fn build_completion_command() -> Command {
                     Arg::new("kill")
                         .short('k')
                         .long("kill")
+                        .help("Kill owner process for selected port")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("force")
                         .short('9')
                         .long("force")
+                        .help("Use SIGKILL when killing")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(query_arg()),

--- a/crates/git-cli/src/completion.rs
+++ b/crates/git-cli/src/completion.rs
@@ -58,19 +58,33 @@ fn build_utils_group() -> Command {
             Command::new("copy-staged")
                 .visible_alias("copy")
                 .about("Copy staged diff to clipboard")
-                .arg(Arg::new("stdout").long("stdout").action(ArgAction::SetTrue))
+                .arg(
+                    Arg::new("stdout")
+                        .long("stdout")
+                        .help("Print staged diff to stdout")
+                        .action(ArgAction::SetTrue),
+                )
                 .arg(
                     Arg::new("print")
                         .short('p')
                         .long("print")
+                        .help("Alias for --stdout")
                         .action(ArgAction::SetTrue),
                 )
-                .arg(Arg::new("both").long("both").action(ArgAction::SetTrue)),
+                .arg(
+                    Arg::new("both")
+                        .long("both")
+                        .help("Print diff and copy it to clipboard")
+                        .action(ArgAction::SetTrue),
+                ),
         )
         .subcommand(
-            Command::new("root")
-                .about("Jump to git root")
-                .arg(Arg::new("shell").long("shell").action(ArgAction::SetTrue)),
+            Command::new("root").about("Jump to git root").arg(
+                Arg::new("shell")
+                    .long("shell")
+                    .help("Print shell command instead of plain output")
+                    .action(ArgAction::SetTrue),
+            ),
         )
         .subcommand(
             Command::new("commit-hash")
@@ -107,35 +121,55 @@ fn build_reset_group() -> Command {
         .subcommand(
             Command::new("remote")
                 .about("Reset to remote branch")
-                .arg(Arg::new("ref").long("ref").value_name("ref"))
+                .arg(
+                    Arg::new("ref")
+                        .long("ref")
+                        .help("Remote ref in <remote>/<branch> form")
+                        .value_name("ref"),
+                )
                 .arg(
                     Arg::new("remote")
                         .short('r')
                         .long("remote")
+                        .help("Remote name")
                         .value_name("remote"),
                 )
                 .arg(
                     Arg::new("branch")
                         .short('b')
                         .long("branch")
+                        .help("Remote branch name")
                         .value_name("branch"),
                 )
                 .arg(
                     Arg::new("no-fetch")
                         .long("no-fetch")
+                        .help("Skip fetching remote refs")
                         .action(ArgAction::SetTrue),
                 )
-                .arg(Arg::new("prune").long("prune").action(ArgAction::SetTrue))
-                .arg(Arg::new("clean").long("clean").action(ArgAction::SetTrue))
+                .arg(
+                    Arg::new("prune")
+                        .long("prune")
+                        .help("Run fetch with --prune")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("clean")
+                        .long("clean")
+                        .help("Run git clean -fd after reset")
+                        .action(ArgAction::SetTrue),
+                )
                 .arg(
                     Arg::new("set-upstream")
                         .long("set-upstream")
+                        .help("Set upstream to the target remote branch")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("yes")
                         .short('y')
                         .long("yes")
+                        .help("Skip confirmation prompts")
                         .action(ArgAction::SetTrue),
                 ),
         )
@@ -148,16 +182,28 @@ fn build_commit_group() -> Command {
         .subcommand(
             Command::new("context")
                 .about("Print commit context")
-                .arg(Arg::new("stdout").long("stdout").action(ArgAction::SetTrue))
-                .arg(Arg::new("both").long("both").action(ArgAction::SetTrue))
+                .arg(
+                    Arg::new("stdout")
+                        .long("stdout")
+                        .help("Print report to stdout")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("both")
+                        .long("both")
+                        .help("Print report and write output file")
+                        .action(ArgAction::SetTrue),
+                )
                 .arg(
                     Arg::new("no-color")
                         .long("no-color")
+                        .help("Disable ANSI colors")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("include")
                         .long("include")
+                        .help("Additional glob(s) to include")
                         .value_name("glob")
                         .num_args(1..),
                 ),
@@ -166,11 +212,36 @@ fn build_commit_group() -> Command {
             Command::new("context-json")
                 .visible_aliases(["context_json", "contextjson", "json"])
                 .about("Print commit context as JSON")
-                .arg(Arg::new("stdout").long("stdout").action(ArgAction::SetTrue))
-                .arg(Arg::new("both").long("both").action(ArgAction::SetTrue))
-                .arg(Arg::new("pretty").long("pretty").action(ArgAction::SetTrue))
-                .arg(Arg::new("bundle").long("bundle").action(ArgAction::SetTrue))
-                .arg(Arg::new("out-dir").long("out-dir").value_name("path")),
+                .arg(
+                    Arg::new("stdout")
+                        .long("stdout")
+                        .help("Print JSON to stdout")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("both")
+                        .long("both")
+                        .help("Print JSON and write files")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("pretty")
+                        .long("pretty")
+                        .help("Pretty-print JSON output")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("bundle")
+                        .long("bundle")
+                        .help("Write bundle files to output directory")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("out-dir")
+                        .long("out-dir")
+                        .help("Output directory for generated files")
+                        .value_name("path"),
+                ),
         )
         .subcommand(
             Command::new("to-stash")
@@ -188,11 +259,18 @@ fn build_branch_group() -> Command {
             Command::new("cleanup")
                 .visible_alias("delete-merged")
                 .about("Delete merged branches")
-                .arg(Arg::new("base").short('b').long("base").value_name("base"))
+                .arg(
+                    Arg::new("base")
+                        .short('b')
+                        .long("base")
+                        .help("Base ref used to determine merged branches")
+                        .value_name("base"),
+                )
                 .arg(
                     Arg::new("squash")
                         .short('s')
                         .long("squash")
+                        .help("Include branches already applied via squash")
                         .action(ArgAction::SetTrue),
                 ),
         )
@@ -209,20 +287,28 @@ fn build_ci_group() -> Command {
                     Arg::new("remote")
                         .short('r')
                         .long("remote")
+                        .help("Remote used for fetch/push")
                         .value_name("name"),
                 )
                 .arg(
                     Arg::new("no-fetch")
                         .long("no-fetch")
+                        .help("Skip remote fetch before branch creation")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("force")
                         .short('f')
                         .long("force")
+                        .help("Reset existing CI branch and force push")
                         .action(ArgAction::SetTrue),
                 )
-                .arg(Arg::new("stay").long("stay").action(ArgAction::SetTrue)),
+                .arg(
+                    Arg::new("stay")
+                        .long("stay")
+                        .help("Stay on CI branch after push")
+                        .action(ArgAction::SetTrue),
+                ),
         )
         .subcommand(Command::new("help").about("Display help message for ci"))
 }

--- a/crates/image-processing/src/cli.rs
+++ b/crates/image-processing/src/cli.rs
@@ -61,26 +61,26 @@ pub struct Cli {
     #[arg(long = "in", action = ArgAction::Append, default_value = None)]
     pub inputs: Vec<String>,
 
-    #[arg(long = "from-svg")]
+    #[arg(long = "from-svg", help = "Trusted SVG input path for convert mode")]
     pub from_svg: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, help = "Output file path")]
     pub out: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, help = "Overwrite existing output file")]
     pub overwrite: bool,
-    #[arg(long = "dry-run")]
+    #[arg(long = "dry-run", help = "Validate and plan without writing output")]
     pub dry_run: bool,
-    #[arg(long)]
+    #[arg(long, help = "Emit machine-readable JSON to stdout")]
     pub json: bool,
-    #[arg(long)]
+    #[arg(long, help = "Print per-item processing report")]
     pub report: bool,
 
-    #[arg(long = "to")]
+    #[arg(long = "to", help = "Output format: png, webp, or svg")]
     pub to: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, help = "Raster output width in pixels")]
     pub width: Option<i32>,
-    #[arg(long)]
+    #[arg(long, help = "Raster output height in pixels")]
     pub height: Option<i32>,
 }

--- a/crates/plan-tooling/src/completion.rs
+++ b/crates/plan-tooling/src/completion.rs
@@ -40,16 +40,23 @@ fn build_completion_command() -> Command {
                 .arg(
                     Arg::new("file")
                         .long("file")
+                        .help("Plan markdown file path")
                         .value_name("path")
                         .required(false),
                 )
                 .arg(
                     Arg::new("sprint")
                         .long("sprint")
+                        .help("Sprint number to parse")
                         .value_name("n")
                         .required(false),
                 )
-                .arg(Arg::new("pretty").long("pretty").action(ArgAction::SetTrue)),
+                .arg(
+                    Arg::new("pretty")
+                        .long("pretty")
+                        .help("Pretty-print JSON output")
+                        .action(ArgAction::SetTrue),
+                ),
         )
         .subcommand(
             Command::new("validate")
@@ -57,12 +64,14 @@ fn build_completion_command() -> Command {
                 .arg(
                     Arg::new("file")
                         .long("file")
+                        .help("Plan markdown file path (repeatable)")
                         .value_name("path")
                         .action(ArgAction::Append),
                 )
                 .arg(
                     Arg::new("format")
                         .long("format")
+                        .help("Validation output format")
                         .value_name("fmt")
                         .value_parser(["text", "json"]),
                 ),
@@ -73,18 +82,21 @@ fn build_completion_command() -> Command {
                 .arg(
                     Arg::new("file")
                         .long("file")
+                        .help("Plan markdown file path")
                         .value_name("path")
                         .required(false),
                 )
                 .arg(
                     Arg::new("sprint")
                         .long("sprint")
+                        .help("Sprint number to analyze")
                         .value_name("n")
                         .required(false),
                 )
                 .arg(
                     Arg::new("format")
                         .long("format")
+                        .help("Batch output format")
                         .value_name("fmt")
                         .value_parser(["json", "text"]),
                 ),
@@ -92,10 +104,30 @@ fn build_completion_command() -> Command {
         .subcommand(
             Command::new("scaffold")
                 .about("Create a new plan from template")
-                .arg(Arg::new("slug").long("slug").value_name("slug"))
-                .arg(Arg::new("file").long("file").value_name("path"))
-                .arg(Arg::new("title").long("title").value_name("text"))
-                .arg(Arg::new("force").long("force").action(ArgAction::SetTrue)),
+                .arg(
+                    Arg::new("slug")
+                        .long("slug")
+                        .help("Plan slug used for output naming")
+                        .value_name("slug"),
+                )
+                .arg(
+                    Arg::new("file")
+                        .long("file")
+                        .help("Explicit output plan path")
+                        .value_name("path"),
+                )
+                .arg(
+                    Arg::new("title")
+                        .long("title")
+                        .help("Plan title override")
+                        .value_name("text"),
+                )
+                .arg(
+                    Arg::new("force")
+                        .long("force")
+                        .help("Overwrite existing output file")
+                        .action(ArgAction::SetTrue),
+                ),
         )
         .subcommand(
             Command::new("completion")

--- a/crates/semantic-commit/src/completion.rs
+++ b/crates/semantic-commit/src/completion.rs
@@ -40,13 +40,20 @@ fn build_completion_command() -> Command {
                 .arg(
                     Arg::new("format")
                         .long("format")
+                        .help("Output format for staged context")
                         .value_name("bundle|json|patch")
                         .value_parser(["bundle", "json", "patch"]),
                 )
-                .arg(Arg::new("json").long("json").action(ArgAction::SetTrue))
+                .arg(
+                    Arg::new("json")
+                        .long("json")
+                        .help("Alias for --format json")
+                        .action(ArgAction::SetTrue),
+                )
                 .arg(
                     Arg::new("repo")
                         .long("repo")
+                        .help("Repository path override")
                         .value_name("path")
                         .value_hint(ValueHint::DirPath),
                 ),
@@ -58,64 +65,80 @@ fn build_completion_command() -> Command {
                     Arg::new("message")
                         .short('m')
                         .long("message")
+                        .help("Inline commit message")
                         .value_name("text"),
                 )
                 .arg(
                     Arg::new("message-file")
                         .short('F')
                         .long("message-file")
+                        .help("Read commit message from file")
                         .value_name("path")
                         .value_hint(ValueHint::FilePath),
                 )
                 .arg(
                     Arg::new("message-out")
                         .long("message-out")
+                        .help("Write final commit message to file")
                         .value_name("path")
                         .value_hint(ValueHint::FilePath),
                 )
                 .arg(
                     Arg::new("summary")
                         .long("summary")
+                        .help("Summary provider")
                         .value_name("git-scope|git-show|none")
                         .value_parser(["git-scope", "git-show", "none"]),
                 )
                 .arg(
                     Arg::new("no-summary")
                         .long("no-summary")
+                        .help("Disable summary section")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("repo")
                         .long("repo")
+                        .help("Repository path override")
                         .value_name("path")
                         .value_hint(ValueHint::DirPath),
                 )
                 .arg(
                     Arg::new("automation")
                         .long("automation")
+                        .help("Disable interactive prompts and stdin input")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("non-interactive")
                         .long("non-interactive")
+                        .help("Fail instead of prompting for input")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("validate-only")
                         .long("validate-only")
+                        .help("Validate message and exit without committing")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("dry-run")
                         .long("dry-run")
+                        .help("Print commit plan without running git commit")
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("no-progress")
                         .long("no-progress")
+                        .help("Disable progress UI")
                         .action(ArgAction::SetTrue),
                 )
-                .arg(Arg::new("quiet").long("quiet").action(ArgAction::SetTrue)),
+                .arg(
+                    Arg::new("quiet")
+                        .long("quiet")
+                        .help("Reduce non-error output")
+                        .action(ArgAction::SetTrue),
+                ),
         )
         .subcommand(
             Command::new("completion")

--- a/scripts/ci/completion-flag-parity-audit.sh
+++ b/scripts/ci/completion-flag-parity-audit.sh
@@ -199,6 +199,11 @@ parse_completion_flag_tokens() {
     | LC_ALL=C sort
 }
 
+parse_zsh_option_descriptions() {
+  local zsh_block="$1"
+  perl -ne 'while(/'\''([^'\'']+)'\''/g){$spec=$1; next unless $spec =~ /^-{1,2}/; if($spec =~ /^([^[]+)\[(.*?)\]/){$opt=$1; $desc=$2; $opt =~ s/[+=]+$//; print "$opt\t$desc\n";}}' <<< "$zsh_block"
+}
+
 decode_path() {
   local path_key="$1"
   PATH_PARTS=()
@@ -568,6 +573,15 @@ audit_binary() {
       continue
     fi
 
+    local -A zsh_help_by_flag=()
+    local opt desc
+    while IFS=$'\t' read -r opt desc; do
+      [[ -n "$opt" ]] || continue
+      if [[ ! -v "zsh_help_by_flag[$opt]" ]] || [[ -z "${zsh_help_by_flag[$opt]}" && -n "$desc" ]]; then
+        zsh_help_by_flag["$opt"]="$desc"
+      fi
+    done < <(parse_zsh_option_descriptions "$zsh_block")
+
     local flag
     for flag in "${flags[@]}"; do
       if ! contains_token "$bash_opts" "$flag"; then
@@ -575,6 +589,10 @@ audit_binary() {
       fi
       if ! contains_token "$zsh_block" "$flag"; then
         FAILURES+=( "${binary}: zsh completion missing flag \`${flag}\` for command \`$(path_to_display "$path_key")\`" )
+        continue
+      fi
+      if [[ -v "zsh_help_by_flag[$flag]" ]] && [[ -z "${zsh_help_by_flag[$flag]}" ]]; then
+        FAILURES+=( "${binary}: zsh completion empty description for flag \`${flag}\` on command \`$(path_to_display "$path_key")\`" )
       fi
     done
   done


### PR DESCRIPTION
# Add completion flag help text and zsh description audit

## Summary
This update fills missing completion flag descriptions across the six affected CLIs (`agent-docs`, `fzf-cli`, `git-cli`, `image-processing`, `plan-tooling`, `semantic-commit`) and hardens CI to fail when zsh completion emits empty flag descriptions.

## Changes
- Add explicit clap `help` text for previously blank-completion flags in the six affected CLIs.
- Keep completion source-of-truth in clap metadata only; no alternate completion path added.
- Extend `scripts/ci/completion-flag-parity-audit.sh` to detect and fail on empty zsh flag descriptions for flags present in command help.

## Testing
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass: 85.57%)

## Risk / Notes
- CI guard is stricter by design: future flags without clap `help` text will now fail completion parity audit.
