### PR TITLE
docs(automation): align macos-agent, fzf-cli, memo-cli, image-processing, screen-record

### DIFF
--- a/crates/fzf-cli/README.md
+++ b/crates/fzf-cli/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 fzf-cli is a Rust CLI that provides interactive pickers for files, Git metadata, processes, ports,
-and shell definitions, all powered by `fzf`.
+shell history, and shell definitions, all powered by `fzf`.
 
 ## Usage
 
@@ -12,46 +12,51 @@ Usage:
   fzf-cli <command> [args]
 
 Commands:
-  file         Search and preview files
-  directory    Browse directories and pick files
-  git-status   Interactive git status viewer
-  git-commit   Browse commits and open changed files
-  git-checkout Pick and checkout a previous commit
-  git-branch   Browse and checkout branches
-  git-tag      Browse and checkout tags
-  process      Browse and kill running processes
-  port         Browse listening ports and owners
-  history      Search command history
-  env          Browse environment variables
-  alias        Browse shell aliases
-  function     Browse shell functions
-  def          Browse env, alias, and function definitions
-  help         Display help message
+  file              Search and preview text files
+  directory         Search directories and cd into selection
+  git-status        Interactive git status viewer
+  git-commit        Browse commits and open changed files in editor
+  git-checkout      Pick and checkout a previous commit
+  git-branch        Browse and checkout branches interactively
+  git-tag           Browse and checkout tags interactively
+  process           Browse and kill running processes (confirm before kill)
+  port              Browse listening ports and owners (confirm before kill)
+  history           Search and execute command history
+  env               Browse environment variables
+  alias             Browse shell aliases
+  function          Browse defined shell functions
+  def               Browse all definitions (env, alias, functions)
+  completion        Export shell completion script
 
 Help:
   fzf-cli help
   fzf-cli --help
