### PR TITLE
Normalize codex auth secret filenames to .json

### DIFF
--- a/crates/codex-cli/README.md
+++ b/crates/codex-cli/README.md
@@ -50,11 +50,11 @@ Help:
 
 - `login [--api-key|--device-code]`: Login via ChatGPT browser flow (`chatgpt-browser`, default), ChatGPT device-code flow
   (`chatgpt-device-code`), or API key flow (`api-key`). `--api-key` and `--device-code` are mutually exclusive (`64` on invalid usage).
-- `use <name|email>`: Switch to a secret by name or email.
-- `save [--yes] <secret.json>`: Save active `CODEX_AUTH_FILE` into `CODEX_SECRET_DIR` with an explicit file name. If target exists,
-  interactive mode prompts for overwrite; non-interactive and JSON mode require `--yes` to overwrite.
-- `remove [--yes] <secret.json>`: Remove a secret file from `CODEX_SECRET_DIR`. Interactive mode prompts for confirmation; non-interactive
-  and JSON mode require `--yes`.
+- `use <name|name.json|email>`: Switch to a secret by name/name.json or email.
+- `save [--yes] <secret|secret.json>`: Save active `CODEX_AUTH_FILE` into `CODEX_SECRET_DIR`. Secret files are normalized to `.json`; if
+  target exists, interactive mode prompts for overwrite, while non-interactive and JSON mode require `--yes` to overwrite.
+- `remove [--yes] <secret|secret.json>`: Remove a secret file from `CODEX_SECRET_DIR`. Secret names are normalized to `.json`; interactive
+  mode prompts for confirmation, while non-interactive and JSON mode require `--yes`.
 - `refresh [secret.json]`: Refresh OAuth tokens.
 - `auto-refresh`: Refresh stale tokens across auth + secrets.
 - `current`: Show which secret matches `CODEX_AUTH_FILE`.
@@ -65,9 +65,9 @@ Auth examples:
 - `codex-cli auth login`: ChatGPT browser login.
 - `codex-cli auth login --device-code`: ChatGPT device-code login.
 - `codex-cli auth login --api-key`: OpenAI API key login.
-- `codex-cli auth save team-alpha.json`: Save and prompt before overwrite when applicable.
+- `codex-cli auth save team-alpha`: Save to `team-alpha.json` and prompt before overwrite when applicable.
 - `codex-cli auth save --yes team-alpha.json`: Force overwrite without prompt.
-- `codex-cli auth remove --yes team-alpha.json`: Remove a saved secret file.
+- `codex-cli auth remove --yes team-alpha`: Remove `team-alpha.json`.
 
 ### diag
 

