### PR TITLE
feat: Wire skill entrypoint to Rust CLI and keep compatibility wrapper (+2 tasks)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,6 +1853,7 @@ name = "nils-plan-issue-cli"
 version = "0.5.1"
 dependencies = [
  "clap",
+ "clap_complete",
  "nils-plan-tooling",
  "nils-test-support",
  "pretty_assertions",

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Each crate is either a standalone CLI binary or a shared library used across the
 - [crates/gemini-cli](crates/gemini-cli): Provider-specific CLI lane for Gemini workflows, with adapters over `nils-common::provider_runtime`.
 - [crates/semantic-commit](crates/semantic-commit): Helper CLI for generating staged context and creating semantic commits.
 - [crates/plan-tooling](crates/plan-tooling): Plan Format v1 tooling CLI (to-json/validate/batches/scaffold/split-prs).
+- [crates/plan-issue-cli](crates/plan-issue-cli): Plan issue orchestration CLI (`plan-issue` for live mode, `plan-issue-local` for local rehearsal).
 
 ## Shared helper policy (`nils-common`)
 
@@ -70,6 +71,7 @@ Assets:
 - [completions/zsh/](completions/zsh/): zsh completions (plus `aliases.zsh`)
 - [completions/bash/](completions/bash/): bash completions (plus `aliases.bash`)
 - [wrappers/](wrappers/): dev-only wrapper scripts
+- [wrappers/plan-issue-delivery-loop.sh](wrappers/plan-issue-delivery-loop.sh): compatibility wrapper that delegates to `plan-issue`
 
 Local shell setup:
 

--- a/completions/bash/plan-issue
+++ b/completions/bash/plan-issue
@@ -1,0 +1,63 @@
+# nils-cli bash completion: plan-issue
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_plan_issue_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
+
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
+
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
+
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
+}
+
+_NILS_PLAN_ISSUE_BASH_GENERATED_STATE=0
+
+_nils_cli_plan_issue_load_generated_bash() {
+  _nils_cli_plan_issue_source_common_bash || return 1
+
+  # command plan-issue completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_PLAN_ISSUE_BASH_GENERATED_STATE" \
+    "_nils_cli_plan_issue_generated" \
+    "plan-issue" \
+    "_plan-issue" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
+_nils_cli_plan_issue_complete() {
+  if ! _nils_cli_plan_issue_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_bash
+    else
+      COMPREPLY=()
+    fi
+    return 0
+  fi
+
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev=''
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
+
+  _nils_cli_plan_issue_generated "plan-issue" "$cur" "$prev"
+}
+
+if _nils_cli_plan_issue_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_plan_issue_complete plan-issue plan-issue-delivery-loop.sh
+else
+  complete -F _nils_cli_plan_issue_complete plan-issue plan-issue-delivery-loop.sh
+fi

--- a/completions/bash/plan-issue-local
+++ b/completions/bash/plan-issue-local
@@ -1,0 +1,63 @@
+# nils-cli bash completion: plan-issue-local
+
+if [[ -z ${BASH_VERSION-} ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+shopt -s progcomp 2>/dev/null || true
+
+_nils_cli_plan_issue_local_source_common_bash() {
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1 && return 0
+
+  local source_file="${BASH_SOURCE[0]}"
+  local script_dir=''
+  script_dir="$(cd -- "$(dirname -- "$source_file")" && pwd -P)" || return 1
+
+  local helper_path="${script_dir}/completion-adapter-common.bash"
+  [[ -r "$helper_path" ]] || return 1
+
+  # shellcheck source=/dev/null
+  source "$helper_path" || return 1
+
+  declare -F _nils_cli_completion_common_load_generated_bash >/dev/null 2>&1
+}
+
+_NILS_PLAN_ISSUE_LOCAL_BASH_GENERATED_STATE=0
+
+_nils_cli_plan_issue_local_load_generated_bash() {
+  _nils_cli_plan_issue_local_source_common_bash || return 1
+
+  # command plan-issue-local completion bash
+  _nils_cli_completion_common_load_generated_bash \
+    "_NILS_PLAN_ISSUE_LOCAL_BASH_GENERATED_STATE" \
+    "_nils_cli_plan_issue_local_generated" \
+    "plan-issue-local" \
+    "_plan-issue-local" \
+    '^if \[\[ "\${BASH_VERSINFO\[0\]}" -eq 4 ' \
+    '^fi$'
+}
+
+_nils_cli_plan_issue_local_complete() {
+  if ! _nils_cli_plan_issue_local_load_generated_bash; then
+    if declare -F _nils_cli_completion_common_fail_closed_bash >/dev/null 2>&1; then
+      _nils_cli_completion_common_fail_closed_bash
+    else
+      COMPREPLY=()
+    fi
+    return 0
+  fi
+
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev=''
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
+
+  _nils_cli_plan_issue_local_generated "plan-issue-local" "$cur" "$prev"
+}
+
+if _nils_cli_plan_issue_local_source_common_bash; then
+  _nils_cli_completion_common_register_bash _nils_cli_plan_issue_local_complete plan-issue-local
+else
+  complete -F _nils_cli_plan_issue_local_complete plan-issue-local
+fi

--- a/completions/zsh/_plan-issue
+++ b/completions/zsh/_plan-issue
@@ -1,0 +1,60 @@
+#compdef plan-issue plan-issue-delivery-loop.sh
+
+_nils_cli_plan_issue_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_plan-issue]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_PLAN_ISSUE_ZSH_GENERATED_STATE=0
+
+_nils_cli_plan_issue_load_generated_zsh() {
+  _nils_cli_plan_issue_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_PLAN_ISSUE_ZSH_GENERATED_STATE" \
+    "_nils_cli_plan_issue_generated" \
+    "plan-issue" \
+    "_plan-issue" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_plan_issue_generated" \]; then$' \
+    '^fi$'
+}
+
+_plan-issue() {
+  emulate -L zsh -o extendedglob
+
+  if ! _nils_cli_plan_issue_load_generated_zsh; then
+    if (( $+functions[_nils_cli_completion_common_fail_closed_zsh] )); then
+      _nils_cli_completion_common_fail_closed_zsh
+    fi
+    return 1
+  fi
+
+  _nils_cli_plan_issue_generated
+}
+
+if _nils_cli_plan_issue_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _plan-issue plan-issue plan-issue-delivery-loop.sh
+else
+  compdef _plan-issue plan-issue plan-issue-delivery-loop.sh
+fi

--- a/completions/zsh/_plan-issue-local
+++ b/completions/zsh/_plan-issue-local
@@ -1,0 +1,60 @@
+#compdef plan-issue-local
+
+_nils_cli_plan_issue_local_source_common_zsh() {
+  (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+
+  local source_file="${functions_source[_plan-issue-local]-}"
+  local helper_path=''
+
+  if [[ -n "$source_file" && -r "$source_file" ]]; then
+    helper_path="${source_file:h}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  fi
+
+  local dir=''
+  for dir in "${fpath[@]}"; do
+    helper_path="${dir}/_completion-adapter-common.zsh"
+    if [[ -r "$helper_path" ]]; then
+      source "$helper_path" || return 1
+      (( $+functions[_nils_cli_completion_common_load_generated_zsh] )) && return 0
+    fi
+  done
+
+  return 1
+}
+
+typeset -gi _NILS_PLAN_ISSUE_LOCAL_ZSH_GENERATED_STATE=0
+
+_nils_cli_plan_issue_local_load_generated_zsh() {
+  _nils_cli_plan_issue_local_source_common_zsh || return 1
+
+  _nils_cli_completion_common_load_generated_zsh \
+    "_NILS_PLAN_ISSUE_LOCAL_ZSH_GENERATED_STATE" \
+    "_nils_cli_plan_issue_local_generated" \
+    "plan-issue-local" \
+    "_plan-issue-local" \
+    '^if \[ "\$funcstack\[1\]" = "_nils_cli_plan_issue_local_generated" \]; then$' \
+    '^fi$'
+}
+
+_plan-issue-local() {
+  emulate -L zsh -o extendedglob
+
+  if ! _nils_cli_plan_issue_local_load_generated_zsh; then
+    if (( $+functions[_nils_cli_completion_common_fail_closed_zsh] )); then
+      _nils_cli_completion_common_fail_closed_zsh
+    fi
+    return 1
+  fi
+
+  _nils_cli_plan_issue_local_generated
+}
+
+if _nils_cli_plan_issue_local_source_common_zsh; then
+  _nils_cli_completion_common_register_zsh _plan-issue-local plan-issue-local
+else
+  compdef _plan-issue-local plan-issue-local
+fi

--- a/crates/plan-issue-cli/Cargo.toml
+++ b/crates/plan-issue-cli/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/bin/plan-issue-local.rs"
 
 [dependencies]
 clap = { workspace = true }
+clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 plan-tooling = { version = "0.5.1", path = "../plan-tooling", package = "nils-plan-tooling" }

--- a/crates/plan-issue-cli/README.md
+++ b/crates/plan-issue-cli/README.md
@@ -8,11 +8,13 @@ Sprint 1 establishes the v1 command contract, gate semantics, and deterministic 
 to preserve orchestration compatibility before implementation cutover.
 
 ## Status
-- Current scope includes Sprint 3 implementation:
+- Current scope includes Sprint 6 implementation:
   - deterministic task-spec generation core using `plan-tooling` parsing primitives
   - issue-body and sprint-comment markdown rendering engine
-  - local-first dry-run workflow for `plan-issue-local`
-  - Sprint 2 scaffold + typed command model + text/JSON output envelopes
+  - live plan-level and sprint-level orchestration commands
+  - local-first rehearsal workflow for `plan-issue-local`
+  - parity and JSON contract regression coverage
+  - `completion <bash|zsh>` export path for `plan-issue` and `plan-issue-local`
 
 ## Specifications
 - [CLI contract v1](docs/specs/plan-issue-cli-contract-v1.md)

--- a/crates/plan-issue-cli/src/commands/completion.rs
+++ b/crates/plan-issue-cli/src/commands/completion.rs
@@ -1,0 +1,15 @@
+use clap::{Args, ValueEnum};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
+pub enum CompletionShell {
+    Bash,
+    Zsh,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct CompletionArgs {
+    /// Shell to generate completion script for.
+    #[arg(value_enum, value_name = "shell")]
+    pub shell: CompletionShell,
+}

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod build;
+pub mod completion;
 pub mod plan;
 pub mod sprint;
 
@@ -9,6 +10,7 @@ use serde_json::Value;
 use crate::ValidationError;
 
 use self::build::{BuildPlanTaskSpecArgs, BuildTaskSpecArgs};
+use self::completion::CompletionArgs;
 use self::plan::{
     CleanupWorktreesArgs, ClosePlanArgs, ReadyPlanArgs, StartPlanArgs, StatusPlanArgs,
 };
@@ -146,6 +148,9 @@ pub enum Command {
 
     /// Print the full repeated command flow for a plan (1 plan = 1 issue).
     MultiSprintGuide(MultiSprintGuideArgs),
+
+    /// Export shell completion script.
+    Completion(CompletionArgs),
 }
 
 impl Command {
@@ -162,6 +167,7 @@ impl Command {
             Self::ReadySprint(_) => "ready-sprint",
             Self::AcceptSprint(_) => "accept-sprint",
             Self::MultiSprintGuide(_) => "multi-sprint-guide",
+            Self::Completion(_) => "completion",
         }
     }
 
@@ -182,6 +188,7 @@ impl Command {
             Self::ReadySprint(args) => serde_json::to_value(args),
             Self::AcceptSprint(args) => serde_json::to_value(args),
             Self::MultiSprintGuide(args) => serde_json::to_value(args),
+            Self::Completion(args) => serde_json::to_value(args),
         };
 
         payload.unwrap_or(Value::Null)
@@ -197,7 +204,10 @@ impl Command {
             Self::AcceptSprint(args) => validate_grouping(&args.grouping),
             Self::ClosePlan(args) => validate_close_plan_args(args, dry_run),
             Self::MultiSprintGuide(args) => validate_multi_sprint_guide_args(args),
-            Self::StatusPlan(_) | Self::ReadyPlan(_) | Self::CleanupWorktrees(_) => Ok(()),
+            Self::Completion(_)
+            | Self::StatusPlan(_)
+            | Self::ReadyPlan(_)
+            | Self::CleanupWorktrees(_) => Ok(()),
         }
     }
 }

--- a/crates/plan-issue-cli/src/completion.rs
+++ b/crates/plan-issue-cli/src/completion.rs
@@ -1,0 +1,24 @@
+use std::io;
+
+use clap::CommandFactory;
+use clap_complete::{Generator, Shell, generate};
+
+use crate::BinaryFlavor;
+use crate::cli::Cli;
+use crate::commands::completion::CompletionShell;
+
+pub fn run(binary: BinaryFlavor, shell: CompletionShell) -> i32 {
+    let mut command = Cli::command().name(binary.binary_name());
+    let bin_name = binary.binary_name();
+
+    match shell {
+        CompletionShell::Bash => print_completion(Shell::Bash, &mut command, bin_name),
+        CompletionShell::Zsh => print_completion(Shell::Zsh, &mut command, bin_name),
+    }
+
+    0
+}
+
+fn print_completion<G: Generator>(generator: G, command: &mut clap::Command, bin_name: &str) {
+    generate(generator, command, bin_name, &mut io::stdout());
+}

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -51,6 +51,10 @@ pub fn execute(binary: BinaryFlavor, cli: &Cli) -> Result<Value, CommandError> {
             run_accept_sprint(binary, cli.dry_run, cli.repo.as_deref(), args)
         }
         CliCommand::MultiSprintGuide(args) => run_multi_sprint_guide(args),
+        CliCommand::Completion(_) => Err(CommandError::usage(
+            "completion-direct-output-only",
+            "completion output is emitted directly; run `<binary> completion <bash|zsh>`",
+        )),
     }
 }
 

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod commands;
+mod completion;
 mod execute;
 mod github;
 mod issue_body;
