### PR TITLE
Adopt shared nils-common and nils-test-support helpers for maintainability

### DIFF
--- a/crates/codex-cli/src/agent/commit.rs
+++ b/crates/codex-cli/src/agent/commit.rs
@@ -322,33 +322,8 @@ fn command_exists(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{command_exists, semantic_commit_prompt, suggested_scope_from_staged};
+    use nils_test_support::{GlobalStateLock, prepend_path};
     use pretty_assertions::assert_eq;
-
-    struct EnvGuard {
-        key: &'static str,
-        old: Option<std::ffi::OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let old = std::env::var_os(key);
-            // SAFETY: tests mutate process env only in scoped guard usage.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, old }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            if let Some(value) = self.old.take() {
-                // SAFETY: tests restore process env only in scoped guard usage.
-                unsafe { std::env::set_var(self.key, value) };
-            } else {
-                // SAFETY: tests restore process env only in scoped guard usage.
-                unsafe { std::env::remove_var(self.key) };
-            }
-        }
-    }
 
     #[test]
     fn suggested_scope_prefers_single_top_level_directory() {
@@ -378,6 +353,7 @@ mod tests {
     fn command_exists_checks_executable_bit() {
         use std::os::unix::fs::PermissionsExt;
 
+        let lock = GlobalStateLock::new();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let executable = dir.path().join("tool-ok");
         let non_executable = dir.path().join("tool-no");
@@ -396,7 +372,7 @@ mod tests {
         perms.set_mode(0o644);
         std::fs::set_permissions(&non_executable, perms).expect("chmod non executable");
 
-        let _path_guard = EnvGuard::set("PATH", dir.path().as_os_str());
+        let _path_guard = prepend_path(&lock, dir.path());
         assert!(command_exists("tool-ok"));
         assert!(!command_exists("tool-no"));
         assert!(!command_exists("tool-missing"));

--- a/crates/codex-cli/src/auth/use_secret.rs
+++ b/crates/codex-cli/src/auth/use_secret.rs
@@ -241,6 +241,7 @@ enum ResolveResult {
 #[cfg(test)]
 mod tests {
     use super::{ResolveResult, file_name, resolve_by_email, secret_timestamp_path};
+    use nils_test_support::{EnvGuard, GlobalStateLock};
     use pretty_assertions::assert_eq;
     use std::path::Path;
 
@@ -258,32 +259,6 @@ mod tests {
             token(payload),
             token(payload)
         )
-    }
-
-    struct EnvGuard {
-        key: &'static str,
-        old: Option<std::ffi::OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let old = std::env::var_os(key);
-            // SAFETY: tests mutate process env only in scoped guard usage.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, old }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            if let Some(value) = self.old.take() {
-                // SAFETY: tests restore process env only in scoped guard usage.
-                unsafe { std::env::set_var(self.key, value) };
-            } else {
-                // SAFETY: tests restore process env only in scoped guard usage.
-                unsafe { std::env::remove_var(self.key) };
-            }
-        }
     }
 
     #[test]
@@ -325,10 +300,12 @@ mod tests {
 
     #[test]
     fn secret_timestamp_path_uses_cache_dir_and_default_file_name() {
+        let lock = GlobalStateLock::new();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let cache = dir.path().join("cache");
         std::fs::create_dir_all(&cache).expect("cache");
-        let _guard = EnvGuard::set("CODEX_SECRET_CACHE_DIR", &cache);
+        let cache_value = cache.to_string_lossy().to_string();
+        let _guard = EnvGuard::set(&lock, "CODEX_SECRET_CACHE_DIR", &cache_value);
 
         let with_name =
             secret_timestamp_path(Path::new("/tmp/demo-auth.json")).expect("timestamp path");

--- a/crates/gemini-cli/src/config.rs
+++ b/crates/gemini-cli/src/config.rs
@@ -1,5 +1,7 @@
 use std::io::Write;
 
+use nils_common::shell::{SingleQuoteEscapeStyle, quote_posix_single_with_style};
+
 pub fn show() -> i32 {
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();
@@ -107,8 +109,7 @@ pub fn set_with_io(
 }
 
 fn quote_posix_single(raw: &str) -> String {
-    let escaped = raw.replace('\'', "'\"'\"'");
-    format!("'{escaped}'")
+    quote_posix_single_with_style(raw, SingleQuoteEscapeStyle::DoubleQuoteBoundary)
 }
 
 #[cfg(test)]

--- a/crates/gemini-cli/tests/agent_prompt.rs
+++ b/crates/gemini-cli/tests/agent_prompt.rs
@@ -1,42 +1,9 @@
 use gemini_cli::agent;
+use nils_test_support::{EnvGuard, GlobalStateLock, prepend_path};
 use std::fs;
 use std::io::{BufReader, Cursor};
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("env lock")
-}
-
-struct EnvGuard {
-    key: &'static str,
-    old: Option<std::ffi::OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-        let old = std::env::var_os(key);
-        // SAFETY: tests mutate process env with a global lock.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, old }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.old.take() {
-            // SAFETY: tests mutate process env with a global lock.
-            unsafe { std::env::set_var(self.key, value) };
-        } else {
-            // SAFETY: tests mutate process env with a global lock.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
 
 fn temp_dir(label: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -83,17 +50,18 @@ fn read_args(log_path: &Path) -> Vec<String> {
 
 #[test]
 fn agent_prompt_requires_dangerous_mode() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = temp_dir("agent-prompt-requires-dangerous");
     let stub = dir.join("gemini");
     let args_log = dir.join("argv.log");
     write_gemini_stub(&stub);
 
-    let _path = EnvGuard::set("PATH", dir.as_os_str());
-    let _danger = EnvGuard::set("GEMINI_ALLOW_DANGEROUS_ENABLED", "false");
-    let _model = EnvGuard::set("GEMINI_CLI_MODEL", "m");
-    let _reasoning = EnvGuard::set("GEMINI_CLI_REASONING", "low");
-    let _argv = EnvGuard::set("GEMINI_TEST_ARGV_LOG", args_log.as_os_str());
+    let args_log_value = args_log.to_string_lossy().to_string();
+    let _path = prepend_path(&lock, &dir);
+    let _danger = EnvGuard::set(&lock, "GEMINI_ALLOW_DANGEROUS_ENABLED", "false");
+    let _model = EnvGuard::set(&lock, "GEMINI_CLI_MODEL", "m");
+    let _reasoning = EnvGuard::set(&lock, "GEMINI_CLI_REASONING", "low");
+    let _argv = EnvGuard::set(&lock, "GEMINI_TEST_ARGV_LOG", &args_log_value);
 
     let mut stdin = BufReader::new(Cursor::new(""));
     let mut stdout: Vec<u8> = Vec::new();
@@ -111,17 +79,18 @@ fn agent_prompt_requires_dangerous_mode() {
 
 #[test]
 fn agent_prompt_execs_gemini_with_expected_args() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = temp_dir("agent-prompt-args");
     let stub = dir.join("gemini");
     let args_log = dir.join("argv.log");
     write_gemini_stub(&stub);
 
-    let _path = EnvGuard::set("PATH", dir.as_os_str());
-    let _danger = EnvGuard::set("GEMINI_ALLOW_DANGEROUS_ENABLED", "true");
-    let _model = EnvGuard::set("GEMINI_CLI_MODEL", "m-test");
-    let _reasoning = EnvGuard::set("GEMINI_CLI_REASONING", "high");
-    let _argv = EnvGuard::set("GEMINI_TEST_ARGV_LOG", args_log.as_os_str());
+    let args_log_value = args_log.to_string_lossy().to_string();
+    let _path = prepend_path(&lock, &dir);
+    let _danger = EnvGuard::set(&lock, "GEMINI_ALLOW_DANGEROUS_ENABLED", "true");
+    let _model = EnvGuard::set(&lock, "GEMINI_CLI_MODEL", "m-test");
+    let _reasoning = EnvGuard::set(&lock, "GEMINI_CLI_REASONING", "high");
+    let _argv = EnvGuard::set(&lock, "GEMINI_TEST_ARGV_LOG", &args_log_value);
 
     let mut stdin = BufReader::new(Cursor::new(""));
     let mut stdout: Vec<u8> = Vec::new();
@@ -155,17 +124,18 @@ fn agent_prompt_execs_gemini_with_expected_args() {
 
 #[test]
 fn agent_prompt_reads_stdin_when_no_args() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = temp_dir("agent-prompt-stdin");
     let stub = dir.join("gemini");
     let args_log = dir.join("argv.log");
     write_gemini_stub(&stub);
 
-    let _path = EnvGuard::set("PATH", dir.as_os_str());
-    let _danger = EnvGuard::set("GEMINI_ALLOW_DANGEROUS_ENABLED", "true");
-    let _model = EnvGuard::set("GEMINI_CLI_MODEL", "m");
-    let _reasoning = EnvGuard::set("GEMINI_CLI_REASONING", "medium");
-    let _argv = EnvGuard::set("GEMINI_TEST_ARGV_LOG", args_log.as_os_str());
+    let args_log_value = args_log.to_string_lossy().to_string();
+    let _path = prepend_path(&lock, &dir);
+    let _danger = EnvGuard::set(&lock, "GEMINI_ALLOW_DANGEROUS_ENABLED", "true");
+    let _model = EnvGuard::set(&lock, "GEMINI_CLI_MODEL", "m");
+    let _reasoning = EnvGuard::set(&lock, "GEMINI_CLI_REASONING", "medium");
+    let _argv = EnvGuard::set(&lock, "GEMINI_TEST_ARGV_LOG", &args_log_value);
 
     let mut stdin = BufReader::new(Cursor::new("from stdin\n"));
     let mut stdout: Vec<u8> = Vec::new();

--- a/crates/gemini-cli/tests/config.rs
+++ b/crates/gemini-cli/tests/config.rs
@@ -1,59 +1,18 @@
 use gemini_cli::config;
-use std::ffi::{OsStr, OsString};
-use std::sync::{Mutex, OnceLock};
-
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("env lock")
-}
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: tests serialize env mutations via env_lock.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-
-    fn remove(key: &'static str) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: tests serialize env mutations via env_lock.
-        unsafe { std::env::remove_var(key) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.previous.take() {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::set_var(self.key, value) };
-        } else {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
+use nils_test_support::{EnvGuard, GlobalStateLock};
 
 #[test]
 fn config_show_with_io_prints_effective_values() {
-    let _lock = env_lock();
-    let _model = EnvGuard::set("GEMINI_CLI_MODEL", "m1");
-    let _reasoning = EnvGuard::set("GEMINI_CLI_REASONING", "low");
-    let _dangerous = EnvGuard::set("GEMINI_ALLOW_DANGEROUS_ENABLED", "true");
-    let _secret = EnvGuard::set("GEMINI_SECRET_DIR", "/tmp/secrets");
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", "/tmp/auth.json");
-    let _cache = EnvGuard::set("GEMINI_SECRET_CACHE_DIR", "/tmp/cache/secrets");
-    let _starship = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let _auto_refresh = EnvGuard::set("GEMINI_AUTO_REFRESH_ENABLED", "true");
-    let _min_days = EnvGuard::set("GEMINI_AUTO_REFRESH_MIN_DAYS", "9");
+    let lock = GlobalStateLock::new();
+    let _model = EnvGuard::set(&lock, "GEMINI_CLI_MODEL", "m1");
+    let _reasoning = EnvGuard::set(&lock, "GEMINI_CLI_REASONING", "low");
+    let _dangerous = EnvGuard::set(&lock, "GEMINI_ALLOW_DANGEROUS_ENABLED", "true");
+    let _secret = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", "/tmp/secrets");
+    let _auth = EnvGuard::set(&lock, "GEMINI_AUTH_FILE", "/tmp/auth.json");
+    let _cache = EnvGuard::set(&lock, "GEMINI_SECRET_CACHE_DIR", "/tmp/cache/secrets");
+    let _starship = EnvGuard::set(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let _auto_refresh = EnvGuard::set(&lock, "GEMINI_AUTO_REFRESH_ENABLED", "true");
+    let _min_days = EnvGuard::set(&lock, "GEMINI_AUTO_REFRESH_MIN_DAYS", "9");
 
     let mut out: Vec<u8> = Vec::new();
     assert_eq!(config::show_with_io(&mut out), 0);
@@ -71,15 +30,15 @@ fn config_show_with_io_prints_effective_values() {
 
 #[test]
 fn config_show_with_io_prints_blank_paths_when_unresolvable() {
-    let _lock = env_lock();
-    let _home = EnvGuard::remove("HOME");
-    let _zdotdir = EnvGuard::remove("ZDOTDIR");
-    let _script = EnvGuard::remove("ZSH_SCRIPT_DIR");
-    let _preload = EnvGuard::remove("_ZSH_BOOTSTRAP_PRELOAD_PATH");
-    let _cache_root = EnvGuard::remove("ZSH_CACHE_DIR");
-    let _secret = EnvGuard::remove("GEMINI_SECRET_DIR");
-    let _auth = EnvGuard::remove("GEMINI_AUTH_FILE");
-    let _secret_cache = EnvGuard::remove("GEMINI_SECRET_CACHE_DIR");
+    let lock = GlobalStateLock::new();
+    let _home = EnvGuard::remove(&lock, "HOME");
+    let _zdotdir = EnvGuard::remove(&lock, "ZDOTDIR");
+    let _script = EnvGuard::remove(&lock, "ZSH_SCRIPT_DIR");
+    let _preload = EnvGuard::remove(&lock, "_ZSH_BOOTSTRAP_PRELOAD_PATH");
+    let _cache_root = EnvGuard::remove(&lock, "ZSH_CACHE_DIR");
+    let _secret = EnvGuard::remove(&lock, "GEMINI_SECRET_DIR");
+    let _auth = EnvGuard::remove(&lock, "GEMINI_AUTH_FILE");
+    let _secret_cache = EnvGuard::remove(&lock, "GEMINI_SECRET_CACHE_DIR");
 
     let mut out: Vec<u8> = Vec::new();
     assert_eq!(config::show_with_io(&mut out), 0);
@@ -91,7 +50,7 @@ fn config_show_with_io_prints_blank_paths_when_unresolvable() {
 
 #[test]
 fn config_set_with_io_model_quotes_value() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let mut out: Vec<u8> = Vec::new();
     let mut err: Vec<u8> = Vec::new();
 
@@ -108,7 +67,7 @@ fn config_set_with_io_model_quotes_value() {
 
 #[test]
 fn config_set_with_io_reason_alias_is_supported() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let mut out: Vec<u8> = Vec::new();
     let mut err: Vec<u8> = Vec::new();
 
@@ -122,7 +81,7 @@ fn config_set_with_io_reason_alias_is_supported() {
 
 #[test]
 fn config_set_with_io_dangerous_rejects_invalid_values() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let mut out: Vec<u8> = Vec::new();
     let mut err: Vec<u8> = Vec::new();
 
@@ -140,7 +99,7 @@ fn config_set_with_io_dangerous_rejects_invalid_values() {
 
 #[test]
 fn config_set_with_io_unknown_key_returns_64() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let mut out: Vec<u8> = Vec::new();
     let mut err: Vec<u8> = Vec::new();
 
@@ -153,7 +112,7 @@ fn config_set_with_io_unknown_key_returns_64() {
 
 #[test]
 fn config_set_with_io_escapes_single_quotes() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let mut out: Vec<u8> = Vec::new();
     let mut err: Vec<u8> = Vec::new();
 


### PR DESCRIPTION
## Summary
Refactors duplicated helper logic to shared workspace crates for maintainability without changing CLI behavior. `nils-gemini-cli` now reuses `nils-common` shell quoting, and selected gemini/codex tests now reuse `nils-test-support` environment/path guards.

## Changes
- Replaced `gemini-cli` local POSIX single-quote escaping with `nils_common::shell::quote_posix_single_with_style(..., DoubleQuoteBoundary)`.
- Removed duplicated test-only `EnvGuard` implementations in `codex-cli` and `gemini-cli` touched modules.
- Switched affected tests to `nils_test_support::{GlobalStateLock, EnvGuard, prepend_path}` for consistent process-global mutation handling.

## Testing
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 85.57%)

## Risk / Notes
- Changes are scoped to helper adoption and test plumbing; command output contracts are covered by workspace required checks.
