### PR TITLE
docs(provider): align agent-docs, codex-cli, gemini-cli, semantic-commit

### DIFF
--- a/crates/agent-docs/README.md
+++ b/crates/agent-docs/README.md
@@ -72,7 +72,7 @@ Path resolution is deterministic and applies to all commands.
 
 ```text
 Usage:
-  agent-docs <command> [options]
+  agent-docs [OPTIONS] <command> [options]
 
 Commands:
   resolve            Resolve required docs for a context
@@ -81,9 +81,25 @@ Commands:
   scaffold-agents    Scaffold default AGENTS.md template
   baseline           Check baseline doc coverage
   scaffold-baseline  Scaffold missing baseline docs
+  completion         Print shell completion script (bash, zsh)
 ```
 
 Use `agent-docs --help` (or `agent-docs <command> --help`) for CLI help text.
+
+### Top-level options
+
+These options sit before the subcommand and apply to every command:
+
+- `--agent-home <path>` — override `AGENT_HOME` root path
+- `--project-path <path>` — override project root path
+- `--worktree-fallback <auto|local-only>` (default: `auto`) — `auto` enables
+  linked-worktree fallback to the primary worktree; `local-only` disables fallback
+  and enforces local project files only
+- `-h`, `--help` — print help
+- `-V`, `--version` — print version
+
+For convenience, the same `--agent-home`, `--project-path`, and
+`--worktree-fallback` flags are also accepted positionally on each subcommand.
 
 ## Commands and Flags
 
@@ -184,10 +200,10 @@ Audit minimum baseline documents.
 
 Flags:
 
-- `--check` (required in Sprint contract)
+- `--check` (run baseline check mode; required to produce a baseline report)
 - `--target home|project|all` (default: `all`)
 - `--format text|json` (default: `text`)
-- `--strict` (missing required docs become exit code `1`)
+- `--strict` (missing required baseline docs become exit code `1`)
 - `--agent-home <path>`
 - `--project-path <path>`
 
@@ -204,6 +220,21 @@ Flags:
 - `--format text|json` (default: `text`)
 - `--agent-home <path>`
 - `--project-path <path>`
+
+### `completion`
+
+Print a shell completion script to stdout. Pipe the output into your shell's
+completion loader.
+
+Usage:
+
+```bash
+agent-docs completion <bash|zsh>
+```
+
+Arguments:
+
+- `<SHELL>` — one of `bash`, `zsh`
 
 ## Exit Codes
 
@@ -288,6 +319,9 @@ summary: required_total=2 present_required=2 missing_required=0 strict=false
   "strict": false,
   "agent_home": "/Users/example/.agents",
   "project_path": "/Users/example/work/nils-cli",
