### PR TITLE
feat: Implement GitHub adapter abstraction and `gh` backend (+2 tasks)

### DIFF
--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -1,29 +1,56 @@
+use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use plan_tooling::parse::parse_plan_with_display;
 use serde_json::{Value, json};
 
 use crate::cli::Cli;
 use crate::commands::build::{BuildPlanTaskSpecArgs, BuildTaskSpecArgs};
-use crate::commands::plan::StartPlanArgs;
-use crate::commands::sprint::{AcceptSprintArgs, ReadySprintArgs, StartSprintArgs};
-use crate::commands::{Command, SummaryArgs};
+use crate::commands::plan::{
+    CleanupWorktreesArgs, ClosePlanArgs, ReadyPlanArgs, StartPlanArgs, StatusPlanArgs,
+};
+use crate::commands::sprint::{
+    AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs,
+};
+use crate::commands::{Command as CliCommand, SummaryArgs};
+use crate::github::{GhCliAdapter, GitHubAdapter};
+use crate::issue_body::{self, TaskRow};
 use crate::render::{self, SprintCommentInput, SprintCommentMode};
-use crate::task_spec::{self, TaskSpecBuildOptions, TaskSpecScope};
+use crate::task_spec::{self, TaskSpecBuildOptions, TaskSpecRow, TaskSpecScope};
 use crate::{BinaryFlavor, CommandError};
 
 pub fn execute(binary: BinaryFlavor, cli: &Cli) -> Result<Value, CommandError> {
     match &cli.command {
-        Command::BuildTaskSpec(args) => run_build_task_spec(args),
-        Command::BuildPlanTaskSpec(args) => run_build_plan_task_spec(args),
-        Command::StartPlan(args) => run_start_plan(binary, cli.dry_run, args),
-        Command::StartSprint(args) => run_start_sprint(binary, cli.dry_run, args),
-        Command::ReadySprint(args) => run_ready_sprint(binary, cli.dry_run, args),
-        Command::AcceptSprint(args) => run_accept_sprint(binary, cli.dry_run, args),
-        _ => Ok(json!({
-            "status": "not-implemented",
-            "detail": "command execution beyond Sprint 3 scope is not implemented yet"
-        })),
+        CliCommand::BuildTaskSpec(args) => run_build_task_spec(args),
+        CliCommand::BuildPlanTaskSpec(args) => run_build_plan_task_spec(args),
+        CliCommand::StartPlan(args) => {
+            run_start_plan(binary, cli.dry_run, cli.repo.as_deref(), args)
+        }
+        CliCommand::StatusPlan(args) => {
+            run_status_plan(binary, cli.dry_run, cli.repo.as_deref(), args)
+        }
+        CliCommand::ReadyPlan(args) => {
+            run_ready_plan(binary, cli.dry_run, cli.repo.as_deref(), args)
+        }
+        CliCommand::ClosePlan(args) => {
+            run_close_plan(binary, cli.dry_run, cli.repo.as_deref(), args)
+        }
+        CliCommand::CleanupWorktrees(args) => {
+            run_cleanup_worktrees(binary, cli.dry_run, cli.repo.as_deref(), args)
+        }
+        CliCommand::StartSprint(args) => {
+            run_start_sprint(binary, cli.dry_run, cli.repo.as_deref(), args)
+        }
+        CliCommand::ReadySprint(args) => {
+            run_ready_sprint(binary, cli.dry_run, cli.repo.as_deref(), args)
+        }
+        CliCommand::AcceptSprint(args) => {
+            run_accept_sprint(binary, cli.dry_run, cli.repo.as_deref(), args)
+        }
+        CliCommand::MultiSprintGuide(args) => run_multi_sprint_guide(args),
     }
 }
 
