### PR TITLE
feat: Add comprehensive auto regression matrix tests (+2 tasks)

### DIFF
--- a/crates/plan-tooling/README.md
+++ b/crates/plan-tooling/README.md
@@ -2,8 +2,8 @@
 
 ## Overview
 plan-tooling works with Plan Format v1 markdown files. It can parse plans to JSON, validate plan
-files, compute dependency batches for a sprint, scaffold new plans, and generate deterministic
-task-to-PR split specs.
+files, compute dependency batches for a sprint, scaffold new plans, and generate task-to-PR split
+specs in deterministic or auto strategy modes.
 
 ## Usage
 ```text
@@ -14,7 +14,7 @@ Commands:
   to-json   Parse a plan markdown file into a stable JSON schema
   validate  Lint plan markdown files
   batches   Compute dependency layers (parallel batches) for a sprint
-  split-prs Build deterministic task-to-PR split records
+  split-prs Build task-to-PR split records (deterministic/auto)
   scaffold  Create a new plan from template
   help      Display help message
 
@@ -41,13 +41,18 @@ Help:
 - deterministic mode:
   - `--pr-grouping per-sprint`: one shared `pr_group` per sprint (`s<n>`).
   - `--pr-grouping group`: every selected task needs explicit `--pr-group` mapping.
-- strategy auto contract (future behavior, currently returns `not implemented`):
+- auto mode:
   - scoring inputs are `Complexity`, dependency topology, and `Location` overlap.
-  - in `pr-grouping=group`, explicit `--pr-group` mappings pin tasks and remaining tasks are auto-grouped.
+  - in `pr-grouping=group`, explicit `--pr-group` mappings are optional pins; remaining tasks are auto-grouped.
+  - `pr-grouping=per-sprint` keeps one shared group per sprint (`s<n>`).
   - ordering and tie-breakers stay deterministic (`Task N.M`, then `SxTy`, then lexical summary).
 - deterministic examples:
   - `split-prs --file docs/plans/example-plan.md --scope sprint --sprint 1 --pr-grouping per-sprint --format tsv`
   - `split-prs --file docs/plans/example-plan.md --scope sprint --sprint 2 --pr-grouping group --pr-group S2T1=isolated --pr-group S2T2=shared --pr-group S2T3=shared --format json`
+- auto example:
+  - `split-prs --file docs/plans/example-plan.md --scope sprint --sprint 2 --pr-grouping group --strategy auto --format json`
+- rollback switchback:
+  - if auto rollout is unhealthy, pin orchestration calls to `--strategy deterministic` until follow-up fixes land.
 
 ### scaffold
 - `scaffold --slug <kebab-case> [--title <title>] [--force]`: Write to

--- a/crates/plan-tooling/docs/runbooks/split-prs-build-task-spec-cutover.md
+++ b/crates/plan-tooling/docs/runbooks/split-prs-build-task-spec-cutover.md
@@ -41,7 +41,8 @@ And preserve these notes keys:
 - optional `shared-pr-anchor=...` when a group has more than one task
 
 ## Group Mode Rules
-- `--pr-grouping group` requires explicit `--pr-group` for every selected task.
+- `--pr-grouping group` + `--strategy deterministic` requires explicit `--pr-group` for every selected task.
+- `--pr-grouping group` + `--strategy auto` accepts optional `--pr-group` pins and auto-assigns remaining tasks.
 - mapping key accepts either `SxTy` or plan task id (`Task N.M`).
 - shared group output should map to one PR (`pr-shared` downstream execution mode).
 
@@ -83,8 +84,10 @@ changing heuristics.
 
 ```bash
 LOCAL_CORPUS="/Users/terry/Project/graysurf/nils-cli/docs/plans"
+OUT_DIR="${AGENT_HOME}/out/plan-tooling-split-prs"
 
 if [ -d "$LOCAL_CORPUS" ]; then