+  fzf-cli <command> --help
 ```
 
 ## Commands
 
 ### file
 
-- `file [--vi|--vscode] [-- <query...>]`: Search files with preview and open the selection.
+- `file [--vi|--vscode] [-- <query...>]`: Search files (`bat` preview) and open the selection.
 
 ### directory
 
-- `directory [--vi|--vscode] [-- <query...>]`: Pick a directory, then pick a file to open. Use
-  `ctrl-d` to emit `cd <path>` to stdout.
+- `directory [--vi|--vscode] [-- <query...>]`: Pick a directory, then pick a file to open (`bat`
+  preview when available, falls back to `sed`). Use `ctrl-d` to emit `cd <path>` to stdout, `esc`
+  to step back to the directory picker.
 
 ### git-status
 
-- `git-status [query...]`: Interactive `git status -s` viewer with diff previews.
+- `git-status [query...]`: Interactive `git status -s` viewer with diff previews (`delta` when
+  available, falls back to `git diff`).
 
 ### git-commit
 
-- `git-commit [--snapshot] [query...]`: Browse commits and open changed files. `--snapshot` opens
-  file snapshots from the selected commit by default.
+- `git-commit [--snapshot] [query...]`: Browse commits, then pick changed files. Default action
+  opens the worktree files in the configured editor (capped by `OPEN_CHANGED_FILES_MAX_FILES`,
+  default `5`); `--snapshot` flips the default to opening file snapshots from the selected commit.
+  `ctrl-o` opens the highlighted file from the worktree regardless of `--snapshot`.
 
 ### git-checkout
 
@@ -67,15 +72,18 @@ Help:
 
 ### process
 
-- `process [-k|--kill] [-9|--force] [query...]`: Browse processes and optionally kill selected PIDs.
+- `process [-k|--kill] [-9|--force] [query...]`: Browse processes and optionally kill selected PIDs
+  (confirm before kill). `-9`/`--force` upgrades the signal to SIGKILL.
 
 ### port
 
-- `port [-k|--kill] [-9|--force] [query...]`: Browse listening ports and optionally kill owning PIDs.
+- `port [-k|--kill] [-9|--force] [query...]`: Browse listening ports and optionally kill owning
+  PIDs (confirm before kill). Uses `lsof` when available; falls back to `netstat` (no PID column
+  in the fallback view).
 
 ### history
 
-- `history [query...]`: Browse shell history and print the selected command to stdout.
+- `history [query...]`: Search shell history and print the selected command to stdout.
 
 ### env
 
@@ -93,12 +101,20 @@ Help:
 
 - `def [query...]`: Browse env, alias, and function definitions.
 
+### completion
+
+- `completion <bash|zsh>`: Print the shell completion script for the requested shell.
+
 ## Environment
 
 - `FZF_FILE_OPEN_WITH`: Default opener for `file`, `directory`, `git-commit` (`vi` or `vscode`).
 - `FZF_FILE_MAX_DEPTH`: Max directory depth for `file` and `directory` (default: `10`).
-- `FZF_PREVIEW_WINDOW`: Preview window layout for `directory` (default: `right:50%:wrap`).
-- `FZF_DEF_DELIM` and `FZF_DEF_DELIM_END`: Required delimiters for `env`, `alias`, `function`, `def`.
+- `FZF_PREVIEW_WINDOW`: Preview window layout for `directory` file picker (default:
+  `right:50%:wrap`).
+- `OPEN_CHANGED_FILES_MAX_FILES`: Max number of worktree files `git-commit` opens at once
+  (default: `5`).
+- `FZF_DEF_DELIM` and `FZF_DEF_DELIM_END`: Required delimiters for `env`, `alias`, `function`,
+  `def`.
 - `FZF_DEF_DOC_CACHE_ENABLED`: Enable definition doc caching.
 - `FZF_DEF_DOC_CACHE_EXPIRE_MINUTES`: Cache TTL in minutes (default: `10`).
 - `FZF_DEF_DOC_SEPARATOR_PAD`: Padding lines between definition docs (default: `2`).
@@ -107,8 +123,13 @@ Help:
 
 - `fzf` is required for all commands.
 - `git` is required for `git-*` commands.
-- `lsof` is optional for `port` (falls back to `netstat`).
-- `code` is required for `--vscode` (falls back to `vi`).
+- `bat` is required for the `file` preview and is the preferred `directory` preview (the
+  `directory` picker degrades to `sed` when `bat` is missing).
+- `lsof` is the preferred backend for `port`; `netstat` is the fallback when `lsof` is missing.
+- `code` is required for `--vscode` (and the `FZF_FILE_OPEN_WITH=vscode` default); the picker
+  falls back to `vi` if `code` is unavailable or fails.
+- See the workspace [`BINARY_DEPENDENCIES.md`](../../BINARY_DEPENDENCIES.md) for the canonical
+  external-tool matrix.
 
 ## Docs
 

--- a/crates/image-processing/README.md
+++ b/crates/image-processing/README.md
@@ -2,12 +2,14 @@
 
 ## Overview
 
-`image-processing` provides a focused conversion and validation flow:
+`image-processing` is a Rust CLI that provides two focused operations on a single input/output pair:
 
-- `svg-validate --in <svg> --out <svg>`
-- `convert --in <path> --to png|webp|jpg --out <file>`
+- `svg-validate --in <svg> --out <svg>`: sanitize an SVG against the policy contract.
+- `convert --in <path> --to png|webp|jpg --out <file>`: render an SVG or transcode a raster
+  (`png|jpg|jpeg|webp`) into `png`, `webp`, or `jpg`.
 
-`generate` is removed.
+The full sanitize policy (allowed/forbidden tags, attribute and `href` rules) lives in the
+[LLM SVG output contract](assets/llm-svg-output-contract.md) and is enforced by `svg-validate`.
 
 ## Usage
 
@@ -87,7 +89,12 @@ cargo run -p nils-image-processing -- convert \
 
 ## Dependencies
 
-- `convert --in` and `svg-validate`: no external binary dependency (Rust backend).
+- `convert` uses the `image` crate for raster decode/encode and `usvg`/`resvg` for SVG input.
+- `svg-validate` uses `roxmltree` for parsing and applies the policy contract in-process.
+- No external runtime binary is required for either subcommand.
+- See the workspace [`BINARY_DEPENDENCIES.md`](../../BINARY_DEPENDENCIES.md) for the canonical
+  external-tool matrix (the `image-processing` runtime policy section confirms the no-binary
+  contract).
 
 ## Docs
 

--- a/crates/image-processing/docs/runbooks/llm-svg-workflow.md
+++ b/crates/image-processing/docs/runbooks/llm-svg-workflow.md
@@ -2,13 +2,30 @@
 
 ## Purpose
 
-Use a provider-agnostic pipeline to turn user intent into policy-compliant SVG, then render with `image-processing convert --in`.
+Use a provider-agnostic pipeline to turn user intent into policy-compliant SVG, then render with
+`image-processing convert --in`. There is no built-in `generate` subcommand; the LLM step happens
+out-of-process so any provider (or hand-authored SVG) can feed the same validate-and-render flow.
 
 ## Contract
 
-- `generate` is removed.
 - `convert --in <path>` is the canonical SVG-to-raster flow.
 - `svg-validate` must gate LLM output before raster export.
+- Validation policy is defined in the
+  [LLM SVG output contract](../../assets/llm-svg-output-contract.md); the system prompt for the LLM
+  step lives in [`assets/llm-svg-system-prompt.md`](../../assets/llm-svg-system-prompt.md).
+
+## Prompt assets
+
+The pipeline script reads two assets from `crates/image-processing/assets/`:
+
+- [`llm-svg-system-prompt.md`](../../assets/llm-svg-system-prompt.md): rules that constrain the LLM
+  to a single, deterministic `<svg>` document.
+- [`llm-svg-output-contract.md`](../../assets/llm-svg-output-contract.md): the allowed tag set,
+  forbidden tags/attributes, `href` policy, and the failure/repair contract enforced by
+  `svg-validate`.
+
+These are runtime assets; treat them as the source of truth for what the LLM must produce and what
+`svg-validate` will accept.
 
 ## Quick start
 
@@ -40,28 +57,29 @@ cargo run -p nils-image-processing -- convert \
 
 ## Pipeline artifacts
 
-Given `--out-svg out/plan-llm/sun.svg`, the pipeline emits:
+Given `--out-svg out/plan-llm/traffic-car.svg`, the pipeline emits:
 
-- `out/plan-llm/sun.prompt.md`
-- `out/plan-llm/sun.raw.txt` (when `SVG_LLM_CMD` is used)
-- `out/plan-llm/sun.candidate.svg`
-- `out/plan-llm/sun.validate.json`
-- `out/plan-llm/sun.repair.prompt.md` (only on validation failure)
+- `out/plan-llm/traffic-car.prompt.md`
+- `out/plan-llm/traffic-car.raw.txt` (when `SVG_LLM_CMD` is used)
+- `out/plan-llm/traffic-car.candidate.svg`
+- `out/plan-llm/traffic-car.validate.json`
+- `out/plan-llm/traffic-car.repair.prompt.md` (only on validation failure)
 
 ## Repair loop
 
-If validation fails, re-run LLM with repair prompt:
+If validation fails, re-run the LLM with the emitted repair prompt:
 
 ```bash
