### PR TITLE
refactor(term): implement issue #239 S3 progress convergence

### DIFF
--- a/crates/api-test/src/main.rs
+++ b/crates/api-test/src/main.rs
@@ -11,7 +11,7 @@ use api_testing_core::suite::resolve::{
 use api_testing_core::suite::runner::{SuiteRunOptions, run_suite};
 use api_testing_core::suite::schema::load_and_validate_suite;
 use api_testing_core::suite::summary::{SummaryOptions, render_summary_from_json_str};
-use nils_term::progress::{Progress, ProgressOptions};
+use nils_term::progress::{Progress, ProgressEnabled, ProgressOptions};
 
 mod completion;
 
@@ -171,6 +171,44 @@ fn print_root_help() {
     println!("  api-test completion zsh");
 }
 
+fn progress_enabled_from_env(raw: Option<&str>) -> ProgressEnabled {
+    let Some(value) = raw.map(str::trim).filter(|v| !v.is_empty()) else {
+        return ProgressEnabled::Auto;
+    };
+
+    if value.eq_ignore_ascii_case("auto") {
+        return ProgressEnabled::Auto;
+    }
+
+    if value.eq_ignore_ascii_case("on")
+        || value == "1"
+        || value.eq_ignore_ascii_case("true")
+        || value.eq_ignore_ascii_case("yes")
+    {
+        return ProgressEnabled::On;
+    }
+
+    if value.eq_ignore_ascii_case("off")
+        || value == "0"
+        || value.eq_ignore_ascii_case("false")
+        || value.eq_ignore_ascii_case("no")
+    {
+        return ProgressEnabled::Off;
+    }
+
+    ProgressEnabled::Auto
+}
+
+fn suite_progress(total_cases: usize) -> Progress {
+    let enabled = progress_enabled_from_env(std::env::var("API_TEST_PROGRESS").ok().as_deref());
+    Progress::new(
+        total_cases as u64,
+        ProgressOptions::default()
+            .with_prefix("api-test ")
+            .with_enabled(enabled),
+    )
+}
+
 fn main() {
     std::process::exit(run());
 }
@@ -242,10 +280,7 @@ fn cmd_run(args: &RunArgs) -> i32 {
         }
     };
 
-    let progress = Progress::new(
-        loaded.manifest.cases.len() as u64,
-        ProgressOptions::default().with_prefix("api-test "),
-    );
+    let progress = suite_progress(loaded.manifest.cases.len());
 
     let out_dir_base_raw = std::env::var("API_TEST_OUTPUT_DIR")
         .ok()
@@ -401,7 +436,8 @@ fn cmd_summary(args: &SummaryArgs) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::argv_with_default_command;
+    use super::{argv_with_default_command, progress_enabled_from_env};
+    use nils_term::progress::ProgressEnabled;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -434,6 +470,38 @@ mod tests {
                 "--suite".to_string(),
                 "smoke".to_string()
             ]
+        );
+    }
+
+    #[test]
+    fn progress_enabled_from_env_parses_auto_on_off_aliases() {
+        assert_eq!(progress_enabled_from_env(None), ProgressEnabled::Auto);
+        assert_eq!(progress_enabled_from_env(Some("")), ProgressEnabled::Auto);
+        assert_eq!(
+            progress_enabled_from_env(Some("auto")),
+            ProgressEnabled::Auto
+        );
+        assert_eq!(
+            progress_enabled_from_env(Some("AUTO")),
+            ProgressEnabled::Auto
+        );
+
+        assert_eq!(progress_enabled_from_env(Some("on")), ProgressEnabled::On);
+        assert_eq!(progress_enabled_from_env(Some("1")), ProgressEnabled::On);
+        assert_eq!(progress_enabled_from_env(Some("true")), ProgressEnabled::On);
+        assert_eq!(progress_enabled_from_env(Some("yes")), ProgressEnabled::On);
+
+        assert_eq!(progress_enabled_from_env(Some("off")), ProgressEnabled::Off);
+        assert_eq!(progress_enabled_from_env(Some("0")), ProgressEnabled::Off);
+        assert_eq!(
+            progress_enabled_from_env(Some("false")),
+            ProgressEnabled::Off
+        );
+        assert_eq!(progress_enabled_from_env(Some("no")), ProgressEnabled::Off);
+
+        assert_eq!(
+            progress_enabled_from_env(Some("unexpected")),
+            ProgressEnabled::Auto
         );
     }
 }

