### PR TITLE
Use nils-common and nils-test-support in agent-docs and memo-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,8 @@ dependencies = [
  "clap",
  "clap_complete",
  "directories",
+ "nils-common",
+ "nils-test-support",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/agent-docs/Cargo.toml
+++ b/crates/agent-docs/Cargo.toml
@@ -19,10 +19,12 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 directories = { workspace = true }
+nils-common = { version = "0.4.8", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 toml_edit = "0.25"
 
 [dev-dependencies]
+nils-test-support = { version = "0.4.8", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/agent-docs/src/env.rs
+++ b/crates/agent-docs/src/env.rs
@@ -1,8 +1,8 @@
 use std::env;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use anyhow::{Context, Result, bail};
+use nils_common::git as shared_git;
 
 use crate::paths::normalize_root_path;
 
@@ -109,21 +109,6 @@ fn resolve_linked_worktree_metadata(cwd: &Path) -> LinkedWorktreeMetadata {
 }
 
 fn git_rev_parse_path(cwd: &Path, arg: &str) -> Option<PathBuf> {
-    let output = Command::new("git")
-        .args(["rev-parse", arg])
-        .current_dir(cwd)
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let trimmed = stdout.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(normalize_root_path(Path::new(trimmed), cwd))
-    }
+    let raw = shared_git::rev_parse_in(cwd, &[arg]).ok().flatten()?;
+    Some(normalize_root_path(Path::new(&raw), cwd))
 }

--- a/crates/agent-docs/tests/common.rs
+++ b/crates/agent-docs/tests/common.rs
@@ -3,12 +3,12 @@
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use agent_docs::env::ResolvedRoots;
 use agent_docs::model::{Context, OutputFormat};
+use nils_test_support::{cmd, fs as test_fs};
 
 static TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -160,27 +160,28 @@ impl CliOutput {
 }
 
 pub fn run_agent_docs_command(workspace: &FixtureWorkspace, args: &[&str]) -> CliOutput {
-    let mut command = Command::new(agent_docs_bin_path());
-    command
-        .arg("--agent-home")
-        .arg(&workspace.agent_home)
-        .arg("--project-path")
-        .arg(&workspace.project_path)
-        .args(args);
+    let agent_home = workspace
+        .agent_home
+        .to_str()
+        .expect("fixture agent_home path should be utf-8");
+    let project_path = workspace
+        .project_path
+        .to_str()
+        .expect("fixture project_path path should be utf-8");
 
-    let output = command.output().expect("run agent-docs command");
+    let mut full_args = vec!["--agent-home", agent_home, "--project-path", project_path];
+    full_args.extend_from_slice(args);
+
+    let output = cmd::run_resolved("agent-docs", &full_args, &cmd::CmdOptions::default());
     CliOutput {
-        exit_code: output.status.code().unwrap_or(-1),
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.code,
+        stdout: output.stdout_text(),
+        stderr: output.stderr_text(),
     }
 }
 
 pub fn write_text(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).expect("create parent directory");
-    }
-    fs::write(path, body).expect("write file");
+    let _ = test_fs::write_text(path, body);
 }
 
 fn parse_begin_line(line: &str) -> ChecklistBegin<'_> {
@@ -321,27 +322,4 @@ impl Drop for TestTempDir {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.path);
     }
-}
-
-fn agent_docs_bin_path() -> PathBuf {
-    for env_name in ["CARGO_BIN_EXE_agent-docs", "CARGO_BIN_EXE_agent_docs"] {
-        if let Some(path) = std::env::var_os(env_name) {
-            return PathBuf::from(path);
-        }
-    }
-
-    let current = std::env::current_exe().expect("current test executable");
-    let Some(target_profile_dir) = current.parent().and_then(|path| path.parent()) else {
-        panic!("failed to resolve target profile directory from current executable");
-    };
-
-    let candidate = target_profile_dir.join(format!("agent-docs{}", std::env::consts::EXE_SUFFIX));
-    if candidate.exists() {
-        return candidate;
-    }
-
-    panic!(
-        "agent-docs binary path not found via env vars or fallback candidate {}",
-        candidate.display()
-    );
 }

