### PR TITLE
fix(api-history): warn on append failure instead of swallowing errors

### DIFF
--- a/crates/api-gql/src/commands/call.rs
+++ b/crates/api-gql/src/commands/call.rs
@@ -203,7 +203,7 @@ pub(crate) fn cmd_call_internal(
         }
         Err(err) => {
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     };
@@ -221,7 +221,7 @@ pub(crate) fn cmd_call_internal(
         }
         Err(err) => {
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     };
@@ -235,7 +235,7 @@ pub(crate) fn cmd_call_internal(
                 Ok(v) => Some(v.variables),
                 Err(err) => {
                     let _ = writeln!(stderr, "{err}");
-                    append_history_best_effort(&history_ctx, exit_code);
+                    append_history_best_effort(&history_ctx, exit_code, stderr);
                     return 1;
                 }
             }
@@ -246,7 +246,7 @@ pub(crate) fn cmd_call_internal(
         Ok(v) => v,
         Err(err) => {
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     };
@@ -269,7 +269,7 @@ pub(crate) fn cmd_call_internal(
         Err(err) => {
             spinner.finish_and_clear();
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     };
@@ -278,7 +278,7 @@ pub(crate) fn cmd_call_internal(
     let _ = stdout.write_all(&executed.response.body);
 
     exit_code = 0;
-    append_history_best_effort(&history_ctx, exit_code);
+    append_history_best_effort(&history_ctx, exit_code, stderr);
 
     exit_code
 }
@@ -297,7 +297,7 @@ struct CallHistoryContext {
     auth_source_used: api_testing_core::graphql::auth::GraphqlAuthSourceUsed,
 }
 
-fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32) {
+fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32, stderr: &mut dyn Write) {
     if !ctx.enabled {
         return;
     }
@@ -370,5 +370,7 @@ fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32) {
         record.push_str("| jq .\n\n");
     }
 
-    let _ = history_writer.append(&record);
+    if let Err(err) = history_writer.append(&record) {
+        let _ = writeln!(stderr, "warning: failed to append api-gql history: {err}");
+    }
 }

--- a/crates/api-grpc/src/commands/call.rs
+++ b/crates/api-grpc/src/commands/call.rs
@@ -236,7 +236,7 @@ pub(crate) fn cmd_call_internal(
         }
         Err(err) => {
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     };
@@ -249,7 +249,7 @@ pub(crate) fn cmd_call_internal(
         }
         Err(err) => {
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     };
@@ -263,7 +263,7 @@ pub(crate) fn cmd_call_internal(
         )
     {
         let _ = writeln!(stderr, "{err}");
-        append_history_best_effort(&history_ctx, exit_code);
+        append_history_best_effort(&history_ctx, exit_code, stderr);
         return 1;
     }
 
@@ -284,7 +284,7 @@ pub(crate) fn cmd_call_internal(
         Err(err) => {
             spinner.finish_and_clear();
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     };
@@ -302,13 +302,13 @@ pub(crate) fn cmd_call_internal(
             stdout_is_tty,
             stderr,
         );
-        append_history_best_effort(&history_ctx, exit_code);
+        append_history_best_effort(&history_ctx, exit_code, stderr);
         return 1;
     }
 
     spinner.finish_and_clear();
     exit_code = 0;
-    append_history_best_effort(&history_ctx, exit_code);
+    append_history_best_effort(&history_ctx, exit_code, stderr);
 
     exit_code
 }
@@ -327,7 +327,7 @@ struct CallHistoryContext {
     token_name_for_log: String,
 }
 
-fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32) {
+fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32, stderr: &mut dyn Write) {
     if !ctx.enabled {
         return;
     }
@@ -362,7 +362,9 @@ fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32) {
         extra_flags: &[],
     });
 
-    let _ = history_writer.append(&record);
+    if let Err(err) = history_writer.append(&record) {
+        let _ = writeln!(stderr, "warning: failed to append api-grpc history: {err}");
+    }
 }
 
 #[cfg(test)]
