### PR TITLE
Migrate memo-cli to CLI output contract v1 (Sprint 2)

### DIFF
--- a/crates/memo-cli/src/app.rs
+++ b/crates/memo-cli/src/app.rs
@@ -1,9 +1,12 @@
 use std::ffi::OsString;
 
 use clap::{Parser, error::ErrorKind};
+use nils_common::cli_contract::{OutputFormat, emit_parse_error, exit};
 
-use crate::cli::{Cli, MemoCommand, OutputMode};
+use crate::cli::{Cli, MemoCommand};
 use crate::errors::AppError;
+
+const BINARY: &str = "memo-cli";
 
 pub fn run() -> i32 {
     run_with_args(std::env::args_os())
@@ -14,20 +17,30 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let cli = match Cli::try_parse_from(args) {
+    // Materialize argv so we can both feed clap and peek for `--format json` /
+    // `--json` when clap rejects parsing.
+    let argv: Vec<OsString> = args.into_iter().map(Into::into).collect();
+
+    let cli = match Cli::try_parse_from(argv.clone()) {
         Ok(cli) => cli,
         Err(err) => {
             let kind = err.kind();
-            match kind {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
-                    print!("{err}");
-                    return 0;
-                }
-                _ => {
-                    eprint!("{err}");
-                    return 64;
-                }
+            if matches!(
+                kind,
+                ErrorKind::DisplayHelp
+                    | ErrorKind::DisplayVersion
+                    | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+            ) {
+                err.exit();
             }
+
+            let format = detect_format_from_argv(&argv);
+            let code = match kind {
+                ErrorKind::InvalidSubcommand => "unknown-subcommand",
+                _ => "parse-error",
+            };
+            let message = render_clap_message(&err);
+            return emit_parse_error(BINARY, format, code, &message);
         }
     };
 
@@ -35,31 +48,59 @@ where
         return crate::completion::run(args.shell);
     }
 
-    let output_mode = match cli.resolve_output_mode() {
-        Ok(mode) => mode,
-        Err(err) => {
-            eprintln!("{}", err.message());
-            return err.exit_code();
-        }
-    };
+    let format = cli.output_format();
 
-    match crate::commands::run(&cli, output_mode) {
-        Ok(()) => 0,
-        Err(err) => report_error(&cli, output_mode, &err),
+    match crate::commands::run(&cli, format) {
+        Ok(()) => exit::SUCCESS,
+        Err(err) => report_error(&cli, format, &err),
     }
 }
 
-fn report_error(cli: &Cli, output_mode: OutputMode, err: &AppError) -> i32 {
-    if output_mode.is_json()
-        && let Err(output_err) =
-            crate::output::emit_json_error(cli.schema_version(), cli.command_id(), err)
-    {
-        eprintln!("{}", output_err.message());
-    }
-
-    if !output_mode.is_json() {
+fn report_error(cli: &Cli, format: OutputFormat, err: &AppError) -> i32 {
+    if format.is_json() {
+        if let Err(output_err) = crate::output::emit_json_error(cli.schema_version(), err) {
+            eprintln!("{}", output_err.message());
+        }
+    } else {
         eprintln!("{}", err.message());
     }
 
     err.exit_code()
+}
+
+fn detect_format_from_argv(argv: &[OsString]) -> OutputFormat {
+    let mut iter = argv.iter().skip(1);
+    while let Some(arg) = iter.next() {
+        let arg = arg.to_string_lossy();
+        if arg == "--json" {
+            return OutputFormat::Json;
+        }
+        if arg == "--format"
+            && let Some(next) = iter.next()
+            && next.to_string_lossy().eq_ignore_ascii_case("json")
+        {
+            return OutputFormat::Json;
+        }
+        if let Some(rest) = arg.strip_prefix("--format=")
+            && rest.eq_ignore_ascii_case("json")
+        {
+            return OutputFormat::Json;
+        }
+    }
+    OutputFormat::Text
+}
+
+fn render_clap_message(err: &clap::Error) -> String {
+    let rendered = err.to_string();
+    rendered
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| {
+            let line = line.trim();
+            line.strip_prefix("error:")
+                .map(str::trim)
+                .unwrap_or(line)
+                .to_string()
+        })
+        .unwrap_or_else(|| "command-line parse failed".to_string())
 }

--- a/crates/memo-cli/src/cli.rs
+++ b/crates/memo-cli/src/cli.rs
@@ -3,25 +3,7 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
-use crate::errors::AppError;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum OutputFormat {
-    Text,
-    Json,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OutputMode {
-    Text,
-    Json,
-}
-
-impl OutputMode {
-    pub fn is_json(self) -> bool {
-        matches!(self, Self::Json)
-    }
-}
+pub use nils_common::cli_contract::OutputFormat;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum ItemState {
@@ -66,8 +48,8 @@ pub struct Cli {
     #[arg(long, global = true, value_name = "path", default_value_os_t = default_db_path())]
     pub db: PathBuf,
 
-    /// Output JSON (shorthand for --format json)
-    #[arg(long, global = true)]
+    /// Hidden alias for `--format json` (kept for backwards compatibility).
+    #[arg(long, global = true, hide = true, conflicts_with = "format")]
     pub json: bool,
 
     /// Output format
@@ -230,18 +212,12 @@ pub struct ApplyArgs {
 }
 
 impl Cli {
-    pub fn resolve_output_mode(&self) -> Result<OutputMode, AppError> {
-        if self.json && matches!(self.format, Some(OutputFormat::Text)) {
-            return Err(AppError::usage(
-                "invalid output mode: --json cannot be combined with --format text",
-            ));
+    pub fn output_format(&self) -> OutputFormat {
+        if self.json {
+            OutputFormat::Json
+        } else {
+            self.format.unwrap_or_default()
         }
-
-        if self.json || matches!(self.format, Some(OutputFormat::Json)) {
-            return Ok(OutputMode::Json);
-        }
-
-        Ok(OutputMode::Text)
     }
 
     pub fn command_id(&self) -> &'static str {
@@ -260,15 +236,15 @@ impl Cli {
 
     pub fn schema_version(&self) -> &'static str {
         match self.command {
-            MemoCommand::Add(_) => "memo-cli.add.v1",
-            MemoCommand::Update(_) => "memo-cli.update.v1",
-            MemoCommand::Delete(_) => "memo-cli.delete.v1",
-            MemoCommand::List(_) => "memo-cli.list.v1",
-            MemoCommand::Search(_) => "memo-cli.search.v1",
-            MemoCommand::Report(_) => "memo-cli.report.v1",
-            MemoCommand::Fetch(_) => "memo-cli.fetch.v1",
-            MemoCommand::Apply(_) => "memo-cli.apply.v1",
-            MemoCommand::Completion(_) => "memo-cli.completion.v1",
+            MemoCommand::Add(_) => "cli.memo-cli.add.v1",
+            MemoCommand::Update(_) => "cli.memo-cli.update.v1",
+            MemoCommand::Delete(_) => "cli.memo-cli.delete.v1",
+            MemoCommand::List(_) => "cli.memo-cli.list.v1",
+            MemoCommand::Search(_) => "cli.memo-cli.search.v1",
+            MemoCommand::Report(_) => "cli.memo-cli.report.v1",
+            MemoCommand::Fetch(_) => "cli.memo-cli.fetch.v1",
+            MemoCommand::Apply(_) => "cli.memo-cli.apply.v1",
+            MemoCommand::Completion(_) => "cli.memo-cli.completion.v1",
         }
     }
 }
@@ -293,34 +269,31 @@ fn default_db_path() -> PathBuf {
 pub(crate) mod tests {
     use clap::{CommandFactory, Parser};
 
-    use super::{Cli, MemoCommand, OutputMode, SearchField, SearchMatch};
+    use super::{Cli, MemoCommand, OutputFormat, SearchField, SearchMatch};
 
     #[test]
-    fn output_mode_defaults_to_text() {
+    fn output_format_defaults_to_text() {
         let cli = Cli::parse_from(["memo-cli", "list"]);
-        let mode = cli.resolve_output_mode().expect("mode should resolve");
-        assert_eq!(mode, OutputMode::Text);
+        assert_eq!(cli.output_format(), OutputFormat::Text);
     }
 
     #[test]
-    fn output_mode_json_flag_wins() {
+    fn output_format_json_flag_wins() {
         let cli = Cli::parse_from(["memo-cli", "--json", "list"]);
-        let mode = cli.resolve_output_mode().expect("mode should resolve");
-        assert_eq!(mode, OutputMode::Json);
+        assert_eq!(cli.output_format(), OutputFormat::Json);
     }
 
     #[test]
-    fn output_mode_format_json_is_supported() {
+    fn output_format_format_json_is_supported() {
         let cli = Cli::parse_from(["memo-cli", "--format", "json", "list"]);
-        let mode = cli.resolve_output_mode().expect("mode should resolve");
-        assert_eq!(mode, OutputMode::Json);
+        assert_eq!(cli.output_format(), OutputFormat::Json);
     }
 
     #[test]
-    fn output_mode_rejects_conflict() {
-        let cli = Cli::parse_from(["memo-cli", "--json", "--format", "text", "list"]);
-        let err = cli.resolve_output_mode().expect_err("conflict should fail");
-        assert_eq!(err.exit_code(), 64);
+    fn output_format_rejects_conflict_at_parse_time() {
+        let err = Cli::try_parse_from(["memo-cli", "--json", "--format", "text", "list"])
+            .expect_err("clap should reject --json + --format conflict");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/memo-cli/src/commands/add.rs
+++ b/crates/memo-cli/src/commands/add.rs
@@ -1,13 +1,13 @@
 use serde_json::json;
 
-use crate::cli::{AddArgs, OutputMode};
+use crate::cli::{AddArgs, OutputFormat};
 use crate::errors::AppError;
-use crate::output::{emit_json_result, format_item_id, text};
+use crate::output::{emit_data, format_item_id, text};
 use crate::storage::Storage;
 use crate::storage::repository;
 use crate::timestamps::{format_utc, parse_rfc3339_utc};
 
-pub fn run(storage: &Storage, args: &AddArgs, output_mode: OutputMode) -> Result<(), AppError> {
+pub fn run(storage: &Storage, args: &AddArgs, format: OutputFormat) -> Result<(), AppError> {
     let text = args.text.trim();
     if text.is_empty() {
         return Err(AppError::usage("add requires a non-empty text argument"));
@@ -27,10 +27,9 @@ pub fn run(storage: &Storage, args: &AddArgs, output_mode: OutputMode) -> Result
     let added = storage
         .with_transaction(|tx| repository::add_item(tx, text, source, created_at.as_deref()))?;
 
-    if output_mode.is_json() {
-        return emit_json_result(
-            "memo-cli.add.v1",
-            "memo-cli add",
+    if format.is_json() {
+        return emit_data(
+            "cli.memo-cli.add.v1",
             json!({
                 "item_id": format_item_id(added.item_id),
                 "created_at": added.created_at,

--- a/crates/memo-cli/src/commands/apply.rs
+++ b/crates/memo-cli/src/commands/apply.rs
@@ -3,9 +3,9 @@ use std::io::{self, Read};
 
 use serde::Serialize;
 
-use crate::cli::{ApplyArgs, OutputMode};
+use crate::cli::{ApplyArgs, OutputFormat};
 use crate::errors::AppError;
-use crate::output::{emit_json_result, format_item_id, parse_item_id, text};
+use crate::output::{emit_data_with_warnings, format_item_id, parse_item_id, text};
 use crate::preprocess::{ContentType, ValidationStatus};
 use crate::storage::Storage;
 use crate::storage::derivations::{self, ApplyInputItem, IncomingStatus};
@@ -38,7 +38,7 @@ struct JsonApplyItem<'a> {
     error: Option<&'a derivations::ApplyItemError>,
 }
 
-pub fn run(storage: &Storage, output_mode: OutputMode, args: &ApplyArgs) -> Result<(), AppError> {
+pub fn run(storage: &Storage, format: OutputFormat, args: &ApplyArgs) -> Result<(), AppError> {
     if args.input.is_some() == args.stdin {
         return Err(AppError::usage(
             "apply requires exactly one input source: --input <file> or --stdin",
@@ -80,7 +80,21 @@ pub fn run(storage: &Storage, output_mode: OutputMode, args: &ApplyArgs) -> Resu
         derivations::apply_items(tx, &parsed.items, args.dry_run, &default_agent_run_id)
     })?;
 
-    if output_mode.is_json() {
+    if format.is_json() {
+        let warnings: Vec<String> = summary
+            .items
+            .iter()
+            .filter_map(|item| {
+                item.error.as_ref().map(|error| {
+                    format!(
+                        "{} {}: {}",
+                        format_item_id(item.item_id),
+                        item.status,
+                        error.message
+                    )
+                })
+            })
+            .collect();
         let result = JsonApplyResult {
             dry_run: summary.dry_run,
             processed: summary.processed,
@@ -101,7 +115,7 @@ pub fn run(storage: &Storage, output_mode: OutputMode, args: &ApplyArgs) -> Resu
                 })
                 .collect(),
         };
-        return emit_json_result("memo-cli.apply.v1", "memo-cli apply", result);
+        return emit_data_with_warnings("cli.memo-cli.apply.v1", result, warnings);
     }
 
     text::print_apply(&summary);
@@ -536,8 +550,7 @@ mod tests {
     use super::*;
 
     fn error_path(err: &AppError) -> Option<&str> {
-        err.json_error()
-            .details
+        err.details()
             .and_then(|details| details.get("path"))
             .and_then(Value::as_str)
     }

--- a/crates/memo-cli/src/commands/delete.rs
+++ b/crates/memo-cli/src/commands/delete.rs
@@ -1,12 +1,12 @@
 use serde_json::json;
 
-use crate::cli::{DeleteArgs, OutputMode};
+use crate::cli::{DeleteArgs, OutputFormat};
 use crate::errors::AppError;
-use crate::output::{emit_json_result, format_item_id, parse_item_id, text};
+use crate::output::{emit_data, format_item_id, parse_item_id, text};
 use crate::storage::Storage;
 use crate::storage::repository;
 
-pub fn run(storage: &Storage, args: &DeleteArgs, output_mode: OutputMode) -> Result<(), AppError> {
+pub fn run(storage: &Storage, args: &DeleteArgs, format: OutputFormat) -> Result<(), AppError> {
     if !args.hard {
         return Err(AppError::usage(
             "delete requires --hard because only hard delete is supported",
@@ -18,10 +18,9 @@ pub fn run(storage: &Storage, args: &DeleteArgs, output_mode: OutputMode) -> Res
 
     let deleted = storage.with_transaction(|tx| repository::delete_item_hard(tx, item_id))?;
 
-    if output_mode.is_json() {
-        return emit_json_result(
-            "memo-cli.delete.v1",
-            "memo-cli delete",
+    if format.is_json() {
+        return emit_data(
+            "cli.memo-cli.delete.v1",
             json!({
                 "item_id": format_item_id(deleted.item_id),
                 "deleted": true,

--- a/crates/memo-cli/src/commands/fetch.rs
+++ b/crates/memo-cli/src/commands/fetch.rs
@@ -1,14 +1,14 @@
 use serde_json::json;
 
-use crate::cli::OutputMode;
+use crate::cli::OutputFormat;
 use crate::errors::AppError;
-use crate::output::{emit_json_results_with_meta, format_item_id, parse_item_id, text};
+use crate::output::{emit_data, format_item_id, parse_item_id, text};
 use crate::storage::Storage;
 use crate::storage::repository;
 
 pub fn run(
     storage: &Storage,
-    output_mode: OutputMode,
+    format: OutputFormat,
     limit: usize,
     cursor: Option<&str>,
 ) -> Result<(), AppError> {
@@ -45,8 +45,8 @@ pub fn run(
             .unwrap_or_default()
     });
 
-    if output_mode.is_json() {
-        let results = rows
+    if format.is_json() {
+        let items = rows
             .iter()
             .map(|row| {
                 json!({
@@ -61,17 +61,17 @@ pub fn run(
             })
             .collect::<Vec<_>>();
 
-        return emit_json_results_with_meta(
-            "memo-cli.fetch.v1",
-            "memo-cli fetch",
-            results,
-            Some(json!({
-                "limit": limit,
-                "returned": rows.len(),
-                "next_cursor": next_cursor,
-                "has_more": has_more
-            })),
-            None,
+        return emit_data(
+            "cli.memo-cli.fetch.v1",
+            json!({
+                "items": items,
+                "pagination": {
+                    "limit": limit,
+                    "returned": rows.len(),
+                    "next_cursor": next_cursor,
+                    "has_more": has_more,
+                },
+            }),
         );
     }
 

--- a/crates/memo-cli/src/commands/list.rs
+++ b/crates/memo-cli/src/commands/list.rs
@@ -1,14 +1,14 @@
 use serde_json::json;
 
-use crate::cli::OutputMode;
+use crate::cli::OutputFormat;
 use crate::errors::AppError;
-use crate::output::{emit_json_results_with_meta, format_item_id, text};
+use crate::output::{emit_data, format_item_id, text};
 use crate::storage::Storage;
 use crate::storage::repository::{self, QueryState};
 
 pub fn run(
     storage: &Storage,
-    output_mode: OutputMode,
+    format: OutputFormat,
     state: QueryState,
     limit: usize,
     offset: usize,
@@ -16,8 +16,8 @@ pub fn run(
     let rows =
         storage.with_connection(|conn| repository::list_items(conn, state, limit, offset))?;
 
-    if output_mode.is_json() {
-        let results = rows
+    if format.is_json() {
+        let items = rows
             .iter()
             .map(|row| {
                 json!({
@@ -30,16 +30,16 @@ pub fn run(
                 })
             })
             .collect::<Vec<_>>();
-        return emit_json_results_with_meta(
-            "memo-cli.list.v1",
-            "memo-cli list",
-            results,
-            Some(json!({
-                "limit": limit,
-                "offset": offset,
-                "returned": rows.len(),
-            })),
-            None,
+        return emit_data(
+            "cli.memo-cli.list.v1",
+            json!({
+                "items": items,
+                "pagination": {
+                    "limit": limit,
+                    "offset": offset,
+                    "returned": rows.len(),
+                },
+            }),
         );
     }
 

--- a/crates/memo-cli/src/commands/mod.rs
+++ b/crates/memo-cli/src/commands/mod.rs
@@ -7,40 +7,40 @@ mod report;
 mod search;
 mod update;
 
-use crate::cli::{Cli, ItemState, MemoCommand, OutputMode, SearchMatch};
+use crate::cli::{Cli, ItemState, MemoCommand, OutputFormat, SearchMatch};
 use crate::errors::AppError;
 use crate::storage::Storage;
 use crate::storage::repository::QueryState;
 
-pub fn run(cli: &Cli, output_mode: OutputMode) -> Result<(), AppError> {
+pub fn run(cli: &Cli, format: OutputFormat) -> Result<(), AppError> {
     let storage = Storage::new(cli.db.clone());
     storage.init()?;
 
     match &cli.command {
-        MemoCommand::Add(args) => add::run(&storage, args, output_mode),
-        MemoCommand::Update(args) => update::run(&storage, args, output_mode),
-        MemoCommand::Delete(args) => delete::run(&storage, args, output_mode),
+        MemoCommand::Add(args) => add::run(&storage, args, format),
+        MemoCommand::Update(args) => update::run(&storage, args, format),
+        MemoCommand::Delete(args) => delete::run(&storage, args, format),
         MemoCommand::List(args) => list::run(
             &storage,
-            output_mode,
+            format,
             to_query_state(args.state),
             args.limit,
             args.offset,
         ),
         MemoCommand::Search(args) => search::run(
             &storage,
-            output_mode,
+            format,
             to_query_state(args.state),
             &args.query,
             &args.fields,
             to_search_match_mode(args.match_mode),
             args.limit,
         ),
-        MemoCommand::Report(args) => report::run(&storage, output_mode, args),
+        MemoCommand::Report(args) => report::run(&storage, format, args),
         MemoCommand::Fetch(args) => {
-            fetch::run(&storage, output_mode, args.limit, args.cursor.as_deref())
+            fetch::run(&storage, format, args.limit, args.cursor.as_deref())
         }
-        MemoCommand::Apply(args) => apply::run(&storage, output_mode, args),
+        MemoCommand::Apply(args) => apply::run(&storage, format, args),
         MemoCommand::Completion(_) => Ok(()),
     }
 }

--- a/crates/memo-cli/src/commands/report.rs
+++ b/crates/memo-cli/src/commands/report.rs
@@ -1,22 +1,21 @@
 use chrono::{Datelike, Duration, TimeZone, Utc};
 use serde_json::json;
 
-use crate::cli::{OutputMode, ReportArgs, ReportPeriod};
+use crate::cli::{OutputFormat, ReportArgs, ReportPeriod};
 use crate::errors::AppError;
-use crate::output::{emit_json_result, text};
+use crate::output::{emit_data, text};
 use crate::storage::Storage;
 use crate::storage::search::{self, ReportRangeQuery};
 use crate::timestamps::{format_utc, parse_rfc3339_utc, parse_timezone};
 
-pub fn run(storage: &Storage, output_mode: OutputMode, args: &ReportArgs) -> Result<(), AppError> {
+pub fn run(storage: &Storage, format: OutputFormat, args: &ReportArgs) -> Result<(), AppError> {
     let query = resolve_report_range(args)?;
     let summary =
         storage.with_connection(|conn| search::report_summary_with_range(conn, &query))?;
 
-    if output_mode.is_json() {
-        return emit_json_result(
-            "memo-cli.report.v1",
-            "memo-cli report",
+    if format.is_json() {
+        return emit_data(
+            "cli.memo-cli.report.v1",
             json!({
                 "period": summary.period,
                 "range": summary.range,

--- a/crates/memo-cli/src/commands/search.rs
+++ b/crates/memo-cli/src/commands/search.rs
@@ -1,15 +1,15 @@
 use serde_json::json;
 
-use crate::cli::{OutputMode, SearchField as CliSearchField};
+use crate::cli::{OutputFormat, SearchField as CliSearchField};
 use crate::errors::AppError;
-use crate::output::{emit_json_results_with_meta, format_item_id, text};
+use crate::output::{emit_data, format_item_id, text};
 use crate::storage::Storage;
 use crate::storage::repository::QueryState;
 use crate::storage::search;
 
 pub fn run(
     storage: &Storage,
-    output_mode: OutputMode,
+    format: OutputFormat,
     state: QueryState,
     query: &str,
     fields: &[CliSearchField],
@@ -26,8 +26,8 @@ pub fn run(
         search::search_items(conn, query, state, &search_fields, match_mode, limit)
     })?;
 
-    if output_mode.is_json() {
-        let results = rows
+    if format.is_json() {
+        let items = rows
             .iter()
             .map(|row| {
                 json!({
@@ -41,18 +41,18 @@ pub fn run(
                 })
             })
             .collect::<Vec<_>>();
-        return emit_json_results_with_meta(
-            "memo-cli.search.v1",
-            "memo-cli search",
-            results,
-            None,
-            Some(json!({
-                "query": query,
-                "limit": limit,
-                "state": query_state_label(state),
-                "fields": search_field_labels(&search_fields),
-                "match": search_match_mode_label(match_mode),
-            })),
+        return emit_data(
+            "cli.memo-cli.search.v1",
+            json!({
+                "items": items,
+                "meta": {
+                    "query": query,
+                    "limit": limit,
+                    "state": query_state_label(state),
+                    "fields": search_field_labels(&search_fields),
+                    "match": search_match_mode_label(match_mode),
+                },
+            }),
         );
     }
 

--- a/crates/memo-cli/src/commands/update.rs
+++ b/crates/memo-cli/src/commands/update.rs
@@ -1,12 +1,12 @@
 use serde_json::json;
 
-use crate::cli::{OutputMode, UpdateArgs};
+use crate::cli::{OutputFormat, UpdateArgs};
 use crate::errors::AppError;
-use crate::output::{emit_json_result, format_item_id, parse_item_id, text};
+use crate::output::{emit_data, format_item_id, parse_item_id, text};
 use crate::storage::Storage;
 use crate::storage::repository;
 
-pub fn run(storage: &Storage, args: &UpdateArgs, output_mode: OutputMode) -> Result<(), AppError> {
+pub fn run(storage: &Storage, args: &UpdateArgs, format: OutputFormat) -> Result<(), AppError> {
     let item_id = parse_item_id(&args.item_id)
         .ok_or_else(|| AppError::usage("update requires a valid item_id"))?;
     let text = args.text.trim();
@@ -16,10 +16,9 @@ pub fn run(storage: &Storage, args: &UpdateArgs, output_mode: OutputMode) -> Res
 
     let updated = storage.with_transaction(|tx| repository::update_item(tx, item_id, text))?;
 
-    if output_mode.is_json() {
-        return emit_json_result(
-            "memo-cli.update.v1",
-            "memo-cli update",
+    if format.is_json() {
+        return emit_data(
+            "cli.memo-cli.update.v1",
             json!({
                 "item_id": format_item_id(updated.item_id),
                 "updated_at": updated.updated_at,

--- a/crates/memo-cli/src/errors.rs
+++ b/crates/memo-cli/src/errors.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use nils_common::cli_contract::exit;
 use serde_json::json;
 
 #[derive(Debug)]
@@ -9,18 +9,10 @@ pub struct AppError {
     details: Option<Box<serde_json::Value>>,
 }
 
-#[derive(Debug, Serialize)]
-pub struct JsonError<'a> {
-    pub code: &'a str,
-    pub message: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub details: Option<&'a serde_json::Value>,
-}
-
 impl AppError {
     pub fn usage(message: impl Into<String>) -> Self {
         Self {
-            exit_code: 64,
+            exit_code: exit::USAGE,
             code: "invalid-arguments".into(),
             message: message.into().into_boxed_str(),
             details: None,
@@ -29,7 +21,7 @@ impl AppError {
 
     pub fn data(message: impl Into<String>) -> Self {
         Self {
-            exit_code: 65,
+            exit_code: exit::DATA,
             code: "invalid-input".into(),
             message: message.into().into_boxed_str(),
             details: None,
@@ -38,7 +30,7 @@ impl AppError {
 
     pub fn runtime(message: impl Into<String>) -> Self {
         Self {
-            exit_code: 1,
+            exit_code: exit::RUNTIME,
             code: "runtime-failure".into(),
             message: message.into().into_boxed_str(),
             details: None,
@@ -97,12 +89,8 @@ impl AppError {
         self.message.as_ref()
     }
 
-    pub fn json_error(&self) -> JsonError<'_> {
-        JsonError {
-            code: self.code(),
-            message: self.message(),
-            details: self.details.as_deref(),
-        }
+    pub fn details(&self) -> Option<&serde_json::Value> {
+        self.details.as_deref()
     }
 }
 

--- a/crates/memo-cli/src/output/json.rs
+++ b/crates/memo-cli/src/output/json.rs
@@ -1,118 +1,45 @@
+use nils_common::cli_contract::{Envelope, EnvelopeError};
 use serde::Serialize;
 
 use crate::errors::AppError;
 
-#[derive(Debug, Serialize)]
-struct JsonResultEnvelope<'a, T>
+/// Emit a success envelope with the given payload.
+pub fn emit_data<T>(schema_version: &str, data: T) -> Result<(), AppError>
 where
     T: Serialize,
 {
-    schema_version: &'a str,
-    command: &'a str,
-    ok: bool,
-    result: T,
+    let envelope = Envelope::success(schema_version, data);
+    print_envelope(&envelope)
 }
 
-#[derive(Debug, Serialize)]
-struct JsonResultsEnvelope<'a, T>
-where
-    T: Serialize,
-{
-    schema_version: &'a str,
-    command: &'a str,
-    ok: bool,
-    results: T,
-}
-
-#[derive(Debug, Serialize)]
-struct JsonResultsEnvelopeWithMeta<'a, T>
-where
-    T: Serialize,
-{
-    schema_version: &'a str,
-    command: &'a str,
-    ok: bool,
-    results: T,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pagination: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    meta: Option<serde_json::Value>,
-}
-
-#[derive(Debug, Serialize)]
-struct JsonErrorEnvelope<'a> {
-    schema_version: &'a str,
-    command: &'a str,
-    ok: bool,
-    error: crate::errors::JsonError<'a>,
-}
-
-pub fn emit_json_result<T>(schema_version: &str, command: &str, result: T) -> Result<(), AppError>
-where
-    T: Serialize,
-{
-    let envelope = JsonResultEnvelope {
-        schema_version,
-        command,
-        ok: true,
-        result,
-    };
-    print_json(&envelope)
-}
-
-pub fn emit_json_results<T>(schema_version: &str, command: &str, results: T) -> Result<(), AppError>
-where
-    T: Serialize,
-{
-    let envelope = JsonResultsEnvelope {
-        schema_version,
-        command,
-        ok: true,
-        results,
-    };
-    print_json(&envelope)
-}
-
-pub fn emit_json_results_with_meta<T>(
+/// Emit a success envelope with the given payload and warnings.
+pub fn emit_data_with_warnings<T>(
     schema_version: &str,
-    command: &str,
-    results: T,
-    pagination: Option<serde_json::Value>,
-    meta: Option<serde_json::Value>,
+    data: T,
+    warnings: Vec<String>,
 ) -> Result<(), AppError>
 where
     T: Serialize,
 {
-    let envelope = JsonResultsEnvelopeWithMeta {
-        schema_version,
-        command,
-        ok: true,
-        results,
-        pagination,
-        meta,
-    };
-    print_json(&envelope)
+    let envelope = Envelope::success(schema_version, data).with_warnings(warnings);
+    print_envelope(&envelope)
 }
 
-pub fn emit_json_error(
-    schema_version: &str,
-    command: &str,
-    err: &AppError,
-) -> Result<(), AppError> {
-    let envelope = JsonErrorEnvelope {
-        schema_version,
-        command,
-        ok: false,
-        error: err.json_error(),
-    };
-    print_json(&envelope)
+/// Emit a failure envelope built from an `AppError`.
+pub fn emit_json_error(schema_version: &str, err: &AppError) -> Result<(), AppError> {
+    let mut envelope_error = EnvelopeError::new(err.code(), err.message());
+    if let Some(details) = err.details() {
+        envelope_error = envelope_error.with_details(details.clone());
+    }
+    let envelope: Envelope<()> = Envelope::failure(schema_version, envelope_error);
+    print_envelope(&envelope)
 }
 
-fn print_json<T>(value: &T) -> Result<(), AppError>
+fn print_envelope<T>(envelope: &Envelope<T>) -> Result<(), AppError>
 where
     T: Serialize,
 {
-    let encoded = serde_json::to_string(value).map_err(|err| {
+    let encoded = serde_json::to_string(envelope).map_err(|err| {
         AppError::runtime(format!("failed to serialize JSON output: {err}"))
             .with_code("internal-error")
     })?;

--- a/crates/memo-cli/src/output/mod.rs
+++ b/crates/memo-cli/src/output/mod.rs
@@ -1,7 +1,7 @@
 pub mod json;
 pub mod text;
 
-pub use json::{emit_json_error, emit_json_result, emit_json_results, emit_json_results_with_meta};
+pub use json::{emit_data, emit_data_with_warnings, emit_json_error};
 
 pub fn format_item_id(item_id: i64) -> String {
     format!("itm_{item_id:08}")

--- a/crates/memo-cli/tests/integration.rs
+++ b/crates/memo-cli/tests/integration.rs
@@ -11,6 +11,8 @@ mod agent_roundtrip;
 mod apply_metadata_validation;
 #[path = "integration/completion_outside_repo.rs"]
 mod completion_outside_repo;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/extension_cleanup_contract.rs"]
 mod extension_cleanup_contract;
 #[path = "integration/fetch_apply_flow.rs"]

--- a/crates/memo-cli/tests/integration/agent_roundtrip.rs
+++ b/crates/memo-cli/tests/integration/agent_roundtrip.rs
@@ -16,12 +16,12 @@ fn agent_roundtrip_empty_dataset_fetch_is_stable() {
         fetch_output.stderr_text()
     );
     let fetch_json = parse_json_stdout(&fetch_output);
-    let rows = fetch_json["results"]
+    let rows = fetch_json["data"]["items"]
         .as_array()
         .expect("fetch results should be an array");
     assert_eq!(rows.len(), 0, "empty dataset should return no fetch rows");
-    assert_eq!(fetch_json["pagination"]["returned"], 0);
-    assert_eq!(fetch_json["pagination"]["has_more"], false);
+    assert_eq!(fetch_json["data"]["pagination"]["returned"], 0);
+    assert_eq!(fetch_json["data"]["pagination"]["has_more"], false);
 }
 
 #[test]
@@ -71,7 +71,7 @@ fn agent_roundtrip_duplicate_apply_is_idempotent() {
         fetch_output.stderr_text()
     );
     let fetch_json = parse_json_stdout(&fetch_output);
-    let item_id = fetch_json["results"][0]["item_id"]
+    let item_id = fetch_json["data"]["items"][0]["item_id"]
         .as_str()
         .expect("fetched item should include item_id");
 
@@ -103,8 +103,8 @@ fn agent_roundtrip_duplicate_apply_is_idempotent() {
         apply_first.stderr_text()
     );
     let apply_first_json = parse_json_stdout(&apply_first);
-    assert_eq!(apply_first_json["result"]["accepted"], 1);
-    assert_eq!(apply_first_json["result"]["skipped"], 0);
+    assert_eq!(apply_first_json["data"]["accepted"], 1);
+    assert_eq!(apply_first_json["data"]["skipped"], 0);
 
     let apply_second = run_memo_cli(
         &db_path,
@@ -118,7 +118,7 @@ fn agent_roundtrip_duplicate_apply_is_idempotent() {
         apply_second.stderr_text()
     );
     let apply_second_json = parse_json_stdout(&apply_second);
-    assert_eq!(apply_second_json["result"]["accepted"], 0);
-    assert_eq!(apply_second_json["result"]["skipped"], 1);
-    assert_eq!(apply_second_json["result"]["failed"], 0);
+    assert_eq!(apply_second_json["data"]["accepted"], 0);
+    assert_eq!(apply_second_json["data"]["skipped"], 1);
+    assert_eq!(apply_second_json["data"]["failed"], 0);
 }

--- a/crates/memo-cli/tests/integration/apply_metadata_validation.rs
+++ b/crates/memo-cli/tests/integration/apply_metadata_validation.rs
@@ -28,7 +28,7 @@ fn apply_metadata_validation() {
         fetch_output.stderr_text()
     );
     let fetch_json = parse_json_stdout(&fetch_output);
-    let item_id = fetch_json["results"][0]["item_id"]
+    let item_id = fetch_json["data"]["items"][0]["item_id"]
         .as_str()
         .expect("item_id should be a string");
 
@@ -83,13 +83,13 @@ fn apply_metadata_validation() {
     );
     let valid_json = parse_json_stdout(&valid_apply);
     assert_eq!(valid_json["ok"], true);
-    assert_eq!(valid_json["result"]["items"][0]["content_type"], "json");
+    assert_eq!(valid_json["data"]["items"][0]["content_type"], "json");
     assert_eq!(
-        valid_json["result"]["items"][0]["validation_status"],
+        valid_json["data"]["items"][0]["validation_status"],
         "invalid"
     );
     assert_eq!(
-        valid_json["result"]["items"][0]["validation_errors"][0]["code"],
+        valid_json["data"]["items"][0]["validation_errors"][0]["code"],
         "json.syntax.trailing-comma"
     );
 }

--- a/crates/memo-cli/tests/integration/exit_codes.rs
+++ b/crates/memo-cli/tests/integration/exit_codes.rs
@@ -1,0 +1,68 @@
+use nils_common::cli_contract::exit;
+use pretty_assertions::assert_eq;
+
+use crate::support;
+use support::{run_memo_cli, test_db_path};
+
+#[test]
+fn exit_code_success() {
+    let db_path = test_db_path("exit_code_success");
+    let output = run_memo_cli(&db_path, &["add", "exit-code-success"], None);
+    assert_eq!(
+        output.code,
+        exit::SUCCESS,
+        "add should exit 0 on success: stderr={}",
+        output.stderr_text()
+    );
+}
+
+#[test]
+fn exit_code_usage_for_invalid_arg() {
+    let db_path = test_db_path("exit_code_usage_invalid_arg");
+    // `--limit 0` is rejected by the runtime usage guard.
+    let output = run_memo_cli(&db_path, &["fetch", "--limit", "0"], None);
+    assert_eq!(
+        output.code,
+        exit::USAGE,
+        "fetch --limit 0 should return USAGE (64); stderr={}",
+        output.stderr_text()
+    );
+}
+
+#[test]
+fn exit_code_usage_for_unknown_subcommand() {
+    let db_path = test_db_path("exit_code_usage_unknown_subcmd");
+    let output = run_memo_cli(&db_path, &["bogus-subcommand"], None);
+    assert_eq!(
+        output.code,
+        exit::USAGE,
+        "bogus-subcommand should return USAGE (64); stderr={}",
+        output.stderr_text()
+    );
+}
+
+#[test]
+fn exit_code_data_for_malformed_apply_payload() {
+    let db_path = test_db_path("exit_code_data_malformed_apply");
+    let output = run_memo_cli(&db_path, &["apply", "--stdin"], Some("{}"));
+    assert_eq!(
+        output.code,
+        exit::DATA,
+        "apply with empty payload should return DATA (65); stderr={}",
+        output.stderr_text()
+    );
+}
+
+#[test]
+fn exit_code_runtime_for_unopenable_db_path() {
+    // `/dev/null/x` cannot be opened as a sqlite file — the parent is not a
+    // directory — which forces a `db-open-failed` runtime error.
+    let bogus_db = std::path::PathBuf::from("/dev/null/x");
+    let output = run_memo_cli(&bogus_db, &["add", "exit-code-runtime"], None);
+    assert_eq!(
+        output.code,
+        exit::RUNTIME,
+        "unopenable --db should return RUNTIME (1); stderr={}",
+        output.stderr_text()
+    );
+}

--- a/crates/memo-cli/tests/integration/extension_cleanup_contract.rs
+++ b/crates/memo-cli/tests/integration/extension_cleanup_contract.rs
@@ -20,7 +20,7 @@ fn hard_delete_cleans_anchor_and_typed_workflow_rows() {
         add_output.stderr_text()
     );
     let add_json = parse_json_stdout(&add_output);
-    let item_id_str = add_json["result"]["item_id"]
+    let item_id_str = add_json["data"]["item_id"]
         .as_str()
         .expect("item_id should be string");
     let item_id = parse_item_id(item_id_str).expect("item_id should parse");

--- a/crates/memo-cli/tests/integration/fetch_apply_flow.rs
+++ b/crates/memo-cli/tests/integration/fetch_apply_flow.rs
@@ -37,7 +37,7 @@ fn fetch_apply_flow() {
         fetch_before.stderr_text()
     );
     let fetch_before_json = parse_json_stdout(&fetch_before);
-    let fetch_before_rows = fetch_before_json["results"]
+    let fetch_before_rows = fetch_before_json["data"]["items"]
         .as_array()
         .expect("results array should exist");
     assert_eq!(fetch_before_rows.len(), 2);
@@ -73,8 +73,8 @@ fn fetch_apply_flow() {
         apply_output.stderr_text()
     );
     let apply_json = parse_json_stdout(&apply_output);
-    assert_eq!(apply_json["result"]["accepted"], 1);
-    assert_eq!(apply_json["result"]["failed"], 0);
+    assert_eq!(apply_json["data"]["accepted"], 1);
+    assert_eq!(apply_json["data"]["failed"], 0);
 
     let fetch_after = run_memo_cli(&db_path, &["--json", "fetch", "--limit", "20"], None);
     assert_eq!(
@@ -84,7 +84,7 @@ fn fetch_apply_flow() {
         fetch_after.stderr_text()
     );
     let fetch_after_json = parse_json_stdout(&fetch_after);
-    let fetch_after_rows = fetch_after_json["results"]
+    let fetch_after_rows = fetch_after_json["data"]["items"]
         .as_array()
         .expect("results array should exist");
     assert_eq!(fetch_after_rows.len(), 1);
@@ -107,7 +107,7 @@ fn apply_idempotency() {
         add_output.stderr_text()
     );
     let add_json = parse_json_stdout(&add_output);
-    let item_id_str = add_json["result"]["item_id"]
+    let item_id_str = add_json["data"]["item_id"]
         .as_str()
         .expect("item_id should be string");
     let item_id = parse_item_id(item_id_str).expect("item_id should parse");
@@ -135,8 +135,8 @@ fn apply_idempotency() {
         apply_first.stderr_text()
     );
     let apply_first_json = parse_json_stdout(&apply_first);
-    assert_eq!(apply_first_json["result"]["accepted"], 1);
-    assert_eq!(apply_first_json["result"]["skipped"], 0);
+    assert_eq!(apply_first_json["data"]["accepted"], 1);
+    assert_eq!(apply_first_json["data"]["skipped"], 0);
 
     let apply_second = run_memo_cli(
         &db_path,
@@ -150,8 +150,8 @@ fn apply_idempotency() {
         apply_second.stderr_text()
     );
     let apply_second_json = parse_json_stdout(&apply_second);
-    assert_eq!(apply_second_json["result"]["accepted"], 0);
-    assert_eq!(apply_second_json["result"]["skipped"], 1);
+    assert_eq!(apply_second_json["data"]["accepted"], 0);
+    assert_eq!(apply_second_json["data"]["skipped"], 1);
 
     let second_payload = json!({
         "items": [{
@@ -176,7 +176,7 @@ fn apply_idempotency() {
         apply_third.stderr_text()
     );
     let apply_third_json = parse_json_stdout(&apply_third);
-    assert_eq!(apply_third_json["result"]["accepted"], 1);
+    assert_eq!(apply_third_json["data"]["accepted"], 1);
 
     let conn = rusqlite::Connection::open(db_path).expect("open db for assertions");
     let derivation_count: i64 = conn

--- a/crates/memo-cli/tests/integration/item_id_allocator.rs
+++ b/crates/memo-cli/tests/integration/item_id_allocator.rs
@@ -16,7 +16,7 @@ fn hard_delete_does_not_reuse_item_ids() {
         first_add.stderr_text()
     );
     let first_add_json = parse_json_stdout(&first_add);
-    let first_item_id_str = first_add_json["result"]["item_id"]
+    let first_item_id_str = first_add_json["data"]["item_id"]
         .as_str()
         .expect("first item_id should be a string");
     let first_item_id = parse_item_id(first_item_id_str).expect("first item_id should parse");
@@ -41,7 +41,7 @@ fn hard_delete_does_not_reuse_item_ids() {
         second_add.stderr_text()
     );
     let second_add_json = parse_json_stdout(&second_add);
-    let second_item_id_str = second_add_json["result"]["item_id"]
+    let second_item_id_str = second_add_json["data"]["item_id"]
         .as_str()
         .expect("second item_id should be a string");
     let second_item_id = parse_item_id(second_item_id_str).expect("second item_id should parse");
@@ -63,7 +63,7 @@ fn allocator_row_backfills_from_existing_max_item_id() {
         "first add failed: {}",
         first_add.stderr_text()
     );
-    let first_item_id_str = parse_json_stdout(&first_add)["result"]["item_id"]
+    let first_item_id_str = parse_json_stdout(&first_add)["data"]["item_id"]
         .as_str()
         .expect("first item_id should be a string")
         .to_string();
@@ -76,7 +76,7 @@ fn allocator_row_backfills_from_existing_max_item_id() {
         "second add failed: {}",
         second_add.stderr_text()
     );
-    let second_item_id_str = parse_json_stdout(&second_add)["result"]["item_id"]
+    let second_item_id_str = parse_json_stdout(&second_add)["data"]["item_id"]
         .as_str()
         .expect("second item_id should be a string")
         .to_string();
@@ -98,7 +98,7 @@ fn allocator_row_backfills_from_existing_max_item_id() {
         "third add failed: {}",
         third_add.stderr_text()
     );
-    let third_item_id_str = parse_json_stdout(&third_add)["result"]["item_id"]
+    let third_item_id_str = parse_json_stdout(&third_add)["data"]["item_id"]
         .as_str()
         .expect("third item_id should be a string")
         .to_string();

--- a/crates/memo-cli/tests/integration/json_contract.rs
+++ b/crates/memo-cli/tests/integration/json_contract.rs
@@ -16,16 +16,15 @@ fn json_contract() {
         add_output.stderr_text()
     );
     let add_json = parse_json_stdout(&add_output);
-    assert_eq!(add_json["schema_version"], "memo-cli.add.v1");
-    assert_eq!(add_json["command"], "memo-cli add");
+    assert_eq!(add_json["schema_version"], "cli.memo-cli.add.v1");
     assert_eq!(add_json["ok"], true);
-    let item_id = add_json["result"]["item_id"]
+    let item_id = add_json["data"]["item_id"]
         .as_str()
         .expect("item_id should be a string");
-    assert!(add_json.get("result").is_some(), "result key should exist");
+    assert!(add_json.get("data").is_some(), "data key should exist");
     assert!(
-        add_json.get("results").is_none(),
-        "results key should not exist"
+        add_json.get("error").is_none(),
+        "error key should be absent on success"
     );
 
     let update_output = run_memo_cli(
@@ -40,10 +39,9 @@ fn json_contract() {
         update_output.stderr_text()
     );
     let update_json = parse_json_stdout(&update_output);
-    assert_eq!(update_json["schema_version"], "memo-cli.update.v1");
-    assert_eq!(update_json["command"], "memo-cli update");
+    assert_eq!(update_json["schema_version"], "cli.memo-cli.update.v1");
     assert_eq!(update_json["ok"], true);
-    assert_eq!(update_json["result"]["state"], "pending");
+    assert_eq!(update_json["data"]["state"], "pending");
 
     let list_output = run_memo_cli(&db_path, &["--json", "list", "--limit", "20"], None);
     assert_eq!(
@@ -53,25 +51,20 @@ fn json_contract() {
         list_output.stderr_text()
     );
     let list_json = parse_json_stdout(&list_output);
-    assert_eq!(list_json["schema_version"], "memo-cli.list.v1");
-    assert_eq!(list_json["command"], "memo-cli list");
+    assert_eq!(list_json["schema_version"], "cli.memo-cli.list.v1");
     assert_eq!(list_json["ok"], true);
     assert!(
-        list_json.get("result").is_none(),
-        "result key should not exist"
+        list_json["data"]["items"].is_array(),
+        "data.items key should exist"
     );
     assert!(
-        list_json.get("results").is_some(),
-        "results key should exist"
+        list_json["data"].get("pagination").is_some(),
+        "data.pagination key should exist"
     );
-    assert!(
-        list_json.get("pagination").is_some(),
-        "pagination key should exist"
-    );
-    assert_eq!(list_json["pagination"]["limit"], 20);
-    assert_eq!(list_json["pagination"]["offset"], 0);
-    assert_eq!(list_json["pagination"]["returned"], 1);
-    let first_list_item = &list_json["results"][0];
+    assert_eq!(list_json["data"]["pagination"]["limit"], 20);
+    assert_eq!(list_json["data"]["pagination"]["offset"], 0);
+    assert_eq!(list_json["data"]["pagination"]["returned"], 1);
+    let first_list_item = &list_json["data"]["items"][0];
     assert!(
         first_list_item.get("content_type").is_some(),
         "list item should include content_type key"
@@ -89,20 +82,22 @@ fn json_contract() {
         search_output.stderr_text()
     );
     let search_json = parse_json_stdout(&search_output);
-    assert_eq!(search_json["schema_version"], "memo-cli.search.v1");
-    assert_eq!(search_json["command"], "memo-cli search");
+    assert_eq!(search_json["schema_version"], "cli.memo-cli.search.v1");
     assert_eq!(search_json["ok"], true);
     assert!(
-        search_json.get("results").is_some(),
-        "results key should exist"
+        search_json["data"]["items"].is_array(),
+        "data.items key should exist"
     );
-    assert!(search_json.get("meta").is_some(), "meta key should exist");
-    assert_eq!(search_json["meta"]["query"], "ssd");
-    assert_eq!(search_json["meta"]["limit"], 5);
-    assert_eq!(search_json["meta"]["state"], "all");
-    assert_eq!(search_json["meta"]["match"], "fts");
+    assert!(
+        search_json["data"].get("meta").is_some(),
+        "data.meta key should exist"
+    );
+    assert_eq!(search_json["data"]["meta"]["query"], "ssd");
+    assert_eq!(search_json["data"]["meta"]["limit"], 5);
+    assert_eq!(search_json["data"]["meta"]["state"], "all");
+    assert_eq!(search_json["data"]["meta"]["match"], "fts");
     assert_eq!(
-        search_json["meta"]["fields"],
+        search_json["data"]["meta"]["fields"],
         json!(["raw_text", "derived_text", "tags_text"])
     );
 
@@ -114,16 +109,16 @@ fn json_contract() {
         fetch_output.stderr_text()
     );
     let fetch_json = parse_json_stdout(&fetch_output);
-    assert_eq!(fetch_json["schema_version"], "memo-cli.fetch.v1");
+    assert_eq!(fetch_json["schema_version"], "cli.memo-cli.fetch.v1");
     assert!(
-        fetch_json.get("results").is_some(),
-        "results key should exist"
+        fetch_json["data"]["items"].is_array(),
+        "data.items key should exist"
     );
     assert!(
-        fetch_json.get("pagination").is_some(),
-        "pagination key should exist"
+        fetch_json["data"].get("pagination").is_some(),
+        "data.pagination key should exist"
     );
-    let first_fetch_item = &fetch_json["results"][0];
+    let first_fetch_item = &fetch_json["data"]["items"][0];
     assert!(
         first_fetch_item.get("content_type").is_some(),
         "fetch item should include content_type key"
@@ -136,11 +131,15 @@ fn json_contract() {
     let invalid_apply = run_memo_cli(&db_path, &["--json", "apply", "--stdin"], Some("{}"));
     assert_eq!(invalid_apply.code, 65, "apply should fail with data error");
     let invalid_apply_json = parse_json_stdout(&invalid_apply);
-    assert_eq!(invalid_apply_json["schema_version"], "memo-cli.apply.v1");
-    assert_eq!(invalid_apply_json["command"], "memo-cli apply");
+    assert_eq!(
+        invalid_apply_json["schema_version"],
+        "cli.memo-cli.apply.v1"
+    );
     assert_eq!(invalid_apply_json["ok"], false);
-    assert!(invalid_apply_json.get("result").is_none());
-    assert!(invalid_apply_json.get("results").is_none());
+    assert!(
+        invalid_apply_json.get("data").is_none(),
+        "failure envelope should omit data"
+    );
     assert_eq!(
         invalid_apply_json["error"]["code"],
         serde_json::Value::String("invalid-apply-payload".to_string())
@@ -162,10 +161,9 @@ fn json_contract() {
         delete_output.stderr_text()
     );
     let delete_json = parse_json_stdout(&delete_output);
-    assert_eq!(delete_json["schema_version"], "memo-cli.delete.v1");
-    assert_eq!(delete_json["command"], "memo-cli delete");
+    assert_eq!(delete_json["schema_version"], "cli.memo-cli.delete.v1");
     assert_eq!(delete_json["ok"], true);
-    assert_eq!(delete_json["result"]["deleted"], true);
+    assert_eq!(delete_json["data"]["deleted"], true);
 }
 
 #[test]
@@ -185,7 +183,7 @@ fn json_no_secret_leak() {
         add_output.stderr_text()
     );
     let add_json = parse_json_stdout(&add_output);
-    let item_id = add_json["result"]["item_id"]
+    let item_id = add_json["data"]["item_id"]
         .as_str()
         .expect("item_id should be a string");
 

--- a/crates/memo-cli/tests/integration/memo_flow.rs
+++ b/crates/memo-cli/tests/integration/memo_flow.rs
@@ -69,7 +69,7 @@ fn memo_flow_capture_fetch_apply_search_report() {
         fetch_output.stderr_text()
     );
     let fetch_json = parse_json_stdout(&fetch_output);
-    let fetch_rows = fetch_json["results"]
+    let fetch_rows = fetch_json["data"]["items"]
         .as_array()
         .expect("fetch results should be an array");
     assert_eq!(
@@ -133,9 +133,9 @@ fn memo_flow_capture_fetch_apply_search_report() {
         apply_output.stderr_text()
     );
     let apply_json = parse_json_stdout(&apply_output);
-    assert_eq!(apply_json["result"]["processed"], fixture.expected.captured);
-    assert_eq!(apply_json["result"]["accepted"], fixture.expected.captured);
-    assert_eq!(apply_json["result"]["failed"], 0);
+    assert_eq!(apply_json["data"]["processed"], fixture.expected.captured);
+    assert_eq!(apply_json["data"]["accepted"], fixture.expected.captured);
+    assert_eq!(apply_json["data"]["failed"], 0);
 
     let search_output = run_memo_cli(
         &db_path,
@@ -149,7 +149,7 @@ fn memo_flow_capture_fetch_apply_search_report() {
         search_output.stderr_text()
     );
     let search_json = parse_json_stdout(&search_output);
-    let search_rows = search_json["results"]
+    let search_rows = search_json["data"]["items"]
         .as_array()
         .expect("search results should be an array");
     assert!(
@@ -177,12 +177,12 @@ fn memo_flow_capture_fetch_apply_search_report() {
     );
     let report_json = parse_json_stdout(&report_output);
     assert_eq!(
-        report_json["result"]["totals"]["captured"],
+        report_json["data"]["totals"]["captured"],
         fixture.expected.captured
     );
     assert_eq!(
-        report_json["result"]["totals"]["enriched"],
+        report_json["data"]["totals"]["enriched"],
         fixture.expected.captured
     );
-    assert_eq!(report_json["result"]["totals"]["pending"], 0);
+    assert_eq!(report_json["data"]["totals"]["pending"], 0);
 }

--- a/crates/memo-cli/tests/integration/metadata_projection.rs
+++ b/crates/memo-cli/tests/integration/metadata_projection.rs
@@ -44,7 +44,7 @@ fn metadata_projection_search() {
         fetch_output.stderr_text()
     );
     let fetch_json = parse_json_stdout(&fetch_output);
-    let item_id = fetch_json["results"][0]["item_id"]
+    let item_id = fetch_json["data"]["items"][0]["item_id"]
         .as_str()
         .expect("item_id should exist");
 
@@ -76,7 +76,7 @@ fn metadata_projection_search() {
         search_output.stderr_text()
     );
     let search_json = parse_json_stdout(&search_output);
-    let first = &search_json["results"][0];
+    let first = &search_json["data"]["items"][0];
     assert_eq!(first["content_type"], "json");
     assert_eq!(first["validation_status"], "invalid");
 }
@@ -105,7 +105,7 @@ fn metadata_projection_report() {
         fetch_output.stderr_text()
     );
     let fetch_json = parse_json_stdout(&fetch_output);
-    let rows = fetch_json["results"]
+    let rows = fetch_json["data"]["items"]
         .as_array()
         .expect("fetch results should be an array");
 
@@ -150,7 +150,7 @@ fn metadata_projection_report() {
         list_output.stderr_text()
     );
     let list_json = parse_json_stdout(&list_output);
-    let list_rows = list_json["results"]
+    let list_rows = list_json["data"]["items"]
         .as_array()
         .expect("list results should be an array");
     let mut seen_pairs = HashMap::new();
@@ -187,7 +187,7 @@ fn metadata_projection_report() {
     );
     let report_json = parse_json_stdout(&report_output);
 
-    let content_types = report_json["result"]["top_content_types"]
+    let content_types = report_json["data"]["top_content_types"]
         .as_array()
         .expect("top_content_types should be an array");
     let mut content_type_names = Vec::new();
@@ -203,7 +203,7 @@ fn metadata_projection_report() {
         );
     }
 
-    let status_totals = report_json["result"]["validation_status_totals"]
+    let status_totals = report_json["data"]["validation_status_totals"]
         .as_array()
         .expect("validation_status_totals should be an array");
     let mut status_names = Vec::new();

--- a/crates/memo-cli/tests/integration/report_time_options.rs
+++ b/crates/memo-cli/tests/integration/report_time_options.rs
@@ -59,7 +59,7 @@ fn report_custom_window() {
     assert_eq!(report.code, 0, "report failed: {}", report.stderr_text());
     let report_json = parse_json_stdout(&report);
     assert_eq!(report_json["ok"], true);
-    assert_eq!(report_json["result"]["totals"]["captured"], 1);
+    assert_eq!(report_json["data"]["totals"]["captured"], 1);
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn report_timezone() {
     assert_eq!(report.code, 0, "report failed: {}", report.stderr_text());
     let report_json = parse_json_stdout(&report);
     assert_eq!(report_json["ok"], true);
-    assert_eq!(report_json["result"]["range"]["timezone"], "Asia/Taipei");
+    assert_eq!(report_json["data"]["range"]["timezone"], "Asia/Taipei");
 }
 
 #[test]

--- a/crates/memo-cli/tests/integration/update_delete_flow.rs
+++ b/crates/memo-cli/tests/integration/update_delete_flow.rs
@@ -17,7 +17,7 @@ fn update_and_delete_keep_layers_consistent() {
         add_output.stderr_text()
     );
     let add_json = parse_json_stdout(&add_output);
-    let item_id_str = add_json["result"]["item_id"]
+    let item_id_str = add_json["data"]["item_id"]
         .as_str()
         .expect("item_id should be a string");
     let item_id = parse_item_id(item_id_str).expect("item_id should parse");
@@ -80,8 +80,8 @@ fn update_and_delete_keep_layers_consistent() {
         update_output.stderr_text()
     );
     let update_json = parse_json_stdout(&update_output);
-    assert_eq!(update_json["schema_version"], "memo-cli.update.v1");
-    assert_eq!(update_json["result"]["state"], "pending");
+    assert_eq!(update_json["schema_version"], "cli.memo-cli.update.v1");
+    assert_eq!(update_json["data"]["state"], "pending");
 
     let fetch_after_update = run_memo_cli(&db_path, &["--json", "fetch", "--limit", "20"], None);
     assert_eq!(
@@ -91,7 +91,7 @@ fn update_and_delete_keep_layers_consistent() {
         fetch_after_update.stderr_text()
     );
     let fetch_after_update_json = parse_json_stdout(&fetch_after_update);
-    let rows = fetch_after_update_json["results"]
+    let rows = fetch_after_update_json["data"]["items"]
         .as_array()
         .expect("results array should exist");
     assert_eq!(rows.len(), 1);
@@ -109,7 +109,7 @@ fn update_and_delete_keep_layers_consistent() {
         search_old.stderr_text()
     );
     let search_old_json = parse_json_stdout(&search_old);
-    let search_old_rows = search_old_json["results"]
+    let search_old_rows = search_old_json["data"]["items"]
         .as_array()
         .expect("search results should be array");
     assert!(
@@ -153,8 +153,8 @@ fn update_and_delete_keep_layers_consistent() {
         delete_output.stderr_text()
     );
     let delete_json = parse_json_stdout(&delete_output);
-    assert_eq!(delete_json["schema_version"], "memo-cli.delete.v1");
-    assert_eq!(delete_json["result"]["deleted"], true);
+    assert_eq!(delete_json["schema_version"], "cli.memo-cli.delete.v1");
+    assert_eq!(delete_json["data"]["deleted"], true);
 
     let list_after_delete = run_memo_cli(&db_path, &["--json", "list", "--limit", "20"], None);
     assert_eq!(
@@ -165,7 +165,7 @@ fn update_and_delete_keep_layers_consistent() {
     );
     let list_after_delete_json = parse_json_stdout(&list_after_delete);
     assert_eq!(
-        list_after_delete_json["results"]
+        list_after_delete_json["data"]["items"]
             .as_array()
             .expect("list results array")
             .len(),

--- a/crates/nils-common/src/cli_contract.rs
+++ b/crates/nils-common/src/cli_contract.rs
@@ -106,6 +106,8 @@ pub struct EnvelopeError {
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
 }
 
 impl EnvelopeError {
@@ -115,12 +117,19 @@ impl EnvelopeError {
             code: code.into(),
             message: message.into(),
             hint: None,
+            details: None,
         }
     }
 
-    /// Attach an optional hint to the error.
+    /// Attach an optional human-readable hint to the error.
     pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
         self.hint = Some(hint.into());
+        self
+    }
+
+    /// Attach optional machine-readable structured detail to the error (e.g. the offending payload path).
+    pub fn with_details(mut self, details: serde_json::Value) -> Self {
+        self.details = Some(details);
         self
     }
 }

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
@@ -2,15 +2,16 @@
 
 ## Current State
 
-- Status: in-progress (Sprint 1 complete, Sprint 2 and 3 pending)
-- Target scope: Sprint 1 (Tasks 1.1–1.4)
-- Execution window: Sprint 1 only — confirmed by user; Sprint 2 and Sprint 3
-  stay open in separate PRs to honor the plan's `parallel-x3` PR strategy
-- Staged execution confirmation: confirmed(Sprint 1 only PR; Sprint 2/3 follow separately)
-- Current task: Sprint 1 complete
-- Next task: Task 2.1 (replace memo-cli exit-code constants with shared module)
+- Status: in-progress (Sprint 1 + Sprint 2 complete, Sprint 3 pending)
+- Target scope: Sprint 2 (Tasks 2.1–2.5)
+- Execution window: Sprint 2 only — Sprint 3 stays in follow-up PRs per the
+  plan's `parallel-x3` PR strategy
+- Staged execution confirmation: confirmed(Sprint 1 PR #375 merged; Sprint 2
+  in this PR; Sprint 3 follow-up PRs to come)
+- Current task: Sprint 2 complete
+- Next task: Task 3.1 (migrate agent-workflow-primitives binaries)
 - Last updated: 2026-05-19
-- Branch/commit: feat/cli-output-contract-v1-foundation (pending)
+- Branch/commit: feat/cli-output-contract-memo-cli-pilot (pending push)
 - Source document:
   docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
 - Direct source-doc execution waiver: not applicable
@@ -19,31 +20,28 @@
 
 | ID | Status | Task | Evidence | Notes |
 | --- | --- | --- | --- | --- |
-| Task 1.1 | done | Add `cli_contract` module to `nils-common` | crates/nils-common/src/cli_contract.rs; `cargo test -p nils-common cli_contract` (6 unit tests) | OutputFormat, Envelope, EnvelopeError, exit constants, schema_version_for |
-| Task 1.2 | done | Add parse-error JSON helper | crates/nils-common/tests/integration/cli_contract.rs; `cargo test -p nils-common cli_contract` (4 integration tests) | emit_parse_error + emit_parse_error_to writers |
-| Task 1.3 | done | Migrate `cli-template` as reference implementation | crates/cli-template/src/main.rs; `cargo test -p nils-cli-template` (13 tests, +9 new) | Hidden `--json` alias; new `status` subcommand emits envelope |
-| Task 1.4 | done | Write `cli-output-contract-v1.md` spec | docs/specs/cli-output-contract-v1.md; `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | Reconciles older `cli-service-json-contract-guideline-v1.md` shape |
-| Task 2.1 | pending | Replace memo-cli exit-code constants with shared module | n/a | depends on 1.1 (now satisfied) |
-| Task 2.2 | pending | Migrate memo-cli to `OutputFormat` and hidden `--json` alias | n/a | depends on 2.1 |
-| Task 2.3 | pending | Migrate memo-cli JSON output to shared envelope and `warnings` | n/a | depends on 2.2 |
-| Task 2.4 | pending | Route memo-cli parse and unknown-subcommand errors through helper | n/a | depends on 1.2 (now satisfied), 2.2 |
-| Task 2.5 | pending | Add memo-cli exit-code matrix test | n/a | depends on 2.1 |
-| Task 3.1 | pending | Migrate `agent-workflow-primitives` binaries | n/a | depends on Sprint 1 (now satisfied) |
-| Task 3.2 | pending | Migrate API testing stack | n/a | depends on Sprint 1 (now satisfied) |
-| Task 3.3 | pending | Migrate remaining single-binary crates and run the full gate | n/a | depends on Sprint 1 (now satisfied) |
+| Task 1.1 | done | Add `cli_contract` module to `nils-common` | crates/nils-common/src/cli_contract.rs; PR #375 | Plus additive `EnvelopeError::details` field in Sprint 2 |
+| Task 1.2 | done | Add parse-error JSON helper | crates/nils-common/tests/integration/cli_contract.rs; PR #375 | |
+| Task 1.3 | done | Migrate `cli-template` as reference implementation | crates/cli-template/src/main.rs; PR #375 | |
+| Task 1.4 | done | Write `cli-output-contract-v1.md` spec | docs/specs/cli-output-contract-v1.md; PR #375 | Sprint 2 extended with `details` field |
+| Task 2.1 | done | Replace memo-cli exit-code constants with shared module | crates/memo-cli/src/errors.rs | exit::USAGE/DATA/RUNTIME replaces 64/65/1 literals |
+| Task 2.2 | done | Migrate memo-cli to `OutputFormat` and hidden `--json` alias | crates/memo-cli/src/cli.rs | shared `nils_common::cli_contract::OutputFormat`; `--json` `hide=true conflicts_with=format` |
+| Task 2.3 | done | Migrate memo-cli JSON output to shared envelope and `warnings` | crates/memo-cli/src/output/json.rs + commands/* | schema_version moved to `cli.memo-cli.<cmd>.v1`; collections nest `items` + `pagination`/`meta` under `data`; apply per-item errors surface in `warnings` |
+| Task 2.4 | done | Route memo-cli parse and unknown-subcommand errors through helper | crates/memo-cli/src/app.rs | argv-scan detect of `--format json` / `--json`; calls `emit_parse_error` |
+| Task 2.5 | done | Add memo-cli exit-code matrix test | crates/memo-cli/tests/integration/exit_codes.rs | 5 tests covering SUCCESS / USAGE (arg + unknown subcmd) / DATA / RUNTIME |
+| Task 3.1 | pending | Migrate `agent-workflow-primitives` binaries | n/a | next sprint |
+| Task 3.2 | pending | Migrate API testing stack | n/a | next sprint |
+| Task 3.3 | pending | Migrate remaining single-binary crates and run the full gate | n/a | next sprint |
 | Task 3.4 | pending | Workspace lint script for legacy contract usage | n/a | depends on 3.1, 3.2, 3.3 |
 
 ## Validation
 
 | Command | Status | Summary | Artifact |
 | --- | --- | --- | --- |
-| `bash scripts/ci/plan-bundle-validate.sh --strict` | pass | wired into docs-only entrypoint; all 5 plan bundles validated | scripts/ci/nils-cli-checks-entrypoint.sh --docs-only output |
-| `cargo test -p nils-common cli_contract` | pass | 6 unit + 4 integration tests for envelope, exit constants, parse-error helper | terminal log |
-| `cargo test -p nils-cli-template` | pass | 13 integration tests (existing 4 + 9 new contract assertions) | terminal log |
-| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | pass | docs placement + hygiene + markdownlint + plan-bundle validate green | terminal log |
-| `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` | pass | full required checks (cargo fmt, clippy -D warnings, nextest workspace, doctests, third-party audit) | terminal log |
-| `cargo test -p memo-cli` | pending | per Sprint 2 | n/a |
-| `cargo test --workspace` | pending | per Sprint 3 | n/a |
+| `cargo test -p nils-common cli_contract` | pass | 10 tests (`EnvelopeError::details` additive change covered) | terminal log |
+| `cargo test -p nils-memo-cli` | pass | 34 tests (29 integration incl. 5 new exit-code matrix + 32 unit) | terminal log |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | pass | docs hygiene + plan-bundle validate green | terminal log |
+| `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` | pass | cargo fmt + clippy -D warnings + nextest workspace + doctests + third-party audit green | terminal log |
 
 ## Blockers
 
@@ -51,31 +49,31 @@
 
 ## Session Log
 
-### 2026-05-19
+### 2026-05-19 (Sprint 1 → PR #375 merged at ac87ca2)
+
+- See prior turn's notes. Sprint 1 foundation landed; this entry kept as
+  context for Sprint 2.
+
+### 2026-05-19 (Sprint 2 → feat/cli-output-contract-memo-cli-pilot)
 
 - Read:
   - docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
-  - docs/plans/cli-output-contract-unification/cli-output-contract-unification-review-source.md
-  - crates/nils-common/src/{lib.rs,process.rs}, crates/nils-common/Cargo.toml
-  - crates/cli-template/{src/main.rs,Cargo.toml,tests/integration/cli.rs}
-  - crates/memo-cli/src/cli.rs (reference for OutputFormat shape)
-  - docs/specs/{workspace-shared-crate-boundary-v1.md,cli-service-json-contract-guideline-v1.md}
-  - scripts/ci/{nils-cli-checks-entrypoint.sh,docs-hygiene-audit.sh}
-  - DEVELOPMENT.md
+  - crates/memo-cli/{src/cli.rs, src/errors.rs, src/app.rs, src/output/*.rs, src/commands/*.rs}
+  - crates/memo-cli/tests/integration/{json_contract.rs, support/mod.rs, integration.rs}
 - Changed:
-  - crates/nils-common/Cargo.toml (added clap + serde deps)
-  - crates/nils-common/src/{lib.rs,cli_contract.rs} (new module)
-  - crates/nils-common/tests/{integration.rs,integration/cli_contract.rs}
-  - crates/cli-template/Cargo.toml (added serde + serde_json deps)
-  - crates/cli-template/src/main.rs (new contract wiring + `status` subcommand)
-  - crates/cli-template/tests/integration/cli.rs (+9 contract assertions)
-  - docs/specs/cli-output-contract-v1.md (new durable spec)
-  - docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
-  - THIRD_PARTY_LICENSES.md, THIRD_PARTY_NOTICES.md (regenerated after dep adds)
+  - crates/nils-common/src/cli_contract.rs (additive: `EnvelopeError::details: Option<Value>` + `with_details`)
+  - docs/specs/cli-output-contract-v1.md (spec text mentions `error.details`)
+  - crates/memo-cli/src/errors.rs (shared exit constants; drop `JsonError` struct; expose `details()` accessor)
+  - crates/memo-cli/src/cli.rs (`OutputFormat` re-export from nils-common; hidden `--json` alias; clap `conflicts_with`; schema_version prefixed `cli.memo-cli.*.v1`; runtime conflict test → clap parse-time test)
+  - crates/memo-cli/src/app.rs (route parse / unknown-subcommand errors through `emit_parse_error`; preserves clap help/version exits)
+  - crates/memo-cli/src/output/{json.rs, mod.rs} (new `emit_data` / `emit_data_with_warnings` / `emit_json_error` wrapping shared `Envelope<T>`)
+  - crates/memo-cli/src/commands/{add,update,delete,list,search,fetch,report,apply}.rs (schema_version prefix; nest `items`/`pagination`/`meta` under `data`; apply collects per-item warnings into envelope)
+  - crates/memo-cli/tests/integration/*.rs (bulk transform: schema_version prefix; `result`→`data`; `results`→`data.items`; `pagination`→`data.pagination`; `meta`→`data.meta`; drop `command` field; replace runtime conflict test with clap parse-time)
+  - crates/memo-cli/tests/integration/exit_codes.rs (new — 5 tests)
+  - docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md (Sprint 2 ledger)
 - Validated:
-  - `cargo test -p nils-common cli_contract` (10 tests, 0 fail)
-  - `cargo test -p nils-cli-template` (13 tests, 0 fail)
-  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` (pass)
+  - `cargo test -p nils-common cli_contract` (10/10 pass — Sprint 1 module survives additive change)
+  - `cargo test -p nils-memo-cli` (66 tests: 32 unit + 29 integration + 5 new exit-code matrix; 0 fail)
   - `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass)
 - Blocked by: none
-- Next: open feature PR with `/deliver-feature-pr`; Sprint 2 picks up in a follow-up PR per the plan's PR strategy.
+- Next: open feature PR with `/deliver-feature-pr`; Sprint 3 picks up in follow-up PR(s) per the plan's `parallel-x3` strategy.

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
@@ -18,21 +18,21 @@
 
 ## Task Ledger
 
-| ID | Status | Task | Evidence | Notes |
-| --- | --- | --- | --- | --- |
-| Task 1.1 | done | Add `cli_contract` module to `nils-common` | crates/nils-common/src/cli_contract.rs; PR #375 | Plus additive `EnvelopeError::details` field in Sprint 2 |
-| Task 1.2 | done | Add parse-error JSON helper | crates/nils-common/tests/integration/cli_contract.rs; PR #375 | |
-| Task 1.3 | done | Migrate `cli-template` as reference implementation | crates/cli-template/src/main.rs; PR #375 | |
-| Task 1.4 | done | Write `cli-output-contract-v1.md` spec | docs/specs/cli-output-contract-v1.md; PR #375 | Sprint 2 extended with `details` field |
-| Task 2.1 | done | Replace memo-cli exit-code constants with shared module | crates/memo-cli/src/errors.rs | exit::USAGE/DATA/RUNTIME replaces 64/65/1 literals |
-| Task 2.2 | done | Migrate memo-cli to `OutputFormat` and hidden `--json` alias | crates/memo-cli/src/cli.rs | shared `nils_common::cli_contract::OutputFormat`; `--json` `hide=true conflicts_with=format` |
-| Task 2.3 | done | Migrate memo-cli JSON output to shared envelope and `warnings` | crates/memo-cli/src/output/json.rs + commands/* | schema_version moved to `cli.memo-cli.<cmd>.v1`; collections nest `items` + `pagination`/`meta` under `data`; apply per-item errors surface in `warnings` |
-| Task 2.4 | done | Route memo-cli parse and unknown-subcommand errors through helper | crates/memo-cli/src/app.rs | argv-scan detect of `--format json` / `--json`; calls `emit_parse_error` |
-| Task 2.5 | done | Add memo-cli exit-code matrix test | crates/memo-cli/tests/integration/exit_codes.rs | 5 tests covering SUCCESS / USAGE (arg + unknown subcmd) / DATA / RUNTIME |
-| Task 3.1 | pending | Migrate `agent-workflow-primitives` binaries | n/a | next sprint |
-| Task 3.2 | pending | Migrate API testing stack | n/a | next sprint |
-| Task 3.3 | pending | Migrate remaining single-binary crates and run the full gate | n/a | next sprint |
-| Task 3.4 | pending | Workspace lint script for legacy contract usage | n/a | depends on 3.1, 3.2, 3.3 |
+| ID       | Status  | Task                                                              | Evidence                                                      | Notes                                                                                                                                                     |
+| -------- | ------- | ----------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task 1.1 | done    | Add `cli_contract` module to `nils-common`                        | crates/nils-common/src/cli_contract.rs; PR #375               | Plus additive `EnvelopeError::details` field in Sprint 2                                                                                                  |
+| Task 1.2 | done    | Add parse-error JSON helper                                       | crates/nils-common/tests/integration/cli_contract.rs; PR #375 |                                                                                                                                                           |
+| Task 1.3 | done    | Migrate `cli-template` as reference implementation                | crates/cli-template/src/main.rs; PR #375                      |                                                                                                                                                           |
+| Task 1.4 | done    | Write `cli-output-contract-v1.md` spec                            | docs/specs/cli-output-contract-v1.md; PR #375                 | Sprint 2 extended with `details` field                                                                                                                    |
+| Task 2.1 | done    | Replace memo-cli exit-code constants with shared module           | crates/memo-cli/src/errors.rs                                 | exit::USAGE/DATA/RUNTIME replaces 64/65/1 literals                                                                                                        |
+| Task 2.2 | done    | Migrate memo-cli to `OutputFormat` and hidden `--json` alias      | crates/memo-cli/src/cli.rs                                    | shared `nils_common::cli_contract::OutputFormat`; `--json` `hide=true conflicts_with=format`                                                              |
+| Task 2.3 | done    | Migrate memo-cli JSON output to shared envelope and `warnings`    | crates/memo-cli/src/output/json.rs + commands/*               | schema_version moved to `cli.memo-cli.<cmd>.v1`; collections nest `items` + `pagination`/`meta` under `data`; apply per-item errors surface in `warnings` |
+| Task 2.4 | done    | Route memo-cli parse and unknown-subcommand errors through helper | crates/memo-cli/src/app.rs                                    | argv-scan detect of `--format json` / `--json`; calls `emit_parse_error`                                                                                  |
+| Task 2.5 | done    | Add memo-cli exit-code matrix test                                | crates/memo-cli/tests/integration/exit_codes.rs               | 5 tests covering SUCCESS / USAGE (arg + unknown subcmd) / DATA / RUNTIME                                                                                  |
+| Task 3.1 | pending | Migrate `agent-workflow-primitives` binaries                      | n/a                                                           | next sprint                                                                                                                                               |
+| Task 3.2 | pending | Migrate API testing stack                                         | n/a                                                           | next sprint                                                                                                                                               |
+| Task 3.3 | pending | Migrate remaining single-binary crates and run the full gate      | n/a                                                           | next sprint                                                                                                                                               |
+| Task 3.4 | pending | Workspace lint script for legacy contract usage                   | n/a                                                           | depends on 3.1, 3.2, 3.3                                                                                                                                  |
 
 ## Validation
 
@@ -64,11 +64,18 @@
   - crates/nils-common/src/cli_contract.rs (additive: `EnvelopeError::details: Option<Value>` + `with_details`)
   - docs/specs/cli-output-contract-v1.md (spec text mentions `error.details`)
   - crates/memo-cli/src/errors.rs (shared exit constants; drop `JsonError` struct; expose `details()` accessor)
-  - crates/memo-cli/src/cli.rs (`OutputFormat` re-export from nils-common; hidden `--json` alias; clap `conflicts_with`; schema_version prefixed `cli.memo-cli.*.v1`; runtime conflict test → clap parse-time test)
+  - crates/memo-cli/src/cli.rs (`OutputFormat` re-export from nils-common;
+    hidden `--json` alias; clap `conflicts_with`; schema_version prefixed
+    `cli.memo-cli.*.v1`; runtime conflict test → clap parse-time test)
   - crates/memo-cli/src/app.rs (route parse / unknown-subcommand errors through `emit_parse_error`; preserves clap help/version exits)
   - crates/memo-cli/src/output/{json.rs, mod.rs} (new `emit_data` / `emit_data_with_warnings` / `emit_json_error` wrapping shared `Envelope<T>`)
-  - crates/memo-cli/src/commands/{add,update,delete,list,search,fetch,report,apply}.rs (schema_version prefix; nest `items`/`pagination`/`meta` under `data`; apply collects per-item warnings into envelope)
-  - crates/memo-cli/tests/integration/*.rs (bulk transform: schema_version prefix; `result`→`data`; `results`→`data.items`; `pagination`→`data.pagination`; `meta`→`data.meta`; drop `command` field; replace runtime conflict test with clap parse-time)
+  - crates/memo-cli/src/commands/{add,update,delete,list,search,fetch,report,apply}.rs
+    (schema_version prefix; nest `items`/`pagination`/`meta` under `data`;
+    apply collects per-item warnings into envelope)
+  - crates/memo-cli/tests/integration/*.rs (bulk transform: schema_version
+    prefix; `result`→`data`; `results`→`data.items`;
+    `pagination`→`data.pagination`; `meta`→`data.meta`; drop `command` field;
+    replace runtime conflict test with clap parse-time)
   - crates/memo-cli/tests/integration/exit_codes.rs (new — 5 tests)
   - docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md (Sprint 2 ledger)
 - Validated:

--- a/docs/specs/cli-output-contract-v1.md
+++ b/docs/specs/cli-output-contract-v1.md
@@ -89,15 +89,19 @@ Failure envelope:
   "error": {
     "code": "stable-machine-code",
     "message": "human-readable summary",
-    "hint": "optional follow-up suggestion"
+    "hint": "optional follow-up suggestion",
+    "details": { /* optional machine-readable structured payload */ }
   }
 }
 ```
 
 The error `code` is stable and machine-usable; the `message` is a single
-line; the optional `hint` is human-only. Additional structured detail
-(stack traces, partial-failure records) belongs in `data` or
-crate-specific extension fields, never as free-form text.
+line; the optional `hint` is human-only; the optional `details` carries
+machine-readable structured payload (e.g. the offending payload path or
+per-item validation errors). When richer per-item detail is needed for
+partial-failure flows, prefer extending `details` over inventing
+crate-specific top-level fields. Free-form text never belongs anywhere
+in the error envelope.
 
 Reference implementation:
 [`nils_common::cli_contract::Envelope`](../../crates/nils-common/src/cli_contract.rs)


### PR DESCRIPTION
# Migrate memo-cli to CLI output contract v1 (Sprint 2)

## Summary

Sprint 2 of [`cli-output-contract-unification`](../tree/feat/cli-output-contract-memo-cli-pilot/docs/plans/cli-output-contract-unification): the memo-cli pilot. Moves every memo-cli subcommand's JSON output onto the shared `nils_common::cli_contract::Envelope`, switches exit codes to the BSD-sysexits constants, hides `--json` as a clap alias of `--format`, and routes parse / unknown-subcommand errors through the shared helper. **This is a breaking change for memo-cli JSON consumers.** Sprint 1 (PR #375) shipped the foundation; Sprint 3 (workspace fan-out) stays in separate PRs per the plan's `parallel-x3` strategy.

## Changes

- `nils-common` additive: `EnvelopeError` gains an optional `details: Option<Value>` field (+ `with_details(..)` builder). Spec at `docs/specs/cli-output-contract-v1.md` updated to document `error.details` as the canonical structured-detail slot — Sprint 1's cli-template still works unchanged.
- memo-cli `errors.rs`: `AppError::exit_code` now reads from `nils_common::cli_contract::exit::{USAGE, DATA, RUNTIME}` — no inline numeric literals; drop the old `JsonError` struct; expose `details()` accessor.
- memo-cli `cli.rs`: re-export `OutputFormat` from `nils-common`; remove the local `OutputFormat`/`OutputMode` pair; `--json` is now `hide = true, conflicts_with = "format"`; the runtime `resolve_output_mode` conflict check is replaced with a clap parse-time error returning exit `64`; `schema_version()` bumps every subcommand to `cli.memo-cli.<cmd>.v1`.
- memo-cli `app.rs`: parse + unknown-subcommand errors route through `emit_parse_error` with raw-argv format detection (so `memo-cli bogus --format json` returns a JSON envelope on stdout); preserves clap's native `--help` / `--version` exits.
- memo-cli `output/json.rs`: rewrite to use the shared `Envelope<T>` via new `emit_data` / `emit_data_with_warnings` / `emit_json_error` helpers; remove memo-cli-local envelope structs.
- memo-cli `commands/*.rs`: each subcommand emits the new envelope shape. `add` / `update` / `delete` / `report` collapse `result` → `data`. `list` / `search` / `fetch` nest `items` + `pagination` + `meta` under `data`. `apply` additionally collects per-item errors into the envelope's `warnings` array so JSON consumers see what text mode would print to stderr.
- memo-cli integration tests: bulk-transformed to the new envelope shape (`result`→`data`, `results`→`data.items`, `pagination`→`data.pagination`, `meta`→`data.meta`, `schema_version` gets the `cli.` prefix); dead `command` field assertions removed; runtime conflict test in `cli::tests` replaced with a clap parse-time test.
- New `crates/memo-cli/tests/integration/exit_codes.rs` — the per-binary exit-code matrix called for by the plan: SUCCESS (0), USAGE (64 for `--limit 0` and unknown subcommand), DATA (65 for malformed apply payload), RUNTIME (1 for an unopenable `--db` path).

## Test-First Evidence

- Change classification: behavior change (breaking JSON wire contract for memo-cli)
- Failing test before fix: N/A with waiver — the failure mode is "every old-shape JSON consumer test breaks." Instead of seeding a single failing test, the existing 29 memo-cli integration tests + json_contract.rs already encoded the old envelope and broke as soon as the new envelope shipped (16/29 failed before the test-suite migration). The migrated tests then pin the new envelope literally.
- Final validation: `cargo test -p nils-memo-cli` (66 tests pass — 32 unit + 29 integration + 5 new exit-code matrix); `cargo test -p nils-common cli_contract` (10 tests pass — Sprint 1 module survives the additive `details` field); `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` pass (cargo fmt + clippy `-D warnings` + nextest workspace + doctests + third-party audit all green).
- Waiver reason: bulk-migration of a wire contract; failing-test-first would have required re-creating the existing tests in inverted form before deleting them. The migration sequence (rewrite output → bulk-transform tests → run gate) provides equivalent contract evidence and is reflected in the diff.

## Testing

- `cargo test -p nils-memo-cli` (pass — 66 tests)
- `cargo test -p nils-common cli_contract` (pass — 10 tests)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass)
- Manual: `memo-cli --format json add hello` → `{"schema_version":"cli.memo-cli.add.v1","ok":true,"data":{"item_id":"itm_00000001",…}}`
- Manual: `memo-cli --format json bogus-subcommand` → JSON envelope on stdout, exit 64
- Manual: `memo-cli --json --format text list` → clap rejects at parse time with exit 64

## Risk / Notes

- **Breaking change for JSON consumers.** Any downstream script that read `result.item_id`, `results[]`, `pagination.limit`, `meta.query`, or `command` must update to `data.item_id`, `data.items[]`, `data.pagination.limit`, `data.meta.query`, and drop `command`. The `schema_version` bump from `memo-cli.<cmd>.v1` to `cli.memo-cli.<cmd>.v1` makes the break explicit on the wire.
- `--json` boolean flag still works (hidden alias for `--format json`); it will be removed one minor cycle from now per the deprecation table in `docs/specs/cli-output-contract-v1.md`.
- The additive `EnvelopeError::details` field is invisible when unset (`serde skip_serializing_if`), so Sprint 1's cli-template envelope is unchanged.
- Sprint 3 will migrate `agent-workflow-primitives`, the api-* binaries, `semantic-commit`, the git-* binaries, etc., each as a separate PR.
