### PR TITLE
feat(issue-275): implement S1T1-S1T3 third-party artifacts contract and generator

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -2,8 +2,8 @@
 
 This file documents third-party Rust crate licenses used by this workspace.
 
-- Generated at (UTC): 2026-03-01 03:58:00Z
 - Data source: `cargo metadata --format-version 1 --locked`
+- Cargo.lock SHA256: `600f9f2f2bd480cf4b773c378af8ef95bcbe31fd1e86d68afa6eec27e27b557e`
 - Third-party crates (`source != null`): 443
 - Workspace crates (`source == null`, excluded below): 25
 
@@ -11,7 +11,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 
 - `License` values are taken from each crate's Cargo metadata (`license` or `license_file`).
 - `Source` is the resolved package source from Cargo metadata.
-- This list is generated from the current `Cargo.lock`; dependency changes require regenerating this file.
+- This list is generated from the current `Cargo.lock`; dependency or script changes require regeneration.
 
 ## License Summary
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,3857 @@
+# THIRD_PARTY_NOTICES
+
+This file documents third-party notice-file discovery for Rust crates used by this workspace.
+
+- Data source: `cargo metadata --format-version 1 --locked`
+- Cargo.lock SHA256: `600f9f2f2bd480cf4b773c378af8ef95bcbe31fd1e86d68afa6eec27e27b557e`
+- Third-party crates (`source != null`): 443
+
+## Notice Extraction Policy
+
+- The generator checks each crate directory for notice files using deterministic name matching.
+- If no notice file is found, the fallback wording below is emitted exactly.
+- Standard fallback wording: `No explicit NOTICE file discovered.`
+
+## Dependency Notices
+
+### adler2 2.0.1
+
+- License: `0BSD OR MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-0BSD`
+
+### aho-corasick 1.1.4
+
+- License: `Unlicense OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
+
+### android_system_properties 0.1.5
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### anstream 0.6.21
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### anstyle 1.0.13
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### anstyle-parse 0.2.7
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### anstyle-query 1.1.5
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### anstyle-wincon 3.0.11
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### anyhow 1.0.102
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### arrayref 0.3.9
+
+- License: `BSD-2-Clause`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### arrayvec 0.7.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### async-broadcast 0.7.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### async-channel 2.5.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### async-executor 1.14.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### async-io 2.6.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### async-lock 3.4.2
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### async-process 2.5.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### async-recursion 1.1.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### async-signal 0.2.13
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### async-task 4.7.1
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### async-trait 0.1.89
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### atomic-waker 1.1.2
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-THIRD-PARTY`
+
+### autocfg 1.5.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### aws-lc-rs 1.16.0
+
+- License: `ISC AND (Apache-2.0 OR ISC)`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### aws-lc-sys 0.37.1
+
+- License: `ISC AND (Apache-2.0 OR ISC) AND OpenSSL`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### base64 0.22.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### bitflags 2.11.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### block-buffer 0.10.4
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### block2 0.6.2
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### blocking 1.6.2
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### bstr 1.12.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `COPYING`
+
+### bumpalo 3.20.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### bytemuck 1.25.0
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-ZLIB`
+
+### byteorder-lite 0.1.0
+
+- License: `Unlicense OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `UNLICENSE`
+
+### bytes 1.11.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### cc 1.2.56
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### cesu8 1.1.0
+
+- License: `Apache-2.0/MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### cfg-if 1.0.4
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### cfg_aliases 0.2.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### chrono 0.4.44
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE.txt`
+
+### chrono-tz 0.10.4
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### clap 4.5.60
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### clap_builder 4.5.60
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### clap_complete 4.5.66
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### clap_derive 4.5.55
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### clap_lex 1.0.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### cmake 0.1.57
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### color_quant 1.1.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### colorchoice 1.0.4
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### combine 4.6.7
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### concurrent-queue 2.5.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### console 0.16.2
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### core-foundation 0.10.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### core-foundation-sys 0.8.7
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### core_maths 0.1.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### cpufeatures 0.2.17
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### crc32fast 1.5.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### crossbeam-utils 0.8.21
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### crypto-common 0.1.7
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### ctrlc 3.5.2
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### data-encoding 2.10.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### data-url 0.3.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### deranged 0.5.8
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### diff 0.1.13
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### digest 0.10.7
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### directories 6.0.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### dirs-sys 0.5.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### dispatch2 0.3.1
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### displaydoc 0.2.5
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### dunce 1.0.5
+
+- License: `CC0-1.0 OR MIT-0 OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### dyn-clone 1.0.20
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### encode_unicode 1.0.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### endi 1.1.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+
+### enumflags2 0.7.12
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### enumflags2_derive 0.7.12
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### equivalent 1.0.2
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### errno 0.3.14
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### euclid 0.22.13
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### event-listener 5.4.1
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### event-listener-strategy 0.5.4
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### fallible-iterator 0.3.0
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### fallible-streaming-iterator 0.1.9
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### fastrand 2.3.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### fdeflate 0.3.7
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### find-msvc-tools 0.1.9
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### flate2 1.1.9
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### float-cmp 0.9.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### foldhash 0.1.5
+
+- License: `Zlib`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### foldhash 0.2.0
+
+- License: `Zlib`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### fontconfig-parser 0.5.8
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### fontdb 0.23.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### form_urlencoded 1.2.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### fs_extra 1.3.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### futures-channel 0.3.32
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### futures-core 0.3.32
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### futures-io 0.3.32
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### futures-lite 2.6.1
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-THIRD-PARTY`
+
+### futures-sink 0.3.32
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### futures-task 0.3.32
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### futures-util 0.3.32
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### generic-array 0.14.7
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### gethostname 1.1.0
+
+- License: `Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### getrandom 0.2.17
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### getrandom 0.3.4
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### getrandom 0.4.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### gif 0.14.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### globset 0.4.18
+
+- License: `Unlicense OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
+
+### hashbrown 0.15.5
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### hashbrown 0.16.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### hashlink 0.11.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### heck 0.5.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### hermit-abi 0.5.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### hex 0.4.3
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### hifijson 0.4.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### http 1.4.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### http-body 1.0.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### http-body-util 0.1.3
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### httparse 1.10.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### hyper 1.8.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### hyper-rustls 0.27.7
+
+- License: `Apache-2.0 OR ISC OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-ISC`
+
+### hyper-util 0.1.20
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### iana-time-zone 0.1.65
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### iana-time-zone-haiku 0.1.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### icu_collections 2.1.1
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### icu_locale_core 2.1.1
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### icu_normalizer 2.1.1
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### icu_normalizer_data 2.1.1
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### icu_properties 2.1.2
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### icu_properties_data 2.1.2
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### icu_provider 2.1.1
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### id-arena 2.3.0
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### idna 1.1.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### idna_adapter 1.2.1
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### image 0.25.9
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### image-webp 0.2.4
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### imagesize 0.14.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### indexmap 2.13.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### indicatif 0.18.4
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### ipnet 2.11.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### iri-string 0.7.10
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE.txt`
+  - `LICENSE-MIT.txt`
+
+### is_terminal_polyfill 1.70.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### itoa 1.0.17
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### jaq-core 3.0.0-beta
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### jaq-json 2.0.0-beta
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### jaq-std 3.0.0-beta
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### jiff 0.2.21
+
+- License: `Unlicense OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
+
+### jiff-static 0.2.21
+
+- License: `Unlicense OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
+
+### jiff-tzdb 0.1.5
+
+- License: `Unlicense OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
+
+### jiff-tzdb-platform 0.1.3
+
+- License: `Unlicense OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
+
+### jni 0.21.1
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### jni-sys 0.3.0
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### jobserver 0.1.34
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### js-sys 0.3.91
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### kurbo 0.13.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### lazy_static 1.5.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### leb128fmt 0.1.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### libc 0.2.180
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### libm 0.2.16
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE.txt`
+
+### libredox 0.1.12
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### libsqlite3-sys 0.36.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### linux-raw-sys 0.11.0
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-Apache-2.0_WITH_LLVM-exception`
+
+### litemap 0.8.1
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### log 0.4.29
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### lru-slab 0.1.2
+
+- License: `MIT OR Apache-2.0 OR Zlib`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-ZLIB`
+
+### matchers 0.2.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### memchr 2.8.0
+
+- License: `Unlicense OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
+
+### memmap2 0.9.10
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### memoffset 0.9.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### mime 0.3.17
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### mime_guess 2.0.5
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### miniz_oxide 0.8.9
+
+- License: `MIT OR Zlib OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+  - `LICENSE-APACHE.md`
+  - `LICENSE-MIT.md`
+  - `LICENSE-ZLIB.md`
+
+### mio 1.1.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### moxcms 0.7.11
+
+- License: `BSD-3-Clause OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE.md`
+  - `LICENSE-APACHE.md`
+
+### nix 0.31.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### nu-ansi-term 0.50.3
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### num-bigint 0.4.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### num-conv 0.2.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### num-integer 0.1.46
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### num-traits 0.2.19
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### num_threads 0.1.7
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### objc2 0.6.4
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-av-foundation 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-avf-audio 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-core-audio 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-core-audio-types 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-core-foundation 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-core-graphics 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-core-image 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-core-media 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-core-video 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-encode 4.1.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-foundation 0.3.2
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-image-io 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-io-surface 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-media-toolbox 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-metal 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-quartz-core 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-screen-capture-kit 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### objc2-uniform-type-identifiers 0.3.2
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### once_cell 1.21.3
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### once_cell_polyfill 1.70.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### openssl-probe 0.2.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### option-ext 0.2.0
+
+- License: `MPL-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE.txt`
+
+### ordered-stream 0.2.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### parking 2.2.1
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-THIRD-PARTY`
+
+### percent-encoding 2.3.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### phf 0.12.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### phf_shared 0.12.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### pico-args 0.5.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### pin-project-lite 0.2.17
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### pin-utils 0.1.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### piper 0.2.4
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### pkg-config 0.3.32
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### png 0.18.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### polling 3.11.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### portable-atomic 1.13.1
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### portable-atomic-util 0.2.5
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### potential_utf 0.1.4
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### powerfmt 0.2.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### ppv-lite86 0.2.21
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### pretty_assertions 1.4.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### prettyplease 0.2.37
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### proc-macro-crate 3.4.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### proc-macro2 1.0.106
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### pxfm 0.1.27
+
+- License: `BSD-3-Clause OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE.md`
+  - `LICENSE-APACHE.md`
+
+### quick-error 2.0.1
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### quinn 0.11.9
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### quinn-proto 0.11.13
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### quinn-udp 0.5.14
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### quote 1.0.44
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### r-efi 5.3.0
+
+- License: `MIT OR Apache-2.0 OR LGPL-2.1-or-later`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### rand 0.9.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### rand_chacha 0.9.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### rand_core 0.9.5
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### redox_users 0.5.2
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### regex 1.12.3
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### regex-automata 0.4.14
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### regex-bites 0.1.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### regex-syntax 0.8.10
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### reqwest 0.13.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### resvg 0.47.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### rgb 0.8.53
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### ring 0.17.14
+
+- License: `Apache-2.0 AND ISC`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+  - `LICENSE-BoringSSL`
+  - `LICENSE-other-bits`
+
+### roxmltree 0.20.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### roxmltree 0.21.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### rsqlite-vfs 0.1.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### rusqlite 0.38.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### rustc-hash 2.1.1
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### rustix 1.1.3
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-Apache-2.0_WITH_LLVM-exception`
+
+### rustls 0.23.37
+
+- License: `Apache-2.0 OR ISC OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-ISC`
+
+### rustls-native-certs 0.8.3
+
+- License: `Apache-2.0 OR ISC OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-ISC`
+
+### rustls-pki-types 1.14.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### rustls-platform-verifier 0.6.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### rustls-platform-verifier-android 0.1.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### rustls-webpki 0.103.9
+
+- License: `ISC`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### rustversion 1.0.22
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### rustybuzz 0.20.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### ryu 1.0.23
+
+- License: `Apache-2.0 OR BSL-1.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-BOOST`
+
+### same-file 1.0.6
+
+- License: `Unlicense/MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
+
+### schannel 0.1.28
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE.md`
+
+### security-framework 3.7.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### security-framework-sys 2.17.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### self_cell 1.2.2
+
+- License: `Apache-2.0 OR GPL-2.0-only`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-GPLv2`
+
+### semver 1.0.27
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### serde 1.0.228
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### serde_core 1.0.228
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### serde_derive 1.0.228
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### serde_json 1.0.149
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### serde_repr 0.1.20
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### serde_spanned 1.0.4
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### serde_urlencoded 0.7.1
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### sha1 0.10.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### sha2 0.10.9
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### sharded-slab 0.1.7
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### shell-words 1.1.1
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### shlex 1.3.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### signal-hook-registry 1.4.8
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### simd-adler32 0.3.8
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE.md`
+
+### simplecss 0.2.2
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### siphasher 1.0.2
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `COPYING`
+
+### slab 0.4.12
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### slotmap 1.1.1
+
+- License: `Zlib`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### smallvec 1.15.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### socket2 0.6.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### sqlite-wasm-rs 0.5.2
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### stable_deref_trait 1.2.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### strict-num 0.1.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### strsim 0.11.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### subtle 2.6.1
+
+- License: `BSD-3-Clause`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### svgtypes 0.16.1
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### syn 2.0.117
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### sync_wrapper 1.0.2
+
+- License: `Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### synstructure 0.13.2
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tempfile 3.25.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### thiserror 1.0.69
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### thiserror 2.0.18
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### thiserror-impl 1.0.69
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### thiserror-impl 2.0.18
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### thread_local 1.1.9
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### time 0.3.47
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### time-core 0.1.8
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### time-macros 0.2.27
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### tiny-skia 0.12.0
+
+- License: `BSD-3-Clause`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tiny-skia-path 0.12.0
+
+- License: `BSD-3-Clause`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tinystr 0.8.2
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tinyvec 1.10.0
+
+- License: `Zlib OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE.md`
+  - `LICENSE-MIT.md`
+  - `LICENSE-ZLIB.md`
+
+### tinyvec_macros 0.1.1
+
+- License: `MIT OR Apache-2.0 OR Zlib`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE.md`
+  - `LICENSE-MIT.md`
+  - `LICENSE-ZLIB.md`
+
+### tokio 1.49.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tokio-rustls 0.26.4
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### toml 1.0.3+spec-1.1.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### toml_datetime 0.7.5+spec-1.1.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### toml_datetime 1.0.0+spec-1.1.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### toml_edit 0.23.10+spec-1.0.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### toml_edit 0.25.3+spec-1.1.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### toml_parser 1.0.9+spec-1.1.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### toml_writer 1.0.6+spec-1.1.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### tower 0.5.3
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tower-http 0.6.8
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tower-layer 0.3.3
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tower-service 0.3.3
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tracing 0.1.44
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tracing-attributes 0.1.31
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tracing-core 0.1.36
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tracing-log 0.2.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### tracing-subscriber 0.3.22
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### try-lock 0.2.5
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### ttf-parser 0.25.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### tungstenite 0.28.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### typed-arena 2.0.2
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### typenum 1.19.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### uds_windows 1.1.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### unicase 2.9.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### unicode-bidi 0.3.18
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### unicode-bidi-mirroring 0.4.0
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### unicode-ccc 0.4.0
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### unicode-ident 1.0.24
+
+- License: `(MIT OR Apache-2.0) AND Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-UNICODE`
+
+### unicode-properties 0.1.4
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### unicode-script 0.5.8
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### unicode-vo 0.1.0
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### unicode-width 0.2.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### unicode-xid 0.2.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### unit-prefix 0.5.2
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### untrusted 0.9.0
+
+- License: `ISC`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE.txt`
+
+### url 2.5.8
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### urlencoding 2.1.3
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### usvg 0.47.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### utf-8 0.7.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### utf8_iter 1.0.4
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### utf8parse 0.2.2
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### uuid 1.21.0
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### valuable 0.1.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### vcpkg 0.2.15
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### version_check 0.9.5
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### walkdir 2.5.0
+
+- License: `Unlicense/MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
+
+### want 0.3.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### wasi 0.11.1+wasi-snapshot-preview1
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-Apache-2.0_WITH_LLVM-exception`
+
+### wasip2 1.0.2+wasi-0.2.9
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### wasm-bindgen 0.2.114
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### wasm-bindgen-futures 0.4.64
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### wasm-bindgen-macro 0.2.114
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### wasm-bindgen-macro-support 0.2.114
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### wasm-bindgen-shared 0.2.114
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### wasm-encoder 0.244.0
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### wasm-metadata 0.244.0
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### wasmparser 0.244.0
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### web-sys 0.3.91
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### web-time 1.1.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### webpki-root-certs 1.0.6
+
+- License: `CDLA-Permissive-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### webpki-roots 0.26.11
+
+- License: `CDLA-Permissive-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### webpki-roots 1.0.6
+
+- License: `CDLA-Permissive-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### weezl 0.1.12
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### winapi 0.3.9
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### winapi-i686-pc-windows-gnu 0.4.0
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### winapi-util 0.1.11
+
+- License: `Unlicense OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
+
+### winapi-x86_64-pc-windows-gnu 0.4.0
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### windows-core 0.62.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-implement 0.60.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-interface 0.59.3
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-link 0.2.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-result 0.4.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-strings 0.5.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-sys 0.45.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-sys 0.52.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-sys 0.60.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-sys 0.61.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-targets 0.42.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-targets 0.52.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows-targets 0.53.5
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_aarch64_gnullvm 0.42.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_aarch64_gnullvm 0.52.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_aarch64_gnullvm 0.53.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_aarch64_msvc 0.42.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_aarch64_msvc 0.52.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_aarch64_msvc 0.53.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_i686_gnu 0.42.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_i686_gnu 0.52.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_i686_gnu 0.53.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_i686_gnullvm 0.52.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_i686_gnullvm 0.53.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_i686_msvc 0.42.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_i686_msvc 0.52.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_i686_msvc 0.53.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_x86_64_gnu 0.42.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_x86_64_gnu 0.52.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_x86_64_gnu 0.53.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_x86_64_gnullvm 0.42.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_x86_64_gnullvm 0.52.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_x86_64_gnullvm 0.53.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_x86_64_msvc 0.42.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_x86_64_msvc 0.52.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### windows_x86_64_msvc 0.53.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `license-apache-2.0`
+
+### winnow 0.7.14
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+
+### wit-bindgen 0.51.0
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-Apache-2.0_WITH_LLVM-exception`
+
+### wit-bindgen-core 0.51.0
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-Apache-2.0_WITH_LLVM-exception`
+
+### wit-bindgen-rust 0.51.0
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-Apache-2.0_WITH_LLVM-exception`
+
+### wit-bindgen-rust-macro 0.51.0
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-Apache-2.0_WITH_LLVM-exception`
+
+### wit-component 0.244.0
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### wit-parser 0.244.0
+
+- License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file reference: none declared
+
+### writeable 0.6.2
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### x11rb 0.13.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### x11rb-protocol 0.13.2
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### xmlwriter 0.1.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### yansi 1.0.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### yoke 0.8.1
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### yoke-derive 0.8.1
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zbus 5.14.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zbus_macros 5.14.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zbus_names 4.3.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zerocopy 0.8.40
+
+- License: `BSD-2-Clause OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-BSD`
+
+### zerocopy-derive 0.8.40
+
+- License: `BSD-2-Clause OR Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-BSD`
+
+### zerofrom 0.1.6
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zerofrom-derive 0.1.6
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zeroize 1.8.2
+
+- License: `Apache-2.0 OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### zerotrie 0.2.3
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zerovec 0.11.5
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zerovec-derive 0.11.2
+
+- License: `Unicode-3.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zmij 1.0.21
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+
+### zune-core 0.5.1
+
+- License: `MIT OR Apache-2.0 OR Zlib`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-ZLIB`
+
+### zune-jpeg 0.5.12
+
+- License: `MIT OR Apache-2.0 OR Zlib`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+  - `LICENSE-ZLIB`
+
+### zvariant 5.10.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zvariant_derive 5.10.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### zvariant_utils 3.3.0
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`

--- a/docs/specs/third-party-artifacts-contract-v1.md
+++ b/docs/specs/third-party-artifacts-contract-v1.md
@@ -1,0 +1,137 @@
+# Third-Party Artifacts Contract v1
+
+## Purpose
+
+This document defines the generation contract for:
+
+- `THIRD_PARTY_LICENSES.md`
+- `THIRD_PARTY_NOTICES.md`
+
+The contract is deterministic and anchored to `cargo metadata --format-version 1 --locked` plus `Cargo.lock`.
+
+## Scope
+
+- In scope:
+  - required sections and table schema for both generated artifacts
+  - deterministic ordering and formatting keys
+  - notice extraction policy and fallback wording
+  - generator mode semantics for `--check` and `--write`
+- Out of scope:
+  - legal interpretation of individual upstream licenses or notice obligations
+  - non-Rust dependency ecosystems
+
+## Canonical Generator Entrypoint
+
+- Script: `scripts/generate-third-party-artifacts.sh`
+- Source-of-truth command: `cargo metadata --format-version 1 --locked`
+- Artifacts are generated together in a single invocation.
+
+## Artifact Requirements
+
+### `THIRD_PARTY_LICENSES.md` (required sections)
+
+The artifact must contain the following sections in order:
+
+1. H1 heading: `# THIRD_PARTY_LICENSES`
+2. Intro paragraph describing third-party Rust crate licenses for the workspace.
+3. Metadata bullets:
+   - data source command
+   - `Cargo.lock` SHA256
+   - third-party crate count (`source != null`)
+   - workspace crate count (`source == null`, excluded)
+4. `## Notes` section with generation/source notes.
+5. `## License Summary` section with markdown table:
+   - columns: `License Expression`, `Crate Count`
+6. `## Dependency List` section with markdown table:
+   - columns: `Crate`, `Version`, `License`, `Source`
+
+### `THIRD_PARTY_NOTICES.md` (required sections)
+
+The artifact must contain the following sections in order:
+
+1. H1 heading: `# THIRD_PARTY_NOTICES`
+2. Intro paragraph describing notice discovery for third-party Rust crates.
+3. Metadata bullets:
+   - data source command
+   - `Cargo.lock` SHA256
+   - third-party crate count (`source != null`)
+4. `## Notice Extraction Policy` section:
+   - deterministic file-discovery statement
+   - fallback wording statement (exact phrase)
+5. `## Dependency Notices` section:
+   - one subsection per third-party crate (`### <crate> <version>`)
+   - per-entry fields:
+     - `License`
+     - `Source`
+     - `Notice files` (discovered list or fallback wording)
+     - `License file references` (deterministic list when discovered)
+     - or `License file reference: none declared`
+
+## Deterministic Rules
+
+### Package set
+
+- Include only third-party packages where `source != null`.
+- Exclude workspace/local packages where `source == null`.
+
+### Ordering keys
+
+- Package entry order (both artifacts):
+  - primary: `name` (ascending)
+  - secondary: `version` (ascending)
+  - tertiary: `source` (ascending)
+  - quaternary: `id` (ascending)
+- License summary order:
+  - primary: `Crate Count` (descending)
+  - secondary: `License Expression` (ascending)
+- Notice file list order:
+  - deterministic preferred filename order, then additional regex-discovered names sorted ascending.
+
+### Stable formatting
+
+- Output must be markdown and stable for unchanged lockfile/metadata input.
+- Markdown table cells escape pipe delimiters.
+- Generated output must not include wall-clock timestamps.
+
+## Notice Extraction Policy
+
+For each third-party crate:
+
+1. Resolve crate directory from package `manifest_path`.
+2. Discover notice files with deterministic filename matching.
+3. If no notice files are discovered, emit this exact fallback wording:
+   - `No explicit NOTICE file discovered.`
+4. Collect license file references in this deterministic order:
+   - `license_file` metadata reference when present
+   - then top-level files matching `LICENSE*`, `COPYING*`, `UNLICENSE*`
+5. If no license file references are discovered, emit `License file reference: none declared`.
+
+## Regeneration Triggers
+
+Regenerate `THIRD_PARTY_LICENSES.md` and `THIRD_PARTY_NOTICES.md` when any of the following changes:
+
+- `Cargo.lock`
+- dependency graph or crate metadata reachable from `cargo metadata --format-version 1 --locked`
+- `scripts/generate-third-party-artifacts.sh`
+- this contract when it changes schema/ordering/output expectations
+
+## Generator Mode Semantics
+
+### `--write`
+
+- Generates both artifacts and writes them in-place at repository root.
+- Success condition: both files are written without generation errors.
+
+### `--check`
+
+- Generates both artifacts to temporary outputs and compares against repository files.
+- Exit `0` only when both files exist and are byte-identical to regenerated outputs.
+- Exit non-zero when either file is missing or differs.
+- On drift, the script prints diagnostics and remediation command:
+  - `bash scripts/generate-third-party-artifacts.sh --write`
+
+## Validation Commands
+
+- `test -f docs/specs/third-party-artifacts-contract-v1.md`
+- `bash scripts/generate-third-party-artifacts.sh --write`
+- `bash scripts/generate-third-party-artifacts.sh --check`

