### PR TITLE
Enforce plan source contracts in plan-tooling

### DIFF
--- a/crates/plan-tooling/README.md
+++ b/crates/plan-tooling/README.md
@@ -35,6 +35,9 @@ Help:
 ### validate
 
 - `validate [--file <path>]... [--format text|json]`: Validate plan files. With no `--file`, scans tracked `docs/plans/*-plan.md` files.
+- `validate` requires a `Read First` section with `Primary source`, `Source type`, and `Open questions carried into execution`. Repo-local
+  primary source paths must exist; use `Source type: plan-only waiver` for explicit plan-only exceptions.
+- If `Complexity` is present it must parse as a 1-10 integer. Omit the field when complexity is intentionally unspecified.
 
 ### batches
 

--- a/crates/plan-tooling/plan-template.md
+++ b/crates/plan-tooling/plan-template.md
@@ -3,6 +3,11 @@
 ## Overview
 <2–5 sentences: what changes, what stays the same, approach>
 
+## Read First
+- Primary source: <repo path, issue/ticket URL, or explicit plan-only waiver>
+- Source type: <discussion-to-implementation-doc | review-to-improvement-doc | existing issue/spec | plan-only waiver>
+- Open questions carried into execution: none
+
 ## Scope
 - In scope: ...
 - Out of scope: ...
@@ -22,7 +27,7 @@
 - **Description**: ...
 - **Dependencies**:
   - <task IDs or "none">
-- **Complexity**:
+- **Complexity**: <optional int 1-10>
 - **Acceptance criteria**:
   - ...
 - **Validation**:

