### PR TITLE
feat: Scaffold `nils-plan-issue-cli` crate with two binaries (+2 tasks)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nils-plan-issue-cli"
+version = "0.5.1"
+dependencies = [
+ "clap",
+ "nils-test-support",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "nils-plan-tooling"
 version = "0.5.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "crates/api-test",
   "crates/semantic-commit",
   "crates/plan-tooling",
+  "crates/plan-issue-cli",
   "crates/agent-docs",
   "crates/gemini-cli",
 ]

--- a/crates/plan-issue-cli/Cargo.toml
+++ b/crates/plan-issue-cli/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "nils-plan-issue-cli"
+version = "0.5.1"
+edition.workspace = true
+license.workspace = true
+default-run = "plan-issue"
+
+description = "CLI crate for nils-plan-issue-cli in the nils-cli workspace."
+repository = "https://github.com/graysurf/nils-cli"
+
+[lib]
+name = "plan_issue_cli"
+path = "src/lib.rs"
+
+[[bin]]
+name = "plan-issue"
+path = "src/main.rs"
+
+[[bin]]
+name = "plan-issue-local"
+path = "src/bin/plan-issue-local.rs"
+
+[dependencies]
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+nils-test-support = { version = "0.5.1", path = "../nils-test-support" }
+pretty_assertions = { workspace = true }

--- a/crates/plan-issue-cli/README.md
+++ b/crates/plan-issue-cli/README.md
@@ -8,8 +8,11 @@ Sprint 1 establishes the v1 command contract, gate semantics, and deterministic 
 to preserve orchestration compatibility before implementation cutover.
 
 ## Status
-- Current scope is documentation + parity fixtures.
-- Runtime command implementation is intentionally deferred to later tasks.
+- Current scope includes Sprint 2 scaffold implementation:
+  - crate package `nils-plan-issue-cli`
+  - binaries `plan-issue` and `plan-issue-local`
+  - typed clap command model for v1 command surface
+  - deterministic text and JSON output envelopes
 
 ## Specifications
 - [CLI contract v1](docs/specs/plan-issue-cli-contract-v1.md)

--- a/crates/plan-issue-cli/docs/README.md
+++ b/crates/plan-issue-cli/docs/README.md
@@ -1,0 +1,9 @@
+# plan-issue-cli docs
+
+## Purpose
+Crate-local documentation for `nils-plan-issue-cli`.
+
+## Specs
+- [plan-issue CLI contract v1](specs/plan-issue-cli-contract-v1.md)
+- [plan-issue state machine and gates v1](specs/plan-issue-state-machine-v1.md)
+- [plan-issue gate matrix v1](specs/plan-issue-gate-matrix-v1.md)

--- a/crates/plan-issue-cli/src/bin/plan-issue-local.rs
+++ b/crates/plan-issue-cli/src/bin/plan-issue-local.rs
@@ -1,0 +1,5 @@
+fn main() {
+    std::process::exit(plan_issue_cli::run(
+        plan_issue_cli::BinaryFlavor::PlanIssueLocal,
+    ));
+}

--- a/crates/plan-issue-cli/src/cli.rs
+++ b/crates/plan-issue-cli/src/cli.rs
@@ -1,0 +1,59 @@
+use clap::{Parser, ValueEnum};
+
+use crate::ValidationError;
+use crate::commands::Command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Debug, Clone, Parser)]
+#[command(
+    version,
+    about = "Rust implementation of the plan-issue orchestration workflow.",
+    after_help = "Usage paths:\n  - plan-issue: live GitHub-backed orchestration\n  - plan-issue-local: local-first rehearsal and dry-run flow\n\nBoth binaries share the same typed command contract.",
+    disable_help_subcommand = true
+)]
+pub struct Cli {
+    /// Repository override for GitHub-backed operations.
+    #[arg(long, global = true, value_name = "owner/repo")]
+    pub repo: Option<String>,
+
+    /// Print write actions without mutating GitHub state.
+    #[arg(long, global = true)]
+    pub dry_run: bool,
+
+    /// Output machine-readable JSON (alias for --format json).
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    /// Output format.
+    #[arg(long, global = true, value_enum)]
+    pub format: Option<OutputFormat>,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+impl Cli {
+    pub fn resolve_output_format(&self) -> Result<OutputFormat, ValidationError> {
+        if self.json && matches!(self.format, Some(OutputFormat::Text)) {
+            return Err(ValidationError::new(
+                "invalid-output-mode",
+                "--json cannot be combined with --format text",
+            ));
+        }
+
+        if self.json || matches!(self.format, Some(OutputFormat::Json)) {
+            return Ok(OutputFormat::Json);
+        }
+
+        Ok(OutputFormat::Text)
+    }
+
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        self.command.validate(self.dry_run)
+    }
+}

