### PR TITLE
Refactor plan-issue-cli writes to shared nils-common helper

### DIFF
--- a/crates/nils-common/src/fs.rs
+++ b/crates/nils-common/src/fs.rs
@@ -69,6 +69,22 @@ pub enum TimestampError {
 }
 
 #[derive(Debug, Error)]
+pub enum WriteTextError {
+    #[error("failed to create parent directory {path}: {source}")]
+    CreateParentDir {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to write file {path}: {source}")]
+    WriteFile {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+}
+
+#[derive(Debug, Error)]
 pub enum FileHashError {
     #[error("failed to open file for hashing {path}: {source}")]
     OpenFile {
@@ -205,6 +221,21 @@ pub fn write_timestamp(path: &Path, iso: Option<&str>) -> Result<(), TimestampEr
             source,
         }),
     }
+}
+
+/// Write UTF-8 text to `path`, creating parent directories when needed.
+pub fn write_text(path: &Path, text: &str) -> Result<(), WriteTextError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| WriteTextError::CreateParentDir {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+
+    fs::write(path, text).map_err(|source| WriteTextError::WriteFile {
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 /// Replace `to` by renaming `from` to `to`.
@@ -572,5 +603,30 @@ mod tests {
         let missing = dir.path().join("missing.timestamp");
 
         write_timestamp(&missing, None).expect("missing remove should not fail");
+    }
+
+    #[test]
+    fn fs_write_text_creates_parent_and_writes_contents() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("nested").join("note.md");
+
+        write_text(&path, "hello").expect("write_text");
+
+        assert_eq!(fs::read_to_string(&path).expect("read text"), "hello");
+    }
+
+    #[test]
+    fn fs_write_text_returns_structured_parent_error() {
+        let dir = TempDir::new().expect("tempdir");
+        let parent_file = dir.path().join("not-a-directory");
+        let target = parent_file.join("note.md");
+        fs::write(&parent_file, "block parent dir creation").expect("seed file");
+
+        let err = write_text(&target, "hello").expect_err("parent dir creation should fail");
+
+        match err {
+            WriteTextError::CreateParentDir { path, .. } => assert_eq!(path, parent_file),
+            other => panic!("unexpected error variant: {other:?}"),
+        }
     }
 }

--- a/crates/plan-issue-cli/src/render.rs
+++ b/crates/plan-issue-cli/src/render.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::issue_body;
 use crate::task_spec::{TaskSpecRow, agent_home};
+use nils_common::fs as common_fs;
 use nils_common::git as common_git;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -327,16 +328,17 @@ pub fn render_sprint_comment(input: SprintCommentInput<'_>) -> Result<String, St
 }
 
 pub fn write_rendered(path: &Path, content: &str) -> Result<(), String> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|err| {
+    common_fs::write_text(path, content).map_err(|err| match err {
+        common_fs::WriteTextError::CreateParentDir { path, source } => {
             format!(
-                "failed to create output directory {}: {err}",
-                parent.display()
+                "failed to create output directory {}: {source}",
+                path.display()
             )
-        })?;
-    }
-    std::fs::write(path, content)
-        .map_err(|err| format!("failed to write {}: {err}", path.display()))
+        }
+        common_fs::WriteTextError::WriteFile { source, .. } => {
+            format!("failed to write {}: {source}", path.display())
+        }
+    })
 }
 
 fn parse_issue_pr_values(issue_body_text: &str) -> HashMap<String, String> {

--- a/crates/plan-issue-cli/src/task_spec.rs
+++ b/crates/plan-issue-cli/src/task_spec.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use nils_common::git as common_git;
+use nils_common::{fs as common_fs, git as common_git};
 use plan_tooling::parse::parse_plan_with_display;
 use plan_tooling::split_prs::{
     SplitPlanOptions, SplitPrGrouping, SplitPrStrategy, SplitScope, build_split_plan_records,
@@ -132,16 +132,17 @@ pub fn render_tsv(rows: &[TaskSpecRow]) -> String {
 }
 
 pub fn write_tsv(path: &Path, rows: &[TaskSpecRow]) -> Result<(), String> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|err| {
+    common_fs::write_text(path, &render_tsv(rows)).map_err(|err| match err {
+        common_fs::WriteTextError::CreateParentDir { path, source } => {
             format!(
-                "failed to create output directory {}: {err}",
-                parent.display()
+                "failed to create output directory {}: {source}",
+                path.display()
             )
-        })?;
-    }
-    std::fs::write(path, render_tsv(rows))
-        .map_err(|err| format!("failed to write task-spec {}: {err}", path.display()))
+        }
+        common_fs::WriteTextError::WriteFile { source, .. } => {
+            format!("failed to write task-spec {}: {source}", path.display())
+        }
+    })
 }
 
 pub fn default_plan_task_spec_path(plan_file: &Path) -> PathBuf {

--- a/crates/plan-issue-cli/tests/task_spec_flow.rs
+++ b/crates/plan-issue-cli/tests/task_spec_flow.rs
@@ -96,6 +96,38 @@ fn task_spec_generation_build_task_spec_writes_grouped_rows() {
 }
 
 #[test]
+fn task_spec_generation_creates_missing_output_directory() {
+    let tmp = TempDir::new().expect("temp dir");
+    let out_path = tmp.path().join("nested").join("deep").join("sprint3.tsv");
+    let out_path_s = out_path.to_string_lossy().to_string();
+    assert!(
+        !out_path.parent().expect("parent").exists(),
+        "precondition: parent should not exist"
+    );
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "build-task-spec",
+        "--plan",
+        PLAN_PATH,
+        "--sprint",
+        "3",
+        "--pr-grouping",
+        "per-sprint",
+        "--task-spec-out",
+        &out_path_s,
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let rendered = fs::read_to_string(&out_path).expect("read task-spec");
+    assert!(
+        rendered.starts_with("# task_id\tsummary\tbranch\tworktree\towner\tnotes\tpr_group\n"),
+        "{rendered}"
+    );
+}
+
+#[test]
 fn strategy_auto_partial_mapping_allows_unmapped_rows() {
     let tmp = TempDir::new().expect("temp dir");
     let out_path = tmp.path().join("sprint3-auto.tsv");
@@ -212,6 +244,49 @@ fn render_issue_body_start_plan_writes_issue_body_artifact() {
     assert!(
         rendered.contains("| S3T1 | Implement task-spec generation core using `plan-tooling` |")
     );
+}
+
+#[test]
+fn render_issue_body_start_plan_creates_missing_issue_body_directory() {
+    let tmp = TempDir::new().expect("temp dir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+
+    let task_spec = tmp.path().join("nested").join("spec").join("plan.tsv");
+    let issue_body = tmp
+        .path()
+        .join("nested")
+        .join("issue")
+        .join("issue-body.md");
+    let task_spec_s = task_spec.to_string_lossy().to_string();
+    let issue_body_s = issue_body.to_string_lossy().to_string();
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+    assert!(
+        !issue_body.parent().expect("parent").exists(),
+        "precondition: parent should not exist"
+    );
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "start-plan",
+            "--plan",
+            PLAN_PATH,
+            "--pr-grouping",
+            "per-sprint",
+            "--task-spec-out",
+            &task_spec_s,
+            "--issue-body-out",
+            &issue_body_s,
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let rendered = fs::read_to_string(&issue_body).expect("read issue body");
+    assert!(rendered.contains("## Task Decomposition"), "{rendered}");
 }
 
 #[test]


### PR DESCRIPTION
# Refactor plan-issue-cli writes to shared nils-common helper

## Summary
This refactor removes duplicated text-file output plumbing in `plan-issue-cli` and moves the reusable primitive into `nils-common`. `write_tsv` and `write_rendered` now use a shared helper while preserving crate-local error strings.

## Changes
- Add `nils_common::fs::write_text` and `WriteTextError` for domain-neutral text writes with parent-directory creation.
- Replace `plan-issue-cli` local `create_dir_all + fs::write` logic in `task_spec::write_tsv` and `render::write_rendered` with the shared helper.
- Add `nils-common` unit tests for `write_text` success/error behavior.
- Add `plan-issue-cli` integration tests for nested output path creation on `--task-spec-out` and `--issue-body-out`.

## Testing
- `cargo test -p nils-common fs_write_text` (pass)
- `cargo test -p nils-plan-issue-cli --test task_spec_flow` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, 86.36%)

## Risk / Notes
- Scope is limited to shared write helper adoption for two `plan-issue-cli` write paths.
- Existing CLI-facing error prefixes are preserved to avoid user-visible contract drift.