+  mkdir -p "$OUT_DIR"
   find "$LOCAL_CORPUS" -name '*-plan.md' -exec plan-tooling validate --file '{}' ';'
 
   # Deterministic baseline output check for an overlap-heavy plan.
@@ -94,16 +97,25 @@ if [ -d "$LOCAL_CORPUS" ]; then
     --sprint 2 \
     --pr-grouping per-sprint \
     --strategy deterministic \
-    --format json | jq -S . > /tmp/split-prs-local-corpus-s2.json
+    --format json | jq -S . > "$OUT_DIR/split-prs-local-corpus-s2-deterministic.json"
+
+  # Auto-mode smoke check for generated grouping without manual mapping.
+  plan-tooling split-prs \
+    --file "$LOCAL_CORPUS/plan-tooling-split-prs-cutover-plan.md" \
+    --scope sprint \
+    --sprint 2 \
+    --pr-grouping group \
+    --strategy auto \
+    --format json | jq -S . > "$OUT_DIR/split-prs-local-corpus-s2-auto.json"
 
   # Conflict-risk visibility: inspect shared-group concentration by sprint record.
   jq -r '.records[] | [.task_id, .pr_group, .summary] | @tsv' \
-    /tmp/split-prs-local-corpus-s2.json | sort
+    "$OUT_DIR/split-prs-local-corpus-s2-auto.json" | sort
 fi
 ```
 
 ## Auto Strategy
-`--strategy auto` is intentionally non-functional in v1 and returns `not implemented` with planned factors:
-- `Complexity`
-- `Location`
-- `Dependencies`
+`--strategy auto` is implemented in v1 with deterministic grouping semantics:
+- scores merge candidates using `Complexity`, dependency topology, and `Location` overlap.
+- preserves stable output ordering and notes schema.
+- allows optional `--pr-group` pins in `pr-grouping=group`.

--- a/crates/plan-tooling/docs/runbooks/split-prs-migration.md
+++ b/crates/plan-tooling/docs/runbooks/split-prs-migration.md
@@ -1,7 +1,8 @@
 # split-prs Migration
 
 ## Objective
-Migrate plan task splitting from embedded downstream logic to `plan-tooling split-prs` with deterministic output compatibility.
+Migrate plan task splitting from embedded downstream logic to `plan-tooling split-prs` with
+deterministic and auto strategy compatibility.
 
 ## Before / After
 Before:
@@ -21,6 +22,18 @@ plan-tooling split-prs \
   [--pr-group <task=group>]... \
   --strategy deterministic \
   --format tsv > <out.tsv>
+```
+
+Auto group example (no full manual mapping):
+
+```bash
+plan-tooling split-prs \
+  --file <plan.md> \
+  --scope sprint \
+  --sprint <n> \
+  --pr-grouping group \
+  --strategy auto \
+  --format json
 ```
 
 ## Required Compatibility
@@ -44,17 +57,19 @@ plan-tooling split-prs \
 - Use `per-sprint` when one shared PR should represent all sprint tasks.
 - Use `group` for mixed isolated/shared PR shapes.
 - In `pr-grouping=group` + `strategy=deterministic`, every selected task must have an explicit mapping.
-- In `pr-grouping=group` + `strategy=auto` (future runtime), explicit mappings are optional pins and remaining tasks are auto-assigned.
+- In `pr-grouping=group` + `strategy=auto`, explicit mappings are optional pins and remaining tasks are auto-assigned.
 
 ## Auto Strategy Status
-- `--strategy auto` is intentionally not implemented in v1.
-- Current message references planned scoring factors: `Complexity`, `Location`, `Dependencies`.
-- Contract is fixed ahead of runtime work: auto grouping remains deterministic and uses stable tie-break keys.
+- `--strategy auto` is implemented in v1 runtime.
+- Grouping uses deterministic heuristics from `Complexity`, dependency topology, and `Location`.
+- Explicit `--pr-group` mappings in auto/group mode are optional pins and still validated.
+- Output ordering and notes schema remain deterministic and backward compatible.
 
 ## Release Gate Checklist
 1. Verify deterministic command output against fixture expectations.