--- a/scripts/generate-third-party-artifacts.sh
+++ b/scripts/generate-third-party-artifacts.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  generate-third-party-artifacts.sh --write
+  generate-third-party-artifacts.sh --check
+
+Generates deterministic third-party dependency artifacts from:
+  cargo metadata --format-version 1 --locked
+
+Artifacts:
+  - THIRD_PARTY_LICENSES.md
+  - THIRD_PARTY_NOTICES.md
+
+Options:
+  --write   Regenerate both artifacts in-place.
+  --check   Verify both artifacts are up-to-date; exits non-zero on drift.
+  -h, --help
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+mode="${1:-}"
+case "$mode" in
+  --write|--check) ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "error: unknown argument: $mode" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
+  echo "error: must run inside a git work tree" >&2
+  exit 2
+fi
+cd "$repo_root"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+metadata_json="$tmp_dir/cargo-metadata.json"
+licenses_tmp="$tmp_dir/THIRD_PARTY_LICENSES.md"
+notices_tmp="$tmp_dir/THIRD_PARTY_NOTICES.md"
+
+cargo metadata --format-version 1 --locked --manifest-path "$repo_root/Cargo.toml" > "$metadata_json"
+
+python3 - "$repo_root" "$metadata_json" "$licenses_tmp" "$notices_tmp" <<'PY'
+import collections
+import hashlib
+import json
+import pathlib
+import re
+import sys
+from urllib.parse import urlparse
+
+
+def md_cell(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ").strip()
+
+
+def cargo_source_label(source: str) -> str:
+    if source == "registry+https://github.com/rust-lang/crates.io-index":
+        return "crates.io"
+    if source.startswith("registry+"):
+        return source.removeprefix("registry+")
+    if source.startswith("git+"):
+        trimmed = source.removeprefix("git+").split("#", 1)[0]
+        return trimmed
+    return source
+
+
+def normalize_manifest_dir(manifest_path: str) -> pathlib.Path:
+    parsed = urlparse(manifest_path)
+    if parsed.scheme == "file":
+        return pathlib.Path(parsed.path).resolve().parent
+    return pathlib.Path(manifest_path).resolve().parent
+
+
+def find_notice_files(crate_dir: pathlib.Path) -> list[str]:
+    preferred = [
+        "NOTICE",
+        "NOTICE.md",
+        "NOTICE.txt",
+        "NOTICE.rst",
+        "notice",
+        "notice.md",
+        "notice.txt",
+        "notice.rst",
+    ]
+    found: list[str] = []
+    seen: set[str] = set()
+
+    for candidate in preferred:
+        path = crate_dir / candidate
+        if path.is_file():
+            found.append(candidate)
+            seen.add(candidate.lower())
+
+    if crate_dir.is_dir():
+        dynamic = []
+        for child in crate_dir.iterdir():
+            if not child.is_file():
+                continue
+            if re.match(r"(?i)^notice(?:[._-].*)?$", child.name):
+                key = child.name.lower()
+                if key not in seen:
+                    dynamic.append(child.name)
+                    seen.add(key)
+        dynamic.sort(key=lambda value: value.lower())
+        found.extend(dynamic)
+
+    return found
+
+
+def resolve_license_file_ref(crate_dir: pathlib.Path, raw_ref: str | None) -> str | None:
+    if not raw_ref:
+        return None
+
+    ref = raw_ref.strip()
+    if not ref:
+        return None
+
+    candidate = pathlib.Path(ref)
+    if candidate.is_absolute():
+        target = candidate
+    else:
+        target = crate_dir / candidate
+
+    if target.exists():
+        try:
+            return str(target.relative_to(crate_dir))
+        except ValueError:
+            return str(target)
+    return ref
+
+
+def find_license_files(crate_dir: pathlib.Path) -> list[str]:
+    preferred = [
+        "LICENSE",
+        "LICENSE.md",
+        "LICENSE.txt",
+        "LICENSE-APACHE",
+        "LICENSE-MIT",
+        "COPYING",
+        "COPYING.md",
+        "COPYING.txt",
+        "UNLICENSE",
+        "UNLICENSE.txt",
+    ]
+    found: list[str] = []
+    seen: set[str] = set()
+
+    for candidate in preferred:
+        path = crate_dir / candidate
+        if path.is_file():
+            found.append(candidate)
+            seen.add(candidate.lower())
+
+    if crate_dir.is_dir():
+        dynamic = []
+        for child in crate_dir.iterdir():
+            if not child.is_file():
+                continue
+            if re.match(r"(?i)^(license|copying|unlicense)(?:[._-].*)?$", child.name):
+                key = child.name.lower()
+                if key not in seen:
+                    dynamic.append(child.name)
+                    seen.add(key)
+        dynamic.sort(key=lambda value: value.lower())
+        found.extend(dynamic)
+
+    return found
+
+
+repo_root = pathlib.Path(sys.argv[1]).resolve()
+metadata_path = pathlib.Path(sys.argv[2]).resolve()
+licenses_path = pathlib.Path(sys.argv[3]).resolve()
+notices_path = pathlib.Path(sys.argv[4]).resolve()
+
+with metadata_path.open("r", encoding="utf-8") as fh:
+    metadata = json.load(fh)
+
+all_packages = metadata.get("packages", [])
+third_party = [pkg for pkg in all_packages if pkg.get("source")]
+workspace_packages = [pkg for pkg in all_packages if not pkg.get("source")]
+
+third_party.sort(
+    key=lambda pkg: (
+        pkg.get("name", ""),
+        pkg.get("version", ""),
+        pkg.get("source", ""),
+        pkg.get("id", ""),
+    )
+)
+
+lockfile_path = repo_root / "Cargo.lock"
+lock_hash = hashlib.sha256(lockfile_path.read_bytes()).hexdigest()
+
+
+def license_value(pkg: dict) -> str:
+    license_expr = (pkg.get("license") or "").strip()
+    if license_expr:
+        return license_expr
+    license_file = (pkg.get("license_file") or "").strip()
+    if license_file:
+        return f"SEE LICENSE FILE ({license_file})"
+    return "UNKNOWN"
+
+
+license_counter: collections.Counter[str] = collections.Counter()
+for pkg in third_party:
+    license_counter[license_value(pkg)] += 1
+
+license_summary_rows = sorted(license_counter.items(), key=lambda entry: (-entry[1], entry[0]))
+
+license_lines: list[str] = [
+    "# THIRD_PARTY_LICENSES",
+    "",
+    "This file documents third-party Rust crate licenses used by this workspace.",
+    "",
+    "- Data source: `cargo metadata --format-version 1 --locked`",
+    f"- Cargo.lock SHA256: `{lock_hash}`",
+    f"- Third-party crates (`source != null`): {len(third_party)}",
+    f"- Workspace crates (`source == null`, excluded below): {len(workspace_packages)}",
+    "",
+    "## Notes",
+    "",
+    "- `License` values are taken from each crate's Cargo metadata (`license` or `license_file`).",
+    "- `Source` is the resolved package source from Cargo metadata.",
+    "- This list is generated from the current `Cargo.lock`; dependency or script changes require regeneration.",
+    "",
+    "## License Summary",
+    "",
+    "| License Expression | Crate Count |",
+    "| --- | ---: |",
+]
+
+for expression, count in license_summary_rows:
+    license_lines.append(f"| {md_cell(expression)} | {count} |")
+
+license_lines.extend(
+    [
+        "",
+        "## Dependency List",
+        "",
+        "| Crate | Version | License | Source |",
+        "| --- | --- | --- | --- |",
+    ]
+)
+
+for pkg in third_party:
+    name = pkg.get("name", "")
+    version = pkg.get("version", "")
+    source = cargo_source_label(pkg.get("source", ""))
+    license_expr = license_value(pkg)
+    license_lines.append(
+        f"| {md_cell(name)} | {md_cell(version)} | {md_cell(license_expr)} | {md_cell(source)} |"
+    )
+
+licenses_path.write_text("\n".join(license_lines) + "\n", encoding="utf-8")
+
+fallback_notice_line = "No explicit NOTICE file discovered."
+
+notice_lines: list[str] = [
+    "# THIRD_PARTY_NOTICES",
+    "",
+    "This file documents third-party notice-file discovery for Rust crates used by this workspace.",
+    "",
+    "- Data source: `cargo metadata --format-version 1 --locked`",
+    f"- Cargo.lock SHA256: `{lock_hash}`",
+    f"- Third-party crates (`source != null`): {len(third_party)}",
+    "",
+    "## Notice Extraction Policy",
+    "",
+    "- The generator checks each crate directory for notice files using deterministic name matching.",
+    "- If no notice file is found, the fallback wording below is emitted exactly.",
+    f"- Standard fallback wording: `{fallback_notice_line}`",
+    "",
+    "## Dependency Notices",
+    "",
+]
+
+for pkg in third_party:
+    name = pkg.get("name", "")
+    version = pkg.get("version", "")
+    source = cargo_source_label(pkg.get("source", ""))
+    license_expr = license_value(pkg)
+    manifest_path = pkg.get("manifest_path", "")
+    crate_dir = normalize_manifest_dir(manifest_path) if manifest_path else pathlib.Path(".")
+
+    notice_refs = find_notice_files(crate_dir)
+    license_refs: list[str] = []
+    seen_license_refs: set[str] = set()
+
+    metadata_license_ref = resolve_license_file_ref(crate_dir, pkg.get("license_file"))
+    if metadata_license_ref:
+        license_refs.append(metadata_license_ref)
+        seen_license_refs.add(metadata_license_ref.lower())
+
+    for discovered_ref in find_license_files(crate_dir):
+        key = discovered_ref.lower()
+        if key in seen_license_refs:
+            continue
+        license_refs.append(discovered_ref)
+        seen_license_refs.add(key)
+
+    notice_lines.append(f"### {name} {version}")
+    notice_lines.append("")
+    notice_lines.append(f"- License: `{license_expr}`")
+    notice_lines.append(f"- Source: `{source}`")
+    if notice_refs:
+        notice_lines.append("- Notice files:")
+        for ref in notice_refs:
+            notice_lines.append(f"  - `{ref}`")
+    else:
+        notice_lines.append(f"- Notice files: {fallback_notice_line}")
+
+    if license_refs:
+        notice_lines.append("- License file references:")
+        for ref in license_refs:
+            notice_lines.append(f"  - `{ref}`")
+    else:
+        notice_lines.append("- License file reference: none declared")
+
+    notice_lines.append("")
+
+notices_path.write_text("\n".join(notice_lines), encoding="utf-8")
+PY
+
+artifacts=("THIRD_PARTY_LICENSES.md" "THIRD_PARTY_NOTICES.md")
+generated=("$licenses_tmp" "$notices_tmp")
+
+case "$mode" in
+  --write)
+    for idx in "${!artifacts[@]}"; do
+      cp "${generated[$idx]}" "${artifacts[$idx]}"
+    done
+    echo "PASS: regenerated ${artifacts[*]}"
+    ;;
+  --check)
+    drift=0
+    for idx in "${!artifacts[@]}"; do
+      artifact="${artifacts[$idx]}"
+      candidate="${generated[$idx]}"
+      if [[ ! -f "$artifact" ]]; then
+        echo "FAIL: missing required artifact: $artifact" >&2
+        drift=1
+        continue
+      fi
+      if ! cmp -s "$artifact" "$candidate"; then
+        echo "FAIL: artifact drift detected: $artifact" >&2
+        diff -u "$artifact" "$candidate" || true
+        drift=1
+      fi
+    done
+
+    if [[ "$drift" -ne 0 ]]; then
+      echo "FAIL: third-party artifacts are stale; run: bash scripts/generate-third-party-artifacts.sh --write" >&2
+      exit 1
+    fi
+
+    echo "PASS: third-party artifacts are up-to-date"
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Implement S1T1-S1T3 for deterministic third-party artifact generation in one lane-owned entrypoint.
- Add contract spec for schema/order/mode semantics and notice fallback wording.
- Generate and commit `THIRD_PARTY_LICENSES.md` and new `THIRD_PARTY_NOTICES.md` from locked cargo metadata.

## Scope
- `docs/specs/third-party-artifacts-contract-v1.md`
- `scripts/generate-third-party-artifacts.sh`
- `THIRD_PARTY_LICENSES.md`
- `THIRD_PARTY_NOTICES.md`

## Testing
- `plan-tooling validate --file docs/plans/third-party-licenses-notices-release-packaging-plan.md` (pass)
- `bash scripts/generate-third-party-artifacts.sh --write` (pass)
- `bash scripts/generate-third-party-artifacts.sh --check` (pass)
- `test -f docs/specs/third-party-artifacts-contract-v1.md` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (fails in unrelated macos-agent nextest tests)

## Issue
- Closes #275
