### PR TITLE
docs(api): align api-* crate docs with current CLI surface and shared contracts

### DIFF
--- a/crates/api-gql/README.md
+++ b/crates/api-gql/README.md
@@ -8,8 +8,7 @@ keeps optional history, and can generate Markdown reports.
 ## Usage
 
 ```text
-Usage:
-  api-gql <command> [args]
+Usage: api-gql <command> [args]
 
 Commands:
   call             Execute an operation and print response JSON (default)
@@ -17,32 +16,79 @@ Commands:
   report           Generate a Markdown API test report
   report-from-cmd  Generate a report from a command snippet (arg or stdin)
   schema           Resolve a schema file path (or print schema contents)
+  completion       Print shell completion script (bash | zsh)
 
 Help:
   api-gql --help
-  api-gql call --help
-  api-gql history --help
-  api-gql report --help
-  api-gql report-from-cmd --help
-  api-gql schema --help
+  api-gql <command> --help    # call | history | report | report-from-cmd | schema | completion
 ```
 
 ## Commands
 
 - `call` (default): Execute an operation (and optional variables) and print response JSON.
-  Options: `--env <name>`, `--url <url>`, `--jwt <name>`, `--config-dir <dir>`, `--list-envs`,
-  `--list-jwts`, `--no-history`.
+  Positional: `[operation.graphql]` (path to a `*.graphql` file), `[variables.json]` (optional).
+  Options: `-e/--env <name>`, `-u/--url <url>`, `--jwt <name>`, `--config-dir <dir>`,
+  `--list-envs`, `--list-jwts`, `--no-history`.
 - `history`: Print the last entry or tail N entries.
   Options: `--config-dir <dir>`, `--file <path>`, `--last`, `--tail <n>`, `--command-only`.
 - `report`: Generate a Markdown report for an operation.
-  Options: `--case <name>`, `--op <file>`, `--vars <file>`, `--run` | `--response <file|->`,
-  `--out <path>`, `--env <name>`, `--url <url>`, `--jwt <name>`, `--allow-empty`, `--no-redact`,
-  `--no-command`, `--no-command-url`, `--project-root <path>`, `--config-dir <dir>`.
+  Required: `--case <name>`, `--op <file>`. Exactly one of `--run` or `--response <file|->`.
+  Options: `--vars <file>`, `--out <path>`, `-e/--env <name>`, `-u/--url <url>`, `--jwt <name>`,
+  `--allow-empty`, `--no-redact`, `--no-command`, `--no-command-url`,
+  `--project-root <path>`, `--config-dir <dir>`. Aliases: `--operation` for `--op`,
+  `--variables` for `--vars`, `--expect-empty` for `--allow-empty`.
 - `report-from-cmd`: Generate a report from a command snippet.
+  Positional: `[snippet]` (or pass `--stdin` to read from stdin).
   Options: `--case <name>`, `--out <path>`, `--response <file|->`, `--allow-empty`, `--dry-run`,
   `--stdin`.
 - `schema`: Resolve a schema file path (or print schema contents).
-  Options: `--config-dir <dir>`, `--file <path>`, `--cat`.
+  Options: `--config-dir <dir>`, `--file <path>` (overrides env + `schema.env`), `--cat`.
+- `completion`: Print shell completion script for `bash` or `zsh`.
+
+## Operation and variables files
+
+- The first positional arg is an operation file path; conventional extension is `*.graphql`
+  (the runtime treats the whole file as the operation body and does not enforce the suffix).
+- The second positional arg is an optional variables file; it must be valid JSON. Numeric
+  fields named `limit` are bumped up to `GQL_VARS_MIN_LIMIT` (default `5`) at load time.
+
+## Schema resolution
+
+`api-gql schema` resolves the schema file using this order:
+
+1. `--file <path>` (CLI flag).
+2. `GQL_SCHEMA_FILE` environment variable.
+3. `GQL_SCHEMA_FILE` declared in `<setup_dir>/schema.env` or `schema.local.env` (last-wins).
+4. Fallback filenames inside the setup dir: `schema.gql`, `schema.graphql`, `schema.graphqls`,
+   `api.graphql`, `api.gql`.
+
+By default the resolved path is printed; pass `--cat` to print the file contents instead.
+
+## Examples
+
+The following snippets are illustrative — replace paths and env names to match your setup.
+
+```bash
+# List endpoint presets discovered under setup/graphql/
+api-gql call --list-envs
+
+# Execute an operation against a preset, with variables
+api-gql call --env staging operations/users.graphql operations/users.vars.json
+
+# Generate a Markdown report by running the request now
+api-gql report --case users-list --op operations/users.graphql \
+  --vars operations/users.vars.json --env staging --run
+
+# Generate a report from a previously captured response
+api-gql report --case users-list --op operations/users.graphql \
+  --response captured/users.json
+
+# Replay a history snippet (e.g. last entry) into a report
+api-gql history --last --command-only | api-gql report-from-cmd --stdin --response -
+
+# Resolve and print the schema file path
+api-gql schema --config-dir setup/graphql
+```
 
 ## Auth selection
 

--- a/crates/api-grpc/README.md
+++ b/crates/api-grpc/README.md
@@ -2,42 +2,73 @@
 
 ## Overview
 
-api-grpc executes JSON-defined GRPC request files, prints response bodies to stdout, keeps
-optional history, and can generate Markdown reports.
+api-grpc executes JSON-defined gRPC unary requests, prints response bodies to stdout, keeps
+optional history, and can generate Markdown reports. Unary execution delegates to the
+`grpcurl` backend exposed by `api-testing-core::grpc::runner`.
 
 ## Usage
 
 ```text
-Usage:
-  api-grpc <command> [args]
+Usage: api-grpc <command> [args]
 
 Commands:
   call             Execute a request file and print the response body to stdout (default)
   history          Print the last (or last N) history entries
   report           Generate a Markdown API test report
   report-from-cmd  Generate a report from a saved `call` snippet
+  completion       Print shell completion script
 
-Help:
+Common options (see subcommand help for full details):
+  --config-dir <dir>   Seed setup/grpc discovery (call/history/report)
+  -h, --help           Print help
+
+Examples:
   api-grpc --help
   api-grpc call --help
-  api-grpc history --help
   api-grpc report --help
   api-grpc report-from-cmd --help
+  api-grpc completion zsh
 ```
 
 ## Commands
 
 - `call` (default): Execute a request file and print the response body.
