### PR TITLE
Bundle plan-tooling scaffold output by slug

### DIFF
--- a/crates/plan-tooling/README.md
+++ b/crates/plan-tooling/README.md
@@ -82,8 +82,8 @@ Help:
 
 ### scaffold
 
-- `scaffold --slug <kebab-case> [--title <title>] [--force]`: Write to `docs/plans/<slug>-plan.md` (or `<slug>.md` if the slug already ends
-  with `-plan`).
+- `scaffold --slug <kebab-case> [--title <title>] [--force]`: Write to `docs/plans/<slug>/<slug>-plan.md` (or
+  `docs/plans/<slug>/<slug>.md` if the slug already ends with `-plan`).
 - `scaffold --file <path> [--title <title>] [--force]`: Write to a specific `-plan.md` path.
 
 ### completion

--- a/crates/plan-tooling/src/scaffold.rs
+++ b/crates/plan-tooling/src/scaffold.rs
@@ -11,8 +11,8 @@ Purpose:
   Create a new plan markdown file from the shared plan template.
 
 Options:
-  --slug <slug>   Base slug (kebab-case). Writes to docs/plans/<slug>-plan.md.
-                 If <slug> already ends with "-plan", writes to docs/plans/<slug>.md.
+  --slug <slug>   Base slug (kebab-case). Writes to docs/plans/<slug>/<slug>-plan.md.
+                 If <slug> already ends with "-plan", writes to docs/plans/<slug>/<slug>.md.
   --file <path>   Explicit output path (must end with "-plan.md")
   --title <text>  Replace the plan title line ("# Plan: ...")
   --force         Overwrite if the output file already exists
@@ -101,11 +101,7 @@ pub fn run(args: &[String]) -> i32 {
         if !is_kebab_case(slug) {
             return die_usage("--slug must be kebab-case (lowercase letters, digits, hyphens)");
         }
-        if slug.ends_with("-plan") {
-            out_file = Some(format!("docs/plans/{slug}.md"));
-        } else {
-            out_file = Some(format!("docs/plans/{slug}-plan.md"));
-        }
+        out_file = Some(default_slug_plan_path(slug));
     }
 
     let Some(out_file_raw) = out_file else {
@@ -157,6 +153,15 @@ fn is_kebab_case(s: &str) -> bool {
     })
 }
 
+fn default_slug_plan_path(slug: &str) -> String {
+    let filename = if slug.ends_with("-plan") {
+        format!("{slug}.md")
+    } else {
+        format!("{slug}-plan.md")
+    };
+    format!("docs/plans/{slug}/{filename}")
+}
+
 fn resolve_repo_relative(repo_root: &Path, path: &Path) -> PathBuf {
     if path.is_absolute() {
         return path.to_path_buf();
@@ -198,7 +203,8 @@ fn relativize_for_created(path: &Path, repo_root: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        TEMPLATE, is_kebab_case, relativize_for_created, resolve_repo_relative, write_template,
+        TEMPLATE, default_slug_plan_path, is_kebab_case, relativize_for_created,
+        resolve_repo_relative, write_template,
     };
     use pretty_assertions::assert_eq;
     use std::path::PathBuf;
@@ -211,6 +217,18 @@ mod tests {
         assert!(!is_kebab_case("Hello-world"));
         assert!(!is_kebab_case("hello--world"));
         assert!(!is_kebab_case("-hello"));
+    }
+
+    #[test]
+    fn default_slug_plan_path_uses_plan_bundle_folder() {
+        assert_eq!(
+            default_slug_plan_path("hello-world"),
+            "docs/plans/hello-world/hello-world-plan.md"
+        );
+        assert_eq!(
+            default_slug_plan_path("hello-world-plan"),
+            "docs/plans/hello-world-plan/hello-world-plan.md"
+        );
     }
 
     #[test]

--- a/crates/plan-tooling/tests/integration/scaffold.rs
+++ b/crates/plan-tooling/tests/integration/scaffold.rs
@@ -20,12 +20,12 @@ fn scaffold_slug_creates_plan_and_replaces_title() {
     assert_eq!(out.code, 0, "stderr: {}", out.stderr);
     assert!(
         out.stdout
-            .contains("created: docs/plans/plan-tooling-cli-consolidation-test-plan.md")
+            .contains("created: docs/plans/plan-tooling-cli-consolidation-test/plan-tooling-cli-consolidation-test-plan.md")
     );
 
     let created_path = dir
         .path()
-        .join("docs/plans/plan-tooling-cli-consolidation-test-plan.md");
+        .join("docs/plans/plan-tooling-cli-consolidation-test/plan-tooling-cli-consolidation-test-plan.md");
     let created = std::fs::read_to_string(created_path).expect("read created");
     assert!(
         created


### PR DESCRIPTION
# Bundle plan-tooling scaffold output by slug

## Summary

Update `plan-tooling scaffold --slug` so generated plans default to a per-plan bundle folder under `docs/plans/<slug>/`, matching the agent-kit plan artifact layout while keeping explicit `--file` callers unchanged.

## Changes

- Changed `--slug` output from `docs/plans/<slug>-plan.md` to `docs/plans/<slug>/<slug>-plan.md`.
- Preserved the existing no-double-suffix handling for slugs that already end in `-plan`.
- Updated README/help text and scaffold integration coverage for the new default.

## Test-First Evidence

- Change classification: behavior change
- Failing test before fix: `cargo test -p nils-plan-tooling scaffold_slug_creates_plan_and_replaces_title` failed because production code still emitted the legacy flat path.
- Final validation: `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` passed, including 2555 nextest tests and 85.72% total line coverage.
- Waiver reason: N/A

## Testing

- `cargo test -p nils-plan-tooling scaffold` (pass)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` (pass)

## Risk / Notes

- `--file` remains the compatibility path for any caller that still needs a custom or legacy flat plan path.
