### PR TITLE
test(agent-docs): reuse shared git/fs helpers in env_paths

### DIFF
--- a/crates/agent-docs/tests/env_paths.rs
+++ b/crates/agent-docs/tests/env_paths.rs
@@ -23,7 +23,13 @@ fn setup_linked_worktree(workspace: &Path) -> (TempDir, PathBuf) {
         .expect("linked worktree path should be utf-8");
     let _ = test_git::git(
         repo.path(),
-        &["worktree", "add", linked_worktree_arg, "-b", "linked-worktree"],
+        &[
+            "worktree",
+            "add",
+            linked_worktree_arg,
+            "-b",
+            "linked-worktree",
+        ],
     );
     (repo, linked_worktree)
 }


### PR DESCRIPTION
## Summary
- replace duplicated git repo/worktree setup in env_paths tests with nils_test_support::git helper usage
- replace fixture markdown writes with nils_test_support::fs::write_text
- keep a small worktree-specific setup helper for linked worktree creation

## Validation
- cargo test -p agent-docs env_paths (fails: package id not found)
- cargo test -p nils-agent-docs env_paths
