### PR TITLE
docs(plan-issue-cli): finalize runtime-truth surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Each crate is either a standalone CLI binary or a shared library used across the
 - [crates/gemini-cli](crates/gemini-cli): Provider-specific CLI lane for Gemini workflows, with adapters over `nils-common::provider_runtime`.
 - [crates/semantic-commit](crates/semantic-commit): Helper CLI for generating staged context and creating semantic commits.
 - [crates/plan-tooling](crates/plan-tooling): Plan Format v1 tooling CLI (`to-json`, `validate`, `batches`, `split-prs`, `scaffold`, `completion`).
-- [crates/plan-issue-cli](crates/plan-issue-cli): Plan issue orchestration binaries (`plan-issue`, `plan-issue-local`) for task-spec build/start/status/ready/accept/close workflows plus completion export.
+- [crates/plan-issue-cli](crates/plan-issue-cli): Plan issue orchestration binaries (`plan-issue`, `plan-issue-local`) where `Task Decomposition` is runtime truth and sprint artifacts are derived outputs.
 
 ## Shared helper policy (`nils-common`)
 

--- a/crates/plan-issue-cli/README.md
+++ b/crates/plan-issue-cli/README.md
@@ -4,6 +4,8 @@
 `plan-issue-cli` provides the Rust command contract for plan/issue delivery orchestration.
 It is the typed replacement lane for `plan-issue-delivery-loop.sh` behavior and is built around
 deterministic task-spec generation, issue-body rendering, and gate-enforced sprint transitions.
+`Task Decomposition` is the runtime-truth execution table; sprint task-spec/prompt artifacts are
+derived from those issue rows.
 
 The crate ships two binaries with the same command surface:
 
@@ -26,7 +28,7 @@ Shell wrapper scripts are deprecated for this crate path. Use `plan-issue` / `pl
 - `cleanup-worktrees`: enforce cleanup of all issue-assigned task worktrees.
 
 ### Sprint-level flow
-- `start-sprint`: open sprint execution loop after previous sprint gate passes.
+- `start-sprint`: open sprint execution loop after previous sprint gate passes, validate runtime-truth rows against plan lanes, and render artifacts without rewriting issue rows.
 - `ready-sprint`: post sprint-ready signal for main-agent review.
 - `accept-sprint`: enforce merged-PR gate and mark sprint accepted.
 - `multi-sprint-guide`: print repeated command flow for a whole plan.

--- a/crates/plan-issue-cli/tests/sprint5_delivery.rs
+++ b/crates/plan-issue-cli/tests/sprint5_delivery.rs
@@ -375,7 +375,10 @@ fn auto_single_lane_end_to_end_keeps_per_sprint_runtime_truth() {
         ready_comment.contains("| S1T2 | Follow-up lane task | TBD (per-sprint) |"),
         "{ready_comment}"
     );
-    assert!(ready_comment.contains("runtime truth ready"), "{ready_comment}");
+    assert!(
+        ready_comment.contains("runtime truth ready"),
+        "{ready_comment}"
+    );
     assert!(!ready_comment.contains("pr-shared"), "{ready_comment}");
 
     let log = fs::read_to_string(&log_path).expect("read gh log");

--- a/crates/plan-tooling/README.md
+++ b/crates/plan-tooling/README.md
@@ -49,6 +49,7 @@ Help:
   - when sprint metadata provides `Execution Profile` parallel width hints, auto grouping targets that lane count (deterministic fallback merges apply when needed).
   - `pr-grouping=per-sprint` keeps one shared group per sprint (`s<n>`).
   - ordering and tie-breakers stay deterministic (`Task N.M`, then `SxTy`, then lexical summary).
+  - emitted lane metadata (`pr_group`, anchor notes, prefixes) is consumed by `plan-issue` runtime-truth validation and sprint artifact rendering.
 - deterministic examples:
   - `split-prs --file docs/plans/example-plan.md --scope sprint --sprint 1 --pr-grouping per-sprint --format tsv`
   - `split-prs --file docs/plans/example-plan.md --scope sprint --sprint 2 --pr-grouping group --pr-group S2T1=isolated --pr-group S2T2=shared --pr-group S2T3=shared --format json`


### PR DESCRIPTION
## Summary
- finalize Sprint 5 runtime-truth wording across workspace README surfaces
- align `plan-issue-cli` README sprint flow wording with issue-table runtime-truth behavior
- keep sprint5 delivery test file rustfmt-aligned

## Testing
- ./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
- cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85
- scripts/ci/coverage-summary.sh target/coverage/lcov.info

## Related
- plan issue: #250
- sprint tasks: S5T1, S5T2