-cat out/plan-llm/sun.repair.prompt.md
+cat out/plan-llm/traffic-car.repair.prompt.md
 ```
 
 Feed that prompt to your LLM provider, write the new candidate SVG, and run `svg-validate` again.
 
-## Migration note
+## Adopting the workflow
 
-Any previous `generate --preset ...` usage must migrate to:
+Any intent-to-icon flow that does not currently gate output through `svg-validate` should adopt the
+three-step pipeline:
 
 1. intent -> SVG (LLM or hand-authored),
-2. `svg-validate`,
-3. `convert --in`.
+2. `svg-validate` (block on diagnostics),
+3. `convert --in` (render to png/webp/jpg).

--- a/crates/macos-agent/README.md
+++ b/crates/macos-agent/README.md
@@ -67,7 +67,7 @@ macos-agent debug bundle --active-window --format json
   - `macos-agent apps list`
 - `window`
   - `macos-agent window activate (--window-id <id> | --active-window | --app <name>`
-    `[--window-title-contains <name>] | --bundle-id <bundle_id>) [--wait-ms <ms>]`
+    `[--window-title-contains <name>] | --bundle-id <bundle_id>) [--wait-ms <ms>] [--reopen-on-fail]`
 - `input`
   - `macos-agent input click --x <px> --y <px> [--button <left|right|middle>] [--count <n>] [--pre-wait-ms <ms>] [--post-wait-ms <ms>]`
   - `macos-agent input type --text <text> [--delay-ms <ms>] [--submit]`
@@ -119,6 +119,8 @@ macos-agent debug bundle --active-window --format json
 - `profile`
   - `macos-agent profile validate --file <profile.json>`
   - `macos-agent profile init [--name <profile-name>] [--path <output.json>]`
+- `completion`
+  - `macos-agent completion <bash|zsh|fish|powershell|elvish>` (prints shell completion script to `stdout`)
 
 ## Global Flags
 
@@ -199,6 +201,10 @@ Exit codes:
 - `1`: runtime failure
 - `2`: usage error
 
+Platform guard: `macos-agent` is macOS-only. On non-macOS hosts every subcommand short-circuits with exit code `2` and the
+message `error: macos-agent is only supported on macOS`. The deterministic test mode (`AGENTS_MACOS_AGENT_TEST_MODE=1`) bypasses
+this guard so CI-safe integration tests can run on Linux.
+
 Error envelope (`--error-format json`):
 
 ```json
