### PR TITLE
test(api): use shared executable/env helpers for grpc mocks

### DIFF
--- a/crates/api-grpc/tests/integration.rs
+++ b/crates/api-grpc/tests/integration.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use nils_test_support::bin::resolve;
 use nils_test_support::cmd::{CmdOptions, CmdOutput, run_with};
-use nils_test_support::fs::write_json;
+use nils_test_support::fs::{write_executable, write_json};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
@@ -42,17 +42,6 @@ fn run_api_grpc(cwd: &Path, args: &[&str], envs: &[(&str, &str)]) -> CmdOutput {
     run_with(&api_grpc_bin(), args, &options)
 }
 
-fn write_executable_script(path: &Path, body: &str) {
-    std::fs::write(path, body).expect("write script");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(path).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(path, perms).expect("chmod");
-    }
-}
-
 fn write_health_request(path: &Path, with_expect: bool) {
     let expect = if with_expect {
         serde_json::json!({"status": 0, "jq": ".ok == true"})
@@ -79,7 +68,7 @@ fn call_success_prints_response_and_writes_history() {
     write_health_request(&root.join("requests/health.grpc.json"), true);
 
     let script = root.join("grpcurl-ok.sh");
-    write_executable_script(&script, "#!/bin/sh\necho '{\"ok\":true}'\nexit 0\n");
+    write_executable(&script, "#!/bin/sh\necho '{\"ok\":true}'\nexit 0\n");
 
     let script_str = script.to_string_lossy().to_string();
     let out = run_api_grpc(
@@ -145,7 +134,7 @@ fn call_expect_failure_non_json_prints_response_preview_to_stderr() {
     write_health_request(&root.join("requests/fail.grpc.json"), true);
 
     let script = root.join("grpcurl-text.sh");
-    write_executable_script(&script, "#!/bin/sh\necho 'boom-body'\nexit 0\n");
+    write_executable(&script, "#!/bin/sh\necho 'boom-body'\nexit 0\n");
     let script_str = script.to_string_lossy().to_string();
 
     let out = run_api_grpc(
@@ -178,7 +167,7 @@ fn report_run_writes_markdown_report() {
 
     write_health_request(&root.join("requests/health.grpc.json"), true);
     let script = root.join("grpcurl-ok.sh");
-    write_executable_script(&script, "#!/bin/sh\necho '{\"ok\":true}'\nexit 0\n");
+    write_executable(&script, "#!/bin/sh\necho '{\"ok\":true}'\nexit 0\n");
     let script_str = script.to_string_lossy().to_string();
 
     let out = run_api_grpc(

--- a/crates/api-test/tests/grpc_integration.rs
+++ b/crates/api-test/tests/grpc_integration.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use nils_test_support::bin::resolve;
 use nils_test_support::cmd::{CmdOptions, CmdOutput, run_with};
-use nils_test_support::fs::write_text;
+use nils_test_support::fs::{write_executable, write_text};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
@@ -28,14 +28,7 @@ fn api_test_run_supports_grpc_case() {
     std::fs::create_dir_all(root.join(".git")).expect("git marker");
 
     let mock = root.join("grpcurl-mock.sh");
-    std::fs::write(&mock, "#!/bin/sh\necho '{\"ok\":true}'\nexit 0\n").expect("write script");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&mock).expect("stat").permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&mock, perms).expect("chmod");
-    }
+    write_executable(&mock, "#!/bin/sh\necho '{\"ok\":true}'\nexit 0\n");
 
     write_text(
         &root.join("setup/grpc/requests/health.grpc.json"),

--- a/crates/api-testing-core/tests/suite_runner_grpc_matrix.rs
+++ b/crates/api-testing-core/tests/suite_runner_grpc_matrix.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 
 use api_testing_core::suite::runner::{SuiteRunOptions, run_suite};
 use api_testing_core::suite::schema::load_and_validate_suite;
+use nils_test_support::fs::write_executable;
+use nils_test_support::{EnvGuard, GlobalStateLock};
 use tempfile::TempDir;
 
 fn write_file(path: &std::path::Path, body: &str) {
@@ -16,14 +18,7 @@ fn suite_runner_executes_grpc_case_with_mock_transport() {
     std::fs::create_dir_all(root.join(".git")).expect("git marker");
 
     let mock = root.join("grpcurl-mock.sh");
-    std::fs::write(&mock, "#!/bin/sh\necho '{\"ok\":true}'\nexit 0\n").expect("write script");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&mock).expect("stat").permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&mock, perms).expect("chmod");
-    }
+    write_executable(&mock, "#!/bin/sh\necho '{\"ok\":true}'\nexit 0\n");
 
     write_file(
         &root.join("requests/health.grpc.json"),
@@ -48,9 +43,9 @@ fn suite_runner_executes_grpc_case_with_mock_transport() {
     );
 
     let loaded = load_and_validate_suite(root.join("grpc.suite.json")).expect("load suite");
-
-    // SAFETY: test-only env mutation in isolated process.
-    unsafe { std::env::set_var("GRPCURL_BIN", &mock) };
+    let lock = GlobalStateLock::new();
+    let mock_path = mock.to_string_lossy().to_string();
+    let _grpcurl_bin = EnvGuard::set(&lock, "GRPCURL_BIN", &mock_path);
 
     let out = run_suite(
         root,
@@ -70,9 +65,6 @@ fn suite_runner_executes_grpc_case_with_mock_transport() {
         },
     )
     .expect("run suite");
-
-    // SAFETY: test-only env mutation in isolated process.
-    unsafe { std::env::remove_var("GRPCURL_BIN") };
 
     assert_eq!(out.results.summary.total, 1);
     assert_eq!(out.results.summary.passed, 1);


### PR DESCRIPTION
## Summary
- replace manual grpc mock chmod paths with nils_test_support::fs::write_executable in scoped grpc tests
- replace raw GRPCURL_BIN env mutation in suite_runner_grpc_matrix with GlobalStateLock + EnvGuard

## Validation
- cargo test -p nils-api-grpc integration
- cargo test -p nils-api-test grpc_integration
- cargo test -p nils-api-testing-core suite_runner_grpc_matrix
- cargo test -p nils-api-grpc --test integration
- cargo test -p nils-api-test --test grpc_integration
- cargo test -p nils-api-testing-core --test suite_runner_grpc_matrix