### PR TITLE
Migrate API testing stack to CLI output contract v1 (Task 3.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,6 +1835,7 @@ version = "0.10.2"
 dependencies = [
  "anyhow",
  "base64",
+ "clap",
  "jaq-core",
  "jaq-json",
  "jaq-std",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `da88819755effc11983026530433ca9fe5d608a27f583cc8288ed4977a5e77cc`
+- Cargo.lock SHA256: `a327f54170303f79097e37083b6835fa3af676587baee806a9ee57919c167070`
 - Third-party crates (`source != null`): 438
 - Workspace crates (`source == null`, excluded below): 30
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `da88819755effc11983026530433ca9fe5d608a27f583cc8288ed4977a5e77cc`
+- Cargo.lock SHA256: `a327f54170303f79097e37083b6835fa3af676587baee806a9ee57919c167070`
 - Third-party crates (`source != null`): 438
 
 ## Notice Extraction Policy

--- a/crates/api-gql/src/main.rs
+++ b/crates/api-gql/src/main.rs
@@ -5,8 +5,10 @@ mod completion;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
+use std::ffi::OsString;
+
+use api_testing_core::cli_contract::handle_parse_error;
 use clap::Parser;
-use clap::error::ErrorKind;
 
 use crate::cli::{Cli, Command};
 use crate::commands::{cmd_call, cmd_history, cmd_report, cmd_report_from_cmd, cmd_schema};
@@ -67,20 +69,10 @@ fn run() -> i32 {
     }
 
     let argv = argv_with_default_command(&raw_args);
-    let cli = match Cli::try_parse_from(argv) {
+    let argv_os: Vec<OsString> = argv.iter().map(OsString::from).collect();
+    let cli = match Cli::try_parse_from(argv_os.iter()) {
         Ok(v) => v,
-        Err(err) => {
-            let code = err.exit_code();
-            if matches!(
-                err.kind(),
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
-            ) {
-                let _ = err.print();
-                return 0;
-            }
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return handle_parse_error("api-gql", argv_os, err),
     };
 
     let invocation_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));

--- a/crates/api-gql/tests/integration/cli_smoke.rs
+++ b/crates/api-gql/tests/integration/cli_smoke.rs
@@ -40,3 +40,21 @@ fn report_from_cmd_dry_run_exits_zero_and_prints_report_command() {
     assert!(out.stdout_text().contains("health"));
     assert!(out.stdout_text().contains("staging"));
 }
+
+#[test]
+fn unknown_arg_returns_usage_exit_code() {
+    let out = run_api_gql(&["--definitely-not-a-real-flag"]);
+    assert_eq!(out.code, 64, "stderr={}", out.stderr_text());
+}
+
+#[test]
+fn unknown_flag_emits_json_envelope_when_format_json_present() {
+    let out = run_api_gql(&["--format", "json", "--definitely-not-a-real-flag"]);
+    assert_eq!(out.code, 64, "stderr={}", out.stderr_text());
+    let stdout = out.stdout_text();
+    assert!(
+        stdout.contains("\"schema_version\":\"cli.api-gql.error.v1\""),
+        "expected error envelope on stdout, got: {stdout}"
+    );
+    assert!(stdout.contains("\"ok\":false"), "stdout={stdout}");
+}

--- a/crates/api-grpc/src/main.rs
+++ b/crates/api-grpc/src/main.rs
@@ -5,8 +5,10 @@ mod completion;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
+use std::ffi::OsString;
+
+use api_testing_core::cli_contract::handle_parse_error;
 use clap::Parser;
-use clap::error::ErrorKind;
 
 use crate::cli::{Cli, Command};
 use crate::commands::{cmd_call, cmd_history, cmd_report, cmd_report_from_cmd};
@@ -69,21 +71,11 @@ fn run() -> i32 {
     }
 
     let argv = argv_with_default_command(&raw_args);
+    let argv_os: Vec<OsString> = argv.iter().map(OsString::from).collect();
 
-    let cli = match Cli::try_parse_from(argv) {
+    let cli = match Cli::try_parse_from(argv_os.iter()) {
         Ok(v) => v,
-        Err(err) => {
-            let code = err.exit_code();
-            if matches!(
-                err.kind(),
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
-            ) {
-                let _ = err.print();
-                return 0;
-            }
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return handle_parse_error("api-grpc", argv_os, err),
     };
 
     let invocation_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));

--- a/crates/api-grpc/tests/integration/cli_smoke.rs
+++ b/crates/api-grpc/tests/integration/cli_smoke.rs
@@ -39,3 +39,21 @@ fn report_from_cmd_dry_run_exits_zero_and_prints_report_command() {
     assert!(out.stdout_text().contains("health"));
     assert!(out.stdout_text().contains("staging"));
 }
+
+#[test]
+fn unknown_arg_returns_usage_exit_code() {
+    let out = run_api_rest(&["--definitely-not-a-real-flag"]);
+    assert_eq!(out.code, 64, "stderr={}", out.stderr_text());
+}
+
+#[test]
+fn unknown_flag_emits_json_envelope_when_format_json_present() {
+    let out = run_api_rest(&["--format", "json", "--definitely-not-a-real-flag"]);
+    assert_eq!(out.code, 64, "stderr={}", out.stderr_text());
+    let stdout = out.stdout_text();
+    assert!(
+        stdout.contains("\"schema_version\":\"cli.api-grpc.error.v1\""),
+        "expected error envelope on stdout, got: {stdout}"
+    );
+    assert!(stdout.contains("\"ok\":false"), "stdout={stdout}");
+}

--- a/crates/api-rest/src/main.rs
+++ b/crates/api-rest/src/main.rs
@@ -5,8 +5,10 @@ mod completion;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
+use std::ffi::OsString;
+
+use api_testing_core::cli_contract::handle_parse_error;
 use clap::Parser;
-use clap::error::ErrorKind;
 
 use crate::cli::{Cli, Command};
 use crate::commands::{cmd_call, cmd_history, cmd_report, cmd_report_from_cmd};
@@ -69,21 +71,11 @@ fn run() -> i32 {
     }
 
     let argv = argv_with_default_command(&raw_args);
+    let argv_os: Vec<OsString> = argv.iter().map(OsString::from).collect();
 
-    let cli = match Cli::try_parse_from(argv) {
+    let cli = match Cli::try_parse_from(argv_os.iter()) {
         Ok(v) => v,
-        Err(err) => {
-            let code = err.exit_code();
-            if matches!(
-                err.kind(),
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
-            ) {
-                let _ = err.print();
-                return 0;
-            }
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return handle_parse_error("api-rest", argv_os, err),
     };
 
     let invocation_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));

--- a/crates/api-rest/tests/integration/cli_smoke.rs
+++ b/crates/api-rest/tests/integration/cli_smoke.rs
@@ -39,3 +39,21 @@ fn report_from_cmd_dry_run_exits_zero_and_prints_report_command() {
     assert!(out.stdout_text().contains("health"));
     assert!(out.stdout_text().contains("staging"));
 }
+
+#[test]
+fn unknown_arg_returns_usage_exit_code() {
+    let out = run_api_rest(&["--definitely-not-a-real-flag"]);
+    assert_eq!(out.code, 64, "stderr={}", out.stderr_text());
+}
+
+#[test]
+fn unknown_flag_emits_json_envelope_when_format_json_present() {
+    let out = run_api_rest(&["--format", "json", "--definitely-not-a-real-flag"]);
+    assert_eq!(out.code, 64, "stderr={}", out.stderr_text());
+    let stdout = out.stdout_text();
+    assert!(
+        stdout.contains("\"schema_version\":\"cli.api-rest.error.v1\""),
+        "expected error envelope on stdout, got: {stdout}"
+    );
+    assert!(stdout.contains("\"ok\":false"), "stdout={stdout}");
+}

--- a/crates/api-test/src/main.rs
+++ b/crates/api-test/src/main.rs
@@ -1,8 +1,9 @@
+use std::ffi::OsString;
 use std::io::{Read, Write};
 
-use clap::error::ErrorKind;
 use clap::{Args, Parser, Subcommand};
 
+use api_testing_core::cli_contract::{Envelope, handle_parse_error};
 use api_testing_core::cli_util;
 use api_testing_core::suite::filter::parse_csv_list;
 use api_testing_core::suite::resolve::{
@@ -222,21 +223,11 @@ fn run() -> i32 {
     }
 
     let argv = argv_with_default_command(&raw_args);
+    let argv_os: Vec<OsString> = argv.iter().map(OsString::from).collect();
 
-    let cli = match Cli::try_parse_from(argv) {
+    let cli = match Cli::try_parse_from(argv_os.iter()) {
         Ok(v) => v,
-        Err(err) => {
-            let code = err.exit_code();
-            if matches!(
-                err.kind(),
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
-            ) {
-                let _ = err.print();
-                return 0;
-            }
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return handle_parse_error("api-test", argv_os, err),
     };
 
     match cli.command {
@@ -345,7 +336,12 @@ fn cmd_run(args: &RunArgs) -> i32 {
         }
     };
 
-    let json_line = match serde_json::to_string(&run_output.results) {
+    // Wrap suite results in the shared CLI envelope; both stdout and the
+    // optional `--out` file emit the byte-identical envelope so consumers see
+    // one shape (`render_summary_from_json_str` transparently unwraps the
+    // envelope so old summary callers keep working).
+    let envelope = Envelope::success("cli.api-test.run.v1", &run_output.results);
+    let json_line = match serde_json::to_string(&envelope) {
         Ok(v) => v,
         Err(err) => {
             eprintln!("error: failed to serialize results JSON: {err}");

--- a/crates/api-test/tests/integration/cli_smoke.rs
+++ b/crates/api-test/tests/integration/cli_smoke.rs
@@ -28,3 +28,21 @@ fn invalid_flag_exits_nonzero() {
     let out = run_api_test(&["--definitely-not-a-flag"]);
     assert_ne!(out.code, 0);
 }
+
+#[test]
+fn unknown_arg_returns_usage_exit_code() {
+    let out = run_api_test(&["definitely-not-a-real-subcommand"]);
+    assert_eq!(out.code, 64, "stderr={}", out.stderr_text());
+}
+
+#[test]
+fn unknown_flag_emits_json_envelope_when_format_json_present() {
+    let out = run_api_test(&["--format", "json", "--definitely-not-a-real-flag"]);
+    assert_eq!(out.code, 64, "stderr={}", out.stderr_text());
+    let stdout = out.stdout_text();
+    assert!(
+        stdout.contains("\"schema_version\":\"cli.api-test.error.v1\""),
+        "expected error envelope on stdout, got: {stdout}"
+    );
+    assert!(stdout.contains("\"ok\":false"), "stdout={stdout}");
+}

--- a/crates/api-test/tests/integration/e2e.rs
+++ b/crates/api-test/tests/integration/e2e.rs
@@ -160,18 +160,18 @@ fn run_e2e_suite_smoke_passes_and_does_not_leak_secrets() {
 
     let results_json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("results json");
-    assert_eq!(results_json["summary"]["total"], 3);
-    assert_eq!(results_json["summary"]["passed"], 3);
-    assert_eq!(results_json["summary"]["failed"], 0);
-    assert_eq!(results_json["summary"]["skipped"], 0);
+    assert_eq!(results_json["data"]["summary"]["total"], 3);
+    assert_eq!(results_json["data"]["summary"]["passed"], 3);
+    assert_eq!(results_json["data"]["summary"]["failed"], 0);
+    assert_eq!(results_json["data"]["summary"]["skipped"], 0);
 
-    let output_dir_rel = results_json["outputDir"].as_str().unwrap_or("");
+    let output_dir_rel = results_json["data"]["outputDir"].as_str().unwrap_or("");
     assert!(!output_dir_rel.is_empty());
     let output_dir_abs = root.join(output_dir_rel);
     assert!(output_dir_abs.is_dir());
 
     // Ensure referenced artifacts exist and do not contain secrets.
-    if let Some(cases) = results_json["cases"].as_array() {
+    if let Some(cases) = results_json["data"]["cases"].as_array() {
         for c in cases {
             if let Some(stdout_rel) = c.get("stdoutFile").and_then(|v| v.as_str()) {
                 let p = root.join(stdout_rel);
@@ -286,12 +286,14 @@ fn run_e2e_suite_guardrails_fails_with_expected_messages() {
 
     let results_json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("results json");
-    assert_eq!(results_json["summary"]["total"], 3);
-    assert_eq!(results_json["summary"]["passed"], 0);
-    assert_eq!(results_json["summary"]["failed"], 2);
-    assert_eq!(results_json["summary"]["skipped"], 1);
+    assert_eq!(results_json["data"]["summary"]["total"], 3);
+    assert_eq!(results_json["data"]["summary"]["passed"], 0);
+    assert_eq!(results_json["data"]["summary"]["failed"], 2);
+    assert_eq!(results_json["data"]["summary"]["skipped"], 1);
 
-    let cases = results_json["cases"].as_array().expect("cases array");
+    let cases = results_json["data"]["cases"]
+        .as_array()
+        .expect("cases array");
     let mut by_id: std::collections::BTreeMap<String, serde_json::Value> =
         std::collections::BTreeMap::new();
     for c in cases {
@@ -315,7 +317,7 @@ fn run_e2e_suite_guardrails_fails_with_expected_messages() {
     assert_eq!(by_id["rest.write_skip"]["status"], "skipped");
     assert_eq!(by_id["rest.write_skip"]["message"], "write_cases_disabled");
 
-    let output_dir_rel = results_json["outputDir"].as_str().unwrap_or("");
+    let output_dir_rel = results_json["data"]["outputDir"].as_str().unwrap_or("");
     assert!(!output_dir_rel.is_empty());
     let output_dir_abs = root.join(output_dir_rel);
     assert!(output_dir_abs.is_dir());

--- a/crates/api-test/tests/integration/grpc_integration.rs
+++ b/crates/api-test/tests/integration/grpc_integration.rs
@@ -75,7 +75,7 @@ fn api_test_run_supports_grpc_case() {
     assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
 
     let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("results json");
-    assert_eq!(json["summary"]["total"], 1);
-    assert_eq!(json["summary"]["passed"], 1);
-    assert_eq!(json["summary"]["failed"], 0);
+    assert_eq!(json["data"]["summary"]["total"], 1);
+    assert_eq!(json["data"]["summary"]["passed"], 1);
+    assert_eq!(json["data"]["summary"]["failed"], 0);
 }

--- a/crates/api-test/tests/integration/progress_contract.rs
+++ b/crates/api-test/tests/integration/progress_contract.rs
@@ -114,7 +114,7 @@ fn progress_auto_and_on_are_silent_in_non_tty_and_keep_stdout_json_clean() {
     let auto_stderr = auto.stderr_text();
     let auto_json: serde_json::Value =
         serde_json::from_slice(&auto.stdout).expect("auto stdout json");
-    assert_eq!(auto_json["summary"]["total"], 1);
+    assert_eq!(auto_json["data"]["summary"]["total"], 1);
     assert!(!auto_stdout.contains("api-test "), "stdout leaked progress");
     assert!(
         !auto_stderr.contains("api-test "),
@@ -140,7 +140,7 @@ fn progress_auto_and_on_are_silent_in_non_tty_and_keep_stdout_json_clean() {
     let on_stdout = on.stdout_text();
     let on_stderr = on.stderr_text();
     let on_json: serde_json::Value = serde_json::from_slice(&on.stdout).expect("on stdout json");
-    assert_eq!(on_json["summary"]["total"], 1);
+    assert_eq!(on_json["data"]["summary"]["total"], 1);
     assert!(!on_stdout.contains("api-test "), "stdout leaked progress");
     assert!(
         !on_stderr.contains("api-test "),
@@ -174,7 +174,7 @@ fn progress_off_disables_progress_output() {
     let stdout = out.stdout_text();
     let stderr = out.stderr_text();
     let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout json");
-    assert_eq!(json["summary"]["total"], 1);
+    assert_eq!(json["data"]["summary"]["total"], 1);
     assert!(!stdout.contains("api-test "), "stdout leaked progress");
     assert!(
         !stderr.contains("api-test "),
@@ -204,7 +204,7 @@ fn progress_with_no_color_keeps_json_clean_and_avoids_sgr_color_sequences() {
     let stdout = out.stdout_text();
     let stderr = out.stderr_text();
     let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout json");
-    assert_eq!(json["summary"]["total"], 1);
+    assert_eq!(json["data"]["summary"]["total"], 1);
     assert!(!stdout.contains("api-test "), "stdout leaked progress");
     assert!(
         !has_sgr_color_sequence(&stderr),

--- a/crates/api-testing-core/Cargo.toml
+++ b/crates/api-testing-core/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.22"
+clap = { workspace = true }
 jaq-core = "3.0.0-gamma"
 jaq-json = { version = "2.0.0-gamma", features = ["serde"] }
 jaq-std = "3.0.0-gamma"

--- a/crates/api-testing-core/src/cli_contract.rs
+++ b/crates/api-testing-core/src/cli_contract.rs
@@ -1,0 +1,82 @@
+//! Shared CLI output contract glue for the five api-* binaries.
+//!
+//! All five `api-rest` / `api-gql` / `api-grpc` / `api-websocket` / `api-test`
+//! binaries route their output through this module so the JSON envelope and
+//! exit codes stay aligned with `nils_common::cli_contract`. Each binary's
+//! tests still pin the literal `schema_version` per subcommand; this module
+//! intentionally adds no new schema versions of its own.
+
+use std::ffi::OsString;
+
+use clap::error::ErrorKind;
+
+pub use nils_common::cli_contract::{
+    Envelope, EnvelopeError, OutputFormat, emit_parse_error, exit, schema_version_for,
+};
+
+/// Route a clap parse error through the shared output contract.
+///
+/// Help and version exits keep clap's native behavior; everything else lands
+/// through `emit_parse_error` with raw-argv format detection so `--format json`
+/// consumers see a JSON envelope on parse and unknown-subcommand errors
+/// instead of clap's text-only error.
+pub fn handle_parse_error<I>(binary: &str, argv: I, err: clap::Error) -> i32
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let kind = err.kind();
+    if matches!(
+        kind,
+        ErrorKind::DisplayHelp
+            | ErrorKind::DisplayVersion
+            | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+    ) {
+        let _ = err.print();
+        return err.exit_code();
+    }
+
+    let argv: Vec<OsString> = argv.into_iter().collect();
+    let format = detect_format_from_argv(&argv);
+    let code = match kind {
+        ErrorKind::InvalidSubcommand => "unknown-subcommand",
+        _ => "parse-error",
+    };
+    let message = render_clap_message(&err);
+    emit_parse_error(binary, format, code, &message)
+}
+
+fn detect_format_from_argv(argv: &[OsString]) -> OutputFormat {
+    let mut iter = argv.iter().skip(1);
+    while let Some(arg) = iter.next() {
+        let arg = arg.to_string_lossy();
+        if arg == "--json" {
+            return OutputFormat::Json;
+        }
+        if arg == "--format"
+            && let Some(next) = iter.next()
+            && next.to_string_lossy().eq_ignore_ascii_case("json")
+        {
+            return OutputFormat::Json;
+        }
+        if let Some(rest) = arg.strip_prefix("--format=")
+            && rest.eq_ignore_ascii_case("json")
+        {
+            return OutputFormat::Json;
+        }
+    }
+    OutputFormat::Text
+}
+
+fn render_clap_message(err: &clap::Error) -> String {
+    err.to_string()
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| {
+            let line = line.trim();
+            line.strip_prefix("error:")
+                .map(str::trim)
+                .unwrap_or(line)
+                .to_string()
+        })
+        .unwrap_or_else(|| "command-line parse failed".to_string())
+}

--- a/crates/api-testing-core/src/lib.rs
+++ b/crates/api-testing-core/src/lib.rs
@@ -1,6 +1,7 @@
 //! Shared core primitives for the api-testing CLIs.
 
 pub mod auth_env;
+pub mod cli_contract;
 pub mod cli_endpoint;
 pub mod cli_history;
 pub mod cli_io;

--- a/crates/api-testing-core/src/suite/summary.rs
+++ b/crates/api-testing-core/src/suite/summary.rs
@@ -354,18 +354,29 @@ pub fn render_summary_from_json_str(
         );
     }
 
-    let results: SuiteRunResults = match serde_json::from_str(raw) {
-        Ok(v) => v,
-        Err(_) => {
-            return format!(
-                "## API test summary\n\n- {}\n",
-                if let Some(label) = input_label {
-                    format!("invalid JSON in: `{label}`")
-                } else {
-                    "invalid JSON from stdin".to_string()
-                }
-            );
-        }
+    // Accept both the raw `SuiteRunResults` shape (pre-Sprint-3.2 callers) and
+    // the new `cli.api-test.run.v1` envelope-wrapped shape. Try envelope first
+    // so post-migration callers parse cleanly without a fallback fail.
+    #[derive(serde::Deserialize)]
+    struct EnvelopeShape {
+        data: Option<SuiteRunResults>,
+    }
+
+    let results: SuiteRunResults = match serde_json::from_str::<EnvelopeShape>(raw) {
+        Ok(envelope) if envelope.data.is_some() => envelope.data.expect("checked above"),
+        _ => match serde_json::from_str(raw) {
+            Ok(v) => v,
+            Err(_) => {
+                return format!(
+                    "## API test summary\n\n- {}\n",
+                    if let Some(label) = input_label {
+                        format!("invalid JSON in: `{label}`")
+                    } else {
+                        "invalid JSON from stdin".to_string()
+                    }
+                );
+            }
+        },
     };
 
     render_summary_markdown(&results, options)

--- a/crates/api-websocket/src/commands/call.rs
+++ b/crates/api-websocket/src/commands/call.rs
@@ -401,9 +401,8 @@ pub(crate) fn cmd_call_internal(
     if json_mode {
         let payload = serde_json::json!({
             "schema_version": CALL_SCHEMA_VERSION,
-            "command": "api-websocket call",
             "ok": true,
-            "result": {
+            "data": {
                 "target": executed.target,
                 "last_received": executed.last_received,
                 "transcript": executed.transcript,
@@ -451,7 +450,6 @@ fn write_json_failure(
 
     let payload = serde_json::json!({
         "schema_version": CALL_SCHEMA_VERSION,
-        "command": "api-websocket call",
         "ok": false,
         "error": error,
     });

--- a/crates/api-websocket/src/commands/history.rs
+++ b/crates/api-websocket/src/commands/history.rs
@@ -101,9 +101,8 @@ pub(crate) fn cmd_history(
     if matches!(args.format, OutputFormat::Json) {
         let payload = serde_json::json!({
             "schema_version": HISTORY_SCHEMA_VERSION,
-            "command": "api-websocket history",
             "ok": true,
-            "result": {
+            "data": {
                 "history_file": history_file.to_string_lossy(),
                 "count": selected.len(),
                 "records": selected,
@@ -157,7 +156,6 @@ fn fail_history(
         }
         let payload = serde_json::json!({
             "schema_version": HISTORY_SCHEMA_VERSION,
-            "command": "api-websocket history",
             "ok": false,
             "error": error,
         });

--- a/crates/api-websocket/src/main.rs
+++ b/crates/api-websocket/src/main.rs
@@ -5,8 +5,10 @@ mod completion;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
+use std::ffi::OsString;
+
+use api_testing_core::cli_contract::handle_parse_error;
 use clap::Parser;
-use clap::error::ErrorKind;
 
 use crate::cli::{Cli, Command};
 use crate::commands::{cmd_call, cmd_history, cmd_report, cmd_report_from_cmd};
@@ -72,21 +74,11 @@ fn run() -> i32 {
     }
 
     let argv = argv_with_default_command(&raw_args);
+    let argv_os: Vec<OsString> = argv.iter().map(OsString::from).collect();
 
-    let cli = match Cli::try_parse_from(argv) {
+    let cli = match Cli::try_parse_from(argv_os.iter()) {
         Ok(v) => v,
-        Err(err) => {
-            let code = err.exit_code();
-            if matches!(
-                err.kind(),
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
-            ) {
-                let _ = err.print();
-                return 0;
-            }
-            let _ = err.print();
-            return code;
-        }
+        Err(err) => return handle_parse_error("api-websocket", argv_os, err),
     };
 
     let invocation_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));

--- a/crates/api-websocket/tests/integration/cli_smoke.rs
+++ b/crates/api-websocket/tests/integration/cli_smoke.rs
@@ -48,7 +48,6 @@ fn call_json_failure_uses_contract_envelope() {
 
     let json: serde_json::Value = serde_json::from_str(&out.stdout_text()).expect("json stdout");
     assert_eq!(json["schema_version"], "cli.api-websocket.call.v1");
-    assert_eq!(json["command"], "api-websocket call");
     assert_eq!(json["ok"], false);
     assert_eq!(json["error"]["code"], "request_not_found");
     assert!(
@@ -57,4 +56,22 @@ fn call_json_failure_uses_contract_envelope() {
             .unwrap_or_default()
             .contains("Request file not found")
     );
+}
+
+#[test]
+fn unknown_arg_returns_usage_exit_code() {
+    let out = run_api_websocket(&["--definitely-not-a-real-flag"]);
+    assert_eq!(out.code, 64, "stderr={}", out.stderr_text());
+}
+
+#[test]
+fn unknown_flag_emits_json_envelope_when_format_json_present() {
+    let out = run_api_websocket(&["--format", "json", "--definitely-not-a-real-flag"]);
+    assert_eq!(out.code, 64, "stderr={}", out.stderr_text());
+    let stdout = out.stdout_text();
+    assert!(
+        stdout.contains("\"schema_version\":\"cli.api-websocket.error.v1\""),
+        "expected error envelope on stdout, got: {stdout}"
+    );
+    assert!(stdout.contains("\"ok\":false"), "stdout={stdout}");
 }

--- a/crates/api-websocket/tests/integration/integration.rs
+++ b/crates/api-websocket/tests/integration/integration.rs
@@ -387,7 +387,6 @@ fn call_json_expectation_failure_returns_stable_error_code() {
         serde_json::from_str(&out.stdout_text()).expect("json failure envelope");
     assert_eq!(value["ok"], false);
     assert_eq!(value["error"]["code"], "expectation_failed");
-    assert_eq!(value["command"], "api-websocket call");
 
     handle.join().expect("join websocket server");
 }
@@ -683,10 +682,9 @@ fn call_json_success_returns_schema_payload() {
     let value: serde_json::Value =
         serde_json::from_str(&out.stdout_text()).expect("json success envelope");
     assert_eq!(value["schema_version"], "cli.api-websocket.call.v1");
-    assert_eq!(value["command"], "api-websocket call");
     assert_eq!(value["ok"], true);
-    assert_eq!(value["result"]["target"], url);
-    assert_eq!(value["result"]["last_received"], "{\"ok\":true}");
+    assert_eq!(value["data"]["target"], url);
+    assert_eq!(value["data"]["last_received"], "{\"ok\":true}");
 
     handle.join().expect("join websocket server");
 }

--- a/crates/api-websocket/tests/integration/json_contract.rs
+++ b/crates/api-websocket/tests/integration/json_contract.rs
@@ -95,11 +95,10 @@ fn call_json_success_contains_required_envelope_fields() {
     let value: serde_json::Value = serde_json::from_str(&out.stdout_text()).expect("json output");
 
     assert_eq!(value["schema_version"], "cli.api-websocket.call.v1");
-    assert_eq!(value["command"], "api-websocket call");
     assert_eq!(value["ok"], true);
-    assert!(value.get("result").is_some());
-    assert!(value["result"]["transcript"].is_array());
-    assert_eq!(value["result"]["last_received"], "{\"ok\":true}");
+    assert!(value.get("data").is_some());
+    assert!(value["data"]["transcript"].is_array());
+    assert_eq!(value["data"]["last_received"], "{\"ok\":true}");
 
     handle.join().expect("join websocket server");
 }
@@ -113,7 +112,6 @@ fn call_json_failure_contains_stable_error_envelope() {
     let value: serde_json::Value = serde_json::from_str(&out.stdout_text()).expect("json output");
 
     assert_eq!(value["schema_version"], "cli.api-websocket.call.v1");
-    assert_eq!(value["command"], "api-websocket call");
     assert_eq!(value["ok"], false);
     assert_eq!(value["error"]["code"], "request_not_found");
     assert!(
@@ -153,12 +151,11 @@ fn history_json_success_uses_results_contract() {
     let value: serde_json::Value = serde_json::from_str(&out.stdout_text()).expect("json output");
 
     assert_eq!(value["schema_version"], "cli.api-websocket.history.v1");
-    assert_eq!(value["command"], "api-websocket history");
     assert_eq!(value["ok"], true);
-    assert!(value.get("result").is_some());
-    assert_eq!(value["result"]["count"], 1);
+    assert!(value.get("data").is_some());
+    assert_eq!(value["data"]["count"], 1);
     assert_eq!(
-        value["result"]["records"].as_array().map(|v| v.len()),
+        value["data"]["records"].as_array().map(|v| v.len()),
         Some(1)
     );
 }

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
@@ -2,37 +2,37 @@
 
 ## Current State
 
-- Status: in-progress (Sprint 1 + Sprint 2 + Task 3.1 complete; Tasks 3.2 / 3.3 / 3.4 pending)
-- Target scope: Task 3.1 (agent-workflow-primitives, 8 binaries)
-- Execution window: Task 3.1 only — Tasks 3.2 / 3.3 stay in follow-up PRs per
-  the plan's `parallel-x3` PR strategy; Task 3.4 (lint script) lands after 3.3
-- Staged execution confirmation: confirmed(Sprint 1 PR #375 + Sprint 2 PR #376
-  merged; Task 3.1 in this PR; Tasks 3.2 / 3.3 / 3.4 follow-up PRs to come)
-- Current task: Task 3.1 complete
-- Next task: Task 3.2 (migrate API testing stack)
+- Status: in-progress (Sprint 1 + Sprint 2 + Tasks 3.1 + 3.2 complete; Tasks 3.3 / 3.4 pending)
+- Target scope: Task 3.2 (api-rest / api-gql / api-grpc / api-websocket / api-test)
+- Execution window: Task 3.2 only — Task 3.3 (remaining single-binary crates)
+  stays in a follow-up PR; Task 3.4 (lint script) lands after 3.3
+- Staged execution confirmation: confirmed(Sprint 1 PR #375, Sprint 2 PR #376,
+  Task 3.1 PR #377 merged; Task 3.2 in this PR; Tasks 3.3 / 3.4 to come)
+- Current task: Task 3.2 complete
+- Next task: Task 3.3 (migrate remaining single-binary crates)
 - Last updated: 2026-05-19
-- Branch/commit: feat/cli-output-contract-awp-migration (pending push)
+- Branch/commit: feat/cli-output-contract-api-testing-stack (pending push)
 - Source document:
   docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger
 
-| ID       | Status  | Task                                                              | Evidence                                                                                                 | Notes                                                                                                                                                                       |
-| -------- | ------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Task 1.1 | done    | Add `cli_contract` module to `nils-common`                        | crates/nils-common/src/cli_contract.rs; PR #375                                                          | Plus additive `EnvelopeError::details` field in Sprint 2                                                                                                                    |
-| Task 1.2 | done    | Add parse-error JSON helper                                       | crates/nils-common/tests/integration/cli_contract.rs; PR #375                                            |                                                                                                                                                                             |
-| Task 1.3 | done    | Migrate `cli-template` as reference implementation                | crates/cli-template/src/main.rs; PR #375                                                                 |                                                                                                                                                                             |
-| Task 1.4 | done    | Write `cli-output-contract-v1.md` spec                            | docs/specs/cli-output-contract-v1.md; PR #375                                                            | Sprint 2 extended with `details` field                                                                                                                                      |
-| Task 2.1 | done    | Replace memo-cli exit-code constants with shared module           | crates/memo-cli/src/errors.rs                                                                            | exit::USAGE/DATA/RUNTIME replaces 64/65/1 literals                                                                                                                          |
-| Task 2.2 | done    | Migrate memo-cli to `OutputFormat` and hidden `--json` alias      | crates/memo-cli/src/cli.rs                                                                               | shared `nils_common::cli_contract::OutputFormat`; `--json` `hide=true conflicts_with=format`                                                                                |
-| Task 2.3 | done    | Migrate memo-cli JSON output to shared envelope and `warnings`    | crates/memo-cli/src/output/json.rs + commands/*                                                          | schema_version moved to `cli.memo-cli.<cmd>.v1`; collections nest `items` + `pagination`/`meta` under `data`; apply per-item errors surface in `warnings`                   |
-| Task 2.4 | done    | Route memo-cli parse and unknown-subcommand errors through helper | crates/memo-cli/src/app.rs                                                                               | argv-scan detect of `--format json` / `--json`; calls `emit_parse_error`                                                                                                    |
-| Task 2.5 | done    | Add memo-cli exit-code matrix test                                | crates/memo-cli/tests/integration/exit_codes.rs                                                          | 5 tests covering SUCCESS / USAGE (arg + unknown subcmd) / DATA / RUNTIME                                                                                                    |
-| Task 3.1 | done    | Migrate `agent-workflow-primitives` binaries                      | crates/agent-workflow-primitives/src/common.rs + per-binary entrypoints; tests/integration/exit_codes.rs | shared `Envelope<T>` via refactored `common.rs`; `handle_parse_error` routes parse errors; 50 cli tests + 3 matrix tests; `RECORD_SCHEMA_VERSION` literals stay byte-stable |
-| Task 3.2 | pending | Migrate API testing stack                                         | n/a                                                                                                      | next sprint                                                                                                                                                                 |
-| Task 3.3 | pending | Migrate remaining single-binary crates and run the full gate      | n/a                                                                                                      | next sprint                                                                                                                                                                 |
-| Task 3.4 | pending | Workspace lint script for legacy contract usage                   | n/a                                                                                                      | depends on 3.1, 3.2, 3.3                                                                                                                                                    |
+| ID       | Status  | Task                                                              | Evidence                                                                                                 | Notes                                                                                                                                                                                                                                                            |
+| -------- | ------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task 1.1 | done    | Add `cli_contract` module to `nils-common`                        | crates/nils-common/src/cli_contract.rs; PR #375                                                          | Plus additive `EnvelopeError::details` field in Sprint 2                                                                                                                                                                                                         |
+| Task 1.2 | done    | Add parse-error JSON helper                                       | crates/nils-common/tests/integration/cli_contract.rs; PR #375                                            |                                                                                                                                                                                                                                                                  |
+| Task 1.3 | done    | Migrate `cli-template` as reference implementation                | crates/cli-template/src/main.rs; PR #375                                                                 |                                                                                                                                                                                                                                                                  |
+| Task 1.4 | done    | Write `cli-output-contract-v1.md` spec                            | docs/specs/cli-output-contract-v1.md; PR #375                                                            | Sprint 2 extended with `details` field                                                                                                                                                                                                                           |
+| Task 2.1 | done    | Replace memo-cli exit-code constants with shared module           | crates/memo-cli/src/errors.rs                                                                            | exit::USAGE/DATA/RUNTIME replaces 64/65/1 literals                                                                                                                                                                                                               |
+| Task 2.2 | done    | Migrate memo-cli to `OutputFormat` and hidden `--json` alias      | crates/memo-cli/src/cli.rs                                                                               | shared `nils_common::cli_contract::OutputFormat`; `--json` `hide=true conflicts_with=format`                                                                                                                                                                     |
+| Task 2.3 | done    | Migrate memo-cli JSON output to shared envelope and `warnings`    | crates/memo-cli/src/output/json.rs + commands/*                                                          | schema_version moved to `cli.memo-cli.<cmd>.v1`; collections nest `items` + `pagination`/`meta` under `data`; apply per-item errors surface in `warnings`                                                                                                        |
+| Task 2.4 | done    | Route memo-cli parse and unknown-subcommand errors through helper | crates/memo-cli/src/app.rs                                                                               | argv-scan detect of `--format json` / `--json`; calls `emit_parse_error`                                                                                                                                                                                         |
+| Task 2.5 | done    | Add memo-cli exit-code matrix test                                | crates/memo-cli/tests/integration/exit_codes.rs                                                          | 5 tests covering SUCCESS / USAGE (arg + unknown subcmd) / DATA / RUNTIME                                                                                                                                                                                         |
+| Task 3.1 | done    | Migrate `agent-workflow-primitives` binaries                      | crates/agent-workflow-primitives/src/common.rs + per-binary entrypoints; tests/integration/exit_codes.rs | shared `Envelope<T>` via refactored `common.rs`; `handle_parse_error` routes parse errors; 50 cli tests + 3 matrix tests; `RECORD_SCHEMA_VERSION` literals stay byte-stable                                                                                      |
+| Task 3.2 | done    | Migrate API testing stack                                         | crates/api-testing-core/src/cli_contract.rs + per-binary main.rs; cli_smoke matrix tests                 | shared `handle_parse_error` helper in api-testing-core; api-websocket envelope drops `command` / renames `result` → `data`; api-test stdout + `--out` both ship `cli.api-test.run.v1` envelope; `render_summary_from_json_str` accepts both wrapped + raw shapes |
+| Task 3.3 | pending | Migrate remaining single-binary crates and run the full gate      | n/a                                                                                                      | next sprint                                                                                                                                                                                                                                                      |
+| Task 3.4 | pending | Workspace lint script for legacy contract usage                   | n/a                                                                                                      | depends on 3.1, 3.2, 3.3                                                                                                                                                                                                                                         |
 
 ## Validation
 
@@ -53,6 +53,54 @@
 
 - See prior turn's notes. Sprint 1 foundation landed; this entry kept as
   context for Sprint 2.
+
+### 2026-05-19 (Task 3.2 → feat/cli-output-contract-api-testing-stack)
+
+- Read:
+  - docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
+  - crates/api-testing-core/{Cargo.toml, src/lib.rs, src/suite/summary.rs}
+  - crates/api-rest/src/main.rs; crates/api-gql/src/main.rs;
+    crates/api-grpc/src/main.rs; crates/api-websocket/{src/main.rs, src/cli.rs,
+    src/commands/call.rs, src/commands/history.rs}; crates/api-test/src/main.rs
+- Changed:
+  - crates/api-testing-core/Cargo.toml (added `clap` dep)
+  - crates/api-testing-core/src/cli_contract.rs (new — shared `handle_parse_error`
+    helper + envelope re-exports)
+  - crates/api-testing-core/src/lib.rs (register new `cli_contract` module)
+  - crates/api-testing-core/src/suite/summary.rs (`render_summary_from_json_str`
+    now accepts both wrapped and raw `SuiteRunResults` JSON for backwards
+    compatibility)
+  - crates/api-{rest,gql,grpc,websocket}/src/main.rs (route parse errors
+    through `api_testing_core::cli_contract::handle_parse_error`; drop
+    `clap::error::ErrorKind` import; `argv_with_default_command` output
+    converted to `OsString` for the helper)
+  - crates/api-websocket/src/commands/{call,history}.rs (drop `command` field
+    from success/failure envelopes; rename `result` → `data` to match the
+    shared contract)
+  - crates/api-test/src/main.rs (wrap stdout + `--out` JSON in
+    `Envelope::success("cli.api-test.run.v1", &results)`; route parse errors
+    through shared helper)
+  - crates/api-{rest,gql,grpc,websocket,test}/tests/integration/cli_smoke.rs
+    (+2 matrix tests per binary: unknown flag → exit 64 in text mode; same
+    flag with `--format json` → JSON parse-error envelope on stdout)
+  - crates/api-websocket/tests/integration/{cli_smoke.rs, integration.rs,
+    json_contract.rs} (bulk transform `["result"]` → `["data"]`; drop
+    `command` assertions)
+  - crates/api-test/tests/integration/{e2e.rs, grpc_integration.rs,
+    progress_contract.rs} (results JSON now lives under `data.*` path)
+  - THIRD_PARTY_LICENSES.md / THIRD_PARTY_NOTICES.md (regenerated for the new
+    `clap` dependency edge in api-testing-core)
+- Validated:
+  - `cargo test -p nils-api-rest` (51 tests pass)
+  - `cargo test -p nils-api-gql` (38 tests pass)
+  - `cargo test -p nils-api-grpc` (10 tests pass)
+  - `cargo test -p nils-api-websocket` (38 tests pass)
+  - `cargo test -p nils-api-test` (12 tests pass)
+  - `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`
+    (pass)
+- Blocked by: none
+- Next: open feature PR with `/deliver-feature-pr`; Task 3.3 (remaining
+  single-binary crates) picks up in a follow-up PR.
 
 ### 2026-05-19 (Task 3.1 → feat/cli-output-contract-awp-migration)
 


### PR DESCRIPTION
# Migrate API testing stack to CLI output contract v1 (Task 3.2)

## Summary

Task 3.2 of [`cli-output-contract-unification`](../tree/feat/cli-output-contract-api-testing-stack/docs/plans/cli-output-contract-unification): second of three Sprint-3 fan-out PRs. Hoists the shared parse-error and envelope handling into `api-testing-core::cli_contract` so all five api-* binaries (`api-rest`, `api-gql`, `api-grpc`, `api-websocket`, `api-test`) inherit one path; api-websocket and api-test now ship the workspace-wide envelope shape; api-rest/gql/grpc gain the JSON parse-error envelope.

**Breaking for downstream consumers of api-websocket JSON and api-test stdout/`--out` JSON.** See "Risk / Notes" below.

Sprint 1 / 2 / Task 3.1 already merged. Task 3.3 (remaining single-binary crates) and Task 3.4 (workspace lint script) follow as separate PRs.

## Changes

- `api-testing-core/Cargo.toml`: add `clap` dep.
- `api-testing-core/src/cli_contract.rs` (new): re-exports `Envelope` / `EnvelopeError` / `OutputFormat` / `exit::*` / `emit_parse_error` from `nils_common::cli_contract`, plus a shared `handle_parse_error(binary, argv, err)` helper that lets clap render `--help` / `--version` natively and routes every other error through the contract with raw-argv `--format json` / `--json` detection.
- `api-testing-core/src/suite/summary.rs`: `render_summary_from_json_str` now accepts both the wrapped (`{schema_version, ok, data: SuiteRunResults}`) and the historical raw `SuiteRunResults` JSON shapes, so existing summary tooling keeps working post-migration.
- `api-{rest,gql,grpc,websocket}/src/main.rs`: replace each binary's inline parse-error block with `handle_parse_error("<binary>", argv_os, err)`; drop `clap::error::ErrorKind` from imports.
- `api-websocket/src/commands/{call.rs, history.rs}`: drop `command` field from success/failure envelopes; rename `result` → `data` to match the shared contract.
- `api-test/src/main.rs`: wrap both stdout and the optional `--out` file JSON in `Envelope::success("cli.api-test.run.v1", &run_output.results)`; route parse errors through the shared helper.
- New matrix tests in each `cli_smoke.rs` (5 binaries × 2 = 10): `unknown_arg_returns_usage_exit_code` (exit 64 in text mode) and `unknown_flag_emits_json_envelope_when_format_json_present` (JSON envelope on stdout with `cli.<binary>.error.v1` schema).
- api-websocket and api-test integration tests bulk-transformed to the new envelope shape (`["result"]` → `["data"]`; drop `["command"]` assertions; results-JSON paths nest under `data`).
- `THIRD_PARTY_LICENSES.md` / `THIRD_PARTY_NOTICES.md` regenerated for the new `clap` edge in api-testing-core.

## Test-First Evidence

- Change classification: behavior change (breaking JSON wire contract for api-websocket and api-test)
- Failing test before fix: N/A with waiver — the migration follows the same pattern as Sprint 2 / Task 3.1. The existing api-websocket json_contract suite pinned the old shape and broke when the new envelope shipped; the migrated tests then pin the new shape literally. api-test e2e + progress + grpc-integration tests pinned `["summary"]` at top-level; after the envelope wrap they pin `["data"]["summary"]`.
- Final validation: `cargo test -p nils-api-rest` (51 tests), `cargo test -p nils-api-gql` (38 tests), `cargo test -p nils-api-grpc` (10 tests), `cargo test -p nils-api-websocket` (38 tests), `cargo test -p nils-api-test` (12 tests). `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` pass.
- Waiver reason: bulk-migration of a wire contract; failing-test-first would have required re-creating the existing tests in inverted form before deleting them. Each binary now has explicit matrix tests for the new contract.

## Testing

- `cargo test -p nils-api-rest` (pass — 51 tests)
- `cargo test -p nils-api-gql` (pass — 38 tests)
- `cargo test -p nils-api-grpc` (pass — 10 tests)
- `cargo test -p nils-api-websocket` (pass — 38 tests)
- `cargo test -p nils-api-test` (pass — 12 tests)
- `cargo test -p nils-common cli_contract` (pass — 10 tests; sanity-check Sprint 1 module still ships)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass)

## Risk / Notes

- **Breaking for api-websocket JSON consumers.** `result.X` → `data.X` and `command` field is removed. `schema_version` literals (e.g. `cli.api-websocket.call.v1`) stay unchanged on the wire; only the surrounding envelope shape changed.
- **Breaking for api-test JSON consumers** that read the stdout or `--out` JSON: every output is now wrapped in `{schema_version: "cli.api-test.run.v1", ok: true, data: SuiteRunResults}`. The summary tool (`api-test summary` / `render_summary_from_json_str`) transparently unwraps both shapes so pre-migration files still render.
- api-rest / api-gql / api-grpc had no CLI JSON envelopes before this PR; they still pass response bodies through unchanged. They only gain the new parse-error JSON envelope (visible when `--format json` is on argv before clap rejects). Their existing tests are untouched.
- Sprint 3 progress: Task 3.3 (remaining single-binary crates — semantic-commit, git-*, agent-out, agent-docs, agent-scope-lock, web-evidence, test-first-evidence, image-processing, codex-cli, gemini-cli, plan-tooling, plan-issue-cli) follows in a separate PR. Task 3.4 (workspace lint script) lands after 3.3.
