### PR TITLE
Improve Linux screen-record coverage for CI parity

### DIFF
--- a/crates/screen-record/src/linux/audio.rs
+++ b/crates/screen-record/src/linux/audio.rs
@@ -187,3 +187,52 @@ fn map_spawn_error(err: std::io::Error) -> CliError {
     }
     CliError::runtime(format!("failed to spawn pactl: {err}"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_info_field_trims_values_and_ignores_empty_or_missing_fields() {
+        let info = "\
+Server Name: PulseAudio (on PipeWire)\n\
+Default Sink:   speakers.main  \n\
+Default Source:   \n";
+
+        assert_eq!(
+            parse_info_field(info, "Default Sink:"),
+            Some("speakers.main".to_string())
+        );
+        assert_eq!(parse_info_field(info, "Default Source:"), None);
+        assert_eq!(parse_info_field(info, "Missing Field:"), None);
+    }
+
+    #[test]
+    fn bounded_utf8_keeps_only_trailing_bytes_when_output_exceeds_limit() {
+        let mut bytes = vec![b'a'; OUTPUT_LIMIT_BYTES + 16];
+        bytes.extend_from_slice(b"tail-marker");
+
+        let out = bounded_utf8(&bytes);
+        assert!(out.ends_with("tail-marker"));
+        assert_eq!(out.len(), OUTPUT_LIMIT_BYTES);
+    }
+
+    #[test]
+    fn output_snippet_and_exit_code_suffix_handle_empty_and_present_values() {
+        assert_eq!(output_snippet(""), "");
+        assert_eq!(output_snippet("   \n\t  "), "");
+        assert_eq!(output_snippet(" ffmpeg exploded \n"), ": ffmpeg exploded");
+
+        assert_eq!(exit_code_suffix(None), "");
+        assert_eq!(exit_code_suffix(Some(17)), " (exit code 17)");
+    }
+
+    #[test]
+    fn map_spawn_error_formats_not_found_and_other_errors() {
+        let missing = map_spawn_error(std::io::Error::from(std::io::ErrorKind::NotFound));
+        assert!(missing.to_string().contains("pactl not found on PATH"));
+
+        let other = map_spawn_error(std::io::Error::other("boom"));
+        assert!(other.to_string().contains("failed to spawn pactl: boom"));
+    }
+}

--- a/crates/screen-record/src/linux/x11.rs
+++ b/crates/screen-record/src/linux/x11.rs
@@ -383,3 +383,68 @@ fn intern_atom<C: Connection>(conn: &C, name: &str) -> Result<Atom, CliError> {
         .map_err(|err| CliError::runtime(format!("failed to intern atom {name}: {err}")))?;
     Ok(reply.atom)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn window(owner_name: &str, owner_pid: i32, id: u32) -> WindowInfo {
+        WindowInfo {
+            id,
+            owner_name: owner_name.to_string(),
+            title: format!("Window {id}"),
+            bounds: Rect {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 80,
+            },
+            on_screen: true,
+            active: false,
+            owner_pid,
+            z_order: 0,
+        }
+    }
+
+    #[test]
+    fn bytes_to_string_trims_non_empty_values_and_rejects_blank_values() {
+        assert_eq!(
+            bytes_to_string(b"  Hello X11  "),
+            Some("Hello X11".to_string())
+        );
+        assert_eq!(bytes_to_string(b" \n\t "), None);
+    }
+
+    #[test]
+    fn z_order_map_assigns_highest_order_to_first_window() {
+        let map = z_order_map(&[10, 20, 30]);
+        assert_eq!(map.get(&10), Some(&2));
+        assert_eq!(map.get(&20), Some(&1));
+        assert_eq!(map.get(&30), Some(&0));
+    }
+
+    #[test]
+    fn derive_apps_deduplicates_by_owner_name_and_pid() {
+        let windows = vec![
+            window("Terminal", 100, 1),
+            window("Terminal", 100, 2),
+            window("Browser", 200, 3),
+            window("Terminal", 101, 4),
+        ];
+
+        let apps = derive_apps(&windows);
+        assert_eq!(apps.len(), 3);
+        assert!(
+            apps.iter()
+                .any(|app| app.name == "Terminal" && app.pid == 100)
+        );
+        assert!(
+            apps.iter()
+                .any(|app| app.name == "Terminal" && app.pid == 101)
+        );
+        assert!(
+            apps.iter()
+                .any(|app| app.name == "Browser" && app.pid == 200)
+        );
+    }
+}

--- a/crates/screen-record/tests/linux_portal_unit.rs
+++ b/crates/screen-record/tests/linux_portal_unit.rs
@@ -71,6 +71,26 @@ mod linux_portal_unit {
     }
 
     #[test]
+    fn portal_without_session_bus_reports_actionable_runtime_error() {
+        let lock = GlobalStateLock::new();
+
+        let _force_available =
+            EnvGuard::remove(&lock, "AGENTS_SCREEN_RECORD_PORTAL_FORCE_AVAILABLE");
+        let _force_missing = EnvGuard::remove(&lock, "AGENTS_SCREEN_RECORD_PORTAL_FORCE_MISSING");
+        let _dbus = EnvGuard::set(
+            &lock,
+            "DBUS_SESSION_BUS_ADDRESS",
+            "unix:path=/definitely-missing-agent-screen-record-portal.sock",
+        );
+
+        let err =
+            portal::ensure_portal_available().expect_err("expected DBus session connect failure");
+        let message = err.to_string();
+        assert!(message.contains("Wayland-only session detected"));
+        assert!(message.contains("DBUS_SESSION_BUS_ADDRESS is unset"));
+    }
+
+    #[test]
     fn parse_session_handle_reports_missing_key_and_type_mismatch() {
         let missing = HashMap::new();
         let err = portal::parse_session_handle_from_results(&missing).expect_err("missing key");
@@ -102,11 +122,62 @@ mod linux_portal_unit {
     }
 
     #[test]
+    fn parse_session_handle_and_streams_accept_valid_values() {
+        let session_path = zbus::zvariant::ObjectPath::try_from(
+            "/org/freedesktop/portal/desktop/session/1_42/screen_record",
+        )
+        .expect("session path");
+        let mut session_dict = HashMap::new();
+        session_dict.insert(
+            "session_handle".to_string(),
+            zbus::zvariant::OwnedValue::from(session_path.clone()),
+        );
+
+        let parsed_session =
+            portal::parse_session_handle_from_results(&session_dict).expect("parse session");
+        assert_eq!(parsed_session.to_string(), session_path.to_string());
+
+        let mut stream_meta = HashMap::new();
+        stream_meta.insert(
+            "source_type".to_string(),
+            zbus::zvariant::OwnedValue::from(1u32),
+        );
+        let expected_streams = vec![(4242u32, stream_meta)];
+        let mut stream_dict = HashMap::new();
+        stream_dict.insert(
+            "streams".to_string(),
+            zbus::zvariant::OwnedValue::try_from(zbus::zvariant::Value::from(
+                expected_streams.clone(),
+            ))
+            .expect("streams value"),
+        );
+
+        let streams = portal::parse_streams_from_results(&stream_dict).expect("parse streams");
+        assert_eq!(streams.len(), 1);
+        assert_eq!(streams[0].0, 4242);
+        assert_eq!(streams[0].1.len(), 1);
+        assert!(streams[0].1.contains_key("source_type"));
+    }
+
+    #[test]
     fn ensure_response_code_ok_rejects_non_zero_portal_response_code() {
         let err = portal::ensure_response_code_ok(2, HashMap::new())
             .expect_err("non-zero response must be rejected");
         let message = err.to_string();
         assert!(message.contains("portal request failed or was cancelled"));
         assert!(message.contains("response=2"));
+    }
+
+    #[test]
+    fn ensure_response_code_ok_accepts_zero_and_preserves_results() {
+        let mut results = HashMap::new();
+        results.insert(
+            "kind".to_string(),
+            zbus::zvariant::OwnedValue::from(zbus::zvariant::Str::from("ok")),
+        );
+
+        let out = portal::ensure_response_code_ok(0, results).expect("zero response should pass");
+        assert_eq!(out.len(), 1);
+        assert!(out.contains_key("kind"));
     }
 }

--- a/crates/screen-record/tests/linux_unit.rs
+++ b/crates/screen-record/tests/linux_unit.rs
@@ -4,7 +4,7 @@ mod linux_unit {
     use std::path::{Path, PathBuf};
 
     use nils_test_support::{EnvGuard, GlobalStateLock, StubBinDir, prepend_path};
-    use screen_record::cli::{AudioMode, ContainerFormat};
+    use screen_record::cli::{AudioMode, ContainerFormat, ImageFormat};
     use screen_record::linux::ffmpeg;
     use screen_record::linux::portal::PortalCapture;
     use screen_record::types::{Rect, WindowInfo};
@@ -65,6 +65,76 @@ EOF
     exit 0
   fi
 done
+
+out="${@: -1}"
+mkdir -p "$(dirname "$out")"
+printf "stub" > "$out"
+"#,
+        );
+    }
+
+    fn write_ffmpeg_stub_with_pipewire_fd_support(dir: &StubBinDir) {
+        dir.write_exe(
+            "ffmpeg",
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${AGENTS_FFMPEG_LOG:-}" ]]; then
+  printf 'CALL\n' >> "${AGENTS_FFMPEG_LOG}"
+  printf '%s\n' "$@" >> "${AGENTS_FFMPEG_LOG}"
+  printf 'END\n' >> "${AGENTS_FFMPEG_LOG}"
+fi
+
+if [[ "$*" == *"-devices"* ]]; then
+  cat <<'EOF'
+Devices:
+ D  pipewire           PipeWire audio and video capture
+EOF
+  exit 0
+fi
+
+if [[ "$*" == *"-h demuxer=pipewire"* ]]; then
+  cat <<'EOF'
+pipewire demuxer options:
+  -pipewire_fd <fd>    Use already-open PipeWire fd
+EOF
+  exit 0
+fi
+
+out="${@: -1}"
+mkdir -p "$(dirname "$out")"
+printf "stub" > "$out"
+"#,
+        );
+    }
+
+    fn write_ffmpeg_stub_with_pipewire_help_but_no_fd_flag(dir: &StubBinDir) {
+        dir.write_exe(
+            "ffmpeg",
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${AGENTS_FFMPEG_LOG:-}" ]]; then
+  printf 'CALL\n' >> "${AGENTS_FFMPEG_LOG}"
+  printf '%s\n' "$@" >> "${AGENTS_FFMPEG_LOG}"
+  printf 'END\n' >> "${AGENTS_FFMPEG_LOG}"
+fi
+
+if [[ "$*" == *"-devices"* ]]; then
+  cat <<'EOF'
+Devices:
+ D  pipewire           PipeWire audio and video capture
+EOF
+  exit 0
+fi
+
+if [[ "$*" == *"-h demuxer=pipewire"* ]]; then
+  cat <<'EOF'
+pipewire demuxer options:
+  -video_size <WxH>    Set capture frame size
+EOF
+  exit 0
+fi
 
 out="${@: -1}"
 mkdir -p "$(dirname "$out")"
@@ -608,5 +678,166 @@ exit 9
         assert_eq!(err.exit_code(), 1);
         assert!(err.to_string().contains("ffmpeg failed (exit code 9)"));
         assert!(err.to_string().contains("encoder failed in stub"));
+    }
+
+    #[test]
+    fn linux_unit_ffmpeg_screenshot_window_uses_single_frame_capture() {
+        let lock = GlobalStateLock::new();
+        let stubs = StubBinDir::new();
+        write_ffmpeg_stub(&stubs);
+
+        let _path_guard = prepend_path(&lock, stubs.path());
+        let _display_guard = EnvGuard::set(&lock, "DISPLAY", ":99");
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let out_path = tmp.path().join("shot.png");
+        let log_path = tmp.path().join("ffmpeg-args.txt");
+        let _ffmpeg_log = EnvGuard::set(&lock, "AGENTS_FFMPEG_LOG", &log_path.to_string_lossy());
+
+        ffmpeg::screenshot_window(&window(321), &out_path, ImageFormat::Png).expect("screenshot");
+
+        let args = read_log(&log_path);
+        assert!(args.contains(&"-window_id".to_string()));
+        assert!(args.contains(&format!("0x{:x}", 321)));
+        assert!(args.contains(&"-frames:v".to_string()));
+        assert!(args.contains(&"1".to_string()));
+        assert!(!args.contains(&"-t".to_string()));
+        assert!(out_path.exists());
+    }
+
+    #[test]
+    fn linux_unit_ffmpeg_screenshot_window_errors_when_display_missing() {
+        let lock = GlobalStateLock::new();
+        let stubs = StubBinDir::new();
+        write_ffmpeg_stub(&stubs);
+
+        let _path_guard = prepend_path(&lock, stubs.path());
+        let _display_guard = EnvGuard::remove(&lock, "DISPLAY");
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let out_path = tmp.path().join("shot.png");
+        let err = ffmpeg::screenshot_window(&window(322), &out_path, ImageFormat::Png)
+            .expect_err("missing DISPLAY");
+        assert_eq!(err.exit_code(), 1);
+        assert!(err.to_string().contains("DISPLAY is unset"));
+    }
+
+    #[test]
+    fn linux_unit_ffmpeg_record_portal_with_remote_uses_pipewire_fd_flag_when_supported() {
+        let lock = GlobalStateLock::new();
+        let stubs = StubBinDir::new();
+        write_ffmpeg_stub_with_pipewire_fd_support(&stubs);
+
+        let _path_guard = prepend_path(&lock, stubs.path());
+        let capture = portal_capture_with_remote(4242);
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let out_path = tmp.path().join("portal-record.mp4");
+        let log_path = tmp.path().join("ffmpeg-args.txt");
+        let _ffmpeg_log = EnvGuard::set(&lock, "AGENTS_FFMPEG_LOG", &log_path.to_string_lossy());
+
+        ffmpeg::record_portal(&capture, 1, &out_path, ContainerFormat::Mp4).expect("record portal");
+
+        let args = read_log(&log_path);
+        assert!(args.iter().any(|arg| arg == "-devices"));
+        assert!(args.iter().any(|arg| arg == "demuxer=pipewire"));
+        assert!(args.iter().any(|arg| arg == "-pipewire_fd"));
+        assert!(args.iter().any(|arg| arg == "3"));
+        assert!(args.iter().any(|arg| arg == "4242"));
+        assert!(args.iter().any(|arg| arg == "-t"));
+        assert!(args.iter().any(|arg| arg == "1"));
+        assert!(out_path.exists());
+    }
+
+    #[test]
+    fn linux_unit_ffmpeg_record_portal_with_remote_errors_when_pipewire_fd_flag_missing() {
+        let lock = GlobalStateLock::new();
+        let stubs = StubBinDir::new();
+        write_ffmpeg_stub_with_pipewire_help_but_no_fd_flag(&stubs);
+
+        let _path_guard = prepend_path(&lock, stubs.path());
+        let capture = portal_capture_with_remote(4242);
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let out_path = tmp.path().join("portal-record.mp4");
+        let err = ffmpeg::record_portal(&capture, 1, &out_path, ContainerFormat::Mp4)
+            .expect_err("missing pipewire fd flag");
+        assert_eq!(err.exit_code(), 1);
+        assert!(err.to_string().contains("missing -pipewire_fd"));
+    }
+
+    #[test]
+    fn linux_unit_ffmpeg_screenshot_portal_without_remote_falls_back_to_pipewire_node() {
+        let lock = GlobalStateLock::new();
+        let stubs = StubBinDir::new();
+        write_ffmpeg_stub_with_devices(&stubs);
+
+        let _path_guard = prepend_path(&lock, stubs.path());
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let out_path = tmp.path().join("portal-shot.png");
+        let log_path = tmp.path().join("ffmpeg-args.txt");
+        let _ffmpeg_log = EnvGuard::set(&lock, "AGENTS_FFMPEG_LOG", &log_path.to_string_lossy());
+
+        let capture = PortalCapture {
+            node_id: 7007,
+            pipewire_remote: None,
+        };
+
+        ffmpeg::screenshot_portal(&capture, &out_path, ImageFormat::Png)
+            .expect("screenshot portal");
+
+        let args = read_log(&log_path);
+        assert!(args.iter().any(|arg| arg == "-devices"));
+        assert!(args.iter().any(|arg| arg == "-f"));
+        assert!(args.iter().any(|arg| arg == "pipewire"));
+        assert!(args.iter().any(|arg| arg == "7007"));
+        assert!(args.iter().any(|arg| arg == "-frames:v"));
+        assert!(args.iter().any(|arg| arg == "1"));
+        assert!(out_path.exists());
+    }
+
+    #[test]
+    fn linux_unit_ffmpeg_screenshot_portal_with_remote_uses_pipewire_fd_flag_when_supported() {
+        let lock = GlobalStateLock::new();
+        let stubs = StubBinDir::new();
+        write_ffmpeg_stub_with_pipewire_fd_support(&stubs);
+
+        let _path_guard = prepend_path(&lock, stubs.path());
+        let capture = portal_capture_with_remote(5555);
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let out_path = tmp.path().join("portal-shot.png");
+        let log_path = tmp.path().join("ffmpeg-args.txt");
+        let _ffmpeg_log = EnvGuard::set(&lock, "AGENTS_FFMPEG_LOG", &log_path.to_string_lossy());
+
+        ffmpeg::screenshot_portal(&capture, &out_path, ImageFormat::Png)
+            .expect("screenshot portal");
+
+        let args = read_log(&log_path);
+        assert!(args.iter().any(|arg| arg == "demuxer=pipewire"));
+        assert!(args.iter().any(|arg| arg == "-pipewire_fd"));
+        assert!(args.iter().any(|arg| arg == "3"));
+        assert!(args.iter().any(|arg| arg == "5555"));
+        assert!(args.iter().any(|arg| arg == "-frames:v"));
+        assert!(args.iter().any(|arg| arg == "1"));
+        assert!(out_path.exists());
+    }
+
+    #[test]
+    fn linux_unit_ffmpeg_screenshot_portal_with_remote_errors_when_pipewire_fd_flag_missing() {
+        let lock = GlobalStateLock::new();
+        let stubs = StubBinDir::new();
+        write_ffmpeg_stub_with_pipewire_help_but_no_fd_flag(&stubs);
+
+        let _path_guard = prepend_path(&lock, stubs.path());
+        let capture = portal_capture_with_remote(5555);
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let out_path = tmp.path().join("portal-shot.png");
+        let err = ffmpeg::screenshot_portal(&capture, &out_path, ImageFormat::Png)
+            .expect_err("missing pipewire fd flag");
+        assert_eq!(err.exit_code(), 1);
+        assert!(err.to_string().contains("missing -pipewire_fd"));
     }
 }


### PR DESCRIPTION
# Improve Linux screen-record coverage for CI parity

## Summary
Add Linux-targeted tests for `screen-record` portal/ffmpeg paths and Linux helper modules to raise Ubuntu CI coverage and reduce the observed macOS-vs-CI coverage gap without changing runtime behavior.

## Changes
- Add Linux-only tests for `ffmpeg` screenshot/portal flows, including PipeWire FD supported and unsupported branches.
- Add portal parser/response success-path tests and DBus session-bus failure coverage.
- Add unit tests for Linux helper logic in `audio.rs` and `x11.rs` (parser/formatting/dedup helpers).

## Testing
- `cargo fmt --all` (pass)
- `cargo test -p nils-screen-record --tests --no-run` (pass on macOS)
- `cargo check -p nils-screen-record --tests --target x86_64-unknown-linux-gnu` (pass)
- not run (full Linux test execution and workspace coverage are delegated to CI)

## Risk / Notes
- Tests only; no production behavior changes.
- Exact Linux coverage increase is expected but not guaranteed until CI coverage job completes.
