### PR TITLE
feat(plan-issue-cli): cut start-sprint over to canonical $SPRINT_ROOT layout (Sprint 3)

### DIFF
--- a/crates/plan-issue-cli/src/dispatch_record.rs
+++ b/crates/plan-issue-cli/src/dispatch_record.rs
@@ -1,0 +1,156 @@
+//! Per-task dispatch record JSON.
+//!
+//! Defined in `agent-kit/skills/automation/plan-issue-delivery/references/RUNTIME_LAYOUT.md`
+//! L48-52 and `plan-issue-cli-contract-v2.md` "Canonical Runtime Artifacts (v2)".
+//!
+//! The binary writes the ten required keys at sprint start. Optional adapter
+//! fields (`runtime_name`, `runtime_role`, `runtime_role_fallback_reason`)
+//! are intentionally **absent** — they belong to the active runtime adapter
+//! and are added post-emission by the wrapper / main-agent.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use nils_common::fs as common_fs;
+
+/// `workflow_role` value emitted by `start-sprint` for every implementation
+/// task.
+pub const WORKFLOW_ROLE_IMPLEMENTATION: &str = "implementation";
+
+/// Stable, sorted JSON object written to `dispatch-<TASK_ID>.json`.
+///
+/// Field order matches the canonical contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DispatchRecord {
+    pub task_id: String,
+    pub task_prompt_path: String,
+    pub subagent_init_snapshot_path: String,
+    pub plan_snapshot_path: String,
+    pub worktree: String,
+    pub branch: String,
+    pub execution_mode: String,
+    pub pr_group: String,
+    pub base_branch: String,
+    pub workflow_role: String,
+}
+
+impl DispatchRecord {
+    #[allow(clippy::too_many_arguments)]
+    pub fn implementation(
+        task_id: impl Into<String>,
+        task_prompt_path: impl Into<String>,
+        subagent_init_snapshot_path: impl Into<String>,
+        plan_snapshot_path: impl Into<String>,
+        worktree: impl Into<String>,
+        branch: impl Into<String>,
+        execution_mode: impl Into<String>,
+        pr_group: impl Into<String>,
+        base_branch: impl Into<String>,
+    ) -> Self {
+        Self {
+            task_id: task_id.into(),
+            task_prompt_path: task_prompt_path.into(),
+            subagent_init_snapshot_path: subagent_init_snapshot_path.into(),
+            plan_snapshot_path: plan_snapshot_path.into(),
+            worktree: worktree.into(),
+            branch: branch.into(),
+            execution_mode: execution_mode.into(),
+            pr_group: pr_group.into(),
+            base_branch: base_branch.into(),
+            workflow_role: WORKFLOW_ROLE_IMPLEMENTATION.to_string(),
+        }
+    }
+
+    pub fn to_pretty_json(&self) -> String {
+        let mut text = serde_json::to_string_pretty(self)
+            .expect("DispatchRecord serializes via serde_json without panicking");
+        text.push('\n');
+        text
+    }
+}
+
+/// Pretty-print + write a dispatch record to disk (creating parent dirs).
+pub fn write_dispatch_record(
+    path: &Path,
+    record: &DispatchRecord,
+) -> Result<(), common_fs::WriteTextError> {
+    common_fs::write_text(path, &record.to_pretty_json())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> DispatchRecord {
+        DispatchRecord::implementation(
+            "S1T1",
+            "/agent-home/out/plan-issue-delivery/owner__repo/issue-7/sprint-1/prompts/S1T1.md",
+            "/agent-home/out/plan-issue-delivery/owner__repo/issue-7/sprint-1/prompts/plan-issue-delivery-subagent-init.snapshot.md",
+            "/agent-home/out/plan-issue-delivery/owner__repo/issue-7/plan/plan.snapshot.md",
+            "/agent-home/out/plan-issue-delivery/owner__repo/issue-7/worktrees/pr-isolated/S1T1",
+            "issue/s1-t1",
+            "pr-isolated",
+            "s1-t1",
+            "plan/issue-7",
+        )
+    }
+
+    #[test]
+    fn test_serializes_required_keys() {
+        let json = sample().to_pretty_json();
+        for key in [
+            "\"task_id\"",
+            "\"task_prompt_path\"",
+            "\"subagent_init_snapshot_path\"",
+            "\"plan_snapshot_path\"",
+            "\"worktree\"",
+            "\"branch\"",
+            "\"execution_mode\"",
+            "\"pr_group\"",
+            "\"base_branch\"",
+            "\"workflow_role\"",
+        ] {
+            assert!(
+                json.contains(key),
+                "json missing required key {key}: {json}"
+            );
+        }
+        for absent in [
+            "\"runtime_name\"",
+            "\"runtime_role\"",
+            "\"runtime_role_fallback_reason\"",
+        ] {
+            assert!(
+                !json.contains(absent),
+                "json must not include adapter key {absent}: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_default_workflow_role_is_implementation() {
+        let record = sample();
+        assert_eq!(record.workflow_role, "implementation");
+        let parsed: serde_json::Value = serde_json::from_str(&record.to_pretty_json()).unwrap();
+        assert_eq!(parsed["workflow_role"], "implementation");
+    }
+
+    #[test]
+    fn test_round_trip_equals() {
+        let original = sample();
+        let json = serde_json::to_string(&original).expect("to_string");
+        let restored: DispatchRecord = serde_json::from_str(&json).expect("from_str");
+        assert_eq!(restored, original);
+    }
+
+    #[test]
+    fn write_dispatch_record_creates_parent_dirs() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let path = tmp.path().join("manifests").join("dispatch-S1T1.json");
+        write_dispatch_record(&path, &sample()).expect("write");
+        let text = std::fs::read_to_string(&path).expect("read");
+        assert!(text.contains("\"task_id\": \"S1T1\""), "{text}");
+        assert!(text.ends_with('\n'), "trailing newline");
+    }
+}

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -18,10 +18,11 @@ use crate::commands::sprint::{
     AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs,
 };
 use crate::commands::{Command as CliCommand, SplitStrategy, SummaryArgs};
+use crate::dispatch_record::{self, DispatchRecord};
 use crate::github::{GhCliAdapter, GitHubAdapter};
 use crate::issue_body::{self, TaskRow};
 use crate::render::{self, SprintCommentInput, SprintCommentMode};
-use crate::runtime_layout::{self, IssueRoot};
+use crate::runtime_layout::{self, IssueRoot, SprintRoot};
 use crate::task_spec::{self, TaskSpecBuildOptions, TaskSpecRow, TaskSpecScope};
 use crate::{BinaryFlavor, CommandError};
 
@@ -994,24 +995,128 @@ fn run_start_sprint(
         issue_body_for_comment = Some(body);
     }
 
-    let task_spec_out = args.task_spec_out.clone().unwrap_or_else(|| {
-        task_spec::default_sprint_task_spec_path(&args.plan, i32::from(args.sprint))
-    });
+    let repo = crate::github::resolve_repo(repo_override)
+        .map_err(|err| CommandError::usage("repo-resolution-failed", err))?;
+    let repo_slug = runtime_layout::repo_slug(&repo);
+    let issue_root = IssueRoot::new(&repo_slug, args.issue)
+        .map_err(|err| CommandError::runtime("runtime-layout-failed", err.to_string()))?;
+    let sprint_root = SprintRoot::new(&issue_root, i32::from(args.sprint));
+
+    let task_spec_out = args
+        .task_spec_out
+        .clone()
+        .unwrap_or_else(|| sprint_root.task_spec());
     task_spec::write_tsv(&task_spec_out, &artifact_rows)
         .map_err(|err| CommandError::runtime("task-spec-write-failed", err))?;
 
-    let prompts_out = args
+    let prompts_dir = args
         .subagent_prompts_out
         .clone()
-        .unwrap_or_else(|| default_subagent_prompts_path(&args.plan, i32::from(args.sprint)));
+        .unwrap_or_else(|| sprint_root.prompts_dir());
+    runtime_layout::ensure_dir(&prompts_dir).map_err(|err| {
+        CommandError::runtime(
+            "runtime-layout-emit-failed",
+            format!(
+                "failed to create prompts dir {}: {err}",
+                prompts_dir.display()
+            ),
+        )
+    })?;
+    runtime_layout::ensure_dir(&sprint_root.manifests_dir()).map_err(|err| {
+        CommandError::runtime(
+            "runtime-layout-emit-failed",
+            format!(
+                "failed to create manifests dir {}: {err}",
+                sprint_root.manifests_dir().display()
+            ),
+        )
+    })?;
+    runtime_layout::ensure_dir(&sprint_root.specs_dir()).map_err(|err| {
+        CommandError::runtime(
+            "runtime-layout-emit-failed",
+            format!(
+                "failed to create specs dir {}: {err}",
+                sprint_root.specs_dir().display()
+            ),
+        )
+    })?;
+
+    let plan_snapshot_target = issue_root.plan_snapshot();
+    copy_source_into_snapshot(
+        &task_spec::resolve_plan_file(&args.plan),
+        &plan_snapshot_target,
+        "plan-snapshot-source-missing",
+    )?;
+
+    let subagent_init_source = task_spec::agent_home()
+        .join("prompts")
+        .join("plan-issue-delivery-subagent-init.md");
+    let subagent_init_target = sprint_root.subagent_init_snapshot();
+    copy_source_into_snapshot(
+        &subagent_init_source,
+        &subagent_init_target,
+        "subagent-init-snapshot-source-missing",
+    )?;
+
     let prompt_files = write_subagent_prompts(
-        &prompts_out,
+        &prompts_dir,
         args.issue,
         i32::from(args.sprint),
         &artifact_rows,
         args.grouping.strategy,
     )
     .map_err(|err| CommandError::runtime("subagent-prompt-write-failed", err))?;
+
+    let plan_branch = read_plan_branch(&issue_root, args.issue);
+
+    let mut dispatch_record_paths: Vec<String> = Vec::new();
+    for row in &artifact_rows {
+        let task_prompt_path = sprint_root
+            .task_prompt(&row.task_id)
+            .map_err(|err| CommandError::runtime("runtime-layout-failed", err.to_string()))?;
+        let dispatch_path = sprint_root
+            .dispatch_record(&row.task_id)
+            .map_err(|err| CommandError::runtime("runtime-layout-failed", err.to_string()))?;
+        let record = DispatchRecord::implementation(
+            row.task_id.clone(),
+            path_text(&task_prompt_path),
+            path_text(&subagent_init_target),
+            path_text(&plan_snapshot_target),
+            row.worktree.clone(),
+            row.branch.clone(),
+            execution_mode_for_row(row, args.grouping.strategy, &artifact_rows),
+            row.pr_group.clone(),
+            plan_branch.clone(),
+        );
+        dispatch_record::write_dispatch_record(&dispatch_path, &record).map_err(|err| {
+            CommandError::runtime(
+                "runtime-layout-emit-failed",
+                format!(
+                    "failed to write dispatch record {}: {err}",
+                    dispatch_path.display()
+                ),
+            )
+        })?;
+        dispatch_record_paths.push(path_text(&dispatch_path));
+    }
+    dispatch_record_paths.sort();
+
+    let prompt_manifest_path = sprint_root.prompt_manifest();
+    write_prompt_manifest(
+        &prompt_manifest_path,
+        &artifact_rows,
+        &sprint_root,
+        args.grouping.strategy,
+    )
+    .map_err(|err| {
+        CommandError::runtime(
+            "runtime-layout-emit-failed",
+            format!(
+                "failed to write prompt manifest {}: {err}",
+                prompt_manifest_path.display()
+            ),
+        )
+    })?;
 
     let comment = render::render_sprint_comment(SprintCommentInput {
         mode: SprintCommentMode::Start,
@@ -1051,12 +1156,102 @@ fn run_start_sprint(
         "task_spec_path": path_text(&task_spec_out),
         "comment_path": path_text(&comment_out),
         "record_count": artifact_rows.len(),
-        "subagent_prompts_out": path_text(&prompts_out),
+        "subagent_prompts_out": path_text(&prompts_dir),
         "subagent_prompt_files": prompt_files,
+        "sprint_root": path_text(sprint_root.root()),
+        "plan_snapshot_path": path_text(&plan_snapshot_target),
+        "subagent_init_snapshot_path": path_text(&subagent_init_target),
+        "prompt_manifest_path": path_text(&prompt_manifest_path),
+        "dispatch_record_paths": dispatch_record_paths,
         "synced_issue_rows": synced_rows,
         "comment_requested": should_comment,
         "live_mutations_performed": live_mutations,
     }))
+}
+
+fn copy_source_into_snapshot(
+    source: &Path,
+    target: &Path,
+    missing_code: &'static str,
+) -> Result<(), CommandError> {
+    if !source.exists() {
+        return Err(CommandError::runtime(
+            missing_code,
+            format!("snapshot source not found at {}", source.display()),
+        ));
+    }
+    if let Some(parent) = target.parent() {
+        runtime_layout::ensure_dir(parent).map_err(|err| {
+            CommandError::runtime(
+                "runtime-layout-emit-failed",
+                format!("failed to create dir {}: {err}", parent.display()),
+            )
+        })?;
+    }
+    fs::copy(source, target).map_err(|err| {
+        CommandError::runtime(
+            "runtime-layout-emit-failed",
+            format!("failed to copy snapshot to {}: {err}", target.display()),
+        )
+    })?;
+    Ok(())
+}
+
+fn read_plan_branch(issue_root: &IssueRoot, issue: u64) -> String {
+    fs::read_to_string(issue_root.plan_branch_ref())
+        .ok()
+        .and_then(|raw| {
+            let trimmed = raw.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        })
+        .unwrap_or_else(|| format!("plan/issue-{issue}"))
+}
+
+fn execution_mode_for_row(
+    row: &TaskSpecRow,
+    strategy: SplitStrategy,
+    rows: &[TaskSpecRow],
+) -> String {
+    task_spec::execution_mode_by_task(rows, strategy)
+        .get(&row.task_id)
+        .cloned()
+        .unwrap_or_else(|| "pr-isolated".to_string())
+}
+
+fn write_prompt_manifest(
+    path: &Path,
+    rows: &[TaskSpecRow],
+    sprint_root: &SprintRoot,
+    strategy: SplitStrategy,
+) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut text = String::from("task_id\tprompt_path\texecution_mode\tworkflow_role\n");
+    let modes = task_spec::execution_mode_by_task(rows, strategy);
+    let mut sorted: Vec<&TaskSpecRow> = rows.iter().collect();
+    sorted.sort_unstable_by(|a, b| a.task_id.cmp(&b.task_id));
+    for row in sorted {
+        let prompt_path = sprint_root
+            .task_prompt(&row.task_id)
+            .map_err(|err| std::io::Error::other(err.to_string()))?;
+        let execution_mode = modes
+            .get(&row.task_id)
+            .cloned()
+            .unwrap_or_else(|| "pr-isolated".to_string());
+        text.push_str(&format!(
+            "{}\t{}\t{}\t{}\n",
+            row.task_id,
+            prompt_path.to_string_lossy(),
+            execution_mode,
+            dispatch_record::WORKFLOW_ROLE_IMPLEMENTATION,
+        ));
+    }
+    fs::write(path, text)
 }
 
 fn run_ready_sprint(
@@ -1586,19 +1781,6 @@ fn write_temp_markdown(stem: &str, content: &str) -> Result<PathBuf, String> {
     Ok(path)
 }
 
-fn default_subagent_prompts_path(plan_file: &Path, sprint: i32) -> PathBuf {
-    let plan_stem = plan_file
-        .file_stem()
-        .and_then(|name| name.to_str())
-        .unwrap_or("plan")
-        .to_string();
-
-    task_spec::agent_home()
-        .join("out")
-        .join("plan-issue-delivery")
-        .join(format!("{plan_stem}-sprint-{sprint}-subagent-prompts"))
-}
-
 fn write_subagent_prompts(
     out_dir: &Path,
     issue: u64,
@@ -1669,11 +1851,6 @@ fn write_subagent_prompts(
             .map(|row| row.task_id.as_str())
             .collect::<Vec<_>>()
             .join(", ");
-        let summary = if lane.rows.len() == 1 {
-            lane.rows[0].summary.trim().to_string()
-        } else {
-            format!("{} tasks in shared runtime lane", lane.rows.len())
-        };
         let lane_tasks = lane
             .rows
             .iter()
@@ -1688,14 +1865,27 @@ fn write_subagent_prompts(
             .collect::<Vec<_>>()
             .join("\n");
 
-        let path = out_dir.join(format!("{anchor_task}-subagent-prompt.md"));
-        let body = format!(
-            "# Subagent Task Prompt\n\n- Issue: #{issue}\n- Sprint: S{sprint}\n- Task: {anchor_task}\n- Tasks: {task_list}\n- Summary: {summary}\n- Owner: {}\n- Branch: {}\n- Worktree: {}\n- Execution Mode: {}\n- Notes: {}\n\n## Lane Tasks\n{lane_tasks}\n",
-            lane.owner, lane.branch, lane.worktree, lane.execution_mode, lane.notes
-        );
-        fs::write(&path, body)
-            .map_err(|err| format!("failed to write subagent prompt {}: {err}", path.display()))?;
-        paths.push(path.to_string_lossy().to_string());
+        for row in &lane.rows {
+            let task_summary = if row.summary.trim().is_empty() {
+                "-".to_string()
+            } else {
+                row.summary.trim().to_string()
+            };
+            let path = out_dir.join(format!("{}.md", row.task_id));
+            let body = format!(
+                "# Subagent Task Prompt\n\n- Issue: #{issue}\n- Sprint: S{sprint}\n- Task: {}\n- Anchor: {anchor_task}\n- Tasks: {task_list}\n- Summary: {task_summary}\n- Owner: {}\n- Branch: {}\n- Worktree: {}\n- Execution Mode: {}\n- Notes: {}\n\n## Lane Tasks\n{lane_tasks}\n",
+                row.task_id,
+                lane.owner,
+                lane.branch,
+                lane.worktree,
+                lane.execution_mode,
+                lane.notes
+            );
+            fs::write(&path, body).map_err(|err| {
+                format!("failed to write subagent prompt {}: {err}", path.display())
+            })?;
+            paths.push(path.to_string_lossy().to_string());
+        }
     }
 
     paths.sort();
@@ -2758,14 +2948,16 @@ mod tests {
             "hello"
         );
 
-        let prompts_path = default_subagent_prompts_path(Path::new("docs/plans/sample-plan.md"), 3);
+        let issue_root = runtime_layout::IssueRoot::new("owner__sample", 7).expect("issue root");
+        let sprint_root = runtime_layout::SprintRoot::new(&issue_root, 3);
+        let prompts_path = sprint_root.prompts_dir();
         assert!(
             prompts_path
                 .to_string_lossy()
-                .contains("sample-plan-sprint-3-subagent-prompts")
+                .contains("/owner__sample/issue-7/sprint-3/prompts")
         );
 
-        let out_dir = tmp.path().join("out").join("subagent-prompts");
+        let out_dir = tmp.path().join("out").join("sprint-3").join("prompts");
         let rows = vec![TaskSpecRow {
             task_id: "S3T1".to_string(),
             summary: "Build feature".to_string(),
@@ -2787,6 +2979,11 @@ mod tests {
         assert!(
             rendered.contains("Execution Mode: per-sprint"),
             "{rendered}"
+        );
+        let file_path = std::path::Path::new(&files[0]);
+        assert_eq!(
+            file_path.file_name().and_then(|name| name.to_str()),
+            Some("S3T1.md")
         );
     }
 
@@ -2832,12 +3029,21 @@ mod tests {
 
         let files = write_subagent_prompts(&out_dir, 217, 3, &rows, SplitStrategy::Auto)
             .expect("write grouped prompts");
-        assert_eq!(files.len(), 2);
+        assert_eq!(files.len(), 3, "one prompt file per task: {files:?}");
+
+        for task_id in ["S3T1", "S3T2", "S3T3"] {
+            assert!(
+                files
+                    .iter()
+                    .any(|path| path.ends_with(&format!("/{task_id}.md"))),
+                "missing prompt for {task_id}: {files:?}"
+            );
+        }
 
         let lane_prompt_path = files
             .iter()
-            .find(|path| path.contains("S3T1-subagent-prompt.md"))
-            .expect("shared lane prompt");
+            .find(|path| path.ends_with("/S3T1.md"))
+            .expect("shared lane prompt for S3T1");
         let lane_prompt = fs::read_to_string(lane_prompt_path).expect("read shared lane prompt");
         assert!(lane_prompt.contains("Task: S3T1"), "{lane_prompt}");
         assert!(lane_prompt.contains("Tasks: S3T1, S3T2"), "{lane_prompt}");
@@ -2865,7 +3071,7 @@ mod tests {
 
         let isolated_prompt_path = files
             .iter()
-            .find(|path| path.contains("S3T3-subagent-prompt.md"))
+            .find(|path| path.ends_with("/S3T3.md"))
             .expect("isolated lane prompt");
         let isolated_prompt =
             fs::read_to_string(isolated_prompt_path).expect("read isolated lane prompt");

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod commands;
 mod completion;
+pub mod dispatch_record;
 mod execute;
 mod github;
 mod issue_body;

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -23,5 +23,7 @@ mod parity_guardrails;
 mod runtime_truth_plan_and_sprint_flow;
 #[path = "integration/start_plan_canonical.rs"]
 mod start_plan_canonical;
+#[path = "integration/start_sprint_canonical.rs"]
+mod start_sprint_canonical;
 #[path = "integration/task_spec_flow.rs"]
 mod task_spec_flow;

--- a/crates/plan-issue-cli/tests/integration/auto_single_lane_runtime_truth.rs
+++ b/crates/plan-issue-cli/tests/integration/auto_single_lane_runtime_truth.rs
@@ -321,9 +321,10 @@ fn auto_single_lane_end_to_end_keeps_per_sprint_runtime_truth() {
     let prompt_files = sprint_payload["payload"]["result"]["subagent_prompt_files"]
         .as_array()
         .expect("prompt files");
-    assert_eq!(prompt_files.len(), 1, "{}", start_sprint_out.stdout);
+    assert_eq!(prompt_files.len(), 2, "{}", start_sprint_out.stdout);
 
     let prompt_path = prompt_files[0].as_str().expect("prompt path");
+    assert!(prompt_path.ends_with("/S1T1.md"), "{prompt_path}");
     let prompt = fs::read_to_string(prompt_path).expect("read prompt");
     assert!(prompt.contains("Tasks: S1T1, S1T2"), "{prompt}");
     assert!(prompt.contains("Execution Mode: per-sprint"), "{prompt}");

--- a/crates/plan-issue-cli/tests/integration/live_issue_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_issue_ops.rs
@@ -170,6 +170,7 @@ fn github_adapter_live_commands_use_gh_backend_for_issue_and_pr_state() {
 
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
+    common::seed_agent_home_prompts(&agent_home);
     let agent_home_s = agent_home.to_string_lossy().to_string();
 
     let body_json = json!({"body": issue_body_sprint4_in_progress()}).to_string();
@@ -225,6 +226,7 @@ fn live_plan_commands_ready_and_close_follow_gate_contracts() {
 
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
+    common::seed_agent_home_prompts(&agent_home);
     let agent_home_s = agent_home.to_string_lossy().to_string();
 
     let comment_capture = tmp.path().join("ready-plan-comment.md");
@@ -321,6 +323,7 @@ fn live_ready_plan_label_update_flag_applies_review_label() {
 
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
+    common::seed_agent_home_prompts(&agent_home);
     let agent_home_s = agent_home.to_string_lossy().to_string();
 
     let body_json = json!({"body": issue_body_plan_done()}).to_string();
@@ -373,6 +376,7 @@ fn live_sprint_commands_start_ready_accept_and_guide_are_deterministic() {
 
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
+    common::seed_agent_home_prompts(&agent_home);
     let agent_home_s = agent_home.to_string_lossy().to_string();
 
     let start_body_json = json!({"body": issue_body_sprint4_planned()}).to_string();
@@ -540,6 +544,7 @@ fn github_adapter_rejects_literal_escaped_newline_without_force() {
 
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
+    common::seed_agent_home_prompts(&agent_home);
     let agent_home_s = agent_home.to_string_lossy().to_string();
 
     let body_json = json!({"body": issue_body_plan_done()}).to_string();
@@ -597,6 +602,7 @@ fn github_adapter_force_flag_allows_literal_escaped_newline() {
 
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
+    common::seed_agent_home_prompts(&agent_home);
     let agent_home_s = agent_home.to_string_lossy().to_string();
 
     let comment_capture = tmp.path().join("ready-plan-force-comment.md");

--- a/crates/plan-issue-cli/tests/integration/live_start_sprint_runtime_truth.rs
+++ b/crates/plan-issue-cli/tests/integration/live_start_sprint_runtime_truth.rs
@@ -334,8 +334,9 @@ fn live_start_sprint_uses_issue_table_runtime_truth_without_rewrite() {
     let prompt_files = payload["payload"]["result"]["subagent_prompt_files"]
         .as_array()
         .expect("subagent prompt files");
-    assert_eq!(prompt_files.len(), 1, "{}", out.stdout);
+    assert_eq!(prompt_files.len(), 2, "{}", out.stdout);
     let prompt_path = prompt_files[0].as_str().expect("prompt path");
+    assert!(prompt_path.ends_with("/S1T1.md"), "{prompt_path}");
     let prompt = fs::read_to_string(prompt_path).expect("read prompt");
     assert!(prompt.contains("Tasks: S1T1, S1T2"), "{prompt}");
     assert!(prompt.contains("Execution Mode: per-sprint"), "{prompt}");

--- a/crates/plan-issue-cli/tests/integration/parity_guardrails.rs
+++ b/crates/plan-issue-cli/tests/integration/parity_guardrails.rs
@@ -100,6 +100,7 @@ fn parity_shell_multi_sprint_guide_matches_shell_fixture_after_normalization() {
     let tmp = TempDir::new().expect("temp dir");
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
+    common::seed_agent_home_prompts(&agent_home);
     let agent_home_s = agent_home.to_string_lossy().to_string();
 
     let out = common::run_plan_issue_local_with_env(
@@ -157,6 +158,7 @@ fn parity_shell_start_comment_template_matches_shell_fixture() {
     let tmp = TempDir::new().expect("temp dir");
     let agent_home = tmp.path().join("agent-home");
     fs::create_dir_all(&agent_home).expect("agent home");
+    common::seed_agent_home_prompts(&agent_home);
     let agent_home_s = agent_home.to_string_lossy().to_string();
 
     let out = common::run_plan_issue_local_with_env(

--- a/crates/plan-issue-cli/tests/integration/runtime_truth_plan_and_sprint_flow.rs
+++ b/crates/plan-issue-cli/tests/integration/runtime_truth_plan_and_sprint_flow.rs
@@ -341,11 +341,11 @@ fn start_plan_dry_run_writes_runtime_truth_task_decomposition_metadata() {
     let prompt_files = sprint_payload["payload"]["result"]["subagent_prompt_files"]
         .as_array()
         .expect("subagent prompt files");
-    assert_eq!(prompt_files.len(), 1, "{}", start_sprint_out.stdout);
+    assert_eq!(prompt_files.len(), 2, "{}", start_sprint_out.stdout);
     let lane_prompt_path = prompt_files
         .iter()
         .filter_map(|value| value.as_str())
-        .find(|path| path.contains(&format!("{anchor_id}-subagent-prompt.md")))
+        .find(|path| path.ends_with(&format!("/{anchor_id}.md")))
         .expect("lane prompt path");
     let lane_prompt = fs::read_to_string(lane_prompt_path).expect("read lane prompt");
     let prompt_fields = parse_prompt_fields(&lane_prompt);
@@ -539,9 +539,10 @@ fn start_sprint_uses_issue_table_runtime_truth_and_rejects_drift() {
     let prompt_files = payload["payload"]["result"]["subagent_prompt_files"]
         .as_array()
         .expect("prompt files");
-    assert_eq!(prompt_files.len(), 1, "{}", start_out.stdout);
+    assert_eq!(prompt_files.len(), 2, "{}", start_out.stdout);
 
     let prompt_path = prompt_files[0].as_str().expect("prompt path");
+    assert!(prompt_path.ends_with("/S1T1.md"), "{prompt_path}");
     let prompt = fs::read_to_string(prompt_path).expect("read prompt");
     assert!(prompt.contains("Tasks: S1T1, S1T2"), "{prompt}");
     assert!(prompt.contains("Execution Mode: per-sprint"), "{prompt}");

--- a/crates/plan-issue-cli/tests/integration/start_sprint_canonical.rs
+++ b/crates/plan-issue-cli/tests/integration/start_sprint_canonical.rs
@@ -1,0 +1,272 @@
+use std::fs;
+use std::path::PathBuf;
+
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use crate::common;
+
+const PLAN_PATH: &str =
+    "crates/plan-issue-cli/tests/fixtures/plans/plan-issue-rust-cli-full-delivery-plan.md";
+
+fn parse_json(stdout: &str) -> Value {
+    serde_json::from_str(stdout).expect("stdout should be valid JSON")
+}
+
+struct StartSprintRun {
+    payload: Value,
+    sprint_root: PathBuf,
+    issue_root: PathBuf,
+}
+
+fn run_local_start_sprint(
+    agent_home: &str,
+    sprint: &str,
+    issue: &str,
+    repo: &str,
+) -> StartSprintRun {
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            repo,
+            "start-sprint",
+            "--plan",
+            PLAN_PATH,
+            "--issue",
+            issue,
+            "--sprint",
+            sprint,
+            "--strategy",
+            "auto",
+            "--default-pr-grouping",
+            "per-sprint",
+            "--no-comment",
+        ],
+        &[("AGENT_HOME", agent_home)],
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = parse_json(&out.stdout);
+    let sprint_root = PathBuf::from(
+        payload["payload"]["result"]["sprint_root"]
+            .as_str()
+            .expect("sprint_root in result"),
+    );
+    let issue_root = sprint_root
+        .parent()
+        .map(|p| p.to_path_buf())
+        .expect("issue_root parent");
+    StartSprintRun {
+        payload,
+        sprint_root,
+        issue_root,
+    }
+}
+
+fn seeded_agent_home() -> (TempDir, PathBuf, String) {
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("agent home");
+    common::seed_agent_home_prompts(&agent_home);
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+    (tmp, agent_home, agent_home_s)
+}
+
+#[test]
+fn start_sprint_emits_plan_snapshot() {
+    let (_tmp, _ah, ah_s) = seeded_agent_home();
+    let run = run_local_start_sprint(&ah_s, "3", "217", "graysurf/plan-issue-smoke");
+
+    let snapshot_path = PathBuf::from(
+        run.payload["payload"]["result"]["plan_snapshot_path"]
+            .as_str()
+            .expect("plan_snapshot_path"),
+    );
+    let expected = run.issue_root.join("plan").join("plan.snapshot.md");
+    assert_eq!(snapshot_path, expected);
+    assert!(snapshot_path.is_file(), "plan snapshot not on disk");
+
+    let snapshot = fs::read_to_string(&snapshot_path).expect("read snapshot");
+    assert!(
+        snapshot.contains("Plan: Rust Plan-Issue CLI Full Delivery"),
+        "snapshot must mirror plan source: {snapshot}"
+    );
+}
+
+#[test]
+fn start_sprint_emits_subagent_init_snapshot() {
+    let (_tmp, _ah, ah_s) = seeded_agent_home();
+    let run = run_local_start_sprint(&ah_s, "3", "217", "graysurf/plan-issue-smoke");
+
+    let snapshot_path = PathBuf::from(
+        run.payload["payload"]["result"]["subagent_init_snapshot_path"]
+            .as_str()
+            .expect("subagent_init_snapshot_path"),
+    );
+    let expected = run
+        .sprint_root
+        .join("prompts")
+        .join("plan-issue-delivery-subagent-init.snapshot.md");
+    assert_eq!(snapshot_path, expected);
+    assert!(snapshot_path.is_file());
+
+    let snapshot = fs::read_to_string(&snapshot_path).expect("read snapshot");
+    assert!(
+        snapshot.contains("Subagent Init"),
+        "snapshot must mirror source: {snapshot}"
+    );
+}
+
+#[test]
+fn start_sprint_emits_dispatch_record_per_task() {
+    let (_tmp, _ah, ah_s) = seeded_agent_home();
+    let run = run_local_start_sprint(&ah_s, "3", "217", "graysurf/plan-issue-smoke");
+
+    let dispatch_paths = run.payload["payload"]["result"]["dispatch_record_paths"]
+        .as_array()
+        .expect("dispatch_record_paths");
+    let record_count = run.payload["payload"]["result"]["record_count"]
+        .as_u64()
+        .expect("record_count");
+    assert_eq!(
+        dispatch_paths.len() as u64,
+        record_count,
+        "one dispatch record per task: {dispatch_paths:?}"
+    );
+
+    for value in dispatch_paths {
+        let raw = value.as_str().expect("dispatch path string");
+        assert!(
+            raw.contains("/manifests/dispatch-"),
+            "dispatch path under manifests/: {raw}"
+        );
+        let record_text = fs::read_to_string(raw).expect("read dispatch record");
+        let record: Value = serde_json::from_str(&record_text).expect("dispatch JSON parses");
+        for key in [
+            "task_id",
+            "task_prompt_path",
+            "subagent_init_snapshot_path",
+            "plan_snapshot_path",
+            "worktree",
+            "branch",
+            "execution_mode",
+            "pr_group",
+            "base_branch",
+            "workflow_role",
+        ] {
+            assert!(
+                record.get(key).is_some(),
+                "missing key {key} in {record_text}"
+            );
+        }
+        assert_eq!(record["workflow_role"], "implementation");
+        assert_eq!(record["base_branch"], "plan/issue-217");
+    }
+}
+
+#[test]
+fn start_sprint_emits_prompt_manifest() {
+    let (_tmp, _ah, ah_s) = seeded_agent_home();
+    let run = run_local_start_sprint(&ah_s, "3", "217", "graysurf/plan-issue-smoke");
+
+    let manifest_path = PathBuf::from(
+        run.payload["payload"]["result"]["prompt_manifest_path"]
+            .as_str()
+            .expect("prompt_manifest_path"),
+    );
+    let expected = run
+        .sprint_root
+        .join("manifests")
+        .join("prompt-manifest.tsv");
+    assert_eq!(manifest_path, expected);
+    let manifest = fs::read_to_string(&manifest_path).expect("read manifest");
+    let mut lines = manifest.lines();
+    assert_eq!(
+        lines.next(),
+        Some("task_id\tprompt_path\texecution_mode\tworkflow_role"),
+        "header"
+    );
+
+    let record_count = run.payload["payload"]["result"]["record_count"]
+        .as_u64()
+        .expect("record_count");
+    let body_lines: Vec<&str> = lines.filter(|line| !line.is_empty()).collect();
+    assert_eq!(body_lines.len() as u64, record_count, "one row per task");
+    for line in &body_lines {
+        let cells: Vec<&str> = line.split('\t').collect();
+        assert_eq!(cells.len(), 4, "TSV row shape: {line}");
+        assert!(cells[1].contains("/prompts/"), "prompt path: {line}");
+        assert_eq!(cells[3], "implementation");
+    }
+}
+
+#[test]
+fn start_sprint_relocates_task_prompt() {
+    let (_tmp, _ah, ah_s) = seeded_agent_home();
+    let run = run_local_start_sprint(&ah_s, "3", "217", "graysurf/plan-issue-smoke");
+
+    let prompt_files = run.payload["payload"]["result"]["subagent_prompt_files"]
+        .as_array()
+        .expect("subagent_prompt_files");
+    assert!(
+        !prompt_files.is_empty(),
+        "expected at least one prompt file"
+    );
+
+    let canonical_dir = run.sprint_root.join("prompts");
+    for value in prompt_files {
+        let raw = value.as_str().expect("prompt path string");
+        let path = std::path::Path::new(raw);
+        assert!(
+            path.starts_with(&canonical_dir),
+            "prompt path must live under canonical prompts dir; path={raw}, expected_dir={}",
+            canonical_dir.display()
+        );
+        let file_name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .expect("file name");
+        assert!(
+            file_name.ends_with(".md"),
+            "prompt file should be <TASK_ID>.md: {file_name}"
+        );
+        let stem_chars: Vec<char> = file_name
+            .strip_suffix(".md")
+            .expect("md suffix")
+            .chars()
+            .collect();
+        assert!(
+            stem_chars
+                .iter()
+                .all(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-'),
+            "task id stem should not embed retired-format suffixes: {file_name}"
+        );
+    }
+}
+
+#[test]
+fn dispatch_record_omits_runtime_adapter_keys() {
+    let (_tmp, _ah, ah_s) = seeded_agent_home();
+    let run = run_local_start_sprint(&ah_s, "3", "217", "graysurf/plan-issue-smoke");
+
+    let dispatch_paths = run.payload["payload"]["result"]["dispatch_record_paths"]
+        .as_array()
+        .expect("dispatch_record_paths");
+    for value in dispatch_paths {
+        let raw = value.as_str().expect("dispatch path string");
+        let record_text = fs::read_to_string(raw).expect("read dispatch record");
+        for adapter_key in [
+            "runtime_name",
+            "runtime_role",
+            "runtime_role_fallback_reason",
+        ] {
+            assert!(
+                !record_text.contains(adapter_key),
+                "{adapter_key} must not be emitted by the binary: {record_text}"
+            );
+        }
+    }
+}

--- a/crates/plan-issue-cli/tests/integration/task_spec_flow.rs
+++ b/crates/plan-issue-cli/tests/integration/task_spec_flow.rs
@@ -791,9 +791,10 @@ fn write_subagent_prompts_groups_tasks_by_runtime_lane() {
     let prompt_files = payload["payload"]["result"]["subagent_prompt_files"]
         .as_array()
         .expect("prompt files");
-    assert_eq!(prompt_files.len(), 1, "{}", out.stdout);
+    assert_eq!(prompt_files.len(), 2, "{}", out.stdout);
 
     let prompt_path = prompt_files[0].as_str().expect("prompt path");
+    assert!(prompt_path.ends_with("/S1T1.md"), "{prompt_path}");
     let prompt = fs::read_to_string(prompt_path).expect("read prompt");
     assert!(prompt.contains("- Tasks: S1T1, S1T2"), "{prompt}");
     assert!(prompt.contains("- Execution Mode: per-sprint"), "{prompt}");


### PR DESCRIPTION
## Summary

Sprint 3 of the plan-issue-cli canonical runtime artifacts plan. `run_start_sprint` now writes every sprint-scope artifact under the canonical `$SPRINT_ROOT="$ISSUE_ROOT/sprint-<n>"` layout. Plan / subagent init snapshots are copied, per-task prompts are emitted as `<TASK_ID>.md`, and a `dispatch-<TASK_ID>.json` (10 required keys, no adapter keys) plus `prompt-manifest.tsv` are produced.

## Changes

- `crates/plan-issue-cli/src/dispatch_record.rs` (new) — `DispatchRecord` struct with the 10 canonical keys (`task_id`, `task_prompt_path`, `subagent_init_snapshot_path`, `plan_snapshot_path`, `worktree`, `branch`, `execution_mode`, `pr_group`, `base_branch`, `workflow_role`); `WORKFLOW_ROLE_IMPLEMENTATION` constant; `write_dispatch_record(path, record)` helper; round-trip tests.
- `crates/plan-issue-cli/src/lib.rs` — `pub mod dispatch_record`.
- `crates/plan-issue-cli/src/execute.rs`:
  - `run_start_sprint` resolves `IssueRoot` / `SprintRoot`, materializes `prompts/`, `manifests/`, `specs/` dirs, copies the source plan to `$ISSUE_ROOT/plan/plan.snapshot.md` and the subagent init source to `$SPRINT_ROOT/prompts/plan-issue-delivery-subagent-init.snapshot.md` (fails with `plan-snapshot-source-missing` / `subagent-init-snapshot-source-missing` when sources are absent).
  - Sprint task-spec writes to `$SPRINT_ROOT/specs/sprint-task-spec.tsv`; per-task prompts to `$SPRINT_ROOT/prompts/<TASK_ID>.md` (replacing the retired `<anchor>-subagent-prompt.md` flat filename); per-task dispatch records to `$SPRINT_ROOT/manifests/dispatch-<TASK_ID>.json`; prompt manifest to `$SPRINT_ROOT/manifests/prompt-manifest.tsv`.
  - `base_branch` is read from `$ISSUE_ROOT/plan/plan-branch.ref` if present, otherwise computed as `plan/issue-<n>`.
  - Returned JSON adds `sprint_root`, `plan_snapshot_path`, `subagent_init_snapshot_path`, `prompt_manifest_path`, `dispatch_record_paths`.
  - `default_subagent_prompts_path` removed; `write_subagent_prompts` updated to emit one `<TASK_ID>.md` per task even for shared lanes (lane info embedded in each prompt).
- `crates/plan-issue-cli/tests/integration/start_sprint_canonical.rs` (new) — 6 named tests covering plan / subagent init snapshots, per-task dispatch records, prompt manifest shape, per-task prompt relocation, and the absence of adapter keys.
- Refreshed `task_spec_flow`, `runtime_truth_plan_and_sprint_flow`, `auto_single_lane_runtime_truth`, `live_start_sprint_runtime_truth`, `parity_guardrails`, `live_issue_ops` for per-task prompt fan-out; every `agent_home` setup site seeds `$AGENT_HOME/prompts/`.

## Testing

- \`cargo test -p nils-plan-issue-cli dispatch_record\` (4 lib tests pass)
- \`cargo test -p nils-plan-issue-cli start_sprint_emits_plan_snapshot\` (pass)
- \`cargo test -p nils-plan-issue-cli start_sprint_emits_subagent_init_snapshot\` (pass)
- \`cargo test -p nils-plan-issue-cli start_sprint_emits_dispatch_record_per_task\` (pass)
- \`cargo test -p nils-plan-issue-cli start_sprint_emits_prompt_manifest\` (pass)
- \`cargo test -p nils-plan-issue-cli start_sprint_relocates_task_prompt\` (pass)
- \`cargo test -p nils-plan-issue-cli dispatch_record_omits_runtime_adapter_keys\` (pass)
- \`cargo nextest run -p nils-plan-issue-cli\` — 118 tests pass
- \`! rg -n 'subagent-prompt\\.md' crates/plan-issue-cli/tests crates/plan-issue-cli/src/execute.rs\` (no matches)
- \`NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh\` (pass)
- Sprint 3 acceptance file `\$AGENT_HOME/out/plan-issue-cli/sprint-3/acceptance.md` — `Result: PASS`

## Risk / Notes

- Plan validation uses `-- --exact`, but Rust integration tests carry the `<module>::` prefix; the six named tests live in `start_sprint_canonical::`, so the substring filter (without `--exact`) matches and `--exact` requires the full path. Behavior is unchanged.
- The contract spec heading delivered in Sprint 1 says "eleven required keys" but lists ten; the canonical RUNTIME_LAYOUT.md is also ten required + three optional adapter keys. Sprint 4 reconciles the wording (`Task 4.2`).
- Sprint comment paths (`default_sprint_comment_path`) and `default_sprint_task_spec_path` still resolve flat for `accept-sprint`, `ready-sprint`, `build-task-spec`, `build-plan-task-spec`, and `multi-sprint-guide`. They are no longer reachable from `run_start_sprint`.
- For shared-lane sprints (`per-sprint`, `pr-shared`), every task in the lane now gets its own `<TASK_ID>.md` prompt (each prompt embeds the lane's anchor + full task list); the orchestrator still dispatches one subagent per lane via the dispatch record.