### PR TITLE
Extract shared starship color helper for codex-cli and gemini-cli

### DIFF
--- a/crates/codex-cli/src/starship/render.rs
+++ b/crates/codex-cli/src/starship/render.rs
@@ -1,6 +1,5 @@
 use chrono::{Local, TimeZone};
 use nils_common::env as shared_env;
-use std::io::{self, IsTerminal};
 use std::path::Path;
 
 use crate::rate_limits::ansi;
@@ -97,21 +96,7 @@ fn format_epoch_local(epoch: i64, fmt: &str) -> Option<String> {
 }
 
 fn should_color() -> bool {
-    if shared_env::no_color_enabled() {
-        return false;
-    }
-
-    if std::env::var("CODEX_STARSHIP_COLOR_ENABLED").is_ok() {
-        return shared_env::env_truthy("CODEX_STARSHIP_COLOR_ENABLED");
-    }
-
-    if std::env::var_os("STARSHIP_SESSION_KEY").is_some()
-        || std::env::var_os("STARSHIP_SHELL").is_some()
-    {
-        return true;
-    }
-
-    io::stdout().is_terminal()
+    shared_env::starship_color_enabled("CODEX_STARSHIP_COLOR_ENABLED")
 }
 
 #[cfg(test)]

--- a/crates/gemini-cli/src/starship/render.rs
+++ b/crates/gemini-cli/src/starship/render.rs
@@ -1,6 +1,5 @@
 use nils_common::env as shared_env;
 use std::path::Path;
-use std::{io, io::IsTerminal};
 
 use crate::rate_limits::ansi;
 
@@ -94,21 +93,7 @@ pub fn render_line(
 }
 
 fn should_color() -> bool {
-    if shared_env::no_color_enabled() {
-        return false;
-    }
-
-    if std::env::var("GEMINI_STARSHIP_COLOR_ENABLED").is_ok() {
-        return shared_env::env_truthy("GEMINI_STARSHIP_COLOR_ENABLED");
-    }
-
-    if std::env::var_os("STARSHIP_SESSION_KEY").is_some()
-        || std::env::var_os("STARSHIP_SHELL").is_some()
-    {
-        return true;
-    }
-
-    io::stdout().is_terminal()
+    shared_env::starship_color_enabled("GEMINI_STARSHIP_COLOR_ENABLED")
 }
 
 #[cfg(test)]

--- a/crates/nils-common/src/env.rs
+++ b/crates/nils-common/src/env.rs
@@ -56,6 +56,24 @@ pub fn no_color_requested(explicit_no_color: bool) -> bool {
     explicit_no_color || no_color_enabled()
 }
 
+pub fn starship_color_enabled(explicit_toggle_env: &str) -> bool {
+    use std::io::IsTerminal;
+
+    if no_color_enabled() {
+        return false;
+    }
+
+    if env_present(explicit_toggle_env) {
+        return env_truthy(explicit_toggle_env);
+    }
+
+    if env_present("STARSHIP_SESSION_KEY") || env_present("STARSHIP_SHELL") {
+        return true;
+    }
+
+    std::io::stdout().is_terminal()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -223,5 +241,49 @@ mod tests {
         let lock = GlobalStateLock::new();
         let _guard = EnvGuard::set(&lock, "NO_COLOR", "1");
         assert!(no_color_requested(false));
+    }
+
+    #[test]
+    fn starship_color_enabled_no_color_has_highest_priority() {
+        let lock = GlobalStateLock::new();
+        let _no_color = EnvGuard::set(&lock, "NO_COLOR", "1");
+        let _explicit = EnvGuard::set(&lock, "NILS_COMMON_STARSHIP_COLOR_ENABLED", "1");
+        let _session = EnvGuard::set(&lock, "STARSHIP_SESSION_KEY", "session");
+        assert!(!starship_color_enabled(
+            "NILS_COMMON_STARSHIP_COLOR_ENABLED"
+        ));
+    }
+
+    #[test]
+    fn starship_color_enabled_honors_explicit_truthy_and_falsey_values() {
+        let lock = GlobalStateLock::new();
+        let _no_color = EnvGuard::remove(&lock, "NO_COLOR");
+        let _session = EnvGuard::remove(&lock, "STARSHIP_SESSION_KEY");
+        let _shell = EnvGuard::remove(&lock, "STARSHIP_SHELL");
+
+        for value in ["1", " true ", "YES", "on"] {
+            let _explicit = EnvGuard::set(&lock, "NILS_COMMON_STARSHIP_COLOR_ENABLED", value);
+            assert!(
+                starship_color_enabled("NILS_COMMON_STARSHIP_COLOR_ENABLED"),
+                "expected truthy value: {value}"
+            );
+        }
+
+        for value in ["", " ", "0", "false", "no", "off", "y", "enabled"] {
+            let _explicit = EnvGuard::set(&lock, "NILS_COMMON_STARSHIP_COLOR_ENABLED", value);
+            assert!(
+                !starship_color_enabled("NILS_COMMON_STARSHIP_COLOR_ENABLED"),
+                "expected falsey value: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn starship_color_enabled_uses_starship_markers_when_not_overridden() {
+        let lock = GlobalStateLock::new();
+        let _no_color = EnvGuard::remove(&lock, "NO_COLOR");
+        let _explicit = EnvGuard::remove(&lock, "NILS_COMMON_STARSHIP_COLOR_ENABLED");
+        let _session = EnvGuard::set(&lock, "STARSHIP_SESSION_KEY", "session");
+        assert!(starship_color_enabled("NILS_COMMON_STARSHIP_COLOR_ENABLED"));
     }
 }


### PR DESCRIPTION
# Extract shared starship color helper for codex-cli and gemini-cli

## Summary

This refactor removes duplicated starship color-selection logic from `nils-codex-cli` and `nils-gemini-cli` by extracting a shared helper into `nils-common`, preserving existing env variable contracts and runtime behavior.

## Changes

- Added `nils_common::env::starship_color_enabled(explicit_toggle_env)` to centralize `NO_COLOR`, explicit toggle, starship marker, and terminal fallback behavior.
- Added new `nils-common` unit tests covering precedence and parsing behavior for the shared helper.
- Updated `codex-cli` and `gemini-cli` starship renderers to use the shared helper with crate-specific env names (`CODEX_STARSHIP_COLOR_ENABLED`, `GEMINI_STARSHIP_COLOR_ENABLED`).

## Testing

- `cargo test -p nils-common starship_color_enabled -- --nocapture` (pass)
- `cargo test -p nils-codex-cli should_color_ -- --nocapture` (pass)
- `cargo test -p nils-gemini-cli should_color_ -- --nocapture` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)

## Risk / Notes

- Low risk: behavior remains covered by existing crate-level `should_color` characterization tests and new shared helper tests.
