### PR TITLE
feat: Consolidate integration test harness around nils-test-support command utilities (+1 tasks)

### DIFF
--- a/crates/nils-test-support/src/cmd.rs
+++ b/crates/nils-test-support/src/cmd.rs
@@ -74,6 +74,13 @@ impl CmdOptions {
         Self::default()
     }
 
+    pub fn with_envs(mut self, envs: &[(&str, &str)]) -> Self {
+        for (key, value) in envs {
+            self = self.with_env(key, value);
+        }
+        self
+    }
+
     pub fn with_env_remove_prefix(mut self, prefix: &str) -> Self {
         for (key, _) in std::env::vars_os() {
             let key = key.to_string_lossy();
@@ -137,10 +144,7 @@ impl CmdOptions {
 /// - `envs` overrides or adds environment variables (existing vars are preserved).
 /// - `stdin` (when `Some`) is piped into the process before waiting for output.
 pub fn run(bin: &Path, args: &[&str], envs: &[(&str, &str)], stdin: Option<&[u8]>) -> CmdOutput {
-    let mut options = CmdOptions::default();
-    for (key, value) in envs {
-        options = options.with_env(key, value);
-    }
+    let mut options = CmdOptions::default().with_envs(envs);
     if let Some(input) = stdin {
         options = options.with_stdin_bytes(input);
     }
@@ -155,10 +159,7 @@ pub fn run_in_dir(
     envs: &[(&str, &str)],
     stdin: Option<&[u8]>,
 ) -> CmdOutput {
-    let mut options = CmdOptions::default().with_cwd(dir);
-    for (key, value) in envs {
-        options = options.with_env(key, value);
-    }
+    let mut options = CmdOptions::default().with_cwd(dir).with_envs(envs);
     if let Some(input) = stdin {
         options = options.with_stdin_bytes(input);
     }
@@ -167,11 +168,7 @@ pub fn run_in_dir(
 
 /// Build command options with cwd + env pairs for common integration test usage.
 pub fn options_in_dir_with_envs(dir: &Path, envs: &[(&str, &str)]) -> CmdOptions {
-    let mut options = CmdOptions::default().with_cwd(dir);
-    for (key, value) in envs {
-        options = options.with_env(key, value);
-    }
-    options
+    CmdOptions::default().with_cwd(dir).with_envs(envs)
 }
 
 /// Resolve a workspace binary by name and run it with explicit options.

--- a/crates/plan-issue-cli/tests/common.rs
+++ b/crates/plan-issue-cli/tests/common.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use nils_test_support::cmd::run_resolved_in_dir;
+use nils_test_support::cmd::{CmdOptions, run_resolved};
 
 pub struct CmdOut {
     pub code: i32,
@@ -8,9 +8,15 @@ pub struct CmdOut {
     pub stderr: String,
 }
 
-fn run_bin_with_env(bin_name: &str, args: &[&str], env: &[(&str, &str)]) -> CmdOut {
-    let cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let output = run_resolved_in_dir(bin_name, cwd, args, env, None);
+/// Build a deterministic baseline for plan-issue integration tests.
+/// Tests can compose env/path overrides via `CmdOptions` instead of ad-hoc
+/// shell-style setup in each test body.
+pub fn plan_issue_cmd_options() -> CmdOptions {
+    CmdOptions::new().with_cwd(Path::new(env!("CARGO_MANIFEST_DIR")))
+}
+
+fn run_bin_with_options(bin_name: &str, args: &[&str], options: CmdOptions) -> CmdOut {
+    let output = run_resolved(bin_name, args, &options);
 
     CmdOut {
         code: output.code,
@@ -19,12 +25,21 @@ fn run_bin_with_env(bin_name: &str, args: &[&str], env: &[(&str, &str)]) -> CmdO
     }
 }
 
+fn run_bin_with_env(bin_name: &str, args: &[&str], env: &[(&str, &str)]) -> CmdOut {
+    run_bin_with_options(bin_name, args, plan_issue_cmd_options().with_envs(env))
+}
+
 fn run_bin(bin_name: &str, args: &[&str]) -> CmdOut {
-    run_bin_with_env(bin_name, args, &[])
+    run_bin_with_options(bin_name, args, plan_issue_cmd_options())
 }
 
 pub fn run_plan_issue(args: &[&str]) -> CmdOut {
     run_bin("plan-issue", args)
+}
+
+#[allow(dead_code)]
+pub fn run_plan_issue_with_options(args: &[&str], options: CmdOptions) -> CmdOut {
+    run_bin_with_options("plan-issue", args, options)
 }
 
 #[allow(dead_code)]
@@ -35,6 +50,11 @@ pub fn run_plan_issue_with_env(args: &[&str], env: &[(&str, &str)]) -> CmdOut {
 #[allow(dead_code)]
 pub fn run_plan_issue_local(args: &[&str]) -> CmdOut {
     run_bin("plan-issue-local", args)
+}
+
+#[allow(dead_code)]
+pub fn run_plan_issue_local_with_options(args: &[&str], options: CmdOptions) -> CmdOut {
+    run_bin_with_options("plan-issue-local", args, options)
 }
 
 #[allow(dead_code)]

--- a/crates/plan-issue-cli/tests/sprint4_delivery.rs
+++ b/crates/plan-issue-cli/tests/sprint4_delivery.rs
@@ -6,6 +6,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use nils_test_support::StubBinDir;
+use nils_test_support::cmd::CmdOptions;
 
 mod common;
 
@@ -93,9 +94,13 @@ esac
 "#
 }
 
-fn env_path_with_stub(stub_dir: &Path) -> String {
-    let base = std::env::var("PATH").unwrap_or_default();
-    format!("{}:{}", stub_dir.display(), base)
+fn gh_cmd_options(stub_dir: &Path, envs: &[(&str, &str)]) -> CmdOptions {
+    common::plan_issue_cmd_options()
+        // Keep stubbed gh behavior deterministic even when the outer shell
+        // exports PLAN_ISSUE_GH_* variables.
+        .with_env_remove_prefix("PLAN_ISSUE_GH_")
+        .with_path_prepend(stub_dir)
+        .with_envs(envs)
 }
 
 fn issue_body_with_preface(task_rows: &str) -> String {
@@ -162,7 +167,6 @@ fn github_adapter_live_commands_use_gh_backend_for_issue_and_pr_state() {
 
     let log_path = tmp.path().join("gh.log");
     let log_s = log_path.to_string_lossy().to_string();
-    let path_env = env_path_with_stub(stub.path());
 
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
@@ -170,7 +174,7 @@ fn github_adapter_live_commands_use_gh_backend_for_issue_and_pr_state() {
 
     let body_json = json!({"body": issue_body_sprint4_in_progress()}).to_string();
 
-    let out = common::run_plan_issue_with_env(
+    let out = common::run_plan_issue_with_options(
         &[
             "--format",
             "json",
@@ -190,12 +194,14 @@ fn github_adapter_live_commands_use_gh_backend_for_issue_and_pr_state() {
             "per-sprint",
             "--no-comment",
         ],
-        &[
-            ("PATH", &path_env),
-            ("PLAN_ISSUE_GH_LOG", &log_s),
-            ("PLAN_ISSUE_GH_BODY_JSON", &body_json),
-            ("AGENT_HOME", &agent_home_s),
-        ],
+        gh_cmd_options(
+            stub.path(),
+            &[
+                ("PLAN_ISSUE_GH_LOG", &log_s),
+                ("PLAN_ISSUE_GH_BODY_JSON", &body_json),
+                ("AGENT_HOME", &agent_home_s),
+            ],
+        ),
     );
 
     assert_eq!(out.code, 0, "stderr: {}", out.stderr);
@@ -218,7 +224,6 @@ fn live_plan_commands_ready_and_close_follow_gate_contracts() {
 
     let log_path = tmp.path().join("gh.log");
     let log_s = log_path.to_string_lossy().to_string();
-    let path_env = env_path_with_stub(stub.path());
 
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
@@ -229,7 +234,7 @@ fn live_plan_commands_ready_and_close_follow_gate_contracts() {
 
     let body_json = json!({"body": issue_body_plan_done()}).to_string();
 
-    let ready_out = common::run_plan_issue_with_env(
+    let ready_out = common::run_plan_issue_with_options(
         &[
             "--format",
             "json",
@@ -241,13 +246,15 @@ fn live_plan_commands_ready_and_close_follow_gate_contracts() {
             "--summary",
             "Final plan review",
         ],
-        &[
-            ("PATH", &path_env),
-            ("PLAN_ISSUE_GH_LOG", &log_s),
-            ("PLAN_ISSUE_GH_BODY_JSON", &body_json),
-            ("PLAN_ISSUE_GH_CAPTURE_COMMENT_FILE", &comment_capture_s),
-            ("AGENT_HOME", &agent_home_s),
-        ],
+        gh_cmd_options(
+            stub.path(),
+            &[
+                ("PLAN_ISSUE_GH_LOG", &log_s),
+                ("PLAN_ISSUE_GH_BODY_JSON", &body_json),
+                ("PLAN_ISSUE_GH_CAPTURE_COMMENT_FILE", &comment_capture_s),
+                ("AGENT_HOME", &agent_home_s),
+            ],
+        ),
     );
 
     assert_eq!(ready_out.code, 0, "stderr: {}", ready_out.stderr);
@@ -262,7 +269,7 @@ fn live_plan_commands_ready_and_close_follow_gate_contracts() {
     fs::write(&close_body_path, issue_body_plan_done()).expect("write close body");
     let close_body_s = close_body_path.to_string_lossy().to_string();
 
-    let close_out = common::run_plan_issue_with_env(
+    let close_out = common::run_plan_issue_with_options(
         &[
             "--format",
             "json",
@@ -275,12 +282,14 @@ fn live_plan_commands_ready_and_close_follow_gate_contracts() {
             "--approved-comment-url",
             "https://github.com/graysurf/nils-cli/issues/217#issuecomment-4000000001",
         ],
-        &[
-            ("PATH", &path_env),
-            ("PLAN_ISSUE_GH_LOG", &log_s),
-            ("PLAN_ISSUE_GH_BODY_JSON", &body_json),
-            ("AGENT_HOME", &agent_home_s),
-        ],
+        gh_cmd_options(
+            stub.path(),
+            &[
+                ("PLAN_ISSUE_GH_LOG", &log_s),
+                ("PLAN_ISSUE_GH_BODY_JSON", &body_json),
+                ("AGENT_HOME", &agent_home_s),
+            ],
+        ),
     );
 
     assert_eq!(close_out.code, 0, "stderr: {}", close_out.stderr);
@@ -311,7 +320,6 @@ fn live_sprint_commands_start_ready_accept_and_guide_are_deterministic() {
 
     let log_path = tmp.path().join("gh.log");
     let log_s = log_path.to_string_lossy().to_string();
-    let path_env = env_path_with_stub(stub.path());
 
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
@@ -321,7 +329,7 @@ fn live_sprint_commands_start_ready_accept_and_guide_are_deterministic() {
     let start_capture_s = start_capture.to_string_lossy().to_string();
     let start_body_json = json!({"body": issue_body_sprint4_planned()}).to_string();
 
-    let start_out = common::run_plan_issue_with_env(
+    let start_out = common::run_plan_issue_with_options(
         &[
             "--format",
             "json",
@@ -338,13 +346,15 @@ fn live_sprint_commands_start_ready_accept_and_guide_are_deterministic() {
             "per-sprint",
             "--no-comment",
         ],
-        &[
-            ("PATH", &path_env),
-            ("PLAN_ISSUE_GH_LOG", &log_s),
-            ("PLAN_ISSUE_GH_BODY_JSON", &start_body_json),
-            ("PLAN_ISSUE_GH_CAPTURE_BODY_FILE", &start_capture_s),
-            ("AGENT_HOME", &agent_home_s),
-        ],
+        gh_cmd_options(
+            stub.path(),
+            &[
+                ("PLAN_ISSUE_GH_LOG", &log_s),
+                ("PLAN_ISSUE_GH_BODY_JSON", &start_body_json),
+                ("PLAN_ISSUE_GH_CAPTURE_BODY_FILE", &start_capture_s),
+                ("AGENT_HOME", &agent_home_s),
+            ],
+        ),
     );
 
     assert_eq!(start_out.code, 0, "stderr: {}", start_out.stderr);
@@ -367,7 +377,7 @@ fn live_sprint_commands_start_ready_accept_and_guide_are_deterministic() {
         "{start_body}"
     );
 
-    let ready_out = common::run_plan_issue_with_env(
+    let ready_out = common::run_plan_issue_with_options(
         &[
             "--format",
             "json",
@@ -387,12 +397,14 @@ fn live_sprint_commands_start_ready_accept_and_guide_are_deterministic() {
             "Sprint 4 ready",
             "--no-comment",
         ],
-        &[
-            ("PATH", &path_env),
-            ("PLAN_ISSUE_GH_LOG", &log_s),
-            ("PLAN_ISSUE_GH_BODY_JSON", &start_body_json),
-            ("AGENT_HOME", &agent_home_s),
-        ],
+        gh_cmd_options(
+            stub.path(),
+            &[
+                ("PLAN_ISSUE_GH_LOG", &log_s),
+                ("PLAN_ISSUE_GH_BODY_JSON", &start_body_json),
+                ("AGENT_HOME", &agent_home_s),
+            ],
+        ),
     );
 
     assert_eq!(ready_out.code, 0, "stderr: {}", ready_out.stderr);
@@ -401,7 +413,7 @@ fn live_sprint_commands_start_ready_accept_and_guide_are_deterministic() {
     let accept_capture_s = accept_capture.to_string_lossy().to_string();
     let accept_body_json = json!({"body": issue_body_sprint4_in_progress()}).to_string();
 
-    let accept_out = common::run_plan_issue_with_env(
+    let accept_out = common::run_plan_issue_with_options(
         &[
             "--format",
             "json",
@@ -420,13 +432,15 @@ fn live_sprint_commands_start_ready_accept_and_guide_are_deterministic() {
             "per-sprint",
             "--no-comment",
         ],
-        &[
-            ("PATH", &path_env),
-            ("PLAN_ISSUE_GH_LOG", &log_s),
-            ("PLAN_ISSUE_GH_BODY_JSON", &accept_body_json),
-            ("PLAN_ISSUE_GH_CAPTURE_BODY_FILE", &accept_capture_s),
-            ("AGENT_HOME", &agent_home_s),
-        ],
+        gh_cmd_options(
+            stub.path(),
+            &[
+                ("PLAN_ISSUE_GH_LOG", &log_s),
+                ("PLAN_ISSUE_GH_BODY_JSON", &accept_body_json),
+                ("PLAN_ISSUE_GH_CAPTURE_BODY_FILE", &accept_capture_s),
+                ("AGENT_HOME", &agent_home_s),
+            ],
+        ),
     );
 
     assert_eq!(accept_out.code, 0, "stderr: {}", accept_out.stderr);


### PR DESCRIPTION
## Summary
- Consolidates the Sprint 4 integration test harness onto `nils-test-support` command utilities for deterministic env/path setup.

## Scope
- Added `CmdOptions::with_envs` in `nils-test-support` and reused it across command helper constructors.
- Refactored `plan-issue-cli` test harness helpers to expose `CmdOptions`-based runners from one shared entrypoint.
- Replaced ad-hoc `PATH` wiring in `sprint4_delivery` with shared `CmdOptions` (`with_path_prepend` + `PLAN_ISSUE_GH_*` cleanup).
- Excluded runtime command behavior changes; this task only updates integration test harness/support plumbing.

## Testing
- `cargo test -p nils-plan-issue-cli --test sprint4_delivery` (pass)
- `cargo test -p nils-plan-issue-cli --test sprint5_delivery` (pass)
- `cargo test -p nils-test-support --test bin_cmd` (pass)

## Issue
- #228
