### PR TITLE
fix(git-cli): align user-facing strings with current binary names

### DIFF
--- a/crates/git-cli/src/clipboard.rs
+++ b/crates/git-cli/src/clipboard.rs
@@ -11,7 +11,7 @@ const CLIPBOARD_TOOL_ORDER: [ClipboardTool; 4] = [
 
 pub fn set_clipboard_best_effort(text: &str) -> Result<()> {
     if env::var("GIT_CLI_FIXTURE_CLIPBOARD_MODE").ok().as_deref() == Some("missing") {
-        eprintln!("⚠️  No clipboard tool found (requires pbcopy, xclip, or xsel)");
+        eprintln!("⚠️  No clipboard tool found (requires pbcopy, wl-copy, xclip, or xsel)");
         return Ok(());
     }
 
@@ -20,7 +20,7 @@ pub fn set_clipboard_best_effort(text: &str) -> Result<()> {
         copy_best_effort(text, &policy),
         ClipboardOutcome::SkippedNoTool | ClipboardOutcome::SkippedFailure
     ) {
-        eprintln!("⚠️  No clipboard tool found (requires pbcopy, xclip, or xsel)");
+        eprintln!("⚠️  No clipboard tool found (requires pbcopy, wl-copy, xclip, or xsel)");
     }
     Ok(())
 }

--- a/crates/git-cli/src/commit.rs
+++ b/crates/git-cli/src/commit.rs
@@ -187,11 +187,13 @@ fn parse_context_args(args: &[String]) -> ParseOutcome<ContextArgs> {
 }
 
 fn print_context_usage() {
-    println!("Usage: git-commit-context [--stdout|--both] [--no-color] [--include <path/glob>]");
-    println!("  --stdout   Print commit context to stdout only");
-    println!("  --both     Print to stdout and copy to clipboard");
-    println!("  --no-color Disable ANSI colors (also via NO_COLOR)");
-    println!("  --include  Show full content for selected paths (repeatable)");
+    println!(
+        "Usage: git-cli commit context [-p|--stdout|--both] [--no-color] [--include <path/glob>]"
+    );
+    println!("  -p, --stdout, --print   Print commit context to stdout only");
+    println!("  --both                  Print to stdout and copy to clipboard");
+    println!("  --no-color              Disable ANSI colors (also via NO_COLOR)");
+    println!("  --include               Show full content for selected paths (repeatable)");
 }
 
 fn git_scope_available() -> bool {

--- a/crates/git-cli/src/commit_json.rs
+++ b/crates/git-cli/src/commit_json.rs
@@ -197,7 +197,7 @@ fn parse_args(args: &[String]) -> ParseOutcome<ContextJsonArgs> {
 
 fn print_usage() {
     println!(
-        "Usage: git-commit-context-json [--stdout|--both] [--pretty] [--bundle] [--out-dir <path>]"
+        "Usage: git-cli commit context-json [--stdout|--both] [--pretty] [--bundle] [--out-dir <path>]"
     );
     println!("  --stdout    Print to stdout only (JSON by default; bundle with --bundle)");
     println!(

--- a/crates/git-cli/src/utils.rs
+++ b/crates/git-cli/src/utils.rs
@@ -66,7 +66,7 @@ fn copy_staged(args: &[String]) -> i32 {
 
     if let Some(arg) = unknown_arg {
         eprintln!("❗ Unknown argument: {arg}");
-        eprintln!("Usage: git-copy-staged [--stdout|--both]");
+        eprintln!("Usage: git-cli utils copy-staged [-p|--stdout|--both]");
         return 1;
     }
 
@@ -191,7 +191,7 @@ fn shell_escape(value: &str) -> String {
 
 fn print_copy_staged_help() {
     print!(
-        "Usage: git-copy-staged [--stdout|--both]\n  --stdout   Print staged diff to stdout (no status message)\n  --both     Print to stdout and copy to clipboard\n"
+        "Usage: git-cli utils copy-staged [-p|--stdout|--both]\n  -p, --stdout, --print   Print staged diff to stdout (no status message)\n  --both                  Print to stdout and copy to clipboard\n"
     );
 }
 

--- a/crates/git-cli/tests/integration/commit.rs
+++ b/crates/git-cli/tests/integration/commit.rs
@@ -187,7 +187,7 @@ fn commit_context_fixture_f031_missing_clipboard() {
     assert_stderr_contains_all(
         "F031",
         &stderr,
-        &["⚠️  No clipboard tool found (requires pbcopy, xclip, or xsel)"],
+        &["⚠️  No clipboard tool found (requires pbcopy, wl-copy, xclip, or xsel)"],
     );
     assert_stdout_contains_all(
         "F031",
@@ -304,7 +304,7 @@ fn commit_context_help_output() {
         "F037",
         &stdout,
         &[
-            "Usage: git-commit-context",
+            "Usage: git-cli commit context",
             "--stdout",
             "--both",
             "--no-color",
@@ -738,7 +738,7 @@ fn commit_context_json_help_output() {
         "F042",
         &stdout,
         &[
-            "Usage: git-commit-context-json",
+            "Usage: git-cli commit context-json",
             "--stdout",
             "--both",
             "--pretty",

--- a/crates/git-cli/tests/integration/utils.rs
+++ b/crates/git-cli/tests/integration/utils.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::Path;
 
 fn copy_staged_help() -> &'static str {
-    "Usage: git-copy-staged [--stdout|--both]\n  --stdout   Print staged diff to stdout (no status message)\n  --both     Print to stdout and copy to clipboard\n"
+    "Usage: git-cli utils copy-staged [-p|--stdout|--both]\n  -p, --stdout, --print   Print staged diff to stdout (no status message)\n  --both                  Print to stdout and copy to clipboard\n"
 }
 
 fn trim_trailing_newlines(input: &str) -> &str {
@@ -140,7 +140,7 @@ fn utils_copy_staged_rejects_unknown_arg() {
     assert_eq!(output.stdout_text(), "");
     assert_eq!(
         output.stderr_text(),
-        "❗ Unknown argument: --nope\nUsage: git-copy-staged [--stdout|--both]\n"
+        "❗ Unknown argument: --nope\nUsage: git-cli utils copy-staged [-p|--stdout|--both]\n"
     );
 }
 

--- a/crates/git-summary/src/cli.rs
+++ b/crates/git-summary/src/cli.rs
@@ -2,18 +2,19 @@ pub fn print_help() {
     println!("Usage: git-summary <command> [args]");
     println!();
     println!("Commands:");
-    println!("  {:<16}  Entire history", "all");
-    println!("  {:<16}  Today only", "today");
-    println!("  {:<16}  Yesterday only", "yesterday");
-    println!("  {:<16}  1st to today", "this-month");
-    println!("  {:<16}  1st to end of last month", "last-month");
-    println!("  {:<16}  This Mon–Sun", "this-week");
-    println!("  {:<16}  Last Mon–Sun", "last-week");
+    println!("  {:<18}  Entire history", "all");
+    println!("  {:<18}  Today only", "today");
+    println!("  {:<18}  Yesterday only", "yesterday");
+    println!("  {:<18}  1st to today", "this-month");
+    println!("  {:<18}  1st to end of last month", "last-month");
+    println!("  {:<18}  This Mon–Sun", "this-week");
+    println!("  {:<18}  Last Mon–Sun", "last-week");
     println!(
-        "  {:<16}  Export shell completion script",
+        "  {:<18}  Export shell completion script",
         "completion <shell>"
     );
-    println!("  {:<16}  Custom date range (YYYY-MM-DD)", "<from> <to>");
+    println!("  {:<18}  Show this help", "help");
+    println!("  {:<18}  Custom date range (YYYY-MM-DD)", "<from> <to>");
     println!();
 }
 


### PR DESCRIPTION
## Summary

PR B in the `repo-code-drift-followup-tracker.md` follow-up series for #336–#342. Fixes four `git-cli` / `git-summary` user-facing strings that still advertise pre-merge wrapper script names or omit currently-supported flags.

- **`clipboard.rs`**: include `wl-copy` in the "no clipboard tool found" warning (both fixture-mode and runtime paths), matching the actual `CLIPBOARD_TOOL_ORDER` `[Pbcopy, WlCopy, Xclip, Xsel]`.
- **`commit.rs::print_context_usage`**: replace `Usage: git-commit-context [...]` with `Usage: git-cli commit context [...]`; document the `-p`/`--print` short aliases for `--stdout`.
- **`commit_json.rs::print_usage`** (sibling drift surfaced by the snapshot test): replace `Usage: git-commit-context-json [...]` with `Usage: git-cli commit context-json [...]`.
- **`utils.rs`**: align `print_copy_staged_help` and the `❗ Unknown argument` error-path message; both now print `Usage: git-cli utils copy-staged [-p|--stdout|--both]` and surface `-p, --stdout, --print` together.
- **`git-summary/cli.rs::print_help`**: bump column width 16 → 18 so `completion <shell>` (18 chars) no longer pushes the description column out of alignment, and add a missing `help` row.

Existing integration snapshots (`commit::commit_context_help_output`, `commit::commit_context_json_help_prints_usage`, `commit::commit_context_fixture_f031_missing_clipboard`, `utils::utils_copy_staged_help_prints_usage`, `utils::utils_copy_staged_rejects_unknown_arg`) are updated in the same commit so any future drift on these strings keeps tripping the regression tests.

Source items in the tracker: 6a, 6b, 6c, 8. The `commit_json.rs` line was found while wiring the snapshot test and bundles into the same PR under the same drift family.

## Test plan

- [x] `cargo run -q -p nils-git-cli --bin git-cli -- commit context --help` — prints the new usage block
- [x] `cargo run -q -p nils-git-cli --bin git-cli -- utils copy-staged --help` — prints the new usage block
- [x] `cargo run -q -p nils-git-summary --` — column alignment matches `completion <shell>` and the new `help` row appears
- [x] `cargo test -p nils-git-cli -p nils-git-summary` — 110 + 14 passed, 0 failed
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh` — `ok: all nils-cli checks passed` (full pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)