### PR TITLE
fix(plan-issue-cli): canonical worktree in dispatch record

### DIFF
--- a/crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v2.md
+++ b/crates/plan-issue-cli/docs/specs/plan-issue-cli-contract-v2.md
@@ -144,6 +144,11 @@ Worktree path rules:
   - `pr-isolated`: `"$WORKTREE_ROOT/pr-isolated/<TASK_ID>"`.
   - `pr-shared`: `"$WORKTREE_ROOT/pr-shared/<PR_GROUP>"`.
   - `per-sprint`: `"$WORKTREE_ROOT/per-sprint/sprint-<N>"`.
+- The dispatch record's `worktree` key is the **absolute** assigned-path
+  computed from this mapping (not the short lane name from
+  `sprint-task-spec.tsv`). The `prompt-manifest.tsv` and
+  `sprint-task-spec.tsv` may keep the short lane name for
+  human-readable lookup; the JSON dispatch record is canonical.
 
 `AGENT_HOME` requirement:
 

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -1077,14 +1077,26 @@ fn run_start_sprint(
         let dispatch_path = sprint_root
             .dispatch_record(&row.task_id)
             .map_err(|err| CommandError::runtime("runtime-layout-failed", err.to_string()))?;
+        let execution_mode = execution_mode_for_row(row, args.grouping.strategy, &artifact_rows);
+        // Canonical contract: dispatch record `worktree` is the absolute
+        // assigned path under $WORKTREE_ROOT (RUNTIME_LAYOUT.md "Worktree
+        // Layout (Assigned Paths)"), not the short name from the TSV.
+        let assigned_worktree = issue_root
+            .assigned_worktree(
+                &execution_mode,
+                &row.task_id,
+                &row.pr_group,
+                i32::from(args.sprint),
+            )
+            .map_err(|err| CommandError::runtime("runtime-layout-failed", err.to_string()))?;
         let record = DispatchRecord::implementation(
             row.task_id.clone(),
             path_text(&task_prompt_path),
             path_text(&subagent_init_target),
             path_text(&plan_snapshot_target),
-            row.worktree.clone(),
+            path_text(&assigned_worktree),
             row.branch.clone(),
-            execution_mode_for_row(row, args.grouping.strategy, &artifact_rows),
+            execution_mode,
             row.pr_group.clone(),
             plan_branch.clone(),
         );

--- a/crates/plan-issue-cli/src/runtime_layout.rs
+++ b/crates/plan-issue-cli/src/runtime_layout.rs
@@ -138,6 +138,41 @@ impl IssueRoot {
     pub fn worktree_root(&self) -> PathBuf {
         self.root.join(WORKTREES_DIR)
     }
+
+    /// Canonical assigned-worktree path for one task.
+    ///
+    /// Per `RUNTIME_LAYOUT.md` "Worktree Layout (Assigned Paths)":
+    ///
+    /// - `pr-isolated` → `$WORKTREE_ROOT/pr-isolated/<TASK_ID>`
+    /// - `pr-shared`   → `$WORKTREE_ROOT/pr-shared/<PR_GROUP>`
+    /// - `per-sprint`  → `$WORKTREE_ROOT/per-sprint/sprint-<N>`
+    ///
+    /// Unknown `execution_mode` falls back to the `pr-isolated` shape so
+    /// the dispatch record always names an absolute path under
+    /// `WORKTREE_ROOT`.
+    pub fn assigned_worktree(
+        &self,
+        execution_mode: &str,
+        task_id: &str,
+        pr_group: &str,
+        sprint: i32,
+    ) -> Result<PathBuf, RuntimeLayoutError> {
+        let trim_segment = |seg: &str| -> Result<String, RuntimeLayoutError> {
+            let t = seg.trim();
+            if t.is_empty() || t.contains('/') || t.contains('\\') || t.contains('\0') {
+                return Err(RuntimeLayoutError::InvalidTaskId {
+                    task_id: seg.to_string(),
+                });
+            }
+            Ok(t.to_string())
+        };
+        let root = self.worktree_root();
+        match execution_mode {
+            "pr-shared" => Ok(root.join("pr-shared").join(trim_segment(pr_group)?)),
+            "per-sprint" => Ok(root.join("per-sprint").join(format!("sprint-{sprint}"))),
+            _ => Ok(root.join("pr-isolated").join(trim_segment(task_id)?)),
+        }
+    }
 }
 
 /// Sprint-scoped runtime root.
@@ -301,6 +336,59 @@ mod tests {
             issue.root().join("plan/issue-body.md")
         );
         assert_eq!(issue.worktree_root(), issue.root().join("worktrees"));
+    }
+
+    #[test]
+    fn test_assigned_worktree_canonical_paths() {
+        let lock = GlobalStateLock::new();
+        let _guard = EnvGuard::set(&lock, "AGENT_HOME", "/tmp/agent-home-fixture");
+
+        let issue = issue_root_for("graysurf__plan-issue-smoke", 17);
+
+        // pr-isolated: pinned by TASK_ID
+        assert_eq!(
+            issue
+                .assigned_worktree("pr-isolated", "S1T1", "s1-auto-g1", 1)
+                .expect("pr-isolated"),
+            issue.worktree_root().join("pr-isolated").join("S1T1")
+        );
+
+        // pr-shared: pinned by PR_GROUP
+        assert_eq!(
+            issue
+                .assigned_worktree("pr-shared", "S1T1", "s1-auto-g1", 1)
+                .expect("pr-shared"),
+            issue.worktree_root().join("pr-shared").join("s1-auto-g1")
+        );
+
+        // per-sprint: pinned by sprint number
+        assert_eq!(
+            issue
+                .assigned_worktree("per-sprint", "S1T1", "s1", 1)
+                .expect("per-sprint"),
+            issue.worktree_root().join("per-sprint").join("sprint-1")
+        );
+        assert_eq!(
+            issue
+                .assigned_worktree("per-sprint", "S2T1", "s2", 2)
+                .expect("per-sprint sprint-2"),
+            issue.worktree_root().join("per-sprint").join("sprint-2")
+        );
+
+        // Unknown mode falls back to pr-isolated shape.
+        assert_eq!(
+            issue
+                .assigned_worktree("unknown-mode", "S1T1", "s1", 1)
+                .expect("fallback"),
+            issue.worktree_root().join("pr-isolated").join("S1T1")
+        );
+
+        // Empty task id rejected for pr-isolated.
+        assert!(issue
+            .assigned_worktree("pr-isolated", "", "g1", 1)
+            .is_err());
+        // Empty pr_group rejected for pr-shared.
+        assert!(issue.assigned_worktree("pr-shared", "S1T1", "", 1).is_err());
     }
 
     #[test]

