### PR TITLE
Add wrapper runtime execution status hints

### DIFF
--- a/docs/runbooks/wrappers-mode-usage.md
+++ b/docs/runbooks/wrappers-mode-usage.md
@@ -8,6 +8,7 @@ This runbook defines how `wrappers/*` choose between:
 - workspace debug execution (`cargo run -q -p ...`).
 
 It also documents the safety rules that prevent wrapper self-recursion and ambiguous fallback behavior.
+Wrappers emit a short status line on `stderr` before execution so users can see which path is active.
 
 ## Scope
 
@@ -73,6 +74,18 @@ Lookup order for installed mode resolution:
 2. `command -v <bin>`
 
 Both `~` and `~/...` forms are expanded.
+
+### `NILS_WRAPPER_STATUS_HINTS`
+
+Controls whether wrappers print execution-path status lines on `stderr`.
+
+- `1` (default): print status hints
+- `0`: disable status hints
+
+Default status hints include:
+
+- `exec=installed mode=<mode> path=<resolved-path>`
+- `exec=cargo mode=<mode> crate=<crate-name> (cargo -q: build may stay silent while compiling)`
 
 ## Safety Guarantees
 
@@ -158,6 +171,11 @@ NILS_WRAPPER_MODE=debug
 
 - Cause: `auto` mode could not find installed binary and cannot run cargo fallback
 - Fix: install binary or ensure Cargo is available
+
+### Need fully quiet wrapper stderr
+
+- Cause: status hints are enabled by default
+- Fix: set `NILS_WRAPPER_STATUS_HINTS=0`
 
 ## Verification Quick Checks
 

--- a/scripts/ci/wrapper-mode-smoke.sh
+++ b/scripts/ci/wrapper-mode-smoke.sh
@@ -39,6 +39,15 @@ assert_file_empty() {
   fi
 }
 
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  if ! grep -Fq "$pattern" "$file"; then
+    die "$label expected pattern '$pattern' in $file"
+  fi
+}
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 wrapper="$repo_root/wrappers/cli-template"
 
@@ -120,18 +129,21 @@ reset_logs
 run_wrapper debug "$tmp_dir/debug.out" "$tmp_dir/debug.err" smoke-debug
 assert_file_has_content "$cargo_log" "debug mode"
 assert_file_empty "$installed_log" "debug mode"
+assert_file_contains "$tmp_dir/debug.err" "exec=cargo mode=debug" "debug mode status hint"
 
 # 2) installed mode: force installed binary path.
 reset_logs
 run_wrapper installed "$tmp_dir/installed.out" "$tmp_dir/installed.err" smoke-installed
 assert_file_has_content "$installed_log" "installed mode"
 assert_file_empty "$cargo_log" "installed mode"
+assert_file_contains "$tmp_dir/installed.err" "exec=installed mode=installed" "installed mode status hint"
 
 # 3) auto mode: prefer installed binary when present.
 reset_logs
 run_wrapper auto "$tmp_dir/auto-prefer.out" "$tmp_dir/auto-prefer.err" smoke-auto-prefer
 assert_file_has_content "$installed_log" "auto mode (prefer installed)"
 assert_file_empty "$cargo_log" "auto mode (prefer installed)"
+assert_file_contains "$tmp_dir/auto-prefer.err" "exec=installed mode=auto" "auto mode (prefer installed) status hint"
 
 # 4) auto mode fallback: if installed missing, fallback to cargo.
 rm -f "$install_prefix/$bin_name"
@@ -139,5 +151,6 @@ reset_logs
 run_wrapper auto "$tmp_dir/auto-fallback.out" "$tmp_dir/auto-fallback.err" smoke-auto-fallback
 assert_file_has_content "$cargo_log" "auto mode (fallback cargo)"
 assert_file_empty "$installed_log" "auto mode (fallback cargo)"
+assert_file_contains "$tmp_dir/auto-fallback.err" "exec=cargo mode=auto" "auto mode (fallback cargo) status hint"
 
 echo "ok: wrapper mode smoke tests passed for $wrapper"