@@ -583,7 +585,7 @@ mod tests {
             token_name_for_log: "default".to_string(),
         };
 
-        append_history_best_effort(&ctx, 0);
+        append_history_best_effort(&ctx, 0, &mut std::io::sink());
 
         let text = fs::read_to_string(&history_file).expect("history text");
         assert!(text.contains("api-grpc call \\\n"));
@@ -618,7 +620,7 @@ mod tests {
             token_name_for_log: String::new(),
         };
 
-        append_history_best_effort(&ctx, 7);
+        append_history_best_effort(&ctx, 7, &mut std::io::sink());
 
         let text = fs::read_to_string(&history_file).expect("history text");
         assert!(text.contains("url=<omitted>"));
@@ -647,7 +649,7 @@ mod tests {
             token_name_for_log: String::new(),
         };
 
-        append_history_best_effort(&ctx, 0);
+        append_history_best_effort(&ctx, 0, &mut std::io::sink());
         assert!(!history_file.exists());
     }
 

--- a/crates/api-rest/src/commands/call.rs
+++ b/crates/api-rest/src/commands/call.rs
@@ -236,7 +236,7 @@ pub(crate) fn cmd_call_internal(
         }
         Err(err) => {
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     };
@@ -249,7 +249,7 @@ pub(crate) fn cmd_call_internal(
         }
         Err(err) => {
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     };
@@ -263,7 +263,7 @@ pub(crate) fn cmd_call_internal(
         )
     {
         let _ = writeln!(stderr, "{err}");
-        append_history_best_effort(&history_ctx, exit_code);
+        append_history_best_effort(&history_ctx, exit_code, stderr);
         return 1;
     }
 
@@ -284,7 +284,7 @@ pub(crate) fn cmd_call_internal(
         Err(err) => {
             spinner.finish_and_clear();
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     };
@@ -302,7 +302,7 @@ pub(crate) fn cmd_call_internal(
             stdout_is_tty,
             stderr,
         );
-        append_history_best_effort(&history_ctx, exit_code);
+        append_history_best_effort(&history_ctx, exit_code, stderr);
         return 1;
     }
 
@@ -317,14 +317,14 @@ pub(crate) fn cmd_call_internal(
         ) {
             spinner.finish_and_clear();
             let _ = writeln!(stderr, "{err}");
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return 1;
         }
     }
 
     spinner.finish_and_clear();
     exit_code = 0;
-    append_history_best_effort(&history_ctx, exit_code);
+    append_history_best_effort(&history_ctx, exit_code, stderr);
 
     exit_code
 }
@@ -343,7 +343,7 @@ struct CallHistoryContext {
     token_name_for_log: String,
 }
 
-fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32) {
+fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32, stderr: &mut dyn Write) {
     if !ctx.enabled {
         return;
     }
@@ -378,7 +378,9 @@ fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32) {
         extra_flags: &[],
     });
 
-    let _ = history_writer.append(&record);
+    if let Err(err) = history_writer.append(&record) {
+        let _ = writeln!(stderr, "warning: failed to append api-rest history: {err}");
+    }
 }
 
 #[cfg(test)]

--- a/crates/api-websocket/src/commands/call.rs
+++ b/crates/api-websocket/src/commands/call.rs
@@ -282,7 +282,7 @@ pub(crate) fn cmd_call_internal(
                 format!("{err}"),
                 None,
             );
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return code;
         }
     };
@@ -302,7 +302,7 @@ pub(crate) fn cmd_call_internal(
                 format!("{err}"),
                 None,
             );
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return code;
         }
     };
@@ -323,7 +323,7 @@ pub(crate) fn cmd_call_internal(
             format!("{err}"),
             None,
         );
-        append_history_best_effort(&history_ctx, exit_code);
+        append_history_best_effort(&history_ctx, exit_code, stderr);
         return code;
     }
 
@@ -359,7 +359,7 @@ pub(crate) fn cmd_call_internal(
                 format!("{err}"),
                 Some(serde_json::json!({"target": endpoint.websocket_url})),
             );
