### PR TITLE
Add CLI output contract v1 (Sprint 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,6 +1877,8 @@ dependencies = [
  "nils-term",
  "nils-test-support",
  "pretty_assertions",
+ "serde",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1905,8 +1907,10 @@ name = "nils-common"
 version = "0.10.2"
 dependencies = [
  "base64",
+ "clap",
  "nils-test-support",
  "pretty_assertions",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `5ebb7e6e779702239bf3218b3381a1ee1ad335075c658afc0c101365a4f1ac64`
+- Cargo.lock SHA256: `ecd4c695be5accbcb2c149a9c074bf81be45bd1f471a07c0547e54a83e8f37b0`
 - Third-party crates (`source != null`): 438
 - Workspace crates (`source == null`, excluded below): 30
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `5ebb7e6e779702239bf3218b3381a1ee1ad335075c658afc0c101365a4f1ac64`
+- Cargo.lock SHA256: `ecd4c695be5accbcb2c149a9c074bf81be45bd1f471a07c0547e54a83e8f37b0`
 - Third-party crates (`source != null`): 438
 
 ## Notice Extraction Policy

--- a/crates/cli-template/Cargo.toml
+++ b/crates/cli-template/Cargo.toml
@@ -15,6 +15,8 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 nils-common = { version = "0.10.2", path = "../nils-common", package = "nils-common" }
 nils-term = { version = "0.10.2", path = "../nils-term", package = "nils-term" }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/cli-template/src/main.rs
+++ b/crates/cli-template/src/main.rs
@@ -1,7 +1,13 @@
 use clap::{Parser, Subcommand};
+use nils_common::cli_contract::{
+    Envelope, OutputFormat, emit_parse_error, exit, schema_version_for,
+};
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
+use serde::Serialize;
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt};
+
+const BINARY: &str = "cli-template";
 
 #[derive(Parser)]
 #[command(
@@ -11,22 +17,48 @@ use tracing_subscriber::{EnvFilter, fmt};
 )]
 struct Cli {
     /// Log level (e.g. trace, debug, info, warn, error)
-    #[arg(long, default_value = "info")]
+    #[arg(long, default_value = "info", global = true)]
     log_level: String,
+
+    /// Output format (defaults to text).
+    #[arg(long, global = true, value_enum)]
+    format: Option<OutputFormat>,
+
+    /// Hidden alias for `--format json` (kept for backwards compatibility).
+    #[arg(long, global = true, hide = true, conflicts_with = "format")]
+    json: bool,
 
     #[command(subcommand)]
     command: Option<Command>,
 }
 
