### PR TITLE
Unflake gemini-cli prompt-segment refresh tests by pinning child exe

### DIFF
--- a/crates/gemini-cli/src/prompt_segment/refresh.rs
+++ b/crates/gemini-cli/src/prompt_segment/refresh.rs
@@ -2,11 +2,15 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, SystemTime};
 
+use nils_common::fs as shared_fs;
+
 use crate::rate_limits;
 use crate::rate_limits::client::{UsageRequest, fetch_usage};
 use crate::rate_limits::render as rate_render;
 
 use super::render as prompt_segment_render;
+
+const REFRESH_MARKER_MODE: u32 = 0o644;
 
 pub(crate) fn enqueue_background_refresh(target_file: &Path) {
     let cache_file = match rate_limits::cache_file_for_target(target_file) {
@@ -163,10 +167,10 @@ fn write_last_attempt(cache_file: &Path) {
         return;
     }
 
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let _ = std::fs::write(path, now_epoch.to_string());
+    // Use an atomic temp+rename so a concurrent `is_within_min_interval`
+    // reader never observes an empty or partial marker (which would parse
+    // as zero, disarm the gate, and fire a redundant background refresh).
+    let _ = shared_fs::write_atomic(&path, now_epoch.to_string().as_bytes(), REFRESH_MARKER_MODE);
 }
 
 fn is_within_min_interval(cache_file: &Path, refresh_min_seconds: u64) -> bool {

--- a/crates/gemini-cli/tests/integration/prompt_segment_refresh.rs
+++ b/crates/gemini-cli/tests/integration/prompt_segment_refresh.rs
@@ -222,6 +222,16 @@ fn prompt_segment_stale_cache_triggers_background_refresh() {
             ("GEMINI_PROMPT_SEGMENT_REFRESH_MIN_SECONDS", "0"),
             ("GEMINI_PROMPT_SEGMENT_CURL_CONNECT_TIMEOUT_SECONDS", "1"),
             ("GEMINI_PROMPT_SEGMENT_CURL_MAX_TIME_SECONDS", "3"),
+            // Pin the refresh subprocess exe explicitly. Sibling
+            // `prompt_segment_cached` tests in this same test binary set
+            // `GEMINI_PROMPT_SEGMENT_EXE=/usr/bin/false` via `std::env::set_var`
+            // (process-wide), which leaks into the env this child inherits at
+            // spawn time and causes the background `--refresh` lane to exec
+            // /usr/bin/false instead of gemini-cli.
+            (
+                "GEMINI_PROMPT_SEGMENT_EXE",
+                gemini_cli_bin().to_str().unwrap(),
+            ),
         ],
     );
     assert_exit(&output, 0);
@@ -307,12 +317,21 @@ fn prompt_segment_refresh_respects_min_interval() {
         ),
     );
 
