### PR TITLE
feat(semantic-commit): allow two-space hanging-indent continuation lines in body

### DIFF
--- a/crates/semantic-commit/README.md
+++ b/crates/semantic-commit/README.md
@@ -54,7 +54,9 @@ Help:
 - Header must be non-empty, `<= 100` characters, and use a lowercase type.
 - Header format: `type(scope): subject` or `type: subject`.
 - If a body exists, line 2 must be blank and each body line must start with `-` + space, followed by an
-  uppercase letter and be `<= 100` characters.
+  uppercase letter and be `<= 100` characters. A bullet may wrap onto a following line by prefixing that
+  continuation line with two spaces (the same indent used on this README bullet); continuation lines
+  also have the `<= 100` character cap.
 
 ## Exit codes
 

--- a/crates/semantic-commit/src/commit.rs
+++ b/crates/semantic-commit/src/commit.rs
@@ -484,11 +484,12 @@ fn validate_commit_message(path: &Path) -> Result<(), i32> {
             return fail_validation("commit body must be separated from header by a blank line");
         }
 
+        let mut prev_was_body_line = false;
         for (idx, line) in lines.iter().enumerate().skip(2) {
             let line_no = idx + 1;
             if line.is_empty() {
                 return fail_validation(&format!(
-                    "commit body line {line_no} is empty; body lines must start with '- ' followed by uppercase letter"
+                    "commit body line {line_no} is empty; body lines must start with '- ' followed by uppercase letter (or '  ' to continue the previous bullet)"
                 ));
             }
             if line.chars().count() > 100 {
@@ -496,17 +497,19 @@ fn validate_commit_message(path: &Path) -> Result<(), i32> {
                     "commit body line {line_no} exceeds 100 characters (max 100)"
                 ));
             }
-            if !line.starts_with("- ")
-                || line
-                    .chars()
-                    .nth(2)
-                    .map(|c| !c.is_ascii_uppercase())
-                    .unwrap_or(true)
-            {
+
+            let is_bullet = line.starts_with("- ")
+                && line.chars().nth(2).is_some_and(|c| c.is_ascii_uppercase());
+            let is_continuation = prev_was_body_line
+                && line.starts_with("  ")
+                && line.chars().nth(2).is_some_and(|c| !c.is_whitespace());
+
+            if !is_bullet && !is_continuation {
                 return fail_validation(&format!(
-                    "commit body line {line_no} must start with '- ' followed by uppercase letter"
+                    "commit body line {line_no} must start with '- ' followed by uppercase letter (or '  ' to continue the previous bullet)"
                 ));
             }
+            prev_was_body_line = true;
         }
     }
 

--- a/crates/semantic-commit/tests/integration/commit.rs
+++ b/crates/semantic-commit/tests/integration/commit.rs
@@ -182,7 +182,41 @@ fn commit_body_line_requires_capitalized_bullet() {
     assert!(
         as_str(&output.stderr).contains(
             "error: commit body line 3 must start with '- ' followed by uppercase letter"
-        )
+        ),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+}
+
+#[test]
+fn commit_body_accepts_two_space_continuation_lines() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let message = "feat: test\n\n- First bullet wraps onto the next line because it is long.\n  Continuation text describes the why in more detail.\n- Second bullet stands on its own.\n";
+    let output = common::run_semantic_commit_output(repo.path(), &["commit"], &[], Some(message));
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+}
+
+#[test]
+fn commit_body_rejects_continuation_without_preceding_bullet() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let message = "feat: test\n\n  Orphan continuation line without a leading bullet.\n";
+    let output = common::run_semantic_commit_output(repo.path(), &["commit"], &[], Some(message));
+
+    assert_eq!(output.status.code(), Some(4));
+    assert!(
+        as_str(&output.stderr).contains("commit body line 3 must start with '- '"),
+        "stderr was: {}",
+        as_str(&output.stderr)
     );
 }
 


### PR DESCRIPTION
## Summary

The commit body validator currently forces every body line to start with `- ` and an uppercase letter, with each bullet capped at 100 characters. That means there is no way to wrap a bullet onto a second line, and long descriptions get crushed into a single line or split into artificial mini-bullets that lose the original meaning. (I hit this trying to write descriptive bodies for the audit-fix PRs.)

## Change

- A body line may now also be a *continuation*: it starts with two spaces (hanging indent) and must follow a previous body line. Continuations have the same `<= 100` character cap and the same non-empty requirement.
- Bullet rule unchanged: a new bullet still starts with `- ` followed by an uppercase letter.
- Orphan continuations (two-space line with no preceding bullet) are still hard-rejected with the same error code.

## Why

- Hanging-indent wrapping is the standard convention for git bodies (Keep a Changelog, conventional-commits docs, `git log` rendering).
- This change is purely additive — every previously-valid message remains valid and produces an identical exit code.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p nils-semantic-commit --all-targets --no-deps`
- [x] `cargo test -p nils-semantic-commit` (43 tests, including 2 new: `commit_body_accepts_two_space_continuation_lines`, `commit_body_rejects_continuation_without_preceding_bullet`)
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh`
- [x] README updated to describe the continuation rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
