### PR TITLE
feat(plan-issue-cli): orchestrator-friendly payload + resolve-approval (Sprint 1)

### DIFF
--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -12,7 +12,8 @@ use crate::{ValidationError, issue_body};
 use self::build::{BuildPlanTaskSpecArgs, BuildTaskSpecArgs};
 use self::completion::CompletionArgs;
 use self::plan::{
-    CleanupWorktreesArgs, ClosePlanArgs, LinkPrArgs, ReadyPlanArgs, StartPlanArgs, StatusPlanArgs,
+    CleanupWorktreesArgs, ClosePlanArgs, LinkPrArgs, ReadyPlanArgs, ResolveApprovalArgs,
+    StartPlanArgs, StatusPlanArgs,
 };
 use self::sprint::{AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs};
 
@@ -173,6 +174,10 @@ pub enum Command {
     /// Print the full repeated command flow for a plan (1 plan = 1 issue).
     MultiSprintGuide(MultiSprintGuideArgs),
 
+    /// Resolve the URL of the most recent `Decision: merge` review-evidence
+    /// comment on a PR, suitable for `accept-sprint --approved-comment-url`.
+    ResolveApproval(ResolveApprovalArgs),
+
     /// Export shell completion script.
     Completion(CompletionArgs),
 }
@@ -192,6 +197,7 @@ impl Command {
             Self::ReadySprint(_) => "ready-sprint",
             Self::AcceptSprint(_) => "accept-sprint",
             Self::MultiSprintGuide(_) => "multi-sprint-guide",
+            Self::ResolveApproval(_) => "resolve-approval",
             Self::Completion(_) => "completion",
         }
     }
@@ -234,6 +240,7 @@ impl Command {
             Self::ReadySprint(args) => serde_json::to_value(args),
             Self::AcceptSprint(args) => serde_json::to_value(args),
             Self::MultiSprintGuide(args) => serde_json::to_value(args),
+            Self::ResolveApproval(args) => serde_json::to_value(args),
             Self::Completion(args) => serde_json::to_value(args),
         };
 
