### PR TITLE
feat: Add parity regression suite against shell fixtures (+2 tasks)

### DIFF
--- a/crates/plan-issue-cli/src/cli.rs
+++ b/crates/plan-issue-cli/src/cli.rs
@@ -17,7 +17,7 @@ pub enum OutputFormat {
     disable_help_subcommand = true
 )]
 pub struct Cli {
-    /// Repository override for GitHub-backed operations.
+    /// Pass-through repository target for GitHub operations.
     #[arg(long, global = true, value_name = "owner/repo")]
     pub repo: Option<String>,
 

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -129,7 +129,7 @@ pub enum Command {
     /// Wrapper of issue-delivery-loop ready-for-review for final plan review.
     ReadyPlan(ReadyPlanArgs),
 
-    /// Close the single plan issue after final approval and merged PR gates.
+    /// Close the single plan issue after final approval + merged PR gates, then enforce worktree cleanup.
     ClosePlan(ClosePlanArgs),
 
     /// Enforce cleanup of all issue-assigned task worktrees.
@@ -144,7 +144,7 @@ pub enum Command {
     /// Enforce merged-PR gate, sync sprint status=done, then post accepted comment.
     AcceptSprint(AcceptSprintArgs),
 
-    /// Print the full repeated command flow for a plan.
+    /// Print the full repeated command flow for a plan (1 plan = 1 issue).
     MultiSprintGuide(MultiSprintGuideArgs),
 }
 
@@ -196,10 +196,8 @@ impl Command {
             Self::ReadySprint(args) => validate_grouping(&args.grouping),
             Self::AcceptSprint(args) => validate_grouping(&args.grouping),
             Self::ClosePlan(args) => validate_close_plan_args(args, dry_run),
-            Self::StatusPlan(_)
-            | Self::ReadyPlan(_)
-            | Self::CleanupWorktrees(_)
-            | Self::MultiSprintGuide(_) => Ok(()),
+            Self::MultiSprintGuide(args) => validate_multi_sprint_guide_args(args),
+            Self::StatusPlan(_) | Self::ReadyPlan(_) | Self::CleanupWorktrees(_) => Ok(()),
         }
     }
 }
