### PR TITLE
docs(workspace): align root + docs against current scripts and code

### DIFF
--- a/BINARY_DEPENDENCIES.md
+++ b/BINARY_DEPENDENCIES.md
@@ -11,20 +11,20 @@ and provides recommended installation commands for Homebrew (macOS) and Linuxbre
 
 ## 1. Runtime Dependencies (Core)
 
-These tools are required for common command paths.
+These tools are required for common command paths. Each row is anchored to at least one
+`Command::new(...)` (or equivalent `shared_process` / `ProcessRequest`) call site in `crates/*/src`.
 
 | Tool | Used By | Requirement Level | Install (brew/linuxbrew) |
 |---|---|---|---|
-| `git` | `git-scope`, `git-cli`, `git-summary`, `git-lock`, `semantic-commit`, `fzf-cli git-*` | Required | `brew install git` |
+| `git` | `git-scope`, `git-cli`, `git-summary`, `git-lock`, `semantic-commit` (via `git-scope`), `codex-cli`, `gemini-cli`, `fzf-cli git-*` | Required | `brew install git` |
 | `fzf` | `fzf-cli` interactive commands | Required (for `fzf-cli`) | `brew install fzf` |
-| `grpcurl` | `api-grpc` unary request execution backend | Required (for `api-grpc call`/suite gRPC cases) | `brew install grpcurl` |
-| `ffmpeg` | `screen-record` on Linux | Required on Linux | `brew install ffmpeg` |
-| `codex` | `codex-cli agent *` flows | Required for agent commands | Install from official Codex distribution |
-
-### 1.2 `api-websocket` transport runtime dependency policy
-
-- `api-websocket` uses an in-process Rust transport (`tungstenite`) via `api-testing-core`.
-- No external adapter binary (for example `websocat`) is required for `api-websocket call` or suite websocket cases.
+| `grpcurl` | `api-grpc` unary backend (via `api-testing-core::grpc::runner`); overridable with `GRPCURL_BIN` | Required (for `api-grpc call` / suite gRPC cases) | `brew install grpcurl` |
+| `ffmpeg` | `screen-record` on Linux (X11 + Wayland portal capture, audio mux) | Required on Linux | `brew install ffmpeg` |
+| `codex` | `codex-cli auth login` and `codex-cli agent *` flows | Required for `codex-cli` runtime | Install from official Codex distribution |
+| `gemini` | `gemini-cli auth login` flow | Required for `gemini-cli` login | Install from official Gemini CLI distribution |
+| `curl` | `gemini-cli` auth refresh + rate-limit client | Required for `gemini-cli` auth flows | Usually preinstalled (`brew install curl`) |
+| `osascript` | `macos-agent` AppleScript backend, preflight checks | Required on macOS for `macos-agent` | Preinstalled on macOS |
+| `gh` | `git-cli open *` GitHub helpers, `plan-issue-cli` GitHub I/O | Required for GitHub-facing flows | `brew install gh` |
 
 ### 1.1 `image-processing` runtime policy
 
@@ -32,23 +32,34 @@ These tools are required for common command paths.
   - Rust-backed (`image` decode/encode for raster inputs, `usvg`/`resvg` for SVG inputs).
   - No external runtime binary requirement.
 
+### 1.2 `api-websocket` transport runtime dependency policy
+
+- `api-websocket` uses an in-process Rust transport (`tungstenite`) via `api-testing-core`.
+- No external adapter binary (for example `websocat`) is required for `api-websocket call` or suite websocket cases.
+
 ## 2. Runtime Dependencies (Optional / Degradation Paths)
 
 These tools enable richer behavior. Missing tools typically trigger fallback behavior or reduced UX.
+Each row is anchored to at least one `Command::new(...)` / `find_in_path` / `cmd_exists` call site
+in `crates/*/src`.
 
 | Tool | Behavior Impact | Install (brew/linuxbrew) |
 |---|---|---|
 | `tree` | Enables directory tree rendering in `git-scope` | `brew install tree` |
 | `file` | MIME-based binary detection in `git-scope` and `git-cli commit context` | Usually preinstalled |
 | `lsof` | Preferred backend for `fzf-cli port` (fallback: `netstat`) | `brew install lsof` |
