### PR TITLE
refactor(unreachable): harden two unreachable!() sites

### DIFF
--- a/crates/git-scope/src/main.rs
+++ b/crates/git-scope/src/main.rs
@@ -249,7 +249,9 @@ fn run() -> Result<()> {
             commit::render_commit(&commit, parent.as_deref(), no_color, print, progress_opt_in)
                 .with_context(|| format!("git-scope commit {commit}"))?;
         }
-        Command::Help | Command::Completion { .. } => unreachable!(),
+        Command::Help | Command::Completion { .. } => {
+            unreachable!("Help/Completion handled by the early-return dispatch above")
+        }
     }
 
     Ok(())

--- a/crates/image-processing/src/svg_validate.rs
+++ b/crates/image-processing/src/svg_validate.rs
@@ -256,7 +256,9 @@ pub fn render_svg_to_output(
                     "png" => write_png(output_path, width, height, &rgba)?,
                     "webp" => write_webp(output_path, width, height, &rgba)?,
                     "jpg" => write_jpg(output_path, width, height, &rgba)?,
-                    _ => unreachable!(),
+                    other => {
+                        return Err(anyhow::anyhow!("unsupported raster output format: {other}"));
+                    }
                 }
             }
             output_info(


### PR DESCRIPTION
## Summary

Low-severity hardening from the workspace bug audit (L1 + L2). Both sites are reachable today only by an internal invariant, not by external input — but a future refactor that breaks that invariant would currently panic with no context.

**L1 — `image-processing/src/svg_validate.rs:259`**
- The outer match guards `output_format` to `"png" | "webp" | "jpg"`; the inner match dispatched on the same string and used `_ => unreachable!()`.
- Replaced with an explicit `Err(anyhow!("unsupported raster output format: {other}"))` so future format additions or refactors get a clear error instead of a panic.

**L2 — `git-scope/src/main.rs:252`**
- `Command::Help | Command::Completion { .. }` are returned/exited by an earlier dispatch (lines ~172-178), making the second match's arm provably unreachable. The bare `unreachable!()` left no context if the invariant ever got broken.
- Added a message: `unreachable!("Help/Completion handled by the early-return dispatch above")` so any future regression panics with a useful breadcrumb.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p nils-image-processing -p nils-git-scope --all-targets --no-deps`
- [x] `cargo test -p nils-image-processing -p nils-git-scope`
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)