-  Options: `--env <name>`, `--url <url>`, `--token <name>`, `--config-dir <dir>`, `--no-history`.
+  Positional: `<request.grpc.json>`.
+  Options: `-e/--env <name>`, `-u/--url <url>`, `--token <name>`, `--config-dir <dir>`,
+  `--no-history`.
 - `history`: Print the last entry or tail N entries.
   Options: `--config-dir <dir>`, `--file <path>`, `--last`, `--tail <n>`, `--command-only`.
 - `report`: Generate a Markdown report for a request.
-  Options: `--case <name>`, `--request <file>`, `--run` | `--response <file|->`, `--out <path>`,
-  `--env <name>`, `--url <url>`, `--token <name>`, `--no-redact`, `--no-command`,
-  `--no-command-url`, `--project-root <path>`, `--config-dir <dir>`.
-- `report-from-cmd`: Generate a report from a saved `call` command snippet.
-  Options: `--case <name>`, `--out <path>`, `--response <file|->`, `--allow-empty`, `--dry-run`,
-  `--stdin`.
+  Required: `--case <name>`, `--request <file>`. Exactly one of `--run` or `--response <file|->`.
+  Options: `--out <path>`, `-e/--env <name>`, `-u/--url <url>`, `--token <name>`,
+  `--no-redact`, `--no-command`, `--no-command-url`, `--project-root <path>`, `--config-dir <dir>`.
+- `report-from-cmd`: Generate a Markdown report from a saved `call` command snippet.
+  Positional: `[snippet]` (or pass via `--stdin`).
+  Options: `--case <name>`, `--out <path>`, `--response <file|->`, `--allow-empty`,
+  `--dry-run`, `--stdin`.
+- `completion`: Print a shell completion script. Argument: `<SHELL>` (`bash` or `zsh`).
+
+## Request file contract
+
+`*.grpc.json` files describe a single unary call. The JSON object is the gRPC request
+envelope consumed by `api-testing-core::grpc::schema`:
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `method` (alias `rpc`) | string | yes | Fully-qualified `service/method` (e.g. `health.HealthService/Check`). |
+| `body` | object | optional | Defaults to `{}`. Must be a JSON object. |
+| `metadata` | object | optional | Scalar values (string/number/bool); empty values are dropped; sorted by key. |
+| `proto` | string | optional | Path to a `.proto` file (relative to the request file). |
+| `importPaths` | string[] | optional | Additional `-import-path` entries (relative paths resolved against the request file). |
+| `plaintext` | bool | optional | Defaults to `true`. When `true`, `grpcurl -plaintext` is added. |
+| `authority` | string | optional | Forwarded as `grpcurl -authority`. |
+| `timeoutSeconds` | integer | optional | Forwarded as `grpcurl -max-time`. |
+| `expect.status` | integer | optional | Expected gRPC status code (numeric). |
+| `expect.jq` | string | optional | jq-style boolean assertion against the decoded response body. |
+
+Bearer tokens resolved by `--token` (or `GRPC_TOKEN_NAME`) are injected as
+`-H 'authorization: Bearer <token>'` unless the request already provides an `authorization`
+metadata entry.
 
 ## Quickstart
 
@@ -71,6 +102,9 @@ GRPC_TOKEN_DEFAULT=<jwt-or-access-token>
   "body": {
     "service": "payments"
   },
