### PR TITLE
chore(docs): retire repo-code-drift followup tracker

### DIFF
--- a/scripts/ci/docs-hygiene-audit.sh
+++ b/scripts/ci/docs-hygiene-audit.sh
@@ -62,6 +62,7 @@ declare -a removed_transient_docs=(
   "docs/reports/completion-coverage-matrix.md"
   "docs/plans/codex-gemini-core-merge-plan.md"
   "docs/plans/markdown-gh-handling-audit-remediation-plan.md"
+  "docs/plans/repo-code-drift-followup-tracker.md"
   "docs/plans/repo-docs-cleanup-and-alignment-plan.md"
   "docs/plans/third-party-licenses-notices-release-packaging-plan.md"
   "docs/runbooks/image-processing-llm-svg.md"


### PR DESCRIPTION
## Summary

Final PR in the `repo-code-drift-followup-tracker.md` follow-up series. All five drift-fix PRs from the workspace doc audit have landed and the two backlog items got their own tracking issues, so the tracker has served its purpose.

- Adds `docs/plans/repo-code-drift-followup-tracker.md` to `scripts/ci/docs-hygiene-audit.sh::removed_transient_docs` so the strict gate keeps guarding against accidental revival, mirroring the way `repo-docs-cleanup-and-alignment-plan.md` was retired in #342.
- The tracker itself was a `transient-dev-record` that was never added to git, so plain `rm` on the working copy was the only mutation needed. No `git rm`.

## Predecessor PRs and follow-up issues

| Item | Link | Title |
|------|------|-------|
| PR A | #343 | chore(repo): drop unused CI scripts and clean stale shared docs |
| PR B | #344 | fix(git-cli): align user-facing strings with current binary names |
| PR C | #345 | fix(git): route subcommand --help correctly in git-scope and git-lock |
| PR D | #346 | refactor(api-testing-core): generic http executor + websocket timeouts |
| PR E | #347 | fix(agent-docs): rename diag-auth specs and add contexts --format checklist |
| Issue | #348 | Re-evaluate `cliclick` dependency in `crates/macos-agent` |
| Issue | #349 | Add `prompt_segment_refresh` integration test for `crates/gemini-cli` |

## Test plan

- [x] `bash scripts/ci/docs-hygiene-audit.sh --strict` — `PASS (warnings=0)` with the new entry guarding the path
- [x] `bash scripts/ci/docs-placement-audit.sh --strict` — `PASS (crates=25, warnings=0)`
- [x] Working tree clean: `docs/plans/` directory was removed once the tracker was deleted (it had no other files); no further git changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)