### PR TITLE
chore(ci): bump softprops/action-gh-release from v2 to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
           path: dist
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary

- Replaces the dependabot PR #327 that was closed because its CI surfaced an unrelated Rust 1.95.0 clippy lint (now fixed on main in 8d9bb96).
- `softprops/action-gh-release@v3` moves the action runtime from Node 20 to Node 24; GitHub-hosted `ubuntu-latest` and `macos-14-arm64` already support Node 24.
- Only the `release.yml` action ref changes (v2 → v3); no action inputs were removed or renamed between v2.x and v3.0.0.

## Test plan

- [ ] CI green on this PR (test, test_macos, coverage, CodeQL).
- [ ] Manual release dry-run or wait until next `v*` tag to validate `Publish GitHub Release` step produces expected assets.

Closes #327 (previously closed without merge).