@@ -216,22 +222,30 @@ Error envelope (`--error-format json`):
 
 ## Permission Matrix
 
-| Capability                | Required setup                                                                       | Typical failure symptom                | Mitigation                                                |
-| ------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------- | --------------------------------------------------------- |
-| Accessibility             | Terminal host allowed in **System Settings > Privacy & Security > Accessibility**    | click/type/hotkey fail                 | Enable the shell host app (Terminal/iTerm/etc.) and retry |
-| Automation (Apple Events) | Terminal host allowed in **System Settings > Privacy & Security > Automation**       | activation / System Events probe fails | Allow the terminal app to control System Events           |
-| Screen Recording          | Terminal host allowed in **System Settings > Privacy & Security > Screen Recording** | observe screenshot fails               | Enable Screen Recording for terminal host                 |
-| `cliclick` binary         | Installed and on `PATH`                                                              | preflight reports missing `cliclick`   | `brew install cliclick`                                   |
+| Capability                | Required setup                                                                       | Typical failure symptom                                           | Mitigation                                                                                   |
+| ------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Accessibility             | Terminal host allowed in **System Settings > Privacy & Security > Accessibility**    | click/type/hotkey fail                                            | Enable the shell host app (Terminal/iTerm/etc.) and retry                                    |
+| Automation (Apple Events) | Terminal host allowed in **System Settings > Privacy & Security > Automation**       | activation / System Events probe fails                            | Allow the terminal app to control System Events                                              |
+| Screen Recording          | Terminal host allowed in **System Settings > Privacy & Security > Screen Recording** | observe screenshot fails                                          | Enable Screen Recording for terminal host                                                    |
+| `osascript` binary        | Preinstalled on macOS; required for AppleScript backend + preflight probes           | preflight reports missing `osascript`                             | Reinstall macOS command-line tools if missing (`xcode-select --install`)                     |
+| `cliclick` binary         | Installed and on `PATH`                                                              | preflight reports missing `cliclick`                              | `brew install cliclick`                                                                      |
+| `hs` (Hammerspoon CLI)    | Required for Hammerspoon AX backend; install Hammerspoon and enable `hs.ipc`         | `ax attr/action/session/watch` fail with backend-unavailable hint | `brew install --cask hammerspoon`, then add `require('hs.ipc')` to `~/.hammerspoon/init.lua` |
+| `im-select` binary        | Required by `input-source current` and `input-source switch`                         | `input-source` commands fail with `missing dependency im-select`  | `brew install im-select`                                                                     |
+
+See the workspace [`BINARY_DEPENDENCIES.md`](../../BINARY_DEPENDENCIES.md) for the canonical install matrix (rows for `hs`, `cliclick`, `im-select`, and `osascript`).
 
 ## AX Backend Capability Matrix
 