--- a/crates/plan-issue-cli/src/runtime_layout.rs
+++ b/crates/plan-issue-cli/src/runtime_layout.rs
@@ -384,9 +384,7 @@ mod tests {
         );
 
         // Empty task id rejected for pr-isolated.
-        assert!(issue
-            .assigned_worktree("pr-isolated", "", "g1", 1)
-            .is_err());
+        assert!(issue.assigned_worktree("pr-isolated", "", "g1", 1).is_err());
         // Empty pr_group rejected for pr-shared.
         assert!(issue.assigned_worktree("pr-shared", "S1T1", "", 1).is_err());
     }


### PR DESCRIPTION
## Summary

Align the `dispatch-<TASK_ID>.json` `worktree` field with `RUNTIME_LAYOUT.md` "Worktree Layout (Assigned Paths)" so the JSON dispatch record carries the canonical absolute path. The TSV column keeps the short lane name unchanged.

## Problem

Since v0.7.3 the binary emits the full canonical artifact tree (issue / sprint roots, snapshots, dispatch records). However the `worktree` key inside `dispatch-<TASK_ID>.json` was being filled from `TaskSpecRow.worktree`, which is the short lane name (`issue-s1-t1`, `issue-s1-t2`) used in `sprint-task-spec.tsv`.

`agent-kit/skills/automation/plan-issue-delivery/references/RUNTIME_LAYOUT.md` L52-65 specifies that assigned worktree values must be absolute paths under `\$WORKTREE_ROOT="\$ISSUE_ROOT/worktrees"`, mapped per execution mode:

