### PR TITLE
Fix fzf-cli git-commit query corruption after Esc return

### DIFF
--- a/crates/fzf-cli/src/git_commit_select.rs
+++ b/crates/fzf-cli/src/git_commit_select.rs
@@ -7,6 +7,14 @@ pub struct CommitPick {
     pub hash: String,
 }
 
+fn restore_bind(default_query: &str) -> String {
+    if default_query.is_empty() {
+        "focus:unbind(focus)+clear-query".to_string()
+    } else {
+        format!("focus:unbind(focus)+change-query[{default_query}]")
+    }
+}
+
 pub fn pick_commit(default_query: &str, selected: Option<&str>) -> Result<Option<CommitPick>> {
     let log_out = util::run_capture(
         "git",
@@ -34,14 +42,9 @@ pub fn pick_commit(default_query: &str, selected: Option<&str>) -> Result<Option
     ];
 
     if let Some(selected) = selected.filter(|s| !s.is_empty()) {
-        let restore_bind = if default_query.is_empty() {
-            "focus:unbind(focus)+clear-query".to_string()
-        } else {
-            format!("focus:unbind(focus)+change-query[[{default_query}]]")
-        };
         args_vec.push("--track".to_string());
         args_vec.push("--bind".to_string());
-        args_vec.push(restore_bind);
+        args_vec.push(restore_bind(default_query));
         args_vec.push("--query".to_string());
         args_vec.push(selected.to_string());
     } else {
@@ -74,4 +77,25 @@ pub fn pick_commit(default_query: &str, selected: Option<&str>) -> Result<Option
     }
 
     Ok(Some(CommitPick { query, hash }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::restore_bind;
+
+    #[test]
+    fn restore_bind_uses_clear_query_when_empty() {
+        assert_eq!(
+            restore_bind(""),
+            "focus:unbind(focus)+clear-query".to_string()
+        );
+    }
+
+    #[test]
+    fn restore_bind_uses_single_bracket_action_argument() {
+        assert_eq!(
+            restore_bind("'gray"),
+            "focus:unbind(focus)+change-query['gray]".to_string()
+        );
+    }
 }

--- a/crates/fzf-cli/tests/git_commit.rs
+++ b/crates/fzf-cli/tests/git_commit.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::{fzf_stub_script, make_stub_dir, run_fzf_cli_with_stub_path, write_exe};
+use nils_test_support::stubs::STUB_LOG_ENV;
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
@@ -155,4 +156,59 @@ exit 0
     let log = fs::read_to_string(&vi_log).unwrap();
     assert!(log.contains("--"));
     assert!(log.contains("snapshot contents"));
+}
+
+#[test]
+fn git_commit_restore_query_after_esc_uses_single_bracket_change_query() {
+    let temp = TempDir::new().unwrap();
+    let repo_root = temp.path().join("repo");
+    fs::create_dir_all(&repo_root).unwrap();
+
+    let stub = make_stub_dir();
+    let out_dir = stub.path().join("fzf-out");
+    fs::create_dir_all(&out_dir).unwrap();
+
+    fs::write(
+        out_dir.join("1.out"),
+        "'gray\nabcdef1 01-01 00:00 User subject\n",
+    )
+    .unwrap();
+    fs::write(out_dir.join("2.out"), "").unwrap();
+    fs::write(out_dir.join("2.code"), "1\n").unwrap();
+    fs::write(out_dir.join("3.out"), "").unwrap();
+    fs::write(out_dir.join("3.code"), "1\n").unwrap();
+
+    let stub_log = temp.path().join("stub.log");
+    fs::write(&stub_log, "").unwrap();
+
+    write_exe(stub.path(), "fzf", fzf_stub_script());
+    write_git_stub(stub.path());
+    write_exe(
+        stub.path(),
+        "vi",
+        "#!/bin/bash\nset -euo pipefail\nexit 0\n",
+    );
+
+    let out_dir_s = out_dir.to_string_lossy().to_string();
+    let repo_root_s = repo_root.to_string_lossy().to_string();
+    let stub_log_s = stub_log.to_string_lossy().to_string();
+    let envs = [
+        ("FZF_STUB_OUT_DIR", out_dir_s.as_str()),
+        ("FZF_FILE_OPEN_WITH", "vi"),
+        ("REPO_ROOT", repo_root_s.as_str()),
+        (STUB_LOG_ENV, stub_log_s.as_str()),
+    ];
+
+    let out = run_fzf_cli_with_stub_path(temp.path(), stub.path(), &["git-commit"], &envs, None);
+    assert_eq!(out.code, 1);
+
+    let log = fs::read_to_string(&stub_log).unwrap();
+    assert!(
+        log.contains("--bind focus:unbind(focus)+change-query['gray]"),
+        "expected query restore bind in fzf args, got:\n{log}"
+    );
+    assert!(
+        !log.contains("change-query[['gray]]"),
+        "invalid old-style restore bind must not appear, got:\n{log}"
+    );
 }


### PR DESCRIPTION
# Fix fzf-cli git-commit query corruption after Esc return

## Summary

This change fixes `fzf-cli git-commit` so query restoration works correctly after entering the file picker and pressing `Esc` to return. The restore bind now uses valid `fzf` `change-query[...]` syntax, and new unit/integration tests lock the behavior for quote-prefixed queries such as `'gray`.

## Problem

- Expected: Returning from the commit file picker should restore the previous query exactly.
- Actual: Query values like `'gray` became corrupted as `['gray` due to malformed bind syntax.
- Impact: Users lose accurate query context when navigating back from file list view, causing confusing filtering behavior.

## Reproduction

1. Run `fzf-cli git-commit` in a git repo.
2. Input query `'gray`, select a commit, enter file list, then press `Esc` to return.

- Expected result: Query remains `'gray`.
- Actual result: Query is corrupted with extra `[` characters.

## Issues Found

Severity: medium | Confidence: high | Status: fixed

|ID|Severity|Confidence|Area|Summary|Evidence|Status|
|---|---|---|---|---|---|---|
|`PR-271-BUG-01`|medium|high|`crates/fzf-cli/src/git_commit_select.rs`|`git-commit` restore bind used invalid `change-query[[...]]` syntax|`crates/fzf-cli/src/git_commit_select.rs:40` and repro above|fixed|

## Fix Approach

- Refactored query restore bind generation into `restore_bind(default_query)`.
- Replaced invalid `change-query[[{default_query}]]` with valid `change-query[{default_query}]`.
- Added focused unit tests for restore bind output.
- Added integration test simulating the Esc round-trip and asserting logged `fzf` bind args.

## Testing

- `cargo test -p nils-fzf-cli git_commit_restore_query_after_esc_uses_single_bracket_change_query -- --nocapture` (pass)
- `cargo test -p nils-fzf-cli` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)

## Risk / Notes

- Behavior change is narrowly scoped to query restore binding in `git-commit` picker flow.
- Test coverage now includes both syntax-level and interactive-path regression checks.
