### PR TITLE
Refactor shared env parsing across codex, gemini, and screen-record

### DIFF
--- a/crates/codex-cli/src/starship/render.rs
+++ b/crates/codex-cli/src/starship/render.rs
@@ -101,8 +101,8 @@ fn should_color() -> bool {
         return false;
     }
 
-    if let Ok(raw) = std::env::var("CODEX_STARSHIP_COLOR_ENABLED") {
-        return shared_env::is_truthy(raw.trim());
+    if std::env::var("CODEX_STARSHIP_COLOR_ENABLED").is_ok() {
+        return shared_env::env_truthy("CODEX_STARSHIP_COLOR_ENABLED");
     }
 
     if std::env::var_os("STARSHIP_SESSION_KEY").is_some()

--- a/crates/gemini-cli/src/rate_limits/ansi.rs
+++ b/crates/gemini-cli/src/rate_limits/ansi.rs
@@ -1,9 +1,10 @@
+use nils_common::env as shared_env;
 use std::io::{self, IsTerminal};
 
 const CURRENT_PROFILE_FG: &str = "\x1b[38;2;199;146;234m";
 
 pub fn should_color() -> bool {
-    if std::env::var_os("NO_COLOR").is_some() {
+    if shared_env::no_color_enabled() {
         return false;
     }
     io::stdout().is_terminal()

--- a/crates/gemini-cli/src/rate_limits/mod.rs
+++ b/crates/gemini-cli/src/rate_limits/mod.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use nils_common::env as shared_env;
+
 use crate::auth;
 use crate::fs as gemini_fs;
 use crate::paths;
@@ -143,7 +145,7 @@ pub fn run(args: &RateLimitsOptions) -> i32 {
         return 1;
     }
 
-    let default_all_enabled = env_truthy("GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED");
+    let default_all_enabled = shared_env::env_truthy("GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED");
     let all_mode = args.all
         || (!args.cached
             && !output_json
@@ -1187,18 +1189,6 @@ fn env_non_empty(key: &str) -> Option<String> {
         .filter(|raw| !raw.is_empty())
 }
 
-fn env_truthy(key: &str) -> bool {
-    match std::env::var(key) {
-        Ok(raw) => {
-            matches!(
-                raw.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        }
-        Err(_) => false,
-    }
-}
-
 struct RunError {
     code: String,
     message: String,
@@ -1441,11 +1431,11 @@ mod tests {
     #[test]
     fn env_truthy_accepts_expected_variants() {
         let _v1 = EnvGuard::set("GEMINI_TEST_TRUTHY", "true");
-        assert!(env_truthy("GEMINI_TEST_TRUTHY"));
+        assert!(shared_env::env_truthy("GEMINI_TEST_TRUTHY"));
         let _v2 = EnvGuard::set("GEMINI_TEST_TRUTHY", "ON");
-        assert!(env_truthy("GEMINI_TEST_TRUTHY"));
+        assert!(shared_env::env_truthy("GEMINI_TEST_TRUTHY"));
         let _v3 = EnvGuard::set("GEMINI_TEST_TRUTHY", "0");
-        assert!(!env_truthy("GEMINI_TEST_TRUTHY"));
+        assert!(!shared_env::env_truthy("GEMINI_TEST_TRUTHY"));
     }
 
     #[test]

--- a/crates/gemini-cli/src/starship/mod.rs
+++ b/crates/gemini-cli/src/starship/mod.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use nils_common::env as shared_env;
+
 use crate::auth;
 use crate::paths;
 use crate::rate_limits;
@@ -52,7 +54,8 @@ pub fn run(options: &StarshipOptions) -> i32 {
         return 0;
     }
 
-    let show_5h = env_truthy_or("GEMINI_STARSHIP_SHOW_5H_ENABLED", true) && !options.no_5h;
+    let show_5h =
+        shared_env::env_truthy_or("GEMINI_STARSHIP_SHOW_5H_ENABLED", true) && !options.no_5h;
     let time_format = match options.time_format.as_deref() {
         Some(value) => value,
         None if options.show_timezone => DEFAULT_TIME_FORMAT_WITH_TIMEZONE,
@@ -206,7 +209,7 @@ fn parse_duration_seconds(raw: &str) -> Option<u64> {
 }
 
 fn starship_enabled() -> bool {
-    env_truthy("GEMINI_STARSHIP_ENABLED")
+    shared_env::env_truthy("GEMINI_STARSHIP_ENABLED")
 }
 
 fn print_ttl_usage() {
@@ -229,8 +232,8 @@ fn resolve_name(target_file: &Path) -> Option<String> {
         .ok()
         .map(|value| value.to_ascii_lowercase())
         .unwrap_or_else(|| "secret".to_string());
-    let show_fallback = env_truthy("GEMINI_STARSHIP_SHOW_FALLBACK_NAME_ENABLED");
-    let show_full_email = env_truthy("GEMINI_STARSHIP_SHOW_FULL_EMAIL_ENABLED");
+    let show_fallback = shared_env::env_truthy("GEMINI_STARSHIP_SHOW_FALLBACK_NAME_ENABLED");
+    let show_full_email = shared_env::env_truthy("GEMINI_STARSHIP_SHOW_FULL_EMAIL_ENABLED");
 
     if source == "email" {
         if let Ok(Some(email)) = auth::email_from_auth_file(target_file) {
@@ -259,20 +262,6 @@ fn format_email_name(raw: &str, show_full_email: bool) -> String {
         return trimmed.to_string();
     }
     trimmed.split('@').next().unwrap_or(trimmed).to_string()
-}
-
-fn env_truthy_or(key: &str, default: bool) -> bool {
-    if let Ok(raw) = std::env::var(key) {
-        return matches!(
-            raw.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        );
-    }
-    default
-}
-
-fn env_truthy(key: &str) -> bool {
-    env_truthy_or(key, false)
 }
 
 fn env_u64(key: &str, default: u64) -> u64 {

--- a/crates/gemini-cli/src/starship/render.rs
+++ b/crates/gemini-cli/src/starship/render.rs
@@ -1,3 +1,4 @@
+use nils_common::env as shared_env;
 use std::path::Path;
 use std::{io, io::IsTerminal};
 
@@ -93,15 +94,12 @@ pub fn render_line(
 }
 
 fn should_color() -> bool {
-    if std::env::var_os("NO_COLOR").is_some() {
+    if shared_env::no_color_enabled() {
         return false;
     }
 
-    if let Ok(raw) = std::env::var("GEMINI_STARSHIP_COLOR_ENABLED") {
-        return matches!(
-            raw.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        );
+    if std::env::var("GEMINI_STARSHIP_COLOR_ENABLED").is_ok() {
+        return shared_env::env_truthy("GEMINI_STARSHIP_COLOR_ENABLED");
     }
 
     if std::env::var_os("STARSHIP_SESSION_KEY").is_some()

--- a/crates/screen-record/src/linux/portal.rs
+++ b/crates/screen-record/src/linux/portal.rs
@@ -29,10 +29,10 @@ fn ov_str(value: &str) -> zbus::zvariant::OwnedValue {
 }
 
 pub fn ensure_portal_available() -> Result<(), CliError> {
-    if env_flag_enabled(ENV_FORCE_AVAILABLE) {
+    if shared_env::env_truthy(ENV_FORCE_AVAILABLE) {
         return Ok(());
     }
-    if env_flag_enabled(ENV_FORCE_MISSING) {
+    if shared_env::env_truthy(ENV_FORCE_MISSING) {
         return Err(portal_missing_error());
     }
 
@@ -268,9 +268,4 @@ fn portal_missing_error() -> CliError {
 Install xdg-desktop-portal and a desktop backend (e.g. xdg-desktop-portal-gnome or xdg-desktop-portal-kde), then log out/in.\n\
 Expected DBus service: org.freedesktop.portal.Desktop",
     )
-}
-
-fn env_flag_enabled(key: &str) -> bool {
-    let value = std::env::var_os(key).map(|raw| raw.to_string_lossy().into_owned());
-    shared_env::is_truthy_or(value.as_deref().map(str::trim), false)
 }

--- a/crates/screen-record/src/run.rs
+++ b/crates/screen-record/src/run.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use chrono::{Local, SecondsFormat, Utc};
+use nils_common::env as shared_env;
 
 use crate::cli::{AudioMode, Cli, ContainerFormat, ImageFormat};
 use crate::error::CliError;
@@ -819,9 +820,7 @@ fn write_motion_intervals_artifact(
 }
 
 fn diagnostics_failure_forced() -> bool {
-    let value = std::env::var_os("AGENTS_SCREEN_RECORD_TEST_MODE_FAIL_DIAGNOSTICS")
-        .map(|raw| raw.to_string_lossy().trim().to_ascii_lowercase());
-    matches!(value.as_deref(), Some("1" | "true" | "yes" | "on"))
+    shared_env::env_truthy("AGENTS_SCREEN_RECORD_TEST_MODE_FAIL_DIAGNOSTICS")
 }
 
 fn write_recording_metadata(path: &Path, metadata: &RecordingMetadata) -> Result<(), CliError> {

--- a/crates/screen-record/src/test_mode.rs
+++ b/crates/screen-record/src/test_mode.rs
@@ -12,7 +12,7 @@ static CTRL_C_INSTALLED: OnceLock<Result<(), CliError>> = OnceLock::new();
 static STOP_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 pub fn enabled() -> bool {
-    env_truthy("AGENTS_SCREEN_RECORD_TEST_MODE")
+    shared_env::env_truthy("AGENTS_SCREEN_RECORD_TEST_MODE")
 }
 
 pub fn shareable_content() -> ShareableContent {
@@ -182,17 +182,12 @@ impl TestWriter {
     }
 }
 
-fn env_truthy(name: &str) -> bool {
-    let value = std::env::var_os(name).map(|raw| raw.to_string_lossy().into_owned());
-    shared_env::is_truthy_or(value.as_deref().map(str::trim), false)
-}
-
 fn realtime_recording_enabled() -> bool {
-    env_truthy("AGENTS_SCREEN_RECORD_TEST_MODE_REALTIME")
+    shared_env::env_truthy("AGENTS_SCREEN_RECORD_TEST_MODE_REALTIME")
 }
 
 fn fail_recording_after_partial_write() -> bool {
-    env_truthy("AGENTS_SCREEN_RECORD_TEST_MODE_FAIL_APPEND")
+    shared_env::env_truthy("AGENTS_SCREEN_RECORD_TEST_MODE_FAIL_APPEND")
 }
 
 fn install_ctrlc_handler() -> Result<(), CliError> {


### PR DESCRIPTION
## Summary
This refactor removes duplicate env truthy and `NO_COLOR` checks across provider/media CLIs and standardizes behavior through `nils-common::env`, reducing drift in runtime toggles without changing command contracts.

## Changes
- Replaced local truthy parsing in `nils-gemini-cli` (`starship` + `rate_limits`) with `nils-common::env` helpers.
- Aligned `nils-codex-cli` starship color override evaluation to use shared env truthy parsing.
- Removed duplicate env-flag helpers in `nils-screen-record` (`test_mode`, Linux portal availability flags, diagnostics fail switch) in favor of shared helpers.

## Testing
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 85.57%)

## Risk / Notes
- Scope is refactor-only: centralized env parsing and no-color checks.
- No output format, command surface, or exit-code contract changes intended.