@@ -86,6 +113,7 @@ fn run_build_plan_task_spec(args: &BuildPlanTaskSpecArgs) -> Result<Value, Comma
 fn run_start_plan(
     binary: BinaryFlavor,
     dry_run: bool,
+    repo_override: Option<&str>,
     args: &StartPlanArgs,
 ) -> Result<Value, CommandError> {
     let options = to_build_options(
@@ -121,6 +149,21 @@ fn run_start_plan(
     render::write_rendered(&issue_body_out, &issue_body)
         .map_err(|err| CommandError::runtime("issue-body-write-failed", err))?;
 
+    let mut issue_number: Option<u64> = None;
+    let mut issue_url: Option<String> = None;
+    let mut live_mutations = false;
+
+    if binary == BinaryFlavor::PlanIssue && !dry_run {
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        let adapter = GhCliAdapter;
+        let (number, url) = adapter
+            .create_issue(&repo, &plan_title, &issue_body_out, &args.label)
+            .map_err(|err| CommandError::runtime("github-issue-create-failed", err))?;
+        issue_number = Some(number);
+        issue_url = Some(url);
+        live_mutations = true;
+    }
+
     Ok(json!({
         "scope": "plan",
         "execution_mode": binary.execution_mode(),
@@ -128,13 +171,346 @@ fn run_start_plan(
         "task_spec_path": path_text(&task_spec_out),
         "issue_body_path": path_text(&issue_body_out),
         "record_count": build.rows.len(),
-        "live_mutations_performed": false,
+        "issue_number": issue_number,
+        "issue_url": issue_url,
+        "labels": args.label,
+        "live_mutations_performed": live_mutations,
+    }))
+}
+
+fn run_status_plan(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    repo_override: Option<&str>,
+    args: &StatusPlanArgs,
+) -> Result<Value, CommandError> {
+    let adapter = GhCliAdapter;
+
+    let (body, issue, repo, source) = if let Some(path) = &args.body_file {
+        let body = fs::read_to_string(path).map_err(|err| {
+            CommandError::runtime(
+                "issue-body-read-failed",
+                format!("failed to read body file {}: {err}", path.display()),
+            )
+        })?;
+        (body, None, None, format!("body-file:{}", path.display()))
+    } else {
+        let issue = args
+            .issue
+            .ok_or_else(|| CommandError::usage("missing-issue", "--issue is required"))?;
+        ensure_live_binary(binary)?;
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        let body = adapter
+            .issue_body(&repo, issue)
+            .map_err(|err| CommandError::runtime("github-issue-read-failed", err))?;
+        (body, Some(issue), Some(repo), format!("issue:{issue}"))
+    };
+
+    let table = issue_body::parse_task_table(&body)
+        .map_err(|err| CommandError::runtime("issue-body-parse-failed", err))?;
+
+    let structure_errors = issue_body::validate_rows(table.rows());
+    if !structure_errors.is_empty() {
+        return Err(CommandError::runtime(
+            "issue-body-invalid",
+            structure_errors.join(" | "),
+        ));
+    }
+
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for row in table.rows() {
+        let status = row.status.trim().to_ascii_lowercase();
+        *counts.entry(status).or_insert(0) += 1;
+    }
+
+    let should_comment = args.comment_mode.comment && !args.comment_mode.no_comment;
+    let comment_text = render_plan_status_comment(table.rows());
+    let mut live_mutations = false;
+
+    if should_comment
+        && binary == BinaryFlavor::PlanIssue
+        && !dry_run
+        && let (Some(issue), Some(repo)) = (issue, repo.as_deref())
+    {
+        let comment_path = write_temp_markdown("status-plan-comment", &comment_text)
+            .map_err(|err| CommandError::runtime("comment-write-failed", err))?;
+        adapter
+            .comment_issue(repo, issue, &comment_path)
+            .map_err(|err| CommandError::runtime("github-comment-failed", err))?;
+        live_mutations = true;
+    }
+
+    Ok(json!({
+        "scope": "plan",
+        "execution_mode": binary.execution_mode(),
+        "dry_run": dry_run,
+        "issue_source": source,
+        "task_count": table.rows().len(),
+        "status_counts": counts,
+        "comment_requested": should_comment,
+        "comment_preview": should_comment.then_some(comment_text),
+        "live_mutations_performed": live_mutations,
+    }))
+}
+
+fn run_ready_plan(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    repo_override: Option<&str>,
+    args: &ReadyPlanArgs,
+) -> Result<Value, CommandError> {
+    let adapter = GhCliAdapter;
+
+    let (body, issue, repo, source) = if let Some(path) = &args.body_file {
+        let body = fs::read_to_string(path).map_err(|err| {
+            CommandError::runtime(
+                "issue-body-read-failed",
+                format!("failed to read body file {}: {err}", path.display()),
+            )
+        })?;
+        (body, None, None, format!("body-file:{}", path.display()))
+    } else {
+        let issue = args
+            .issue
+            .ok_or_else(|| CommandError::usage("missing-issue", "--issue is required"))?;
+        ensure_live_binary(binary)?;
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        let body = adapter
+            .issue_body(&repo, issue)
+            .map_err(|err| CommandError::runtime("github-issue-read-failed", err))?;
+        (body, Some(issue), Some(repo), format!("issue:{issue}"))
+    };
+
+    let table = issue_body::parse_task_table(&body)
+        .map_err(|err| CommandError::runtime("issue-body-parse-failed", err))?;
+    let structure_errors = issue_body::validate_rows(table.rows());
+    if !structure_errors.is_empty() {
+        return Err(CommandError::runtime(
+            "issue-body-invalid",
+            structure_errors.join(" | "),
+        ));
+    }
+
+    let summary = load_summary(&args.summary)?;
+    let should_comment = !args.comment_mode.no_comment;
+    let comment_text = summary.unwrap_or_else(|| "Final plan review requested.".to_string());
+
+    let mut labels_updated = false;
+    let mut comment_posted = false;
+    let mut live_mutations = false;
+
+    if binary == BinaryFlavor::PlanIssue
+        && !dry_run
+        && let (Some(issue), Some(repo)) = (issue, repo.as_deref())
+    {
+        if !args.no_label_update {
+            adapter
+                .edit_issue_labels(
+                    repo,
+                    issue,
+                    std::slice::from_ref(&args.label),
+                    &args.remove_label,
+                )
+                .map_err(|err| CommandError::runtime("github-label-update-failed", err))?;
+            labels_updated = true;
+            live_mutations = true;
+        }
+
+        if should_comment {
+            let comment_path = write_temp_markdown("ready-plan-comment", &comment_text)
+                .map_err(|err| CommandError::runtime("comment-write-failed", err))?;
+            adapter
+                .comment_issue(repo, issue, &comment_path)
+                .map_err(|err| CommandError::runtime("github-comment-failed", err))?;
+            comment_posted = true;
+            live_mutations = true;
+        }
+    }
+
+    Ok(json!({
+        "scope": "plan",
+        "execution_mode": binary.execution_mode(),
+        "dry_run": dry_run,
+        "issue_source": source,
+        "task_count": table.rows().len(),
+        "summary": comment_text,
+        "label": args.label,
+        "remove_label": args.remove_label,
+        "label_update_requested": !args.no_label_update,
+        "label_update_applied": labels_updated,
+        "comment_requested": should_comment,
+        "comment_posted": comment_posted,
+        "live_mutations_performed": live_mutations,
+    }))
+}
+
+fn run_close_plan(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    repo_override: Option<&str>,
+    args: &ClosePlanArgs,
+) -> Result<Value, CommandError> {
+    if !approval_comment_url_looks_valid(&args.approved_comment_url) {
+        return Err(CommandError::usage(
+            "invalid-approval-comment-url",
+            "--approved-comment-url must be a GitHub issue/pull comment URL",
+        ));
+    }
+
+    let adapter = GhCliAdapter;
+    let close_comment = load_close_comment(&args.close_comment)?;
+
+    let (body, issue, repo, source) = if let Some(path) = &args.body_file {
+        let body = fs::read_to_string(path).map_err(|err| {
+            CommandError::runtime(
+                "issue-body-read-failed",
+                format!("failed to read body file {}: {err}", path.display()),
+            )
+        })?;
+        let repo = (binary == BinaryFlavor::PlanIssue)
+            .then(|| resolve_repo_for_live(binary, repo_override))
+            .transpose()?;
+        (
+            body,
+            args.issue,
+            repo,
+            format!("body-file:{}", path.display()),
+        )
+    } else {
+        let issue = args
+            .issue
+            .ok_or_else(|| CommandError::usage("missing-issue", "--issue is required"))?;
+        ensure_live_binary(binary)?;
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        let body = adapter
+            .issue_body(&repo, issue)
+            .map_err(|err| CommandError::runtime("github-issue-read-failed", err))?;
+        (body, Some(issue), Some(repo), format!("issue:{issue}"))
+    };
+
+    let table = issue_body::parse_task_table(&body)
+        .map_err(|err| CommandError::runtime("issue-body-parse-failed", err))?;
+
+    let mut gate_errors = issue_body::validate_rows(table.rows());
+
+    if !args.allow_not_done {
+        for row in table.rows() {
+            if !row.status.trim().eq_ignore_ascii_case("done") {
+                gate_errors.push(format!(
+                    "{}: close gate requires Status=done (found `{}`)",
+                    row.task,
+                    row.status.trim()
+                ));
+            }
+        }
+    }
+
+    let required_prs = collect_required_prs(table.rows(), "close-plan")
+        .map_err(|err| CommandError::runtime("close-gate-failed", err))?;
+
+    let mut merge_checks_skipped = false;
+    if let Some(repo) = repo.as_deref() {
+        ensure_prs_merged(&adapter, repo, &required_prs, "close-plan")
+            .map_err(|err| CommandError::runtime("close-gate-failed", err))?;
+    } else {
+        merge_checks_skipped = true;
+    }
+
+    if !gate_errors.is_empty() {
+        return Err(CommandError::runtime(
+            "close-gate-failed",
+            gate_errors.join(" | "),
+        ));
+    }
+
+    let cleanup = cleanup_worktrees_from_rows(table.rows(), dry_run)
+        .map_err(|err| CommandError::runtime("worktree-cleanup-failed", err))?;
+
+    let mut issue_closed = false;
+    let mut live_mutations = false;
+
+    if binary == BinaryFlavor::PlanIssue && !dry_run {
+        let issue = issue.ok_or_else(|| {
+            CommandError::usage("missing-issue", "--issue is required for live close-plan")
+        })?;
+        let repo = repo.as_deref().ok_or_else(|| {
+            CommandError::usage(
+                "missing-repo",
+                "unable to resolve repository for live close-plan",
+            )
+        })?;
+
+        adapter
+            .close_issue(repo, issue, args.reason, close_comment.as_deref())
+            .map_err(|err| CommandError::runtime("github-issue-close-failed", err))?;
+        issue_closed = true;
+        live_mutations = true;
+    }
+
+    Ok(json!({
+        "scope": "plan",
+        "execution_mode": binary.execution_mode(),
+        "dry_run": dry_run,
+        "issue_source": source,
+        "approval_comment_url": args.approved_comment_url,
+        "allow_not_done": args.allow_not_done,
+        "issue_closed": issue_closed,
+        "close_comment_applied": close_comment.as_ref().is_some_and(|v| !v.trim().is_empty()),
+        "cleanup": {
+            "targeted": cleanup.targeted,
+            "removed": cleanup.removed,
+            "residual": cleanup.residual,
+        },
+        "merge_checks_skipped": merge_checks_skipped,
+        "live_mutations_performed": live_mutations,
+    }))
+}
+
+fn run_cleanup_worktrees(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    repo_override: Option<&str>,
+    args: &CleanupWorktreesArgs,
+) -> Result<Value, CommandError> {
+    ensure_live_binary(binary)?;
+
+    let repo = resolve_repo_for_live(binary, repo_override)?;
+    let adapter = GhCliAdapter;
+    let body = adapter
+        .issue_body(&repo, args.issue)
+        .map_err(|err| CommandError::runtime("github-issue-read-failed", err))?;
+
+    let table = issue_body::parse_task_table(&body)
+        .map_err(|err| CommandError::runtime("issue-body-parse-failed", err))?;
+    let structure_errors = issue_body::validate_rows(table.rows());
+    if !structure_errors.is_empty() {
+        return Err(CommandError::runtime(
+            "issue-body-invalid",
+            structure_errors.join(" | "),
+        ));
+    }
+
+    let cleanup = cleanup_worktrees_from_rows(table.rows(), dry_run)
+        .map_err(|err| CommandError::runtime("worktree-cleanup-failed", err))?;
+
+    Ok(json!({
+        "scope": "plan",
+        "execution_mode": binary.execution_mode(),
+        "dry_run": dry_run,
+        "issue": args.issue,
+        "cleanup": {
+            "targeted": cleanup.targeted,
+            "removed": cleanup.removed,
+            "residual": cleanup.residual,
+        },
+        "live_mutations_performed": !dry_run && !cleanup.removed.is_empty(),
     }))
 }
 
 fn run_start_sprint(
     binary: BinaryFlavor,
     dry_run: bool,
+    repo_override: Option<&str>,
     args: &StartSprintArgs,
 ) -> Result<Value, CommandError> {
     let options = to_build_options(
@@ -158,10 +534,65 @@ fn run_start_sprint(
     task_spec::write_tsv(&task_spec_out, &build.rows)
         .map_err(|err| CommandError::runtime("task-spec-write-failed", err))?;
 
+    let prompts_out = args
+        .subagent_prompts_out
+        .clone()
+        .unwrap_or_else(|| default_subagent_prompts_path(&args.plan, i32::from(args.sprint)));
+    let prompt_files = write_subagent_prompts(
+        &prompts_out,
+        args.issue,
+        i32::from(args.sprint),
+        &build.rows,
+    )
+    .map_err(|err| CommandError::runtime("subagent-prompt-write-failed", err))?;
+
     let sprint_name = build
         .sprint_name
         .clone()
         .unwrap_or_else(|| format!("Sprint {}", args.sprint));
+
+    let adapter = GhCliAdapter;
+    let mut issue_body_for_comment: Option<String> = None;
+    let mut synced_rows = 0usize;
+    let mut live_mutations = false;
+
+    if binary == BinaryFlavor::PlanIssue {
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        let body = adapter
+            .issue_body(&repo, args.issue)
+            .map_err(|err| CommandError::runtime("github-issue-read-failed", err))?;
+
+        let mut table = issue_body::parse_task_table(&body)
+            .map_err(|err| CommandError::runtime("issue-body-parse-failed", err))?;
+
+        let structure_errors = issue_body::validate_rows(table.rows());
+        if !structure_errors.is_empty() {
+            return Err(CommandError::runtime(
+                "issue-body-invalid",
+                structure_errors.join(" | "),
+            ));
+        }
+
+        if args.sprint > 1 {
+            enforce_previous_sprint_gate(&adapter, &repo, table.rows(), i32::from(args.sprint))
+                .map_err(|err| CommandError::runtime("previous-sprint-gate-failed", err))?;
+        }
+
+        synced_rows = sync_issue_rows_from_task_spec(&mut table, &build.rows)
+            .map_err(|err| CommandError::runtime("task-sync-failed", err))?;
+
+        let updated_body = table.render();
+        issue_body_for_comment = Some(updated_body.clone());
+
+        if !dry_run {
+            let body_path = write_temp_markdown("start-sprint-issue-body", &updated_body)
+                .map_err(|err| CommandError::runtime("issue-body-write-failed", err))?;
+            adapter
+                .edit_issue_body(&repo, args.issue, &body_path)
+                .map_err(|err| CommandError::runtime("github-issue-update-failed", err))?;
+            live_mutations = true;
+        }
+    }
 
     let comment = render::render_sprint_comment(SprintCommentInput {
         mode: SprintCommentMode::Start,
@@ -171,7 +602,7 @@ fn run_start_sprint(
         rows: &build.rows,
         note_text: None,
         approval_comment_url: None,
-        issue_body_text: None,
+        issue_body_text: issue_body_for_comment.as_deref(),
     })
     .map_err(|err| CommandError::runtime("render-sprint-comment-failed", err))?;
 
@@ -183,6 +614,15 @@ fn run_start_sprint(
     render::write_rendered(&comment_out, &comment)
         .map_err(|err| CommandError::runtime("comment-write-failed", err))?;
 
+    let should_comment = should_emit_comment(&args.comment_mode);
+    if binary == BinaryFlavor::PlanIssue && should_comment && !dry_run {
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        adapter
+            .comment_issue(&repo, args.issue, &comment_out)
+            .map_err(|err| CommandError::runtime("github-comment-failed", err))?;
+        live_mutations = true;
+    }
+
     Ok(json!({
         "scope": "sprint",
         "sprint": args.sprint,
@@ -191,14 +631,18 @@ fn run_start_sprint(
         "task_spec_path": path_text(&task_spec_out),
         "comment_path": path_text(&comment_out),
         "record_count": build.rows.len(),
-        "subagent_prompts_out": args.subagent_prompts_out.as_ref().map(|path| path_text(path)),
-        "live_mutations_performed": false,
+        "subagent_prompts_out": path_text(&prompts_out),
+        "subagent_prompt_files": prompt_files,
+        "synced_issue_rows": synced_rows,
+        "comment_requested": should_comment,
+        "live_mutations_performed": live_mutations,
     }))
 }
 
 fn run_ready_sprint(
     binary: BinaryFlavor,
     dry_run: bool,
+    repo_override: Option<&str>,
     args: &ReadySprintArgs,
 ) -> Result<Value, CommandError> {
     let options = to_build_options(
@@ -228,6 +672,27 @@ fn run_ready_sprint(
         .clone()
         .unwrap_or_else(|| format!("Sprint {}", args.sprint));
 
+    let adapter = GhCliAdapter;
+    let mut issue_body_for_comment: Option<String> = None;
+    let mut live_mutations = false;
+
+    if binary == BinaryFlavor::PlanIssue {
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        let body = adapter
+            .issue_body(&repo, args.issue)
+            .map_err(|err| CommandError::runtime("github-issue-read-failed", err))?;
+        let table = issue_body::parse_task_table(&body)
+            .map_err(|err| CommandError::runtime("issue-body-parse-failed", err))?;
+        let structure_errors = issue_body::validate_rows(table.rows());
+        if !structure_errors.is_empty() {
+            return Err(CommandError::runtime(
+                "issue-body-invalid",
+                structure_errors.join(" | "),
+            ));
+        }
+        issue_body_for_comment = Some(body);
+    }
+
     let comment = render::render_sprint_comment(SprintCommentInput {
         mode: SprintCommentMode::Ready,
         plan_file: &args.plan,
@@ -236,7 +701,7 @@ fn run_ready_sprint(
         rows: &build.rows,
         note_text: summary.as_deref(),
         approval_comment_url: None,
-        issue_body_text: None,
+        issue_body_text: issue_body_for_comment.as_deref(),
     })
     .map_err(|err| CommandError::runtime("render-sprint-comment-failed", err))?;
 
@@ -248,6 +713,15 @@ fn run_ready_sprint(
     render::write_rendered(&comment_out, &comment)
         .map_err(|err| CommandError::runtime("comment-write-failed", err))?;
 
+    let should_comment = should_emit_comment(&args.comment_mode);
+    if binary == BinaryFlavor::PlanIssue && should_comment && !dry_run {
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        adapter
+            .comment_issue(&repo, args.issue, &comment_out)
+            .map_err(|err| CommandError::runtime("github-comment-failed", err))?;
+        live_mutations = true;
+    }
+
     Ok(json!({
         "scope": "sprint",
         "sprint": args.sprint,
@@ -256,13 +730,15 @@ fn run_ready_sprint(
         "task_spec_path": path_text(&task_spec_out),
         "comment_path": path_text(&comment_out),
         "record_count": build.rows.len(),
-        "live_mutations_performed": false,
+        "comment_requested": should_comment,
+        "live_mutations_performed": live_mutations,
     }))
 }
 
 fn run_accept_sprint(
     binary: BinaryFlavor,
     dry_run: bool,
+    repo_override: Option<&str>,
     args: &AcceptSprintArgs,
 ) -> Result<Value, CommandError> {
     if !approval_comment_url_looks_valid(&args.approved_comment_url) {
@@ -299,6 +775,65 @@ fn run_accept_sprint(
         .clone()
         .unwrap_or_else(|| format!("Sprint {}", args.sprint));
 
+    let adapter = GhCliAdapter;
+    let mut issue_body_for_comment: Option<String> = None;
+    let mut synced_done_rows = 0usize;
+    let mut live_mutations = false;
+
+    if binary == BinaryFlavor::PlanIssue {
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        let body = adapter
+            .issue_body(&repo, args.issue)
+            .map_err(|err| CommandError::runtime("github-issue-read-failed", err))?;
+
+        let mut table = issue_body::parse_task_table(&body)
+            .map_err(|err| CommandError::runtime("issue-body-parse-failed", err))?;
+        let structure_errors = issue_body::validate_rows(table.rows());
+        if !structure_errors.is_empty() {
+            return Err(CommandError::runtime(
+                "issue-body-invalid",
+                structure_errors.join(" | "),
+            ));
+        }
+
+        let sprint_indexes = table.sprint_row_indexes(i32::from(args.sprint));
+        if sprint_indexes.is_empty() {
+            return Err(CommandError::runtime(
+                "sprint-not-found",
+                format!("issue task table has no rows for sprint {}", args.sprint),
+            ));
+        }
+
+        let sprint_rows: Vec<TaskRow> = sprint_indexes
+            .iter()
+            .map(|idx| table.rows()[*idx].clone())
+            .collect();
+
+        let required_prs = collect_required_prs(&sprint_rows, "accept-sprint")
+            .map_err(|err| CommandError::runtime("sprint-acceptance-gate-failed", err))?;
+        ensure_prs_merged(&adapter, &repo, &required_prs, "accept-sprint")
+            .map_err(|err| CommandError::runtime("sprint-acceptance-gate-failed", err))?;
+
+        for idx in sprint_indexes {
+            let row = &mut table.rows_mut()[idx];
+            row.status = "done".to_string();
+            row.pr = issue_body::normalize_pr_display(&row.pr);
+            synced_done_rows += 1;
+        }
+
+        let updated_body = table.render();
+        issue_body_for_comment = Some(updated_body.clone());
+
+        if !dry_run {
+            let body_path = write_temp_markdown("accept-sprint-issue-body", &updated_body)
+                .map_err(|err| CommandError::runtime("issue-body-write-failed", err))?;
+            adapter
+                .edit_issue_body(&repo, args.issue, &body_path)
+                .map_err(|err| CommandError::runtime("github-issue-update-failed", err))?;
+            live_mutations = true;
+        }
+    }
+
     let comment = render::render_sprint_comment(SprintCommentInput {
         mode: SprintCommentMode::Accepted,
         plan_file: &args.plan,
@@ -307,7 +842,7 @@ fn run_accept_sprint(
         rows: &build.rows,
         note_text: summary.as_deref(),
         approval_comment_url: Some(&args.approved_comment_url),
-        issue_body_text: None,
+        issue_body_text: issue_body_for_comment.as_deref(),
     })
     .map_err(|err| CommandError::runtime("render-sprint-comment-failed", err))?;
 
@@ -319,6 +854,15 @@ fn run_accept_sprint(
     render::write_rendered(&comment_out, &comment)
         .map_err(|err| CommandError::runtime("comment-write-failed", err))?;
 
+    let should_comment = should_emit_comment(&args.comment_mode);
+    if binary == BinaryFlavor::PlanIssue && should_comment && !dry_run {
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        adapter
+            .comment_issue(&repo, args.issue, &comment_out)
+            .map_err(|err| CommandError::runtime("github-comment-failed", err))?;
+        live_mutations = true;
+    }
+
     Ok(json!({
         "scope": "sprint",
         "sprint": args.sprint,
@@ -327,8 +871,111 @@ fn run_accept_sprint(
         "task_spec_path": path_text(&task_spec_out),
         "comment_path": path_text(&comment_out),
         "record_count": build.rows.len(),
-        "live_mutations_performed": false,
         "approval_comment_url": args.approved_comment_url,
+        "synced_done_rows": synced_done_rows,
+        "comment_requested": should_comment,
+        "live_mutations_performed": live_mutations,
+    }))
+}
+
+fn run_multi_sprint_guide(args: &MultiSprintGuideArgs) -> Result<Value, CommandError> {
+    let display_path = args.plan.to_string_lossy().to_string();
+    let resolved_plan_path = task_spec::resolve_plan_file(&args.plan);
+    if !resolved_plan_path.is_file() {
+        return Err(CommandError::runtime(
+            "plan-parse-failed",
+            format!("plan file not found: {display_path}"),
+        ));
+    }
+    let (plan, parse_errors) = parse_plan_with_display(&resolved_plan_path, &display_path)
+        .map_err(|err| CommandError::runtime("plan-parse-failed", err.to_string()))?;
+
+    if !parse_errors.is_empty() {
+        return Err(CommandError::runtime(
+            "plan-parse-failed",
+            parse_errors.join(" | "),
+        ));
+    }
+
+    let from_sprint = i32::from(args.from_sprint);
+    let max_sprint = plan
+        .sprints
+        .iter()
+        .map(|s| s.number)
+        .max()
+        .unwrap_or(from_sprint);
+    let to_sprint = args
+        .to_sprint
+        .map(i32::from)
+        .unwrap_or(max_sprint)
+        .max(from_sprint);
+
+    if to_sprint < from_sprint {
+        return Err(CommandError::usage(
+            "invalid-sprint-range",
+            "--to-sprint must be greater than or equal to --from-sprint",
+        ));
+    }
+
+    let issue_body_path = render::default_plan_issue_body_path(&args.plan);
+    let script = "$AGENT_HOME/skills/automation/plan-issue-delivery-loop/scripts/plan-issue-delivery-loop.sh";
+
+    let mut lines = vec![
+        "MULTI_SPRINT_GUIDE_BEGIN".to_string(),
+        "DESIGN=ONE_PLAN_ONE_ISSUE".to_string(),
+        "MODE=DRY_RUN_LOCAL".to_string(),
+        format!("PLAN_FILE={display_path}"),
+        format!("PLAN_TITLE={}", plan.title),
+        format!("FROM_SPRINT={from_sprint}"),
+        format!("TO_SPRINT={to_sprint}"),
+        "DRY_RUN_PLAN_ISSUE=DRY_RUN_PLAN_ISSUE".to_string(),
+        format!("DRY_RUN_ISSUE_BODY={}", issue_body_path.display()),
+    ];
+
+    let mut step = 1usize;
+    lines.push(format!(
+        "STEP_{step}={script} start-plan --plan {display_path} --pr-grouping <per-sprint\\|group> --dry-run"
+    ));
+    step += 1;
+
+    for sprint in from_sprint..=to_sprint {
+        lines.push(format!(
+            "STEP_{step}={script} start-sprint --plan {display_path} --issue DRY_RUN_PLAN_ISSUE --sprint {sprint} --pr-grouping <per-sprint\\|group> --no-comment --dry-run"
+        ));
+        step += 1;
+
+        if sprint < to_sprint {
+            lines.push(format!(
+                "STEP_{step}={script} accept-sprint --plan {display_path} --issue DRY_RUN_PLAN_ISSUE --sprint {sprint} --approved-comment-url <approval-comment-url-sprint-{sprint}> --pr-grouping <per-sprint\\|group> --no-comment --dry-run"
+            ));
+            step += 1;
+        }
+    }
+
+    lines.push(format!(
+        "STEP_{step}={script} ready-plan --body-file {} --summary Final\\ plan\\ review --no-comment --no-label-update --dry-run",
+        issue_body_path.display()
+    ));
+    step += 1;
+
+    lines.push(format!(
+        "STEP_{step}={script} close-plan --body-file {} --approved-comment-url <final-plan-approval-comment-url> --dry-run",
+        issue_body_path.display()
+    ));
+
+    lines.extend([
+        "NOTE_DRY_RUN=Dry-run guide is local-only and does not call GitHub.".to_string(),
+        "NOTE_GROUP_MODE=When using --pr-grouping group, pass --pr-group for every task in the selected scope.".to_string(),
+        "NOTE_SPRINT_GATE=Before starting sprint N+1, sprint N must be reviewed, merged, and accepted.".to_string(),
+        "NOTE_ACCEPT_SYNC=accept-sprint enforces merged PRs for the sprint and syncs sprint task Status to done.".to_string(),
+        "MULTI_SPRINT_GUIDE_END".to_string(),
+    ]);
+
+    Ok(json!({
+        "scope": "plan",
+        "from_sprint": from_sprint,
+        "to_sprint": to_sprint,
+        "guide": lines.join("\n"),
     }))
 }
 
@@ -364,6 +1011,28 @@ fn load_summary(summary: &SummaryArgs) -> Result<Option<String>, CommandError> {
     Ok(None)
 }
 
+fn load_close_comment(
+    comment: &crate::commands::CommentTextArgs,
+) -> Result<Option<String>, CommandError> {
+    if let Some(inline) = &comment.comment {
+        return Ok(Some(inline.to_string()));
+    }
+    if let Some(path) = &comment.comment_file {
+        let text = fs::read_to_string(path).map_err(|err| {
+            CommandError::runtime(
+                "close-comment-read-failed",
+                format!(
+                    "failed to read close comment file {}: {err}",
+                    path.display()
+                ),
+            )
+        })?;
+        return Ok(Some(text));
+    }
+
+    Ok(None)
+}
+
 fn approval_comment_url_looks_valid(url: &str) -> bool {
     let trimmed = url.trim();
     if !trimmed.starts_with("https://github.com/") {
@@ -380,4 +1049,506 @@ fn approval_comment_url_looks_valid(url: &str) -> bool {
 
 fn path_text(path: &Path) -> String {
     path.to_string_lossy().to_string()
+}
+
+fn ensure_live_binary(binary: BinaryFlavor) -> Result<(), CommandError> {
+    if binary == BinaryFlavor::PlanIssue {
+        Ok(())
+    } else {
+        Err(CommandError::usage(
+            "live-command-unavailable",
+            "this command path requires the live `plan-issue` binary",
+        ))
+    }
+}
+
+fn resolve_repo_for_live(
+    binary: BinaryFlavor,
+    repo_override: Option<&str>,
+) -> Result<String, CommandError> {
+    ensure_live_binary(binary)?;
+    crate::github::resolve_repo(repo_override)
+        .map_err(|err| CommandError::usage("repo-resolution-failed", err))
+}
+
+fn render_plan_status_comment(rows: &[TaskRow]) -> String {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for row in rows {
+        let status = row.status.trim().to_ascii_lowercase();
+        *counts.entry(status).or_insert(0) += 1;
+    }
+
+    format!(
+        "## Plan Status Snapshot\n\n- Total tasks: {}\n- planned: {}\n- in-progress: {}\n- blocked: {}\n- done: {}\n",
+        rows.len(),
+        counts.get("planned").copied().unwrap_or(0),
+        counts.get("in-progress").copied().unwrap_or(0),
+        counts.get("blocked").copied().unwrap_or(0),
+        counts.get("done").copied().unwrap_or(0),
+    )
+}
+
+fn should_emit_comment(comment_mode: &crate::commands::CommentModeArgs) -> bool {
+    !comment_mode.no_comment
+}
+
+fn write_temp_markdown(stem: &str, content: &str) -> Result<PathBuf, String> {
+    let dir = task_spec::agent_home()
+        .join("out")
+        .join("plan-issue-delivery-loop")
+        .join("tmp");
+    fs::create_dir_all(&dir).map_err(|err| {
+        format!(
+            "failed to create temp output directory {}: {err}",
+            dir.display()
+        )
+    })?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| format!("failed to compute timestamp: {err}"))?
+        .as_millis();
+    let path = dir.join(format!("{stem}-{now}.md"));
+    fs::write(&path, content).map_err(|err| {
+        format!(
+            "failed to write temporary markdown {}: {err}",
+            path.display()
+        )
+    })?;
+    Ok(path)
+}
+
+fn default_subagent_prompts_path(plan_file: &Path, sprint: i32) -> PathBuf {
+    let plan_stem = plan_file
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("plan")
+        .to_string();
+
+    task_spec::agent_home()
+        .join("out")
+        .join("plan-issue-delivery-loop")
+        .join(format!("{plan_stem}-sprint-{sprint}-subagent-prompts"))
+}
+
+fn write_subagent_prompts(
+    out_dir: &Path,
+    issue: u64,
+    sprint: i32,
+    rows: &[TaskSpecRow],
+) -> Result<Vec<String>, String> {
+    fs::create_dir_all(out_dir).map_err(|err| {
+        format!(
+            "failed to create subagent prompt dir {}: {err}",
+            out_dir.display()
+        )
+    })?;
+
+    let mut paths = Vec::new();
+    for row in rows {
+        let path = out_dir.join(format!("{}-subagent-prompt.md", row.task_id));
+        let body = format!(
+            "# Subagent Task Prompt\n\n- Issue: #{issue}\n- Sprint: S{sprint}\n- Task: {}\n- Summary: {}\n- Owner: {}\n- Branch: {}\n- Worktree: {}\n- Notes: {}\n",
+            row.task_id, row.summary, row.owner, row.branch, row.worktree, row.notes
+        );
+        fs::write(&path, body)
+            .map_err(|err| format!("failed to write subagent prompt {}: {err}", path.display()))?;
+        paths.push(path.to_string_lossy().to_string());
+    }
+
+    Ok(paths)
+}
+
+fn collect_required_prs(rows: &[TaskRow], scope: &str) -> Result<Vec<u64>, String> {
+    let mut errors = Vec::new();
+    let mut prs = Vec::new();
+    let mut seen = HashSet::new();
+
+    for row in rows {
+        match issue_body::parse_pr_number(&row.pr) {
+            Some(number) => {
+                if seen.insert(number) {
+                    prs.push(number);
+                }
+            }
+            None => errors.push(format!(
+                "{}: {} requires concrete PR reference (found `{}`)",
+                row.task,
+                scope,
+                row.pr.trim()
+            )),
+        }
+    }
+
+    if !errors.is_empty() {
+        return Err(errors.join(" | "));
+    }
+
+    Ok(prs)
+}
+
+fn ensure_prs_merged(
+    adapter: &impl GitHubAdapter,
+    repo: &str,
+    prs: &[u64],
+    scope: &str,
+) -> Result<(), String> {
+    let mut errors = Vec::new();
+
+    for pr in prs {
+        let merged = adapter
+            .pr_is_merged(repo, *pr)
+            .map_err(|err| format!("failed to query PR #{pr}: {err}"))?;
+        if !merged {
+            errors.push(format!("{scope}: PR #{pr} is not merged"));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join(" | "))
+    }
+}
+
+fn enforce_previous_sprint_gate(
+    adapter: &impl GitHubAdapter,
+    repo: &str,
+    rows: &[TaskRow],
+    sprint: i32,
+) -> Result<(), String> {
+    let previous = sprint - 1;
+    let prev_rows: Vec<TaskRow> = rows
+        .iter()
+        .filter(|row| issue_body::row_sprint(row) == Some(previous))
+        .cloned()
+        .collect();
+
+    if prev_rows.is_empty() {
+        return Err(format!(
+            "start-sprint gate: no rows found for previous sprint S{previous}"
+        ));
+    }
+
+    let mut errors = Vec::new();
+    for row in &prev_rows {
+        if !row.status.trim().eq_ignore_ascii_case("done") {
+            errors.push(format!(
+                "{}: previous sprint gate requires Status=done (found `{}`)",
+                row.task,
+                row.status.trim()
+            ));
+        }
+    }
+
+    let prs = prev_rows
+        .iter()
+        .map(|row| {
+            issue_body::parse_pr_number(&row.pr).ok_or_else(|| {
+                format!(
+                    "{}: previous sprint gate requires concrete PR reference (found `{}`)",
+                    row.task,
+                    row.pr.trim()
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut unique_prs = prs;
+    unique_prs.sort_unstable();
+    unique_prs.dedup();
+
+    if let Err(err) = ensure_prs_merged(adapter, repo, &unique_prs, "previous-sprint-gate") {
+        errors.push(err);
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join(" | "))
+    }
+}
+
+fn sync_issue_rows_from_task_spec(
+    table: &mut issue_body::TaskTable,
+    spec_rows: &[TaskSpecRow],
+) -> Result<usize, String> {
+    let mut group_sizes: HashMap<String, usize> = HashMap::new();
+    for spec in spec_rows {
+        *group_sizes.entry(spec.pr_group.clone()).or_insert(0) += 1;
+    }
+
+    let mut spec_by_task: HashMap<String, (TaskSpecRow, String)> = HashMap::new();
+    for spec in spec_rows {
+        let mode = if spec.grouping == crate::commands::PrGrouping::PerSprint {
+            "per-sprint".to_string()
+        } else if group_sizes.get(&spec.pr_group).copied().unwrap_or(0) > 1 {
+            "pr-shared".to_string()
+        } else {
+            "pr-isolated".to_string()
+        };
+        spec_by_task.insert(spec.task_id.clone(), (spec.clone(), mode));
+    }
+
+    let mut touched = HashSet::new();
+    let mut updated = 0usize;
+
+    for row in table.rows_mut() {
+        if let Some((spec, mode)) = spec_by_task.get(&row.task) {
+            row.summary = spec.summary.clone();
+            row.owner = spec.owner.clone();
+            row.branch = spec.branch.clone();
+            row.worktree = spec.worktree.clone();
+            row.execution_mode = mode.clone();
+            row.notes = spec.notes.clone();
+            if issue_body::is_placeholder(&row.pr) {
+                row.pr = "TBD".to_string();
+            } else {
+                row.pr = issue_body::normalize_pr_display(&row.pr);
+            }
+            if row.status.trim().is_empty() {
+                row.status = "planned".to_string();
+            }
+            touched.insert(spec.task_id.clone());
+            updated += 1;
+        }
+    }
+
+    if touched.len() != spec_rows.len() {
+        let missing = spec_rows
+            .iter()
+            .filter(|row| !touched.contains(&row.task_id))
+            .map(|row| row.task_id.clone())
+            .collect::<Vec<_>>();
+        return Err(format!(
+            "issue task table missing rows for sprint tasks: {}",
+            missing.join(",")
+        ));
+    }
+
+    Ok(updated)
+}
+
+#[derive(Debug, Default)]
+struct CleanupOutcome {
+    targeted: Vec<String>,
+    removed: Vec<String>,
+    residual: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct LinkedWorktree {
+    path: PathBuf,
+    branch: Option<String>,
+}
+
+fn cleanup_worktrees_from_rows(rows: &[TaskRow], dry_run: bool) -> Result<CleanupOutcome, String> {
+    let repo_root = repo_root()?;
+    let cwd = std::env::current_dir()
+        .map_err(|err| format!("failed to read current directory: {err}"))?;
+
+    let mut branch_targets: HashSet<String> = HashSet::new();
+    let mut path_targets: HashSet<String> = HashSet::new();
+
+    for row in rows {
+        if !issue_body::is_placeholder(&row.branch) {
+            branch_targets.insert(normalize_branch_name(&row.branch));
+        }
+        if !issue_body::is_placeholder(&row.worktree) {
+            let resolved = resolve_worktree_path(&repo_root, row.worktree.trim());
+            path_targets.insert(path_key(&resolved));
+        }
+    }
+
+    let linked = list_linked_worktrees()?;
+    let repo_root_key = path_key(&repo_root);
+
+    let mut outcome = CleanupOutcome::default();
+
+    for worktree in linked {
+        let worktree_key = path_key(&worktree.path);
+        let branch_key = worktree.branch.as_ref().map(|b| normalize_branch_name(b));
+
+        let targeted = path_targets.contains(&worktree_key)
+            || branch_key
+                .as_ref()
+                .is_some_and(|branch| branch_targets.contains(branch));
+
+        if !targeted {
+            continue;
+        }
+
+        outcome
+            .targeted
+            .push(worktree.path.to_string_lossy().to_string());
+
+        if worktree_key == repo_root_key {
+            continue;
+        }
+
+        if cwd == worktree.path || cwd.starts_with(&worktree.path) {
+            outcome
+                .residual
+                .push(worktree.path.to_string_lossy().to_string());
+            continue;
+        }
+
+        if dry_run {
+            outcome
+                .removed
+                .push(worktree.path.to_string_lossy().to_string());
+            continue;
+        }
+
+        let status = ProcessCommand::new("git")
+            .args([
+                "worktree",
+                "remove",
+                "--force",
+                worktree.path.to_string_lossy().as_ref(),
+            ])
+            .status()
+            .map_err(|err| format!("failed to execute `git worktree remove`: {err}"))?;
+
+        if status.success() {
+            outcome
+                .removed
+                .push(worktree.path.to_string_lossy().to_string());
+        } else {
+            outcome
+                .residual
+                .push(worktree.path.to_string_lossy().to_string());
+        }
+    }
+
+    if !dry_run {
+        let prune_status = ProcessCommand::new("git")
+            .args(["worktree", "prune"])
+            .status()
+            .map_err(|err| format!("failed to execute `git worktree prune`: {err}"))?;
+        if !prune_status.success() {
+            return Err("git worktree prune failed".to_string());
+        }
+
+        let remaining = list_linked_worktrees()?;
+        for worktree in remaining {
+            let worktree_key = path_key(&worktree.path);
+            let branch_key = worktree.branch.as_ref().map(|b| normalize_branch_name(b));
+            let targeted = path_targets.contains(&worktree_key)
+                || branch_key
+                    .as_ref()
+                    .is_some_and(|branch| branch_targets.contains(branch));
+
+            if targeted && worktree_key != repo_root_key {
+                let path = worktree.path.to_string_lossy().to_string();
+                if !outcome.residual.contains(&path) {
+                    outcome.residual.push(path);
+                }
+            }
+        }
+
+        if !outcome.residual.is_empty() {
+            return Err(format!(
+                "cleanup left targeted residual worktrees: {}",
+                outcome.residual.join(", ")
+            ));
+        }
+    }
+
+    outcome.targeted.sort();
+    outcome.targeted.dedup();
+    outcome.removed.sort();
+    outcome.removed.dedup();
+
+    Ok(outcome)
+}
+
+fn list_linked_worktrees() -> Result<Vec<LinkedWorktree>, String> {
+    let output = ProcessCommand::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+        .map_err(|err| format!("failed to run `git worktree list --porcelain`: {err}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!(
+            "`git worktree list --porcelain` failed: {}",
+            if stderr.is_empty() {
+                "unknown error"
+            } else {
+                &stderr
+            }
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut rows = Vec::new();
+    let mut current: Option<LinkedWorktree> = None;
+
+    for line in stdout.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            if let Some(prev) = current.take() {
+                rows.push(prev);
+            }
+            current = Some(LinkedWorktree {
+                path: PathBuf::from(path.trim()),
+                branch: None,
+            });
+            continue;
+        }
+
+        if let Some(branch) = line.strip_prefix("branch ")
+            && let Some(current) = current.as_mut()
+        {
+            current.branch = Some(branch.trim().trim_start_matches("refs/heads/").to_string());
+            continue;
+        }
+
+        if line.trim().is_empty()
+            && let Some(prev) = current.take()
+        {
+            rows.push(prev);
+        }
+    }
+
+    if let Some(prev) = current {
+        rows.push(prev);
+    }
+
+    Ok(rows)
+}
+
+fn repo_root() -> Result<PathBuf, String> {
+    let output = ProcessCommand::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .map_err(|err| format!("failed to run `git rev-parse --show-toplevel`: {err}"))?;
+
+    if !output.status.success() {
+        return Err("unable to resolve repository root".to_string());
+    }
+
+    Ok(PathBuf::from(
+        String::from_utf8_lossy(&output.stdout).trim(),
+    ))
+}
+
+fn resolve_worktree_path(repo_root: &Path, worktree: &str) -> PathBuf {
+    let path = PathBuf::from(worktree);
+    if path.is_absolute() {
+        path
+    } else {
+        repo_root.join(path)
+    }
+}
+
+fn normalize_branch_name(branch: &str) -> String {
+    branch.trim().trim_start_matches("refs/heads/").to_string()
+}
+
+fn path_key(path: &Path) -> String {
+    fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
 }

--- a/crates/plan-issue-cli/src/github.rs
+++ b/crates/plan-issue-cli/src/github.rs
@@ -1,0 +1,354 @@
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+
+use crate::commands::plan::CloseReason;
+
+pub trait GitHubAdapter {
+    fn issue_body(&self, repo: &str, issue: u64) -> Result<String, String>;
+
+    fn create_issue(
+        &self,
+        repo: &str,
+        title: &str,
+        body_file: &Path,
+        labels: &[String],
+    ) -> Result<(u64, String), String>;
+
+    fn edit_issue_body(&self, repo: &str, issue: u64, body_file: &Path) -> Result<(), String>;
+
+    fn comment_issue(&self, repo: &str, issue: u64, body_file: &Path) -> Result<(), String>;
+
+    fn edit_issue_labels(
+        &self,
+        repo: &str,
+        issue: u64,
+        add_labels: &[String],
+        remove_labels: &[String],
+    ) -> Result<(), String>;
+
+    fn close_issue(
+        &self,
+        repo: &str,
+        issue: u64,
+        reason: CloseReason,
+        close_comment: Option<&str>,
+    ) -> Result<(), String>;
+
+    fn pr_is_merged(&self, repo: &str, pr: u64) -> Result<bool, String>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GhCliAdapter;
+
+impl GhCliAdapter {
+    fn run(args: &[String]) -> Result<String, String> {
+        let output = Command::new("gh")
+            .args(args)
+            .output()
+            .map_err(|err| format!("failed to execute gh: {err}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let detail = if stderr.is_empty() { stdout } else { stderr };
+            return Err(format!("gh {} failed: {detail}", args.join(" ")));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+
+    fn parse_json(stdout: &str, context: &str) -> Result<Value, String> {
+        serde_json::from_str(stdout.trim())
+            .map_err(|err| format!("failed to parse gh JSON for {context}: {err}"))
+    }
+}
+
+impl GitHubAdapter for GhCliAdapter {
+    fn issue_body(&self, repo: &str, issue: u64) -> Result<String, String> {
+        let args = vec![
+            "issue".to_string(),
+            "view".to_string(),
+            issue.to_string(),
+            "--repo".to_string(),
+            repo.to_string(),
+            "--json".to_string(),
+            "body".to_string(),
+        ];
+        let stdout = Self::run(&args)?;
+        let json = Self::parse_json(&stdout, "issue view")?;
+        let body = json
+            .get("body")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "gh issue view JSON missing `body`".to_string())?;
+        Ok(body.to_string())
+    }
+
+    fn create_issue(
+        &self,
+        repo: &str,
+        title: &str,
+        body_file: &Path,
+        labels: &[String],
+    ) -> Result<(u64, String), String> {
+        let mut args = vec![
+            "issue".to_string(),
+            "create".to_string(),
+            "--repo".to_string(),
+            repo.to_string(),
+            "--title".to_string(),
+            title.to_string(),
+            "--body-file".to_string(),
+            body_file.to_string_lossy().to_string(),
+        ];
+
+        for label in labels {
+            let trimmed = label.trim();
+            if !trimmed.is_empty() {
+                args.push("--label".to_string());
+                args.push(trimmed.to_string());
+            }
+        }
+
+        let stdout = Self::run(&args)?;
+        let url = stdout.trim().to_string();
+        let issue_number = issue_number_from_url(&url)
+            .ok_or_else(|| format!("unable to parse issue number from gh output: {url}"))?;
+        Ok((issue_number, url))
+    }
+
+    fn edit_issue_body(&self, repo: &str, issue: u64, body_file: &Path) -> Result<(), String> {
+        let args = vec![
+            "issue".to_string(),
+            "edit".to_string(),
+            issue.to_string(),
+            "--repo".to_string(),
+            repo.to_string(),
+            "--body-file".to_string(),
+            body_file.to_string_lossy().to_string(),
+        ];
+        Self::run(&args).map(|_| ())
+    }
+
+    fn comment_issue(&self, repo: &str, issue: u64, body_file: &Path) -> Result<(), String> {
+        let args = vec![
+            "issue".to_string(),
+            "comment".to_string(),
+            issue.to_string(),
+            "--repo".to_string(),
+            repo.to_string(),
+            "--body-file".to_string(),
+            body_file.to_string_lossy().to_string(),
+        ];
+        Self::run(&args).map(|_| ())
+    }
+
+    fn edit_issue_labels(
+        &self,
+        repo: &str,
+        issue: u64,
+        add_labels: &[String],
+        remove_labels: &[String],
+    ) -> Result<(), String> {
+        let mut args = vec![
+            "issue".to_string(),
+            "edit".to_string(),
+            issue.to_string(),
+            "--repo".to_string(),
+            repo.to_string(),
+        ];
+
+        let add_csv = add_labels
+            .iter()
+            .map(|label| label.trim())
+            .filter(|label| !label.is_empty())
+            .collect::<Vec<_>>()
+            .join(",");
+        if !add_csv.is_empty() {
+            args.push("--add-label".to_string());
+            args.push(add_csv);
+        }
+
+        let remove_csv = remove_labels
+            .iter()
+            .map(|label| label.trim())
+            .filter(|label| !label.is_empty())
+            .collect::<Vec<_>>()
+            .join(",");
+        if !remove_csv.is_empty() {
+            args.push("--remove-label".to_string());
+            args.push(remove_csv);
+        }
+
+        if args.len() == 5 {
+            return Ok(());
+        }
+
+        Self::run(&args).map(|_| ())
+    }
+
+    fn close_issue(
+        &self,
+        repo: &str,
+        issue: u64,
+        reason: CloseReason,
+        close_comment: Option<&str>,
+    ) -> Result<(), String> {
+        let mut args = vec![
+            "issue".to_string(),
+            "close".to_string(),
+            issue.to_string(),
+            "--repo".to_string(),
+            repo.to_string(),
+            "--reason".to_string(),
+            match reason {
+                CloseReason::Completed => "completed",
+                CloseReason::NotPlanned => "not planned",
+            }
+            .to_string(),
+        ];
+
+        if let Some(comment) = close_comment {
+            let trimmed = comment.trim();
+            if !trimmed.is_empty() {
+                args.push("--comment".to_string());
+                args.push(trimmed.to_string());
+            }
+        }
+
+        Self::run(&args).map(|_| ())
+    }
+
+    fn pr_is_merged(&self, repo: &str, pr: u64) -> Result<bool, String> {
+        let args = vec![
+            "pr".to_string(),
+            "view".to_string(),
+            pr.to_string(),
+            "--repo".to_string(),
+            repo.to_string(),
+            "--json".to_string(),
+            "state,mergedAt".to_string(),
+        ];
+        let stdout = Self::run(&args)?;
+        let json = Self::parse_json(&stdout, "pr view")?;
+
+        let merged_at_present = !json.get("mergedAt").is_some_and(Value::is_null);
+        let merged_state = json
+            .get("state")
+            .and_then(Value::as_str)
+            .is_some_and(|state| state.eq_ignore_ascii_case("merged"));
+
+        Ok(merged_at_present || merged_state)
+    }
+}
+
+pub fn resolve_repo(repo_override: Option<&str>) -> Result<String, String> {
+    if let Some(repo) = repo_override {
+        return normalize_repo_slug(repo).ok_or_else(|| format!("invalid --repo value: {repo}"));
+    }
+
+    let output = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .map_err(|err| format!("failed to run `git remote get-url origin`: {err}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!(
+            "failed to resolve repository from git remote: {}",
+            if stderr.is_empty() {
+                "unknown error"
+            } else {
+                &stderr
+            }
+        ));
+    }
+
+    let remote = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    normalize_repo_slug(&remote).ok_or_else(|| {
+        format!(
+            "unable to derive owner/repo from origin remote `{remote}`; pass --repo <owner/repo>"
+        )
+    })
+}
+
+fn normalize_repo_slug(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let candidate = trimmed
+        .strip_prefix("git@github.com:")
+        .or_else(|| trimmed.strip_prefix("https://github.com/"))
+        .or_else(|| trimmed.strip_prefix("http://github.com/"))
+        .or_else(|| trimmed.strip_prefix("ssh://git@github.com/"));
+
+    if let Some(candidate) = candidate {
+        let normalized = candidate.trim_end_matches(".git").trim_end_matches('/');
+        if is_owner_repo(normalized) {
+            return Some(normalized.to_string());
+        }
+    }
+
+    if is_owner_repo(trimmed) {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
+fn is_owner_repo(value: &str) -> bool {
+    if value.contains(':') || value.contains("://") || value.ends_with(".git") {
+        return false;
+    }
+
+    let mut parts = value.split('/');
+    let owner = parts.next().unwrap_or_default().trim();
+    let repo = parts.next().unwrap_or_default().trim();
+    parts.next().is_none() && !owner.is_empty() && !repo.is_empty()
+}
+
+fn issue_number_from_url(url: &str) -> Option<u64> {
+    let trimmed = url.trim().trim_end_matches('/');
+    let tail = trimmed.rsplit('/').next()?;
+    tail.parse::<u64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{issue_number_from_url, normalize_repo_slug};
+
+    #[test]
+    fn normalize_repo_slug_accepts_common_remote_forms() {
+        let samples = [
+            ("graysurf/nils-cli", "graysurf/nils-cli"),
+            ("git@github.com:graysurf/nils-cli.git", "graysurf/nils-cli"),
+            (
+                "https://github.com/graysurf/nils-cli.git",
+                "graysurf/nils-cli",
+            ),
+            (
+                "ssh://git@github.com/graysurf/nils-cli.git",
+                "graysurf/nils-cli",
+            ),
+        ];
+
+        for (raw, expected) in samples {
+            assert_eq!(normalize_repo_slug(raw).as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn issue_number_from_url_extracts_tail_numeric_segment() {
+        assert_eq!(
+            issue_number_from_url("https://github.com/graysurf/nils-cli/issues/217"),
+            Some(217)
+        );
+        assert_eq!(
+            issue_number_from_url("https://github.com/graysurf/nils-cli/pull/221"),
+            Some(221)
+        );
+    }
+}

--- a/crates/plan-issue-cli/src/issue_body.rs
+++ b/crates/plan-issue-cli/src/issue_body.rs
@@ -1,0 +1,418 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskRow {
+    pub task: String,
+    pub summary: String,
+    pub owner: String,
+    pub branch: String,
+    pub worktree: String,
+    pub execution_mode: String,
+    pub pr: String,
+    pub status: String,
+    pub notes: String,
+    pub line_index: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskTable {
+    lines: Vec<String>,
+    rows: Vec<TaskRow>,
+    trailing_newline: bool,
+}
+
+impl TaskTable {
+    pub fn rows(&self) -> &[TaskRow] {
+        &self.rows
+    }
+
+    pub fn rows_mut(&mut self) -> &mut [TaskRow] {
+        &mut self.rows
+    }
+
+    pub fn sprint_row_indexes(&self, sprint: i32) -> Vec<usize> {
+        self.rows
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, row)| (row_sprint(row) == Some(sprint)).then_some(idx))
+            .collect()
+    }
+
+    pub fn render(&self) -> String {
+        let mut lines = self.lines.clone();
+        for row in &self.rows {
+            lines[row.line_index] = format_markdown_row(row);
+        }
+
+        let mut rendered = lines.join("\n");
+        if self.trailing_newline {
+            rendered.push('\n');
+        }
+        rendered
+    }
+}
+
+pub fn parse_task_table(body: &str) -> Result<TaskTable, String> {
+    let trailing_newline = body.ends_with('\n');
+    let lines: Vec<String> = body.lines().map(ToString::to_string).collect();
+
+    let section_idx = lines
+        .iter()
+        .position(|line| line.trim() == "## Task Decomposition")
+        .ok_or_else(|| "issue body missing `## Task Decomposition` section".to_string())?;
+
+    let mut header_idx = None;
+    for (idx, line) in lines.iter().enumerate().skip(section_idx + 1) {
+        let trimmed = line.trim();
+        if trimmed.starts_with("## ") {
+            break;
+        }
+        if trimmed.starts_with('|') {
+            let cells = split_table_cells(trimmed);
+            if normalize_header_cells(&cells) {
+                header_idx = Some(idx);
+                break;
+            }
+        }
+    }
+
+    let header_idx = header_idx.ok_or_else(|| {
+        "task decomposition table header not found or does not match expected columns".to_string()
+    })?;
+
+    let separator_idx = header_idx + 1;
+    if separator_idx >= lines.len() || !lines[separator_idx].trim().starts_with("| ---") {
+        return Err("task decomposition table separator row is missing".to_string());
+    }
+
+    let mut rows = Vec::new();
+    for (idx, line) in lines.iter().enumerate().skip(separator_idx + 1) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("## ") || !trimmed.starts_with('|') {
+            break;
+        }
+
+        let cells = split_table_cells(trimmed);
+        if cells.len() != 9 {
+            return Err(format!(
+                "task decomposition row has {} columns (expected 9): {}",
+                cells.len(),
+                trimmed
+            ));
+        }
+
+        rows.push(TaskRow {
+            task: cells[0].clone(),
+            summary: cells[1].clone(),
+            owner: cells[2].clone(),
+            branch: cells[3].clone(),
+            worktree: cells[4].clone(),
+            execution_mode: cells[5].clone(),
+            pr: cells[6].clone(),
+            status: cells[7].clone(),
+            notes: cells[8].clone(),
+            line_index: idx,
+        });
+    }
+
+    if rows.is_empty() {
+        return Err("task decomposition table has no task rows".to_string());
+    }
+
+    Ok(TaskTable {
+        lines,
+        rows,
+        trailing_newline,
+    })
+}
+
+pub fn validate_rows(rows: &[TaskRow]) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    let mut per_task_branches: HashMap<String, String> = HashMap::new();
+    let mut per_task_worktrees: HashMap<String, String> = HashMap::new();
+
+    for row in rows {
+        let status = row.status.trim().to_ascii_lowercase();
+        if !matches!(
+            status.as_str(),
+            "planned" | "in-progress" | "blocked" | "done"
+        ) {
+            errors.push(format!(
+                "{}: invalid Status `{}`",
+                row.task,
+                row.status.trim()
+            ));
+        }
+
+        let execution_mode = row.execution_mode.trim().to_ascii_lowercase();
+        if !matches!(
+            execution_mode.as_str(),
+            "per-task" | "per-sprint" | "pr-isolated" | "pr-shared" | "tbd"
+        ) {
+            errors.push(format!(
+                "{}: invalid Execution Mode `{}`",
+                row.task,
+                row.execution_mode.trim()
+            ));
+        }
+
+        if matches!(status.as_str(), "in-progress" | "done") {
+            for (label, value) in [
+                ("Owner", row.owner.as_str()),
+                ("Branch", row.branch.as_str()),
+                ("Worktree", row.worktree.as_str()),
+                ("Execution Mode", row.execution_mode.as_str()),
+                ("PR", row.pr.as_str()),
+            ] {
+                if is_placeholder(value) {
+                    errors.push(format!(
+                        "{}: Status `{}` requires non-placeholder {}",
+                        row.task, status, label
+                    ));
+                }
+            }
+        }
+
+        if !matches!(status.as_str(), "planned" | "blocked") {
+            let owner = row.owner.trim().to_ascii_lowercase();
+            if !owner.contains("subagent") {
+                errors.push(format!(
+                    "{}: Owner must include `subagent` for status `{}`",
+                    row.task, status
+                ));
+            }
+            if owner.contains("main-agent") {
+                errors.push(format!(
+                    "{}: Owner cannot reference main-agent for status `{}`",
+                    row.task, status
+                ));
+            }
+        }
+
+        if execution_mode == "per-task" {
+            if !is_placeholder(&row.branch) {
+                let key = row.branch.trim().to_ascii_lowercase();
+                if let Some(prev_task) = per_task_branches.insert(key.clone(), row.task.clone()) {
+                    errors.push(format!(
+                        "{}: per-task Branch `{}` duplicates task {}",
+                        row.task,
+                        row.branch.trim(),
+                        prev_task
+                    ));
+                }
+            }
+
+            if !is_placeholder(&row.worktree) {
+                let key = row.worktree.trim().to_ascii_lowercase();
+                if let Some(prev_task) = per_task_worktrees.insert(key.clone(), row.task.clone()) {
+                    errors.push(format!(
+                        "{}: per-task Worktree `{}` duplicates task {}",
+                        row.task,
+                        row.worktree.trim(),
+                        prev_task
+                    ));
+                }
+            }
+        }
+    }
+
+    errors
+}
+
+pub fn row_sprint(row: &TaskRow) -> Option<i32> {
+    for token in row.notes.split(';').map(str::trim) {
+        if let Some(value) = token.strip_prefix("sprint=S")
+            && let Ok(number) = value.trim().parse::<i32>()
+        {
+            return Some(number);
+        }
+    }
+
+    parse_sprint_from_task_id(&row.task)
+}
+
+pub fn parse_pr_number(value: &str) -> Option<u64> {
+    let trimmed = value.trim();
+    if is_placeholder(trimmed) {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix('#') {
+        let digits: String = rest.chars().take_while(|ch| ch.is_ascii_digit()).collect();
+        return digits.parse::<u64>().ok();
+    }
+
+    if trimmed.chars().all(|ch| ch.is_ascii_digit()) {
+        return trimmed.parse::<u64>().ok();
+    }
+
+    if let Some((_, tail)) = trimmed.rsplit_once("/pull/") {
+        let digits: String = tail.chars().take_while(|ch| ch.is_ascii_digit()).collect();
+        return digits.parse::<u64>().ok();
+    }
+
+    None
+}
+
+pub fn normalize_pr_display(value: &str) -> String {
+    parse_pr_number(value)
+        .map(|pr| format!("#{pr}"))
+        .unwrap_or_else(|| value.trim().to_string())
+}
+
+pub fn is_placeholder(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return true;
+    }
+
+    if matches!(normalized.as_str(), "-" | "none" | "null" | "n/a" | "?") {
+        return true;
+    }
+
+    normalized.starts_with("tbd")
+}
+
+fn normalize_header_cells(cells: &[String]) -> bool {
+    let expected = [
+        "task",
+        "summary",
+        "owner",
+        "branch",
+        "worktree",
+        "execution mode",
+        "pr",
+        "status",
+        "notes",
+    ];
+
+    if cells.len() != expected.len() {
+        return false;
+    }
+
+    cells
+        .iter()
+        .zip(expected)
+        .all(|(cell, expected)| cell.trim().eq_ignore_ascii_case(expected))
+}
+
+fn split_table_cells(line: &str) -> Vec<String> {
+    let mut cells: Vec<String> = line
+        .trim()
+        .split('|')
+        .map(|cell| cell.trim().to_string())
+        .collect();
+
+    if cells.first().is_some_and(|cell| cell.is_empty()) {
+        cells.remove(0);
+    }
+    if cells.last().is_some_and(|cell| cell.is_empty()) {
+        cells.pop();
+    }
+
+    cells
+}
+
+fn parse_sprint_from_task_id(task: &str) -> Option<i32> {
+    let normalized = task.trim();
+    if !normalized.starts_with('S') {
+        return None;
+    }
+
+    let rest = &normalized[1..];
+    let digits: String = rest.chars().take_while(|ch| ch.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return None;
+    }
+
+    if !rest[digits.len()..].starts_with('T') {
+        return None;
+    }
+
+    digits.parse::<i32>().ok()
+}
+
+fn sanitize_table_value(value: &str) -> String {
+    value.replace(['\n', '\r'], " ").replace('|', "/")
+}
+
+fn format_markdown_row(row: &TaskRow) -> String {
+    format!(
+        "| {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+        sanitize_table_value(&row.task),
+        sanitize_table_value(&row.summary),
+        sanitize_table_value(&row.owner),
+        sanitize_table_value(&row.branch),
+        sanitize_table_value(&row.worktree),
+        sanitize_table_value(&row.execution_mode),
+        sanitize_table_value(&row.pr),
+        sanitize_table_value(&row.status),
+        sanitize_table_value(&row.notes),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        TaskRow, is_placeholder, normalize_pr_display, parse_pr_number, parse_task_table,
+        row_sprint, validate_rows,
+    };
+
+    #[test]
+    fn parse_task_table_extracts_rows() {
+        let body = "## Task Decomposition\n\n| Task | Summary | Owner | Branch | Worktree | Execution Mode | PR | Status | Notes |\n| --- | --- | --- | --- | --- | --- | --- | --- | --- |\n| S4T1 | A | subagent | issue/s4 | issue-s4 | per-sprint | #1 | done | sprint=S4 |\n";
+        let table = parse_task_table(body).expect("parse table");
+        assert_eq!(table.rows().len(), 1);
+        assert_eq!(table.rows()[0].task, "S4T1");
+    }
+
+    #[test]
+    fn row_sprint_prefers_notes_then_task_id() {
+        let row = TaskRow {
+            task: "S2T1".to_string(),
+            summary: String::new(),
+            owner: String::new(),
+            branch: String::new(),
+            worktree: String::new(),
+            execution_mode: String::new(),
+            pr: String::new(),
+            status: String::new(),
+            notes: "x=1; sprint=S9".to_string(),
+            line_index: 0,
+        };
+        assert_eq!(row_sprint(&row), Some(9));
+    }
+
+    #[test]
+    fn placeholder_and_pr_normalization_cover_common_cases() {
+        assert!(is_placeholder("TBD (per-sprint)"));
+        assert_eq!(parse_pr_number("#221"), Some(221));
+        assert_eq!(
+            parse_pr_number("https://github.com/graysurf/nils-cli/pull/221"),
+            Some(221)
+        );
+        assert_eq!(
+            normalize_pr_display("https://github.com/x/y/pull/17"),
+            "#17"
+        );
+    }
+
+    #[test]
+    fn validate_rows_flags_non_subagent_owner_for_done_rows() {
+        let rows = [TaskRow {
+            task: "S4T1".to_string(),
+            summary: "x".to_string(),
+            owner: "main-agent".to_string(),
+            branch: "issue/s4".to_string(),
+            worktree: "issue-s4".to_string(),
+            execution_mode: "per-sprint".to_string(),
+            pr: "#1".to_string(),
+            status: "done".to_string(),
+            notes: "sprint=S4".to_string(),
+            line_index: 0,
+        }];
+        let errs = validate_rows(&rows);
+        assert!(!errs.is_empty());
+    }
+}

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod cli;
 pub mod commands;
 mod execute;
+mod github;
+mod issue_body;
 pub mod output;
 mod render;
 mod task_spec;

--- a/crates/plan-issue-cli/src/task_spec.rs
+++ b/crates/plan-issue-cli/src/task_spec.rs
@@ -62,9 +62,8 @@ pub fn build_task_spec(
     scope: TaskSpecScope,
     options: &TaskSpecBuildOptions,
 ) -> Result<TaskSpecBuild, String> {
-    let repo_root = detect_repo_root();
     let display_path = plan_file.to_string_lossy().to_string();
-    let resolved_plan_path = resolve_repo_relative(&repo_root, plan_file);
+    let resolved_plan_path = resolve_plan_file(plan_file);
     if !resolved_plan_path.is_file() {
         return Err(format!("plan file not found: {display_path}"));
     }
@@ -265,6 +264,11 @@ pub fn agent_home() -> PathBuf {
         }
     }
     detect_repo_root().join(".agents")
+}
+
+pub fn resolve_plan_file(plan_file: &Path) -> PathBuf {
+    let repo_root = detect_repo_root();
+    resolve_repo_relative(&repo_root, plan_file)
 }
 
 fn apply_pr_groups(

--- a/crates/plan-issue-cli/tests/sprint4_delivery.rs
+++ b/crates/plan-issue-cli/tests/sprint4_delivery.rs
@@ -1,0 +1,441 @@
+use std::fs;
+use std::path::Path;
+
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use nils_test_support::StubBinDir;
+
+mod common;
+
+const PLAN_PATH: &str = "docs/plans/plan-issue-rust-cli-full-delivery-plan.md";
+
+fn parse_json(stdout: &str) -> Value {
+    serde_json::from_str(stdout).expect("stdout should be valid JSON")
+}
+
+fn gh_stub_script() -> &'static str {
+    r#"#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${PLAN_ISSUE_GH_LOG:-}" ]]; then
+  printf '%s\n' "$*" >> "$PLAN_ISSUE_GH_LOG"
+fi
+
+cmd="${1:-}"
+sub="${2:-}"
+
+capture_body_file() {
+  local body_file=""
+  local prev=""
+  for arg in "$@"; do
+    if [[ "$prev" == "--body-file" ]]; then
+      body_file="$arg"
+      break
+    fi
+    prev="$arg"
+  done
+
+  if [[ -n "${PLAN_ISSUE_GH_CAPTURE_BODY_FILE:-}" && -n "$body_file" ]]; then
+    cp "$body_file" "$PLAN_ISSUE_GH_CAPTURE_BODY_FILE"
+  fi
+}
+
+capture_comment_file() {
+  local body_file=""
+  local prev=""
+  for arg in "$@"; do
+    if [[ "$prev" == "--body-file" ]]; then
+      body_file="$arg"
+      break
+    fi
+    prev="$arg"
+  done
+
+  if [[ -n "${PLAN_ISSUE_GH_CAPTURE_COMMENT_FILE:-}" && -n "$body_file" ]]; then
+    cp "$body_file" "$PLAN_ISSUE_GH_CAPTURE_COMMENT_FILE"
+  fi
+}
+
+case "$cmd $sub" in
+  "issue view")
+    body_json="${PLAN_ISSUE_GH_BODY_JSON:-}"
+    if [[ -z "$body_json" ]]; then
+      body_json='{"body":""}'
+    fi
+    printf '%s\n' "$body_json"
+    ;;
+  "issue create")
+    printf '%s\n' "${PLAN_ISSUE_GH_CREATE_URL:-https://github.com/graysurf/nils-cli/issues/999}"
+    ;;
+  "issue edit")
+    capture_body_file "$@"
+    ;;
+  "issue comment")
+    capture_comment_file "$@"
+    ;;
+  "issue close")
+    ;;
+  "pr view")
+    pr="${3:-0}"
+    if [[ ",${PLAN_ISSUE_GH_UNMERGED_PRS:-}," == *",${pr},"* ]]; then
+      printf '%s\n' '{"state":"OPEN","mergedAt":null}'
+    else
+      printf '%s\n' '{"state":"MERGED","mergedAt":"2026-02-25T00:00:00Z"}'
+    fi
+    ;;
+  *)
+    printf 'unsupported gh call: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+"#
+}
+
+fn env_path_with_stub(stub_dir: &Path) -> String {
+    let base = std::env::var("PATH").unwrap_or_default();
+    format!("{}:{}", stub_dir.display(), base)
+}
+
+fn issue_body_sprint4_planned() -> String {
+    r#"## Task Decomposition
+
+| Task | Summary | Owner | Branch | Worktree | Execution Mode | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| S3T1 | Implement task-spec generation core using `plan-tooling` | subagent-s3-t1 | issue/s3-t1-implement-task-spec-generation-core-using-plan-t | issue-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.1 |
+| S3T2 | Implement issue-body and sprint-comment rendering engine | subagent-s3-t2 | issue/s3-t2-implement-issue-body-and-sprint-comment-rendering | issue-s3-t2 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.2 |
+| S3T3 | Implement independent local dry-run workflow | subagent-s3-t3 | issue/s3-t3-implement-independent-local-dry-run-workflow | issue-s3-t3 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.3 |
+| S4T1 | Implement GitHub adapter abstraction and `gh` backend | TBD | TBD | TBD | TBD | TBD | planned | sprint=S4; plan-task:Task 4.1 |
+| S4T2 | Implement live plan-level commands | TBD | TBD | TBD | TBD | TBD | planned | sprint=S4; plan-task:Task 4.2 |
+| S4T3 | Implement live sprint-level commands and guide output | TBD | TBD | TBD | TBD | TBD | planned | sprint=S4; plan-task:Task 4.3 |
+"#
+    .to_string()
+}
+
+fn issue_body_sprint4_in_progress() -> String {
+    r#"## Task Decomposition
+
+| Task | Summary | Owner | Branch | Worktree | Execution Mode | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| S3T1 | Implement task-spec generation core using `plan-tooling` | subagent-s3-t1 | issue/s3-t1-implement-task-spec-generation-core-using-plan-t | issue-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.1 |
+| S3T2 | Implement issue-body and sprint-comment rendering engine | subagent-s3-t2 | issue/s3-t2-implement-issue-body-and-sprint-comment-rendering | issue-s3-t2 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.2 |
+| S3T3 | Implement independent local dry-run workflow | subagent-s3-t3 | issue/s3-t3-implement-independent-local-dry-run-workflow | issue-s3-t3 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.3 |
+| S4T1 | Implement GitHub adapter abstraction and `gh` backend | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | #222 | in-progress | sprint=S4; plan-task:Task 4.1 |
+| S4T2 | Implement live plan-level commands | subagent-s4-t2 | issue/s4-t2-implement-live-plan-level-commands | issue-s4-t2 | per-sprint | #223 | in-progress | sprint=S4; plan-task:Task 4.2 |
+| S4T3 | Implement live sprint-level commands and guide output | subagent-s4-t3 | issue/s4-t3-implement-live-sprint-level-commands-and-guide-out | issue-s4-t3 | per-sprint | #224 | in-progress | sprint=S4; plan-task:Task 4.3 |
+"#
+    .to_string()
+}
+
+fn issue_body_plan_done() -> String {
+    r#"## Task Decomposition
+
+| Task | Summary | Owner | Branch | Worktree | Execution Mode | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| S4T1 | Implement GitHub adapter abstraction and `gh` backend | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | #222 | done | sprint=S4; plan-task:Task 4.1 |
+| S4T2 | Implement live plan-level commands | subagent-s4-t2 | issue/s4-t2-implement-live-plan-level-commands | issue-s4-t2 | per-sprint | #223 | done | sprint=S4; plan-task:Task 4.2 |
+| S4T3 | Implement live sprint-level commands and guide output | subagent-s4-t3 | issue/s4-t3-implement-live-sprint-level-commands-and-guide-out | issue-s4-t3 | per-sprint | #224 | done | sprint=S4; plan-task:Task 4.3 |
+"#
+    .to_string()
+}
+
+#[test]
+fn github_adapter_live_commands_use_gh_backend_for_issue_and_pr_state() {
+    let tmp = TempDir::new().expect("temp dir");
+    let stub = StubBinDir::new();
+    stub.write_exe("gh", gh_stub_script());
+
+    let log_path = tmp.path().join("gh.log");
+    let log_s = log_path.to_string_lossy().to_string();
+    let path_env = env_path_with_stub(stub.path());
+
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let body_json = json!({"body": issue_body_sprint4_in_progress()}).to_string();
+
+    let out = common::run_plan_issue_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            "graysurf/nils-cli",
+            "accept-sprint",
+            "--plan",
+            PLAN_PATH,
+            "--issue",
+            "217",
+            "--sprint",
+            "4",
+            "--approved-comment-url",
+            "https://github.com/graysurf/nils-cli/issues/217#issuecomment-4000000000",
+            "--pr-grouping",
+            "per-sprint",
+            "--no-comment",
+        ],
+        &[
+            ("PATH", &path_env),
+            ("PLAN_ISSUE_GH_LOG", &log_s),
+            ("PLAN_ISSUE_GH_BODY_JSON", &body_json),
+            ("AGENT_HOME", &agent_home_s),
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = parse_json(&out.stdout);
+    assert_eq!(payload["command"], "accept-sprint");
+    assert_eq!(payload["status"], "ok");
+
+    let log = fs::read_to_string(&log_path).expect("read log");
+    assert!(log.contains("issue view 217"), "{log}");
+    assert!(log.contains("pr view 222"), "{log}");
+    assert!(log.contains("pr view 223"), "{log}");
+    assert!(log.contains("pr view 224"), "{log}");
+}
+
+#[test]
+fn live_plan_commands_ready_and_close_follow_gate_contracts() {
+    let tmp = TempDir::new().expect("temp dir");
+    let stub = StubBinDir::new();
+    stub.write_exe("gh", gh_stub_script());
+
+    let log_path = tmp.path().join("gh.log");
+    let log_s = log_path.to_string_lossy().to_string();
+    let path_env = env_path_with_stub(stub.path());
+
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let comment_capture = tmp.path().join("ready-plan-comment.md");
+    let comment_capture_s = comment_capture.to_string_lossy().to_string();
+
+    let body_json = json!({"body": issue_body_plan_done()}).to_string();
+
+    let ready_out = common::run_plan_issue_with_env(
+        &[
+            "--format",
+            "json",
+            "--repo",
+            "graysurf/nils-cli",
+            "ready-plan",
+            "--issue",
+            "217",
+            "--summary",
+            "Final plan review",
+        ],
+        &[
+            ("PATH", &path_env),
+            ("PLAN_ISSUE_GH_LOG", &log_s),
+            ("PLAN_ISSUE_GH_BODY_JSON", &body_json),
+            ("PLAN_ISSUE_GH_CAPTURE_COMMENT_FILE", &comment_capture_s),
+            ("AGENT_HOME", &agent_home_s),
+        ],
+    );
+
+    assert_eq!(ready_out.code, 0, "stderr: {}", ready_out.stderr);
+    let ready_payload = parse_json(&ready_out.stdout);
+    assert_eq!(ready_payload["command"], "ready-plan");
+    assert_eq!(
+        ready_payload["payload"]["result"]["label_update_applied"],
+        true
+    );
+
+    let close_body_path = tmp.path().join("close-body.md");
+    fs::write(&close_body_path, issue_body_plan_done()).expect("write close body");
+    let close_body_s = close_body_path.to_string_lossy().to_string();
+
+    let close_out = common::run_plan_issue_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            "graysurf/nils-cli",
+            "close-plan",
+            "--body-file",
+            &close_body_s,
+            "--approved-comment-url",
+            "https://github.com/graysurf/nils-cli/issues/217#issuecomment-4000000001",
+        ],
+        &[
+            ("PATH", &path_env),
+            ("PLAN_ISSUE_GH_LOG", &log_s),
+            ("PLAN_ISSUE_GH_BODY_JSON", &body_json),
+            ("AGENT_HOME", &agent_home_s),
+        ],
+    );
+
+    assert_eq!(close_out.code, 0, "stderr: {}", close_out.stderr);
+    let close_payload = parse_json(&close_out.stdout);
+    assert_eq!(close_payload["command"], "close-plan");
+    assert_eq!(close_payload["payload"]["result"]["issue_closed"], false);
+
+    let log = fs::read_to_string(&log_path).expect("read log");
+    assert!(
+        log.contains("issue edit 217 --repo graysurf/nils-cli --add-label needs-review"),
+        "{log}"
+    );
+    assert!(
+        log.contains("issue comment 217 --repo graysurf/nils-cli --body-file"),
+        "{log}"
+    );
+    assert!(
+        log.contains("pr view 222 --repo graysurf/nils-cli --json state,mergedAt"),
+        "{log}"
+    );
+}
+
+#[test]
+fn live_sprint_commands_start_ready_accept_and_guide_are_deterministic() {
+    let tmp = TempDir::new().expect("temp dir");
+    let stub = StubBinDir::new();
+    stub.write_exe("gh", gh_stub_script());
+
+    let log_path = tmp.path().join("gh.log");
+    let log_s = log_path.to_string_lossy().to_string();
+    let path_env = env_path_with_stub(stub.path());
+
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let start_capture = tmp.path().join("start-sprint-body.md");
+    let start_capture_s = start_capture.to_string_lossy().to_string();
+    let start_body_json = json!({"body": issue_body_sprint4_planned()}).to_string();
+
+    let start_out = common::run_plan_issue_with_env(
+        &[
+            "--format",
+            "json",
+            "--repo",
+            "graysurf/nils-cli",
+            "start-sprint",
+            "--plan",
+            PLAN_PATH,
+            "--issue",
+            "217",
+            "--sprint",
+            "4",
+            "--pr-grouping",
+            "per-sprint",
+            "--no-comment",
+        ],
+        &[
+            ("PATH", &path_env),
+            ("PLAN_ISSUE_GH_LOG", &log_s),
+            ("PLAN_ISSUE_GH_BODY_JSON", &start_body_json),
+            ("PLAN_ISSUE_GH_CAPTURE_BODY_FILE", &start_capture_s),
+            ("AGENT_HOME", &agent_home_s),
+        ],
+    );
+
+    assert_eq!(start_out.code, 0, "stderr: {}", start_out.stderr);
+    let start_payload = parse_json(&start_out.stdout);
+    assert_eq!(start_payload["command"], "start-sprint");
+    assert_eq!(start_payload["payload"]["result"]["synced_issue_rows"], 3);
+
+    let start_body = fs::read_to_string(&start_capture).expect("captured start body");
+    assert!(start_body.contains("subagent-s4-t1"), "{start_body}");
+    assert!(
+        start_body.contains("pr-grouping=per-sprint"),
+        "{start_body}"
+    );
+
+    let ready_out = common::run_plan_issue_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            "graysurf/nils-cli",
+            "ready-sprint",
+            "--plan",
+            PLAN_PATH,
+            "--issue",
+            "217",
+            "--sprint",
+            "4",
+            "--pr-grouping",
+            "per-sprint",
+            "--summary",
+            "Sprint 4 ready",
+            "--no-comment",
+        ],
+        &[
+            ("PATH", &path_env),
+            ("PLAN_ISSUE_GH_LOG", &log_s),
+            ("PLAN_ISSUE_GH_BODY_JSON", &start_body_json),
+            ("AGENT_HOME", &agent_home_s),
+        ],
+    );
+
+    assert_eq!(ready_out.code, 0, "stderr: {}", ready_out.stderr);
+
+    let accept_capture = tmp.path().join("accept-sprint-body.md");
+    let accept_capture_s = accept_capture.to_string_lossy().to_string();
+    let accept_body_json = json!({"body": issue_body_sprint4_in_progress()}).to_string();
+
+    let accept_out = common::run_plan_issue_with_env(
+        &[
+            "--format",
+            "json",
+            "--repo",
+            "graysurf/nils-cli",
+            "accept-sprint",
+            "--plan",
+            PLAN_PATH,
+            "--issue",
+            "217",
+            "--sprint",
+            "4",
+            "--approved-comment-url",
+            "https://github.com/graysurf/nils-cli/issues/217#issuecomment-4000000002",
+            "--pr-grouping",
+            "per-sprint",
+            "--no-comment",
+        ],
+        &[
+            ("PATH", &path_env),
+            ("PLAN_ISSUE_GH_LOG", &log_s),
+            ("PLAN_ISSUE_GH_BODY_JSON", &accept_body_json),
+            ("PLAN_ISSUE_GH_CAPTURE_BODY_FILE", &accept_capture_s),
+            ("AGENT_HOME", &agent_home_s),
+        ],
+    );
+
+    assert_eq!(accept_out.code, 0, "stderr: {}", accept_out.stderr);
+    let accept_body = fs::read_to_string(&accept_capture).expect("captured accept body");
+    assert!(accept_body.contains("| S4T1 |"), "{accept_body}");
+    assert!(accept_body.contains("| done |"), "{accept_body}");
+
+    let guide_out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "--dry-run",
+        "multi-sprint-guide",
+        "--plan",
+        PLAN_PATH,
+        "--from-sprint",
+        "3",
+        "--to-sprint",
+        "4",
+    ]);
+    assert_eq!(guide_out.code, 0, "stderr: {}", guide_out.stderr);
+    let guide_payload = parse_json(&guide_out.stdout);
+    let guide_text = guide_payload["payload"]["result"]["guide"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        guide_text.contains("MULTI_SPRINT_GUIDE_BEGIN"),
+        "{guide_text}"
+    );
+    assert!(guide_text.contains("STEP_1="), "{guide_text}");
+    assert!(
+        guide_text.contains("MULTI_SPRINT_GUIDE_END"),
+        "{guide_text}"
+    );
+}


### PR DESCRIPTION
## Summary
- Implements issue #217 Sprint 4 scope (S4T1+S4T2+S4T3) for `nils-plan-issue-cli` live delivery workflows.

## Scope
- Added `GitHubAdapter` abstraction and `GhCliAdapter` backend for issue/PR read-write operations.
- Implemented live plan-level commands (`start-plan`, `status-plan`, `ready-plan`, `close-plan`, `cleanup-worktrees`) with merge/close gates.
- Implemented live sprint-level commands (`start-sprint`, `ready-sprint`, `accept-sprint`) and deterministic `multi-sprint-guide` output.
- Added Sprint 4 integration coverage in `tests/sprint4_delivery.rs` for backend calls and gate contract behavior.
- Excluded: post-Sprint 4 follow-on tasks and unrelated workspace refactors.

## Testing
- `cargo test -p nils-plan-issue-cli github_adapter` (pass)
- `cargo test -p nils-plan-issue-cli live_plan_commands` (pass)
- `cargo test -p nils-plan-issue-cli live_sprint_commands` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, 85.71%)

## Issue
- #217
