### PR TITLE
refactor(test-support): implement issue #239 S4 executable helper convergence

### DIFF
--- a/crates/fzf-cli/src/defs/block_preview.rs
+++ b/crates/fzf-cli/src/defs/block_preview.rs
@@ -127,35 +127,10 @@ BEGIN {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nils_test_support::{EnvGuard, GlobalStateLock, StubBinDir, prepend_path};
+    use nils_test_support::{EnvGuard, GlobalStateLock, StubBinDir, prepend_path, stubs};
     use pretty_assertions::assert_eq;
     use std::fs;
     use tempfile::TempDir;
-
-    fn fzf_stub_script() -> &'static str {
-        r#"#!/bin/bash
-set -euo pipefail
-
-dir="${FZF_STUB_OUT_DIR:?FZF_STUB_OUT_DIR is required}"
-counter="$dir/.counter"
-n=1
-if [[ -f "$counter" ]]; then
-  n=$(( $(/bin/cat "$counter") + 1 ))
-fi
-echo "$n" > "$counter"
-
-out="$dir/$n.out"
-code_file="$dir/$n.code"
-if [[ -f "$out" ]]; then
-  /bin/cat "$out"
-fi
-
-if [[ -f "$code_file" ]]; then
-  exit "$(/bin/cat "$code_file")"
-fi
-exit 0
-"#
-    }
 
     #[test]
     fn run_requires_delimiters() {
@@ -179,7 +154,7 @@ exit 0
 
         let clipboard = temp.path().join("clipboard.txt");
         let stub = StubBinDir::new();
-        stub.write_exe("fzf", fzf_stub_script());
+        stub.write_exe("fzf", stubs::fzf_stub_script());
         stub.write_exe(
             "pbcopy",
             r#"#!/bin/bash

--- a/crates/fzf-cli/src/util.rs
+++ b/crates/fzf-cli/src/util.rs
@@ -85,7 +85,7 @@ pub fn zsh_cache_dir() -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nils_test_support::{EnvGuard, GlobalStateLock, StubBinDir};
+    use nils_test_support::{EnvGuard, GlobalStateLock, StubBinDir, prepend_path};
     use tempfile::TempDir;
 
     #[test]
@@ -148,7 +148,7 @@ fi
 exit 1
 "#,
         );
-        let _path_success = EnvGuard::set(&lock, "PATH", &success_stubs.path_str());
+        let _path_success = prepend_path(&lock, success_stubs.path());
         assert!(probe());
         drop(_path_success);
 
@@ -163,7 +163,7 @@ fi
 exit 1
 "#,
         );
-        let _path_fail = EnvGuard::set(&lock, "PATH", &fail_stubs.path_str());
+        let _path_fail = prepend_path(&lock, fail_stubs.path());
         assert!(!probe());
         drop(_path_fail);
 

--- a/crates/fzf-cli/tests/common.rs
+++ b/crates/fzf-cli/tests/common.rs
@@ -1,10 +1,7 @@
-use nils_test_support::bin;
-use nils_test_support::cmd;
-use std::path::{Path, PathBuf};
-
-use nils_test_support::StubBinDir;
 #[allow(unused_imports)]
 pub use nils_test_support::write_exe;
