### PR TITLE
test(gemini-cli): migrate integration scaffolding to nils-test-support

### DIFF
--- a/crates/gemini-cli/tests/agent_prompt.rs
+++ b/crates/gemini-cli/tests/agent_prompt.rs
@@ -1,35 +1,10 @@
 use gemini_cli::agent;
-use nils_test_support::{EnvGuard, GlobalStateLock, prepend_path};
+use nils_test_support::{EnvGuard, GlobalStateLock, StubBinDir, prepend_path};
 use std::fs;
 use std::io::{BufReader, Cursor};
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::path::Path;
 
-fn temp_dir(label: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    let path = std::env::temp_dir().join(format!(
-        "nils-gemini-cli-{label}-{}-{nanos}",
-        std::process::id()
-    ));
-    let _ = fs::remove_dir_all(&path);
-    fs::create_dir_all(&path).expect("temp dir");
-    path
-}
-
-#[cfg(unix)]
-fn write_executable(path: &Path, content: &str) {
-    use std::os::unix::fs::PermissionsExt;
-
-    fs::write(path, content).expect("write executable");
-    let mut perms = fs::metadata(path).expect("metadata").permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(path, perms).expect("chmod");
-}
-
-fn write_gemini_stub(stub_path: &Path) {
+fn write_gemini_stub(stub: &StubBinDir) {
     let script = r#"#!/bin/sh
 set -eu
 out="${GEMINI_TEST_ARGV_LOG:?missing GEMINI_TEST_ARGV_LOG}"
@@ -38,7 +13,7 @@ for a in "$@"; do
   echo "$a" >> "$out"
 done
 "#;
-    write_executable(stub_path, script);
+    stub.write_exe("gemini", script);
 }
 
 fn read_args(log_path: &Path) -> Vec<String> {
@@ -51,13 +26,13 @@ fn read_args(log_path: &Path) -> Vec<String> {
 #[test]
 fn agent_prompt_requires_dangerous_mode() {
     let lock = GlobalStateLock::new();
-    let dir = temp_dir("agent-prompt-requires-dangerous");
-    let stub = dir.join("gemini");
-    let args_log = dir.join("argv.log");
-    write_gemini_stub(&stub);
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let stubs = StubBinDir::new();
+    let args_log = dir.path().join("argv.log");
+    write_gemini_stub(&stubs);
 
     let args_log_value = args_log.to_string_lossy().to_string();
-    let _path = prepend_path(&lock, &dir);
+    let _path = prepend_path(&lock, stubs.path());
     let _danger = EnvGuard::set(&lock, "GEMINI_ALLOW_DANGEROUS_ENABLED", "false");
     let _model = EnvGuard::set(&lock, "GEMINI_CLI_MODEL", "m");
     let _reasoning = EnvGuard::set(&lock, "GEMINI_CLI_REASONING", "low");
@@ -73,20 +48,18 @@ fn agent_prompt_requires_dangerous_mode() {
             .contains("gemini-tools:prompt: disabled (set GEMINI_ALLOW_DANGEROUS_ENABLED=true)")
     );
     assert!(read_args(&args_log).is_empty());
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn agent_prompt_execs_gemini_with_expected_args() {
     let lock = GlobalStateLock::new();
-    let dir = temp_dir("agent-prompt-args");
-    let stub = dir.join("gemini");
-    let args_log = dir.join("argv.log");
-    write_gemini_stub(&stub);
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let stubs = StubBinDir::new();
+    let args_log = dir.path().join("argv.log");
+    write_gemini_stub(&stubs);
 
     let args_log_value = args_log.to_string_lossy().to_string();
-    let _path = prepend_path(&lock, &dir);
+    let _path = prepend_path(&lock, stubs.path());
     let _danger = EnvGuard::set(&lock, "GEMINI_ALLOW_DANGEROUS_ENABLED", "true");
     let _model = EnvGuard::set(&lock, "GEMINI_CLI_MODEL", "m-test");
     let _reasoning = EnvGuard::set(&lock, "GEMINI_CLI_REASONING", "high");
@@ -118,20 +91,18 @@ fn agent_prompt_execs_gemini_with_expected_args() {
         .map(|value| value.to_string())
         .collect::<Vec<_>>()
     );
-
-    let _ = fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn agent_prompt_reads_stdin_when_no_args() {
     let lock = GlobalStateLock::new();
-    let dir = temp_dir("agent-prompt-stdin");
-    let stub = dir.join("gemini");
-    let args_log = dir.join("argv.log");
-    write_gemini_stub(&stub);
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let stubs = StubBinDir::new();
+    let args_log = dir.path().join("argv.log");
+    write_gemini_stub(&stubs);
 
     let args_log_value = args_log.to_string_lossy().to_string();
-    let _path = prepend_path(&lock, &dir);
+    let _path = prepend_path(&lock, stubs.path());
     let _danger = EnvGuard::set(&lock, "GEMINI_ALLOW_DANGEROUS_ENABLED", "true");
     let _model = EnvGuard::set(&lock, "GEMINI_CLI_MODEL", "m");
     let _reasoning = EnvGuard::set(&lock, "GEMINI_CLI_REASONING", "medium");
@@ -148,6 +119,4 @@ fn agent_prompt_reads_stdin_when_no_args() {
     let args = read_args(&args_log);
     let prompt_flag = args.first().map(String::as_str).unwrap_or_default();
     assert_eq!(prompt_flag, "--prompt=from stdin");
-
-    let _ = fs::remove_dir_all(&dir);
 }

--- a/crates/gemini-cli/tests/auth_refresh.rs
+++ b/crates/gemini-cli/tests/auth_refresh.rs
@@ -1,3 +1,4 @@
+use nils_test_support::StubBinDir;
 use nils_test_support::bin;
 use nils_test_support::cmd::{self, CmdOptions, CmdOutput};
 use pretty_assertions::assert_eq;
@@ -9,8 +10,16 @@ fn gemini_cli_bin() -> PathBuf {
     bin::resolve("gemini-cli")
 }
 
-fn run(args: &[&str], envs: &[(&str, &Path)], vars: &[(&str, &str)]) -> CmdOutput {
+fn run(
+    args: &[&str],
+    envs: &[(&str, &Path)],
+    vars: &[(&str, &str)],
+    path_prepend: Option<&Path>,
+) -> CmdOutput {
     let mut options = CmdOptions::default();
+    if let Some(path) = path_prepend {
+        options = options.with_path_prepend(path);
+    }
     for (key, path) in envs {
         let value = path.to_string_lossy();
         options = options.with_env(key, value.as_ref());
@@ -34,26 +43,8 @@ fn assert_exit(output: &CmdOutput, code: i32) {
     assert_eq!(output.code, code);
 }
 
-fn write_curl_stub(dir: &Path, script_body: &str) -> PathBuf {
-    let path = dir.join("curl");
-    fs::write(&path, script_body).expect("write curl stub");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&path).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&path, perms).expect("chmod");
-    }
-    path
-}
-
-fn path_with_stub(stub_dir: &Path) -> String {
-    let current = std::env::var("PATH").unwrap_or_default();
-    if current.is_empty() {
-        stub_dir.display().to_string()
-    } else {
-        format!("{}:{current}", stub_dir.display())
-    }
+fn write_curl_stub(stubs: &StubBinDir, script_body: &str) {
+    stubs.write_exe("curl", script_body);
 }
 
 #[test]
@@ -66,6 +57,7 @@ fn auth_refresh_missing_token() {
         &["auth", "refresh"],
         &[("GEMINI_AUTH_FILE", &auth_file)],
         &[],
+        None,
     );
     assert_exit(&output, 2);
     assert!(stderr(&output).contains("failed to read refresh token"));
@@ -73,7 +65,7 @@ fn auth_refresh_missing_token() {
 
 #[test]
 fn auth_refresh_invalid_name() {
-    let output = run(&["auth", "refresh", "../bad.json"], &[], &[]);
+    let output = run(&["auth", "refresh", "../bad.json"], &[], &[], None);
     assert_exit(&output, 64);
     assert!(stderr(&output).contains("invalid secret file name"));
 }
@@ -88,6 +80,7 @@ fn auth_refresh_missing_secret_file() {
         &["auth", "refresh", "missing.json"],
         &[("GEMINI_SECRET_DIR", &secrets)],
         &[],
+        None,
     );
     assert_exit(&output, 1);
     assert!(stderr(&output).contains("not found"));
@@ -103,6 +96,7 @@ fn auth_refresh_json_missing_token() {
         &["auth", "refresh", "--json"],
         &[("GEMINI_AUTH_FILE", &auth_file)],
         &[],
+        None,
     );
     assert_exit(&output, 2);
     let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
@@ -113,7 +107,12 @@ fn auth_refresh_json_missing_token() {
 
 #[test]
 fn auth_refresh_json_invalid_name() {
-    let output = run(&["auth", "refresh", "--json", "../bad.json"], &[], &[]);
+    let output = run(
+        &["auth", "refresh", "--json", "../bad.json"],
+        &[],
+        &[],
+        None,
+    );
     assert_exit(&output, 64);
     let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
     assert_eq!(payload["ok"], false);
@@ -130,6 +129,7 @@ fn auth_refresh_json_missing_secret_file() {
         &["auth", "refresh", "--json", "missing.json"],
         &[("GEMINI_SECRET_DIR", &secrets)],
         &[],
+        None,
     );
     assert_exit(&output, 1);
     let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
@@ -140,18 +140,16 @@ fn auth_refresh_json_missing_secret_file() {
 #[test]
 fn auth_refresh_success_updates_tokens_and_timestamp() {
     let dir = tempfile::TempDir::new().expect("tempdir");
-    let bin_dir = dir.path().join("bin");
-    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let stubs = StubBinDir::new();
     let secrets = dir.path().join("secrets");
     fs::create_dir_all(&secrets).expect("secrets");
     let cache_dir = dir.path().join("cache");
     fs::create_dir_all(&cache_dir).expect("cache");
 
     write_curl_stub(
-        &bin_dir,
+        &stubs,
         "#!/bin/sh\ncat <<'EOF'\n{\"access_token\":\"new_access\",\"refresh_token\":\"new_refresh\",\"id_token\":\"new_id\"}\n__HTTP_STATUS__:200\nEOF\n",
     );
-    let path_env = path_with_stub(&bin_dir);
 
     let target = secrets.join("alpha.json");
     fs::write(
@@ -166,7 +164,8 @@ fn auth_refresh_success_updates_tokens_and_timestamp() {
             ("GEMINI_SECRET_DIR", &secrets),
             ("GEMINI_SECRET_CACHE_DIR", &cache_dir),
         ],
-        &[("PATH", &path_env)],
+        &[],
+        Some(stubs.path()),
     );
     assert_exit(&output, 0);
     assert!(stdout(&output).contains("gemini: refreshed"));
@@ -184,14 +183,12 @@ fn auth_refresh_success_updates_tokens_and_timestamp() {
 #[test]
 fn auth_refresh_json_http_error_contains_summary() {
     let dir = tempfile::TempDir::new().expect("tempdir");
-    let bin_dir = dir.path().join("bin");
-    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let stubs = StubBinDir::new();
 
     write_curl_stub(
-        &bin_dir,
+        &stubs,
         "#!/bin/sh\ncat <<'EOF'\n{\"error\":{\"code\":\"invalid_grant\",\"message\":\"expired\"},\"error_description\":\"reauth\"}\n__HTTP_STATUS__:401\nEOF\n",
     );
-    let path_env = path_with_stub(&bin_dir);
 
     let auth_file = dir.path().join("auth.json");
     fs::write(
@@ -203,7 +200,8 @@ fn auth_refresh_json_http_error_contains_summary() {
     let output = run(
         &["auth", "refresh", "--json"],
         &[("GEMINI_AUTH_FILE", &auth_file)],
-        &[("PATH", &path_env)],
+        &[],
+        Some(stubs.path()),
     );
     assert_exit(&output, 3);
     let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
@@ -220,14 +218,12 @@ fn auth_refresh_json_http_error_contains_summary() {
 #[test]
 fn auth_refresh_invalid_json_payload_returns_4() {
     let dir = tempfile::TempDir::new().expect("tempdir");
-    let bin_dir = dir.path().join("bin");
-    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let stubs = StubBinDir::new();
 
     write_curl_stub(
-        &bin_dir,
+        &stubs,
         "#!/bin/sh\ncat <<'EOF'\nnot-json\n__HTTP_STATUS__:200\nEOF\n",
     );
-    let path_env = path_with_stub(&bin_dir);
 
     let auth_file = dir.path().join("auth.json");
     fs::write(
@@ -239,7 +235,8 @@ fn auth_refresh_invalid_json_payload_returns_4() {
     let output = run(
         &["auth", "refresh"],
         &[("GEMINI_AUTH_FILE", &auth_file)],
-        &[("PATH", &path_env)],
+        &[],
+        Some(stubs.path()),
     );
     assert_exit(&output, 4);
     assert!(stderr(&output).contains("invalid JSON"));
@@ -248,14 +245,12 @@ fn auth_refresh_invalid_json_payload_returns_4() {
 #[test]
 fn auth_refresh_merge_failed_when_endpoint_payload_not_object() {
     let dir = tempfile::TempDir::new().expect("tempdir");
-    let bin_dir = dir.path().join("bin");
-    fs::create_dir_all(&bin_dir).expect("bin dir");
+    let stubs = StubBinDir::new();
 
     write_curl_stub(
-        &bin_dir,
+        &stubs,
         "#!/bin/sh\ncat <<'EOF'\n123\n__HTTP_STATUS__:200\nEOF\n",
     );
-    let path_env = path_with_stub(&bin_dir);
 
     let auth_file = dir.path().join("auth.json");
     fs::write(
@@ -267,7 +262,8 @@ fn auth_refresh_merge_failed_when_endpoint_payload_not_object() {
     let output = run(
         &["auth", "refresh", "--json"],
         &[("GEMINI_AUTH_FILE", &auth_file)],
-        &[("PATH", &path_env)],
+        &[],
+        Some(stubs.path()),
     );
     assert_exit(&output, 5);
     let payload: Value = serde_json::from_str(&stdout(&output)).expect("json");
@@ -288,6 +284,7 @@ fn auth_refresh_missing_curl_binary_returns_3() {
         &["auth", "refresh"],
         &[("GEMINI_AUTH_FILE", &auth_file)],
         &[("PATH", "")],
+        None,
     );
     assert_exit(&output, 3);
     assert!(stderr(&output).contains("token endpoint request failed"));

--- a/crates/gemini-cli/tests/paths.rs
+++ b/crates/gemini-cli/tests/paths.rs
@@ -1,120 +1,44 @@
 use gemini_cli::paths;
-use std::ffi::{OsStr, OsString};
+use nils_test_support::{EnvGuard, GlobalStateLock};
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-struct TestDir {
-    path: PathBuf,
-}
-
-impl TestDir {
-    fn new(label: &str) -> Self {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or(0);
-        let path = std::env::temp_dir().join(format!(
-            "nils-gemini-cli-{label}-{}-{nanos}",
-            std::process::id()
-        ));
-        fs::create_dir_all(&path).expect("create temp test dir");
-        Self { path }
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-impl Drop for TestDir {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.path);
-    }
-}
-
-struct EnvVarGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvVarGuard {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let previous = std::env::var_os(key);
-        set_env_var(key, value);
-        Self { key, previous }
-    }
-
-    fn remove(key: &'static str) -> Self {
-        let previous = std::env::var_os(key);
-        remove_env_var(key);
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(previous) = &self.previous {
-            set_env_var(self.key, previous);
-        } else {
-            remove_env_var(self.key);
-        }
-    }
-}
-
-fn env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
-fn set_env_var(key: &str, value: impl AsRef<OsStr>) {
-    // SAFETY: tests serialize env access with env_lock.
-    unsafe {
-        std::env::set_var(key, value);
-    }
-}
-
-fn remove_env_var(key: &str) {
-    // SAFETY: tests serialize env access with env_lock.
-    unsafe {
-        std::env::remove_var(key);
-    }
+fn set_env(lock: &GlobalStateLock, key: &str, value: impl AsRef<std::ffi::OsStr>) -> EnvGuard {
+    let value = value.as_ref().to_string_lossy().into_owned();
+    EnvGuard::set(lock, key, &value)
 }
 
 #[test]
 fn paths_resolve_zdotdir_variants() {
-    let _lock = env_lock().lock().expect("lock");
-    let dir = TestDir::new("paths-zdotdir");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
 
     let zdotdir_env = dir.path().join("zdot_env");
     fs::create_dir_all(&zdotdir_env).expect("zdot_env");
 
     {
-        let _zdotdir = EnvVarGuard::set("ZDOTDIR", zdotdir_env.as_os_str());
-        let _preload = EnvVarGuard::remove("_ZSH_BOOTSTRAP_PRELOAD_PATH");
+        let _zdotdir = set_env(&lock, "ZDOTDIR", zdotdir_env.as_os_str());
+        let _preload = EnvGuard::remove(&lock, "_ZSH_BOOTSTRAP_PRELOAD_PATH");
         assert_eq!(paths::resolve_zdotdir().expect("zdotdir"), zdotdir_env);
     }
 
     {
-        let _zdotdir = EnvVarGuard::remove("ZDOTDIR");
+        let _zdotdir = EnvGuard::remove(&lock, "ZDOTDIR");
 
         let preload = dir.path().join("a").join("b").join("preload.zsh");
         fs::create_dir_all(preload.parent().expect("parent")).expect("preload parent");
 
-        let _preload = EnvVarGuard::set("_ZSH_BOOTSTRAP_PRELOAD_PATH", preload.as_os_str());
+        let _preload = set_env(&lock, "_ZSH_BOOTSTRAP_PRELOAD_PATH", preload.as_os_str());
 
         let expected = dir.path().join("a");
         assert_eq!(paths::resolve_zdotdir().expect("zdotdir"), expected);
     }
 
     {
-        let _zdotdir = EnvVarGuard::remove("ZDOTDIR");
-        let _preload = EnvVarGuard::remove("_ZSH_BOOTSTRAP_PRELOAD_PATH");
+        let _zdotdir = EnvGuard::remove(&lock, "ZDOTDIR");
+        let _preload = EnvGuard::remove(&lock, "_ZSH_BOOTSTRAP_PRELOAD_PATH");
 
         let home = dir.path().join("home");
         fs::create_dir_all(&home).expect("home");
-        let _home = EnvVarGuard::set("HOME", home.as_os_str());
+        let _home = set_env(&lock, "HOME", home.as_os_str());
 
         assert_eq!(
             paths::resolve_zdotdir().expect("zdotdir"),
@@ -125,14 +49,14 @@ fn paths_resolve_zdotdir_variants() {
 
 #[test]
 fn paths_resolve_secret_dir_from_feature_dir() {
-    let _lock = env_lock().lock().expect("lock");
-    let dir = TestDir::new("paths-secret-dir");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
 
     let override_dir = dir.path().join("override_secrets");
     fs::create_dir_all(&override_dir).expect("override dir");
 
     {
-        let _secret = EnvVarGuard::set("GEMINI_SECRET_DIR", override_dir.as_os_str());
+        let _secret = set_env(&lock, "GEMINI_SECRET_DIR", override_dir.as_os_str());
         assert_eq!(
             paths::resolve_secret_dir().expect("secret dir"),
             override_dir
@@ -147,8 +71,8 @@ fn paths_resolve_secret_dir_from_feature_dir() {
     {
         let home = dir.path().join("home");
         fs::create_dir_all(&home).expect("home");
-        let _secret = EnvVarGuard::remove("GEMINI_SECRET_DIR");
-        let _home = EnvVarGuard::set("HOME", home.as_os_str());
+        let _secret = EnvGuard::remove(&lock, "GEMINI_SECRET_DIR");
+        let _home = set_env(&lock, "HOME", home.as_os_str());
         assert_eq!(
             paths::resolve_secret_dir().expect("secret dir"),
             home.join(".gemini").join("secrets")
@@ -156,9 +80,9 @@ fn paths_resolve_secret_dir_from_feature_dir() {
     }
 
     {
-        let _secret = EnvVarGuard::remove("GEMINI_SECRET_DIR");
-        let _home = EnvVarGuard::remove("HOME");
-        let _script_dir = EnvVarGuard::set("ZSH_SCRIPT_DIR", script_dir.as_os_str());
+        let _secret = EnvGuard::remove(&lock, "GEMINI_SECRET_DIR");
+        let _home = EnvGuard::remove(&lock, "HOME");
+        let _script_dir = set_env(&lock, "ZSH_SCRIPT_DIR", script_dir.as_os_str());
 
         fs::write(feature_dir.join("init.zsh"), "#").expect("init.zsh");
         assert_eq!(
@@ -176,12 +100,12 @@ fn paths_resolve_secret_dir_from_feature_dir() {
 
 #[test]
 fn paths_resolve_secret_cache_dir_variants() {
-    let _lock = env_lock().lock().expect("lock");
-    let dir = TestDir::new("paths-cache-dir");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
 
     let override_dir = dir.path().join("cache_override");
     {
-        let _override = EnvVarGuard::set("GEMINI_SECRET_CACHE_DIR", override_dir.as_os_str());
+        let _override = set_env(&lock, "GEMINI_SECRET_CACHE_DIR", override_dir.as_os_str());
         assert_eq!(
             paths::resolve_secret_cache_dir().expect("secret cache dir"),
             override_dir
@@ -189,9 +113,9 @@ fn paths_resolve_secret_cache_dir_variants() {
     }
 
     {
-        let _override = EnvVarGuard::remove("GEMINI_SECRET_CACHE_DIR");
+        let _override = EnvGuard::remove(&lock, "GEMINI_SECRET_CACHE_DIR");
         let cache_root = dir.path().join("cache_root");
-        let _cache_root = EnvVarGuard::set("ZSH_CACHE_DIR", cache_root.as_os_str());
+        let _cache_root = set_env(&lock, "ZSH_CACHE_DIR", cache_root.as_os_str());
 
         assert_eq!(
             paths::resolve_secret_cache_dir().expect("secret cache dir"),
@@ -200,11 +124,11 @@ fn paths_resolve_secret_cache_dir_variants() {
     }
 
     {
-        let _override = EnvVarGuard::remove("GEMINI_SECRET_CACHE_DIR");
-        let _cache_root = EnvVarGuard::remove("ZSH_CACHE_DIR");
+        let _override = EnvGuard::remove(&lock, "GEMINI_SECRET_CACHE_DIR");
+        let _cache_root = EnvGuard::remove(&lock, "ZSH_CACHE_DIR");
         let home = dir.path().join("home");
         fs::create_dir_all(&home).expect("home");
-        let _home = EnvVarGuard::set("HOME", home.as_os_str());
+        let _home = set_env(&lock, "HOME", home.as_os_str());
 
         assert_eq!(
             paths::resolve_secret_cache_dir().expect("secret cache dir"),
@@ -213,11 +137,11 @@ fn paths_resolve_secret_cache_dir_variants() {
     }
 
     {
-        let _override = EnvVarGuard::remove("GEMINI_SECRET_CACHE_DIR");
-        let _cache_root = EnvVarGuard::remove("ZSH_CACHE_DIR");
-        let _home = EnvVarGuard::remove("HOME");
+        let _override = EnvGuard::remove(&lock, "GEMINI_SECRET_CACHE_DIR");
+        let _cache_root = EnvGuard::remove(&lock, "ZSH_CACHE_DIR");
+        let _home = EnvGuard::remove(&lock, "HOME");
         let zdotdir = dir.path().join("zdotdir");
-        let _zdotdir = EnvVarGuard::set("ZDOTDIR", zdotdir.as_os_str());
+        let _zdotdir = set_env(&lock, "ZDOTDIR", zdotdir.as_os_str());
         assert_eq!(
             paths::resolve_secret_cache_dir().expect("secret cache dir"),
             zdotdir.join("cache").join("gemini").join("secrets")
@@ -227,25 +151,25 @@ fn paths_resolve_secret_cache_dir_variants() {
 
 #[test]
 fn paths_resolve_auth_file_prefers_env() {
-    let _lock = env_lock().lock().expect("lock");
-    let dir = TestDir::new("paths-auth-file");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
 
     let auth_file = dir.path().join("auth.json");
-    let _auth = EnvVarGuard::set("GEMINI_AUTH_FILE", auth_file.as_os_str());
+    let _auth = set_env(&lock, "GEMINI_AUTH_FILE", auth_file.as_os_str());
 
     assert_eq!(paths::resolve_auth_file().expect("auth file"), auth_file);
 }
 
 #[test]
 fn paths_resolve_script_dir_ignores_empty_env_override() {
-    let _lock = env_lock().lock().expect("lock");
-    let dir = TestDir::new("paths-script-dir");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
 
     let zdotdir = dir.path().join("zdotdir");
     fs::create_dir_all(&zdotdir).expect("zdotdir");
 
-    let _zdotdir = EnvVarGuard::set("ZDOTDIR", zdotdir.as_os_str());
-    let _script = EnvVarGuard::set("ZSH_SCRIPT_DIR", "");
+    let _zdotdir = set_env(&lock, "ZDOTDIR", zdotdir.as_os_str());
+    let _script = EnvGuard::set(&lock, "ZSH_SCRIPT_DIR", "");
 
     assert_eq!(
         paths::resolve_script_dir().expect("script dir"),

--- a/crates/gemini-cli/tests/prompts.rs
+++ b/crates/gemini-cli/tests/prompts.rs
@@ -1,101 +1,16 @@
 use gemini_cli::prompts;
+use nils_test_support::{EnvGuard, GlobalStateLock};
 use prompts::PromptTemplateError;
-use std::ffi::{OsStr, OsString};
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-struct TestDir {
-    path: PathBuf,
-}
-
-impl TestDir {
-    fn new(label: &str) -> Self {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or(0);
-        let path = std::env::temp_dir().join(format!(
-            "nils-gemini-cli-{label}-{}-{nanos}",
-            std::process::id()
-        ));
-        fs::create_dir_all(&path).expect("create temp test dir");
-        Self { path }
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-impl Drop for TestDir {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.path);
-    }
-}
-
-struct EnvVarGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvVarGuard {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let previous = std::env::var_os(key);
-        set_env_var(key, value);
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(previous) = &self.previous {
-            set_env_var(self.key, previous);
-        } else {
-            remove_env_var(self.key);
-        }
-    }
-}
-
-fn env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
-fn set_env_var(key: &str, value: impl AsRef<OsStr>) {
-    // SAFETY: tests serialize env access with env_lock.
-    unsafe {
-        std::env::set_var(key, value);
-    }
-}
-
-fn remove_env_var(key: &str) {
-    // SAFETY: tests serialize env access with env_lock.
-    unsafe {
-        std::env::remove_var(key);
-    }
-}
-
-fn set_mode(path: &Path, mode: u32) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(path).expect("metadata").permissions();
-        perms.set_mode(mode);
-        fs::set_permissions(path, perms).expect("chmod");
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = (path, mode);
-    }
+fn set_env(lock: &GlobalStateLock, key: &str, value: impl AsRef<std::ffi::OsStr>) -> EnvGuard {
+    let value = value.as_ref().to_string_lossy().into_owned();
+    EnvGuard::set(lock, key, &value)
 }
 
 #[test]
 fn prompts_resolve_uses_feature_dir_fallback_when_zdotdir_prompts_missing() {
-    let _lock = env_lock().lock().expect("lock");
-    let dir = TestDir::new("prompts-feature-fallback");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
 
     let zdotdir = dir.path().join("zdotdir");
     fs::create_dir_all(&zdotdir).expect("zdotdir");
@@ -109,8 +24,8 @@ fn prompts_resolve_uses_feature_dir_fallback_when_zdotdir_prompts_missing() {
     )
     .expect("write template");
 
-    let _zdotdir_env = EnvVarGuard::set("ZDOTDIR", zdotdir.as_os_str());
-    let _script_env = EnvVarGuard::set("ZSH_SCRIPT_DIR", script_dir.as_os_str());
+    let _zdotdir_env = set_env(&lock, "ZDOTDIR", zdotdir.as_os_str());
+    let _script_env = set_env(&lock, "ZSH_SCRIPT_DIR", script_dir.as_os_str());
 
     let resolved = prompts::resolve_prompts_dir().expect("resolve prompts dir");
     assert_eq!(resolved, feature_prompts);
@@ -122,8 +37,8 @@ fn prompts_resolve_uses_feature_dir_fallback_when_zdotdir_prompts_missing() {
 
 #[test]
 fn prompts_resolve_returns_none_when_no_prompts_dirs_exist() {
-    let _lock = env_lock().lock().expect("lock");
-    let dir = TestDir::new("prompts-no-dirs");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
 
     let zdotdir = dir.path().join("zdotdir");
     fs::create_dir_all(&zdotdir).expect("zdotdir");
@@ -132,24 +47,24 @@ fn prompts_resolve_returns_none_when_no_prompts_dirs_exist() {
     let feature_dir = script_dir.join("_features").join("gemini");
     fs::create_dir_all(&feature_dir).expect("feature dir");
 
-    let _zdotdir_env = EnvVarGuard::set("ZDOTDIR", zdotdir.as_os_str());
-    let _script_env = EnvVarGuard::set("ZSH_SCRIPT_DIR", script_dir.as_os_str());
+    let _zdotdir_env = set_env(&lock, "ZDOTDIR", zdotdir.as_os_str());
+    let _script_env = set_env(&lock, "ZSH_SCRIPT_DIR", script_dir.as_os_str());
 
     assert!(prompts::resolve_prompts_dir().is_none());
 }
 
 #[test]
 fn prompts_read_template_errors_when_prompts_dir_missing() {
-    let _lock = env_lock().lock().expect("lock");
-    let dir = TestDir::new("prompts-missing-dir");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
 
     let zdotdir = dir.path().join("zdotdir");
     fs::create_dir_all(&zdotdir).expect("zdotdir");
     let script_dir = dir.path().join("scripts");
     fs::create_dir_all(&script_dir).expect("scripts dir");
 
-    let _zdotdir_env = EnvVarGuard::set("ZDOTDIR", zdotdir.as_os_str());
-    let _script_env = EnvVarGuard::set("ZSH_SCRIPT_DIR", script_dir.as_os_str());
+    let _zdotdir_env = set_env(&lock, "ZDOTDIR", zdotdir.as_os_str());
+    let _script_env = set_env(&lock, "ZSH_SCRIPT_DIR", script_dir.as_os_str());
 
     let err = prompts::read_template("anything").expect_err("missing prompts dir");
     assert!(matches!(err, PromptTemplateError::PromptsDirNotFound));
@@ -157,14 +72,14 @@ fn prompts_read_template_errors_when_prompts_dir_missing() {
 
 #[test]
 fn prompts_read_template_errors_when_template_missing() {
-    let _lock = env_lock().lock().expect("lock");
-    let dir = TestDir::new("prompts-missing-template");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
 
     let zdotdir = dir.path().join("zdotdir");
     let prompts_dir = zdotdir.join("prompts");
     fs::create_dir_all(&prompts_dir).expect("prompts dir");
 
-    let _zdotdir_env = EnvVarGuard::set("ZDOTDIR", zdotdir.as_os_str());
+    let _zdotdir_env = set_env(&lock, "ZDOTDIR", zdotdir.as_os_str());
 
     let err = prompts::read_template("missing-template").expect_err("missing template");
     match err {
@@ -177,17 +92,21 @@ fn prompts_read_template_errors_when_template_missing() {
 
 #[test]
 fn prompts_read_template_errors_when_template_unreadable() {
-    let _lock = env_lock().lock().expect("lock");
-    let dir = TestDir::new("prompts-unreadable");
+    let lock = GlobalStateLock::new();
+    let dir = tempfile::TempDir::new().expect("tempdir");
 
     let zdotdir = dir.path().join("zdotdir");
     let prompts_dir = zdotdir.join("prompts");
     fs::create_dir_all(&prompts_dir).expect("prompts dir");
     let template = prompts_dir.join("unreadable.md");
-    fs::write(&template, "hi").expect("write template");
-    set_mode(&template, 0o000);
 
-    let _zdotdir_env = EnvVarGuard::set("ZDOTDIR", zdotdir.as_os_str());
+    #[cfg(unix)]
+    fs::write(&template, [0xFF]).expect("write invalid template");
+
+    #[cfg(not(unix))]
+    fs::write(&template, "hi").expect("write template");
+
+    let _zdotdir_env = set_env(&lock, "ZDOTDIR", zdotdir.as_os_str());
 
     #[cfg(unix)]
     {


### PR DESCRIPTION
## Summary
- migrate gemini integration tests to nils_test_support env/path primitives in task T51 scope
- replace bespoke EnvVarGuard/temp dir scaffolding with GlobalStateLock/EnvGuard/TempDir
- replace manual stub chmod and PATH string assembly with StubBinDir and CmdOptions::with_path_prepend

## Validation
- cargo test -p nils-gemini-cli paths
- cargo test -p nils-gemini-cli prompts
- cargo test -p nils-gemini-cli agent_prompt
- cargo test -p nils-gemini-cli auth_refresh