### PR TITLE
feat: Update user-facing documentation and migration notes (+2 tasks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each crate is either a standalone CLI binary or a shared library used across the
 - [crates/codex-cli](crates/codex-cli): Provider-specific CLI for OpenAI/Codex workflows (auth, diagnostics, execution wrappers, Starship), with adapters over `nils-common::provider_runtime`.
 - [crates/gemini-cli](crates/gemini-cli): Provider-specific CLI lane for Gemini workflows, with adapters over `nils-common::provider_runtime`.
 - [crates/semantic-commit](crates/semantic-commit): Helper CLI for generating staged context and creating semantic commits.
-- [crates/plan-tooling](crates/plan-tooling): Plan Format v1 tooling CLI (to-json/validate/batches/scaffold).
+- [crates/plan-tooling](crates/plan-tooling): Plan Format v1 tooling CLI (to-json/validate/batches/scaffold/split-prs).
 
 ## Shared helper policy (`nils-common`)
 

--- a/crates/plan-tooling/README.md
+++ b/crates/plan-tooling/README.md
@@ -40,6 +40,9 @@ Help:
 - `split-prs --file <plan.md> --scope <plan|sprint> [--sprint <n>] --pr-grouping <per-sprint|group> [--pr-group <task-or-plan-id>=<group>]... [--strategy deterministic|auto] [--format json|tsv]`
 - `--strategy auto` is reserved for future scoring based on `Complexity`, `Location`, and
   `Dependencies`; in v1 it intentionally returns `not implemented`.
+- deterministic examples:
+  - `split-prs --file docs/plans/example-plan.md --scope sprint --sprint 1 --pr-grouping per-sprint --format tsv`
+  - `split-prs --file docs/plans/example-plan.md --scope sprint --sprint 2 --pr-grouping group --pr-group S2T1=isolated --pr-group S2T2=shared --pr-group S2T3=shared --format json`
 
 ### scaffold
 - `scaffold --slug <kebab-case> [--title <title>] [--force]`: Write to
@@ -57,3 +60,4 @@ Help:
 ## Docs
 
 - [Docs index](docs/README.md)
+- [Migration runbook](docs/runbooks/split-prs-migration.md)

--- a/crates/plan-tooling/docs/README.md
+++ b/crates/plan-tooling/docs/README.md
@@ -11,6 +11,8 @@
 
 - [`split-prs Build Task-Spec Cutover`](runbooks/split-prs-build-task-spec-cutover.md):
   command mapping and parity checks for downstream `build-task-spec` migration.
+- [`split-prs Migration`](runbooks/split-prs-migration.md): rollout, compatibility contract,
+  and rollback checklist for adopting `split-prs`.
 
 ## Reports
 

--- a/crates/plan-tooling/docs/runbooks/split-prs-build-task-spec-cutover.md
+++ b/crates/plan-tooling/docs/runbooks/split-prs-build-task-spec-cutover.md
@@ -5,7 +5,7 @@ Replace downstream `build-task-spec` split generation with `plan-tooling split-p
 
 ## Command Mapping
 
-Legacy shape:
+Prior command shape:
 
 ```bash
 build-task-spec --plan <plan.md> --sprint <n> --pr-grouping <mode> [--pr-group <task=group>]... --task-spec-out <out.tsv>

--- a/crates/plan-tooling/docs/runbooks/split-prs-migration.md
+++ b/crates/plan-tooling/docs/runbooks/split-prs-migration.md
@@ -1,0 +1,60 @@
+# split-prs Migration
+
+## Objective
+Migrate plan task splitting from embedded downstream logic to `plan-tooling split-prs` with deterministic output compatibility.
+
+## Before / After
+Before:
+
+```bash
+build-task-spec --plan <plan.md> --sprint <n> --pr-grouping <mode> [--pr-group <task=group>]... --task-spec-out <out.tsv>
+```
+
+After:
+
+```bash
+plan-tooling split-prs \
+  --file <plan.md> \
+  --scope sprint \
+  --sprint <n> \
+  --pr-grouping <mode> \
+  [--pr-group <task=group>]... \
+  --strategy deterministic \
+  --format tsv > <out.tsv>
+```
+
+## Required Compatibility
+- Keep TSV header exactly:
+
+```text
+# task_id\tsummary\tbranch\tworktree\towner\tnotes\tpr_group
+```
+
+- Keep notes keys expected by downstream orchestration:
+  - `sprint=S<n>`
+  - `plan-task:Task N.M`
+  - `pr-grouping=<mode>`
+  - `pr-group=<group>`
+  - optional `deps=...`
+  - optional `validate=...`
+  - optional `shared-pr-anchor=...`
+
+## Grouping Guidance
+- Use `per-sprint` when one shared PR should represent all sprint tasks.
+- Use `group` for mixed isolated/shared PR shapes.
+- In `group` mode every selected task must have an explicit mapping.
+
+## Auto Strategy Status
+- `--strategy auto` is intentionally not implemented in v1.
+- Current message references planned scoring factors: `Complexity`, `Location`, `Dependencies`.
+
+## Release Gate Checklist
+1. Verify deterministic command output against fixture expectations.
+2. Verify downstream consumers still parse TSV columns/notes without changes.
+3. Verify fallback/rollback command sequence is documented before rollout.
+
+## Rollback
+If downstream integration fails:
+1. Keep `split-prs` implementation intact.
+2. Revert downstream invocation wiring only.
+3. Re-run fixture parity checks and reopen cutover PR once fixed.

--- a/crates/plan-tooling/tests/split_prs.rs
+++ b/crates/plan-tooling/tests/split_prs.rs
@@ -18,6 +18,15 @@ fn fixture_text(name: &str) -> String {
     fs::read_to_string(fixture_path(name)).expect("fixture exists")
 }
 
+fn tsv_rows(name: &str) -> Vec<Vec<String>> {
+    fixture_text(name)
+        .lines()
+        .skip(1)
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.split('\t').map(|part| part.to_string()).collect())
+        .collect()
+}
+
 #[test]
 fn split_prs_deterministic_per_sprint_tsv_matches_fixture() {
     let dir = TempDir::new().expect("tempdir");
@@ -177,6 +186,33 @@ fn split_prs_fixture_tsv_header_is_stable() {
             first,
             "# task_id\tsummary\tbranch\tworktree\towner\tnotes\tpr_group"
         );
+    }
+}
+
+#[test]
+fn split_prs_non_regression_required_notes_keys() {
+    for row in tsv_rows("per_sprint_expected.tsv") {
+        assert_eq!(row.len(), 7);
+        let notes = &row[5];
+        assert!(notes.contains("sprint=S1"));
+        assert!(notes.contains("plan-task:Task "));
+        assert!(notes.contains("pr-grouping=per-sprint"));
+        assert!(notes.contains("pr-group=s1"));
+    }
+}
+
+#[test]
+fn split_prs_non_regression_shared_anchor_rules() {
+    for row in tsv_rows("group_expected.tsv") {
+        assert_eq!(row.len(), 7);
+        let task_id = &row[0];
+        let notes = &row[5];
+        assert!(notes.contains("pr-grouping=group"));
+        if task_id == "S2T1" {
+            assert!(!notes.contains("shared-pr-anchor="));
+        } else {
+            assert!(notes.contains("shared-pr-anchor=S2T2"));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Implements issue #212 Sprint 4 documentation and migration deliverables for `plan-tooling split-prs` cutover.

## Scope
- Update workspace/crate docs and add migration runbook for `split-prs` deterministic rollout.
- Add non-regression tests for required TSV notes keys and shared anchor behavior.

## Testing
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `mkdir -p target/coverage && cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass)

## Issue
- #212
