### PR TITLE
Add watch mode for async codex rate limits

### DIFF
--- a/crates/codex-cli/src/cli.rs
+++ b/crates/codex-cli/src/cli.rs
@@ -199,6 +199,9 @@ pub struct RateLimitsArgs {
     /// Run concurrent async mode
     #[arg(long = "async")]
     pub async_mode: bool,
+    /// Refresh output every 60 seconds until interrupted (requires --async)
+    #[arg(long = "watch")]
+    pub watch: bool,
     /// Max concurrent jobs (async mode)
     #[arg(long = "jobs")]
     pub jobs: Option<String>,

--- a/crates/codex-cli/src/main.rs
+++ b/crates/codex-cli/src/main.rs
@@ -135,6 +135,7 @@ fn handle_diag(args: &cli::DiagArgs) -> i32 {
                 one_line: rate_args.one_line,
                 all: rate_args.all,
                 async_mode: rate_args.async_mode,
+                watch: rate_args.watch,
                 jobs: rate_args.jobs.clone(),
                 secret: rate_args.secret.clone(),
             };

--- a/crates/codex-cli/src/rate_limits/mod.rs
+++ b/crates/codex-cli/src/rate_limits/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use chrono::Utc;
 use serde::Serialize;
 use serde_json::Value;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread;
@@ -29,12 +30,15 @@ pub struct RateLimitsOptions {
     pub one_line: bool,
     pub all: bool,
     pub async_mode: bool,
+    pub watch: bool,
     pub jobs: Option<String>,
     pub secret: Option<String>,
 }
 
 const DIAG_SCHEMA_VERSION: &str = "codex-cli.diag.rate-limits.v1";
 const DIAG_COMMAND: &str = "diag rate-limits";
+const WATCH_INTERVAL_SECONDS: u64 = 60;
+const ANSI_CLEAR_SCREEN_AND_HOME: &str = "\x1b[2J\x1b[H";
 
 #[derive(Debug, Clone, Serialize)]
 struct RateLimitSummary {
@@ -95,12 +99,32 @@ pub fn run(args: &RateLimitsOptions) -> Result<i32> {
         debug_mode = true;
     }
 
+    if args.watch && !args.async_mode {
+        if output_json {
+            diag_output::emit_error(
+                DIAG_SCHEMA_VERSION,
+                DIAG_COMMAND,
+                "invalid-flag-combination",
+                "codex-rate-limits: --watch requires --async",
+                Some(serde_json::json!({
+                    "flags": ["--watch", "--async"],
+                })),
+            )?;
+        } else {
+            eprintln!("codex-rate-limits: --watch requires --async");
+        }
+        return Ok(64);
+    }
+
     if args.async_mode {
         if !args.cached {
             maybe_sync_all_mode_auth_silent(debug_mode);
         }
         if args.json {
             return run_async_json_mode(args, debug_mode);
+        }
+        if args.watch {
+            return run_async_watch_mode(args, debug_mode);
         }
         return run_async_mode(args, debug_mode);
     }
@@ -591,6 +615,18 @@ struct AsyncFetchResult {
 }
 
 fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
+    run_async_mode_impl(args, debug_mode, false)
+}
+
+fn run_async_watch_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
+    run_async_mode_impl(args, debug_mode, true)
+}
+
+fn run_async_mode_impl(
+    args: &RateLimitsOptions,
+    debug_mode: bool,
+    watch_mode: bool,
+) -> Result<i32> {
     if args.json {
         eprintln!("codex-rate-limits: --async does not support --json");
         return Ok(64);
@@ -654,6 +690,72 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
 
     secret_files.sort();
 
+    let current_name = current_secret_basename(&secret_files);
+
+    if !watch_mode {
+        let round = collect_async_round(&secret_files, args.cached, args.no_refresh_auth, jobs);
+        render_all_accounts_table(
+            round.rows,
+            &round.window_labels,
+            current_name.as_deref(),
+            None,
+        );
+        emit_async_debug(debug_mode, &secret_files, &round.stderr_map);
+        return Ok(round.rc);
+    }
+
+    let mut overall_rc = 0;
+    let mut rendered_rounds = 0u64;
+    let max_rounds = watch_max_rounds_for_test();
+    let is_terminal_stdout = std::io::stdout().is_terminal();
+
+    loop {
+        let round = collect_async_round(&secret_files, args.cached, args.no_refresh_auth, jobs);
+        if round.rc != 0 {
+            overall_rc = 1;
+        }
+
+        if is_terminal_stdout {
+            print!("{ANSI_CLEAR_SCREEN_AND_HOME}");
+        }
+
+        let now_epoch = Utc::now().timestamp();
+        let update_time = format_watch_update_time(now_epoch);
+        render_all_accounts_table(
+            round.rows,
+            &round.window_labels,
+            current_name.as_deref(),
+            Some(update_time.as_str()),
+        );
+        emit_async_debug(debug_mode, &secret_files, &round.stderr_map);
+        let _ = std::io::stdout().flush();
+
+        rendered_rounds += 1;
+        if let Some(limit) = max_rounds
+            && rendered_rounds >= limit
+        {
+            break;
+        }
+
+        thread::sleep(Duration::from_secs(WATCH_INTERVAL_SECONDS));
+    }
+
+    Ok(overall_rc)
+}
+
+struct AsyncRound {
+    rc: i32,
+    rows: Vec<Row>,
+    window_labels: std::collections::HashSet<String>,
+    stderr_map: std::collections::HashMap<String, String>,
+}
+
+fn collect_async_round(
+    secret_files: &[PathBuf],
+    cached_mode: bool,
+    no_refresh_auth: bool,
+    jobs: usize,
+) -> AsyncRound {
     let total = secret_files.len();
     let progress = if total > 1 {
         Some(Progress::new(
@@ -695,12 +797,7 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
     while index < total && handles.len() < worker_count {
         let path = secret_files[index].clone();
         index += 1;
-        handles.push(spawn_worker(
-            path,
-            args.cached,
-            args.no_refresh_auth,
-            tx.clone(),
-        ));
+        handles.push(spawn_worker(path, cached_mode, no_refresh_auth, tx.clone()));
     }
 
     let mut events: std::collections::HashMap<String, AsyncEvent> =
@@ -719,12 +816,7 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
         if index < total {
             let path = secret_files[index].clone();
             index += 1;
-            handles.push(spawn_worker(
-                path,
-                args.cached,
-                args.no_refresh_auth,
-                tx.clone(),
-            ));
+            handles.push(spawn_worker(path, cached_mode, no_refresh_auth, tx.clone()));
         }
     }
 
@@ -737,15 +829,13 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
         let _ = handle.join();
     }
 
-    println!("\n🚦 Codex rate limits for all accounts\n");
-
     let mut rc = 0;
     let mut rows: Vec<Row> = Vec::new();
     let mut window_labels = std::collections::HashSet::new();
     let mut stderr_map: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
 
-    for secret_file in &secret_files {
+    for secret_file in secret_files {
         let secret_name = secret_file
             .file_name()
             .and_then(|name| name.to_str())
@@ -758,7 +848,7 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
             if !event.err.is_empty() {
                 stderr_map.insert(secret_name.clone(), event.err.clone());
             }
-            if !args.cached && event.rc != 0 {
+            if !cached_mode && event.rc != 0 {
                 rc = 1;
             }
 
@@ -770,7 +860,7 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
                 row.weekly_remaining = parsed.weekly_remaining;
                 row.weekly_reset_iso = parsed.weekly_reset_iso.clone();
 
-                if args.cached {
+                if cached_mode {
                     if let Ok(cache_entry) = cache::read_cache_entry(secret_file) {
                         row.non_weekly_reset_epoch = cache_entry.non_weekly_reset_epoch;
                         row.weekly_reset_epoch = Some(cache_entry.weekly_reset_epoch);
@@ -805,19 +895,33 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
             }
         }
 
-        if !args.cached {
+        if !cached_mode {
             rc = 1;
         }
         rows.push(row);
     }
+
+    AsyncRound {
+        rc,
+        rows,
+        window_labels,
+        stderr_map,
+    }
+}
+
+fn render_all_accounts_table(
+    mut rows: Vec<Row>,
+    window_labels: &std::collections::HashSet<String>,
+    current_name: Option<&str>,
+    update_time: Option<&str>,
+) {
+    println!("\n🚦 Codex rate limits for all accounts\n");
 
     let mut non_weekly_header = "Non-weekly".to_string();
     let multiple_labels = window_labels.len() != 1;
     if !multiple_labels && let Some(label) = window_labels.iter().next() {
         non_weekly_header = label.clone();
     }
-
-    let current_name = current_secret_basename(&secret_files);
 
     let now_epoch = Utc::now().timestamp();
 
@@ -862,7 +966,7 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
             ansi::format_percent_cell("-", 8, None)
         };
 
-        let is_current = current_name.as_deref() == Some(row.name.as_str());
+        let is_current = current_name == Some(row.name.as_str());
         let name_display = ansi::format_name_cell(&row.name, 15, is_current, None);
 
         println!(
@@ -876,30 +980,53 @@ fn run_async_mode(args: &RateLimitsOptions, debug_mode: bool) -> Result<i32> {
         );
     }
 
-    if debug_mode {
-        let mut printed = false;
-        for secret_file in &secret_files {
-            let secret_name = secret_file
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("")
-                .to_string();
-            if let Some(err) = stderr_map.get(&secret_name) {
-                if err.is_empty() {
-                    continue;
-                }
-                if !printed {
-                    printed = true;
-                    eprintln!();
-                    eprintln!("codex-rate-limits-async: per-account stderr (captured):");
-                }
-                eprintln!("---- {} ----", secret_name);
-                eprintln!("{err}");
-            }
-        }
+    if let Some(update_time) = update_time {
+        println!();
+        println!("Last update: {update_time}");
+    }
+}
+
+fn emit_async_debug(
+    debug_mode: bool,
+    secret_files: &[PathBuf],
+    stderr_map: &std::collections::HashMap<String, String>,
+) {
+    if !debug_mode {
+        return;
     }
 
-    Ok(rc)
+    let mut printed = false;
+    for secret_file in secret_files {
+        let secret_name = secret_file
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("")
+            .to_string();
+        if let Some(err) = stderr_map.get(&secret_name) {
+            if err.is_empty() {
+                continue;
+            }
+            if !printed {
+                printed = true;
+                eprintln!();
+                eprintln!("codex-rate-limits-async: per-account stderr (captured):");
+            }
+            eprintln!("---- {} ----", secret_name);
+            eprintln!("{err}");
+        }
+    }
+}
+
+fn watch_max_rounds_for_test() -> Option<u64> {
+    std::env::var("CODEX_RATE_LIMITS_WATCH_MAX_ROUNDS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+}
+
+fn format_watch_update_time(now_epoch: i64) -> String {
+    render::format_epoch_local(now_epoch, "%Y-%m-%d %H:%M:%S %:z")
+        .unwrap_or_else(|| now_epoch.to_string())
 }
 
 fn async_fetch_one_line(

--- a/crates/codex-cli/tests/rate_limits_async.rs
+++ b/crates/codex-cli/tests/rate_limits_async.rs
@@ -207,6 +207,66 @@ fn rate_limits_async_one_line_conflict() {
 }
 
 #[test]
+fn rate_limits_watch_requires_async() {
+    let output = run(&["diag", "rate-limits", "--watch"], &[], &[]);
+    assert_exit(&output, 64);
+    assert!(stderr(&output).contains("--watch requires --async"));
+}
+
+#[test]
+fn rate_limits_async_watch_renders_last_update_timestamp() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secret_dir = dir.path().join("secrets");
+    fs::create_dir_all(&secret_dir).expect("secret dir");
+    fs::write(
+        secret_dir.join("alpha.json"),
+        r#"{"tokens":{"access_token":"tok-alpha","account_id":"acct_001"}}"#,
+    )
+    .expect("write alpha");
+
+    let cache_root = dir.path().join("cache_root");
+    fs::create_dir_all(&cache_root).expect("cache root");
+
+    let server = LoopbackServer::new().expect("server");
+    server.add_route(
+        "GET",
+        "/wham/usage",
+        HttpResponse::new(
+            200,
+            r#"{
+  "rate_limit": {
+    "primary_window": { "limit_window_seconds": 18000, "used_percent": 6, "reset_at": 1700003600 },
+    "secondary_window": { "limit_window_seconds": 604800, "used_percent": 12, "reset_at": 1700600000 }
+  }
+}"#,
+        ),
+    );
+
+    let output = run(
+        &["diag", "rate-limits", "--async", "--watch"],
+        &[
+            ("CODEX_SECRET_DIR", &secret_dir),
+            ("ZSH_CACHE_DIR", &cache_root),
+        ],
+        &[
+            ("CODEX_CHATGPT_BASE_URL", &server.url()),
+            ("CODEX_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false"),
+            ("CODEX_RATE_LIMITS_CURL_CONNECT_TIMEOUT_SECONDS", "1"),
+            ("CODEX_RATE_LIMITS_CURL_MAX_TIME_SECONDS", "3"),
+            ("CODEX_RATE_LIMITS_WATCH_MAX_ROUNDS", "1"),
+            ("TZ", "UTC"),
+            ("NO_COLOR", "1"),
+        ],
+    );
+    assert_exit(&output, 0);
+
+    let out = stdout(&output);
+    assert!(out.contains("🚦 Codex rate limits for all accounts"));
+    assert!(out.contains("alpha"));
+    assert!(out.contains("Last update: "));
+}
+
+#[test]
 fn rate_limits_async_jobs_zero_defaults() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let secret_dir = dir.path().join("secrets");


### PR DESCRIPTION
# Add watch mode for async codex rate limits

## Summary

Add a new `--watch` mode for `codex-cli diag rate-limits` that refreshes async all-account output every 60 seconds until interrupted. The watch loop keeps existing cache behavior, rewrites the terminal view each cycle (no append), and prints a final "Last update" timestamp below the table.

## Changes

- Add `--watch` to `diag rate-limits` CLI args and wire it through to `RateLimitsOptions`.
- Implement async watch loop for `--async --watch`:
- Runs existing async fetch/render path every 60 seconds.
- Clears and redraws the full output each cycle for terminal sessions.
- Adds a blank line and `Last update: <local timestamp>` after the table.
- Keep existing cache semantics (no per-minute cache clear; `-c/--clear-cache` runs once at startup).
- Refactor async one-shot path into reusable helpers used by both one-shot and watch modes.
- Add tests for watch argument validation and one-round watch rendering via a bounded test-only env knob.

## Testing

- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `mkdir -p target/coverage && cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass)

## Risk / Notes

- Watch mode is intentionally constrained to async mode (`--watch` requires `--async`).
- Output redraw uses ANSI clear/home when stdout is a TTY; non-TTY output still emits refreshed snapshots without terminal control behavior.