+    let exe = gemini_cli_bin();
+    let exe_str = exe.to_str().expect("utf8 exe path");
     let vars = [
         ("GEMINI_PROMPT_SEGMENT_ENABLED", "true"),
         ("CODE_ASSIST_ENDPOINT", base_url.as_str()),
         ("GEMINI_PROMPT_SEGMENT_REFRESH_MIN_SECONDS", "9999"),
         ("GEMINI_PROMPT_SEGMENT_CURL_CONNECT_TIMEOUT_SECONDS", "1"),
         ("GEMINI_PROMPT_SEGMENT_CURL_MAX_TIME_SECONDS", "3"),
+        // Pin the refresh subprocess exe explicitly. Sibling
+        // `prompt_segment_cached` tests in this same test binary set
+        // `GEMINI_PROMPT_SEGMENT_EXE=/usr/bin/false` via `std::env::set_var`
+        // (process-wide), which leaks into the env this child inherits at
+        // spawn time and causes the background `--refresh` lane to exec
+        // /usr/bin/false instead of gemini-cli.
+        ("GEMINI_PROMPT_SEGMENT_EXE", exe_str),
     ];
     let envs = [
         ("GEMINI_AUTH_FILE", auth_file.as_path()),


### PR DESCRIPTION
# Unflake gemini-cli prompt-segment refresh tests by pinning child exe

## Summary

Two `prompt_segment_refresh` integration tests in `nils-gemini-cli` were flaking under `cargo test --workspace` (~70% failure rate locally on macOS). Root cause: `GEMINI_PROMPT_SEGMENT_EXE=/usr/bin/false`, set process-wide by sibling `prompt_segment_cached` tests via `std::env::set_var`, leaked into the env that the spawned background `--refresh` subprocess inherits at fork time, so the child execed `/usr/bin/false` instead of gemini-cli and exited 1 silently. Pinning `GEMINI_PROMPT_SEGMENT_EXE` to the real binary in the affected tests fixes the leak; also harden `write_last_attempt` to use atomic write so the foreground gate isn't observable mid-write.

## Problem

Under `cargo test --workspace` parallel load, two tests fail intermittently (4-6 reps out of 5 stress runs before fix):

- `prompt_segment_refresh::prompt_segment_stale_cache_triggers_background_refresh` — asserts the cache file gets `weekly_remaining=88` within 30s after a background refresh; cache never updates.
- `prompt_segment_refresh::prompt_segment_refresh_respects_min_interval` — asserts exactly 1 HTTP request hits the loopback server after two foreground calls; observed `0` requests.

Both pass in isolation (`cargo test -p nils-gemini-cli --test integration prompt_segment_refresh`) and pass on CI's GitHub Actions runners. Local `cargo test --workspace` (and any environment with high subprocess parallelism) trips them.

## Reproduction

1. `cargo test --workspace` on macOS with the `nils-gemini-cli` integration tests in scope (run 5–10 reps to surface the flake).
2. Observe one or both `prompt_segment_refresh::*` tests fail with either:
   - "expected background refresh to update cache kv" (stale_cache test), or
   - "expected the min-interval gate to suppress the second refresh" with diff `< 0  > 1` (min_interval test).

Expected: tests pass deterministically.
Actual: tests fail intermittently with the patterns above.

Diagnostic confirming root cause (instrumented `enqueue_background_refresh` to log spawn args during one failing run):

```
PARENT pre-spawn: refresh_exe="/usr/bin/false" cwd=Some(".../crates/gemini-cli")
  current_exe()=Ok(".../target/debug/gemini-cli")
  GEMINI_PROMPT_SEGMENT_EXE=/usr/bin/false      <-- leaked from sibling test!
  argv=[".../target/debug/gemini-cli", "prompt-segment", "--ttl", "1s", ...]
PARENT spawn OK: child_pid=70702
```

`refresh_exe()` prefers `GEMINI_PROMPT_SEGMENT_EXE` over `current_exe()` — the sibling-leaked value won, so the child execed `/usr/bin/false` and the test waited 30s for cache changes that would never come.

## Issues Found

- `crates/gemini-cli/tests/integration/prompt_segment_cached.rs:85,150,192` set `GEMINI_PROMPT_SEGMENT_EXE=/usr/bin/false` via `EnvGuard::set` (process-wide `std::env::set_var`); Rust runs integration tests as parallel threads in the same binary, so this leaks into the env that `cmd::run_with`-spawned subprocesses inherit at fork time. The `prompt_segment_refresh` tests rely on the spawned child being the real gemini-cli for the background refresh to actually hit the loopback server.
- `crates/gemini-cli/src/prompt_segment/refresh.rs:write_last_attempt` writes the `.refresh.at` marker via plain `std::fs::write`, which has a brief window where a concurrent `is_within_min_interval` reader can observe an empty file — that parses to zero, disarms the min-interval gate, and double-fires the background refresh. Not the trigger for the current flake (which was env-leak driven, count=0 not count=2), but a real production multi-shell race worth closing.

## Fix Approach

- Pin `GEMINI_PROMPT_SEGMENT_EXE` to `gemini_cli_bin()` in both affected tests (`prompt_segment_stale_cache_triggers_background_refresh`, `prompt_segment_refresh_respects_min_interval`). Explicit override beats whatever sibling tests have leaked into the parent env at spawn time.
- Switch `write_last_attempt` to `nils_common::fs::write_atomic` (temp + rename) so the marker is never observable mid-write. Uses the same helper `write_prompt_segment_cache` already uses.

## Testing

- `cargo test -p nils-gemini-cli --test integration prompt_segment_refresh` (pass — 4 tests)
- `cargo test --workspace` 10 reps after fix (pass — 0/10 prompt_segment_refresh failures, vs ~7/10 before)
- `cargo fmt --all -- --check` (pass)
- `cargo clippy --all-targets --all-features -- -D warnings` (pass)
- `bash scripts/ci/completion-flag-parity-audit.sh --strict` (pass)
- `zsh -f tests/zsh/completion.test.zsh` (pass)
- Full `nils-cli-verify-required-checks` pipeline (pass)

## Risk / Notes

- `write_atomic` change is strictly safer than the previous non-atomic write; uses the same helper as the cache file itself.
- Test-only env pinning has no production impact.
- Other unrelated flakes in the same workspace (e.g., `agent_commit::*`, `agent_templates::agent_advice_*`) appear to be the same family of bug — env-var leaks across sibling integration tests in the same test binary — but with different env vars (`PATH=""`, `GEMINI_CLI_MODEL`, etc.). Out of scope for this PR; worth a separate audit.