+use nils_test_support::{StubBinDir, bin, cmd};
+use std::path::{Path, PathBuf};
 
 #[allow(dead_code)]
 pub struct CmdOutput {
@@ -19,13 +16,59 @@ pub fn fzf_cli_bin() -> PathBuf {
     bin::resolve("fzf-cli")
 }
 
+#[allow(dead_code)]
 pub fn run_fzf_cli(
     dir: &Path,
     args: &[&str],
     envs: &[(&str, &str)],
     stdin: Option<&str>,
 ) -> CmdOutput {
-    let output = cmd::run_resolved_in_dir("fzf-cli", dir, args, envs, stdin.map(str::as_bytes));
+    let mut options = cmd::options_in_dir_with_envs(dir, envs);
+    if let Some(input) = stdin {
+        options = options.with_stdin_str(input);
+    }
+    let output = cmd::run_resolved("fzf-cli", args, &options);
+    CmdOutput {
+        code: output.code,
+        stdout: output.stdout_text(),
+        stderr: output.stderr_text(),
+    }
+}
+
+#[allow(dead_code)]
+pub fn run_fzf_cli_with_stub_path(
+    dir: &Path,
+    stub_path: &Path,
+    args: &[&str],
+    envs: &[(&str, &str)],
+    stdin: Option<&str>,
+) -> CmdOutput {
+    let mut options = cmd::options_in_dir_with_envs(dir, envs).with_path_prepend(stub_path);
+    if let Some(input) = stdin {
+        options = options.with_stdin_str(input);
+    }
+    let output = cmd::run_resolved("fzf-cli", args, &options);
+    CmdOutput {
+        code: output.code,
+        stdout: output.stdout_text(),
+        stderr: output.stderr_text(),
+    }
+}
+
+#[allow(dead_code)]
+pub fn run_fzf_cli_with_stub_only_path(
+    dir: &Path,
+    stub_path: &Path,
+    args: &[&str],
+    envs: &[(&str, &str)],
+    stdin: Option<&str>,
+) -> CmdOutput {
+    let path = stub_path.to_string_lossy().to_string();
+    let mut options = cmd::options_in_dir_with_envs(dir, envs).with_env("PATH", &path);
+    if let Some(input) = stdin {
+        options = options.with_stdin_str(input);
+    }
+    let output = cmd::run_resolved("fzf-cli", args, &options);
     CmdOutput {
         code: output.code,
         stdout: output.stdout_text(),
@@ -36,17 +79,6 @@ pub fn run_fzf_cli(
 #[allow(dead_code)]
 pub fn make_stub_dir() -> StubBinDir {
     StubBinDir::new()
-}
-
-#[allow(dead_code)]
-pub fn path_with_prepend(dir: &Path) -> String {
-    cmd::CmdOptions::default()
-        .with_path_prepend(dir)
-        .envs
-        .into_iter()
-        .rev()
-        .find_map(|(key, value)| (key == "PATH").then_some(value))
-        .expect("PATH should be set")
 }
 
 #[allow(dead_code)]

--- a/crates/fzf-cli/tests/edge_cases.rs
+++ b/crates/fzf-cli/tests/edge_cases.rs
@@ -73,18 +73,13 @@ fn history_parsing_strips_icon_prefix() {
 
     let hist_s = hist.to_string_lossy().to_string();
     let out_dir_s = out_dir.to_string_lossy().to_string();
-    let path_s = format!(
-        "{}:{}",
-        stub.path().display(),
-        std::env::var("PATH").unwrap()
-    );
     let envs = [
         ("HISTFILE", hist_s.as_str()),
-        ("PATH", path_s.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
     ];
 
-    let out = common::run_fzf_cli(dir.path(), &["history"], &envs, None);
+    let out =
+        common::run_fzf_cli_with_stub_path(dir.path(), stub.path(), &["history"], &envs, None);
     assert_eq!(out.code, 0);
     assert_eq!(out.stdout.trim(), "echo hi");
 }
@@ -104,17 +99,10 @@ fn directory_ctrl_d_emits_cd_command() {
     common::write_exe(stub.path(), "fzf", common::fzf_stub_script());
 
     let out_dir_s = out_dir.to_string_lossy().to_string();
-    let path_s = format!(
-        "{}:{}",
-        stub.path().display(),
-        std::env::var("PATH").unwrap()
-    );
-    let envs = [
-        ("PATH", path_s.as_str()),
-        ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
-    ];
+    let envs = [("FZF_STUB_OUT_DIR", out_dir_s.as_str())];
 
-    let out = common::run_fzf_cli(dir.path(), &["directory"], &envs, None);
+    let out =
+        common::run_fzf_cli_with_stub_path(dir.path(), stub.path(), &["directory"], &envs, None);
     assert_eq!(out.code, 0);
     assert!(
         out.stdout.contains("cd "),
@@ -156,20 +144,21 @@ echo "$@" >> "${KILL_LOG:?}"
 
     let kill_log = dir.path().join("kill.log");
     fs::write(&kill_log, "").unwrap();
-    let kill_bin = stub.path().join("kill");
 
-    let path_s = stub.path().to_string_lossy().to_string();
     let out_dir_s = out_dir.to_string_lossy().to_string();
     let kill_log_s = kill_log.to_string_lossy().to_string();
-    let kill_bin_s = kill_bin.to_string_lossy().to_string();
     let envs = [
-        ("PATH", path_s.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
         ("KILL_LOG", kill_log_s.as_str()),
-        ("NILS_TEST_KILL_BIN", kill_bin_s.as_str()),
     ];
 
-    let out = common::run_fzf_cli(dir.path(), &["process", "-k"], &envs, None);
+    let out = common::run_fzf_cli_with_stub_only_path(
+        dir.path(),
+        stub.path(),
+        &["process", "-k"],
+        &envs,
+        None,
+    );
     assert_eq!(out.code, 0);
     assert!(
         out.stdout.contains("SIGTERM"),
@@ -208,20 +197,21 @@ echo "$@" >> "${KILL_LOG:?}"
 
     let kill_log = dir.path().join("kill.log");
     fs::write(&kill_log, "").unwrap();
-    let kill_bin = stub.path().join("kill");
 
-    let path_s = stub.path().to_string_lossy().to_string();
     let out_dir_s = out_dir.to_string_lossy().to_string();
     let kill_log_s = kill_log.to_string_lossy().to_string();
-    let kill_bin_s = kill_bin.to_string_lossy().to_string();
     let envs = [
-        ("PATH", path_s.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
         ("KILL_LOG", kill_log_s.as_str()),
-        ("NILS_TEST_KILL_BIN", kill_bin_s.as_str()),
     ];
 
-    let out = common::run_fzf_cli(dir.path(), &["process"], &envs, Some("n\n"));
+    let out = common::run_fzf_cli_with_stub_only_path(
+        dir.path(),
+        stub.path(),
+        &["process"],
+        &envs,
+        Some("n\n"),
+    );
     assert_eq!(out.code, 1);
     assert!(
         out.stdout.contains("🚫 Aborted."),
@@ -253,14 +243,11 @@ echo "tcp4 0 0 127.0.0.1.1234 *.* LISTEN"
 "#,
     );
 
-    let path_s = stub.path().to_string_lossy().to_string();
     let out_dir_s = out_dir.to_string_lossy().to_string();
-    let envs = [
-        ("PATH", path_s.as_str()),
-        ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
-    ];
+    let envs = [("FZF_STUB_OUT_DIR", out_dir_s.as_str())];
 
-    let out = common::run_fzf_cli(dir.path(), &["port"], &envs, None);
+    let out =
+        common::run_fzf_cli_with_stub_only_path(dir.path(), stub.path(), &["port"], &envs, None);
     assert_eq!(out.code, 0);
 }
 
@@ -292,20 +279,21 @@ echo "$@" >> "${KILL_LOG:?}"
 
     let kill_log = dir.path().join("kill.log");
     fs::write(&kill_log, "").unwrap();
-    let kill_bin = stub.path().join("kill");
 
-    let path_s = stub.path().to_string_lossy().to_string();
     let out_dir_s = out_dir.to_string_lossy().to_string();
     let kill_log_s = kill_log.to_string_lossy().to_string();
-    let kill_bin_s = kill_bin.to_string_lossy().to_string();
     let envs = [
-        ("PATH", path_s.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
         ("KILL_LOG", kill_log_s.as_str()),
-        ("NILS_TEST_KILL_BIN", kill_bin_s.as_str()),
     ];
 
-    let out = common::run_fzf_cli(dir.path(), &["port", "-k"], &envs, None);
+    let out = common::run_fzf_cli_with_stub_only_path(
+        dir.path(),
+        stub.path(),
+        &["port", "-k"],
+        &envs,
+        None,
+    );
     assert_eq!(out.code, 0);
     let log = fs::read_to_string(&kill_log).unwrap();
     assert!(log.contains("999"), "kill log missing pid: {log}");

--- a/crates/fzf-cli/tests/git_commands.rs
+++ b/crates/fzf-cli/tests/git_commands.rs
@@ -42,16 +42,20 @@ exit 0
 "#,
     );
 
-    let path_s = common::path_with_prepend(stub.path());
     let out_dir_s = out_dir.to_string_lossy().to_string();
     let git_log_s = git_log.to_string_lossy().to_string();
     let envs = [
-        ("PATH", path_s.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
         ("GIT_LOG", git_log_s.as_str()),
     ];
 
-    let out = common::run_fzf_cli(temp.path(), &["git-branch"], &envs, Some("y\n"));
+    let out = common::run_fzf_cli_with_stub_path(
+        temp.path(),
+        stub.path(),
+        &["git-branch"],
+        &envs,
+        Some("y\n"),
+    );
     assert_eq!(out.code, 0);
     assert!(out.stdout.contains("✅ Checked out to main"));
     let log = fs::read_to_string(&git_log).unwrap();
@@ -100,16 +104,20 @@ exit 0
 "#,
     );
 
-    let path_s = common::path_with_prepend(stub.path());
     let out_dir_s = out_dir.to_string_lossy().to_string();
     let git_log_s = git_log.to_string_lossy().to_string();
     let envs = [
-        ("PATH", path_s.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
         ("GIT_LOG", git_log_s.as_str()),
     ];
 
-    let out = common::run_fzf_cli(temp.path(), &["git-tag"], &envs, Some("y\n"));
+    let out = common::run_fzf_cli_with_stub_path(
+        temp.path(),
+        stub.path(),
+        &["git-tag"],
+        &envs,
+        Some("y\n"),
+    );
     assert_eq!(out.code, 0);
     assert!(
         out.stdout
@@ -183,16 +191,20 @@ exit 0
 "#,
     );
 
-    let path_s = common::path_with_prepend(stub.path());
     let out_dir_s = out_dir.to_string_lossy().to_string();
     let checkout_count_s = checkout_count.to_string_lossy().to_string();
     let envs = [
-        ("PATH", path_s.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
         ("CHECKOUT_COUNT", checkout_count_s.as_str()),
     ];
 
-    let out = common::run_fzf_cli(temp.path(), &["git-checkout"], &envs, Some("y\ny\n"));
+    let out = common::run_fzf_cli_with_stub_path(
+        temp.path(),
+        stub.path(),
+        &["git-checkout"],
+        &envs,
+        Some("y\ny\n"),
+    );
     assert_eq!(out.code, 0);
     assert!(out.stdout.contains("📦 Changes stashed"));
     assert!(out.stdout.contains("✅ Checked out to abc123"));
@@ -227,14 +239,11 @@ exit 0
 "#,
     );
 
-    let path_s = common::path_with_prepend(stub.path());
     let out_dir_s = out_dir.to_string_lossy().to_string();
-    let envs = [
-        ("PATH", path_s.as_str()),
-        ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
-    ];
+    let envs = [("FZF_STUB_OUT_DIR", out_dir_s.as_str())];
 
-    let out = common::run_fzf_cli(temp.path(), &["git-status"], &envs, None);
+    let out =
+        common::run_fzf_cli_with_stub_path(temp.path(), stub.path(), &["git-status"], &envs, None);
     assert_eq!(out.code, 0);
 }
 
@@ -301,19 +310,18 @@ exit 0
 "#,
     );
 
-    let path_s = common::path_with_prepend(stub.path());
     let out_dir_s = out_dir.to_string_lossy().to_string();
     let repo_root_s = repo_root.to_string_lossy().to_string();
     let vi_log_s = vi_log.to_string_lossy().to_string();
     let envs = [
-        ("PATH", path_s.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
         ("FZF_FILE_OPEN_WITH", "vi"),
         ("REPO_ROOT", repo_root_s.as_str()),
         ("VI_LOG", vi_log_s.as_str()),
     ];
 
-    let out = common::run_fzf_cli(temp.path(), &["git-commit"], &envs, None);
+    let out =
+        common::run_fzf_cli_with_stub_path(temp.path(), stub.path(), &["git-commit"], &envs, None);
     assert_eq!(out.code, 0);
     let log = fs::read_to_string(&vi_log).unwrap();
     assert!(log.contains("file.txt"));

--- a/crates/fzf-cli/tests/git_commit.rs
+++ b/crates/fzf-cli/tests/git_commit.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{fzf_stub_script, make_stub_dir, path_with_prepend, run_fzf_cli, write_exe};
+use common::{fzf_stub_script, make_stub_dir, run_fzf_cli_with_stub_path, write_exe};
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
@@ -82,19 +82,23 @@ exit 0
 "#,
     );
 
-    let path_env = path_with_prepend(stub.path());
     let out_dir_s = out_dir.to_string_lossy().to_string();
     let repo_root_s = repo_root.to_string_lossy().to_string();
     let vi_log_s = vi_log.to_string_lossy().to_string();
     let envs = [
-        ("PATH", path_env.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
         ("FZF_FILE_OPEN_WITH", "vi"),
         ("REPO_ROOT", repo_root_s.as_str()),
         ("VI_LOG", vi_log_s.as_str()),
     ];
 
-    let out = run_fzf_cli(temp.path(), &["git-commit"], &envs, Some("n\n"));
+    let out = run_fzf_cli_with_stub_path(
+        temp.path(),
+        stub.path(),
+        &["git-commit"],
+        &envs,
+        Some("n\n"),
+    );
     assert_eq!(out.code, 1);
     assert!(out.stderr.contains("File no longer exists in working tree"));
     let log = fs::read_to_string(&vi_log).unwrap();
@@ -130,19 +134,23 @@ exit 0
 "#,
     );
 
-    let path_env = path_with_prepend(stub.path());
     let out_dir_s = out_dir.to_string_lossy().to_string();
     let repo_root_s = repo_root.to_string_lossy().to_string();
     let vi_log_s = vi_log.to_string_lossy().to_string();
     let envs = [
-        ("PATH", path_env.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
         ("FZF_FILE_OPEN_WITH", "vi"),
         ("REPO_ROOT", repo_root_s.as_str()),
         ("VI_LOG", vi_log_s.as_str()),
     ];
 
-    let out = run_fzf_cli(temp.path(), &["git-commit"], &envs, Some("y\n"));
+    let out = run_fzf_cli_with_stub_path(
+        temp.path(),
+        stub.path(),
+        &["git-commit"],
+        &envs,
+        Some("y\n"),
+    );
     assert_eq!(out.code, 0);
     let log = fs::read_to_string(&vi_log).unwrap();
     assert!(log.contains("--"));

--- a/crates/fzf-cli/tests/open_and_file.rs
+++ b/crates/fzf-cli/tests/open_and_file.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{fzf_stub_script, make_stub_dir, path_with_prepend, run_fzf_cli, write_exe};
+use common::{fzf_stub_script, make_stub_dir, run_fzf_cli_with_stub_path, write_exe};
 use std::fs;
 use tempfile::TempDir;
 
@@ -28,15 +28,13 @@ exit 0
 "#,
     );
 
-    let path_env = path_with_prepend(stub.path());
     let envs = [
-        ("PATH", path_env.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir.to_str().unwrap()),
         ("FZF_FILE_OPEN_WITH", "vscode"),
         ("CODE_STUB_LOG", code_log.to_str().unwrap()),
     ];
 
-    let output = run_fzf_cli(temp.path(), &["file"], &envs, None);
+    let output = run_fzf_cli_with_stub_path(temp.path(), stub.path(), &["file"], &envs, None);
     assert_eq!(output.code, 0);
 
     let code_args = fs::read_to_string(&code_log).unwrap();
@@ -78,16 +76,14 @@ exit 0
 "#,
     );
 
-    let path_env = path_with_prepend(stub.path());
     let envs = [
-        ("PATH", path_env.as_str()),
         ("FZF_STUB_OUT_DIR", out_dir.to_str().unwrap()),
         ("FZF_FILE_OPEN_WITH", "vscode"),
         ("CODE_STUB_LOG", code_log.to_str().unwrap()),
         ("VI_STUB_LOG", vi_log.to_str().unwrap()),
     ];
 
-    let output = run_fzf_cli(temp.path(), &["file"], &envs, None);
+    let output = run_fzf_cli_with_stub_path(temp.path(), stub.path(), &["file"], &envs, None);
     assert_eq!(output.code, 0);
 
     let vi_args = fs::read_to_string(&vi_log).unwrap();


### PR DESCRIPTION
## Summary
- Implement S4T2 for issue #239 by converging `nils-fzf-cli` tests on shared `nils-test-support` cmd/stubs utilities.
- Replace manual PATH/bin test wiring with shared `cmd::CmdOptions`-based helpers in `crates/fzf-cli/tests/common.rs`.
- Migrate affected fzf-cli integration tests to the shared helper flow and remove direct `NILS_TEST_KILL_BIN` path wiring in edge-case tests.
- Replace duplicated local `fzf` stub script in block-preview tests with `nils_test_support::stubs::fzf_stub_script`, and use `prepend_path` in util tests.

## Validation
- `cargo test -p nils-fzf-cli`

## Refs
- #239
- S4T2