### PR TITLE
Extend heuristic-inbox verify redaction guardrail to ENTRY.md / RECORD.md body

### DIFF
--- a/completions/bash/heuristic-inbox
+++ b/completions/bash/heuristic-inbox
@@ -301,7 +301,7 @@ _heuristic-inbox() {
             return 0
             ;;
         heuristic__inbox__verify)
-            opts="-h --inbox-dir --format --help <PATH>"
+            opts="-h --inbox-dir --strict --format --help <PATH>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/zsh/_heuristic-inbox
+++ b/completions/zsh/_heuristic-inbox
@@ -42,6 +42,7 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '--inbox-dir=[Inbox directory used for duplicate detection]:DIR:_files -/' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--strict[Escalate ENTRY.md/RECORD.md body redaction findings to ok=false]' \
 '-h[Print help]' \
 '--help[Print help]' \
 ':entry -- Case folder or ENTRY.md/RECORD.md path:_files' \
@@ -57,7 +58,7 @@ _arguments "${_arguments_options[@]}" : \
 '--status=[Lifecycle status for the new entry]:STATUS:(open promoted wontfix)' \
 '--severity=[Severity for the new entry]:SEVERITY:(low medium high)' \
 '--next-action=[Optional Next Action override]:NEXT_ACTION:_default' \
-'--log-dir=[Optional execution log directory]:DIR:_files -/' \
+'--log-dir=[Execution log directory override (defaults to agent-out topic heuristic-inbox)]:DIR:_files -/' \
 '--format=[Output format]:FORMAT:(text json)' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -65,10 +66,10 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (set-status)
 _arguments "${_arguments_options[@]}" : \
-'--status=[New lifecycle status\: open|promoted|wontfix. Legacy values triaged|planned cannot be re-set]:STATUS:_default' \
+'--status=[New lifecycle status\: open|promoted|wontfix. Retired values triaged|planned cannot be re-set]:STATUS:_default' \
 '--link=[Optional durable link to append to Next Action]:LINK:_default' \
 '--next-action=[Optional Next Action override]:NEXT_ACTION:_default' \
-'--log-dir=[Optional execution log directory]:DIR:_files -/' \
+'--log-dir=[Execution log directory override (defaults to agent-out topic heuristic-inbox)]:DIR:_files -/' \
 '--format=[Output format]:FORMAT:(text json)' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -82,7 +83,7 @@ _arguments "${_arguments_options[@]}" : \
 '--date=[Archive date (YYYY-MM-DD). Defaults to today]:DATE:_default' \
 '--link=[Optional durable outcome link]:LINK:_default' \
 '--reason=[Optional archive reason]:REASON:_default' \
-'--log-dir=[Optional execution log directory]:DIR:_files -/' \
+'--log-dir=[Execution log directory override (defaults to agent-out topic heuristic-inbox)]:DIR:_files -/' \
 '--format=[Output format]:FORMAT:(text json)' \
 '--dry-run[Report destination without moving the case folder]' \
 '-h[Print help]' \
@@ -96,7 +97,7 @@ _arguments "${_arguments_options[@]}" : \
 '--label=[Evidence label (default\: source stem)]:LABEL:_default' \
 '--suffix=[Evidence file suffix (default\: .md)]:SUFFIX:_default' \
 '--max-bytes=[Reject sources larger than this many bytes]:MAX_BYTES:_default' \
-'--log-dir=[Optional execution log directory]:DIR:_files -/' \
+'--log-dir=[Execution log directory override (defaults to agent-out topic heuristic-inbox)]:DIR:_files -/' \
 '--format=[Output format]:FORMAT:(text json)' \
 '--force[Overwrite existing evidence with same label]' \
 '-h[Print help]' \

