### PR TITLE
refactor(gemini-cli): use shared command probe in agent commit

### DIFF
--- a/crates/gemini-cli/src/agent/commit.rs
+++ b/crates/gemini-cli/src/agent/commit.rs
@@ -348,7 +348,9 @@ mod tests {
         let non_executable = dir.path().join("tool-no");
         test_fs::write_executable(&executable, "#!/bin/sh\necho ok\n");
         fs::write(&non_executable, "plain text").expect("write non executable");
-        let mut perms = fs::metadata(&non_executable).expect("metadata").permissions();
+        let mut perms = fs::metadata(&non_executable)
+            .expect("metadata")
+            .permissions();
         perms.set_mode(0o644);
         fs::set_permissions(&non_executable, perms).expect("chmod non executable");
 


### PR DESCRIPTION
## Summary
- replace local command existence probe in gemini agent commit with nils_common::process::cmd_exists
- migrate commit.rs unit test helpers to nils_test_support equivalents for env/path/executable setup

## Testing
- cargo test -p nils-gemini-cli command_exists_checks_executable_bit
- cargo test -p nils-gemini-cli agent_commit_fallback