### PR TITLE
docs(plan-issue-cli): S1T1 runtime-truth Task Decomposition contract (#250)

### DIFF
--- a/crates/plan-issue-cli/docs/README.md
+++ b/crates/plan-issue-cli/docs/README.md
@@ -3,6 +3,8 @@
 ## Purpose
 Crate-local documentation for `nils-plan-issue-cli`.
 
+`Task Decomposition` is the crate's documented runtime-truth execution table for plan/sprint orchestration. Specs define `Owner` as a dispatch alias, document `group + auto` single-lane normalization to `per-sprint`, and treat task-spec/subagent prompts as derived artifacts (not a second issue-body dispatch table).
+
 ## Specs
 - [plan-issue CLI contract v1](specs/plan-issue-cli-contract-v1.md)
 - [plan-issue state machine and gates v1](specs/plan-issue-state-machine-v1.md)

--- a/crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v1.md
+++ b/crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v1.md
@@ -66,6 +66,20 @@ v1 subcommands:
 - `--summary` and `--summary-file` are mutually exclusive where provided (`ready-plan`, `ready-sprint`).
 - `close-plan --dry-run` requires `--body-file` when no live issue read is available.
 
+## Task Decomposition Runtime-Truth Contract (v1)
+
+- `## Task Decomposition` in the plan issue body is the single runtime-truth execution table for plan/sprint orchestration.
+- No second issue-body dispatch table is introduced in v1; task dispatch artifacts are derived from `Task Decomposition`.
+- Column roles are split as follows:
+  - runtime-truth execution columns: `Owner`, `Branch`, `Worktree`, `Execution Mode`, and lane metadata tokens in `Notes`.
+  - runtime-progress columns: `PR`, `Status` (may remain placeholders until execution/review advances).
+  - descriptive row identity columns: `Task`, `Summary`.
+- `Owner` stores a stable dispatch alias (for example `subagent-s1-t1`, or a shared-lane `dispatch` alias), not a platform-internal ephemeral spawned-agent identifier.
+- `task-spec` TSV rows and subagent prompt artifacts must be derived from the same `Task Decomposition` runtime-truth rows and must not intentionally diverge from the issue table.
+- Lane canonicalization rules:
+  - rows that share one execution lane (`per-sprint` or `pr-shared`) must keep canonical lane metadata (`Owner`, `Branch`, `Worktree`, lane-note tokens) synchronized across the lane.
+  - `--pr-grouping group --strategy auto` single-lane sprints normalize to `Execution Mode=per-sprint` and use canonical per-sprint lane metadata rather than per-task pseudo-lanes.
+
 ## Deterministic Artifact Contracts
 
 ### Task-spec TSV
@@ -98,6 +112,9 @@ When explicit output paths are omitted, v1 keeps AGENT_HOME-based deterministic 
 ## Gate Semantics (v1)
 
 - Single-plan issue model: one plan maps to one GitHub issue for the full delivery lifecycle.
+- `Task Decomposition` runtime-truth ownership:
+  - sprint execution and issue-sync flows read runtime-truth lane metadata from the issue table.
+  - task-spec and prompt generation are derived outputs, not an alternate source of runtime execution truth.
 - Sprint ordering gate:
   - `start-sprint` for sprint `N>1` is blocked until sprint `N-1` has merged PRs and `done` task statuses.
 - Acceptance gate:

--- a/crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md
+++ b/crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md
@@ -21,6 +21,15 @@ This document is normative for lifecycle transitions that must remain compatible
   - `Notes` token `sprint=S<N>`, or
   - task id pattern `S<N>T<k>`.
 
+## Task Decomposition Runtime-Truth Row Model
+- `## Task Decomposition` is the only runtime-truth execution table in the issue body for plan/sprint orchestration.
+- No second issue-body dispatch table is introduced; task-spec and subagent prompt artifacts are derived views of the same runtime-truth rows.
+- Column role split:
+  - runtime-truth execution metadata: `Owner`, `Branch`, `Worktree`, `Execution Mode`, lane metadata tokens in `Notes`
+  - runtime-progress fields: `PR`, `Status`
+  - descriptive row identity: `Task`, `Summary`
+- `Owner` is a stable dispatch alias (for example `subagent-s1-t1` or a shared-lane `dispatch` alias), not an ephemeral platform-internal worker identifier.
+
 ## Plan Lifecycle State Machine
 
 States:
@@ -95,8 +104,9 @@ Row-level status rules:
 - Execution Mode derivation rule:
   - `group + auto` that resolves to one shared PR lane for a sprint is represented as `per-sprint` (single-lane execution).
   - `group + auto|deterministic` with multiple resolved PR groups keeps `pr-shared` / `pr-isolated` per group size.
+  - rows that share a `per-sprint` or `pr-shared` lane must keep canonical runtime-truth lane metadata aligned (`Owner`, `Branch`, `Worktree`, lane-note tokens).
 - Owner policy for non-planned/non-blocked rows:
-  - must include `subagent`
+  - must be a stable dispatch alias (`subagent-*` and shared-lane `dispatch` alias are valid shapes)
   - must not reference main-agent identity.
 - `pr-isolated` rows must have unique `Branch` and unique `Worktree`.
 
@@ -126,7 +136,7 @@ Row-level status rules:
   - all task rows are `Status=done` unless `--allow-not-done` is explicitly used
   - every task row has non-placeholder PR
   - every referenced PR is merged
-  - subagent-owner policy passes.
+  - dispatch-owner alias policy passes (including subagent alias compatibility checks).
 - After close gate success, strict task worktree cleanup is enforced.
 
 ### Worktree Cleanup Invariants


### PR DESCRIPTION
## Summary
- Implements issue #250 Sprint 1 Task 1.1 (S1T1) in an isolated worktree/branch.
- Defines `Task Decomposition` as the single runtime-truth execution table in plan-issue-cli docs/specs.
- Clarifies `Owner` as a dispatch alias and documents `group + auto` single-lane `per-sprint` semantics.

## Scope
- Update `plan-issue-cli` contract/state-machine specs and crate docs README wording for runtime-truth semantics.
- Keep changes docs-only within S1T1 ownership files.

## Testing
- `rg -n 'runtime-truth|Task Decomposition|dispatch alias|single-lane|per-sprint' crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v1.md crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md crates/plan-issue-cli/docs/README.md` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh --docs-only` (pass)

## Issue
- #250
- Task: S1T1