+impl Cli {
+    fn output_format(&self) -> OutputFormat {
+        if self.json {
+            OutputFormat::Json
+        } else {
+            self.format.unwrap_or_default()
+        }
+    }
+}
+
 #[derive(Subcommand)]
 enum Command {
-    /// Print a greeting to stdout
+    /// Print a greeting to stdout (text only).
     Hello {
-        /// Name to greet (defaults to "world")
+        /// Name to greet (defaults to "world").
         name: Option<String>,
     },
-    /// Render a short progress demo (progress on stderr, stdout stays clean)
+    /// Render a short progress demo (progress on stderr, stdout stays clean).
     ProgressDemo,
+    /// Emit a structured status envelope (text or JSON).
+    Status,
+}
+
+#[derive(Serialize)]
+struct StatusPayload {
+    binary: &'static str,
+    version: &'static str,
 }
 
 fn init_tracing(level: &str) {
@@ -37,16 +69,104 @@ fn init_tracing(level: &str) {
     fmt().with_env_filter(filter).init();
 }
 
-fn main() -> anyhow::Result<()> {
-    let cli = Cli::parse();
-    init_tracing(&cli.log_level);
+fn detect_format_from_argv() -> OutputFormat {
+    let mut iter = std::env::args().skip(1);
+    while let Some(arg) = iter.next() {
+        if arg == "--json" {
+            return OutputFormat::Json;
+        }
+        if arg == "--format"
+            && let Some(next) = iter.next()
+            && next.eq_ignore_ascii_case("json")
+        {
+            return OutputFormat::Json;
+        }
+        if let Some(rest) = arg.strip_prefix("--format=")
+            && rest.eq_ignore_ascii_case("json")
+        {
+            return OutputFormat::Json;
+        }
+    }
+    OutputFormat::Text
+}
 
-    match cli.command {
+fn render_clap_message(err: &clap::Error) -> String {
+    let rendered = err.to_string();
+    rendered
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| {
+            let line = line.trim();
+            line.strip_prefix("error:")
+                .map(str::trim)
+                .unwrap_or(line)
+                .to_string()
+        })
+        .unwrap_or_else(|| "command-line parse failed".to_string())
+}
+
+fn parse_or_exit() -> Cli {
+    match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(err) => {
+            use clap::error::ErrorKind;
+            let kind = err.kind();
+            if matches!(
+                kind,
+                ErrorKind::DisplayHelp
+                    | ErrorKind::DisplayVersion
+                    | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+            ) {
+                err.exit();
+            }
+
+            let format = detect_format_from_argv();
+            let code = match kind {
+                ErrorKind::InvalidSubcommand => "unknown-subcommand",
+                _ => "parse-error",
+            };
+            let message = render_clap_message(&err);
+            let exit_code = emit_parse_error(BINARY, format, code, &message);
+            std::process::exit(exit_code);
+        }
+    }
+}
+
+fn emit_status(format: OutputFormat) -> i32 {
+    let payload = StatusPayload {
+        binary: "cli-template",
+        version: env!("CARGO_PKG_VERSION"),
+    };
+    match format {
+        OutputFormat::Json => {
+            let envelope = Envelope::success(schema_version_for(BINARY, "status", 1), payload);
+            match serde_json::to_string(&envelope) {
+                Ok(serialized) => {
+                    println!("{serialized}");
+                    exit::SUCCESS
+                }
+                Err(_) => exit::SOFTWARE,
+            }
+        }
+        OutputFormat::Text => {
+            println!("{} {}", payload.binary, payload.version);
+            exit::SUCCESS
+        }
+    }
+}
+
+fn main() {
+    let cli = parse_or_exit();
+    init_tracing(&cli.log_level);
+    let format = cli.output_format();
+
+    let exit_code = match cli.command {
         Some(Command::Hello { name }) => {
             let name = name.unwrap_or_else(|| "world".to_string());
             let greeting = nils_common::greeting(&name);
             info!(%greeting, "generated greeting");
             println!("{greeting}");
+            exit::SUCCESS
         }
         Some(Command::ProgressDemo) => {
             let progress = Progress::new(
@@ -64,11 +184,14 @@ fn main() -> anyhow::Result<()> {
 
             progress.finish_and_clear();
             println!("done");
+            exit::SUCCESS
         }
+        Some(Command::Status) => emit_status(format),
         None => {
             info!("no subcommand selected");
+            exit::SUCCESS
         }
-    }
+    };
 
-    Ok(())
+    std::process::exit(exit_code);
 }

--- a/crates/cli-template/tests/integration/cli.rs
+++ b/crates/cli-template/tests/integration/cli.rs
@@ -54,3 +54,95 @@ fn cli_template_invalid_log_level_still_prints_greeting() {
     let stdout = output.stdout_text();
     assert!(stdout.contains("Hello, Nils!"), "stdout={stdout}");
 }
+
+#[test]
+fn cli_template_status_format_json_emits_envelope() {
+    let output = run(&["--format", "json", "status"]);
+    assert_eq!(output.code, 0);
+    let stdout = output.stdout_text();
+    // Snapshot-pin the literal schema_version per the contract spec.
+    assert!(
+        stdout.contains("\"schema_version\":\"cli.cli-template.status.v1\""),
+        "stdout={stdout}"
+    );
+    assert!(stdout.contains("\"ok\":true"), "stdout={stdout}");
+    assert!(
+        stdout.contains("\"binary\":\"cli-template\""),
+        "stdout={stdout}"
+    );
+}
+
+#[test]
+fn cli_template_status_json_alias_matches_format_json() {
+    let format_run = run(&["--format", "json", "status"]);
+    let alias_run = run(&["--json", "status"]);
+    assert_eq!(format_run.code, 0);
+    assert_eq!(alias_run.code, 0);
+    assert_eq!(format_run.stdout_text(), alias_run.stdout_text());
+}
+
+#[test]
+fn cli_template_status_text_omits_envelope() {
+    let output = run(&["status"]);
+    assert_eq!(output.code, 0);
+    let stdout = output.stdout_text();
+    assert!(stdout.contains("cli-template"), "stdout={stdout}");
+    assert!(
+        !stdout.contains("schema_version"),
+        "text mode must not emit JSON envelope: {stdout}"
+    );
+}
+
+#[test]
+fn cli_template_unknown_subcommand_exits_usage() {
+    let output = run(&["bogus-subcommand"]);
+    assert_eq!(output.code, 64);
+}
+
+#[test]
+fn cli_template_unknown_subcommand_json_emits_envelope() {
+    let output = run(&["--format", "json", "bogus-subcommand"]);
+    assert_eq!(output.code, 64);
+    let stdout = output.stdout_text();
+    assert!(
+        stdout.contains("\"schema_version\":\"cli.cli-template.error.v1\""),
+        "stdout={stdout}"
+    );
+    assert!(stdout.contains("\"ok\":false"), "stdout={stdout}");
+    assert!(
+        stdout.contains("\"code\":\"unknown-subcommand\""),
+        "stdout={stdout}"
+    );
+}
+
+#[test]
+fn cli_template_unknown_subcommand_text_prints_error_prefix() {
+    let output = run(&["bogus-subcommand"]);
+    assert_eq!(output.code, 64);
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.to_ascii_lowercase().starts_with("error:"),
+        "stderr should start with 'error:' prefix: {stderr}"
+    );
+}
+
+#[test]
+fn cli_template_help_lists_format_not_json_alias() {
+    let output = run(&["--help"]);
+    assert_eq!(output.code, 0);
+    let stdout = output.stdout_text();
+    assert!(
+        stdout.contains("--format"),
+        "help should advertise --format: {stdout}"
+    );
+    assert!(
+        !stdout.contains("--json"),
+        "help should not advertise hidden --json alias: {stdout}"
+    );
+}
+
+#[test]
+fn cli_template_format_and_json_conflict_at_parse_time() {
+    let output = run(&["--json", "--format", "text", "status"]);
+    assert_eq!(output.code, 64);
+}

--- a/crates/nils-common/Cargo.toml
+++ b/crates/nils-common/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/sympoies/nils-cli"
 
 [dependencies]
 base64 = "0.22"
+clap = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/nils-common/src/cli_contract.rs
+++ b/crates/nils-common/src/cli_contract.rs
@@ -1,0 +1,281 @@
+//! Workspace-wide CLI output contract primitives.
+//!
+//! Every binary in the `nils-cli` workspace renders machine-readable output
+//! through the [`Envelope`] type and signals failure through the BSD sysexits
+//! constants in the [`exit`] module. The durable spec lives at
+//! `docs/specs/cli-output-contract-v1.md`; `crates/cli-template` is the
+//! reference implementation.
+//!
+//! The crate-level boundary rule (see `crates/nils-common/README.md`) still
+//! applies — these primitives expose structured data and constants; user-facing
+//! warning/error text and exit-code mapping live in caller adapters.
+
+use std::io::{self, Write};
+
+use serde::Serialize;
+
+/// Canonical output-format flag value for every workspace CLI.
+///
+/// Binaries surface this enum via `clap`'s `value_enum`, typically as
+/// `--format text|json`. Pre-contract `--json` boolean flags may remain as
+/// hidden aliases for one minor cycle (see the contract spec).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum OutputFormat {
+    /// Human-readable text output (default).
+    #[default]
+    Text,
+    /// Single-record JSON envelope (snake_case).
+    Json,
+}
+
+impl OutputFormat {
+    /// Returns `true` when the caller asked for machine-readable JSON.
+    pub fn is_json(self) -> bool {
+        matches!(self, Self::Json)
+    }
+
+    /// Returns `true` when the caller is rendering text.
+    pub fn is_text(self) -> bool {
+        matches!(self, Self::Text)
+    }
+}
+
+/// Envelope shared by every JSON-emitting subcommand.
+///
+/// The shape is intentionally narrow: `schema_version` pins the wire contract,
+/// `ok` is a boolean success flag, `data` carries the per-subcommand payload,
+/// `warnings` collects non-fatal diagnostics (so JSON consumers see what text
+/// mode would print to stderr), and `error` carries a structured failure.
+#[derive(Debug, Clone, Serialize)]
+pub struct Envelope<T: Serialize> {
+    pub schema_version: String,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<T>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<EnvelopeError>,
+}
+
+impl<T: Serialize> Envelope<T> {
+    /// Build a successful envelope.
+    pub fn success(schema_version: impl Into<String>, data: T) -> Self {
+        Self {
+            schema_version: schema_version.into(),
+            ok: true,
+            data: Some(data),
+            warnings: Vec::new(),
+            error: None,
+        }
+    }
+
+    /// Build a failure envelope with no payload.
+    pub fn failure(schema_version: impl Into<String>, error: EnvelopeError) -> Self {
+        Self {
+            schema_version: schema_version.into(),
+            ok: false,
+            data: None,
+            warnings: Vec::new(),
+            error: Some(error),
+        }
+    }
+
+    /// Append a single warning to the envelope.
+    pub fn with_warning(mut self, warning: impl Into<String>) -> Self {
+        self.warnings.push(warning.into());
+        self
+    }
+
+    /// Append multiple warnings to the envelope.
+    pub fn with_warnings<I, S>(mut self, warnings: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.warnings.extend(warnings.into_iter().map(|w| w.into()));
+        self
+    }
+}
+
+/// Structured error rendered inside the JSON envelope's `error` field.
+#[derive(Debug, Clone, Serialize)]
+pub struct EnvelopeError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+}
+
+impl EnvelopeError {
+    /// Build an error with a code and message.
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            hint: None,
+        }
+    }
+
+    /// Attach an optional hint to the error.
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+}
+
+/// Build the canonical `cli.<binary>.<command>.v<N>` schema-version string.
+pub fn schema_version_for(binary: &str, command: &str, version: u32) -> String {
+    format!("cli.{binary}.{command}.v{version}")
+}
+
+/// BSD sysexits-aligned exit-code constants used by every workspace binary.
+///
+/// The full table is captured in `docs/specs/cli-output-contract-v1.md`.
+pub mod exit {
+    /// Successful termination.
+    pub const SUCCESS: i32 = 0;
+    /// Generic runtime error (the historic catch-all for "something went wrong at runtime").
+    pub const RUNTIME: i32 = 1;
+    /// `EX_USAGE` — command-line syntax error.
+    pub const USAGE: i32 = 64;
+    /// `EX_DATAERR` — input data is malformed or otherwise invalid.
+    pub const DATA: i32 = 65;
+    /// `EX_UNAVAILABLE` — a required service or resource is unavailable.
+    pub const UNAVAILABLE: i32 = 69;
+    /// `EX_SOFTWARE` — internal software error (an invariant was violated).
+    pub const SOFTWARE: i32 = 70;
+}
+
+/// Emit a parse-error / unknown-subcommand failure through the shared contract.
+///
+/// When `format` is [`OutputFormat::Json`] the helper writes a single-line JSON
+/// envelope (schema `cli.<binary>.error.v1`) to stdout. In text mode it writes
+/// the historical `error: <msg>` line to stderr. Both branches return
+/// [`exit::USAGE`] so callers can do `std::process::exit(emit_parse_error(...))`.
+pub fn emit_parse_error(binary: &str, format: OutputFormat, code: &str, message: &str) -> i32 {
+    emit_parse_error_to(
+        &mut io::stdout().lock(),
+        &mut io::stderr().lock(),
+        binary,
+        format,
+        code,
+        message,
+    )
+}
+
+/// Test-friendly variant of [`emit_parse_error`] that writes to caller-provided sinks.
+pub fn emit_parse_error_to<W1: Write, W2: Write>(
+    stdout: &mut W1,
+    stderr: &mut W2,
+    binary: &str,
+    format: OutputFormat,
+    code: &str,
+    message: &str,
+) -> i32 {
+    match format {
+        OutputFormat::Json => {
+            let envelope: Envelope<()> = Envelope::failure(
+                schema_version_for(binary, "error", 1),
+                EnvelopeError::new(code, message),
+            );
+            // Single-line JSON so log scrapers see one record per error.
+            let serialized =
+                serde_json::to_string(&envelope).unwrap_or_else(|_| String::from("{\"ok\":false}"));
+            let _ = writeln!(stdout, "{serialized}");
+        }
+        OutputFormat::Text => {
+            let _ = writeln!(stderr, "error: {message}");
+        }
+    }
+    exit::USAGE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::ValueEnum;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn output_format_round_trips_through_value_enum() {
+        let text = OutputFormat::from_str("text", false).expect("text variant");
+        let json = OutputFormat::from_str("json", false).expect("json variant");
+        assert_eq!(text, OutputFormat::Text);
+        assert_eq!(json, OutputFormat::Json);
+        assert!(json.is_json());
+        assert!(text.is_text());
+        assert_eq!(OutputFormat::default(), OutputFormat::Text);
+    }
+
+    #[test]
+    fn envelope_success_serializes_snake_case() {
+        #[derive(Serialize)]
+        struct Payload {
+            item_count: u32,
+        }
+        let envelope = Envelope::success(
+            schema_version_for("cli-template", "status", 1),
+            Payload { item_count: 3 },
+        );
+        let json = serde_json::to_string(&envelope).expect("serialize envelope");
+        assert_eq!(
+            json,
+            "{\"schema_version\":\"cli.cli-template.status.v1\",\"ok\":true,\"data\":{\"item_count\":3}}"
+        );
+    }
+
+    #[test]
+    fn envelope_success_includes_warnings_when_present() {
+        let envelope: Envelope<()> = Envelope {
+            schema_version: schema_version_for("memo-cli", "apply", 1),
+            ok: true,
+            data: None,
+            warnings: Vec::new(),
+            error: None,
+        }
+        .with_warning("entry-42 skipped: missing body");
+        let json = serde_json::to_string(&envelope).expect("serialize envelope");
+        assert_eq!(
+            json,
+            "{\"schema_version\":\"cli.memo-cli.apply.v1\",\"ok\":true,\"warnings\":[\"entry-42 skipped: missing body\"]}"
+        );
+    }
+
+    #[test]
+    fn envelope_failure_serializes_error_only() {
+        let envelope: Envelope<()> = Envelope::failure(
+            schema_version_for("cli-template", "error", 1),
+            EnvelopeError::new("parse-error", "missing required argument <name>")
+                .with_hint("see --help"),
+        );
+        let json = serde_json::to_string(&envelope).expect("serialize envelope");
+        assert_eq!(
+            json,
+            "{\"schema_version\":\"cli.cli-template.error.v1\",\"ok\":false,\"error\":{\"code\":\"parse-error\",\"message\":\"missing required argument <name>\",\"hint\":\"see --help\"}}"
+        );
+    }
+
+    #[test]
+    fn exit_constants_match_bsd_sysexits() {
+        assert_eq!(exit::SUCCESS, 0);
+        assert_eq!(exit::RUNTIME, 1);
+        assert_eq!(exit::USAGE, 64);
+        assert_eq!(exit::DATA, 65);
+        assert_eq!(exit::UNAVAILABLE, 69);
+        assert_eq!(exit::SOFTWARE, 70);
+    }
+
+    #[test]
+    fn schema_version_for_builds_canonical_string() {
+        assert_eq!(
+            schema_version_for("memo-cli", "list", 1),
+            "cli.memo-cli.list.v1"
+        );
+        assert_eq!(
+            schema_version_for("cli-template", "status", 2),
+            "cli.cli-template.status.v2"
+        );
+    }
+}