-2. Verify downstream consumers still parse TSV columns/notes without changes.
-3. Verify fallback/rollback command sequence is documented before rollout.
+2. Verify auto/group output is byte-stable across repeated runs.
+3. Verify downstream consumers still parse TSV columns/notes without changes.
+4. Verify fallback/rollback command sequence is documented before rollout.
 
 ## Deterministic Rollback Command Path
 If auto rollout is disabled or deferred, keep downstream command paths pinned to deterministic mode:
@@ -75,3 +90,23 @@ If downstream integration fails:
 1. Keep `split-prs` implementation intact.
 2. Revert downstream invocation wiring only.
 3. Re-run fixture parity checks and reopen cutover PR once fixed.
+
+## Emergency Switchback (Restore Auto to Not-Implemented)
+Use this only if production incidents require disabling auto runtime behavior in the CLI itself.
+
+Impacted files:
+- `crates/plan-tooling/src/split_prs.rs`
+- `crates/plan-tooling/tests/split_prs.rs`
+- `crates/plan-tooling/docs/specs/split-prs-contract-v1.md`
+- `crates/plan-tooling/README.md`
+
+Switchback commands:
+
+```bash
+# Revert the auto-runtime introduction commit from issue #220 Sprint 2.
+git revert --no-edit e1cdc5a
+
+# Validate fallback behavior and deterministic guardrails.
+cargo test -p nils-plan-tooling --test split_prs split_prs_auto_not_implemented -- --exact
+cargo test -p nils-plan-tooling --test split_prs split_prs_error_group_requires_mapping -- --exact
+```

--- a/crates/plan-tooling/docs/specs/split-prs-contract-v1.md
+++ b/crates/plan-tooling/docs/specs/split-prs-contract-v1.md
@@ -6,8 +6,7 @@ schema and deterministic ordering.
 
 v1 runtime behavior:
 - `strategy=deterministic` is fully implemented.
-- `strategy=auto` contract is frozen for implementation, but runtime still returns
-  `not implemented`.
+- `strategy=auto` is fully implemented with deterministic heuristics.
 
 ## CLI
 
@@ -43,9 +42,9 @@ Defaults:
 - `strategy=deterministic`, `pr-grouping=group`:
   - every selected task must have explicit `--pr-group` mapping.
   - mapping key can be generated task id (`SxTy`) or plan task id (`Task N.M`).
-- `strategy=auto`, `pr-grouping=per-sprint` (contract):
+- `strategy=auto`, `pr-grouping=per-sprint`:
   - generated grouping is still deterministic and anchored by sprint key.
-- `strategy=auto`, `pr-grouping=group` (contract):
+- `strategy=auto`, `pr-grouping=group`:
   - explicit `--pr-group` mappings are optional pins.
   - unmapped tasks are auto-assigned by rubric.
   - output still preserves deterministic ordering and stable anchor semantics.
@@ -69,26 +68,29 @@ Defaults:
 ## Deterministic Ordering
 - Records are emitted by sprint number, then task appearance order in plan markdown.
 - Group anchors are the first emitted record in each `pr_group`.
-- Tie-break rules for future auto assignment are stable and deterministic:
+- Auto assignment tie-break rules are stable and deterministic:
   - primary stable key: `Task N.M`
   - secondary key: generated `SxTy`
   - tertiary key: lexical summary
 
-## Auto Scoring Rubric (Contract for Future Runtime)
-When `strategy=auto` is implemented, grouping decisions use three scored signals:
+## Auto Scoring Rubric (Runtime)
+When `strategy=auto` is used in `pr-grouping=group`, grouping decisions use three scored signals:
 - `Complexity`:
