### PR TITLE
feat(release): implement sprint 3 third-party tarball contract (#275)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Regenerate third-party artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/generate-third-party-artifacts.sh --write
+          bash scripts/generate-third-party-artifacts.sh --check
+
       - name: Install cross
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         uses: taiki-e/install-action@v2
@@ -81,7 +88,7 @@ jobs:
           done
 
           cp -R completions "${out_dir}/"
-          cp README.md LICENSE "${out_dir}/"
+          cp README.md LICENSE THIRD_PARTY_LICENSES.md THIRD_PARTY_NOTICES.md "${out_dir}/"
 
           tarball="dist/nils-cli-${tag}-${target}.tar.gz"
           tar -C dist -czf "${tarball}" "nils-cli-${tag}-${target}"
@@ -94,6 +101,14 @@ jobs:
             echo "error: sha256sum/shasum not found" >&2
             exit 1
           fi
+
+      - name: Audit release tarball third-party artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/release-tarball-third-party-audit.sh \
+            --target "${{ matrix.target }}" \
+            --tag "${{ github.ref_name }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ To trigger a release build, push a tag like `v0.6.1`:
 
 Then download the matching `nils-cli-<tag>-<target>.tar.gz` asset, extract it, and add `<extract_dir>/bin` to your `PATH`.
 
-Release packaging contract: shipped artifacts must include `completions/zsh/`, `completions/bash/`, `completions/zsh/aliases.zsh`, and
-`completions/bash/aliases.bash`. After extracting release assets, follow the same setup flow from
+Release packaging contract: shipped artifacts must include `completions/zsh/`, `completions/bash/`, `completions/zsh/aliases.zsh`,
+`completions/bash/aliases.bash`, `THIRD_PARTY_LICENSES.md`, and `THIRD_PARTY_NOTICES.md`. After extracting release assets, follow the
+same setup flow from
 ["Shell wrappers and completions"](#shell-wrappers-and-completions).
 
 ## crates.io publishing (shared crates)

--- a/scripts/ci/release-tarball-third-party-audit.sh
+++ b/scripts/ci/release-tarball-third-party-audit.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ci/release-tarball-third-party-audit.sh --target <target-triple> [--tag <tag>] [--dist-dir <path>]
+
+Checks that a release tarball includes required third-party artifacts:
+  - THIRD_PARTY_LICENSES.md
+  - THIRD_PARTY_NOTICES.md
+
+Options:
+  --target <triple>  Required Rust target triple used in tarball name.
+  --tag <tag>        Optional release tag. If omitted, script requires exactly one tarball for the target.
+  --dist-dir <path>  Optional dist directory. Default: dist
+  -h, --help         Show this help.
+USAGE
+}
+
+target=""
+tag=""
+dist_dir="dist"
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --target)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --target requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      target="$2"
+      shift 2
+      ;;
+    --tag)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --tag requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      tag="$2"
+      shift 2
+      ;;
+    --dist-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --dist-dir requires a value" >&2
+        usage >&2
+        exit 2
+      fi
+      dist_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: ${1:-}" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$target" ]]; then
+  echo "error: --target is required" >&2
+  usage >&2
+  exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
+  echo "error: must run inside a git work tree" >&2
+  exit 2
+fi
+cd "$repo_root"
+
+if [[ ! -d "$dist_dir" ]]; then
+  echo "FAIL: missing dist directory: $dist_dir"
+  exit 1
+fi
+
+if [[ -n "$tag" ]]; then
+  tarball="${dist_dir}/nils-cli-${tag}-${target}.tar.gz"
+else
+  mapfile -t matches < <(find "$dist_dir" -maxdepth 1 -type f -name "nils-cli-*-${target}.tar.gz" -print | LC_ALL=C sort)
+  if (( ${#matches[@]} == 0 )); then
+    echo "FAIL: no tarball found for target: ${target} in ${dist_dir}"
+    exit 1
+  fi
+  if (( ${#matches[@]} > 1 )); then
+    echo "error: multiple tarballs found for target ${target}; pass --tag to disambiguate" >&2
+    printf '%s\n' "${matches[@]}" >&2
+    exit 2
+  fi
+  tarball="${matches[0]}"
+fi
+
+if [[ ! -f "$tarball" ]]; then
+  echo "FAIL: missing tarball: $tarball"
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/release-tarball-third-party-audit.XXXXXX")"
+listing_file="${tmp_dir}/contents.txt"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+if ! tar -tzf "$tarball" >"$listing_file"; then
+  echo "error: failed to read tarball: $tarball" >&2
+  exit 2
+fi
+
+required_artifacts=("THIRD_PARTY_LICENSES.md" "THIRD_PARTY_NOTICES.md")
+missing_count=0
+for artifact in "${required_artifacts[@]}"; do
+  if ! rg -q "/${artifact}$" "$listing_file"; then
+    echo "FAIL: missing required file in tarball: ${artifact}"
+    missing_count=$((missing_count + 1))
+  fi
+done
+
+if (( missing_count > 0 )); then
+  echo "FAIL: release tarball third-party audit (target=${target}, missing=${missing_count}, tarball=${tarball})"
+  exit 1
+fi
+
+echo "PASS: release tarball third-party audit (target=${target}, missing=0, tarball=${tarball})"

--- a/tests/third-party-artifacts/release-package.test.sh
+++ b/tests/third-party-artifacts/release-package.test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+AUDIT_SCRIPT="$REPO_ROOT/scripts/ci/release-tarball-third-party-audit.sh"
+LICENSES_FILE="$REPO_ROOT/THIRD_PARTY_LICENSES.md"
+NOTICES_FILE="$REPO_ROOT/THIRD_PARTY_NOTICES.md"
+README_FILE="$REPO_ROOT/README.md"
+LICENSE_FILE="$REPO_ROOT/LICENSE"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local context="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail "$context missing '$needle'"
+  fi
+}
+
+run_audit() {
+  local target="$1"
+  local tag="$2"
+  local dist_dir="$3"
+  local output_file="$4"
+  local rc_file="$5"
+  (
+    cd "$REPO_ROOT"
+    bash "$AUDIT_SCRIPT" --target "$target" --tag "$tag" --dist-dir "$dist_dir"
+  ) >"$output_file" 2>&1
+  printf '%s\n' "$?" >"$rc_file"
+}
+
+package_fixture() {
+  local dist_dir="$1"
+  local tag="$2"
+  local target="$3"
+  local include_notices="$4"
+  local package_dir="$dist_dir/nils-cli-${tag}-${target}"
+  local tarball="$dist_dir/nils-cli-${tag}-${target}.tar.gz"
+
+  rm -rf "$package_dir"
+  mkdir -p "$package_dir/bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$package_dir/bin/nils-cli-smoke"
+  chmod 0755 "$package_dir/bin/nils-cli-smoke"
+
+  cp "$README_FILE" "$LICENSE_FILE" "$LICENSES_FILE" "$package_dir/"
+  if [[ "$include_notices" == "1" ]]; then
+    cp "$NOTICES_FILE" "$package_dir/"
+  fi
+
+  tar -C "$dist_dir" -czf "$tarball" "nils-cli-${tag}-${target}"
+}
+
+[[ -f "$AUDIT_SCRIPT" ]] || fail "missing audit script: $AUDIT_SCRIPT"
+[[ -f "$LICENSES_FILE" ]] || fail "missing licenses artifact: $LICENSES_FILE"
+[[ -f "$NOTICES_FILE" ]] || fail "missing notices artifact: $NOTICES_FILE"
+
+TMP_DIR="$(mktemp -d)"
+TARGET="x86_64-unknown-linux-gnu"
+TAG="v0.0.0-test"
+DIST_DIR="$TMP_DIR/dist"
+mkdir -p "$DIST_DIR"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+# Happy path: package includes both third-party artifacts and audit passes.
+package_fixture "$DIST_DIR" "$TAG" "$TARGET" "1"
+run_audit "$TARGET" "$TAG" "$DIST_DIR" "$TMP_DIR/audit-pass.out" "$TMP_DIR/audit-pass.rc"
+[[ "$(cat "$TMP_DIR/audit-pass.rc")" -eq 0 ]] || fail "audit should pass for complete package"
+AUDIT_PASS_OUTPUT="$(cat "$TMP_DIR/audit-pass.out")"
+assert_contains "$AUDIT_PASS_OUTPUT" "PASS: release tarball third-party audit (target=${TARGET}, missing=0" "audit pass output"
+
+EXTRACT_DIR="$TMP_DIR/extract"
+mkdir -p "$EXTRACT_DIR"
+tar -C "$EXTRACT_DIR" -xzf "$DIST_DIR/nils-cli-${TAG}-${TARGET}.tar.gz"
+EXTRACT_ROOT="$EXTRACT_DIR/nils-cli-${TAG}-${TARGET}"
+[[ -f "$EXTRACT_ROOT/THIRD_PARTY_LICENSES.md" ]] || fail "extracted archive missing THIRD_PARTY_LICENSES.md"
+[[ -f "$EXTRACT_ROOT/THIRD_PARTY_NOTICES.md" ]] || fail "extracted archive missing THIRD_PARTY_NOTICES.md"
+
+# Failure diagnostics path: missing notices artifact should fail with clear messaging.
+package_fixture "$DIST_DIR" "$TAG" "$TARGET" "0"
+set +e
+run_audit "$TARGET" "$TAG" "$DIST_DIR" "$TMP_DIR/audit-fail.out" "$TMP_DIR/audit-fail.rc"
+set -e
+[[ "$(cat "$TMP_DIR/audit-fail.rc")" -eq 1 ]] || fail "audit should fail when notices artifact is omitted"
+AUDIT_FAIL_OUTPUT="$(cat "$TMP_DIR/audit-fail.out")"
+assert_contains "$AUDIT_FAIL_OUTPUT" "FAIL: missing required file in tarball: THIRD_PARTY_NOTICES.md" "audit fail diagnostics"
+assert_contains "$AUDIT_FAIL_OUTPUT" "FAIL: release tarball third-party audit (target=${TARGET}, missing=1" "audit fail summary"
+
+printf 'OK\n'


### PR DESCRIPTION
## Summary

- Implements Sprint 3 lane tasks S3T1-S3T4 for issue #275 in the shared per-sprint branch.
- Regenerates and verifies third-party artifacts in each release matrix build before packaging.
- Adds release tarball third-party compliance audit and end-to-end fixture coverage.

## Scope

- Update `.github/workflows/release.yml` to:
  - run `scripts/generate-third-party-artifacts.sh --write` and `--check` before packaging
  - copy `THIRD_PARTY_LICENSES.md` and `THIRD_PARTY_NOTICES.md` into release tarball outputs
  - run `scripts/ci/release-tarball-third-party-audit.sh` before artifact upload
- Add `scripts/ci/release-tarball-third-party-audit.sh`.
- Add `tests/third-party-artifacts/release-package.test.sh`.
- Update `README.md` release packaging contract with required third-party files.

## Testing

- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass; total line coverage 86.56%)
- `rg -n 'generate-third-party-artifacts\.sh' .github/workflows/release.yml` (pass)
- `rg -n 'THIRD_PARTY_LICENSES\.md|THIRD_PARTY_NOTICES\.md' .github/workflows/release.yml README.md` (pass)
- `bash scripts/ci/release-tarball-third-party-audit.sh --target x86_64-unknown-linux-gnu` (pass; local fixture tarball)
- `bash tests/third-party-artifacts/release-package.test.sh` (pass)

## Issue

- #275