--- a/crates/api-test/tests/progress_contract.rs
+++ b/crates/api-test/tests/progress_contract.rs
@@ -1,0 +1,213 @@
+use std::path::{Path, PathBuf};
+
+use nils_test_support::bin::resolve;
+use nils_test_support::cmd::{CmdOptions, CmdOutput, run_with};
+use nils_test_support::fs::write_text;
+use nils_test_support::http::{HttpResponse, RecordedRequest, TestServer};
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+fn api_test_bin() -> PathBuf {
+    resolve("api-test")
+}
+
+fn start_server() -> TestServer {
+    TestServer::new(
+        |req: &RecordedRequest| match (req.method.as_str(), req.path.as_str()) {
+            ("GET", "/health") => HttpResponse::new(200, r#"{"ok":true}"#)
+                .with_header("Content-Type", "application/json"),
+            _ => HttpResponse::new(404, r#"{"error":"not_found"}"#)
+                .with_header("Content-Type", "application/json"),
+        },
+    )
+    .expect("start test server")
+}
+
+fn setup_suite(root: &Path, server: &TestServer) {
+    std::fs::create_dir_all(root.join(".git")).expect("mkdir .git");
+    write_text(
+        &root.join("setup/rest/requests/health.request.json"),
+        r#"{"method":"GET","path":"/health"}"#,
+    );
+
+    let suite_json = serde_json::json!({
+      "version": 1,
+      "name": "progress",
+      "defaults": {
+        "env": "local",
+        "noHistory": true,
+        "rest": { "url": server.url() }
+      },
+      "cases": [
+        { "id": "rest.health", "type": "rest", "request": "setup/rest/requests/health.request.json" }
+      ]
+    });
+    write_text(
+        &root.join("tests/api/suites/progress.suite.json"),
+        &serde_json::to_string_pretty(&suite_json).expect("suite json"),
+    );
+}
+
+fn run_progress_suite(cwd: &Path, output_dir: &str, extra_env: &[(&str, &str)]) -> CmdOutput {
+    let mut options = CmdOptions::default().with_cwd(cwd);
+    for key in [
+        "ACCESS_TOKEN",
+        "SERVICE_TOKEN",
+        "REST_TOKEN_NAME",
+        "GQL_JWT_NAME",
+        "API_TEST_PROGRESS",
+        "API_TEST_REST_URL",
+        "API_TEST_GQL_URL",
+        "API_TEST_GRPC_URL",
+        "API_TEST_WS_URL",
+        "NO_COLOR",
+    ] {
+        options = options.with_env_remove(key);
+    }
+    options = options.with_env("API_TEST_OUTPUT_DIR", output_dir);
+    for (k, v) in extra_env {
+        options = options.with_env(k, v);
+    }
+
+    run_with(&api_test_bin(), &["run", "--suite", "progress"], &options)
+}
+
+fn has_sgr_color_sequence(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == 0x1b && bytes[i + 1] == b'[' {
+            i += 2;
+            while i < bytes.len() {
+                let b = bytes[i];
+                i += 1;
+                if b == b'm' {
+                    return true;
+                }
+                if b.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+            continue;
+        }
+        i += 1;
+    }
+    false
+}
+
+#[test]
+fn progress_auto_and_on_are_silent_in_non_tty_and_keep_stdout_json_clean() {
+    let tmp = TempDir::new().expect("tmp");
+    let root = tmp.path();
+    let server = start_server();
+    setup_suite(root, &server);
+
+    let auto = run_progress_suite(root, "out/api-test-progress-auto", &[]);
+    assert_eq!(
+        auto.code,
+        0,
+        "stdout={}\nstderr={}",
+        auto.stdout_text(),
+        auto.stderr_text()
+    );
+    let auto_stdout = auto.stdout_text();
+    let auto_stderr = auto.stderr_text();
+    let auto_json: serde_json::Value =
+        serde_json::from_slice(&auto.stdout).expect("auto stdout json");
+    assert_eq!(auto_json["summary"]["total"], 1);
+    assert!(!auto_stdout.contains("api-test "), "stdout leaked progress");
+    assert!(
+        !auto_stderr.contains("api-test "),
+        "stderr showed progress in auto/non-tty"
+    );
+    assert!(
+        auto_stderr.contains("api-test-runner: suite="),
+        "missing run summary stderr line"
+    );
+
+    let on = run_progress_suite(
+        root,
+        "out/api-test-progress-on",
+        &[("API_TEST_PROGRESS", "on")],
+    );
+    assert_eq!(
+        on.code,
+        0,
+        "stdout={}\nstderr={}",
+        on.stdout_text(),
+        on.stderr_text()
+    );
+    let on_stdout = on.stdout_text();
+    let on_stderr = on.stderr_text();
+    let on_json: serde_json::Value = serde_json::from_slice(&on.stdout).expect("on stdout json");
+    assert_eq!(on_json["summary"]["total"], 1);
+    assert!(!on_stdout.contains("api-test "), "stdout leaked progress");
+    assert!(
+        !on_stderr.contains("api-test "),
+        "non-TTY contract should keep progress quiet even when API_TEST_PROGRESS=on; stderr={on_stderr}"
+    );
+    assert!(
+        on_stderr.contains("api-test-runner: suite="),
+        "missing run summary stderr line"
+    );
+}
+
+#[test]
+fn progress_off_disables_progress_output() {
+    let tmp = TempDir::new().expect("tmp");
+    let root = tmp.path();
+    let server = start_server();
+    setup_suite(root, &server);
+
+    let out = run_progress_suite(
+        root,
+        "out/api-test-progress-off",
+        &[("API_TEST_PROGRESS", "off")],
+    );
+    assert_eq!(
+        out.code,
+        0,
+        "stdout={}\nstderr={}",
+        out.stdout_text(),
+        out.stderr_text()
+    );
+    let stdout = out.stdout_text();
+    let stderr = out.stderr_text();
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout json");
+    assert_eq!(json["summary"]["total"], 1);
+    assert!(!stdout.contains("api-test "), "stdout leaked progress");
+    assert!(
+        !stderr.contains("api-test "),
+        "stderr showed progress while API_TEST_PROGRESS=off"
+    );
+}
+
+#[test]
+fn progress_with_no_color_keeps_json_clean_and_avoids_sgr_color_sequences() {
+    let tmp = TempDir::new().expect("tmp");
+    let root = tmp.path();
+    let server = start_server();
+    setup_suite(root, &server);
+
+    let out = run_progress_suite(
+        root,
+        "out/api-test-progress-no-color",
+        &[("API_TEST_PROGRESS", "on"), ("NO_COLOR", "1")],
+    );
+    assert_eq!(
+        out.code,
+        0,
+        "stdout={}\nstderr={}",
+        out.stdout_text(),
+        out.stderr_text()
+    );
+    let stdout = out.stdout_text();
+    let stderr = out.stderr_text();
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout json");
+    assert_eq!(json["summary"]["total"], 1);
+    assert!(!stdout.contains("api-test "), "stdout leaked progress");
+    assert!(
+        !has_sgr_color_sequence(&stderr),
+        "stderr contains SGR color escapes under NO_COLOR: {stderr:?}"
+    );
+}

--- a/crates/nils-term/tests/progress.rs
+++ b/crates/nils-term/tests/progress.rs
@@ -61,6 +61,42 @@ fn disabled_mode_produces_no_output() {
 }
 
 #[test]
+fn writer_target_tty_contract_distinguishes_auto_and_off() {
+    let auto_buffer = Arc::new(Mutex::new(Vec::new()));
+    let auto = Progress::new(
+        2,
+        ProgressOptions::default()
+            .with_enabled(ProgressEnabled::Auto)
+            .with_draw_target(ProgressDrawTarget::to_writer(auto_buffer.clone()))
+            .with_width(Some(60))
+            .with_prefix("tty "),
+    );
+    auto.inc(1);
+    auto.finish();
+
+    let auto_out = normalize(&read_output(&auto_buffer));
+    assert!(auto_out.contains("1/2"), "output was: {auto_out:?}");
+    assert!(auto_out.contains("tty"), "output was: {auto_out:?}");
+
+    let off_buffer = Arc::new(Mutex::new(Vec::new()));
+    let off = Progress::new(
+        2,
+        ProgressOptions::default()
+            .with_enabled(ProgressEnabled::Off)
+            .with_draw_target(ProgressDrawTarget::to_writer(off_buffer.clone()))
+            .with_width(Some(60))
+            .with_prefix("tty "),
+    );
+    off.inc(1);
+    off.finish();
+
+    assert!(
+        read_output(&off_buffer).is_empty(),
+        "off mode should stay silent"
+    );
+}
+
+#[test]
 fn determinate_renders_and_finishes() {
     let buffer = Arc::new(Mutex::new(Vec::new()));
     let opts = ProgressOptions::default()


### PR DESCRIPTION
## Summary
- Implement S3 grouped delivery for issue #239 in one branch/PR covering S3T1/S3T2/S3T3/S3T4.
- S3T1: Updated `$AGENT_HOME/out/workspace-shared-audit/hotspots-nils-term.md` with an explicit policy signal line (`progress_policy/adopt/keep-local/no-progress`) and explicit `25/25` crate coverage status.
- S3T2: Kept `nils-term` public API unchanged (audit gap remains unproven) and added a progress contract test for TTY-like writer auto/off behavior.
- S3T3: Migrated `api-test` suite progress construction to `nils-term` policy wiring via `API_TEST_PROGRESS` -> `ProgressEnabled` mapping.
- S3T4: Added progress contract integration tests for non-TTY behavior, `off` behavior, JSON stdout cleanliness, and `NO_COLOR` compatibility.

## Validation
- `rg -n 'progress_policy|adopt|keep-local|no-progress' "$AGENT_HOME/out/workspace-shared-audit/hotspots-nils-term.md"`
- `cargo test -p nils-term`
- `cargo test -p nils-api-testing-core`
- `cargo test -p nils-api-test`

## Refs
- Refs #239
- Includes S3T1/S3T2/S3T3/S3T4
