### PR TITLE
Surface shell completion adapter load failures

### DIFF
--- a/completions/bash/completion-adapter-common.bash
+++ b/completions/bash/completion-adapter-common.bash
@@ -18,6 +18,33 @@ _nils_cli_completion_common_fail_closed_bash() {
   return 0
 }
 
+_nils_cli_completion_common_warn_once_bash() {
+  local state_var="${1-}"
+  local cli_bin="${2-}"
+  local reason="${3-}"
+  local diag_var=''
+
+  if [[ -n "$state_var" ]]; then
+    diag_var="${state_var}_DIAG_SHOWN"
+    if [[ "${!diag_var:-0}" == "1" ]]; then
+      return 0
+    fi
+    printf -v "$diag_var" '%s' '1'
+  fi
+
+  local msg='nils-cli completion (bash): generated completion load failed'
+  if [[ -n "$cli_bin" ]]; then
+    msg+=" for '${cli_bin}'"
+  fi
+  msg+='; fail-closed mode active'
+  if [[ -n "$reason" ]]; then
+    msg+=" (${reason})"
+  fi
+
+  printf '%s\n' "$msg" >&2
+  return 0
+}
+
 _nils_cli_completion_common_has_word_bash() {
   local needle="$1"
   shift
@@ -38,6 +65,7 @@ _nils_cli_completion_common_load_generated_bash() {
   local strip_end_regex="${6-}"
 
   if [[ -z "$state_var" || -z "$generated_fn" || -z "$cli_bin" || -z "$generated_symbol" ]]; then
+    _nils_cli_completion_common_warn_once_bash '' "${cli_bin}" 'invalid helper arguments'
     _nils_cli_completion_common_fail_closed_bash
     return 1
   fi
@@ -47,13 +75,23 @@ _nils_cli_completion_common_load_generated_bash() {
     declare -F "$generated_fn" >/dev/null 2>&1 && return 0
     printf -v "$state_var" '%s' '0'
   elif [[ "$state" == "-1" ]]; then
+    _nils_cli_completion_common_warn_once_bash \
+      "$state_var" \
+      "$cli_bin" \
+      'cached previous load failure; restart shell after fixing the CLI'
     _nils_cli_completion_common_fail_closed_bash
     return 1
   fi
 
   local script=''
-  script="$(command "$cli_bin" completion bash 2>/dev/null)" || {
+  local cmd_rc=0
+  script="$(command "$cli_bin" completion bash)" || {
+    cmd_rc=$?
     printf -v "$state_var" '%s' '-1'
+    _nils_cli_completion_common_warn_once_bash \
+      "$state_var" \
+      "$cli_bin" \
+      "command '${cli_bin} completion bash' failed (exit ${cmd_rc})"
     _nils_cli_completion_common_fail_closed_bash
     return 1
   }
@@ -63,6 +101,10 @@ _nils_cli_completion_common_load_generated_bash() {
   if [[ -n "$strip_begin_regex" && -n "$strip_end_regex" ]]; then
     script="$(printf '%s\n' "$script" | sed "/${strip_begin_regex}/,/${strip_end_regex}/d")" || {
       printf -v "$state_var" '%s' '-1'
+      _nils_cli_completion_common_warn_once_bash \
+        "$state_var" \
+        "$cli_bin" \
+        'failed to post-process generated bash completion script'
       _nils_cli_completion_common_fail_closed_bash
       return 1
     }
@@ -70,17 +112,26 @@ _nils_cli_completion_common_load_generated_bash() {
 
   eval "$script" || {
     printf -v "$state_var" '%s' '-1'
+    _nils_cli_completion_common_warn_once_bash \
+      "$state_var" \
+      "$cli_bin" \
+      'failed to eval generated bash completion script'
     _nils_cli_completion_common_fail_closed_bash
     return 1
   }
 
   declare -F "$generated_fn" >/dev/null 2>&1 || {
     printf -v "$state_var" '%s' '-1'
+    _nils_cli_completion_common_warn_once_bash \
+      "$state_var" \
+      "$cli_bin" \
+      "generated function '${generated_fn}' was not defined"
     _nils_cli_completion_common_fail_closed_bash
     return 1
   }
 
   printf -v "$state_var" '%s' '1'
+  printf -v "${state_var}_DIAG_SHOWN" '%s' '0'
   return 0
 }
 

--- a/completions/zsh/_completion-adapter-common.zsh
+++ b/completions/zsh/_completion-adapter-common.zsh
@@ -17,6 +17,35 @@ _nils_cli_completion_common_fail_closed_zsh() {
   return 1
 }
 
+_nils_cli_completion_common_warn_once_zsh() {
+  emulate -L zsh
+
+  local state_var="${1-}"
+  local cli_bin="${2-}"
+  local reason="${3-}"
+  local diag_var=''
+
+  if [[ -n "$state_var" ]]; then
+    diag_var="${state_var}_DIAG_SHOWN"
+    if [[ "${(P)diag_var-0}" == "1" ]]; then
+      return 0
+    fi
+    typeset -g "${diag_var}=1"
+  fi
+
+  local msg='nils-cli completion (zsh): generated completion load failed'
+  if [[ -n "$cli_bin" ]]; then
+    msg="${msg} for '${cli_bin}'"
+  fi
+  msg="${msg}; fail-closed mode active"
+  if [[ -n "$reason" ]]; then
+    msg="${msg} (${reason})"
+  fi
+
+  print -u2 -r -- "$msg"
+  return 0
+}
+
 _nils_cli_completion_common_load_generated_zsh() {
   emulate -L zsh -o extendedglob
 
@@ -28,6 +57,7 @@ _nils_cli_completion_common_load_generated_zsh() {
   local strip_end_regex="${6-}"
 
   if [[ -z "$state_var" || -z "$generated_fn" || -z "$cli_bin" || -z "$generated_symbol" ]]; then
+    _nils_cli_completion_common_warn_once_zsh '' "${cli_bin}" 'invalid helper arguments'
     _nils_cli_completion_common_fail_closed_zsh
     return 1
   fi
@@ -37,13 +67,23 @@ _nils_cli_completion_common_load_generated_zsh() {
     (( $+functions[$generated_fn] )) && return 0
     typeset -g "${state_var}=0"
   elif [[ "$state" == "-1" ]]; then
+    _nils_cli_completion_common_warn_once_zsh \
+      "$state_var" \
+      "$cli_bin" \
+      'cached previous load failure; restart shell after fixing the CLI'
     _nils_cli_completion_common_fail_closed_zsh
     return 1
   fi
 
   local script=''
-  script="$(command "$cli_bin" completion zsh 2>/dev/null)" || {
+  local cmd_rc=0
+  script="$(command "$cli_bin" completion zsh)" || {
+    cmd_rc=$?
     typeset -g "${state_var}=-1"
+    _nils_cli_completion_common_warn_once_zsh \
+      "$state_var" \
+      "$cli_bin" \
+      "command '${cli_bin} completion zsh' failed (exit ${cmd_rc})"
     _nils_cli_completion_common_fail_closed_zsh
     return 1
   }
@@ -53,6 +93,10 @@ _nils_cli_completion_common_load_generated_zsh() {
   if [[ -n "$strip_begin_regex" && -n "$strip_end_regex" ]]; then
     script="$(printf '%s\n' "$script" | sed "/${strip_begin_regex}/,/${strip_end_regex}/d")" || {
       typeset -g "${state_var}=-1"
+      _nils_cli_completion_common_warn_once_zsh \
+        "$state_var" \
+        "$cli_bin" \
+        'failed to post-process generated zsh completion script'
       _nils_cli_completion_common_fail_closed_zsh
       return 1
     }
@@ -60,17 +104,26 @@ _nils_cli_completion_common_load_generated_zsh() {
 
   eval "$script" || {
     typeset -g "${state_var}=-1"
+    _nils_cli_completion_common_warn_once_zsh \
+      "$state_var" \
+      "$cli_bin" \
+      'failed to eval generated zsh completion script'
     _nils_cli_completion_common_fail_closed_zsh
     return 1
   }
 
   if (( ! $+functions[$generated_fn] )); then
     typeset -g "${state_var}=-1"
+    _nils_cli_completion_common_warn_once_zsh \
+      "$state_var" \
+      "$cli_bin" \
+      "generated function '${generated_fn}' was not defined"
     _nils_cli_completion_common_fail_closed_zsh
     return 1
   fi
 
   typeset -g "${state_var}=1"
+  typeset -g "${state_var}_DIAG_SHOWN=0"
   return 0
 }
 

--- a/tests/completion/adapter_error_visibility.sh
+++ b/tests/completion/adapter_error_visibility.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ZSH_HELPER="$REPO_ROOT/completions/zsh/_completion-adapter-common.zsh"
+BASH_HELPER="$REPO_ROOT/completions/bash/completion-adapter-common.bash"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local context="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail "$context missing '$needle'"
+  fi
+}
+
+assert_file_line_count() {
+  local file="$1"
+  local expected="$2"
+  local actual=0
+  if [[ -f "$file" ]]; then
+    actual="$(wc -l < "$file" | tr -d '[:space:]')"
+  fi
+  [[ "$actual" == "$expected" ]] || fail "expected $expected calls in $file, got $actual"
+}
+
+[[ -f "$ZSH_HELPER" ]] || fail "missing zsh helper: $ZSH_HELPER"
+[[ -f "$BASH_HELPER" ]] || fail "missing bash helper: $BASH_HELPER"
+command -v zsh >/dev/null 2>&1 || fail "zsh not found"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat >"$TMP_DIR/fake-zsh-cli" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_CLI_CALL_MARKER:-call}" >> "${FAKE_CLI_COUNT_FILE:?}"
+printf 'fake-zsh-cli simulated failure (%s %s)\n' "${1-}" "${2-}" >&2
+exit 23
+EOF
+chmod +x "$TMP_DIR/fake-zsh-cli"
+
+cat >"$TMP_DIR/fake-bash-cli" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_CLI_CALL_MARKER:-call}" >> "${FAKE_CLI_COUNT_FILE:?}"
+printf 'fake-bash-cli simulated failure (%s %s)\n' "${1-}" "${2-}" >&2
+exit 29
+EOF
+chmod +x "$TMP_DIR/fake-bash-cli"
+
+ZSH_COUNT_FILE="$TMP_DIR/zsh.count"
+ZSH_STDOUT_FILE="$TMP_DIR/zsh.stdout"
+ZSH_STDERR_FILE="$TMP_DIR/zsh.stderr"
+
+FAKE_CLI_COUNT_FILE="$ZSH_COUNT_FILE" PATH="$TMP_DIR:$PATH" \
+  zsh -f -c '
+source "$1"
+typeset -gi ZSH_STATE=0
+_nils_cli_completion_common_load_generated_zsh \
+  "ZSH_STATE" "_nils_test_generated_zsh" "fake-zsh-cli" "_fake-zsh-cli" "" ""
+first_rc=$?
+_nils_cli_completion_common_load_generated_zsh \
+  "ZSH_STATE" "_nils_test_generated_zsh" "fake-zsh-cli" "_fake-zsh-cli" "" ""
+second_rc=$?
+print -r -- "state=${ZSH_STATE} first_rc=${first_rc} second_rc=${second_rc}"
+' -- "$ZSH_HELPER" >"$ZSH_STDOUT_FILE" 2>"$ZSH_STDERR_FILE" || true
+
+ZSH_STDOUT="$(cat "$ZSH_STDOUT_FILE")"
+ZSH_STDERR="$(cat "$ZSH_STDERR_FILE")"
+assert_contains "$ZSH_STDOUT" "state=-1" "zsh state"
+assert_contains "$ZSH_STDOUT" "first_rc=1" "zsh first rc"
+assert_contains "$ZSH_STDOUT" "second_rc=1" "zsh second rc"
+assert_contains "$ZSH_STDERR" "fake-zsh-cli simulated failure (completion zsh)" "zsh stderr passthrough"
+assert_contains "$ZSH_STDERR" "nils-cli completion (zsh): generated completion load failed for 'fake-zsh-cli'" "zsh diagnostic"
+assert_contains "$ZSH_STDERR" "fail-closed mode active" "zsh fail-closed message"
+assert_file_line_count "$ZSH_COUNT_FILE" "1"
+
+BASH_COUNT_FILE="$TMP_DIR/bash.count"
+BASH_STDOUT_FILE="$TMP_DIR/bash.stdout"
+BASH_STDERR_FILE="$TMP_DIR/bash.stderr"
+
+FAKE_CLI_COUNT_FILE="$BASH_COUNT_FILE" PATH="$TMP_DIR:$PATH" \
+  bash -c '
+source "$1"
+BASH_STATE=0
+_nils_cli_completion_common_load_generated_bash \
+  "BASH_STATE" "_nils_test_generated_bash" "fake-bash-cli" "_fake-bash-cli" "" ""
+first_rc=$?
+_nils_cli_completion_common_load_generated_bash \
+  "BASH_STATE" "_nils_test_generated_bash" "fake-bash-cli" "_fake-bash-cli" "" ""
+second_rc=$?
+printf "state=%s first_rc=%s second_rc=%s compreply_len=%s\n" \
+  "$BASH_STATE" "$first_rc" "$second_rc" "${#COMPREPLY[@]}"
+' -- "$BASH_HELPER" >"$BASH_STDOUT_FILE" 2>"$BASH_STDERR_FILE" || true
+
+BASH_STDOUT="$(cat "$BASH_STDOUT_FILE")"
+BASH_STDERR="$(cat "$BASH_STDERR_FILE")"
+assert_contains "$BASH_STDOUT" "state=-1" "bash state"
+assert_contains "$BASH_STDOUT" "first_rc=1" "bash first rc"
+assert_contains "$BASH_STDOUT" "second_rc=1" "bash second rc"
+assert_contains "$BASH_STDOUT" "compreply_len=0" "bash fail-closed COMPREPLY"
+assert_contains "$BASH_STDERR" "fake-bash-cli simulated failure (completion bash)" "bash stderr passthrough"
+assert_contains "$BASH_STDERR" "nils-cli completion (bash): generated completion load failed for 'fake-bash-cli'" "bash diagnostic"
+assert_contains "$BASH_STDERR" "fail-closed mode active" "bash fail-closed message"
+assert_file_line_count "$BASH_COUNT_FILE" "1"
+
+printf 'OK\n'


### PR DESCRIPTION
# Surface shell completion adapter load failures

## Summary
Surface runtime completion-generation failures for all clap-first CLI adapters by fixing the shared zsh/bash loader helpers to preserve generator stderr and emit a fail-closed diagnostic instead of failing silently.

## Changes
- Added one-time diagnostic warnings in the shared zsh/bash completion adapter helpers for command, post-processing, eval, and generated-symbol load failures.
- Removed stderr suppression around `<cli> completion <shell>` so underlying generator errors are visible during completion failures.
- Added `tests/completion/adapter_error_visibility.sh` to verify stderr visibility, fail-closed behavior, and cached no-retry behavior for both zsh and bash helpers.

## Testing
- `zsh -n completions/zsh/_completion-adapter-common.zsh && bash -n completions/bash/completion-adapter-common.bash && bash -n tests/completion/adapter_error_visibility.sh` (pass)
- `bash tests/completion/adapter_error_visibility.sh` (pass)
- `tests/completion/coverage_matrix.sh && zsh -f tests/zsh/completion.test.zsh` (pass)

## Risk / Notes
- Diagnostics are emitted only on generated-load failure and are cached per adapter state variable to avoid repeated noise in the same shell session.