-            append_history_best_effort(&history_ctx, exit_code);
+            append_history_best_effort(&history_ctx, exit_code, stderr);
             return code;
         }
     };
@@ -390,7 +390,7 @@ pub(crate) fn cmd_call_internal(
             let _ = writeln!(stderr, "{err}");
             maybe_print_failure_body_to_stderr(&last_received, 8192, stdout_is_tty, stderr);
         }
-        append_history_best_effort(&history_ctx, exit_code);
+        append_history_best_effort(&history_ctx, exit_code, stderr);
         return 1;
     }
 
@@ -414,7 +414,7 @@ pub(crate) fn cmd_call_internal(
     }
 
     exit_code = 0;
-    append_history_best_effort(&history_ctx, exit_code);
+    append_history_best_effort(&history_ctx, exit_code, stderr);
 
     exit_code
 }
@@ -476,7 +476,7 @@ struct CallHistoryContext {
     output_format: OutputFormat,
 }
 
-fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32) {
+fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32, stderr: &mut dyn Write) {
     if !ctx.enabled {
         return;
     }
@@ -518,7 +518,12 @@ fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32) {
         extra_flags,
     });
 
-    let _ = history_writer.append(&record);
+    if let Err(err) = history_writer.append(&record) {
+        let _ = writeln!(
+            stderr,
+            "warning: failed to append api-websocket history: {err}"
+        );
+    }
 }
 
 fn maybe_print_failure_body_to_stderr(
@@ -629,7 +634,7 @@ mod tests {
             output_format: OutputFormat::Text,
         };
 
-        append_history_best_effort(&ctx, 0);
+        append_history_best_effort(&ctx, 0, &mut std::io::sink());
 
         let text = fs::read_to_string(&history_file).expect("history text");
         assert!(text.contains("api-websocket call \\\n"));
@@ -665,7 +670,7 @@ mod tests {
             output_format: OutputFormat::Text,
         };
 
-        append_history_best_effort(&ctx, 7);
+        append_history_best_effort(&ctx, 7, &mut std::io::sink());
 
         let text = fs::read_to_string(&history_file).expect("history text");
         assert!(text.contains("url=<omitted>"));
@@ -695,7 +700,7 @@ mod tests {
             output_format: OutputFormat::Json,
         };
 
-        append_history_best_effort(&ctx, 0);
+        append_history_best_effort(&ctx, 0, &mut std::io::sink());
         let text = fs::read_to_string(&history_file).expect("history text");
         assert!(text.contains("--format json"));
     }
@@ -721,7 +726,7 @@ mod tests {
             output_format: OutputFormat::Text,
         };
 
-        append_history_best_effort(&ctx, 0);
+        append_history_best_effort(&ctx, 0, &mut std::io::sink());
         assert!(!history_file.exists());
     }
 


### PR DESCRIPTION
## Summary

- The four api-* CLI crates (`api-gql`, `api-rest`, `api-grpc`, `api-websocket`) discarded the `Result` from `history_writer.append(...)` with `let _ =`, so disk-full / permission-denied / read-only errors silently dropped history records — the user got no signal.
- Add a `stderr: &mut dyn Write` parameter to each crate's `append_history_best_effort` and emit a `warning: failed to append <crate> history: <err>` line when the underlying write fails.
- The intentional `Ok(false)` "lock-not-acquired, silent skip" path from `append_record` is preserved — only real `Err` is reported.

## Background

Found during a workspace bug audit. The `history_writer.append` API documents `Ok(false)` as "lock could not be acquired (skip silently)" and `Err` as a real write failure (open failure, write_all failure). The previous code conflated both into the silent path.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p nils-api-gql -p nils-api-rest -p nils-api-grpc -p nils-api-websocket --all-targets --no-deps`
- [x] `cargo test -p nils-api-gql -p nils-api-rest -p nils-api-grpc -p nils-api-websocket` (36/36 + parity tests across all four crates)
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)