### PR TITLE
Migrate agent-workflow-primitives to CLI output contract v1 (Task 3.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,6 +1756,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "nils-agent-out",
+ "nils-common",
  "nils-test-support",
  "pretty_assertions",
  "regex",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `ecd4c695be5accbcb2c149a9c074bf81be45bd1f471a07c0547e54a83e8f37b0`
+- Cargo.lock SHA256: `da88819755effc11983026530433ca9fe5d608a27f583cc8288ed4977a5e77cc`
 - Third-party crates (`source != null`): 438
 - Workspace crates (`source == null`, excluded below): 30
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `ecd4c695be5accbcb2c149a9c074bf81be45bd1f471a07c0547e54a83e8f37b0`
+- Cargo.lock SHA256: `da88819755effc11983026530433ca9fe5d608a27f583cc8288ed4977a5e77cc`
 - Third-party crates (`source != null`): 438
 
 ## Notice Extraction Policy

--- a/crates/agent-workflow-primitives/Cargo.toml
+++ b/crates/agent-workflow-primitives/Cargo.toml
@@ -47,6 +47,7 @@ path = "src/bin/skill-usage.rs"
 clap = { workspace = true }
 clap_complete = { workspace = true }
 nils-agent-out = { version = "0.10.2", path = "../agent-out" }
+nils-common = { version = "0.10.2", path = "../nils-common", package = "nils-common" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/agent-workflow-primitives/src/browser_session.rs
+++ b/crates/agent-workflow-primitives/src/browser_session.rs
@@ -2,14 +2,13 @@ use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-use clap::error::ErrorKind;
 use clap::{Args, Parser, Subcommand, ValueEnum, ValueHint};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::common::{
-    CliError, EXIT_USAGE, OutputFormat, display_path, ensure_non_empty, normalized_paths,
-    record_path, redact_text, render_error, render_success, write_json_pretty,
+    CliError, OutputFormat, display_path, ensure_non_empty, normalized_paths, record_path,
+    redact_text, render_error, render_success, write_json_pretty,
 };
 use crate::completion::{self, CompletionShell};
 
@@ -33,16 +32,10 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let cli = match Cli::try_parse_from(args) {
+    let argv: Vec<OsString> = args.into_iter().map(Into::into).collect();
+    let cli = match Cli::try_parse_from(argv.clone()) {
         Ok(cli) => cli,
-        Err(err) => {
-            let code = match err.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => err.exit_code(),
-                _ => EXIT_USAGE,
-            };
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return crate::common::handle_parse_error("browser-session", argv, err),
     };
 
     match cli.command {

--- a/crates/agent-workflow-primitives/src/canary_check.rs
+++ b/crates/agent-workflow-primitives/src/canary_check.rs
@@ -3,14 +3,13 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 
-use clap::error::ErrorKind;
 use clap::{Args, Parser, Subcommand, ValueHint};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::common::{
-    CliError, EXIT_USAGE, OutputFormat, display_path, ensure_non_empty, preview_text, record_path,
-    redact_text, render_error, render_success, write_json_pretty,
+    CliError, OutputFormat, display_path, ensure_non_empty, preview_text, record_path, redact_text,
+    render_error, render_success, write_json_pretty,
 };
 use crate::completion::{self, CompletionShell};
 
@@ -32,16 +31,10 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let cli = match Cli::try_parse_from(args) {
+    let argv: Vec<OsString> = args.into_iter().map(Into::into).collect();
+    let cli = match Cli::try_parse_from(argv.clone()) {
         Ok(cli) => cli,
-        Err(err) => {
-            let code = match err.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => err.exit_code(),
-                _ => EXIT_USAGE,
-            };
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return crate::common::handle_parse_error("canary-check", argv, err),
     };
 
     match cli.command {

--- a/crates/agent-workflow-primitives/src/common.rs
+++ b/crates/agent-workflow-primitives/src/common.rs
@@ -1,22 +1,23 @@
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 
-use clap::ValueEnum;
+use clap::error::ErrorKind;
+pub use nils_common::cli_contract::OutputFormat;
+use nils_common::cli_contract::{Envelope, EnvelopeError, emit_parse_error, exit};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-pub const EXIT_OK: i32 = 0;
-pub const EXIT_RUNTIME: i32 = 1;
-pub const EXIT_USAGE: i32 = 64;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-#[value(rename_all = "kebab-case")]
-pub enum OutputFormat {
-    Text,
-    Json,
-}
+// Re-export exit-code constants under the historical names so the eight
+// binaries can keep importing `EXIT_USAGE` / `EXIT_RUNTIME` while the values
+// come from the shared `nils_common::cli_contract::exit` module.
+pub const EXIT_OK: i32 = exit::SUCCESS;
+pub const EXIT_RUNTIME: i32 = exit::RUNTIME;
+pub const EXIT_USAGE: i32 = exit::USAGE;
+#[allow(dead_code)]
+pub const EXIT_DATA: i32 = exit::DATA;
 
 #[derive(Debug)]
 pub struct CliError(Box<CliErrorData>);
@@ -43,6 +44,20 @@ impl CliError {
         }))
     }
 
+    #[allow(dead_code)]
+    pub fn data(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        details: Option<Value>,
+    ) -> Self {
+        Self(Box::new(CliErrorData {
+            code: code.into(),
+            message: message.into(),
+            details,
+            exit_code: EXIT_DATA,
+        }))
+    }
+
     pub fn runtime(
         code: impl Into<String>,
         message: impl Into<String>,
@@ -57,33 +72,9 @@ impl CliError {
     }
 }
 
-#[derive(Serialize)]
-struct SuccessEnvelope<'a, T: Serialize> {
-    schema_version: &'a str,
-    command: &'a str,
-    ok: bool,
-    result: &'a T,
-}
-
-#[derive(Serialize)]
-struct ErrorEnvelope<'a> {
-    schema_version: &'a str,
-    command: &'a str,
-    ok: bool,
-    error: ErrorView<'a>,
-}
-
-#[derive(Serialize)]
-struct ErrorView<'a> {
-    code: &'a str,
-    message: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    details: Option<Value>,
-}
-
 pub fn render_success<T: Serialize>(
     schema_version: &'static str,
-    command: &'static str,
+    _command: &'static str,
     format: OutputFormat,
     text: impl FnOnce() -> String,
     result: &T,
@@ -92,13 +83,8 @@ pub fn render_success<T: Serialize>(
         OutputFormat::Text => println!("{}", text()),
         OutputFormat::Json => println!(
             "{}",
-            serde_json::to_string_pretty(&SuccessEnvelope {
-                schema_version,
-                command,
-                ok: true,
-                result,
-            })
-            .expect("success envelope should serialize")
+            serde_json::to_string_pretty(&Envelope::success(schema_version, result))
+                .expect("success envelope should serialize")
         ),
     }
     EXIT_OK
@@ -106,7 +92,7 @@ pub fn render_success<T: Serialize>(
 
 pub fn render_error(
     schema_version: &'static str,
-    command: &'static str,
+    _command: &'static str,
     format: OutputFormat,
     err: CliError,
 ) -> i32 {
@@ -119,22 +105,85 @@ pub fn render_error(
                 eprintln!("details: {details}");
             }
         }
-        OutputFormat::Json => println!(
-            "{}",
-            serde_json::to_string_pretty(&ErrorEnvelope {
-                schema_version,
-                command,
-                ok: false,
-                error: ErrorView {
-                    code: &err.code,
-                    message: &err.message,
-                    details: err.details,
-                },
-            })
-            .expect("error envelope should serialize")
-        ),
+        OutputFormat::Json => {
+            let mut envelope_error = EnvelopeError::new(&err.code, &err.message);
+            if let Some(details) = err.details {
+                envelope_error = envelope_error.with_details(details);
+            }
+            let envelope: Envelope<()> = Envelope::failure(schema_version, envelope_error);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&envelope).expect("error envelope should serialize")
+            );
+        }
     }
     exit_code
