### PR TITLE
fix(git-cli): correct SHA detection logic in back_checkout()

### DIFF
--- a/crates/git-cli/src/reset.rs
+++ b/crates/git-cli/src/reset.rs
@@ -351,8 +351,7 @@ fn back_checkout() -> i32 {
         }
     };
 
-    if !from_branch.chars().all(|c| c.is_ascii_digit())
-        && from_branch.len() >= 7
+    if from_branch.len() >= 7
         && from_branch.len() <= 40
         && from_branch.chars().all(|c| c.is_ascii_hexdigit())
     {


### PR DESCRIPTION
## Summary
- Remove the contradictory `!all(is_ascii_digit)` condition in `back_checkout()` SHA detection
- Pure-numeric hex SHAs (e.g. `1234567`) were not being caught, allowing users to accidentally enter detached HEAD state
- The remaining conditions (length 7-40, all hex chars) are sufficient to identify commit SHAs

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] Verify that `back_checkout()` correctly rejects pure-numeric SHAs like `1234567`

🤖 Generated with [Claude Code](https://claude.com/claude-code)