--- a/crates/nils-common/src/lib.rs
+++ b/crates/nils-common/src/lib.rs
@@ -10,6 +10,7 @@
 //! - APIs stay domain-neutral and must not encode crate-specific UX policies.
 //! - Quoting and ANSI differences are expressed via explicit mode/policy parameters.
 //!
+pub mod cli_contract;
 pub mod clipboard;
 pub mod env;
 pub mod fs;

--- a/crates/nils-common/tests/integration.rs
+++ b/crates/nils-common/tests/integration.rs
@@ -3,6 +3,8 @@
 // links one integration test binary instead of many. This keeps the
 // dev-loop link phase O(crates) instead of O(test-files).
 
+#[path = "integration/cli_contract.rs"]
+mod cli_contract;
 #[path = "integration/markdown_table_canonicalization.rs"]
 mod markdown_table_canonicalization;
 #[path = "integration/provider_runtime_contract.rs"]

--- a/crates/nils-common/tests/integration/cli_contract.rs
+++ b/crates/nils-common/tests/integration/cli_contract.rs
@@ -1,0 +1,85 @@
+use nils_common::cli_contract::{
+    Envelope, EnvelopeError, OutputFormat, emit_parse_error_to, exit, schema_version_for,
+};
+use pretty_assertions::assert_eq;
+
+#[test]
+fn emit_parse_error_json_writes_envelope_to_stdout() {
+    let mut stdout: Vec<u8> = Vec::new();
+    let mut stderr: Vec<u8> = Vec::new();
+    let code = emit_parse_error_to(
+        &mut stdout,
+        &mut stderr,
+        "cli-template",
+        OutputFormat::Json,
+        "parse-error",
+        "missing required argument <name>",
+    );
+    assert_eq!(code, exit::USAGE);
+    let stdout = String::from_utf8(stdout).expect("stdout utf-8");
+    let stderr = String::from_utf8(stderr).expect("stderr utf-8");
+    assert!(
+        stderr.is_empty(),
+        "stderr should stay clean in JSON mode: {stderr:?}"
+    );
+    assert_eq!(
+        stdout,
+        "{\"schema_version\":\"cli.cli-template.error.v1\",\"ok\":false,\"error\":{\"code\":\"parse-error\",\"message\":\"missing required argument <name>\"}}\n"
+    );
+}
+
+#[test]
+fn emit_parse_error_text_writes_historical_error_prefix() {
+    let mut stdout: Vec<u8> = Vec::new();
+    let mut stderr: Vec<u8> = Vec::new();
+    let code = emit_parse_error_to(
+        &mut stdout,
+        &mut stderr,
+        "cli-template",
+        OutputFormat::Text,
+        "unknown-subcommand",
+        "unrecognized subcommand 'bogus'",
+    );
+    assert_eq!(code, exit::USAGE);
+    let stdout = String::from_utf8(stdout).expect("stdout utf-8");
+    let stderr = String::from_utf8(stderr).expect("stderr utf-8");
+    assert!(
+        stdout.is_empty(),
+        "stdout should stay clean in text mode: {stdout:?}"
+    );
+    assert_eq!(stderr, "error: unrecognized subcommand 'bogus'\n");
+}
+
+#[test]
+fn emit_parse_error_returns_usage_for_unknown_subcommand() {
+    let mut stdout: Vec<u8> = Vec::new();
+    let mut stderr: Vec<u8> = Vec::new();
+    let code = emit_parse_error_to(
+        &mut stdout,
+        &mut stderr,
+        "memo-cli",
+        OutputFormat::Json,
+        "unknown-subcommand",
+        "no such subcommand: bogus",
+    );
+    assert_eq!(code, exit::USAGE);
+}
+
+#[test]
+fn envelope_failure_round_trips_through_serde_json_value() {
+    let envelope: Envelope<()> = Envelope::failure(
+        schema_version_for("cli-template", "error", 1),
+        EnvelopeError::new("parse-error", "missing required argument <name>"),
+    );
+    let value: serde_json::Value =
+        serde_json::to_value(&envelope).expect("serialize via serde_json::Value");
+    assert_eq!(value["schema_version"], "cli.cli-template.error.v1");
+    assert_eq!(value["ok"], false);
+    assert_eq!(value["error"]["code"], "parse-error");
+    assert_eq!(
+        value["error"]["message"],
+        "missing required argument <name>"
+    );
+    assert!(value.get("data").is_none());
+    assert!(value.get("warnings").is_none());
+}

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
@@ -4,7 +4,8 @@
 
 - Status: in-progress (Sprint 1 complete, Sprint 2 and 3 pending)
 - Target scope: Sprint 1 (Tasks 1.1–1.4)