@@ -259,6 +266,7 @@ impl Command {
             Self::Completion(_)
             | Self::StatusPlan(_)
             | Self::ReadyPlan(_)
+            | Self::ResolveApproval(_)
             | Self::CleanupWorktrees(_) => Ok(()),
         }
     }

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -197,7 +197,27 @@ impl Command {
     }
 
     pub fn schema_version(&self) -> String {
-        format!("plan-issue-cli.{}.v1", self.command_id().replace('-', "."))
+        // Most commands stay on `.v1`. Commands whose `result` payload picked
+        // up new orchestrator-friendly fields in Sprint 1 (`repo_slug`,
+        // `pr_groups`, `worktree_abs_path`) bump to `.v2`. Existing v1
+        // readers that read only the older fields are still compatible —
+        // the new fields are additive — but should be considered deprecated
+        // and updated to the v2 schema.
+        let suffix = match self {
+            // Result now exposes `repo_slug` (Task 1.1).
+            Self::StartPlan(_) => "v2",
+            // Result now exposes `repo_slug` (Task 1.1).
+            Self::StatusPlan(_) => "v2",
+            // Result now exposes `repo_slug` (Task 1.1) + `pr_groups`
+            // (Task 1.3); dispatch records gain `worktree_abs_path`
+            // (Task 1.4).
+            Self::StartSprint(_) => "v2",
+            _ => "v1",
+        };
+        format!(
+            "plan-issue-cli.{}.{suffix}",
+            self.command_id().replace('-', ".")
+        )
     }
 
     pub fn payload(&self) -> Value {

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -245,9 +245,14 @@ impl Command {
             Self::BuildTaskSpec(args) => validate_grouping(&args.grouping),
             Self::BuildPlanTaskSpec(args) => validate_grouping(&args.grouping),
             Self::StartPlan(args) => validate_grouping(&args.grouping),
-            Self::StartSprint(args) => validate_grouping(&args.grouping),
-            Self::ReadySprint(args) => validate_grouping(&args.grouping),
-            Self::AcceptSprint(args) => validate_grouping(&args.grouping),
+            // Sprint commands may infer `--strategy` / `--default-pr-grouping`
+            // from the plan markdown's `pr-grouping` metadata at runtime
+            // (Task 1.2), so the no-flag deterministic path is intentionally
+            // permitted here; the runtime resolver enforces the real
+            // requirement once the plan has been read.
+            Self::StartSprint(args) => validate_grouping_with_plan_inference(&args.grouping),
+            Self::ReadySprint(args) => validate_grouping_with_plan_inference(&args.grouping),
+            Self::AcceptSprint(args) => validate_grouping_with_plan_inference(&args.grouping),
             Self::ClosePlan(args) => validate_close_plan_args(args, dry_run),
             Self::LinkPr(args) => validate_link_pr_args(args),
             Self::MultiSprintGuide(args) => validate_multi_sprint_guide_args(args),
@@ -296,6 +301,23 @@ fn validate_grouping(grouping: &GroupingArgs) -> Result<(), ValidationError> {
             Ok(())
         }
     }
+}
+
+/// Validate grouping for sprint commands that may infer flags from the
+/// plan's per-sprint `pr-grouping` metadata (Task 1.2). Identical to
+/// `validate_grouping` except the "deterministic with no `--pr-grouping`"
+/// case is permitted: the runtime resolver in `execute::run_*_sprint`
+/// either substitutes plan-derived defaults or surfaces a richer error.
+fn validate_grouping_with_plan_inference(grouping: &GroupingArgs) -> Result<(), ValidationError> {
+    // No-flag path that downstream inference will fill in.
+    if grouping.strategy == SplitStrategy::Deterministic
+        && grouping.pr_grouping.is_none()
+        && grouping.default_pr_grouping.is_none()
+        && grouping.pr_group.is_empty()
+    {
+        return Ok(());
+    }
+    validate_grouping(grouping)
 }
 
 fn validate_close_plan_args(args: &ClosePlanArgs, dry_run: bool) -> Result<(), ValidationError> {

--- a/crates/plan-issue-cli/src/commands/plan.rs
+++ b/crates/plan-issue-cli/src/commands/plan.rs
@@ -182,3 +182,15 @@ pub struct CleanupWorktreesArgs {
     #[arg(long, value_name = "number")]
     pub issue: u64,
 }
+
+/// Args for the `resolve-approval` subcommand (Task 1.5).
+///
+/// Wraps the orchestrator pattern of finding the latest review-evidence
+/// comment whose body contains `Decision: merge` on a PR and returning its
+/// `html_url`.
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct ResolveApprovalArgs {
+    /// PR number (live `plan-issue` path only).
+    #[arg(long, value_name = "number")]
+    pub pr: u64,
+}

--- a/crates/plan-issue-cli/src/dispatch_record.rs
+++ b/crates/plan-issue-cli/src/dispatch_record.rs
@@ -21,13 +21,24 @@ pub const WORKFLOW_ROLE_IMPLEMENTATION: &str = "implementation";
 /// Stable, sorted JSON object written to `dispatch-<TASK_ID>.json`.
 ///
 /// Field order matches the canonical contract.
+///
+/// **Deprecation note (Task 1.4)**: `worktree` is retained verbatim for
+/// backwards compatibility with existing v1 readers. New consumers should
+/// read `worktree_abs_path` instead — both fields carry the canonical
+/// absolute path under `$AGENT_HOME/out/plan-issue-delivery/<slug>/issue-<N>/worktrees/`,
+/// but `worktree_abs_path` is the explicit, self-describing name and will
+/// remain stable across future refactors. `worktree` may eventually be
+/// removed in a v3 schema bump.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DispatchRecord {
     pub task_id: String,
     pub task_prompt_path: String,
     pub subagent_init_snapshot_path: String,
     pub plan_snapshot_path: String,
+    /// Deprecated alias for `worktree_abs_path`; kept for v1 readers.
     pub worktree: String,
+    /// Canonical absolute path of the assigned worktree (Task 1.4).
+    pub worktree_abs_path: String,
     pub branch: String,
     pub execution_mode: String,
     pub pr_group: String,
@@ -42,18 +53,23 @@ impl DispatchRecord {
         task_prompt_path: impl Into<String>,
         subagent_init_snapshot_path: impl Into<String>,
         plan_snapshot_path: impl Into<String>,
-        worktree: impl Into<String>,
+        worktree_abs_path: impl Into<String>,
         branch: impl Into<String>,
         execution_mode: impl Into<String>,
         pr_group: impl Into<String>,
         base_branch: impl Into<String>,
     ) -> Self {
+        let worktree_abs = worktree_abs_path.into();
         Self {
             task_id: task_id.into(),
             task_prompt_path: task_prompt_path.into(),
             subagent_init_snapshot_path: subagent_init_snapshot_path.into(),
             plan_snapshot_path: plan_snapshot_path.into(),
-            worktree: worktree.into(),
+            // `worktree` was already the assigned absolute path post the
+            // canonical-runtime refactor; keep it identical to
+            // `worktree_abs_path` for v1 reader compatibility.
+            worktree: worktree_abs.clone(),
+            worktree_abs_path: worktree_abs,
             branch: branch.into(),
             execution_mode: execution_mode.into(),
             pr_group: pr_group.into(),
@@ -105,6 +121,8 @@ mod tests {
             "\"subagent_init_snapshot_path\"",
             "\"plan_snapshot_path\"",
             "\"worktree\"",
+            // Task 1.4: explicit absolute path field for orchestrators.
+            "\"worktree_abs_path\"",
             "\"branch\"",
             "\"execution_mode\"",
             "\"pr_group\"",
@@ -126,6 +144,17 @@ mod tests {
                 "json must not include adapter key {absent}: {json}"
             );
         }
+    }
+
+    #[test]
+    fn test_worktree_abs_path_mirrors_worktree() {
+        let record = sample();
+        assert_eq!(record.worktree_abs_path, record.worktree);
+        assert!(
+            record.worktree_abs_path.starts_with('/'),
+            "worktree_abs_path must be absolute: {}",
+            record.worktree_abs_path
+        );
     }
 
     #[test]

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -11,8 +11,8 @@ use serde_json::{Value, json};
 use crate::cli::Cli;
 use crate::commands::build::{BuildPlanTaskSpecArgs, BuildTaskSpecArgs};
 use crate::commands::plan::{
-    CleanupWorktreesArgs, ClosePlanArgs, LinkPrArgs, LinkPrStatus, ReadyPlanArgs, StartPlanArgs,
-    StatusPlanArgs,
+    CleanupWorktreesArgs, ClosePlanArgs, LinkPrArgs, LinkPrStatus, ReadyPlanArgs,
+    ResolveApprovalArgs, StartPlanArgs, StatusPlanArgs,
 };
 use crate::commands::sprint::{
     AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs,
@@ -60,6 +60,9 @@ pub fn execute(binary: BinaryFlavor, cli: &Cli) -> Result<Value, CommandError> {
             run_accept_sprint(binary, cli.dry_run, cli.force, cli.repo.as_deref(), args)
         }
         CliCommand::MultiSprintGuide(args) => run_multi_sprint_guide(binary, args),
+        CliCommand::ResolveApproval(args) => {
+            run_resolve_approval_json(binary, cli.force, cli.repo.as_deref(), args)
+        }
         CliCommand::Completion(_) => Err(CommandError::usage(
             "completion-direct-output-only",
             "completion output is emitted directly; run `<binary> completion <bash|zsh>`",
@@ -1727,6 +1730,164 @@ fn run_multi_sprint_guide(
     }))
 }
 
+// ----------------------------------------------------------------------------
+// Task 1.5: resolve-approval
+// ----------------------------------------------------------------------------
+
+/// One review-evidence comment whose body matched `Decision: merge`.
+#[derive(Debug, Clone)]
+struct ApprovalCandidate {
+    html_url: String,
+    created_at: Option<String>,
+    body_excerpt: String,
+}
+
+#[derive(Debug, Clone)]
+struct ResolveApprovalOutcome {
+    repo: String,
+    pr: u64,
+    candidates: Vec<ApprovalCandidate>,
+}
+
+impl ResolveApprovalOutcome {
+    fn latest_url(&self) -> Option<&str> {
+        self.candidates.first().map(|c| c.html_url.as_str())
+    }
+}
+
+fn collect_approval_candidates(
+    binary: BinaryFlavor,
+    force: bool,
+    repo_override: Option<&str>,
+    pr: u64,
+) -> Result<ResolveApprovalOutcome, CommandError> {
+    ensure_live_binary_for_command(
+        binary,
+        "resolve-approval --pr <number>",
+        Some("plan-issue resolve-approval --pr <number> --repo <owner/repo>"),
+    )?;
+    let repo = resolve_repo_for_live(binary, repo_override)?;
+
+    let adapter = GhCliAdapter::new(force);
+    let comments = adapter
+        .pr_comments(&repo, pr)
+        .map_err(|err| CommandError::runtime("github-pr-comments-failed", err))?;
+
+    let mut matched: Vec<ApprovalCandidate> = comments
+        .into_iter()
+        .filter_map(|comment| {
+            let body = comment.get("body").and_then(Value::as_str)?;
+            // Match canonical "Decision: merge" line; allow surrounding
+            // whitespace/punctuation (Markdown bullet, bold, etc.) so the
+            // orchestrator's actual review-evidence comment shape is
+            // accepted verbatim.
+            if !body.lines().any(|line| line.contains("Decision: merge")) {
+                return None;
+            }
+            let html_url = comment.get("html_url").and_then(Value::as_str)?.to_string();
+            let created_at = comment
+                .get("created_at")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let body_excerpt = body
+                .lines()
+                .find(|line| line.contains("Decision: merge"))
+                .unwrap_or("Decision: merge")
+                .chars()
+                .take(120)
+                .collect::<String>();
+            Some(ApprovalCandidate {
+                html_url,
+                created_at,
+                body_excerpt,
+            })
+        })
+        .collect();
+
+    // Latest first by `created_at` (lexicographic on ISO-8601 is correct).
+    matched.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+    Ok(ResolveApprovalOutcome {
+        repo,
+        pr,
+        candidates: matched,
+    })
+}
+
+fn run_resolve_approval_json(
+    binary: BinaryFlavor,
+    force: bool,
+    repo_override: Option<&str>,
+    args: &ResolveApprovalArgs,
+) -> Result<Value, CommandError> {
+    let outcome = collect_approval_candidates(binary, force, repo_override, args.pr)?;
+    let candidates: Vec<Value> = outcome
+        .candidates
+        .iter()
+        .map(|c| {
+            json!({
+                "html_url": c.html_url,
+                "created_at": c.created_at,
+                "body_excerpt": c.body_excerpt,
+            })
+        })
+        .collect();
+    Ok(json!({
+        "repo": outcome.repo,
+        "pr": outcome.pr,
+        "count": candidates.len(),
+        "url": outcome.latest_url(),
+        "candidates": candidates,
+    }))
+}
+
+/// Text-mode driver for `resolve-approval` — returns the process exit
+/// code so the binary can short-circuit the standard text envelope. On
+/// exactly one match prints the URL on stdout; otherwise prints a clear
+/// stderr message naming the count and exits non-zero.
+pub fn run_resolve_approval_text(
+    binary: BinaryFlavor,
+    repo_override: Option<&str>,
+    args: &ResolveApprovalArgs,
+) -> i32 {
+    // Force flag is irrelevant for read-only `gh api` calls; pass `false`.
+    let outcome = match collect_approval_candidates(binary, false, repo_override, args.pr) {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            eprintln!(
+                "error[{code}]: {message}",
+                code = err.code,
+                message = err.message
+            );
+            return err.exit_code;
+        }
+    };
+
+    match outcome.candidates.len() {
+        0 => {
+            eprintln!(
+                "no merge-decision review-evidence comment found on PR #{pr} of {repo}",
+                pr = outcome.pr,
+                repo = outcome.repo
+            );
+            crate::EXIT_FAILURE
+        }
+        1 => {
+            // SAFETY: count == 1.
+            println!("{}", outcome.latest_url().expect("single candidate"));
+            crate::EXIT_SUCCESS
+        }
+        many => {
+            eprintln!(
+                "found {many} merge-decision review-evidence comments on PR #{pr} of {repo}; pass --format json to inspect candidates and choose explicitly",
+                pr = outcome.pr,
+                repo = outcome.repo
+            );
+            crate::EXIT_FAILURE
+        }
+    }
+}
+
 fn to_build_options(
     owner_prefix: String,
     branch_prefix: String,
@@ -1762,14 +1923,14 @@ pub(crate) struct InferredGroupingDefaults {
 ///
 /// Behaviour (Task 1.2):
 ///
-/// * Returns `None` when the operator passed any explicit grouping flag
+/// * Returns `Ok(None)` when the operator passed any explicit grouping flag
 ///   (so CLI flags always win).
-/// * Returns `None` when the plan parses cleanly but the named sprint
+/// * Returns `Ok(None)` when the plan parses cleanly but the named sprint
 ///   has no `pr-grouping` metadata.
-/// * Returns `Some(_)` when the plan declares the sprint's intent and
+/// * Returns `Ok(Some(_))` when the plan declares the sprint's intent and
 ///   no CLI flag overrode it; the caller mutates `grouping` accordingly
 ///   and prints the hint to stderr.
-/// * Returns `None` when the plan cannot be parsed; the downstream
+/// * Returns `Ok(None)` when the plan cannot be parsed; the downstream
 ///   `task_spec::build_task_spec` call surfaces the same parse error with
 ///   a richer message.
 pub(crate) fn infer_grouping_defaults_from_plan(
@@ -2752,6 +2913,10 @@ mod tests {
 
         fn pr_is_merged(&self, _repo: &str, pr: u64) -> Result<bool, String> {
             self.merged.get(&pr).cloned().unwrap_or(Ok(true))
+        }
+
+        fn pr_comments(&self, _repo: &str, _pr: u64) -> Result<Vec<Value>, String> {
+            unreachable!("pr_comments is not needed in this test")
         }
     }
 

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -267,6 +267,7 @@ fn run_start_plan(
         "task_spec_path": path_text(&task_spec_out),
         "issue_body_path": path_text(&issue_body_out),
         "issue_root": path_text(issue_root.root()),
+        "repo_slug": repo_slug,
         "main_agent_init_snapshot_path": path_text(&main_agent_init_target),
         "plan_branch_ref_path": path_text(&plan_branch_ref),
         "record_count": build.rows.len(),
@@ -344,11 +345,23 @@ fn run_status_plan(
         live_mutations = true;
     }
 
+    // Repo slug is the runtime fact orchestrators most often rebuild from
+    // strings; expose it whenever we know it. For body-file flows where the
+    // operator did not pass `--repo`, fall back to whatever repo_override
+    // resolves to (None when no remote is detected).
+    let repo_slug = match repo.as_deref() {
+        Some(repo) => Some(runtime_layout::repo_slug(repo)),
+        None => crate::github::resolve_repo(repo_override)
+            .ok()
+            .map(|repo| runtime_layout::repo_slug(&repo)),
+    };
+
     Ok(json!({
         "scope": "plan",
         "execution_mode": binary.execution_mode(),
         "dry_run": dry_run,
         "issue_source": source,
+        "repo_slug": repo_slug,
         "task_count": table.rows().len(),
         "status_counts": counts,
         "comment_requested": should_comment,
@@ -581,13 +594,36 @@ fn select_link_pr_rows_by_sprint(
     let mut target_label = format!("sprint:S{sprint}");
     if let Some(group_raw) = pr_group {
         let group = group_raw.trim();
+        // Enumerate the actual pr-group values present on this sprint's
+        // rows so the error message names the real options. Aligns with
+        // start-sprint's `pr_groups` payload (Task 1.3) — orchestrators
+        // should pass the same names verbatim.
+        let mut available_groups: BTreeSet<String> = BTreeSet::new();
+        for idx in &row_indexes {
+            if let Some(value) = note_value(&rows[*idx].notes, "pr-group") {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    available_groups.insert(trimmed.to_string());
+                }
+            }
+        }
         row_indexes.retain(|idx| {
             note_value(&rows[*idx].notes, "pr-group")
                 .is_some_and(|value| value.trim().eq_ignore_ascii_case(group))
         });
         if row_indexes.is_empty() {
+            let suggestion = if available_groups.is_empty() {
+                String::from("this sprint has no pr-group rows; use --task instead")
+            } else {
+                let options = available_groups
+                    .iter()
+                    .map(|name| format!("`{name}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("valid pr-group values for sprint S{sprint}: {options}")
+            };
             return Err(format!(
-                "sprint S{sprint} has no rows with pr-group `{group}`; use --task or a valid --pr-group"
+                "sprint S{sprint} has no rows with pr-group `{group}`; {suggestion}"
             ));
         }
         target_label = format!("sprint:S{sprint}/pr-group:{group}");
@@ -1113,6 +1149,27 @@ fn run_start_sprint(
     }
     dispatch_record_paths.sort();
 
+    // Aggregate pr_groups for the start-sprint result payload (Task 1.3).
+    // Each row carries the resolved `pr_group` string (e.g. `s1`,
+    // `s1-auto-g1`, `s2-core`); group rows by that name so orchestrators
+    // can pass the value verbatim to `link-pr --pr-group`.
+    let pr_groups: Vec<Value> = {
+        let mut by_group: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for row in &artifact_rows {
+            by_group
+                .entry(row.pr_group.clone())
+                .or_default()
+                .push(row.task_id.clone());
+        }
+        by_group
+            .into_iter()
+            .map(|(name, mut task_ids)| {
+                task_ids.sort();
+                json!({ "name": name, "task_ids": task_ids })
+            })
+            .collect()
+    };
+
     let prompt_manifest_path = sprint_root.prompt_manifest();
     write_prompt_manifest(
         &prompt_manifest_path,
@@ -1171,10 +1228,12 @@ fn run_start_sprint(
         "subagent_prompts_out": path_text(&prompts_dir),
         "subagent_prompt_files": prompt_files,
         "sprint_root": path_text(sprint_root.root()),
+        "repo_slug": repo_slug,
         "plan_snapshot_path": path_text(&plan_snapshot_target),
         "subagent_init_snapshot_path": path_text(&subagent_init_target),
         "prompt_manifest_path": path_text(&prompt_manifest_path),
         "dispatch_record_paths": dispatch_record_paths,
+        "pr_groups": pr_groups,
         "synced_issue_rows": synced_rows,
         "comment_requested": should_comment,
         "live_mutations_performed": live_mutations,

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -968,14 +968,32 @@ fn run_start_sprint(
     repo_override: Option<&str>,
     args: &StartSprintArgs,
 ) -> Result<Value, CommandError> {
+    // Task 1.2: read plan-declared `pr-grouping` for this sprint and
+    // default `--strategy` / `--default-pr-grouping` from it when the
+    // operator passed neither.
+    let mut grouping = args.grouping.clone();
+    let mut inferred_defaults_note: Option<String> = None;
+    if let Some(inferred) =
+        infer_grouping_defaults_from_plan(&args.plan, i32::from(args.sprint), &grouping)
+    {
+        apply_inferred_grouping_defaults(&mut grouping, &inferred);
+        inferred_defaults_note = Some(format!(
+            "auto/{}",
+            match inferred.default_pr_grouping {
+                crate::commands::PrGrouping::PerSprint => "per-sprint",
+                crate::commands::PrGrouping::Group => "group",
+            }
+        ));
+    }
+
     let options = to_build_options(
         args.prefixes.owner_prefix.clone(),
         args.prefixes.branch_prefix.clone(),
         args.prefixes.worktree_prefix.clone(),
-        args.grouping.pr_grouping,
-        args.grouping.default_pr_grouping,
-        args.grouping.strategy,
-        args.grouping.pr_group.clone(),
+        grouping.pr_grouping,
+        grouping.default_pr_grouping,
+        grouping.strategy,
+        grouping.pr_group.clone(),
     );
 
     let build = task_spec::build_task_spec(
@@ -1025,7 +1043,7 @@ fn run_start_sprint(
             table.rows(),
             i32::from(args.sprint),
             &build.rows,
-            args.grouping.strategy,
+            grouping.strategy,
         )
         .map_err(|err| CommandError::runtime("task-sync-drift-detected", err))?;
         issue_body_for_comment = Some(body);
@@ -1099,7 +1117,7 @@ fn run_start_sprint(
         args.issue,
         i32::from(args.sprint),
         &artifact_rows,
-        args.grouping.strategy,
+        grouping.strategy,
     )
     .map_err(|err| CommandError::runtime("subagent-prompt-write-failed", err))?;
 
@@ -1113,7 +1131,7 @@ fn run_start_sprint(
         let dispatch_path = sprint_root
             .dispatch_record(&row.task_id)
             .map_err(|err| CommandError::runtime("runtime-layout-failed", err.to_string()))?;
-        let execution_mode = execution_mode_for_row(row, args.grouping.strategy, &artifact_rows);
+        let execution_mode = execution_mode_for_row(row, grouping.strategy, &artifact_rows);
         // Canonical contract: dispatch record `worktree` is the absolute
         // assigned path under $WORKTREE_ROOT (RUNTIME_LAYOUT.md "Worktree
         // Layout (Assigned Paths)"), not the short name from the TSV.
@@ -1175,7 +1193,7 @@ fn run_start_sprint(
         &prompt_manifest_path,
         &artifact_rows,
         &sprint_root,
-        args.grouping.strategy,
+        grouping.strategy,
     )
     .map_err(|err| {
         CommandError::runtime(
@@ -1193,7 +1211,7 @@ fn run_start_sprint(
         sprint: i32::from(args.sprint),
         sprint_name: &sprint_name,
         rows: &artifact_rows,
-        strategy: args.grouping.strategy,
+        strategy: grouping.strategy,
         note_text: None,
         approval_comment_url: None,
         issue_body_text: issue_body_for_comment.as_deref(),
@@ -1235,6 +1253,7 @@ fn run_start_sprint(
         "dispatch_record_paths": dispatch_record_paths,
         "pr_groups": pr_groups,
         "synced_issue_rows": synced_rows,
+        "inferred_grouping_defaults": inferred_defaults_note,
         "comment_requested": should_comment,
         "live_mutations_performed": live_mutations,
     }))
@@ -1332,14 +1351,23 @@ fn run_ready_sprint(
     repo_override: Option<&str>,
     args: &ReadySprintArgs,
 ) -> Result<Value, CommandError> {
+    // Task 1.2: inherit grouping defaults from plan metadata when the
+    // operator passed no explicit flags.
+    let mut grouping = args.grouping.clone();
+    if let Some(inferred) =
+        infer_grouping_defaults_from_plan(&args.plan, i32::from(args.sprint), &grouping)
+    {
+        apply_inferred_grouping_defaults(&mut grouping, &inferred);
+    }
+
     let options = to_build_options(
         args.prefixes.owner_prefix.clone(),
         args.prefixes.branch_prefix.clone(),
         args.prefixes.worktree_prefix.clone(),
-        args.grouping.pr_grouping,
-        args.grouping.default_pr_grouping,
-        args.grouping.strategy,
-        args.grouping.pr_group.clone(),
+        grouping.pr_grouping,
+        grouping.default_pr_grouping,
+        grouping.strategy,
+        grouping.pr_group.clone(),
     );
 
     let build = task_spec::build_task_spec(
@@ -1388,7 +1416,7 @@ fn run_ready_sprint(
         sprint: i32::from(args.sprint),
         sprint_name: &sprint_name,
         rows: &build.rows,
-        strategy: args.grouping.strategy,
+        strategy: grouping.strategy,
         note_text: summary.as_deref(),
         approval_comment_url: None,
         issue_body_text: issue_body_for_comment.as_deref(),
@@ -1439,14 +1467,23 @@ fn run_accept_sprint(
         ));
     }
 
+    // Task 1.2: inherit grouping defaults from plan metadata when the
+    // operator passed no explicit flags.
+    let mut grouping = args.grouping.clone();
+    if let Some(inferred) =
+        infer_grouping_defaults_from_plan(&args.plan, i32::from(args.sprint), &grouping)
+    {
+        apply_inferred_grouping_defaults(&mut grouping, &inferred);
+    }
+
     let options = to_build_options(
         args.prefixes.owner_prefix.clone(),
         args.prefixes.branch_prefix.clone(),
         args.prefixes.worktree_prefix.clone(),
-        args.grouping.pr_grouping,
-        args.grouping.default_pr_grouping,
-        args.grouping.strategy,
-        args.grouping.pr_group.clone(),
+        grouping.pr_grouping,
+        grouping.default_pr_grouping,
+        grouping.strategy,
+        grouping.pr_group.clone(),
     );
 
     let build = task_spec::build_task_spec(
@@ -1533,7 +1570,7 @@ fn run_accept_sprint(
         sprint: i32::from(args.sprint),
         sprint_name: &sprint_name,
         rows: &build.rows,
-        strategy: args.grouping.strategy,
+        strategy: grouping.strategy,
         note_text: summary.as_deref(),
         approval_comment_url: Some(&args.approved_comment_url),
         issue_body_text: issue_body_for_comment.as_deref(),
@@ -1708,6 +1745,90 @@ fn to_build_options(
         strategy,
         pr_group,
     }
+}
+
+/// Inferred grouping defaults derived from a plan sprint's `pr-grouping`
+/// metadata (Task 1.2). Returned only when the operator did NOT pass any of
+/// `--strategy` / `--pr-grouping` / `--default-pr-grouping` and the sprint
+/// declared an intent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InferredGroupingDefaults {
+    pub strategy: crate::commands::SplitStrategy,
+    pub default_pr_grouping: crate::commands::PrGrouping,
+    pub source_sprint: i32,
+}
+
+/// Resolve plan-derived defaults for `--strategy` and `--default-pr-grouping`.
+///
+/// Behaviour (Task 1.2):
+///
+/// * Returns `None` when the operator passed any explicit grouping flag
+///   (so CLI flags always win).
+/// * Returns `None` when the plan parses cleanly but the named sprint
+///   has no `pr-grouping` metadata.
+/// * Returns `Some(_)` when the plan declares the sprint's intent and
+///   no CLI flag overrode it; the caller mutates `grouping` accordingly
+///   and prints the hint to stderr.
+/// * Returns `None` when the plan cannot be parsed; the downstream
+///   `task_spec::build_task_spec` call surfaces the same parse error with
+///   a richer message.
+pub(crate) fn infer_grouping_defaults_from_plan(
+    plan_path: &Path,
+    sprint: i32,
+    grouping: &crate::commands::GroupingArgs,
+) -> Option<InferredGroupingDefaults> {
+    // Operator already pinned at least one grouping decision — never
+    // override.
+    if grouping.pr_grouping.is_some()
+        || grouping.default_pr_grouping.is_some()
+        || grouping.strategy != crate::commands::SplitStrategy::Deterministic
+        || !grouping.pr_group.is_empty()
+    {
+        return None;
+    }
+
+    let resolved = task_spec::resolve_plan_file(plan_path);
+    let display = plan_path.to_string_lossy().to_string();
+    let (plan, parse_errors) = parse_plan_with_display(&resolved, &display).ok()?;
+    if !parse_errors.is_empty() {
+        return None;
+    }
+
+    let target = plan.sprints.iter().find(|s| s.number == sprint)?;
+    let intent = target.metadata.pr_grouping_intent.as_deref()?;
+    let pr_grouping = match intent {
+        "per-sprint" => crate::commands::PrGrouping::PerSprint,
+        "group" => crate::commands::PrGrouping::Group,
+        _ => return None,
+    };
+
+    Some(InferredGroupingDefaults {
+        strategy: crate::commands::SplitStrategy::Auto,
+        default_pr_grouping: pr_grouping,
+        source_sprint: sprint,
+    })
+}
+
+/// Apply inferred defaults to a mutable `GroupingArgs` clone and emit the
+/// stderr hint required by Task 1.2.
+pub(crate) fn apply_inferred_grouping_defaults(
+    grouping: &mut crate::commands::GroupingArgs,
+    inferred: &InferredGroupingDefaults,
+) {
+    grouping.strategy = inferred.strategy;
+    grouping.default_pr_grouping = Some(inferred.default_pr_grouping);
+    let strategy_text = match inferred.strategy {
+        crate::commands::SplitStrategy::Auto => "auto",
+        crate::commands::SplitStrategy::Deterministic => "deterministic",
+    };
+    let grouping_text = match inferred.default_pr_grouping {
+        crate::commands::PrGrouping::PerSprint => "per-sprint",
+        crate::commands::PrGrouping::Group => "group",
+    };
+    eprintln!(
+        "inferred --strategy={strategy_text}; --default-pr-grouping={grouping_text} from plan sprint S{}",
+        inferred.source_sprint
+    );
 }
 
 fn load_summary(summary: &SummaryArgs) -> Result<Option<String>, CommandError> {

--- a/crates/plan-issue-cli/src/github.rs
+++ b/crates/plan-issue-cli/src/github.rs
@@ -40,6 +40,11 @@ pub trait GitHubAdapter {
     ) -> Result<(), String>;
 
     fn pr_is_merged(&self, repo: &str, pr: u64) -> Result<bool, String>;
+
+    /// List the PR's issue-style comments via `gh api`. Returns an array of
+    /// objects with at least `body` and `html_url` keys (passed through
+    /// from the GitHub REST response). Used by `resolve-approval`.
+    fn pr_comments(&self, repo: &str, pr: u64) -> Result<Vec<Value>, String>;
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -281,6 +286,57 @@ impl GitHubAdapter for GhCliAdapter {
             .is_some_and(|state| state.eq_ignore_ascii_case("merged"));
 
         Ok(merged_at_present || merged_state)
+    }
+
+    fn pr_comments(&self, repo: &str, pr: u64) -> Result<Vec<Value>, String> {
+        // Use `--paginate` so PRs with > 100 comments still return the full
+        // list. Endpoint mirrors REST `/repos/{owner}/{repo}/issues/{n}/comments`
+        // which is the issue-style stream used for review-evidence comments.
+        let endpoint = format!("repos/{repo}/issues/{pr}/comments");
+        let args = vec!["api".to_string(), "--paginate".to_string(), endpoint];
+        let stdout = Self::run(&args)?;
+
+        // `gh api --paginate` concatenates JSON arrays back-to-back without
+        // a wrapping comma, so we parse each top-level array on its own
+        // line first; falling back to a single-array parse keeps the simple
+        // case fast.
+        let trimmed = stdout.trim();
+        if trimmed.is_empty() {
+            return Ok(Vec::new());
+        }
+        if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+            return Ok(match value {
+                Value::Array(items) => items,
+                other => vec![other],
+            });
+        }
+
+        // Fall back to splitting concatenated arrays.
+        let mut combined: Vec<Value> = Vec::new();
+        for chunk in trimmed.split("][") {
+            let chunk = chunk.trim();
+            if chunk.is_empty() {
+                continue;
+            }
+            let normalized = if !chunk.starts_with('[') {
+                format!("[{chunk}")
+            } else {
+                chunk.to_string()
+            };
+            let normalized = if !normalized.ends_with(']') {
+                format!("{normalized}]")
+            } else {
+                normalized
+            };
+            let value: Value = serde_json::from_str(&normalized)
+                .map_err(|err| format!("failed to parse pr comments page: {err}"))?;
+            if let Value::Array(items) = value {
+                combined.extend(items);
+            } else {
+                combined.push(value);
+            }
+        }
+        Ok(combined)
     }
 }
 

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -118,6 +118,16 @@ where
         }
     };
 
+    // Task 1.5: `resolve-approval` text mode prints just the URL (or fails
+    // with a clear stderr message naming the count). JSON mode falls
+    // through to the standard envelope so consumers can read the candidate
+    // array.
+    if let Command::ResolveApproval(args) = &cli.command
+        && matches!(output_format, crate::cli::OutputFormat::Text)
+    {
+        return execute::run_resolve_approval_text(binary, cli.repo.as_deref(), args);
+    }
+
     if let Err(err) = cli.validate() {
         let schema_version = cli.command.schema_version();
         if let Err(render_err) = output::emit_error(

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -21,6 +21,8 @@ mod live_start_sprint_runtime_truth;
 mod output_contract;
 #[path = "integration/parity_guardrails.rs"]
 mod parity_guardrails;
+#[path = "integration/resolve_approval.rs"]
+mod resolve_approval;
 #[path = "integration/runtime_layout_parity.rs"]
 mod runtime_layout_parity;
 #[path = "integration/runtime_truth_plan_and_sprint_flow.rs"]

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -9,6 +9,8 @@ mod auto_single_lane_runtime_truth;
 mod cli_contract;
 #[path = "integration/common.rs"]
 pub mod common;
+#[path = "integration/grouping_default.rs"]
+mod grouping_default;
 #[path = "integration/link_pr_flow.rs"]
 mod link_pr_flow;
 #[path = "integration/live_issue_ops.rs"]

--- a/crates/plan-issue-cli/tests/integration/cli_contract.rs
+++ b/crates/plan-issue-cli/tests/integration/cli_contract.rs
@@ -26,6 +26,8 @@ fn cli_help_lists_full_surface_for_live_and_local_bins() {
         "ready-sprint",
         "accept-sprint",
         "multi-sprint-guide",
+        // Task 1.5
+        "resolve-approval",
         "-V, --version",
         "Usage paths",
         "plan-issue-local",

--- a/crates/plan-issue-cli/tests/integration/grouping_default.rs
+++ b/crates/plan-issue-cli/tests/integration/grouping_default.rs
@@ -1,0 +1,346 @@
+// Task 1.2: defaulting `--strategy` and `--default-pr-grouping` from the
+// plan markdown's per-sprint `pr-grouping` metadata.
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use crate::common;
+
+fn parse_json(stdout: &str) -> Value {
+    serde_json::from_str(stdout).expect("stdout should be valid JSON")
+}
+
+/// Plan declares `PR grouping intent: per-sprint` for sprint 1 — start-sprint
+/// invoked without any grouping flag should infer `--strategy=auto` and
+/// `--default-pr-grouping=per-sprint`, succeed, and emit the resolved hint to
+/// stderr.
+#[test]
+fn start_sprint_grouping_default_inferred_when_plan_only() {
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    common::seed_agent_home_prompts(&agent_home);
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let plan_path = tmp.path().join("plan-grouping-per-sprint.md");
+    fs::write(
+        &plan_path,
+        r#"# Plan: Grouping inference per-sprint
+
+## Overview
+Plan that declares per-sprint pr-grouping intent so plan-issue can default
+`--strategy` and `--default-pr-grouping` without operator flags.
+
+## Sprint 1: Inferred per-sprint
+**PR grouping intent**: per-sprint
+**Execution Profile**: serial
+
+### Task 1.1: First task
+- **Location**:
+  - crates/plan-issue-cli/src/lib.rs
+- **Description**: Single-task sprint demonstrating per-sprint inference.
+- **Dependencies**:
+  - none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - start-sprint succeeds without explicit grouping flags.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli start_sprint_grouping_default_inferred_when_plan_only -- --exact
+"#,
+    )
+    .expect("write plan fixture");
+
+    let plan_s = plan_path.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            "graysurf/plan-issue-smoke",
+            "start-sprint",
+            "--plan",
+            &plan_s,
+            "--issue",
+            "217",
+            "--sprint",
+            "1",
+            "--no-comment",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    assert!(
+        out.stderr.contains(
+            "inferred --strategy=auto; --default-pr-grouping=per-sprint from plan sprint S1"
+        ),
+        "stderr should contain the inferred-defaults hint: {:?}",
+        out.stderr
+    );
+
+    let payload = parse_json(&out.stdout);
+    assert_eq!(
+        payload["payload"]["result"]["inferred_grouping_defaults"], "auto/per-sprint",
+        "result should record the inferred grouping defaults"
+    );
+}
+
+/// Plan declares `PR grouping intent: group` for sprint 2 — inference picks
+/// up `--default-pr-grouping=group` and tasks share a single auto group.
+#[test]
+fn start_sprint_grouping_default_inferred_for_group_intent() {
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    common::seed_agent_home_prompts(&agent_home);
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let plan_path = tmp.path().join("plan-grouping-group.md");
+    fs::write(
+        &plan_path,
+        r#"# Plan: Grouping inference group
+
+## Overview
+Two-task sprint with `PR grouping intent: group`. plan-issue should infer
+auto/group without explicit flags and produce a single combined PR group.
+
+## Sprint 1: Setup
+**PR grouping intent**: per-sprint
+**Execution Profile**: serial
+
+### Task 1.1: Setup task
+- **Location**:
+  - crates/plan-issue-cli/src/lib.rs
+- **Description**: Setup task.
+- **Dependencies**:
+  - none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Setup completes.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli start_sprint_grouping_default_inferred_for_group_intent -- --exact
+
+## Sprint 2: Inferred group
+**PR grouping intent**: group
+**Execution Profile**: serial
+
+### Task 2.1: Group task A
+- **Location**:
+  - crates/plan-issue-cli/src/lib.rs
+- **Description**: First task that should share a PR group with task 2.2.
+- **Dependencies**:
+  - none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Group inferred.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli start_sprint_grouping_default_inferred_for_group_intent -- --exact
+
+### Task 2.2: Group task B
+- **Location**:
+  - crates/plan-issue-cli/src/lib.rs
+- **Description**: Second task that should share a PR group with task 2.1.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Group inferred.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli start_sprint_grouping_default_inferred_for_group_intent -- --exact
+"#,
+    )
+    .expect("write plan fixture");
+
+    let plan_s = plan_path.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            "graysurf/plan-issue-smoke",
+            "start-sprint",
+            "--plan",
+            &plan_s,
+            "--issue",
+            "217",
+            "--sprint",
+            "2",
+            "--no-comment",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    assert!(
+        out.stderr
+            .contains("inferred --strategy=auto; --default-pr-grouping=group from plan sprint S2"),
+        "stderr should contain the inferred-defaults hint: {:?}",
+        out.stderr
+    );
+
+    let payload = parse_json(&out.stdout);
+    let pr_groups = payload["payload"]["result"]["pr_groups"]
+        .as_array()
+        .expect("pr_groups");
+    assert_eq!(
+        pr_groups.len(),
+        1,
+        "two-task sprint with group intent should collapse into one PR group: {pr_groups:?}"
+    );
+    let task_ids = pr_groups[0]["task_ids"].as_array().expect("task_ids array");
+    assert_eq!(task_ids.len(), 2, "{pr_groups:?}");
+}
+
+/// Operator passes explicit `--strategy=auto --default-pr-grouping=per-sprint`
+/// — that should win over plan metadata, and no inference hint should fire.
+#[test]
+fn start_sprint_grouping_cli_overrides_plan_metadata() {
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    common::seed_agent_home_prompts(&agent_home);
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let plan_path = tmp.path().join("plan-grouping-override.md");
+    fs::write(
+        &plan_path,
+        r#"# Plan: CLI flags override plan metadata
+
+## Overview
+Plan declares `group` intent for sprint 1 but the operator passes
+`--default-pr-grouping=per-sprint` explicitly; CLI must win.
+
+## Sprint 1: Group intent
+**PR grouping intent**: group
+**Execution Profile**: serial
+
+### Task 1.1: Solo task
+- **Location**:
+  - crates/plan-issue-cli/src/lib.rs
+- **Description**: Solo task; per-sprint override gives one row per sprint.
+- **Dependencies**:
+  - none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - CLI wins.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli start_sprint_grouping_cli_overrides_plan_metadata -- --exact
+"#,
+    )
+    .expect("write plan fixture");
+
+    let plan_s = plan_path.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            "graysurf/plan-issue-smoke",
+            "start-sprint",
+            "--plan",
+            &plan_s,
+            "--issue",
+            "217",
+            "--sprint",
+            "1",
+            "--strategy",
+            "auto",
+            "--default-pr-grouping",
+            "per-sprint",
+            "--no-comment",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    assert!(
+        !out.stderr.contains("inferred --strategy"),
+        "no inference hint expected when CLI overrides: {:?}",
+        out.stderr
+    );
+
+    let payload = parse_json(&out.stdout);
+    assert!(
+        payload["payload"]["result"]["inferred_grouping_defaults"].is_null(),
+        "result.inferred_grouping_defaults must be null when CLI flags override: {}",
+        payload
+    );
+}
+
+/// Plan with no `pr-grouping` metadata still requires explicit grouping
+/// flags; absent both, validation falls back to the original error.
+#[test]
+fn start_sprint_grouping_silent_plan_still_requires_explicit_flags() {
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    common::seed_agent_home_prompts(&agent_home);
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let plan_path = tmp.path().join("plan-grouping-silent.md");
+    fs::write(
+        &plan_path,
+        r#"# Plan: No grouping metadata
+
+## Overview
+Plan with a sprint that declares no `pr-grouping`. plan-issue must not
+infer; the existing validation should still demand `--pr-grouping`.
+
+## Sprint 1: Silent
+### Task 1.1: Sole task
+- **Location**:
+  - crates/plan-issue-cli/src/lib.rs
+- **Description**: Plan declares no grouping intent so default validation runs.
+- **Dependencies**:
+  - none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Validation surfaces invalid-pr-grouping.
+- **Validation**:
+  - cargo test -p nils-plan-issue-cli start_sprint_grouping_silent_plan_still_requires_explicit_flags -- --exact
+"#,
+    )
+    .expect("write plan fixture");
+
+    let plan_s = plan_path.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            "graysurf/plan-issue-smoke",
+            "start-sprint",
+            "--plan",
+            &plan_s,
+            "--issue",
+            "217",
+            "--sprint",
+            "1",
+            "--no-comment",
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+
+    assert_eq!(
+        out.code, 1,
+        "expected failure when plan is silent and CLI passes no flags"
+    );
+    let combined = format!("{}{}", out.stdout, out.stderr);
+    assert!(
+        combined.contains("--strategy deterministic requires --pr-grouping"),
+        "should still surface the standard grouping requirement; stdout={} stderr={}",
+        out.stdout,
+        out.stderr
+    );
+}

--- a/crates/plan-issue-cli/tests/integration/parity_guardrails.rs
+++ b/crates/plan-issue-cli/tests/integration/parity_guardrails.rs
@@ -46,6 +46,7 @@ fn parity_shell_help_surface_tracks_current_command_contract() {
         "ready-sprint          Post sprint-ready comment for main-agent review before merge",
         "accept-sprint         Enforce merged-PR gate, sync sprint status=done, then post accepted comment",
         "multi-sprint-guide    Print the full repeated command flow for a plan (1 plan = 1 issue)",
+        "resolve-approval      Resolve the URL of the most recent `Decision: merge` review-evidence comment on a PR, suitable for `accept-sprint --approved-comment-url`",
         "completion            Export shell completion script",
     ] {
         assert!(

--- a/crates/plan-issue-cli/tests/integration/resolve_approval.rs
+++ b/crates/plan-issue-cli/tests/integration/resolve_approval.rs
@@ -1,0 +1,258 @@
+// Task 1.5: `plan-issue resolve-approval` — wrap the orchestrator pattern
+// of finding the latest review-evidence comment whose body contains
+// `Decision: merge` on a PR. Drives the live `plan-issue` binary with a
+// stubbed `gh` so we can pin the comment payload deterministically.
+
+use std::fs;
+
+use nils_test_support::StubBinDir;
+use nils_test_support::cmd::CmdOptions;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use crate::common;
+
+fn parse_json(stdout: &str) -> Value {
+    serde_json::from_str(stdout).expect("stdout should be valid JSON")
+}
+
+/// `gh api repos/.../issues/<pr>/comments` stub. Reads JSON from the path
+/// in `RESOLVE_APPROVAL_GH_COMMENTS` and prints it back unchanged. Other
+/// `gh` calls are rejected so we catch unintended live calls.
+fn comments_stub_script() -> &'static str {
+    r#"#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="${1:-}"
+if [[ "$cmd" != "api" ]]; then
+  printf 'unsupported gh call: %s\n' "$*" >&2
+  exit 1
+fi
+
+# Skip past `--paginate` if present.
+shift 1
+while [[ ${1:-} == "--paginate" ]]; do
+  shift 1
+done
+
+endpoint="${1:-}"
+case "$endpoint" in
+  repos/*/issues/*/comments)
+    src="${RESOLVE_APPROVAL_GH_COMMENTS:-}"
+    if [[ -z "$src" ]]; then
+      printf '[]\n'
+    else
+      cat "$src"
+    fi
+    ;;
+  *)
+    printf 'unsupported gh api endpoint: %s\n' "$endpoint" >&2
+    exit 1
+    ;;
+esac
+"#
+}
+
+fn cmd_options(stub: &StubBinDir, comments_file: &std::path::Path) -> CmdOptions {
+    common::plan_issue_cmd_options()
+        .with_env_remove_prefix("RESOLVE_APPROVAL_GH_")
+        .with_path_prepend(stub.path())
+        .with_envs(&[(
+            "RESOLVE_APPROVAL_GH_COMMENTS",
+            &comments_file.to_string_lossy(),
+        )])
+}
+
+#[test]
+fn resolve_approval_text_prints_url_when_exactly_one_match() {
+    let tmp = TempDir::new().expect("tempdir");
+    let comments = tmp.path().join("comments.json");
+    fs::write(
+        &comments,
+        r#"[
+  {
+    "html_url": "https://github.com/owner/repo/pull/12#issuecomment-1",
+    "created_at": "2026-04-25T10:00:00Z",
+    "body": "Triage: Pending\nDecision: pending\n"
+  },
+  {
+    "html_url": "https://github.com/owner/repo/pull/12#issuecomment-2",
+    "created_at": "2026-04-25T11:00:00Z",
+    "body": "Decision: merge\nVerdict: ready\n"
+  }
+]"#,
+    )
+    .expect("write comments");
+
+    let stub = StubBinDir::new();
+    stub.write_exe("gh", comments_stub_script());
+
+    let out = common::run_plan_issue_with_options(
+        &["--repo", "owner/repo", "resolve-approval", "--pr", "12"],
+        cmd_options(&stub, &comments),
+    );
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    assert_eq!(
+        out.stdout.trim(),
+        "https://github.com/owner/repo/pull/12#issuecomment-2",
+        "single-match text output should print only the URL: stdout={:?} stderr={:?}",
+        out.stdout,
+        out.stderr
+    );
+}
+
+#[test]
+fn resolve_approval_text_fails_when_no_decision_merge_comment() {
+    let tmp = TempDir::new().expect("tempdir");
+    let comments = tmp.path().join("comments.json");
+    fs::write(
+        &comments,
+        r#"[
+  {
+    "html_url": "https://github.com/owner/repo/pull/12#issuecomment-1",
+    "created_at": "2026-04-25T10:00:00Z",
+    "body": "Decision: pending\n"
+  }
+]"#,
+    )
+    .expect("write comments");
+
+    let stub = StubBinDir::new();
+    stub.write_exe("gh", comments_stub_script());
+
+    let out = common::run_plan_issue_with_options(
+        &["--repo", "owner/repo", "resolve-approval", "--pr", "12"],
+        cmd_options(&stub, &comments),
+    );
+
+    assert_ne!(out.code, 0, "expected non-zero exit on no-match");
+    assert!(
+        out.stderr
+            .contains("no merge-decision review-evidence comment found"),
+        "stderr should describe the empty case: {:?}",
+        out.stderr
+    );
+    assert!(
+        out.stdout.trim().is_empty(),
+        "stdout must stay empty when text mode fails: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
+fn resolve_approval_text_fails_when_multiple_decision_merge_comments() {
+    let tmp = TempDir::new().expect("tempdir");
+    let comments = tmp.path().join("comments.json");
+    fs::write(
+        &comments,
+        r#"[
+  {
+    "html_url": "https://github.com/owner/repo/pull/12#issuecomment-1",
+    "created_at": "2026-04-25T10:00:00Z",
+    "body": "Decision: merge\n"
+  },
+  {
+    "html_url": "https://github.com/owner/repo/pull/12#issuecomment-2",
+    "created_at": "2026-04-25T11:00:00Z",
+    "body": "Decision: merge\n"
+  }
+]"#,
+    )
+    .expect("write comments");
+
+    let stub = StubBinDir::new();
+    stub.write_exe("gh", comments_stub_script());
+
+    let out = common::run_plan_issue_with_options(
+        &["--repo", "owner/repo", "resolve-approval", "--pr", "12"],
+        cmd_options(&stub, &comments),
+    );
+
+    assert_ne!(out.code, 0, "expected non-zero exit when ambiguous");
+    assert!(
+        out.stderr
+            .contains("found 2 merge-decision review-evidence comments"),
+        "stderr should name the count: {:?}",
+        out.stderr
+    );
+    assert!(
+        out.stdout.trim().is_empty(),
+        "stdout must stay empty when text mode fails: {:?}",
+        out.stdout
+    );
+}
+
+#[test]
+fn resolve_approval_json_reports_zero_one_or_many_candidates() {
+    // Many candidates: latest sorts first, all listed.
+    let tmp = TempDir::new().expect("tempdir");
+    let comments = tmp.path().join("comments.json");
+    fs::write(
+        &comments,
+        r#"[
+  {
+    "html_url": "https://github.com/owner/repo/pull/12#issuecomment-old",
+    "created_at": "2026-04-20T10:00:00Z",
+    "body": "Decision: merge\n"
+  },
+  {
+    "html_url": "https://github.com/owner/repo/pull/12#issuecomment-new",
+    "created_at": "2026-04-25T18:00:00Z",
+    "body": "Decision: merge\n"
+  }
+]"#,
+    )
+    .expect("write comments");
+    let stub = StubBinDir::new();
+    stub.write_exe("gh", comments_stub_script());
+
+    let out = common::run_plan_issue_with_options(
+        &[
+            "--format",
+            "json",
+            "--repo",
+            "owner/repo",
+            "resolve-approval",
+            "--pr",
+            "12",
+        ],
+        cmd_options(&stub, &comments),
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = parse_json(&out.stdout);
+    let result = &payload["payload"]["result"];
+    assert_eq!(result["count"], 2);
+    assert_eq!(
+        result["url"], "https://github.com/owner/repo/pull/12#issuecomment-new",
+        "result.url must be the latest html_url"
+    );
+    let candidates = result["candidates"].as_array().expect("candidates");
+    assert_eq!(candidates.len(), 2);
+    assert_eq!(
+        candidates[0]["html_url"], "https://github.com/owner/repo/pull/12#issuecomment-new",
+        "candidates[0] is the latest"
+    );
+
+    // Zero candidates: count == 0, url == null, exit still 0 in JSON mode.
+    fs::write(&comments, "[]").expect("rewrite comments");
+    let out = common::run_plan_issue_with_options(
+        &[
+            "--format",
+            "json",
+            "--repo",
+            "owner/repo",
+            "resolve-approval",
+            "--pr",
+            "12",
+        ],
+        cmd_options(&stub, &comments),
+    );
+    assert_eq!(out.code, 0, "JSON mode keeps exit 0: {}", out.stderr);
+    let payload = parse_json(&out.stdout);
+    let result = &payload["payload"]["result"];
+    assert_eq!(result["count"], 0);
+    assert!(result["url"].is_null());
+    assert_eq!(result["candidates"].as_array().expect("array").len(), 0);
+}

--- a/crates/plan-issue-cli/tests/integration/start_plan_canonical.rs
+++ b/crates/plan-issue-cli/tests/integration/start_plan_canonical.rs
@@ -163,6 +163,88 @@ fn start_plan_local_uses_placeholder_issue() {
 }
 
 #[test]
+fn status_plan_emits_repo_slug_and_v2_schema_version() {
+    // Task 1.1: status-plan exposes the runtime repo slug and bumps to v2.
+    // Drive it via a body-file flow with an explicit --repo so the slug is
+    // derivable without contacting GitHub.
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    common::seed_agent_home_prompts(&agent_home);
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    // First run start-plan to produce an issue body we can feed into
+    // status-plan.
+    let start = run_local_start_plan(&agent_home_s, "graysurf/plan-issue-smoke");
+    assert_eq!(start.code, 0, "start-plan stderr: {}", start.stderr);
+    let start_payload = parse_json(&start.stdout);
+    let issue_body_path = start_payload["payload"]["result"]["issue_body_path"]
+        .as_str()
+        .expect("issue_body_path")
+        .to_string();
+
+    let status = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            "graysurf/plan-issue-smoke",
+            "status-plan",
+            "--body-file",
+            &issue_body_path,
+        ],
+        &[("AGENT_HOME", &agent_home_s)],
+    );
+    assert_eq!(status.code, 0, "status-plan stderr: {}", status.stderr);
+
+    let payload = parse_json(&status.stdout);
+    assert_eq!(
+        payload["schema_version"], "plan-issue-cli.status.plan.v2",
+        "schema_version should bump to v2"
+    );
+    assert_eq!(
+        payload["payload"]["result"]["repo_slug"], "graysurf__plan-issue-smoke",
+        "result.repo_slug should mirror runtime_layout::repo_slug derivation"
+    );
+}
+
+#[test]
+fn start_plan_emits_repo_slug_and_v2_schema_version() {
+    // Task 1.1: result payload exposes the runtime repo slug; schema_version
+    // bumps to v2 so consumers know the new field is present.
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    common::seed_agent_home_prompts(&agent_home);
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let out = run_local_start_plan(&agent_home_s, "graysurf/plan-issue-smoke");
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    let payload = parse_json(&out.stdout);
+    assert_eq!(
+        payload["schema_version"], "plan-issue-cli.start.plan.v2",
+        "schema_version should bump to v2: {}",
+        out.stdout
+    );
+    let result = &payload["payload"]["result"];
+    assert_eq!(
+        result["repo_slug"], "graysurf__plan-issue-smoke",
+        "result.repo_slug should mirror runtime_layout::repo_slug derivation"
+    );
+
+    // Round-trip: a second run produces an identical repo_slug.
+    let out2 = run_local_start_plan(&agent_home_s, "graysurf/plan-issue-smoke");
+    assert_eq!(out2.code, 0, "stderr: {}", out2.stderr);
+    let payload2 = parse_json(&out2.stdout);
+    assert_eq!(
+        payload2["payload"]["result"]["repo_slug"], result["repo_slug"],
+        "repo_slug must round-trip identically across runs"
+    );
+}
+
+#[test]
 fn start_plan_fails_on_missing_main_agent_init_source() {
     let tmp = TempDir::new().expect("tempdir");
     let agent_home = tmp.path().join("agent-home");

--- a/crates/plan-issue-cli/tests/integration/start_sprint_canonical.rs
+++ b/crates/plan-issue-cli/tests/integration/start_sprint_canonical.rs
@@ -151,6 +151,8 @@ fn start_sprint_emits_dispatch_record_per_task() {
             "subagent_init_snapshot_path",
             "plan_snapshot_path",
             "worktree",
+            // Task 1.4: explicit absolute worktree path for orchestrators.
+            "worktree_abs_path",
             "branch",
             "execution_mode",
             "pr_group",
@@ -164,6 +166,23 @@ fn start_sprint_emits_dispatch_record_per_task() {
         }
         assert_eq!(record["workflow_role"], "implementation");
         assert_eq!(record["base_branch"], "plan/issue-217");
+        // Task 1.4: worktree_abs_path is absolute and lives under the
+        // canonical $AGENT_HOME/out/plan-issue-delivery/<slug>/issue-N/worktrees/ tree.
+        let worktree_abs = record["worktree_abs_path"]
+            .as_str()
+            .expect("worktree_abs_path string");
+        assert!(
+            std::path::Path::new(worktree_abs).is_absolute(),
+            "worktree_abs_path must be absolute: {worktree_abs}"
+        );
+        assert!(
+            worktree_abs.contains("/out/plan-issue-delivery/")
+                && worktree_abs.contains("/issue-217/worktrees/"),
+            "worktree_abs_path must live under canonical runtime root: {worktree_abs}"
+        );
+        // For backwards compatibility v1 readers expect `worktree` to be
+        // identical to the new field.
+        assert_eq!(record["worktree"], record["worktree_abs_path"]);
     }
 }
 
@@ -245,6 +264,61 @@ fn start_sprint_relocates_task_prompt() {
             "task id stem should not embed retired-format suffixes: {file_name}"
         );
     }
+}
+
+#[test]
+fn start_sprint_emits_repo_slug_and_v2_schema_version() {
+    // Task 1.1: start-sprint result exposes the runtime repo slug;
+    // schema_version bumps to v2.
+    let (_tmp, _ah, ah_s) = seeded_agent_home();
+    let run = run_local_start_sprint(&ah_s, "3", "217", "graysurf/plan-issue-smoke");
+    assert_eq!(
+        run.payload["schema_version"], "plan-issue-cli.start.sprint.v2",
+        "schema_version should bump to v2"
+    );
+    assert_eq!(
+        run.payload["payload"]["result"]["repo_slug"], "graysurf__plan-issue-smoke",
+        "result.repo_slug should mirror runtime_layout::repo_slug derivation"
+    );
+}
+
+#[test]
+fn start_sprint_emits_pr_groups_array() {
+    // Task 1.3: start-sprint payload includes `pr_groups` listing every
+    // group actually created (name + task_ids).
+    let (_tmp, _ah, ah_s) = seeded_agent_home();
+    let run = run_local_start_sprint(&ah_s, "3", "217", "graysurf/plan-issue-smoke");
+
+    let pr_groups = run.payload["payload"]["result"]["pr_groups"]
+        .as_array()
+        .expect("pr_groups in result");
+    assert!(
+        !pr_groups.is_empty(),
+        "pr_groups must list at least one group: {pr_groups:?}"
+    );
+
+    let mut total_tasks = 0;
+    for group in pr_groups {
+        let name = group["name"].as_str().expect("group name");
+        assert!(
+            !name.is_empty(),
+            "pr_group name must be non-empty: {group:?}"
+        );
+        let task_ids = group["task_ids"].as_array().expect("task_ids array");
+        assert!(
+            !task_ids.is_empty(),
+            "pr_group task_ids must be non-empty: {group:?}"
+        );
+        total_tasks += task_ids.len();
+    }
+
+    let record_count = run.payload["payload"]["result"]["record_count"]
+        .as_u64()
+        .expect("record_count");
+    assert_eq!(
+        total_tasks as u64, record_count,
+        "every task should appear in exactly one pr-group"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Sprint 1 of the plan-issue-delivery improvements plan: surface enough machine-readable fields in `plan-issue` payloads that the orchestrator never has to re-derive runtime facts (slug, group name, worktree path) by parsing strings or running shell helpers, default `--strategy` / `--default-pr-grouping` from each sprint's plan metadata, and add a new `resolve-approval` subcommand that wraps the orchestrator's `gh api .../comments | jq` pattern. All five tasks (1.1 through 1.5) bundled per the plan's `PR grouping intent: group` directive.

## Changes

- Surface `repo_slug` (start-plan / status-plan / start-sprint), `pr_groups` (start-sprint), and `worktree_abs_path` (dispatch JSON) so orchestrators read runtime facts directly; bump `schema_version` to `.v2` on the three changed commands (Tasks 1.1, 1.3, 1.4).
- `link-pr --pr-group` now enumerates the actual sprint-row pr-group values when an unknown name is passed (Task 1.3).
- Default `--strategy=auto` and `--default-pr-grouping=<intent>` from each sprint's plan-declared `pr-grouping` metadata when the operator passes neither; CLI flags still win and an `inferred --strategy=...` hint goes to stderr (Task 1.2).
- New `plan-issue resolve-approval --pr N --repo OWNER/REPO [--format text|json]` wraps `gh api .../comments` to find the latest `Decision: merge` review-evidence comment; text mode prints the URL on a single match, JSON reports zero/one/many candidates (Task 1.5).
- Tests: extended `start_plan_canonical.rs` / `start_sprint_canonical.rs` for the new payload fields; new `grouping_default.rs` (4 tests) and `resolve_approval.rs` (4 tests); updated `cli_contract.rs` / `parity_guardrails.rs` for the new subcommand surface.

## Testing

- `cargo fmt --all -- --check` (pass)
- `cargo clippy -p nils-plan-issue-cli -- -D warnings` (pass)
- `cargo test -p nils-plan-issue-cli` (pass — 50 unit + 83 integration tests)

## Risk / Notes

- `schema_version` v2 is additive only — every v1 reader keeps working because the new fields are appended to the existing payload. Documented as deprecated in the dispatch-record struct doc (`worktree` mirrors `worktree_abs_path` and may be dropped in a future v3 bump).
- The plan metadata defaulting only fires when the operator passed none of `--strategy` / `--pr-grouping` / `--default-pr-grouping` / `--pr-group`; explicit CLI flags continue to override (asserted by `start_sprint_grouping_cli_overrides_plan_metadata`). Existing pipelines that always pass `--pr-grouping` see no behavior change.
- `resolve-approval` is read-only (`gh api`) and supports `--paginate`, so PRs with > 100 comments still return the full list. Text-mode failure paths exit non-zero with a count-aware stderr message, never a partial URL on stdout.

