### PR TITLE
Plan-issue-cli: opt-out env var for init-prompt snapshots

### DIFF
--- a/BINARY_DEPENDENCIES.md
+++ b/BINARY_DEPENDENCIES.md
@@ -92,6 +92,16 @@ These are repository scripts (not third-party packages):
   - `scripts/ci/coverage-summary.sh`
   - `scripts/ci/coverage-badge.sh`
 
+## 4.1 Adapter Opt-Outs
+
+`plan-issue-cli` exposes one runtime opt-out env var consumed at command time.
+
+| Env var | Effect | Intended consumer |
+|---|---|---|
+| `PLAN_ISSUE_SKIP_INIT_SNAPSHOT` | When set non-empty, `start-plan` and `start-sprint` skip both the existence check on `<AGENT_HOME>/prompts/plan-issue-delivery-{main,subagent}-init.md` and the matching `.snapshot.md` copy into the per-issue / per-sprint workspace. The result payload sets `init_snapshot_skipped: true` for auditability; every other artifact (plan snapshot, dispatch records, prompt manifest, etc.) is unaffected. | Runtime adapters (such as the Claude Code `plan-issue` plugin) that ship their own role/protocol prompts inline with their adapter agents and do not need the canonical init-prompt snapshots in sprint workspaces. |
+
+The codex and opencode adapters must not set this var; they continue to rely on the canonical init prompts. The env var defaults to unset, so the binary's behaviour is unchanged for every other caller.
+
 ## 5. `agent-docs` integration for `project-dev`
 
 Use `agent-docs add` to register this file as a required project-level document for

