### PR TITLE
Refresh plan workflow READMEs for current CLI contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Each crate is either a standalone CLI binary or a shared library used across the
 - [crates/codex-cli](crates/codex-cli): Provider-specific CLI for OpenAI/Codex workflows (auth, diagnostics, execution wrappers, Starship), with adapters over `nils-common::provider_runtime`.
 - [crates/gemini-cli](crates/gemini-cli): Provider-specific CLI lane for Gemini workflows, with adapters over `nils-common::provider_runtime`.
 - [crates/semantic-commit](crates/semantic-commit): Helper CLI for generating staged context and creating semantic commits.
-- [crates/plan-tooling](crates/plan-tooling): Plan Format v1 tooling CLI (to-json/validate/batches/scaffold/split-prs).
-- [crates/plan-issue-cli](crates/plan-issue-cli): Plan issue orchestration CLI (`plan-issue` for live mode, `plan-issue-local` for local rehearsal).
+- [crates/plan-tooling](crates/plan-tooling): Plan Format v1 tooling CLI (`to-json`, `validate`, `batches`, `split-prs`, `scaffold`, `completion`).
+- [crates/plan-issue-cli](crates/plan-issue-cli): Plan issue orchestration binaries (`plan-issue`, `plan-issue-local`) for task-spec build/start/status/ready/accept/close workflows plus completion export.
 
 ## Shared helper policy (`nils-common`)
 

--- a/crates/plan-issue-cli/README.md
+++ b/crates/plan-issue-cli/README.md
@@ -1,20 +1,72 @@
 # plan-issue-cli
 
 ## Overview
-`plan-issue-cli` is the contract-first workspace crate for the Rust replacement of
-`plan-issue-delivery-loop.sh`.
+`plan-issue-cli` provides the Rust command contract for plan/issue delivery orchestration.
+It is the typed replacement lane for `plan-issue-delivery-loop.sh` behavior and is built around
+deterministic task-spec generation, issue-body rendering, and gate-enforced sprint transitions.
 
-Sprint 1 establishes the v1 command contract, gate semantics, and deterministic artifacts needed
-to preserve orchestration compatibility before implementation cutover.
+The crate ships two binaries with the same command surface:
 
-## Status
-- Current scope includes Sprint 6 implementation:
-  - deterministic task-spec generation core using `plan-tooling` parsing primitives
-  - issue-body and sprint-comment markdown rendering engine
-  - live plan-level and sprint-level orchestration commands
-  - local-first rehearsal workflow for `plan-issue-local`
-  - parity and JSON contract regression coverage
-  - `completion <bash|zsh>` export path for `plan-issue` and `plan-issue-local`
+- `plan-issue`: live GitHub-backed mode
+- `plan-issue-local`: local-first rehearsal mode (offline/dry-run friendly)
+
+## Command surface
+
+### Build and preparation
+- `build-task-spec`: build sprint-scoped task-spec TSV from a plan.
+- `build-plan-task-spec`: build plan-scoped task-spec TSV (all sprints).
+
+### Plan-level flow
+- `start-plan`: open one plan issue and emit plan artifacts.
+- `status-plan`: summarize Task Decomposition status from issue body/body file.
+- `ready-plan`: apply review-ready markers and optional review summary comment.
+- `close-plan`: enforce final close gate and close the plan issue.
+- `cleanup-worktrees`: enforce cleanup of all issue-assigned task worktrees.
+
+### Sprint-level flow
+- `start-sprint`: open sprint execution loop after previous sprint gate passes.
+- `ready-sprint`: post sprint-ready signal for main-agent review.
+- `accept-sprint`: enforce merged-PR gate and mark sprint accepted.
+- `multi-sprint-guide`: print repeated command flow for a whole plan.
+
+### Shell completion
+- `completion <bash|zsh>`: export completion script for each binary.
+
+## Global flags
+- `--repo <owner/repo>`: pass-through repo target for GitHub operations.
+- `--dry-run`: print write actions without mutating GitHub state.
+- `-f, --force`: bypass markdown payload guard for body/comment writes.
+- `--json` or `--format json`: machine-readable contract output.
+- `--format text`: human-readable output.
+
+## Grouping and strategy rules
+- `--pr-grouping` is required for build/start/ready/accept flows.
+- `--pr-grouping per-sprint`: one shared group per sprint (default style).
+- `--pr-grouping group --strategy deterministic`: requires explicit `--pr-group <task>=<group>` mappings.
+- `--pr-grouping group --strategy auto`: allows optional pins and auto assignment for remaining tasks.
+
+## Quick examples
+```bash
+# 1) Build plan-scoped task spec locally
+plan-issue-local build-plan-task-spec \
+  --plan docs/plans/example-plan.md \
+  --pr-grouping per-sprint
+
+# 2) Start plan issue in live mode
+plan-issue start-plan \
+  --repo owner/repo \
+  --plan docs/plans/example-plan.md \
+  --pr-grouping per-sprint
+
+# 3) Export completion
+plan-issue completion zsh > completions/zsh/_plan-issue
+plan-issue-local completion bash > completions/bash/plan-issue-local
+```
+
+## Exit codes
+- `0`: success
+- `1`: runtime/validation failure
+- `2`: usage failure
 
 ## Specifications
 - [CLI contract v1](docs/specs/plan-issue-cli-contract-v1.md)
