### PR TITLE
refactor: implement issue #239 S2T1 shared git/process plumbing

### DIFF
--- a/crates/nils-common/src/git.rs
+++ b/crates/nils-common/src/git.rs
@@ -1,8 +1,9 @@
+use crate::process;
 use std::error::Error;
 use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus, Output, Stdio};
+use std::process::{ExitStatus, Output};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GitContextError {
@@ -88,27 +89,57 @@ pub fn is_lockfile_path(path: &str) -> bool {
 }
 
 pub fn run_output(args: &[&str]) -> io::Result<Output> {
-    run_output_inner(None, args)
+    run_output_inner(None, args, &[])
 }
 
 pub fn run_output_in(cwd: &Path, args: &[&str]) -> io::Result<Output> {
-    run_output_inner(Some(cwd), args)
+    run_output_inner(Some(cwd), args, &[])
+}
+
+pub fn run_output_with_env(
+    args: &[&str],
+    env: &[process::ProcessEnvPair<'_>],
+) -> io::Result<Output> {
+    run_output_inner(None, args, env)
+}
+
+pub fn run_output_in_with_env(
+    cwd: &Path,
+    args: &[&str],
+    env: &[process::ProcessEnvPair<'_>],
+) -> io::Result<Output> {
+    run_output_inner(Some(cwd), args, env)
 }
 
 pub fn run_status_quiet(args: &[&str]) -> io::Result<ExitStatus> {
-    run_status_quiet_inner(None, args)
+    run_status_quiet_inner(None, args, &[])
 }
 
 pub fn run_status_quiet_in(cwd: &Path, args: &[&str]) -> io::Result<ExitStatus> {
-    run_status_quiet_inner(Some(cwd), args)
+    run_status_quiet_inner(Some(cwd), args, &[])
 }
 
 pub fn run_status_inherit(args: &[&str]) -> io::Result<ExitStatus> {
-    run_status_inherit_inner(None, args)
+    run_status_inherit_inner(None, args, &[])
 }
 
 pub fn run_status_inherit_in(cwd: &Path, args: &[&str]) -> io::Result<ExitStatus> {
-    run_status_inherit_inner(Some(cwd), args)
+    run_status_inherit_inner(Some(cwd), args, &[])
+}
+
+pub fn run_status_inherit_with_env(
+    args: &[&str],
+    env: &[process::ProcessEnvPair<'_>],
+) -> io::Result<ExitStatus> {
+    run_status_inherit_inner(None, args, env)
+}
+
+pub fn run_status_inherit_in_with_env(
+    cwd: &Path,
+    args: &[&str],
+    env: &[process::ProcessEnvPair<'_>],
+) -> io::Result<ExitStatus> {
+    run_status_inherit_inner(Some(cwd), args, env)
 }
 
 pub fn is_git_available() -> bool {
@@ -187,33 +218,28 @@ pub fn rev_parse_in(cwd: &Path, args: &[&str]) -> io::Result<Option<String>> {
     Ok(trimmed_stdout_if_success(&output))
 }
 
-fn run_output_inner(cwd: Option<&Path>, args: &[&str]) -> io::Result<Output> {
-    let mut cmd = Command::new("git");
-    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
-    if let Some(cwd) = cwd {
-        cmd.current_dir(cwd);
-    }
-    cmd.output()
+fn run_output_inner(
+    cwd: Option<&Path>,
+    args: &[&str],
+    env: &[process::ProcessEnvPair<'_>],
+) -> io::Result<Output> {
+    process::run_output_with("git", args, cwd, env).map(|output| output.into_std_output())
 }
 
-fn run_status_quiet_inner(cwd: Option<&Path>, args: &[&str]) -> io::Result<ExitStatus> {
-    let mut cmd = Command::new("git");
-    cmd.args(args).stdout(Stdio::null()).stderr(Stdio::null());
-    if let Some(cwd) = cwd {
-        cmd.current_dir(cwd);
-    }
-    cmd.status()
+fn run_status_quiet_inner(
+    cwd: Option<&Path>,
+    args: &[&str],
+    env: &[process::ProcessEnvPair<'_>],
+) -> io::Result<ExitStatus> {
+    process::run_status_quiet_with("git", args, cwd, env)
 }
 
-fn run_status_inherit_inner(cwd: Option<&Path>, args: &[&str]) -> io::Result<ExitStatus> {
-    let mut cmd = Command::new("git");
-    cmd.args(args)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-    if let Some(cwd) = cwd {
-        cmd.current_dir(cwd);
-    }
-    cmd.status()
+fn run_status_inherit_inner(
+    cwd: Option<&Path>,
+    args: &[&str],
+    env: &[process::ProcessEnvPair<'_>],
+) -> io::Result<ExitStatus> {
+    process::run_status_inherit_with("git", args, cwd, env)
 }
 
 fn require_context(cwd: Option<&Path>, probe_args: &[&str]) -> Result<(), GitContextError> {
@@ -293,6 +319,39 @@ mod tests {
 
         assert!(ok.success());
         assert!(!bad.success());
+    }
+
+    #[test]
+    fn run_output_with_env_passes_environment_variables_to_git() {
+        let output = run_output_with_env(
+            &["config", "--get", "nils.test-env"],
+            &[
+                ("GIT_CONFIG_COUNT", "1"),
+                ("GIT_CONFIG_KEY_0", "nils.test-env"),
+                ("GIT_CONFIG_VALUE_0", "ready"),
+            ],
+        )
+        .expect("run git output with env");
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "ready");
+    }
+
+    #[test]
+    fn run_status_inherit_in_with_env_applies_cwd_and_environment() {
+        let repo = init_repo_with(InitRepoOptions::new().with_initial_commit());
+        let status = run_status_inherit_in_with_env(
+            repo.path(),
+            &["config", "--get", "nils.test-status"],
+            &[
+                ("GIT_CONFIG_COUNT", "1"),
+                ("GIT_CONFIG_KEY_0", "nils.test-status"),
+                ("GIT_CONFIG_VALUE_0", "ok"),
+            ],
+        )
+        .expect("run git status in with env");
+
+        assert!(status.success());
     }
 
     #[test]

--- a/crates/nils-common/src/process.rs
+++ b/crates/nils-common/src/process.rs
@@ -11,6 +11,8 @@ pub struct ProcessOutput {
     pub stderr: Vec<u8>,
 }
 
+pub type ProcessEnvPair<'a> = (&'a str, &'a str);
+
 impl ProcessOutput {
     pub fn into_std_output(self) -> Output {
         Output {
@@ -74,8 +76,21 @@ impl From<io::Error> for ProcessError {
 }
 
 pub fn run_output(program: &str, args: &[&str]) -> io::Result<ProcessOutput> {
-    Command::new(program)
-        .args(args)
+    run_output_with(program, args, None, &[])
+}
+
+pub fn run_output_in(program: &str, args: &[&str], cwd: &Path) -> io::Result<ProcessOutput> {
+    run_output_with(program, args, Some(cwd), &[])
+}
+
+pub fn run_output_with(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    env: &[ProcessEnvPair<'_>],
+) -> io::Result<ProcessOutput> {
+    let mut command = command_with(program, args, cwd, env);
+    command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -102,16 +117,39 @@ pub fn run_stdout_trimmed(program: &str, args: &[&str]) -> Result<String, Proces
 }
 
 pub fn run_status_quiet(program: &str, args: &[&str]) -> io::Result<ExitStatus> {
-    Command::new(program)
-        .args(args)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
+    run_status_quiet_with(program, args, None, &[])
+}
+
+pub fn run_status_quiet_in(program: &str, args: &[&str], cwd: &Path) -> io::Result<ExitStatus> {
+    run_status_quiet_with(program, args, Some(cwd), &[])
+}
+
+pub fn run_status_quiet_with(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    env: &[ProcessEnvPair<'_>],
+) -> io::Result<ExitStatus> {
+    let mut command = command_with(program, args, cwd, env);
+    command.stdout(Stdio::null()).stderr(Stdio::null()).status()
 }
 
 pub fn run_status_inherit(program: &str, args: &[&str]) -> io::Result<ExitStatus> {
-    Command::new(program)
-        .args(args)
+    run_status_inherit_with(program, args, None, &[])
+}
+
+pub fn run_status_inherit_in(program: &str, args: &[&str], cwd: &Path) -> io::Result<ExitStatus> {
+    run_status_inherit_with(program, args, Some(cwd), &[])
+}
+
+pub fn run_status_inherit_with(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    env: &[ProcessEnvPair<'_>],
+) -> io::Result<ExitStatus> {
+    let mut command = command_with(program, args, cwd, env);
+    command
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()
@@ -230,6 +268,23 @@ fn looks_like_path(program: &str) -> bool {
     // Treat both separators as paths, even on unix. It is harmless and avoids surprises when a
     // caller passes a Windows-style path.
     program.contains('/') || program.contains('\\')
+}
+
+fn command_with<'a>(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    env: &[ProcessEnvPair<'a>],
+) -> Command {
+    let mut command = Command::new(program);
+    command.args(args);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    if !env.is_empty() {
+        command.envs(env.iter().copied());
+    }
+    command
 }
 
 fn is_executable_file(path: &Path) -> bool {
@@ -372,6 +427,31 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn run_output_with_applies_cwd_and_env_overrides() {
+        let cwd = tempfile::TempDir::new().expect("tempdir");
+        let output = run_output_with(
+            shell_program(),
+            &["-c", "printf '%s|%s' \"$PWD\" \"$NILS_PROCESS_TEST_ENV\""],
+            Some(cwd.path()),
+            &[("NILS_PROCESS_TEST_ENV", "ok")],
+        )
+        .expect("run output with cwd/env");
+
+        let rendered = output.stdout_trimmed();
+        let (reported_pwd, reported_flag) = rendered
+            .split_once('|')
+            .expect("expected delimiter in output");
+        assert_eq!(reported_flag, "ok");
+
+        let expected = cwd.path().canonicalize().expect("canonicalize cwd");
+        let reported = Path::new(reported_pwd)
+            .canonicalize()
+            .expect("canonicalize reported pwd");
+        assert_eq!(reported, expected);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn run_checked_returns_nonzero_error_with_captured_output() {
         let err = run_checked(
             shell_program(),
@@ -407,6 +487,20 @@ mod tests {
         let inherit =
             run_status_inherit(shell_program(), &["-c", "exit 3"]).expect("inherit status");
         assert_eq!(inherit.code(), Some(3));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_status_quiet_with_applies_env_overrides() {
+        let status = run_status_quiet_with(
+            shell_program(),
+            &["-c", "test \"$NILS_PROCESS_TEST_FLAG\" = on"],
+            None,
+            &[("NILS_PROCESS_TEST_FLAG", "on")],
+        )
+        .expect("status with env");
+
+        assert!(status.success());
     }
 
     #[test]

--- a/crates/semantic-commit/src/commit.rs
+++ b/crates/semantic-commit/src/commit.rs
@@ -1,7 +1,6 @@
 use crate::git;
 use nils_common::git as common_git;
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
-use std::ffi::OsString;
 use std::fs::File;
 use std::io::{BufRead, BufReader, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
@@ -12,6 +11,7 @@ const EXIT_NO_STAGED_CHANGES: i32 = 2;
 const EXIT_MESSAGE_REQUIRED: i32 = 3;
 const EXIT_VALIDATION_FAILED: i32 = 4;
 const EXIT_DEPENDENCY_ERROR: i32 = 5;
+const CAT_PAGER_ENV: [(&str, &str); 2] = [("GIT_PAGER", "cat"), ("PAGER", "cat")];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SummaryMode {
@@ -333,54 +333,21 @@ fn read_message_contents(options: &CommitOptions) -> Result<String, i32> {
     Ok(message_contents)
 }
 
-struct EnvVarGuard {
-    key: &'static str,
-    old: Option<OsString>,
-}
-
-impl EnvVarGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let old = std::env::var_os(key);
-        // SAFETY: semantic-commit is single-process CLI flow; we mutate and restore env in a
-        // tight scope before returning to caller.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, old }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(old) = self.old.take() {
-            // SAFETY: restore original env value for scoped mutation.
-            unsafe { std::env::set_var(self.key, old) };
-        } else {
-            // SAFETY: restore original env state for scoped mutation.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
-
-fn with_cat_pager_env<T>(f: impl FnOnce() -> T) -> T {
-    let _git_pager = EnvVarGuard::set("GIT_PAGER", "cat");
-    let _pager = EnvVarGuard::set("PAGER", "cat");
-    f()
-}
-
 fn run_git_output_with_pager(repo: Option<&Path>, args: &[&str]) -> std::io::Result<Output> {
-    with_cat_pager_env(|| match repo {
-        Some(repo) => common_git::run_output_in(repo, args),
-        None => common_git::run_output(args),
-    })
+    match repo {
+        Some(repo) => common_git::run_output_in_with_env(repo, args, &CAT_PAGER_ENV),
+        None => common_git::run_output_with_env(args, &CAT_PAGER_ENV),
+    }
 }
 
 fn run_git_status_inherit_with_pager(
     repo: Option<&Path>,
     args: &[&str],
 ) -> std::io::Result<ExitStatus> {
-    with_cat_pager_env(|| match repo {
-        Some(repo) => common_git::run_status_inherit_in(repo, args),
-        None => common_git::run_status_inherit(args),
-    })
+    match repo {
+        Some(repo) => common_git::run_status_inherit_in_with_env(repo, args, &CAT_PAGER_ENV),
+        None => common_git::run_status_inherit_with_env(args, &CAT_PAGER_ENV),
+    }
 }
 
 fn git_commit(

--- a/crates/semantic-commit/src/staged_context.rs
+++ b/crates/semantic-commit/src/staged_context.rs
@@ -2,7 +2,6 @@ use crate::git;
 use nils_common::git as common_git;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
-use std::ffi::OsString;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Output;
@@ -12,6 +11,7 @@ use time::format_description::well_known::Rfc3339;
 const EXIT_ERROR: i32 = 1;
 const EXIT_NO_STAGED_CHANGES: i32 = 2;
 const EXIT_DEPENDENCY_ERROR: i32 = 5;
+const CAT_PAGER_ENV: [(&str, &str); 2] = [("GIT_PAGER", "cat"), ("PAGER", "cat")];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum OutputFormat {
@@ -434,39 +434,6 @@ fn is_lockfile(path: &str) -> bool {
     common_git::is_lockfile_path(path)
 }
 
-struct EnvVarGuard {
-    key: &'static str,
-    old: Option<OsString>,
-}
-
-impl EnvVarGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let old = std::env::var_os(key);
-        // SAFETY: semantic-commit is single-process CLI flow; we mutate and restore env in a
-        // tight scope before returning to caller.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, old }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(old) = self.old.take() {
-            // SAFETY: restore original env value for scoped mutation.
-            unsafe { std::env::set_var(self.key, old) };
-        } else {
-            // SAFETY: restore original env state for scoped mutation.
-            unsafe { std::env::remove_var(self.key) };
-        }
-    }
-}
-
-fn with_cat_pager_env<T>(f: impl FnOnce() -> T) -> T {
-    let _git_pager = EnvVarGuard::set("GIT_PAGER", "cat");
-    let _pager = EnvVarGuard::set("PAGER", "cat");
-    f()
-}
-
 fn git_string(repo: Option<&Path>, args: &[&str]) -> anyhow::Result<String> {
     let output = git_output(repo, args)?;
 
@@ -509,10 +476,10 @@ fn git_bytes(repo: Option<&Path>, args: &[&str]) -> anyhow::Result<Vec<u8>> {
 }
 
 fn git_output(repo: Option<&Path>, args: &[&str]) -> anyhow::Result<Output> {
-    with_cat_pager_env(|| match repo {
-        Some(repo) => common_git::run_output_in(repo, args),
-        None => common_git::run_output(args),
-    })
+    match repo {
+        Some(repo) => common_git::run_output_in_with_env(repo, args, &CAT_PAGER_ENV),
+        None => common_git::run_output_with_env(args, &CAT_PAGER_ENV),
+    }
     .map_err(Into::into)
 }
 


### PR DESCRIPTION
## Summary
- Implement issue #239 Sprint 2 Task 1 (S2T1): standardize process/git command plumbing through `nils-common`.
- Route `nils_common::git` subprocess execution through `nils_common::process` shared wrappers.
- Add env/cwd-aware shared command wrappers in `nils-common` and migrate semantic-commit pager command paths to those wrappers.
- Preserve crate-local error and exit-code behavior.

## Scope
- `crates/nils-common/src/process.rs`
- `crates/nils-common/src/git.rs`
- `crates/semantic-commit/src/commit.rs`
- `crates/semantic-commit/src/staged_context.rs`

## Validation
- `cargo test -p nils-common` ✅
- `cargo test -p nils-git-lock` ✅
- `cargo test -p nils-git-scope` ✅
- `cargo test -p nils-semantic-commit` ✅
- `cargo test -p nils-plan-tooling` ✅
- `cargo test -p nils-git-cli` ✅

Refs #239