--- a/wrappers/agent-docs
+++ b/wrappers/agent-docs
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/api-gql
+++ b/wrappers/api-gql
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/api-grpc
+++ b/wrappers/api-grpc
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/api-rest
+++ b/wrappers/api-rest
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/api-test
+++ b/wrappers/api-test
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/api-websocket
+++ b/wrappers/api-websocket
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/cli-template
+++ b/wrappers/cli-template
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/codex-cli
+++ b/wrappers/codex-cli
@@ -20,6 +20,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -46,8 +54,10 @@ resolve_installed_for() {
 
 run_debug_for() {
   local target_crate="$1"
+  local effective_mode="${2:-$mode}"
 
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "codex-cli: exec=cargo mode=${effective_mode} crate=${target_crate} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$target_crate" -- "${args[@]}"
   fi
 
@@ -56,9 +66,11 @@ run_debug_for() {
 
 run_installed_for() {
   local target_bin="$1"
+  local effective_mode="${2:-$mode}"
   local installed=""
 
   if installed="$(resolve_installed_for "$target_bin")"; then
+    emit_status "codex-cli: exec=installed mode=${effective_mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -69,11 +81,11 @@ run_auto_for() {
   local target_bin="$1"
   local target_crate="$2"
 
-  if run_installed_for "$target_bin"; then
+  if run_installed_for "$target_bin" "auto"; then
     return 0
   fi
 
-  if run_debug_for "$target_crate"; then
+  if run_debug_for "$target_crate" "auto"; then
     return 0
   fi
 
@@ -96,14 +108,14 @@ fi
 
 case "$mode" in
   debug)
-    if run_debug_for "nils-codex-cli"; then
+    if run_debug_for "nils-codex-cli" "debug"; then
       exit 0
     fi
     echo "codex-cli: cargo not found (required when NILS_WRAPPER_MODE=debug)" >&2
     exit 1
     ;;
   installed)
-    if run_installed_for "codex-cli"; then
+    if run_installed_for "codex-cli" "installed"; then
       exit 0
     fi
     echo "codex-cli: installed binary not found (NILS_WRAPPER_MODE=installed)" >&2

--- a/wrappers/fzf-cli
+++ b/wrappers/fzf-cli
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/gemini-cli
+++ b/wrappers/gemini-cli
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/git-cli
+++ b/wrappers/git-cli
@@ -25,6 +25,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -50,6 +58,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -60,6 +69,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -79,10 +89,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/git-lock
+++ b/wrappers/git-lock
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/git-scope
+++ b/wrappers/git-scope
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/git-summary
+++ b/wrappers/git-summary
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/image-processing
+++ b/wrappers/image-processing
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/macos-agent
+++ b/wrappers/macos-agent
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/memo-cli
+++ b/wrappers/memo-cli
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/plan-issue
+++ b/wrappers/plan-issue
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/plan-issue-local
+++ b/wrappers/plan-issue-local
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" --bin plan-issue-local -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" --bin plan-issue-local -- "${args[@]}"
 fi
 

--- a/wrappers/plan-tooling
+++ b/wrappers/plan-tooling
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/screen-record
+++ b/wrappers/screen-record
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 

--- a/wrappers/semantic-commit
+++ b/wrappers/semantic-commit
@@ -22,6 +22,14 @@ if [[ "$mode" != "auto" && "$mode" != "debug" && "$mode" != "installed" ]]; then
   exit 64
 fi
 
+emit_status() {
+  if [[ "${NILS_WRAPPER_STATUS_HINTS:-1}" == "0" ]]; then
+    return 0
+  fi
+
+  echo "$*" >&2
+}
+
 is_self_candidate() {
   local candidate="$1"
   [[ -n "$candidate" && -e "$candidate" && "$candidate" -ef "$self_path" ]]
@@ -47,6 +55,7 @@ resolve_installed() {
 
 run_debug() {
   if command -v cargo >/dev/null 2>&1; then
+    emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
     exec cargo run -q -p "$crate_name" -- "${args[@]}"
   fi
 
@@ -57,6 +66,7 @@ run_debug() {
 run_installed() {
   local installed=""
   if installed="$(resolve_installed)"; then
+    emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
     exec "$installed" "${args[@]}"
   fi
 
@@ -76,10 +86,12 @@ esac
 
 installed=""
 if installed="$(resolve_installed)"; then
+  emit_status "${bin_name}: exec=installed mode=${mode} path=${installed}"
   exec "$installed" "${args[@]}"
 fi
 
 if command -v cargo >/dev/null 2>&1; then
+  emit_status "${bin_name}: exec=cargo mode=${mode} crate=${crate_name} (cargo -q: build may stay silent while compiling)"
   exec cargo run -q -p "$crate_name" -- "${args[@]}"
 fi
 


### PR DESCRIPTION
# Add wrapper runtime execution status hints

## Summary

Add runtime status hints to wrapper scripts so users can see which execution path is selected (`installed` vs `cargo`) and get an immediate notice when `cargo -q` may remain silent during compilation.

## Changes

- Add `emit_status()` to all wrapper scripts and print an execution hint on `stderr` before each `exec` path.
- Keep existing `cargo run -q` behavior, but add a wait-oriented hint line before cargo execution.
- Add `NILS_WRAPPER_STATUS_HINTS` (default `1`) to allow disabling status hints with `NILS_WRAPPER_STATUS_HINTS=0`.
- Update wrapper mode runbook with the new status-hint contract and quiet-mode opt-out behavior.
- Extend `scripts/ci/wrapper-mode-smoke.sh` to assert mode-specific status-hint output on `stderr`.

## Testing

- `bash scripts/ci/wrapper-mode-smoke.sh` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 86.57%)

## Risk / Notes

- Wrappers now emit one informational `stderr` line before execution by default.
- Automation that requires silent wrapper `stderr` can set `NILS_WRAPPER_STATUS_HINTS=0`.
