### PR TITLE
refactor(git-lock,git-scope): adopt shared git/process wrappers

### DIFF
--- a/crates/git-lock/src/diff.rs
+++ b/crates/git-lock/src/diff.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use nils_common::env as shared_env;
-use std::process::Command;
+use nils_common::git as common_git;
 
 use crate::messages;
 use crate::store::LockStore;
@@ -78,7 +78,7 @@ pub fn run(args: &[String]) -> Result<i32> {
     let range = format!("{hash1}..{hash2}");
     log_args.push(&range);
 
-    let status = Command::new("git").args(&log_args).status()?;
+    let status = common_git::run_status_inherit(&log_args)?;
 
     Ok(status.code().unwrap_or(1))
 }

--- a/crates/git-lock/src/tag.rs
+++ b/crates/git-lock/src/tag.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use std::process::Command;
+use nils_common::git as common_git;
 
 use crate::git;
 use crate::messages;
@@ -83,9 +83,8 @@ pub fn run(args: &[String]) -> Result<i32> {
         }
     }
 
-    let status = Command::new("git")
-        .args(["tag", "-a", tag_name, &hash, "-m", &message])
-        .status()?;
+    let create_tag_args = ["tag", "-a", tag_name, hash.as_str(), "-m", message.as_str()];
+    let status = common_git::run_status_inherit(&create_tag_args)?;
     if !status.success() {
         return Ok(status.code().unwrap_or(1));
     }
@@ -94,15 +93,13 @@ pub fn run(args: &[String]) -> Result<i32> {
     println!("📝 Message: {message}");
 
     if do_push {
-        let status = Command::new("git")
-            .args(["push", "origin", tag_name])
-            .status()?;
+        let status = common_git::run_status_inherit(&["push", "origin", tag_name])?;
         if !status.success() {
             return Ok(status.code().unwrap_or(1));
         }
         println!("🚀 Pushed tag [{tag_name}] to origin");
 
-        let status = Command::new("git").args(["tag", "-d", tag_name]).status()?;
+        let status = common_git::run_status_inherit(&["tag", "-d", tag_name])?;
         if status.success() {
             println!("🧹 Deleted local tag [{tag_name}]");
         }

--- a/crates/git-scope/src/print.rs
+++ b/crates/git-scope/src/print.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
+use nils_common::git as common_git;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::sync::OnceLock;
 use tempfile::NamedTempFile;
 
@@ -146,19 +147,13 @@ fn emit_from_head(path: &str, fallback: HeadFallback) -> Result<()> {
 }
 
 fn git_has_object(spec: &str) -> Result<bool> {
-    let status = Command::new("git")
-        .args(["cat-file", "-e", spec])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()?;
+    let status = common_git::run_status_quiet(&["cat-file", "-e", spec])?;
     Ok(status.success())
 }
 
 fn git_show_to_file(spec: &str, dest: &Path) -> Result<()> {
-    let output = Command::new("git")
-        .args(["show", spec])
-        .output()
-        .with_context(|| format!("git show {spec}"))?;
+    let output =
+        common_git::run_output(&["show", spec]).with_context(|| format!("git show {spec}"))?;
     if !output.status.success() {
         anyhow::bail!("git show {spec} failed");
     }


### PR DESCRIPTION
## Summary
- replace direct `Command::new("git")` usage in git-lock diff/tag paths with shared wrappers
- replace direct `Command::new("git")` usage in git-scope print plumbing with shared wrappers
- preserve existing output/warning/exit-code behavior

## Testing
- cargo test -p nils-git-lock
- cargo test -p nils-git-scope
