### PR TITLE
Fix git-scope directory tree hangs and align status colors across terminals

### DIFF
--- a/crates/git-scope/src/render.rs
+++ b/crates/git-scope/src/render.rs
@@ -148,13 +148,20 @@ fn kind_color(kind: &str, no_color: bool) -> &'static str {
     if no_color {
         return "";
     }
+
+    // Use explicit RGB values for former xterm-256 indices so color output
+    // stays visually consistent across terminal renderers.
+    const COLOR_A: &str = "\x1b[38;2;95;135;135m"; // was 38;5;66
+    const COLOR_M: &str = "\x1b[38;2;135;175;215m"; // was 38;5;110
+    const COLOR_D: &str = "\x1b[38;2;135;95;95m"; // was 38;5;95
+
     match kind {
-        "A" => "\x1b[38;5;66m",
-        "M" => "\x1b[38;5;110m",
-        "D" => "\x1b[38;5;95m",
-        "U" => "\x1b[38;5;110m",
+        "A" => COLOR_A,
+        "M" => COLOR_M,
+        "D" => COLOR_D,
+        "U" => COLOR_M,
         "-" => "\x1b[0m",
-        _ => "\x1b[38;5;110m",
+        _ => COLOR_M,
     }
 }
 
@@ -195,9 +202,21 @@ fn render_tree(files: &[String], no_color: bool) -> Result<()> {
         .stdout(std::process::Stdio::piped());
 
     let mut child = cmd.spawn()?;
-    write_tree_input(child.stdin.take(), &tree_input)?;
+    if let Err(err) = write_tree_input(child.stdin.take(), &tree_input) {
+        let _ = child.wait();
+        println!("⚠️  Failed to stream paths to tree --fromfile ({err}). Skipping directory tree.");
+        return Ok(());
+    }
 
     let output = child.wait_with_output()?;
+    if !output.status.success() {
+        println!(
+            "⚠️  tree exited with status {}. Skipping directory tree output.",
+            output.status
+        );
+        return Ok(());
+    }
+
     let mut text = String::from_utf8_lossy(&output.stdout).to_string();
     if no_color {
         text = strip_ansi(&text);
@@ -264,9 +283,9 @@ mod tests {
 
     #[test]
     fn color_mode_uses_expected_commit_palette() {
-        assert_eq!(kind_color_for_commit("A", false), "\x1b[38;5;66m");
-        assert_eq!(kind_color_for_commit("M", false), "\x1b[38;5;110m");
-        assert_eq!(kind_color_for_commit("D", false), "\x1b[38;5;95m");
+        assert_eq!(kind_color_for_commit("A", false), "\x1b[38;2;95;135;135m");
+        assert_eq!(kind_color_for_commit("M", false), "\x1b[38;2;135;175;215m");
+        assert_eq!(kind_color_for_commit("D", false), "\x1b[38;2;135;95;95m");
         assert_eq!(color_reset_for_commit(false), "\x1b[0m");
     }
 

--- a/crates/git-scope/src/tree.rs
+++ b/crates/git-scope/src/tree.rs
@@ -27,7 +27,9 @@ fn detect_tree_support() -> TreeSupport {
         };
     }
 
-    let support = shared_process::run_status_quiet("tree", &["--fromfile"]);
+    // Probe support without reading interactive stdin. `tree --fromfile`
+    // alone reads from stdin and can block on a TTY.
+    let support = shared_process::run_status_quiet("tree", &["--fromfile", "/dev/null"]);
 
     if support.map(|s| !s.success()).unwrap_or(true) {
         return TreeSupport {


### PR DESCRIPTION
# Fix git-scope directory tree hangs and align status colors across terminals

## Summary

This PR fixes a `git-scope commit` hang that could stall after `📂 Directory tree:` in interactive TTY sessions, and aligns
`Changed files` status colors across terminal emulators by switching from xterm-256 index SGR to explicit RGB SGR values.

## Problem

- Expected: `git-scope commit <ref>` should always finish and print a directory tree (or degrade with a warning).
- Actual: tree support probing could block on stdin in interactive sessions, making output appear truncated.
- Impact: Commit inspection flow could hang and break developer workflows in cmux/debug wrapper paths.

## Reproduction

1. In a repo with staged/committed file changes, run:
   `NILS_WRAPPER_MODE=debug ./wrappers/git-scope commit HEAD`
2. Observe output in an interactive terminal.

- Expected result: output reaches and completes `📂 Directory tree` section.
- Actual result: output may stall at `📂 Directory tree:` due to stdin-blocking probe behavior.

## Issues Found

Severity: critical | high | medium | low Confidence: high | medium | low Status: open | fixed | deferred | needs-info

|ID|Severity|Confidence|Area|Summary|Evidence|Status|
|---|---|---|---|---|---|---|
|`PR-268-BUG-01`|high|high|`crates/git-scope/src/tree.rs`|`tree --fromfile` support probe could block on TTY stdin and stall command output.|`crates/git-scope/src/tree.rs:30`|fixed|
|`PR-268-BUG-02`|medium|high|`crates/git-scope/src/render.rs`|Changed-files status colors used fixed xterm-256 indexes, causing inconsistent appearance across terminals.|`crates/git-scope/src/render.rs:152`|fixed|

## Fix Approach

- Probe `tree` capability with `/dev/null` input (`tree --fromfile /dev/null`) to avoid interactive stdin blocking.
- Add graceful fallback when tree input streaming or tree execution fails; emit warnings and continue output.
- Replace `A/M/D` status colors with explicit RGB SGR values equivalent to previous 256-color choices.
- Update color expectation tests to assert RGB SGR output.

## Testing

- `cargo test -p nils-git-scope` (pass)

## Risk / Notes

- Full workspace required-checks script was started but user-interrupted during execution; crate-level target tests were rerun and passed.