-| `bat` | Syntax-highlighted previews in `fzf-cli file` | `brew install bat` |
-| `code` | VS Code open mode for `fzf-cli` (`--vscode`) | macOS: `brew install --cask visual-studio-code` |
-| `pbcopy` / `wl-copy` / `xclip` / `xsel` | Clipboard integration for `git-cli commit context` | Linux: `brew install wl-clipboard xclip xsel` |
-| `cwebp` / `dwebp` | WebP optimization path; macOS WebP screenshot fallback in `screen-record` | `brew install webp` |
+| `netstat` | Fallback backend for `fzf-cli port` when `lsof` is missing | Usually preinstalled |
+| `bat` | Syntax-highlighted previews in `fzf-cli file` / `directory` (invoked via fzf preview shell) | `brew install bat` |
+| `vi` | Default editor for `fzf-cli` open / `git-commit` flows (override via `FZF_FILE_OPEN_WITH`) | Usually preinstalled |
+| `code` | VS Code open mode for `fzf-cli` (`--vscode`) and `git-commit --vscode` | macOS: `brew install --cask visual-studio-code` |
+| `pbcopy` / `wl-copy` / `xclip` / `xsel` | Clipboard integration via `nils-common::clipboard` (used by `git-cli commit context`, `fzf-cli` block preview) | Linux: `brew install wl-clipboard xclip xsel` |
+| `cwebp` | WebP encode path for `screen-record` macOS WebP screenshot fallback | `brew install webp` |
 | `pactl` | Linux audio source discovery for `screen-record --audio ...` | `brew install pulseaudio` |
 | `xdg-desktop-portal` + backend + PipeWire | Wayland portal capture path (`screen-record --portal`) | Prefer distro packages |
-| `open-changed-files` | Optional helper used by `fzf-cli git-commit` | Project-specific optional tool |
+| `open` | macOS `open` invocation for `screen-record` permission prompts | Preinstalled on macOS |
+| `open-changed-files` | Optional helper used by `fzf-cli git-commit` to launch changed files | Project-specific optional tool |
 | `hs` (Hammerspoon CLI) | Preferred AX backend path for `macos-agent ax *` (fallback to JXA when unavailable) | `brew install --cask hammerspoon` |
+| `cliclick` | Probed by `macos-agent` preflight as an alternate input backend | `brew install cliclick` |
 | `im-select` | Required by `macos-agent input-source *` and macOS real E2E keyboard/input-source setup | `brew install im-select` |
 
 ## 3. Development and Validation Toolchain
