### PR TITLE
feat(plan-issue-cli): runtime layout parity test + cutover docs (Sprint 4)

### DIFF
--- a/crates/plan-issue-cli/CHANGELOG.md
+++ b/crates/plan-issue-cli/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to `nils-plan-issue-cli` are documented here. The
+format follows Keep a Changelog and the project follows semantic
+versioning.
+
+## [Unreleased]
+
+### BREAKING
+
+- `start-plan` and `start-sprint` retire the previous flat artifact
+  layout under `$AGENT_HOME/out/plan-issue-delivery/<plan-slug>-...`
+  and now materialize every required artifact under the canonical
+  nested layout
+  `$AGENT_HOME/out/plan-issue-delivery/<repo-slug>/issue-<n>/...`
+  defined by
+  [`agent-kit RUNTIME_LAYOUT.md`](https://github.com/sympoies/agent-kit/blob/main/skills/automation/plan-issue-delivery/references/RUNTIME_LAYOUT.md)
+  and [`docs/plans/plan-issue-cli-canonical-runtime-artifacts-plan.md`](../../docs/plans/plan-issue-cli-canonical-runtime-artifacts-plan.md).
+  Retired filenames:
+  - `<plan-slug>-plan-tasks.tsv`
+  - `<plan-slug>-plan-issue-body.md`
+  - `<plan-slug>-sprint-<N>-tasks.tsv`
+  - `<plan-slug>-sprint-<N>-subagent-prompts/<anchor>-subagent-prompt.md`
+  Migration: the only known consumer is the `plan-issue-delivery`
+  wrapper (claude-kit / codex / opencode adapters), which already
+  expects the canonical layout. Direct callers should switch to the
+  new `task_spec_path`, `issue_body_path`, `sprint_root`,
+  `plan_snapshot_path`, `subagent_init_snapshot_path`,
+  `prompt_manifest_path`, and `dispatch_record_paths` fields in the
+  command JSON output instead of computing flat paths from the plan
+  slug.
+- `start-plan` and `start-sprint` now hard-require `AGENT_HOME` to be
+  set; missing or empty `AGENT_HOME` fails fast with exit code `1` and
+  the `runtime-layout-failed` error code.
+- `start-sprint` writes one `<TASK_ID>.md` prompt per dispatched task
+  under `$SPRINT_ROOT/prompts/`. The retired
+  `<anchor>-subagent-prompt.md` flat filename is no longer produced.
+
+### Added
+
+- `runtime_layout` module exposing `runtime_root`, `repo_slug`,
+  `IssueRoot`, `SprintRoot`, and `RuntimeLayoutError` for canonical
+  path math.
+- `dispatch_record` module with the ten-key `DispatchRecord`
+  serializer (`task_id`, `task_prompt_path`,
+  `subagent_init_snapshot_path`, `plan_snapshot_path`, `worktree`,
+  `branch`, `execution_mode`, `pr_group`, `base_branch`,
+  `workflow_role`) and `write_dispatch_record` helper. Optional
+  adapter fields (`runtime_name`, `runtime_role`,
+  `runtime_role_fallback_reason`) are intentionally absent from the
+  binary's emission and are added post-emission by the wrapper /
+  main-agent.
+- `start-plan` JSON gains `issue_root`,
+  `main_agent_init_snapshot_path`, and `plan_branch_ref_path`.
+- `start-sprint` JSON gains `sprint_root`, `plan_snapshot_path`,
+  `subagent_init_snapshot_path`, `prompt_manifest_path`, and
+  `dispatch_record_paths`.
+- Gate matrix `G11` (canonical runtime artifact emission) wired into
+  the spec.

--- a/crates/plan-issue-cli/README.md
+++ b/crates/plan-issue-cli/README.md
@@ -117,6 +117,23 @@ plan-issue-local build-plan-task-spec \
 - `1`: runtime/validation failure
 - `2`: usage failure
 
+## Canonical runtime artifact layout
+
+`start-plan` and `start-sprint` materialize artifacts under
+`$AGENT_HOME/out/plan-issue-delivery/<repo-slug>/issue-<n>/...`, where
+`<repo-slug>` is `owner__repo`. Plan-scope artifacts live under
+`<issue-root>/plan/` and `<issue-root>/prompts/`; sprint-scope artifacts
+live under `<issue-root>/sprint-<n>/{prompts,manifests,specs}/`. Per-task
+dispatch records (`dispatch-<TASK_ID>.json`) carry the canonical ten-key
+shape; runtime-adapter fields (`runtime_name`, `runtime_role`,
+`runtime_role_fallback_reason`) are added by the active wrapper at
+dispatch time and are intentionally absent from the binary's emission.
+
+See [`CLI contract v2`](docs/specs/plan-issue-cli-contract-v2.md)
+"Canonical Runtime Artifacts (v2)" for the full path catalogue and
+[`agent-kit RUNTIME_LAYOUT.md`](https://github.com/sympoies/agent-kit/blob/main/skills/automation/plan-issue-delivery/references/RUNTIME_LAYOUT.md)
+for the upstream contract.
+
 ## Specifications
 
 - [CLI contract v2](docs/specs/plan-issue-cli-contract-v2.md)

--- a/crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v2.md
+++ b/crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v2.md
@@ -116,7 +116,7 @@ Sprint-scoped artifacts (owned by `start-sprint`):
 Per-task dispatch record (owned by `start-sprint`):
 
 - `DISPATCH_RECORD_PATH="$SPRINT_ROOT/manifests/dispatch-<TASK_ID>.json"`.
-- Required keys (snake_case, eleven total):
+- Required keys (snake_case, ten total):
   - `task_id`
   - `task_prompt_path`
   - `subagent_init_snapshot_path`
@@ -153,14 +153,11 @@ Worktree path rules:
 
 ### Breaking Change: Retired Flat Layout
 
-This contract **retires** the prior flat artifact layout:
+This contract **retires** the prior flat artifact layout entirely. The
+retired filenames and the migration note are catalogued in the crate
+[`CHANGELOG.md`](../../CHANGELOG.md) under the `BREAKING` section.
+Downstream consumers must read artifacts from the canonical
+`$ISSUE_ROOT` / `$SPRINT_ROOT` paths above.
 
-- `$AGENT_HOME/out/plan-issue-delivery/<plan-slug>-plan-tasks.tsv`
-- `$AGENT_HOME/out/plan-issue-delivery/<plan-slug>-plan-issue-body.md`
-- `$AGENT_HOME/out/plan-issue-delivery/<plan-slug>-sprint-<N>-tasks.tsv`
-- `$AGENT_HOME/out/plan-issue-delivery/<plan-slug>-sprint-<N>-subagent-prompts/<anchor>-subagent-prompt.md`
-
-The retirement is a breaking change; downstream consumers must read
-artifacts from the canonical `$ISSUE_ROOT` / `$SPRINT_ROOT` paths above.
 Migration delivered by
 [`docs/plans/plan-issue-cli-canonical-runtime-artifacts-plan.md`](../../../../docs/plans/plan-issue-cli-canonical-runtime-artifacts-plan.md).

--- a/crates/plan-issue-cli/tests/fixtures/runtime_layout/plan.md
+++ b/crates/plan-issue-cli/tests/fixtures/runtime_layout/plan.md
@@ -1,0 +1,44 @@
+# Plan: Runtime Layout Parity Fixture
+
+## Overview
+
+Tiny end-to-end fixture used by the canonical runtime-layout parity test.
+Plan content is intentionally minimal so the parity assertions can pin the
+shape of every emitted artifact without churning on plan content.
+
+## Scope
+
+- In scope:
+  - One sprint with one task that the parity test can cover end-to-end.
+- Out of scope:
+  - Anything beyond canonical artifact emission.
+
+## Assumptions
+
+1. Test uses a temp `AGENT_HOME` and seeded prompts.
+
+## Sprint 1: Smoke
+
+**Goal**: Trip the canonical artifact emission path.
+**Demo/Validation**:
+
+- Command(s):
+  - `cargo test -p nils-plan-issue-cli runtime_layout_parity`
+
+**PR grouping intent**: `per-sprint`
+**Execution Profile**: `serial`
+
+### Task 1.1: Touch a sentinel
+
+- **Location**:
+  - `crates/plan-issue-cli/tests/fixtures/runtime_layout/plan.md`
+- **Description**: No-op smoke task. The parity test asserts on the
+  canonical artifacts emitted by `start-plan` + `start-sprint` for this
+  one row.
+- **Dependencies**:
+  - none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Canonical artifacts emitted.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli runtime_layout_parity`

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -19,6 +19,8 @@ mod live_start_sprint_runtime_truth;
 mod output_contract;
 #[path = "integration/parity_guardrails.rs"]
 mod parity_guardrails;
+#[path = "integration/runtime_layout_parity.rs"]
+mod runtime_layout_parity;
 #[path = "integration/runtime_truth_plan_and_sprint_flow.rs"]
 mod runtime_truth_plan_and_sprint_flow;
 #[path = "integration/start_plan_canonical.rs"]

--- a/crates/plan-issue-cli/tests/integration/runtime_layout_parity.rs
+++ b/crates/plan-issue-cli/tests/integration/runtime_layout_parity.rs
@@ -1,0 +1,230 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use crate::common;
+
+const FIXTURE_PLAN_FROM_REPO: &str = "crates/plan-issue-cli/tests/fixtures/runtime_layout/plan.md";
+const FIXTURE_PLAN_FROM_CRATE: &str = "tests/fixtures/runtime_layout/plan.md";
+const FIXTURE_REPO: &str = "graysurf/runtime-layout-fixture";
+const FIXTURE_REPO_SLUG: &str = "graysurf__runtime-layout-fixture";
+const PLACEHOLDER_ISSUE: u64 = 999;
+
+fn parse_json(stdout: &str) -> Value {
+    serde_json::from_str(stdout).expect("stdout should be valid JSON")
+}
+
+fn relativize(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .map(|stripped| stripped.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.to_string_lossy().to_string())
+}
+
+fn collect_relative_paths(root: &Path) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    walk_recursive(root, root, &mut out);
+    out
+}
+
+fn walk_recursive(root: &Path, current: &Path, sink: &mut BTreeSet<String>) {
+    let Ok(entries) = fs::read_dir(current) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let path = entry.path();
+        if metadata.is_dir() {
+            walk_recursive(root, &path, sink);
+        } else if metadata.is_file() {
+            sink.insert(relativize(root, &path));
+        }
+    }
+}
+
+#[test]
+fn runtime_layout_parity() {
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("agent home");
+    common::seed_agent_home_prompts(&agent_home);
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let start_plan_out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            FIXTURE_REPO,
+            "start-plan",
+            "--plan",
+            FIXTURE_PLAN_FROM_REPO,
+            "--pr-grouping",
+            "per-sprint",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+    assert_eq!(start_plan_out.code, 0, "stderr: {}", start_plan_out.stderr);
+
+    let start_sprint_out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            FIXTURE_REPO,
+            "start-sprint",
+            "--plan",
+            FIXTURE_PLAN_FROM_REPO,
+            "--issue",
+            "999",
+            "--sprint",
+            "1",
+            "--pr-grouping",
+            "per-sprint",
+            "--no-comment",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+    assert_eq!(
+        start_sprint_out.code, 0,
+        "stderr: {}",
+        start_sprint_out.stderr
+    );
+
+    let runtime_root = agent_home
+        .join("out")
+        .join("plan-issue-delivery")
+        .join(FIXTURE_REPO_SLUG)
+        .join(format!("issue-{PLACEHOLDER_ISSUE}"));
+    let actual_files = collect_relative_paths(&runtime_root);
+    let expected_files: BTreeSet<String> = [
+        "plan/issue-body.md",
+        "plan/plan-branch.ref",
+        "plan/plan.snapshot.md",
+        "plan/tasks.tsv",
+        "prompts/plan-issue-delivery-main-agent-init.snapshot.md",
+        "sprint-1/manifests/dispatch-S1T1.json",
+        "sprint-1/manifests/prompt-manifest.tsv",
+        "sprint-1/prompts/S1T1.md",
+        "sprint-1/prompts/plan-issue-delivery-subagent-init.snapshot.md",
+        "sprint-1/specs/sprint-task-spec.tsv",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    assert_eq!(
+        actual_files,
+        expected_files,
+        "canonical artifact tree mismatch under {}",
+        runtime_root.display()
+    );
+
+    let plan_branch = fs::read_to_string(runtime_root.join("plan/plan-branch.ref"))
+        .expect("read plan-branch.ref");
+    assert_eq!(plan_branch, format!("plan/issue-{PLACEHOLDER_ISSUE}"));
+
+    let plan_snapshot =
+        fs::read_to_string(runtime_root.join("plan/plan.snapshot.md")).expect("read plan snapshot");
+    let plan_source = fs::read_to_string(FIXTURE_PLAN_FROM_CRATE).expect("read fixture plan");
+    assert_eq!(
+        plan_snapshot, plan_source,
+        "plan snapshot must mirror source byte-for-byte"
+    );
+
+    let main_init = fs::read_to_string(
+        runtime_root.join("prompts/plan-issue-delivery-main-agent-init.snapshot.md"),
+    )
+    .expect("read main-init snapshot");
+    let main_source =
+        fs::read_to_string(agent_home.join("prompts/plan-issue-delivery-main-agent-init.md"))
+            .expect("read main-init source");
+    assert_eq!(main_init, main_source);
+
+    let subagent_init = fs::read_to_string(
+        runtime_root.join("sprint-1/prompts/plan-issue-delivery-subagent-init.snapshot.md"),
+    )
+    .expect("read subagent-init snapshot");
+    let subagent_source =
+        fs::read_to_string(agent_home.join("prompts/plan-issue-delivery-subagent-init.md"))
+            .expect("read subagent-init source");
+    assert_eq!(subagent_init, subagent_source);
+
+    let dispatch_path = runtime_root.join("sprint-1/manifests/dispatch-S1T1.json");
+    let dispatch_text = fs::read_to_string(&dispatch_path).expect("read dispatch");
+    let dispatch: Value = serde_json::from_str(&dispatch_text).expect("dispatch parses");
+    assert_eq!(dispatch["task_id"], "S1T1");
+    assert_eq!(dispatch["execution_mode"], "per-sprint");
+    assert_eq!(dispatch["base_branch"], "plan/issue-999");
+    assert_eq!(dispatch["workflow_role"], "implementation");
+    assert_eq!(
+        dispatch["task_prompt_path"]
+            .as_str()
+            .expect("task_prompt_path string"),
+        runtime_root
+            .join("sprint-1/prompts/S1T1.md")
+            .to_string_lossy()
+            .to_string()
+    );
+    assert_eq!(
+        dispatch["plan_snapshot_path"]
+            .as_str()
+            .expect("plan_snapshot_path string"),
+        runtime_root
+            .join("plan/plan.snapshot.md")
+            .to_string_lossy()
+            .to_string()
+    );
+    for adapter_key in [
+        "runtime_name",
+        "runtime_role",
+        "runtime_role_fallback_reason",
+    ] {
+        assert!(
+            dispatch.get(adapter_key).is_none(),
+            "binary must not emit {adapter_key}: {dispatch_text}"
+        );
+    }
+
+    let manifest_path = runtime_root.join("sprint-1/manifests/prompt-manifest.tsv");
+    let manifest = fs::read_to_string(&manifest_path).expect("read prompt manifest");
+    let mut lines = manifest.lines();
+    assert_eq!(
+        lines.next(),
+        Some("task_id\tprompt_path\texecution_mode\tworkflow_role"),
+        "manifest header"
+    );
+    let body_lines: Vec<&str> = lines.filter(|line| !line.is_empty()).collect();
+    assert_eq!(body_lines.len(), 1, "one row per task");
+    let cells: Vec<&str> = body_lines[0].split('\t').collect();
+    assert_eq!(
+        cells,
+        vec![
+            "S1T1",
+            runtime_root
+                .join("sprint-1/prompts/S1T1.md")
+                .to_string_lossy()
+                .as_ref(),
+            "per-sprint",
+            "implementation",
+        ]
+    );
+
+    let plan_payload = parse_json(&start_plan_out.stdout);
+    let sprint_payload = parse_json(&start_sprint_out.stdout);
+    assert_eq!(
+        plan_payload["payload"]["result"]["issue_number"], 999,
+        "plan-issue-local placeholder issue"
+    );
+    assert_eq!(sprint_payload["payload"]["result"]["record_count"], 1);
+    let sprint_root = sprint_payload["payload"]["result"]["sprint_root"]
+        .as_str()
+        .expect("sprint_root in result");
+    assert_eq!(PathBuf::from(sprint_root), runtime_root.join("sprint-1"));
+}


### PR DESCRIPTION
## Summary

Sprint 4 (final sprint) of the plan-issue-cli canonical runtime artifacts plan. Adds the end-to-end parity test that pins the canonical `$ISSUE_ROOT` / `$SPRINT_ROOT` artifact tree, lands the per-crate CHANGELOG.md with a `BREAKING` entry for the retired flat layout, and updates README + contract spec for the new layout. Pre-delivery gate stack (`NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage`) is green.

## Changes

- `crates/plan-issue-cli/tests/integration/runtime_layout_parity.rs` (new) — `runtime_layout_parity` integration test runs `plan-issue-local start-plan` then `plan-issue-local start-sprint --sprint 1` against the fixture under a temp `AGENT_HOME`, walks the canonical artifact tree, and pins the file set + snapshot bytes + dispatch-record JSON shape + prompt-manifest TSV header.
- `crates/plan-issue-cli/tests/fixtures/runtime_layout/plan.md` (new) — minimal one-task fixture plan.
- `crates/plan-issue-cli/CHANGELOG.md` (new, per-crate) — Keep a Changelog format with `BREAKING` entry naming retired filenames and migration note.
- `crates/plan-issue-cli/README.md` — added "Canonical runtime artifact layout" section linking to the contract spec and agent-kit `RUNTIME_LAYOUT.md`.
- `crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v2.md` — fixed Sprint 1 wording drift ("eleven" → "ten" required keys), moved the retired-filename catalogue to the CHANGELOG so the `! rg` validation against `README.md` + `docs/` is clean.

## Testing

- \`cargo test -p nils-plan-issue-cli runtime_layout_parity\` (pass)
- \`rg -n 'BREAKING' crates/plan-issue-cli/CHANGELOG.md\` (matches)
- \`! rg -n 'plan-tasks\\.tsv|plan-issue-body\\.md|subagent-prompts/' crates/plan-issue-cli/README.md crates/plan-issue-cli/docs\` (no matches)
- \`rg -n 'plan-issue-cli-canonical-runtime-artifacts-plan' crates/plan-issue-cli/CHANGELOG.md\` (matches)
- \`NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh\` (pass)
- \`NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage\` (pass; line coverage gate satisfied)
- Sprint 4 acceptance file `\$AGENT_HOME/out/plan-issue-cli/sprint-4/acceptance.md` — `Result: PASS`

## Risk / Notes

- `bash scripts/ci/nils-cli-checks-entrypoint.sh` (workspace `cargo test --workspace` mode) hits two pre-existing flaky timing tests in `nils-gemini-cli prompt_segment_refresh`. They retry-stable and unrelated to plan-issue-cli changes. Per `DEVELOPMENT.md`, the canonical pre-delivery flow is `NILS_CLI_TEST_RUNNER=nextest`, which is fully green; the flake is a separate bug to address in the gemini-cli crate.
- Plan validation pattern uses `-- --exact`, but Rust integration tests carry the `<module>::` prefix; the `runtime_layout_parity` test lives in `runtime_layout_parity::runtime_layout_parity`, so substring filtering matches and `--exact` requires the full path.
- After this PR merges, the canonical runtime layout cutover is complete. `plan-issue` and `plan-issue-local` only emit the new layout; the wrapper / adapters can rely on the canonical paths.