--- a/crates/agent-workflow-primitives/README.md
+++ b/crates/agent-workflow-primitives/README.md
@@ -52,6 +52,25 @@ model-cross-check init --out /tmp/cross-check --prompt "review patch" --primary-
 skill-usage init --out /tmp/skill --skill tools/devex/review-evidence --intent "record review" --user-request-summary "review this PR"
 ```
 
+## `heuristic-inbox verify` redaction guardrail
+
+`verify` scans both the case body (`ENTRY.md` / `RECORD.md`) and any
+`evidence/` files using the same four redaction rules:
+
+1. token-like patterns (Bearer / `sk-` / `api_key=` / `-----BEGIN ...`)
+2. body / file byte size against the `--max-bytes` (default 64 KiB) limit
+3. raw `skill-usage.record.v1` JSON shape (matches `"schema":"skill-usage.record.v1"`)
+4. absolute `$HOME` paths (`/Users/...` or `/home/...`)
+
+Findings on the body are surfaced under the `body_violations` array and a
+`body warning:` line in `warnings`. By default they do **not** flip `ok` to
+`false` so migrated cases that preserve absolute audit paths keep passing
+`verify`. Use `--strict` to escalate body findings to `ok=false`; downstream
+tooling can opt in once collaborators have rotated their cases.
+
+`evidence/` files keep the existing strict behaviour: any violation fails
+`verify` regardless of `--strict`.
+
 ## `skill-usage` flow
 
 `skill-usage` is the broadest recorder in this crate. It links the rest of the evidence records back to one skill invocation.

--- a/crates/agent-workflow-primitives/src/heuristic_inbox.rs
+++ b/crates/agent-workflow-primitives/src/heuristic_inbox.rs
@@ -376,17 +376,21 @@ struct ParsedEntry {
 
 fn parse_entry(path: &Path) -> Result<ParsedEntry, CliError> {
     let text = read_text(path)?;
-    let sections = extract_sections(&text);
+    Ok(parse_entry_from_text(path, &text))
+}
+
+fn parse_entry_from_text(path: &Path, text: &str) -> ParsedEntry {
+    let sections = extract_sections(text);
     let fields = extract_status_fields(sections.get("Status").map(String::as_str).unwrap_or(""));
     let raw_records =
         extract_raw_records(sections.get("Evidence").map(String::as_str).unwrap_or(""));
-    Ok(ParsedEntry {
+    ParsedEntry {
         path: path.to_path_buf(),
-        title: extract_title(&text),
+        title: extract_title(text),
         sections,
         fields,
         raw_records,
-    })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -589,6 +593,50 @@ fn evidence_violations(name: &str, text: &str, max_bytes: u64) -> Vec<Violation>
     violations
 }
 
+fn raw_skill_usage_json_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#""schema"\s*:\s*"skill-usage\.record\.v1""#)
+            .expect("raw skill usage json regex")
+    })
+}
+
+fn body_violations(text: &str, max_bytes: u64) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    let byte_size = text.len() as u64;
+    if byte_size > max_bytes {
+        violations.push(Violation::new(
+            "body_too_large",
+            format!("body is {byte_size} bytes; limit is {max_bytes}"),
+        ));
+    }
+    for pattern in token_regexes() {
+        if pattern.is_match(text) {
+            violations.push(Violation::new(
+                "body_token_pattern",
+                format!(
+                    "body matches redacted-secret pattern '{}'",
+                    pattern.as_str()
+                ),
+            ));
+            break;
+        }
+    }
+    if home_path_regex().is_match(text) {
+        violations.push(Violation::new(
+            "body_absolute_home_path",
+            "body contains absolute home path; rewrite to <workspace>",
+        ));
+    }
+    if raw_skill_usage_json_regex().is_match(text) {
+        violations.push(Violation::new(
+            "body_raw_skill_usage",
+            "body contains raw skill-usage record JSON shape; extract curated fields instead",
+        ));
+    }
+    violations
+}
+
 fn is_raw_skill_usage_record(src: &Path, sniff: bool) -> bool {
     if src.file_name().and_then(|s| s.to_str()) == Some(RAW_RECORD_FILENAME) {
         return true;
@@ -718,6 +766,7 @@ struct EvidenceFile {
 #[derive(Debug, Serialize)]
 struct VerifyResult {
     ok: bool,
+    strict: bool,
     path: String,
     folder: String,
     kind: &'static str,
@@ -727,6 +776,7 @@ struct VerifyResult {
     duplicates: Vec<DuplicateRef>,
     evidence: Vec<EvidenceFile>,
     violations: Vec<Violation>,
+    body_violations: Vec<Violation>,
     warnings: Vec<String>,
 }
 
@@ -803,8 +853,11 @@ fn verify_case(
     case: &Case,
     inbox_dir: Option<&Path>,
     max_bytes: u64,
+    strict: bool,
 ) -> Result<VerifyResult, CliError> {
-    let parsed = parse_entry(&case.doc_path)?;
+    let body_text = read_text(&case.doc_path)?;
+    let parsed = parse_entry_from_text(&case.doc_path, &body_text);
+    let body_findings = body_violations(&body_text, max_bytes);
     let mut violations: Vec<Violation> = Vec::new();
 
     if parsed.title.is_empty() {
@@ -947,8 +1000,18 @@ fn verify_case(
         }
     }
 
+    if strict {
+        violations.extend(body_findings.clone());
+    }
+    let mut warnings: Vec<String> = Vec::new();
+    if !strict {
+        for finding in &body_findings {
+            warnings.push(format!("body warning: {}", finding.message));
+        }
+    }
     Ok(VerifyResult {
         ok: violations.is_empty(),
+        strict,
         path: display_path(&case.doc_path),
         folder: display_path(&case.folder),
         kind: case.kind.as_str(),
@@ -958,7 +1021,8 @@ fn verify_case(
         duplicates,
         evidence: evidence_files,
         violations,
-        warnings: Vec::new(),
+        body_violations: body_findings,
+        warnings,
     })
 }
 
@@ -1517,7 +1581,12 @@ fn run_archive(args: &ArchiveArgs) -> Result<ArchiveResult, CliError> {
     } else {
         args.reason.clone()
     };
-    let verification = verify_case(&case, Some(&args.inbox_dir), DEFAULT_EVIDENCE_MAX_BYTES)?;
+    let verification = verify_case(
+        &case,
+        Some(&args.inbox_dir),
+        DEFAULT_EVIDENCE_MAX_BYTES,
+        false,
+    )?;
     let parsed = parse_entry(&case.doc_path)?;
     let sections = parsed.sections.clone();
     let fields = parsed.fields.clone();
@@ -2031,7 +2100,7 @@ fn dispatch_verify(args: VerifyArgs) -> i32 {
         Err(err) => return render_error(VERIFY_SCHEMA_VERSION, VERIFY_COMMAND, format, err),
     };
     let inbox_dir = args.inbox_dir.as_deref();
-    match verify_case(&case, inbox_dir, DEFAULT_EVIDENCE_MAX_BYTES) {
+    match verify_case(&case, inbox_dir, DEFAULT_EVIDENCE_MAX_BYTES, args.strict) {
         Ok(result) if result.ok => render_success(
             VERIFY_SCHEMA_VERSION,
             VERIFY_COMMAND,
@@ -2245,6 +2314,10 @@ struct VerifyArgs {
     /// Inbox directory used for duplicate detection.
     #[arg(long = "inbox-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
     inbox_dir: Option<PathBuf>,
+
+    /// Escalate ENTRY.md/RECORD.md body redaction findings to ok=false.
+    #[arg(long)]
+    strict: bool,
 
     /// Output format.
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]

--- a/crates/agent-workflow-primitives/tests/integration/cli.rs
+++ b/crates/agent-workflow-primitives/tests/integration/cli.rs
@@ -1891,6 +1891,168 @@ Promote after a durable fix and validation are linked.\n\n\
     }
 
     #[test]
+    fn verify_warns_on_body_home_path_without_strict() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let inbox = inbox_root(tmp.path());
+        let entry = write_entry(
+            &inbox.join("body-home-path"),
+            EntryOpts {
+                raw_record: "/Users/example/project/out/skill-usage.record.json",
+                ..EntryOpts::default()
+            },
+        );
+        let out = run(
+            "heuristic-inbox",
+            tmp.path(),
+            &[
+                "verify",
+                entry.parent().unwrap().to_str().unwrap(),
+                "--inbox-dir",
+                inbox.to_str().unwrap(),
+                "--format",
+                "json",
+            ],
+        );
+        assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+        let payload = json_stdout(&out);
+        assert_eq!(payload["result"]["ok"], true);
+        assert_eq!(payload["result"]["strict"], false);
+        let body_violations = payload["result"]["body_violations"]
+            .as_array()
+            .expect("body_violations array");
+        assert!(
+            body_violations
+                .iter()
+                .any(|v| { v["kind"].as_str().unwrap_or("") == "body_absolute_home_path" })
+        );
+        let warnings = payload["result"]["warnings"]
+            .as_array()
+            .expect("warnings array");
+        assert!(warnings.iter().any(|w| {
+            w.as_str()
+                .unwrap_or("")
+                .contains("body warning: body contains absolute home path")
+        }));
+    }
+
+    #[test]
+    fn verify_strict_fails_on_body_home_path() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let inbox = inbox_root(tmp.path());
+        let entry = write_entry(
+            &inbox.join("body-home-path-strict"),
+            EntryOpts {
+                raw_record: "/Users/example/project/out/skill-usage.record.json",
+                ..EntryOpts::default()
+            },
+        );
+        let out = run(
+            "heuristic-inbox",
+            tmp.path(),
+            &[
+                "verify",
+                entry.parent().unwrap().to_str().unwrap(),
+                "--inbox-dir",
+                inbox.to_str().unwrap(),
+                "--strict",
+                "--format",
+                "json",
+            ],
+        );
+        assert_ne!(out.code, 0);
+        let payload = json_stdout(&out);
+        assert_eq!(payload["error"]["details"]["strict"], true);
+        let violations = payload["error"]["details"]["violations"]
+            .as_array()
+            .expect("violations array");
+        assert!(
+            violations
+                .iter()
+                .any(|v| { v["kind"].as_str().unwrap_or("") == "body_absolute_home_path" })
+        );
+        let body_violations = payload["error"]["details"]["body_violations"]
+            .as_array()
+            .expect("body_violations array");
+        assert!(
+            body_violations
+                .iter()
+                .any(|v| { v["kind"].as_str().unwrap_or("") == "body_absolute_home_path" })
+        );
+    }
+
+    #[test]
+    fn verify_strict_fails_on_body_token_pattern() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let inbox = inbox_root(tmp.path());
+        let entry = write_entry(
+            &inbox.join("body-token-strict"),
+            EntryOpts {
+                evidence_extra: "- Auth: Bearer abcdefghijklmnopqrstuvwxyz1234567890\n",
+                ..EntryOpts::default()
+            },
+        );
+        let out = run(
+            "heuristic-inbox",
+            tmp.path(),
+            &[
+                "verify",
+                entry.parent().unwrap().to_str().unwrap(),
+                "--inbox-dir",
+                inbox.to_str().unwrap(),
+                "--strict",
+                "--format",
+                "json",
+            ],
+        );
+        assert_ne!(out.code, 0);
+        let payload = json_stdout(&out);
+        let violations = payload["error"]["details"]["violations"]
+            .as_array()
+            .expect("violations array");
+        assert!(
+            violations
+                .iter()
+                .any(|v| { v["kind"].as_str().unwrap_or("") == "body_token_pattern" })
+        );
+    }
+
+    #[test]
+    fn verify_strict_fails_on_body_raw_skill_usage_schema() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let inbox = inbox_root(tmp.path());
+        let entry = write_entry(
+            &inbox.join("body-raw-schema-strict"),
+            EntryOpts {
+                evidence_extra: "- Inline raw JSON: `{\"schema\":\"skill-usage.record.v1\"}`\n",
+                ..EntryOpts::default()
+            },
+        );
+        let out = run(
+            "heuristic-inbox",
+            tmp.path(),
+            &[
+                "verify",
+                entry.parent().unwrap().to_str().unwrap(),
+                "--inbox-dir",
+                inbox.to_str().unwrap(),
+                "--strict",
+                "--format",
+                "json",
+            ],
+        );
+        assert_ne!(out.code, 0);
+        let payload = json_stdout(&out);
+        let violations = payload["error"]["details"]["violations"]
+            .as_array()
+            .expect("violations array");
+        assert!(
+            violations
+                .iter()
+                .any(|v| { v["kind"].as_str().unwrap_or("") == "body_raw_skill_usage" })
+        );
+    }
+
+    #[test]
     fn ingest_evidence_rejects_raw_skill_usage_record() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let inbox = inbox_root(tmp.path());