--- a/crates/agent-docs/tests/completion_outside_repo.rs
+++ b/crates/agent-docs/tests/completion_outside_repo.rs
@@ -1,44 +1,13 @@
-use std::path::PathBuf;
-use std::process::{Command, Stdio};
-
-fn agent_docs_bin() -> PathBuf {
-    for env_name in ["CARGO_BIN_EXE_agent-docs", "CARGO_BIN_EXE_agent_docs"] {
-        if let Some(path) = std::env::var_os(env_name) {
-            return PathBuf::from(path);
-        }
-    }
-
-    let current = std::env::current_exe().expect("current test executable");
-    let target_profile_dir = current
-        .parent()
-        .and_then(|path| path.parent())
-        .expect("target profile dir");
-    let candidate = target_profile_dir.join(format!("agent-docs{}", std::env::consts::EXE_SUFFIX));
-    assert!(
-        candidate.exists(),
-        "agent-docs binary path not found via env vars or fallback candidate {}",
-        candidate.display()
-    );
-    candidate
-}
+use nils_test_support::cmd;
 
 #[test]
 fn completion_export_succeeds_outside_git_repo() {
     let temp = tempfile::TempDir::new().unwrap();
-    let output = Command::new(agent_docs_bin())
-        .args(["completion", "zsh"])
-        .current_dir(temp.path())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("run agent-docs completion zsh");
+    let options = cmd::CmdOptions::default().with_cwd(temp.path());
+    let output = cmd::run_resolved("agent-docs", &["completion", "zsh"], &options);
 
-    assert!(
-        output.status.success(),
-        "expected exit code 0, got: {output:?}"
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(output.code, 0, "expected exit code 0, got: {output:?}");
+    let stdout = output.stdout_text();
     assert!(
         stdout.contains("#compdef agent-docs"),
         "missing zsh completion header: {stdout}"
@@ -48,20 +17,14 @@ fn completion_export_succeeds_outside_git_repo() {
 #[test]
 fn completion_rejects_unknown_shell_outside_git_repo() {
     let temp = tempfile::TempDir::new().unwrap();
-    let output = Command::new(agent_docs_bin())
-        .args(["completion", "fish"])
-        .current_dir(temp.path())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("run agent-docs completion fish");
+    let options = cmd::CmdOptions::default().with_cwd(temp.path());
+    let output = cmd::run_resolved("agent-docs", &["completion", "fish"], &options);
 
     assert!(
-        !output.status.success(),
+        output.code != 0,
         "expected non-zero exit code for unknown shell, got: {output:?}"
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = output.stderr_text();
     assert!(
         stderr.contains("invalid value") && stderr.contains("fish"),
         "missing invalid shell error: {stderr}"

--- a/crates/agent-docs/tests/env_paths.rs
+++ b/crates/agent-docs/tests/env_paths.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use nils_test_support::cmd;
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -19,22 +20,20 @@ fn write_markdown(path: &Path) {
 }
 
 fn run_agent_docs(cwd: &Path, args: &[&str], envs: &[(&str, &Path)], unset: &[&str]) -> CmdOutput {
-    let mut command = Command::new(agent_docs_bin());
-    command.current_dir(cwd).args(args);
-
+    let mut options = cmd::CmdOptions::default().with_cwd(cwd);
     for key in unset {
-        command.env_remove(key);
+        options = options.with_env_remove(key);
     }
-
     for (key, value) in envs {
-        command.env(key, value);
+        let value = value.to_str().expect("fixture env path should be utf-8");
+        options = options.with_env(key, value);
     }
 
-    let output = command.output().expect("run agent-docs");
+    let output = cmd::run_resolved("agent-docs", args, &options);
     CmdOutput {
-        code: output.status.code().unwrap_or(-1),
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        code: output.code,
+        stdout: output.stdout_text(),
+        stderr: output.stderr_text(),
     }
 }
 
@@ -493,24 +492,4 @@ fn resolve_strict_auto_uses_primary_worktree_fallback_but_local_only_keeps_local
         "local-only baseline strict should keep local-only failure semantics: stdout=\n{}\nstderr=\n{}",
         baseline_local_only_output.stdout, baseline_local_only_output.stderr
     );
-}
-
-fn agent_docs_bin() -> PathBuf {
-    for env_name in ["CARGO_BIN_EXE_agent-docs", "CARGO_BIN_EXE_agent_docs"] {
-        if let Some(path) = std::env::var_os(env_name) {
-            return PathBuf::from(path);
-        }
-    }
-
-    let current = std::env::current_exe().expect("current exe");
-    let Some(target_profile_dir) = current.parent().and_then(|path| path.parent()) else {
-        panic!("failed to resolve target profile dir");
-    };
-
-    let candidate = target_profile_dir.join(format!("agent-docs{}", std::env::consts::EXE_SUFFIX));
-    if candidate.exists() {
-        return candidate;
-    }
-
-    panic!("agent-docs binary path not found: {}", candidate.display());
 }

--- a/crates/memo-cli/tests/completion_outside_repo.rs
+++ b/crates/memo-cli/tests/completion_outside_repo.rs
@@ -1,44 +1,13 @@
-use std::path::PathBuf;
-use std::process::{Command, Stdio};
-
-fn memo_cli_bin() -> PathBuf {
-    for env_name in ["CARGO_BIN_EXE_memo-cli", "CARGO_BIN_EXE_memo_cli"] {
-        if let Some(path) = std::env::var_os(env_name) {
-            return PathBuf::from(path);
-        }
-    }
-
-    let current = std::env::current_exe().expect("current test executable");
-    let target_profile_dir = current
-        .parent()
-        .and_then(|path| path.parent())
-        .expect("target profile dir");
-    let candidate = target_profile_dir.join(format!("memo-cli{}", std::env::consts::EXE_SUFFIX));
-    assert!(
-        candidate.exists(),
-        "memo-cli binary path not found via env vars or fallback candidate {}",
-        candidate.display()
-    );
-    candidate
-}
+use nils_test_support::cmd;
 
 #[test]
 fn completion_export_succeeds_outside_git_repo() {
     let temp = tempfile::TempDir::new().unwrap();
-    let output = Command::new(memo_cli_bin())
-        .args(["completion", "zsh"])
-        .current_dir(temp.path())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("run memo-cli completion zsh");
+    let options = cmd::CmdOptions::default().with_cwd(temp.path());
+    let output = cmd::run_resolved("memo-cli", &["completion", "zsh"], &options);
 
-    assert!(
-        output.status.success(),
-        "expected exit code 0, got: {output:?}"
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(output.code, 0, "expected exit code 0, got: {output:?}");
+    let stdout = output.stdout_text();
     assert!(
         stdout.contains("#compdef memo-cli"),
         "missing zsh completion header: {stdout}"
@@ -48,20 +17,14 @@ fn completion_export_succeeds_outside_git_repo() {
 #[test]
 fn completion_rejects_unknown_shell_outside_git_repo() {
     let temp = tempfile::TempDir::new().unwrap();
-    let output = Command::new(memo_cli_bin())
-        .args(["completion", "fish"])
-        .current_dir(temp.path())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("run memo-cli completion fish");
+    let options = cmd::CmdOptions::default().with_cwd(temp.path());
+    let output = cmd::run_resolved("memo-cli", &["completion", "fish"], &options);
 
     assert!(
-        !output.status.success(),
+        output.code != 0,
         "expected non-zero exit code for unknown shell, got: {output:?}"
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = output.stderr_text();
     assert!(
         stderr.contains("invalid value") && stderr.contains("fish"),
         "missing invalid shell error: {stderr}"


### PR DESCRIPTION
# Use nils-common and nils-test-support in agent-docs and memo-cli

## Summary
Refactor agent-docs and memo-cli to reuse workspace shared helpers instead of local duplicated test/runtime glue. This keeps behavior unchanged while reducing maintenance cost and centralizing binary resolution, command execution, and git rev-parse handling in `nils-test-support` and `nils-common`.

## Changes
- Add `nils-common` and `nils-test-support` dependencies to `nils-agent-docs` and route `agent-docs/src/env.rs` git `rev-parse` path resolution through `nils_common::git::rev_parse_in`.
- Replace duplicated `CARGO_BIN_EXE_*` binary path resolution and direct `std::process::Command` test helpers in `agent-docs` tests with `nils_test_support::bin`/`cmd` helpers.
- Replace duplicated memo-cli completion test binary resolver/command invocation with `nils_test_support::cmd::run_resolved`.

## Testing
- `cargo test -p nils-agent-docs` (pass)
- `cargo test -p nils-memo-cli --test completion_outside_repo` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, 85.57%)

## Risk / Notes
- Behavior is intended to be parity-preserving; changes are limited to helper call sites and test infrastructure.
- `Cargo.lock` changed only to reflect the new workspace dependency edges for `nils-agent-docs`.
