### PR TITLE
Adopt shared nils-common and nils-test-support helpers

### DIFF
--- a/crates/fzf-cli/src/defs/cache.rs
+++ b/crates/fzf-cli/src/defs/cache.rs
@@ -53,40 +53,9 @@ fn write_cache(
 mod tests {
     use super::*;
     use crate::defs::index::{AliasDef, DefIndex};
+    use nils_test_support::{EnvGuard, GlobalStateLock};
     use pretty_assertions::assert_eq;
-    use std::sync::Mutex;
     use tempfile::TempDir;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvGuard {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let original = std::env::var(key).ok();
-            // SAFETY: tests mutate process env only in scoped guard usage.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, original }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(value) => {
-                    // SAFETY: tests restore process env only in scoped guard usage.
-                    unsafe { std::env::set_var(self.key, value) };
-                }
-                None => {
-                    // SAFETY: tests restore process env only in scoped guard usage.
-                    unsafe { std::env::remove_var(self.key) };
-                }
-            }
-        }
-    }
 
     fn write(path: &std::path::Path, contents: &str) {
         if let Some(parent) = path.parent() {
@@ -97,13 +66,13 @@ mod tests {
 
     #[test]
     fn cache_disabled_builds_index_from_zsh_root() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let lock = GlobalStateLock::new();
         let temp = TempDir::new().unwrap();
         let root = temp.path();
         write(&root.join(".zshrc"), "alias ll='ls -la'\n");
 
-        let _guard = EnvGuard::set("ZDOTDIR", root.to_string_lossy().as_ref());
-        let _guard_cache = EnvGuard::set("FZF_DEF_DOC_CACHE_ENABLED", "0");
+        let _guard = EnvGuard::set(&lock, "ZDOTDIR", root.to_string_lossy().as_ref());
+        let _guard_cache = EnvGuard::set(&lock, "FZF_DEF_DOC_CACHE_ENABLED", "0");
 
         let index = load_or_build().expect("load");
         assert!(index.aliases.iter().any(|a| a.name == "ll"));
@@ -111,7 +80,7 @@ mod tests {
 
     #[test]
     fn cache_enabled_uses_fresh_cache() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let lock = GlobalStateLock::new();
         let temp = TempDir::new().unwrap();
         let cache_dir = temp.path().join("cache");
         std::fs::create_dir_all(&cache_dir).unwrap();
@@ -132,10 +101,11 @@ mod tests {
             &serde_json::to_string(&cached).unwrap(),
         );
 
-        let _guard_cache = EnvGuard::set("FZF_DEF_DOC_CACHE_ENABLED", "1");
-        let _guard_ttl = EnvGuard::set("FZF_DEF_DOC_CACHE_EXPIRE_MINUTES", "10");
-        let _guard_cache_dir = EnvGuard::set("ZSH_CACHE_DIR", cache_dir.to_string_lossy().as_ref());
-        let _guard_zdot = EnvGuard::set("ZDOTDIR", temp.path().to_string_lossy().as_ref());
+        let _guard_cache = EnvGuard::set(&lock, "FZF_DEF_DOC_CACHE_ENABLED", "1");
+        let _guard_ttl = EnvGuard::set(&lock, "FZF_DEF_DOC_CACHE_EXPIRE_MINUTES", "10");
+        let _guard_cache_dir =
+            EnvGuard::set(&lock, "ZSH_CACHE_DIR", cache_dir.to_string_lossy().as_ref());
+        let _guard_zdot = EnvGuard::set(&lock, "ZDOTDIR", temp.path().to_string_lossy().as_ref());
 
         let index = load_or_build().expect("load");
         assert_eq!(index.aliases.len(), 1);
@@ -144,7 +114,7 @@ mod tests {
 
     #[test]
     fn cache_stale_rebuilds_and_overwrites() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let lock = GlobalStateLock::new();
         let temp = TempDir::new().unwrap();
         let root = temp.path().join("zsh");
         std::fs::create_dir_all(&root).unwrap();
@@ -171,10 +141,11 @@ mod tests {
             &serde_json::to_string(&stale).unwrap(),
         );
 
-        let _guard_cache = EnvGuard::set("FZF_DEF_DOC_CACHE_ENABLED", "1");
-        let _guard_ttl = EnvGuard::set("FZF_DEF_DOC_CACHE_EXPIRE_MINUTES", "0");
-        let _guard_cache_dir = EnvGuard::set("ZSH_CACHE_DIR", cache_dir.to_string_lossy().as_ref());
-        let _guard_zdot = EnvGuard::set("ZDOTDIR", root.to_string_lossy().as_ref());
+        let _guard_cache = EnvGuard::set(&lock, "FZF_DEF_DOC_CACHE_ENABLED", "1");
+        let _guard_ttl = EnvGuard::set(&lock, "FZF_DEF_DOC_CACHE_EXPIRE_MINUTES", "0");
+        let _guard_cache_dir =
+            EnvGuard::set(&lock, "ZSH_CACHE_DIR", cache_dir.to_string_lossy().as_ref());
+        let _guard_zdot = EnvGuard::set(&lock, "ZDOTDIR", root.to_string_lossy().as_ref());
 
         let index = load_or_build().expect("load");
         assert!(index.aliases.iter().any(|a| a.name == "fresh"));

--- a/crates/fzf-cli/src/defs/commands.rs
+++ b/crates/fzf-cli/src/defs/commands.rs
@@ -190,40 +190,13 @@ fn docblock_with_separators(doc: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nils_test_support::{EnvGuard, GlobalStateLock};
     use pretty_assertions::assert_eq;
-
-    struct EnvGuard {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let original = std::env::var(key).ok();
-            // SAFETY: tests mutate process env only in scoped guard usage.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, original }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(value) => {
-                    // SAFETY: tests restore process env only in scoped guard usage.
-                    unsafe { std::env::set_var(self.key, value) };
-                }
-                None => {
-                    // SAFETY: tests restore process env only in scoped guard usage.
-                    unsafe { std::env::remove_var(self.key) };
-                }
-            }
-        }
-    }
 
     #[test]
     fn docblock_with_separators_respects_indent_and_pad() {
-        let _guard = EnvGuard::set("FZF_DEF_DOC_SEPARATOR_PAD", "2");
+        let lock = GlobalStateLock::new();
+        let _guard = EnvGuard::set(&lock, "FZF_DEF_DOC_SEPARATOR_PAD", "2");
         let doc = "  # Alpha\n  # Beta";
         let out = docblock_with_separators(doc);
         let lines: Vec<&str> = out.lines().collect();
@@ -242,7 +215,8 @@ mod tests {
 
     #[test]
     fn build_alias_body_includes_doc_value_and_footer() {
-        let _guard = EnvGuard::set("FZF_DEF_DOC_SEPARATOR_PAD", "2");
+        let lock = GlobalStateLock::new();
+        let _guard = EnvGuard::set(&lock, "FZF_DEF_DOC_SEPARATOR_PAD", "2");
         let def = AliasDef {
             name: "ll".to_string(),
             value: "ls -la".to_string(),

--- a/crates/fzf-cli/src/file.rs
+++ b/crates/fzf-cli/src/file.rs
@@ -92,31 +92,12 @@ fn list_files(max_depth: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
-    use std::sync::Mutex;
+    use nils_test_support::{CwdGuard, GlobalStateLock};
     use tempfile::TempDir;
-
-    static CWD_LOCK: Mutex<()> = Mutex::new(());
-
-    struct CwdGuard {
-        original: PathBuf,
-    }
-
-    impl CwdGuard {
-        fn new(original: PathBuf) -> Self {
-            Self { original }
-        }
-    }
-
-    impl Drop for CwdGuard {
-        fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.original);
-        }
-    }
 
     #[test]
     fn list_files_skips_git_and_sorts() {
-        let _lock = CWD_LOCK.lock().unwrap();
+        let lock = GlobalStateLock::new();
         let dir = TempDir::new().unwrap();
 
         std::fs::create_dir_all(dir.path().join(".git/objects")).unwrap();
@@ -126,9 +107,7 @@ mod tests {
         std::fs::write(dir.path().join("b.txt"), "x").unwrap();
         std::fs::write(dir.path().join("nested/c.txt"), "x").unwrap();
 
-        let original = std::env::current_dir().unwrap();
-        let _guard = CwdGuard::new(original);
-        std::env::set_current_dir(dir.path()).unwrap();
+        let _cwd = CwdGuard::set(&lock, dir.path()).expect("cwd");
 
         let files = list_files(5);
         assert_eq!(files, vec!["a.txt", "b.txt", "nested/c.txt"]);
@@ -136,16 +115,14 @@ mod tests {
 
     #[test]
     fn list_files_respects_max_depth() {
-        let _lock = CWD_LOCK.lock().unwrap();
+        let lock = GlobalStateLock::new();
         let dir = TempDir::new().unwrap();
 
         std::fs::write(dir.path().join("root.txt"), "x").unwrap();
         std::fs::create_dir_all(dir.path().join("nested")).unwrap();
         std::fs::write(dir.path().join("nested/deeper.txt"), "x").unwrap();
 
-        let original = std::env::current_dir().unwrap();
-        let _guard = CwdGuard::new(original);
-        std::env::set_current_dir(dir.path()).unwrap();
+        let _cwd = CwdGuard::set(&lock, dir.path()).expect("cwd");
 
         let files = list_files(1);
         assert_eq!(files, vec!["root.txt"]);

--- a/crates/fzf-cli/src/open.rs
+++ b/crates/fzf-cli/src/open.rs
@@ -170,45 +170,14 @@ fn run_code(args: &[String]) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nils_test_support::{EnvGuard, GlobalStateLock};
     use pretty_assertions::assert_eq;
-    use std::sync::Mutex;
     use tempfile::TempDir;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvGuard {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let original = std::env::var(key).ok();
-            // SAFETY: tests mutate process env only in scoped guard usage.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, original }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(value) => {
-                    // SAFETY: tests restore process env only in scoped guard usage.
-                    unsafe { std::env::set_var(self.key, value) };
-                }
-                None => {
-                    // SAFETY: tests restore process env only in scoped guard usage.
-                    unsafe { std::env::remove_var(self.key) };
-                }
-            }
-        }
-    }
 
     #[test]
     fn parse_open_with_flags_respects_env_and_explicit_flags() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _guard = EnvGuard::set("FZF_FILE_OPEN_WITH", "vscode");
+        let lock = GlobalStateLock::new();
+        let _guard = EnvGuard::set(&lock, "FZF_FILE_OPEN_WITH", "vscode");
         let (open_with, rest) = parse_open_with_flags(&[String::from("file.txt")]).expect("parse");
         assert_eq!(open_with, OpenWith::Vscode);
         assert_eq!(rest, vec!["file.txt".to_string()]);
@@ -225,7 +194,7 @@ mod tests {
 
     #[test]
     fn parse_open_with_flags_rejects_conflicts_and_unknowns() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = GlobalStateLock::new();
         let err =
             parse_open_with_flags(&[String::from("--vi"), String::from("--vscode")]).unwrap_err();
         assert_eq!(err, 2);

--- a/crates/git-scope/src/tree.rs
+++ b/crates/git-scope/src/tree.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use nils_common::process as shared_process;
 use std::sync::OnceLock;
 
 pub const TREE_MISSING_WARNING: &str =
@@ -19,7 +19,7 @@ pub fn tree_support() -> &'static TreeSupport {
 }
 
 fn detect_tree_support() -> TreeSupport {
-    if Command::new("tree").arg("--version").output().is_err() {
+    if !shared_process::cmd_exists("tree") {
         return TreeSupport {
             is_installed: false,
             supports_fromfile: false,
@@ -27,12 +27,7 @@ fn detect_tree_support() -> TreeSupport {
         };
     }
 
-    let support = Command::new("tree")
-        .arg("--fromfile")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
+    let support = shared_process::run_status_quiet("tree", &["--fromfile"]);
 
     if support.map(|s| !s.success()).unwrap_or(true) {
         return TreeSupport {

--- a/crates/git-scope/tests/characterization_warnings.rs
+++ b/crates/git-scope/tests/characterization_warnings.rs
@@ -53,7 +53,7 @@ fn tree_missing_warning_is_stable() {
     common::git(root, &["add", "file.txt"]);
 
     let stub = tempfile::TempDir::new().unwrap();
-    let git_path = which_cmd("git");
+    let git_path = common::resolve_path_command("git");
     symlink(&git_path, stub.path().join("git")).unwrap();
 
     let path_env = stub.path().to_string_lossy().to_string();
@@ -126,14 +126,4 @@ fn missing_index_file_falls_back_to_head() {
         output.contains("📄 index.txt (deleted in index; from HEAD)"),
         "missing index fallback not found: {output}"
     );
-}
-
-fn which_cmd(cmd: &str) -> String {
-    let output = std::process::Command::new("which")
-        .arg(cmd)
-        .output()
-        .unwrap_or_else(|_| panic!("which {cmd}"));
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    assert!(!path.is_empty(), "{cmd} not found in PATH for tests");
-    path
 }

--- a/crates/git-scope/tests/common.rs
+++ b/crates/git-scope/tests/common.rs
@@ -33,3 +33,10 @@ pub fn run_git_scope_output(dir: &Path, args: &[&str], envs: &[(&str, &str)]) ->
     }
     output.into_output()
 }
+
+#[allow(dead_code)]
+pub fn resolve_path_command(cmd: &str) -> String {
+    nils_common::process::find_in_path(cmd)
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_else(|| panic!("{cmd} not found in PATH for tests"))
+}

--- a/crates/git-scope/tests/rendering.rs
+++ b/crates/git-scope/tests/rendering.rs
@@ -32,7 +32,7 @@ fn tree_missing_emits_warning() {
     common::git(root, &["add", "file.txt"]);
 
     let temp_path = tempfile::TempDir::new().unwrap();
-    let git_path = which_git();
+    let git_path = common::resolve_path_command("git");
     let link_path = temp_path.path().join("git");
     symlink(&git_path, &link_path).unwrap();
 
@@ -61,7 +61,7 @@ fn tree_fromfile_unsupported_emits_warning() {
     common::git(root, &["add", "file.txt"]);
 
     let temp_path = tempfile::TempDir::new().unwrap();
-    let git_path = which_git();
+    let git_path = common::resolve_path_command("git");
     let link_path = temp_path.path().join("git");
     symlink(&git_path, &link_path).unwrap();
 
@@ -85,14 +85,4 @@ fn tree_fromfile_unsupported_emits_warning() {
         output.contains("tree does not support --fromfile"),
         "tree unsupported warning not found: {output}"
     );
-}
-
-fn which_git() -> String {
-    let output = std::process::Command::new("which")
-        .arg("git")
-        .output()
-        .expect("which git");
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    assert!(!path.is_empty(), "git not found in PATH for tests");
-    path
 }

--- a/crates/git-scope/tests/tool_degradation.rs
+++ b/crates/git-scope/tests/tool_degradation.rs
@@ -13,7 +13,7 @@ fn tracked_warns_when_tree_missing() {
     common::git(root, &["commit", "-m", "tracked"]);
 
     let stub = tempfile::TempDir::new().unwrap();
-    let git_path = which_git();
+    let git_path = common::resolve_path_command("git");
     let link_path = stub.path().join("git");
     symlink(&git_path, &link_path).unwrap();
 
@@ -39,7 +39,7 @@ fn tracked_print_works_when_file_missing() {
     common::git(root, &["commit", "-m", "add files"]);
 
     let stub = tempfile::TempDir::new().unwrap();
-    let git_path = which_cmd("git");
+    let git_path = common::resolve_path_command("git");
     symlink(&git_path, stub.path().join("git")).unwrap();
 
     let path_env = stub.path().to_string_lossy().to_string();
@@ -80,7 +80,7 @@ fn staged_print_works_without_mktemp_or_file() {
     common::git(root, &["add", "tracked.txt"]);
 
     let stub = tempfile::TempDir::new().unwrap();
-    let git_path = which_cmd("git");
+    let git_path = common::resolve_path_command("git");
     symlink(&git_path, stub.path().join("git")).unwrap();
 
     let path_env = stub.path().to_string_lossy().to_string();
@@ -98,18 +98,4 @@ fn staged_print_works_without_mktemp_or_file() {
         output.contains("STAGED_LINE"),
         "staged content missing: {output}"
     );
-}
-
-fn which_git() -> String {
-    which_cmd("git")
-}
-
-fn which_cmd(cmd: &str) -> String {
-    let output = std::process::Command::new("which")
-        .arg(cmd)
-        .output()
-        .unwrap_or_else(|_| panic!("which {cmd}"));
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    assert!(!path.is_empty(), "{cmd} not found in PATH for tests");
-    path
 }


### PR DESCRIPTION
## Summary
Improve maintainability by replacing local duplicated helper code with workspace shared helpers in affected CLI test/runtime paths.

## Changes
- Replace local `EnvGuard` / `CwdGuard` test helpers in `fzf-cli` with `nils-test-support` (`GlobalStateLock`, `EnvGuard`, `CwdGuard`).
- Route `git-scope` tree capability probing through `nils-common::process` helpers.
- Replace duplicated `which`-based git path lookup in `git-scope` tests with shared `nils-common::process::find_in_path` helper wiring via `tests/common.rs`.

## Testing
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `mkdir -p target/coverage && cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 85.57%)

## Risk / Notes
- Behavior should remain parity-equivalent; changes are helper-substitution focused and validated by workspace checks.