### PR TITLE
fix(api-history): surface report dir + rotation errors instead of swallowing

### DIFF
--- a/crates/api-gql/src/commands/report.rs
+++ b/crates/api-gql/src/commands/report.rs
@@ -79,8 +79,15 @@ pub(crate) fn cmd_report(
             stderr,
         );
 
-    if let Some(parent) = out_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    if let Some(parent) = out_path.parent()
+        && let Err(err) = std::fs::create_dir_all(parent)
+    {
+        let _ = writeln!(
+            stderr,
+            "error: cannot create report directory {}: {err}",
+            parent.display()
+        );
+        return 1;
     }
 
     let endpoint_note = cli_report::endpoint_note(

--- a/crates/api-grpc/src/commands/report.rs
+++ b/crates/api-grpc/src/commands/report.rs
@@ -63,8 +63,15 @@ pub(crate) fn cmd_report(
             stderr,
         );
 
-    if let Some(parent) = out_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    if let Some(parent) = out_path.parent()
+        && let Err(err) = std::fs::create_dir_all(parent)
+    {
+        let _ = writeln!(
+            stderr,
+            "error: cannot create report directory {}: {err}",
+            parent.display()
+        );
+        return 1;
     }
 
     let endpoint_note = cli_report::endpoint_note(

--- a/crates/api-rest/src/commands/report.rs
+++ b/crates/api-rest/src/commands/report.rs
@@ -63,8 +63,15 @@ pub(crate) fn cmd_report(
             stderr,
         );
 
-    if let Some(parent) = out_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    if let Some(parent) = out_path.parent()
+        && let Err(err) = std::fs::create_dir_all(parent)
+    {
+        let _ = writeln!(
+            stderr,
+            "error: cannot create report directory {}: {err}",
+            parent.display()
+        );
+        return 1;
     }
 
     let endpoint_note = cli_report::endpoint_note(

--- a/crates/api-testing-core/src/history.rs
+++ b/crates/api-testing-core/src/history.rs
@@ -73,8 +73,23 @@ fn rotate_file_keep_n(history_file: &Path, keep: u32) {
             continue;
         }
 
-        let _ = std::fs::remove_file(&dst);
-        let _ = std::fs::rename(&src, &dst);
+        if let Err(err) = std::fs::remove_file(&dst)
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            eprintln!(
+                "warning: history rotation failed to remove {}: {err}",
+                dst.display()
+            );
+            return;
+        }
+        if let Err(err) = std::fs::rename(&src, &dst) {
+            eprintln!(
+                "warning: history rotation failed to rename {} -> {}: {err}",
+                src.display(),
+                dst.display()
+            );
+            return;
+        }
     }
 }
 

--- a/crates/api-websocket/src/commands/report.rs
+++ b/crates/api-websocket/src/commands/report.rs
@@ -66,8 +66,15 @@ pub(crate) fn cmd_report(
             stderr,
         );
 
-    if let Some(parent) = out_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+    if let Some(parent) = out_path.parent()
+        && let Err(err) = std::fs::create_dir_all(parent)
+    {
+        let _ = writeln!(
+            stderr,
+            "error: cannot create report directory {}: {err}",
+            parent.display()
+        );
+        return 1;
     }
 
     let endpoint_note = cli_report::endpoint_note(


### PR DESCRIPTION
## Summary

Two related history/report subsystem fixes (M2 + M3 from the workspace bug audit):

**M3 — `commands/report.rs` × 4 crates**
- The four sibling report subcommands (`api-gql`, `api-rest`, `api-grpc`, `api-websocket`) used `let _ = std::fs::create_dir_all(parent);`. If the parent directory could not be created, the original error was lost and the user only saw the downstream "failed to write report" message.
- Now: surface a clear `error: cannot create report directory <path>: <err>` and return 1 before attempting the write.

**M2 — `api-testing-core/src/history.rs::rotate_file_keep_n`**
- The rotation loop did `let _ = remove_file(&dst); let _ = rename(&src, &dst);`. If `rename` failed mid-loop (e.g. EACCES, EXDEV, ENOSPC), the next iteration would `remove_file` the file we *just orphaned*, compounding the data loss silently.
- Now: warn on stderr and abort the rotation early on `rename` failure or unexpected `remove_file` failure (NotFound is still ignored, since the rotated slot legitimately may not exist yet).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p nils-api-{gql,rest,grpc,websocket} -p nils-api-testing-core --all-targets --no-deps`
- [x] `cargo test -p nils-api-{gql,rest,grpc,websocket} -p nils-api-testing-core`
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)