### PR DESCRIPTION
# Extend heuristic-inbox verify redaction guardrail to ENTRY.md / RECORD.md body

## Summary

`heuristic-inbox verify` now scans the case body (`ENTRY.md` / `RECORD.md`)
with the same four redaction rules used for `ingest-evidence` (token-like
patterns, oversize, raw `skill-usage.record.v1` JSON shape, absolute `$HOME`
paths). Findings surface under a new `body_violations` array and `body
warning:` entries in `warnings`. A new `--strict` flag escalates body
findings to `ok=false`; default behaviour stays warn-only so migrated cases
that intentionally preserve absolute audit paths keep passing `verify`.
Closes [#372](https://github.com/sympoies/nils-cli/issues/372).

## Problem

The redaction guardrail introduced for case-folder migration only enforced
its checks on files written to `<case>/evidence/` via `ingest-evidence`. The
body of `ENTRY.md` / `RECORD.md` was not scanned, so raw `$HOME` paths and
other unredacted material survived `verify` even though the same content
would be rejected if it landed inside `evidence/`.

## Reproduction

1. Pick any migrated case whose `ENTRY.md` keeps an absolute `$HOME` raw
   record pointer, e.g. an entry referencing
   `` `/Users/<user>/.config/agent-kit/out/.../skill-usage.record.json` ``.
2. Run
   `heuristic-inbox verify <case>/ --format json`.

Expected: warnings/violations flag the unredacted absolute path.
Actual (prior to this PR): `verify` reports `"ok": true` with no signal that
the body contains an absolute `$HOME` path; the same path would be rejected
by `ingest-evidence`.

## Issues Found

- `verify_case` only validates `evidence/` files; the markdown body bypasses
  the four `ingest-evidence` redaction rules — [crates/agent-workflow-primitives/src/heuristic_inbox.rs:802](crates/agent-workflow-primitives/src/heuristic_inbox.rs:802)
- Deterministic boundary (redaction inside the primitive) was diverging
  between `evidence/` and the body in the same case folder.

## Fix Approach

- Add a `body_violations` scanner (`body_too_large`, `body_token_pattern`,
  `body_absolute_home_path`, `body_raw_skill_usage`) reusing
  `token_regexes`, `home_path_regex`, and a new JSON-shape regex
  (`"schema"\s*:\s*"skill-usage.record.v1"`) so curated prose mentioning the
  schema name in backticks does not false-positive.
- `verify_case` now reads the case body once, runs the body scan, and
  always returns `body_violations` in the result envelope.
- Non-strict mode (default) emits `body warning:` lines in `warnings`; only
  `--strict` folds body findings into the failure `violations` list and
  flips `ok` to `false`. `run_archive`'s embedded `verify_case` call passes
  `strict=false` so archiving migrated cases is unaffected.
- Refactored `parse_entry` to expose `parse_entry_from_text` so the body
  scan reuses the same parsed view without a second filesystem read.

## Test-First Evidence

- Change classification: `bug fix` (extend existing guardrail surface; no
  new feature).
- Failing test before fix: `cargo test -p nils-agent-workflow-primitives
  --test integration cli::heuristic_inbox::verify_strict_fails_on_body_home_path`
  — fails on `main` because `--strict` does not exist and body findings are
  never produced.
- Final validation: `NILS_CLI_TEST_RUNNER=nextest bash
  scripts/ci/nils-cli-checks-entrypoint.sh` → `ok: all nils-cli checks
  passed`; `cargo test -p nils-agent-workflow-primitives --test integration
  cli::heuristic_inbox` → `34 passed; 0 failed`.
- Waiver reason: N/A.

## Testing

- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass)
- `cargo test -p nils-agent-workflow-primitives --test integration cli::heuristic_inbox` (34 pass; 4 new tests)
- `cargo fmt --all -- --check` (pass)
- `cargo clippy --all-targets --all-features -- -D warnings` (pass)

## Risk / Notes

- Backward compatible: existing cases with absolute `$HOME` paths keep
  passing `verify` without `--strict`. Downstream gates (e.g. agent-kit
  `scripts/check.sh`) can opt in to `--strict` once collaborators have
  rotated their cases.
- The JSON-shape regex is intentionally narrower than the file-content
  sniff used by `ingest-evidence`: it requires the literal
  `"schema":"skill-usage.record.v1"` JSON pair so curated prose using the
  bare schema string in backticks does not false-positive (the default
  `new` template already does this).
- Completion assets regenerated: `--strict` is now offered by both the
  bash and zsh completion scripts.