-- Execution window: Sprint 1 only — confirmed by user; Sprint 2 and Sprint 3 stay open in separate PRs to honor the plan's `parallel-x3` PR strategy
+- Execution window: Sprint 1 only — confirmed by user; Sprint 2 and Sprint 3
+  stay open in separate PRs to honor the plan's `parallel-x3` PR strategy
 - Staged execution confirmation: confirmed(Sprint 1 only PR; Sprint 2/3 follow separately)
 - Current task: Sprint 1 complete
 - Next task: Task 2.1 (replace memo-cli exit-code constants with shared module)

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
@@ -1,0 +1,80 @@
+# CLI Output Contract Unification Execution State
+
+## Current State
+
+- Status: in-progress (Sprint 1 complete, Sprint 2 and 3 pending)
+- Target scope: Sprint 1 (Tasks 1.1–1.4)
+- Execution window: Sprint 1 only — confirmed by user; Sprint 2 and Sprint 3 stay open in separate PRs to honor the plan's `parallel-x3` PR strategy
+- Staged execution confirmation: confirmed(Sprint 1 only PR; Sprint 2/3 follow separately)
+- Current task: Sprint 1 complete
+- Next task: Task 2.1 (replace memo-cli exit-code constants with shared module)
+- Last updated: 2026-05-19
+- Branch/commit: feat/cli-output-contract-v1-foundation (pending)
+- Source document:
+  docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
+- Direct source-doc execution waiver: not applicable
+
+## Task Ledger
+
+| ID | Status | Task | Evidence | Notes |
+| --- | --- | --- | --- | --- |
+| Task 1.1 | done | Add `cli_contract` module to `nils-common` | crates/nils-common/src/cli_contract.rs; `cargo test -p nils-common cli_contract` (6 unit tests) | OutputFormat, Envelope, EnvelopeError, exit constants, schema_version_for |
+| Task 1.2 | done | Add parse-error JSON helper | crates/nils-common/tests/integration/cli_contract.rs; `cargo test -p nils-common cli_contract` (4 integration tests) | emit_parse_error + emit_parse_error_to writers |
+| Task 1.3 | done | Migrate `cli-template` as reference implementation | crates/cli-template/src/main.rs; `cargo test -p nils-cli-template` (13 tests, +9 new) | Hidden `--json` alias; new `status` subcommand emits envelope |
+| Task 1.4 | done | Write `cli-output-contract-v1.md` spec | docs/specs/cli-output-contract-v1.md; `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | Reconciles older `cli-service-json-contract-guideline-v1.md` shape |
+| Task 2.1 | pending | Replace memo-cli exit-code constants with shared module | n/a | depends on 1.1 (now satisfied) |
+| Task 2.2 | pending | Migrate memo-cli to `OutputFormat` and hidden `--json` alias | n/a | depends on 2.1 |
+| Task 2.3 | pending | Migrate memo-cli JSON output to shared envelope and `warnings` | n/a | depends on 2.2 |
+| Task 2.4 | pending | Route memo-cli parse and unknown-subcommand errors through helper | n/a | depends on 1.2 (now satisfied), 2.2 |
+| Task 2.5 | pending | Add memo-cli exit-code matrix test | n/a | depends on 2.1 |
+| Task 3.1 | pending | Migrate `agent-workflow-primitives` binaries | n/a | depends on Sprint 1 (now satisfied) |
+| Task 3.2 | pending | Migrate API testing stack | n/a | depends on Sprint 1 (now satisfied) |
+| Task 3.3 | pending | Migrate remaining single-binary crates and run the full gate | n/a | depends on Sprint 1 (now satisfied) |
+| Task 3.4 | pending | Workspace lint script for legacy contract usage | n/a | depends on 3.1, 3.2, 3.3 |
+
+## Validation
+
+| Command | Status | Summary | Artifact |
+| --- | --- | --- | --- |
+| `bash scripts/ci/plan-bundle-validate.sh --strict` | pass | wired into docs-only entrypoint; all 5 plan bundles validated | scripts/ci/nils-cli-checks-entrypoint.sh --docs-only output |
+| `cargo test -p nils-common cli_contract` | pass | 6 unit + 4 integration tests for envelope, exit constants, parse-error helper | terminal log |
+| `cargo test -p nils-cli-template` | pass | 13 integration tests (existing 4 + 9 new contract assertions) | terminal log |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | pass | docs placement + hygiene + markdownlint + plan-bundle validate green | terminal log |
+| `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` | pass | full required checks (cargo fmt, clippy -D warnings, nextest workspace, doctests, third-party audit) | terminal log |
+| `cargo test -p memo-cli` | pending | per Sprint 2 | n/a |
+| `cargo test --workspace` | pending | per Sprint 3 | n/a |
+
+## Blockers
+
+- none
+
+## Session Log
+
+### 2026-05-19
+
+- Read:
+  - docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
+  - docs/plans/cli-output-contract-unification/cli-output-contract-unification-review-source.md
+  - crates/nils-common/src/{lib.rs,process.rs}, crates/nils-common/Cargo.toml
+  - crates/cli-template/{src/main.rs,Cargo.toml,tests/integration/cli.rs}
+  - crates/memo-cli/src/cli.rs (reference for OutputFormat shape)
+  - docs/specs/{workspace-shared-crate-boundary-v1.md,cli-service-json-contract-guideline-v1.md}
+  - scripts/ci/{nils-cli-checks-entrypoint.sh,docs-hygiene-audit.sh}
+  - DEVELOPMENT.md
+- Changed:
+  - crates/nils-common/Cargo.toml (added clap + serde deps)
+  - crates/nils-common/src/{lib.rs,cli_contract.rs} (new module)
+  - crates/nils-common/tests/{integration.rs,integration/cli_contract.rs}
+  - crates/cli-template/Cargo.toml (added serde + serde_json deps)
+  - crates/cli-template/src/main.rs (new contract wiring + `status` subcommand)
+  - crates/cli-template/tests/integration/cli.rs (+9 contract assertions)
+  - docs/specs/cli-output-contract-v1.md (new durable spec)
+  - docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
+  - THIRD_PARTY_LICENSES.md, THIRD_PARTY_NOTICES.md (regenerated after dep adds)
+- Validated:
+  - `cargo test -p nils-common cli_contract` (10 tests, 0 fail)
+  - `cargo test -p nils-cli-template` (13 tests, 0 fail)
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` (pass)
+  - `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass)
+- Blocked by: none
+- Next: open feature PR with `/deliver-feature-pr`; Sprint 2 picks up in a follow-up PR per the plan's PR strategy.

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
@@ -17,12 +17,15 @@ remaining binaries in three batches grouped by ownership.
 - Open questions carried into execution:
   - Whether `cli-template` migrates before or after `memo-cli` (default: `cli-template` first as a contract reference implementation).
   - Whether the parse-error envelope ships as a `nils-common` helper or a per-binary copy (default: shared helper to ensure shape parity).
-  - Whether `staged-context` camelCase fields stay as a versioned alias or are removed at the same minor bump (default: versioned alias for one minor cycle).
+  - Whether `staged-context` camelCase fields stay as a versioned alias or are
+    removed at the same minor bump (default: versioned alias for one minor cycle).
 
 ## Scope
 
 - In scope:
-  - New `crates/nils-common/src/cli_contract.rs` (or `cli/` submodule) with the envelope type, `schema_version` helpers, exit-code constants, parse-error JSON helper, and shared `OutputFormat` enum.
+  - New `crates/nils-common/src/cli_contract.rs` (or `cli/` submodule) with the
+    envelope type, `schema_version` helpers, exit-code constants, parse-error
+    JSON helper, and shared `OutputFormat` enum.
   - Updated `crates/cli-template` as the reference implementation.
   - Per-binary clap-layer changes to introduce `--format text|json` and keep `--json` as a hidden alias where it already exists.
   - Per-binary exit-code call-site updates to consume the shared constants.
@@ -309,7 +312,9 @@ binaries with shared crates can be reviewed together.
 - Commands:
   - `cargo test --workspace`
   - `bash scripts/ci/nils-cli-checks-entrypoint.sh`
-  - Per binary: `<binary> --format json <cmd>` (envelope present), `<binary> bogus --format json` (parse-error envelope), `<binary> bogus` (exit 64).
+  - Per binary: `<binary> --format json <cmd>` (envelope present),
+    `<binary> bogus --format json` (parse-error envelope), `<binary> bogus`
+    (exit 64).
 - Verify: every JSON-emitting subcommand has a `schema_version` snapshot
   test; every binary has an exit-code matrix test; no binary still ships
   ad-hoc `1`/`2` exit codes for usage errors.

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
@@ -1,0 +1,482 @@
+# Plan: CLI Output Contract Unification
+
+## Overview
+
+Publish a single, workspace-wide contract for machine-readable output and exit
+codes, then migrate binaries from highest-traffic to lowest. Sprint 1 lands the
+shared primitives in `nils-common` and writes the public contract spec. Sprint
+2 migrates the two pilot binaries (`memo-cli`, `cli-template`) end to end and
+proves the contract is testable. Sprint 3 fans out the migration across the
+remaining binaries in three batches grouped by ownership.
+
+## Read First
+
+- Primary source:
+  docs/plans/cli-output-contract-unification/cli-output-contract-unification-review-source.md
+- Source type: review-to-improvement-doc
+- Open questions carried into execution:
+  - Whether `cli-template` migrates before or after `memo-cli` (default: `cli-template` first as a contract reference implementation).
+  - Whether the parse-error envelope ships as a `nils-common` helper or a per-binary copy (default: shared helper to ensure shape parity).
+  - Whether `staged-context` camelCase fields stay as a versioned alias or are removed at the same minor bump (default: versioned alias for one minor cycle).
+
+## Scope
+
+- In scope:
+  - New `crates/nils-common/src/cli_contract.rs` (or `cli/` submodule) with the envelope type, `schema_version` helpers, exit-code constants, parse-error JSON helper, and shared `OutputFormat` enum.
+  - Updated `crates/cli-template` as the reference implementation.
+  - Per-binary clap-layer changes to introduce `--format text|json` and keep `--json` as a hidden alias where it already exists.
+  - Per-binary exit-code call-site updates to consume the shared constants.
+  - Per-binary JSON serializer updates to embed `schema_version` and use snake_case.
+  - One snapshot test per JSON-emitting subcommand pinning `schema_version`.
+  - One exit-code matrix test per binary.
+  - New durable spec `docs/specs/cli-output-contract-v1.md`.
+- Out of scope:
+  - Replacing `clap` or the JSON serializer (`serde_json` stays).
+  - Adding new subcommands to any binary.
+  - Changing the JSON contract of `agent-workflow-primitives` records beyond adding `warnings` (their envelope is already canonical).
+  - Help/env discoverability — see `cli-help-and-env-discoverability` plan.
+  - Dispatch modernization (hand-rolled → clap) — see `cli-dispatch-modernization` plan.
+
+## Assumptions
+
+1. `nils-common` is allowed to add a new public module without violating
+   the shared-helper boundary (it currently exports `env`, `fs`,
+   `markdown`, etc. — `cli` fits the same shape).
+2. Workspace builds and tests run under
+   `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`.
+3. `pretty_assertions` is acceptable for snapshot diffs per `AGENTS.md`.
+4. A hidden `--json` alias on `clap` (via `#[arg(hide = true)]`) is
+   acceptable for backward compatibility.
+5. `serde`'s `rename_all = "snake_case"` does not collide with any existing
+   field name (verified by inspection of the four binaries with custom
+   serializers).
+
+## Sprint 1: Shared primitives + public spec
+
+**Goal**: Land the workspace-wide contract primitives in `nils-common` plus
+the durable spec, with `cli-template` as the working example. Nothing else
+migrates until the primitives are stable and snapshot-tested.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-common cli_contract`
+  - `cargo run -p cli-template -- --format json status`
+  - `cargo run -p cli-template -- bogus-subcommand` (exit code 64)
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+- Verify: `cli-template` emits a snake_case JSON envelope with
+  `schema_version: "cli.cli-template.status.v1"`; parse errors emit a JSON
+  envelope when `--format json` is set; exit codes match
+  `nils_common::cli_contract::exit::{USAGE, DATA, RUNTIME, SOFTWARE}`.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 1.1: Add `cli_contract` module to `nils-common`
+
+- **Location**:
+  - crates/nils-common/src/cli_contract.rs
+  - crates/nils-common/src/lib.rs
+  - crates/nils-common/Cargo.toml
+- **Description**: Introduce `cli_contract` with: (a) `OutputFormat` enum
+  (`Text`, `Json`) implementing `clap::ValueEnum`; (b) `Envelope<T>` struct
+  with `schema_version: String`, `ok: bool`, `data: Option<T>`,
+  `warnings: Vec<String>`, `error: Option<EnvelopeError>` plus a builder;
+  (c) `EnvelopeError { code, message, hint }`; (d) `exit` submodule with
+  the BSD sysexits constants we need (`SUCCESS=0`, `RUNTIME=1`, `USAGE=64`,
+  `DATA=65`, `UNAVAILABLE=69`, `SOFTWARE=70`); (e) `schema_version_for`
+  helper that builds the `cli.<binary>.<command>.v<N>` string.
+- **Dependencies**:
+  - none
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - `nils_common::cli_contract::{OutputFormat, Envelope, exit}` are publicly exported.
+  - `OutputFormat` round-trips through `clap::ValueEnum`.
+  - Envelope serializes with snake_case via `serde`.
+  - Exit-code constants match BSD sysexits values.
+  - Unit tests cover envelope success, envelope error, exit constants, and `schema_version_for` building.
+- **Validation**:
+  - `cargo test -p nils-common cli_contract`
+  - `cargo build -p nils-common`
+
+### Task 1.2: Add parse-error JSON helper
+
+- **Location**:
+  - crates/nils-common/src/cli_contract.rs
+  - crates/nils-common/tests/integration/cli_contract.rs (new)
+- **Description**: Add `emit_parse_error(binary, format, code, message)`
+  that writes the JSON envelope to stdout when format is `Json` and the
+  plain message to stderr when format is `Text`, and returns the right exit
+  code. Intercepting `clap::Error::exit_code()` is the caller's
+  responsibility; helper only formats and writes.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**:
+  - 3
+- **Acceptance criteria**:
+  - JSON branch emits an envelope with `ok: false`, `error.code`, `error.message`, no `data`.
+  - Text branch matches the historical `error: <msg>` prefix.
+  - Helper returns `exit::USAGE` for `code = "parse-error"` and `"unknown-subcommand"`.
+  - Integration test asserts byte-stable JSON output.
+- **Validation**:
+  - `cargo test -p nils-common cli_contract`
+
+### Task 1.3: Migrate `cli-template` as reference implementation
+
+- **Location**:
+  - crates/cli-template/src/main.rs
+  - crates/cli-template/src/lib.rs (if needed for testability)
+  - crates/cli-template/tests/integration/json_contract.rs (new)
+- **Description**: Wire `cli-template` to use `OutputFormat` from
+  `nils-common`, emit a JSON envelope when `--format json`, intercept
+  unknown-subcommand and parse errors through the new helper, and exit with
+  the shared constants. Keep `--json` as a hidden alias.
+- **Dependencies**:
+  - Task 1.1
+  - Task 1.2
+- **Complexity**:
+  - 4
+- **Acceptance criteria**:
+  - `cli-template --format json status` prints the envelope.
+  - `cli-template --json status` prints the same envelope.
+  - `cli-template bogus` exits `64` and prints the JSON envelope when `--format json` was also supplied.
+  - `cli-template --help` lists `--format` (not `--json`).
+  - Integration test pins the literal `schema_version` string.
+- **Validation**:
+  - `cargo test -p cli-template`
+  - Manual: `cargo run -p cli-template -- --format json status`
+
+### Task 1.4: Write `cli-output-contract-v1.md` spec
+
+- **Location**:
+  - docs/specs/cli-output-contract-v1.md (new)
+  - docs/specs/workspace-shared-crate-boundary-v1.md (cross-reference only)
+- **Description**: Capture the contract as durable spec: envelope shape,
+  field casing rule, `schema_version` naming, exit code table, parse-error
+  behaviour, deprecation path for the `--json` bool, and the migration
+  policy ("new binary MUST adopt; existing binaries SHOULD migrate within
+  one minor cycle"). Cross-link to `nils-common`'s `cli_contract` module
+  and `cli-template` as the worked example.
+- **Dependencies**:
+  - Task 1.3
+- **Complexity**:
+  - 3
+- **Acceptance criteria**:
+  - Spec lives at `docs/specs/cli-output-contract-v1.md`.
+  - All four sections (envelope, exit codes, parse errors, deprecation) are present.
+  - Spec references the `cli-template` example and the `nils-common` helper.
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` passes.
+- **Validation**:
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+
+## Sprint 2: Pilot migration (memo-cli)
+
+**Goal**: Move `memo-cli` end to end onto the new contract and prove the
+migration shape is repeatable. `memo-cli` already has the most integration
+tests for `--format` and `schema_version`, so any drift surfaces fastest
+here.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p memo-cli`
+  - `memo-cli --format json list`
+  - `memo-cli --json list` (alias still works, no warning when hidden)
+  - `memo-cli bogus --format json` (JSON parse-error envelope)
+  - `memo-cli list --limit -1` (exit 64 with usage error envelope)
+- Verify: `memo-cli` returns `64` for all usage errors, `65` for data
+  errors, `1` for runtime errors; every JSON output contains a
+  snake_case envelope with `schema_version: "cli.memo-cli.<cmd>.v1"`.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 2.1: Replace memo-cli exit-code constants with shared module
+
+- **Location**:
+  - crates/memo-cli/src/errors.rs
+  - crates/memo-cli/src/main.rs
+  - crates/memo-cli/src/app.rs
+- **Description**: Delete the local `AppError::exit_code` magic numbers
+  and call `nils_common::cli_contract::exit::{USAGE, DATA, RUNTIME}`
+  instead. Leave the existing `AppError` enum shape but route its codes
+  through the shared constants.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**:
+  - 3
+- **Acceptance criteria**:
+  - `AppError::exit_code` reads from the shared constants only (no inline numeric literals).
+  - Existing `cargo test -p memo-cli` passes without functional change.
+- **Validation**:
+  - `cargo test -p memo-cli`
+
+### Task 2.2: Migrate memo-cli to `OutputFormat` and hidden `--json` alias
+
+- **Location**:
+  - crates/memo-cli/src/cli.rs
+- **Description**: Replace the local `OutputFormat`/`OutputMode` pair with
+  the shared `nils_common::cli_contract::OutputFormat`. Keep `--json`
+  available as a hidden boolean alias via `#[arg(long, hide = true,
+  global = true)]`. Move `--json` ↔ `--format` conflict to a clap
+  `conflicts_with` declaration so parse-time errors fire instead of the
+  runtime check in `resolve_output_mode`.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - `memo-cli --help` lists `--format` and not `--json` (alias hidden).
+  - `memo-cli --json --format text list` fails at parse time with exit code `64`.
+  - All existing `cli` tests still pass; the runtime `resolve_output_mode` test is replaced by a clap parse-time test.
+- **Validation**:
+  - `cargo test -p memo-cli`
+  - Manual: `memo-cli --json --format text list`
+
+### Task 2.3: Migrate memo-cli JSON output to shared envelope and `warnings`
+
+- **Location**:
+  - crates/memo-cli/src/output/json.rs
+  - crates/memo-cli/src/output/mod.rs
+  - crates/memo-cli/src/commands/
+- **Description**: Wrap each subcommand's JSON output in the shared
+  `Envelope<T>`. Move every `eprintln!` that conveys a per-record warning
+  (e.g. `output/text.rs:135-140`) into the envelope's `warnings` array
+  when `OutputFormat::Json`. Keep text-mode behaviour unchanged. Pin the
+  literal `schema_version` per subcommand in integration tests.
+- **Dependencies**:
+  - Task 2.2
+- **Complexity**:
+  - 6
+- **Acceptance criteria**:
+  - Every `memo-cli --format json <cmd>` output is a single envelope object (no streaming changes).
+  - The envelope's `schema_version` matches `cli.memo-cli.<cmd>.v1` for every subcommand.
+  - Apply warnings appear in `warnings` when JSON, on stderr when text.
+  - Snapshot tests under `tests/integration/json_contract.rs` cover every subcommand's `schema_version`.
+- **Validation**:
+  - `cargo test -p memo-cli json_contract`
+  - `cargo test -p memo-cli`
+
+### Task 2.4: Route memo-cli parse and unknown-subcommand errors through helper
+
+- **Location**:
+  - crates/memo-cli/src/app.rs
+  - crates/memo-cli/src/main.rs
+- **Description**: When clap parsing fails, detect whether `--format
+  json` or `--json` appeared in argv and call
+  `nils_common::cli_contract::emit_parse_error` accordingly before
+  exiting. Otherwise let clap render its native error.
+- **Dependencies**:
+  - Task 1.2
+  - Task 2.2
+- **Complexity**:
+  - 4
+- **Acceptance criteria**:
+  - `memo-cli bogus --format json` prints the JSON envelope to stdout and exits `64`.
+  - `memo-cli bogus` (no `--format`) prints clap's text error to stderr and exits `64`.
+  - `memo-cli --json bogus` matches the JSON path.
+  - New integration test covers both paths.
+- **Validation**:
+  - `cargo test -p memo-cli`
+
+### Task 2.5: Add memo-cli exit-code matrix test
+
+- **Location**:
+  - crates/memo-cli/tests/integration/exit_codes.rs (new)
+- **Description**: One test per exit-code path: success (0), usage error
+  (64, missing arg), data error (65, malformed payload), runtime error
+  (1, simulated I/O failure on a temp DB). Use the existing test
+  harness; do not introduce new fixtures unless required.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**:
+  - 3
+- **Acceptance criteria**:
+  - Four tests cover four exit codes.
+  - Each test asserts the literal exit-code constant from `nils_common::cli_contract::exit`.
+- **Validation**:
+  - `cargo test -p memo-cli exit_codes`
+
+## Sprint 3: Fan-out migration
+
+**Goal**: Migrate every remaining JSON-emitting binary in three parallel
+batches. Each batch is its own PR so blast radius stays bounded and
+binaries with shared crates can be reviewed together.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test --workspace`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh`
+  - Per binary: `<binary> --format json <cmd>` (envelope present), `<binary> bogus --format json` (parse-error envelope), `<binary> bogus` (exit 64).
+- Verify: every JSON-emitting subcommand has a `schema_version` snapshot
+  test; every binary has an exit-code matrix test; no binary still ships
+  ad-hoc `1`/`2` exit codes for usage errors.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `parallel-x3`
+
+### Task 3.1: Migrate `agent-workflow-primitives` binaries
+
+- **Location**:
+  - crates/agent-workflow-primitives/src/
+  - crates/agent-workflow-primitives/tests/integration/
+- **Description**: Cover all eight binaries (`browser-session`,
+  `canary-check`, `docs-impact`, `heuristic-inbox`, `model-cross-check`,
+  `repo-retro`, `review-evidence`, `skill-usage`). Replace the existing
+  `schema_version` constants with the shared envelope wrapper, swap exit
+  codes onto the shared constants, and add the parse-error helper.
+  Existing `RECORD_SCHEMA_VERSION` literals stay byte-stable; only the
+  surrounding envelope changes.
+- **Dependencies**:
+  - Task 1.4
+- **Complexity**:
+  - 6
+- **Acceptance criteria**:
+  - All eight binaries route `--format json` through the shared envelope.
+  - All eight binaries return `64` for usage errors and `65` for data errors.
+  - Existing JSON-byte-stable contract tests still pass (no field name or `schema_version` literal changes).
+  - One new exit-code matrix test per binary.
+- **Validation**:
+  - `cargo test -p agent-workflow-primitives`
+
+### Task 3.2: Migrate API testing stack (api-rest / api-gql / api-grpc / api-websocket / api-test)
+
+- **Location**:
+  - crates/api-testing-core/src/
+  - crates/api-rest/src/
+  - crates/api-gql/src/
+  - crates/api-grpc/src/
+  - crates/api-websocket/src/
+  - crates/api-test/src/
+- **Description**: Hoist the shared `OutputFormat`/exit-code handling into
+  `api-testing-core` so the five binaries inherit it once. Add
+  `schema_version` where missing (notably `api-gql/src/commands/report.rs`,
+  which currently emits no version field). Migrate the suite runner's
+  JSON output last so reporting tests stay byte-stable.
+- **Dependencies**:
+  - Task 1.4
+- **Complexity**:
+  - 8
+- **Acceptance criteria**:
+  - Each of the five binaries emits a `schema_version` field on every JSON output.
+  - `api-test` suite reports keep their existing JUnit shape but JSON runs through the shared envelope.
+  - Exit codes match the workspace contract.
+  - Snapshot tests cover one subcommand per binary.
+- **Validation**:
+  - `cargo test -p api-rest`
+  - `cargo test -p api-gql`
+  - `cargo test -p api-grpc`
+  - `cargo test -p api-websocket`
+  - `cargo test -p api-test`
+
+### Task 3.3: Migrate remaining single-binary crates and run the full gate
+
+- **Location**:
+  - crates/semantic-commit/src/
+  - crates/git-scope/src/
+  - crates/git-summary/src/
+  - crates/git-lock/src/
+  - crates/agent-out/src/
+  - crates/agent-docs/src/
+  - crates/agent-scope-lock/src/
+  - crates/web-evidence/src/
+  - crates/test-first-evidence/src/
+  - crates/image-processing/src/
+  - crates/codex-cli/src/
+  - crates/gemini-cli/src/
+  - crates/plan-tooling/src/
+  - crates/plan-issue-cli/src/
+- **Description**: Migrate each remaining binary onto the shared
+  contract. Pay special attention to `semantic-commit/src/staged_context.rs`
+  which uses camelCase (`schemaVersion`, `oldPath`) — emit a versioned
+  alias (`schema_version: "cli.semantic-commit.staged-context.v2"`) and
+  keep the camelCase fields as deprecated aliases for one minor cycle.
+  `git-cli` participates here for exit-code consolidation but its
+  dispatch refactor stays in the `cli-dispatch-modernization` plan.
+- **Dependencies**:
+  - Task 1.4
+- **Complexity**:
+  - 8
+- **Acceptance criteria**:
+  - Every listed binary returns sysexit-aligned codes.
+  - Every JSON-emitting subcommand has `schema_version`.
+  - `staged-context` ships `v2` schema and a documented alias path.
+  - One exit-code matrix test per binary.
+- **Validation**:
+  - `cargo test --workspace`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh`
+
+### Task 3.4: Workspace lint script for legacy contract usage
+
+- **Location**:
+  - scripts/ci/cli-output-contract-lint.sh (new)
+  - scripts/ci/nils-cli-checks-entrypoint.sh
+  - DEVELOPMENT.md
+- **Description**: Add a small grep-based lint script that fails on:
+  (a) any new `--json` bool flag without `hide = true`; (b) any
+  `std::process::exit(1|2)` for usage errors in `main.rs` files; (c)
+  any JSON serializer that emits camelCase outside the documented
+  aliases. Wire it into the docs-only required-check path so drift gets
+  caught on PRs that only touch CLIs.
+- **Dependencies**:
+  - Task 3.1
+  - Task 3.2
+  - Task 3.3
+- **Complexity**:
+  - 4
+- **Acceptance criteria**:
+  - Lint script returns 0 on the post-migration workspace.
+  - Lint script fails on a synthetic regression fixture (a new binary that re-introduces `--json` without `hide = true`).
+  - Script appears in docs-only checks and `DEVELOPMENT.md`.
+- **Validation**:
+  - `bash scripts/ci/cli-output-contract-lint.sh`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+
+## Testing Strategy
+
+- Unit: cover the `nils-common::cli_contract` envelope, helpers, and exit
+  constants.
+- Integration (per binary): one snapshot test per JSON-emitting subcommand
+  pinning `schema_version`; one exit-code matrix test per binary.
+- Cross-binary: a workspace integration test that builds every binary and
+  asserts the shared exit-code constants resolve to the same value at the
+  ELF boundary (sanity check that no binary linked an older copy of the
+  constants).
+- Workspace gate: `NILS_CLI_TEST_RUNNER=nextest bash
+  scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` must remain
+  green after each sprint.
+- Docs-only gate: `bash scripts/ci/nils-cli-checks-entrypoint.sh
+  --docs-only` after the spec and lint script land.
+
+## Risks & gotchas
+
+- `agent-workflow-primitives` records ship in user state directories; the
+  envelope wrapper must not change the byte-stable `RECORD_SCHEMA_VERSION`
+  string or persisted records will fail validation. Treat their tests as
+  the contract.
+- `staged-context` is consumed by other agents in the wider toolchain —
+  the camelCase alias must remain accepted for one minor cycle; bumping
+  `schema_version` is the breaking signal.
+- Clap parse errors are emitted before our helper runs; the parse-error
+  helper has to detect `--format json` / `--json` from raw argv (not
+  parsed flags) to render the JSON envelope. Cover this with a test that
+  feeds a deliberately malformed flag.
+- `nils-common` adds a new public module; downstream crates may have
+  already named a local `cli_contract` symbol. Confirm before the rename
+  lands.
+- `cargo test --workspace` reuses one process for all binaries; tests
+  that mutate the environment must use `EnvGuard` from
+  `nils-test-support` to avoid cross-test bleed.
+
+## Rollback plan
+
+- Sprint 1 rollback: revert the new `cli_contract` module; `cli-template`
+  reverts to its prior shape. No production binary depends on it yet.
+- Sprint 2 rollback: revert `memo-cli` migration commits one task at a
+  time; the shared module stays in place and is exercised only by
+  `cli-template`.
+- Sprint 3 rollback (per task): each binary lands as its own PR, so
+  reverting a single binary's migration leaves the rest intact. The lint
+  script can be marked non-required until the workspace re-converges.

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-review-source.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-review-source.md
@@ -1,0 +1,115 @@
+# CLI Output Contract Unification Review Source
+
+- Status: open, ready for implementation planning
+- Date: 2026-05-19
+- Source: static `/code-review-specialists` audit of the `nils-cli` workspace
+  (`main` @ `bf740b5`).
+- Scope: workspace-wide standardisation of machine-readable output, exit
+  codes, and JSON contract for every user-facing binary.
+
+## Execution
+
+- Recommended plan:
+  docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
+- Recommended execution state:
+  docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
+
+## Purpose
+
+Three foundational gaps were observed across ~30 workspace binaries and they
+compound: each binary advertises a slightly different way to ask for JSON,
+emits JSON with different envelopes, and signals failure with a different
+exit code. Once any of these is standardised in isolation it becomes a
+breaking change for downstream agents and scripts, so this record groups the
+fixes into one coherent contract and sets up the rest of the docs/plans/*
+backlog (help, dispatch modernization, destructive-op safety, progress) to
+build on top of it.
+
+This document is the source of truth for the unified CLI output contract.
+Other plan-source docs in the `cli-*` family should `Read First` this record
+when they need the contract envelope or exit-code constants.
+
+## Current Judgment
+
+The workspace is in an "almost there" state: several binaries already model
+the right shape (`memo-cli` for `--format`/`--json` conflict detection,
+`agent-workflow-primitives` for `schema_version`, `plan-issue-cli` for
+`EXIT_USAGE = 2`), but no single binary models all of them and nothing in
+`nils-common` exposes them as shared primitives. The most efficient path is
+to publish the contract once in `nils-common` and migrate binaries from
+highest-traffic to lowest.
+
+## Findings
+
+| Priority | ID | Issue | Evidence | Fix Location | Acceptance |
+| --- | --- | --- | --- | --- | --- |
+| high | A1 | Three coexisting JSON flag styles (`--json` bool, `--format text/json`, ad-hoc `--output`) | `crates/memo-cli/src/cli.rs:70-75`; `crates/agent-docs/src/cli.rs:60-70`; `crates/image-processing/src/cli.rs:47`; `crates/agent-out/src/cli.rs:50-51`; `crates/agent-scope-lock/src/cli.rs:39-40` | every user-facing binary's clap layer + a shared helper in `nils-common` | `--format text\|json` is the canonical form on every binary; `--json` survives as a hidden alias on prior binaries; new binaries reject `--json` bool at lint time |
+| high | B1 | Exit codes diverge (`1` / `2` / `64` / `65` all used for usage error) | `crates/semantic-commit/src/usage.rs:30`; `crates/plan-tooling/src/usage.rs:31`; `crates/git-cli/src/usage.rs:66,74`; `crates/memo-cli/src/errors.rs:23-26`; `crates/plan-issue-cli/src/lib.rs:22-25` | `crates/nils-common/src/exit.rs` (new module) + per-binary call sites | every binary maps usage error → `64`, data error → `65`, runtime error → `1`, software error → `70` |
+| medium | A2 | `schema_version` only present on a subset of JSON-emitting commands | `crates/agent-workflow-primitives/src/canary_check.rs:237,141`; `crates/semantic-commit/src/staged_context.rs:280`; `crates/codex-cli/src/diag_output.rs:15`; `crates/api-gql/src/commands/report.rs` (missing) | every JSON-emitting subcommand + a shared envelope type in `nils-common` | every JSON record has a `schema_version` field shaped `cli.<binary>.<command>.v<N>`; snapshot tests assert the literal string |
+| medium | A3 | JSON field casing is inconsistent (camelCase in `staged-context`, snake_case elsewhere) | `crates/semantic-commit/src/staged_context.rs:248,254,280` | `staged_context` serializer | all JSON output uses snake_case (`#[serde(rename_all = "snake_case")]`); `staged-context` migrates with a `schema_version` bump |
+| medium | A4 | Parse-time errors fall back to plain stderr even when `--json` was requested | `crates/semantic-commit/src/usage.rs:27-30`; `crates/git-cli/src/usage.rs:64-66`; `crates/memo-cli/src/errors.rs:12-18`; `crates/plan-issue-cli/src/lib.rs:97-100` | every binary's main entry point | when `--format json` (or `--json`) is detected on argv, parse and unknown-subcommand errors emit `{ "schema_version": ..., "ok": false, "error": { "code": ..., "message": ... } }` and exit `64` |
+| medium | I2 | `schema_version` literal not snapshot-locked | `crates/memo-cli/tests/integration/json_contract.rs:19` (only one binary) | per-binary `tests/integration/json_contract.rs` | one snapshot test per JSON-emitting subcommand pins the exact `schema_version` string |
+| medium | B2 | Exit-code matrix coverage is patchy | `crates/semantic-commit/tests/integration/commit.rs` (good); `crates/api-gql/src/main.rs:73`; `crates/memo-cli/tests/integration/json_contract.rs` (partial) | per-binary integration tests | every binary has at least one test per exit code variant (`success`, `usage`, `data`, `runtime`) |
+| low | A5 | `memo-cli` warnings go to stderr while JSON goes to stdout — JSON consumers miss them | `crates/memo-cli/src/output/text.rs:135-140`; `crates/memo-cli/src/output/json.rs:119` | `memo-cli` JSON output module; the shared envelope | `--format json` JSON envelope has a `warnings: []` array; text mode keeps stderr behaviour |
+
+## Ownership Boundary
+
+- Runtime: every workspace binary that emits JSON or returns an exit code.
+- Shared library: a new `nils-common::cli_contract` module (envelope type,
+  exit-code constants, parse-error JSON helper).
+- Test/harness: per-binary `tests/integration/json_contract.rs` snapshot
+  files.
+- Docs: `docs/specs/cli-output-contract-v1.md` (new) — the public contract
+  spec that other plans `Read First`.
+
+## Backlog / Next Fixes
+
+1. Publish the envelope and exit-code primitives in `nils-common`.
+2. Migrate `memo-cli` first (it already models most of the right shape and
+   has the most integration tests).
+3. Migrate `agent-workflow-primitives` binaries next (they already use
+   `schema_version`; mainly need exit-code alignment and `--format`).
+4. Migrate `api-rest` / `api-gql` / `api-grpc` / `api-websocket` / `api-test`
+   together (they share `api-testing-core`).
+5. Migrate `semantic-commit`, `git-scope`, `git-summary`, `git-lock`
+   one-by-one.
+6. Backfill snapshot tests as each binary lands.
+
+## Retention Intent
+
+- This source doc is execution coordination — delete `docs/plans/cli-output-contract-unification/`
+  once execution completes.
+- Promote `docs/specs/cli-output-contract-v1.md` as long-lived spec
+  (durable knowledge for future binaries).
+
+## Validation Gate
+
+- `bash scripts/ci/plan-bundle-validate.sh --strict`
+- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+- Per-binary: `cargo test -p <crate> json_contract`
+- Workspace: `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage`
+
+## Do Not Do
+
+- Do not silently drop the `--json` bool flag from binaries that already
+  ship it — keep as a hidden alias for one minor version, then remove.
+- Do not change the JSON shape for binaries that already publish a
+  `schema_version` without bumping the version field.
+- Do not standardise exit code `2` (clap's default parse-error code) — clap
+  may emit it before our parse-error envelope runs; document this and
+  intercept where possible.
+- Do not introduce a new top-level `error` schema that differs from
+  agent-workflow-primitives' existing `Record { schema_version, ok, ... }`
+  shape; reuse it.
+
+## Open Questions
+
+- Should `cli-template` ship the canonical contract as a worked example
+  before any production binary migrates? (Recommended: yes; lower-risk to
+  validate the envelope on the template first.)
+- Where should `schema_version` live in the JSON envelope when the binary
+  also emits a single-record payload (e.g. `semantic-commit
+  staged-context`)? (Recommended: top-level alongside `ok`/`data`.)
+- Do we need a migration-period flag to opt back into legacy exit codes for
+  any caller? (Recommended: no; treat as a documented breaking change at
+  the next minor version.)

--- a/docs/specs/cli-output-contract-v1.md
+++ b/docs/specs/cli-output-contract-v1.md
@@ -109,14 +109,14 @@ and the worked example in
 Every binary returns one of the BSD sysexits-aligned constants exposed by
 `nils_common::cli_contract::exit`:
 
-| Constant      | Value | When                                                                |
-| ------------- | ----- | ------------------------------------------------------------------- |
-| `SUCCESS`     | `0`   | Subcommand finished without error.                                  |
-| `RUNTIME`     | `1`   | Generic runtime failure (the historic catch-all).                   |
-| `USAGE`       | `64`  | `EX_USAGE`: bad CLI syntax, missing arg, unknown subcommand.        |
-| `DATA`        | `65`  | `EX_DATAERR`: input data malformed or otherwise invalid.            |
-| `UNAVAILABLE` | `69`  | `EX_UNAVAILABLE`: a required service or resource is unavailable.    |
-| `SOFTWARE`    | `70`  | `EX_SOFTWARE`: internal software error / invariant violation.       |
+| Constant      | Value | When                                                             |
+| ------------- | ----- | ---------------------------------------------------------------- |
+| `SUCCESS`     | `0`   | Subcommand finished without error.                               |
+| `RUNTIME`     | `1`   | Generic runtime failure (the historic catch-all).                |
+| `USAGE`       | `64`  | `EX_USAGE`: bad CLI syntax, missing arg, unknown subcommand.     |
+| `DATA`        | `65`  | `EX_DATAERR`: input data malformed or otherwise invalid.         |
+| `UNAVAILABLE` | `69`  | `EX_UNAVAILABLE`: a required service or resource is unavailable. |
+| `SOFTWARE`    | `70`  | `EX_SOFTWARE`: internal software error / invariant violation.    |
 
 Rules:
 
@@ -154,10 +154,10 @@ pattern:
 
 Stable error codes for the parse path:
 
-| `error.code`           | Trigger                                                       |
-| ---------------------- | ------------------------------------------------------------- |
-| `parse-error`          | Any clap error that is not an unknown-subcommand or info exit. |
-| `unknown-subcommand`   | `ErrorKind::InvalidSubcommand`.                               |
+| `error.code`         | Trigger                                                        |
+| -------------------- | -------------------------------------------------------------- |
+| `parse-error`        | Any clap error that is not an unknown-subcommand or info exit. |
+| `unknown-subcommand` | `ErrorKind::InvalidSubcommand`.                                |
 
 The worked example is in
 [`crates/cli-template/src/main.rs`](../../crates/cli-template/src/main.rs)

--- a/docs/specs/cli-output-contract-v1.md
+++ b/docs/specs/cli-output-contract-v1.md
@@ -1,0 +1,213 @@
+# CLI Output Contract v1
+
+## Purpose
+
+This spec is the single source of truth for how every binary in the
+`nils-cli` workspace renders machine-readable output and signals failure
+to its callers. The contract is implemented by the
+`nils_common::cli_contract` module and exercised end-to-end by
+`crates/cli-template` as the reference implementation.
+
+Goals:
+
+- one shape for every JSON-emitting subcommand (`Envelope<T>`);
+- one set of exit codes (BSD sysexits-aligned);
+- one path for parse and unknown-subcommand errors that respects
+  `--format json`;
+- a documented deprecation path for pre-contract `--json` boolean flags
+  so downstream agents and scripts do not break during the migration.
+
+## Scope
+
+Apply this contract to every user-facing binary in the workspace:
+
+- New binaries MUST adopt the contract before they ship.
+- Existing binaries SHOULD migrate within one minor release cycle. The
+  rollout plan lives in
+  `docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md`.
+- Binaries that already publish a `schema_version` (notably
+  `agent-workflow-primitives`) keep their string literals byte-stable;
+  only the surrounding envelope changes when they migrate.
+
+This spec supersedes the per-field shape in
+`docs/specs/cli-service-json-contract-guideline-v1.md`: the older
+guideline kept a top-level `command` field and used
+`result` / `results`. The new envelope drops `command` (the binary +
+schema version already disambiguate the source) and uses a single `data`
+field plus a top-level `warnings` array. The retry / fallback guidance,
+partial-failure handling, and sensitive-data policy from that older
+guideline still apply unchanged.
+
+## Output format
+
+- The canonical flag is `--format text|json` (rendered through
+  `nils_common::cli_contract::OutputFormat`'s `clap::ValueEnum`).
+- Binaries that previously shipped `--json` MAY keep it as a hidden alias
+  (`#[arg(long, global = true, hide = true, conflicts_with = "format")]`)
+  for one minor cycle, after which it MUST be removed.
+- New binaries MUST NOT introduce a `--json` boolean flag. The lint
+  script at `scripts/ci/cli-output-contract-lint.sh` (added in Sprint 3
+  of the migration plan) enforces this on PRs.
+- Help output MUST advertise `--format` only; the hidden alias does not
+  appear in `--help`.
+
+## Envelope
+
+Every JSON-emitting subcommand renders a single envelope object to
+stdout. Multi-record commands wrap their list inside `data`; this keeps
+the wire shape uniform regardless of payload cardinality.
+
+```jsonc
+{
+  "schema_version": "cli.<binary>.<command>.v<N>",
+  "ok": true,
+  "data": { /* per-subcommand payload */ },
+  "warnings": ["optional", "non-fatal", "messages"]
+}
+```
+
+Rules:
+
+- Field casing is snake_case across the whole envelope and every payload
+  body (`#[serde(rename_all = "snake_case")]` where applicable).
+- `schema_version` is the literal string
+  `cli.<binary>.<command>.v<N>`. The helper
+  `nils_common::cli_contract::schema_version_for` builds it.
+- `ok` mirrors success/failure regardless of payload presence.
+- `data` is omitted when there is no payload (Serde
+  `skip_serializing_if = "Option::is_none"`).
+- `warnings` is omitted when empty. JSON consumers see what text mode
+  would print to stderr.
+- `error` (failure only) is described below.
+
+Failure envelope:
+
+```jsonc
+{
+  "schema_version": "cli.<binary>.<command>.v<N>",
+  "ok": false,
+  "error": {
+    "code": "stable-machine-code",
+    "message": "human-readable summary",
+    "hint": "optional follow-up suggestion"
+  }
+}
+```
+
+The error `code` is stable and machine-usable; the `message` is a single
+line; the optional `hint` is human-only. Additional structured detail
+(stack traces, partial-failure records) belongs in `data` or
+crate-specific extension fields, never as free-form text.
+
+Reference implementation:
+[`nils_common::cli_contract::Envelope`](../../crates/nils-common/src/cli_contract.rs)
+and the worked example in
+[`crates/cli-template/src/main.rs`](../../crates/cli-template/src/main.rs).
+
+## Exit codes
+
+Every binary returns one of the BSD sysexits-aligned constants exposed by
+`nils_common::cli_contract::exit`:
+
+| Constant      | Value | When                                                                |
+| ------------- | ----- | ------------------------------------------------------------------- |
+| `SUCCESS`     | `0`   | Subcommand finished without error.                                  |
+| `RUNTIME`     | `1`   | Generic runtime failure (the historic catch-all).                   |
+| `USAGE`       | `64`  | `EX_USAGE`: bad CLI syntax, missing arg, unknown subcommand.        |
+| `DATA`        | `65`  | `EX_DATAERR`: input data malformed or otherwise invalid.            |
+| `UNAVAILABLE` | `69`  | `EX_UNAVAILABLE`: a required service or resource is unavailable.    |
+| `SOFTWARE`    | `70`  | `EX_SOFTWARE`: internal software error / invariant violation.       |
+
+Rules:
+
+- Binaries MUST NOT inline numeric exit literals for usage errors. Call
+  the shared constants so `cargo grep std::process::exit\(64\)` stays
+  empty post-migration.
+- Each binary MUST ship at least one exit-code matrix test covering
+  `success`, `usage`, `data`, and `runtime` paths.
+- Clap's default unmatched-flag/value exit code is `2`. This contract
+  does not standardise on `2`; instead the parse-error path below
+  intercepts that case before clap calls `exit()` and remaps it to
+  `USAGE = 64`.
+
+## Parse and unknown-subcommand errors
+
+`clap` renders parse errors before any subcommand runs. To make `--format
+json` work for those errors too, every binary's `main` MUST follow this
+pattern:
+
+1. Call `Cli::try_parse()` (instead of `parse()`).
+2. Let clap handle informational exits unchanged:
+   - `ErrorKind::DisplayHelp` → clap's `err.exit()`.
+   - `ErrorKind::DisplayVersion` → clap's `err.exit()`.
+   - `ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand` → clap's
+     `err.exit()`.
+3. For every other error kind, detect the output format from raw argv
+   (NOT from the parsed flags, which are not available yet) and call
+   `nils_common::cli_contract::emit_parse_error(binary, format, code,
+   message)`. The helper writes:
+   - In JSON mode: a single-line envelope on stdout with
+     `schema_version = "cli.<binary>.error.v1"`, `ok = false`, and
+     `error = { code, message }`.
+   - In text mode: the historical `error: <msg>` line on stderr.
+4. Exit with the value the helper returned (`exit::USAGE = 64`).
+
+Stable error codes for the parse path:
+
+| `error.code`           | Trigger                                                       |
+| ---------------------- | ------------------------------------------------------------- |
+| `parse-error`          | Any clap error that is not an unknown-subcommand or info exit. |
+| `unknown-subcommand`   | `ErrorKind::InvalidSubcommand`.                               |
+
+The worked example is in
+[`crates/cli-template/src/main.rs`](../../crates/cli-template/src/main.rs)
+(see `parse_or_exit` and `detect_format_from_argv`).
+
+## Deprecation: `--json` boolean flag
+
+The workspace converges on `--format text|json`. For binaries that
+previously shipped `--json`:
+
+- Keep `--json` as a hidden alias for one minor release cycle:
+  `#[arg(long, global = true, hide = true, conflicts_with = "format")]`.
+- The clap `conflicts_with` declaration makes `--json --format text`
+  fail at parse time (exit `64`) instead of relying on a runtime check.
+- After the minor cycle, remove the alias. The contract lint script
+  fails any new binary that re-introduces `--json` without `hide = true`.
+
+`agent-workflow-primitives` and `staged-context` carry their own
+schema-version aliases; their deprecation timelines are documented in
+their respective migration tasks. See
+`docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md`.
+
+## Testing requirements
+
+Per binary:
+
+- One JSON snapshot test per JSON-emitting subcommand. The test MUST
+  pin the literal `schema_version` string so any drift fails fast.
+- One exit-code matrix test covering `success`, `usage`, `data`, and at
+  least one of `runtime` / `unavailable` / `software` depending on the
+  binary's failure modes.
+
+Per workspace (covered by the migration plan's Sprint 3 lint script):
+
+- `scripts/ci/cli-output-contract-lint.sh` fails on:
+  - any new `--json` boolean flag without `hide = true`;
+  - any `std::process::exit(1|2)` literal for usage errors in `main.rs`;
+  - any JSON serializer that emits camelCase outside the documented
+    aliases.
+
+## Cross-references
+
+- Implementation:
+  [`crates/nils-common/src/cli_contract.rs`](../../crates/nils-common/src/cli_contract.rs).
+- Reference binary:
+  [`crates/cli-template`](../../crates/cli-template).
+- Migration plan:
+  [`docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md`](../plans/cli-output-contract-unification/cli-output-contract-unification-plan.md).
+- Shared-crate boundary rules:
+  [`docs/specs/workspace-shared-crate-boundary-v1.md`](workspace-shared-crate-boundary-v1.md).
+- Predecessor guideline (retry / partial-failure / sensitive-data
+  policy still applies):
+  [`docs/specs/cli-service-json-contract-guideline-v1.md`](cli-service-json-contract-guideline-v1.md).


### PR DESCRIPTION
# Add CLI output contract v1 (Sprint 1)

## Summary

Sprint 1 of the [`cli-output-contract-unification`](../tree/feat/cli-output-contract-v1-foundation/docs/plans/cli-output-contract-unification) plan. Lands the workspace-wide CLI output contract primitives in `nils-common`, migrates `cli-template` as the worked reference implementation, and publishes the durable spec at `docs/specs/cli-output-contract-v1.md`. No production binary is migrated by this PR — Sprint 2 (memo-cli pilot) and Sprint 3 (workspace fan-out) follow as separate PRs per the plan's `parallel-x3` strategy.

## Changes

- New `nils_common::cli_contract` module: `OutputFormat` enum (`clap::ValueEnum`), `Envelope<T>` + `EnvelopeError` (snake_case serde), BSD sysexits-aligned `exit` constants (`SUCCESS`/`RUNTIME`/`USAGE`/`DATA`/`UNAVAILABLE`/`SOFTWARE`), `schema_version_for(binary, command, version)`, and `emit_parse_error(...)` helper (plus a writer-injected `emit_parse_error_to` for tests).
- `cli-template` migrated as reference implementation: new `status` subcommand emits `cli.cli-template.status.v1` envelope; global `--format text|json` with hidden `--json` alias (`hide = true`, `conflicts_with = "format"`); parse and unknown-subcommand errors detect the format from raw argv and route through `emit_parse_error`, exiting `64`; success paths exit via the shared `exit` constants.
- New durable spec `docs/specs/cli-output-contract-v1.md` covering envelope shape, exit-code table, parse-error path, and the `--json` deprecation policy; cross-references the predecessor `cli-service-json-contract-guideline-v1.md` for retry / partial-failure / sensitive-data guidance that still applies unchanged.
- Plan bundle + Sprint 1 execution state committed under `docs/plans/cli-output-contract-unification/`.
- `THIRD_PARTY_LICENSES.md` / `THIRD_PARTY_NOTICES.md` regenerated to track the new `clap` / `serde` deps in `nils-common` and `serde` / `serde_json` in `cli-template`.

## Test-First Evidence

- Change classification: feature
- Failing test before fix: N/A with waiver — there was no pre-existing `cli_contract` module to fail against; the contract is introduced by this PR and proven by 10 new tests in `nils-common` (6 unit + 4 integration) plus 9 new contract integration tests in `cli-template` that pin the literal `schema_version` string, the hidden-alias parity, the parse-error envelope path, and the `--format` / `--json` conflict at parse time.
- Final validation: `cargo test -p nils-common cli_contract` (10/10 pass); `cargo test -p nils-cli-template` (13/13 pass, including 4 pre-existing + 9 new); `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` pass; `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` pass (cargo fmt + clippy -D warnings + nextest workspace + doctests + third-party audit all green).
- Waiver reason: introducing a brand-new shared module — failing-test-first would require constructing a temporary fixture that exists only to fail; the new test suite locks the contract instead.

## Testing

- `cargo test -p nils-common cli_contract` (pass — 10 tests)
- `cargo test -p nils-cli-template` (pass — 13 tests)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` (pass)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass)
- Manual: `cargo run -p nils-cli-template -- --format json status` → `{"schema_version":"cli.cli-template.status.v1","ok":true,"data":{"binary":"cli-template","version":"0.10.2"}}`
- Manual: `cargo run -p nils-cli-template -- bogus-subcommand` → exit 64 with `error: unrecognized subcommand 'bogus-subcommand'` on stderr (text mode); same path with `--format json` emits the `cli.cli-template.error.v1` envelope on stdout.

## Risk / Notes

- `nils-common` gains `clap` + `serde` as runtime deps (previously only `serde_json` + `thiserror`). The crate-level boundary rule still applies — these primitives expose structured data + constants only; user-facing wording stays in caller adapters.
- This PR does NOT migrate any production binary (memo-cli, agent-workflow-primitives, api-*, semantic-commit, git-*, etc.). Those land in Sprint 2 (memo-cli) and Sprint 3 (3 parallel PRs). The plan calls this out under "PR grouping intent: parallel-x3" and "Rollback plan: each binary lands as its own PR".
- Hidden `--json` alias is only added to `cli-template` here; existing per-binary `--json` flags keep their current behaviour until each binary migrates.
- THIRD_PARTY_*.md regen is auto-detected by the third-party-artifacts-audit; future Sprint PRs that touch deps will need the same regen step.