--- a/crates/plan-issue-cli/src/cli.rs
+++ b/crates/plan-issue-cli/src/cli.rs
@@ -13,7 +13,7 @@ pub enum OutputFormat {
 #[command(
     version,
     about = "Rust implementation of the plan-issue orchestration workflow.",
-    after_help = "Usage paths:\n  - plan-issue: live GitHub-backed orchestration\n  - plan-issue-local: local-first rehearsal and dry-run flow\n\nUnsupported in plan-issue-local:\n  - Any --issue path that requires live GitHub reads/writes (for example: status-plan/ready-plan with --issue, close-plan with --issue-only, cleanup-worktrees).\n\nUse instead:\n  - plan-issue <command> ...        (live GitHub path)\n  - --body-file + --dry-run flows   (local rehearsal path where supported)\n\nBoth binaries share the same typed command contract.",
+    after_help = "Usage paths:\n  - plan-issue: live GitHub-backed orchestration\n  - plan-issue-local: local-first rehearsal and dry-run flow\n\nUnsupported in plan-issue-local:\n  - Any --issue path that requires live GitHub reads/writes (for example: status-plan/ready-plan with --issue, close-plan with --issue-only, cleanup-worktrees).\n\nUse instead:\n  - plan-issue <command> ...        (live GitHub path)\n  - --body-file + --dry-run flows   (local rehearsal path where supported)\n\nAdapter opt-outs:\n  - PLAN_ISSUE_SKIP_INIT_SNAPSHOT=1 makes start-plan / start-sprint skip the canonical *-init.snapshot.md copy entirely; intended for runtime adapters (such as Claude Code) that ship their own role/protocol prompts. Codex / opencode adapters must not set this.\n\nBoth binaries share the same typed command contract.",
     disable_help_subcommand = true
 )]
 pub struct Cli {

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -23,6 +23,7 @@ use crate::github::{GhCliAdapter, GitHubAdapter};
 use crate::issue_body::{self, TaskRow};
 use crate::render::{self, SprintCommentInput, SprintCommentMode};
 use crate::runtime_layout::{self, IssueRoot, SprintRoot};
+use crate::runtime_skip;
 use crate::task_spec::{self, TaskSpecBuildOptions, TaskSpecRow, TaskSpecScope};
 use crate::{BinaryFlavor, CommandError};
 
@@ -212,36 +213,39 @@ fn run_start_plan(
     render::write_rendered(&issue_body_out, &issue_body)
         .map_err(|err| CommandError::runtime("issue-body-write-failed", err))?;
 
-    let main_agent_init_source = task_spec::agent_home()
-        .join("prompts")
-        .join("plan-issue-delivery-main-agent-init.md");
-    if !main_agent_init_source.exists() {
-        return Err(CommandError::runtime(
-            "main-agent-init-snapshot-source-missing",
-            format!(
-                "main-agent init source not found at {}; ensure agent-kit is installed",
-                main_agent_init_source.display()
-            ),
-        ));
-    }
     let main_agent_init_target = issue_root.main_agent_init_snapshot();
-    if let Some(parent) = main_agent_init_target.parent() {
-        runtime_layout::ensure_dir(parent).map_err(|err| {
+    let init_snapshot_skipped = runtime_skip::should_skip_init_snapshot();
+    if !init_snapshot_skipped {
+        let main_agent_init_source = task_spec::agent_home()
+            .join("prompts")
+            .join("plan-issue-delivery-main-agent-init.md");
+        if !main_agent_init_source.exists() {
+            return Err(CommandError::runtime(
+                "main-agent-init-snapshot-source-missing",
+                format!(
+                    "main-agent init source not found at {}; ensure agent-kit is installed",
+                    main_agent_init_source.display()
+                ),
+            ));
+        }
+        if let Some(parent) = main_agent_init_target.parent() {
+            runtime_layout::ensure_dir(parent).map_err(|err| {
+                CommandError::runtime(
+                    "runtime-layout-emit-failed",
+                    format!("failed to create dir {}: {err}", parent.display()),
+                )
+            })?;
+        }
+        fs::copy(&main_agent_init_source, &main_agent_init_target).map_err(|err| {
             CommandError::runtime(
                 "runtime-layout-emit-failed",
-                format!("failed to create dir {}: {err}", parent.display()),
+                format!(
+                    "failed to copy main-agent init snapshot to {}: {err}",
+                    main_agent_init_target.display()
+                ),
             )
         })?;
     }
-    fs::copy(&main_agent_init_source, &main_agent_init_target).map_err(|err| {
-        CommandError::runtime(
-            "runtime-layout-emit-failed",
-            format!(
-                "failed to copy main-agent init snapshot to {}: {err}",
-                main_agent_init_target.display()
-            ),
-        )
-    })?;
 
     let plan_branch_name = format!("plan/issue-{}", issue_root_number);
     let plan_branch_ref = issue_root.plan_branch_ref();
@@ -272,6 +276,7 @@ fn run_start_plan(
         "issue_root": path_text(issue_root.root()),
         "repo_slug": repo_slug,
         "main_agent_init_snapshot_path": path_text(&main_agent_init_target),
+        "init_snapshot_skipped": init_snapshot_skipped,
         "plan_branch_ref_path": path_text(&plan_branch_ref),
         "record_count": build.rows.len(),
         "issue_number": issue_number,
@@ -1105,15 +1110,18 @@ fn run_start_sprint(
         "plan-snapshot-source-missing",
     )?;
 
-    let subagent_init_source = task_spec::agent_home()
-        .join("prompts")
-        .join("plan-issue-delivery-subagent-init.md");
     let subagent_init_target = sprint_root.subagent_init_snapshot();
-    copy_source_into_snapshot(
-        &subagent_init_source,
-        &subagent_init_target,
-        "subagent-init-snapshot-source-missing",
-    )?;
+    let init_snapshot_skipped = runtime_skip::should_skip_init_snapshot();
+    if !init_snapshot_skipped {
+        let subagent_init_source = task_spec::agent_home()
+            .join("prompts")
+            .join("plan-issue-delivery-subagent-init.md");
+        copy_source_into_snapshot(
+            &subagent_init_source,
+            &subagent_init_target,
+            "subagent-init-snapshot-source-missing",
+        )?;
+    }
 
     let prompt_files = write_subagent_prompts(
         &prompts_dir,
@@ -1252,6 +1260,7 @@ fn run_start_sprint(
         "repo_slug": repo_slug,
         "plan_snapshot_path": path_text(&plan_snapshot_target),
         "subagent_init_snapshot_path": path_text(&subagent_init_target),
+        "init_snapshot_skipped": init_snapshot_skipped,
         "prompt_manifest_path": path_text(&prompt_manifest_path),
         "dispatch_record_paths": dispatch_record_paths,
         "pr_groups": pr_groups,

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -8,6 +8,7 @@ mod issue_body;
 pub mod output;
 mod render;
 pub mod runtime_layout;
+pub mod runtime_skip;
 mod task_spec;
 
 use std::ffi::OsString;

--- a/crates/plan-issue-cli/src/runtime_skip.rs
+++ b/crates/plan-issue-cli/src/runtime_skip.rs
@@ -1,0 +1,24 @@
+//! Adapter opt-outs for the canonical init-prompt snapshot mechanism.
+//!
+//! Runtime adapters (such as Claude Code) that ship their own
+//! role/protocol prompts can set `PLAN_ISSUE_SKIP_INIT_SNAPSHOT=1` to
+//! make the binary skip both the existence check on
+//! `<AGENT_HOME>/prompts/plan-issue-delivery-{main,subagent}-init.md`
+//! and the matching `.snapshot.md` copy in per-sprint workspaces.
+//!
+//! The codex / opencode adapters keep their current behaviour and
+//! must not set this var.
+use nils_common::env as common_env;
+
+pub const PLAN_ISSUE_SKIP_INIT_SNAPSHOT_ENV: &str = "PLAN_ISSUE_SKIP_INIT_SNAPSHOT";
+
+/// Returns `true` when `PLAN_ISSUE_SKIP_INIT_SNAPSHOT` is set to a
+/// non-empty value, signalling that the caller wants the binary to
+/// skip the init-prompt snapshot mechanism end-to-end (no existence
+/// check on the source, no copy into the runtime workspace).
+///
+/// This is the single read of the env var inside the crate; other
+/// modules must call this helper instead of touching the env directly.
+pub fn should_skip_init_snapshot() -> bool {
+    common_env::env_non_empty(PLAN_ISSUE_SKIP_INIT_SNAPSHOT_ENV).is_some()
+}

--- a/crates/plan-issue-cli/tests/integration/runtime_layout_parity.rs
+++ b/crates/plan-issue-cli/tests/integration/runtime_layout_parity.rs
@@ -227,4 +227,116 @@ fn runtime_layout_parity() {
         .as_str()
         .expect("sprint_root in result");
     assert_eq!(PathBuf::from(sprint_root), runtime_root.join("sprint-1"));
+    assert_eq!(
+        plan_payload["payload"]["result"]["init_snapshot_skipped"], false,
+        "init_snapshot_skipped must be false when env unset"
+    );
+    assert_eq!(
+        sprint_payload["payload"]["result"]["init_snapshot_skipped"], false,
+        "init_snapshot_skipped must be false when env unset"
+    );
+}
+
+#[test]
+fn runtime_layout_parity_with_skip_init_snapshot() {
+    // Mirror of `runtime_layout_parity` but with
+    // PLAN_ISSUE_SKIP_INIT_SNAPSHOT=1 and an empty `$AGENT_HOME/prompts/`.
+    // The init-prompt snapshots must be absent; every other artifact
+    // (plan snapshot, dispatch record, prompt manifest, etc.) is
+    // produced byte-for-byte the same.
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let start_plan_out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            FIXTURE_REPO,
+            "start-plan",
+            "--plan",
+            FIXTURE_PLAN_FROM_REPO,
+            "--pr-grouping",
+            "per-sprint",
+        ],
+        &[
+            ("AGENT_HOME", &agent_home_s),
+            ("PLAN_ISSUE_SKIP_INIT_SNAPSHOT", "1"),
+        ],
+    );
+    assert_eq!(start_plan_out.code, 0, "stderr: {}", start_plan_out.stderr);
+
+    let start_sprint_out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            FIXTURE_REPO,
+            "start-sprint",
+            "--plan",
+            FIXTURE_PLAN_FROM_REPO,
+            "--issue",
+            "999",
+            "--sprint",
+            "1",
+            "--pr-grouping",
+            "per-sprint",
+            "--no-comment",
+        ],
+        &[
+            ("AGENT_HOME", &agent_home_s),
+            ("PLAN_ISSUE_SKIP_INIT_SNAPSHOT", "1"),
+        ],
+    );
+    assert_eq!(
+        start_sprint_out.code, 0,
+        "stderr: {}",
+        start_sprint_out.stderr
+    );
+
+    let runtime_root = agent_home
+        .join("out")
+        .join("plan-issue-delivery")
+        .join(FIXTURE_REPO_SLUG)
+        .join(format!("issue-{PLACEHOLDER_ISSUE}"));
+    let actual_files = collect_relative_paths(&runtime_root);
+    let expected_files: BTreeSet<String> = [
+        "plan/issue-body.md",
+        "plan/plan-branch.ref",
+        "plan/plan.snapshot.md",
+        "plan/tasks.tsv",
+        "sprint-1/manifests/dispatch-S1T1.json",
+        "sprint-1/manifests/prompt-manifest.tsv",
+        "sprint-1/prompts/S1T1.md",
+        "sprint-1/specs/sprint-task-spec.tsv",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    assert_eq!(
+        actual_files, expected_files,
+        "skip-init layout must drop both *-init.snapshot.md files"
+    );
+
+    for stray in actual_files.iter() {
+        assert!(
+            !stray.ends_with("-init.snapshot.md"),
+            "no init-snapshot file allowed under runtime root: {stray}"
+        );
+    }
+
+    let plan_payload = parse_json(&start_plan_out.stdout);
+    let sprint_payload = parse_json(&start_sprint_out.stdout);
+    assert_eq!(
+        plan_payload["payload"]["result"]["init_snapshot_skipped"], true,
+        "start-plan must flag init_snapshot_skipped"
+    );
+    assert_eq!(
+        sprint_payload["payload"]["result"]["init_snapshot_skipped"], true,
+        "start-sprint must flag init_snapshot_skipped"
+    );
 }

--- a/crates/plan-issue-cli/tests/integration/start_plan_canonical.rs
+++ b/crates/plan-issue-cli/tests/integration/start_plan_canonical.rs
@@ -264,3 +264,81 @@ fn start_plan_fails_on_missing_main_agent_init_source() {
         out.stderr
     );
 }
+
+#[test]
+fn start_plan_skips_init_snapshot_when_env_set() {
+    // Adapter opt-out: setting PLAN_ISSUE_SKIP_INIT_SNAPSHOT=1 makes
+    // the binary skip both the existence check on the canonical
+    // main-agent init prompt and the copy into the runtime workspace,
+    // even if `$AGENT_HOME/prompts/` is empty.
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            "graysurf/plan-issue-smoke",
+            "start-plan",
+            "--plan",
+            PLAN_PATH,
+            "--pr-grouping",
+            "per-sprint",
+        ],
+        &[
+            ("AGENT_HOME", &agent_home_s),
+            ("PLAN_ISSUE_SKIP_INIT_SNAPSHOT", "1"),
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    let payload = parse_json(&out.stdout);
+    let result = &payload["payload"]["result"];
+    assert_eq!(
+        result["init_snapshot_skipped"], true,
+        "result must flag init_snapshot_skipped when env is set"
+    );
+
+    let main_init_path = result["main_agent_init_snapshot_path"]
+        .as_str()
+        .expect("main_agent_init_snapshot_path string");
+    assert!(
+        !std::path::Path::new(main_init_path).exists(),
+        "main-agent init snapshot must NOT be written when env is set: {main_init_path}"
+    );
+
+    let issue_root = result["issue_root"].as_str().expect("issue_root in result");
+    let issue_root_path = std::path::Path::new(issue_root);
+    let stray = walk_for_init_snapshot(issue_root_path);
+    assert!(
+        stray.is_empty(),
+        "no *-init.snapshot.md files allowed under issue_root when env is set: {stray:?}"
+    );
+}
+
+fn walk_for_init_snapshot(root: &std::path::Path) -> Vec<String> {
+    let mut hits = Vec::new();
+    walk_recursive(root, &mut hits);
+    hits
+}
+
+fn walk_recursive(dir: &std::path::Path, sink: &mut Vec<String>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(meta) = entry.metadata() else { continue };
+        let path = entry.path();
+        if meta.is_dir() {
+            walk_recursive(&path, sink);
+        } else if let Some(name) = path.file_name().and_then(|s| s.to_str())
+            && name.ends_with("-init.snapshot.md")
+        {
+            sink.push(path.to_string_lossy().to_string());
+        }
+    }
+}

--- a/crates/plan-issue-cli/tests/integration/start_sprint_canonical.rs
+++ b/crates/plan-issue-cli/tests/integration/start_sprint_canonical.rs
@@ -344,3 +344,108 @@ fn dispatch_record_omits_runtime_adapter_keys() {
         }
     }
 }
+
+#[test]
+fn start_sprint_skips_init_snapshot_when_env_set() {
+    // Adapter opt-out: setting PLAN_ISSUE_SKIP_INIT_SNAPSHOT=1 makes
+    // start-sprint skip the canonical subagent-init snapshot copy
+    // entirely. Plan snapshot, prompt manifest, and dispatch records
+    // are still produced (only the init snapshot is conditional).
+    let tmp = TempDir::new().expect("tempdir");
+    let agent_home = tmp.path().join("agent-home");
+    fs::create_dir_all(&agent_home).expect("create agent home");
+    let agent_home_s = agent_home.to_string_lossy().to_string();
+
+    let out = common::run_plan_issue_local_with_env(
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--repo",
+            "graysurf/plan-issue-smoke",
+            "start-sprint",
+            "--plan",
+            PLAN_PATH,
+            "--issue",
+            "217",
+            "--sprint",
+            "3",
+            "--strategy",
+            "auto",
+            "--default-pr-grouping",
+            "per-sprint",
+            "--no-comment",
+        ],
+        &[
+            ("AGENT_HOME", &agent_home_s),
+            ("PLAN_ISSUE_SKIP_INIT_SNAPSHOT", "1"),
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    let payload = parse_json(&out.stdout);
+    let result = &payload["payload"]["result"];
+    assert_eq!(
+        result["init_snapshot_skipped"], true,
+        "result must flag init_snapshot_skipped when env is set"
+    );
+
+    let subagent_init_path = result["subagent_init_snapshot_path"]
+        .as_str()
+        .expect("subagent_init_snapshot_path string");
+    assert!(
+        !std::path::Path::new(subagent_init_path).exists(),
+        "subagent init snapshot must NOT be written when env is set: {subagent_init_path}"
+    );
+
+    let plan_snapshot_path = result["plan_snapshot_path"]
+        .as_str()
+        .expect("plan_snapshot_path string");
+    assert!(
+        std::path::Path::new(plan_snapshot_path).is_file(),
+        "plan snapshot must still be written: {plan_snapshot_path}"
+    );
+
+    let dispatch_paths = result["dispatch_record_paths"]
+        .as_array()
+        .expect("dispatch_record_paths");
+    assert!(
+        !dispatch_paths.is_empty(),
+        "dispatch records must still be produced when env is set"
+    );
+
+    let sprint_root = PathBuf::from(
+        result["sprint_root"]
+            .as_str()
+            .expect("sprint_root in result"),
+    );
+    let issue_root_path = sprint_root.parent().expect("issue_root parent");
+    let stray = walk_init_snapshots(issue_root_path);
+    assert!(
+        stray.is_empty(),
+        "no *-init.snapshot.md files allowed under issue_root when env is set: {stray:?}"
+    );
+}
+
+fn walk_init_snapshots(root: &std::path::Path) -> Vec<String> {
+    let mut hits = Vec::new();
+    walk_init_recursive(root, &mut hits);
+    hits
+}
+
+fn walk_init_recursive(dir: &std::path::Path, sink: &mut Vec<String>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(meta) = entry.metadata() else { continue };
+        let path = entry.path();
+        if meta.is_dir() {
+            walk_init_recursive(&path, sink);
+        } else if let Some(name) = path.file_name().and_then(|s| s.to_str())
+            && name.ends_with("-init.snapshot.md")
+        {
+            sink.push(path.to_string_lossy().to_string());
+        }
+    }
+}


### PR DESCRIPTION
# Plan-issue-cli: opt-out env var for init-prompt snapshots

## Summary

Sprint 1 of the plan-issue plugin independence plan: `plan-issue-cli` now honours `PLAN_ISSUE_SKIP_INIT_SNAPSHOT=1` so runtime adapters that ship their own role/protocol prompts (specifically the Claude Code `plan-issue` plugin) can skip the canonical `*-init.snapshot.md` copy in `start-plan` / `start-sprint` workspaces. Codex / opencode adapters are unaffected (env var defaults to unset), so this lands as an additive opt-out with no behaviour change for current consumers.

## Changes

- New `crates/plan-issue-cli/src/runtime_skip.rs` exposes `should_skip_init_snapshot()`; `start-plan` and `start-sprint` wrap their existence check + copy of `plan-issue-delivery-{main,subagent}-init.md` behind it, and the result payload sets `init_snapshot_skipped: true` for auditability while every other artifact (plan snapshot, dispatch records, prompt manifest) stays byte-identical.
- `--help` (`Adapter opt-outs:` paragraph) and `BINARY_DEPENDENCIES.md` (`§4.1 Adapter Opt-Outs`) document the new env var contract, intended consumer, and the explicit "codex / opencode must not set this" guardrail.
- Three new integration tests cover the env-set path: `start_plan_skips_init_snapshot_when_env_set`, `start_sprint_skips_init_snapshot_when_env_set`, and `runtime_layout_parity_with_skip_init_snapshot` (asserts the canonical file tree drops both `*-init.snapshot.md` files and the JSON envelope flags `init_snapshot_skipped: true`).

## Testing

- `cargo test -p nils-plan-issue-cli` (pass — 86 tests, includes the 3 new env-set cases)
- `cargo clippy -p nils-plan-issue-cli --all-targets -- -D warnings` (pass)
- `cargo build --release -p nils-plan-issue-cli` (pass)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass — fmt / docs / completion / workspace tests green; one transient gemini-cli timing flake re-ran clean)
- Manual `PLAN_ISSUE_SKIP_INIT_SNAPSHOT=1 AGENT_HOME=$tmp plan-issue-local start-plan / start-sprint --dry-run`: zero `*-init.snapshot.md` files under the runtime tree; plan snapshot + dispatch records + prompt manifest still produced.

## Risk / Notes

- Env var defaults to unset → behaviour is byte-identical for codex / opencode adapters and every existing caller.
- Sprint 2+ of the plugin-independence plan (claude-kit side) requires a published nils-cli release that includes this commit. Coordinate the brew bottle bump (plan Task 1.3) before merging the matching plugin SKILL preflight changes; the plugin's preflight will gate on minimum nils-cli version.
- The result payload's `subagent_init_snapshot_path` / `main_agent_init_snapshot_path` still carry the would-be path string when skipped (file does not exist on disk). Consumers should branch on `init_snapshot_skipped: true` rather than reading the path blindly.