--- a/crates/codex-cli/src/auth/mod.rs
+++ b/crates/codex-cli/src/auth/mod.rs
@@ -30,3 +30,34 @@ pub fn last_refresh_from_auth_file(path: &Path) -> Result<Option<String>> {
 pub fn identity_key_from_auth_file(path: &Path) -> Result<Option<String>> {
     crate::runtime::auth::identity_key_from_auth_file(path).map_err(anyhow::Error::from)
 }
+
+pub fn is_invalid_secret_target(target: &str) -> bool {
+    target.contains('/') || target.contains('\\') || target.contains("..")
+}
+
+pub fn normalize_secret_file_name(target: &str) -> String {
+    if target.ends_with(".json") {
+        return target.to_string();
+    }
+    format!("{target}.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_invalid_secret_target, normalize_secret_file_name};
+
+    #[test]
+    fn secret_target_validation_rejects_paths_and_traversal() {
+        assert!(is_invalid_secret_target("../a.json"));
+        assert!(is_invalid_secret_target("a/b.json"));
+        assert!(is_invalid_secret_target(r"a\b.json"));
+        assert!(!is_invalid_secret_target("alpha"));
+        assert!(!is_invalid_secret_target("alpha.json"));
+    }
+
+    #[test]
+    fn normalize_secret_file_name_appends_json_suffix_only_once() {
+        assert_eq!(normalize_secret_file_name("alpha"), "alpha.json");
+        assert_eq!(normalize_secret_file_name("alpha.json"), "alpha.json");
+    }
+}

--- a/crates/codex-cli/src/auth/remove.rs
+++ b/crates/codex-cli/src/auth/remove.rs
@@ -3,6 +3,7 @@ use serde_json::json;
 use std::io::{self, IsTerminal, Write};
 use std::path::Path;
 
+use crate::auth;
 use crate::auth::output::{self, AuthRemoveResult};
 use crate::fs;
 use crate::paths;
@@ -15,11 +16,11 @@ pub fn run_with_json(target: &str, yes: bool, output_json: bool) -> Result<i32> 
     if target.is_empty() {
         return usage_error(
             output_json,
-            "codex-remove: usage: codex-remove [--yes] <secret.json>",
+            "codex-remove: usage: codex-remove [--yes] <secret|secret.json>",
         );
     }
 
-    if is_invalid_target(target) {
+    if auth::is_invalid_secret_target(target) {
         if output_json {
             output::emit_error(
                 "auth remove",
@@ -72,7 +73,8 @@ pub fn run_with_json(target: &str, yes: bool, output_json: bool) -> Result<i32> 
         return Ok(1);
     }
 
-    let target_file = secret_dir.join(target);
+    let secret_name = auth::normalize_secret_file_name(target);
+    let target_file = secret_dir.join(&secret_name);
     if !target_file.is_file() {
         if output_json {
             output::emit_error(
@@ -171,10 +173,6 @@ fn usage_error(output_json: bool, message: &str) -> Result<i32> {
     Ok(64)
 }
 
-fn is_invalid_target(target: &str) -> bool {
-    target.contains('/') || target.contains('\\') || target.contains("..")
-}
-
 fn interactive_io_available() -> bool {
     io::stdin().is_terminal() && io::stdout().is_terminal()
 }
@@ -203,16 +201,16 @@ fn remove_target_timestamp(target_file: &Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::is_invalid_target;
+    use crate::auth::is_invalid_secret_target;
     use crate::paths;
     use nils_test_support::{EnvGuard, GlobalStateLock};
 
     #[test]
     fn invalid_target_rejects_paths_and_traversal() {
-        assert!(is_invalid_target("../a.json"));
-        assert!(is_invalid_target("a/b.json"));
-        assert!(is_invalid_target(r"a\b.json"));
-        assert!(!is_invalid_target("alpha.json"));
+        assert!(is_invalid_secret_target("../a.json"));
+        assert!(is_invalid_secret_target("a/b.json"));
+        assert!(is_invalid_secret_target(r"a\b.json"));
+        assert!(!is_invalid_secret_target("alpha.json"));
     }
 
     #[test]

--- a/crates/codex-cli/src/auth/save.rs
+++ b/crates/codex-cli/src/auth/save.rs
@@ -16,11 +16,11 @@ pub fn run_with_json(target: &str, yes: bool, output_json: bool) -> Result<i32> 
     if target.is_empty() {
         return usage_error(
             output_json,
-            "codex-save: usage: codex-save [--yes] <secret.json>",
+            "codex-save: usage: codex-save [--yes] <secret|secret.json>",
         );
     }
 
-    if is_invalid_target(target) {
+    if auth::is_invalid_secret_target(target) {
         if output_json {
             output::emit_error(
                 "auth save",
@@ -106,7 +106,8 @@ pub fn run_with_json(target: &str, yes: bool, output_json: bool) -> Result<i32> 
         return Ok(1);
     }
 
-    let target_file = secret_dir.join(target);
+    let secret_name = auth::normalize_secret_file_name(target);
+    let target_file = secret_dir.join(&secret_name);
     let mut overwritten = false;
     if target_file.exists() {
         if yes {
@@ -228,10 +229,6 @@ fn usage_error(output_json: bool, message: &str) -> Result<i32> {
     Ok(64)
 }
 
-fn is_invalid_target(target: &str) -> bool {
-    target.contains('/') || target.contains('\\') || target.contains("..")
-}
-
 fn interactive_io_available() -> bool {
     io::stdin().is_terminal() && io::stdout().is_terminal()
 }
@@ -266,16 +263,16 @@ fn write_target_timestamp(target_file: &Path, auth_file: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_invalid_target;
+    use crate::auth::is_invalid_secret_target;
     use crate::paths;
     use nils_test_support::{EnvGuard, GlobalStateLock};
 
     #[test]
     fn invalid_target_rejects_paths_and_traversal() {
-        assert!(is_invalid_target("../a.json"));
-        assert!(is_invalid_target("a/b.json"));
-        assert!(is_invalid_target(r"a\b.json"));
-        assert!(!is_invalid_target("alpha.json"));
+        assert!(is_invalid_secret_target("../a.json"));
+        assert!(is_invalid_secret_target("a/b.json"));
+        assert!(is_invalid_secret_target(r"a\b.json"));
+        assert!(!is_invalid_secret_target("alpha.json"));
     }
 
     #[test]

--- a/crates/codex-cli/src/auth/use_secret.rs
+++ b/crates/codex-cli/src/auth/use_secret.rs
@@ -26,7 +26,7 @@ pub fn run_with_json(target: &str, output_json: bool) -> Result<i32> {
         return Ok(64);
     }
 
-    if target.contains('/') || target.contains("..") {
+    if auth::is_invalid_secret_target(target) {
         if output_json {
             output::emit_error(
                 "auth use",
@@ -62,10 +62,11 @@ pub fn run_with_json(target: &str, output_json: bool) -> Result<i32> {
     };
 
     let is_email = target.contains('@');
-    let mut secret_name = target.to_string();
-    if !secret_name.ends_with(".json") && !is_email {
-        secret_name.push_str(".json");
-    }
+    let secret_name = if is_email {
+        target.to_string()
+    } else {
+        auth::normalize_secret_file_name(target)
+    };
 
     if secret_dir.join(&secret_name).is_file() {
         let (code, auth_file) = apply_secret(&secret_dir, &secret_name, output_json)?;

--- a/crates/codex-cli/src/cli.rs
+++ b/crates/codex-cli/src/cli.rs
@@ -107,14 +107,14 @@ pub enum AuthCommand {
         #[arg(long = "device-code")]
         device_code: bool,
     },
-    /// Switch to a secret by name or email
+    /// Switch to a secret by name/name.json or email
     Use {
         #[command(flatten)]
         output: OutputModeArgs,
         #[arg(id = "target", value_name = "target", num_args = 0..)]
         args: Vec<String>,
     },
-    /// Save active CODEX_AUTH_FILE into CODEX_SECRET_DIR as SECRET_JSON
+    /// Save active CODEX_AUTH_FILE into CODEX_SECRET_DIR as SECRET_JSON (auto-appends .json when missing)
     Save {
         #[command(flatten)]
         output: OutputModeArgs,
@@ -124,7 +124,7 @@ pub enum AuthCommand {
         #[arg(id = "secret", value_name = "secret", num_args = 0..)]
         args: Vec<String>,
     },
-    /// Remove SECRET_JSON from CODEX_SECRET_DIR
+    /// Remove SECRET_JSON from CODEX_SECRET_DIR (auto-appends .json when missing)
     Remove {
         #[command(flatten)]
         output: OutputModeArgs,

--- a/crates/codex-cli/src/main.rs
+++ b/crates/codex-cli/src/main.rs
@@ -89,14 +89,14 @@ fn handle_auth(args: &cli::AuthArgs) -> i32 {
         }
         Some(cli::AuthCommand::Save { output, yes, args }) => {
             if args.len() != 1 || args[0].is_empty() {
-                eprintln!("codex-save: usage: codex-save [--yes] <secret.json>");
+                eprintln!("codex-save: usage: codex-save [--yes] <secret|secret.json>");
                 return 64;
             }
             auth::save::run_with_json(&args[0], *yes, output.is_json()).unwrap_or(1)
         }
         Some(cli::AuthCommand::Remove { output, yes, args }) => {
             if args.len() != 1 || args[0].is_empty() {
-                eprintln!("codex-remove: usage: codex-remove [--yes] <secret.json>");
+                eprintln!("codex-remove: usage: codex-remove [--yes] <secret|secret.json>");
                 return 64;
             }
             auth::remove::run_with_json(&args[0], *yes, output.is_json()).unwrap_or(1)

--- a/crates/codex-cli/tests/auth_remove.rs
+++ b/crates/codex-cli/tests/auth_remove.rs
@@ -137,6 +137,23 @@ fn auth_remove_yes_deletes_file_and_timestamp() {
 }
 
 #[test]
+fn auth_remove_appends_json_suffix_when_missing() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    fs::create_dir_all(&secrets).expect("secrets");
+    let target = secrets.join("alpha.json");
+    fs::write(&target, r#"{"tokens":{"access_token":"tok"}}"#).expect("target");
+
+    let output = run_with(
+        &["auth", "remove", "--yes", "alpha"],
+        &[("CODEX_SECRET_DIR", &secrets)],
+        &[],
+    );
+    assert_eq!(output.code, 0);
+    assert!(!target.exists(), "alpha.json should be removed");
+}
+
+#[test]
 fn auth_remove_yes_does_not_create_missing_cache_dir() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let secrets = dir.path().join("secrets");

--- a/crates/codex-cli/tests/auth_save.rs
+++ b/crates/codex-cli/tests/auth_save.rs
@@ -130,6 +130,31 @@ fn auth_save_writes_target_file() {
 }
 
 #[test]
+fn auth_save_appends_json_suffix_when_missing() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    fs::create_dir_all(&secrets).expect("secrets");
+    let auth_file = dir.path().join("auth.json");
+    fs::write(
+        &auth_file,
+        r#"{"tokens":{"access_token":"tok","refresh_token":"refresh"}}"#,
+    )
+    .expect("write auth");
+
+    let output = run_with(
+        &["auth", "save", "alpha"],
+        &[
+            ("CODEX_AUTH_FILE", &auth_file),
+            ("CODEX_SECRET_DIR", &secrets),
+        ],
+        &[],
+    );
+    assert_eq!(output.code, 0);
+    assert!(secrets.join("alpha.json").is_file());
+    assert!(!secrets.join("alpha").is_file());
+}
+
+#[test]
 fn auth_save_overwrite_prompt_default_no_in_non_tty_mode() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let secrets = dir.path().join("secrets");

--- a/crates/codex-cli/tests/auth_use.rs
+++ b/crates/codex-cli/tests/auth_use.rs
@@ -70,6 +70,47 @@ fn auth_use_invalid_path() {
 }
 
 #[test]
+fn auth_use_rejects_backslash_path() {
+    let output = run(&["auth", "use", r"a\\secret"], &[]);
+    assert_exit(&output, 64);
+    assert!(stderr(&output).contains("codex-use: invalid secret name"));
+}
+
+#[test]
+fn auth_use_name_without_json_suffix_resolves_json_secret() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let secrets = dir.path().join("secrets");
+    let cache = dir.path().join("cache");
+    fs::create_dir_all(&secrets).expect("secrets dir");
+    fs::create_dir_all(&cache).expect("cache dir");
+
+    let auth_file = dir.path().join("auth.json");
+    let secret_file = secrets.join("alpha.json");
+    let content = auth_json(
+        PAYLOAD_ALPHA,
+        "acct_001",
+        "refresh_a",
+        "2025-01-20T12:34:56Z",
+    );
+    fs::write(&secret_file, &content).expect("write secret");
+
+    let output = run(
+        &["auth", "use", "alpha"],
+        &[
+            ("CODEX_AUTH_FILE", &auth_file),
+            ("CODEX_SECRET_DIR", &secrets),
+            ("CODEX_SECRET_CACHE_DIR", &cache),
+        ],
+    );
+
+    assert_exit(&output, 0);
+    let out = stdout(&output);
+    assert!(out.contains("applied alpha.json"));
+    let applied = fs::read_to_string(&auth_file).expect("read auth file");
+    assert_eq!(applied, content);
+}
+
+#[test]
 fn auth_use_email_resolution() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let secrets = dir.path().join("secrets");


### PR DESCRIPTION
# Normalize codex auth secret filenames to .json

## Summary

Normalize `codex-cli auth` secret filename handling so `save/remove/use` apply one consistent rule: secret files are `.json`, users may pass names with or without suffix, and existing `.json` inputs are preserved without double-appending.

## Changes

- Added shared auth helpers to validate secret targets and normalize secret names to `.json` in one place.
- Updated `auth save`, `auth remove`, and `auth use` to use shared validation/normalization behavior.
- Updated CLI usage/help strings and `crates/codex-cli/README.md` examples to reflect `name|name.json` behavior.
- Added/updated auth tests to cover suffix auto-append, no double-append, and backslash path rejection.

## Testing

- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85` (pass)
- `scripts/ci/coverage-summary.sh target/coverage/lcov.info` (pass, total line coverage 86.58%)

## Risk / Notes

- This intentionally does not include migration for legacy non-`.json` filenames; users can re-login/re-save and manually clean old files.
