### PR TITLE
Enforce TTL-aware cached rate-limits behavior in codex-cli

### DIFF
--- a/crates/codex-cli/README.md
+++ b/crates/codex-cli/README.md
@@ -73,6 +73,8 @@ Auth examples:
 
 - `rate-limits [options] [secret.json]`: Rate-limit diagnostics. Options: `-c/--clear-cache`, `-d/--debug`, `--cached`, `--no-refresh-auth`,
   `--json`, `--one-line`, `--all`, `--async`, `--jobs <n>`.
+- `--cached` reads cache only. Freshness is controlled by `CODEX_RATE_LIMITS_CACHE_TTL` (default `300s`); stale cache is rejected unless
+  `CODEX_RATE_LIMITS_CACHE_ALLOW_STALE=true`.
 
 ### config
 
@@ -94,13 +96,20 @@ Auth examples:
 
 ## Environment
 
-- `CODEX_ALLOW_DANGEROUS_ENABLED=true` is required for `agent` commands.
-- `CODEX_CLI_MODEL` and `CODEX_CLI_REASONING` set `codex exec` defaults.
-- `CODEX_SECRET_DIR` controls the secret directory path. When unset, it defaults to `~/.config/codex_secrets`.
-- `CODEX_AUTH_FILE` controls the active auth file path. When unset, it defaults to `~/.agents/auth.json`.
-- `CODEX_SECRET_CACHE_DIR` controls secret cache timestamps.
-- `CODEX_STARSHIP_ENABLED=true` enables Starship output.
-- `CODEX_STARSHIP_TTL` overrides the cache TTL.
+- `CODEX_ALLOW_DANGEROUS_ENABLED`: gate for `agent` commands (default: `false`).
+- `CODEX_CLI_MODEL`: `codex exec` default model (default: `gpt-5.1-codex-mini`).
+- `CODEX_CLI_REASONING`: `codex exec` default reasoning level (default: `medium`).
+- `CODEX_SECRET_DIR`: secret directory path (default: `~/.config/codex_secrets`).
+- `CODEX_AUTH_FILE`: active auth file path (default: `~/.agents/auth.json`).
+- `CODEX_SECRET_CACHE_DIR`: secret timestamp cache directory. If unset, resolver order is:
+  `ZSH_CACHE_DIR/codex/secrets` -> `ZDOTDIR/cache/codex/secrets` -> `~/.config/zsh/cache/codex/secrets`.
+- `CODEX_RATE_LIMITS_CACHE_TTL`: `diag rate-limits --cached` TTL (default: `300s`; supports `s|m|h|d|w` suffixes or raw seconds).
+- `CODEX_RATE_LIMITS_CACHE_ALLOW_STALE`: allow stale cache in `--cached` mode (default: `false`).
+- `CODEX_RATE_LIMITS_DEFAULT_ALL_ENABLED`: default `diag rate-limits` to `--all` when no target is provided (default: `false`).
+- `CODEX_STARSHIP_ENABLED`: enable Starship output (default: `false`; set `true` to enable).
+- `CODEX_STARSHIP_TTL`: Starship cache TTL override (default: `300s`; supports `s|m|h|d|w` suffixes or raw seconds).
+- `CODEX_AUTO_REFRESH_ENABLED`: enable `auth auto-refresh` behavior where applicable (default: `false`).
+- `CODEX_AUTO_REFRESH_MIN_DAYS`: `auth auto-refresh` minimum token age threshold (default: `5`).
 
 ## Dependencies
 

--- a/crates/codex-cli/src/rate_limits/cache.rs
+++ b/crates/codex-cli/src/rate_limits/cache.rs
@@ -5,14 +5,21 @@ use std::path::{Path, PathBuf};
 use crate::auth;
 use crate::fs as codex_fs;
 use crate::paths;
+use nils_common::env as shared_env;
 
+#[derive(Debug)]
 pub struct CacheEntry {
+    pub fetched_at_epoch: Option<i64>,
     pub non_weekly_label: String,
     pub non_weekly_remaining: i64,
     pub non_weekly_reset_epoch: Option<i64>,
     pub weekly_remaining: i64,
     pub weekly_reset_epoch: i64,
 }
