### PR TITLE
fix(git-cli): remove flawed all-digit exclusion from SHA detection in back_checkout

### DIFF
--- a/crates/git-cli/src/reset.rs
+++ b/crates/git-cli/src/reset.rs
@@ -351,8 +351,7 @@ fn back_checkout() -> i32 {
         }
     };
 
-    if !from_branch.chars().all(|c| c.is_ascii_digit())
-        && from_branch.len() >= 7
+    if from_branch.len() >= 7
         && from_branch.len() <= 40
         && from_branch.chars().all(|c| c.is_ascii_hexdigit())
     {


### PR DESCRIPTION
## Summary
- The SHA detection guard in `back_checkout()` had a `!chars().all(is_ascii_digit)` precondition that caused **all-digit hex SHAs** (e.g. `1234567`) to bypass the check, allowing an unintended detached HEAD checkout.
- Removed the flawed precondition so the guard now correctly catches all hex strings of length 7–40.

## Test plan
- [x] Existing test `reset_back_checkout_sha_like_from_refuses` still passes
- [x] Full `nils-cli-checks-entrypoint.sh` (nextest + clippy + fmt + audits) passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)