-| Backend preference | `ax list/click/type`                                                             | `ax attr/action/session/watch` | Notes                                                                        |
-| ------------------ | -------------------------------------------------------------------------------- | ------------------------------ | ---------------------------------------------------------------------------- |
-| `auto` (default)   | Hammerspoon first, fallback to AppleScript (JXA) when Hammerspoon is unavailable | Hammerspoon-only               | Best default for resilience; fallback does not apply to extended AX commands |
-| `hammerspoon`      | Supported                                                                        | Supported                      | Full AX surface; requires `hs` CLI and `hs.ipc` enabled                      |
-| `applescript`      | Supported (JXA)                                                                  | Not supported directly         | Extended AX commands still depend on Hammerspoon runtime                     |
+| Backend preference    | `ax list/click/type`                                                                              | `ax attr/action/session/watch` | Notes                                                                                                         |
+| --------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `auto` (default)      | Hammerspoon `hs` first; falls back to AppleScript (JXA) only when the Hammerspoon path is missing | Hammerspoon-only               | Best default for resilience; fallback does not apply to extended AX commands and surfaces a "fallback" hint   |
+| `hammerspoon` / `hs`  | Hammerspoon-only (no JXA fallback)                                                                | Supported                      | Full AX surface; requires the `hs` CLI on `PATH` and `require('hs.ipc')` enabled in `~/.hammerspoon/init.lua` |
+| `applescript` / `jxa` | AppleScript (JXA via `osascript`) only                                                            | Not supported directly         | Extended AX commands still require Hammerspoon; selecting this preference does not avoid the dependency       |
 
-Preflight now emits an `ax_backend_capabilities` row so operators can verify backend mode and fallback expectations before failures.
+Preflight emits an `ax_backend_capabilities` row so operators can verify backend mode and fallback expectations before failures.
+The row carries the `AX backend preference=<auto|hammerspoon|applescript>` message; when the preference is anything other than
+`hammerspoon`, the row also adds a hint pointing operators back to `AGENTS_MACOS_AGENT_AX_BACKEND` and
+`preflight --include-probes`.
 
 ## Reliability Boundaries and Practices
 
@@ -248,8 +262,13 @@ stability:
   - `--timeout-ms 5000`
 - Use `wait app-active` / `wait window-present` before mutating actions.
 - Prefer `ax click/type` first, then opt in to fallback flags when app AX trees are unstable.
-- AX backend selection defaults to `auto` (Hammerspoon first, JXA fallback).
+- AX backend selection defaults to `auto` (Hammerspoon `hs` CLI first, AppleScript JXA fallback for `ax list/click/type`).
   - Override with `AGENTS_MACOS_AGENT_AX_BACKEND=hammerspoon|applescript|auto`.
+  - Aliases `hs` and `jxa` are also accepted (mapped to `hammerspoon` and `applescript` respectively).
+  - Extended AX commands (`attr`, `action`, `session`, `watch`) always require Hammerspoon; the `applescript` and `auto`
+    paths do not provide a JXA fallback for them.
+  - In deterministic test mode (`AGENTS_MACOS_AGENT_TEST_MODE=1`) without an explicit override, the resolver picks
+    `applescript` to keep the JXA stub deterministic.
 
 ## Command Decision Matrix (AX/Input/Wait/Fallback/Backend)
 

--- a/crates/memo-cli/docs/specs/memo-cli-release-policy.md
+++ b/crates/memo-cli/docs/specs/memo-cli-release-policy.md
@@ -20,7 +20,7 @@
 
 - Release order is controlled by `release/crates-io-publish-order.txt`.
 - `nils-memo-cli` must be listed in dependency-safe position:
-  - after shared dependencies it consumes (for MVP: `nils-common`, `nils-term`)
+  - after shared dependencies it consumes (for MVP: `nils-common`)
   - before any future crates that depend on `nils-memo-cli`
 
 ## Dry-run verification gate

--- a/crates/memo-cli/docs/specs/memo-cli-storage-schema-v1.md
+++ b/crates/memo-cli/docs/specs/memo-cli-storage-schema-v1.md
@@ -376,6 +376,12 @@ The SQL file must keep these object names unchanged:
   - `idx_item_tags_tag_id_derivation_id`
   - `idx_workflow_item_anchors_type_item`
 
+In addition, the runtime migration layer creates and maintains:
+
+- `schema_migrations(version, applied_at)`: bookkeeping table that records which
+  versions of `schema_v1.sql` have been applied; not part of the v1 data
+  schema and not queried by any command surface.
+
 ## Compatibility Policy
 
 - Post-consolidation builds initialize and maintain storage from

--- a/crates/screen-record/README.md
+++ b/crates/screen-record/README.md
@@ -3,9 +3,11 @@
 ## Overview
 
 screen-record is a macOS 12+ and Linux CLI that records a single window (or a full display)