--- a/crates/plan-issue-cli/src/commands/build.rs
+++ b/crates/plan-issue-cli/src/commands/build.rs
@@ -1,0 +1,44 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use serde::Serialize;
+
+use super::{GroupingArgs, PrefixArgs};
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct BuildTaskSpecArgs {
+    /// Plan markdown path.
+    #[arg(long, value_name = "path")]
+    pub plan: PathBuf,
+
+    /// Sprint number.
+    #[arg(long, value_parser = clap::value_parser!(u16).range(1..), value_name = "number")]
+    pub sprint: u16,
+
+    /// Output task-spec TSV path.
+    #[arg(long, value_name = "path")]
+    pub task_spec_out: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub prefixes: PrefixArgs,
+
+    #[command(flatten)]
+    pub grouping: GroupingArgs,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct BuildPlanTaskSpecArgs {
+    /// Plan markdown path.
+    #[arg(long, value_name = "path")]
+    pub plan: PathBuf,
+
+    /// Output task-spec TSV path.
+    #[arg(long, value_name = "path")]
+    pub task_spec_out: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub prefixes: PrefixArgs,
+
+    #[command(flatten)]
+    pub grouping: GroupingArgs,
+}

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -1,0 +1,237 @@
+pub mod build;
+pub mod plan;
+pub mod sprint;
+
+use clap::{Args, Subcommand, ValueEnum};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::ValidationError;
+
+use self::build::{BuildPlanTaskSpecArgs, BuildTaskSpecArgs};
+use self::plan::{
+    CleanupWorktreesArgs, ClosePlanArgs, ReadyPlanArgs, StartPlanArgs, StatusPlanArgs,
+};
+use self::sprint::{AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
+pub enum PrGrouping {
+    #[value(name = "per-sprint", alias = "per-spring")]
+    PerSprint,
+    #[value(name = "group")]
+    Group,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PrGroupMapping {
+    pub task: String,
+    pub group: String,
+}
+
+fn parse_pr_group_mapping(raw: &str) -> Result<PrGroupMapping, String> {
+    let (task_raw, group_raw) = raw
+        .split_once('=')
+        .ok_or_else(|| "expected format <task>=<group>".to_string())?;
+
+    let task = task_raw.trim();
+    let group = group_raw.trim();
+
+    if task.is_empty() {
+        return Err("task key in --pr-group cannot be empty".to_string());
+    }
+    if group.is_empty() {
+        return Err("group name in --pr-group cannot be empty".to_string());
+    }
+
+    Ok(PrGroupMapping {
+        task: task.to_string(),
+        group: group.to_string(),
+    })
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct PrefixArgs {
+    /// Task owner prefix.
+    #[arg(long, default_value = "subagent", value_name = "text")]
+    pub owner_prefix: String,
+
+    /// Branch prefix.
+    #[arg(long, default_value = "issue", value_name = "text")]
+    pub branch_prefix: String,
+
+    /// Worktree prefix.
+    #[arg(long, default_value = "issue__", value_name = "text")]
+    pub worktree_prefix: String,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct GroupingArgs {
+    /// PR grouping mode.
+    #[arg(long, value_enum, value_name = "mode")]
+    pub pr_grouping: PrGrouping,
+
+    /// Explicit task->group mapping (`<task>=<group>`). Repeatable.
+    #[arg(
+        long = "pr-group",
+        value_name = "task=group",
+        value_parser = parse_pr_group_mapping
+    )]
+    pub pr_group: Vec<PrGroupMapping>,
+}
+
+#[derive(Debug, Clone, Args, Default, Serialize)]
+pub struct SummaryArgs {
+    /// Inline review summary text.
+    #[arg(long, conflicts_with = "summary_file", value_name = "text")]
+    pub summary: Option<String>,
+
+    /// Path to markdown/text review summary.
+    #[arg(long, conflicts_with = "summary", value_name = "path")]
+    pub summary_file: Option<std::path::PathBuf>,
+}
+
+#[derive(Debug, Clone, Args, Default, Serialize)]
+pub struct CommentModeArgs {
+    /// Emit comment output.
+    #[arg(long, conflicts_with = "no_comment")]
+    pub comment: bool,
+
+    /// Disable comment output.
+    #[arg(long = "no-comment", conflicts_with = "comment")]
+    pub no_comment: bool,
+}
+
+#[derive(Debug, Clone, Args, Default, Serialize)]
+pub struct CommentTextArgs {
+    /// Inline close comment.
+    #[arg(long, conflicts_with = "comment_file", value_name = "text")]
+    pub comment: Option<String>,
+
+    /// Path to close comment markdown/text.
+    #[arg(long, conflicts_with = "comment", value_name = "path")]
+    pub comment_file: Option<std::path::PathBuf>,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum Command {
+    /// Build sprint-scoped task-spec TSV from a plan.
+    BuildTaskSpec(BuildTaskSpecArgs),
+
+    /// Build plan-scoped task-spec TSV (all sprints) for the single plan issue.
+    BuildPlanTaskSpec(BuildPlanTaskSpecArgs),
+
+    /// Open one plan issue with all plan tasks in Task Decomposition.
+    StartPlan(StartPlanArgs),
+
+    /// Wrapper of issue-delivery-loop status for the plan issue.
+    StatusPlan(StatusPlanArgs),
+
+    /// Wrapper of issue-delivery-loop ready-for-review for final plan review.
+    ReadyPlan(ReadyPlanArgs),
+
+    /// Close the single plan issue after final approval and merged PR gates.
+    ClosePlan(ClosePlanArgs),
+
+    /// Enforce cleanup of all issue-assigned task worktrees.
+    CleanupWorktrees(CleanupWorktreesArgs),
+
+    /// Start sprint only after previous sprint merge+done gate passes.
+    StartSprint(StartSprintArgs),
+
+    /// Post sprint-ready comment for main-agent review before merge.
+    ReadySprint(ReadySprintArgs),
+
+    /// Enforce merged-PR gate, sync sprint status=done, then post accepted comment.
+    AcceptSprint(AcceptSprintArgs),
+
+    /// Print the full repeated command flow for a plan.
+    MultiSprintGuide(MultiSprintGuideArgs),
+}
+
+impl Command {
+    pub fn command_id(&self) -> &'static str {
+        match self {
+            Self::BuildTaskSpec(_) => "build-task-spec",
+            Self::BuildPlanTaskSpec(_) => "build-plan-task-spec",
+            Self::StartPlan(_) => "start-plan",
+            Self::StatusPlan(_) => "status-plan",
+            Self::ReadyPlan(_) => "ready-plan",
+            Self::ClosePlan(_) => "close-plan",
+            Self::CleanupWorktrees(_) => "cleanup-worktrees",
+            Self::StartSprint(_) => "start-sprint",
+            Self::ReadySprint(_) => "ready-sprint",
+            Self::AcceptSprint(_) => "accept-sprint",
+            Self::MultiSprintGuide(_) => "multi-sprint-guide",
+        }
+    }
+
+    pub fn schema_version(&self) -> String {
+        format!("plan-issue-cli.{}.v1", self.command_id().replace('-', "."))
+    }
+
+    pub fn payload(&self) -> Value {
+        let payload = match self {
+            Self::BuildTaskSpec(args) => serde_json::to_value(args),
+            Self::BuildPlanTaskSpec(args) => serde_json::to_value(args),
+            Self::StartPlan(args) => serde_json::to_value(args),
+            Self::StatusPlan(args) => serde_json::to_value(args),
+            Self::ReadyPlan(args) => serde_json::to_value(args),
+            Self::ClosePlan(args) => serde_json::to_value(args),
+            Self::CleanupWorktrees(args) => serde_json::to_value(args),
+            Self::StartSprint(args) => serde_json::to_value(args),
+            Self::ReadySprint(args) => serde_json::to_value(args),
+            Self::AcceptSprint(args) => serde_json::to_value(args),
+            Self::MultiSprintGuide(args) => serde_json::to_value(args),
+        };
+
+        payload.unwrap_or(Value::Null)
+    }
+
+    pub fn validate(&self, dry_run: bool) -> Result<(), ValidationError> {
+        match self {
+            Self::BuildTaskSpec(args) => validate_grouping(&args.grouping),
+            Self::BuildPlanTaskSpec(args) => validate_grouping(&args.grouping),
+            Self::StartPlan(args) => validate_grouping(&args.grouping),
+            Self::StartSprint(args) => validate_grouping(&args.grouping),
+            Self::ClosePlan(args) => validate_close_plan_args(args, dry_run),
+            Self::StatusPlan(_)
+            | Self::ReadyPlan(_)
+            | Self::CleanupWorktrees(_)
+            | Self::ReadySprint(_)
+            | Self::AcceptSprint(_)
+            | Self::MultiSprintGuide(_) => Ok(()),
+        }
+    }
+}
+
+fn validate_grouping(grouping: &GroupingArgs) -> Result<(), ValidationError> {
+    match grouping.pr_grouping {
+        PrGrouping::PerSprint if !grouping.pr_group.is_empty() => Err(ValidationError::new(
+            "invalid-pr-grouping",
+            "--pr-group is only valid when --pr-grouping group",
+        )),
+        PrGrouping::Group if grouping.pr_group.is_empty() => Err(ValidationError::new(
+            "invalid-pr-grouping",
+            "--pr-grouping group requires at least one --pr-group",
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn validate_close_plan_args(args: &ClosePlanArgs, dry_run: bool) -> Result<(), ValidationError> {
+    if !dry_run && args.issue.is_none() {
+        return Err(ValidationError::new(
+            "missing-issue",
+            "--issue is required for close-plan unless --dry-run is enabled",
+        ));
+    }
+
+    if dry_run && args.issue.is_none() && args.body_file.is_none() {
+        return Err(ValidationError::new(
+            "missing-issue-source",
+            "--dry-run close-plan requires --issue or --body-file",
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/plan-issue-cli/src/commands/plan.rs
+++ b/crates/plan-issue-cli/src/commands/plan.rs
@@ -1,0 +1,128 @@
+use std::path::PathBuf;
+
+use clap::{ArgGroup, Args, ValueEnum};
+use serde::Serialize;
+
+use super::{CommentModeArgs, CommentTextArgs, GroupingArgs, PrefixArgs, SummaryArgs};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
+pub enum CloseReason {
+    Completed,
+    #[value(name = "not-planned")]
+    NotPlanned,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct StartPlanArgs {
+    /// Plan markdown path.
+    #[arg(long, value_name = "path")]
+    pub plan: PathBuf,
+
+    /// Override plan issue title.
+    #[arg(long, value_name = "text")]
+    pub title: Option<String>,
+
+    /// Plan task-spec output path override.
+    #[arg(long, value_name = "path")]
+    pub task_spec_out: Option<PathBuf>,
+
+    /// Rendered plan issue body output path override.
+    #[arg(long, value_name = "path")]
+    pub issue_body_out: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub prefixes: PrefixArgs,
+
+    #[command(flatten)]
+    pub grouping: GroupingArgs,
+
+    /// Labels to add at issue creation time.
+    #[arg(long = "label", value_name = "name", default_values = ["issue", "plan"])]
+    pub label: Vec<String>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+#[command(group(
+    ArgGroup::new("issue_source")
+        .required(true)
+        .args(["issue", "body_file"])
+))]
+pub struct StatusPlanArgs {
+    /// Plan issue number.
+    #[arg(long, value_name = "number")]
+    pub issue: Option<u64>,
+
+    /// Offline issue body path.
+    #[arg(long, value_name = "path")]
+    pub body_file: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub comment_mode: CommentModeArgs,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+#[command(group(
+    ArgGroup::new("issue_source")
+        .required(true)
+        .args(["issue", "body_file"])
+))]
+pub struct ReadyPlanArgs {
+    /// Plan issue number.
+    #[arg(long, value_name = "number")]
+    pub issue: Option<u64>,
+
+    /// Offline issue body path.
+    #[arg(long, value_name = "path")]
+    pub body_file: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub summary: SummaryArgs,
+
+    /// Review label.
+    #[arg(long = "label", value_name = "name", default_value = "needs-review")]
+    pub label: String,
+
+    /// Labels to remove.
+    #[arg(long = "remove-label", value_name = "name")]
+    pub remove_label: Vec<String>,
+
+    #[command(flatten)]
+    pub comment_mode: CommentModeArgs,
+
+    /// Skip label updates.
+    #[arg(long)]
+    pub no_label_update: bool,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct ClosePlanArgs {
+    /// Plan issue number.
+    #[arg(long, value_name = "number")]
+    pub issue: Option<u64>,
+
+    /// Local issue body path (dry-run mode).
+    #[arg(long, value_name = "path")]
+    pub body_file: Option<PathBuf>,
+
+    /// Final approval comment URL.
+    #[arg(long = "approved-comment-url", value_name = "url")]
+    pub approved_comment_url: String,
+
+    /// Close reason.
+    #[arg(long, value_enum, default_value_t = CloseReason::Completed)]
+    pub reason: CloseReason,
+
+    #[command(flatten)]
+    pub close_comment: CommentTextArgs,
+
+    /// Allow closing when some tasks are not done.
+    #[arg(long)]
+    pub allow_not_done: bool,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct CleanupWorktreesArgs {
+    /// Plan issue number.
+    #[arg(long, value_name = "number")]
+    pub issue: u64,
+}

--- a/crates/plan-issue-cli/src/commands/sprint.rs
+++ b/crates/plan-issue-cli/src/commands/sprint.rs
@@ -1,0 +1,99 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use serde::Serialize;
+
+use super::{CommentModeArgs, GroupingArgs, PrefixArgs, SummaryArgs};
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct StartSprintArgs {
+    /// Plan markdown path.
+    #[arg(long, value_name = "path")]
+    pub plan: PathBuf,
+
+    /// Plan issue number.
+    #[arg(long, value_name = "number")]
+    pub issue: u64,
+
+    /// Sprint number.
+    #[arg(long, value_parser = clap::value_parser!(u16).range(1..), value_name = "number")]
+    pub sprint: u16,
+
+    /// Sprint task-spec output path override.
+    #[arg(long, value_name = "path")]
+    pub task_spec_out: Option<PathBuf>,
+
+    /// start-sprint output directory for subagent task prompts.
+    #[arg(long, value_name = "path")]
+    pub subagent_prompts_out: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub prefixes: PrefixArgs,
+
+    #[command(flatten)]
+    pub grouping: GroupingArgs,
+
+    #[command(flatten)]
+    pub comment_mode: CommentModeArgs,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct ReadySprintArgs {
+    /// Plan markdown path.
+    #[arg(long, value_name = "path")]
+    pub plan: PathBuf,
+
+    /// Plan issue number.
+    #[arg(long, value_name = "number")]
+    pub issue: u64,
+
+    /// Sprint number.
+    #[arg(long, value_parser = clap::value_parser!(u16).range(1..), value_name = "number")]
+    pub sprint: u16,
+
+    #[command(flatten)]
+    pub summary: SummaryArgs,
+
+    #[command(flatten)]
+    pub comment_mode: CommentModeArgs,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct AcceptSprintArgs {
+    /// Plan markdown path.
+    #[arg(long, value_name = "path")]
+    pub plan: PathBuf,
+
+    /// Plan issue number.
+    #[arg(long, value_name = "number")]
+    pub issue: u64,
+
+    /// Sprint number.
+    #[arg(long, value_parser = clap::value_parser!(u16).range(1..), value_name = "number")]
+    pub sprint: u16,
+
+    /// Review approval comment URL.
+    #[arg(long = "approved-comment-url", value_name = "url")]
+    pub approved_comment_url: String,
+
+    #[command(flatten)]
+    pub summary: SummaryArgs,
+
+    #[command(flatten)]
+    pub comment_mode: CommentModeArgs,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct MultiSprintGuideArgs {
+    /// Plan markdown path.
+    #[arg(long, value_name = "path")]
+    pub plan: PathBuf,
+
+    /// First sprint to include.
+    #[arg(long, value_parser = clap::value_parser!(u16).range(1..), default_value_t = 1)]
+    pub from_sprint: u16,
+
+    /// Last sprint to include.
+    #[arg(long, value_parser = clap::value_parser!(u16).range(1..), value_name = "number")]
+    pub to_sprint: Option<u16>,
+}

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -1,0 +1,117 @@
+pub mod cli;
+pub mod commands;
+pub mod output;
+
+use std::ffi::OsString;
+
+use clap::Parser;
+use serde_json::json;
+
+use crate::cli::Cli;
+
+pub const EXIT_SUCCESS: i32 = 0;
+pub const EXIT_FAILURE: i32 = 1;
+pub const EXIT_USAGE: i32 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryFlavor {
+    PlanIssue,
+    PlanIssueLocal,
+}
+
+impl BinaryFlavor {
+    pub fn binary_name(self) -> &'static str {
+        match self {
+            Self::PlanIssue => "plan-issue",
+            Self::PlanIssueLocal => "plan-issue-local",
+        }
+    }
+
+    pub fn execution_mode(self) -> &'static str {
+        match self {
+            Self::PlanIssue => "live",
+            Self::PlanIssueLocal => "local",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl ValidationError {
+    pub fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+pub fn run(binary: BinaryFlavor) -> i32 {
+    run_with_args(binary, std::env::args_os())
+}
+
+pub fn run_with_args<I, T>(binary: BinaryFlavor, args: I) -> i32
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let cli = match Cli::try_parse_from(args) {
+        Ok(cli) => cli,
+        Err(err) => {
+            let code = if err.use_stderr() {
+                EXIT_USAGE
+            } else {
+                EXIT_SUCCESS
+            };
+            let _ = err.print();
+            return code;
+        }
+    };
+
+    let output_format = match cli.resolve_output_format() {
+        Ok(format) => format,
+        Err(err) => {
+            eprintln!("error: {}", err.message);
+            return EXIT_USAGE;
+        }
+    };
+
+    if let Err(err) = cli.validate() {
+        let schema_version = cli.command.schema_version();
+        if let Err(render_err) = output::emit_error(
+            output_format,
+            &schema_version,
+            cli.command.command_id(),
+            err.code,
+            &err.message,
+        ) {
+            eprintln!("error: {render_err}");
+        }
+        return EXIT_FAILURE;
+    }
+
+    let schema_version = cli.command.schema_version();
+    let payload = json!({
+        "binary": binary.binary_name(),
+        "execution_mode": binary.execution_mode(),
+        "dry_run": cli.dry_run,
+        "repo": cli.repo,
+        "arguments": cli.command.payload(),
+    });
+
+    if let Err(err) = output::emit_success(
+        output_format,
+        &schema_version,
+        cli.command.command_id(),
+        &payload,
+    ) {
+        eprintln!("error: {err}");
+        return EXIT_FAILURE;
+    }
+
+    EXIT_SUCCESS
+}

--- a/crates/plan-issue-cli/src/main.rs
+++ b/crates/plan-issue-cli/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::process::exit(plan_issue_cli::run(plan_issue_cli::BinaryFlavor::PlanIssue));
+}

--- a/crates/plan-issue-cli/src/output/json.rs
+++ b/crates/plan-issue-cli/src/output/json.rs
@@ -1,0 +1,57 @@
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Debug, Serialize)]
+struct JsonSuccessEnvelope<'a> {
+    schema_version: &'a str,
+    command: &'a str,
+    status: &'a str,
+    payload: &'a Value,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonErrorEnvelope<'a> {
+    schema_version: &'a str,
+    command: &'a str,
+    status: &'a str,
+    error: JsonError<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonError<'a> {
+    code: &'a str,
+    message: &'a str,
+}
+
+pub fn print_success(schema_version: &str, command: &str, payload: &Value) -> Result<(), String> {
+    let envelope = JsonSuccessEnvelope {
+        schema_version,
+        command,
+        status: "ok",
+        payload,
+    };
+
+    let rendered = serde_json::to_string(&envelope)
+        .map_err(|err| format!("failed to serialize JSON output: {err}"))?;
+    println!("{rendered}");
+    Ok(())
+}
+
+pub fn print_error(
+    schema_version: &str,
+    command: &str,
+    code: &str,
+    message: &str,
+) -> Result<(), String> {
+    let envelope = JsonErrorEnvelope {
+        schema_version,
+        command,
+        status: "error",
+        error: JsonError { code, message },
+    };
+
+    let rendered = serde_json::to_string(&envelope)
+        .map_err(|err| format!("failed to serialize JSON error output: {err}"))?;
+    println!("{rendered}");
+    Ok(())
+}

--- a/crates/plan-issue-cli/src/output/mod.rs
+++ b/crates/plan-issue-cli/src/output/mod.rs
@@ -1,0 +1,31 @@
+pub mod json;
+pub mod text;
+
+use serde_json::Value;
+
+use crate::cli::OutputFormat;
+
+pub fn emit_success(
+    format: OutputFormat,
+    schema_version: &str,
+    command: &str,
+    payload: &Value,
+) -> Result<(), String> {
+    match format {
+        OutputFormat::Text => text::print_success(schema_version, command, payload),
+        OutputFormat::Json => json::print_success(schema_version, command, payload),
+    }
+}
+
+pub fn emit_error(
+    format: OutputFormat,
+    schema_version: &str,
+    command: &str,
+    code: &str,
+    message: &str,
+) -> Result<(), String> {
+    match format {
+        OutputFormat::Text => text::print_error(schema_version, command, code, message),
+        OutputFormat::Json => json::print_error(schema_version, command, code, message),
+    }
+}

--- a/crates/plan-issue-cli/src/output/text.rs
+++ b/crates/plan-issue-cli/src/output/text.rs
@@ -1,0 +1,27 @@
+use serde_json::Value;
+
+pub fn print_success(schema_version: &str, command: &str, payload: &Value) -> Result<(), String> {
+    let payload_json = serde_json::to_string(payload)
+        .map_err(|err| format!("failed to serialize payload: {err}"))?;
+
+    println!("schema_version: {schema_version}");
+    println!("command: {command}");
+    println!("status: ok");
+    println!("payload: {payload_json}");
+
+    Ok(())
+}
+
+pub fn print_error(
+    schema_version: &str,
+    command: &str,
+    code: &str,
+    message: &str,
+) -> Result<(), String> {
+    eprintln!("schema_version: {schema_version}");
+    eprintln!("command: {command}");
+    eprintln!("status: error");
+    eprintln!("code: {code}");
+    eprintln!("message: {message}");
+    Ok(())
+}

--- a/crates/plan-issue-cli/tests/cli_contract.rs
+++ b/crates/plan-issue-cli/tests/cli_contract.rs
@@ -1,0 +1,175 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use pretty_assertions::assert_eq;
+
+use plan_issue_cli::cli::{Cli, OutputFormat};
+use plan_issue_cli::commands::{Command, PrGrouping};
+
+mod common;
+
+#[test]
+fn cli_help_lists_full_surface_for_live_and_local_bins() {
+    let live = common::run_plan_issue(&["--help"]);
+    assert_eq!(live.code, 0, "stderr: {}", live.stderr);
+
+    for token in [
+        "build-task-spec",
+        "build-plan-task-spec",
+        "start-plan",
+        "status-plan",
+        "ready-plan",
+        "close-plan",
+        "cleanup-worktrees",
+        "start-sprint",
+        "ready-sprint",
+        "accept-sprint",
+        "multi-sprint-guide",
+        "-V, --version",
+        "Usage paths",
+        "plan-issue-local",
+    ] {
+        assert!(
+            live.stdout.contains(token),
+            "help output missing token `{token}`\n{}",
+            live.stdout
+        );
+    }
+
+    let local = common::run_plan_issue_local(&["--help"]);
+    assert_eq!(local.code, 0, "stderr: {}", local.stderr);
+    assert!(
+        local.stdout.contains("plan-issue-local"),
+        "{}",
+        local.stdout
+    );
+    assert!(local.stdout.contains("Usage paths"), "{}", local.stdout);
+}
+
+#[test]
+fn cli_parse_contract_build_task_spec_accepts_per_spring_alias() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "build-task-spec",
+        "--plan",
+        "docs/plans/plan-issue-rust-cli-full-delivery-plan.md",
+        "--sprint",
+        "2",
+        "--pr-grouping",
+        "per-spring",
+    ])
+    .expect("parse build-task-spec");
+
+    assert_eq!(
+        cli.resolve_output_format().expect("output format"),
+        OutputFormat::Text
+    );
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::BuildTaskSpec(args) => {
+            assert_eq!(
+                args.plan,
+                PathBuf::from("docs/plans/plan-issue-rust-cli-full-delivery-plan.md")
+            );
+            assert_eq!(args.sprint, 2);
+            assert_eq!(args.grouping.pr_grouping, PrGrouping::PerSprint);
+            assert!(args.grouping.pr_group.is_empty());
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parse_contract_start_sprint_parses_typed_group_mapping() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "start-sprint",
+        "--plan",
+        "docs/plans/plan-issue-rust-cli-full-delivery-plan.md",
+        "--issue",
+        "217",
+        "--sprint",
+        "2",
+        "--pr-grouping",
+        "group",
+        "--pr-group",
+        "S2T1=s2-core",
+        "--pr-group",
+        "Task 2.2=s2-core",
+    ])
+    .expect("parse start-sprint");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::StartSprint(args) => {
+            assert_eq!(args.issue, 217);
+            assert_eq!(args.sprint, 2);
+            assert_eq!(args.grouping.pr_grouping, PrGrouping::Group);
+            assert_eq!(args.grouping.pr_group.len(), 2);
+            assert_eq!(args.grouping.pr_group[0].task, "S2T1");
+            assert_eq!(args.grouping.pr_group[0].group, "s2-core");
+            assert_eq!(args.grouping.pr_group[1].task, "Task 2.2");
+            assert_eq!(args.grouping.pr_group[1].group, "s2-core");
+        }
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_conflict_rules_reject_pr_group_without_group_mode() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "build-plan-task-spec",
+        "--plan",
+        "plan.md",
+        "--pr-grouping",
+        "per-sprint",
+        "--pr-group",
+        "S2T1=s2-core",
+    ])
+    .expect("parse should succeed before semantic validation");
+
+    let err = cli.validate().expect_err("semantic validation should fail");
+    assert_eq!(err.code, "invalid-pr-grouping");
+    assert!(err.message.contains("only valid"), "{}", err.message);
+}
+
+#[test]
+fn cli_conflict_rules_require_pr_group_mapping_for_group_mode() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "build-plan-task-spec",
+        "--plan",
+        "plan.md",
+        "--pr-grouping",
+        "group",
+    ])
+    .expect("parse should succeed before semantic validation");
+
+    let err = cli.validate().expect_err("semantic validation should fail");
+    assert_eq!(err.code, "invalid-pr-grouping");
+    assert!(err.message.contains("requires at least one --pr-group"));
+}
+
+#[test]
+fn cli_conflict_rules_reject_summary_and_summary_file_together() {
+    let err = Cli::try_parse_from([
+        "plan-issue",
+        "ready-plan",
+        "--issue",
+        "217",
+        "--summary",
+        "done",
+        "--summary-file",
+        "summary.md",
+    ])
+    .expect_err("clap should reject conflicting args");
+
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("cannot be used with") || rendered.contains("conflicts with"),
+        "{rendered}"
+    );
+}

--- a/crates/plan-issue-cli/tests/common.rs
+++ b/crates/plan-issue-cli/tests/common.rs
@@ -1,0 +1,29 @@
+use std::path::Path;
+
+use nils_test_support::cmd::run_resolved_in_dir;
+
+pub struct CmdOut {
+    pub code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+fn run_bin(bin_name: &str, args: &[&str]) -> CmdOut {
+    let cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let output = run_resolved_in_dir(bin_name, cwd, args, &[], None);
+
+    CmdOut {
+        code: output.code,
+        stdout: output.stdout_text(),
+        stderr: output.stderr_text(),
+    }
+}
+
+pub fn run_plan_issue(args: &[&str]) -> CmdOut {
+    run_bin("plan-issue", args)
+}
+
+#[allow(dead_code)]
+pub fn run_plan_issue_local(args: &[&str]) -> CmdOut {
+    run_bin("plan-issue-local", args)
+}

--- a/crates/plan-issue-cli/tests/output_contract.rs
+++ b/crates/plan-issue-cli/tests/output_contract.rs
@@ -1,0 +1,128 @@
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+
+mod common;
+
+#[test]
+fn output_json_contract_success_envelope_contains_version_status_and_payload() {
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "build-task-spec",
+        "--plan",
+        "docs/plans/plan-issue-rust-cli-full-delivery-plan.md",
+        "--sprint",
+        "2",
+        "--pr-grouping",
+        "per-sprint",
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    assert!(
+        out.stderr.trim().is_empty(),
+        "stderr should be empty: {}",
+        out.stderr
+    );
+
+    let payload: Value = serde_json::from_str(&out.stdout).expect("stdout should be JSON");
+    assert!(
+        payload["schema_version"]
+            .as_str()
+            .is_some_and(|value| value.starts_with("plan-issue-cli.")),
+        "{}",
+        out.stdout
+    );
+    assert_eq!(payload["command"], "build-task-spec");
+    assert_eq!(payload["status"], "ok");
+    assert!(payload["payload"].is_object(), "{}", out.stdout);
+    assert_eq!(payload["payload"]["execution_mode"], "live");
+    assert_eq!(payload["payload"]["arguments"]["sprint"], 2);
+}
+
+#[test]
+fn output_json_contract_error_envelope_contains_code_and_message() {
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "build-task-spec",
+        "--plan",
+        "docs/plans/plan-issue-rust-cli-full-delivery-plan.md",
+        "--sprint",
+        "2",
+        "--pr-grouping",
+        "group",
+    ]);
+
+    assert_eq!(out.code, 1);
+
+    let payload: Value = serde_json::from_str(&out.stdout).expect("stdout should be JSON");
+    assert_eq!(payload["status"], "error");
+    assert_eq!(payload["error"]["code"], "invalid-pr-grouping");
+    assert!(
+        payload["error"]["message"]
+            .as_str()
+            .is_some_and(|value| value.contains("requires at least one --pr-group")),
+        "{}",
+        out.stdout
+    );
+}
+
+#[test]
+fn output_text_contract_success_output_is_deterministic() {
+    let out = common::run_plan_issue(&[
+        "build-plan-task-spec",
+        "--plan",
+        "docs/plans/plan-issue-rust-cli-full-delivery-plan.md",
+        "--pr-grouping",
+        "per-sprint",
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    assert!(
+        out.stderr.trim().is_empty(),
+        "stderr should be empty: {}",
+        out.stderr
+    );
+
+    let lines: Vec<&str> = out.stdout.lines().collect();
+    assert_eq!(lines.len(), 4, "unexpected output: {}", out.stdout);
+    assert_eq!(
+        lines[0],
+        "schema_version: plan-issue-cli.build.plan.task.spec.v1"
+    );
+    assert_eq!(lines[1], "command: build-plan-task-spec");
+    assert_eq!(lines[2], "status: ok");
+    assert!(lines[3].starts_with("payload: {"), "{}", lines[3]);
+}
+
+#[test]
+fn output_text_contract_error_output_is_deterministic() {
+    let out = common::run_plan_issue(&[
+        "build-plan-task-spec",
+        "--plan",
+        "docs/plans/plan-issue-rust-cli-full-delivery-plan.md",
+        "--pr-grouping",
+        "group",
+    ]);
+
+    assert_eq!(out.code, 1);
+    assert!(
+        out.stdout.trim().is_empty(),
+        "stdout should be empty: {}",
+        out.stdout
+    );
+
+    let lines: Vec<&str> = out.stderr.lines().collect();
+    assert_eq!(lines.len(), 5, "unexpected stderr: {}", out.stderr);
+    assert_eq!(
+        lines[0],
+        "schema_version: plan-issue-cli.build.plan.task.spec.v1"
+    );
+    assert_eq!(lines[1], "command: build-plan-task-spec");
+    assert_eq!(lines[2], "status: error");
+    assert_eq!(lines[3], "code: invalid-pr-grouping");
+    assert_eq!(
+        lines[4],
+        "message: --pr-grouping group requires at least one --pr-group"
+    );
+}

--- a/docs/reports/completion-coverage-matrix.md
+++ b/docs/reports/completion-coverage-matrix.md
@@ -5,6 +5,7 @@
 - Inventory source of truth: `bash scripts/workspace-bins.sh`.
 - Obligation rule for this matrix: all workspace binaries are `required` unless explicitly `excluded` as internal/example binaries.
 - Explicit exclusion: `cli-template` is `excluded` because it is an example/template CLI and is out of scope for user-facing release contract migration (`docs/plans/repo-completion-standard-rollout-plan.md`).
+- Explicit exclusion: `plan-issue` and `plan-issue-local` are `excluded` until Sprint 6 completion rollout finalizes their user-facing command surface.
 - Explicit treatment: `image-processing` is `required` (user-facing CLI in `README.md`) and must ship clap-first thin completion adapters in both shells.
 - Alias policy: alias families are required only for `git-scope` (`gs*`), `git-cli` (`gx*`), `codex-cli` (`cx*`), and `fzf-cli` (`fx*`) per `AGENTS.md`; other binaries have no alias requirement.
 - Completion quality baseline for every `required` binary: subcommands + long/short flags + declared value candidates.
@@ -35,11 +36,13 @@
 | `image-processing` | `required` | `present` (`_image-processing`) | `present` (`image-processing`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Explicitly treated as a user-facing CLI (not internal/example); completion is exported by `image-processing completion <bash|zsh>` and loaded through thin fail-closed shell adapters. |
 | `macos-agent` | `required` | `present` (`_macos-agent`) | `present` (`macos-agent`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories. |
 | `memo-cli` | `required` | `present` (`_memo-cli`) | `present` (`memo-cli`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories. |
+| `plan-issue` | `excluded` | `missing` | `missing` | not required | `not required (excluded)` | Sprint 2 scaffold binary; completion assets are deferred until Sprint 6 completion rollout. |
+| `plan-issue-local` | `excluded` | `missing` | `missing` | not required | `not required (excluded)` | Sprint 2 scaffold binary; completion assets are deferred until Sprint 6 completion rollout. |
 | `plan-tooling` | `required` | `present` (`_plan-tooling`) | `present` (`plan-tooling`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories. |
 | `screen-record` | `required` | `present` (`_screen-record`) | `present` (`screen-record`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories. |
 | `semantic-commit` | `required` | `present` (`_semantic-commit`) | `present` (`semantic-commit`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories. |
 
 ## Exclusion summary
 
-- `excluded`: `cli-template` (explicit internal/example-template exclusion).
+- `excluded`: `cli-template`, `plan-issue`, `plan-issue-local` (explicit staged exclusions).
 - No other workspace binary is excluded in this matrix.

--- a/release/crates-io-publish-order.txt
+++ b/release/crates-io-publish-order.txt
@@ -15,6 +15,7 @@ nils-git-scope
 nils-git-summary
 nils-image-processing
 nils-plan-tooling
+nils-plan-issue-cli
 nils-semantic-commit
 nils-macos-agent
 nils-api-gql


### PR DESCRIPTION
## Summary
- Scaffolds `nils-plan-issue-cli` as a new workspace crate with shared command model and output envelopes.
- Adds two binaries, `plan-issue` and `plan-issue-local`, with binary-flavor specific execution mode metadata.
- Introduces contract-focused tests for CLI surface, argument validation rules, and text/JSON output behavior.

## Scope
- Included: workspace membership/publish-order wiring, crate skeleton (`src`, tests), and Sprint 2 documentation/status updates.
- Excluded: runtime orchestration execution against GitHub workflows and completion asset rollout (deferred by plan to later sprints).

## Testing
- `cargo check -p nils-plan-issue-cli` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass; total line coverage 86.26%)

## Issue
- #217