- `pr-isolated` → `\$WORKTREE_ROOT/pr-isolated/<TASK_ID>`
- `pr-shared`   → `\$WORKTREE_ROOT/pr-shared/<PR_GROUP>`
- `per-sprint`  → `\$WORKTREE_ROOT/per-sprint/sprint-<N>`

A strict reader of the dispatch record would not be able to `git worktree add` the path as-is.

## Reproduction

```bash
plan-issue-local --repo owner/demo start-plan --plan demo.md --strategy deterministic --pr-grouping per-sprint
plan-issue-local --repo owner/demo start-sprint --plan demo.md --sprint 1 --issue 999 --strategy deterministic --pr-grouping per-sprint
jq '.worktree' "\$AGENT_HOME/out/plan-issue-delivery/owner__demo/issue-999/sprint-1/manifests/dispatch-S1T1.json"
# Before: "issue-s1-t1"
# After:  "/Users/.../out/plan-issue-delivery/owner__demo/issue-999/worktrees/per-sprint/sprint-1"
```

## Issues Found

| Where | What | Severity |
| --- | --- | --- |
| `dispatch_record.json` `worktree` field | Carried short lane name (`issue-s1-t1`) instead of canonical absolute path | Medium — strict canonical readers fail; subagents that re-read the snapshot still cope |

## Fix Approach

- Add `IssueRoot::assigned_worktree(execution_mode, task_id, pr_group, sprint)` in `runtime_layout.rs`. Returns `\$WORKTREE_ROOT/{pr-isolated/<TASK_ID> | pr-shared/<PR_GROUP> | per-sprint/sprint-<N>}` per RUNTIME_LAYOUT.md. Unknown modes fall back to the `pr-isolated` shape so the record always names an absolute path. Empty / slashed segments rejected as `InvalidTaskId`.
- In `execute.rs` `start-sprint`, compute `assigned_worktree` once per task using the resolved `execution_mode`, then pass that into `DispatchRecord::implementation` instead of `row.worktree.clone()`.
- TSV (`sprint-task-spec.tsv`) and `prompt-manifest.tsv` retain the short lane name — those are for human-readable lookup and existing tooling. The JSON dispatch record is the canonical contract.
- `plan-issue-cli-contract-v2.md`: spell out the JSON-vs-TSV split so future readers do not assume both must match.
- New unit test `test_assigned_worktree_canonical_paths` covers the four mode cases plus invalid-input rejection.

## Testing

- `cargo test -p nils-plan-issue-cli` → 49 lib + 71 integration = 120 passed, 0 failed.
- New unit test alone: `cargo test -p nils-plan-issue-cli --lib -- runtime_layout::tests::test_assigned_worktree_canonical_paths` → ok.
- Manual end-to-end with the locally-built `plan-issue-local` 0.7.3+:
  - `per-sprint` mode → `worktree` is `\$ISSUE_ROOT/worktrees/per-sprint/sprint-1` for both tasks.
  - `pr-isolated` mode (deterministic, isolated) → `worktree` is `\$ISSUE_ROOT/worktrees/pr-isolated/<TASK_ID>`.
- `nils-gemini-cli` integration test failures observed locally are pre-existing on `main` (verified by stash + rerun) and unrelated to this change.

## Risk / Notes

- Behaviour change is limited to one JSON field. TSV format and on-disk artifact tree are otherwise unchanged.
- Downstream wrappers (claude-kit, agent-kit) that previously had to guess / patch the worktree path now get it canonically. Wrappers that hard-coded short-name expectations (none observed in agent-kit) would need a follow-up.
- No version bump in this PR; treat as a 0.7.4 candidate fix.