### PR TITLE
Show dot-prefixed paths in git-scope directory tree output

### DIFF
--- a/crates/git-scope/src/render.rs
+++ b/crates/git-scope/src/render.rs
@@ -190,10 +190,7 @@ fn render_tree(files: &[String], no_color: bool) -> Result<()> {
         return Ok(());
     }
 
-    let mut tree_args = vec!["--fromfile"];
-    if !no_color {
-        tree_args.push("-C");
-    }
+    let tree_args = build_tree_args(no_color);
 
     let tree_input = expand_tree_paths(files);
     let mut cmd = Command::new("tree");
@@ -245,6 +242,17 @@ pub fn render_tree_for_commit(files: &[String], no_color: bool) -> Result<()> {
     render_tree(files, no_color)
 }
 
+fn build_tree_args(no_color: bool) -> Vec<&'static str> {
+    // `-a` is required even when callers feed paths via stdin: `tree --fromfile`
+    // still applies its hidden-name filter on each node, so dot-prefixed paths
+    // (e.g. `.agents/`, `.github/`) are silently dropped without it.
+    let mut args = vec!["--fromfile", "-a"];
+    if !no_color {
+        args.push("-C");
+    }
+    args
+}
+
 fn expand_tree_paths(files: &[String]) -> Vec<String> {
     let mut set = BTreeSet::new();
     for file in files {
@@ -269,8 +277,8 @@ fn strip_ansi(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        color_reset_for_commit, expand_tree_paths, kind_color_for_commit, strip_ansi,
-        write_tree_input,
+        build_tree_args, color_reset_for_commit, expand_tree_paths, kind_color_for_commit,
+        strip_ansi, write_tree_input,
     };
 
     #[test]
@@ -311,6 +319,36 @@ mod tests {
             String::from_utf8(sink).expect("utf8"),
             "src/main.rs\nsrc/lib.rs\n"
         );
+    }
+
+    #[test]
+    fn build_tree_args_always_includes_dash_a_to_show_dot_paths() {
+        // Regression: `tree --fromfile` would silently drop dot-prefixed paths
+        // (e.g. `.agents/...`) from the rendered tree without `-a`.
+        assert!(build_tree_args(true).contains(&"-a"));
+        assert!(build_tree_args(false).contains(&"-a"));
+    }
+
+    #[test]
+    fn build_tree_args_toggles_color_flag() {
+        assert!(!build_tree_args(true).contains(&"-C"));
+        assert!(build_tree_args(false).contains(&"-C"));
+    }
+
+    #[test]
+    fn expand_tree_paths_preserves_dot_prefixed_segments() {
+        let files = vec![
+            ".agents/skills/foo/SKILL.md".to_string(),
+            ".github/workflows/ci.yml".to_string(),
+            "docs/plans/plan.md".to_string(),
+        ];
+        let paths = expand_tree_paths(&files);
+        assert!(paths.contains(&".agents".to_string()));
+        assert!(paths.contains(&".agents/skills".to_string()));
+        assert!(paths.contains(&".agents/skills/foo".to_string()));
+        assert!(paths.contains(&".agents/skills/foo/SKILL.md".to_string()));
+        assert!(paths.contains(&".github/workflows/ci.yml".to_string()));
+        assert!(paths.contains(&"docs/plans/plan.md".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
# Show dot-prefixed paths in git-scope directory tree output

## Summary

`git-scope` was rendering its "📂 Directory tree" via `tree --fromfile` without `-a`, which silently dropped any path whose first segment begins with `.` (e.g. `.agents/`, `.github/`). Fix passes `-a` so dot-prefixed paths feed via stdin still render in the tree summary, and adds unit tests around the new arg builder.

## Problem

When a commit touches paths under `.agents/`, `.github/`, `.vscode/`, etc., the file-list section above the tree shows them, but the tree section omits them entirely. Users see an inconsistent summary that under-represents the change scope.

## Reproduction

1. Stage / commit any change that touches `.agents/...` plus `docs/...`
2. Run `git-scope commit <sha>` (or whichever subcommand drives the tree section)
3. Observe the "📂 Directory tree" section

Expected: tree includes all changed files (`.agents/...` + `docs/...`).
Actual: only non-dot-prefixed paths appear; `.agents/...` is silently dropped.

Confirmed cause via direct `tree --fromfile` reproduction:

```
$ printf '.agents/skills/foo/SKILL.md\ndocs/plans/plan.md\n' | tree --fromfile
.
`-- docs
    `-- plans
        `-- plan.md
3 directories, 1 file

$ printf '.agents/skills/foo/SKILL.md\ndocs/plans/plan.md\n' | tree --fromfile -a
.
|-- .agents
|   `-- skills
|       `-- foo
|           `-- SKILL.md
`-- docs
    `-- plans
        `-- plan.md
5 directories, 2 files
```

## Issues Found

- Missing `-a` flag when invoking `tree --fromfile` — [crates/git-scope/src/render.rs:193](crates/git-scope/src/render.rs#L193) (pre-fix)

## Fix Approach

- Extract a `build_tree_args(no_color)` helper that always includes `-a` alongside `--fromfile`, and conditionally adds `-C` when color is enabled. `--fromfile` mode never reads from disk, so `-a` has no side effect on directory traversal — it only stops `tree` from filtering nodes whose names start with `.`.
- Add unit tests asserting (a) `-a` is always present regardless of color mode, (b) `-C` toggles correctly, and (c) `expand_tree_paths` preserves dot-prefixed segments end-to-end.

## Testing

- `cargo test -p nils-git-scope` (pass — 35 tests)
- `cargo test --workspace -- --test-threads=1` (pass — full suite serial)
- `cargo fmt --all -- --check` (pass)
- `cargo clippy --all-targets --all-features -- -D warnings` (pass)
- `bash scripts/ci/completion-flag-parity-audit.sh --strict` (pass)
- `zsh -f tests/zsh/completion.test.zsh` (pass)

## Risk / Notes

- Behaviour change is strictly additive: previously-dropped dot paths now appear; non-dot output is unchanged.
- During the workspace test run, three pre-existing flaky tests in `nils-gemini-cli` (`agent_commit_fallback_*`, `prompt_segment_refresh_*`) fail under `cargo test --workspace` parallel mode but pass on `main`, in isolation, and under `--test-threads=1`. Unrelated to this fix; pre-existing issue worth filing separately.