+  "metadata": {
+    "x-trace-id": "demo-001"
+  },
   "plaintext": true,
   "expect": {
     "status": 0,
@@ -95,9 +129,14 @@ api-grpc history --command-only | api-grpc report-from-cmd --stdin --dry-run
 
 ## Runtime dependency
 
-- Unary execution uses `grpcurl` backend (`GRPCURL_BIN` can override executable path).
+- `grpcurl` is a required runtime dependency for `api-grpc call` and any suite gRPC cases
+  (the unary backend in `api-testing-core::grpc::runner` shells out to it).
+- The executable resolves to `grpcurl` on `PATH` by default; set `GRPCURL_BIN` to override
+  the path (e.g. when pinning a vendored binary).
 - Install:
-  - macOS: `brew install grpcurl`
+  - macOS / Linuxbrew: `brew install grpcurl`
+- See the workspace-level [`BINARY_DEPENDENCIES.md`](../../BINARY_DEPENDENCIES.md) for the
+  canonical runtime-tooling matrix.
 
 ## Docs
 

--- a/crates/api-rest/README.md
+++ b/crates/api-rest/README.md
@@ -8,36 +8,45 @@ optional history, and can generate Markdown reports.
 ## Usage
 
 ```text
-Usage:
-  api-rest <command> [args]
+Usage: api-rest <command> [args]
 
 Commands:
   call             Execute a request file and print the response body to stdout (default)
   history          Print the last (or last N) history entries
   report           Generate a Markdown API test report
   report-from-cmd  Generate a report from a saved `call` snippet
+  completion       Print shell completion script
 
-Help:
+Common options (see subcommand help for full details):
+  --config-dir <dir>   Seed setup/rest discovery (call/history/report)
+  -h, --help           Print help
+
+Examples:
   api-rest --help
   api-rest call --help
-  api-rest history --help
   api-rest report --help
   api-rest report-from-cmd --help
+  api-rest completion zsh
 ```
 
 ## Commands
 
 - `call` (default): Execute a request file and print the response body.
-  Options: `--env <name>`, `--url <url>`, `--token <name>`, `--config-dir <dir>`, `--no-history`.
+  Positional: `<request.request.json>`.
+  Options: `-e/--env <name>`, `-u/--url <url>`, `--token <name>`, `--config-dir <dir>`,
+  `--no-history`.
 - `history`: Print the last entry or tail N entries.
   Options: `--config-dir <dir>`, `--file <path>`, `--last`, `--tail <n>`, `--command-only`.
 - `report`: Generate a Markdown report for a request.
-  Options: `--case <name>`, `--request <file>`, `--run` | `--response <file|->`, `--out <path>`,
-  `--env <name>`, `--url <url>`, `--token <name>`, `--no-redact`, `--no-command`,
-  `--no-command-url`, `--project-root <path>`, `--config-dir <dir>`.
-- `report-from-cmd`: Generate a report from a saved `call` command snippet.
-  Options: `--case <name>`, `--out <path>`, `--response <file|->`, `--allow-empty`, `--dry-run`,
-  `--stdin`.
+  Required: `--case <name>`, `--request <file>`.
+  Options: `--out <path>`, `-e/--env <name>`, `-u/--url <url>`, `--token <name>`,
+  `--run`, `--response <file|->`, `--no-redact`, `--no-command`, `--no-command-url`,
+  `--project-root <path>`, `--config-dir <dir>`.
+- `report-from-cmd`: Generate a Markdown report from a saved `call` command snippet.
+  Positional: `[snippet]` (or pass via `--stdin`).
+  Options: `--case <name>`, `--out <path>`, `--response <file|->`, `--allow-empty`,
+  `--dry-run`, `--stdin`.
+- `completion`: Print a shell completion script. Argument: `<SHELL>` (`bash` or `zsh`).
 
 ## Docs
 

--- a/crates/api-test/README.md
+++ b/crates/api-test/README.md
@@ -2,75 +2,129 @@
 
 ## Overview
 
-`api-test` runs REST + GraphQL + gRPC + WebSocket suites from a JSON manifest, emits results JSON to stdout, and can render a Markdown summary.
+`api-test` is the suite orchestrator for the api-testing stack. It loads a v1
+suite manifest, dispatches each case to the matching backend runner
+(REST / GraphQL / gRPC / WebSocket), captures results JSON to stdout, and
+optionally writes a JUnit XML file plus a Markdown summary.
+
+The dispatch + run loop is implemented by `api_testing_core::suite::runner`;
+JUnit rendering by `api_testing_core::suite::junit`; results by
+`api_testing_core::suite::results::{SuiteRunResults, SuiteCaseResult}`. See
+[`crates/api-testing-core/README.md`](../api-testing-core/README.md) for the
+shared library surface.
 
 ## Usage
 
 ```text
-Usage:
-  api-test <command> [args]
+Usage: api-test <command> [args]
 
 Commands:
-  run       Run a suite (default)
-  summary   Render a Markdown summary from results JSON
+  run         Run a suite (default)
+  summary     Render a Markdown summary from results JSON
+  completion  Print shell completion script
+
+Common options (run; see `api-test run --help` for full details):
+  --suite <name>        Resolve suite under tests/api/suites/<name>.suite.json
+  --suite-file <path>   Explicit suite file path
+  --tag <tag>           Filter cases by tag (repeatable; AND semantics)
+  --only <csv>          Run only listed case IDs (comma-separated)
+  --skip <csv>          Skip listed case IDs (comma-separated)
+  --fail-fast           Stop after first failure
+  --out <path>          Write results JSON to a file (stdout still emits JSON)
+  --junit <path>        Write optional JUnit XML to a file
+  -h, --help            Print help
+
+Examples:
+  api-test --help
+  api-test --suite smoke --help
+  api-test run --suite smoke --out results.json
+  api-test completion zsh
 ```
+
+The first positional `run` is implicit: bare flag invocations
+(e.g. `api-test --suite smoke`) are rewritten to
+`api-test run --suite smoke` before parsing. Explicit `run` / `summary` /
+`completion` words are honored as-is.
 
 ## Commands
 
 - `run` (default): execute a suite and write results JSON to stdout.
-  Options: `--suite <name>` | `--suite-file <path>`, `--tag <tag>`, `--only <csv>`, `--skip <csv>`,
-  `--allow-writes`, `--fail-fast`/`--continue`, `--out <path>`, `--junit <path>`.
-- `summary`: render a Markdown summary from results JSON (stdin or `--in`).
+  Required: exactly one of `--suite <name>` or `--suite-file <path>`.
+  Options: `--out <path>`, `--junit <path>`, `--allow-writes`,
+  `--tag <tag>` (repeatable; AND semantics), `--only <csv>`, `--skip <csv>`,
+  `--fail-fast` / `--continue` (mutually exclusive; `--continue` is the
+  default).
+- `summary`: render a Markdown summary from a results JSON document
+  (stdin by default, or `--in <path>`).
+  Options: `--out <path>`, `--slow <n>` (default `5`), `--hide-skipped`,
+  `--max-failed <n>` (default `50`), `--max-skipped <n>` (default `50`),
+  `--no-github-summary` (skip writing to `$GITHUB_STEP_SUMMARY`).
+- `completion`: print a shell completion script. Argument: `<SHELL>`
+  (`bash` or `zsh`).
 
-## WebSocket suite contract (`type: websocket`)
+`run` exit codes (driven by `SuiteRunResults::exit_code`):
 
-Additive defaults:
+- `0` — every case `passed` or `skipped`.
+- `2` — at least one case `failed`.
+- `1` — orchestrator-level error (suite not found, schema invalid,
+  results serialization failure, JUnit write failure).
 
-- `defaults.websocket.configDir` (default: `setup/websocket`)
-- `defaults.websocket.url` (endpoint preset or literal URL)
-- `defaults.websocket.token` (token profile name)
+## Suite manifest (`v1`)
 
-Additive case fields:
+Top-level fields (camelCase):
 
-- `type: "websocket"` (alias: `"ws"`)
-- `request` (required, path to `*.ws.json` or `*.websocket.json`)
-- optional: `env`, `url`, `token`, `configDir`, `noHistory`
+- `version` (required, must be `1`).
+- `name` (optional; falls back to the suite filename).
+- `defaults` (optional; per-protocol overrides applied to each case).
+- `auth` (optional; shared login flow that produces a bearer token reused
+  by REST/GraphQL cases — see `api-testing-core` docs for details).
+- `cases` (required, ordered list of case objects).
 
-Validation rules:
+`defaults` accepts one block per backend (every block is independently
+optional):
 
-- `type: "websocket"` without `request` is rejected.
-- Existing REST/GraphQL/gRPC schema contracts remain unchanged.
+| Block | Fields |
+| --- | --- |
+| `defaults.rest` | `configDir` (default `setup/rest`), `url`, `token` |
+| `defaults.graphql` | `configDir` (default `setup/graphql`), `url`, `jwt` |
+| `defaults.grpc` | `configDir` (default `setup/grpc`), `url`, `token` |
+| `defaults.websocket` | `configDir` (default `setup/websocket`), `url`, `token` |
 
-Runtime override:
+`url` is either an endpoint preset name resolved against the backend's
+`endpoints.env` or a literal URL/target; `token` / `jwt` is a profile name
+resolved against the backend's token store. Suite-level `defaults.env`
+and `defaults.noHistory` apply to every case unless overridden inline.
 
-- `API_TEST_WS_URL` overrides resolved WebSocket target for suite runs.
+## Case dispatch
 
-## gRPC suite contract (`type: grpc`)
+Each case object selects a backend via the `type` field. The runner
+normalizes `ws` to `websocket` before dispatch (see
+`api_testing_core::suite::runner::context::case_type_normalized`), so both
+spellings are accepted.
 
-Additive defaults:
+| `type` value | Backend runner | Required case field | Notes |
+| --- | --- | --- | --- |
+| `rest` | `api-rest` (in-process via `api_testing_core::rest`) | `request` (path to `*.request.json`) | Optional: `env`, `url`, `token`, `configDir`, `noHistory`, `allowWrite`, `cleanup`. |
+| `rest-flow` (alias `rest_flow`) | `api-rest` login + main request | `loginRequest` and `request` | Optional: `tokenJq` (jq filter that extracts the bearer token from the login response; defaults to a permissive `accessToken`/`access_token`/`token` selector). |
+| `graphql` | `api-gql` (in-process via `api_testing_core::graphql`) | `op` (path to `*.graphql`) | Optional: `vars` (path to JSON variables), `jwt`, `allowErrors`, `expect.jq` (required when `allowErrors=true`). |
+| `grpc` | `api-grpc` (in-process via `api_testing_core::grpc`) | `request` (path to `*.grpc.json`) | Optional: `env`, `url`, `token`, `configDir`, `noHistory`, plus gRPC-only fields handled by the request file (`grpcProto`, `grpcImportPaths`, `grpcPlaintext`). |
+| `websocket` (alias `ws`) | `api-websocket` (in-process via `api_testing_core::websocket`) | `request` (path to `*.ws.json` or `*.websocket.json`) | Optional: `env`, `url`, `token`, `configDir`, `noHistory`. |
 
-- `defaults.grpc.configDir` (default: `setup/grpc`)
-- `defaults.grpc.url` (endpoint preset or literal target)
-- `defaults.grpc.token` (token profile name)
-
-Additive case fields:
-
-- `type: "grpc"`
-- `request` (required, path to `*.grpc.json`)
-- optional: `env`, `url`, `token`, `configDir`, `noHistory`
-
-Runtime override:
-
-- `API_TEST_GRPC_URL` overrides resolved gRPC target for suite runs.
+Cases are filtered before dispatch using `--tag` (AND semantics across
+repeats), `--only`, `--skip`, and the `allowWrite` safety gate. A case
+that opts into writes (`allowWrite: true`) only runs when `--allow-writes`
+is set, or when the suite-level
+`API_TEST_ALLOW_WRITES_ENABLED` env var is truthy.
 
 ## Mixed protocol suite example
 
 ```json
 {
   "version": 1,
+  "name": "smoke",
   "defaults": {
     "rest": {"configDir": "setup/rest"},
-    "graphql": {"configDir": "setup/graphql"},
+    "graphql": {"configDir": "setup/graphql", "jwt": "default"},
     "grpc": {"configDir": "setup/grpc", "url": "local", "token": "default"},
     "websocket": {"configDir": "setup/websocket", "url": "local", "token": "default"}
   },
@@ -82,6 +136,96 @@ Runtime override:
   ]
 }
 ```
+
+## Results JSON envelope
+
+Stdout is exactly one JSON object per `run` invocation, also written to
+`--out <path>` when supplied:
+
+```json
+{
+  "version": 1,
+  "suite": "smoke",
+  "suiteFile": "tests/api/suites/smoke.suite.json",
+  "runId": "20260131-000000Z",
+  "startedAt": "2026-01-31T00:00:00Z",
+  "finishedAt": "2026-01-31T00:00:01Z",
+  "outputDir": "out/api-test-runner/20260131-000000Z",
+  "summary": {"total": 4, "passed": 3, "failed": 1, "skipped": 0},
+  "cases": [
+    {
+      "id": "rest-health",
+      "type": "rest",
+      "status": "passed",
+      "durationMs": 12,
+      "tags": [],
+      "stdoutFile": "out/api-test-runner/.../rest-health.response.json",
+      "stderrFile": "out/api-test-runner/.../rest-health.stderr.log"
+    }
+  ]
+}
+```
+
+Per-case fields (camelCase, optional fields are omitted when empty):
+
+- `status` is one of `passed`, `failed`, `skipped`.
+- `type` is the normalized dispatch value (`ws` collapses to `websocket`).
+- `command` carries the rendered backend command snippet (REST/GraphQL
+  emit the equivalent `api-rest call` / `api-gql call` invocation; gRPC
+  and WebSocket emit the in-process equivalent).
+- `message` is set on `failed`/`skipped` cases (e.g. `cleanup_failed`,
+  `rest_flow_login_failed`, the selection-skip reason, or the runner's
+  own diagnostic).
+- `assertions` mirrors per-runner expect output (currently surfaced by
+  GraphQL expect/allow-errors flow and gRPC/WebSocket assertions).
+- `stdoutFile` / `stderrFile` are repo-relative paths under `outputDir`.
+
+The output directory defaults to `<repo>/out/api-test-runner/<runId>/`
+and can be overridden with the `API_TEST_OUTPUT_DIR` env var (relative
+paths resolve against the repo root).
+
+## JUnit XML output
+
+`--junit <path>` writes a single `<testsuite>` element per run via
+`api_testing_core::suite::junit::render_junit_xml`. The shape is:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<testsuite name="smoke" tests="4" failures="1" skipped="0">
+  <testcase name="rest-health" classname="rest" time="0.012"/>
+  <testcase name="gql-health" classname="graphql" time="0.034">
+    <failure message="graphql_runner_failed">command: api-gql call ...
+stdoutFile: out/.../gql-health.response.json
+stderrFile: out/.../gql-health.stderr.log</failure>
+  </testcase>
+  <testcase name="ws-skip" classname="websocket" time="0.000"><skipped message="filtered_by_only"/></testcase>
+</testsuite>
+```
+
+Notes:
+
+- `<testsuite>` attributes: `name` (suite name or filename), `tests`,
+  `failures`, `skipped` (taken from `summary`).
+- `<testcase>` attributes: `name` = case `id`, `classname` = normalized
+  case `type`, `time` = `durationMs / 1000` formatted to 3 decimals.
+- `<failure>` carries the runner `message` and a body listing
+  `command`, `stdoutFile`, `stderrFile` when present (XML-escaped).
+- `<skipped>` carries the skip reason in `message`.
+- Passed cases emit `<testcase ... />` with no child element.
+
+## Environment variables
+
+| Variable | Effect |
+| --- | --- |
+| `API_TEST_OUTPUT_DIR` | Override the per-run output directory base (default `<repo>/out/api-test-runner`). Relative values resolve against the repo root. |
+| `API_TEST_PROGRESS` | `auto` (default), `on`/`1`/`true`/`yes`, or `off`/`0`/`false`/`no`. Controls the stderr progress bar. |
+| `API_TEST_ALLOW_WRITES_ENABLED` | Truthy value forces `--allow-writes` on for every case (still gated by per-case `allowWrite: true`). |
+| `API_TEST_REST_URL` | Overrides REST endpoint resolution for suite runs. |
+| `API_TEST_GQL_URL` | Overrides GraphQL endpoint resolution for suite runs. |
+| `API_TEST_GRPC_URL` | Overrides gRPC target resolution for suite runs. |
+| `API_TEST_WS_URL` | Overrides WebSocket target resolution for suite runs. |
+| `API_TEST_AUTH_JSON` | Default secret-env name for `auth.secretEnv` (overridable in the manifest). |
+| `GITHUB_STEP_SUMMARY` | When set and `summary --no-github-summary` is not passed, the rendered Markdown summary is appended to this file. |
 
 ## Reuse matrix (unchanged vs additive protocol paths)
 
@@ -98,3 +242,7 @@ Runtime override:
 ## Docs
 
 - [Docs index](docs/README.md)
+- Sibling backend crates: [`api-rest`](../api-rest/README.md),
+  [`api-gql`](../api-gql/README.md), [`api-grpc`](../api-grpc/README.md),
+  [`api-websocket`](../api-websocket/README.md).
+- Shared library: [`api-testing-core`](../api-testing-core/README.md).

--- a/crates/api-test/docs/README.md
+++ b/crates/api-test/docs/README.md
@@ -12,6 +12,28 @@
 
 - None yet. Add documents under `docs/reports/` and register them here.
 
+## Cross-references
+
+- Suite manifest schema, dispatch loop, results envelope, and JUnit
+  rendering live in `api-testing-core`. Source of truth modules:
+  - `api_testing_core::suite::schema` — manifest (`SuiteManifest`,
+    `SuiteCase`, `SuiteDefaults*`, `SuiteCleanup`).
+  - `api_testing_core::suite::runner` — per-backend dispatch and
+    `SuiteRunOptions` plumbing (REST / REST-flow / GraphQL / gRPC /
+    WebSocket).
+  - `api_testing_core::suite::results` — results JSON envelope
+    (`SuiteRunResults`, `SuiteCaseResult`, `SuiteRunSummary`).
+  - `api_testing_core::suite::junit` — JUnit XML rendering.
+  - `api_testing_core::suite::summary` — Markdown summary used by
+    `api-test summary`.
+- Per-backend READMEs:
+  - [`api-rest`](../../api-rest/README.md)
+  - [`api-gql`](../../api-gql/README.md)
+  - [`api-grpc`](../../api-grpc/README.md)
+  - [`api-websocket`](../../api-websocket/README.md)
+- Shared library docs index:
+  [`api-testing-core/docs/README.md`](../../api-testing-core/docs/README.md).
+
 ## Links
 
 - Back to crate README: [`../README.md`](../README.md)

--- a/crates/api-testing-core/README.md
+++ b/crates/api-testing-core/README.md
@@ -49,18 +49,34 @@ Notes:
 
 ## api-testing-core scope
 
-`api-testing-core` is a library crate used by all five CLIs. Key modules:
+`api-testing-core` is a library crate used by all five CLIs.
 
-- `config`: setup dir discovery for REST/GraphQL/gRPC/WebSocket configs.
-- `env_file`: `.env` parsing + key normalization helpers.
-- `cli_*`: shared CLI helpers (endpoint resolution, history I/O, report args, CLI utilities).
-- `history`, `report`, `markdown`, `redact`, `cmd_snippet`: shared report/history rendering and snippet parsing.
-- `rest`: request schema, runner, expect/cleanup logic, report rendering.
-- `graphql`: schema/vars loading, auth/JWT resolution, runner, expect/allow-errors, report rendering, mutation detection.
-- `grpc`: unary request schema, transport runner, expect logic, report rendering.
-- `websocket`: request schema, scripted runner, expect logic, report rendering.
-- `suite`: suite schema v1, path resolution, filters, safety gates, auth integration, runner, cleanup, results, summary, JUnit (including
-  `type: websocket`).
+### Public modules
+
+The `lib.rs` re-exports the following top-level modules (see `crates/api-testing-core/src/lib.rs`):
+
+- `auth_env`: profile/env-fallback bearer-token resolution shared by REST/gRPC/WebSocket.
+- `cli_endpoint`: env-preset / `--url` resolution with `endpoints.env` lookup.
+- `cli_history`: history-file path resolution, append, and `history` subcommand rendering helpers.
+- `cli_io`: shared CLI I/O helpers (read response file/stdin, conditional stderr body printing).
+- `cli_report`: report metadata/path builder for the `report` subcommand.
+- `cli_util`: misc helpers (env-key normalization, slugify, timestamps, `WarnSink`).
+- `cmd_snippet`: parser for saved `call` command snippets used by `report-from-cmd`.
+- `config`: setup-dir discovery for REST/GraphQL/gRPC/WebSocket configs (resolves history defaults).
+- `env_file`: `.env` parsing with last-wins precedence and `.local.env` overrides.
+- `graphql`: schema/vars loading, auth/JWT resolution, runner, expect / allow-errors, report rendering, mutation detection.
+- `grpc`: unary request schema, transport runner (delegates to `grpcurl`), expect logic, report rendering.
+- `history`: rotating append-only history writer + path resolver.
+- `http`: placeholder HTTP executor (currently unimplemented; REST runner uses `nils_common` HTTP).
+- `jq`: in-process `jq`-style query helper backed by `jaq`.
+- `jwt`: JWT validation helpers (exp/nbf checks with leeway, strict/non-strict modes).
+- `markdown`: Markdown rendering helpers (headings, code blocks, JSON pretty-print).
+- `redact`: secret-key redaction for response bodies and report payloads.
+- `report`: shared report-builder primitives (header / sections).
+- `rest`: request schema, runner, expect / cleanup logic, report rendering.
+- `suite`: suite schema v1, path resolution, filters, safety gates, auth integration, runner, cleanup, results, summary, JUnit (covers
+  REST / GraphQL / gRPC / WebSocket case types).
+- `websocket`: request schema, scripted runner (native Rust `tungstenite`), expect logic, report rendering.
 
 ## Transport decision and reuse matrix
 

--- a/crates/api-websocket/README.md
+++ b/crates/api-websocket/README.md
@@ -7,16 +7,20 @@ It follows the same CLI conventions as `api-rest`, `api-gql`, and `api-grpc`.
 
 ## Transport decision
 
-- Selected backend: native Rust transport via `tungstenite` in `api-testing-core::websocket::runner`.
-- Rejected backend: external adapter (`websocat`-style shell-out) for MVP.
+- Selected backend: in-process Rust transport via `tungstenite` in
+  `api-testing-core::websocket::runner`. This is the only supported runtime path.
+- Rejected backend (historical): an external adapter that shells out to `websocat` was
+  considered for the MVP and rejected. `websocat` is **not** a runtime dependency of
+  `api-websocket` and is not invoked at any point.
 - Revisit when:
   - streaming/session orchestration needs async multiplexing beyond scripted send/receive steps;
   - platform/runtime behavior diverges in CI and a swap behind the transport boundary is justified.
 
 ## Runtime dependency policy
 
-- Runtime dependency policy: no extra external binary is required for WebSocket execution.
+- No extra external binary is required for WebSocket execution.
 - `api-websocket` uses the embedded Rust transport path only.
+- Cross-reference: see `BINARY_DEPENDENCIES.md` section 1.2 for the workspace-level statement.
 
 ## Setup and naming conventions
 
@@ -75,16 +79,55 @@ Quick example:
 }
 ```
 
+## Usage
+
+```text
+Usage: api-websocket <command> [args]
+
+Commands:
+  call             Execute a request file and print the last received message to stdout (default)
+  history          Print the last (or last N) history entries
+  report           Generate a Markdown API test report
+  report-from-cmd  Generate a report from a saved `call` snippet
+  completion       Print shell completion script
+
+Common options (see subcommand help for full details):
+  --config-dir <dir>   Seed setup/websocket discovery (call/history/report)
+  --format <text|json> Structured output for call/history
+  -h, --help           Print help
+
+Examples:
+  api-websocket --help
+  api-websocket call --help
+  api-websocket report --help
+  api-websocket report-from-cmd --help
+  api-websocket completion zsh
+```
+
 ## Commands
 
-- `call` (default): execute request and print the last received message.
-- `history`: print last entry or tail entries.
-- `report`: generate Markdown report from `--run` or `--response`.
-- `report-from-cmd`: reconstruct `report` args from a saved `call` snippet.
+- `call` (default): Execute a request file and print the last received message.
+  Positional: `<request.ws.json>` (also accepts `*.websocket.json`).
+  Options: `-e/--env <name>`, `-u/--url <url>`, `--token <name>`, `--config-dir <dir>`,
+  `--no-history`, `--format <text|json>`.
+- `history`: Print the last entry or tail N entries.
+  Options: `--config-dir <dir>`, `--file <path>`, `--last`, `--tail <n>`, `--command-only`,
+  `--format <text|json>`.
+- `report`: Generate a Markdown report for a request.
+  Required: `--case <name>`, `--request <file>`. Exactly one of `--run` or `--response <file|->`.
+  Options: `--out <path>`, `-e/--env <name>`, `-u/--url <url>`, `--token <name>`,
+  `--no-redact`, `--no-command`, `--no-command-url`, `--project-root <path>`,
+  `--config-dir <dir>`.
+- `report-from-cmd`: Generate a Markdown report from a saved `call` command snippet.
+  Positional: `[snippet]` (or pass `--stdin` to read from stdin).
+  Options: `--case <name>`, `--out <path>`, `--response <file|->`, `--allow-empty`
+  (alias `--expect-empty`; no-op for `api-websocket`, kept for parity), `--dry-run`,
+  `--stdin`.
+- `completion`: Print a shell completion script. Argument: `<SHELL>` (`bash` or `zsh`).
 
 ## JSON contract (`--format json`)
 
-Supported for `call` and `history`.
+Supported for `call` and `history`. Other subcommands ignore `--format`.
 
 Success envelope:
 
@@ -106,10 +149,15 @@ Failure envelope:
   "ok": false,
   "error": {
     "code": "stable-machine-code",
-    "message": "human-readable summary"
+    "message": "human-readable summary",
+    "details": {}
   }
 }
 ```
+
+`error.details` is optional and only present for failure modes that carry contextual
+data (for example `expectation_failed` includes `target` and `last_received`;
+`history_not_found` includes `history_file`).
 
 Full CLI/JSON contract: [`docs/specs/websocket-cli-contract-v1.md`](docs/specs/websocket-cli-contract-v1.md)
 

--- a/crates/api-websocket/docs/README.md
+++ b/crates/api-websocket/docs/README.md
@@ -1,14 +1,21 @@
 # api-websocket Docs Index
 
+> Ownership: Maintained by the `api-websocket` crate maintainers. Keep this index updated when docs are added, moved, or removed.
+
 ## Specs
 
-- [`specs/websocket-request-schema-v1.md`](specs/websocket-request-schema-v1.md)
-- [`specs/websocket-cli-contract-v1.md`](specs/websocket-cli-contract-v1.md)
+- [`specs/websocket-request-schema-v1.md`](specs/websocket-request-schema-v1.md) — request file schema (top-level fields, step types, expectations).
+- [`specs/websocket-cli-contract-v1.md`](specs/websocket-cli-contract-v1.md) — CLI surface, exit codes, and JSON envelope.
 
 ## Runbooks
 
 - None yet. Add documents under `docs/runbooks/` and register them here.
 
+## Reports
+
+- None yet. Add documents under `docs/reports/` and register them here.
+
 ## Links
 
 - Back to crate README: [`../README.md`](../README.md)
+- Workspace policy: [`../../../BINARY_DEPENDENCIES.md`](../../../BINARY_DEPENDENCIES.md) (section 1.2 covers the WebSocket transport policy).

--- a/crates/api-websocket/docs/specs/websocket-cli-contract-v1.md
+++ b/crates/api-websocket/docs/specs/websocket-cli-contract-v1.md
@@ -1,5 +1,9 @@
 # WebSocket CLI Contract v1
 
+> Source of truth: `crates/api-websocket/src/cli.rs` (clap definitions),
+> `crates/api-websocket/src/commands/{call,history,report}.rs` (envelope shapes),
+> `crates/api-testing-core/src/websocket/{schema,runner}.rs` (request schema and transcript).
+
 ## Commands
 
 `api-websocket` supports:
@@ -8,10 +12,12 @@
 - `history`
 - `report`
 - `report-from-cmd`
+- `completion` (prints a `bash` or `zsh` completion script; no JSON envelope)
 
 Default command behavior:
 
 - bare positional request path is treated as `call`.
+- `--help` / `-h` and `--version` / `-V` are handled at the root before the default insertion.
 
 ## Exit codes
 
@@ -29,7 +35,8 @@ Default command behavior:
 ## JSON mode
 
 - Explicit only: `--format json`
-- Supported commands: `call`, `history`
+- Supported commands: `call`, `history`. `report`, `report-from-cmd`, and `completion`
+  do not accept `--format`.
 - Human-readable mode remains default.
 
 ## JSON envelope
@@ -48,10 +55,22 @@ Guideline reference:
   "result": {
     "target": "ws://127.0.0.1:9001/ws",
     "last_received": "{\"ok\":true}",
-    "transcript": []
+    "transcript": [
+      {"direction": "send", "payload": "ping"},
+      {"direction": "receive", "payload": "{\"ok\":true}"},
+      {"direction": "close", "payload": ""}
+    ]
   }
 }
 ```