--- a/crates/plan-tooling/src/parse.rs
+++ b/crates/plan-tooling/src/parse.rs
@@ -23,7 +23,19 @@ fn sprint_metadata_is_empty(metadata: &SprintMetadata) -> bool {
 pub struct Plan {
     pub title: String,
     pub file: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_first: Option<ReadFirst>,
     pub sprints: Vec<Sprint>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ReadFirst {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open_questions: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -65,6 +77,8 @@ pub fn parse_plan_with_display(
             break;
         }
     }
+
+    let read_first = parse_read_first(&raw_lines);
 
     let mut errors: Vec<String> = Vec::new();
 
@@ -197,16 +211,28 @@ pub fn parse_plan_with_display(
 
         match field.as_str() {
             "Description" => {
-                let v = rest.unwrap_or_default();
+                let (v, next_idx) = parse_scalar_continuation(
+                    &raw_lines,
+                    i + 1,
+                    base_indent,
+                    &rest.unwrap_or_default(),
+                );
                 if let Some(task) = current_task.as_mut() {
                     task.description = Some(v);
                 }
-                i += 1;
+                i = next_idx;
             }
             "Complexity" => {
-                let v = rest.unwrap_or_default();
-                if !v.trim().is_empty() {
-                    match v.trim().parse::<i32>() {
+                let (v, next_idx) =
+                    parse_complexity_value(&raw_lines, i + 1, base_indent, rest.as_deref());
+                let trimmed = v.trim();
+                if trimmed.is_empty() {
+                    errors.push(format!(
+                        "{display_path}:{}: missing Complexity value; omit the field or set a 1-10 integer",
+                        i + 1,
+                    ));
+                } else {
+                    match trimmed.parse::<i32>() {
                         Ok(n) => {
                             if let Some(task) = current_task.as_mut() {
                                 task.complexity = Some(n);
@@ -216,17 +242,19 @@ pub fn parse_plan_with_display(
                             errors.push(format!(
                                 "{display_path}:{}: invalid Complexity (expected int): {}",
                                 i + 1,
-                                crate::repr::py_repr(v.trim())
+                                crate::repr::py_repr(trimmed)
                             ));
                         }
                     }
                 }
-                i += 1;
+                i = next_idx;
             }
             "Location" | "Dependencies" | "Acceptance criteria" | "Validation" => {
                 let (items, next_idx) = if let Some(r) = rest.clone() {
                     if !r.trim().is_empty() {
-                        (vec![strip_inline_code(&r)], i + 1)
+                        let (value, next_idx) =
+                            parse_scalar_continuation(&raw_lines, i + 1, base_indent, &r);
+                        (vec![value], next_idx)
                     } else {
                         parse_list_block(&raw_lines, i + 1, base_indent)
                     }
@@ -298,6 +326,7 @@ pub fn parse_plan_with_display(
         Plan {
             title: plan_title,
             file: display_path.to_string(),
+            read_first,
             sprints,
         },
         errors,
@@ -368,6 +397,48 @@ fn parse_any_field_line(line: &str) -> Option<(usize, String, Option<String>)> {
     let (field, rest) = after_star.split_once("**:")?;
     let field = field.to_string();
     Some((base_indent, field, Some(rest.trim().to_string())))
+}
+
+fn parse_read_first(lines: &[String]) -> Option<ReadFirst> {
+    let start = lines
+        .iter()
+        .position(|line| line.trim() == "## Read First")?;
+    let mut end = lines.len();
+    for (idx, line) in lines.iter().enumerate().skip(start + 1) {
+        if idx > start && line.starts_with("## ") {
+            end = idx;
+            break;
+        }
+    }
+
+    let mut read_first = ReadFirst::default();
+    let mut i = start + 1;
+    while i < end {
+        let Some((base_indent, field, rest)) = parse_read_first_field_line(&lines[i]) else {
+            i += 1;
+            continue;
+        };
+
+        let (value, next_idx) = parse_scalar_continuation(lines, i + 1, base_indent, &rest);
+        match field.as_str() {
+            "Primary source" => read_first.primary_source = Some(value),
+            "Source type" => read_first.source_type = Some(value),
+            "Open questions carried into execution" => read_first.open_questions = Some(value),
+            _ => {}
+        }
+        i = next_idx.min(end);
+    }
+
+    Some(read_first)
+}
+
+fn parse_read_first_field_line(line: &str) -> Option<(usize, String, String)> {
+    let base_indent = line.chars().take_while(|c| *c == ' ').count();
+    let trimmed = line.trim_start_matches(' ');
+    let after_dash = trimmed.strip_prefix('-')?.trim_start();
+    let (field, rest) = after_dash.split_once(':')?;
+    let field = field.trim().trim_matches('*').to_string();
+    Some((base_indent, field, rest.trim().to_string()))
 }
 
 fn canonical_metadata_field_name(field: &str) -> Option<&'static str> {
@@ -473,6 +544,86 @@ fn strip_inline_code(text: &str) -> String {
     t.to_string()
 }
 
+fn parse_scalar_continuation(
+    lines: &[String],
+    start_idx: usize,
+    base_indent: usize,
+    initial: &str,
+) -> (String, usize) {
+    let mut parts: Vec<String> = Vec::new();
+    let first = strip_inline_code(initial);
+    if !first.trim().is_empty() {
+        parts.push(first);
+    }
+
+    let mut i = start_idx;
+    while i < lines.len() {
+        let raw = lines[i].as_str();
+        if raw.trim().is_empty() {
+            i += 1;
+            continue;
+        }
+
+        let indent = raw.chars().take_while(|c| *c == ' ').count();
+        if indent <= base_indent {
+            break;
+        }
+        if parse_any_field_line(raw).is_some() {
+            break;
+        }
+
+        parts.push(strip_inline_code(raw.trim_start_matches(' ')));
+        i += 1;
+    }
+
+    (join_continuation_parts(parts), i)
+}
+
+fn parse_complexity_value(
+    lines: &[String],
+    start_idx: usize,
+    base_indent: usize,
+    rest: Option<&str>,
+) -> (String, usize) {
+    let Some(rest) = rest else {
+        return (String::new(), start_idx);
+    };
+    if !rest.trim().is_empty() {
+        return parse_scalar_continuation(lines, start_idx, base_indent, rest);
+    }
+
+    let (items, next_idx) = parse_list_block(lines, start_idx, base_indent);
+    if items.len() == 1 {
+        (items[0].clone(), next_idx)
+    } else if items.is_empty() {
+        (String::new(), next_idx)
+    } else {
+        (items.join(" "), next_idx)
+    }
+}
+
+fn join_continuation_parts(parts: Vec<String>) -> String {
+    parts
+        .into_iter()
+        .map(|part| part.trim().to_string())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<String>>()
+        .join(" ")
+}
+
+fn parse_list_item_line(line: &str) -> Option<(usize, String)> {
+    let indent = line.chars().take_while(|c| *c == ' ').count();
+    let trimmed = line.trim_start_matches(' ');
+    let after_dash = trimmed.strip_prefix('-')?;
+    if after_dash.is_empty() || !after_dash.chars().next().unwrap_or('x').is_whitespace() {
+        return None;
+    }
+    Some((
+        indent,
+        strip_inline_code(after_dash.trim_start().trim_end()),
+    ))
+}
+
 fn parse_list_block(
     lines: &[String],
     start_idx: usize,
@@ -487,21 +638,39 @@ fn parse_list_block(
             continue;
         }
 
-        let indent = raw.chars().take_while(|c| *c == ' ').count();
-        let trimmed = raw.trim_start_matches(' ');
-        if !trimmed.starts_with('-') {
+        let Some((indent, text)) = parse_list_item_line(raw) else {
             break;
-        }
-        let after_dash = &trimmed[1..];
-        if after_dash.is_empty() || !after_dash.chars().next().unwrap_or('x').is_whitespace() {
-            break;
-        }
+        };
         if indent <= base_indent {
             break;
         }
-        let text = after_dash.trim_start().trim_end();
-        items.push(strip_inline_code(text));
+
+        let mut parts = vec![text];
         i += 1;
+        while i < lines.len() {
+            let raw = lines[i].as_str();
+            if raw.trim().is_empty() {
+                i += 1;
+                continue;
+            }
+
+            let next_indent = raw.chars().take_while(|c| *c == ' ').count();
+            if next_indent <= base_indent {
+                break;
+            }
+            if let Some((item_indent, _)) = parse_list_item_line(raw)
+                && item_indent <= indent
+            {
+                break;
+            }
+            if parse_any_field_line(raw).is_some() {
+                break;
+            }
+
+            parts.push(strip_inline_code(raw.trim_start_matches(' ')));
+            i += 1;
+        }
+        items.push(join_continuation_parts(parts));
     }
 
     (items, i)

--- a/crates/plan-tooling/src/validate.rs
+++ b/crates/plan-tooling/src/validate.rs
@@ -147,7 +147,7 @@ pub fn run(args: &[String]) -> i32 {
             }
             continue;
         }
-        errors.extend(validate_plan(&display_path, &read_path));
+        errors.extend(validate_plan(&display_path, &read_path, &repo_root));
 
         if let Some(p) = progress.as_ref() {
             p.set_position((idx + 1) as u64);
@@ -265,7 +265,7 @@ fn resolve_repo_relative(repo_root: &Path, path: &Path) -> PathBuf {
     repo_root.join(path)
 }
 
-fn validate_plan(display_path: &str, read_path: &Path) -> Vec<String> {
+fn validate_plan(display_path: &str, read_path: &Path, repo_root: &Path) -> Vec<String> {
     let plan: Plan;
     let parse_errors: Vec<String>;
     match parse_plan_with_display(read_path, display_path) {
@@ -303,11 +303,108 @@ fn validate_plan(display_path: &str, read_path: &Path) -> Vec<String> {
 
     let all_task_ids: HashSet<String> = tasks.iter().map(|t| t.id.trim().to_string()).collect();
 
-    let mut errs: Vec<String> = validate_sprint_metadata(display_path, &plan.sprints);
+    let mut errs: Vec<String> = validate_read_first(display_path, &plan, repo_root);
+    errs.extend(validate_sprint_metadata(display_path, &plan.sprints));
     for task in tasks {
         errs.extend(validate_task(display_path, task, &all_task_ids));
     }
     errs
+}
+
+fn validate_read_first(plan_path: &str, plan: &Plan, repo_root: &Path) -> Vec<String> {
+    let mut errs = Vec::new();
+    let Some(read_first) = plan.read_first.as_ref() else {
+        return vec![format!(
+            "{plan_path}: missing Read First section (expected Primary source, Source type, and Open questions carried into execution)"
+        )];
+    };
+
+    let primary_source = read_first
+        .primary_source
+        .as_deref()
+        .map(clean_source_value)
+        .unwrap_or_default();
+    let source_type = read_first
+        .source_type
+        .as_deref()
+        .map(clean_source_value)
+        .unwrap_or_default();
+    let open_questions = read_first
+        .open_questions
+        .as_deref()
+        .map(clean_source_value)
+        .unwrap_or_default();
+
+    if primary_source.trim().is_empty() {
+        errs.push(format!("{plan_path}: Read First missing Primary source"));
+    }
+    if source_type.trim().is_empty() {
+        errs.push(format!("{plan_path}: Read First missing Source type"));
+    } else if !is_allowed_source_type(&source_type) {
+        errs.push(format!(
+            "{plan_path}: invalid Read First Source type (expected discussion-to-implementation-doc|review-to-improvement-doc|existing issue/spec|plan-only waiver): {}",
+            crate::repr::py_repr(&source_type)
+        ));
+    }
+    if open_questions.trim().is_empty() {
+        errs.push(format!(
+            "{plan_path}: Read First missing Open questions carried into execution"
+        ));
+    }
+
+    if source_type == "plan-only waiver" {
+        if !primary_source.to_ascii_lowercase().contains("waiver") {
+            errs.push(format!(
+                "{plan_path}: plan-only waiver requires Primary source to state an explicit waiver"
+            ));
+        }
+        return errs;
+    }
+
+    if primary_source.trim().is_empty()
+        || primary_source.starts_with("http://")
+        || primary_source.starts_with("https://")
+        || primary_source.starts_with('#')
+    {
+        return errs;
+    }
+    if Path::new(&primary_source).is_absolute() {
+        errs.push(format!(
+            "{plan_path}: Primary source must be repo-relative or a URL: {}",
+            crate::repr::py_repr(&primary_source)
+        ));
+        return errs;
+    }
+
+    let source_path = repo_root.join(&primary_source);
+    if !source_path.is_file() {
+        errs.push(format!(
+            "{plan_path}: Primary source path not found: {}",
+            crate::repr::py_repr(&primary_source)
+        ));
+    }
+
+    errs
+}
+
+fn clean_source_value(value: &str) -> String {
+    let trimmed = value.trim();
+    let unwrapped = if trimmed.len() >= 2 && trimmed.starts_with('`') && trimmed.ends_with('`') {
+        &trimmed[1..trimmed.len() - 1]
+    } else {
+        trimmed
+    };
+    unwrapped.trim().to_string()
+}
+
+fn is_allowed_source_type(value: &str) -> bool {
+    matches!(
+        value,
+        "discussion-to-implementation-doc"
+            | "review-to-improvement-doc"
+            | "existing issue/spec"
+            | "plan-only waiver"
+    )
 }
 
 fn validate_sprint_metadata(plan_path: &str, sprints: &[Sprint]) -> Vec<String> {
@@ -587,6 +684,30 @@ struct ExplainCatalogEntry {
 
 const EXPLAIN_CATALOG: &[ExplainCatalogEntry] = &[
     ExplainCatalogEntry {
+        pattern: "missing Read First",
+        explain: ExplainEntry {
+            class: "read-first-missing",
+            rule: "Plans must start with a Read First section that names the primary source artifact.",
+            example: "## Read First\n\n- Primary source: docs/runbooks/example-source.md\n- Source type: review-to-improvement-doc\n- Open questions carried into execution: none",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "Primary source path not found",
+        explain: ExplainEntry {
+            class: "read-first-source-missing",
+            rule: "Repo-local Primary source paths must exist; use a URL or explicit plan-only waiver when no repo file exists.",
+            example: "- Primary source: docs/runbooks/example-source.md\n- Source type: existing issue/spec",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "invalid Read First Source type",
+        explain: ExplainEntry {
+            class: "read-first-source-type",
+            rule: "Source type must be one of the canonical plan source categories.",
+            example: "- Source type: discussion-to-implementation-doc",
+        },
+    },
+    ExplainCatalogEntry {
         pattern: "Location must be repo-relative",
         explain: ExplainEntry {
             class: "location-absolute",
@@ -657,6 +778,14 @@ const EXPLAIN_CATALOG: &[ExplainCatalogEntry] = &[
             class: "dependency-unknown",
             rule: "Dependency must reference a `### Task N.M` heading present in the plan.",
             example: "- **Dependencies**:\n  - Task 1.1     # must match an actual task heading",
+        },
+    },
+    ExplainCatalogEntry {
+        pattern: "missing Complexity value",
+        explain: ExplainEntry {
+            class: "complexity-missing-value",
+            rule: "If the Complexity field is present, set a 1-10 integer or omit the field entirely.",
+            example: "- **Complexity**: 5",
         },
     },
     ExplainCatalogEntry {
@@ -771,8 +900,9 @@ mod tests {
     use crate::parse::Task;
 
     use super::{
-        contains_angle_placeholder, contains_word_case_insensitive, has_placeholder,
-        is_non_empty_list, is_task_id, strip_backtick_spans, validate_task,
+        clean_source_value, contains_angle_placeholder, contains_word_case_insensitive,
+        has_placeholder, is_allowed_source_type, is_non_empty_list, is_task_id,
+        strip_backtick_spans, validate_task,
     };
 
     #[test]
@@ -930,5 +1060,20 @@ mod tests {
         let all_ids = HashSet::from(["Task 2.1".to_string(), "Task 2.3".to_string()]);
         let errs = validate_task("plan.md", &task, &all_ids);
         assert!(errs.is_empty(), "{errs:?}");
+    }
+
+    #[test]
+    fn clean_source_value_unwraps_backticks() {
+        assert_eq!(clean_source_value("`docs/source.md`"), "docs/source.md");
+        assert_eq!(clean_source_value(" docs/source.md "), "docs/source.md");
+    }
+
+    #[test]
+    fn allowed_source_types_are_exact() {
+        assert!(is_allowed_source_type("discussion-to-implementation-doc"));
+        assert!(is_allowed_source_type("review-to-improvement-doc"));
+        assert!(is_allowed_source_type("existing issue/spec"));
+        assert!(is_allowed_source_type("plan-only waiver"));
+        assert!(!is_allowed_source_type("review"));
     }
 }

--- a/crates/plan-tooling/tests/integration/to_json.rs
+++ b/crates/plan-tooling/tests/integration/to_json.rs
@@ -15,12 +15,39 @@ fn to_json_pretty_parses_and_includes_start_lines() {
     let v: serde_json::Value = serde_json::from_str(&out.stdout).expect("json");
     assert_eq!(v["title"], "Plan: Example");
     assert_eq!(v["file"], "plan.md");
+    assert_eq!(
+        v["read_first"]["primary_source"],
+        "plan-only waiver: integration fixture"
+    );
+    assert_eq!(v["read_first"]["source_type"], "plan-only waiver");
+    assert_eq!(v["read_first"]["open_questions"], "none");
     assert_eq!(v["sprints"][0]["number"], 1);
-    assert_eq!(v["sprints"][0]["start_line"], 3);
+    assert_eq!(v["sprints"][0]["start_line"], 9);
     assert_eq!(v["sprints"][0]["tasks"][0]["id"], "Task 1.1");
-    assert_eq!(v["sprints"][0]["tasks"][0]["start_line"], 9);
+    assert_eq!(v["sprints"][0]["tasks"][0]["start_line"], 15);
     assert_eq!(v["sprints"][0]["tasks"][1]["id"], "Task 1.2");
-    assert_eq!(v["sprints"][0]["tasks"][1]["start_line"], 21);
+    assert_eq!(v["sprints"][0]["tasks"][1]["start_line"], 27);
+}
+
+#[test]
+fn to_json_merges_scalar_and_list_continuation_lines() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let plan_path = dir.path().join("plan.md");
+    write_file(&plan_path, CONTINUATION_PLAN);
+
+    let out = run_plan_tooling(dir.path(), &["to-json", "--file", "plan.md"]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let v: serde_json::Value = serde_json::from_str(&out.stdout).expect("json");
+    let task = &v["sprints"][0]["tasks"][0];
+    assert_eq!(
+        task["description"],
+        "Document nested area rules and link the target map source."
+    );
+    assert_eq!(task["complexity"], 3);
+    assert_eq!(
+        task["acceptance_criteria"][0],
+        "The target map is referenced from the source artifact rather than copied into multiple docs."
+    );
 }
 
 #[test]
@@ -153,6 +180,12 @@ fn to_json_missing_file_is_parse_error() {
 
 const VALID_PLAN: &str = r#"# Plan: Example
 
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
+
 ## Sprint 1: First sprint
 **Goal**: ...
 **Demo/Validation**:
@@ -186,6 +219,12 @@ const VALID_PLAN: &str = r#"# Plan: Example
 
 const METADATA_PLAN: &str = r#"# Plan: Metadata Example
 
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
+
 ## Sprint 1: First sprint
 - **PR grouping intent**: `group`
 - **Execution Profile**: `parallel-x2` (parallel width 2)
@@ -205,6 +244,12 @@ const METADATA_PLAN: &str = r#"# Plan: Metadata Example
 
 const METADATA_BAD_FIELD_PLAN: &str = r#"# Plan: Metadata Bad Field
 
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
+
 ## Sprint 1: First sprint
 - **PR Grouping Intent**: `group`
 - **Execution Profile**: `serial` (parallel width 1)
@@ -218,6 +263,33 @@ const METADATA_BAD_FIELD_PLAN: &str = r#"# Plan: Metadata Bad Field
 - **Complexity**: 3
 - **Acceptance criteria**:
   - A works
+- **Validation**:
+  - cargo test -p plan-tooling
+"#;
+
+const CONTINUATION_PLAN: &str = r#"# Plan: Continuation Example
+
+## Read First
+
+- Primary source:
+  plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
+
+## Sprint 1: First sprint
+
+### Task 1.1: Document nested area rules
+- **Location**:
+  - `src/a.rs`
+- **Description**: Document nested area rules and link
+  the target map source.
+- **Dependencies**:
+  - none
+- **Complexity**:
+  - 3
+- **Acceptance criteria**:
+  - The target map is referenced from the source artifact rather than copied
+    into multiple docs.
 - **Validation**:
   - cargo test -p plan-tooling
 "#;

--- a/crates/plan-tooling/tests/integration/validate.rs
+++ b/crates/plan-tooling/tests/integration/validate.rs
@@ -35,6 +35,67 @@ fn validate_explicit_file_without_git_repo() {
 }
 
 #[test]
+fn validate_fails_when_read_first_section_is_missing() {
+    let repo = init_repo();
+    write_file(
+        &repo.path().join("missing-read-first.md"),
+        MISSING_READ_FIRST_PLAN,
+    );
+
+    let out = run_plan_tooling(
+        repo.path(),
+        &["validate", "--file", "missing-read-first.md"],
+    );
+    assert_eq!(out.code, 1);
+    assert!(out.stderr.contains("missing Read First"));
+    assert!(out.stderr.contains("Primary source"));
+}
+
+#[test]
+fn validate_fails_when_read_first_source_path_is_missing() {
+    let repo = init_repo();
+    write_file(
+        &repo.path().join("missing-source.md"),
+        MISSING_SOURCE_PATH_PLAN,
+    );
+
+    let out = run_plan_tooling(repo.path(), &["validate", "--file", "missing-source.md"]);
+    assert_eq!(out.code, 1);
+    assert!(out.stderr.contains("Primary source path not found"));
+    assert!(out.stderr.contains("docs/source/missing.md"));
+}
+
+#[test]
+fn validate_accepts_existing_read_first_source_path() {
+    let repo = init_repo();
+    write_file(&repo.path().join("docs/source/spec.md"), "# Spec\n");
+    write_file(&repo.path().join("source-backed.md"), SOURCE_BACKED_PLAN);
+
+    let out = run_plan_tooling(repo.path(), &["validate", "--file", "source-backed.md"]);
+    assert_eq!(
+        out.code, 0,
+        "stdout: {}\nstderr: {}",
+        out.stdout, out.stderr
+    );
+    assert!(out.stdout.is_empty());
+    assert!(out.stderr.is_empty());
+}
+
+#[test]
+fn validate_fails_when_complexity_field_is_present_without_integer() {
+    let repo = init_repo();
+    write_file(
+        &repo.path().join("empty-complexity.md"),
+        EMPTY_COMPLEXITY_PLAN,
+    );
+
+    let out = run_plan_tooling(repo.path(), &["validate", "--file", "empty-complexity.md"]);
+    assert_eq!(out.code, 1);
+    assert!(out.stderr.contains("missing Complexity"));
+    assert!(out.stderr.contains("omit the field or set a 1-10 integer"));
+}
+
+#[test]
 fn validate_fails_with_errors() {
     let repo = init_repo();
     write_file(&repo.path().join("bad.md"), INVALID_PLAN);
@@ -379,6 +440,12 @@ fn validate_fails_when_sprint_metadata_is_partial() {
 
 const VALID_PLAN: &str = r#"# Plan: Example
 
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
+
 ## Sprint 1: First sprint
 
 ### Task 1.1: Do thing
@@ -394,6 +461,12 @@ const VALID_PLAN: &str = r#"# Plan: Example
 "#;
 
 const INVALID_PLAN: &str = r#"# Plan: Bad
+
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
 
 ## Sprint 1: Bad sprint
 
@@ -411,6 +484,12 @@ const INVALID_PLAN: &str = r#"# Plan: Bad
 
 const MISSING_DEPS_PLAN: &str = r#"# Plan: Missing deps
 
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
+
 ## Sprint 1: First sprint
 
 ### Task 1.1: Do thing
@@ -425,6 +504,12 @@ const MISSING_DEPS_PLAN: &str = r#"# Plan: Missing deps
 "#;
 
 const REDIRECT_VALIDATION_PLAN: &str = r#"# Plan: Redirect
+
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
 
 ## Sprint 1: First sprint
 
@@ -442,6 +527,12 @@ const REDIRECT_VALIDATION_PLAN: &str = r#"# Plan: Redirect
 
 const BACKTICK_DESCRIPTION_PLAN: &str = r#"# Plan: Backtick description
 
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
+
 ## Sprint 1: First sprint
 
 ### Task 1.1: Document a usage slot
@@ -457,6 +548,12 @@ const BACKTICK_DESCRIPTION_PLAN: &str = r#"# Plan: Backtick description
 "#;
 
 const INVALID_DEP_FORMAT_PLAN: &str = r#"# Plan: Bad deps
+
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
 
 ## Sprint 1: First sprint
 
@@ -474,6 +571,12 @@ const INVALID_DEP_FORMAT_PLAN: &str = r#"# Plan: Bad deps
 "#;
 
 const METADATA_MISMATCH_PLAN: &str = r#"# Plan: Metadata mismatch
+
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
 
 ## Sprint 1: First sprint
 - **PR grouping intent**: `per-sprint`
@@ -493,6 +596,12 @@ const METADATA_MISMATCH_PLAN: &str = r#"# Plan: Metadata mismatch
 
 const METADATA_PARTIAL_PLAN: &str = r#"# Plan: Metadata partial
 
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
+
 ## Sprint 1: First sprint
 - **PR grouping intent**: `group`
 
@@ -502,6 +611,89 @@ const METADATA_PARTIAL_PLAN: &str = r#"# Plan: Metadata partial
 - **Description**: Do A
 - **Dependencies**:
   - none
+- **Acceptance criteria**:
+  - A works
+- **Validation**:
+  - cargo test -p plan-tooling
+"#;
+
+const MISSING_READ_FIRST_PLAN: &str = r#"# Plan: Missing Read First
+
+## Sprint 1: First sprint
+
+### Task 1.1: Do thing
+- **Location**:
+  - `src/a.rs`
+- **Description**: Do A
+- **Dependencies**:
+  - none
+- **Acceptance criteria**:
+  - A works
+- **Validation**:
+  - cargo test -p plan-tooling
+"#;
+
+const MISSING_SOURCE_PATH_PLAN: &str = r#"# Plan: Missing source path
+
+## Read First
+
+- Primary source: docs/source/missing.md
+- Source type: review-to-improvement-doc
+- Open questions carried into execution: none
+
+## Sprint 1: First sprint
+
+### Task 1.1: Do thing
+- **Location**:
+  - `src/a.rs`
+- **Description**: Do A
+- **Dependencies**:
+  - none
+- **Acceptance criteria**:
+  - A works
+- **Validation**:
+  - cargo test -p plan-tooling
+"#;
+
+const SOURCE_BACKED_PLAN: &str = r#"# Plan: Source backed
+
+## Read First
+
+- Primary source: docs/source/spec.md
+- Source type: existing issue/spec
+- Open questions carried into execution: none
+
+## Sprint 1: First sprint
+
+### Task 1.1: Do thing
+- **Location**:
+  - `src/a.rs`
+- **Description**: Do A
+- **Dependencies**:
+  - none
+- **Acceptance criteria**:
+  - A works
+- **Validation**:
+  - cargo test -p plan-tooling
+"#;
+
+const EMPTY_COMPLEXITY_PLAN: &str = r#"# Plan: Empty complexity
+
+## Read First
+
+- Primary source: plan-only waiver: integration fixture
+- Source type: plan-only waiver
+- Open questions carried into execution: none
+
+## Sprint 1: First sprint
+
+### Task 1.1: Do thing
+- **Location**:
+  - `src/a.rs`
+- **Description**: Do A
+- **Dependencies**:
+  - none
+- **Complexity**:
 - **Acceptance criteria**:
   - A works
 - **Validation**:

--- a/docs/plans/plan-issue-cli-canonical-runtime-artifacts-plan.md
+++ b/docs/plans/plan-issue-cli-canonical-runtime-artifacts-plan.md
@@ -19,6 +19,12 @@ backward-compat shim is shipped because the user explicitly
 authorized it and the only consumers (the wrapper + adapter agents)
 already expect the canonical layout.
 
+## Read First
+
+- Primary source: plan-only waiver: historical plan predates source artifact split
+- Source type: plan-only waiver
+- Open questions carried into execution: none
+
 ## Scope
 
 - In scope:


### PR DESCRIPTION
# Enforce plan source contracts in plan-tooling

## Summary

This adds a source-artifact contract to plan-tooling plans so implementation plans must point back to a durable discussion, review, issue, spec, or explicit plan-only waiver. It also makes the parser preserve wrapped field text and complexity values so generated plan JSON matches the Markdown authors actually wrote.

## Changes

- Parse and emit a top-level `read_first` JSON object from `## Read First` plan sections.
- Require `Primary source`, canonical `Source type`, and carried-open-question metadata during `plan-tooling validate`.
- Validate repo-local primary source paths and require explicit `plan-only waiver` wording for plan-only exceptions.
- Preserve scalar and list continuation lines for descriptions, acceptance criteria, and validation fields.
- Parse multiline single-item `Complexity` values and reject present-but-empty complexity fields.
- Update the plan template, README, integration fixtures, and one historical nils-cli plan waiver.

## Test-First Evidence

- Change classification: feature / behavior change for plan-tooling validation and JSON parsing.
- Failing test before fix: targeted plan-tooling regression test run initially failed 4 cases covering wrapped text, missing Read First, missing source path, and empty Complexity.
- Final validation: `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` passed with 85.71% total line coverage.
- Waiver reason: N/A.

## Testing

- `cargo test -p nils-plan-tooling --test integration` (pass, 69 tests)
- `cargo test -p nils-plan-tooling --lib` (pass, 27 tests)
- `cargo clippy -p nils-plan-tooling --all-targets -- -D warnings` (pass)
- `cargo fmt --all -- --check` (pass)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` (pass, coverage 85.71%)
- `plan-tooling validate --file docs/plans/skill-folder-migration-plan.md` from agent-kit with the new binary (pass)

## Risk / Notes

- Existing plan files without `## Read First` now fail validation by design.
- `plan-only waiver` remains available for historical plans or rare cases without a durable source artifact.