@@ -139,7 +150,7 @@ eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 ## 8. Quick Environment Verification
 
 ```bash
-for c in git gh fzf tree file ffmpeg bat im-select; do
+for c in git gh fzf grpcurl tree file ffmpeg bat im-select curl; do
   if command -v "$c" >/dev/null 2>&1; then
     echo "[OK]   $c -> $(command -v "$c")"
   else

--- a/docs/runbooks/new-cli-crate-development-standard.md
+++ b/docs/runbooks/new-cli-crate-development-standard.md
@@ -14,7 +14,7 @@ Priority model:
 
 Use these as the source of truth to avoid policy drift:
 
-- Global CLI priorities and completion/wrapper expectations:
+- Global CLI priorities and completion expectations:
   - `AGENTS.md`
 - Required checks and coverage policy:
   - `DEVELOPMENT.md`
@@ -51,7 +51,10 @@ If a crate is intentionally internal-only, keep this standard for UX/testing qua
 For a new publishable CLI crate:
 
 - `Cargo.toml` must include:
-  - `version = "0.3.0"` (or current workspace release version).
+  - `version` matching the current workspace release version (see root
+    `Cargo.toml` `[workspace.package]` and the latest published value in
+    `release/crates-io-publish-order.txt` / `crates/cli-template/Cargo.toml`
+    as the live exemplar).
   - `edition.workspace = true`
   - `license.workspace = true`
   - `description = "CLI crate for nils-<name> in the nils-cli workspace."`

--- a/docs/specs/codex-gemini-cli-parity-contract-v1.md
+++ b/docs/specs/codex-gemini-cli-parity-contract-v1.md
@@ -62,26 +62,22 @@ Compatibility rules:
 
 - `--refresh` remains the only blocking refresh path in both lanes. The default prompt path must keep printing the cached line first and
   keep appending the lane-specific stale suffix when the cache is stale.
-- Current gap: `gemini-cli` still calls `refresh_blocking()` from the default stale/missing-cache path, while `codex-cli` enqueues a
-  best-effort background refresh and returns immediately.
-- Current Gemini missing-cache behavior is part of the same gap: no cache entry falls through to the same inline `refresh_blocking()`
-  path instead of a detached enqueue.
-- When porting Codex semantics to Gemini, preserve these guardrails:
+- Current state: both `codex-cli` and `gemini-cli` call `refresh::enqueue_background_refresh(&target_file)` from the default
+  stale/missing-cache path (see `crates/codex-cli/src/prompt_segment/mod.rs` and `crates/gemini-cli/src/prompt_segment/mod.rs`). Inline
+  `refresh_blocking()` is reserved for the explicit `--refresh` path in both lanes.
+- The parity guardrails below are required invariants for both lanes; treat any future regression as a contract break:
   - Best-effort background spawn via the current executable; `current_exe` or spawn failures stay silent no-ops.
   - Minimum refresh interval throttling via `*_PROMPT_SEGMENT_REFRESH_MIN_SECONDS`.
   - Last-attempt markers are written before `spawn()` so prompt storms still throttle after child-launch failure.
   - Lock contention stays a no-op for prompt rendering, with stale-lock recovery via `*_PROMPT_SEGMENT_LOCK_STALE_SECONDS`.
   - Lock and throttle files stay cache-adjacent (`<cache-stem>.refresh.lock` and `<cache-stem>.refresh.at`).
   - Cache format, stale suffix rendering, and exit codes stay unchanged.
-- Existing Gemini tests that must change when the default path stops refreshing inline:
-  - `crates/gemini-cli/tests/prompt_segment_refresh.rs`: `prompt_segment_stale_cached_entry_refreshes_on_run`
-  - `crates/gemini-cli/tests/prompt_segment_cached.rs`: `prompt_segment_stale_cache_with_failed_refresh_returns_0`
-  - `crates/gemini-cli/tests/prompt_segment_cached.rs`: `prompt_segment_missing_cache_root_is_treated_as_no_cache`
-- Coverage still missing after the port:
-  - A default missing-cache test that asserts background enqueue instead of inline fetch.
-  - Lock/min-interval/stale-lock recovery coverage that matches the existing `codex-cli` prompt-segment contract.
-- `crates/gemini-cli/tests/prompt_segment_refresh.rs`: `prompt_segment_refresh_updates_cache` remains the blocking-path anchor and should stay
-  unchanged by the background-refresh rewrite.
+- Anchor tests for the cached/refresh paths live under the per-crate `integration` test target:
+  - `crates/gemini-cli/tests/integration/prompt_segment_cached.rs`
+  - `crates/codex-cli/tests/integration/prompt_segment_cached.rs`
+  - `crates/codex-cli/tests/integration/prompt_segment_refresh.rs`
+- Coverage gap to track separately: a dedicated `crates/gemini-cli/tests/integration/prompt_segment_refresh.rs` mirroring the codex
+  blocking-path test surface (lock/min-interval/stale-lock recovery) does not exist yet; backlog only — do not patch under this contract.
 
 ### Async rate-limits guardrails
 
@@ -116,14 +112,16 @@ Compatibility rules:
 
 ### Focused concurrency validation
 
-- `cargo test -p nils-gemini-cli --test prompt_segment_cached --test prompt_segment_refresh`
-- `cargo test -p nils-gemini-cli --test rate_limits_async --test rate_limits_network`
-- `cargo test -p nils-codex-cli --test prompt_segment_cached --test prompt_segment_refresh`
-- `cargo test -p nils-codex-cli --test rate_limits_async`
+Per-crate integration tests are consolidated under a single `--test integration` target; filter to the relevant submodule by name:
+
+- `cargo test -p nils-gemini-cli --test integration -- prompt_segment_cached`
+- `cargo test -p nils-gemini-cli --test integration -- rate_limits_async rate_limits_network`
+- `cargo test -p nils-codex-cli --test integration -- prompt_segment_cached prompt_segment_refresh`
+- `cargo test -p nils-codex-cli --test integration -- rate_limits_async`
 
 ## Validation anchors
 
-- `cargo test -p nils-codex-cli --test parity_oracle`
-- `cargo test -p nils-gemini-cli --test parity_oracle`
-- `cargo test -p nils-codex-cli --test runtime_auth_contract --test runtime_error_contract --test runtime_exec_contract --test runtime_paths_config_contract`
-- `cargo test -p nils-gemini-cli --test runtime_auth_contract --test runtime_error_contract --test runtime_exec_contract --test runtime_paths_config_contract`
+- `cargo test -p nils-codex-cli --test integration -- parity_oracle`
+- `cargo test -p nils-gemini-cli --test integration -- parity_oracle`
+- `cargo test -p nils-codex-cli --test integration -- runtime_auth_contract runtime_error_contract runtime_exec_contract runtime_paths_config_contract`
+- `cargo test -p nils-gemini-cli --test integration -- runtime_auth_contract runtime_error_contract runtime_exec_contract runtime_paths_config_contract`

--- a/docs/specs/workspace-ci-entrypoint-inventory-v1.md
+++ b/docs/specs/workspace-ci-entrypoint-inventory-v1.md
@@ -13,7 +13,9 @@ A helper path is `keep` only when at least one active caller is discoverable by 
 - Canonical contributor docs (`README.md`, `DEVELOPMENT.md`, `docs/runbooks/**`, crate READMEs)
 - Canonical runtime entrypoints (`scripts/**`, `.agents/**`, `wrappers/**`) used by active workflows/docs
 
-A helper path is `delete` when no active caller exists outside historical/transient planning artifacts.
+A helper path is `delete-candidate` when no active caller exists outside historical/transient
+planning artifacts. Removal of a `delete-candidate` script is a separate code-change task and is
+out of scope for this governance inventory; flag it as a follow-up.
 
 ## Canonical Workflow Owners
 
@@ -57,21 +59,40 @@ No workflow may duplicate these audit commands as independent pre-steps unless t
 
 ## Helper Surface Decisions (Sprint 1 Scope)
 
+This section enumerates every script under `scripts/ci/*.sh` (matches `ls scripts/ci/*.sh`) and
+records the keep/delete decision plus the active caller evidence.
+
 | Path | Decision | Active caller evidence |
 | --- | --- | --- |
-| `scripts/ci/wrapper-mode-smoke.sh` | keep | `README.md` wrapper contributor flow + wrapper smoke command examples |
-| `scripts/ci/agent-docs-snapshots.sh` | keep | `crates/agent-docs/README.md` snapshot workflow |
-| obsolete completion matrix shell helper | delete | no active caller outside itself |
-| obsolete release package shell helper | delete | no active CI/release/contributor caller; replaced by canonical release tarball audit script |
-| `wrappers/plan-tooling` | keep | `README.md` wrapper contributor flow + runbook wrapper scope includes `plan-tooling` |
-| `wrappers/git-cli` | keep | `README.md` wrapper contributor flow includes `git-cli` wrapper behavior |
+| `scripts/ci/agent-docs-snapshots.sh` | keep | `crates/agent-docs/README.md` snapshot workflow (`scripts/ci/agent-docs-snapshots.sh [--bless]`) |
+| `scripts/ci/completion-asset-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` step |
+| `scripts/ci/completion-flag-parity-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` step |
+| `scripts/ci/coverage-badge.sh` | keep | `.github/workflows/ci.yml` `coverage_badge` job |
+| `scripts/ci/coverage-summary.sh` | keep | `.github/workflows/ci.yml` `coverage` job + `DEVELOPMENT.md` coverage flow |
+| `scripts/ci/docs-hygiene-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` docs-only and full passes |
+| `scripts/ci/docs-placement-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` docs-only and full passes |
+| `scripts/ci/markdownlint-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` docs-only and full passes |
+| `scripts/ci/nils-cli-checks-entrypoint.sh` | keep | `.github/workflows/ci.yml` `test` and `test_macos` jobs + `DEVELOPMENT.md` contributor commands |
+| `scripts/ci/plan-issue-cli-coverage-delta.sh` | delete-candidate | No active caller found in workflows / contributor docs / required-checks scripts. Removal is a code-change task; flag as follow-up rather than patching here. |
+| `scripts/ci/release-tarball-third-party-audit.sh` | keep | `.github/workflows/release.yml` `build` job |
+| `scripts/ci/test-stale-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` step |
+| `scripts/ci/third-party-artifacts-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` step + dependabot bump skill |
+| `scripts/ci/wrapper-mode-smoke.sh` | delete-candidate | No active caller currently references the script outside itself. Previous evidence claim ("`README.md` wrapper contributor flow + wrapper smoke command examples") is stale. Removal is a code-change task; flag as follow-up rather than patching here. |
+
+## Auxiliary Wrapper / Tooling Decisions
+
+| Path | Decision | Active caller evidence |
+| --- | --- | --- |
+| `wrappers/plan-tooling` | keep | `README.md` wrapper contributor flow + workspace wrapper directory contract |
+| `wrappers/git-cli` | keep | `README.md` wrapper contributor flow + `git-cli` wrapper behavior |
 
 ## Validation Commands
 
 ```bash
 test -f docs/specs/workspace-ci-entrypoint-inventory-v1.md
+ls scripts/ci/*.sh
 rg -n 'scripts/ci/|nils-cli-verify-required-checks' \
   .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/publish-crates.yml \
   DEVELOPMENT.md .agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
-rg -n 'canonical|delete|keep|workflow' docs/specs/workspace-ci-entrypoint-inventory-v1.md
+rg -n 'canonical|delete|delete-candidate|keep|workflow' docs/specs/workspace-ci-entrypoint-inventory-v1.md
 ```

--- a/docs/specs/workspace-doc-retention-matrix-v1.md
+++ b/docs/specs/workspace-doc-retention-matrix-v1.md
@@ -40,6 +40,82 @@ Decision fields:
 All paths below are classified as `scope=crate-local`, `lifecycle=canonical`, `decision=keep`.
 Rationale: each file is owned by one crate and lives under `crates/<crate>/docs/**`.
 
+This section is the authoritative crate-local docs inventory. It MUST match the canonical find
+output exactly:
+
+```bash
+find crates -type f -name '*.md' \
+  -not -path '*/tests/*' \
+  -not -path '*/src/*' \
+  -not -path '*/assets/*' \
+  -not -path 'crates/*/README.md' \
+  -not -path 'crates/plan-tooling/plan-template.md'
+```
+
+Top-level `crates/<crate>/README.md` files and `crates/<crate>/docs/README.md` index files are
+tracked separately in the [Crate Top-Level README Inventory](#crate-top-level-readme-inventory-keep)
+below; the canonical `find` glob `crates/*/README.md` excludes any `README.md` under a crate root
+because BSD-style `-path` lets `*` cross slash boundaries.
+
+- `crates/api-websocket/docs/specs/websocket-cli-contract-v1.md`
+- `crates/api-websocket/docs/specs/websocket-request-schema-v1.md`
+- `crates/codex-cli/docs/runbooks/json-consumers.md`
+- `crates/codex-cli/docs/specs/codex-cli-diag-auth-json-contract-v1.md`
+- `crates/gemini-cli/docs/runbooks/json-consumers.md`
+- `crates/gemini-cli/docs/specs/gemini-cli-diag-auth-json-contract-v1.md`
+- `crates/image-processing/docs/runbooks/llm-svg-workflow.md`
+- `crates/memo-cli/docs/runbooks/memo-cli-agent-workflow.md`
+- `crates/memo-cli/docs/specs/memo-cli-command-contract-v1.md`
+- `crates/memo-cli/docs/specs/memo-cli-json-contract-v1.md`
+- `crates/memo-cli/docs/specs/memo-cli-release-policy.md`
+- `crates/memo-cli/docs/specs/memo-cli-storage-schema-v1.md`
+- `crates/memo-cli/docs/specs/memo-cli-workflow-extension-contract-v1.md`
+- `crates/nils-common/docs/specs/markdown-helpers-contract-v1.md`
+- `crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v2.md`
+- `crates/plan-issue-cli/docs/specs/plan-issue-gate-matrix-v1.md`
+- `crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md`
+- `crates/plan-tooling/docs/runbooks/split-prs-build-task-spec-cutover.md`
+- `crates/plan-tooling/docs/specs/split-prs-contract-v1.md`
+- `crates/plan-tooling/docs/specs/split-prs-contract-v2.md`
+
+## Crate Top-Level README Inventory (Keep)
+
+All paths below are classified as `scope=crate-local`, `lifecycle=canonical`, `decision=keep`.
+Rationale: every workspace member crate ships a top-level `README.md` (rendered on crates.io and
+as the GitHub crate-directory landing page) and a `docs/README.md` index for crate-local docs.
+These files are excluded from the canonical Crate-Local Inventory `find` pattern, so they are
+tracked here.
+
+Top-level crate READMEs (one per workspace member, 25 total):
+
+- `crates/agent-docs/README.md`
+- `crates/api-gql/README.md`
+- `crates/api-grpc/README.md`
+- `crates/api-rest/README.md`
+- `crates/api-test/README.md`
+- `crates/api-testing-core/README.md`
+- `crates/api-websocket/README.md`
+- `crates/cli-template/README.md`
+- `crates/codex-cli/README.md`
+- `crates/fzf-cli/README.md`
+- `crates/gemini-cli/README.md`
+- `crates/git-cli/README.md`
+- `crates/git-lock/README.md`
+- `crates/git-scope/README.md`
+- `crates/git-summary/README.md`
+- `crates/image-processing/README.md`
+- `crates/macos-agent/README.md`
+- `crates/memo-cli/README.md`
+- `crates/nils-common/README.md`
+- `crates/nils-term/README.md`
+- `crates/nils-test-support/README.md`
+- `crates/plan-issue-cli/README.md`
+- `crates/plan-tooling/README.md`
+- `crates/screen-record/README.md`
+- `crates/semantic-commit/README.md`
+
+Crate `docs/README.md` index files (one per workspace member, 25 total):
+
 - `crates/agent-docs/docs/README.md`
 - `crates/api-gql/docs/README.md`
 - `crates/api-grpc/docs/README.md`
@@ -47,53 +123,31 @@ Rationale: each file is owned by one crate and lives under `crates/<crate>/docs/
 - `crates/api-test/docs/README.md`
 - `crates/api-testing-core/docs/README.md`
 - `crates/api-websocket/docs/README.md`
-- `crates/api-websocket/docs/specs/websocket-cli-contract-v1.md`
-- `crates/api-websocket/docs/specs/websocket-request-schema-v1.md`
 - `crates/cli-template/docs/README.md`
 - `crates/codex-cli/docs/README.md`
-- `crates/codex-cli/docs/runbooks/json-consumers.md`
-- `crates/codex-cli/docs/specs/codex-cli-diag-auth-json-contract-v1.md`
 - `crates/fzf-cli/docs/README.md`
 - `crates/gemini-cli/docs/README.md`
-- `crates/gemini-cli/docs/runbooks/json-consumers.md`
-- `crates/gemini-cli/docs/specs/gemini-cli-diag-auth-json-contract-v1.md`
 - `crates/git-cli/docs/README.md`
 - `crates/git-lock/docs/README.md`
 - `crates/git-scope/docs/README.md`
 - `crates/git-summary/docs/README.md`
 - `crates/image-processing/docs/README.md`
-- `crates/image-processing/docs/runbooks/llm-svg-workflow.md`
 - `crates/macos-agent/docs/README.md`
 - `crates/memo-cli/docs/README.md`
-- `crates/memo-cli/docs/runbooks/memo-cli-agent-workflow.md`
-- `crates/memo-cli/docs/specs/memo-cli-command-contract-v1.md`
-- `crates/memo-cli/docs/specs/memo-cli-json-contract-v1.md`
-- `crates/memo-cli/docs/specs/memo-cli-release-policy.md`
-- `crates/memo-cli/docs/specs/memo-cli-storage-schema-v1.md`
-- `crates/memo-cli/docs/specs/memo-cli-workflow-extension-contract-v1.md`
 - `crates/nils-common/docs/README.md`
-- `crates/nils-common/docs/specs/markdown-helpers-contract-v1.md`
 - `crates/nils-term/docs/README.md`
 - `crates/nils-test-support/docs/README.md`
 - `crates/plan-issue-cli/docs/README.md`
-- `crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v2.md`
-- `crates/plan-issue-cli/docs/specs/plan-issue-gate-matrix-v1.md`
-- `crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md`
 - `crates/plan-tooling/docs/README.md`
-- `crates/plan-tooling/docs/runbooks/split-prs-build-task-spec-cutover.md`
-- `crates/plan-tooling/docs/specs/split-prs-contract-v1.md`
-- `crates/plan-tooling/docs/specs/split-prs-contract-v2.md`
 - `crates/screen-record/docs/README.md`
 - `crates/semantic-commit/docs/README.md`
 
 ## Transient/Obsolete Inventory (Delete or Move)
 
-| Path | Scope | Lifecycle | Decision | Reason | Inbound-reference proof |
-| --- | --- | --- | --- | --- | --- |
-| `docs/plans/markdown-gh-handling-audit-remediation-plan.md` | `transient-dev-record` | `delete` | `delete` | Completed migration plan; no active workflow caller remains. | `rg -n 'markdown-gh-handling-audit-remediation-plan\\.md' README.md DEVELOPMENT.md AGENTS.md BINARY_DEPENDENCIES.md docs crates scripts tests .github` -> no matches. |
-| `docs/plans/third-party-licenses-notices-release-packaging-plan.md` | `transient-dev-record` | `delete` | `delete` | Completed migration plan; contract moved to canonical spec + scripts. | `rg -n 'third-party-licenses-notices-release-packaging-plan\\.md' README.md DEVELOPMENT.md AGENTS.md BINARY_DEPENDENCIES.md docs crates scripts tests .github` -> no matches. |
-| `docs/reports/completion-coverage-matrix.md` | `workspace-level` | `delete` | `move` | Promoted from report to canonical workspace spec. | `rg -n 'docs/reports/completion-coverage-matrix\\.md' README.md DEVELOPMENT.md AGENTS.md BINARY_DEPENDENCIES.md docs crates scripts tests .github` -> no matches. |
-| `docs/runbooks/wrappers-mode-usage.md` | `transient-dev-record` | `delete` | `delete` | Compatibility-only wrapper-mode runbook superseded by canonical README guidance. | `rg -n 'wrappers-mode-usage\\.md' README.md DEVELOPMENT.md AGENTS.md BINARY_DEPENDENCIES.md docs crates scripts tests .github` -> no matches. |
-| `docs/specs/markdown-github-handling-audit-v1.md` | `transient-dev-record` | `delete` | `delete` | Audit artifact completed; no active policy gate depends on it. | `rg -n 'markdown-github-handling-audit-v1\\.md' README.md DEVELOPMENT.md AGENTS.md BINARY_DEPENDENCIES.md docs crates scripts tests .github` -> no matches. |
-| `crates/plan-tooling/docs/runbooks/split-prs-migration.md` | `crate-local` | `delete` | `delete` | Migration-only runbook superseded by cutover runbook + v2 contract docs. | `rg -n 'split-prs-migration\\.md' README.md DEVELOPMENT.md AGENTS.md BINARY_DEPENDENCIES.md docs crates scripts tests .github` -> no matches. |
-| `crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v1.md` | `crate-local` | `delete` | `delete` | Compatibility-era contract superseded by active v2 contract. | `rg -n 'plan-issue-cli-contract-v1\\.md' README.md DEVELOPMENT.md AGENTS.md BINARY_DEPENDENCIES.md docs crates scripts tests .github` -> no matches. |
+All transient/obsolete entries previously tracked here have been removed from the working tree and
+are kept off-tree by the `removed_transient_docs` allowlist in
+`scripts/ci/docs-hygiene-audit.sh`. No active rows remain in this matrix.
+
+If a new transient/obsolete artifact is added in the future, append it here with `scope`,
+`lifecycle`, `decision`, `reason`, and an inbound-reference proof; update
+`scripts/ci/docs-hygiene-audit.sh` to assert the file stays removed once delete is decided.


### PR DESCRIPTION
## Summary

Sprint 1 of the `repo-docs-cleanup-and-alignment-plan.md` workspace doc audit. Reconciles root-level + `docs/` documentation against current scripts, audits, and shared-crate boundary so contributor entrypoints stop drifting from the codebase.

- **`docs/specs/workspace-doc-retention-matrix-v1.md`**: Crate-Local Inventory rebuilt from canonical `find` output (20 entries match current state); Transient/Obsolete table replaced with a pointer to the hygiene-audit `removed_transient_docs` allowlist (the live enforcement gate); top-level READMEs split into a separate inventory section.
- **`docs/specs/workspace-ci-entrypoint-inventory-v1.md`**: Helper Surface Decisions table now enumerates the full 14 `scripts/ci/*.sh` entries instead of 2; auxiliary wrappers split into their own subsection.
- **`docs/specs/codex-gemini-cli-parity-contract-v1.md`**: Closed the stale "current gap" — both lanes already call `enqueue_background_refresh` (verified at `crates/{codex,gemini}-cli/src/prompt_segment/mod.rs`); rewrote test anchors from non-existent `--test prompt_segment_*` targets to `--test integration -- <filter>`.
- **`docs/runbooks/new-cli-crate-development-standard.md`**: Replaced hardcoded `version = "0.3.0"` scaffold rule with a directive pointing at canonical sources (current workspace version is `0.7.2`); removed vestigial "wrapper" wording.
- **`BINARY_DEPENDENCIES.md`**: Re-anchored §1 + §2 tool tables to live `Command::new(...)` call sites — added `gemini`, `curl`, `osascript`, `gh`, `vi`, `netstat`, `open`, `cliclick`; dropped `dwebp` (only test stub); reordered §1.1 ↔ §1.2; added preamble noting each row is anchored to a real call site.

## Code drift findings (deferred — not patched in this PR)

These surfaced during the audit and need follow-up code/script changes outside this docs-only PR:

- `scripts/ci/wrapper-mode-smoke.sh`: no active caller in workflows/docs/required-checks/skills (flagged `delete-candidate` in CI inventory).
- `scripts/ci/plan-issue-cli-coverage-delta.sh`: no active caller anywhere (flagged `delete-candidate`).
- `crates/macos-agent` invokes `cliclick` only via `find_in_path` preflight probe (no command path actually executes it today).
- `crates/api-testing-core/README.md` and `crates/api-websocket/README.md` still mention `websocat` in "rejected backend" historical context (not docs-drift, but worth a sweep when Sprint 2 touches API-testing crate READMEs).
- Backlog: a dedicated `crates/gemini-cli/tests/integration/prompt_segment_refresh.rs` mirroring the codex blocking-path lock/min-interval/stale-lock surface does not yet exist (kept as doc note).

## Test plan

- [x] `bash scripts/ci/docs-placement-audit.sh --strict` — PASS (`crates=25, warnings=0`)
- [x] `bash scripts/ci/docs-hygiene-audit.sh --strict` — PASS (`warnings=0`)
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` — PASS (87 files, 0 issues)
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` — PASS
- [x] `agent-docs resolve --context startup --strict --format checklist` — PASS (`required=5 present=5 missing=0`)
- [x] `agent-docs resolve --context project-dev --strict --format checklist` — PASS (`required=6 present=6 missing=0`)
- [x] `bash scripts/ci/completion-flag-parity-audit.sh --strict` — PASS (`required=21, failures=0`)
- [x] `bash scripts/ci/completion-asset-audit.sh --strict` — PASS (`workspace_bins=22, matrix_rows=22`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)