### PR TITLE
test(issue-275): implement S1T4 generator regression tests and usage docs

### DIFF
--- a/BINARY_DEPENDENCIES.md
+++ b/BINARY_DEPENDENCIES.md
@@ -74,6 +74,7 @@ These are repository scripts (not third-party packages):
 - Run required repository checks:
   - `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
 - Supporting utilities:
+  - `scripts/generate-third-party-artifacts.sh`
   - `scripts/workspace-bins.sh`
   - `scripts/ci/coverage-summary.sh`
   - `scripts/ci/coverage-badge.sh`

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Use [DEVELOPMENT.md](DEVELOPMENT.md) as the canonical checklist.
 
 - Full required checks: `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
 - Docs-only fast path: `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh --docs-only`
+- Regenerate third-party license/notice artifacts after dependency or metadata changes:
+  - `bash scripts/generate-third-party-artifacts.sh --write`
+- Verify third-party artifacts are current (fails on drift):
+  - `bash scripts/generate-third-party-artifacts.sh --check`
 
 ## Local install (release)
 

--- a/tests/third-party-artifacts/generator.test.sh
+++ b/tests/third-party-artifacts/generator.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GENERATOR_SCRIPT="$REPO_ROOT/scripts/generate-third-party-artifacts.sh"
+LICENSES_FILE="$REPO_ROOT/THIRD_PARTY_LICENSES.md"
+NOTICES_FILE="$REPO_ROOT/THIRD_PARTY_NOTICES.md"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local context="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail "$context missing '$needle'"
+  fi
+}
+
+run_generator() {
+  local mode="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  (
+    cd "$REPO_ROOT"
+    bash "$GENERATOR_SCRIPT" "$mode"
+  ) >"$stdout_file" 2>"$stderr_file"
+}
+
+[[ -x "$GENERATOR_SCRIPT" ]] || fail "missing executable script: $GENERATOR_SCRIPT"
+[[ -f "$LICENSES_FILE" ]] || fail "missing licenses artifact: $LICENSES_FILE"
+[[ -f "$NOTICES_FILE" ]] || fail "missing notices artifact: $NOTICES_FILE"
+
+TMP_DIR="$(mktemp -d)"
+cp "$LICENSES_FILE" "$TMP_DIR/licenses.original"
+cp "$NOTICES_FILE" "$TMP_DIR/notices.original"
+
+cleanup() {
+  if [[ -f "$TMP_DIR/licenses.original" ]]; then
+    cp "$TMP_DIR/licenses.original" "$LICENSES_FILE"
+  fi
+  if [[ -f "$TMP_DIR/notices.original" ]]; then
+    cp "$TMP_DIR/notices.original" "$NOTICES_FILE"
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+# Determinism check: two consecutive --write runs must produce byte-identical artifacts.
+run_generator --write "$TMP_DIR/write-first.stdout" "$TMP_DIR/write-first.stderr"
+cp "$LICENSES_FILE" "$TMP_DIR/licenses.after-first-write"
+cp "$NOTICES_FILE" "$TMP_DIR/notices.after-first-write"
+
+run_generator --write "$TMP_DIR/write-second.stdout" "$TMP_DIR/write-second.stderr"
+cmp -s "$LICENSES_FILE" "$TMP_DIR/licenses.after-first-write" || fail "--write is not deterministic for THIRD_PARTY_LICENSES.md"
+cmp -s "$NOTICES_FILE" "$TMP_DIR/notices.after-first-write" || fail "--write is not deterministic for THIRD_PARTY_NOTICES.md"
+
+run_generator --check "$TMP_DIR/check-clean.stdout" "$TMP_DIR/check-clean.stderr"
+CHECK_CLEAN_STDOUT="$(cat "$TMP_DIR/check-clean.stdout")"
+assert_contains "$CHECK_CLEAN_STDOUT" "PASS: third-party artifacts are up-to-date" "clean --check output"
+
+# Drift detection path: mutate one artifact and ensure --check fails with actionable guidance.
+printf '\n<!-- test drift marker -->\n' >>"$LICENSES_FILE"
+
+set +e
+run_generator --check "$TMP_DIR/check-drift.stdout" "$TMP_DIR/check-drift.stderr"
+DRIFT_RC=$?
+set -e
+[[ "$DRIFT_RC" -ne 0 ]] || fail "expected --check to fail after introducing drift"
+
+CHECK_DRIFT_STDERR="$(cat "$TMP_DIR/check-drift.stderr")"
+assert_contains "$CHECK_DRIFT_STDERR" "FAIL: artifact drift detected: THIRD_PARTY_LICENSES.md" "drift --check diagnostics"
+assert_contains \
+  "$CHECK_DRIFT_STDERR" \
+  "FAIL: third-party artifacts are stale; run: bash scripts/generate-third-party-artifacts.sh --write" \
+  "drift --check remediation hint"
+
+# Recovery path: re-run --write and verify --check returns to success.
+run_generator --write "$TMP_DIR/write-repair.stdout" "$TMP_DIR/write-repair.stderr"
+run_generator --check "$TMP_DIR/check-repaired.stdout" "$TMP_DIR/check-repaired.stderr"
+CHECK_REPAIRED_STDOUT="$(cat "$TMP_DIR/check-repaired.stdout")"
+assert_contains "$CHECK_REPAIRED_STDOUT" "PASS: third-party artifacts are up-to-date" "repaired --check output"
+
+printf 'OK\n'


### PR DESCRIPTION
## Summary

- Implement S1T4 by adding regression coverage for the third-party artifact generator script.
- Document contributor usage and dependency-entrypoint references for the generator.

## Scope

- Added `tests/third-party-artifacts/generator.test.sh` covering determinism, drift detection, and recovery paths.
- Updated `README.md` with `--write` and `--check` generator commands for contributors.
- Updated `BINARY_DEPENDENCIES.md` repository-local script entrypoints to include `scripts/generate-third-party-artifacts.sh`.

## Testing

- `bash tests/third-party-artifacts/generator.test.sh` (pass)
- `rg -n 'generate-third-party-artifacts\.sh' README.md BINARY_DEPENDENCIES.md` (pass)

## Issue

- Closes #275
- Task lane: S1T4
