### PR TITLE
Refactor shared helper reuse for test and git checks

### DIFF
--- a/crates/gemini-cli/tests/agent_commit.rs
+++ b/crates/gemini-cli/tests/agent_commit.rs
@@ -1,84 +1,13 @@
 use gemini_cli::agent;
 use nils_common::process as shared_process;
+use nils_test_support::{CwdGuard, EnvGuard, GlobalStateLock, StubBinDir, prepend_path};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
-use std::sync::{Mutex, OnceLock};
-use std::time::{SystemTime, UNIX_EPOCH};
 
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("env lock")
-}
-
-struct EnvGuard {
-    key: &'static str,
-    old: Option<std::ffi::OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-        let old = std::env::var_os(key);
-        // SAFETY: tests mutate process env with a global lock.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, old }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.old.take() {
-            // SAFETY: tests mutate process env with a global lock.
-            unsafe { std::env::set_var(self.key, value) };
-        } else {
-            // SAFETY: tests mutate process env with a global lock.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
-
-struct CwdGuard {
-    old: PathBuf,
-}
-
-impl CwdGuard {
-    fn enter(path: &Path) -> Self {
-        let old = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(path).expect("set cwd");
-        Self { old }
-    }
-}
-
-impl Drop for CwdGuard {
-    fn drop(&mut self) {
-        let _ = std::env::set_current_dir(&self.old);
-    }
-}
-
-fn temp_dir(label: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    let path = std::env::temp_dir().join(format!(
-        "nils-gemini-cli-{label}-{}-{nanos}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&path);
-    fs::create_dir_all(&path).expect("temp dir");
-    path
-}
-
-#[cfg(unix)]
-fn write_executable(path: &Path, content: &str) {
-    use std::os::unix::fs::PermissionsExt;
-
-    fs::write(path, content).expect("write executable");
-    let mut perms = fs::metadata(path).expect("metadata").permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(path, perms).expect("chmod");
+fn set_env(lock: &GlobalStateLock, key: &str, value: impl AsRef<std::ffi::OsStr>) -> EnvGuard {
+    let value = value.as_ref().to_string_lossy().into_owned();
+    EnvGuard::set(lock, key, &value)
 }
 
 fn real_git_path() -> String {
@@ -87,21 +16,21 @@ fn real_git_path() -> String {
         .unwrap_or_else(|| panic!("git not found in PATH for tests"))
 }
 
-fn write_stub_git(dir: &Path) {
+fn write_stub_git(stubs: &StubBinDir) {
     let git = real_git_path();
     let script = format!(
         r#"#!/bin/sh
 exec "{git}" "$@"
 "#
     );
-    write_executable(&dir.join("git"), &script);
+    stubs.write_exe("git", &script);
 }
 
-fn write_stub_semantic_commit(dir: &Path) {
-    write_executable(&dir.join("semantic-commit"), "#!/bin/sh\nexit 0\n");
+fn write_stub_semantic_commit(stubs: &StubBinDir) {
+    stubs.write_exe("semantic-commit", "#!/bin/sh\nexit 0\n");
 }
 
-fn write_stub_gemini(dir: &Path) {
+fn write_stub_gemini(stubs: &StubBinDir) {
     let script = r#"#!/bin/sh
 set -eu
 out_dir="${GEMINI_STUB_OUT_DIR:?missing GEMINI_STUB_OUT_DIR}"
@@ -111,7 +40,7 @@ for arg in "$@"; do
   i=$((i+1))
 done
 "#;
-    write_executable(&dir.join("gemini"), script);
+    stubs.write_exe("gemini", script);
 }
 
 fn init_repo(path: &Path) {
@@ -144,8 +73,8 @@ fn init_repo(path: &Path) {
 
 #[test]
 fn agent_commit_returns_1_when_git_missing() {
-    let _lock = env_lock();
-    let _path = EnvGuard::set("PATH", "");
+    let lock = GlobalStateLock::new();
+    let _path = EnvGuard::set(&lock, "PATH", "");
 
     let options = agent::commit::CommitOptions {
         push: false,
@@ -158,14 +87,14 @@ fn agent_commit_returns_1_when_git_missing() {
 
 #[test]
 fn agent_commit_semantic_mode_executes_gemini_with_template_and_push_note() {
-    let _lock = env_lock();
-    let dir = temp_dir("agent-commit-semantic");
-    let repo = dir.join("repo");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let repo = dir.path().join("repo");
     fs::create_dir_all(&repo).expect("repo dir");
     init_repo(&repo);
     fs::write(repo.join("a.txt"), "hello").expect("write file");
 
-    let zdotdir = dir.join("zdotdir");
+    let zdotdir = dir.path().join("zdotdir");
     let prompts_dir = zdotdir.join("prompts");
     fs::create_dir_all(&prompts_dir).expect("prompts dir");
     fs::write(
@@ -174,22 +103,21 @@ fn agent_commit_semantic_mode_executes_gemini_with_template_and_push_note() {
     )
     .expect("write prompt template");
 
-    let stub_dir = dir.join("bin");
-    fs::create_dir_all(&stub_dir).expect("stub dir");
-    write_stub_git(&stub_dir);
-    write_stub_semantic_commit(&stub_dir);
-    write_stub_gemini(&stub_dir);
+    let stubs = StubBinDir::new();
+    write_stub_git(&stubs);
+    write_stub_semantic_commit(&stubs);
+    write_stub_gemini(&stubs);
 
-    let out_dir = dir.join("out");
+    let out_dir = dir.path().join("out");
     fs::create_dir_all(&out_dir).expect("out dir");
 
-    let _path = EnvGuard::set("PATH", stub_dir.as_os_str());
-    let _danger = EnvGuard::set("GEMINI_ALLOW_DANGEROUS_ENABLED", "true");
-    let _model = EnvGuard::set("GEMINI_CLI_MODEL", "m-test");
-    let _reasoning = EnvGuard::set("GEMINI_CLI_REASONING", "low");
-    let _zdotdir = EnvGuard::set("ZDOTDIR", zdotdir.as_os_str());
-    let _out_dir = EnvGuard::set("GEMINI_STUB_OUT_DIR", out_dir.as_os_str());
-    let _cwd = CwdGuard::enter(&repo);
+    let _path = prepend_path(&lock, stubs.path());
+    let _danger = EnvGuard::set(&lock, "GEMINI_ALLOW_DANGEROUS_ENABLED", "true");
+    let _model = EnvGuard::set(&lock, "GEMINI_CLI_MODEL", "m-test");
+    let _reasoning = EnvGuard::set(&lock, "GEMINI_CLI_REASONING", "low");
+    let _zdotdir = set_env(&lock, "ZDOTDIR", zdotdir.as_os_str());
+    let _out_dir = set_env(&lock, "GEMINI_STUB_OUT_DIR", out_dir.as_os_str());
+    let _cwd = CwdGuard::set(&lock, &repo).expect("set cwd");
 
     let options = agent::commit::CommitOptions {
         push: true,
@@ -207,6 +135,4 @@ fn agent_commit_semantic_mode_executes_gemini_with_template_and_push_note() {
 
     let arg2 = fs::read_to_string(out_dir.join("arg-2")).expect("model");
     assert_eq!(arg2, "m-test");
-
-    let _ = fs::remove_dir_all(&dir);
 }

--- a/crates/gemini-cli/tests/auth_login.rs
+++ b/crates/gemini-cli/tests/auth_login.rs
@@ -1,91 +1,10 @@
 use gemini_cli::auth;
-
+use nils_test_support::{EnvGuard, GlobalStateLock, StubBinDir, prepend_path};
 use std::fs;
-use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
 
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    match LOCK.get_or_init(|| Mutex::new(())).lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-struct TempDir {
-    path: PathBuf,
-}
-
-impl TempDir {
-    fn new(prefix: &str) -> Self {
-        let mut path = std::env::temp_dir();
-        let unique = format!(
-            "{prefix}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|duration| duration.as_secs())
-                .unwrap_or(0)
-        );
-        path.push(unique);
-        let _ = fs::remove_dir_all(&path);
-        fs::create_dir_all(&path).expect("temp dir");
-        Self { path }
-    }
-
-    fn path(&self) -> &PathBuf {
-        &self.path
-    }
-}
-
-impl Drop for TempDir {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.path);
-    }
-}
-
-struct EnvGuard {
-    key: String,
-    old: Option<std::ffi::OsString>,
-}
-
-impl EnvGuard {
-    fn set(key: &str, value: &str) -> Self {
-        let old = std::env::var_os(key);
-        // SAFETY: scoped test env mutation.
-        unsafe { std::env::set_var(key, value) };
-        Self {
-            key: key.to_string(),
-            old,
-        }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.old.take() {
-            // SAFETY: scoped test env restore.
-            unsafe { std::env::set_var(&self.key, value) };
-        } else {
-            // SAFETY: scoped test env restore.
-            unsafe { std::env::remove_var(&self.key) };
-        }
-    }
-}
-
-#[cfg(unix)]
-fn write_exe(path: &std::path::Path, content: &str) {
-    use std::os::unix::fs::PermissionsExt;
-
-    fs::write(path, content).expect("write exe");
-    let mut perms = fs::metadata(path).expect("meta").permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(path, perms).expect("chmod");
-}
-
-#[cfg(not(unix))]
-fn write_exe(path: &std::path::Path, content: &str) {
-    fs::write(path, content).expect("write exe");
+fn set_env(lock: &GlobalStateLock, key: &str, value: impl AsRef<std::ffi::OsStr>) -> EnvGuard {
+    let value = value.as_ref().to_string_lossy().into_owned();
+    EnvGuard::set(lock, key, &value)
 }
 
 fn curl_stub_script() -> &'static str {
@@ -120,38 +39,35 @@ exit 0
 
 #[test]
 fn auth_login_rejects_conflicting_flags() {
-    let _lock = env_lock();
+    let _lock = GlobalStateLock::new();
     let code = auth::login::run_with_json(true, true, false);
     assert_eq!(code, 64);
 }
 
 #[test]
 fn auth_login_api_key_requires_env() {
-    let _lock = env_lock();
-    let _api = EnvGuard::set("GEMINI_API_KEY", "");
-    let _google = EnvGuard::set("GOOGLE_API_KEY", "");
+    let lock = GlobalStateLock::new();
+    let _api = EnvGuard::set(&lock, "GEMINI_API_KEY", "");
+    let _google = EnvGuard::set(&lock, "GOOGLE_API_KEY", "");
     let code = auth::login::run_with_json(true, false, false);
     assert_eq!(code, 64);
 }
 
 #[test]
 fn auth_login_api_key_succeeds_with_env() {
-    let _lock = env_lock();
-    let _api = EnvGuard::set("GEMINI_API_KEY", "dummy-key");
+    let lock = GlobalStateLock::new();
+    let _api = EnvGuard::set(&lock, "GEMINI_API_KEY", "dummy-key");
     let code = auth::login::run_with_json(true, false, false);
     assert_eq!(code, 0);
 }
 
 #[test]
 fn auth_login_browser_and_device_code_use_userinfo_flow() {
-    let _lock = env_lock();
-    let dir = TempDir::new("gemini-auth-login-browser");
-    let bin_dir = dir.path().join("bin");
-    fs::create_dir_all(&bin_dir).expect("bin dir");
-    let curl_path = bin_dir.join("curl");
-    let gemini_path = bin_dir.join("gemini");
-    write_exe(&curl_path, curl_stub_script());
-    write_exe(&gemini_path, gemini_stub_script());
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let stubs = StubBinDir::new();
+    stubs.write_exe("curl", curl_stub_script());
+    stubs.write_exe("gemini", gemini_stub_script());
 
     let auth_file = dir.path().join("oauth_creds.json");
     fs::write(
@@ -160,13 +76,8 @@ fn auth_login_browser_and_device_code_use_userinfo_flow() {
     )
     .expect("write auth");
 
-    let path = format!(
-        "{}:{}",
-        bin_dir.display(),
-        std::env::var("PATH").unwrap_or_default()
-    );
-    let _path = EnvGuard::set("PATH", &path);
-    let _auth = EnvGuard::set("GEMINI_AUTH_FILE", &auth_file.display().to_string());
+    let _path = prepend_path(&lock, stubs.path());
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", auth_file.as_os_str());
 
     assert_eq!(auth::login::run_with_json(false, false, false), 0);
     assert_eq!(auth::login::run_with_json(false, true, false), 0);

--- a/crates/nils-common/src/git.rs
+++ b/crates/nils-common/src/git.rs
@@ -141,6 +141,16 @@ pub fn is_inside_work_tree_in(cwd: &Path) -> io::Result<bool> {
     Ok(run_status_quiet_in(cwd, &["rev-parse", "--is-inside-work-tree"])?.success())
 }
 
+pub fn has_staged_changes() -> io::Result<bool> {
+    let status = run_status_quiet(&["diff", "--cached", "--quiet", "--"])?;
+    Ok(has_staged_changes_from_status(status))
+}
+
+pub fn has_staged_changes_in(cwd: &Path) -> io::Result<bool> {
+    let status = run_status_quiet_in(cwd, &["diff", "--cached", "--quiet", "--"])?;
+    Ok(has_staged_changes_from_status(status))
+}
+
 pub fn is_git_repo() -> io::Result<bool> {
     Ok(run_status_quiet(&["rev-parse", "--git-dir"])?.success())
 }
@@ -230,6 +240,14 @@ fn rev_parse_args<'a>(args: &'a [&'a str]) -> Vec<&'a str> {
     full.push("rev-parse");
     full.extend_from_slice(args);
     full
+}
+
+fn has_staged_changes_from_status(status: ExitStatus) -> bool {
+    match status.code() {
+        Some(0) => false,
+        Some(1) => true,
+        _ => !status.success(),
+    }
 }
 
 fn trimmed_stdout_if_success(output: &Output) -> Option<String> {
@@ -338,10 +356,23 @@ mod tests {
 
         assert!(is_git_repo().expect("is_git_repo"));
         assert!(is_inside_work_tree().expect("is_inside_work_tree"));
+        assert!(!has_staged_changes().expect("has_staged_changes"));
         assert_eq!(require_repo(), Ok(()));
         assert_eq!(require_work_tree(), Ok(()));
         assert_eq!(repo_root().expect("repo_root"), Some(root.into()));
         assert_eq!(rev_parse(&["HEAD"]).expect("rev_parse"), Some(head));
+    }
+
+    #[test]
+    fn has_staged_changes_in_reports_index_state() {
+        let repo = init_repo_with(InitRepoOptions::new().with_initial_commit());
+
+        assert!(!has_staged_changes_in(repo.path()).expect("no staged changes"));
+
+        std::fs::write(repo.path().join("a.txt"), "hello\n").expect("write staged file");
+        run_git(repo.path(), &["add", "a.txt"]);
+
+        assert!(has_staged_changes_in(repo.path()).expect("staged changes present"));
     }
 
     #[test]

--- a/crates/semantic-commit/src/git.rs
+++ b/crates/semantic-commit/src/git.rs
@@ -1,46 +1,21 @@
-use nils_common::process;
+use nils_common::{git as shared_git, process};
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 pub fn command_exists(program: &str) -> bool {
     process::cmd_exists(program)
 }
 
 pub fn is_inside_work_tree(repo: Option<&Path>) -> bool {
-    let output = git_command(repo)
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .output();
-
-    match output {
-        Ok(output) if output.status.success() => {
-            String::from_utf8_lossy(&output.stdout).trim() == "true"
-        }
-        _ => false,
+    match repo {
+        Some(repo) => shared_git::is_inside_work_tree_in(repo),
+        None => shared_git::is_inside_work_tree(),
     }
+    .unwrap_or(false)
 }
 
 pub fn has_staged_changes(repo: Option<&Path>) -> anyhow::Result<bool> {
-    let status = git_command(repo)
-        .args(["diff", "--cached", "--quiet", "--"])
-        .status()?;
-
-    match status.code() {
-        Some(0) => Ok(false),
-        Some(1) => Ok(true),
-        _ => Ok(!status.success()),
-    }
-}
-
-fn git_command(repo: Option<&Path>) -> Command {
-    let mut command = Command::new("git");
-    if let Some(repo) = repo {
-        command.arg("-C").arg(repo);
-    }
-
-    command
-        .env("GIT_PAGER", "cat")
-        .env("PAGER", "cat")
-        .stdin(Stdio::null());
-
-    command
+    Ok(match repo {
+        Some(repo) => shared_git::has_staged_changes_in(repo)?,
+        None => shared_git::has_staged_changes()?,
+    })
 }


### PR DESCRIPTION
# Refactor shared helper reuse for test and git checks

## Summary
Refactor duplicated test/process-git helper logic to reuse the workspace shared foundations crates. This change replaces ad-hoc environment/stub helpers in `gemini-cli` tests with `nils-test-support`, and routes `semantic-commit` staged/work-tree git probes through `nils-common::git` by adding shared staged-change helpers.

## Changes
- Replace custom env lock, env guard, cwd guard, temp dir, and executable stub helpers in `crates/gemini-cli/tests/auth_login.rs` with `nils-test-support::{GlobalStateLock, EnvGuard, StubBinDir, prepend_path}`.
- Replace duplicated test guards/stub-bin wiring in `crates/gemini-cli/tests/agent_commit.rs` with `nils-test-support::{GlobalStateLock, EnvGuard, CwdGuard, StubBinDir, prepend_path}`.
- Add `nils-common::git::{has_staged_changes, has_staged_changes_in}` and unit coverage for staged index detection semantics.
- Simplify `crates/semantic-commit/src/git.rs` to delegate shared git work-tree and staged-change checks to `nils-common::git`.

## Testing
- `cargo test -p nils-gemini-cli --test auth_login --test agent_commit` (pass)
- `cargo test -p nils-common has_staged_changes_in_reports_index_state --lib` (pass)
- `cargo test -p nils-semantic-commit --test commit --test staged_context` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, 85.57%)

## Risk / Notes
- Intended as behavior-preserving maintenance refactor; observable CLI output/exit behavior should remain unchanged.
- `semantic-commit` keeps the existing staged-change exit-status interpretation (0=false, 1=true, other non-success=true), now centralized in `nils-common`.
