### PR TITLE
Add macOS CI tests and use macOS coverage source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,11 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Install ripgrep
+      - name: Install bash + ripgrep
         run: |
+          if ! /opt/homebrew/bin/bash --version >/dev/null 2>&1; then
+            brew install bash
+          fi
           if ! command -v rg >/dev/null 2>&1; then
             brew install ripgrep
           fi
@@ -89,12 +92,12 @@ jobs:
           tool: cargo-nextest
 
       - name: Completion asset audit
-        run: bash scripts/ci/completion-asset-audit.sh --strict
+        run: /opt/homebrew/bin/bash scripts/ci/completion-asset-audit.sh --strict
 
       - name: Nils CLI checks (includes docs-placement-audit)
         env:
           NILS_CLI_TEST_RUNNER: nextest
-        run: ./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
+        run: /opt/homebrew/bin/bash ./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
 
       - name: Publish JUnit report
         if: always() && hashFiles('target/nextest/ci/junit.xml') != ''


### PR DESCRIPTION
# Add macOS CI tests and use macOS coverage source

## Summary
This updates CI to run required checks on macOS and makes coverage generation run on macOS so coverage gate and badge reflect macOS coverage values.

## Changes
- Add `test_macos` job on `macos-14` running completion audit and required checks via nextest.
- Move `coverage` job from `ubuntu-24.04` to `macos-14`.
- Remove Linux-only `xvfb` install/use from coverage generation and doctest steps.
- Keep `coverage_badge` consuming the `coverage` artifact, which now comes from macOS coverage output.

## Testing
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `bash scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, 85.86%)

## Risk / Notes
- macOS runner time/cost may differ from Linux runner behavior.
