### PR TITLE
feat: Implement task-spec generation core using `plan-tooling` (+2 tasks)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,10 +1853,12 @@ name = "nils-plan-issue-cli"
 version = "0.5.1"
 dependencies = [
  "clap",
+ "nils-plan-tooling",
  "nils-test-support",
  "pretty_assertions",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/plan-issue-cli/Cargo.toml
+++ b/crates/plan-issue-cli/Cargo.toml
@@ -24,7 +24,9 @@ path = "src/bin/plan-issue-local.rs"
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+plan-tooling = { version = "0.5.1", path = "../plan-tooling", package = "nils-plan-tooling" }
 
 [dev-dependencies]
 nils-test-support = { version = "0.5.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
+tempfile = "3"

--- a/crates/plan-issue-cli/README.md
+++ b/crates/plan-issue-cli/README.md
@@ -8,11 +8,11 @@ Sprint 1 establishes the v1 command contract, gate semantics, and deterministic 
 to preserve orchestration compatibility before implementation cutover.
 
 ## Status
-- Current scope includes Sprint 2 scaffold implementation:
-  - crate package `nils-plan-issue-cli`
-  - binaries `plan-issue` and `plan-issue-local`
-  - typed clap command model for v1 command surface
-  - deterministic text and JSON output envelopes
+- Current scope includes Sprint 3 implementation:
+  - deterministic task-spec generation core using `plan-tooling` parsing primitives
+  - issue-body and sprint-comment markdown rendering engine
+  - local-first dry-run workflow for `plan-issue-local`
+  - Sprint 2 scaffold + typed command model + text/JSON output envelopes
 
 ## Specifications
 - [CLI contract v1](docs/specs/plan-issue-cli-contract-v1.md)

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -193,12 +193,12 @@ impl Command {
             Self::BuildPlanTaskSpec(args) => validate_grouping(&args.grouping),
             Self::StartPlan(args) => validate_grouping(&args.grouping),
             Self::StartSprint(args) => validate_grouping(&args.grouping),
+            Self::ReadySprint(args) => validate_grouping(&args.grouping),
+            Self::AcceptSprint(args) => validate_grouping(&args.grouping),
             Self::ClosePlan(args) => validate_close_plan_args(args, dry_run),
             Self::StatusPlan(_)
             | Self::ReadyPlan(_)
             | Self::CleanupWorktrees(_)
-            | Self::ReadySprint(_)
-            | Self::AcceptSprint(_)
             | Self::MultiSprintGuide(_) => Ok(()),
         }
     }

--- a/crates/plan-issue-cli/src/commands/sprint.rs
+++ b/crates/plan-issue-cli/src/commands/sprint.rs
@@ -51,6 +51,16 @@ pub struct ReadySprintArgs {
     #[arg(long, value_parser = clap::value_parser!(u16).range(1..), value_name = "number")]
     pub sprint: u16,
 
+    /// Sprint task-spec output path override.
+    #[arg(long, value_name = "path")]
+    pub task_spec_out: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub prefixes: PrefixArgs,
+
+    #[command(flatten)]
+    pub grouping: GroupingArgs,
+
     #[command(flatten)]
     pub summary: SummaryArgs,
 
@@ -71,6 +81,16 @@ pub struct AcceptSprintArgs {
     /// Sprint number.
     #[arg(long, value_parser = clap::value_parser!(u16).range(1..), value_name = "number")]
     pub sprint: u16,
+
+    /// Sprint task-spec output path override.
+    #[arg(long, value_name = "path")]
+    pub task_spec_out: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub prefixes: PrefixArgs,
+
+    #[command(flatten)]
+    pub grouping: GroupingArgs,
 
     /// Review approval comment URL.
     #[arg(long = "approved-comment-url", value_name = "url")]

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -1,0 +1,383 @@
+use std::fs;
+use std::path::Path;
+
+use serde_json::{Value, json};
+
+use crate::cli::Cli;
+use crate::commands::build::{BuildPlanTaskSpecArgs, BuildTaskSpecArgs};
+use crate::commands::plan::StartPlanArgs;
+use crate::commands::sprint::{AcceptSprintArgs, ReadySprintArgs, StartSprintArgs};
+use crate::commands::{Command, SummaryArgs};
+use crate::render::{self, SprintCommentInput, SprintCommentMode};
+use crate::task_spec::{self, TaskSpecBuildOptions, TaskSpecScope};
+use crate::{BinaryFlavor, CommandError};
+
+pub fn execute(binary: BinaryFlavor, cli: &Cli) -> Result<Value, CommandError> {
+    match &cli.command {
+        Command::BuildTaskSpec(args) => run_build_task_spec(args),
+        Command::BuildPlanTaskSpec(args) => run_build_plan_task_spec(args),
+        Command::StartPlan(args) => run_start_plan(binary, cli.dry_run, args),
+        Command::StartSprint(args) => run_start_sprint(binary, cli.dry_run, args),
+        Command::ReadySprint(args) => run_ready_sprint(binary, cli.dry_run, args),
+        Command::AcceptSprint(args) => run_accept_sprint(binary, cli.dry_run, args),
+        _ => Ok(json!({
+            "status": "not-implemented",
+            "detail": "command execution beyond Sprint 3 scope is not implemented yet"
+        })),
+    }
+}
+
+fn run_build_task_spec(args: &BuildTaskSpecArgs) -> Result<Value, CommandError> {
+    let options = to_build_options(
+        args.prefixes.owner_prefix.clone(),
+        args.prefixes.branch_prefix.clone(),
+        args.prefixes.worktree_prefix.clone(),
+        args.grouping.pr_grouping,
+        args.grouping.pr_group.clone(),
+    );
+    let build = task_spec::build_task_spec(
+        &args.plan,
+        TaskSpecScope::Sprint(i32::from(args.sprint)),
+        &options,
+    )
+    .map_err(|err| CommandError::runtime("task-spec-generation-failed", err))?;
+
+    let out_path = args.task_spec_out.clone().unwrap_or_else(|| {
+        task_spec::default_sprint_task_spec_path(&args.plan, i32::from(args.sprint))
+    });
+    task_spec::write_tsv(&out_path, &build.rows)
+        .map_err(|err| CommandError::runtime("task-spec-write-failed", err))?;
+
+    Ok(json!({
+        "scope": "sprint",
+        "sprint": args.sprint,
+        "task_spec_path": path_text(&out_path),
+        "record_count": build.rows.len(),
+        "plan_title": build.plan_title,
+    }))
+}
+
+fn run_build_plan_task_spec(args: &BuildPlanTaskSpecArgs) -> Result<Value, CommandError> {
+    let options = to_build_options(
+        args.prefixes.owner_prefix.clone(),
+        args.prefixes.branch_prefix.clone(),
+        args.prefixes.worktree_prefix.clone(),
+        args.grouping.pr_grouping,
+        args.grouping.pr_group.clone(),
+    );
+    let build = task_spec::build_task_spec(&args.plan, TaskSpecScope::Plan, &options)
+        .map_err(|err| CommandError::runtime("task-spec-generation-failed", err))?;
+
+    let out_path = args
+        .task_spec_out
+        .clone()
+        .unwrap_or_else(|| task_spec::default_plan_task_spec_path(&args.plan));
+    task_spec::write_tsv(&out_path, &build.rows)
+        .map_err(|err| CommandError::runtime("task-spec-write-failed", err))?;
+
+    Ok(json!({
+        "scope": "plan",
+        "task_spec_path": path_text(&out_path),
+        "record_count": build.rows.len(),
+        "plan_title": build.plan_title,
+    }))
+}
+
+fn run_start_plan(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    args: &StartPlanArgs,
+) -> Result<Value, CommandError> {
+    let options = to_build_options(
+        args.prefixes.owner_prefix.clone(),
+        args.prefixes.branch_prefix.clone(),
+        args.prefixes.worktree_prefix.clone(),
+        args.grouping.pr_grouping,
+        args.grouping.pr_group.clone(),
+    );
+
+    let build = task_spec::build_task_spec(&args.plan, TaskSpecScope::Plan, &options)
+        .map_err(|err| CommandError::runtime("task-spec-generation-failed", err))?;
+
+    let task_spec_out = args
+        .task_spec_out
+        .clone()
+        .unwrap_or_else(|| task_spec::default_plan_task_spec_path(&args.plan));
+    task_spec::write_tsv(&task_spec_out, &build.rows)
+        .map_err(|err| CommandError::runtime("task-spec-write-failed", err))?;
+
+    let issue_body_out = args
+        .issue_body_out
+        .clone()
+        .unwrap_or_else(|| render::default_plan_issue_body_path(&args.plan));
+
+    let plan_title = args
+        .title
+        .clone()
+        .unwrap_or_else(|| build.plan_title.clone());
+
+    let issue_body =
+        render::render_plan_issue_body(&build.display_plan_path, &plan_title, &build.rows);
+    render::write_rendered(&issue_body_out, &issue_body)
+        .map_err(|err| CommandError::runtime("issue-body-write-failed", err))?;
+
+    Ok(json!({
+        "scope": "plan",
+        "execution_mode": binary.execution_mode(),
+        "dry_run": dry_run,
+        "task_spec_path": path_text(&task_spec_out),
+        "issue_body_path": path_text(&issue_body_out),
+        "record_count": build.rows.len(),
+        "live_mutations_performed": false,
+    }))
+}
+
+fn run_start_sprint(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    args: &StartSprintArgs,
+) -> Result<Value, CommandError> {
+    let options = to_build_options(
+        args.prefixes.owner_prefix.clone(),
+        args.prefixes.branch_prefix.clone(),
+        args.prefixes.worktree_prefix.clone(),
+        args.grouping.pr_grouping,
+        args.grouping.pr_group.clone(),
+    );
+
+    let build = task_spec::build_task_spec(
+        &args.plan,
+        TaskSpecScope::Sprint(i32::from(args.sprint)),
+        &options,
+    )
+    .map_err(|err| CommandError::runtime("task-spec-generation-failed", err))?;
+
+    let task_spec_out = args.task_spec_out.clone().unwrap_or_else(|| {
+        task_spec::default_sprint_task_spec_path(&args.plan, i32::from(args.sprint))
+    });
+    task_spec::write_tsv(&task_spec_out, &build.rows)
+        .map_err(|err| CommandError::runtime("task-spec-write-failed", err))?;
+
+    let sprint_name = build
+        .sprint_name
+        .clone()
+        .unwrap_or_else(|| format!("Sprint {}", args.sprint));
+
+    let comment = render::render_sprint_comment(SprintCommentInput {
+        mode: SprintCommentMode::Start,
+        plan_file: &args.plan,
+        sprint: i32::from(args.sprint),
+        sprint_name: &sprint_name,
+        rows: &build.rows,
+        note_text: None,
+        approval_comment_url: None,
+        issue_body_text: None,
+    })
+    .map_err(|err| CommandError::runtime("render-sprint-comment-failed", err))?;
+
+    let comment_out = render::default_sprint_comment_path(
+        &args.plan,
+        i32::from(args.sprint),
+        SprintCommentMode::Start,
+    );
+    render::write_rendered(&comment_out, &comment)
+        .map_err(|err| CommandError::runtime("comment-write-failed", err))?;
+
+    Ok(json!({
+        "scope": "sprint",
+        "sprint": args.sprint,
+        "execution_mode": binary.execution_mode(),
+        "dry_run": dry_run,
+        "task_spec_path": path_text(&task_spec_out),
+        "comment_path": path_text(&comment_out),
+        "record_count": build.rows.len(),
+        "subagent_prompts_out": args.subagent_prompts_out.as_ref().map(|path| path_text(path)),
+        "live_mutations_performed": false,
+    }))
+}
+
+fn run_ready_sprint(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    args: &ReadySprintArgs,
+) -> Result<Value, CommandError> {
+    let options = to_build_options(
+        args.prefixes.owner_prefix.clone(),
+        args.prefixes.branch_prefix.clone(),
+        args.prefixes.worktree_prefix.clone(),
+        args.grouping.pr_grouping,
+        args.grouping.pr_group.clone(),
+    );
+
+    let build = task_spec::build_task_spec(
+        &args.plan,
+        TaskSpecScope::Sprint(i32::from(args.sprint)),
+        &options,
+    )
+    .map_err(|err| CommandError::runtime("task-spec-generation-failed", err))?;
+
+    let task_spec_out = args.task_spec_out.clone().unwrap_or_else(|| {
+        task_spec::default_sprint_task_spec_path(&args.plan, i32::from(args.sprint))
+    });
+    task_spec::write_tsv(&task_spec_out, &build.rows)
+        .map_err(|err| CommandError::runtime("task-spec-write-failed", err))?;
+
+    let summary = load_summary(&args.summary)?;
+    let sprint_name = build
+        .sprint_name
+        .clone()
+        .unwrap_or_else(|| format!("Sprint {}", args.sprint));
+
+    let comment = render::render_sprint_comment(SprintCommentInput {
+        mode: SprintCommentMode::Ready,
+        plan_file: &args.plan,
+        sprint: i32::from(args.sprint),
+        sprint_name: &sprint_name,
+        rows: &build.rows,
+        note_text: summary.as_deref(),
+        approval_comment_url: None,
+        issue_body_text: None,
+    })
+    .map_err(|err| CommandError::runtime("render-sprint-comment-failed", err))?;
+
+    let comment_out = render::default_sprint_comment_path(
+        &args.plan,
+        i32::from(args.sprint),
+        SprintCommentMode::Ready,
+    );
+    render::write_rendered(&comment_out, &comment)
+        .map_err(|err| CommandError::runtime("comment-write-failed", err))?;
+
+    Ok(json!({
+        "scope": "sprint",
+        "sprint": args.sprint,
+        "execution_mode": binary.execution_mode(),
+        "dry_run": dry_run,
+        "task_spec_path": path_text(&task_spec_out),
+        "comment_path": path_text(&comment_out),
+        "record_count": build.rows.len(),
+        "live_mutations_performed": false,
+    }))
+}
+
+fn run_accept_sprint(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    args: &AcceptSprintArgs,
+) -> Result<Value, CommandError> {
+    if !approval_comment_url_looks_valid(&args.approved_comment_url) {
+        return Err(CommandError::usage(
+            "invalid-approval-comment-url",
+            "--approved-comment-url must be a GitHub issue/pull comment URL",
+        ));
+    }
+
+    let options = to_build_options(
+        args.prefixes.owner_prefix.clone(),
+        args.prefixes.branch_prefix.clone(),
+        args.prefixes.worktree_prefix.clone(),
+        args.grouping.pr_grouping,
+        args.grouping.pr_group.clone(),
+    );
+
+    let build = task_spec::build_task_spec(
+        &args.plan,
+        TaskSpecScope::Sprint(i32::from(args.sprint)),
+        &options,
+    )
+    .map_err(|err| CommandError::runtime("task-spec-generation-failed", err))?;
+
+    let task_spec_out = args.task_spec_out.clone().unwrap_or_else(|| {
+        task_spec::default_sprint_task_spec_path(&args.plan, i32::from(args.sprint))
+    });
+    task_spec::write_tsv(&task_spec_out, &build.rows)
+        .map_err(|err| CommandError::runtime("task-spec-write-failed", err))?;
+
+    let summary = load_summary(&args.summary)?;
+    let sprint_name = build
+        .sprint_name
+        .clone()
+        .unwrap_or_else(|| format!("Sprint {}", args.sprint));
+
+    let comment = render::render_sprint_comment(SprintCommentInput {
+        mode: SprintCommentMode::Accepted,
+        plan_file: &args.plan,
+        sprint: i32::from(args.sprint),
+        sprint_name: &sprint_name,
+        rows: &build.rows,
+        note_text: summary.as_deref(),
+        approval_comment_url: Some(&args.approved_comment_url),
+        issue_body_text: None,
+    })
+    .map_err(|err| CommandError::runtime("render-sprint-comment-failed", err))?;
+
+    let comment_out = render::default_sprint_comment_path(
+        &args.plan,
+        i32::from(args.sprint),
+        SprintCommentMode::Accepted,
+    );
+    render::write_rendered(&comment_out, &comment)
+        .map_err(|err| CommandError::runtime("comment-write-failed", err))?;
+
+    Ok(json!({
+        "scope": "sprint",
+        "sprint": args.sprint,
+        "execution_mode": binary.execution_mode(),
+        "dry_run": dry_run,
+        "task_spec_path": path_text(&task_spec_out),
+        "comment_path": path_text(&comment_out),
+        "record_count": build.rows.len(),
+        "live_mutations_performed": false,
+        "approval_comment_url": args.approved_comment_url,
+    }))
+}
+
+fn to_build_options(
+    owner_prefix: String,
+    branch_prefix: String,
+    worktree_prefix: String,
+    pr_grouping: crate::commands::PrGrouping,
+    pr_group: Vec<crate::commands::PrGroupMapping>,
+) -> TaskSpecBuildOptions {
+    TaskSpecBuildOptions {
+        owner_prefix,
+        branch_prefix,
+        worktree_prefix,
+        pr_grouping,
+        pr_group,
+    }
+}
+
+fn load_summary(summary: &SummaryArgs) -> Result<Option<String>, CommandError> {
+    if let Some(inline) = &summary.summary {
+        return Ok(Some(inline.to_string()));
+    }
+    if let Some(path) = &summary.summary_file {
+        let text = fs::read_to_string(path).map_err(|err| {
+            CommandError::runtime(
+                "summary-read-failed",
+                format!("failed to read summary file {}: {err}", path.display()),
+            )
+        })?;
+        return Ok(Some(text));
+    }
+    Ok(None)
+}
+
+fn approval_comment_url_looks_valid(url: &str) -> bool {
+    let trimmed = url.trim();
+    if !trimmed.starts_with("https://github.com/") {
+        return false;
+    }
+    let Some((base, suffix)) = trimmed.split_once("#issuecomment-") else {
+        return false;
+    };
+    if !suffix.chars().all(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+    base.contains("/issues/") || base.contains("/pull/")
+}
+
+fn path_text(path: &Path) -> String {
+    path.to_string_lossy().to_string()
+}

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod cli;
 pub mod commands;
+mod execute;
 pub mod output;
+mod render;
+mod task_spec;
 
 use std::ffi::OsString;
 
@@ -50,6 +53,31 @@ impl ValidationError {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandError {
+    pub code: &'static str,
+    pub message: String,
+    pub exit_code: i32,
+}
+
+impl CommandError {
+    pub fn new(code: &'static str, message: impl Into<String>, exit_code: i32) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            exit_code,
+        }
+    }
+
+    pub fn runtime(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(code, message, EXIT_FAILURE)
+    }
+
+    pub fn usage(code: &'static str, message: impl Into<String>) -> Self {
+        Self::new(code, message, EXIT_USAGE)
+    }
+}
+
 pub fn run(binary: BinaryFlavor) -> i32 {
     run_with_args(binary, std::env::args_os())
 }
@@ -94,6 +122,23 @@ where
         return EXIT_FAILURE;
     }
 
+    let execution_result = match execute::execute(binary, &cli) {
+        Ok(result) => result,
+        Err(err) => {
+            let schema_version = cli.command.schema_version();
+            if let Err(render_err) = output::emit_error(
+                output_format,
+                &schema_version,
+                cli.command.command_id(),
+                err.code,
+                &err.message,
+            ) {
+                eprintln!("error: {render_err}");
+            }
+            return err.exit_code;
+        }
+    };
+
     let schema_version = cli.command.schema_version();
     let payload = json!({
         "binary": binary.binary_name(),
@@ -101,6 +146,7 @@ where
         "dry_run": cli.dry_run,
         "repo": cli.repo,
         "arguments": cli.command.payload(),
+        "result": execution_result,
     });
 
     if let Err(err) = output::emit_success(

--- a/crates/plan-issue-cli/src/render.rs
+++ b/crates/plan-issue-cli/src/render.rs
@@ -1,0 +1,486 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::task_spec::{TaskSpecRow, agent_home};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SprintCommentMode {
+    Start,
+    Ready,
+    Accepted,
+}
+
+#[derive(Debug, Clone)]
+pub struct SprintCommentInput<'a> {
+    pub mode: SprintCommentMode,
+    pub plan_file: &'a Path,
+    pub sprint: i32,
+    pub sprint_name: &'a str,
+    pub rows: &'a [TaskSpecRow],
+    pub note_text: Option<&'a str>,
+    pub approval_comment_url: Option<&'a str>,
+    pub issue_body_text: Option<&'a str>,
+}
+
+pub fn default_plan_issue_body_path(plan_file: &Path) -> PathBuf {
+    let plan_stem = plan_file
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("plan")
+        .to_string();
+    agent_home()
+        .join("out")
+        .join("plan-issue-delivery-loop")
+        .join(format!("{plan_stem}-plan-issue-body.md"))
+}
+
+pub fn default_sprint_comment_path(
+    plan_file: &Path,
+    sprint: i32,
+    mode: SprintCommentMode,
+) -> PathBuf {
+    let plan_stem = plan_file
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("plan")
+        .to_string();
+    let mode_label = match mode {
+        SprintCommentMode::Start => "start",
+        SprintCommentMode::Ready => "ready",
+        SprintCommentMode::Accepted => "accepted",
+    };
+
+    agent_home()
+        .join("out")
+        .join("plan-issue-delivery-loop")
+        .join(format!(
+            "{plan_stem}-sprint-{sprint}-{mode_label}-comment.md"
+        ))
+}
+
+pub fn render_plan_issue_body(
+    plan_file_display: &str,
+    plan_title: &str,
+    rows: &[TaskSpecRow],
+) -> String {
+    let title = if plan_title.trim().is_empty() {
+        let fallback = Path::new(plan_file_display)
+            .file_stem()
+            .and_then(|v| v.to_str())
+            .unwrap_or("Plan");
+        fallback.to_string()
+    } else {
+        plan_title.trim().to_string()
+    };
+
+    let mut out: Vec<String> = vec![
+        format!("# {title}"),
+        String::new(),
+        "## Goal".to_string(),
+        String::new(),
+        format!(
+            "- Execute plan `{plan_file_display}` end-to-end using one GitHub issue and subagent-owned PRs."
+        ),
+        "- Track sprint progress via issue comments while keeping task/PR state in the issue body.".to_string(),
+        String::new(),
+        "## Acceptance Criteria".to_string(),
+        String::new(),
+        "- All in-scope plan tasks are implemented via subagent PRs and linked in the issue task table."
+            .to_string(),
+        "- Final plan review approval comment URL is recorded.".to_string(),
+        "- The single plan issue closes after close-gate checks pass.".to_string(),
+        String::new(),
+        "## Scope".to_string(),
+        String::new(),
+        format!("- In-scope: tasks defined in `{plan_file_display}`"),
+        "- Out-of-scope: work not represented in the plan task list".to_string(),
+        String::new(),
+        "## Task Decomposition".to_string(),
+        String::new(),
+        "| Task | Summary | Owner | Branch | Worktree | Execution Mode | PR | Status | Notes |"
+            .to_string(),
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |".to_string(),
+    ];
+
+    for row in rows {
+        let notes = if row.notes.trim().is_empty() {
+            "-".to_string()
+        } else {
+            row.notes.trim().to_string()
+        };
+        out.push(format!(
+            "| {} | {} | TBD | TBD | TBD | TBD | TBD | planned | {} |",
+            row.task_id, row.summary, notes
+        ));
+    }
+
+    out.extend([
+        String::new(),
+        "## Consistency Rules".to_string(),
+        String::new(),
+        "- `Status` must be one of: `planned`, `in-progress`, `blocked`, `done`.".to_string(),
+        "- `Status` = `in-progress` or `done` requires non-`TBD` execution metadata (`Owner`, `Branch`, `Worktree`, `Execution Mode`, `PR`).".to_string(),
+        "- `Owner` must be a subagent identifier (contains `subagent`) once the task is assigned; `main-agent` ownership is invalid for implementation tasks.".to_string(),
+        "- `Execution Mode` should be one of: `per-task`, `per-sprint`, `pr-isolated`, `pr-shared` (or `TBD` before assignment).".to_string(),
+        "- `Branch` and `Worktree` uniqueness is enforced only for rows using `Execution Mode = per-task`.".to_string(),
+        String::new(),
+        "## Risks / Uncertainties".to_string(),
+        String::new(),
+        "- Sprint approvals may be recorded before final close; issue stays open until final plan acceptance.".to_string(),
+        "- Close gate fails if task statuses or PR merge states in the issue body are incomplete.".to_string(),
+        String::new(),
+        "## Evidence".to_string(),
+        String::new(),
+        format!("- Plan source: `{plan_file_display}`"),
+        "- Sprint approvals: issue comments (one comment per accepted sprint)".to_string(),
+        "- Final approval: issue/pull comment URL passed to `close-plan`".to_string(),
+    ]);
+
+    format!("{}\n", out.join("\n"))
+}
+
+pub fn render_sprint_comment(input: SprintCommentInput<'_>) -> Result<String, String> {
+    let SprintCommentInput {
+        mode,
+        plan_file,
+        sprint,
+        sprint_name,
+        rows,
+        note_text,
+        approval_comment_url,
+        issue_body_text,
+    } = input;
+
+    if rows.is_empty() {
+        return Err("task spec contains no rows".to_string());
+    }
+
+    let mut group_sizes: HashMap<String, usize> = HashMap::new();
+    for row in rows {
+        *group_sizes.entry(row.pr_group.clone()).or_insert(0) += 1;
+    }
+
+    let issue_pr_values = issue_body_text
+        .map(parse_issue_pr_values)
+        .unwrap_or_default();
+
+    let mut out: Vec<String> = Vec::new();
+    let (heading, lead) = match mode {
+        SprintCommentMode::Start => (
+            format!("## Sprint {sprint} Start"),
+            "Main-agent starts this sprint on the plan issue and dispatches implementation to subagents.",
+        ),
+        SprintCommentMode::Ready => (
+            format!("## Sprint {sprint} Ready for Review"),
+            "Main-agent requests sprint-level review before merge/acceptance on the plan issue (the issue remains open).",
+        ),
+        SprintCommentMode::Accepted => (
+            format!("## Sprint {sprint} Accepted"),
+            "Main-agent records sprint acceptance after merge gate passes and sprint rows are synced to done (issue remains open for remaining sprints).",
+        ),
+    };
+
+    out.push(heading);
+    out.push(String::new());
+    out.push(format!("- Sprint: {sprint} ({sprint_name})"));
+    out.push(format!("- Tasks in sprint: {}", rows.len()));
+    out.push(format!("- Note: {lead}"));
+    if mode == SprintCommentMode::Start {
+        out.push(
+            "- Execution Mode comes from current Task Decomposition for each sprint task."
+                .to_string(),
+        );
+    } else {
+        out.push(
+            "- PR values come from current Task Decomposition; unresolved tasks remain `TBD` until PRs are linked."
+                .to_string(),
+        );
+    }
+
+    if let Some(url) = approval_comment_url {
+        let trimmed = url.trim();
+        if !trimmed.is_empty() {
+            out.push(format!("- Approval comment URL: {trimmed}"));
+        }
+    }
+
+    out.push(String::new());
+    match mode {
+        SprintCommentMode::Start => {
+            out.push("| Task | Summary | Execution Mode |".to_string());
+            out.push("| --- | --- | --- |".to_string());
+            for row in rows {
+                let execution_mode = if row.grouping == crate::commands::PrGrouping::PerSprint {
+                    "per-sprint"
+                } else if group_sizes.get(&row.pr_group).copied().unwrap_or(0) > 1 {
+                    "pr-shared"
+                } else {
+                    "pr-isolated"
+                };
+                out.push(format!(
+                    "| {} | {} | {} |",
+                    row.task_id,
+                    if row.summary.is_empty() {
+                        "-"
+                    } else {
+                        &row.summary
+                    },
+                    execution_mode
+                ));
+            }
+
+            let sprint_section = extract_sprint_section(plan_file, sprint)?;
+            if !sprint_section.is_empty() {
+                out.push(String::new());
+                out.push(sprint_section);
+            }
+        }
+        SprintCommentMode::Ready | SprintCommentMode::Accepted => {
+            out.push("| Task | Summary | PR |".to_string());
+            out.push("| --- | --- | --- |".to_string());
+            for row in rows {
+                let mut pr_value = issue_pr_values
+                    .get(&row.task_id)
+                    .map(|v| normalize_pr_display(v))
+                    .unwrap_or_default();
+                if pr_value.is_empty() {
+                    pr_value = if row.grouping == crate::commands::PrGrouping::PerSprint {
+                        "TBD (per-sprint)".to_string()
+                    } else {
+                        format!("TBD (group:{})", row.pr_group)
+                    };
+                }
+                out.push(format!(
+                    "| {} | {} | {} |",
+                    row.task_id,
+                    if row.summary.is_empty() {
+                        "-"
+                    } else {
+                        &row.summary
+                    },
+                    pr_value
+                ));
+            }
+        }
+    }
+
+    if let Some(note) = note_text {
+        let trimmed = note.trim();
+        if !trimmed.is_empty() {
+            out.push(String::new());
+            out.push("## Main-Agent Notes".to_string());
+            out.push(String::new());
+            out.push(trimmed.to_string());
+        }
+    }
+
+    Ok(format!("{}\n", out.join("\n")))
+}
+
+pub fn write_rendered(path: &Path, content: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            format!(
+                "failed to create output directory {}: {err}",
+                parent.display()
+            )
+        })?;
+    }
+    std::fs::write(path, content)
+        .map_err(|err| format!("failed to write {}: {err}", path.display()))
+}
+
+fn parse_issue_pr_values(issue_body_text: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let lines: Vec<&str> = issue_body_text.lines().collect();
+
+    let Some((start, end)) = section_bounds(&lines, "## Task Decomposition") else {
+        return out;
+    };
+
+    let table_lines: Vec<&str> = lines[start..end]
+        .iter()
+        .copied()
+        .filter(|line| line.trim().starts_with('|'))
+        .collect();
+
+    if table_lines.len() < 3 {
+        return out;
+    }
+
+    let headers = parse_markdown_row(table_lines[0]);
+    let Some(task_idx) = headers.iter().position(|h| h == "Task") else {
+        return out;
+    };
+    let Some(pr_idx) = headers.iter().position(|h| h == "PR") else {
+        return out;
+    };
+
+    for line in table_lines.iter().skip(2) {
+        let cells = parse_markdown_row(line);
+        if cells.len() != headers.len() {
+            continue;
+        }
+        let task = cells[task_idx].trim();
+        let pr = cells[pr_idx].trim();
+        if task.is_empty() {
+            continue;
+        }
+        let normalized = normalize_pr_display(pr);
+        if !normalized.is_empty() {
+            out.insert(task.to_string(), normalized);
+        }
+    }
+
+    out
+}
+
+fn section_bounds(lines: &[&str], heading: &str) -> Option<(usize, usize)> {
+    let mut start = None;
+    for (idx, line) in lines.iter().enumerate() {
+        if line.trim() == heading {
+            start = Some(idx + 1);
+            break;
+        }
+    }
+    let start = start?;
+
+    let mut end = lines.len();
+    for (idx, line) in lines.iter().enumerate().skip(start) {
+        if line.starts_with("## ") {
+            end = idx;
+            break;
+        }
+    }
+
+    Some((start, end))
+}
+
+fn parse_markdown_row(line: &str) -> Vec<String> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('|') || !trimmed.ends_with('|') {
+        return Vec::new();
+    }
+    trimmed[1..trimmed.len() - 1]
+        .split('|')
+        .map(|cell| cell.trim().to_string())
+        .collect()
+}
+
+fn is_placeholder(value: &str) -> bool {
+    let token = value.trim().to_ascii_lowercase();
+    if matches!(
+        token.as_str(),
+        "" | "-" | "tbd" | "none" | "n/a" | "na" | "..."
+    ) {
+        return true;
+    }
+    if token.starts_with("tbd") {
+        return true;
+    }
+    if token.starts_with('<') && token.ends_with('>') {
+        return true;
+    }
+    token.contains("task ids")
+}
+
+fn parse_digits(token: &str) -> Option<String> {
+    if token.is_empty() || !token.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(token.to_string())
+}
+
+fn normalize_pr_display(value: &str) -> String {
+    let token = value.trim();
+    if is_placeholder(token) {
+        return String::new();
+    }
+
+    if let Some(rest) = token.strip_prefix('#')
+        && let Some(num) = parse_digits(rest)
+    {
+        return format!("#{num}");
+    }
+
+    if let Some(rest) = token.to_ascii_lowercase().strip_prefix("pr#")
+        && let Some(num) = parse_digits(rest)
+    {
+        return format!("#{num}");
+    }
+
+    if let Some((_, tail)) = token.rsplit_once('#')
+        && let Some(num) = parse_digits(tail)
+        && token.contains('/')
+    {
+        return format!("#{num}");
+    }
+
+    if let Some(idx) = token.to_ascii_lowercase().find("/pull/") {
+        let after = &token[idx + "/pull/".len()..];
+        let number: String = after.chars().take_while(|ch| ch.is_ascii_digit()).collect();
+        if let Some(num) = parse_digits(&number) {
+            return format!("#{num}");
+        }
+    }
+
+    token.to_string()
+}
+
+fn extract_sprint_section(plan_file: &Path, sprint: i32) -> Result<String, String> {
+    let repo_root = detect_repo_root();
+    let resolved = resolve_repo_relative(&repo_root, plan_file);
+    let text = std::fs::read_to_string(&resolved).map_err(|err| {
+        format!(
+            "failed to read plan file {}: {err}",
+            plan_file.to_string_lossy()
+        )
+    })?;
+    let lines: Vec<&str> = text.lines().collect();
+
+    let target_prefix = format!("## Sprint {sprint}");
+    let mut start = None;
+    for (idx, line) in lines.iter().enumerate() {
+        if line.trim().starts_with(&target_prefix) {
+            start = Some(idx);
+            break;
+        }
+    }
+
+    let Some(start_idx) = start else {
+        return Ok(String::new());
+    };
+
+    let mut end_idx = lines.len();
+    for (idx, line) in lines.iter().enumerate().skip(start_idx + 1) {
+        if line.starts_with("## ") {
+            end_idx = idx;
+            break;
+        }
+    }
+
+    Ok(lines[start_idx..end_idx].join("\n").trim().to_string())
+}
+
+fn detect_repo_root() -> PathBuf {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output();
+    if let Ok(out) = output
+        && out.status.success()
+    {
+        let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if !raw.is_empty() {
+            return PathBuf::from(raw);
+        }
+    }
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+fn resolve_repo_relative(repo_root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    repo_root.join(path)
+}

--- a/crates/plan-issue-cli/src/task_spec.rs
+++ b/crates/plan-issue-cli/src/task_spec.rs
@@ -1,0 +1,475 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use plan_tooling::parse::{Plan, Sprint, parse_plan_with_display};
+
+use crate::commands::{PrGroupMapping, PrGrouping};
+
+pub const TASK_SPEC_HEADER: &str = "# task_id\tsummary\tbranch\tworktree\towner\tnotes\tpr_group";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskSpecScope {
+    Plan,
+    Sprint(i32),
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskSpecBuildOptions {
+    pub owner_prefix: String,
+    pub branch_prefix: String,
+    pub worktree_prefix: String,
+    pub pr_grouping: PrGrouping,
+    pub pr_group: Vec<PrGroupMapping>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskSpecRow {
+    pub task_id: String,
+    pub summary: String,
+    pub branch: String,
+    pub worktree: String,
+    pub owner: String,
+    pub notes: String,
+    pub pr_group: String,
+    pub sprint: i32,
+    pub grouping: PrGrouping,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskSpecBuild {
+    pub plan_title: String,
+    pub display_plan_path: String,
+    pub sprint_name: Option<String>,
+    pub rows: Vec<TaskSpecRow>,
+}
+
+#[derive(Debug, Clone)]
+struct WorkingRecord {
+    task_id: String,
+    plan_task_id: String,
+    sprint: i32,
+    summary: String,
+    branch: String,
+    worktree: String,
+    owner: String,
+    notes_parts: Vec<String>,
+    pr_group: String,
+}
+
+pub fn build_task_spec(
+    plan_file: &Path,
+    scope: TaskSpecScope,
+    options: &TaskSpecBuildOptions,
+) -> Result<TaskSpecBuild, String> {
+    let repo_root = detect_repo_root();
+    let display_path = plan_file.to_string_lossy().to_string();
+    let resolved_plan_path = resolve_repo_relative(&repo_root, plan_file);
+    if !resolved_plan_path.is_file() {
+        return Err(format!("plan file not found: {display_path}"));
+    }
+
+    let (plan, parse_errors) = parse_plan_with_display(&resolved_plan_path, &display_path)
+        .map_err(|err| format!("{display_path}: {err}"))?;
+    if !parse_errors.is_empty() {
+        return Err(format!("{display_path}: {}", parse_errors.join(" | ")));
+    }
+
+    let (selected_sprints, sprint_name) = select_sprints(&plan, scope)?;
+
+    let mut records: Vec<WorkingRecord> = Vec::new();
+    for sprint in selected_sprints {
+        for (idx, task) in sprint.tasks.iter().enumerate() {
+            let ordinal = idx + 1;
+            let task_id = format!("S{}T{ordinal}", sprint.number);
+            let plan_task_id = task.id.trim().to_string();
+            let summary = normalize_spaces(if task.name.trim().is_empty() {
+                if plan_task_id.is_empty() {
+                    format!("sprint-{}-task-{ordinal}", sprint.number)
+                } else {
+                    plan_task_id.clone()
+                }
+            } else {
+                task.name.trim().to_string()
+            });
+
+            let slug = normalize_token(&summary, &format!("task-{ordinal}"), 48);
+            let branch_prefix = normalize_branch_prefix(&options.branch_prefix);
+            let worktree_prefix = normalize_worktree_prefix(&options.worktree_prefix);
+            let owner_prefix = normalize_owner_prefix(&options.owner_prefix);
+
+            let deps: Vec<String> = task
+                .dependencies
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|d| d.trim().to_string())
+                .filter(|d| !d.is_empty())
+                .filter(|d| !is_placeholder(d))
+                .collect();
+
+            let validations: Vec<String> = task
+                .validation
+                .iter()
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .filter(|v| !is_placeholder(v))
+                .collect();
+
+            let mut notes_parts = vec![
+                format!("sprint=S{}", sprint.number),
+                format!(
+                    "plan-task:{}",
+                    if plan_task_id.is_empty() {
+                        task_id.clone()
+                    } else {
+                        plan_task_id.clone()
+                    }
+                ),
+            ];
+            if !deps.is_empty() {
+                notes_parts.push(format!("deps={}", deps.join(",")));
+            }
+            if let Some(first) = validations.first() {
+                notes_parts.push(format!("validate={first}"));
+            }
+
+            records.push(WorkingRecord {
+                task_id,
+                plan_task_id,
+                sprint: sprint.number,
+                summary,
+                branch: format!("{branch_prefix}/s{}-t{ordinal}-{slug}", sprint.number),
+                worktree: format!("{worktree_prefix}-s{}-t{ordinal}", sprint.number),
+                owner: format!("{owner_prefix}-s{}-t{ordinal}", sprint.number),
+                notes_parts,
+                pr_group: String::new(),
+            });
+        }
+    }
+
+    if records.is_empty() {
+        return Err(format!("{display_path}: selected scope has no tasks"));
+    }
+
+    apply_pr_groups(&mut records, options)?;
+
+    let mut group_sizes: HashMap<String, usize> = HashMap::new();
+    let mut group_anchor: HashMap<String, String> = HashMap::new();
+    for rec in &records {
+        let size = group_sizes.entry(rec.pr_group.clone()).or_insert(0);
+        *size += 1;
+        group_anchor
+            .entry(rec.pr_group.clone())
+            .or_insert_with(|| rec.task_id.clone());
+    }
+
+    let mut rows: Vec<TaskSpecRow> = Vec::new();
+    for rec in records {
+        let mut notes = rec.notes_parts.clone();
+        notes.push(format!(
+            "pr-grouping={}",
+            grouping_label(options.pr_grouping)
+        ));
+        notes.push(format!("pr-group={}", rec.pr_group));
+        if group_sizes.get(&rec.pr_group).copied().unwrap_or(0) > 1
+            && let Some(anchor) = group_anchor.get(&rec.pr_group)
+        {
+            notes.push(format!("shared-pr-anchor={anchor}"));
+        }
+
+        rows.push(TaskSpecRow {
+            task_id: rec.task_id,
+            summary: rec.summary,
+            branch: rec.branch,
+            worktree: rec.worktree,
+            owner: rec.owner,
+            notes: notes.join("; "),
+            pr_group: rec.pr_group,
+            sprint: rec.sprint,
+            grouping: options.pr_grouping,
+        });
+    }
+
+    Ok(TaskSpecBuild {
+        plan_title: plan.title,
+        display_plan_path: display_path,
+        sprint_name,
+        rows,
+    })
+}
+
+pub fn render_tsv(rows: &[TaskSpecRow]) -> String {
+    let mut out = String::new();
+    out.push_str(TASK_SPEC_HEADER);
+    out.push('\n');
+    for row in rows {
+        out.push_str(&format!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+            row.task_id.replace('\t', " "),
+            row.summary.replace('\t', " "),
+            row.branch.replace('\t', " "),
+            row.worktree.replace('\t', " "),
+            row.owner.replace('\t', " "),
+            row.notes.replace('\t', " "),
+            row.pr_group.replace('\t', " "),
+        ));
+    }
+    out
+}
+
+pub fn write_tsv(path: &Path, rows: &[TaskSpecRow]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            format!(
+                "failed to create output directory {}: {err}",
+                parent.display()
+            )
+        })?;
+    }
+    std::fs::write(path, render_tsv(rows))
+        .map_err(|err| format!("failed to write task-spec {}: {err}", path.display()))
+}
+
+pub fn default_plan_task_spec_path(plan_file: &Path) -> PathBuf {
+    let plan_stem = plan_file
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("plan")
+        .to_string();
+
+    agent_home()
+        .join("out")
+        .join("plan-issue-delivery-loop")
+        .join(format!("{plan_stem}-plan-tasks.tsv"))
+}
+
+pub fn default_sprint_task_spec_path(plan_file: &Path, sprint: i32) -> PathBuf {
+    let plan_stem = plan_file
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("plan")
+        .to_string();
+
+    agent_home()
+        .join("out")
+        .join("plan-issue-delivery-loop")
+        .join(format!("{plan_stem}-sprint-{sprint}-tasks.tsv"))
+}
+
+pub fn agent_home() -> PathBuf {
+    if let Ok(raw) = std::env::var("AGENT_HOME") {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    detect_repo_root().join(".agents")
+}
+
+fn apply_pr_groups(
+    records: &mut [WorkingRecord],
+    options: &TaskSpecBuildOptions,
+) -> Result<(), String> {
+    let mut group_assignments: HashMap<String, String> = HashMap::new();
+    let mut assignment_sources: Vec<String> = Vec::new();
+    for entry in &options.pr_group {
+        let key = entry.task.trim();
+        let group = normalize_token(entry.group.trim(), "", 48);
+        if key.is_empty() || group.is_empty() {
+            return Err("--pr-group must include both task key and group".to_string());
+        }
+        assignment_sources.push(key.to_string());
+        group_assignments.insert(key.to_ascii_lowercase(), group);
+    }
+
+    if options.pr_grouping == PrGrouping::Group {
+        let mut known: HashMap<String, bool> = HashMap::new();
+        for rec in records.iter() {
+            known.insert(rec.task_id.to_ascii_lowercase(), true);
+            if !rec.plan_task_id.is_empty() {
+                known.insert(rec.plan_task_id.to_ascii_lowercase(), true);
+            }
+        }
+
+        let unknown: Vec<String> = assignment_sources
+            .iter()
+            .filter(|key| !known.contains_key(&key.to_ascii_lowercase()))
+            .cloned()
+            .collect();
+        if !unknown.is_empty() {
+            return Err(format!(
+                "--pr-group references unknown task keys: {}",
+                unknown
+                    .iter()
+                    .take(5)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
+
+    if options.pr_grouping == PrGrouping::Group {
+        let mut missing: Vec<String> = Vec::new();
+        for rec in records.iter_mut() {
+            let mut found = String::new();
+            for key in [&rec.task_id, &rec.plan_task_id] {
+                if key.is_empty() {
+                    continue;
+                }
+                if let Some(v) = group_assignments.get(&key.to_ascii_lowercase()) {
+                    found = v.to_string();
+                    break;
+                }
+            }
+            if found.is_empty() {
+                missing.push(rec.task_id.clone());
+            } else {
+                rec.pr_group = found;
+            }
+        }
+        if !missing.is_empty() {
+            return Err(format!(
+                "--pr-grouping group requires mapping for every task; missing: {}",
+                missing
+                    .iter()
+                    .take(8)
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    } else {
+        for rec in records.iter_mut() {
+            rec.pr_group =
+                normalize_token(&format!("s{}", rec.sprint), &format!("s{}", rec.sprint), 48);
+        }
+    }
+
+    Ok(())
+}
+
+fn select_sprints(
+    plan: &Plan,
+    scope: TaskSpecScope,
+) -> Result<(Vec<&Sprint>, Option<String>), String> {
+    match scope {
+        TaskSpecScope::Plan => {
+            let selected: Vec<&Sprint> = plan
+                .sprints
+                .iter()
+                .filter(|sprint| !sprint.tasks.is_empty())
+                .collect();
+            if selected.is_empty() {
+                return Err("selected scope has no tasks".to_string());
+            }
+            Ok((selected, None))
+        }
+        TaskSpecScope::Sprint(want) => match plan.sprints.iter().find(|s| s.number == want) {
+            Some(sprint) if !sprint.tasks.is_empty() => {
+                Ok((vec![sprint], Some(sprint.name.clone())))
+            }
+            Some(_) => Err(format!("sprint {want} has no tasks")),
+            None => Err(format!("sprint not found: {want}")),
+        },
+    }
+}
+
+fn detect_repo_root() -> PathBuf {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output();
+    if let Ok(out) = output
+        && out.status.success()
+    {
+        let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if !raw.is_empty() {
+            return PathBuf::from(raw);
+        }
+    }
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+fn resolve_repo_relative(repo_root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    repo_root.join(path)
+}
+
+fn normalize_branch_prefix(value: &str) -> &str {
+    let trimmed = value.trim().trim_end_matches('/');
+    if trimmed.is_empty() { "issue" } else { trimmed }
+}
+
+fn normalize_worktree_prefix(value: &str) -> &str {
+    let trimmed = value.trim().trim_end_matches(['-', '_']);
+    if trimmed.is_empty() { "issue" } else { trimmed }
+}
+
+fn normalize_owner_prefix(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::from("subagent");
+    }
+    if trimmed.to_ascii_lowercase().contains("subagent") {
+        return trimmed.to_string();
+    }
+    format!("subagent-{trimmed}")
+}
+
+fn normalize_spaces(value: String) -> String {
+    let joined = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if joined.is_empty() {
+        String::from("task")
+    } else {
+        joined
+    }
+}
+
+fn normalize_token(value: &str, fallback: &str, max_len: usize) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            last_dash = false;
+        } else if !last_dash {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+
+    let normalized = out.trim_matches('-').to_string();
+    let mut token = if normalized.is_empty() {
+        fallback.to_string()
+    } else {
+        normalized
+    };
+
+    if token.len() > max_len {
+        token.truncate(max_len);
+        token = token.trim_matches('-').to_string();
+    }
+
+    token
+}
+
+fn is_placeholder(value: &str) -> bool {
+    let token = value.trim().to_ascii_lowercase();
+    if matches!(token.as_str(), "" | "-" | "none" | "n/a" | "na" | "...") {
+        return true;
+    }
+    if token.starts_with('<') && token.ends_with('>') {
+        return true;
+    }
+    token.contains("task ids")
+}
+
+fn grouping_label(grouping: PrGrouping) -> &'static str {
+    match grouping {
+        PrGrouping::PerSprint => "per-sprint",
+        PrGrouping::Group => "group",
+    }
+}

--- a/crates/plan-issue-cli/tests/common.rs
+++ b/crates/plan-issue-cli/tests/common.rs
@@ -8,9 +8,9 @@ pub struct CmdOut {
     pub stderr: String,
 }
 
-fn run_bin(bin_name: &str, args: &[&str]) -> CmdOut {
+fn run_bin_with_env(bin_name: &str, args: &[&str], env: &[(&str, &str)]) -> CmdOut {
     let cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let output = run_resolved_in_dir(bin_name, cwd, args, &[], None);
+    let output = run_resolved_in_dir(bin_name, cwd, args, env, None);
 
     CmdOut {
         code: output.code,
@@ -19,11 +19,25 @@ fn run_bin(bin_name: &str, args: &[&str]) -> CmdOut {
     }
 }
 
+fn run_bin(bin_name: &str, args: &[&str]) -> CmdOut {
+    run_bin_with_env(bin_name, args, &[])
+}
+
 pub fn run_plan_issue(args: &[&str]) -> CmdOut {
     run_bin("plan-issue", args)
 }
 
 #[allow(dead_code)]
+pub fn run_plan_issue_with_env(args: &[&str], env: &[(&str, &str)]) -> CmdOut {
+    run_bin_with_env("plan-issue", args, env)
+}
+
+#[allow(dead_code)]
 pub fn run_plan_issue_local(args: &[&str]) -> CmdOut {
     run_bin("plan-issue-local", args)
+}
+
+#[allow(dead_code)]
+pub fn run_plan_issue_local_with_env(args: &[&str], env: &[(&str, &str)]) -> CmdOut {
+    run_bin_with_env("plan-issue-local", args, env)
 }

--- a/crates/plan-issue-cli/tests/sprint3_delivery.rs
+++ b/crates/plan-issue-cli/tests/sprint3_delivery.rs
@@ -1,0 +1,272 @@
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+mod common;
+
+const PLAN_PATH: &str = "docs/plans/plan-issue-rust-cli-full-delivery-plan.md";
+
+fn parse_json(stdout: &str) -> Value {
+    serde_json::from_str(stdout).expect("stdout should be valid JSON")
+}
+
+fn result_path(payload: &Value, key: &str) -> String {
+    payload["payload"]["result"][key]
+        .as_str()
+        .unwrap_or_else(|| panic!("missing result path key: {key}"))
+        .to_string()
+}
+
+#[test]
+fn task_spec_generation_build_task_spec_writes_grouped_rows() {
+    let tmp = TempDir::new().expect("temp dir");
+    let out_path = tmp.path().join("sprint3.tsv");
+    let out_path_s = out_path.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "build-task-spec",
+        "--plan",
+        PLAN_PATH,
+        "--sprint",
+        "3",
+        "--pr-grouping",
+        "group",
+        "--pr-group",
+        "S3T1=s3-a",
+        "--pr-group",
+        "S3T2=s3-b",
+        "--pr-group",
+        "S3T3=s3-c",
+        "--task-spec-out",
+        &out_path_s,
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = parse_json(&out.stdout);
+    assert_eq!(payload["command"], "build-task-spec");
+    assert_eq!(payload["status"], "ok");
+
+    let rendered = fs::read_to_string(&out_path).expect("read task-spec");
+    let mut lines = rendered.lines();
+    assert_eq!(
+        lines.next().unwrap_or_default(),
+        "# task_id\tsummary\tbranch\tworktree\towner\tnotes\tpr_group"
+    );
+
+    let task_rows: Vec<&str> = rendered
+        .lines()
+        .filter(|line| line.starts_with("S3T"))
+        .collect();
+    assert_eq!(task_rows.len(), 3, "{rendered}");
+    assert!(rendered.contains("\ts3-a"), "{rendered}");
+    assert!(rendered.contains("\ts3-b"), "{rendered}");
+    assert!(rendered.contains("\ts3-c"), "{rendered}");
+}
+
+#[test]
+fn render_issue_body_start_plan_writes_issue_body_artifact() {
+    let tmp = TempDir::new().expect("temp dir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+
+    let task_spec = tmp.path().join("plan.tsv");
+    let issue_body = tmp.path().join("issue-body.md");
+    let task_spec_s = task_spec.to_string_lossy().to_string();
+    let issue_body_s = issue_body.to_string_lossy().to_string();
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "start-plan",
+            "--plan",
+            PLAN_PATH,
+            "--pr-grouping",
+            "per-sprint",
+            "--task-spec-out",
+            &task_spec_s,
+            "--issue-body-out",
+            &issue_body_s,
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let rendered = fs::read_to_string(&issue_body).expect("read issue body");
+    assert!(rendered.contains("## Task Decomposition"), "{rendered}");
+    assert!(
+        rendered.contains("| S3T1 | Implement task-spec generation core using `plan-tooling` |")
+    );
+}
+
+#[test]
+fn render_issue_body_start_sprint_writes_start_comment_with_modes() {
+    let tmp = TempDir::new().expect("temp dir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let task_spec = tmp.path().join("s3.tsv");
+    let task_spec_s = task_spec.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "start-sprint",
+            "--plan",
+            PLAN_PATH,
+            "--issue",
+            "217",
+            "--sprint",
+            "3",
+            "--task-spec-out",
+            &task_spec_s,
+            "--pr-grouping",
+            "group",
+            "--pr-group",
+            "S3T1=s3-a",
+            "--pr-group",
+            "S3T2=s3-b",
+            "--pr-group",
+            "S3T3=s3-c",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = parse_json(&out.stdout);
+    let comment_path = result_path(&payload, "comment_path");
+    let comment = fs::read_to_string(&comment_path).expect("read sprint comment");
+    assert!(comment.contains("## Sprint 3 Start"), "{comment}");
+    assert!(
+        comment.contains("| Task | Summary | Execution Mode |"),
+        "{comment}"
+    );
+    assert!(comment.contains("pr-isolated"), "{comment}");
+}
+
+#[test]
+fn local_flow_plan_issue_local_dry_run_end_to_end_generates_artifacts() {
+    let tmp = TempDir::new().expect("temp dir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let start_plan_out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "start-plan",
+            "--plan",
+            PLAN_PATH,
+            "--pr-grouping",
+            "per-sprint",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+    assert_eq!(start_plan_out.code, 0, "stderr: {}", start_plan_out.stderr);
+    let start_plan_json = parse_json(&start_plan_out.stdout);
+    let issue_body_path = result_path(&start_plan_json, "issue_body_path");
+    assert!(std::path::Path::new(&issue_body_path).is_file());
+
+    let start_sprint_out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "start-sprint",
+            "--plan",
+            PLAN_PATH,
+            "--issue",
+            "217",
+            "--sprint",
+            "3",
+            "--pr-grouping",
+            "per-sprint",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+    assert_eq!(
+        start_sprint_out.code, 0,
+        "stderr: {}",
+        start_sprint_out.stderr
+    );
+    let start_sprint_json = parse_json(&start_sprint_out.stdout);
+    let start_comment_path = result_path(&start_sprint_json, "comment_path");
+    assert!(std::path::Path::new(&start_comment_path).is_file());
+
+    let ready_sprint_out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "ready-sprint",
+            "--plan",
+            PLAN_PATH,
+            "--issue",
+            "217",
+            "--sprint",
+            "3",
+            "--pr-grouping",
+            "per-sprint",
+            "--summary",
+            "Ready for review",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+    assert_eq!(
+        ready_sprint_out.code, 0,
+        "stderr: {}",
+        ready_sprint_out.stderr
+    );
+    let ready_sprint_json = parse_json(&ready_sprint_out.stdout);
+    let ready_comment_path = result_path(&ready_sprint_json, "comment_path");
+    assert!(std::path::Path::new(&ready_comment_path).is_file());
+
+    let accept_sprint_out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "accept-sprint",
+            "--plan",
+            PLAN_PATH,
+            "--issue",
+            "217",
+            "--sprint",
+            "3",
+            "--pr-grouping",
+            "per-sprint",
+            "--approved-comment-url",
+            "https://github.com/graysurf/nils-cli/issues/217#issuecomment-123456789",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+    assert_eq!(
+        accept_sprint_out.code, 0,
+        "stderr: {}",
+        accept_sprint_out.stderr
+    );
+    let accept_sprint_json = parse_json(&accept_sprint_out.stdout);
+    let accepted_comment_path = result_path(&accept_sprint_json, "comment_path");
+    let accepted_comment =
+        fs::read_to_string(&accepted_comment_path).expect("read accepted comment");
+    assert!(
+        accepted_comment.contains("## Sprint 3 Accepted"),
+        "{accepted_comment}"
+    );
+    assert!(
+        accepted_comment
+            .contains("https://github.com/graysurf/nils-cli/issues/217#issuecomment-123456789"),
+        "{accepted_comment}"
+    );
+}

--- a/crates/plan-tooling/src/lib.rs
+++ b/crates/plan-tooling/src/lib.rs
@@ -1,6 +1,6 @@
 mod batches;
 mod completion;
-mod parse;
+pub mod parse;
 mod repo_root;
 mod repr;
 mod scaffold;

--- a/docs/plans/plan-issue-rust-cli-full-delivery-plan.md
+++ b/docs/plans/plan-issue-rust-cli-full-delivery-plan.md
@@ -1,0 +1,245 @@
+# Plan: Rust Plan-Issue CLI Full Delivery
+
+## Sprint 1: Contract and parity fixtures
+
+### Task 1.1: Write Rust CLI contract v1 and command matrix
+- **Location**:
+  - crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v1.md
+- **Description**: Define v1 command matrix, global flags, and output contracts for the Rust CLI.
+- **Dependencies**:
+  - none
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - Contract spec documents command surface and option semantics.
+- **Validation**:
+  - test -f crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v1.md
+
+### Task 1.2: Capture baseline shell fixtures for parity assertions
+- **Location**:
+  - crates/plan-issue-cli/tests/fixtures/shell_parity/help.txt
+- **Description**: Capture deterministic shell parity fixtures used by Rust compatibility assertions.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - Fixture corpus includes help and guide baselines.
+- **Validation**:
+  - test -f crates/plan-issue-cli/tests/fixtures/shell_parity/help.txt
+
+### Task 1.3: Define state machine and gate invariants
+- **Location**:
+  - crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md
+  - crates/plan-issue-cli/docs/specs/plan-issue-gate-matrix-v1.md
+- **Description**: Define gate ordering and status transitions for plan/sprint orchestration.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - State and gate specs are documented with deterministic rules.
+- **Validation**:
+  - test -f crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md
+
+## Sprint 2: Rust CLI scaffold and baseline envelopes
+
+### Task 2.1: Scaffold `nils-plan-issue-cli` crate with two binaries
+- **Location**:
+  - crates/plan-issue-cli/Cargo.toml
+  - crates/plan-issue-cli/src/main.rs
+  - crates/plan-issue-cli/src/bin/plan-issue-local.rs
+- **Description**: Create workspace crate and binary entrypoints for live and local modes.
+- **Dependencies**:
+  - Task 1.3
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - Crate builds with both binaries registered.
+- **Validation**:
+  - cargo check -p nils-plan-issue-cli
+
+### Task 2.2: Implement clap command tree and typed argument model
+- **Location**:
+  - crates/plan-issue-cli/src/cli.rs
+  - crates/plan-issue-cli/src/commands/
+- **Description**: Implement typed command/subcommand and argument parsing for v1 command surface.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Help output and grouping args match command contract.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli cli_help
+
+### Task 2.3: Add output envelope for text and JSON modes
+- **Location**:
+  - crates/plan-issue-cli/src/output/
+  - crates/plan-issue-cli/tests/output_contract.rs
+- **Description**: Add deterministic text and JSON envelope outputs for success and error responses.
+- **Dependencies**:
+  - Task 2.1
+  - Task 2.2
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - Output envelope is stable and machine-consumable.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli output_json_contract
+
+## Sprint 3: Rendering and local workflow core
+
+### Task 3.1: Implement task-spec generation core using `plan-tooling`
+- **Location**:
+  - crates/plan-issue-cli/src/task_spec.rs
+  - crates/plan-issue-cli/src/execute.rs
+- **Description**: Generate deterministic sprint/plan task-spec TSV artifacts from plan markdown using shared plan-tooling parsing core.
+- **Dependencies**:
+  - Task 2.2
+  - Task 2.3
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Task-spec generation supports both grouping modes and deterministic note fields.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli task_spec_generation
+
+### Task 3.2: Implement issue-body and sprint-comment rendering engine
+- **Location**:
+  - crates/plan-issue-cli/src/render.rs
+  - crates/plan-issue-cli/src/execute.rs
+- **Description**: Render plan issue body and sprint comment markdown from task-spec + plan context.
+- **Dependencies**:
+  - Task 3.1
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Start/ready/accepted comment modes render deterministic tables and headings.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli render_issue_body
+
+### Task 3.3: Implement independent local dry-run workflow
+- **Location**:
+  - crates/plan-issue-cli/src/lib.rs
+  - crates/plan-issue-cli/src/execute.rs
+- **Description**: Implement local-first dry-run command execution flow without GitHub side effects.
+- **Dependencies**:
+  - Task 3.2
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - `plan-issue-local --dry-run` supports end-to-end artifact generation flow.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli local_flow
+
+## Sprint 4: Live adapter and orchestration
+
+### Task 4.1: Implement GitHub adapter abstraction and `gh` backend
+- **Location**:
+  - crates/plan-issue-cli/src/github/
+- **Description**: Add adapter abstraction and initial `gh`-backed implementation.
+- **Dependencies**:
+  - Task 3.3
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Adapter surface supports issue read/write and PR status lookup.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli github_adapter
+
+### Task 4.2: Implement live plan-level commands
+- **Location**:
+  - crates/plan-issue-cli/src/execute.rs
+- **Description**: Implement live start/status/ready/close plan command flow.
+- **Dependencies**:
+  - Task 4.1
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Plan-level live commands enforce gate invariants and lifecycle updates.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli live_plan_commands
+
+### Task 4.3: Implement live sprint-level commands and guide output
+- **Location**:
+  - crates/plan-issue-cli/src/execute.rs
+- **Description**: Implement live start/ready/accept sprint commands and multi-sprint guide output.
+- **Dependencies**:
+  - Task 4.1
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Sprint-level live commands enforce sequencing and merge gates.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli live_sprint_commands
+
+## Sprint 5: Guardrails and compatibility hardening
+
+### Task 5.1: Add parity regression suite against shell fixtures
+- **Location**:
+  - crates/plan-issue-cli/tests/fixtures/shell_parity/
+  - crates/plan-issue-cli/tests/
+- **Description**: Add regression suite to compare Rust outputs against shell fixture snapshots.
+- **Dependencies**:
+  - Task 4.3
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Parity suite catches user-visible drift in key outputs.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli parity_shell
+
+### Task 5.2: Implement command guardrails and preflight checks
+- **Location**:
+  - crates/plan-issue-cli/src/execute.rs
+- **Description**: Add command-level guardrails for missing inputs and invalid operation modes.
+- **Dependencies**:
+  - Task 4.2
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Guardrails emit stable structured error codes/messages.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli command_guardrails
+
+### Task 5.3: Add contract-level JSON compatibility tests
+- **Location**:
+  - crates/plan-issue-cli/tests/output_contract.rs
+- **Description**: Add compatibility-focused JSON assertions for machine-consumed command envelopes.
+- **Dependencies**:
+  - Task 4.3
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - JSON contract tests cover success/failure envelopes and required fields.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli json_contract
+
+## Sprint 6: Skill cutover and final acceptance
+
+### Task 6.1: Wire skill entrypoint to Rust CLI and keep compatibility wrapper
+- **Location**:
+  - wrappers/plan-issue-delivery-loop.sh
+- **Description**: Move skill entrypoint to Rust CLI while preserving compatibility wrapper behavior.
+- **Dependencies**:
+  - Task 5.1
+  - Task 5.2
+  - Task 5.3
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Wrapper delegates to Rust CLI without behavioral regressions.
+- **Validation**:
+  - test -f wrappers/plan-issue-delivery-loop.sh
+
+### Task 6.2: Update completion, aliases, and user docs
+- **Location**:
+  - completions/zsh/
+  - completions/bash/
+  - README.md
+- **Description**: Add completion assets and documentation for new Rust CLI entrypoints.
+- **Dependencies**:
+  - Task 5.2
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Completion scripts and docs match command surface and rollout policy.
+- **Validation**:
+  - zsh -n completions/zsh/_plan-issue
+
+### Task 6.3: Final verification and sprint-6 acceptance artifact
+- **Location**:
+  - $AGENT_HOME/out/plan-issue-rust-cli/sprint-6/acceptance.md
+- **Description**: Run final required checks and write acceptance artifact for the full delivery plan.
+- **Dependencies**:
+  - Task 6.1
+  - Task 6.2
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - Required checks pass and acceptance artifact is recorded.
+- **Validation**:
+  - ./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh


### PR DESCRIPTION
## Summary
- Implements Sprint 3 task-spec generation and rendering core for issue #217 in the assigned subagent worktree.

## Scope
- Add deterministic task-spec generation from `plan-tooling` parse primitives and wire command execution for `build-task-spec`, `build-plan-task-spec`, `start-plan`, `start-sprint`, `ready-sprint`, and `accept-sprint`.
- Add markdown renderers for plan issue body and sprint comments, plus Sprint 3 delivery integration coverage and plan/status doc updates.
- Excluded: live GitHub mutation adapters and post-Sprint-3 orchestration behavior.

## Testing
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass, 86.10% lines)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass)
- `cargo test -p nils-plan-issue-cli task_spec_generation` (pass)

## Issue
- #217