-  - normalized to bucket (`low`, `medium`, `high`) from integer range.
-  - missing complexity uses stable fallback bucket `medium`.
+  - complexity is summed per candidate group.
+  - merges are capped at total complexity `<= 20`.
+  - missing/invalid complexity falls back to `5`.
 - `Dependencies`:
-  - dependency-layer depth increases grouping pressure for coordination-heavy tasks.
-  - missing dependencies use fallback layer `0`.
+  - dependency links between candidate groups increase merge affinity.
+  - dependency layering contributes a serial-span penalty to reduce long-chain merges.
+  - unresolved/external dependencies are ignored for intra-scope topology.
 - `Location`:
-  - overlap of normalized location tokens prefers co-location when risk is low.
-  - missing locations use fallback token `unscoped`.
+  - same-layer tasks with normalized path overlap are unioned first.
+  - overlap count contributes to merge affinity scoring.
+  - missing locations simply contribute no overlap signal.
 
 Deterministic tie-break algorithm for equal scores:
 1. Prefer explicit pinned `--pr-group` entries.
-2. Prefer lower dependency-layer index when coordination risk is equal.
+2. Prefer highest scored merge candidates.
 3. Prefer lexical `Task N.M`.
 4. Prefer lexical generated `SxTy`.
 
@@ -128,10 +130,9 @@ Object shape:
 
 ## Strategy Runtime Status
 - `strategy=deterministic`: enabled in v1 runtime.
-- `strategy=auto`: **not implemented in v1 runtime**.
-  - command returns non-zero.
-  - error message must mention planned factors exactly once each:
-    `Complexity`, `Location`, `Dependencies`.
+- `strategy=auto`: enabled in v1 runtime.
+  - deterministic ordering and notes schema are preserved.
+  - in `pr-grouping=group`, explicit pins are optional and validated when provided.
 
 ## Error Matrix
 Core errors:
@@ -148,10 +149,10 @@ Deterministic/group-mode errors:
 - unknown mapping key in `--pr-group`
 - missing mapping for any selected task in `group` mode
 
-Auto-contract errors (future runtime):
+Auto-mode errors:
 - `strategy=auto` with unknown pinned mapping key
 - `strategy=auto` with invalid pin syntax in `--pr-group`
-- `strategy=auto` fallback assignment impossible because selected scope has no eligible tasks
+- `strategy=auto` request where selected scope has no tasks
 
 ## Compatibility Guarantees
 - TSV and JSON field names remain unchanged across strategies.

