### PR TITLE
Normalize auto single-lane execution mode to per-sprint

### DIFF
--- a/crates/api-testing-core/tests/cli_endpoint.rs
+++ b/crates/api-testing-core/tests/cli_endpoint.rs
@@ -116,9 +116,11 @@ fn resolve_cli_endpoint_unknown_env_lists_available() {
 
 #[test]
 fn resolve_cli_endpoint_env_default_from_env_file() {
+    let lock = GlobalStateLock::new();
     let tmp = TempDir::new().unwrap();
     let endpoints_env = tmp.path().join("endpoints.env");
     let endpoints_local = tmp.path().join("endpoints.local.env");
+    let _url_guard = EnvGuard::remove(&lock, "REST_URL");
     write_file(
         &endpoints_env,
         "REST_ENV_DEFAULT=prod\nREST_URL_PROD=http://prod\n",

--- a/crates/plan-issue-cli/README.md
+++ b/crates/plan-issue-cli/README.md
@@ -59,6 +59,7 @@ Shell wrapper scripts are deprecated for this crate path. Use `plan-issue` / `pl
 - `--pr-grouping per-sprint`: one shared group per sprint (default style).
 - `--pr-grouping group --strategy deterministic`: requires explicit `--pr-group <task>=<group>` mappings.
 - `--pr-grouping group --strategy auto`: allows optional pins and auto assignment for remaining tasks.
+  - when auto resolves a sprint to a single shared PR group, `Execution Mode` is normalized to `per-sprint` (instead of `pr-shared`) to reflect single-lane execution semantics.
 
 ## Quick examples
 ```bash

--- a/crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v1.md
+++ b/crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v1.md
@@ -58,6 +58,7 @@ v1 subcommands:
 - `--pr-grouping <per-sprint|group>`:
   - required for `build-task-spec`, `build-plan-task-spec`, `start-plan`, `start-sprint`.
   - `per-spring` must be accepted as compatibility alias for `per-sprint`.
+  - with `--pr-grouping group --strategy auto`, when a sprint resolves to exactly one shared PR group, issue-sync/render paths normalize `Execution Mode` to `per-sprint` (single-lane semantics).
 - `--pr-group <task=group>`:
   - repeatable.
   - valid only when `--pr-grouping group`.

--- a/crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md
+++ b/crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md
@@ -92,6 +92,9 @@ Row-level status rules:
   - `Task`, `Summary`, `Owner`, `Branch`, `Worktree`, `Execution Mode`, `PR`, `Status`, `Notes`
 - `Status` must be one of `{planned, in-progress, blocked, done}`.
 - `Execution Mode` must be one of `{per-sprint, pr-isolated, pr-shared}` or `TBD`.
+- Execution Mode derivation rule:
+  - `group + auto` that resolves to one shared PR lane for a sprint is represented as `per-sprint` (single-lane execution).
+  - `group + auto|deterministic` with multiple resolved PR groups keeps `pr-shared` / `pr-isolated` per group size.
 - Owner policy for non-planned/non-blocked rows:
   - must include `subagent`
   - must not reference main-agent identity.

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -15,7 +15,7 @@ use crate::commands::plan::{
 use crate::commands::sprint::{
     AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs,
 };
-use crate::commands::{Command as CliCommand, SummaryArgs};
+use crate::commands::{Command as CliCommand, SplitStrategy, SummaryArgs};
 use crate::github::{GhCliAdapter, GitHubAdapter};
 use crate::issue_body::{self, TaskRow};
 use crate::render::{self, SprintCommentInput, SprintCommentMode};
@@ -613,8 +613,9 @@ fn run_start_sprint(
                 .map_err(|err| CommandError::runtime("previous-sprint-gate-failed", err))?;
         }
 
-        synced_rows = sync_issue_rows_from_task_spec(&mut table, &build.rows)
-            .map_err(|err| CommandError::runtime("task-sync-failed", err))?;
+        synced_rows =
+            sync_issue_rows_from_task_spec(&mut table, &build.rows, args.grouping.strategy)
+                .map_err(|err| CommandError::runtime("task-sync-failed", err))?;
 
         let updated_body = table.render();
         issue_body_for_comment = Some(updated_body.clone());
@@ -635,6 +636,7 @@ fn run_start_sprint(
         sprint: i32::from(args.sprint),
         sprint_name: &sprint_name,
         rows: &build.rows,
+        strategy: args.grouping.strategy,
         note_text: None,
         approval_comment_url: None,
         issue_body_text: issue_body_for_comment.as_deref(),
@@ -736,6 +738,7 @@ fn run_ready_sprint(
         sprint: i32::from(args.sprint),
         sprint_name: &sprint_name,
         rows: &build.rows,
+        strategy: args.grouping.strategy,
         note_text: summary.as_deref(),
         approval_comment_url: None,
         issue_body_text: issue_body_for_comment.as_deref(),
@@ -879,6 +882,7 @@ fn run_accept_sprint(
         sprint: i32::from(args.sprint),
         sprint_name: &sprint_name,
         rows: &build.rows,
+        strategy: args.grouping.strategy,
         note_text: summary.as_deref(),
         approval_comment_url: Some(&args.approved_comment_url),
         issue_body_text: issue_body_for_comment.as_deref(),
@@ -1338,34 +1342,27 @@ fn enforce_previous_sprint_gate(
 fn sync_issue_rows_from_task_spec(
     table: &mut issue_body::TaskTable,
     spec_rows: &[TaskSpecRow],
+    strategy: SplitStrategy,
 ) -> Result<usize, String> {
-    let mut group_sizes: HashMap<String, usize> = HashMap::new();
+    let execution_modes = task_spec::execution_mode_by_task(spec_rows, strategy);
+    let mut spec_by_task: HashMap<String, TaskSpecRow> = HashMap::new();
     for spec in spec_rows {
-        *group_sizes.entry(spec.pr_group.clone()).or_insert(0) += 1;
-    }
-
-    let mut spec_by_task: HashMap<String, (TaskSpecRow, String)> = HashMap::new();
-    for spec in spec_rows {
-        let mode = if spec.grouping == crate::commands::PrGrouping::PerSprint {
-            "per-sprint".to_string()
-        } else if group_sizes.get(&spec.pr_group).copied().unwrap_or(0) > 1 {
-            "pr-shared".to_string()
-        } else {
-            "pr-isolated".to_string()
-        };
-        spec_by_task.insert(spec.task_id.clone(), (spec.clone(), mode));
+        spec_by_task.insert(spec.task_id.clone(), spec.clone());
     }
 
     let mut touched = HashSet::new();
     let mut updated = 0usize;
 
     for row in table.rows_mut() {
-        if let Some((spec, mode)) = spec_by_task.get(&row.task) {
+        if let Some(spec) = spec_by_task.get(&row.task) {
             row.summary = spec.summary.clone();
             row.owner = spec.owner.clone();
             row.branch = spec.branch.clone();
             row.worktree = spec.worktree.clone();
-            row.execution_mode = mode.clone();
+            row.execution_mode = execution_modes
+                .get(&spec.task_id)
+                .cloned()
+                .unwrap_or_else(|| "pr-isolated".to_string());
             row.notes = spec.notes.clone();
             if issue_body::is_placeholder(&row.pr) {
                 row.pr = "TBD".to_string();
@@ -2038,7 +2035,9 @@ mod tests {
             },
         ];
 
-        let updated = sync_issue_rows_from_task_spec(&mut table, &specs).expect("sync");
+        let updated =
+            sync_issue_rows_from_task_spec(&mut table, &specs, SplitStrategy::Deterministic)
+                .expect("sync");
         assert_eq!(updated, 2);
         let rows = table.rows();
         assert_eq!(rows[0].branch, "issue/s1-t1");
@@ -2060,12 +2059,110 @@ mod tests {
                 sprint: 9,
                 grouping: PrGrouping::PerSprint,
             }],
+            SplitStrategy::Deterministic,
         )
         .expect_err("missing table rows should fail");
         assert!(
             missing.contains("issue task table missing rows"),
             "{missing}"
         );
+    }
+
+    #[test]
+    fn sync_issue_rows_from_task_spec_auto_single_group_uses_per_sprint_mode() {
+        let body = task_table_markdown(&[
+            task_row("S3T1", "TBD", "TBD", "TBD", "", "sprint=S3"),
+            task_row("S3T2", "TBD", "TBD", "TBD", "", "sprint=S3"),
+        ]);
+        let mut table = issue_body::parse_task_table(&body).expect("table");
+
+        let specs = vec![
+            TaskSpecRow {
+                task_id: "S3T1".to_string(),
+                summary: "Task 1".to_string(),
+                branch: "issue/s3-t1".to_string(),
+                worktree: "wt-1".to_string(),
+                owner: "subagent-s3-t1".to_string(),
+                notes: "sprint=S3; plan-task:Task 3.1; pr-group=s3-auto-g1".to_string(),
+                pr_group: "s3-auto-g1".to_string(),
+                sprint: 3,
+                grouping: PrGrouping::Group,
+            },
+            TaskSpecRow {
+                task_id: "S3T2".to_string(),
+                summary: "Task 2".to_string(),
+                branch: "issue/s3-t2".to_string(),
+                worktree: "wt-2".to_string(),
+                owner: "subagent-s3-t2".to_string(),
+                notes: "sprint=S3; plan-task:Task 3.2; pr-group=s3-auto-g1".to_string(),
+                pr_group: "s3-auto-g1".to_string(),
+                sprint: 3,
+                grouping: PrGrouping::Group,
+            },
+        ];
+
+        let updated =
+            sync_issue_rows_from_task_spec(&mut table, &specs, SplitStrategy::Auto).expect("sync");
+        assert_eq!(updated, 2);
+
+        let rows = table.rows();
+        assert_eq!(rows[0].execution_mode, "per-sprint");
+        assert_eq!(rows[1].execution_mode, "per-sprint");
+    }
+
+    #[test]
+    fn sync_issue_rows_from_task_spec_auto_multi_group_keeps_group_modes() {
+        let body = task_table_markdown(&[
+            task_row("S4T1", "TBD", "TBD", "TBD", "", "sprint=S4"),
+            task_row("S4T2", "TBD", "TBD", "TBD", "", "sprint=S4"),
+            task_row("S4T3", "TBD", "TBD", "TBD", "", "sprint=S4"),
+        ]);
+        let mut table = issue_body::parse_task_table(&body).expect("table");
+
+        let specs = vec![
+            TaskSpecRow {
+                task_id: "S4T1".to_string(),
+                summary: "Task 1".to_string(),
+                branch: "issue/s4-t1".to_string(),
+                worktree: "wt-1".to_string(),
+                owner: "subagent-s4-t1".to_string(),
+                notes: "sprint=S4; plan-task:Task 4.1; pr-group=s4-auto-g1".to_string(),
+                pr_group: "s4-auto-g1".to_string(),
+                sprint: 4,
+                grouping: PrGrouping::Group,
+            },
+            TaskSpecRow {
+                task_id: "S4T2".to_string(),
+                summary: "Task 2".to_string(),
+                branch: "issue/s4-t2".to_string(),
+                worktree: "wt-2".to_string(),
+                owner: "subagent-s4-t2".to_string(),
+                notes: "sprint=S4; plan-task:Task 4.2; pr-group=s4-auto-g1".to_string(),
+                pr_group: "s4-auto-g1".to_string(),
+                sprint: 4,
+                grouping: PrGrouping::Group,
+            },
+            TaskSpecRow {
+                task_id: "S4T3".to_string(),
+                summary: "Task 3".to_string(),
+                branch: "issue/s4-t3".to_string(),
+                worktree: "wt-3".to_string(),
+                owner: "subagent-s4-t3".to_string(),
+                notes: "sprint=S4; plan-task:Task 4.3; pr-group=s4-auto-g2".to_string(),
+                pr_group: "s4-auto-g2".to_string(),
+                sprint: 4,
+                grouping: PrGrouping::Group,
+            },
+        ];
+
+        let updated =
+            sync_issue_rows_from_task_spec(&mut table, &specs, SplitStrategy::Auto).expect("sync");
+        assert_eq!(updated, 3);
+
+        let rows = table.rows();
+        assert_eq!(rows[0].execution_mode, "pr-shared");
+        assert_eq!(rows[1].execution_mode, "pr-shared");
+        assert_eq!(rows[2].execution_mode, "pr-isolated");
     }
 
     fn setup_repo_with_linked_worktree() -> (TempDir, PathBuf) {

--- a/crates/plan-issue-cli/src/render.rs
+++ b/crates/plan-issue-cli/src/render.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::commands::SplitStrategy;
 use crate::issue_body;
-use crate::task_spec::{TaskSpecRow, agent_home};
+use crate::task_spec::{TaskSpecRow, agent_home, execution_mode_by_task};
 use nils_common::fs as common_fs;
 use nils_common::git as common_git;
 
@@ -21,6 +22,7 @@ pub struct SprintCommentInput<'a> {
     pub sprint: i32,
     pub sprint_name: &'a str,
     pub rows: &'a [TaskSpecRow],
+    pub strategy: SplitStrategy,
     pub note_text: Option<&'a str>,
     pub approval_comment_url: Option<&'a str>,
     pub issue_body_text: Option<&'a str>,
@@ -196,6 +198,7 @@ pub fn render_sprint_comment(input: SprintCommentInput<'_>) -> Result<String, St
         sprint,
         sprint_name,
         rows,
+        strategy,
         note_text,
         approval_comment_url,
         issue_body_text,
@@ -205,10 +208,7 @@ pub fn render_sprint_comment(input: SprintCommentInput<'_>) -> Result<String, St
         return Err("task spec contains no rows".to_string());
     }
 
-    let mut group_sizes: HashMap<String, usize> = HashMap::new();
-    for row in rows {
-        *group_sizes.entry(row.pr_group.clone()).or_insert(0) += 1;
-    }
+    let execution_modes = execution_mode_by_task(rows, strategy);
 
     let issue_pr_values = issue_body_text
         .map(parse_issue_pr_values)
@@ -260,13 +260,10 @@ pub fn render_sprint_comment(input: SprintCommentInput<'_>) -> Result<String, St
             out.push("| Task | Summary | Execution Mode |".to_string());
             out.push("| --- | --- | --- |".to_string());
             for row in rows {
-                let execution_mode = if row.grouping == crate::commands::PrGrouping::PerSprint {
-                    "per-sprint"
-                } else if group_sizes.get(&row.pr_group).copied().unwrap_or(0) > 1 {
-                    "pr-shared"
-                } else {
-                    "pr-isolated"
-                };
+                let execution_mode = execution_modes
+                    .get(&row.task_id)
+                    .map(String::as_str)
+                    .unwrap_or("pr-isolated");
                 out.push(format!(
                     "| {} | {} | {} |",
                     row.task_id,
@@ -294,7 +291,11 @@ pub fn render_sprint_comment(input: SprintCommentInput<'_>) -> Result<String, St
                     .map(|v| normalize_pr_display(v))
                     .unwrap_or_default();
                 if pr_value.is_empty() {
-                    pr_value = if row.grouping == crate::commands::PrGrouping::PerSprint {
+                    let execution_mode = execution_modes
+                        .get(&row.task_id)
+                        .map(String::as_str)
+                        .unwrap_or("pr-isolated");
+                    pr_value = if execution_mode == "per-sprint" {
                         "TBD (per-sprint)".to_string()
                     } else {
                         format!("TBD (group:{})", row.pr_group)

--- a/crates/plan-issue-cli/src/task_spec.rs
+++ b/crates/plan-issue-cli/src/task_spec.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
 use nils_common::{fs as common_fs, git as common_git};
@@ -143,6 +144,50 @@ pub fn write_tsv(path: &Path, rows: &[TaskSpecRow]) -> Result<(), String> {
             format!("failed to write task-spec {}: {source}", path.display())
         }
     })
+}
+
+pub fn execution_mode_by_task(
+    rows: &[TaskSpecRow],
+    strategy: SplitStrategy,
+) -> HashMap<String, String> {
+    let mut sprint_group_set: HashMap<i32, BTreeSet<String>> = HashMap::new();
+    let mut sprint_group_sizes: HashMap<(i32, String), usize> = HashMap::new();
+    for row in rows {
+        sprint_group_set
+            .entry(row.sprint)
+            .or_default()
+            .insert(row.pr_group.clone());
+        *sprint_group_sizes
+            .entry((row.sprint, row.pr_group.clone()))
+            .or_insert(0) += 1;
+    }
+
+    let mut out = HashMap::new();
+    for row in rows {
+        let sprint_group_count = sprint_group_set
+            .get(&row.sprint)
+            .map(BTreeSet::len)
+            .unwrap_or(0);
+        let group_size = sprint_group_sizes
+            .get(&(row.sprint, row.pr_group.clone()))
+            .copied()
+            .unwrap_or(0);
+
+        let mode = if row.grouping == PrGrouping::PerSprint {
+            "per-sprint"
+        } else if strategy == SplitStrategy::Auto && sprint_group_count == 1 && group_size > 1 {
+            // Auto/group can converge to a single shared PR lane. Expose that as per-sprint so
+            // downstream execution semantics match explicit per-sprint mode.
+            "per-sprint"
+        } else if group_size > 1 {
+            "pr-shared"
+        } else {
+            "pr-isolated"
+        };
+        out.insert(row.task_id.clone(), mode.to_string());
+    }
+
+    out
 }
 
 pub fn default_plan_task_spec_path(plan_file: &Path) -> PathBuf {

--- a/crates/plan-issue-cli/tests/task_spec_flow.rs
+++ b/crates/plan-issue-cli/tests/task_spec_flow.rs
@@ -501,6 +501,78 @@ fn render_issue_body_start_sprint_writes_start_comment_with_modes() {
 }
 
 #[test]
+fn render_issue_body_start_sprint_group_auto_single_pr_lane_uses_per_sprint_mode() {
+    let tmp = TempDir::new().expect("temp dir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let plan_file = tmp.path().join("auto-single-lane-plan.md");
+    let plan_file_s = plan_file.to_string_lossy().to_string();
+    fs::write(
+        &plan_file,
+        r#"# Plan: auto single lane mode test
+
+## Sprint 1: Serial lane
+- **PR grouping intent**: `per-sprint`.
+- **Execution Profile**: `serial` (parallel width 1).
+
+### Task 1.1: First lane task
+- **Location**:
+  - crates/plan-issue-cli/src/a.rs
+- **Dependencies**:
+  - none
+
+### Task 1.2: Follow-up task
+- **Location**:
+  - crates/plan-issue-cli/src/b.rs
+- **Dependencies**:
+  - Task 1.1
+"#,
+    )
+    .expect("write plan");
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "start-sprint",
+            "--plan",
+            &plan_file_s,
+            "--issue",
+            "217",
+            "--sprint",
+            "1",
+            "--pr-grouping",
+            "group",
+            "--strategy",
+            "auto",
+            "--no-comment",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = parse_json(&out.stdout);
+    let comment_path = result_path(&payload, "comment_path");
+    let comment = fs::read_to_string(&comment_path).expect("read sprint comment");
+    assert!(
+        comment.contains("| Task | Summary | Execution Mode |"),
+        "{comment}"
+    );
+    assert!(
+        comment.contains("| S1T1 | First lane task | per-sprint |"),
+        "{comment}"
+    );
+    assert!(
+        comment.contains("| S1T2 | Follow-up task | per-sprint |"),
+        "{comment}"
+    );
+    assert!(!comment.contains("pr-shared"), "{comment}");
+}
+
+#[test]
 fn local_flow_plan_issue_local_dry_run_end_to_end_generates_artifacts() {
     let tmp = TempDir::new().expect("temp dir");
     let agent_home = tmp.path().join("agent-home");


### PR DESCRIPTION
# Normalize auto single-lane execution mode to per-sprint

## Summary
When `--pr-grouping group --strategy auto` resolves all tasks in a sprint into one shared PR lane, the
workflow previously rendered `pr-shared`, which obscured the effective single-lane behavior. This change
normalizes that scenario to `per-sprint` in sprint comment rendering and issue row synchronization while
keeping mixed-lane behavior unchanged.

## Changes
- Add strategy-aware `execution_mode_by_task` derivation in task-spec utilities.
- Normalize `group + auto + single shared lane` to `per-sprint` execution mode.
- Wire derived execution mode into sprint start/ready/accept comment rendering and issue-row sync.
- Add tests for single-lane normalization and multi-group non-regression behavior.
- Update plan-issue-cli docs/specs to document the normalized execution-mode semantics.
- Stabilize `api-testing-core` endpoint env-default test by guarding `REST_URL` global env state.

## Testing
- `env -u NILS_CLI_TEST_RUNNER ./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 86.45%)
- `cargo run -q -p nils-plan-tooling --bin plan-tooling -- split-prs --file /Users/terry/Project/graysurf/nils-cli/docs/plans/workspace-shared-crates-testability-stability-refactor-plan.md --scope sprint --sprint 3 --pr-grouping group --strategy auto --format tsv` (pass)

## Risk / Notes
- Mode normalization is intentionally limited to `group + auto` sprints that resolve to one shared group.
- Multi-group `auto` behavior remains `pr-shared` / `pr-isolated` based on resolved group sizes.
