### PR TITLE
Fail fast on unresolved REST cleanup placeholders

### DIFF
--- a/crates/api-testing-core/src/rest/cleanup.rs
+++ b/crates/api-testing-core/src/rest/cleanup.rs
@@ -20,6 +20,10 @@ pub fn render_cleanup_path(cleanup: &RestCleanup, main_response_body: &[u8]) -> 
         path = path.replace(&format!("{{{{{key}}}}}"), &value);
     }
 
+    if path.contains("{{") || path.contains("}}") {
+        anyhow::bail!("cleanup.pathTemplate has unresolved placeholders: {path}");
+    }
+
     if !path.starts_with('/') {
         anyhow::bail!("cleanup.pathTemplate must resolve to an absolute path (starts with /)");
     }
@@ -123,5 +127,24 @@ mod tests {
         let body = serde_json::to_vec(&serde_json::json!({"key": "abc"})).unwrap();
         let err = render_cleanup_path(&cleanup, &body).unwrap_err();
         assert!(err.to_string().contains("absolute path"));
+    }
+
+    #[test]
+    fn rest_cleanup_unresolved_placeholder_is_error() {
+        let cleanup = crate::rest::schema::parse_rest_request_json(serde_json::json!({
+            "method": "GET",
+            "path": "/x",
+            "cleanup": {
+                "pathTemplate": "/files/{{key}}/{{missing}}",
+                "vars": { "key": ".key" }
+            }
+        }))
+        .unwrap()
+        .cleanup
+        .unwrap();
+
+        let body = serde_json::to_vec(&serde_json::json!({"key": "abc"})).unwrap();
+        let err = render_cleanup_path(&cleanup, &body).unwrap_err();
+        assert!(err.to_string().contains("unresolved placeholders"));
     }
 }


### PR DESCRIPTION
# Fail fast on unresolved REST cleanup placeholders

## Summary

This change makes REST cleanup path rendering fail fast when `cleanup.pathTemplate` still contains unresolved `{{placeholder}}` tokens after variable substitution. It prevents cleanup steps from sending requests to literal placeholder paths and adds a unit test that locks this behavior.

## Problem

- Expected: `cleanup.pathTemplate` should fully resolve before the cleanup HTTP request is executed.
- Actual: unresolved placeholders were left in the path and the request could execute against a literal path like `/files/{{missing}}`.
- Impact: cleanup runs can target unintended endpoints and produce confusing failures that are harder to diagnose.

## Reproduction

1. Configure a REST cleanup with a path template containing two placeholders but provide vars for only one:
   - `pathTemplate: "/files/{{key}}/{{missing}}"`
   - `vars: { "key": ".key" }`
2. Call `render_cleanup_path` (or execute cleanup) with a response body containing only `key`.

- Expected result: cleanup path rendering fails before making a request.
- Actual result (before fix): rendered path remains `/files/abc/{{missing}}` and proceeds.

## Issues Found

Severity: critical | high | medium | low Confidence: high | medium | low Status: open | fixed | deferred | needs-info

|ID|Severity|Confidence|Area|Summary|Evidence|Status|
|---|---|---|---|---|---|---|
|`PR-269-BUG-01`|medium|high|`crates/api-testing-core/src/rest/cleanup.rs`|REST cleanup allowed unresolved `{{...}}` placeholders to pass through as literal paths|`render_cleanup_path` now errors when placeholders remain; covered by `rest_cleanup_unresolved_placeholder_is_error`|fixed|

## Fix Approach

- Added unresolved-placeholder validation in `render_cleanup_path`:
  - return error when rendered path still contains `{{` or `}}`.
- Added regression test `rest_cleanup_unresolved_placeholder_is_error`.

## Testing

- `cargo test -p nils-api-testing-core rest_cleanup_` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `mkdir -p target/coverage && cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass; 86.52%)

## Risk / Notes

- This is a behavior-tightening change: cleanup now fails early for unresolved placeholders instead of issuing a likely-invalid request.