--- a/crates/plan-tooling/src/completion.rs
+++ b/crates/plan-tooling/src/completion.rs
@@ -103,7 +103,7 @@ fn build_completion_command() -> Command {
         )
         .subcommand(
             Command::new("split-prs")
-                .about("Build deterministic task-to-PR split records")
+                .about("Build task-to-PR split records (deterministic/auto)")
                 .arg(
                     Arg::new("file")
                         .long("file")
@@ -135,14 +135,16 @@ fn build_completion_command() -> Command {
                 .arg(
                     Arg::new("pr-group")
                         .long("pr-group")
-                        .help("Explicit group mapping: <task-or-plan-id>=<group>")
+                        .help(
+                            "Group pin: <task-or-plan-id>=<group> (required in deterministic/group, optional in auto/group)",
+                        )
                         .value_name("mapping")
                         .action(ArgAction::Append),
                 )
                 .arg(
                     Arg::new("strategy")
                         .long("strategy")
-                        .help("Split strategy")
+                        .help("Split strategy (deterministic requires full group mapping)")
                         .value_name("strategy")
                         .value_parser(["deterministic", "auto"]),
                 )

--- a/crates/plan-tooling/src/split_prs.rs
+++ b/crates/plan-tooling/src/split_prs.rs
@@ -10,7 +10,7 @@ const USAGE: &str = r#"Usage:
   plan-tooling split-prs --file <plan.md> --pr-grouping <per-sprint|group> [options]
 
 Purpose:
-  Build deterministic task-to-PR split records from a Plan Format v1 file.
+  Build task-to-PR split records from a Plan Format v1 file.
 
 Required:
   --file <path>                    Plan file to parse
@@ -19,7 +19,9 @@ Required:
 Options:
   --scope <plan|sprint>            Scope to split (default: sprint)
   --sprint <n>                     Sprint number when --scope sprint
-  --pr-group <task=group>          Explicit mapping; repeatable (group mode only)
+  --pr-group <task=group>          Group pin; repeatable (group mode only)
+                                   deterministic/group: required for every task
+                                   auto/group: optional pins + auto assignment for remaining tasks
   --strategy <deterministic|auto>  Split strategy (default: deterministic)
   --owner-prefix <text>            Owner prefix (default: subagent)
   --branch-prefix <text>           Branch prefix (default: issue)

--- a/crates/plan-tooling/src/usage.rs
+++ b/crates/plan-tooling/src/usage.rs
@@ -74,7 +74,7 @@ fn print_help(stderr: bool) {
     );
     let _ = writeln!(
         out,
-        "  {:<10}  Build deterministic task-to-PR split records",
+        "  {:<10}  Build task-to-PR split records (deterministic/auto)",
         "split-prs"
     );
     let _ = writeln!(out, "  {:<10}  Create a new plan from template", "scaffold");

--- a/crates/plan-tooling/tests/fixtures/split_prs/auto_regression_matrix_expected.json
+++ b/crates/plan-tooling/tests/fixtures/split_prs/auto_regression_matrix_expected.json
@@ -1,0 +1,45 @@
+{
+  "file": "plan.md",
+  "scope": "sprint",
+  "sprint": 1,
+  "pr_grouping": "group",
+  "strategy": "auto",
+  "records": [
+    {
+      "task_id": "S1T1",
+      "summary": "Build scheduler conflict model",
+      "branch": "issue/s1-t1-build-scheduler-conflict-model",
+      "worktree": "issue-s1-t1",
+      "owner": "subagent-s1-t1",
+      "notes": "sprint=S1; plan-task:Task 1.1; validate=cargo test -p nils-plan-tooling split_prs; pr-grouping=group; pr-group=s1-auto-g1; shared-pr-anchor=S1T1",
+      "pr_group": "s1-auto-g1"
+    },
+    {
+      "task_id": "S1T2",
+      "summary": "Pair scheduler conflict signals with dependency scoring",
+      "branch": "issue/s1-t2-pair-scheduler-conflict-signals-with-dependency",
+      "worktree": "issue-s1-t2",
+      "owner": "subagent-s1-t2",
+      "notes": "sprint=S1; plan-task:Task 1.2; deps=Task 1.1; validate=cargo test -p nils-plan-tooling batches; pr-grouping=group; pr-group=s1-auto-g1; shared-pr-anchor=S1T1",
+      "pr_group": "s1-auto-g1"
+    },
+    {
+      "task_id": "S1T3",
+      "summary": "Integrate external blocker reconciliation",
+      "branch": "issue/s1-t3-integrate-external-blocker-reconciliation",
+      "worktree": "issue-s1-t3",
+      "owner": "subagent-s1-t3",
+      "notes": "sprint=S1; plan-task:Task 1.3; deps=EXT-API-BLOCKER,Task 1.1; validate=bash scripts/ci/docs-hygiene-audit.sh --strict; pr-grouping=group; pr-group=s1-auto-g2; shared-pr-anchor=S1T3",
+      "pr_group": "s1-auto-g2"
+    },
+    {
+      "task_id": "S1T4",
+      "summary": "Publish rollback and migration notes",
+      "branch": "issue/s1-t4-publish-rollback-and-migration-notes",
+      "worktree": "issue-s1-t4",
+      "owner": "subagent-s1-t4",
+      "notes": "sprint=S1; plan-task:Task 1.4; deps=Task 1.3; validate=rg -n 'rollback' crates/plan-tooling/docs/runbooks/split-prs-migration.md; pr-grouping=group; pr-group=s1-auto-g2; shared-pr-anchor=S1T3",
+      "pr_group": "s1-auto-g2"
+    }
+  ]
+}

--- a/crates/plan-tooling/tests/fixtures/split_prs/auto_regression_matrix_plan.md
+++ b/crates/plan-tooling/tests/fixtures/split_prs/auto_regression_matrix_plan.md
@@ -1,0 +1,49 @@
+# Plan: split-prs auto regression matrix fixture
+
+## Overview
+Fixture for auto strategy matrix coverage: complexity pressure, external blockers, and location overlap.
+
+## Sprint 1: Auto matrix
+
+### Task 1.1: Build scheduler conflict model
+- **Location**:
+  - crates/plan-tooling/src/split_prs.rs
+  - crates/plan-tooling/src/batches.rs
+- **Description**: High-complexity base task that anchors shared overlap heuristics.
+- **Dependencies**:
+  - none
+- **Complexity**: 9
+- **Validation**:
+  - cargo test -p nils-plan-tooling split_prs
+
+### Task 1.2: Pair scheduler conflict signals with dependency scoring
+- **Location**:
+  - crates/plan-tooling/src/split_prs.rs
+  - crates/plan-tooling/src/batches.rs
+- **Description**: Shares locations with Task 1.1 and depends on it.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 8
+- **Validation**:
+  - cargo test -p nils-plan-tooling batches
+
+### Task 1.3: Integrate external blocker reconciliation
+- **Location**:
+  - scripts/ci/docs-hygiene-audit.sh
+- **Description**: Includes an unresolved external blocker dependency while still depending on Task 1.1.
+- **Dependencies**:
+  - EXT-API-BLOCKER
+  - Task 1.1
+- **Complexity**: 6
+- **Validation**:
+  - bash scripts/ci/docs-hygiene-audit.sh --strict
+
+### Task 1.4: Publish rollback and migration notes
+- **Location**:
+  - crates/plan-tooling/docs/runbooks/split-prs-migration.md
+- **Description**: Lightweight docs task depending on external blocker integration.
+- **Dependencies**:
+  - Task 1.3
+- **Complexity**: 2
+- **Validation**:
+  - rg -n 'rollback' crates/plan-tooling/docs/runbooks/split-prs-migration.md

--- a/crates/plan-tooling/tests/split_prs.rs
+++ b/crates/plan-tooling/tests/split_prs.rs
@@ -1,6 +1,8 @@
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::PathBuf;
 
+use pretty_assertions::assert_eq;
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -178,12 +180,9 @@ fn split_prs_auto_group_without_mapping_succeeds() {
     let records = value["records"].as_array().expect("records");
     assert_eq!(records.len(), 3);
 
-    let mut group_by_task: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
-    let mut first_task_by_group: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
-    let mut size_by_group: std::collections::HashMap<String, usize> =
-        std::collections::HashMap::new();
+    let mut group_by_task: HashMap<String, String> = HashMap::new();
+    let mut first_task_by_group: HashMap<String, String> = HashMap::new();
+    let mut size_by_group: HashMap<String, usize> = HashMap::new();
     for record in records {
         let task_id = record["task_id"].as_str().unwrap_or_default().to_string();
         let group = record["pr_group"].as_str().unwrap_or_default().to_string();
@@ -212,6 +211,243 @@ fn split_prs_auto_group_without_mapping_succeeds() {
             );
         }
     }
+}
+
+#[test]
+fn split_prs_auto_group_partial_mapping_preserves_pinned_group() {
+    let dir = TempDir::new().expect("tempdir");
+    common::write_file(&dir.path().join("plan.md"), &fixture_text("duck-plan.md"));
+
+    let out = common::run_plan_tooling(
+        dir.path(),
+        &[
+            "split-prs",
+            "--file",
+            "plan.md",
+            "--scope",
+            "sprint",
+            "--sprint",
+            "2",
+            "--pr-grouping",
+            "group",
+            "--strategy",
+            "auto",
+            "--pr-group",
+            "S2T3=manual-docs",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    let value: Value = serde_json::from_str(&out.stdout).expect("json");
+    let records = value["records"].as_array().expect("records");
+    assert_eq!(records.len(), 3);
+
+    let mut group_by_task: HashMap<String, String> = HashMap::new();
+    let mut notes_by_task: HashMap<String, String> = HashMap::new();
+    for record in records {
+        let task_id = record["task_id"].as_str().unwrap_or_default().to_string();
+        let group = record["pr_group"].as_str().unwrap_or_default().to_string();
+        let notes = record["notes"].as_str().unwrap_or_default().to_string();
+        group_by_task.insert(task_id.clone(), group);
+        notes_by_task.insert(task_id, notes);
+    }
+
+    let pinned = group_by_task.get("S2T3").expect("S2T3 group");
+    assert_eq!(pinned, "manual-docs");
+    assert!(
+        notes_by_task
+            .get("S2T3")
+            .expect("S2T3 notes")
+            .contains("pr-group=manual-docs")
+    );
+    assert!(
+        !notes_by_task
+            .get("S2T3")
+            .expect("S2T3 notes")
+            .contains("shared-pr-anchor=")
+    );
+
+    let auto_a = group_by_task.get("S2T1").expect("S2T1 group");
+    let auto_b = group_by_task.get("S2T2").expect("S2T2 group");
+    assert_eq!(auto_a, auto_b, "overlap pair should stay shared");
+    assert!(auto_a.starts_with("s2-auto-g"), "{auto_a}");
+    assert_ne!(auto_a, pinned);
+    assert!(
+        notes_by_task
+            .get("S2T1")
+            .expect("S2T1 notes")
+            .contains("shared-pr-anchor=S2T1")
+    );
+    assert!(
+        notes_by_task
+            .get("S2T2")
+            .expect("S2T2 notes")
+            .contains("shared-pr-anchor=S2T1")
+    );
+}
+
+#[test]
+fn split_prs_auto_group_rejects_malformed_pin_entry() {
+    let dir = TempDir::new().expect("tempdir");
+    common::write_file(&dir.path().join("plan.md"), &fixture_text("duck-plan.md"));
+
+    let out = common::run_plan_tooling(
+        dir.path(),
+        &[
+            "split-prs",
+            "--file",
+            "plan.md",
+            "--scope",
+            "sprint",
+            "--sprint",
+            "2",
+            "--pr-grouping",
+            "group",
+            "--strategy",
+            "auto",
+            "--pr-group",
+            "S2T2",
+        ],
+    );
+    assert_eq!(out.code, 1);
+    assert!(
+        out.stderr
+            .contains("--pr-group must use <task-or-plan-id>=<group> format"),
+        "{}",
+        out.stderr
+    );
+}
+
+#[test]
+fn split_prs_auto_group_rejects_unknown_pin_key() {
+    let dir = TempDir::new().expect("tempdir");
+    common::write_file(&dir.path().join("plan.md"), &fixture_text("duck-plan.md"));
+
+    let out = common::run_plan_tooling(
+        dir.path(),
+        &[
+            "split-prs",
+            "--file",
+            "plan.md",
+            "--scope",
+            "sprint",
+            "--sprint",
+            "2",
+            "--pr-grouping",
+            "group",
+            "--strategy",
+            "auto",
+            "--pr-group",
+            "S2T9=manual-docs",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(out.code, 1);
+    assert!(out.stderr.contains("unknown task keys"), "{}", out.stderr);
+}
+
+#[test]
+fn split_prs_auto_repeatability_is_byte_stable() {
+    for fixture in [
+        "duck-plan.md",
+        "auto_sparse_plan.md",
+        "auto_overlap_plan.md",
+        "auto_regression_matrix_plan.md",
+    ] {
+        let dir = TempDir::new().expect("tempdir");
+        common::write_file(&dir.path().join("plan.md"), &fixture_text(fixture));
+
+        let first = common::run_plan_tooling(
+            dir.path(),
+            &[
+                "split-prs",
+                "--file",
+                "plan.md",
+                "--scope",
+                "sprint",
+                "--sprint",
+                "1",
+                "--pr-grouping",
+                "group",
+                "--strategy",
+                "auto",
+                "--format",
+                "json",
+            ],
+        );
+        let second = common::run_plan_tooling(
+            dir.path(),
+            &[
+                "split-prs",
+                "--file",
+                "plan.md",
+                "--scope",
+                "sprint",
+                "--sprint",
+                "1",
+                "--pr-grouping",
+                "group",
+                "--strategy",
+                "auto",
+                "--format",
+                "json",
+            ],
+        );
+
+        assert_eq!(
+            first.code, 0,
+            "first run failed for fixture {fixture}: {}",
+            first.stderr
+        );
+        assert_eq!(
+            second.code, 0,
+            "second run failed for fixture {fixture}: {}",
+            second.stderr
+        );
+        assert_eq!(
+            first.stdout, second.stdout,
+            "repeatability drift in {fixture}"
+        );
+    }
+}
+
+#[test]
+fn split_prs_auto_matrix_fixture_matches_expected_json() {
+    let dir = TempDir::new().expect("tempdir");
+    common::write_file(
+        &dir.path().join("plan.md"),
+        &fixture_text("auto_regression_matrix_plan.md"),
+    );
+
+    let out = common::run_plan_tooling(
+        dir.path(),
+        &[
+            "split-prs",
+            "--file",
+            "plan.md",
+            "--scope",
+            "sprint",
+            "--sprint",
+            "1",
+            "--pr-grouping",
+            "group",
+            "--strategy",
+            "auto",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    let actual: Value = serde_json::from_str(&out.stdout).expect("json");
+    let mut expected: Value =
+        serde_json::from_str(&fixture_text("auto_regression_matrix_expected.json"))
+            .expect("fixture json");
+    expected["file"] = actual["file"].clone();
+    assert_eq!(actual, expected);
 }
 
 #[test]
@@ -344,7 +580,7 @@ fn split_prs_non_regression_auto_overlap_heavy_plan_scaffold() {
     let records = value["records"].as_array().expect("records");
     assert_eq!(records.len(), 3);
 
-    let mut unique_groups = std::collections::BTreeSet::new();
+    let mut unique_groups = BTreeSet::new();
     for record in records {
         let group = record["pr_group"].as_str().unwrap_or_default();
         let notes = record["notes"].as_str().unwrap_or_default();


### PR DESCRIPTION
## Summary
- Adds comprehensive `split-prs --strategy auto` regression matrix coverage, including repeatability, pin validation, and high-complexity/external-blocker overlap fixture assertions.
- Aligns `split-prs` help/completion and plan-tooling documentation with shipped auto behavior and deterministic fallback guidance.
- Completes Sprint 3 release-gate validation for issue #220 with required checks and coverage threshold evidence.

## Scope
- Implemented Sprint 3 shared scope for S3T1/S3T2/S3T3 in `plan-tooling` tests, fixtures, CLI help/completion, and migration/cutover docs.
- Added rollback switchback guidance and local-corpus regression command updates using `$AGENT_HOME/out` artifacts.
- Explicitly excluded runtime auto-scoring algorithm changes and downstream orchestration script rewiring.

## Testing
- `cargo test -p nils-plan-tooling split_prs` (pass)
- `cargo test -p nils-plan-tooling --test completion_outside_repo` (pass)
- `cargo test -p nils-plan-tooling to_json` (pass)
- `cargo test -p nils-plan-tooling batches` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass: 85.74% line coverage)

## Issue
- #220
