### PR TITLE
Auto-clear ~/.local/nils-cli/bin after successful release

### DIFF
--- a/.agents/skills/nils-cli-bump-version-tag-release/SKILL.md
+++ b/.agents/skills/nils-cli-bump-version-tag-release/SKILL.md
@@ -44,6 +44,7 @@ Inputs:
   - `--from-tap` (resume mode: skip nils-cli stages 1-8 and run only the tap stage; requires
     an existing local `v<version>` tag in the nils-cli work tree)
   - `--tap-formula <name>` (formula basename, default `nils-cli`; reserved for AWL et al.)
+  - `--skip-dev-clean` (do not clear `~/.local/nils-cli/bin` after a successful release)
   - `NILS_CLI_HOMEBREW_TAP_DIR` (env var; tap path)
   - `NILS_CLI_RELEASE_WAIT_SECONDS` (env var; max seconds to wait for source `release.yml`, default 1200)
   - `NILS_CLI_TAP_WAIT_SECONDS` (env var; max seconds to wait for tap `release.yml`, default 1200)
@@ -89,6 +90,7 @@ Outputs (tap stage):
 - Creates a tap-side semantic commit `chore(formula): bump <formula> to v<version>` and pushes `main`.
 - Creates an annotated prefix tag `<formula>-v<version>` and pushes it to trigger the tap `release.yml`.
 - Unless `--skip-tap-wait`, waits for the tap `release.yml` run on the prefix tag to finish `success`.
+- Unless `--skip-dev-clean`, clears `~/.local/nils-cli/bin` so the freshly published brew formula takes precedence over any prior dev install (no-op when the directory is missing or already empty).
 
 Exit codes:
 

--- a/.agents/skills/nils-cli-bump-version-tag-release/scripts/nils-cli-bump-version-tag-release.sh
+++ b/.agents/skills/nils-cli-bump-version-tag-release/scripts/nils-cli-bump-version-tag-release.sh
@@ -21,6 +21,7 @@ Options:
   --from-tap              Resume mode: skip nils-cli stages 1-8 and run only the tap stage.
                           Requires --version and an existing v<version> tag in this repo.
   --tap-formula <name>    Formula basename to bump (default: nils-cli). Reserved for AWL et al.
+  --skip-dev-clean        Do not clear ~/.local/nils-cli/bin after a successful release.
   -h, --help              Show help.
 
 Default behavior:
@@ -584,6 +585,23 @@ run_tap_stage() {
   note "tap release.yml green for ${prefix_tag}"
 }
 
+clean_dev_install() {
+  local skip="$1"
+  if [[ "$skip" -eq 1 ]]; then
+    note "--skip-dev-clean set; leaving ~/.local/nils-cli/bin untouched"
+    return 0
+  fi
+  local dev_bin="${HOME}/.local/nils-cli/bin"
+  if [[ ! -d "$dev_bin" ]]; then
+    return 0
+  fi
+  if [[ -z "$(ls -A "$dev_bin" 2>/dev/null)" ]]; then
+    return 0
+  fi
+  note "clearing dev install at ${dev_bin} so brew copies take precedence"
+  find "$dev_bin" -mindepth 1 -delete
+}
+
 # === Argument parsing ========================================================
 
 version=""
@@ -599,6 +617,7 @@ skip_tap_wait=0
 skip_tap_tag=0
 from_tap=0
 tap_formula="nils-cli"
+skip_dev_clean=0
 
 while [[ $# -gt 0 ]]; do
   case "${1:-}" in
@@ -662,6 +681,10 @@ while [[ $# -gt 0 ]]; do
       fi
       tap_formula="${2:-}"
       shift 2
+      ;;
+    --skip-dev-clean)
+      skip_dev_clean=1
+      shift
       ;;
     -h|--help)
       usage
@@ -741,6 +764,7 @@ if [[ "$from_tap" -eq 1 ]]; then
     "$tap_formula" \
     "$skip_tap_tag" \
     "$skip_tap_wait"
+  clean_dev_install "$skip_dev_clean"
   exit 0
 fi
 
@@ -1030,3 +1054,5 @@ run_tap_stage \
   "$tap_formula" \
   "$skip_tap_tag" \
   "$skip_tap_wait"
+
+clean_dev_install "$skip_dev_clean"


### PR DESCRIPTION
## Summary

After a successful release, the `nils-cli-bump-version-tag-release` script now clears `~/.local/nils-cli/bin/` (populated by `nils-cli-install-local-release-binaries`) so the freshly published Homebrew formula takes precedence on the next shell invocation. A new `--skip-dev-clean` flag preserves the prior behaviour for users who want their dev install to stay around. Pairs with a one-line PATH addition in `$ZDOTDIR/.zshenv` (out-of-repo) that prepends `~/.local/nils-cli/bin` ahead of `/opt/homebrew/bin` so dev binaries shadow brew while present and fall through cleanly when the directory is empty.

## Changes

- Add `clean_dev_install` helper that no-ops on missing/empty dir and otherwise empties `~/.local/nils-cli/bin/` via `find -mindepth 1 -delete`
- Wire the helper into both standard-flow and `--from-tap` exit paths so cleanup runs only when the tap stage completes successfully (`set -e` bails on tap failure before cleanup)
- Add `--skip-dev-clean` opt-out flag, parser case, and `usage()` doc line
- Update `SKILL.md` Inputs / Outputs sections to document the new flag and behaviour

## Testing

- `bash -n` syntax check on the modified script (pass)
- `--help` output verification (pass — new flag listed in correct section)
- Behaviour will be exercised end-to-end on the next `/nils-cli-bump-version-tag-release` invocation; deferred to that release run

## Risk / Notes

- Default-on cleanup is a behaviour change for anyone who currently relies on dev binaries surviving past a release. The escape hatch is `--skip-dev-clean`; the new behaviour is announced in `SKILL.md`.
- `--skip-push` and `--skip-tap` exit early so the cleanup is never reached in those modes — intentional, since brew didn't get a new release in those paths and clearing dev would leave the user without a working CLI.