@@ -23,5 +75,4 @@ to preserve orchestration compatibility before implementation cutover.
 
 ## Fixtures
 - Shell parity fixtures live under `tests/fixtures/shell_parity/`.
-- Use `tests/fixtures/shell_parity/regenerate.sh` to refresh fixture snapshots when shell source
-  behavior intentionally changes.
+- Use `tests/fixtures/shell_parity/regenerate.sh` to refresh fixture snapshots when shell behavior intentionally changes.

--- a/crates/plan-tooling/README.md
+++ b/crates/plan-tooling/README.md
@@ -16,6 +16,7 @@ Commands:
   batches   Compute dependency layers (parallel batches) for a sprint
   split-prs Build task-to-PR split records (deterministic/auto)
   scaffold  Create a new plan from template
+  completion Export shell completion script
   help      Display help message
 
 Help:
@@ -58,6 +59,35 @@ Help:
 - `scaffold --slug <kebab-case> [--title <title>] [--force]`: Write to
   `docs/plans/<slug>-plan.md` (or `<slug>.md` if the slug already ends with `-plan`).
 - `scaffold --file <path> [--title <title>] [--force]`: Write to a specific `-plan.md` path.
+
+### completion
+- `completion <bash|zsh>`: Export completion script for shell integration.
+
+## Quick examples
+```bash
+# Parse one plan to JSON
+plan-tooling to-json --file docs/plans/example-plan.md --pretty
+
+# Validate all tracked plan docs (default discovery)
+plan-tooling validate
+
+# Compute sprint batches in text mode
+plan-tooling batches --file docs/plans/example-plan.md --sprint 2 --format text
+
+# Split sprint tasks with deterministic groups
+plan-tooling split-prs \
+  --file docs/plans/example-plan.md \
+  --scope sprint \
+  --sprint 2 \
+  --pr-grouping group \
+  --pr-group S2T1=isolated \
+  --pr-group S2T2=shared \
+  --strategy deterministic \
+  --format json
+
+# Export completion
+plan-tooling completion zsh > completions/zsh/_plan-tooling
+```
 
 ## Template
 - Plan template: `crates/plan-tooling/plan-template.md`.


### PR DESCRIPTION
# Refresh plan workflow READMEs for current CLI contracts

## Summary
This PR updates documentation for the plan orchestration tooling so the workspace README and crate READMEs reflect the current command surfaces and usage expectations.

## Changes
- Expand `crates/plan-issue-cli/README.md` with command groups, global flags, grouping rules, examples, and exit codes.
- Add `completion` coverage and command examples to `crates/plan-tooling/README.md`.
- Update root `README.md` crate summaries for `plan-tooling` and `plan-issue-cli` to match current capabilities.

## Testing
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh --docs-only` (pass)

## Risk / Notes
- Documentation-only changes; no runtime behavior changed.