+
+const DEFAULT_CACHE_TTL_SECONDS: u64 = 300;
+const CACHE_MISS_HINT: &str =
+    "rerun without --cached to refresh, or set CODEX_RATE_LIMITS_CACHE_ALLOW_STALE=true";
 
 pub fn clear_starship_cache() -> Result<()> {
     let root = cache_root().context("cache root")?;
@@ -84,6 +91,7 @@ pub fn read_cache_entry(target_file: &Path) -> Result<CacheEntry> {
 
     let content = fs::read_to_string(&cache_file)
         .with_context(|| format!("failed to read cache: {}", cache_file.display()))?;
+    let mut fetched_at_epoch: Option<i64> = None;
     let mut non_weekly_label: Option<String> = None;
     let mut non_weekly_remaining: Option<i64> = None;
     let mut non_weekly_reset_epoch: Option<i64> = None;
@@ -91,7 +99,9 @@ pub fn read_cache_entry(target_file: &Path) -> Result<CacheEntry> {
     let mut weekly_reset_epoch: Option<i64> = None;
 
     for line in content.lines() {
-        if let Some(value) = line.strip_prefix("non_weekly_label=") {
+        if let Some(value) = line.strip_prefix("fetched_at=") {
+            fetched_at_epoch = value.parse::<i64>().ok();
+        } else if let Some(value) = line.strip_prefix("non_weekly_label=") {
             non_weekly_label = Some(value.to_string());
         } else if let Some(value) = line.strip_prefix("non_weekly_remaining=") {
             non_weekly_remaining = value.parse::<i64>().ok();
@@ -134,12 +144,22 @@ pub fn read_cache_entry(target_file: &Path) -> Result<CacheEntry> {
     };
 
     Ok(CacheEntry {
+        fetched_at_epoch,
         non_weekly_label,
         non_weekly_remaining,
         non_weekly_reset_epoch,
         weekly_remaining,
         weekly_reset_epoch,
     })
+}
+
+pub fn read_cache_entry_for_cached_mode(target_file: &Path) -> Result<CacheEntry> {
+    let entry = read_cache_entry(target_file)?;
+    if cache_allow_stale() {
+        return Ok(entry);
+    }
+    ensure_cache_fresh(target_file, &entry)?;
+    Ok(entry)
 }
 
 pub fn write_starship_cache(
@@ -174,6 +194,88 @@ pub fn write_starship_cache(
 fn starship_cache_dir() -> Result<PathBuf> {
     let root = cache_root().context("cache root")?;
     Ok(root.join("codex").join("starship-rate-limits"))
+}
+
+fn ensure_cache_fresh(target_file: &Path, entry: &CacheEntry) -> Result<()> {
+    let ttl_seconds = cache_ttl_seconds();
+    let ttl_i64 = i64::try_from(ttl_seconds).unwrap_or(i64::MAX);
+    let cache_file = cache_file_for_target(target_file)?;
+
+    let fetched_at_epoch = match entry.fetched_at_epoch {
+        Some(value) if value > 0 => value,
+        _ => {
+            anyhow::bail!(
+                "codex-rate-limits: cache expired (missing fetched_at): {} ({})",
+                cache_file.display(),
+                CACHE_MISS_HINT
+            );
+        }
+    };
+
+    let now_epoch = chrono::Utc::now().timestamp();
+    if now_epoch <= 0 {
+        return Ok(());
+    }
+
+    let age_seconds = if now_epoch >= fetched_at_epoch {
+        now_epoch - fetched_at_epoch
+    } else {
+        0
+    };
+    if age_seconds > ttl_i64 {
+        anyhow::bail!(
+            "codex-rate-limits: cache expired (age={}s, ttl={}s): {} ({})",
+            age_seconds,
+            ttl_seconds,
+            cache_file.display(),
+            CACHE_MISS_HINT
+        );
+    }
+
+    Ok(())
+}
+
+fn cache_ttl_seconds() -> u64 {
+    if let Ok(raw) = std::env::var("CODEX_RATE_LIMITS_CACHE_TTL")
+        && let Some(value) = parse_duration_seconds(&raw)
+    {
+        return value;
+    }
+    DEFAULT_CACHE_TTL_SECONDS
+}
+
+fn cache_allow_stale() -> bool {
+    shared_env::env_truthy_or("CODEX_RATE_LIMITS_CACHE_ALLOW_STALE", false)
+}
+
+fn parse_duration_seconds(raw: &str) -> Option<u64> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let raw = raw.to_ascii_lowercase();
+    let (num_part, multiplier): (&str, u64) = match raw.chars().last()? {
+        's' => (&raw[..raw.len().saturating_sub(1)], 1),
+        'm' => (&raw[..raw.len().saturating_sub(1)], 60),
+        'h' => (&raw[..raw.len().saturating_sub(1)], 60 * 60),
+        'd' => (&raw[..raw.len().saturating_sub(1)], 60 * 60 * 24),
+        'w' => (&raw[..raw.len().saturating_sub(1)], 60 * 60 * 24 * 7),
+        ch if ch.is_ascii_digit() => (raw.as_str(), 1),
+        _ => return None,
+    };
+
+    let num_part = num_part.trim();
+    if num_part.is_empty() {
+        return None;
+    }
+
+    let value = num_part.parse::<u64>().ok()?;
+    if value == 0 {
+        return None;
+    }
+
+    value.checked_mul(multiplier)
 }
 
 fn cache_root() -> Option<PathBuf> {
@@ -243,10 +345,11 @@ fn cache_key(name: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        cache_file_for_target, clear_starship_cache, read_cache_entry, secret_name_for_target,
-        write_starship_cache,
+        cache_file_for_target, clear_starship_cache, read_cache_entry,
+        read_cache_entry_for_cached_mode, secret_name_for_target, write_starship_cache,
     };
     use crate::fs as codex_fs;
+    use chrono::Utc;
     use nils_test_support::{EnvGuard, GlobalStateLock};
     use std::fs;
     use std::path::Path;
@@ -500,9 +603,7 @@ mod tests {
         )
         .expect("write invalid cache");
 
-        let err = read_cache_entry(&target)
-            .err()
-            .expect("missing weekly reset should fail");
+        let err = read_cache_entry(&target).expect_err("missing weekly reset should fail");
         assert!(err.to_string().contains("missing weekly data"));
     }
 
@@ -526,9 +627,76 @@ mod tests {
         )
         .expect("write invalid cache");
 
-        let err = read_cache_entry(&target)
-            .err()
-            .expect("missing non-weekly fields should fail");
+        let err = read_cache_entry(&target).expect_err("missing non-weekly fields should fail");
         assert!(err.to_string().contains("missing non-weekly data"));
+    }
+
+    #[test]
+    fn read_cache_entry_for_cached_mode_rejects_expired_cache_by_default() {
+        let lock = GlobalStateLock::new();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let secret_dir = dir.path().join("secrets");
+        let cache_root = dir.path().join("cache");
+        fs::create_dir_all(&secret_dir).expect("secret dir");
+        fs::create_dir_all(&cache_root).expect("cache root");
+        let _env = set_cache_env(&lock, &secret_dir, &cache_root);
+
+        let target = secret_dir.join("alpha.json");
+        fs::write(&target, "{}").expect("write target");
+        write_starship_cache(&target, 1, "5h", 91, 12, 1_700_600_000, Some(1_700_003_600))
+            .expect("write cache");
+
+        let err = read_cache_entry_for_cached_mode(&target).expect_err("stale cache should fail");
+        assert!(err.to_string().contains("cache expired"));
+    }
+
+    #[test]
+    fn read_cache_entry_for_cached_mode_honors_ttl_env() {
+        let lock = GlobalStateLock::new();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let secret_dir = dir.path().join("secrets");
+        let cache_root = dir.path().join("cache");
+        fs::create_dir_all(&secret_dir).expect("secret dir");
+        fs::create_dir_all(&cache_root).expect("cache root");
+        let _env = set_cache_env(&lock, &secret_dir, &cache_root);
+        let _ttl = EnvGuard::set(&lock, "CODEX_RATE_LIMITS_CACHE_TTL", "1h");
+
+        let target = secret_dir.join("alpha.json");
+        fs::write(&target, "{}").expect("write target");
+        let now = Utc::now().timestamp();
+        let fetched_at = now.saturating_sub(30 * 60);
+        write_starship_cache(
+            &target,
+            fetched_at,
+            "5h",
+            91,
+            12,
+            1_700_600_000,
+            Some(1_700_003_600),
+        )
+        .expect("write cache");
+
+        let entry = read_cache_entry_for_cached_mode(&target).expect("fresh cache");
+        assert_eq!(entry.non_weekly_label, "5h");
+    }
+
+    #[test]
+    fn read_cache_entry_for_cached_mode_allows_stale_when_enabled() {
+        let lock = GlobalStateLock::new();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let secret_dir = dir.path().join("secrets");
+        let cache_root = dir.path().join("cache");
+        fs::create_dir_all(&secret_dir).expect("secret dir");
+        fs::create_dir_all(&cache_root).expect("cache root");
+        let _env = set_cache_env(&lock, &secret_dir, &cache_root);
+        let _allow_stale = EnvGuard::set(&lock, "CODEX_RATE_LIMITS_CACHE_ALLOW_STALE", "true");
+
+        let target = secret_dir.join("alpha.json");
+        fs::write(&target, "{}").expect("write target");
+        write_starship_cache(&target, 1, "5h", 91, 12, 1_700_600_000, Some(1_700_003_600))
+            .expect("write cache");
+
+        let entry = read_cache_entry_for_cached_mode(&target).expect("allow stale");
+        assert_eq!(entry.non_weekly_remaining, 91);
     }
 }

--- a/crates/codex-cli/src/rate_limits/mod.rs
+++ b/crates/codex-cli/src/rate_limits/mod.rs
@@ -392,7 +392,7 @@ fn collect_json_result_for_secret(
     allow_cache_fallback: bool,
 ) -> RateLimitJsonResult {
     if cached_mode {
-        return collect_json_from_cache(target_file, "cache");
+        return collect_json_from_cache(target_file, "cache", true);
     }
 
     let base_url = std::env::var("CODEX_CHATGPT_BASE_URL")
@@ -468,7 +468,7 @@ fn collect_json_result_for_secret(
         }
         Err(err) => {
             if allow_cache_fallback {
-                let fallback = collect_json_from_cache(target_file, "cache-fallback");
+                let fallback = collect_json_from_cache(target_file, "cache-fallback", false);
                 if fallback.ok {
                     return fallback;
                 }
@@ -484,8 +484,18 @@ fn collect_json_result_for_secret(
     }
 }
 
-fn collect_json_from_cache(target_file: &Path, source: &str) -> RateLimitJsonResult {
-    match cache::read_cache_entry(target_file) {
+fn collect_json_from_cache(
+    target_file: &Path,
+    source: &str,
+    enforce_ttl: bool,
+) -> RateLimitJsonResult {
+    let cache_entry = if enforce_ttl {
+        cache::read_cache_entry_for_cached_mode(target_file)
+    } else {
+        cache::read_cache_entry(target_file)
+    };
+
+    match cache_entry {
         Ok(entry) => RateLimitJsonResult {
             name: secret_display_name(target_file),
             target_file: target_file_name(target_file),
@@ -861,7 +871,7 @@ fn collect_async_round(
                 row.weekly_reset_iso = parsed.weekly_reset_iso.clone();
 
                 if cached_mode {
-                    if let Ok(cache_entry) = cache::read_cache_entry(secret_file) {
+                    if let Ok(cache_entry) = cache::read_cache_entry_for_cached_mode(secret_file) {
                         row.non_weekly_reset_epoch = cache_entry.non_weekly_reset_epoch;
                         row.weekly_reset_epoch = Some(cache_entry.weekly_reset_epoch);
                     }
@@ -1221,7 +1231,7 @@ fn fetch_one_line_network(target_file: &Path, no_refresh_auth: bool) -> AsyncFet
 }
 
 fn fetch_one_line_cached(target_file: &Path) -> AsyncFetchResult {
-    match cache::read_cache_entry(target_file) {
+    match cache::read_cache_entry_for_cached_mode(target_file) {
         Ok(entry) => AsyncFetchResult {
             line: Some(format_one_line_output(
                 target_file,
@@ -1436,7 +1446,7 @@ fn run_all_mode(args: &RateLimitsOptions, cached_mode: bool, debug_mode: bool) -
             row.weekly_reset_iso = parsed.weekly_reset_iso.clone();
 
             if cached_mode {
-                if let Ok(cache_entry) = cache::read_cache_entry(&secret_file) {
+                if let Ok(cache_entry) = cache::read_cache_entry_for_cached_mode(&secret_file) {
                     row.non_weekly_reset_epoch = cache_entry.non_weekly_reset_epoch;
                     row.weekly_reset_epoch = Some(cache_entry.weekly_reset_epoch);
                 }
@@ -1603,7 +1613,7 @@ fn run_single_mode(
     }
 
     if cached_mode {
-        match cache::read_cache_entry(&target_file) {
+        match cache::read_cache_entry_for_cached_mode(&target_file) {
             Ok(entry) => {
                 let weekly_reset_iso =
                     render::format_epoch_local_datetime(entry.weekly_reset_epoch)
@@ -1836,7 +1846,7 @@ fn single_one_line(
     }
 
     if cached_mode {
-        return match cache::read_cache_entry(target_file) {
+        return match cache::read_cache_entry_for_cached_mode(target_file) {
             Ok(entry) => {
                 let weekly_reset_iso =
                     render::format_epoch_local_datetime(entry.weekly_reset_epoch)
@@ -1896,6 +1906,18 @@ fn single_one_line(
     };
     let values = render::render_values(&usage_data);
     let weekly = render::weekly_values(&values);
+    let fetched_at_epoch = Utc::now().timestamp();
+    if fetched_at_epoch > 0 {
+        let _ = cache::write_starship_cache(
+            target_file,
+            fetched_at_epoch,
+            &weekly.non_weekly_label,
+            weekly.non_weekly_remaining,
+            weekly.weekly_remaining,
+            weekly.weekly_reset_epoch,
+            weekly.non_weekly_reset_epoch,
+        );
+    }
     let prefix = cache::secret_name_for_target(target_file)
         .map(|name| format!("{name} "))
         .unwrap_or_default();
@@ -2043,6 +2065,7 @@ mod tests {
         redact_sensitive_json, resolve_target, secret_display_name, single_one_line,
         sync_auth_silent, target_file_name,
     };
+    use chrono::Utc;
     use nils_test_support::{EnvGuard, GlobalStateLock};
     use serde_json::json;
     use std::fs;
@@ -2070,6 +2093,10 @@ mod tests {
             account_id,
             last_refresh
         )
+    }
+
+    fn fresh_fetched_at() -> i64 {
+        Utc::now().timestamp()
     }
 
     #[test]
@@ -2224,7 +2251,7 @@ mod tests {
         let _cache = EnvGuard::set(&lock, "ZSH_CACHE_DIR", cache_root.to_str().expect("cache"));
         cache::write_starship_cache(
             &alpha,
-            1_700_000_000,
+            fresh_fetched_at(),
             "3h",
             92,
             88,
@@ -2233,7 +2260,7 @@ mod tests {
         )
         .expect("write cache");
 
-        let hit = collect_json_from_cache(&alpha, "cache");
+        let hit = collect_json_from_cache(&alpha, "cache", true);
         assert!(hit.ok);
         assert_eq!(hit.status, "ok");
         let summary = hit.summary.expect("summary");
@@ -2242,7 +2269,7 @@ mod tests {
         assert_eq!(summary.weekly_remaining, 88);
 
         let missing_target = secret_dir.join("missing.json");
-        let miss = collect_json_from_cache(&missing_target, "cache");
+        let miss = collect_json_from_cache(&missing_target, "cache", true);
         assert!(!miss.ok);
         let error = miss.error.expect("error");
         assert_eq!(error.code, "cache-read-failed");
@@ -2269,7 +2296,7 @@ mod tests {
         let _cache = EnvGuard::set(&lock, "ZSH_CACHE_DIR", cache_root.to_str().expect("cache"));
         cache::write_starship_cache(
             &alpha,
-            1_700_000_000,
+            fresh_fetched_at(),
             "3h",
             70,
             55,
@@ -2307,7 +2334,7 @@ mod tests {
         let _cache = EnvGuard::set(&lock, "ZSH_CACHE_DIR", cache_root.to_str().expect("cache"));
         cache::write_starship_cache(
             &missing,
-            1_700_000_000,
+            fresh_fetched_at(),
             "3h",
             68,
             42,
@@ -2345,7 +2372,7 @@ mod tests {
         let _cache = EnvGuard::set(&lock, "ZSH_CACHE_DIR", cache_root.to_str().expect("cache"));
         cache::write_starship_cache(
             &alpha,
-            1_700_000_000,
+            fresh_fetched_at(),
             "3h",
             61,
             39,

--- a/crates/codex-cli/tests/rate_limits_single.rs
+++ b/crates/codex-cli/tests/rate_limits_single.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use nils_test_support::bin;
 use nils_test_support::cmd::{self, CmdOptions, CmdOutput};
 use nils_test_support::http::{HttpResponse, LoopbackServer};
@@ -143,9 +144,12 @@ fn rate_limits_single_cached_success_reads_cache() {
     let cache_root = dir.path().join("cache_root");
     let kv_path = cache_kv_path(&cache_root, "alpha");
     fs::create_dir_all(kv_path.parent().expect("cache parent")).expect("cache dir");
+    let fetched_at = Utc::now().timestamp();
     fs::write(
         &kv_path,
-        "fetched_at=1700000000\nnon_weekly_label=5h\nnon_weekly_remaining=94\nweekly_remaining=88\nweekly_reset_epoch=1700600000\n",
+        format!(
+            "fetched_at={fetched_at}\nnon_weekly_label=5h\nnon_weekly_remaining=94\nweekly_remaining=88\nweekly_reset_epoch=1700600000\n"
+        ),
     )
     .expect("kv");
 
@@ -163,6 +167,38 @@ fn rate_limits_single_cached_success_reads_cache() {
     );
     assert_exit(&output, 0);
     assert_eq!(stdout(&output), "alpha 5h:94% W:88% 11-21 20:53\n");
+}
+
+#[test]
+fn rate_limits_single_cached_stale_cache_is_rejected() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    fs::create_dir_all(&secrets).expect("secrets dir");
+    fs::write(
+        secrets.join("alpha.json"),
+        r#"{"tokens":{"access_token":"tok","account_id":"acct_001"}}"#,
+    )
+    .expect("alpha");
+
+    let cache_root = dir.path().join("cache_root");
+    let kv_path = cache_kv_path(&cache_root, "alpha");
+    fs::create_dir_all(kv_path.parent().expect("cache parent")).expect("cache dir");
+    fs::write(
+        &kv_path,
+        "fetched_at=1\nnon_weekly_label=5h\nnon_weekly_remaining=94\nweekly_remaining=88\nweekly_reset_epoch=1700600000\n",
+    )
+    .expect("kv");
+
+    let output = run(
+        &["diag", "rate-limits", "--cached", "alpha.json"],
+        &[
+            ("CODEX_SECRET_DIR", &secrets),
+            ("ZSH_CACHE_DIR", &cache_root),
+        ],
+        &[("CODEX_RATE_LIMITS_DEFAULT_ALL_ENABLED", "false")],
+    );
+    assert_exit(&output, 1);
+    assert!(stderr(&output).contains("cache expired"));
 }
 
 #[test]


### PR DESCRIPTION
# Enforce TTL-aware cached rate-limits behavior in codex-cli

## Summary

This feature makes `codex-cli diag rate-limits --cached` enforce a configurable cache TTL and stale policy, and ensures `--all` network reads refresh cache entries so cached mode stays useful and predictable.

## Changes

- Added TTL-aware cache reads for rate-limits cached mode with defaults and duration parsing.
- Added `CODEX_RATE_LIMITS_CACHE_ALLOW_STALE` support to permit stale reads when explicitly enabled.
- Updated one-line all-mode path to write cache after successful network fetches.
- Updated unit/integration tests for fresh and stale cached behavior.
- Updated `crates/codex-cli/README.md` with command behavior and env defaults.

## Testing

- `cargo test -p nils-codex-cli rate_limits` (pass)
- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `mkdir -p target/coverage && cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85 && scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, 86.58%)

## Risk / Notes

- `--cached` now fails on expired cache unless `CODEX_RATE_LIMITS_CACHE_ALLOW_STALE=true`; this is an intentional behavior tightening.
