### PR TITLE
Clarify CLI surface documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,33 @@
 [![Release](https://img.shields.io/github/v/release/sympoies/nils-cli?sort=semver)](https://github.com/sympoies/nils-cli/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A Rust workspace of focused CLI binaries for Git operations, API test orchestration, and workflow automation, unified by shared cross-crate
-helpers.
+A Rust workspace of focused CLI binaries for API testing, Git operations, agent workflow evidence, provider automation, planning, and
+desktop/media utilities. Shared crates keep JSON contracts, terminal UX, and cross-CLI behavior consistent.
+
+## CLI surface map
+
+Start here when choosing a binary. The source of truth for the current installable binary list is:
+
+```bash
+bash scripts/workspace-bins.sh
+```
+
+Completion obligations for those binaries are tracked in
+[docs/specs/completion-coverage-matrix-v1.md](docs/specs/completion-coverage-matrix-v1.md).
+
+| Area | Binaries | Use when |
+| ---- | -------- | -------- |
+| API testing | `api-rest`, `api-gql`, `api-grpc`, `api-websocket`, `api-test` | Run protocol-specific API checks or orchestrate a mixed API test suite. |
+| Git tooling | `git-scope`, `git-cli`, `git-summary`, `git-lock` | Inspect changes, run Git helper flows, summarize commits, or manage repo-local commit locks. |
+| Agent policy and evidence | `agent-docs`, `agent-out`, `agent-scope-lock`, `test-first-evidence`, `web-evidence`, `browser-session`, `canary-check`, `docs-impact`, `model-cross-check`, `review-evidence`, `skill-usage` | Resolve agent policy docs, allocate artifact paths, enforce edit scope, or persist deterministic workflow evidence. |
+| Planning and delivery | `plan-tooling`, `plan-issue`, `plan-issue-local`, `semantic-commit` | Validate/split implementation plans, orchestrate issue delivery, rehearse local plan flows, or create semantic commits. |
+| Provider lanes | `codex-cli`, `gemini-cli` | Run provider-specific diagnostics, auth checks, and workflow adapters. |
+| Desktop, media, and local utilities | `macos-agent`, `screen-record`, `image-processing`, `fzf-cli`, `memo-cli` | Automate local desktop tasks, capture media, convert images, use interactive shell helpers, or record/search local memos. |
+| Development-only/internal | `cli-template` | Validate packaging and new-crate patterns; excluded from user-facing completion obligations. |
 
 ## Workspace layout
 
-Each crate is either a standalone CLI binary or a shared library used across the workspace.
+Each crate is either a standalone CLI binary, a multi-binary crate, or a shared library used across the workspace.
 
 ### Shared foundations
 
@@ -37,7 +58,7 @@ Each crate is either a standalone CLI binary or a shared library used across the
 - [crates/git-summary](crates/git-summary): Per-author contribution summaries over a date range (adds/dels/net/commits).
 - [crates/git-lock](crates/git-lock): Label-based commit locks per repo (lock/list/diff/unlock/tag).
 
-### Automation and utility CLIs
+### Desktop, media, and local utility CLIs
 
 - [crates/macos-agent](crates/macos-agent): macOS desktop automation primitives for app/window discovery, input actions, screenshot, and
   wait helpers.
@@ -48,7 +69,7 @@ Each crate is either a standalone CLI binary or a shared library used across the
 - [crates/screen-record](crates/screen-record): macOS ScreenCaptureKit + Linux (X11) recorder for a single window or display with optional
   audio.
 
-### Agent and workflow tooling
+### Agent policy and evidence tooling
 
 - [crates/agent-docs](crates/agent-docs): Deterministic policy-document resolver for Codex/agent workflows (`resolve`, `contexts`, `add`,
   `baseline`).
@@ -58,8 +79,11 @@ Each crate is either a standalone CLI binary or a shared library used across the
 - [crates/web-evidence](crates/web-evidence): Redacted static HTTP evidence capture for agent workflows (`capture`, `completion`).
 - [crates/test-first-evidence](crates/test-first-evidence): Deterministic failing-test/waiver/final-validation evidence records for
   test-first workflow gates.
-- [crates/agent-workflow-primitives](crates/agent-workflow-primitives): Local-first agent workflow primitives (`browser-session`,
-  `canary-check`, `docs-impact`, `model-cross-check`, `review-evidence`, `skill-usage`).
+- [crates/agent-workflow-primitives](crates/agent-workflow-primitives): Multi-binary local-first agent workflow primitives
+  (`browser-session`, `canary-check`, `docs-impact`, `model-cross-check`, `review-evidence`, `skill-usage`).
+
+### Planning, delivery, and provider lanes
+
 - [crates/codex-cli](crates/codex-cli): Provider-specific CLI for OpenAI/Codex workflows (auth, diagnostics, execution flows, Starship),
   with adapters over `nils-common::provider_runtime`.
 - [crates/gemini-cli](crates/gemini-cli): Provider-specific CLI lane for Gemini workflows, with adapters over

--- a/crates/agent-workflow-primitives/README.md
+++ b/crates/agent-workflow-primitives/README.md
@@ -1,26 +1,56 @@
-# agent workflow primitives
+# agent-workflow-primitives
 
-This crate ships small, deterministic CLIs used by agent-kit skills and runbooks.
-The binaries are intentionally local-first: they create structured evidence,
-run safe local checks, or inspect the current repository without requiring
+## Overview
+
+`agent-workflow-primitives` is a multi-binary crate for deterministic, local-first agent workflow records. The binaries are designed for
+skills and runbooks that need evidence, validation notes, or lightweight repository inspection without invoking AI providers or requiring
 provider credentials.
 
-## Binaries
+## Package vs binary names
 
-- `docs-impact`: scan a Git worktree for changed docs and non-docs paths.
-- `canary-check`: run one local canary command and persist a redacted result.
-- `review-evidence`: record review findings and validation status.
-- `browser-session`: record browser-session goals, steps, and evidence artifacts.
-- `model-cross-check`: record primary/checker model observations without owning
-  provider invocation.
-- `skill-usage`: record skill invocation intent, linked evidence, validation,
-  outcome, and failure handling.
+| Field | Value |
+| ----- | ----- |
+| Package name | `nils-agent-workflow-primitives` |
+| Binary names | `browser-session`, `canary-check`, `docs-impact`, `model-cross-check`, `review-evidence`, `skill-usage` |
 
 Each binary supports `--version` and `completion <bash|zsh>`.
 
-## skill-usage
+## Binary map
 
-`skill-usage` writes `skill-usage.record.json` under `--out DIR`.
+| Binary | Primary purpose | Record/artifact written |
+| ------ | --------------- | ----------------------- |
+| `browser-session` | Record browser goals, steps, statuses, and evidence artifacts. | `browser-session.json` under `--out DIR` |
+| `canary-check` | Run one local command and persist a redacted pass/fail result. | `canary-check.json` under `--out DIR` |
+| `docs-impact` | Classify changed Git paths as docs or non-docs and suggest documentation review. | stdout/JSON only |
+| `model-cross-check` | Record primary/checker model observations without owning provider calls. | `model-cross-check.json` under `--out DIR` |
+| `review-evidence` | Record review findings and passing validation evidence. | `review-evidence.json` under `--out DIR` |
+| `skill-usage` | Record skill invocation intent, linked records, validation, failures, outcome, and follow-up. | `skill-usage.record.json` under `--out DIR` |
+
+## Common command shape
+
+Most record-oriented binaries use this flow:
+
+1. `init --out DIR ...`
+2. one or more `record-* --out DIR ...` commands
+3. `verify --out DIR`
+4. optional `show --out DIR --format json`
+
+`canary-check` uses `run`, `verify`, and `show`. `docs-impact` uses `scan`.
+
+Examples:
+
+```bash
+docs-impact scan --repo . --include-untracked --format json
+canary-check run --out /tmp/canary --name smoke --command "cargo test smoke"
+browser-session init --out /tmp/browser --target http://localhost:3000 --goal "verify checkout flow"
+review-evidence init --out /tmp/review --subject "PR #123"
+model-cross-check init --out /tmp/cross-check --prompt "review patch" --primary-model gpt-5.4 --checker-model gpt-5.5
+skill-usage init --out /tmp/skill --skill tools/devex/review-evidence --intent "record review" --user-request-summary "review this PR"
+```
+
+## `skill-usage` flow
+
+`skill-usage` is the broadest recorder in this crate. It links the rest of the evidence records back to one skill invocation.
 
 ```bash
 skill-usage init --out <dir> --skill <skill-path> \
@@ -36,10 +66,9 @@ skill-usage verify --out <dir> --format json
 skill-usage show --out <dir> --format json
 ```
 
-## JSON contract
+## Output contract
 
-Service-consumed commands support `--format json` and return a versioned
-envelope:
+Human-readable text is the default. Service-consumed commands support `--format json` and return a versioned envelope:
 
 ```json
 {
@@ -52,3 +81,21 @@ envelope:
 
 Errors use the same envelope with `ok=false` and an `error` object containing
 `code`, `message`, and optional `details`.
+
+Exit codes:
+
+- `0`: success
+- `1`: runtime failure or incomplete evidence from `verify`
+- `64`: usage/configuration error
+
+## Secret-safety boundary
+
+The recorders redact common secret assignments and token-like values from command lines, summaries, paths, and previews before writing
+records or printing JSON/text output. They do not read linked artifact contents.
+
+## Docs
+
+- [Docs index](docs/README.md)
+- [Completion coverage matrix](../../docs/specs/completion-coverage-matrix-v1.md)
+- [CLI service JSON contract guideline](../../docs/specs/cli-service-json-contract-guideline-v1.md)
+- [New CLI crate development standard](../../docs/runbooks/new-cli-crate-development-standard.md)

--- a/crates/agent-workflow-primitives/docs/README.md
+++ b/crates/agent-workflow-primitives/docs/README.md
@@ -1,6 +1,9 @@
 # agent-workflow-primitives docs
 
-This crate owns local-first agent workflow primitives:
+This crate owns local-first agent workflow primitive binaries. Keep crate-specific specs, runbooks, and reports here; keep workspace-wide
+completion, release, and new-crate rules in the root `docs/` tree.
+
+## Binary overview
 
 - `docs-impact`: Git change classification for docs impact review.
 - `canary-check`: redacted local canary command records.
@@ -10,5 +13,18 @@ This crate owns local-first agent workflow primitives:
 - `skill-usage`: skill invocation, linked evidence, validation, outcome, and
   failure handling records.
 
-Workspace-level release, completion, and new-crate rules remain in the root
-`docs/` tree.
+## Specs
+
+- None yet. Add documents under `docs/specs/` and register them here.
+
+## Runbooks
+
+- None yet. Add documents under `docs/runbooks/` and register them here.
+
+## Reports
+
+- None yet. Add documents under `docs/reports/` and register them here.
+
+## Links
+
+- Back to crate README: [`../README.md`](../README.md)


### PR DESCRIPTION
# Clarify CLI surface documentation

## Summary

Clarifies the expanded nils-cli command surface after the recent workflow primitive additions by adding a root README CLI map and expanding the multi-binary `agent-workflow-primitives` crate docs.

## Changes

- Add a root README CLI surface map grouped by API testing, Git tooling, agent evidence, planning/delivery, provider lanes, desktop/media utilities, and internal development tools.
- Reorganize the root workspace layout headings so crate categories match the current binary surface more closely.
- Expand `crates/agent-workflow-primitives` docs with package-vs-binary names, per-binary artifact behavior, common command flow, output contract, exit codes, and secret-safety notes.
- Align the crate docs index with workspace docs hygiene rules.

## Test-First Evidence

- Change classification: docs-only waiver
- Failing test before fix: N/A; this change only edits Markdown documentation.
- Final validation: `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh --docs-only` passed.
- Waiver reason: failing-test evidence is not practical for documentation-only clarity updates.

## Testing

- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh --docs-only` (pass)
- `git diff --check` (pass)

## Risk / Notes

- No runtime code, generated completion assets, or package metadata changed.