+  "is_linked_worktree": false,
+  "git_common_dir": null,
+  "primary_worktree_path": null,
   "documents": [
     {
       "context": "startup",
@@ -315,6 +349,10 @@ summary: required_total=2 present_required=2 missing_required=0 strict=false
   }
 }
 ```
+
+The `is_linked_worktree`, `git_common_dir`, and `primary_worktree_path` fields are
+emitted on every `resolve --format json` invocation. They are populated only when
+the project root is a linked Git worktree (see "Worktree fallback").
 
 ### `resolve` checklist example
 

--- a/crates/codex-cli/README.md
+++ b/crates/codex-cli/README.md
@@ -12,13 +12,15 @@ for common primitives.
 Usage:
   codex-cli <group> <command> [args]
   codex-cli prompt-segment [options]
+  codex-cli completion <shell>
 
 Groups:
-  agent    prompt | advice | knowledge | commit
-  auth     login | use | save | remove | refresh | auto-refresh | current | sync
-  diag     rate-limits
-  config   show | set
-  prompt-segment (options)
+  agent           prompt | advice | knowledge | commit
+  auth            login | use | save | remove | refresh | auto-refresh | current | sync
+  diag            rate-limits
+  config          show | set
+  prompt-segment  (options)
+  completion      bash | zsh
 
 Help:
   codex-cli help
@@ -75,10 +77,11 @@ Auth examples:
 
 ### diag
 
-- `rate-limits [options] [secret.json]`: Rate-limit diagnostics. Options: `-c/--clear-cache`, `-d/--debug`, `--cached`, `--no-refresh-auth`,
-  `--json`, `--one-line`, `--all`, `--async`, `--jobs <n>`.
+- `rate-limits [options] [secret.json]`: Rate-limit diagnostics. Options: `-c/--clear-cache`, `-d/--debug`, `--cached`,
+  `--no-refresh-auth`, `--format <text|json>`, `--json`, `--one-line`, `--all`, `--async`, `--watch`, `--jobs <n>`.
 - `--cached` reads cache only. Freshness is controlled by `CODEX_RATE_LIMITS_CACHE_TTL` (default `3m`); stale cache is rejected unless
   `CODEX_RATE_LIMITS_CACHE_ALLOW_STALE=true`.
+- `--watch` refreshes output every 60 seconds until interrupted and requires `--async`.
 
 ### config
 
@@ -89,6 +92,10 @@ Auth examples:
 
 - `prompt-segment [--no-5h] [--ttl <duration>] [--time-format <strftime>] [--show-timezone] [--refresh] [--is-enabled]`: Render or refresh
   the prompt segment. Default reset time uses local time without timezone; `--show-timezone` adds the local offset.
+
+### completion
+
+- `completion <bash|zsh>`: Print the shell completion script for the requested shell to stdout.
 
 ## JSON contract (service consumers)
 

--- a/crates/gemini-cli/README.md
+++ b/crates/gemini-cli/README.md
@@ -107,6 +107,12 @@ Auth examples:
 - `GEMINI_SECRET_CACHE_DIR` controls secret cache timestamps.
 - `GEMINI_PROMPT_SEGMENT_ENABLED=true` enables prompt-segment output.
 - `GEMINI_PROMPT_SEGMENT_TTL` overrides the prompt-segment cache TTL.
+- `GEMINI_PROMPT_SEGMENT_REFRESH_MIN_SECONDS` (default `30`) throttles background-refresh attempts; see
+  parity contract for invariants.
+- `GEMINI_PROMPT_SEGMENT_LOCK_STALE_SECONDS` (default `90`) controls stale-lock recovery for
+  background refresh.
+- `GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED=true` makes `diag rate-limits` default to `--all` when no
+  positional secret is supplied.
 - `GEMINI_AUTO_REFRESH_ENABLED` and `GEMINI_AUTO_REFRESH_MIN_DAYS` configure auth auto-refresh behavior.
 
 ## Dependencies

--- a/crates/gemini-cli/docs/runbooks/json-consumers.md
+++ b/crates/gemini-cli/docs/runbooks/json-consumers.md
@@ -23,9 +23,12 @@ Gemini-specific contract source:
 ## Gemini-specific integration notes
 
 - `auth login` stable method values:
-  - `chatgpt-browser`
-  - `chatgpt-device-code`
+  - `gemini-browser`
+  - `gemini-device-code`
   - `api-key`
+- `auth login` stable provider values:
+  - `gemini` (browser / device-code)
+  - `gemini-api` (api-key)
 - `auth save` overwrite confirmation failure code:
   - `overwrite-confirmation-required`
 - `auth remove` confirmation failure code:
@@ -34,6 +37,8 @@ Gemini-specific contract source:
   - `secret-dir-not-configured`
   - `secret-dir-not-found`
   - `secret-dir-read-failed`
+- `auth current` no-match failure code:
+  - `secret-not-matched`
 
 ## Consumer checklist
 

--- a/crates/gemini-cli/docs/specs/gemini-cli-diag-auth-json-contract-v1.md
+++ b/crates/gemini-cli/docs/specs/gemini-cli-diag-auth-json-contract-v1.md
@@ -88,8 +88,8 @@ Stable (safe for strict parsing):
     `summary.weekly_remaining`, `summary.weekly_reset_at_epoch`,
     `summary.non_weekly_reset_at_epoch`
 - Auth:
-  - `auth login`: `method` (`chatgpt-browser|chatgpt-device-code|api-key`),
-    `provider` (`chatgpt|openai-api`), `completed`
+  - `auth login`: `method` (`gemini-browser|gemini-device-code|api-key`),
+    `provider` (`gemini|gemini-api`), `completed`
   - `auth use`: `target`, `matched_secret`, `applied`, `auth_file`
   - `auth save`: `auth_file`, `target_file`, `saved`, `overwritten`
     (`true` when an existing target file is replaced)
@@ -189,10 +189,10 @@ Informational (do not hard-depend for schema validation):
   "command": "diag rate-limits",
   "ok": false,
   "error": {
-    "code": "invalid-arguments",
-    "message": "--one-line is not compatible with --json",
+    "code": "invalid-flag-combination",
+    "message": "gemini-rate-limits: --one-line is not compatible with --json",
     "details": {
-      "flag": "--one-line"
+      "flags": ["--one-line", "--json"]
     }
   }
 }
@@ -222,8 +222,8 @@ Informational (do not hard-depend for schema validation):
   "command": "auth login",
   "ok": true,
   "result": {
-    "method": "chatgpt-device-code",
-    "provider": "chatgpt",
+    "method": "gemini-device-code",
+    "provider": "gemini",
     "completed": true
   }
 }
@@ -233,9 +233,9 @@ Informational (do not hard-depend for schema validation):
 
 | CLI invocation | `result.method` | `result.provider` |
 | --- | --- | --- |
-| `auth login` | `chatgpt-browser` | `chatgpt` |
-| `auth login --device-code` | `chatgpt-device-code` | `chatgpt` |
-| `auth login --api-key` | `api-key` | `openai-api` |
+| `auth login` | `gemini-browser` | `gemini` |
+| `auth login --device-code` | `gemini-device-code` | `gemini` |
+| `auth login --api-key` | `api-key` | `gemini-api` |
 
 ### auth save (success)
 
@@ -343,6 +343,60 @@ Informational (do not hard-depend for schema validation):
         "status": "failed",
         "reason": "token-endpoint-failed"
       }
+    ]
+  }
+}
+```
+
+### auth current (failure: secret-not-matched)
+
+```json
+{
+  "schema_version": "gemini-cli.auth.v1",
+  "command": "auth current",
+  "ok": false,
+  "error": {
+    "code": "secret-not-matched",
+    "message": "/home/user/.gemini/oauth_creds.json does not match any known secret",
+    "details": {
+      "auth_file": "/home/user/.gemini/oauth_creds.json",
+      "matched": false
+    }
+  }
+}
+```
+
+### auth current (failure: secret-dir-not-found)
+
+```json
+{
+  "schema_version": "gemini-cli.auth.v1",
+  "command": "auth current",
+  "ok": false,
+  "error": {
+    "code": "secret-dir-not-found",
+    "message": "/home/user/.gemini/secrets not found",
+    "details": {
+      "secret_dir": "/home/user/.gemini/secrets"
+    }
+  }
+}
+```
+
+### auth sync (success)
+
+```json
+{
+  "schema_version": "gemini-cli.auth.v1",
+  "command": "auth sync",
+  "ok": true,
+  "result": {
+    "auth_file": "/home/user/.gemini/oauth_creds.json",
+    "synced": 1,
+    "skipped": 3,
+    "failed": 0,
+    "updated_files": [
+      "/home/user/.gemini/secrets/alpha.json"
     ]
   }
 }

--- a/crates/semantic-commit/README.md
+++ b/crates/semantic-commit/README.md
@@ -8,46 +8,73 @@ change context for message generation.
 ## Usage
 
 ```text
