### PR TITLE
refactor(codex,gemini): migrate fs adapters to nils-common

### DIFF
--- a/crates/codex-cli/src/fs.rs
+++ b/crates/codex-cli/src/fs.rs
@@ -1,121 +1,59 @@
-use anyhow::{Context, Result};
-use sha2::{Digest, Sha256};
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use anyhow::Result;
+use nils_common::fs as shared_fs;
+use std::io;
+use std::path::Path;
 
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-
-pub const SECRET_FILE_MODE: u32 = 0o600;
+pub const SECRET_FILE_MODE: u32 = shared_fs::SECRET_FILE_MODE;
 
 pub fn sha256_file(path: &Path) -> Result<String> {
-    let mut file = File::open(path)
-        .with_context(|| format!("failed to open for sha256: {}", path.display()))?;
-    let mut hasher = Sha256::new();
-    let mut buf = [0u8; 8192];
-    loop {
-        let read = file.read(&mut buf)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buf[..read]);
+    match shared_fs::sha256_file(path) {
+        Ok(hash) => Ok(hash),
+        Err(shared_fs::FileHashError::OpenFile { source, .. }) => Err(anyhow::Error::new(source)
+            .context(format!("failed to open for sha256: {}", path.display()))),
+        Err(shared_fs::FileHashError::ReadFile { source, .. }) => Err(source.into()),
     }
-    let digest = hasher.finalize();
-    let mut out = String::with_capacity(digest.len() * 2);
-    for byte in digest {
-        out.push_str(&format!("{:02x}", byte));
-    }
-    Ok(out)
 }
 
 pub fn write_atomic(path: &Path, contents: &[u8], mode: u32) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create dir: {}", parent.display()))?;
-    }
-
-    let mut attempt = 0u32;
-    loop {
-        let tmp_path = temp_path(path, attempt);
-        match OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&tmp_path)
-        {
-            Ok(mut file) => {
-                file.write_all(contents).with_context(|| {
-                    format!("failed to write temp file: {}", tmp_path.display())
-                })?;
-                file.flush().ok();
-
-                set_permissions(&tmp_path, mode)?;
-                drop(file);
-
-                fs::rename(&tmp_path, path).with_context(|| {
-                    format!(
-                        "failed to rename {} -> {}",
-                        tmp_path.display(),
-                        path.display()
-                    )
-                })?;
-                set_permissions(path, mode)?;
-                return Ok(());
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-                attempt += 1;
-                if attempt > 10 {
-                    return Err(err).context("failed to create unique temp file");
-                }
-            }
-            Err(err) => return Err(err).context("failed to create temp file"),
-        }
-    }
+    shared_fs::write_atomic(path, contents, mode).map_err(map_atomic_write_error)
 }
 
 pub fn write_timestamp(path: &Path, iso: Option<&str>) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create dir: {}", parent.display()))?;