+
+`result.transcript` is an array of `{ "direction": "send" | "receive" | "close", "payload": "<text>" }`
+entries. `payload` is always a string; binary frames are decoded as lossy UTF-8, and control
+frames render as `<PING:...>`, `<PONG:...>`, `<CLOSE:<code>:<reason>>`, or `<FRAME>` placeholders
+(see `api_testing_core::websocket::runner::parse_message_text`).
+
+`result.last_received` mirrors the most recent `receive` step's `payload` (or `null` if no
+`receive` step ran successfully).
 
 ### `call` failure
 
@@ -62,10 +81,16 @@ Guideline reference:
   "ok": false,
   "error": {
     "code": "request_not_found",
-    "message": "Request file not found: ..."
+    "message": "Request file not found: ...",
+    "details": {}
   }
 }
 ```
+
+`error.details` is optional. It is included for failure modes that carry contextual data:
+
+- `websocket_execute_error`: `{ "target": "<resolved url>" }`
+- `expectation_failed`: `{ "target": "<resolved url>", "last_received": "<text or null>" }`
 
 ### `history` success
 
@@ -91,10 +116,15 @@ Guideline reference:
   "ok": false,
   "error": {
     "code": "history_not_found",
-    "message": "History file not found: ..."
+    "message": "History file not found: ...",
+    "details": {
+      "history_file": ".../.ws_history"
+    }
   }
 }
 ```
