### PR TITLE
feat(plan-tooling): improve validate UX with line-aware errors, backtick-safe placeholders, and --explain catalog

### DIFF
--- a/crates/plan-tooling/src/validate.rs
+++ b/crates/plan-tooling/src/validate.rs
@@ -443,11 +443,35 @@ fn validate_task(plan_path: &str, task: &Task, all_task_ids: &HashSet<String>) -
 }
 
 fn has_placeholder(value: &str) -> bool {
-    if contains_angle_placeholder(value) {
+    let scan = strip_backtick_spans(value);
+    if contains_angle_placeholder(&scan) {
         return true;
     }
 
-    contains_word_case_insensitive(value, "TBD") || contains_word_case_insensitive(value, "TODO")
+    contains_word_case_insensitive(&scan, "TBD") || contains_word_case_insensitive(&scan, "TODO")
+}
+
+/// Drop the contents of paired backtick spans so placeholder checks only fire
+/// on prose. An unpaired trailing backtick is kept verbatim (treated as
+/// literal text), matching how Markdown renders it.
+fn strip_backtick_spans(value: &str) -> String {
+    let chars: Vec<char> = value.chars().collect();
+    let mut out = String::with_capacity(value.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '`' {
+            if let Some(rel_end) = chars[i + 1..].iter().position(|c| *c == '`') {
+                i = i + 1 + rel_end + 1;
+                continue;
+            }
+            out.push('`');
+            i += 1;
+            continue;
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
 }
 
 fn contains_angle_placeholder(value: &str) -> bool {
@@ -537,7 +561,7 @@ mod tests {
 
     use super::{
         contains_angle_placeholder, contains_word_case_insensitive, has_placeholder,
-        is_non_empty_list, is_task_id, validate_task,
+        is_non_empty_list, is_task_id, strip_backtick_spans, validate_task,
     };
 
     #[test]
@@ -565,6 +589,28 @@ mod tests {
         assert!(has_placeholder("mark as tBd"));
         assert!(!has_placeholder("cat < input > output"));
         assert!(!has_placeholder("all good"));
+    }
+
+    #[test]
+    fn has_placeholder_ignores_tokens_inside_backtick_spans() {
+        // Legitimate usage docs that wrap argument slots in backticks.
+        assert!(!has_placeholder("invoke `<arg>` with the path"));
+        assert!(!has_placeholder("plan-issue resolve-approval `<TBD>`"));
+        assert!(!has_placeholder("write `TODO: hook entry` then return"));
+        // Bare placeholders outside backticks still fail.
+        assert!(has_placeholder("invoke <arg> with the path"));
+        assert!(has_placeholder("plan-issue resolve-approval <TBD>"));
+        assert!(has_placeholder("write TODO: hook entry then return"));
+    }
+
+    #[test]
+    fn strip_backtick_spans_handles_pairs_and_dangling() {
+        assert_eq!(strip_backtick_spans("hi `code` bye"), "hi  bye");
+        assert_eq!(strip_backtick_spans("a `b` c `d` e"), "a  c  e");
+        // Unpaired backtick is preserved as literal text.
+        assert_eq!(strip_backtick_spans("a `b c"), "a `b c");
+        // Empty span drops nothing visible (just two backticks).
+        assert_eq!(strip_backtick_spans("a `` b"), "a  b");
     }
 
     #[test]

--- a/crates/plan-tooling/src/validate.rs
+++ b/crates/plan-tooling/src/validate.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use crate::parse::{Plan, Sprint, Task, parse_plan_with_display};
 
 const USAGE: &str = r#"Usage:
-  validate_plans.sh [--file <path>]... [--format text|json]
+  validate_plans.sh [--file <path>]... [--format text|json] [--explain]
 
 Purpose:
   Lint plan markdown files under docs/plans/ against Plan Format v1.
@@ -17,6 +17,8 @@ Purpose:
 Options:
   --file <path>  Validate a specific plan file (may be repeated)
   --format <fmt> text (default) or json
+  --explain      Append canonical accepted-shape examples per error class.
+                 Output is independent of exit code (also prints on success).
   -h, --help     Show help
 
 Defaults:
@@ -42,11 +44,21 @@ struct ValidateOutput {
     ok: bool,
     files: Vec<String>,
     errors: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    explanations: Option<Vec<ExplainEntry>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ExplainEntry {
+    class: &'static str,
+    rule: &'static str,
+    example: &'static str,
 }
 
 pub fn run(args: &[String]) -> i32 {
     let mut files: Vec<String> = Vec::new();
     let mut format = "text".to_string();
+    let mut explain = false;
 
     let mut i = 0;
     while i < args.len() {
@@ -64,6 +76,10 @@ pub fn run(args: &[String]) -> i32 {
                 }
                 format = args[i + 1].to_string();
                 i += 2;
+            }
+            "--explain" => {
+                explain = true;
+                i += 1;
             }
             "-h" | "--help" => {
                 print_usage();
@@ -94,8 +110,16 @@ pub fn run(args: &[String]) -> i32 {
                 ok: true,
                 files: Vec::new(),
                 errors: Vec::new(),
+                explanations: if explain {
+                    Some(all_explanations())
+                } else {
+                    None
+                },
             };
             return print_json_output(output, 0);
+        }
+        if explain {
+            print_explanations_text(&all_explanations());
         }
         return 0;
     }
@@ -136,20 +160,32 @@ pub fn run(args: &[String]) -> i32 {
 
     if format == "json" {
         let code = if errors.is_empty() { 0 } else { 1 };
+        let explanations = if explain {
+            Some(explanations_for(&errors))
+        } else {
+            None
+        };
         let output = ValidateOutput {
             ok: errors.is_empty(),
             files: discovered_for_output,
             errors,
+            explanations,
         };
         return print_json_output(output, code);
     }
 
     if errors.is_empty() {
+        if explain {
+            print_explanations_text(&all_explanations());
+        }
         return 0;
     }
 
-    for err in errors {
+    for err in &errors {
         eprintln!("error: {err}");
+    }
+    if explain {
+        print_explanations_text(&explanations_for(&errors));
     }
     1
 }
@@ -540,6 +576,181 @@ fn is_task_id(s: &str) -> bool {
         return false;
     }
     a.chars().all(|c| c.is_ascii_digit()) && b.chars().all(|c| c.is_ascii_digit())
+}
+
+struct ExplainCatalogEntry {
+    /// Substring used to detect that this error class fired. Must appear in
+    /// the matching error message and be unique across the catalog.
+    pattern: &'static str,
+    explain: ExplainEntry,
+}
+
+const EXPLAIN_CATALOG: &[ExplainCatalogEntry] = &[
+    ExplainCatalogEntry {
+        pattern: "Location must be repo-relative",
+        explain: ExplainEntry {
+            class: "location-absolute",
+            rule: "Location entries must be repo-relative paths (no leading '/').",
+            example: "- **Location**:\n  - `crates/foo/src/bar.rs`",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "Location must be a file path",
+        explain: ExplainEntry {
+            class: "location-directory",
+            rule: "Location entries must point at files, not directories.",
+            example: "- **Location**:\n  - `crates/foo/src/lib.rs`",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "must not use globs",
+        explain: ExplainEntry {
+            class: "location-glob",
+            rule: "Enumerate every touched file; globs and braces are rejected.",
+            example: "- **Location**:\n  - `crates/foo/src/a.rs`\n  - `crates/foo/src/b.rs`",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "Location contains placeholder",
+        explain: ExplainEntry {
+            class: "location-placeholder",
+            rule: "Replace `<...>` / TODO / TBD placeholders with real paths.",
+            example: "- **Location**:\n  - `crates/plan-tooling/src/validate.rs`",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "missing Description",
+        explain: ExplainEntry {
+            class: "description-missing",
+            rule: "Description is required and must be non-empty prose.",
+            example: "- **Description**: Validate task dependencies against the plan's task IDs.",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "Description contains placeholder",
+        explain: ExplainEntry {
+            class: "description-placeholder",
+            rule: "Description must not contain `<...>` / TODO / TBD outside backticks. \
+                   Wrap usage slots in backticks (e.g. `<arg>`) when documenting CLI shapes.",
+            example: "- **Description**: Invoke `<arg>` to wire the slot.",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "missing Dependencies",
+        explain: ExplainEntry {
+            class: "dependencies-missing",
+            rule: "Dependencies field is required: use 'none' or list `Task N.M` IDs.",
+            example: "- **Dependencies**:\n  - none",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "invalid dependency",
+        explain: ExplainEntry {
+            class: "dependency-invalid",
+            rule: "Dependency entries must use the canonical `Task N.M` form.",
+            example: "- **Dependencies**:\n  - Task 1.2\n  - Task 2.1",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "unknown dependency",
+        explain: ExplainEntry {
+            class: "dependency-unknown",
+            rule: "Dependency must reference a `### Task N.M` heading present in the plan.",
+            example: "- **Dependencies**:\n  - Task 1.1     # must match an actual task heading",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "Complexity out of range",
+        explain: ExplainEntry {
+            class: "complexity-range",
+            rule: "Complexity is a 1-10 integer.",
+            example: "- **Complexity**: 5",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "missing Acceptance criteria",
+        explain: ExplainEntry {
+            class: "acceptance-missing",
+            rule: "Acceptance criteria is a non-empty list of testable outcomes.",
+            example: "- **Acceptance criteria**:\n  - All callers of foo() return Result<()>.",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "Acceptance criteria contains placeholder",
+        explain: ExplainEntry {
+            class: "acceptance-placeholder",
+            rule: "Acceptance criteria entries must be concrete; no `<...>` / TODO / TBD placeholders.",
+            example: "- **Acceptance criteria**:\n  - validate() rejects empty input with exit 2.",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "missing Validation",
+        explain: ExplainEntry {
+            class: "validation-missing",
+            rule: "Validation is a non-empty list of runnable commands or steps.",
+            example: "- **Validation**:\n  - cargo test -p plan-tooling",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "Validation contains placeholder",
+        explain: ExplainEntry {
+            class: "validation-placeholder",
+            rule: "Validation entries must be concrete commands; no `<...>` / TODO / TBD placeholders.",
+            example: "- **Validation**:\n  - cargo nextest run --profile ci -p plan-tooling",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "must include both `PR grouping intent` and `Execution Profile`",
+        explain: ExplainEntry {
+            class: "sprint-metadata-partial",
+            rule: "Sprint metadata must declare both `PR grouping intent` and `Execution Profile`.",
+            example: "**PR grouping intent**: `per-sprint`\n**Execution Profile**: `serial`",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "is per-sprint but `Execution Profile` indicates parallel width",
+        explain: ExplainEntry {
+            class: "sprint-metadata-mismatch",
+            rule: "`per-sprint` grouping cannot run with parallel execution; use `group` for parallel-x{N}.",
+            example: "**PR grouping intent**: `group`\n**Execution Profile**: `parallel-x2`",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "invalid or missing task id",
+        explain: ExplainEntry {
+            class: "task-id-invalid",
+            rule: "Task headings must use `### Task N.M: name` (numeric N and M).",
+            example: "### Task 2.1: Validate sprint metadata",
+        },
+    },
+];
+
+fn all_explanations() -> Vec<ExplainEntry> {
+    EXPLAIN_CATALOG.iter().map(|e| e.explain.clone()).collect()
+}
+
+fn explanations_for(errors: &[String]) -> Vec<ExplainEntry> {
+    let mut hits: Vec<ExplainEntry> = Vec::new();
+    for entry in EXPLAIN_CATALOG {
+        if errors.iter().any(|err| err.contains(entry.pattern)) {
+            hits.push(entry.explain.clone());
+        }
+    }
+    hits
+}
+
+fn print_explanations_text(entries: &[ExplainEntry]) {
+    if entries.is_empty() {
+        return;
+    }
+    eprintln!();
+    eprintln!("Examples:");
+    for entry in entries {
+        eprintln!("  [{}] {}", entry.class, entry.rule);
+        for line in entry.example.lines() {
+            eprintln!("      {line}");
+        }
+    }
 }
 
 fn parse_parallel_width_from_execution_profile(profile: &str) -> Option<usize> {

--- a/crates/plan-tooling/src/validate.rs
+++ b/crates/plan-tooling/src/validate.rs
@@ -373,22 +373,32 @@ fn validate_task(plan_path: &str, task: &Task, all_task_ids: &HashSet<String>) -
             "{prefix}: missing Dependencies (use 'none' or list task IDs)"
         )),
         Some(deps) => {
+            let mut invalid: Vec<String> = Vec::new();
+            let mut unknown: Vec<String> = Vec::new();
             for dep in deps {
                 let d = dep.trim();
                 if d.is_empty() {
                     continue;
                 }
                 if !is_task_id(d) {
-                    errs.push(format!(
-                        "{prefix}: invalid dependency (expected 'Task N.M'): {}",
-                        crate::repr::py_repr(dep)
-                    ));
+                    invalid.push(crate::repr::py_repr(dep));
                 } else if !all_task_ids.contains(d) {
-                    errs.push(format!(
-                        "{prefix}: unknown dependency (not found in plan): {}",
-                        crate::repr::py_repr(d)
-                    ));
+                    unknown.push(crate::repr::py_repr(d));
                 }
+            }
+            if !invalid.is_empty() {
+                errs.push(format!(
+                    "{prefix}: line {line}: invalid dependency (expected 'Task N.M', e.g. 'Task 1.2'): {values}",
+                    line = task.start_line,
+                    values = invalid.join(", ")
+                ));
+            }
+            if !unknown.is_empty() {
+                errs.push(format!(
+                    "{prefix}: line {line}: unknown dependency (not found in plan): {values}",
+                    line = task.start_line,
+                    values = unknown.join(", ")
+                ));
             }
         }
     }
@@ -580,7 +590,7 @@ mod tests {
             id: "Task 1.1".to_string(),
             name: "demo".to_string(),
             sprint: 1,
-            start_line: 1,
+            start_line: 42,
             location: vec![
                 "/abs/path.rs".to_string(),
                 "dir/".to_string(),
@@ -602,6 +612,48 @@ mod tests {
         assert!(errs.iter().any(|e| e.contains("invalid dependency")));
         assert!(errs.iter().any(|e| e.contains("unknown dependency")));
         assert!(errs.iter().any(|e| e.contains("Complexity out of range")));
+        assert!(
+            errs.iter()
+                .any(|e| e.contains("line 42") && e.contains("e.g. 'Task 1.2'")),
+            "expected dep error to carry task line + canonical example, got: {errs:?}",
+        );
+    }
+
+    #[test]
+    fn validate_task_groups_invalid_deps_into_single_error() {
+        let task = Task {
+            id: "Task 2.5".to_string(),
+            name: "multi-bad-deps".to_string(),
+            sprint: 2,
+            start_line: 87,
+            location: vec!["src/lib.rs".to_string()],
+            description: Some("Ship feature".to_string()),
+            dependencies: Some(vec![
+                "Task x.y".to_string(),
+                "1.1".to_string(),
+                "Task 1".to_string(),
+            ]),
+            complexity: Some(3),
+            acceptance_criteria: vec!["Done".to_string()],
+            validation: vec!["cargo test".to_string()],
+        };
+        let all_ids = HashSet::from(["Task 2.5".to_string()]);
+        let errs = validate_task("plan.md", &task, &all_ids);
+        let invalid: Vec<&String> = errs
+            .iter()
+            .filter(|e| e.contains("invalid dependency"))
+            .collect();
+        assert_eq!(
+            invalid.len(),
+            1,
+            "expected a single grouped invalid-dep error, got: {errs:?}",
+        );
+        let msg = invalid[0];
+        assert!(msg.contains("line 87"), "missing line ref: {msg}");
+        assert!(msg.contains("e.g. 'Task 1.2'"), "missing example: {msg}");
+        assert!(msg.contains("'Task x.y'"), "missing first bad value: {msg}");
+        assert!(msg.contains("'1.1'"), "missing second bad value: {msg}");
+        assert!(msg.contains("'Task 1'"), "missing third bad value: {msg}");
     }
 
     #[test]

--- a/crates/plan-tooling/tests/integration/validate.rs
+++ b/crates/plan-tooling/tests/integration/validate.rs
@@ -112,6 +112,31 @@ fn validate_redirect_command_is_not_placeholder() {
 }
 
 #[test]
+fn validate_dependency_error_carries_line_and_example() {
+    let repo = init_repo();
+    write_file(&repo.path().join("bad-deps.md"), INVALID_DEP_FORMAT_PLAN);
+
+    let out = run_plan_tooling(repo.path(), &["validate", "--file", "bad-deps.md"]);
+    assert_eq!(out.code, 1);
+    assert!(out.stdout.is_empty());
+    assert!(
+        out.stderr.contains("invalid dependency"),
+        "stderr: {}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("e.g. 'Task 1.2'"),
+        "stderr: {}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("line "),
+        "stderr should reference a line number, got: {}",
+        out.stderr
+    );
+}
+
+#[test]
 fn validate_json_ok_with_explicit_file() {
     let repo = init_repo();
     write_file(&repo.path().join("plan.md"), VALID_PLAN);
@@ -288,6 +313,23 @@ const REDIRECT_VALIDATION_PLAN: &str = r#"# Plan: Redirect
   - Redirect command is accepted
 - **Validation**:
   - cat < input.txt > output.txt
+"#;
+
+const INVALID_DEP_FORMAT_PLAN: &str = r#"# Plan: Bad deps
+
+## Sprint 1: First sprint
+
+### Task 1.1: Do thing
+- **Location**:
+  - `src/a.rs`
+- **Description**: Do A
+- **Dependencies**:
+  - 1.1
+  - Task x.y
+- **Acceptance criteria**:
+  - A works
+- **Validation**:
+  - cargo test
 "#;
 
 const METADATA_MISMATCH_PLAN: &str = r#"# Plan: Metadata mismatch

--- a/crates/plan-tooling/tests/integration/validate.rs
+++ b/crates/plan-tooling/tests/integration/validate.rs
@@ -112,6 +112,21 @@ fn validate_redirect_command_is_not_placeholder() {
 }
 
 #[test]
+fn validate_backtick_wrapped_placeholder_in_description_is_accepted() {
+    let repo = init_repo();
+    write_file(&repo.path().join("backtick.md"), BACKTICK_DESCRIPTION_PLAN);
+
+    let out = run_plan_tooling(repo.path(), &["validate", "--file", "backtick.md"]);
+    assert_eq!(
+        out.code, 0,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    assert!(out.stdout.is_empty());
+    assert!(out.stderr.is_empty());
+}
+
+#[test]
 fn validate_dependency_error_carries_line_and_example() {
     let repo = init_repo();
     write_file(&repo.path().join("bad-deps.md"), INVALID_DEP_FORMAT_PLAN);
@@ -313,6 +328,22 @@ const REDIRECT_VALIDATION_PLAN: &str = r#"# Plan: Redirect
   - Redirect command is accepted
 - **Validation**:
   - cat < input.txt > output.txt
+"#;
+
+const BACKTICK_DESCRIPTION_PLAN: &str = r#"# Plan: Backtick description
+
+## Sprint 1: First sprint
+
+### Task 1.1: Document a usage slot
+- **Location**:
+  - `src/a.rs`
+- **Description**: Invoke `<arg>` and `<TBD>` like `TODO: keep` to wire the slot.
+- **Dependencies**:
+  - none
+- **Acceptance criteria**:
+  - Slot resolves
+- **Validation**:
+  - cargo test
 "#;
 
 const INVALID_DEP_FORMAT_PLAN: &str = r#"# Plan: Bad deps

--- a/crates/plan-tooling/tests/integration/validate.rs
+++ b/crates/plan-tooling/tests/integration/validate.rs
@@ -152,6 +152,116 @@ fn validate_dependency_error_carries_line_and_example() {
 }
 
 #[test]
+fn validate_explain_appends_examples_only_for_triggered_classes_on_failure() {
+    let repo = init_repo();
+    write_file(&repo.path().join("bad.md"), INVALID_PLAN);
+
+    let out = run_plan_tooling(repo.path(), &["validate", "--file", "bad.md", "--explain"]);
+    assert_eq!(out.code, 1);
+    assert!(out.stdout.is_empty());
+    // Errors still printed.
+    assert!(out.stderr.contains("error:"));
+    // Examples block appears.
+    assert!(
+        out.stderr.contains("Examples:"),
+        "stderr should append Examples block, got: {}",
+        out.stderr
+    );
+    // Triggered classes from INVALID_PLAN: location-absolute, description-placeholder
+    // (TODO), dependency-unknown (Task 1.2 not in plan), acceptance-placeholder
+    // (<TBD>), validation-placeholder (TBD).
+    assert!(out.stderr.contains("[location-absolute]"));
+    assert!(out.stderr.contains("[description-placeholder]"));
+    assert!(out.stderr.contains("[dependency-unknown]"));
+    // Classes that did NOT fire should be absent (no globs, no missing fields).
+    assert!(!out.stderr.contains("[location-glob]"));
+    assert!(!out.stderr.contains("[description-missing]"));
+    assert!(!out.stderr.contains("[dependencies-missing]"));
+}
+
+#[test]
+fn validate_explain_on_success_prints_full_catalog() {
+    let repo = init_repo();
+    write_file(&repo.path().join("plan.md"), VALID_PLAN);
+
+    let out = run_plan_tooling(repo.path(), &["validate", "--file", "plan.md", "--explain"]);
+    assert_eq!(
+        out.code, 0,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    assert!(out.stdout.is_empty());
+    // Successful validate prints zero errors but still emits the explainer.
+    assert!(!out.stderr.contains("error:"));
+    assert!(out.stderr.contains("Examples:"));
+    // Catalog should expose every known class on success.
+    for class in [
+        "[location-absolute]",
+        "[location-glob]",
+        "[description-placeholder]",
+        "[dependency-invalid]",
+        "[dependency-unknown]",
+        "[sprint-metadata-mismatch]",
+    ] {
+        assert!(
+            out.stderr.contains(class),
+            "stderr missing class {class}, got: {}",
+            out.stderr
+        );
+    }
+}
+
+#[test]
+fn validate_explain_json_includes_explanations_array() {
+    let repo = init_repo();
+    write_file(&repo.path().join("bad.md"), INVALID_PLAN);
+
+    let out = run_plan_tooling(
+        repo.path(),
+        &[
+            "validate",
+            "--file",
+            "bad.md",
+            "--format",
+            "json",
+            "--explain",
+        ],
+    );
+    assert_eq!(out.code, 1);
+    assert!(out.stderr.is_empty());
+
+    let v: serde_json::Value = serde_json::from_str(&out.stdout).expect("json");
+    assert_eq!(v["ok"], false);
+    let explanations = v["explanations"].as_array().expect("explanations array");
+    assert!(!explanations.is_empty());
+    let classes: Vec<&str> = explanations
+        .iter()
+        .map(|e| e["class"].as_str().unwrap_or(""))
+        .collect();
+    assert!(classes.contains(&"location-absolute"));
+    assert!(classes.contains(&"description-placeholder"));
+}
+
+#[test]
+fn validate_no_explain_omits_explanations() {
+    let repo = init_repo();
+    write_file(&repo.path().join("bad.md"), INVALID_PLAN);
+
+    let out = run_plan_tooling(
+        repo.path(),
+        &["validate", "--file", "bad.md", "--format", "json"],
+    );
+    assert_eq!(out.code, 1);
+    let v: serde_json::Value = serde_json::from_str(&out.stdout).expect("json");
+    // explanations field should be absent (skip_serializing_if).
+    assert!(
+        v.get("explanations").is_none(),
+        "default validate must not emit explanations: {}",
+        out.stdout
+    );
+}
+
+#[test]
 fn validate_json_ok_with_explicit_file() {
     let repo = init_repo();
     write_file(&repo.path().join("plan.md"), VALID_PLAN);


### PR DESCRIPTION
## Summary

Three plan-author-facing wins for `plan-tooling validate`: dependency errors now carry the offending task line plus a canonical `Task 1.2` example (and group all bad deps per task into a single message); `<arg>` / TODO / TBD wrapped in backticks no longer trip the placeholder rule, so Description text can document CLI shapes without rewording; and a new `--explain` flag prints accepted-shape examples per error class (full catalog on success, triggered classes on failure). Surfaced by the `/plan-issue:plan-issue-delivery` end-to-end test as the top three plan-author friction points in Sprint 2 of the plan-issue-delivery improvements plan.

## Changes

- `crates/plan-tooling/src/validate.rs`: dep error now includes `line N` + `e.g. 'Task 1.2'` and groups all invalid / unknown deps per task into one message
- `crates/plan-tooling/src/validate.rs`: `has_placeholder` strips paired-backtick spans before scanning, so `` `<arg>` `` / `` `TODO: ...` `` validate clean while bare placeholders still fail
- `crates/plan-tooling/src/validate.rs`: new `--explain` flag, static `EXPLAIN_CATALOG`, `explanations_for()` matcher, and `print_explanations_text` writer; JSON adds optional `explanations` field (skipped when flag absent)
- `crates/plan-tooling/tests/integration/validate.rs`: 5 new integration tests covering line+example, backtick wrapping, --explain on failure / success, JSON `explanations`, and default-path no-emit
- `crates/plan-tooling/src/validate.rs` inline tests: 3 new unit tests for grouped-deps formatting, backtick-aware placeholder, and `strip_backtick_spans` helper

## Testing

- `cargo test -p nils-plan-tooling` (pass — 25 unit + 64 integration)
- `cargo fmt -p nils-plan-tooling --check` (pass)
- `cargo clippy -p nils-plan-tooling --all-targets -- -D warnings` (pass)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass — full nils-cli required-checks suite)
- Manual smoke: `plan-tooling validate --file <real plan> --explain` prints the full catalog when validation succeeds

## Risk / Notes

- `ValidateOutput` JSON gains an optional `explanations` field. `serde(skip_serializing_if = "Option::is_none")` keeps existing consumers unaffected when `--explain` is absent.
- Default text output is unchanged when `--explain` is not passed; the dep error format gains `line N` + example but keeps the `invalid dependency` / `unknown dependency` substrings used by integration assertions and downstream parsers.
- Out of scope: Sprint 1 (plan-issue CLI ergonomics), Sprint 3 (manage_issue_pr_review.sh), Sprint 4 (claude-kit wrapper). To be scheduled separately after re-running the e2e test against this PR's binary.