-Usage:
-  semantic-commit <command> [args]
+Usage: semantic-commit <command> [args]
 
 Commands:
-  staged-context  Print staged change context for commit message generation
-  commit          Commit staged changes with a prepared commit message
-  help            Display help message
-
-Help:
-  semantic-commit help
-  semantic-commit --help
+  staged-context    Print staged change context for commit message generation
+  commit            Commit staged changes with a prepared commit message
+  completion        Export shell completion script
+  help              Display help message
 ```
 
-## Commands
+Use `semantic-commit --help` (or `semantic-commit <command> --help`) for CLI help text.
 
-### staged-context
+### Top-level options
 
-- `staged-context [--format <bundle|json|patch>] [--json] [--repo <path>]`
-- Output formats:
-  - `bundle` (default): `commit-context.json` + `staged.patch`
-  - `json`: only `commit-context.json`
-  - `patch`: only `staged.patch`
-- `--repo <path>` runs against a repository path without changing shell cwd.
+- `-h`, `--help` — print help
+- `-V`, `--version` — print version
 
-### commit
+## Commands and Flags
 
-- `commit [options]`
-- Message sources:
-  - `-m, --message <text>`
-  - `-F, --message-file <path>`
-  - stdin (disabled with `--automation`)
-- Useful options:
-  - `--summary <git-scope|git-show|none>` (default: `git-scope` with fallback to `git-show`)
-  - `--no-summary`
-  - `--validate-only`
-  - `--dry-run`
-  - `--message-out <path>`
-  - `--repo <path>`
-  - `--no-progress`
-  - `--quiet`
+### `staged-context`
+
+Print staged change context for commit message generation.
+
+Flags:
+
+- `--format <bundle|json|patch>` (default: `bundle`)
+- `--json` — equivalent to `--format json`
+- `--repo <path>` — run git commands against the repository path
+
+Output formats:
+
+- `bundle` (default): emits both `commit-context.json` and `staged.patch` to
+  stdout, separated by `===== commit-context.json =====` and
+  `===== staged.patch =====` banners.
+- `json`: emits the `commit-context.json` payload only.
+- `patch`: emits the `git diff --cached` patch only.
+
+### `commit`
+
+Commit staged changes with a prepared commit message.
+
+Message sources (mutually exclusive):
+
+- `-m`, `--message <text>` — inline commit message
+- `-F`, `--message-file <path>` — read commit message from file
+- stdin — used when no message flag is supplied and stdin is non-TTY;
+  disabled by `--automation` / `--non-interactive`
+
+Flags:
+
+- `--message-out <path>` — write the resolved commit message to a file for recovery
+- `--summary <git-scope|git-show|none>` (default: `git-scope` with fallback to `git-show`)
+- `--no-summary` — equivalent to `--summary none`
+- `--repo <path>` — run git commands against the repository path
+- `--automation` (alias: `--non-interactive`) — disallow stdin message fallback
+- `--validate-only` — validate the commit message format and exit without committing
+- `--dry-run` — run validation and staged-change checks, then skip `git commit`
+- `--no-progress` — disable the progress spinner
+- `--quiet` — suppress progress and summary output (implies `--no-progress` and `--no-summary`)
+
+### `completion`
+
+Print a shell completion script to stdout. Pipe the output into your shell's
+completion loader.
+
+```text
+semantic-commit completion <bash|zsh>
+```
 
 ## Commit Message Validation
 


### PR DESCRIPTION
## Summary

Sprint 6 of the workspace doc audit. Reconciles the 4 agent/provider crate doc surfaces. `agent-docs`, `codex-cli`, and `gemini-cli` carry the largest doc surface in the workspace; gemini-cli also gets a parity sweep against the contract Sprint 1 Task 1.3 reconciled.

- **`agent-docs`** (Task 6.1): surfaces the three top-level options (`--agent-home`, `--project-path`, `--worktree-fallback`) as a dedicated section instead of inline-only examples; adds `completion <bash|zsh>` to the command surface; restores three missing fields in the `resolve --format json` example (`is_linked_worktree`, `git_common_dir`, `primary_worktree_path`); rewords `baseline --check`/`--strict` semantics for unambiguous behavior. Verified `--context` values (`startup`/`skill-dev`/`task-tools`/`project-dev`) match `agent-docs contexts --format text` exactly.
- **`codex-cli`** (Task 6.2): adds the missing `completion bash | zsh` group; documents previously-undocumented `diag rate-limits --format <text|json>` and `--watch` flags. Verified auth backend names match `auth login --help` (`chatgpt-browser`/`chatgpt-device-code`/`api-key`); agent flow steps (`prompt`/`advice`/`knowledge`/`commit` + `--ephemeral`) match source.
- **`gemini-cli`** (Task 6.3): mirrored parity fix — corrected `auth login` method values from the wrong (codex-templated) `chatgpt-browser`/`chatgpt-device-code` to the actual `gemini-browser`/`gemini-device-code`/`api-key`; corrected provider values from `chatgpt`/`openai-api` to `gemini`/`gemini-api` (`crates/gemini-cli/src/auth/login.rs:619-621, 1048-1050`); README env section adds missing `GEMINI_RATE_LIMITS_DEFAULT_ALL_ENABLED`, `GEMINI_PROMPT_SEGMENT_REFRESH_MIN_SECONDS`, `GEMINI_PROMPT_SEGMENT_LOCK_STALE_SECONDS`; runbook + spec corrected `diag rate-limits` failure example (`invalid-flag-combination`, `details.flags` array); added `auth current` failure code (`secret-not-matched`) and `auth sync` examples for parity with codex-cli spec.
- **`semantic-commit`** (Task 6.4): adds `completion`; documents the `staged-context bundle` separator format (`===== commit-context.json =====` / `===== staged.patch =====`); surfaces `commit --non-interactive` alias and `--quiet` forced implications for `--no-progress`/`--no-summary`.

## Code drift findings (deferred — not patched in this PR)

- Spec filename `crates/{codex,gemini}-cli/docs/specs/*-diag-auth-json-contract-v1.md` is a misnomer — it covers `diag rate-limits` + `auth *` group, not a non-existent `diag auth` subcommand. Renaming would touch retention-matrix tracking and is more naturally handled in Sprint 7.
- `crates/agent-docs contexts` does not support `--format checklist` (only `text|json`), even though the project-wide `agent-docs resolve --format checklist` does. Either a missing format or intentional asymmetry; needs source clarification.

## Test plan

- [x] `cargo run -p nils-agent-docs -- --help` (+ resolve/contexts/add/baseline) — output matches README content
- [x] `cargo run -p nils-codex-cli -- --help` + `diag --help` — matches README
- [x] `cargo run -p nils-gemini-cli -- --help` + `diag --help` — matches README; provider/method names verified against `src/auth/login.rs`
- [x] `cargo run -p nils-semantic-commit -- --help` — output mirrored verbatim
- [x] `bash scripts/ci/markdownlint-audit.sh --strict` — PASS (87 files, 0 issues)
- [x] `bash scripts/ci/docs-placement-audit.sh --strict` — PASS
- [x] `bash scripts/ci/docs-hygiene-audit.sh --strict` — PASS
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)