-    }
-
-    if let Some(raw) = iso {
-        let trimmed = raw.split(&['\n', '\r'][..]).next().unwrap_or("");
-        if !trimmed.is_empty() {
-            fs::write(path, trimmed)
-                .with_context(|| format!("failed to write timestamp: {}", path.display()))?;
-            return Ok(());
+    match shared_fs::write_timestamp(path, iso) {
+        Ok(()) => Ok(()),
+        Err(shared_fs::TimestampError::CreateParentDir { path, source }) => {
+            Err(anyhow::Error::new(source)
+                .context(format!("failed to create dir: {}", path.display())))
         }
+        Err(shared_fs::TimestampError::WriteFile { path, source }) => {
+            Err(anyhow::Error::new(source)
+                .context(format!("failed to write timestamp: {}", path.display())))
+        }
+        Err(shared_fs::TimestampError::RemoveFile { .. }) => Ok(()),
     }
-
-    let _ = fs::remove_file(path);
-    Ok(())
 }
 
-#[cfg(unix)]
-fn set_permissions(path: &Path, mode: u32) -> Result<()> {
-    let perm = fs::Permissions::from_mode(mode);
-    fs::set_permissions(path, perm)
-        .with_context(|| format!("failed to set permissions: {}", path.display()))?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn set_permissions(_path: &Path, _mode: u32) -> Result<()> {
-    Ok(())
-}
-
-fn temp_path(path: &Path, attempt: u32) -> PathBuf {
-    let filename = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("tmp");
-    let pid = std::process::id();
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let tmp_name = format!(".{filename}.tmp-{pid}-{nanos}-{attempt}");
-    path.with_file_name(tmp_name)
+fn map_atomic_write_error(err: shared_fs::AtomicWriteError) -> anyhow::Error {
+    match err {
+        shared_fs::AtomicWriteError::CreateParentDir { path, source } => {
+            anyhow::Error::new(source).context(format!("failed to create dir: {}", path.display()))
+        }
+        shared_fs::AtomicWriteError::CreateTempFile { source, .. } => {
+            anyhow::Error::new(source).context("failed to create temp file")
+        }
+        shared_fs::AtomicWriteError::TempPathExhausted { .. } => anyhow::Error::new(
+            io::Error::new(io::ErrorKind::AlreadyExists, "temp file already exists"),
+        )
+        .context("failed to create unique temp file"),
+        shared_fs::AtomicWriteError::WriteTempFile { path, source } => anyhow::Error::new(source)
+            .context(format!("failed to write temp file: {}", path.display())),
+        shared_fs::AtomicWriteError::SetPermissions { path, source } => anyhow::Error::new(source)
+            .context(format!("failed to set permissions: {}", path.display())),
+        shared_fs::AtomicWriteError::ReplaceFile { from, to, source } => anyhow::Error::new(source)
+            .context(format!(
+                "failed to rename {} -> {}",
+                from.display(),
+                to.display()
+            )),
+    }
 }

--- a/crates/gemini-cli/src/fs.rs
+++ b/crates/gemini-cli/src/fs.rs
@@ -1,271 +1,37 @@
-use std::fs::{self, File, OpenOptions};
-use std::io::{self, Read, Write};
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use nils_common::fs as shared_fs;
+use std::io;
+use std::path::Path;
 
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-
-pub const SECRET_FILE_MODE: u32 = 0o600;
+pub const SECRET_FILE_MODE: u32 = shared_fs::SECRET_FILE_MODE;
 
 pub fn sha256_file(path: &Path) -> io::Result<String> {
-    let mut file = File::open(path)?;
-    let mut hasher = Sha256::new();
-    let mut buf = [0u8; 8192];
-
-    loop {
-        let read = file.read(&mut buf)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buf[..read]);
+    match shared_fs::sha256_file(path) {
+        Ok(hash) => Ok(hash),
+        Err(shared_fs::FileHashError::OpenFile { source, .. }) => Err(source),
+        Err(shared_fs::FileHashError::ReadFile { source, .. }) => Err(source),
     }
-
-    Ok(hex_encode(&hasher.finalize()))
 }
 
 pub fn write_atomic(path: &Path, contents: &[u8], mode: u32) -> io::Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
-    let mut attempt = 0u32;
-    loop {
-        let tmp_path = temp_path(path, attempt);
-        match OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&tmp_path)
-        {
-            Ok(mut file) => {
-                file.write_all(contents)?;
-                let _ = file.flush();
-                set_permissions(&tmp_path, mode)?;
-                drop(file);
-
-                fs::rename(&tmp_path, path)?;
-                set_permissions(path, mode)?;
-                return Ok(());
-            }
-            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                attempt += 1;
-                if attempt > 10 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::AlreadyExists,
-                        format!("failed to create unique temp file for {}", path.display()),
-                    ));
-                }
-            }
-            Err(err) => return Err(err),
-        }
+    match shared_fs::write_atomic(path, contents, mode) {
+        Ok(()) => Ok(()),
+        Err(shared_fs::AtomicWriteError::CreateParentDir { source, .. }) => Err(source),
+        Err(shared_fs::AtomicWriteError::CreateTempFile { source, .. }) => Err(source),
+        Err(shared_fs::AtomicWriteError::WriteTempFile { source, .. }) => Err(source),
+        Err(shared_fs::AtomicWriteError::SetPermissions { source, .. }) => Err(source),
+        Err(shared_fs::AtomicWriteError::ReplaceFile { source, .. }) => Err(source),
+        Err(shared_fs::AtomicWriteError::TempPathExhausted { target, .. }) => Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("failed to create unique temp file for {}", target.display()),
+        )),
     }
 }
 
 pub fn write_timestamp(path: &Path, iso: Option<&str>) -> io::Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
-    if let Some(raw) = iso {
-        let trimmed = raw.split(&['\n', '\r'][..]).next().unwrap_or("");
-        if !trimmed.is_empty() {
-            fs::write(path, trimmed)?;
-            return Ok(());
-        }
-    }
-
-    match fs::remove_file(path) {
+    match shared_fs::write_timestamp(path, iso) {
         Ok(()) => Ok(()),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(err),
+        Err(shared_fs::TimestampError::CreateParentDir { source, .. }) => Err(source),
+        Err(shared_fs::TimestampError::WriteFile { source, .. }) => Err(source),
+        Err(shared_fs::TimestampError::RemoveFile { source, .. }) => Err(source),
     }
 }