-to a video file. On macOS it uses ScreenCaptureKit and AVFoundation; on Linux it relies on X11 for
-discovery and `ffmpeg` for capture/encoding. On Wayland-only sessions, it can use an interactive
-portal picker (`--portal`) via xdg-desktop-portal + PipeWire. It also exposes parseable
+to a video file. On macOS it uses ScreenCaptureKit (`SCShareableContent` for discovery,
+`SCStream` for capture) and AVFoundation (`AVAssetWriter` for mux/encoding). On Linux it relies on
+X11 (`x11rb`) for window/display discovery and `ffmpeg` for capture/encoding. On Wayland-only
+sessions, it can use an interactive portal picker (`--portal`) via xdg-desktop-portal
+(`org.freedesktop.portal.ScreenCast` over DBus) + PipeWire. It also exposes parseable
 window/app/display lists (X11) to make selection deterministic in scripts.
 
 ## Linux (X11 + Wayland portal)
@@ -22,6 +24,11 @@ Prerequisites:
   - xdg-desktop-portal + a desktop backend (e.g. `xdg-desktop-portal-gnome` or
     `xdg-desktop-portal-kde`)
   - a PipeWire session (Ubuntu default)
+- For `--audio system|mic|both`: `pactl` (PulseAudio compatibility) on `PATH`.
+
+See the workspace [`BINARY_DEPENDENCIES.md`](../../BINARY_DEPENDENCIES.md) for the canonical install
+matrix (rows for `ffmpeg`, `pactl`, `xdg-desktop-portal` + PipeWire, and the macOS `cwebp` WebP
+fallback).
 
 Selection parity:
 
@@ -79,8 +86,10 @@ screen-record --display --duration 3 --audio off --path "./recordings/display.mp
   error: ffmpeg not found on PATH. Install it with: sudo apt-get install ffmpeg
   ```
 
-- **Audio capture prerequisites (`--audio system|mic`)**: Linux audio capture uses PulseAudio
-  compatibility via `pactl`. On Ubuntu, install:
+- **Audio capture prerequisites (`--audio system|mic|both`)**: Linux audio capture uses PulseAudio
+  compatibility via `pactl`. `--audio mic` resolves the PulseAudio default source; `--audio system`
+  resolves the default sink and records its `.monitor` source; `--audio both` combines both inputs
+  and requires a `.mov` container. On Ubuntu, install:
 
   ```text
   sudo apt-get install pulseaudio-utils pipewire-pulse
@@ -114,7 +123,7 @@ screen-record [options]
 | `--app` | `<name>` | (none) | Select a window by app/owner name (case-insensitive substring). |
 | `--window-name` | `<name>` | (none) | Narrow `--app` selection by window title substring. |
 | `--active-window` | (none) | (none) | Record the frontmost window on the current Space. |
-| `--display` | (none) | (none) | Record the main display. |
+| `--display` | (none) | (none) | Record the primary display. |
 | `--display-id` | `<id>` | (none) | Record a specific display id. |
 | `--duration` | `<seconds>` | (required for recording) | Record for N seconds. |
 | `--audio` | `off\|system\|mic\|both` | `off` | Control audio capture. `both` requires `.mov`. |
@@ -251,9 +260,13 @@ Candidate rows are identical to `--list-windows` TSV output and are printed to s
 - Otherwise, `.png`, `.jpg`/`.jpeg`, or `.webp` is selected from the `--path` extension.
 - If `--path` has no extension (or `--path` is omitted), the format defaults to `.png`.
 - If `--image-format` conflicts with the `--path` extension, exit 2 with a usage error.
-- Note: WebP encoding is best-effort. `screen-record` tries macOS ImageIO first, then falls back to
-  `cwebp` (install: `brew install webp`). If no encoder is available, `--image-format webp` fails
-  with exit 1.
+- Note: WebP encoding on macOS is best-effort with a two-stage fallback chain:
+  1. macOS ImageIO (`CGImageDestination` with the `org.webmproject.webp` UTI). Available when the
+     installed macOS bundles a WebP encoder for ImageIO.
+  2. `cwebp` (`brew install webp`). The capture is encoded as a temporary PNG via ImageIO, then
+     piped through `cwebp -lossless` to produce the final `.webp`.
+  If neither stage succeeds (no ImageIO WebP encoder and `cwebp` is missing or fails),
+  `--image-format webp` exits with code 1. Use `--image-format png|jpg` as a workaround.
 
 ## Diff-aware screenshot capture (`--if-changed`)
 