@@ -13,6 +14,7 @@ use clap::Parser;
 use serde_json::json;
 
 use crate::cli::Cli;
+use crate::commands::Command;
 
 pub const EXIT_SUCCESS: i32 = 0;
 pub const EXIT_FAILURE: i32 = 1;
@@ -101,6 +103,10 @@ where
             return code;
         }
     };
+
+    if let Command::Completion(args) = &cli.command {
+        return completion::run(binary, args.shell);
+    }
 
     let output_format = match cli.resolve_output_format() {
         Ok(format) => format,

--- a/docs/reports/completion-coverage-matrix.md
+++ b/docs/reports/completion-coverage-matrix.md
@@ -5,7 +5,6 @@
 - Inventory source of truth: `bash scripts/workspace-bins.sh`.
 - Obligation rule for this matrix: all workspace binaries are `required` unless explicitly `excluded` as internal/example binaries.
 - Explicit exclusion: `cli-template` is `excluded` because it is an example/template CLI and is out of scope for user-facing release contract migration (`docs/plans/repo-completion-standard-rollout-plan.md`).
-- Explicit exclusion: `plan-issue` and `plan-issue-local` are `excluded` until Sprint 6 completion rollout finalizes their user-facing command surface.
 - Explicit treatment: `image-processing` is `required` (user-facing CLI in `README.md`) and must ship clap-first thin completion adapters in both shells.
 - Alias policy: alias families are required only for `git-scope` (`gs*`), `git-cli` (`gx*`), `codex-cli` (`cx*`), and `fzf-cli` (`fx*`) per `AGENTS.md`; other binaries have no alias requirement.
 - Completion quality baseline for every `required` binary: subcommands + long/short flags + declared value candidates.
@@ -36,13 +35,13 @@
 | `image-processing` | `required` | `present` (`_image-processing`) | `present` (`image-processing`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Explicitly treated as a user-facing CLI (not internal/example); completion is exported by `image-processing completion <bash|zsh>` and loaded through thin fail-closed shell adapters. |
 | `macos-agent` | `required` | `present` (`_macos-agent`) | `present` (`macos-agent`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories. |
 | `memo-cli` | `required` | `present` (`_memo-cli`) | `present` (`memo-cli`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories. |
-| `plan-issue` | `excluded` | `missing` | `missing` | not required | `not required (excluded)` | Sprint 2 scaffold binary; completion assets are deferred until Sprint 6 completion rollout. |
-| `plan-issue-local` | `excluded` | `missing` | `missing` | not required | `not required (excluded)` | Sprint 2 scaffold binary; completion assets are deferred until Sprint 6 completion rollout. |
+| `plan-issue` | `required` | `present` (`_plan-issue`) | `present` (`plan-issue`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Rust orchestration CLI entrypoint; completion is exported by `plan-issue completion <bash|zsh>` and loaded through thin fail-closed shell adapters. |
+| `plan-issue-local` | `required` | `present` (`_plan-issue-local`) | `present` (`plan-issue-local`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Local rehearsal binary paired with `plan-issue`; completion is exported by `plan-issue-local completion <bash|zsh>` and loaded through thin fail-closed shell adapters. |
 | `plan-tooling` | `required` | `present` (`_plan-tooling`) | `present` (`plan-tooling`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories. |
 | `screen-record` | `required` | `present` (`_screen-record`) | `present` (`screen-record`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories. |
 | `semantic-commit` | `required` | `present` (`_semantic-commit`) | `present` (`semantic-commit`) | not required | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories. |
 
 ## Exclusion summary
 
-- `excluded`: `cli-template`, `plan-issue`, `plan-issue-local` (explicit staged exclusions).
+- `excluded`: `cli-template` (explicit staged exclusion).
 - No other workspace binary is excluded in this matrix.

--- a/docs/runbooks/wrappers-mode-usage.md
+++ b/docs/runbooks/wrappers-mode-usage.md
@@ -28,9 +28,14 @@ This applies to all current wrappers under `wrappers/`:
 - `image-processing`
 - `macos-agent`
 - `memo-cli`
+- `plan-issue`
+- `plan-issue-local`
 - `plan-tooling`
 - `screen-record`
 - `semantic-commit`
+
+Compatibility shim:
+- `plan-issue-delivery-loop.sh` delegates to `plan-issue` and preserves historical entrypoint naming.
 
 ## Environment Contract
 

--- a/wrappers/plan-issue
+++ b/wrappers/plan-issue
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bin_name="plan-issue"
+crate_name="nils-plan-issue-cli"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
+fi
+
+if command -v cargo >/dev/null 2>&1; then
+  exec cargo run -q -p "$crate_name" -- "${args[@]}"
+fi
+
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
+exit 1

--- a/wrappers/plan-issue-delivery-loop.sh
+++ b/wrappers/plan-issue-delivery-loop.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+plan_issue_wrapper="${script_dir}/plan-issue"
+
+if [[ -x "$plan_issue_wrapper" ]]; then
+  exec "$plan_issue_wrapper" "$@"
+fi
+
+if command -v plan-issue >/dev/null 2>&1; then
+  exec plan-issue "$@"
+fi
+
+if command -v cargo >/dev/null 2>&1; then
+  exec cargo run -q -p nils-plan-issue-cli -- "$@"
+fi
+
+echo "plan-issue-delivery-loop.sh: plan-issue binary not found (install or build nils-plan-issue-cli)" >&2
+exit 1

--- a/wrappers/plan-issue-local
+++ b/wrappers/plan-issue-local
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bin_name="plan-issue-local"
+crate_name="nils-plan-issue-cli"
+args=("$@")
+
+self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+self_path="$self_dir/$(basename -- "${BASH_SOURCE[0]}")"
+
+mode="${NILS_WRAPPER_MODE:-auto}"
+install_prefix="${NILS_WRAPPER_INSTALL_PREFIX:-$HOME/.local/nils-cli}"
+
+if [[ "$install_prefix" == "~" ]]; then
+  install_prefix="$HOME"
+elif [[ "$install_prefix" == "~/"* ]]; then
+  install_prefix="$HOME/${install_prefix#~/}"
+fi
+
+if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
+  echo "${bin_name}: invalid NILS_WRAPPER_MODE='${mode}' (expected: auto|debug|installed)" >&2
+  exit 64
+fi
+
+is_self_candidate() {
+  local candidate="$1"
+  [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
+}
+
+resolve_installed() {
+  local candidate=""
+
+  candidate="${install_prefix}/${bin_name}"
+  if [[ -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v "$bin_name" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]] && ! is_self_candidate "$candidate"; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+run_debug() {
+  if command -v cargo >/dev/null 2>&1; then
+    exec cargo run -q -p "$crate_name" --bin plan-issue-local -- "${args[@]}"
+  fi
+
+  echo "${bin_name}: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
+  exit 1
+}
+
+run_installed() {
+  local installed=""
+  if installed="$(resolve_installed)"; then
+    exec "$installed" "${args[@]}"
+  fi
+
+  echo "${bin_name}: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2
+  echo "${bin_name}: expected ${install_prefix}/${bin_name} or a PATH entry" >&2
+  exit 1
+}
+
+case "$mode" in
+  debug)
+    run_debug
+    ;;
+  installed)
+    run_installed
+    ;;
+esac
+
+installed=""
+if installed="$(resolve_installed)"; then
+  exec "$installed" "${args[@]}"
+fi
+
+if command -v cargo >/dev/null 2>&1; then
+  exec cargo run -q -p "$crate_name" --bin plan-issue-local -- "${args[@]}"
+fi
+
+echo "${bin_name}: binary not found (install via cargo install or build the workspace)" >&2
+exit 1


### PR DESCRIPTION
## Summary
- Implements Sprint 6 for issue #217 on the shared sprint branch/worktree/PR path.
- Completes wrapper cutover to Rust `plan-issue`, completion rollout for `plan-issue`/`plan-issue-local`, and final readiness artifacts.

## Scope
- Added Rust wrapper entrypoints: `wrappers/plan-issue`, `wrappers/plan-issue-local`, and compatibility shim `wrappers/plan-issue-delivery-loop.sh` delegating to `plan-issue`.
- Added `completion bash|zsh` support to `nils-plan-issue-cli` for both binaries and committed shell completion adapters:
  - `completions/zsh/_plan-issue`, `completions/bash/plan-issue`
  - `completions/zsh/_plan-issue-local`, `completions/bash/plan-issue-local`
- Updated completion rollout/docs metadata and user docs:
  - `docs/reports/completion-coverage-matrix.md`
  - `docs/runbooks/wrappers-mode-usage.md`
  - `README.md`, `crates/plan-issue-cli/README.md`
- Wrote Sprint 6 acceptance artifact and final readiness artifact:
  - `$AGENT_HOME/out/plan-issue-rust-cli/sprint-6/acceptance.md` (`Result: PASS`)
  - `$AGENT_HOME/out/plan-issue-rust-cli/final-readiness.md`

## Testing
- `test -f wrappers/plan-issue-delivery-loop.sh` (pass)
- `zsh -n completions/zsh/_plan-issue` (pass)
- `zsh -n completions/zsh/_plan-issue-local` (pass)
- `bash -n completions/bash/plan-issue` (pass)
- `bash -n completions/bash/plan-issue-local` (pass)
- `zsh -f tests/zsh/completion.test.zsh` (pass)
- `cargo test -p nils-plan-issue-cli cli_help -- --nocapture` (pass)
- `cargo run -q -p nils-plan-issue-cli -- completion bash` (pass)
- `cargo run -q -p nils-plan-issue-cli -- completion zsh` (pass)
- `cargo run -q -p nils-plan-issue-cli --bin plan-issue-local -- completion bash` (pass)
- `cargo run -q -p nils-plan-issue-cli --bin plan-issue-local -- completion zsh` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass; total line coverage 85.72%)

## Issue
- #217
