### PR TITLE
docs(shared): implement issue #239 S6 shared-crate docs refresh

### DIFF
--- a/crates/nils-common/README.md
+++ b/crates/nils-common/README.md
@@ -22,7 +22,6 @@ Primary constraint: shared helpers must preserve behavioral parity for each cons
 
 ## Modules and purpose
 
-- `env`: truthy parsing helpers and `NO_COLOR` presence checks.
 - `env`: truthy parsing helpers, `NO_COLOR` checks, and trimmed non-empty env lookup.
 - `shell`: POSIX single-quote escaping and ANSI stripping modes.
 - `process`: command execution wrappers plus PATH lookup helpers.

--- a/crates/nils-term/README.md
+++ b/crates/nils-term/README.md
@@ -3,6 +3,20 @@
 ## Overview
 Small terminal utilities shared across the workspace.
 
+## Shared helper policy
+
+### What belongs in `nils-term`
+
+- Domain-neutral progress primitives that can be reused by multiple binaries.
+- Structured APIs (`Progress`, `ProgressOptions`, `ProgressEnabled`) that callers can compose.
+- Behavior that can be verified with deterministic unit/integration tests.
+
+### What stays crate-local
+
+- Product-specific progress copy, emoji/prefix style, and section wording.
+- CLI-specific policy decisions about when progress should appear for a command.
+- Exit-code mapping and command-level error/warning text.
+
 ## Progress
 `nils-term` provides a minimal, RAII-friendly progress abstraction that is safe for
 machine-readable stdout output:
@@ -44,6 +58,14 @@ Prefer accepting a `Progress` (or `ProgressOptions`) from the caller instead of 
 inside library code. This keeps libraries deterministic and lets binaries decide whether to show
 progress (e.g. interactive vs CI).
 
+## Migration guidance
+
+When migrating crate-local progress code into `nils-term`:
+
+1. Add/keep characterization tests before moving behavior.
+2. Keep progress rendering to `stderr` so machine-readable `stdout` remains stable.
+3. Keep CLI-local adapters for command wording and error/exit semantics.
+4. Re-run command-contract tests for TTY, non-TTY, JSON, and `NO_COLOR` flows.
 
 ## Docs
 

--- a/crates/nils-test-support/README.md
+++ b/crates/nils-test-support/README.md
@@ -6,6 +6,20 @@
 It provides small utilities to keep tests deterministic when they need to manipulate global state
 or stub external commands.
 
+## Shared helper policy
+
+### What belongs in `nils-test-support`
+
+- Test-only utilities reused by multiple crates (guards, git helpers, command wrappers, stubs).
+- Deterministic helpers that reduce flakiness and remove local test boilerplate.
+- APIs that keep tests explicit while avoiding duplicated harness logic.
+
+### What stays crate-local
+
+- Test assertions specific to one CLI's output/contract expectations.
+- Product-specific fixture semantics that are not reusable elsewhere.
+- Command-specific golden text snapshots and local approval-test policy.
+
 ## Utilities
 - Global guards
   - `GlobalStateLock`: serialize tests that mutate process-global state (env, cwd, PATH, etc.)
@@ -36,6 +50,15 @@ let stub_dir = StubBinDir::new();
 let _path = prepend_path(&lock, stub_dir.path());
 let _env = EnvGuard::set(&lock, "EXAMPLE", "1");
 ```
+
+## Migration guidance
+
+When migrating existing crate-local test helpers:
+
+1. Move only reusable primitives; keep command-specific assertions local.
+2. Prefer `GlobalStateLock`, `EnvGuard`, and `CwdGuard` for global-state safety.
+3. Replace manual `PATH`/stub setup with `StubBinDir`, `prepend_path`, and `stubs`.
+4. Re-run affected crate tests and keep flaky-risk notes up to date.
 
 ## Docs
 


### PR DESCRIPTION
## Summary
- Implement Sprint 6 grouped docs delivery for issue #239 (S6T1/S6T2/S6T3).
- S6T1: generated shared-crate public API snapshot at `$AGENT_HOME/out/workspace-shared-audit/public-api.txt`.
- S6T2: refreshed shared-crate READMEs (`nils-common`, `nils-term`, `nils-test-support`) with consistent policy/migration/docs-index guidance.
- S6T3: validated docs placement/docs-only checks and published final docs checklist at `$AGENT_HOME/out/workspace-shared-audit/final-docs-checklist.md`.

## Validation
- `rg -n '^pub (fn|struct|enum|type)' crates/nils-common/src crates/nils-term/src crates/nils-test-support/src > "$AGENT_HOME/out/workspace-shared-audit/public-api.txt"`
- `rg -n 'Migration|What belongs|What stays crate-local|Docs index' crates/nils-common/README.md crates/nils-term/README.md crates/nils-test-support/README.md`
- `bash scripts/ci/docs-placement-audit.sh --strict`
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh --docs-only`

## Refs
- Refs #239
- Includes S6T1/S6T2/S6T3
