### PR TITLE
fix(git): route subcommand --help correctly in git-scope and git-lock

### DIFF
--- a/crates/git-lock/src/main.rs
+++ b/crates/git-lock/src/main.rs
@@ -88,6 +88,15 @@ fn run() -> i32 {
         return 0;
     }
 
+    if args.len() > 2
+        && is_known_command(&args[1])
+        && is_help(&args[2])
+        && let Some(text) = messages::subcommand_help(&args[1])
+    {
+        println!("{text}");
+        return 0;
+    }
+
     if args.len() > 1 && args[1] == "completion" {
         let cli = Cli::parse_from(&args);
         let command = cli.command.unwrap_or(Command::Help);

--- a/crates/git-lock/src/messages.rs
+++ b/crates/git-lock/src/messages.rs
@@ -1,11 +1,40 @@
 pub const NOT_GIT_REPO: &str = "❗ Not a Git repository. Run this command inside a Git project.";
 pub const UNKNOWN_COMMAND_HINT: &str = "Run 'git-lock help' for usage.";
-pub const COPY_USAGE: &str = "❗ Usage: git-lock-copy <source-label> <target-label>";
+pub const COPY_USAGE: &str = "❗ Usage: git-lock copy <source-label> <target-label>";
 pub const TARGET_LABEL_MISSING: &str = "❗ Target label is missing";
 pub const NO_GIT_LOCKS_FOUND: &str = "❌ No git-locks found";
 pub const DIFF_USAGE: &str = "❗ Usage: git-lock diff <label1> <label2> [--no-color]";
 pub const TAG_USAGE: &str =
     "❗ Usage: git-lock tag <git-lock-label> <tag-name> [-m <tag-message>] [--push]";
+
+pub fn subcommand_help(subcmd: &str) -> Option<&'static str> {
+    let text = match subcmd {
+        "lock" => {
+            "Usage: git-lock lock [label] [note] [commit]\n  Save HEAD (or <commit>) to a lock label."
+        }
+        "unlock" => {
+            "Usage: git-lock unlock [label]\n  Reset HEAD to the commit recorded in the lock."
+        }
+        "list" => "Usage: git-lock list\n  Show every lock for the current repository.",
+        "copy" => {
+            "Usage: git-lock copy <source-label> <target-label>\n  Duplicate a lock under a new label."
+        }
+        "delete" => {
+            "Usage: git-lock delete [label]\n  Remove the lock entry; defaults to the latest label."
+        }
+        "diff" => {
+            "Usage: git-lock diff <label1> <label2> [--no-color]\n  Show the commit diff between two locks."
+        }
+        "tag" => {
+            "Usage: git-lock tag <label> <tag-name> [-m <message>] [--push]\n  Create a git tag pointing at the lock's commit."
+        }
+        "completion" => {
+            "Usage: git-lock completion <bash|zsh>\n  Print the shell completion script."
+        }
+        _ => return None,
+    };
+    Some(text)
+}
 
 pub fn unknown_command(cmd: &str) -> String {
     format!("❗ Unknown command: '{cmd}'")

--- a/crates/git-lock/tests/integration/help_outside_repo.rs
+++ b/crates/git-lock/tests/integration/help_outside_repo.rs
@@ -34,6 +34,41 @@ fn help_subcommand_outside_repo_exits_zero() {
 }
 
 #[test]
+fn subcommand_help_flag_outside_repo_exits_zero_for_each_subcommand() {
+    for subcmd in [
+        "lock",
+        "unlock",
+        "list",
+        "copy",
+        "delete",
+        "diff",
+        "tag",
+        "completion",
+    ] {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let output = run_git_lock_output(
+            dir.path(),
+            &[subcmd, "--help"],
+            &[("ZSH_CACHE_DIR", dir.path().to_str().unwrap())],
+            None,
+        );
+        assert!(
+            output.status.success(),
+            "expected `git-lock {subcmd} --help` to exit 0"
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.starts_with(&format!("Usage: git-lock {subcmd}")),
+            "expected stdout to begin with `Usage: git-lock {subcmd}`; got: {stdout}"
+        );
+        assert!(
+            !stdout.contains("Not a Git repository"),
+            "expected `--help` to short-circuit before the repo check"
+        );
+    }
+}
+
+#[test]
 fn version_flag_outside_repo_exits_zero() {
     let dir = tempfile::TempDir::new().expect("tempdir");
     let output = run_git_lock_output(

--- a/crates/git-scope/src/main.rs
+++ b/crates/git-scope/src/main.rs
@@ -77,7 +77,7 @@ enum Command {
         #[arg(long = "parent", short = 'P')]
         parent: Option<String>,
         /// Commit-ish (hash, HEAD, etc.)
-        commit: String,
+        commit: Option<String>,
     },
     /// Display help message for git-scope
     Help,
@@ -246,6 +246,15 @@ fn run() -> Result<()> {
             parent,
             commit,
         } => {
+            let Some(commit) = commit else {
+                eprintln!("error: the following required arguments were not provided:");
+                eprintln!("  <COMMIT>");
+                eprintln!();
+                eprintln!("Usage: git-scope commit [OPTIONS] <COMMIT>");
+                eprintln!();
+                eprintln!("For more information, try '--help commit <COMMIT>'.");
+                process::exit(2);
+            };
             commit::render_commit(&commit, parent.as_deref(), no_color, print, progress_opt_in)
                 .with_context(|| format!("git-scope commit {commit}"))?;
         }

--- a/crates/git-scope/tests/integration/commit_mode.rs
+++ b/crates/git-scope/tests/integration/commit_mode.rs
@@ -2,6 +2,24 @@ use crate::common;
 use std::fs;
 
 #[test]
+fn commit_help_exits_zero_and_prints_subcommand_help() {
+    let repo = common::init_repo();
+    let (code, stdout) = common::run_git_scope_allow_fail(repo.path(), &["commit", "--help"], &[]);
+    assert_eq!(
+        code, 0,
+        "expected `commit --help` to exit 0; stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Show commit details"),
+        "expected commit subcommand help; got: {stdout}"
+    );
+    assert!(
+        stdout.contains("[COMMIT]"),
+        "expected [COMMIT] argument in help; got: {stdout}"
+    );
+}
+
+#[test]
 fn commit_merge_parent_selection() {
     let repo = common::init_repo();
     let root = repo.path();


### PR DESCRIPTION
## Summary

PR C in the `repo-code-drift-followup-tracker.md` follow-up series for #336–#342. Fixes two long-standing `--help`-routing bugs surfaced during the workspace doc audit.

### `git-scope commit --help` (was: exit 2)

clap was validating the positional `<COMMIT>` argument before the global `--help` flag, so `git-scope commit --help` exited 2 with a "missing required arguments" error. Workaround was `git-scope --help commit HEAD`, which is unintuitive.

- Switch `Commit { ..., commit: String }` to `Commit { ..., commit: Option<String> }` so clap no longer enforces the positional at parse time. (`required_unless_present = "help"` panics at clap-builder asserts because `String` is implicitly `required = true`, hence the `Option` route.)
- The `Command::Commit` branch now emits a clap-style "missing required arguments / Usage / try '--help'" block on `None`, exiting 2 — preserves the existing UX for the genuine omission case.
- Adds `commit_mode::commit_help_exits_zero_and_prints_subcommand_help` regression test.

### `git-lock <subcmd> --help` (was: persisted as a lockfile label)

For every subcommand except `diff`, `--help` was being consumed as the positional `<label>` and written to the lockfile. Subcommand-level help was simply unavailable.

- Add a centralised dispatcher in `main::run`: when `args[2]` is `--help`/`-h`/`help` and `args[1]` is a known command, print the subcommand-specific usage and exit 0 — short-circuits before the lockfile is ever touched.
- Backed by a new `messages::subcommand_help` table covering `lock` / `unlock` / `list` / `copy` / `delete` / `diff` / `tag` / `completion`.
- Repairs the stale `messages::COPY_USAGE` (`git-lock-copy <args>` → `git-lock copy <args>`) discovered while extending the messages module — same drift family as the PR B `git-cli` strings.
- Adds `help_outside_repo::subcommand_help_flag_outside_repo_exits_zero_for_each_subcommand` regression test that iterates all eight subcommands.

Source items in the tracker: 5 and 7.

## Test plan

- [x] `cargo run -q -p nils-git-scope -- commit --help` → exit 0, prints commit subcommand help with `[COMMIT]` argument
- [x] `cargo run -q -p nils-git-scope -- commit` → exit 2, prints "the following required arguments were not provided" block
- [x] `for cmd in lock unlock list copy delete diff tag completion; do cargo run -q -p nils-git-lock -- $cmd --help; done` → all exit 0, all print `Usage: git-lock <cmd>` block
- [x] `cargo test -p nils-git-scope -p nils-git-lock` — 35 + 32 passed, 0 failed
- [x] `cargo test --workspace` — clean (one transient `git-spawn NotFound` flake in `nils-codex-cli::agent_commit::*` reproduced once on a parallel run; passes on retry both in isolation and with the full workspace, unrelated to git-scope/git-lock)
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh` — `ok: all nils-cli checks passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)