+
+`error.details.history_file` is included for `history_not_found` and `history_empty`.
 
 ## Stable error codes
 
@@ -121,3 +151,12 @@ Guideline reference:
 - JSON output must not include bearer token material.
 - Tokens are never emitted in `result` payloads.
 - history command snippets mask token values (`REDACTED`) in suite artifacts.
+
+## Transport runtime
+
+- `api-websocket` always uses the in-process `tungstenite`-backed runner exposed by
+  `api_testing_core::websocket::runner::execute_websocket_request`. There is no shell-out
+  to an external WebSocket binary at any point in the CLI surface. See
+  `BINARY_DEPENDENCIES.md` section 1.2 and `crates/api-websocket/README.md` ("Transport
+  decision") for the workspace-level statement and the historical "rejected backend"
+  rationale.

--- a/crates/api-websocket/docs/specs/websocket-request-schema-v1.md
+++ b/crates/api-websocket/docs/specs/websocket-request-schema-v1.md
@@ -1,5 +1,8 @@
 # WebSocket Request Schema v1
 
+> Source of truth: `crates/api-testing-core/src/websocket/schema.rs`
+> (`parse_websocket_request_json` and friends).
+
 ## Scope
 
 This schema defines deterministic, file-based WebSocket request execution used by:
@@ -10,31 +13,43 @@ This schema defines deterministic, file-based WebSocket request execution used b
 
 ## Top-level object
 
-A request file must be a JSON object.
+A request file must be a JSON object. File extension is conventionally `*.ws.json` or
+`*.websocket.json`, but the schema parser does not enforce the suffix.
 
 Supported top-level fields:
 
-- `url` (string, optional): explicit WebSocket target.
-- `headers` (object, optional): handshake headers.
-- `connectTimeoutSeconds` (integer/string, optional): reserved timeout input (accepted for contract parity).
-- `steps` (array, required): ordered scripted session steps.
-- `expect` (object, optional): assertion against the last received message.
+- `url` (string, optional): explicit WebSocket target. CLI flags (`--url`/`--env`) take
+  precedence; the runner errors if neither the request file nor the CLI provides a URL.
+- `headers` (object, optional): handshake headers. Values must be scalar (string,
+  number, boolean, or null); empty values are dropped. Keys are inserted into the
+  client request as-is.
+- `connectTimeoutSeconds` (integer or numeric string, optional): handshake-timeout
+  hint. Currently parsed for contract parity but not enforced by the in-process
+  `tungstenite` runner; see "Drift / known gaps" below.
+- `steps` (array, required, non-empty): ordered scripted session steps.
+- `expect` (object, optional): assertion against the last received message
+  (see "Expect object" below).
+
+Unknown top-level fields are accepted and ignored.
 
 ## Step schema
 
-Each `steps[i]` must include `type`.
+Each `steps[i]` must be a JSON object that includes `type` (case-insensitive after trim).
 
 ### `type: "send"`
 
-- `text` or `json` or `payload` (required)
-- payload is serialized to text before send.
+- Payload field (one of, in resolution order): `text`, `json`, `payload`. At least one
+  must be present.
+- The chosen value is coerced to a text frame:
+  - JSON strings are sent as-is;
+  - JSON objects, arrays, numbers, booleans, and `null` are JSON-stringified before send.
 
 ### `type: "receive"`
 
-- `timeoutSeconds` (optional)
-- `expect` (optional):
-  - `textContains` (string)
-  - `jq` (string, evaluated against JSON-parsed receive text)
+- `timeoutSeconds` (integer or numeric string, optional): per-receive timeout hint.
+  Currently parsed for contract parity but not enforced by the in-process runner;
+  the underlying `tungstenite::WebSocket::read` call blocks until the next message.
+- `expect` (optional): see "Expect object" below.
 
 ### `type: "close"`
 
@@ -44,13 +59,33 @@ Each `steps[i]` must include `type`.
 
 Top-level or step-level `expect` supports:
 
-- `textContains`: substring match
-- `jq`: jq expression evaluated against JSON message text
+- `textContains` (string): substring match against the received text. The shorter key
+  `contains` is also accepted as an alias.
+- `jq` (string): jq expression evaluated against the JSON-parsed receive text.
 
 Validation behavior:
 
-- if both are omitted/empty, expect is ignored.
-- jq assertions fail when receive text is not valid JSON.
+- if both are omitted/empty/whitespace-only, the expect block is ignored;
+- the top-level `expect` is evaluated against the most recent received message
+  (`last_received`); if no `receive` step ran, it is evaluated against an empty string;
+- jq assertions fail when the receive text is not valid JSON.
+
+## Frame handling
+
+- Text frames pass through verbatim.
+- Binary frames are decoded as lossy UTF-8 before assertion.
+- Control frames render as placeholders for transcript and assertion purposes:
+  `<PING:<payload>>`, `<PONG:<payload>>`, `<CLOSE:<code>:<reason>>`, `<FRAME>` for
+  raw frames. There are no schema options for selectively suppressing these frames;
+  scripted `receive` steps observe whichever message arrives next.
+
+## Drift / known gaps
+
+`connectTimeoutSeconds` and per-step `timeoutSeconds` are accepted by the schema
+parser but the current in-process runner ignores both values
+(`crates/api-testing-core/src/websocket/runner.rs` discards them via `let _ = …`).
+Documenting this honestly so request files written today remain forward-compatible
+once the runner wires the timeouts through.
 
 ## Error behavior
 


### PR DESCRIPTION
## Summary

Sprint 3 of the workspace doc audit. Reconciles the 6 `api-*` crate doc surfaces so the suite-level description in `api-test/README.md` matches each backend runner's contract and the shared-core spec.

- **`api-testing-core`** (Task 3.1): "Public modules" section now mirrors `src/lib.rs` re-exports 1:1 (21 modules, alphabetised); `http::execute_request` flagged as currently `unimplemented`; suite description corrected to cover all four case types.
- **`api-rest`** (Task 3.2): added missing `completion` subcommand; documented `--config-dir` common option; corrected `report` `--run` / `--response` mutual exclusivity; added explicit positional arguments + short flag aliases.
- **`api-gql`** (Task 3.3): added "Schema resolution" section listing the `--file` -> `GQL_SCHEMA_FILE` -> `schema.env`/`schema.local.env` -> filename-fallback precedence; documented JSON variables file model and `GQL_VARS_MIN_LIMIT` (default `5`); added `completion` subcommand and `--list-envs`.
- **`api-grpc`** (Task 3.4): added request-file contract table sourced from `api-testing-core::grpc::schema` (covers `method/body/metadata/proto/importPaths/plaintext/authority/timeoutSeconds/expect.{status,jq}`); documented `GRPCURL_BIN` override and cross-linked root `BINARY_DEPENDENCIES.md`.
- **`api-websocket`** (Task 3.5): README + 2 specs reconciled against the in-process `tungstenite` runner — `websocat` only as historical rejected backend; `call` success transcript shape (`direction`, `payload`) explicit; `expect.textContains` documented with `contains` short-key alias; **honest "Drift / known gaps" section** flags that `connectTimeoutSeconds` and step `timeoutSeconds` are parsed-but-unenforced (`runner.rs:88-90, 110` use `let _ = …`).
- **`api-test`** (Task 3.6): rewrote suite-orchestrator README to enumerate `run`/`summary`/`completion` subcommands, mutually-exclusive `--fail-fast` vs `--continue`, the 5-row `type` -> backend dispatch table (`rest`/`rest-flow`/`graphql`/`grpc`/`websocket` plus `ws`/`rest_flow` aliases), JUnit XML element/attribute shape, suite-results JSON envelope, exit code mapping (`SuiteRunResults::exit_code`), and `API_TEST_*` env var matrix; populated `docs/README.md` cross-reference index.

## Code drift findings (deferred — not patched in this PR)

- `crates/api-testing-core/src/http.rs::execute_request` is `unimplemented`. Either delete the module or open a tracking issue.
- `connectTimeoutSeconds` and step `timeoutSeconds` in `crates/api-testing-core/src/websocket/runner.rs:88-90, 110` are parsed but discarded with `let _ = …`. Spec section "Drift / known gaps" honestly flags this; needs a code follow-up to either enforce or remove.
- `SuiteCase.token_jq` / `default_rest_flow_token_jq` candidate selectors diverge between `runner/context.rs` and `schema.rs::default_auth_token_jq` (the latter includes `.jwt?`). README uses neutral wording rather than locking in either form; needs a code reconcile.

## Test plan

- [x] `cargo run -p nils-api-rest -- --help` — output matches README usage block
- [x] `cargo run -p nils-api-gql -- --help` — output matches README usage block
- [x] `cargo run -p nils-api-grpc -- --help` — output matches README usage block
- [x] `cargo run -p nils-api-websocket -- --help` — output matches README usage block
- [x] `cargo run -p nils-api-test -- --help` — output matches README usage block
- [x] `cargo doc -p nils-api-testing-core --no-deps` — clean (no warnings)
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` — PASS (87 files, 0 issues)
- [x] `bash scripts/ci/docs-placement-audit.sh --strict` — PASS
- [x] `bash scripts/ci/docs-hygiene-audit.sh --strict` — PASS
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)