### PR TITLE
refactor(api-testing-core): generic http executor + websocket timeouts

### DIFF
--- a/crates/api-testing-core/src/http.rs
+++ b/crates/api-testing-core/src/http.rs
@@ -1,5 +1,11 @@
+use anyhow::Context;
+use reqwest::Method;
+use reqwest::blocking::{Body, Client, multipart::Form};
+use reqwest::header::{CONTENT_TYPE, HeaderMap};
+
 use crate::Result;
 
+/// Minimal protocol-agnostic HTTP response, shared by every backend runner.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HttpResponse {
     pub status: u16,
@@ -7,20 +13,128 @@ pub struct HttpResponse {
     pub content_type: Option<String>,
 }
 
-pub fn execute_request(_request_json: &serde_json::Value) -> Result<HttpResponse> {
-    anyhow::bail!("api-testing-core::http::execute_request is not implemented yet");
+/// Body shape for [`execute_request`].
+///
+/// `Multipart` intentionally exposes [`reqwest::blocking::multipart::Form`]
+/// because the form is composed by the caller (REST runners assemble fields,
+/// files, and base64 payloads outside the generic HTTP layer). Inline reqwest
+/// types are an acceptable leak inside this workspace: every consumer already
+/// depends on reqwest, and abstracting `Form` would only add boilerplate.
+pub enum HttpBody {
+    None,
+    Bytes(Vec<u8>),
+    Multipart(Form),
+}
+
+/// Send a blocking HTTP request and read the response into [`HttpResponse`].
+///
+/// This helper is deliberately protocol-agnostic: the caller composes the URL,
+/// headers, and body, then hands them in. REST-aware decisions
+/// (Accept defaults, bearer-token shaping, JSON serialisation, multipart
+/// assembly) live in `rest::runner::execute_rest_request`; future
+/// non-REST backends layer their own conventions on top of this primitive.
+pub fn execute_request(
+    method: Method,
+    url: &str,
+    headers: HeaderMap,
+    body: HttpBody,
+) -> Result<HttpResponse> {
+    let client = Client::new();
+    let mut builder = client.request(method.clone(), url).headers(headers);
+
+    builder = match body {
+        HttpBody::None => builder,
+        HttpBody::Bytes(bytes) => builder.body(Body::from(bytes)),
+        HttpBody::Multipart(form) => builder.multipart(form),
+    };
+
+    let response = builder
+        .send()
+        .with_context(|| format!("HTTP request failed: {method} {url}"))?;
+
+    let status = response.status().as_u16();
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let body = response
+        .bytes()
+        .context("failed to read response body")?
+        .to_vec();
+
+    Ok(HttpResponse {
+        status,
+        body,
+        content_type,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nils_test_support::http::{HttpResponse as StubResponse, LoopbackServer};
+    use reqwest::header::{ACCEPT, HeaderValue};
 
     #[test]
-    fn execute_request_reports_unimplemented() {
-        let err = execute_request(&serde_json::json!({"method": "GET"})).unwrap_err();
+    fn execute_request_returns_status_body_and_content_type_for_get() {
+        let server = LoopbackServer::new().expect("server");
+        server.add_route(
+            "GET",
+            "/echo",
+            StubResponse::new(200, r#"{"ok":true}"#)
+                .with_header("Content-Type", "application/json"),
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+
+        let url = format!("{}/echo", server.url());
+        let response =
+            execute_request(Method::GET, &url, headers, HttpBody::None).expect("execute");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.content_type.as_deref(), Some("application/json"));
+        assert_eq!(response.body, br#"{"ok":true}"#.to_vec());
+    }
+
+    #[test]
+    fn execute_request_sends_body_bytes_for_post() {
+        let server = LoopbackServer::new().expect("server");
+        server.add_route(
+            "POST",
+            "/widgets",
+            StubResponse::new(201, "").with_header("Content-Type", "text/plain"),
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let url = format!("{}/widgets", server.url());
+        let body = br#"{"name":"alpha"}"#.to_vec();
+        let response =
+            execute_request(Method::POST, &url, headers, HttpBody::Bytes(body)).expect("execute");
+
+        assert_eq!(response.status, 201);
+        let received = server.take_requests();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].method, "POST");
+        assert!(received[0].body_text().contains("\"name\":\"alpha\""));
+    }
+
+    #[test]
+    fn execute_request_surfaces_transport_errors_with_method_and_url() {
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+
+        // Port 1 is reserved (tcpmux) and effectively guaranteed to refuse a
+        // local TCP connection on test infrastructure.
+        let url = "http://127.0.0.1:1/unreachable";
+        let err = execute_request(Method::GET, url, headers, HttpBody::None).unwrap_err();
+        let msg = format!("{err:#}");
         assert!(
-            err.to_string()
-                .contains("api-testing-core::http::execute_request is not implemented")
+            msg.contains("HTTP request failed: GET") && msg.contains(url),
+            "expected error to mention method + URL; got: {msg}"
         );
     }
 }

--- a/crates/api-testing-core/src/rest/expect.rs
+++ b/crates/api-testing-core/src/rest/expect.rs
@@ -43,7 +43,7 @@ mod tests {
         RestExecutedRequest {
             method: "GET".to_string(),
             url: "http://localhost:6700/health".to_string(),
-            response: crate::rest::runner::RestHttpResponse {
+            response: crate::http::HttpResponse {
                 status,
                 body: serde_json::to_vec(&body).unwrap(),
                 content_type: Some("application/json".to_string()),

--- a/crates/api-testing-core/src/rest/runner.rs
+++ b/crates/api-testing-core/src/rest/runner.rs
@@ -4,20 +4,14 @@ use anyhow::Context;
 use base64::Engine;
 
 use crate::Result;
+use crate::http::{HttpBody, HttpResponse, execute_request};
 use crate::rest::schema::{RestMultipartPart, RestRequestFile};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RestHttpResponse {
-    pub status: u16,
-    pub body: Vec<u8>,
-    pub content_type: Option<String>,
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RestExecutedRequest {
     pub method: String,
     pub url: String,
-    pub response: RestHttpResponse,
+    pub response: HttpResponse,
 }
 
 fn resolve_part_file_path(request_file: &Path, raw: &str) -> Result<PathBuf> {
@@ -168,42 +162,24 @@ pub fn execute_rest_request(
         headers.append(name, value);
     }
 
-    let client = reqwest::blocking::Client::new();
-    let mut builder = client.request(method, &url).headers(headers);
-
-    if let Some(body) = &req.body {
+    let body = if let Some(body) = &req.body {
         let bytes = serde_json::to_vec(body).context("failed to serialize request body as JSON")?;
-        builder = builder.body(bytes);
+        HttpBody::Bytes(bytes)
     } else if let Some(parts) = &req.multipart {
-        let form = build_multipart_form(&request_file.path, parts)?;
-        if let Some(form) = form {
-            builder = builder.multipart(form);
+        match build_multipart_form(&request_file.path, parts)? {
+            Some(form) => HttpBody::Multipart(form),
+            None => HttpBody::None,
         }
-    }
+    } else {
+        HttpBody::None
+    };
 
-    let response = builder
-        .send()
-        .with_context(|| format!("HTTP request failed: {} {}", req.method, url))?;
-
-    let status = response.status().as_u16();
-    let content_type = response
-        .headers()
-        .get(reqwest::header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
-    let body = response
-        .bytes()
-        .context("failed to read response body")?
-        .to_vec();
+    let response = execute_request(method, &url, headers, body)?;
 
     Ok(RestExecutedRequest {
         method: req.method.clone(),
         url,
-        response: RestHttpResponse {
-            status,
-            body,
-            content_type,
-        },
+        response,
     })
 }
 

--- a/crates/api-testing-core/src/suite/runner/context.rs
+++ b/crates/api-testing-core/src/suite/runner/context.rs
@@ -50,5 +50,25 @@ pub(super) fn case_type_normalized(case_type_raw: &str) -> String {
 }
 
 pub(super) fn default_rest_flow_token_jq() -> String {
-    ".. | objects | (.accessToken? // .access_token? // .token? // empty) | select(type==\"string\" and length>0) | .".to_string()
+    crate::suite::schema::DEFAULT_AUTH_TOKEN_JQ.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::default_rest_flow_token_jq;
+    use crate::suite::schema::DEFAULT_AUTH_TOKEN_JQ;
+
+    #[test]
+    fn default_auth_token_jq_matches_rest_flow_default() {
+        assert_eq!(default_rest_flow_token_jq(), DEFAULT_AUTH_TOKEN_JQ);
+    }
+
+    #[test]
+    fn default_jq_selector_includes_jwt_alternative() {
+        assert!(
+            DEFAULT_AUTH_TOKEN_JQ.contains(".jwt?"),
+            "DEFAULT_AUTH_TOKEN_JQ must include `.jwt?` so suites can extract JWT-shaped tokens \
+             without overriding the default selector"
+        );
+    }
 }

--- a/crates/api-testing-core/src/suite/schema.rs
+++ b/crates/api-testing-core/src/suite/schema.rs
@@ -14,8 +14,21 @@ fn default_auth_secret_env() -> String {
     "API_TEST_AUTH_JSON".to_string()
 }
 
+/// Canonical jq selector for extracting auth tokens from login responses.
+///
+/// Shared by:
+/// - [`default_auth_token_jq`] for `SuiteRestAuth::token_jq` / `SuiteGraphqlAuth::token_jq`
+///   (the schema-level default for explicit `auth.*` blocks).
+/// - `suite::runner::context::default_rest_flow_token_jq` (the per-flow default applied
+///   when a suite case omits `token_jq`).
+///
+/// Keep both consumers in sync — see the regression test
+/// `default_auth_token_jq_matches_rest_flow_default` in
+/// `crates/api-testing-core/src/suite/runner/context.rs`.
+pub(super) const DEFAULT_AUTH_TOKEN_JQ: &str = ".. | objects | (.accessToken? // .access_token? // .token? // .jwt? // empty) | select(type==\"string\" and length>0) | .";
+
 fn default_auth_token_jq() -> String {
-    ".. | objects | (.accessToken? // .access_token? // .token? // .jwt? // empty) | select(type==\"string\" and length>0) | .".to_string()
+    DEFAULT_AUTH_TOKEN_JQ.to_string()
 }
 
 fn default_rest_config_dir() -> String {

--- a/crates/api-testing-core/src/websocket/runner.rs
+++ b/crates/api-testing-core/src/websocket/runner.rs
@@ -1,7 +1,14 @@
+use std::net::TcpStream;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
 use anyhow::Context;
 use serde::Serialize;
+use tungstenite::WebSocket;
 use tungstenite::client::IntoClientRequest;
 use tungstenite::http::{HeaderName, HeaderValue};
+use tungstenite::stream::MaybeTlsStream;
 use tungstenite::{Message, connect};
 
 use crate::Result;
@@ -18,6 +25,22 @@ pub struct WebsocketExecutedRequest {
     pub target: String,
     pub transcript: Vec<WebsocketTranscriptEntry>,
     pub last_received: Option<String>,
+}
+
+/// Apply a read timeout to the underlying TCP socket so per-step `read()`
+/// calls cannot hang forever. Pass `None` to clear the timeout.
+fn set_socket_read_timeout(
+    socket: &mut WebSocket<MaybeTlsStream<TcpStream>>,
+    timeout: Option<Duration>,
+) -> std::io::Result<()> {
+    let tcp = match socket.get_mut() {
+        MaybeTlsStream::Plain(stream) => stream,
+        MaybeTlsStream::Rustls(stream) => stream.get_mut(),
+        // Forward-compat: other variants (e.g. NativeTls if a future feature is
+        // enabled) do not expose a TcpStream we can configure here.
+        _ => return Ok(()),
+    };
+    tcp.set_read_timeout(timeout)
 }
 
 fn parse_message_text(message: Message) -> String {
@@ -82,12 +105,28 @@ pub fn execute_websocket_request(
         }
     }
 
-    let (mut socket, _resp) = connect(request)
-        .with_context(|| format!("failed to connect websocket target '{target}'"))?;
-
-    if let Some(connect_timeout_seconds) = request_file.request.connect_timeout_seconds {
-        let _ = connect_timeout_seconds;
-    }
+    let (mut socket, _resp) = match request_file.request.connect_timeout_seconds {
+        Some(secs) => {
+            let (tx, rx) = mpsc::channel();
+            thread::spawn(move || {
+                let _ = tx.send(connect(request));
+            });
+            match rx.recv_timeout(Duration::from_secs(secs)) {
+                Ok(Ok(pair)) => pair,
+                Ok(Err(err)) => {
+                    return Err(anyhow::Error::new(err))
+                        .with_context(|| format!("failed to connect websocket target '{target}'"));
+                }
+                Err(_) => {
+                    anyhow::bail!(
+                        "websocket connect timed out after {secs}s for target '{target}'"
+                    );
+                }
+            }
+        }
+        None => connect(request)
+            .with_context(|| format!("failed to connect websocket target '{target}'"))?,
+    };
 
     let mut transcript: Vec<WebsocketTranscriptEntry> = Vec::new();
     let mut last_received: Option<String> = None;
@@ -107,10 +146,22 @@ pub fn execute_websocket_request(
                 timeout_seconds,
                 expect,
             } => {
-                let _ = timeout_seconds;
-                let message = socket
-                    .read()
-                    .with_context(|| format!("websocket receive failed at step {idx}"))?;
+                let timeout = timeout_seconds.map(Duration::from_secs);
+                if let Some(dur) = timeout {
+                    set_socket_read_timeout(&mut socket, Some(dur)).with_context(|| {
+                        format!("failed to set read timeout for websocket step {idx}")
+                    })?;
+                }
+                let read_result = socket.read();
+                if timeout.is_some() {
+                    let _ = set_socket_read_timeout(&mut socket, None);
+                }
+                let message = read_result.with_context(|| match timeout_seconds {
+                    Some(secs) => {
+                        format!("websocket receive timed out after {secs}s at step {idx}")
+                    }
+                    None => format!("websocket receive failed at step {idx}"),
+                })?;
                 let text = parse_message_text(message);
                 apply_expect(
                     expect.as_ref(),
@@ -181,6 +232,62 @@ mod tests {
         });
 
         (format!("ws://{addr}"), handle)
+    }
+
+    fn spawn_silent_server() -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind silent listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept stream");
+            let mut ws = tungstenite::accept(stream).expect("accept handshake on silent server");
+            // Block on read until the client closes the connection — never
+            // sending anything ourselves so the client read times out.
+            let _ = ws.read();
+            let _ = ws.close(None);
+        });
+
+        (format!("ws://{addr}"), handle)
+    }
+
+    #[test]
+    fn websocket_runner_step_receive_timeout_surfaces_error() {
+        let tmp = TempDir::new().expect("tmp");
+        let request_path = tmp.path().join("silent.ws.json");
+
+        let (url, handle) = spawn_silent_server();
+
+        std::fs::write(
+            &request_path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "url": url,
+                "steps": [
+                    {"type": "receive", "timeoutSeconds": 1}
+                ]
+            }))
+            .expect("serialize request"),
+        )
+        .expect("write request");
+
+        let loaded = WebsocketRequestFile::load(&request_path).expect("load request");
+        let started = std::time::Instant::now();
+        let err =
+            execute_websocket_request(&loaded, "", None).expect_err("expected receive to time out");
+        let elapsed = started.elapsed();
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("timed out after 1s"),
+            "expected timeout message; got: {msg}"
+        );
+        // Cushion for OS scheduling and TLS handshake — keep well under the
+        // default integration-test budget.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "expected timeout to fire within 5s; got {elapsed:?}"
+        );
+
+        let _ = handle.join();
     }
 
     #[test]

--- a/crates/api-websocket/docs/specs/websocket-request-schema-v1.md
+++ b/crates/api-websocket/docs/specs/websocket-request-schema-v1.md
@@ -24,8 +24,9 @@ Supported top-level fields:
   number, boolean, or null); empty values are dropped. Keys are inserted into the
   client request as-is.
 - `connectTimeoutSeconds` (integer or numeric string, optional): handshake-timeout
-  hint. Currently parsed for contract parity but not enforced by the in-process
-  `tungstenite` runner; see "Drift / known gaps" below.
+  ceiling. The runner spawns the connect on a worker thread and aborts the request
+  with a `websocket connect timed out after <secs>s` error if the handshake has
+  not completed in time.
 - `steps` (array, required, non-empty): ordered scripted session steps.
 - `expect` (object, optional): assertion against the last received message
   (see "Expect object" below).
@@ -46,9 +47,11 @@ Each `steps[i]` must be a JSON object that includes `type` (case-insensitive aft
 
 ### `type: "receive"`
 
-- `timeoutSeconds` (integer or numeric string, optional): per-receive timeout hint.
-  Currently parsed for contract parity but not enforced by the in-process runner;
-  the underlying `tungstenite::WebSocket::read` call blocks until the next message.
+- `timeoutSeconds` (integer or numeric string, optional): per-receive timeout
+  applied to the underlying TCP socket via `set_read_timeout` for the duration of
+  the step. The error surfaces as `websocket receive timed out after <secs>s at
+  step <i>` and the timeout is cleared before the next step runs. When the field
+  is absent the read call blocks until the next message.
 - `expect` (optional): see "Expect object" below.
 
 ### `type: "close"`
@@ -78,14 +81,6 @@ Validation behavior:
   `<PING:<payload>>`, `<PONG:<payload>>`, `<CLOSE:<code>:<reason>>`, `<FRAME>` for
   raw frames. There are no schema options for selectively suppressing these frames;
   scripted `receive` steps observe whichever message arrives next.
-
-## Drift / known gaps
-
-`connectTimeoutSeconds` and per-step `timeoutSeconds` are accepted by the schema
-parser but the current in-process runner ignores both values
-(`crates/api-testing-core/src/websocket/runner.rs` discards them via `let _ = …`).
-Documenting this honestly so request files written today remain forward-compatible
-once the runner wires the timeouts through.
 
 ## Error behavior
 


### PR DESCRIPTION
## Summary

PR D in the `repo-code-drift-followup-tracker.md` follow-up series for #336–#342. The largest of the five — three deferred drift items from PR #338 plus the design decision the user made when this PR opened (refactor api-rest onto the new helper; drop backwards-compat where it gets in the way).

### `http::execute_request` is now a real, generic helper

Previously a one-line `unimplemented!()` stub with zero callers. The new shape:

```rust
pub fn execute_request(
    method: Method,
    url: &str,
    headers: HeaderMap,
    body: HttpBody,
) -> Result<HttpResponse>;

pub enum HttpBody { None, Bytes(Vec<u8>), Multipart(Form) }
```

- **Protocol-agnostic**: caller composes URL/headers/body, helper does reqwest blocking + response read. REST-specific decisions (Accept defaults, Authorization shaping, JSON body serialisation, multipart assembly) stay in `rest::runner::execute_rest_request`; the lower layer is now reusable for future non-REST adapters.
- **Reqwest leak is intentional**: every consumer in the workspace already depends on reqwest, and abstracting `multipart::Form` would only add boilerplate. Documented in the module rustdoc.
- `rest::runner::execute_rest_request` is rewritten to delegate the actual send: it now builds `HttpBody`, hands the four-tuple to `http::execute_request`, and stores the returned `HttpResponse` directly.
- `RestHttpResponse` is deleted (was a structural duplicate of `HttpResponse`); `RestExecutedRequest.response: HttpResponse` swap propagates to the `rest/expect.rs` test helper.
- Three new unit tests via `nils_test_support::http::LoopbackServer` cover GET happy path, POST byte body, and transport-error context.

### Websocket timeouts: parsed-and-enforced (was: parsed-and-discarded)

PR #338 honestly flagged that `connectTimeoutSeconds` and per-step `timeoutSeconds` were dropped via `let _ = …` and added a "Drift / known gaps" section to the spec. Both are now enforced:

- **`connectTimeoutSeconds`**: runs `tungstenite::connect` on a worker thread; main thread blocks on `mpsc::recv_timeout`. On timeout the runner aborts with `websocket connect timed out after <secs>s for target '<url>'`. The leaked thread is acceptable for short-lived client behaviour and matches the standard pattern for blocking connect with deadlines.
- **Per-step `timeoutSeconds`**: walks the `MaybeTlsStream<TcpStream>` (Plain or Rustls — both visible under the crate's enabled features) and calls `set_read_timeout(Some(dur))`; clears the timeout after the step regardless of outcome. Errors surface as `websocket receive timed out after <secs>s at step <i>`.
- The "Drift / known gaps" section is dropped from `websocket-request-schema-v1.md`; both fields now have field-level descriptions that document enforcement and the exact error wording.
- New `websocket_runner_step_receive_timeout_surfaces_error` test fails fast (asserts <5s wall-clock) against a silent server.

### `token_jq` selector reconciled (wider version wins)

`suite::schema::default_auth_token_jq` already shipped the wider `(.accessToken? // .access_token? // .token? // .jwt?)` selector; the parallel `suite::runner::context::default_rest_flow_token_jq` was missing the `.jwt?` alternative. Per the user's pick:

- The canonical jq expression is lifted to `pub(super) const DEFAULT_AUTH_TOKEN_JQ` in `suite::schema`. Both call sites read from it (`default_auth_token_jq().to_string()` and `default_rest_flow_token_jq().to_string()`).
- Two regression tests in `suite/runner/context.rs` pin the equivalence and the `.jwt?` alternative.

Source items in the tracker: 2, 3, 4.

## Test plan

- [x] `cargo test -p nils-api-testing-core` — 245 unit + 48 integration passed (incl. new `execute_request_*`, `set_socket_read_timeout` consumers, `default_auth_token_jq_matches_rest_flow_default`, `websocket_runner_step_receive_timeout_surfaces_error`)
- [x] `cargo clippy -p nils-api-testing-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh` — `ok: all nils-cli checks passed` (full pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)