@@ -219,19 +217,45 @@ fn validate_grouping(grouping: &GroupingArgs) -> Result<(), ValidationError> {
 }
 
 fn validate_close_plan_args(args: &ClosePlanArgs, dry_run: bool) -> Result<(), ValidationError> {
+    if args.issue.is_some() && args.body_file.is_some() {
+        return Err(ValidationError::new(
+            "conflicting-issue-source",
+            "use either --issue or --body-file for close-plan, not both",
+        ));
+    }
+
+    if dry_run && args.body_file.is_none() {
+        return Err(ValidationError::new(
+            "missing-body-file",
+            "--body-file is required for close-plan --dry-run",
+        ));
+    }
+
     if !dry_run && args.issue.is_none() {
         return Err(ValidationError::new(
             "missing-issue",
-            "--issue is required for close-plan unless --dry-run is enabled",
+            "--issue is required for close-plan",
         ));
     }
 
-    if dry_run && args.issue.is_none() && args.body_file.is_none() {
+    if !dry_run && args.body_file.is_some() {
         return Err(ValidationError::new(
-            "missing-issue-source",
-            "--dry-run close-plan requires --issue or --body-file",
+            "invalid-body-file-mode",
+            "--body-file is only supported with --dry-run",
         ));
     }
 
+    Ok(())
+}
+
+fn validate_multi_sprint_guide_args(args: &MultiSprintGuideArgs) -> Result<(), ValidationError> {
+    if let Some(to_sprint) = args.to_sprint
+        && to_sprint < args.from_sprint
+    {
+        return Err(ValidationError::new(
+            "invalid-sprint-range",
+            "--from-sprint must be <= --to-sprint",
+        ));
+    }
     Ok(())
 }

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -904,11 +904,7 @@ fn run_multi_sprint_guide(args: &MultiSprintGuideArgs) -> Result<Value, CommandE
         .map(|s| s.number)
         .max()
         .unwrap_or(from_sprint);
-    let to_sprint = args
-        .to_sprint
-        .map(i32::from)
-        .unwrap_or(max_sprint)
-        .max(from_sprint);
+    let to_sprint = args.to_sprint.map(i32::from).unwrap_or(max_sprint);
 
     if to_sprint < from_sprint {
         return Err(CommandError::usage(

--- a/crates/plan-issue-cli/tests/sprint5_delivery.rs
+++ b/crates/plan-issue-cli/tests/sprint5_delivery.rs
@@ -1,0 +1,322 @@
+use std::fs;
+use std::path::PathBuf;
+
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+mod common;
+
+const DUCK_PLAN: &str = "crates/plan-tooling/tests/fixtures/split_prs/duck-plan.md";
+const SHELL_PARITY_DIR: &str = "tests/fixtures/shell_parity";
+
+fn parse_json(stdout: &str) -> Value {
+    serde_json::from_str(stdout).expect("stdout should be valid JSON")
+}
+
+fn shell_fixture(name: &str) -> String {
+    let path = PathBuf::from(SHELL_PARITY_DIR).join(name);
+    fs::read_to_string(&path).unwrap_or_else(|err| {
+        panic!("failed to read fixture {}: {err}", path.display());
+    })
+}
+
+fn normalize_shell_text(text: &str, agent_home: &str) -> String {
+    text.trim()
+        .replace(agent_home, "$AGENT_HOME")
+        .replace("\\<", "<")
+        .replace("\\>", ">")
+}
+
+fn fixture_subcommands(help_fixture: &str) -> Vec<(String, String)> {
+    let mut rows = Vec::new();
+    let mut in_section = false;
+    for line in help_fixture.lines() {
+        if line.trim() == "Subcommands:" {
+            in_section = true;
+            continue;
+        }
+        if in_section && line.trim().is_empty() {
+            break;
+        }
+        if !in_section {
+            continue;
+        }
+
+        if !line.starts_with("  ") {
+            continue;
+        }
+        let trimmed = line.trim();
+        let mut parts = trimmed.splitn(2, char::is_whitespace);
+        let Some(name) = parts.next() else { continue };
+        let desc = parts.next().unwrap_or("").trim();
+        if !name.is_empty() && !desc.is_empty() {
+            rows.push((name.to_string(), desc.to_string()));
+        }
+    }
+    rows
+}
+
+#[test]
+fn parity_shell_help_surface_tracks_shell_fixture_commands() {
+    let fixture = shell_fixture("help.txt");
+    let out = common::run_plan_issue(&["--help"]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    for (name, description) in fixture_subcommands(&fixture) {
+        assert!(
+            out.stdout.contains(&name),
+            "help output missing subcommand `{name}`\n{}",
+            out.stdout
+        );
+        assert!(
+            out.stdout.contains(&description),
+            "help output missing description `{description}`\n{}",
+            out.stdout
+        );
+    }
+
+    for token in [
+        "--repo <owner/repo>",
+        "Pass-through repository target for GitHub operations",
+        "--dry-run",
+        "Print write actions without mutating GitHub state",
+    ] {
+        assert!(
+            out.stdout.contains(token),
+            "help output missing token `{token}`\n{}",
+            out.stdout
+        );
+    }
+}
+
+#[test]
+fn parity_shell_multi_sprint_guide_matches_shell_fixture_after_normalization() {
+    let tmp = TempDir::new().expect("temp dir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "multi-sprint-guide",
+            "--plan",
+            DUCK_PLAN,
+            "--from-sprint",
+            "1",
+            "--to-sprint",
+            "2",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    let payload = parse_json(&out.stdout);
+    let actual = payload["payload"]["result"]["guide"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    let expected = shell_fixture("multi_sprint_guide_dry_run.txt");
+
+    assert_eq!(
+        normalize_shell_text(&actual, &agent_home_s),
+        normalize_shell_text(&expected, &agent_home_s),
+    );
+}
+
+#[test]
+fn parity_shell_start_comment_template_matches_shell_fixture() {
+    let tmp = TempDir::new().expect("temp dir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "start-sprint",
+            "--plan",
+            DUCK_PLAN,
+            "--issue",
+            "217",
+            "--sprint",
+            "1",
+            "--pr-grouping",
+            "per-sprint",
+            "--no-comment",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    let payload = parse_json(&out.stdout);
+    let comment_path = payload["payload"]["result"]["comment_path"]
+        .as_str()
+        .expect("comment path");
+    let actual = fs::read_to_string(comment_path).expect("read rendered comment");
+    let expected = shell_fixture("comment_template_start.md");
+
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+#[test]
+fn command_guardrails_close_plan_requires_body_file_in_dry_run_mode() {
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "--dry-run",
+        "close-plan",
+        "--issue",
+        "217",
+        "--approved-comment-url",
+        "https://github.com/graysurf/nils-cli/issues/217#issuecomment-5000000001",
+    ]);
+
+    assert_eq!(out.code, 1, "stderr: {}", out.stderr);
+    let payload = parse_json(&out.stdout);
+    assert_eq!(payload["status"], "error");
+    assert_eq!(payload["error"]["code"], "missing-body-file");
+    assert_eq!(
+        payload["error"]["message"],
+        "--body-file is required for close-plan --dry-run"
+    );
+}
+
+#[test]
+fn command_guardrails_close_plan_rejects_body_file_without_dry_run() {
+    let tmp = TempDir::new().expect("temp dir");
+    let body_file = tmp.path().join("body.md");
+    fs::write(&body_file, "## Task Decomposition\n").expect("body file");
+    let body_file_s = body_file.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "close-plan",
+        "--issue",
+        "217",
+        "--body-file",
+        &body_file_s,
+        "--approved-comment-url",
+        "https://github.com/graysurf/nils-cli/issues/217#issuecomment-5000000002",
+    ]);
+
+    assert_eq!(out.code, 1, "stderr: {}", out.stderr);
+    let payload = parse_json(&out.stdout);
+    assert_eq!(payload["status"], "error");
+    assert_eq!(payload["error"]["code"], "conflicting-issue-source");
+    assert_eq!(
+        payload["error"]["message"],
+        "use either --issue or --body-file for close-plan, not both"
+    );
+}
+
+#[test]
+fn command_guardrails_multi_sprint_guide_rejects_reverse_range() {
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "multi-sprint-guide",
+        "--plan",
+        DUCK_PLAN,
+        "--from-sprint",
+        "3",
+        "--to-sprint",
+        "1",
+    ]);
+
+    assert_eq!(out.code, 1, "stderr: {}", out.stderr);
+    let payload = parse_json(&out.stdout);
+    assert_eq!(payload["status"], "error");
+    assert_eq!(payload["error"]["code"], "invalid-sprint-range");
+    assert_eq!(
+        payload["error"]["message"],
+        "--from-sprint must be <= --to-sprint"
+    );
+}
+
+#[test]
+fn json_contract_multi_sprint_guide_success_envelope_is_stable() {
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "--dry-run",
+        "multi-sprint-guide",
+        "--plan",
+        DUCK_PLAN,
+        "--from-sprint",
+        "1",
+        "--to-sprint",
+        "2",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    let payload = parse_json(&out.stdout);
+    assert_eq!(
+        payload["schema_version"],
+        "plan-issue-cli.multi.sprint.guide.v1"
+    );
+    assert_eq!(payload["command"], "multi-sprint-guide");
+    assert_eq!(payload["status"], "ok");
+    assert_eq!(payload["payload"]["binary"], "plan-issue");
+    assert_eq!(payload["payload"]["execution_mode"], "live");
+    assert_eq!(payload["payload"]["dry_run"], true);
+    assert_eq!(payload["payload"]["arguments"]["from_sprint"], 1);
+    assert_eq!(payload["payload"]["arguments"]["to_sprint"], 2);
+    assert!(
+        payload["payload"]["result"]["guide"]
+            .as_str()
+            .is_some_and(|guide| guide.contains("MULTI_SPRINT_GUIDE_BEGIN")),
+        "{}",
+        out.stdout
+    );
+}
+
+#[test]
+fn json_contract_guardrail_error_envelope_is_stable() {
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "--dry-run",
+        "close-plan",
+        "--issue",
+        "217",
+        "--approved-comment-url",
+        "https://github.com/graysurf/nils-cli/issues/217#issuecomment-5000000003",
+    ]);
+    assert_eq!(out.code, 1, "stderr: {}", out.stderr);
+
+    let payload = parse_json(&out.stdout);
+    assert_eq!(payload["schema_version"], "plan-issue-cli.close.plan.v1");
+    assert_eq!(payload["command"], "close-plan");
+    assert_eq!(payload["status"], "error");
+    assert_eq!(payload["error"]["code"], "missing-body-file");
+    assert!(payload["error"]["message"].is_string(), "{}", out.stdout);
+}
+
+#[test]
+fn json_contract_local_binary_success_envelope_is_stable() {
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "build-task-spec",
+        "--plan",
+        "docs/plans/plan-issue-rust-cli-full-delivery-plan.md",
+        "--sprint",
+        "2",
+        "--pr-grouping",
+        "per-sprint",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    let payload = parse_json(&out.stdout);
+    assert_eq!(payload["command"], "build-task-spec");
+    assert_eq!(payload["status"], "ok");
+    assert_eq!(payload["payload"]["binary"], "plan-issue-local");
+    assert_eq!(payload["payload"]["execution_mode"], "local");
+}


### PR DESCRIPTION
## Summary
- Implements Sprint 5 for issue #217 on the shared sprint branch/worktree/PR path.
- Adds parity regressions, command guardrails, and JSON contract compatibility coverage for `plan-issue`.

## Scope
- Added `crates/plan-issue-cli/tests/sprint5_delivery.rs` with `parity_shell`, `command_guardrails`, and `json_contract` coverage for Sprint 5 acceptance.
- Hardened command validation in `crates/plan-issue-cli/src/commands/mod.rs` for `close-plan` input modes and `multi-sprint-guide` sprint range checks.
- Updated `crates/plan-issue-cli/src/execute.rs` to preserve explicit reverse-range validation behavior.
- Synced help text wording in `crates/plan-issue-cli/src/cli.rs` / `commands/mod.rs` to match shell parity fixtures.

## Testing
- `cargo test -p nils-plan-issue-cli parity_shell -- --nocapture` (pass)
- `cargo test -p nils-plan-issue-cli command_guardrails -- --nocapture` (pass)
- `cargo test -p nils-plan-issue-cli json_contract -- --nocapture` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass; total line coverage 85.72%)

## Issue
- #217
