### PR TITLE
refactor(codex-cli): share auth secret-dir env resolver

### DIFF
--- a/crates/codex-cli/src/auth/remove.rs
+++ b/crates/codex-cli/src/auth/remove.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde_json::json;
 use std::io::{self, IsTerminal, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::auth::output::{self, AuthRemoveResult};
 use crate::paths;
@@ -32,7 +32,7 @@ pub fn run_with_json(target: &str, yes: bool, output_json: bool) -> Result<i32> 
         return Ok(64);
     }
 
-    let secret_dir = match resolve_secret_dir_from_env() {
+    let secret_dir = match paths::resolve_secret_dir_from_env() {
         Some(path) => path,
         None => {
             if output_json {
@@ -170,14 +170,6 @@ fn usage_error(output_json: bool, message: &str) -> Result<i32> {
     Ok(64)
 }
 
-fn resolve_secret_dir_from_env() -> Option<PathBuf> {
-    let raw = std::env::var_os("CODEX_SECRET_DIR")?;
-    if raw.is_empty() {
-        return None;
-    }
-    Some(PathBuf::from(raw))
-}
-
 fn is_invalid_target(target: &str) -> bool {
     target.contains('/') || target.contains('\\') || target.contains("..")
 }
@@ -210,7 +202,8 @@ fn remove_target_timestamp(target_file: &Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_invalid_target, resolve_secret_dir_from_env};
+    use super::is_invalid_target;
+    use crate::paths;
     use nils_test_support::{EnvGuard, GlobalStateLock};
 
     #[test]
@@ -226,7 +219,7 @@ mod tests {
         let lock = GlobalStateLock::new();
         let _set = EnvGuard::set(&lock, "CODEX_SECRET_DIR", "/tmp/secrets");
         assert_eq!(
-            resolve_secret_dir_from_env().expect("secret dir"),
+            paths::resolve_secret_dir_from_env().expect("secret dir"),
             std::path::PathBuf::from("/tmp/secrets")
         );
     }

--- a/crates/codex-cli/src/auth/save.rs
+++ b/crates/codex-cli/src/auth/save.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde_json::json;
 use std::io::{self, IsTerminal, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::auth;
 use crate::auth::output::{self, AuthSaveResult};
@@ -34,7 +34,7 @@ pub fn run_with_json(target: &str, yes: bool, output_json: bool) -> Result<i32> 
         return Ok(64);
     }
 
-    let secret_dir = match resolve_secret_dir_from_env() {
+    let secret_dir = match paths::resolve_secret_dir_from_env() {
         Some(path) => path,
         None => {
             if output_json {
@@ -228,14 +228,6 @@ fn usage_error(output_json: bool, message: &str) -> Result<i32> {
     Ok(64)
 }
 
-fn resolve_secret_dir_from_env() -> Option<PathBuf> {
-    let raw = std::env::var_os("CODEX_SECRET_DIR")?;
-    if raw.is_empty() {
-        return None;
-    }
-    Some(PathBuf::from(raw))
-}
-
 fn is_invalid_target(target: &str) -> bool {
     target.contains('/') || target.contains('\\') || target.contains("..")
 }
@@ -274,7 +266,8 @@ fn write_target_timestamp(target_file: &Path, auth_file: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_invalid_target, resolve_secret_dir_from_env};
+    use super::is_invalid_target;
+    use crate::paths;
     use nils_test_support::{EnvGuard, GlobalStateLock};
 
     #[test]
@@ -290,7 +283,7 @@ mod tests {
         let lock = GlobalStateLock::new();
         let _set = EnvGuard::set(&lock, "CODEX_SECRET_DIR", "/tmp/secrets");
         assert_eq!(
-            resolve_secret_dir_from_env().expect("secret dir"),
+            paths::resolve_secret_dir_from_env().expect("secret dir"),
             std::path::PathBuf::from("/tmp/secrets")
         );
     }

--- a/crates/codex-cli/src/paths.rs
+++ b/crates/codex-cli/src/paths.rs
@@ -1,7 +1,13 @@
 use std::path::PathBuf;
 
+use crate::provider_profile::CODEX_PROVIDER_PROFILE;
+
 pub fn resolve_secret_dir() -> Option<PathBuf> {
     crate::runtime::resolve_secret_dir()
+}
+
+pub fn resolve_secret_dir_from_env() -> Option<PathBuf> {
+    nils_common::provider_runtime::paths::resolve_secret_dir_from_env(&CODEX_PROVIDER_PROFILE)
 }
 
 pub fn resolve_auth_file() -> Option<PathBuf> {

--- a/crates/codex-cli/tests/auth_remove.rs
+++ b/crates/codex-cli/tests/auth_remove.rs
@@ -55,6 +55,29 @@ fn auth_remove_errors_when_secret_dir_missing() {
 }
 
 #[test]
+fn auth_remove_keeps_env_only_contract_even_if_home_secret_dir_exists() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let home = dir.path().join("home");
+    let fallback_secret_dir = home.join(".config").join("codex_secrets");
+    let target = fallback_secret_dir.join("alpha.json");
+    fs::create_dir_all(&fallback_secret_dir).expect("fallback secret dir");
+    fs::write(&target, r#"{"tokens":{"access_token":"tok"}}"#).expect("target");
+
+    let output = run_with(
+        &["auth", "remove", "--yes", "alpha.json"],
+        &[("HOME", &home)],
+        &[("CODEX_SECRET_DIR", "")],
+    );
+
+    assert_eq!(output.code, 1);
+    assert!(stderr(&output).contains("CODEX_SECRET_DIR is not configured"));
+    assert!(
+        target.exists(),
+        "remove must not use HOME fallback when CODEX_SECRET_DIR is empty"
+    );
+}
+
+#[test]
 fn auth_remove_errors_when_target_missing() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let secrets = dir.path().join("secrets");

--- a/crates/codex-cli/tests/auth_save.rs
+++ b/crates/codex-cli/tests/auth_save.rs
@@ -59,6 +59,30 @@ fn auth_save_errors_when_secret_dir_missing() {
 }
 
 #[test]
+fn auth_save_keeps_env_only_contract_even_if_home_secret_dir_exists() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let home = dir.path().join("home");
+    let fallback_secret_dir = home.join(".config").join("codex_secrets");
+    fs::create_dir_all(&fallback_secret_dir).expect("fallback secret dir");
+
+    let auth_file = dir.path().join("auth.json");
+    fs::write(&auth_file, r#"{"tokens":{"access_token":"tok"}}"#).expect("write auth");
+
+    let output = run_with(
+        &["auth", "save", "alpha.json"],
+        &[("CODEX_AUTH_FILE", &auth_file), ("HOME", &home)],
+        &[("CODEX_SECRET_DIR", "")],
+    );
+
+    assert_eq!(output.code, 1);
+    assert!(stderr(&output).contains("CODEX_SECRET_DIR is not configured"));
+    assert!(
+        !fallback_secret_dir.join("alpha.json").exists(),
+        "save must not use HOME fallback when CODEX_SECRET_DIR is empty"
+    );
+}
+
+#[test]
 fn auth_save_errors_when_auth_file_missing() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let secrets = dir.path().join("secrets");

--- a/crates/nils-common/src/provider_runtime/paths.rs
+++ b/crates/nils-common/src/provider_runtime/paths.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use super::profile::{HomePathSelection, ProviderProfile};
 
 pub fn resolve_secret_dir(profile: &ProviderProfile) -> Option<PathBuf> {
-    if let Some(dir) = env_path(profile.env.secret_dir) {
+    if let Some(dir) = resolve_secret_dir_from_env(profile) {
         return Some(dir);
     }
 
@@ -21,6 +21,10 @@ pub fn resolve_secret_dir(profile: &ProviderProfile) -> Option<PathBuf> {
         return Some(feature_dir.join("secrets"));
     }
     Some(feature_dir)
+}
+
+pub fn resolve_secret_dir_from_env(profile: &ProviderProfile) -> Option<PathBuf> {
+    env_path(profile.env.secret_dir)
 }
 
 pub fn resolve_auth_file(profile: &ProviderProfile) -> Option<PathBuf> {


### PR DESCRIPTION
## Summary
- Remove duplicated env-only CODEX secret-dir resolver from `auth save/remove`.
- Route resolver through shared helper (`nils-common provider_runtime` + codex thin adapter).
- Preserve existing missing secret-dir UX/error/exit contract.

## Changes
- Added `resolve_secret_dir_from_env(profile)` in `nils-common` runtime paths.
- Added codex adapter `resolve_secret_dir_from_env()` in `crates/codex-cli/src/paths.rs`.
- Updated `auth save/remove` to consume shared helper and removed local duplicate resolver logic.
- Added characterization tests proving `CODEX_SECRET_DIR` must be configured even if HOME fallback exists.

## Testing
- `cargo test -p nils-codex-cli auth_save`
- `cargo test -p nils-codex-cli auth_remove`

## Risk / Notes
- Scope-limited refactor; only secret-dir resolution wiring changed for save/remove.
- Existing error strings/exit codes retained.
