### PR TITLE
feat: Rewire build-task-spec to call plan-tooling split-prs (+2 tasks)

### DIFF
--- a/crates/plan-tooling/docs/README.md
+++ b/crates/plan-tooling/docs/README.md
@@ -9,7 +9,8 @@
 
 ## Runbooks
 
-- None yet. Add documents under `docs/runbooks/` and register them here.
+- [`split-prs Build Task-Spec Cutover`](runbooks/split-prs-build-task-spec-cutover.md):
+  command mapping and parity checks for downstream `build-task-spec` migration.
 
 ## Reports
 

--- a/crates/plan-tooling/docs/runbooks/split-prs-build-task-spec-cutover.md
+++ b/crates/plan-tooling/docs/runbooks/split-prs-build-task-spec-cutover.md
@@ -1,0 +1,81 @@
+# split-prs Build Task-Spec Cutover
+
+## Goal
+Replace downstream `build-task-spec` split generation with `plan-tooling split-prs` while preserving TSV compatibility.
+
+## Command Mapping
+
+Legacy shape:
+
+```bash
+build-task-spec --plan <plan.md> --sprint <n> --pr-grouping <mode> [--pr-group <task=group>]... --task-spec-out <out.tsv>
+```
+
+Equivalent with `plan-tooling`:
+
+```bash
+plan-tooling split-prs \
+  --file <plan.md> \
+  --scope sprint \
+  --sprint <n> \
+  --pr-grouping <mode> \
+  [--pr-group <task=group>]... \
+  --strategy deterministic \
+  --format tsv > <out.tsv>
+```
+
+## Compatibility Contract
+The generated TSV must keep this exact header:
+
+```text
+# task_id\tsummary\tbranch\tworktree\towner\tnotes\tpr_group
+```
+
+And preserve these notes keys:
+- `sprint=S<n>`
+- `plan-task:Task N.M`
+- `pr-grouping=<mode>`
+- `pr-group=<group>`
+- optional `deps=...`
+- optional `validate=...`
+- optional `shared-pr-anchor=...` when a group has more than one task
+
+## Group Mode Rules
+- `--pr-grouping group` requires explicit `--pr-group` for every selected task.
+- mapping key accepts either `SxTy` or plan task id (`Task N.M`).
+- shared group output should map to one PR (`pr-shared` downstream execution mode).
+
+## Parity Checks
+
+```bash
+mkdir -p "$AGENT_HOME/out/plan-issue-delivery-loop"
+
+plan-tooling split-prs \
+  --file crates/plan-tooling/tests/fixtures/split_prs/duck-plan.md \
+  --scope sprint \
+  --sprint 1 \
+  --pr-grouping per-sprint \
+  --strategy deterministic \
+  --format tsv > "$AGENT_HOME/out/plan-issue-delivery-loop/duck-s1.tsv"
+
+plan-tooling split-prs \
+  --file crates/plan-tooling/tests/fixtures/split_prs/duck-plan.md \
+  --scope sprint \
+  --sprint 2 \
+  --pr-grouping group \
+  --pr-group S2T1=s2-isolated \
+  --pr-group S2T2=s2-shared \
+  --pr-group S2T3=s2-shared \
+  --strategy deterministic \
+  --format tsv > "$AGENT_HOME/out/plan-issue-delivery-loop/duck-s2.tsv"
+
+rg -n '^# task_id\tsummary\tbranch\tworktree\towner\tnotes\tpr_group$' \
+  "$AGENT_HOME/out/plan-issue-delivery-loop/duck-s1.tsv" \
+  "$AGENT_HOME/out/plan-issue-delivery-loop/duck-s2.tsv"
+```
+
+## Auto Strategy
+`--strategy auto` is intentionally non-functional in v1 and returns `not implemented` with planned factors:
+- `Complexity`
+- `Location`
+- `Dependencies`


### PR DESCRIPTION
## Summary
- Implements Sprint 3 tasks for issue #212.
- Adds downstream cutover runbook for `build-task-spec` to `plan-tooling split-prs` migration.

## Scope
- Adds command mapping for deterministic sprint split generation.
- Documents TSV compatibility keys and group mapping expectations.
- Adds parity-check command set for per-sprint and group scenarios.

## Testing
- `PATH="$HOME/.cargo/bin:$PATH" plan-tooling split-prs --help` (pass)
- `PATH="$HOME/.cargo/bin:$PATH" $AGENT_HOME/skills/automation/plan-issue-delivery-loop/scripts/plan-issue-delivery-loop.sh build-task-spec --plan "$AGENT_HOME/docs/plans/duck-issue-loop-test-plan.md" --sprint 1 --pr-grouping per-sprint --task-spec-out "$AGENT_HOME/out/plan-issue-delivery-loop/duck-s1.tsv"` (pass)
- `PATH="$HOME/.cargo/bin:$PATH" $AGENT_HOME/skills/automation/plan-issue-delivery-loop/scripts/plan-issue-delivery-loop.sh build-task-spec --plan "$AGENT_HOME/docs/plans/duck-issue-loop-test-plan.md" --sprint 2 --pr-grouping group --pr-group S2T1=s2-isolated --pr-group S2T2=s2-shared --pr-group S2T3=s2-shared --task-spec-out "$AGENT_HOME/out/plan-issue-delivery-loop/duck-s2.tsv"` (pass)
- `PATH="$HOME/.cargo/bin:$PATH" $AGENT_HOME/skills/automation/plan-issue-delivery-loop/scripts/plan-issue-delivery-loop.sh build-task-spec --plan "$AGENT_HOME/docs/plans/duck-issue-loop-test-plan.md" --sprint 3 --pr-grouping group --pr-group S3T1=s3-a --pr-group S3T2=s3-b --pr-group S3T3=s3-c --task-spec-out "$AGENT_HOME/out/plan-issue-delivery-loop/duck-s3.tsv"` (pass)

## Issue
- #212