### PR DESCRIPTION
## Summary

Sprint 5 of the workspace doc audit. Reconciles the 5 automation/utility crate doc surfaces — `macos-agent` and `screen-record` are the largest READMEs in this group (~387/397 lines), `memo-cli` carries the largest doc-tree (1 README + 1 runbook + 5 specs).

- **`macos-agent`** (Task 5.1): added missing `window activate --reopen-on-fail` and `completion` subcommand; clarified AX backend resolution prose so extended AX commands are Hammerspoon-only on every preference (including `auto`); rewrote `auto` row in Backend Capability Matrix to match `AutoAxBackend` fallback (only `list/click/type` fall back); added Permission Matrix rows for `osascript`, `hs`, `im-select`; documented macOS-only platform guard (`run.rs::ensure_supported_platform`, exit code `2`, bypassed by `AGENTS_MACOS_AGENT_TEST_MODE=1`); cross-linked root `BINARY_DEPENDENCIES.md`.
- **`fzf-cli`** (Task 5.2): added `completion` command; aligned per-mode preview-tool fallback prose (`file` is `bat` only; `directory` has `bat → sed`; `git-status` has `delta → git diff`; `port` has `lsof → netstat` no-PID-column; `--vscode` falls back to `vi` when `code` is missing); documented `git-commit` worktree/snapshot key bindings (`ctrl-o` worktree, `ctrl-d` cd) and `OPEN_CHANGED_FILES_MAX_FILES` env (default `5`).
- **`memo-cli`** (Task 5.3): release policy drops `nils-term` from MVP shared deps (`Cargo.toml` only depends on `nils-common`); storage schema spec adds note that runtime-managed `schema_migrations` bookkeeping table created by `src/storage/migrate.rs` is not part of v1 data schema. Verified the rest of the 8-doc set against `--help`, JSON envelopes (`memo-cli.<cmd>.v1`), on-disk schema (`schema_v1.sql`), and `Cargo.toml::version = "0.7.2"` — all clean.
- **`image-processing`** (Task 5.4): replaced orphan "`generate` is removed" line with positive description + sanitize-policy pointer; expanded Dependencies block to name the Rust crates (`image`, `usvg`/`resvg`, `roxmltree`) and link `BINARY_DEPENDENCIES.md` §1.1; runbook now links the runtime prompt assets (`llm-svg-system-prompt.md`, `llm-svg-output-contract.md`) and uses forward-looking "Adopting the workflow" framing.
- **`screen-record`** (Task 5.5): added load-bearing macOS frameworks (`SCShareableContent`, `SCStream`, `AVAssetWriter`) and Linux portal interface (`org.freedesktop.portal.ScreenCast` over DBus); documented the actual 2-stage WebP fallback (ImageIO `org.webmproject.webp` UTI → temp PNG via ImageIO + `cwebp -lossless`); added `--audio both` and `pactl` discovery prose; aligned `--display` description (primary, not main); cross-linked `BINARY_DEPENDENCIES.md`.

## Test plan

- [x] `cargo run -p nils-macos-agent -- --help` (+ subcommands) — output matches README content (validated on macOS Darwin 25.4.0)
- [x] `cargo run -p nils-fzf-cli -- --help` — matches README
- [x] `cargo run -p nils-memo-cli -- --help` + `list --help` + `list/fetch/search/report --json` envelope spot-check — matches spec
- [x] `cargo run -p nils-image-processing -- --help` — exposes only `convert` + `svg-validate`
- [x] `cargo run -p nils-screen-record -- --help` — flag set matches README (validated on macOS; Linux paths reviewed via source only)
- [x] `cargo doc -p nils-macos-agent --no-deps` — clean
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` — PASS (87 files, 0 issues)
- [x] `bash scripts/ci/docs-placement-audit.sh --strict` — PASS
- [x] `bash scripts/ci/docs-hygiene-audit.sh --strict` — PASS
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)