### PR TITLE
Refactor gemini tests to use nils-test-support env guards

### DIFF
--- a/crates/gemini-cli/src/rate_limits/mod.rs
+++ b/crates/gemini-cli/src/rate_limits/mod.rs
@@ -1385,32 +1385,11 @@ fn json_escape(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
+    use nils_test_support::{EnvGuard, GlobalStateLock};
 
-    struct EnvGuard {
-        key: &'static str,
-        old: Option<OsString>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let old = std::env::var_os(key);
-            // SAFETY: test-scoped env mutation.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, old }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            if let Some(value) = self.old.take() {
-                // SAFETY: test-scoped env restore.
-                unsafe { std::env::set_var(self.key, value) };
-            } else {
-                // SAFETY: test-scoped env restore.
-                unsafe { std::env::remove_var(self.key) };
-            }
-        }
+    fn set_env(lock: &GlobalStateLock, key: &str, value: impl AsRef<std::ffi::OsStr>) -> EnvGuard {
+        let value = value.as_ref().to_string_lossy().into_owned();
+        EnvGuard::set(lock, key, &value)
     }
 
     #[test]
@@ -1430,11 +1409,12 @@ mod tests {
 
     #[test]
     fn env_truthy_accepts_expected_variants() {
-        let _v1 = EnvGuard::set("GEMINI_TEST_TRUTHY", "true");
+        let lock = GlobalStateLock::new();
+        let _v1 = set_env(&lock, "GEMINI_TEST_TRUTHY", "true");
         assert!(shared_env::env_truthy("GEMINI_TEST_TRUTHY"));
-        let _v2 = EnvGuard::set("GEMINI_TEST_TRUTHY", "ON");
+        let _v2 = set_env(&lock, "GEMINI_TEST_TRUTHY", "ON");
         assert!(shared_env::env_truthy("GEMINI_TEST_TRUTHY"));
-        let _v3 = EnvGuard::set("GEMINI_TEST_TRUTHY", "0");
+        let _v3 = set_env(&lock, "GEMINI_TEST_TRUTHY", "0");
         assert!(!shared_env::env_truthy("GEMINI_TEST_TRUTHY"));
     }
 
@@ -1507,13 +1487,14 @@ mod tests {
 
     #[test]
     fn collect_secret_files_returns_sorted_json_files() {
+        let lock = GlobalStateLock::new();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let secrets = dir.path().join("secrets");
         std::fs::create_dir_all(&secrets).expect("secrets");
         std::fs::write(secrets.join("b.json"), "{}").expect("b");
         std::fs::write(secrets.join("a.json"), "{}").expect("a");
         std::fs::write(secrets.join("skip.txt"), "x").expect("skip");
-        let _secret = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
+        let _secret = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
 
         let files = collect_secret_files().expect("files");
         assert_eq!(
@@ -1527,12 +1508,13 @@ mod tests {
 
     #[test]
     fn resolve_single_target_appends_json_when_secret_dir_is_configured() {
+        let lock = GlobalStateLock::new();
         let dir = tempfile::TempDir::new().expect("tempdir");
         let secrets = dir.path().join("secrets");
         std::fs::create_dir_all(&secrets).expect("secrets");
         let target = secrets.join("alpha.json");
         std::fs::write(&target, "{}").expect("target");
-        let _secret = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
+        let _secret = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
 
         let resolved = resolve_single_target(Some("alpha")).expect("resolved");
         assert_eq!(resolved, target);
@@ -1540,7 +1522,8 @@ mod tests {
 
     #[test]
     fn clear_starship_cache_rejects_non_absolute_cache_root() {
-        let _cache = EnvGuard::set("ZSH_CACHE_DIR", "relative-cache");
+        let lock = GlobalStateLock::new();
+        let _cache = set_env(&lock, "ZSH_CACHE_DIR", "relative-cache");
         let err = clear_starship_cache().expect_err("non-absolute should fail");
         assert!(err.contains("non-absolute cache root"));
     }

--- a/crates/gemini-cli/tests/agent_exec.rs
+++ b/crates/gemini-cli/tests/agent_exec.rs
@@ -1,38 +1,5 @@
 use gemini_cli::agent::exec;
-use std::sync::{Mutex, OnceLock};
-
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("env lock")
-}
-
-struct EnvGuard {
-    key: &'static str,
-    old: Option<std::ffi::OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let old = std::env::var_os(key);
-        // SAFETY: tests mutate process env with a global lock.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, old }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.old.take() {
-            // SAFETY: tests mutate process env with a global lock.
-            unsafe { std::env::set_var(self.key, value) };
-        } else {
-            // SAFETY: tests mutate process env with a global lock.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
+use nils_test_support::{EnvGuard, GlobalStateLock};
 
 #[test]
 fn exec_dangerous_missing_prompt_exits_1() {
@@ -44,8 +11,8 @@ fn exec_dangerous_missing_prompt_exits_1() {
 
 #[test]
 fn require_allow_dangerous_without_caller_uses_gemini_prefix() {
-    let _lock = env_lock();
-    let _danger = EnvGuard::set("GEMINI_ALLOW_DANGEROUS_ENABLED", "false");
+    let lock = GlobalStateLock::new();
+    let _danger = EnvGuard::set(&lock, "GEMINI_ALLOW_DANGEROUS_ENABLED", "false");
 
     let mut stderr: Vec<u8> = Vec::new();
     let allowed = exec::require_allow_dangerous(None, &mut stderr);
@@ -58,8 +25,8 @@ fn require_allow_dangerous_without_caller_uses_gemini_prefix() {
 
 #[test]
 fn require_allow_dangerous_warns_on_invalid_value() {
-    let _lock = env_lock();
-    let _danger = EnvGuard::set("GEMINI_ALLOW_DANGEROUS_ENABLED", "wat");
+    let lock = GlobalStateLock::new();
+    let _danger = EnvGuard::set(&lock, "GEMINI_ALLOW_DANGEROUS_ENABLED", "wat");
 
     let mut stderr: Vec<u8> = Vec::new();
     let allowed = exec::require_allow_dangerous(Some("caller"), &mut stderr);

--- a/crates/gemini-cli/tests/auth_auto_refresh.rs
+++ b/crates/gemini-cli/tests/auth_auto_refresh.rs
@@ -1,14 +1,7 @@
 use gemini_cli::auth;
+use nils_test_support::{EnvGuard, GlobalStateLock};
 use std::fs;
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
-
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("env lock")
-}
 
 struct TempDir {
     path: PathBuf,
@@ -38,45 +31,21 @@ impl Drop for TempDir {
     }
 }
 
-struct EnvGuard {
-    key: String,
-    old: Option<std::ffi::OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-        let old = std::env::var_os(key);
-        // SAFETY: test-scoped env mutation.
-        unsafe { std::env::set_var(key, value) };
-        Self {
-            key: key.to_string(),
-            old,
-        }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.old.take() {
-            // SAFETY: test-scoped env restore.
-            unsafe { std::env::set_var(&self.key, value) };
-        } else {
-            // SAFETY: test-scoped env restore.
-            unsafe { std::env::remove_var(&self.key) };
-        }
-    }
+fn set_env(lock: &GlobalStateLock, key: &str, value: impl AsRef<std::ffi::OsStr>) -> EnvGuard {
+    let value = value.as_ref().to_string_lossy().into_owned();
+    EnvGuard::set(lock, key, &value)
 }
 
 #[test]
 fn auth_auto_refresh_invalid_min_days() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
 
     let dir = TempDir::new("gemini-auto-refresh-invalid");
     let auth_file = dir.join("auth.json");
     fs::write(&auth_file, r#"{"last_refresh":"2025-01-20T12:34:56Z"}"#).expect("write auth");
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _min = EnvGuard::set("GEMINI_AUTO_REFRESH_MIN_DAYS", "oops");
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _min = set_env(&lock, "GEMINI_AUTO_REFRESH_MIN_DAYS", "oops");
 
     let code = auth::auto_refresh::run();
     assert_eq!(code, 64);
@@ -84,15 +53,15 @@ fn auth_auto_refresh_invalid_min_days() {
 
 #[test]
 fn auth_auto_refresh_unconfigured_exits_zero() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
 
     let dir = TempDir::new("gemini-auto-refresh-unconfigured");
     let auth_file = dir.join("missing_auth.json");
     let secrets = dir.join("secrets");
     fs::create_dir_all(&secrets).expect("secrets");
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _secret = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
 
     let code = auth::auto_refresh::run();
     assert_eq!(code, 0);
@@ -100,7 +69,7 @@ fn auth_auto_refresh_unconfigured_exits_zero() {
 
 #[test]
 fn auth_auto_refresh_backfills_timestamp() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
 
     let dir = TempDir::new("gemini-auto-refresh-backfill");
     let auth_file = dir.join("auth.json");
@@ -115,10 +84,10 @@ fn auth_auto_refresh_backfills_timestamp() {
     )
     .expect("write auth");
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _cache = EnvGuard::set("GEMINI_SECRET_CACHE_DIR", &cache);
-    let _secret = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _min = EnvGuard::set("GEMINI_AUTO_REFRESH_MIN_DAYS", "9999");
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _cache = set_env(&lock, "GEMINI_SECRET_CACHE_DIR", &cache);
+    let _secret = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
+    let _min = set_env(&lock, "GEMINI_AUTO_REFRESH_MIN_DAYS", "9999");
 
     let code = auth::auto_refresh::run();
     assert_eq!(code, 0);

--- a/crates/gemini-cli/tests/diag_json_contract.rs
+++ b/crates/gemini-cli/tests/diag_json_contract.rs
@@ -1,44 +1,9 @@
 use gemini_cli::rate_limits;
+use nils_test_support::{EnvGuard, GlobalStateLock};
 
-use std::ffi::{OsStr, OsString};
 use std::fs as stdfs;
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    match LOCK.get_or_init(|| Mutex::new(())).lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: tests serialize env mutations via env_lock.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.previous.take() {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::set_var(self.key, value) };
-        } else {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
 
 struct TestDir {
     path: PathBuf,
@@ -81,7 +46,7 @@ fn diag_json_contract_schema_constants_are_stable() {
 
 #[test]
 fn diag_json_contract_single_missing_access_token_returns_2() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("diag-json-contract-missing-token");
 
     let secrets = dir.join("secrets");
@@ -93,8 +58,9 @@ fn diag_json_contract_single_missing_access_token_returns_2() {
     .expect("write secret");
     let secrets = stdfs::canonicalize(&secrets).expect("canonical secrets");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _default_all = EnvGuard::set("GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false");
+    let secrets_env = secrets.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _default_all = EnvGuard::set(&lock, "GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false");
 
     let options = rate_limits::RateLimitsOptions {
         json: true,
@@ -106,13 +72,14 @@ fn diag_json_contract_single_missing_access_token_returns_2() {
 
 #[test]
 fn diag_json_contract_all_empty_secret_dir_returns_1() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("diag-json-contract-all-empty");
     let secrets = dir.join("secrets");
     stdfs::create_dir_all(&secrets).expect("secrets");
     let secrets = stdfs::canonicalize(&secrets).expect("canonical secrets");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
+    let secrets_env = secrets.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
 
     let options = rate_limits::RateLimitsOptions {
         all: true,
@@ -124,7 +91,7 @@ fn diag_json_contract_all_empty_secret_dir_returns_1() {
 
 #[test]
 fn diag_json_contract_rejects_one_line_with_json() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let options = rate_limits::RateLimitsOptions {
         json: true,
         one_line: true,

--- a/crates/gemini-cli/tests/rate_limits_all.rs
+++ b/crates/gemini-cli/tests/rate_limits_all.rs
@@ -1,44 +1,9 @@
 use gemini_cli::rate_limits;
+use nils_test_support::{EnvGuard, GlobalStateLock};
 
-use std::ffi::{OsStr, OsString};
 use std::fs as stdfs;
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    match LOCK.get_or_init(|| Mutex::new(())).lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: tests serialize env mutations via env_lock.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.previous.take() {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::set_var(self.key, value) };
-        } else {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
 
 struct TestDir {
     path: PathBuf,
@@ -80,11 +45,12 @@ fn write_secret(path: PathBuf) {
 
 #[test]
 fn rate_limits_all_missing_secret_dir_returns_1() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-all-missing-secret-dir");
     let missing = dir.join("missing");
+    let missing_env = missing.display().to_string();
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &missing);
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &missing_env);
     let options = rate_limits::RateLimitsOptions {
         all: true,
         ..Default::default()
@@ -94,7 +60,7 @@ fn rate_limits_all_missing_secret_dir_returns_1() {
 
 #[test]
 fn rate_limits_all_with_positional_secret_returns_64() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let options = rate_limits::RateLimitsOptions {
         all: true,
         secret: Some("alpha.json".to_string()),
@@ -105,13 +71,14 @@ fn rate_limits_all_with_positional_secret_returns_64() {
 
 #[test]
 fn rate_limits_all_json_empty_secret_dir_returns_1() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-all-json-empty-secret-dir");
     let secrets = dir.join("secrets");
     stdfs::create_dir_all(&secrets).expect("secrets");
     let secrets = stdfs::canonicalize(&secrets).expect("canonical secrets");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
+    let secrets_env = secrets.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
     let options = rate_limits::RateLimitsOptions {
         all: true,
         json: true,
@@ -122,7 +89,7 @@ fn rate_limits_all_json_empty_secret_dir_returns_1() {
 
 #[test]
 fn rate_limits_all_cached_success_returns_0() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-all-cached-success");
 
     let secrets = dir.join("secrets");
@@ -138,8 +105,10 @@ fn rate_limits_all_cached_success_returns_0() {
     let cache_root = dir.join("cache-root");
     stdfs::create_dir_all(&cache_root).expect("cache root");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
+    let secrets_env = secrets.display().to_string();
+    let cache_root_env = cache_root.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _cache_root = EnvGuard::set(&lock, "ZSH_CACHE_DIR", &cache_root_env);
 
     for target in [&alpha, &beta] {
         let cache = rate_limits::cache_file_for_target(target).expect("cache file");
@@ -163,7 +132,7 @@ fn rate_limits_all_cached_success_returns_0() {
 
 #[test]
 fn rate_limits_all_cached_partial_failure_returns_1() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-all-cached-partial-failure");
 
     let secrets = dir.join("secrets");
@@ -178,8 +147,10 @@ fn rate_limits_all_cached_partial_failure_returns_1() {
     let cache_root = dir.join("cache-root");
     stdfs::create_dir_all(&cache_root).expect("cache root");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
+    let secrets_env = secrets.display().to_string();
+    let cache_root_env = cache_root.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _cache_root = EnvGuard::set(&lock, "ZSH_CACHE_DIR", &cache_root_env);
 
     let alpha_cache = rate_limits::cache_file_for_target(&alpha).expect("alpha cache");
     if let Some(parent) = alpha_cache.parent() {

--- a/crates/gemini-cli/tests/rate_limits_async.rs
+++ b/crates/gemini-cli/tests/rate_limits_async.rs
@@ -1,44 +1,9 @@
 use gemini_cli::rate_limits;
+use nils_test_support::{EnvGuard, GlobalStateLock};
 
-use std::ffi::{OsStr, OsString};
 use std::fs as stdfs;
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    match LOCK.get_or_init(|| Mutex::new(())).lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: tests serialize env mutations via env_lock.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.previous.take() {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::set_var(self.key, value) };
-        } else {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
 
 struct TestDir {
     path: PathBuf,
@@ -95,7 +60,7 @@ fn write_cache_for_target(target: &std::path::Path, remaining: i64) {
 
 #[test]
 fn rate_limits_async_one_line_conflict_returns_64() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let options = rate_limits::RateLimitsOptions {
         async_mode: true,
         one_line: true,
@@ -106,7 +71,7 @@ fn rate_limits_async_one_line_conflict_returns_64() {
 
 #[test]
 fn rate_limits_async_positional_secret_conflict_returns_64() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let options = rate_limits::RateLimitsOptions {
         async_mode: true,
         secret: Some("alpha.json".to_string()),
@@ -117,7 +82,7 @@ fn rate_limits_async_positional_secret_conflict_returns_64() {
 
 #[test]
 fn rate_limits_async_cached_clear_conflict_returns_64() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let options = rate_limits::RateLimitsOptions {
         async_mode: true,
         cached: true,
@@ -129,14 +94,15 @@ fn rate_limits_async_cached_clear_conflict_returns_64() {
 
 #[test]
 fn rate_limits_async_clear_cache_non_absolute_root_returns_1() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-async-clear-cache-invalid-root");
     let secrets = dir.join("secrets");
     stdfs::create_dir_all(&secrets).expect("secrets");
     let secrets = stdfs::canonicalize(&secrets).expect("canonical secrets");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", "relative-cache");
+    let secrets_env = secrets.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _cache_root = EnvGuard::set(&lock, "ZSH_CACHE_DIR", "relative-cache");
 
     let options = rate_limits::RateLimitsOptions {
         async_mode: true,
@@ -148,11 +114,12 @@ fn rate_limits_async_clear_cache_non_absolute_root_returns_1() {
 
 #[test]
 fn rate_limits_async_missing_secret_dir_returns_1() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-async-missing-secret-dir");
     let missing = dir.join("missing");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &missing);
+    let missing_env = missing.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &missing_env);
     let options = rate_limits::RateLimitsOptions {
         async_mode: true,
         ..Default::default()
@@ -162,7 +129,7 @@ fn rate_limits_async_missing_secret_dir_returns_1() {
 
 #[test]
 fn rate_limits_async_cached_success_returns_0() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-async-cached-success");
 
     let secrets = dir.join("secrets");
@@ -178,8 +145,10 @@ fn rate_limits_async_cached_success_returns_0() {
     let cache_root = dir.join("cache-root");
     stdfs::create_dir_all(&cache_root).expect("cache root");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
+    let secrets_env = secrets.display().to_string();
+    let cache_root_env = cache_root.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _cache_root = EnvGuard::set(&lock, "ZSH_CACHE_DIR", &cache_root_env);
 
     write_cache_for_target(&alpha, 90);
     write_cache_for_target(&beta, 91);
@@ -194,7 +163,7 @@ fn rate_limits_async_cached_success_returns_0() {
 
 #[test]
 fn rate_limits_async_json_missing_access_token_uses_cache_fallback() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-async-json-cache-fallback");
 
     let secrets = dir.join("secrets");
@@ -207,8 +176,10 @@ fn rate_limits_async_json_missing_access_token_uses_cache_fallback() {
     let cache_root = dir.join("cache-root");
     stdfs::create_dir_all(&cache_root).expect("cache root");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
+    let secrets_env = secrets.display().to_string();
+    let cache_root_env = cache_root.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _cache_root = EnvGuard::set(&lock, "ZSH_CACHE_DIR", &cache_root_env);
 
     write_cache_for_target(&alpha, 77);
 
@@ -222,7 +193,7 @@ fn rate_limits_async_json_missing_access_token_uses_cache_fallback() {
 
 #[test]
 fn rate_limits_async_json_missing_access_token_without_cache_returns_1() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-async-json-no-cache-fallback");
 
     let secrets = dir.join("secrets");
@@ -232,8 +203,10 @@ fn rate_limits_async_json_missing_access_token_without_cache_returns_1() {
     let cache_root = dir.join("cache-root");
     stdfs::create_dir_all(&cache_root).expect("cache root");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
+    let secrets_env = secrets.display().to_string();
+    let cache_root_env = cache_root.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _cache_root = EnvGuard::set(&lock, "ZSH_CACHE_DIR", &cache_root_env);
 
     let options = rate_limits::RateLimitsOptions {
         async_mode: true,

--- a/crates/gemini-cli/tests/rate_limits_single.rs
+++ b/crates/gemini-cli/tests/rate_limits_single.rs
@@ -1,44 +1,9 @@
 use gemini_cli::rate_limits;
+use nils_test_support::{EnvGuard, GlobalStateLock};
 
-use std::ffi::{OsStr, OsString};
 use std::fs as stdfs;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    match LOCK.get_or_init(|| Mutex::new(())).lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: tests serialize env mutations via env_lock.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.previous.take() {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::set_var(self.key, value) };
-        } else {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
 
 struct TestDir {
     path: PathBuf,
@@ -81,7 +46,7 @@ fn write_secret(path: &Path, with_access_token: bool) {
 
 #[test]
 fn rate_limits_single_json_one_line_conflict_returns_64() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
 
     let options = rate_limits::RateLimitsOptions {
         json: true,
@@ -93,7 +58,7 @@ fn rate_limits_single_json_one_line_conflict_returns_64() {
 
 #[test]
 fn rate_limits_single_cached_json_conflict_returns_64() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
 
     let options = rate_limits::RateLimitsOptions {
         cached: true,
@@ -105,7 +70,7 @@ fn rate_limits_single_cached_json_conflict_returns_64() {
 
 #[test]
 fn rate_limits_single_cached_clear_cache_conflict_returns_64() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
 
     let options = rate_limits::RateLimitsOptions {
         cached: true,
@@ -117,14 +82,15 @@ fn rate_limits_single_cached_clear_cache_conflict_returns_64() {
 
 #[test]
 fn rate_limits_single_json_target_not_found_returns_1() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-single-target-not-found");
     let secrets = dir.join("secrets");
     stdfs::create_dir_all(&secrets).expect("secrets");
     let secrets = stdfs::canonicalize(&secrets).expect("canonical secrets");
+    let secrets_env = secrets.display().to_string();
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _default_all = EnvGuard::set("GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false");
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _default_all = EnvGuard::set(&lock, "GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false");
 
     let options = rate_limits::RateLimitsOptions {
         json: true,
@@ -136,7 +102,7 @@ fn rate_limits_single_json_target_not_found_returns_1() {
 
 #[test]
 fn rate_limits_single_cached_missing_cache_returns_1() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-single-missing-cache");
 
     let auth_file = dir.join("auth.json");
@@ -144,9 +110,11 @@ fn rate_limits_single_cached_missing_cache_returns_1() {
     let cache_root = dir.join("cache-root");
     stdfs::create_dir_all(&cache_root).expect("cache root");
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _default_all = EnvGuard::set("GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false");
+    let auth_file_env = auth_file.display().to_string();
+    let cache_root_env = cache_root.display().to_string();
+    let _auth = EnvGuard::set(&lock, "GEMINI_AUTH_FILE", &auth_file_env);
+    let _cache_root = EnvGuard::set(&lock, "ZSH_CACHE_DIR", &cache_root_env);
+    let _default_all = EnvGuard::set(&lock, "GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false");
 
     let options = rate_limits::RateLimitsOptions {
         cached: true,
@@ -157,7 +125,7 @@ fn rate_limits_single_cached_missing_cache_returns_1() {
 
 #[test]
 fn rate_limits_single_cached_success_returns_0() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-single-cached-success");
 
     let secrets = dir.join("secrets");
@@ -170,9 +138,11 @@ fn rate_limits_single_cached_success_returns_0() {
     let cache_root = dir.join("cache-root");
     stdfs::create_dir_all(&cache_root).expect("cache root");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _default_all = EnvGuard::set("GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false");
+    let secrets_env = secrets.display().to_string();
+    let cache_root_env = cache_root.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _cache_root = EnvGuard::set(&lock, "ZSH_CACHE_DIR", &cache_root_env);
+    let _default_all = EnvGuard::set(&lock, "GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false");
 
     let cache_file = rate_limits::cache_file_for_target(&secret_file).expect("cache path");
     if let Some(parent) = cache_file.parent() {
@@ -194,7 +164,7 @@ fn rate_limits_single_cached_success_returns_0() {
 
 #[test]
 fn rate_limits_single_json_missing_access_token_returns_2() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("rate-limits-single-json-missing-token");
 
     let secrets = dir.join("secrets");
@@ -202,8 +172,9 @@ fn rate_limits_single_json_missing_access_token_returns_2() {
     write_secret(&secrets.join("alpha.json"), false);
     let secrets = stdfs::canonicalize(&secrets).expect("canonical secrets");
 
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _default_all = EnvGuard::set("GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false");
+    let secrets_env = secrets.display().to_string();
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _default_all = EnvGuard::set(&lock, "GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false");
 
     let options = rate_limits::RateLimitsOptions {
         json: true,

--- a/crates/gemini-cli/tests/starship_cached.rs
+++ b/crates/gemini-cli/tests/starship_cached.rs
@@ -1,44 +1,9 @@
 use gemini_cli::{rate_limits, starship};
+use nils_test_support::{EnvGuard, GlobalStateLock};
 
-use std::ffi::{OsStr, OsString};
 use std::fs as stdfs;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    match LOCK.get_or_init(|| Mutex::new(())).lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: tests serialize env mutations via env_lock.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.previous.take() {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::set_var(self.key, value) };
-        } else {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
 
 struct TestDir {
     path: PathBuf,
@@ -103,62 +68,67 @@ fn write_auth_with_id_token(path: &Path, id_token: &str) {
     .expect("write auth with id token");
 }
 
-fn set_fast_fail_refresh_env() -> (EnvGuard, EnvGuard, EnvGuard) {
+fn set_env(lock: &GlobalStateLock, key: &str, value: impl AsRef<std::ffi::OsStr>) -> EnvGuard {
+    let value = value.as_ref().to_string_lossy().into_owned();
+    EnvGuard::set(lock, key, &value)
+}
+
+fn set_fast_fail_refresh_env(lock: &GlobalStateLock) -> (EnvGuard, EnvGuard, EnvGuard) {
     (
-        EnvGuard::set("CODE_ASSIST_ENDPOINT", "http://127.0.0.1:9/"),
-        EnvGuard::set("GEMINI_STARSHIP_CURL_CONNECT_TIMEOUT_SECONDS", "1"),
-        EnvGuard::set("GEMINI_STARSHIP_CURL_MAX_TIME_SECONDS", "1"),
+        set_env(lock, "CODE_ASSIST_ENDPOINT", "http://127.0.0.1:9/"),
+        set_env(lock, "GEMINI_STARSHIP_CURL_CONNECT_TIMEOUT_SECONDS", "1"),
+        set_env(lock, "GEMINI_STARSHIP_CURL_MAX_TIME_SECONDS", "1"),
     )
 }
 
 #[test]
 fn starship_disabled_returns_0() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let options = starship::StarshipOptions::default();
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "false");
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "false");
     assert_eq!(starship::run(&options), 0);
 }
 
 #[test]
 fn starship_is_enabled_flag_reflects_env() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let options = starship::StarshipOptions {
         is_enabled: true,
         ..Default::default()
     };
 
-    let _enabled_false = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "false");
+    let _enabled_false = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "false");
     assert_eq!(starship::run(&options), 1);
     drop(_enabled_false);
 
-    let _enabled_true = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
+    let _enabled_true = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
     assert_eq!(starship::run(&options), 0);
 }
 
 #[test]
 fn starship_invalid_ttl_returns_2() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let options = starship::StarshipOptions {
         ttl: Some("bogus".to_string()),
         ..Default::default()
     };
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
     assert_eq!(starship::run(&options), 2);
 }
 
 #[test]
 fn starship_non_stale_cache_skips_failed_refresh() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-non-stale-cache");
     let (auth_file, secrets, cache_root) = write_auth_secret(&dir);
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let _base = EnvGuard::set("CODE_ASSIST_ENDPOINT", "http://127.0.0.1:9/");
-    let _connect = EnvGuard::set("GEMINI_STARSHIP_CURL_CONNECT_TIMEOUT_SECONDS", "1");
-    let _max_time = EnvGuard::set("GEMINI_STARSHIP_CURL_MAX_TIME_SECONDS", "1");
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _secret_dir = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
+    let _cache_root = set_env(&lock, "ZSH_CACHE_DIR", &cache_root);
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let _base = set_env(&lock, "CODE_ASSIST_ENDPOINT", "http://127.0.0.1:9/");
+    let _connect = set_env(&lock, "GEMINI_STARSHIP_CURL_CONNECT_TIMEOUT_SECONDS", "1");
+    let _max_time = set_env(&lock, "GEMINI_STARSHIP_CURL_MAX_TIME_SECONDS", "1");
 
     rate_limits::write_starship_cache(
         &auth_file,
@@ -185,17 +155,17 @@ fn starship_non_stale_cache_skips_failed_refresh() {
 
 #[test]
 fn starship_stale_cache_with_failed_refresh_returns_0() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-stale-cache-failed-refresh");
     let (auth_file, secrets, cache_root) = write_auth_secret(&dir);
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let _base = EnvGuard::set("CODE_ASSIST_ENDPOINT", "http://127.0.0.1:9/");
-    let _connect = EnvGuard::set("GEMINI_STARSHIP_CURL_CONNECT_TIMEOUT_SECONDS", "1");
-    let _max_time = EnvGuard::set("GEMINI_STARSHIP_CURL_MAX_TIME_SECONDS", "1");
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _secret_dir = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
+    let _cache_root = set_env(&lock, "ZSH_CACHE_DIR", &cache_root);
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let _base = set_env(&lock, "CODE_ASSIST_ENDPOINT", "http://127.0.0.1:9/");
+    let _connect = set_env(&lock, "GEMINI_STARSHIP_CURL_CONNECT_TIMEOUT_SECONDS", "1");
+    let _max_time = set_env(&lock, "GEMINI_STARSHIP_CURL_MAX_TIME_SECONDS", "1");
 
     rate_limits::write_starship_cache(
         &auth_file,
@@ -218,8 +188,8 @@ fn starship_stale_cache_with_failed_refresh_returns_0() {
 
 #[test]
 fn starship_valid_ttl_units_parse_when_disabled() {
-    let _lock = env_lock();
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "false");
+    let lock = GlobalStateLock::new();
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "false");
 
     for ttl in ["1s", "2m", "3h", "4d", "1w", "5"] {
         let options = starship::StarshipOptions {
@@ -232,8 +202,8 @@ fn starship_valid_ttl_units_parse_when_disabled() {
 
 #[test]
 fn starship_zero_ttl_returns_2() {
-    let _lock = env_lock();
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "false");
+    let lock = GlobalStateLock::new();
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "false");
     let options = starship::StarshipOptions {
         ttl: Some("0".to_string()),
         ..Default::default()
@@ -243,61 +213,61 @@ fn starship_zero_ttl_returns_2() {
 
 #[test]
 fn starship_env_ttl_parse_when_cli_absent() {
-    let _lock = env_lock();
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "false");
-    let _ttl = EnvGuard::set("GEMINI_STARSHIP_TTL", "2m");
+    let lock = GlobalStateLock::new();
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "false");
+    let _ttl = set_env(&lock, "GEMINI_STARSHIP_TTL", "2m");
     let options = starship::StarshipOptions::default();
     assert_eq!(starship::run(&options), 0);
 }
 
 #[test]
 fn starship_missing_auth_file_returns_0() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-missing-auth-file");
     let missing = dir.join("missing.json");
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &missing);
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &missing);
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
     assert_eq!(starship::run(&starship::StarshipOptions::default()), 0);
 }
 
 #[test]
 fn starship_unresolvable_auth_path_returns_0() {
-    let _lock = env_lock();
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", "");
-    let _home = EnvGuard::set("HOME", "");
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
+    let lock = GlobalStateLock::new();
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", "");
+    let _home = set_env(&lock, "HOME", "");
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
     assert_eq!(starship::run(&starship::StarshipOptions::default()), 0);
 }
 
 #[test]
 fn starship_missing_cache_root_is_treated_as_no_cache() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-missing-cache-root");
     let (auth_file, secrets, _cache_root) = write_auth_secret(&dir);
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _home = EnvGuard::set("HOME", "");
-    let _zdot = EnvGuard::set("ZDOTDIR", "");
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", "");
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let (_base, _connect, _max_time) = set_fast_fail_refresh_env();
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _secret_dir = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
+    let _home = set_env(&lock, "HOME", "");
+    let _zdot = set_env(&lock, "ZDOTDIR", "");
+    let _cache_root = set_env(&lock, "ZSH_CACHE_DIR", "");
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let (_base, _connect, _max_time) = set_fast_fail_refresh_env(&lock);
 
     assert_eq!(starship::run(&starship::StarshipOptions::default()), 0);
 }
 
 #[test]
 fn starship_invalid_cache_entry_is_ignored() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-invalid-cache-entry");
     let (auth_file, secrets, cache_root) = write_auth_secret(&dir);
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let (_base, _connect, _max_time) = set_fast_fail_refresh_env();
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _secret_dir = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
+    let _cache_root = set_env(&lock, "ZSH_CACHE_DIR", &cache_root);
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let (_base, _connect, _max_time) = set_fast_fail_refresh_env(&lock);
 
     let cache_file = rate_limits::cache_file_for_target(&auth_file).expect("cache file");
     if let Some(parent) = cache_file.parent() {
@@ -310,15 +280,15 @@ fn starship_invalid_cache_entry_is_ignored() {
 
 #[test]
 fn starship_non_positive_fetched_at_is_treated_as_stale() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-non-positive-fetched-at");
     let (auth_file, secrets, cache_root) = write_auth_secret(&dir);
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let (_base, _connect, _max_time) = set_fast_fail_refresh_env();
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _secret_dir = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
+    let _cache_root = set_env(&lock, "ZSH_CACHE_DIR", &cache_root);
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let (_base, _connect, _max_time) = set_fast_fail_refresh_env(&lock);
 
     rate_limits::write_starship_cache(&auth_file, 0, "5h", 94, 88, 1700600000, Some(1700003600))
         .expect("write cache");
@@ -328,15 +298,15 @@ fn starship_non_positive_fetched_at_is_treated_as_stale() {
 
 #[test]
 fn starship_default_time_format_paths_execute() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-default-time-format");
     let (auth_file, secrets, cache_root) = write_auth_secret(&dir);
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let (_base, _connect, _max_time) = set_fast_fail_refresh_env();
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _secret_dir = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
+    let _cache_root = set_env(&lock, "ZSH_CACHE_DIR", &cache_root);
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let (_base, _connect, _max_time) = set_fast_fail_refresh_env(&lock);
 
     rate_limits::write_starship_cache(
         &auth_file,
@@ -364,28 +334,28 @@ fn starship_email_name_source_paths_execute() {
         "x.eyJlbWFpbCI6ImFsaWNlQGV4YW1wbGUuY29tIiwic3ViIjoiYWxpY2UtaWQifQ.y";
     const TOKEN_WITH_SUB_ONLY: &str = "x.eyJzdWIiOiJhbGljZS1pZCJ9.y";
 
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-email-name-source");
     let (auth_file, secrets, cache_root) = write_auth_secret(&dir);
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let _source = EnvGuard::set("GEMINI_STARSHIP_NAME_SOURCE", "email");
-    let (_base, _connect, _max_time) = set_fast_fail_refresh_env();
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _secret_dir = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
+    let _cache_root = set_env(&lock, "ZSH_CACHE_DIR", &cache_root);
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let _source = set_env(&lock, "GEMINI_STARSHIP_NAME_SOURCE", "email");
+    let (_base, _connect, _max_time) = set_fast_fail_refresh_env(&lock);
 
     write_auth_with_id_token(&auth_file, TOKEN_WITH_EMAIL);
     assert_eq!(starship::run(&starship::StarshipOptions::default()), 0);
 
     write_auth_with_id_token(&auth_file, TOKEN_WITH_SUB_ONLY);
-    let _fallback = EnvGuard::set("GEMINI_STARSHIP_SHOW_FALLBACK_NAME_ENABLED", "true");
-    let _show_full = EnvGuard::set("GEMINI_STARSHIP_SHOW_FULL_EMAIL_ENABLED", "true");
+    let _fallback = set_env(&lock, "GEMINI_STARSHIP_SHOW_FALLBACK_NAME_ENABLED", "true");
+    let _show_full = set_env(&lock, "GEMINI_STARSHIP_SHOW_FULL_EMAIL_ENABLED", "true");
     assert_eq!(starship::run(&starship::StarshipOptions::default()), 0);
     drop(_show_full);
     drop(_fallback);
 
-    let _fallback_off = EnvGuard::set("GEMINI_STARSHIP_SHOW_FALLBACK_NAME_ENABLED", "false");
+    let _fallback_off = set_env(&lock, "GEMINI_STARSHIP_SHOW_FALLBACK_NAME_ENABLED", "false");
     assert_eq!(starship::run(&starship::StarshipOptions::default()), 0);
 }
 
@@ -393,7 +363,7 @@ fn starship_email_name_source_paths_execute() {
 fn starship_secret_name_fallback_paths_execute() {
     const TOKEN_WITH_SUB_ONLY: &str = "x.eyJzdWIiOiJhbGljZS1pZCJ9.y";
 
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-secret-name-fallback");
     let auth_file = dir.join("auth.json");
     write_auth_with_id_token(&auth_file, TOKEN_WITH_SUB_ONLY);
@@ -403,16 +373,16 @@ fn starship_secret_name_fallback_paths_execute() {
     let cache_root = dir.join("cache-root");
     stdfs::create_dir_all(&cache_root).expect("cache root");
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let (_base, _connect, _max_time) = set_fast_fail_refresh_env();
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", &auth_file);
+    let _secret_dir = set_env(&lock, "GEMINI_SECRET_DIR", &secrets);
+    let _cache_root = set_env(&lock, "ZSH_CACHE_DIR", &cache_root);
+    let _enabled = set_env(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let (_base, _connect, _max_time) = set_fast_fail_refresh_env(&lock);
 
-    let _fallback_on = EnvGuard::set("GEMINI_STARSHIP_SHOW_FALLBACK_NAME_ENABLED", "true");
+    let _fallback_on = set_env(&lock, "GEMINI_STARSHIP_SHOW_FALLBACK_NAME_ENABLED", "true");
     assert_eq!(starship::run(&starship::StarshipOptions::default()), 0);
     drop(_fallback_on);
 
-    let _fallback_off = EnvGuard::set("GEMINI_STARSHIP_SHOW_FALLBACK_NAME_ENABLED", "false");
+    let _fallback_off = set_env(&lock, "GEMINI_STARSHIP_SHOW_FALLBACK_NAME_ENABLED", "false");
     assert_eq!(starship::run(&starship::StarshipOptions::default()), 0);
 }

--- a/crates/gemini-cli/tests/starship_refresh.rs
+++ b/crates/gemini-cli/tests/starship_refresh.rs
@@ -1,47 +1,12 @@
 use gemini_cli::{rate_limits, starship};
+use nils_test_support::{EnvGuard, GlobalStateLock};
 
-use std::ffi::{OsStr, OsString};
 use std::fs as stdfs;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    match LOCK.get_or_init(|| Mutex::new(())).lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: tests serialize env mutations via env_lock.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.previous.take() {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::set_var(self.key, value) };
-        } else {
-            // SAFETY: tests serialize env mutations via env_lock.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
 
 struct TestDir {
     path: PathBuf,
@@ -151,19 +116,22 @@ fn spawn_usage_server() -> (String, thread::JoinHandle<usize>) {
 
 #[test]
 fn starship_refresh_updates_cache() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-refresh-updates-cache");
     let (auth_file, secrets, cache_root) = write_auth_secret(&dir);
 
     let (base_url, server) = spawn_usage_server();
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let _base = EnvGuard::set("CODE_ASSIST_ENDPOINT", &base_url);
-    let _connect = EnvGuard::set("GEMINI_STARSHIP_CURL_CONNECT_TIMEOUT_SECONDS", "1");
-    let _max_time = EnvGuard::set("GEMINI_STARSHIP_CURL_MAX_TIME_SECONDS", "3");
+    let auth_file_env = auth_file.display().to_string();
+    let secrets_env = secrets.display().to_string();
+    let cache_root_env = cache_root.display().to_string();
+    let _auth = EnvGuard::set(&lock, "GEMINI_AUTH_FILE", &auth_file_env);
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _cache_root = EnvGuard::set(&lock, "ZSH_CACHE_DIR", &cache_root_env);
+    let _enabled = EnvGuard::set(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let _base = EnvGuard::set(&lock, "CODE_ASSIST_ENDPOINT", &base_url);
+    let _connect = EnvGuard::set(&lock, "GEMINI_STARSHIP_CURL_CONNECT_TIMEOUT_SECONDS", "1");
+    let _max_time = EnvGuard::set(&lock, "GEMINI_STARSHIP_CURL_MAX_TIME_SECONDS", "3");
 
     let options = starship::StarshipOptions {
         refresh: true,
@@ -181,19 +149,22 @@ fn starship_refresh_updates_cache() {
 
 #[test]
 fn starship_stale_cached_entry_refreshes_on_run() {
-    let _lock = env_lock();
+    let lock = GlobalStateLock::new();
     let dir = TestDir::new("starship-stale-cache-refreshes");
     let (auth_file, secrets, cache_root) = write_auth_secret(&dir);
 
     let (base_url, server) = spawn_usage_server();
 
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file);
-    let _secret_dir = EnvGuard::set("GEMINI_SECRET_DIR", &secrets);
-    let _cache_root = EnvGuard::set("ZSH_CACHE_DIR", &cache_root);
-    let _enabled = EnvGuard::set("GEMINI_STARSHIP_ENABLED", "true");
-    let _base = EnvGuard::set("CODE_ASSIST_ENDPOINT", &base_url);
-    let _connect = EnvGuard::set("GEMINI_STARSHIP_CURL_CONNECT_TIMEOUT_SECONDS", "1");
-    let _max_time = EnvGuard::set("GEMINI_STARSHIP_CURL_MAX_TIME_SECONDS", "3");
+    let auth_file_env = auth_file.display().to_string();
+    let secrets_env = secrets.display().to_string();
+    let cache_root_env = cache_root.display().to_string();
+    let _auth = EnvGuard::set(&lock, "GEMINI_AUTH_FILE", &auth_file_env);
+    let _secret_dir = EnvGuard::set(&lock, "GEMINI_SECRET_DIR", &secrets_env);
+    let _cache_root = EnvGuard::set(&lock, "ZSH_CACHE_DIR", &cache_root_env);
+    let _enabled = EnvGuard::set(&lock, "GEMINI_STARSHIP_ENABLED", "true");
+    let _base = EnvGuard::set(&lock, "CODE_ASSIST_ENDPOINT", &base_url);
+    let _connect = EnvGuard::set(&lock, "GEMINI_STARSHIP_CURL_CONNECT_TIMEOUT_SECONDS", "1");
+    let _max_time = EnvGuard::set(&lock, "GEMINI_STARSHIP_CURL_MAX_TIME_SECONDS", "3");
 
     let stale_fetched = now_epoch().saturating_sub(10).max(1);
     rate_limits::write_starship_cache(


### PR DESCRIPTION
# Refactor gemini test env guards to use nils-test-support

## Summary
This change removes duplicated per-file environment mutation helpers in `nils-gemini-cli` tests and standardizes those tests on `nils-test-support`'s `GlobalStateLock` and `EnvGuard` utilities to improve maintainability and consistency.

## Changes
- Replaced custom `env_lock` + local `EnvGuard` implementations in gemini test files with `nils_test_support::{GlobalStateLock, EnvGuard}`.
- Added thin `set_env` adapters where tests pass `Path`/`OsStr` values, so call sites remain readable while still using shared test support.
- Updated `crates/gemini-cli/src/rate_limits/mod.rs` unit tests to use shared env guards instead of local unsafe env mutation helpers.

## Testing
- `cargo fmt --all -- --check` (pass)
- `cargo clippy -p nils-gemini-cli --all-targets -- -D warnings` (pass)
- `cargo test -p nils-gemini-cli --test rate_limits_single --test rate_limits_all --test rate_limits_async --test diag_json_contract --test starship_cached --test starship_refresh --test agent_exec --test auth_auto_refresh` (pass)
- `cargo test -p nils-gemini-cli` (fails: 7 existing `auth::login` unit tests; includes `cat: command not found` in stubbed login flows)

## Risk / Notes
- Runtime behavior is unchanged; scope is test code refactoring for shared helper adoption.
- One unit-test module (`rate_limits::tests`) now uses `nils-test-support` env guards for consistency.