-
-#[cfg(unix)]
-fn set_permissions(path: &Path, mode: u32) -> io::Result<()> {
-    let perm = fs::Permissions::from_mode(mode);
-    fs::set_permissions(path, perm)
-}
-
-#[cfg(not(unix))]
-fn set_permissions(_path: &Path, _mode: u32) -> io::Result<()> {
-    Ok(())
-}
-
-fn temp_path(path: &Path, attempt: u32) -> PathBuf {
-    let filename = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("tmp");
-    let pid = std::process::id();
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    let tmp_name = format!(".{filename}.tmp-{pid}-{nanos}-{attempt}");
-    path.with_file_name(tmp_name)
-}
-
-fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push(HEX[(byte >> 4) as usize] as char);
-        out.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    out
-}
-
-struct Sha256 {
-    state: [u32; 8],
-    buffer: [u8; 64],
-    buffer_len: usize,
-    total_len: u64,
-}
-
-impl Sha256 {
-    fn new() -> Self {
-        Self {
-            state: [
-                0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
-                0x5be0cd19,
-            ],
-            buffer: [0u8; 64],
-            buffer_len: 0,
-            total_len: 0,
-        }
-    }
-
-    fn update(&mut self, mut data: &[u8]) {
-        self.total_len = self.total_len.wrapping_add(data.len() as u64);
-
-        if self.buffer_len > 0 {
-            let need = 64 - self.buffer_len;
-            let take = need.min(data.len());
-            self.buffer[self.buffer_len..self.buffer_len + take].copy_from_slice(&data[..take]);
-            self.buffer_len += take;
-            data = &data[take..];
-
-            if self.buffer_len == 64 {
-                let block = self.buffer;
-                self.compress(&block);
-                self.buffer_len = 0;
-            }
-        }
-
-        while data.len() >= 64 {
-            let block: [u8; 64] = data[..64].try_into().expect("64-byte block");
-            self.compress(&block);
-            data = &data[64..];
-        }
-
-        if !data.is_empty() {
-            self.buffer[..data.len()].copy_from_slice(data);
-            self.buffer_len = data.len();
-        }
-    }
-
-    fn finalize(mut self) -> [u8; 32] {
-        let bit_len = self.total_len.wrapping_mul(8);
-
-        self.buffer[self.buffer_len] = 0x80;
-        self.buffer_len += 1;
-
-        if self.buffer_len > 56 {
-            self.buffer[self.buffer_len..].fill(0);
-            let block = self.buffer;
-            self.compress(&block);
-            self.buffer = [0u8; 64];
-            self.buffer_len = 0;
-        }
-
-        self.buffer[self.buffer_len..56].fill(0);
-        self.buffer[56..64].copy_from_slice(&bit_len.to_be_bytes());
-        let block = self.buffer;
-        self.compress(&block);
-
-        let mut out = [0u8; 32];
-        for (index, chunk) in out.chunks_exact_mut(4).enumerate() {
-            chunk.copy_from_slice(&self.state[index].to_be_bytes());
-        }
-        out
-    }
-
-    fn compress(&mut self, block: &[u8; 64]) {
-        let mut schedule = [0u32; 64];
-        for (index, word) in schedule.iter_mut().take(16).enumerate() {
-            let offset = index * 4;
-            *word = u32::from_be_bytes([
-                block[offset],
-                block[offset + 1],
-                block[offset + 2],
-                block[offset + 3],
-            ]);
-        }
-
-        for index in 16..64 {
-            let s0 = schedule[index - 15].rotate_right(7)
-                ^ schedule[index - 15].rotate_right(18)
-                ^ (schedule[index - 15] >> 3);
-            let s1 = schedule[index - 2].rotate_right(17)
-                ^ schedule[index - 2].rotate_right(19)
-                ^ (schedule[index - 2] >> 10);
-            schedule[index] = schedule[index - 16]
-                .wrapping_add(s0)
-                .wrapping_add(schedule[index - 7])
-                .wrapping_add(s1);
-        }
-
-        let mut a = self.state[0];
-        let mut b = self.state[1];
-        let mut c = self.state[2];
-        let mut d = self.state[3];
-        let mut e = self.state[4];
-        let mut f = self.state[5];
-        let mut g = self.state[6];
-        let mut h = self.state[7];
-
-        for index in 0..64 {
-            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
-            let choice = (e & f) ^ ((!e) & g);
-            let t1 = h
-                .wrapping_add(s1)
-                .wrapping_add(choice)
-                .wrapping_add(ROUND_CONSTANTS[index])
-                .wrapping_add(schedule[index]);
-            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
-            let majority = (a & b) ^ (a & c) ^ (b & c);
-            let t2 = s0.wrapping_add(majority);
-
-            h = g;
-            g = f;
-            f = e;
-            e = d.wrapping_add(t1);
-            d = c;
-            c = b;
-            b = a;
-            a = t1.wrapping_add(t2);
-        }
-
-        self.state[0] = self.state[0].wrapping_add(a);
-        self.state[1] = self.state[1].wrapping_add(b);
-        self.state[2] = self.state[2].wrapping_add(c);
-        self.state[3] = self.state[3].wrapping_add(d);
-        self.state[4] = self.state[4].wrapping_add(e);
-        self.state[5] = self.state[5].wrapping_add(f);
-        self.state[6] = self.state[6].wrapping_add(g);
-        self.state[7] = self.state[7].wrapping_add(h);
-    }
-}
-
-const ROUND_CONSTANTS: [u32; 64] = [
-    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
-];


### PR DESCRIPTION
## Summary
- migrate `crates/codex-cli/src/fs.rs` to a thin adapter over `nils-common::fs`
- migrate `crates/gemini-cli/src/fs.rs` to a thin adapter over `nils-common::fs`
- preserve crate-local return types and rate-limit call behavior

## Testing
- cargo test -p nils-codex-cli rate_limits
- cargo test -p nils-gemini-cli rate_limits