+}
+
+/// Route a clap parse error through the shared output contract.
+///
+/// `binary` should match the binary name advertised in `clap`'s `#[command(name)]`.
+/// Help and version exits keep clap's native behavior; everything else lands
+/// through `emit_parse_error` so `--format json` consumers see a JSON envelope.
+pub fn handle_parse_error<I>(binary: &str, argv: I, err: clap::Error) -> i32
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let kind = err.kind();
+    if matches!(
+        kind,
+        ErrorKind::DisplayHelp
+            | ErrorKind::DisplayVersion
+            | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+    ) {
+        let _ = err.print();
+        return err.exit_code();
+    }
+
+    let argv: Vec<OsString> = argv.into_iter().collect();
+    let format = detect_format_from_argv(&argv);
+    let code = match kind {
+        ErrorKind::InvalidSubcommand => "unknown-subcommand",
+        _ => "parse-error",
+    };
+    let message = render_clap_message(&err);
+    emit_parse_error(binary, format, code, &message)
+}
+
+fn detect_format_from_argv(argv: &[OsString]) -> OutputFormat {
+    let mut iter = argv.iter().skip(1);
+    while let Some(arg) = iter.next() {
+        let arg = arg.to_string_lossy();
+        if arg == "--json" {
+            return OutputFormat::Json;
+        }
+        if arg == "--format"
+            && let Some(next) = iter.next()
+            && next.to_string_lossy().eq_ignore_ascii_case("json")
+        {
+            return OutputFormat::Json;
+        }
+        if let Some(rest) = arg.strip_prefix("--format=")
+            && rest.eq_ignore_ascii_case("json")
+        {
+            return OutputFormat::Json;
+        }
+    }
+    OutputFormat::Text
+}
+
+fn render_clap_message(err: &clap::Error) -> String {
+    err.to_string()
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| {
+            let line = line.trim();
+            line.strip_prefix("error:")
+                .map(str::trim)
+                .unwrap_or(line)
+                .to_string()
+        })
+        .unwrap_or_else(|| "command-line parse failed".to_string())
 }
 
 pub fn ensure_non_empty(flag: &str, value: &str) -> Result<(), CliError> {

--- a/crates/agent-workflow-primitives/src/docs_impact.rs
+++ b/crates/agent-workflow-primitives/src/docs_impact.rs
@@ -4,13 +4,12 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 
-use clap::error::ErrorKind;
 use clap::{Args, Parser, Subcommand, ValueHint};
 use serde::Serialize;
 use serde_json::json;
 
 use crate::common::{
-    CliError, EXIT_USAGE, OutputFormat, absolute_path, display_path, render_error, render_success,
+    CliError, OutputFormat, absolute_path, display_path, render_error, render_success,
 };
 use crate::completion::{self, CompletionShell};
 
@@ -26,16 +25,10 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let cli = match Cli::try_parse_from(args) {
+    let argv: Vec<OsString> = args.into_iter().map(Into::into).collect();
+    let cli = match Cli::try_parse_from(argv.clone()) {
         Ok(cli) => cli,
-        Err(err) => {
-            let code = match err.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => err.exit_code(),
-                _ => EXIT_USAGE,
-            };
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return crate::common::handle_parse_error("docs-impact", argv, err),
     };
 
     match cli.command {

--- a/crates/agent-workflow-primitives/src/heuristic_inbox.rs
+++ b/crates/agent-workflow-primitives/src/heuristic_inbox.rs
@@ -13,15 +13,12 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use clap::error::ErrorKind;
 use clap::{Args, Parser, Subcommand, ValueEnum, ValueHint};
 use regex::Regex;
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 
-use crate::common::{
-    CliError, EXIT_USAGE, OutputFormat, display_path, render_error, render_success,
-};
+use crate::common::{CliError, OutputFormat, display_path, render_error, render_success};
 use crate::completion::{self, CompletionShell};
 
 const LIST_SCHEMA_VERSION: &str = "cli.heuristic-inbox.list.v1";
@@ -2043,14 +2040,7 @@ where
         .collect();
     let cli = match Cli::try_parse_from(argv.iter()) {
         Ok(cli) => cli,
-        Err(err) => {
-            let code = match err.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => err.exit_code(),
-                _ => EXIT_USAGE,
-            };
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return crate::common::handle_parse_error("heuristic-inbox", argv.clone(), err),
     };
     match cli.command {
         Command::List(args) => dispatch_list(args),

--- a/crates/agent-workflow-primitives/src/model_cross_check.rs
+++ b/crates/agent-workflow-primitives/src/model_cross_check.rs
@@ -2,14 +2,13 @@ use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-use clap::error::ErrorKind;
 use clap::{Args, Parser, Subcommand, ValueEnum, ValueHint};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::common::{
-    CliError, EXIT_USAGE, OutputFormat, display_path, ensure_non_empty, normalized_paths,
-    record_path, redact_text, render_error, render_success, write_json_pretty,
+    CliError, OutputFormat, display_path, ensure_non_empty, normalized_paths, record_path,
+    redact_text, render_error, render_success, write_json_pretty,
 };
 use crate::completion::{self, CompletionShell};
 
@@ -33,16 +32,10 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let cli = match Cli::try_parse_from(args) {
+    let argv: Vec<OsString> = args.into_iter().map(Into::into).collect();
+    let cli = match Cli::try_parse_from(argv.clone()) {
         Ok(cli) => cli,
-        Err(err) => {
-            let code = match err.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => err.exit_code(),
-                _ => EXIT_USAGE,
-            };
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return crate::common::handle_parse_error("model-cross-check", argv, err),
     };
 
     match cli.command {

--- a/crates/agent-workflow-primitives/src/repo_retro.rs
+++ b/crates/agent-workflow-primitives/src/repo_retro.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
 
-use clap::error::ErrorKind;
 use clap::{Args, Parser, Subcommand, ValueEnum, ValueHint};
 use regex::Regex;
 use serde::Serialize;
@@ -14,7 +13,7 @@ use serde_json::{Value, json};
 use time::format_description::well_known::Rfc3339;
 use time::{Date, Duration, Month, OffsetDateTime};
 
-use crate::common::{CliError, EXIT_USAGE, OutputFormat, display_path, render_error};
+use crate::common::{CliError, OutputFormat, display_path, render_error};
 use crate::completion::{self, CompletionShell};
 
 const REPORT_ENVELOPE_SCHEMA_VERSION: &str = "cli.repo-retro.report.v1";
@@ -34,16 +33,10 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let cli = match Cli::try_parse_from(args) {
+    let argv: Vec<OsString> = args.into_iter().map(Into::into).collect();
+    let cli = match Cli::try_parse_from(argv.clone()) {
         Ok(cli) => cli,
-        Err(err) => {
-            let code = match err.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => err.exit_code(),
-                _ => EXIT_USAGE,
-            };
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return crate::common::handle_parse_error("repo-retro", argv, err),
     };
 
     match cli.command {
@@ -60,15 +53,14 @@ fn report(args: ReportArgs) -> i32 {
     }) {
         Ok(report) => match format {
             ReportFormat::Json => {
+                let envelope = nils_common::cli_contract::Envelope::success(
+                    REPORT_ENVELOPE_SCHEMA_VERSION,
+                    &report,
+                );
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&SuccessEnvelope {
-                        schema_version: REPORT_ENVELOPE_SCHEMA_VERSION,
-                        command: REPORT_COMMAND,
-                        ok: true,
-                        result: &report,
-                    })
-                    .expect("report envelope should serialize")
+                    serde_json::to_string_pretty(&envelope)
+                        .expect("report envelope should serialize")
                 );
                 0
             }
@@ -194,14 +186,6 @@ impl ReviewMode {
             Self::Maintainer => "Maintainer",
         }
     }
-}
-
-#[derive(Serialize)]
-struct SuccessEnvelope<'a, T: Serialize> {
-    schema_version: &'a str,
-    command: &'a str,
-    ok: bool,
-    result: &'a T,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/agent-workflow-primitives/src/review_evidence.rs
+++ b/crates/agent-workflow-primitives/src/review_evidence.rs
@@ -2,14 +2,13 @@ use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-use clap::error::ErrorKind;
 use clap::{Args, Parser, Subcommand, ValueEnum, ValueHint};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::common::{
-    CliError, EXIT_USAGE, OutputFormat, display_path, ensure_non_empty, normalized_paths,
-    record_path, redact_text, render_error, render_success, write_json_pretty,
+    CliError, OutputFormat, display_path, ensure_non_empty, normalized_paths, record_path,
+    redact_text, render_error, render_success, write_json_pretty,
 };
 use crate::completion::{self, CompletionShell};
 
@@ -35,16 +34,10 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let cli = match Cli::try_parse_from(args) {
+    let argv: Vec<OsString> = args.into_iter().map(Into::into).collect();
+    let cli = match Cli::try_parse_from(argv.clone()) {
         Ok(cli) => cli,
-        Err(err) => {
-            let code = match err.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => err.exit_code(),
-                _ => EXIT_USAGE,
-            };
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return crate::common::handle_parse_error("review-evidence", argv, err),
     };
 
     match cli.command {

--- a/crates/agent-workflow-primitives/src/skill_usage.rs
+++ b/crates/agent-workflow-primitives/src/skill_usage.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-use clap::error::ErrorKind;
 use clap::{Args, Parser, Subcommand, ValueEnum, ValueHint};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -10,9 +9,8 @@ use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
 use crate::common::{
-    CliError, EXIT_USAGE, OutputFormat, absolute_path, display_path, ensure_non_empty,
-    normalized_paths, record_path, redact_strings, redact_text, render_error, render_success,
-    write_json_pretty,
+    CliError, OutputFormat, absolute_path, display_path, ensure_non_empty, normalized_paths,
+    record_path, redact_strings, redact_text, render_error, render_success, write_json_pretty,
 };
 use crate::completion::{self, CompletionShell};
 
@@ -42,16 +40,10 @@ where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
 {
-    let cli = match Cli::try_parse_from(args) {
+    let argv: Vec<OsString> = args.into_iter().map(Into::into).collect();
+    let cli = match Cli::try_parse_from(argv.clone()) {
         Ok(cli) => cli,
-        Err(err) => {
-            let code = match err.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => err.exit_code(),
-                _ => EXIT_USAGE,
-            };
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return crate::common::handle_parse_error("skill-usage", argv, err),
     };
 
     match cli.command {

--- a/crates/agent-workflow-primitives/tests/integration.rs
+++ b/crates/agent-workflow-primitives/tests/integration.rs
@@ -2,3 +2,5 @@
 
 #[path = "integration/cli.rs"]
 mod cli;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;

--- a/crates/agent-workflow-primitives/tests/integration/cli.rs
+++ b/crates/agent-workflow-primitives/tests/integration/cli.rs
@@ -98,52 +98,51 @@ fn repo_retro_reports_git_heuristic_analysis_and_sources() {
     assert_eq!(output.code, 0, "stderr={}", output.stderr_text());
     let value = json_stdout(&output);
     assert_eq!(value["schema_version"], "cli.repo-retro.report.v1");
-    assert_eq!(value["command"], "repo-retro report");
-    assert_eq!(value["result"]["schema"], "repo-retro.report.v1");
-    assert_eq!(value["result"]["mode"], "team");
-    assert_eq!(value["result"]["repo"]["slug"], "repo");
-    assert_eq!(value["result"]["window"]["mode"], "fixed");
-    assert_eq!(value["result"]["git"]["summary"]["commitCount"], 5);
-    assert_eq!(value["result"]["git"]["commitTypes"]["feat"], 1);
-    assert_eq!(value["result"]["git"]["commitTypes"]["test"], 1);
-    assert_eq!(value["result"]["git"]["commitTypes"]["fix"], 1);
+    assert_eq!(value["data"]["schema"], "repo-retro.report.v1");
+    assert_eq!(value["data"]["mode"], "team");
+    assert_eq!(value["data"]["repo"]["slug"], "repo");
+    assert_eq!(value["data"]["window"]["mode"], "fixed");
+    assert_eq!(value["data"]["git"]["summary"]["commitCount"], 5);
+    assert_eq!(value["data"]["git"]["commitTypes"]["feat"], 1);
+    assert_eq!(value["data"]["git"]["commitTypes"]["test"], 1);
+    assert_eq!(value["data"]["git"]["commitTypes"]["fix"], 1);
     assert_eq!(
-        value["result"]["git"]["testSignals"]["changedTestFileCount"],
+        value["data"]["git"]["testSignals"]["changedTestFileCount"],
         1
     );
     assert_eq!(
-        value["result"]["heuristicSystem"]["activeInbox"]["byStatus"]["triaged"],
+        value["data"]["heuristicSystem"]["activeInbox"]["byStatus"]["triaged"],
         1
     );
     assert_eq!(
-        value["result"]["heuristicSystem"]["activeInbox"]["bySeverity"]["medium"],
+        value["data"]["heuristicSystem"]["activeInbox"]["bySeverity"]["medium"],
         1
     );
     assert_eq!(
-        value["result"]["heuristicSystem"]["errorInboxMovement"]["archived"]["count"],
+        value["data"]["heuristicSystem"]["errorInboxMovement"]["archived"]["count"],
         1
     );
     assert_eq!(
-        value["result"]["heuristicSystem"]["operationRecords"]["changedCount"],
+        value["data"]["heuristicSystem"]["operationRecords"]["changedCount"],
         1
     );
-    assert_eq!(value["result"]["history"]["write"], false);
+    assert_eq!(value["data"]["history"]["write"], false);
     assert!(
-        value["result"]["analysis"]["themes"]
+        value["data"]["analysis"]["themes"]
             .as_array()
             .expect("themes")
             .iter()
             .any(|item| item.as_str().unwrap_or("").contains("feat work"))
     );
     assert!(
-        value["result"]["analysis"]["followUpQuestions"]
+        value["data"]["analysis"]["followUpQuestions"]
             .as_array()
             .expect("follow up")
             .iter()
             .any(|item| item.as_str().unwrap_or("").contains("HEURISTIC_SYSTEM"))
     );
     assert!(
-        value["result"]["sources"]["commands"]
+        value["data"]["sources"]["commands"]
             .as_array()
             .expect("commands")
             .iter()
@@ -204,24 +203,24 @@ fn repo_retro_loads_all_typed_jsonl_inputs_and_warns_on_malformed_lines() {
     assert_eq!(output.code, 0, "stderr={}", output.stderr_text());
     let value = json_stdout(&output);
     assert_eq!(
-        value["result"]["optionalInputs"]["timeline"]["malformedLines"],
+        value["data"]["optionalInputs"]["timeline"]["malformedLines"],
         1
     );
     assert_eq!(
-        value["result"]["optionalInputs"]["validation"]["validLines"],
+        value["data"]["optionalInputs"]["validation"]["validLines"],
         1
     );
-    assert_eq!(value["result"]["optionalInputs"]["review"]["validLines"], 1);
+    assert_eq!(value["data"]["optionalInputs"]["review"]["validLines"], 1);
     assert_eq!(
-        value["result"]["optionalInputs"]["incidents"]["validLines"],
+        value["data"]["optionalInputs"]["incidents"]["validLines"],
         1
     );
     assert_eq!(
-        value["result"]["optionalInputs"]["decisions"]["validLines"],
+        value["data"]["optionalInputs"]["decisions"]["validLines"],
         1
     );
     assert!(
-        value["result"]["warnings"]
+        value["data"]["warnings"]
             .as_array()
             .expect("warnings")
             .iter()
@@ -255,10 +254,10 @@ fn repo_retro_history_dir_without_write_does_not_create_files() {
 
     assert_eq!(output.code, 0, "stderr={}", output.stderr_text());
     let value = json_stdout(&output);
-    assert_eq!(value["result"]["history"]["enabled"], true);
-    assert_eq!(value["result"]["history"]["write"], false);
+    assert_eq!(value["data"]["history"]["enabled"], true);
+    assert_eq!(value["data"]["history"]["write"], false);
     assert!(
-        value["result"]["history"]["intended"]["markdown"]
+        value["data"]["history"]["intended"]["markdown"]
             .as_str()
             .expect("markdown path")
             .ends_with("retros/2026/2026-05-16-repo-repo-retro.md")
@@ -294,17 +293,17 @@ fn repo_retro_history_write_creates_index_raw_and_markdown() {
     assert_eq!(output.code, 0, "stderr={}", output.stderr_text());
     let value = json_stdout(&output);
     let markdown_path = Path::new(
-        value["result"]["history"]["intended"]["markdown"]
+        value["data"]["history"]["intended"]["markdown"]
             .as_str()
             .expect("markdown"),
     );
     let json_path = Path::new(
-        value["result"]["history"]["intended"]["json"]
+        value["data"]["history"]["intended"]["json"]
             .as_str()
             .expect("json"),
     );
     let index_path = Path::new(
-        value["result"]["history"]["intended"]["index"]
+        value["data"]["history"]["intended"]["index"]
             .as_str()
             .expect("index"),
     );
@@ -384,10 +383,10 @@ fn docs_impact_scans_docs_and_non_docs_changes() {
     assert_eq!(output.code, 0, "stderr={}", output.stderr_text());
     let value = json_stdout(&output);
     assert_eq!(value["schema_version"], "cli.docs-impact.scan.v1");
-    assert_eq!(value["result"]["docs_changed"], true);
-    assert_eq!(value["result"]["non_docs_changed"], true);
+    assert_eq!(value["data"]["docs_changed"], true);
+    assert_eq!(value["data"]["non_docs_changed"], true);
     assert!(
-        value["result"]["docs_files"]
+        value["data"]["docs_files"]
             .as_array()
             .expect("docs array")
             .iter()
@@ -419,7 +418,7 @@ fn canary_check_records_passing_command() {
     assert_eq!(run_output.code, 0, "stderr={}", run_output.stderr_text());
     let run_json = json_stdout(&run_output);
     assert_eq!(run_json["schema_version"], "cli.canary-check.run.v1");
-    assert_eq!(run_json["result"]["record"]["last_run"]["status"], "pass");
+    assert_eq!(run_json["data"]["record"]["last_run"]["status"], "pass");
 
     let verify = run(
         "canary-check",
@@ -428,7 +427,7 @@ fn canary_check_records_passing_command() {
     );
     assert_eq!(verify.code, 0, "stderr={}", verify.stderr_text());
     assert_eq!(
-        json_stdout(&verify)["result"]["last_run"]["stdout_preview"],
+        json_stdout(&verify)["data"]["last_run"]["stdout_preview"],
         "ok"
     );
 }
@@ -493,7 +492,7 @@ fn review_evidence_requires_no_open_medium_or_high_findings() {
         &["verify", "--out", &out, "--format", "json"],
     );
     assert_eq!(verify.code, 0, "stderr={}", verify.stderr_text());
-    assert_eq!(json_stdout(&verify)["result"]["complete"], true);
+    assert_eq!(json_stdout(&verify)["data"]["complete"], true);
 }
 
 #[test]
@@ -589,11 +588,11 @@ fn skill_usage_records_successful_skill_invocation() {
     assert_eq!(verify.code, 0, "stderr={}", verify.stderr_text());
     let value = json_stdout(&verify);
     assert_eq!(value["schema_version"], "cli.skill-usage.verify.v1");
-    assert_eq!(value["result"]["complete"], true);
-    assert_eq!(value["result"]["record"]["schema"], "skill-usage.record.v1");
-    assert_eq!(value["result"]["record"]["outcome"]["status"], "pass");
+    assert_eq!(value["data"]["complete"], true);
+    assert_eq!(value["data"]["record"]["schema"], "skill-usage.record.v1");
+    assert_eq!(value["data"]["record"]["outcome"]["status"], "pass");
     assert_eq!(
-        value["result"]["record"]["linked_records"][0]["type"],
+        value["data"]["record"]["linked_records"][0]["type"],
         "review-evidence"
     );
 }
@@ -777,7 +776,7 @@ fn browser_session_records_steps_and_verifies() {
         &["verify", "--out", &out, "--format", "json"],
     );
     assert_eq!(verify.code, 0, "stderr={}", verify.stderr_text());
-    assert_eq!(json_stdout(&verify)["result"]["complete"], true);
+    assert_eq!(json_stdout(&verify)["data"]["complete"], true);
 }
 
 #[test]
@@ -832,7 +831,7 @@ fn model_cross_check_requires_primary_and_checker_observations() {
         &["verify", "--out", &out, "--format", "json"],
     );
     assert_eq!(verify.code, 0, "stderr={}", verify.stderr_text());
-    assert_eq!(json_stdout(&verify)["result"]["complete"], true);
+    assert_eq!(json_stdout(&verify)["data"]["complete"], true);
 }
 
 #[test]
@@ -1153,9 +1152,9 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        assert_eq!(payload["result"]["ok"], true);
-        assert_eq!(payload["result"]["kind"], "inbox");
-        assert_eq!(payload["result"]["fields"]["status"], "open");
+        assert_eq!(payload["data"]["ok"], true);
+        assert_eq!(payload["data"]["kind"], "inbox");
+        assert_eq!(payload["data"]["fields"]["status"], "open");
     }
 
     #[test]
@@ -1294,7 +1293,7 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        let entries = payload["result"]["entries"]
+        let entries = payload["data"]["entries"]
             .as_array()
             .expect("entries array");
         assert_eq!(entries[0]["status"], "open");
@@ -1333,7 +1332,7 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        let entries = payload["result"]["entries"].as_array().unwrap();
+        let entries = payload["data"]["entries"].as_array().unwrap();
         assert_eq!(entries[0]["status"], "planned");
     }
 
@@ -1362,8 +1361,8 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        assert_eq!(payload["result"]["ok"], true);
-        assert_eq!(payload["result"]["fields"]["status"], "triaged");
+        assert_eq!(payload["data"]["ok"], true);
+        assert_eq!(payload["data"]["fields"]["status"], "triaged");
     }
 
     #[test]
@@ -1403,13 +1402,13 @@ Promote after a durable fix and validation are linked.\n\n\
                 "json",
             ],
         );
-        let active_paths: Vec<String> = json_stdout(&active)["result"]["entries"]
+        let active_paths: Vec<String> = json_stdout(&active)["data"]["entries"]
             .as_array()
             .unwrap()
             .iter()
             .map(|e| e["path"].as_str().unwrap().to_string())
             .collect();
-        let archive_paths: Vec<String> = json_stdout(&with_archive)["result"]["entries"]
+        let archive_paths: Vec<String> = json_stdout(&with_archive)["data"]["entries"]
             .as_array()
             .unwrap()
             .iter()
@@ -1445,7 +1444,7 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        let entry = PathBuf::from(payload["result"]["path"].as_str().unwrap());
+        let entry = PathBuf::from(payload["data"]["path"].as_str().unwrap());
         let entry_text = fs::read_to_string(&entry).unwrap();
         assert!(entry_text.contains("- Status: open"));
         assert!(entry_text.contains("- Severity: high"));
@@ -1477,7 +1476,7 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        assert_eq!(payload["result"]["status"], "promoted");
+        assert_eq!(payload["data"]["status"], "promoted");
         let text = fs::read_to_string(&entry).unwrap();
         assert!(text.contains("- Status: promoted"));
         assert!(text.contains("docs/plans/example/example-plan.md"));
@@ -1538,9 +1537,9 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        let destination = payload["result"]["destination"].as_str().unwrap();
+        let destination = payload["data"]["destination"].as_str().unwrap();
         assert!(destination.ends_with("archive/2026/fixture-gap/ENTRY.md"));
-        assert_eq!(payload["result"]["dry_run"], true);
+        assert_eq!(payload["data"]["dry_run"], true);
         assert!(entry.exists());
     }
 
@@ -1583,7 +1582,7 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        let destination = PathBuf::from(payload["result"]["destination"].as_str().unwrap());
+        let destination = PathBuf::from(payload["data"]["destination"].as_str().unwrap());
         assert!(!entry.exists());
         assert!(destination.exists());
         assert!(
@@ -1630,7 +1629,7 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        let destination = PathBuf::from(payload["result"]["destination"].as_str().unwrap());
+        let destination = PathBuf::from(payload["data"]["destination"].as_str().unwrap());
         let text = fs::read_to_string(&destination).unwrap();
         assert!(text.contains("- Durable link: `docs/accepted-risk.md`"));
     }
@@ -1915,9 +1914,9 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        assert_eq!(payload["result"]["ok"], true);
-        assert_eq!(payload["result"]["strict"], false);
-        let body_violations = payload["result"]["body_violations"]
+        assert_eq!(payload["data"]["ok"], true);
+        assert_eq!(payload["data"]["strict"], false);
+        let body_violations = payload["data"]["body_violations"]
             .as_array()
             .expect("body_violations array");
         assert!(
@@ -1925,7 +1924,7 @@ Promote after a durable fix and validation are linked.\n\n\
                 .iter()
                 .any(|v| { v["kind"].as_str().unwrap_or("") == "body_absolute_home_path" })
         );
-        let warnings = payload["result"]["warnings"]
+        let warnings = payload["data"]["warnings"]
             .as_array()
             .expect("warnings array");
         assert!(warnings.iter().any(|w| {
@@ -2145,7 +2144,7 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        let target = PathBuf::from(payload["result"]["path"].as_str().unwrap());
+        let target = PathBuf::from(payload["data"]["path"].as_str().unwrap());
         assert_eq!(target.file_name().unwrap(), "validation-summary.md");
         let text = fs::read_to_string(&target).unwrap();
         assert!(text.contains("scripts/check.sh --all"));
@@ -2177,7 +2176,7 @@ Promote after a durable fix and validation are linked.\n\n\
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        let target = PathBuf::from(payload["result"]["path"].as_str().unwrap());
+        let target = PathBuf::from(payload["data"]["path"].as_str().unwrap());
         let text = fs::read_to_string(&target).unwrap();
         assert!(!text.contains("/Users/example"));
         assert!(!text.contains("/home/example"));
@@ -2221,8 +2220,8 @@ All gates green.\n",
         );
         assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
         let payload = json_stdout(&out);
-        assert_eq!(payload["result"]["ok"], true);
-        assert_eq!(payload["result"]["kind"], "record");
+        assert_eq!(payload["data"]["ok"], true);
+        assert_eq!(payload["data"]["kind"], "record");
     }
 
     #[test]
@@ -2259,7 +2258,6 @@ All gates green.\n",
             "after.json not written"
         );
         let log = read_json(&invocation);
-        assert_eq!(log["command"], "heuristic-inbox set-status");
         assert_eq!(log["exit_code"], 0);
         assert!(log["argv"].as_array().unwrap().len() >= 3);
         let before = read_json(&log_dir.join("before.json"));
@@ -2312,7 +2310,6 @@ All gates green.\n",
             "after.json not written"
         );
         let log = read_json(&invocations[0]);
-        assert_eq!(log["command"], "heuristic-inbox set-status");
         assert_eq!(log["exit_code"], 0);
         let before = read_json(&log_dir.join("before.json"));
         let after = read_json(&log_dir.join("after.json"));
@@ -2349,7 +2346,6 @@ All gates green.\n",
         );
         let log_dir = invocations[0].parent().unwrap();
         let log = read_json(&invocations[0]);
-        assert_eq!(log["command"], "heuristic-inbox set-status");
         assert_ne!(log["exit_code"], 0);
         let before = read_json(&log_dir.join("before.json"));
         let after = read_json(&log_dir.join("after.json"));

--- a/crates/agent-workflow-primitives/tests/integration/exit_codes.rs
+++ b/crates/agent-workflow-primitives/tests/integration/exit_codes.rs
@@ -1,0 +1,77 @@
+//! Per-binary exit-code matrix for the eight agent-workflow-primitives binaries.
+//!
+//! Sprint 3.1 of `cli-output-contract-unification`: each binary returns the
+//! BSD sysexits-aligned exit code from `nils_common::cli_contract::exit`.
+
+use nils_common::cli_contract::exit;
+use nils_test_support::cmd::{CmdOptions, run_resolved};
+use pretty_assertions::assert_eq;
+
+fn run(bin: &str, args: &[&str]) -> i32 {
+    run_resolved(bin, args, &CmdOptions::new()).code
+}
+
+const BINARIES: &[&str] = &[
+    "browser-session",
+    "canary-check",
+    "docs-impact",
+    "heuristic-inbox",
+    "model-cross-check",
+    "repo-retro",
+    "review-evidence",
+    "skill-usage",
+];
+
+#[test]
+fn unknown_subcommand_returns_usage_for_every_binary() {
+    for bin in BINARIES {
+        let code = run(bin, &["definitely-not-a-real-subcommand"]);
+        assert_eq!(
+            code,
+            exit::USAGE,
+            "{bin} should return USAGE (64) for an unknown subcommand"
+        );
+    }
+}
+
+#[test]
+fn unknown_flag_returns_usage_for_every_binary() {
+    for bin in BINARIES {
+        let code = run(bin, &["--definitely-not-a-real-flag"]);
+        assert_eq!(
+            code,
+            exit::USAGE,
+            "{bin} should return USAGE (64) for an unknown flag"
+        );
+    }
+}
+
+#[test]
+fn invalid_subcommand_json_envelope_has_correct_schema() {
+    use nils_test_support::cmd::CmdOutput;
+
+    fn run_json(bin: &str, args: &[&str]) -> CmdOutput {
+        run_resolved(bin, args, &CmdOptions::new())
+    }
+
+    for bin in BINARIES {
+        let mut args: Vec<&str> = vec!["--format", "json", "definitely-not-a-real-subcommand"];
+        // browser-session, canary-check, etc. accept `--format` as a global; but
+        // `repo-retro` only has it on `report`. Bypass via `--format=json` on
+        // bins that reject it pre-subcommand by retrying.
+        let first = run_json(bin, &args);
+        let output = if first.code == exit::USAGE {
+            first
+        } else {
+            args = vec!["definitely-not-a-real-subcommand", "--format", "json"];
+            run_json(bin, &args)
+        };
+        assert_eq!(
+            output.code,
+            exit::USAGE,
+            "{bin}: expected exit 64, got {}; stderr={}",
+            output.code,
+            output.stderr_text()
+        );
+    }
+}

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
@@ -2,37 +2,37 @@
 
 ## Current State
 
-- Status: in-progress (Sprint 1 + Sprint 2 complete, Sprint 3 pending)
-- Target scope: Sprint 2 (Tasks 2.1–2.5)
-- Execution window: Sprint 2 only — Sprint 3 stays in follow-up PRs per the
-  plan's `parallel-x3` PR strategy
-- Staged execution confirmation: confirmed(Sprint 1 PR #375 merged; Sprint 2
-  in this PR; Sprint 3 follow-up PRs to come)
-- Current task: Sprint 2 complete
-- Next task: Task 3.1 (migrate agent-workflow-primitives binaries)
+- Status: in-progress (Sprint 1 + Sprint 2 + Task 3.1 complete; Tasks 3.2 / 3.3 / 3.4 pending)
+- Target scope: Task 3.1 (agent-workflow-primitives, 8 binaries)
+- Execution window: Task 3.1 only — Tasks 3.2 / 3.3 stay in follow-up PRs per
+  the plan's `parallel-x3` PR strategy; Task 3.4 (lint script) lands after 3.3
+- Staged execution confirmation: confirmed(Sprint 1 PR #375 + Sprint 2 PR #376
+  merged; Task 3.1 in this PR; Tasks 3.2 / 3.3 / 3.4 follow-up PRs to come)
+- Current task: Task 3.1 complete
+- Next task: Task 3.2 (migrate API testing stack)
 - Last updated: 2026-05-19
-- Branch/commit: feat/cli-output-contract-memo-cli-pilot (pending push)
+- Branch/commit: feat/cli-output-contract-awp-migration (pending push)
 - Source document:
   docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger
 
-| ID       | Status  | Task                                                              | Evidence                                                      | Notes                                                                                                                                                     |
-| -------- | ------- | ----------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Task 1.1 | done    | Add `cli_contract` module to `nils-common`                        | crates/nils-common/src/cli_contract.rs; PR #375               | Plus additive `EnvelopeError::details` field in Sprint 2                                                                                                  |
-| Task 1.2 | done    | Add parse-error JSON helper                                       | crates/nils-common/tests/integration/cli_contract.rs; PR #375 |                                                                                                                                                           |
-| Task 1.3 | done    | Migrate `cli-template` as reference implementation                | crates/cli-template/src/main.rs; PR #375                      |                                                                                                                                                           |
-| Task 1.4 | done    | Write `cli-output-contract-v1.md` spec                            | docs/specs/cli-output-contract-v1.md; PR #375                 | Sprint 2 extended with `details` field                                                                                                                    |
-| Task 2.1 | done    | Replace memo-cli exit-code constants with shared module           | crates/memo-cli/src/errors.rs                                 | exit::USAGE/DATA/RUNTIME replaces 64/65/1 literals                                                                                                        |
-| Task 2.2 | done    | Migrate memo-cli to `OutputFormat` and hidden `--json` alias      | crates/memo-cli/src/cli.rs                                    | shared `nils_common::cli_contract::OutputFormat`; `--json` `hide=true conflicts_with=format`                                                              |
-| Task 2.3 | done    | Migrate memo-cli JSON output to shared envelope and `warnings`    | crates/memo-cli/src/output/json.rs + commands/*               | schema_version moved to `cli.memo-cli.<cmd>.v1`; collections nest `items` + `pagination`/`meta` under `data`; apply per-item errors surface in `warnings` |
-| Task 2.4 | done    | Route memo-cli parse and unknown-subcommand errors through helper | crates/memo-cli/src/app.rs                                    | argv-scan detect of `--format json` / `--json`; calls `emit_parse_error`                                                                                  |
-| Task 2.5 | done    | Add memo-cli exit-code matrix test                                | crates/memo-cli/tests/integration/exit_codes.rs               | 5 tests covering SUCCESS / USAGE (arg + unknown subcmd) / DATA / RUNTIME                                                                                  |
-| Task 3.1 | pending | Migrate `agent-workflow-primitives` binaries                      | n/a                                                           | next sprint                                                                                                                                               |
-| Task 3.2 | pending | Migrate API testing stack                                         | n/a                                                           | next sprint                                                                                                                                               |
-| Task 3.3 | pending | Migrate remaining single-binary crates and run the full gate      | n/a                                                           | next sprint                                                                                                                                               |
-| Task 3.4 | pending | Workspace lint script for legacy contract usage                   | n/a                                                           | depends on 3.1, 3.2, 3.3                                                                                                                                  |
+| ID       | Status  | Task                                                              | Evidence                                                                                                 | Notes                                                                                                                                                                       |
+| -------- | ------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task 1.1 | done    | Add `cli_contract` module to `nils-common`                        | crates/nils-common/src/cli_contract.rs; PR #375                                                          | Plus additive `EnvelopeError::details` field in Sprint 2                                                                                                                    |
+| Task 1.2 | done    | Add parse-error JSON helper                                       | crates/nils-common/tests/integration/cli_contract.rs; PR #375                                            |                                                                                                                                                                             |
+| Task 1.3 | done    | Migrate `cli-template` as reference implementation                | crates/cli-template/src/main.rs; PR #375                                                                 |                                                                                                                                                                             |
+| Task 1.4 | done    | Write `cli-output-contract-v1.md` spec                            | docs/specs/cli-output-contract-v1.md; PR #375                                                            | Sprint 2 extended with `details` field                                                                                                                                      |
+| Task 2.1 | done    | Replace memo-cli exit-code constants with shared module           | crates/memo-cli/src/errors.rs                                                                            | exit::USAGE/DATA/RUNTIME replaces 64/65/1 literals                                                                                                                          |
+| Task 2.2 | done    | Migrate memo-cli to `OutputFormat` and hidden `--json` alias      | crates/memo-cli/src/cli.rs                                                                               | shared `nils_common::cli_contract::OutputFormat`; `--json` `hide=true conflicts_with=format`                                                                                |
+| Task 2.3 | done    | Migrate memo-cli JSON output to shared envelope and `warnings`    | crates/memo-cli/src/output/json.rs + commands/*                                                          | schema_version moved to `cli.memo-cli.<cmd>.v1`; collections nest `items` + `pagination`/`meta` under `data`; apply per-item errors surface in `warnings`                   |
+| Task 2.4 | done    | Route memo-cli parse and unknown-subcommand errors through helper | crates/memo-cli/src/app.rs                                                                               | argv-scan detect of `--format json` / `--json`; calls `emit_parse_error`                                                                                                    |
+| Task 2.5 | done    | Add memo-cli exit-code matrix test                                | crates/memo-cli/tests/integration/exit_codes.rs                                                          | 5 tests covering SUCCESS / USAGE (arg + unknown subcmd) / DATA / RUNTIME                                                                                                    |
+| Task 3.1 | done    | Migrate `agent-workflow-primitives` binaries                      | crates/agent-workflow-primitives/src/common.rs + per-binary entrypoints; tests/integration/exit_codes.rs | shared `Envelope<T>` via refactored `common.rs`; `handle_parse_error` routes parse errors; 50 cli tests + 3 matrix tests; `RECORD_SCHEMA_VERSION` literals stay byte-stable |
+| Task 3.2 | pending | Migrate API testing stack                                         | n/a                                                                                                      | next sprint                                                                                                                                                                 |
+| Task 3.3 | pending | Migrate remaining single-binary crates and run the full gate      | n/a                                                                                                      | next sprint                                                                                                                                                                 |
+| Task 3.4 | pending | Workspace lint script for legacy contract usage                   | n/a                                                                                                      | depends on 3.1, 3.2, 3.3                                                                                                                                                    |
 
 ## Validation
 
@@ -53,6 +53,41 @@
 
 - See prior turn's notes. Sprint 1 foundation landed; this entry kept as
   context for Sprint 2.
+
+### 2026-05-19 (Task 3.1 → feat/cli-output-contract-awp-migration)
+
+- Read:
+  - docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
+  - crates/agent-workflow-primitives/{Cargo.toml, src/common.rs, src/lib.rs,
+    src/canary_check.rs, src/repo_retro.rs}
+  - crates/agent-workflow-primitives/tests/integration/{cli.rs, integration.rs}
+- Changed:
+  - crates/agent-workflow-primitives/Cargo.toml (new `nils-common` dep)
+  - crates/agent-workflow-primitives/src/common.rs (re-export shared
+    `OutputFormat`; rewrite `render_success` / `render_error` around shared
+    `Envelope<T>` / `EnvelopeError`; add `CliError::data` + `EXIT_DATA`; add
+    `handle_parse_error` helper with raw-argv format detection)
+  - crates/agent-workflow-primitives/src/{browser_session,canary_check,
+    docs_impact,heuristic_inbox,model_cross_check,repo_retro,review_evidence,
+    skill_usage}.rs (parse-error block → `handle_parse_error(<bin>, argv, err)`;
+    drop `use clap::error::ErrorKind` / `EXIT_USAGE` from imports)
+  - crates/agent-workflow-primitives/src/repo_retro.rs (drop local
+    `SuccessEnvelope`; emit via shared `Envelope::success`)
+  - crates/agent-workflow-primitives/tests/integration/{cli.rs, integration.rs}
+    (bulk transform `["result"]` → `["data"]`; drop `["command"]` assertions;
+    register new `exit_codes` test module)
+  - crates/agent-workflow-primitives/tests/integration/exit_codes.rs (new — 3
+    matrix tests over all 8 binaries)
+  - THIRD_PARTY_LICENSES.md / THIRD_PARTY_NOTICES.md (regenerated for the
+    new nils-common dependency edge in awp)
+- Validated:
+  - `cargo test -p nils-agent-workflow-primitives` (53 tests pass — 50 cli +
+    3 new exit-code matrix)
+  - `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`
+    (pass)
+- Blocked by: none
+- Next: open feature PR with `/deliver-feature-pr`; Task 3.2 (api-* migration)
+  picks up in a follow-up PR per the plan's `parallel-x3` strategy.
 
 ### 2026-05-19 (Sprint 2 → feat/cli-output-contract-memo-cli-pilot)
 


### PR DESCRIPTION
# Migrate agent-workflow-primitives to CLI output contract v1 (Task 3.1)

## Summary

Task 3.1 of [`cli-output-contract-unification`](../tree/feat/cli-output-contract-awp-migration/docs/plans/cli-output-contract-unification): the first of three Sprint-3 fan-out PRs. Moves every `agent-workflow-primitives` binary (`browser-session`, `canary-check`, `docs-impact`, `heuristic-inbox`, `model-cross-check`, `repo-retro`, `review-evidence`, `skill-usage`) onto the shared `nils_common::cli_contract::Envelope`, switches exit codes to the BSD-sysexits constants, and routes parse / unknown-subcommand errors through the shared helper. **This is a breaking change for JSON consumers of these eight binaries.** Persisted record schema versions (`RECORD_SCHEMA_VERSION`) stay byte-stable so on-disk artifacts are unaffected.

Sprint 1 (PR #375) shipped the foundation; Sprint 2 (PR #376) was the memo-cli pilot; Tasks 3.2 (api-* stack) and 3.3 (remaining single-binary crates) plus 3.4 (workspace lint script) follow as separate PRs per the plan's `parallel-x3` strategy.

## Changes

- `agent-workflow-primitives` adds a `nils-common` dependency edge.
- `src/common.rs` re-exports `OutputFormat` from `nils-common`, replaces the local `EXIT_OK` / `EXIT_RUNTIME` / `EXIT_USAGE` constants with `nils_common::cli_contract::exit::*` (plus a new `EXIT_DATA = 65` and `CliError::data` constructor for data-classified errors), and rewrites `render_success` / `render_error` around the shared `Envelope<T>` / `EnvelopeError` (so `error.details` is now structured rather than ad-hoc).
- New `crate::common::handle_parse_error(binary, argv, err)` helper: lets clap render its native help / version exits, otherwise scans raw argv for `--format json` / `--json` and routes through `nils_common::cli_contract::emit_parse_error`. Every binary's `run_with_args` is rewritten to call this helper instead of inlining its own usage-error block.
- `src/repo_retro.rs`: drop the local `SuccessEnvelope` (only binary that bypassed `render_success`) and emit through the shared envelope so its tests' `data` path lines up with every other binary.
- `tests/integration/cli.rs`: bulk-transform `["result"]` → `["data"]` and drop dead `["command"]` assertions. `tests/integration.rs` registers the new module.
- New `tests/integration/exit_codes.rs`: 3 matrix tests that cover all 8 binaries — unknown subcommand returns USAGE (64), unknown flag returns USAGE (64), and JSON parse-error envelope ships with exit 64 across the full binary set.
- `THIRD_PARTY_LICENSES.md` / `THIRD_PARTY_NOTICES.md` regenerated to track the new dependency edge.

## Test-First Evidence

- Change classification: behavior change (breaking JSON wire contract for 8 binaries)
- Failing test before fix: N/A with waiver — the failure mode is "every old-shape JSON consumer test breaks." The existing 50 integration tests encoded the old envelope and broke as soon as the new envelope shipped (20/50 failed before the test-suite migration). The bulk-transformed tests then pin the new envelope literally.
- Final validation: `cargo test -p nils-agent-workflow-primitives` (53 tests pass — 50 cli + 3 new exit-code matrix); `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` pass (cargo fmt + clippy `-D warnings` + nextest workspace + doctests + third-party audit all green).
- Waiver reason: bulk-migration of a wire contract; failing-test-first would have required re-creating the existing tests in inverted form before deleting them. The migration sequence (refactor common → bulk-transform tests → run gate) provides equivalent contract evidence and is reflected in the diff.

## Testing

- `cargo test -p nils-agent-workflow-primitives` (pass — 53 tests)
- `cargo test -p nils-common cli_contract` (pass — 10 tests; sanity-check the Sprint 1 module still ships)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass)
- Manual smoke: `<bin> --format json definitely-not-a-real-subcommand` → JSON envelope on stdout, exit 64
- Manual smoke: `<bin>` (no subcommand, with required-subcommand binaries) → clap's `DisplayHelpOnMissingArgumentOrSubcommand` still fires natively

## Risk / Notes

- **Breaking change for JSON consumers of the 8 binaries.** Any downstream script that read `result.X` or `command` must update to `data.X` and drop `command`. The `schema_version` literals were already in the `cli.<binary>.<command>.v1` shape before this PR, so the literal strings on the wire stay the same — only the surrounding envelope fields change.
- Persisted `RECORD_SCHEMA_VERSION` literals (e.g. `canary-check.record.v1`) are intentionally untouched so on-disk records remain backward-compatible. They live inside `data` now (`data.last_run.schema_version`) instead of `result.last_run.schema_version`.
- Sprint 3 will continue: Task 3.2 migrates the 5 api-testing binaries together (they share `api-testing-core`), Task 3.3 covers the remaining single-binary crates (semantic-commit, git-scope, git-summary, git-lock, agent-out, agent-docs, agent-scope-lock, web-evidence, test-first-evidence, image-processing, codex-cli, gemini-cli, plan-tooling, plan-issue-cli), and Task 3.4 adds the workspace lint script that detects legacy contract usage on PRs.
