### PR TITLE
Land forge-cli v1 spec, ops catalog, dispatch plan, and discussion source

### DIFF
--- a/docs/plans/forge-cli/forge-cli-discussion-source.md
+++ b/docs/plans/forge-cli/forge-cli-discussion-source.md
@@ -1,0 +1,93 @@
+# forge-cli v1 — Discussion → Implementation Source
+
+## Purpose
+
+Captures the converged decisions handed off to dispatch planning for
+`forge-cli` v1. Pairs with the authoritative contract at
+`docs/specs/forge-cli-spec-v1.md` and the machine-readable op catalog at
+`docs/specs/forge-cli-ops-v1.yaml`. The plan at
+`docs/plans/forge-cli/forge-cli-plan.md` consumes this doc as its
+primary source.
+
+## Locked decisions (carry into execution)
+
+1. **Backend strategy**: subprocess wrap `gh` and `glab`. No direct
+   REST client. Auth, SSO, and enterprise hosts come from the user's
+   existing `gh auth` / `glab auth` state.
+2. **v1 scope**: PR/MR lifecycle + Issue lifecycle + CI wait. Releases,
+   labels, raw `gh api` / `glab api` passthrough, repo creation,
+   branch protection, and issue macros are explicitly v2 or later.
+3. **Exit codes**: only the six sysexits constants from
+   `nils_common::cli_contract::exit` (`SUCCESS`, `RUNTIME`, `USAGE`,
+   `DATA`, `UNAVAILABLE`, `SOFTWARE`). Numeric exit literals are
+   forbidden anywhere in the binary. Policy violations all map to
+   `DATA 65`; the discriminator lives in `data.error.kind`.
+4. **Provider detection precedence**: `--provider` flag > `git remote
+   get-url <--remote>` host parse > `gh/glab auth status` host match.
+   Unknown host → `USAGE 64` with `error.kind = "provider_unsupported"`.
+   No silent fallback to a third provider in v1.
+5. **Macro `pr deliver`** = `auth.status` → `repo.view` → `pr.create` →
+   `pr.wait-checks` → `pr.ready` → `pr.merge`. Macro failure does NOT
+   remap the inner exit code; callers branch on `data.steps[]` to
+   identify which step failed.
+6. **`glab ci status` text parser scope**: pin parser to the currently
+   installed `glab` minor. Out-of-range versions trigger
+   `UNAVAILABLE 69` with `error.kind = "glab_version_unsupported"` and
+   a "please upgrade/downgrade glab" hint. No best-effort parse across
+   versions.
+7. **Wrapper + Homebrew tap formula** ship in this v1 (Sprint 8).
+8. **Release vehicle**: cut a `nils-cli` minor bump once Sprint 8
+   passes the acceptance gate, via
+   `nils-cli-bump-version-tag-release` + tap formula bump.
+9. **Contract baseline**: `forge-cli` adopts `cli-output-contract-v1`
+   from day one. No `--json` boolean alias. `--format text|json` only.
+   Snake_case envelope throughout. Schema literals follow
+   `cli.forge-cli.<op>.v1`.
+10. **Sprint cadence**: each sprint = one GitHub PR, cut from `main`
+    via `create-feature-pr` → `close-feature-pr`. Sprint 0 (this PR)
+    lands the spec + plan + this discussion source. Subsequent sprints
+    rebase onto `main` after Sprint 0 merges.
+11. **agent-kit migration deferral**: the migration from agent-kit
+    skills' direct `gh` / `glab` invocations to `forge-cli` happens
+    after v1 ships and is accepted by the user; it is NOT part of
+    this plan.
+
+## Acceptance gate (v1 done definition)
+
+Every row in spec §"Migration plan: agent-kit skills → forge-cli" is
+reachable through `forge-cli`. Parity test passes (envelope
+byte-identical between backends except `data.provider` and URL host).
+Exit-code matrix test covers all six sysexits paths. `--dry-run` works
+for every op. `scripts/ci/cli-output-contract-lint.sh` passes.
+
+## Read-first companions
+
+- Contract: `docs/specs/forge-cli-spec-v1.md`
+- Op catalog: `docs/specs/forge-cli-ops-v1.yaml`
+- Workspace envelope contract: `docs/specs/cli-output-contract-v1.md`
+- Crate layout precedent: `crates/git-cli/`
+- Workspace rules: `AGENTS.md`, `DEVELOPMENT.md`,
+  `docs/runbooks/new-cli-crate-development-standard.md`,
+  `docs/runbooks/cli-completion-development-standard.md`
+
+## Execution
+
+- Recommended plan: docs/plans/forge-cli/forge-cli-plan.md
+- Recommended execution state: docs/plans/forge-cli/forge-cli-execution-state.md
+- Plan shape: dispatch-ready, 8 sprints (Sprint 0 lands docs; Sprints
+  1–8 implement atoms → macro → tests → release).
+- PR cadence: one PR per sprint, cut from `main`.
+- Per-task complexity required.
+- Execution state cadence: after each sprint PR merges, record the
+  sprint outcome plus the acceptance-gate row(s) it cleared. Final
+  state: all 8 sprints `completed`, every acceptance-gate row in spec
+  §"Migration plan: agent-kit skills → forge-cli" marked reachable.
+
+## Open questions deliberately NOT answered here
+
+- Whether agent-kit skill migration lands in `nils-cli` workspace or
+  in `agent-kit` (the latter, per current ownership). Tracked as a
+  follow-up after v1 ships.
+- Whether `gh api` / `glab api` passthrough returns in v2. Spec
+  documents the deferral and the re-evaluation criterion (a real
+  workflow that needs a non-CRUD call).

--- a/docs/plans/forge-cli/forge-cli-plan.md
+++ b/docs/plans/forge-cli/forge-cli-plan.md
@@ -1,0 +1,1204 @@
+# Plan: forge-cli v1 — Provider-Neutral Forge Operations
+
+## Overview
+
+Add a new workspace binary `forge-cli` that fronts every remote forge
+operation (PR/MR lifecycle, Issue lifecycle, CI wait) today executed by
+agent-kit skills as raw `gh` / `glab` calls. Two backends ship in
+lock-step: GitHub (wraps `gh`) and GitLab (wraps `glab`). The binary
+adopts `cli-output-contract-v1` from day one, enforces branch / body /
+state policy at the type level, and exposes one macro (`pr deliver`)
+that composes the agent-kit "open draft → wait CI → ready → merge"
+flow in Rust. Sprint 0 lands the spec + this plan as a docs-only PR;
+Sprints 1–8 then ship the crate atom-first, macro-second, with the
+final sprint wiring the brew wrapper and cutting the `nils-cli` minor
+release.
+
+## Read First
+
+- Primary source: docs/plans/forge-cli/forge-cli-discussion-source.md
+- Source type: discussion-to-implementation-doc
+- Companion sources (authoritative for contract / catalog / envelope):
+  - docs/specs/forge-cli-spec-v1.md
+  - docs/specs/forge-cli-ops-v1.yaml
+  - docs/specs/cli-output-contract-v1.md
+- Open questions carried into execution:
+  - Wrapper + Homebrew tap formula land in this v1 (Sprint 8).
+  - `glab ci status` text parser pinned to current installed `glab`
+    minor; out-of-range versions trigger `UNAVAILABLE 69` with a
+    "please upgrade/downgrade" hint, not a guessed parse.
+  - `nils-cli` minor bump cut once Sprint 8 passes the acceptance gate,
+    via `nils-cli-bump-version-tag-release` + tap formula bump.
+
+## Scope
+
+- In scope (v1):
+  - New crate `crates/forge-cli/` (`nils-forge-cli` package, `forge-cli`
+    binary) using `clap`, `serde`, `serde_json`, and the existing
+    `nils-common::cli_contract` primitives.
+  - Atoms: `auth status`, `repo view`, `pr create`, `pr view`,
+    `pr list`, `pr edit`, `pr comment`, `pr ready`, `pr merge`,
+    `pr close`, `pr checks`, `pr wait-checks`, `issue create`,
+    `issue view`, `issue edit`, `issue comment`, `issue close`,
+    `issue reopen`.
+  - Macro: `pr deliver --kind feature|bug`.
+  - Provider detection from `git remote get-url <--remote>` host plus
+    `gh auth status` / `glab auth status` host match.
+  - Lock-down validations (branch naming, body schema, title length,
+    worktree clean, push state, default-branch protection, draft-merge
+    refusal, required-check gating at merge time, merge method support,
+    keep-branch conflict).
+  - `--dry-run` rendering the constructed backend argv under
+    `data.plan` for every op.
+  - Per-repo `.forge-cli.toml` (merge method, body headings, checks
+    timeout) and env overrides `FORGE_CLI_GH_BIN`, `FORGE_CLI_GLAB_BIN`,
+    `FORGE_CLI_DEFAULT_PROVIDER`.
+  - Tests: per-op fixture pair (gh + glab), parity harness, exit-code
+    matrix, dry-run smoke. Token-shaped strings redacted in every
+    fixture.
+  - Wrapper `wrappers/forge-cli`, completions
+    `completions/_forge-cli` + `completions/forge-cli.bash`.
+  - Homebrew tap formula bump and `nils-cli` minor release at the end.
+
+- Out of scope (v1 — explicitly deferred to v2 or later):
+  - Release management (`gh release`, GitLab releases).
+  - Label management.
+  - Raw `gh api` / GitLab REST passthrough.
+  - Issue *macros* (`issue deliver`, `issue close-when-prs-merged`,
+    `issue cross-link`).
+  - Repo creation, branch protection management, code review state
+    mutation beyond `pr ready`.
+  - Gitea / Forgejo backend.
+  - agent-kit skill migration (happens after this v1 ships and is
+    accepted; tracked separately).
+  - Local-git operations beyond what is already in `git-cli` / shell
+    wrappers (the spec keeps `git push`, local branch deletion, etc.
+    outside `forge-cli`).
+
+## Assumptions
+
+1. `nils-common::cli_contract` already exposes `OutputFormat`,
+   `Envelope<T>`, `EnvelopeError`, `exit::{SUCCESS, RUNTIME, USAGE,
+   DATA, UNAVAILABLE, SOFTWARE}`, and `emit_parse_error`. `forge-cli`
+   consumes them unchanged; the contract migration on existing binaries
+   (`fdaf5d6`) shipped these primitives.
+2. Workspace conventions for new crates are documented in
+   `docs/runbooks/new-cli-crate-development-standard.md` and exemplified
+   by `crates/git-cli/` (lib + bin, `nils-*` package name, edition +
+   license inherited from workspace `Cargo.toml`). `forge-cli` mirrors
+   that shape.
+3. The local environment has both `gh` and `glab` installed and
+   authenticated. CI fixtures replace the binaries with controlled
+   stubs (via `FORGE_CLI_GH_BIN` / `FORGE_CLI_GLAB_BIN`) so no live
+   network access is required for the default test gate.
+4. `gh pr create --json` and `glab mr view -F json` outputs are stable
+   across the installed minor releases on developer machines and CI.
+   Backend stdout shape mismatches surface as `SOFTWARE 70`, not silent
+   coercion.
+5. Per workspace policy, `NILS_CLI_TEST_RUNNER=nextest bash
+   scripts/ci/nils-cli-checks-entrypoint.sh` is the canonical local
+   gate. `scripts/ci/cli-output-contract-lint.sh` is part of that gate
+   and catches `--json` boolean / numeric exit literal regressions.
+6. Each sprint lands as its own GitHub PR cut from `main` (Sprint 0
+   first, others rebased onto `main` after Sprint 0 merges). PRs go
+   through `create-feature-pr` → `close-feature-pr`; commits go through
+   `semantic-commit`. Direct `git commit` and `gh pr create` are
+   blocked by hook.
+
+## Sprint 1: Crate scaffold + global flags + provider detection + read-only atoms
+
+**Goal**: Land an empty but correctly-shaped `nils-forge-cli` crate
+that already exposes the canonical command tree, parses every global
+flag, detects the provider, plumbs `--dry-run`, and implements the two
+read-only atoms (`auth status`, `repo view`) end to end on both
+backends. Nothing else in the binary mutates remote state yet, so this
+sprint is the safest place to debug provider detection, envelope
+plumbing, and the subprocess wrapper layer.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo build -p nils-forge-cli`
+  - `cargo test -p nils-forge-cli`
+  - `forge-cli --help` (lists `pr`, `issue`, `repo`, `auth`,
+    `completion`; lists `--format`, `--remote`, `--provider`, `--repo`,
+    `--dry-run`).
+  - `forge-cli auth status --format json` (envelope with
+    `schema_version: cli.forge-cli.auth.status.v1`).
+  - `forge-cli repo view --format json` (envelope with normalized
+    `owner`, `name`, `default_branch`, `merge_methods_allowed`).
+  - `forge-cli auth status --provider github --dry-run --format json`
+    (envelope carries `data.plan = ["gh", "auth", "status"]`, no
+    subprocess invoked).
+- Verify: `forge-cli` returns `64` on unknown provider host, `69` when
+  `gh`/`glab` is missing (force via
+  `FORGE_CLI_GH_BIN=/bin/false`), `0` on success; envelope is
+  snake_case; no inline numeric exit literals appear under
+  `crates/forge-cli/src/`.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 1.1: Scaffold `crates/forge-cli/` package and workspace wiring
+
+- **Location**:
+  - `crates/forge-cli/Cargo.toml` (new)
+  - `crates/forge-cli/src/main.rs` (new)
+  - `crates/forge-cli/src/lib.rs` (new)
+  - `crates/forge-cli/README.md` (new — minimal pointer to spec)
+  - `Cargo.toml` (workspace `members`)
+- **Description**: Create the `nils-forge-cli` package mirroring
+  `crates/git-cli/Cargo.toml` (lib `forge_cli` + bin `forge-cli`,
+  edition / license inherited, version pinned to current workspace
+  version). Wire it into the workspace `members`. `main.rs` is a thin
+  wrapper that calls `forge_cli::run()` and exits with its returned
+  code. `README.md` is a one-paragraph pointer to
+  `docs/specs/forge-cli-spec-v1.md`.
+- **Dependencies**:
+  - none
+- **Complexity**:
+  - 3
+- **Acceptance criteria**:
+  - `cargo build -p nils-forge-cli` succeeds.
+  - `cargo test --workspace --no-run` succeeds (no dangling reference).
+  - Package version matches the current workspace version and
+    `nils-common` dependency is on the workspace path / version.
+  - Crate appears in `cargo metadata --no-deps` output.
+- **Validation**:
+  - `cargo build -p nils-forge-cli`
+  - `cargo metadata --no-deps --format-version 1 | jq '.packages[].name' | grep -F nils-forge-cli`
+
+### Task 1.2: Define clap command tree + global flags
+
+- **Location**:
+  - `crates/forge-cli/src/cli.rs` (new)
+  - `crates/forge-cli/src/lib.rs`
+- **Description**: Build the clap derive tree exactly matching the
+  spec's command topology (`pr`, `issue`, `repo`, `auth`, `completion`
+  parents with all v1 children declared, even if their handlers are
+  `todo!()` stubs in this sprint). Wire global flags:
+  `--format` (enum: text or json),
+  `--remote <name>` (default `origin`),
+  `--provider` (enum: github or gitlab; optional, auto-detected when
+  absent),
+  `--repo <owner/name>` (optional),
+  `--dry-run` (bool, default false).
+  No `--json` boolean alias.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**:
+  - 4
+- **Acceptance criteria**:
+  - `forge-cli --help` lists every subcommand listed in spec §"Command
+    tree".
+  - `forge-cli pr --help`, `forge-cli issue --help`, etc. list every
+    expected child subcommand.
+  - Global flags are present on every subcommand (verified by snapshot
+    of `forge-cli pr create --help`).
+  - No `--json` flag appears anywhere.
+- **Validation**:
+  - `cargo test -p nils-forge-cli cli::help`
+  - Manual: `cargo run -p nils-forge-cli -- --help`
+
+### Task 1.3: Implement provider detection
+
+- **Location**:
+  - `crates/forge-cli/src/provider.rs` (new)
+  - `crates/forge-cli/tests/integration/provider.rs` (new)
+- **Description**: Implement the spec's detection ladder: explicit
+  `--provider` → `git remote get-url <--remote>` host parse → cached
+  `gh auth status` / `glab auth status` host match → otherwise
+  `USAGE 64` with `error.kind = "provider_unsupported"`. URL parser
+  accepts `https://`, `ssh://`, `git@host:owner/repo.git`, and the
+  enterprise-host variants (`*.ghe.com`, internal GitLab hostnames).
+  Auth status calls are memoised per `forge-cli` invocation (one call
+  per provider, in `OnceCell` or equivalent). Provider lookup result is
+  carried in a `ProviderContext` that downstream ops accept.
+- **Dependencies**:
+  - Task 1.2
+- **Complexity**:
+  - 6
+- **Acceptance criteria**:
+  - Detection table covers `github.com`, `gitlab.com`,
+    `*.gitlab.<corp>`, `git@github.com:<owner>/<repo>.git`,
+    `ssh://git@gitlab.com/<owner>/<repo>.git`, and rejects an
+    unknown host with the documented error kind.
+  - Auth fallback is exercised by a test that mocks `gh auth status`
+    via `FORGE_CLI_GH_BIN`.
+  - Repeat calls within a run hit the cache (assert via call counter
+    in a test stub).
+- **Validation**:
+  - `cargo test -p nils-forge-cli provider`
+  - Manual: `forge-cli auth status --provider github` from a non-git
+    directory (succeeds; remote URL not consulted).
+
+### Task 1.4: Subprocess wrapper + envelope serializer + dry-run plumbing
+
+- **Location**:
+  - `crates/forge-cli/src/backend.rs` (new)
+  - `crates/forge-cli/src/envelope.rs` (new)
+  - `crates/forge-cli/src/error.rs` (new)
+  - `crates/forge-cli/tests/integration/backend.rs` (new)
+- **Description**: Implement the canonical "run backend subprocess,
+  parse JSON, wrap in envelope" loop in one place. Inputs: a typed
+  argv vector + an expected response shape. Outputs: an
+  `nils_common::cli_contract::Envelope<T>` on success or the typed
+  `ForgeError` on failure. Stderr is captured, tail-trimmed to 2 KiB,
+  token-redacted (regex matching `gh[ps]_*`, `glpat-*`, `ghr_*`,
+  `gho_*`), and placed under `data.error.detail` when the call fails.
+  `--dry-run` short-circuits before subprocess invocation and instead
+  returns `Envelope { ok: true, data: { plan: argv, provider } }`. Exit
+  codes are routed exclusively through `nils_common::cli_contract::exit`
+  constants; no numeric literals in this module.
+- **Dependencies**:
+  - Task 1.3
+- **Complexity**:
+  - 7
+- **Acceptance criteria**:
+  - `--dry-run` produces a stable `data.plan` array and never invokes
+    `gh` / `glab`.
+  - Missing backend binary (`FORGE_CLI_GH_BIN=/bin/false`) maps to
+    `UNAVAILABLE 69` with `error.kind = "backend_missing"`.
+  - Backend non-zero exit propagates as `RUNTIME 1` plus
+    `error.kind = "backend_error"` and a redacted stderr tail.
+  - Token-shaped strings in fixture stderr are replaced with
+    `<redacted-token>` before emission.
+  - Subprocess invocation goes through a single audited code path
+    (unit test asserts only one `Command::new` site).
+- **Validation**:
+  - `cargo test -p nils-forge-cli backend`
+  - `bash scripts/ci/cli-output-contract-lint.sh`
+
+### Task 1.5: Implement `auth status` atom
+
+- **Location**:
+  - `crates/forge-cli/src/ops/auth_status.rs` (new)
+  - `crates/forge-cli/src/ops/mod.rs`
+  - `crates/forge-cli/tests/fixtures/github/auth_status/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/auth_status/` (new)
+  - `crates/forge-cli/tests/integration/auth_status.rs` (new)
+- **Description**: Implement the spec's `auth.status` atom. Backend
+  stdout is text (both `gh auth status` and `glab auth status` are
+  text-only), parsed into `{ provider, host, user?, scopes }` via a
+  small per-backend parser. Empty `scopes` is allowed. Envelope
+  schema literal: `cli.forge-cli.auth.status.v1`.
+- **Dependencies**:
+  - Task 1.4
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - Both backends parse to byte-identical envelopes except for
+    `data.provider` and `data.host`.
+  - Fixture pair lands under
+    `tests/fixtures/{github,gitlab}/auth_status/{stdout,stderr,exit}`.
+  - Token-shaped strings in fixtures are pre-redacted to
+    `<redacted-token>`.
+- **Validation**:
+  - `cargo test -p nils-forge-cli auth_status`
+
+### Task 1.6: Implement `repo view` atom
+
+- **Location**:
+  - `crates/forge-cli/src/ops/repo_view.rs` (new)
+  - `crates/forge-cli/tests/fixtures/github/repo_view/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/repo_view/` (new)
+  - `crates/forge-cli/tests/integration/repo_view.rs` (new)
+- **Description**: Implement the spec's `repo.view` atom. `gh repo
+  view --json …` JSON is mapped to the canonical
+  `{ owner, name, url, default_branch, merge_methods_allowed }` shape
+  in snake_case. `glab repo view -F json` is mapped through a
+  per-backend deserializer that handles its slightly different field
+  names (`default_branch` vs `defaultBranchRef.name`,
+  `merge_methods_allowed` derived from the boolean trio for GitHub /
+  the corresponding GitLab fields). Schema literal:
+  `cli.forge-cli.repo.view.v1`.
+- **Dependencies**:
+  - Task 1.4
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - Output envelope is byte-identical between backends except for
+    `data.url` host and `data.provider`.
+  - `merge_methods_allowed` enumerates exactly the values the backend
+    reports (`squash`, `merge`, `rebase` subset).
+  - Test pair covers a repo with all three methods enabled and a repo
+    with only `squash`.
+- **Validation**:
+  - `cargo test -p nils-forge-cli repo_view`
+
+### Task 1.7: Sprint 1 exit-code matrix + workspace gate
+
+- **Location**:
+  - `crates/forge-cli/tests/integration/exit_codes.rs` (new)
+  - `scripts/ci/cli-output-contract-lint.sh` (allowlist update if any)
+- **Description**: Add the binary's first exit-code matrix covering
+  `SUCCESS` (auth status with stubbed `gh`), `USAGE` (unknown
+  subcommand), `DATA` (parse failure on a deliberately mangled
+  `.forge-cli.toml`), `UNAVAILABLE` (missing backend via
+  `FORGE_CLI_GH_BIN=/bin/false`), and `SOFTWARE` (mangled fixture
+  JSON). `RUNTIME` is deferred to Sprint 3 where check failures
+  naturally produce it. Ensure
+  `bash scripts/ci/cli-output-contract-lint.sh` passes against the
+  scaffolded crate.
+- **Dependencies**:
+  - Task 1.5
+  - Task 1.6
+- **Complexity**:
+  - 4
+- **Acceptance criteria**:
+  - Five tests cover five exit-code constants; each test asserts the
+    literal constant from `nils_common::cli_contract::exit`, not the
+    numeric value.
+  - `scripts/ci/cli-output-contract-lint.sh` passes.
+- **Validation**:
+  - `cargo test -p nils-forge-cli exit_codes`
+  - `bash scripts/ci/cli-output-contract-lint.sh`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh`
+
+## Sprint 2: PR atoms (create / view / list / edit / comment / ready / close)
+
+**Goal**: Land every PR/MR lifecycle atom except `merge` and the
+check atoms. `pr create` carries the heaviest validation surface
+(branch / title / body / worktree / push) and is the prerequisite for
+the macro; the read/append atoms are mostly thin parse-and-render
+layers on top of Sprint 1's subprocess wrapper.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-forge-cli pr_`
+  - `forge-cli pr create --kind feature --title "demo: test" --body-file <(printf '## Summary\nx\n\n## Test plan\ny\n') --dry-run --format json`
+  - `forge-cli pr view 1 --dry-run --format json`
+  - `forge-cli pr list --dry-run --format json`
+- Verify: every PR atom emits a snake_case envelope with the spec's
+  schema literal; `pr create` refuses dirty worktree, unpushed HEAD,
+  branch/kind mismatch, body without `## Summary` or `## Test plan`,
+  and title > 70 chars — each rejection maps to `DATA 65` with the
+  documented `error.kind`.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 2.1: PR body / title / branch validation module
+
+- **Location**:
+  - `crates/forge-cli/src/validations.rs` (new)
+  - `crates/forge-cli/tests/integration/validations.rs` (new)
+- **Description**: Implement the validation rules from
+  `forge-cli-ops-v1.yaml::validations_catalog` that PR ops will share:
+  `branch_name`, `branch_kind_matches`, `title_length`, `body_summary`,
+  `body_test_plan`, `worktree_clean`, `head_pushed`. Each returns a
+  typed result mapping to one of the `error.kind` values listed in
+  spec §"Lock-down policy". The body parser MUST treat any non-empty
+  text under the configured H2 heading (default `## Summary` /
+  `## Test plan`, overridable via `.forge-cli.toml`) as the section
+  body; the H2 line itself must not count as content.
+- **Dependencies**:
+  - Task 1.7
+- **Complexity**:
+  - 6
+- **Acceptance criteria**:
+  - Every rule has a positive + negative unit test.
+  - Body parser correctly rejects "section present but empty" and
+    "section absent", with distinct `error.kind` values
+    (`body_missing_summary` for absent, also for empty; spec maps both
+    to the same kind because the user-visible failure is identical).
+  - Branch / kind mismatch produces `branch_kind_mismatch`, not
+    `branch_name_invalid`.
+- **Validation**:
+  - `cargo test -p nils-forge-cli validations`
+
+### Task 2.2: `pr create` atom
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_create.rs` (new)
+  - `crates/forge-cli/tests/fixtures/github/pr_create/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/pr_create/` (new)
+  - `crates/forge-cli/tests/integration/pr_create.rs` (new)
+- **Description**: Implement `pr create` per spec §"pr create" and
+  the ops YAML's argv template. Use Task 2.1's validator chain.
+  `gh pr create` does not return JSON; after creation, the
+  implementation MUST call `gh pr view --json …` to fetch the new
+  PR's metadata and produce the envelope. For GitLab, `glab mr
+  create` returns the URL on stdout; the implementation does an
+  immediate `glab mr view -F json` follow-up using the parsed `iid`.
+  Body content may come from `--body` or `--body-file`; passing both
+  is a `USAGE 64` parse error.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**:
+  - 8
+- **Acceptance criteria**:
+  - Output envelope: `cli.forge-cli.pr.create.v1` with `data = {
+    number, url, head, base, draft, title, kind, provider }`.
+  - Validation failure paths each emit `DATA 65` with the right
+    `error.kind` (covered in matrix test).
+  - `--draft` defaults to `true`.
+  - Reviewer/label flags pass through to the backend argv when
+    supplied; no-op otherwise.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_create`
+
+### Task 2.3: `pr view`, `pr list`, `pr close` atoms
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_view.rs` (new)
+  - `crates/forge-cli/src/ops/pr_list.rs` (new)
+  - `crates/forge-cli/src/ops/pr_close.rs` (new)
+  - `crates/forge-cli/tests/fixtures/github/pr_view/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/pr_view/` (new)
+  - `crates/forge-cli/tests/fixtures/github/pr_list/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/pr_list/` (new)
+  - `crates/forge-cli/tests/fixtures/github/pr_close/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/pr_close/` (new)
+  - `crates/forge-cli/tests/integration/pr_view.rs` (new)
+  - `crates/forge-cli/tests/integration/pr_list.rs` (new)
+- **Description**: Implement three read/no-validation atoms.
+  `pr view` accepts either a numeric id or a branch name (resolved
+  via `gh pr view <branch>` / `glab mr list --source-branch`).
+  `pr list` supports `--state`, `--author`, `--head`, `--limit`. All
+  outputs go through the snake_case envelope with `data.state` mapped
+  to the spec's `enum<open|closed|merged>` (GitLab's `opened` becomes
+  `open`; `locked` becomes `closed`; everything else is a `SOFTWARE
+  70`). `pr close` has no envelope payload beyond `{ number, url,
+  state }`.
+- **Dependencies**:
+  - Task 2.2
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - State normalization is covered by paired fixtures (open / closed /
+    merged on both backends).
+  - `pr list --limit 1 --dry-run` produces a backend argv that
+    includes the limit clamp.
+  - `pr view <branch>` resolves to a numeric id via the documented
+    fallback.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_view pr_list pr_close`
+
+### Task 2.4: `pr edit`, `pr comment`, `pr ready` atoms
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_edit.rs` (new)
+  - `crates/forge-cli/src/ops/pr_comment.rs` (new)
+  - `crates/forge-cli/src/ops/pr_ready.rs` (new)
+  - `crates/forge-cli/tests/fixtures/github/pr_edit/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/pr_edit/` (new)
+  - `crates/forge-cli/tests/fixtures/github/pr_comment/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/pr_comment/` (new)
+  - `crates/forge-cli/tests/fixtures/github/pr_ready/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/pr_ready/` (new)
+  - `crates/forge-cli/tests/integration/pr_edit.rs` (new)
+  - `crates/forge-cli/tests/integration/pr_comment.rs` (new)
+  - `crates/forge-cli/tests/integration/pr_ready.rs` (new)
+- **Description**: Implement the three mutating atoms with the
+  validations declared in the ops YAML: `pr edit` re-runs
+  `title_length` (when `--title` set) and the body checks (when
+  `--body` / `--body-file` set); `pr comment` has no validation;
+  `pr ready` runs `worktree_clean`. Argv construction follows the
+  spec / YAML. After mutation, each op calls the backend's `view`
+  command to fetch the fresh PR state and emits the canonical
+  envelope.
+- **Dependencies**:
+  - Task 2.1
+  - Task 2.2
+- **Complexity**:
+  - 6
+- **Acceptance criteria**:
+  - `pr edit --add-label x` and `--remove-label y` produce the right
+    backend argv on both providers.
+  - `pr ready` on a non-draft PR succeeds (idempotent — backend's own
+    response is bubbled up).
+  - `pr comment --body-file -` reads from stdin.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_edit pr_comment pr_ready`
+
+## Sprint 3: Check atoms (`pr checks` + `pr wait-checks`)
+
+**Goal**: Implement the two check atoms. GitHub uses `gh pr checks
+--json`; GitLab has no equivalent JSON output in the currently
+installed `glab` minor, so the implementation pins the parser to that
+exact minor and fails-fast on out-of-range versions with
+`UNAVAILABLE 69` and a "please upgrade/downgrade glab" hint.
+`pr wait-checks` reuses `pr.checks` schema, layering polling and
+timeout semantics on top.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-forge-cli pr_checks pr_wait_checks`
+  - `forge-cli pr checks 1 --dry-run --format json`
+  - `forge-cli pr wait-checks 1 --interval 1s --timeout 5s --dry-run --format json`
+- Verify: `state` value is one of the spec's normalized enum on both
+  backends; `pr wait-checks` exit code matrix: required-all-success →
+  `SUCCESS 0`, any-failure / cancelled / timed_out → `RUNTIME 1` with
+  `error.kind = "checks_failed"`, deadline reached → `UNAVAILABLE 69`
+  with `error.kind = "checks_timeout"`.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 3.1: `pr checks` GitHub backend
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_checks.rs` (new)
+  - `crates/forge-cli/tests/fixtures/github/pr_checks/` (new)
+  - `crates/forge-cli/tests/integration/pr_checks_github.rs` (new)
+- **Description**: Implement `pr checks` for GitHub by calling `gh pr
+  checks <id> --json name,state,conclusion,bucket,workflow,link,
+  startedAt,completedAt,description,isRequired`. Normalize the
+  response into the canonical schema: required-only filtering
+  (when `--required-only=true`, default), aggregate `state` derived
+  per the spec's terminal-state mapping. Schema literal:
+  `cli.forge-cli.pr.checks.v1`.
+- **Dependencies**:
+  - Task 2.4
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - Five fixtures cover all-success, mixed-failure, all-pending,
+    cancelled, and empty-checks shapes.
+  - `--required-only=false` includes optional checks under
+    `data.checks` but they still feed the gating decision per the
+    spec ("`--required-only=true` ignores non-required checks for the
+    gating decision but still reports them in `data.checks`").
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_checks_github`
+
+### Task 3.2: `pr checks` GitLab text parser with version fail-fast
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_checks_gitlab.rs` (new)
+  - `crates/forge-cli/src/glab_version.rs` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/pr_checks/` (new)
+  - `crates/forge-cli/tests/integration/pr_checks_gitlab.rs` (new)
+- **Description**: At startup of any GitLab check op, call `glab
+  --version`, parse the minor (e.g. `glab 1.45.0`). If outside the
+  pinned support range (current local install's minor ± 0 — single
+  minor only, per locked decision), return `UNAVAILABLE 69` with
+  `error.kind = "glab_version_unsupported"` and a hint to upgrade /
+  downgrade. Inside the supported minor, parse `glab ci status -b
+  <branch>` text output. The parser is small, deliberately strict,
+  and covered by ≥ 6 fixtures (all-success, one-failure,
+  mixed-states, pending-only, empty pipeline, manual-only).
+- **Dependencies**:
+  - Task 3.1
+- **Complexity**:
+  - 8
+- **Acceptance criteria**:
+  - Version probe is cached for the lifetime of the `forge-cli`
+    invocation.
+  - Out-of-range version produces `UNAVAILABLE 69` and never invokes
+    `glab ci status`.
+  - In-range parser produces an envelope byte-identical to the
+    GitHub backend's envelope shape for the same logical state (with
+    different `data.provider` and link host).
+  - Tests must NOT call out to live `glab`; they stub via
+    `FORGE_CLI_GLAB_BIN`.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_checks_gitlab glab_version`
+
+### Task 3.3: `pr wait-checks` polling loop
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_wait_checks.rs` (new)
+  - `crates/forge-cli/tests/integration/pr_wait_checks.rs` (new)
+- **Description**: Implement the blocking poll on top of `pr.checks`.
+  Inputs: `<id>` (numeric or branch), `--timeout` (default `30m`),
+  `--interval` (default `20s`), `--required-only` (default `true`).
+  Loop sleeps `--interval` between snapshots; emits a single envelope
+  at the end (no streaming). Exit-code mapping per spec:
+  - all required `success` → `SUCCESS 0`.
+  - any required `failure`/`cancelled`/`timed_out` → `RUNTIME 1`,
+    `error.kind = checks_failed`.
+  - timeout reached → `UNAVAILABLE 69`,
+    `error.kind = checks_timeout`.
+  Polling timer uses `tokio::time::sleep` if a runtime is convenient,
+  otherwise `std::thread::sleep`; implementation decides. `--dry-run`
+  short-circuits with `data.plan` showing the would-be invocation
+  loop summary, not an infinite list.
+- **Dependencies**:
+  - Task 3.1
+  - Task 3.2
+- **Complexity**:
+  - 7
+- **Acceptance criteria**:
+  - Test "succeeds on third poll" passes deterministically via a
+    fixture sequence.
+  - Test "fails on first poll with required failure" exits
+    `RUNTIME 1`.
+  - Test "times out after N intervals" exits `UNAVAILABLE 69` and
+    reports `duration_ms` ≥ timeout.
+  - Schema literal stays `cli.forge-cli.pr.checks.v1` (shared with
+    snapshot atom).
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_wait_checks`
+
+## Sprint 4: `pr merge` with lock-down + TTL-zero required-check re-check
+
+**Goal**: The riskiest single atom. Lands every lock-down validation
+listed in spec §"Lock-down policy" rules 4 / 6 / 7 / 8 / 9 / 10 in one
+place, plus the TTL-zero re-check that addresses the
+`github-pr-required-check-gating` operation record. After this sprint
+the binary can complete the macro flow except for the macro
+composition step itself.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-forge-cli pr_merge`
+  - `forge-cli pr merge 1 --method squash --dry-run --format json`
+  - `forge-cli pr merge 1 --method merge --allow-non-default-base --dry-run --format json`
+- Verify: refusal paths produce `DATA 65` with the documented
+  `error.kind`; `--method` overrides `.forge-cli.toml`; `--keep-branch`
+  prevents `--delete-branch` (gh) / `--remove-source-branch` (glab).
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 4.1: Merge-method resolution + `.forge-cli.toml` loader
+
+- **Location**:
+  - `crates/forge-cli/src/config.rs` (new)
+  - `crates/forge-cli/tests/integration/config.rs` (new)
+  - `crates/forge-cli/tests/fixtures/config/` (new)
+- **Description**: Implement the per-repo `.forge-cli.toml` loader
+  (search upwards from CWD to the git toplevel, stop at toplevel). Map
+  recognized keys to typed structs; unknown keys generate a
+  `warnings[]` entry, never an error (forward compat for v2). Provide
+  the resolution function: explicit flag > `.forge-cli.toml` > spec
+  default. Cover `[merge].method`, `[merge].delete_branch`,
+  `[body].summary_heading`, `[body].test_plan_heading`,
+  `[branch].feature_prefix`, `[branch].bug_prefix`, `[checks].timeout`,
+  `[checks].interval`, `[checks].required_only`.
+- **Dependencies**:
+  - Task 3.3
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - Loader finds `.forge-cli.toml` at any ancestor up to git toplevel.
+  - Unknown key produces exactly one warning per key, prefixed
+    `unknown-config-key:`.
+  - Resolution precedence is verified by a unit test for each
+    setting.
+- **Validation**:
+  - `cargo test -p nils-forge-cli config`
+
+### Task 4.2: TTL-zero required-check re-check helper
+
+- **Location**:
+  - `crates/forge-cli/src/ops/required_check_gate.rs` (new)
+  - `crates/forge-cli/tests/integration/required_check_gate.rs` (new)
+- **Description**: Extract the "snapshot required checks right now and
+  bail if not all green" logic into a reusable helper. This is called
+  by `pr merge` immediately before the backend subprocess invocation
+  even when `pr wait-checks` succeeded earlier in the macro. Calls
+  `pr.checks` internally (no new subprocess wrapper). Returns one of
+  `Ok(())`, `Err(checks_pending)` → `DATA 65`, or `Err(checks_failed)`
+  → `RUNTIME 1`. The split between pending and failed mirrors the
+  ops YAML's `required_checks_green` rule.
+- **Dependencies**:
+  - Task 3.3
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - Pending re-check exits `DATA 65` with
+    `error.kind = "checks_pending"`.
+  - Failed re-check exits `RUNTIME 1` with
+    `error.kind = "checks_failed"`.
+  - Helper is invoked even when `pr wait-checks` ran < 1s before
+    (no caching across atoms).
+- **Validation**:
+  - `cargo test -p nils-forge-cli required_check_gate`
+
+### Task 4.3: `pr merge` atom
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_merge.rs` (new)
+  - `crates/forge-cli/tests/fixtures/github/pr_merge/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/pr_merge/` (new)
+  - `crates/forge-cli/tests/integration/pr_merge.rs` (new)
+- **Description**: Wire every lock-down rule from spec §"Lock-down
+  policy" that applies to `pr merge`: `worktree_clean`,
+  `draft_merge_refused` (require non-draft state from `pr view`),
+  `default_branch_protected` (compare base to `repo view`'s
+  `default_branch` unless `--allow-non-default-base`),
+  `required_checks_green` via Task 4.2's helper,
+  `merge_method_supported` (intersect `--method` with
+  `repo view`'s `merge_methods_allowed`), `keep_branch_conflict`.
+  Backend argv per ops YAML: `gh pr merge <id> --{method}
+  --delete-branch?` and `glab mr merge <id> --squash?
+  --remove-source-branch?`. Post-merge: re-fetch via `pr view` to
+  populate `merge_sha` and report `deleted_branch`. Schema literal:
+  `cli.forge-cli.pr.merge.v1`.
+- **Dependencies**:
+  - Task 4.1
+  - Task 4.2
+- **Complexity**:
+  - 9
+- **Acceptance criteria**:
+  - All six lock-down failure paths exit `DATA 65` with the
+    documented `error.kind` (or `RUNTIME 1` for `checks_failed`),
+    each covered by a test.
+  - Successful merge envelope contains `merge_sha`, `method`,
+    `deleted_branch`.
+  - `--method` overrides `.forge-cli.toml`; `--method` not in
+    `merge_methods_allowed` exits with
+    `error.kind = "merge_method_unsupported"`.
+  - `--keep-branch` mutually exclusive with `--delete-branch` (which
+    is implicit-true by default); explicit conflict path covered.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_merge`
+
+## Sprint 5: Issue atoms (create / view / edit / comment / close / reopen)
+
+**Goal**: Complete the Issue surface. Issue ops have a much smaller
+validation footprint than PRs (no branch / body / push state), so
+this sprint is mostly a structural mirror of Sprint 2's PR atoms.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-forge-cli issue_`
+  - `forge-cli issue create --title "demo" --body "..." --dry-run --format json`
+  - `forge-cli issue view 1 --dry-run --format json`
+- Verify: every issue atom emits a snake_case envelope with the
+  spec's schema literal; `title_length` violation on `issue create`
+  exits `DATA 65` with `error.kind = "title_too_long"`.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 5.1: `issue create`, `issue view`, `issue close`, `issue reopen`
+
+- **Location**:
+  - `crates/forge-cli/src/ops/issue_create.rs` (new)
+  - `crates/forge-cli/src/ops/issue_view.rs` (new)
+  - `crates/forge-cli/src/ops/issue_close.rs` (new)
+  - `crates/forge-cli/src/ops/issue_reopen.rs` (new)
+  - `crates/forge-cli/tests/fixtures/github/issue_create/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/issue_create/` (new)
+  - `crates/forge-cli/tests/fixtures/github/issue_view/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/issue_view/` (new)
+  - `crates/forge-cli/tests/fixtures/github/issue_close/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/issue_close/` (new)
+  - `crates/forge-cli/tests/fixtures/github/issue_reopen/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/issue_reopen/` (new)
+  - `crates/forge-cli/tests/integration/issue_create.rs` (new)
+  - `crates/forge-cli/tests/integration/issue_view.rs` (new)
+  - `crates/forge-cli/tests/integration/issue_close.rs` (new)
+  - `crates/forge-cli/tests/integration/issue_reopen.rs` (new)
+- **Description**: Mirror the structure of Sprint 2's PR atoms.
+  `issue create` validates only `title_length`. Output envelopes
+  follow the ops YAML's `data` shape. Reopen and close are simple
+  argv passthroughs with a follow-up `issue view --json` for the
+  fresh state.
+- **Dependencies**:
+  - Task 1.7
+- **Complexity**:
+  - 6
+- **Acceptance criteria**:
+  - Schema literals: `cli.forge-cli.issue.create.v1`, `.view.v1`,
+    `.close.v1`, `.reopen.v1`.
+  - State normalization (`open` / `closed`) matches PR
+    normalization rules.
+  - Fixture pairs land for every op.
+- **Validation**:
+  - `cargo test -p nils-forge-cli issue_create issue_view issue_close issue_reopen`
+
+### Task 5.2: `issue edit`, `issue comment`
+
+- **Location**:
+  - `crates/forge-cli/src/ops/issue_edit.rs` (new)
+  - `crates/forge-cli/src/ops/issue_comment.rs` (new)
+  - `crates/forge-cli/tests/fixtures/github/issue_edit/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/issue_edit/` (new)
+  - `crates/forge-cli/tests/fixtures/github/issue_comment/` (new)
+  - `crates/forge-cli/tests/fixtures/gitlab/issue_comment/` (new)
+  - `crates/forge-cli/tests/integration/issue_edit.rs` (new)
+  - `crates/forge-cli/tests/integration/issue_comment.rs` (new)
+- **Description**: `issue edit` runs `title_length` when `--title`
+  set; supports `--add-label` / `--remove-label` / `--add-assignee`.
+  `issue comment` has no validation; supports `--body` /
+  `--body-file`. Same backend invocation + follow-up `issue view`
+  pattern as Sprint 2.
+- **Dependencies**:
+  - Task 5.1
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - Label add/remove argv constructed correctly on both backends.
+  - `--body-file -` reads from stdin.
+- **Validation**:
+  - `cargo test -p nils-forge-cli issue_edit issue_comment`
+
+## Sprint 6: `pr deliver` macro
+
+**Goal**: Compose Sprints 1–4's atoms into the canonical macro that
+matches agent-kit's `deliver-{feature,bug}-pr` flow. The macro is the
+single biggest behavioural lock-in for forge-cli: callers must NOT be
+able to skip steps or reorder them.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-forge-cli pr_deliver`
+  - `forge-cli pr deliver --kind feature --title "demo" --body-file <(printf '## Summary\nx\n\n## Test plan\ny\n') --dry-run --format json`
+  - `forge-cli pr deliver --kind bug --no-merge --dry-run --format json`
+- Verify: envelope schema `cli.forge-cli.pr.deliver.v1`, `data.steps[]`
+  contains exactly the steps that ran in order; a failing step
+  short-circuits and is the last entry; outer exit code matches the
+  failing atom's exit code (no remapping).
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 6.1: Macro composition + step envelope
+
+- **Location**:
+  - `crates/forge-cli/src/macros/pr_deliver.rs` (new)
+  - `crates/forge-cli/tests/integration/pr_deliver.rs` (new)
+- **Description**: Implement the sequence per spec §"Macro: pr
+  deliver": `auth.status` → `repo.view` → `pr.create` →
+  `pr.wait-checks` → `pr.ready` (skip if `--no-merge`) →
+  `pr.merge` (skip if `--no-merge`). Each step calls into the
+  underlying atom's pure function (no subprocess re-spawn through a
+  child binary). The macro accumulates per-step envelopes under
+  `data.steps[]` as `{ step, ok, schema_version, payload }`. On
+  failure the macro propagates the failing atom's exit code
+  unchanged.
+- **Dependencies**:
+  - Task 4.3
+- **Complexity**:
+  - 8
+- **Acceptance criteria**:
+  - Successful end-to-end run lists all six steps (or four with
+    `--no-merge`).
+  - Failure at any step omits later steps from `data.steps[]` (no
+    "step did not run" entries; spec explicit).
+  - `--no-merge` exits with macro's outer code = `pr.wait-checks`
+    exit code (typically `0`).
+  - Outer exit on `pr.create` validation failure is `DATA 65`, not
+    a remapped runtime code.
+  - Test asserts byte-stable envelope ordering of `data.steps[]`.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_deliver`
+
+### Task 6.2: Macro CLI surface + dry-run plan rendering
+
+- **Location**:
+  - `crates/forge-cli/src/cli.rs`
+  - `crates/forge-cli/tests/integration/pr_deliver_cli.rs` (new)
+- **Description**: Wire the `pr deliver` subcommand to the macro from
+  Task 6.1. Surface all flags from the ops YAML (`--kind`, `--title`,
+  `--body`, `--body-file`, `--head`, `--base`, `--method`,
+  `--reviewer`, `--timeout`, `--no-merge`,
+  `--allow-non-default-base`). `--dry-run` collects each atom's own
+  `data.plan` into a top-level `data.plan_steps[]` array so the
+  caller can preview the full chain.
+- **Dependencies**:
+  - Task 6.1
+- **Complexity**:
+  - 4
+- **Acceptance criteria**:
+  - `forge-cli pr deliver --help` lists every documented flag.
+  - `--dry-run` emits `data.plan_steps[]` with one entry per atom that
+    would run; no subprocess is invoked.
+  - `--no-merge` excludes `pr.ready` and `pr.merge` from the dry-run
+    plan.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_deliver_cli`
+
+## Sprint 7: Parity harness + exit-code matrix + fixture corpus
+
+**Goal**: Lock the v1 contract behind tests. A single parity harness
+asserts the envelope is byte-identical across providers for every
+atom (modulo `data.provider` and host fragments of URLs). The
+exit-code matrix covers all six sysexits paths. The fixture corpus is
+fully redacted and stable.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-forge-cli parity`
+  - `cargo test -p nils-forge-cli exit_codes_full`
+  - `bash scripts/ci/cli-output-contract-lint.sh`
+  - `grep -RInE 'gh[ps]_[A-Za-z0-9]+|glpat-[A-Za-z0-9_-]+|ghr_[A-Za-z0-9]+|gho_[A-Za-z0-9]+' crates/forge-cli/tests/fixtures/`
+- Verify: parity harness passes for every paired op; grep returns no
+  un-redacted token-shaped strings in any fixture; exit-code matrix
+  covers `SUCCESS / RUNTIME / USAGE / DATA / UNAVAILABLE / SOFTWARE`.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 7.1: Parity harness
+
+- **Location**:
+  - `crates/forge-cli/tests/integration/parity.rs` (new)
+  - `crates/forge-cli/tests/support/parity.rs` (new)
+- **Description**: Build a small driver that iterates the spec's
+  parity matrix and, for each row, runs both backends through the
+  same logical input, then diffs the resulting envelopes. The diff
+  IGNORES `data.provider` and any `data.url` host fragment (a
+  normalizer replaces `https://gitlab.com/<owner>` with
+  `https://<host>/<owner>` before compare). Any other field difference
+  is a failure.
+- **Dependencies**:
+  - Task 5.2
+  - Task 6.2
+- **Complexity**:
+  - 7
+- **Acceptance criteria**:
+  - Parity rows for `auth status`, `repo view`, `pr create`,
+    `pr view`, `pr list`, `pr edit`, `pr comment`, `pr ready`,
+    `pr merge`, `pr close`, `pr checks`, `pr wait-checks`,
+    `issue create`, `issue view`, `issue edit`, `issue comment`,
+    `issue close`, `issue reopen`, `pr deliver` all pass.
+  - One deliberate fixture mutation (e.g. flip a field on GitLab
+    side) is caught by the harness in a separate negative test.
+- **Validation**:
+  - `cargo test -p nils-forge-cli parity`
+
+### Task 7.2: Exit-code matrix completion
+
+- **Location**:
+  - `crates/forge-cli/tests/integration/exit_codes_full.rs` (new)
+- **Description**: Extend Sprint 1's matrix to cover every code +
+  every triggering kind. One test per `(exit_constant, error.kind)`
+  pair from the spec's exit code table and the lock-down `error.kind`
+  table. Each test asserts the constant name from
+  `nils_common::cli_contract::exit`, not the numeric value.
+- **Dependencies**:
+  - Task 7.1
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - Every row in spec §"Exit code map" has at least one test.
+  - Every row in spec §"Lock-down policy"'s `error.kind` table has at
+    least one test.
+  - `bash scripts/ci/cli-output-contract-lint.sh` passes.
+- **Validation**:
+  - `cargo test -p nils-forge-cli exit_codes_full`
+  - `bash scripts/ci/cli-output-contract-lint.sh`
+
+### Task 7.3: Fixture redaction audit
+
+- **Location**:
+  - `crates/forge-cli/tests/fixtures/README.md` (new)
+  - `scripts/ci/forge-cli-fixture-lint.sh` (new)
+- **Description**: Add a tiny lint script that greps the fixture tree
+  for token-shaped strings (`gh[ps]_*`, `glpat-*`, `ghr_*`, `gho_*`,
+  `Bearer [A-Za-z0-9._-]+`) and fails on any match. Wire it into
+  `nils-cli-checks-entrypoint.sh --docs-only` so PR review catches
+  un-redacted fixtures before merge. Audit every existing fixture
+  added by Sprints 1–6 and replace any token-shaped placeholder with
+  `<redacted-token>`.
+- **Dependencies**:
+  - Task 7.2
+- **Complexity**:
+  - 3
+- **Acceptance criteria**:
+  - `bash scripts/ci/forge-cli-fixture-lint.sh` returns 0.
+  - A synthetic regression fixture (a fake `ghp_aaa...` string) is
+    caught by the lint and reported with file path + line.
+  - Script appears in `--docs-only` checks and `DEVELOPMENT.md`.
+- **Validation**:
+  - `bash scripts/ci/forge-cli-fixture-lint.sh`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+
+## Sprint 8: Wrapper + completion + Homebrew tap formula + nils-cli minor bump
+
+**Goal**: Ship `forge-cli` as a first-class workspace binary that
+users can `brew install` and shell-complete. After this sprint the
+binary is feature-complete and the v1 acceptance gate can be checked.
+
+**Demo/Validation**:
+
+- Commands:
+  - `wrappers/forge-cli --help` (delegates to the installed binary).
+  - `compdef _forge-cli forge-cli && forge-cli pr <TAB>` (zsh
+    completion lists subcommands).
+  - `bash completions/forge-cli.bash && complete -p forge-cli`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh`
+  - `brew bump-formula-pr` dry-run on the tap (manual step).
+- Verify: brew tap formula installs the binary and the wrapper;
+  shell completions list every subcommand from spec §"Command tree";
+  workspace gate is green; `nils-cli` minor is bumped to the next
+  patch boundary.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 8.1: `wrappers/forge-cli` + shell completions
+
+- **Location**:
+  - `wrappers/forge-cli` (new — bash wrapper mirroring
+    `wrappers/git-cli`)
+  - `completions/_forge-cli` (new — zsh completion)
+  - `completions/forge-cli.bash` (new — bash completion)
+  - `crates/forge-cli/src/cli.rs` (add `completion` subcommand that
+    emits clap-generated scripts per workspace standard)
+- **Description**: Follow
+  `docs/runbooks/cli-completion-development-standard.md` and the
+  `git-cli` precedent. The `forge-cli completion zsh|bash` subcommand
+  prints the script; checked-in completion files are the snapshot of
+  that output and a generation test asserts they stay in sync.
+- **Dependencies**:
+  - Task 7.3
+- **Complexity**:
+  - 5
+- **Acceptance criteria**:
+  - `forge-cli completion zsh` and `forge-cli completion bash`
+    succeed and print non-empty content.
+  - Checked-in completion files equal the output of the corresponding
+    subcommand (test asserts byte-equality, regenerates on diff).
+  - `wrappers/forge-cli` resolves the binary the same way
+    `wrappers/git-cli` does.
+- **Validation**:
+  - `cargo test -p nils-forge-cli completion`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh`
+
+### Task 8.2: Homebrew tap formula update
+
+- **Location**:
+  - `wrappers/forge-cli`
+  - tap repository (external — `homebrew-tap`): the formula update is
+    driven by the existing `nils-cli-bump-version-tag-release` flow,
+    so this task only ensures the workspace side is ready (wrapper
+    path, completion install hooks, README mention) and lists the tap
+    formula bump as a Sprint 9 release action.
+- **Description**: Audit `Formula/nils-cli.rb`-equivalent in the tap
+  for the install hooks pattern used by `git-cli`. Confirm
+  `forge-cli` follows the same convention so the bump skill picks it
+  up automatically. No tap-repo edit lands in this PR; the bump
+  happens in Task 8.3.
+- **Dependencies**:
+  - Task 8.1
+- **Complexity**:
+  - 2
+- **Acceptance criteria**:
+  - `wrappers/forge-cli` is referenced in the binary list the bump
+    skill consumes (verify via dry-run of the bump skill).
+  - README cross-link from `nils-cli` workspace README to the
+    `forge-cli` crate README is in place.
+- **Validation**:
+  - Manual dry-run of `nils-cli-bump-version-tag-release` (do not
+    execute the bump in this PR).
+
+### Task 8.3: `nils-cli` minor bump + tag + tap formula bump
+
+- **Location**:
+  - workspace `Cargo.toml` (`workspace.package.version`)
+  - per-crate `Cargo.toml` patches the bump skill emits
+  - `CHANGELOG.md` (if present) — release notes entry for `forge-cli`
+  - external `homebrew-tap` formula
+- **Description**: After Sprint 8.1 and 8.2 land on `main`, run the
+  workspace's release flow via the `nils-cli-bump-version-tag-release`
+  skill (minor bump). The skill handles annotated tag, push, tap
+  formula bump, and post-release verification. The acceptance gate is
+  considered met once the resulting release passes
+  `nils-cli-verify-required-checks` and the tap formula installs the
+  new binary.
+- **Dependencies**:
+  - Task 8.1
+  - Task 8.2
+- **Complexity**:
+  - 3
+- **Acceptance criteria**:
+  - Workspace version bumps minor (e.g. `0.10.x` → `0.11.0`).
+  - Tag `vX.Y.0` is pushed.
+  - Tap formula bump PR is merged.
+  - `brew upgrade nils-cli` installs `forge-cli` on a clean tap
+    checkout.
+- **Validation**:
+  - `nils-cli-verify-required-checks` reports green.
+  - Manual: `brew upgrade nils-cli && forge-cli --version`.
+
+## Testing Strategy
+
+- **Unit**: every op's pure helpers (provider detection, body parser,
+  validation rules, glab text parser, merge-method resolver) have at
+  least one positive + one negative unit test in the same file as the
+  helper.
+- **Integration (per op)**: each atom has a paired fixture under
+  `crates/forge-cli/tests/fixtures/{github,gitlab}/<op>/` and an
+  integration test driving the backend stub via `FORGE_CLI_GH_BIN` /
+  `FORGE_CLI_GLAB_BIN`. Fixtures cover the success path plus every
+  documented error kind.
+- **Parity**: Sprint 7 harness asserts envelope byte-equality across
+  backends per parity row.
+- **Exit-code matrix**: per workspace policy + spec §"Exit code
+  map" — one test per `(exit_constant, error.kind)` pair.
+- **Dry-run smoke**: every op's integration test includes a
+  `--dry-run` invocation that asserts the `data.plan` array shape;
+  this is what proves no live network call is required for the
+  default gate.
+- **Lint**: `bash scripts/ci/cli-output-contract-lint.sh` + new
+  `bash scripts/ci/forge-cli-fixture-lint.sh` run as part of the
+  docs-only gate.
+- **Workspace gate**: `NILS_CLI_TEST_RUNNER=nextest bash
+  scripts/ci/nils-cli-checks-entrypoint.sh` stays green after every
+  sprint.
+- **End-to-end (opt-in)**: tests behind `FORGE_CLI_E2E=1` exercise a
+  designated sandbox repo; default CI does not run them. These guard
+  against drift in `gh` / `glab` JSON shape between the fixture
+  snapshot and the live binary.
+
+## Risks & gotchas
+
+- `gh pr create` does not return JSON; the implementation MUST do a
+  follow-up `gh pr view --json …` to populate the envelope. Skipping
+  this step would leave `merge_sha` and `head` empty on success and
+  break the parity test.
+- `glab` JSON output for `ci status` does not exist in the installed
+  minor; the text parser is brittle by definition. Pinning to the
+  current minor + fail-fast (Sprint 3.2) keeps blast radius bounded
+  but creates a tooling-upgrade hazard: developers who upgrade `glab`
+  outside the supported minor will see `UNAVAILABLE 69`. The error
+  message must point them at the exact supported range.
+- `pr wait-checks` shares schema with `pr checks` deliberately. A
+  refactor that splits them later must NOT change the schema literal
+  without bumping to `v2`.
+- The macro propagates inner exit codes unchanged. Callers that grep
+  for a specific code without also reading `error.kind` will
+  misclassify a `DATA 65` from `pr.create` as the same class as a
+  `DATA 65` from `pr.merge`. This is intentional; the spec's
+  callers-must-branch-on-error.kind contract is documented in spec
+  §"Exit code map".
+- `.forge-cli.toml` is read at startup and not re-read mid-run. A
+  long-running `pr wait-checks` that survives a `.forge-cli.toml`
+  edit will use the original values; this is acceptable for v1 but
+  worth a release-note line.
+- Token redaction relies on regex matching of the four documented
+  prefixes. Backend stderr that contains a personal access token in
+  an undocumented shape will leak. The Sprint 7 fixture lint provides
+  test-time defence; production runs rely on the regex set staying
+  in sync with provider docs.
+- Workspace tests reuse one process; tests that mutate environment
+  variables (e.g. `FORGE_CLI_GH_BIN`) MUST use the `EnvGuard` pattern
+  from `nils-test-support` to avoid cross-test bleed.
+- The parity test normalises `data.url` host fragments. A future
+  change that introduces backend-specific path fragments (e.g.
+  `/merge_requests/` vs `/pull/`) needs to extend the normalizer or
+  the test will start flapping. Capture URL shape divergence in
+  `data.url` and leave the host normalization narrow.
+
+## Rollback plan
+
+- **Sprint 1 rollback**: revert the new crate; nothing else in the
+  workspace depends on `nils-forge-cli` yet.
+- **Sprint 2–6 rollback**: each sprint is its own PR. Reverting a
+  single sprint leaves earlier ops working; the macro Sprint 6
+  rollback is the only one that visibly impacts user-facing flows
+  because `pr deliver` would disappear, but the atoms remain.
+- **Sprint 7 rollback**: revert removes the parity / matrix tests but
+  leaves the binary intact. Re-introduce by cherry-picking the
+  reverted commits.
+- **Sprint 8 rollback**: leave wrapper + completions in place but
+  revert the brew tap formula bump in a follow-up. The minor bump
+  cannot be unbumped; a patch follow-up bump that ships only docs is
+  the recovery path.
+- **Cross-sprint rollback**: if the binary is found unsafe in the
+  field, the agent-kit migration (out of v1 scope) is the
+  fail-safe — agent-kit skills keep calling `gh` / `glab` directly
+  until forge-cli is re-validated.

--- a/docs/specs/forge-cli-ops-v1.yaml
+++ b/docs/specs/forge-cli-ops-v1.yaml
@@ -1,0 +1,459 @@
+# forge-cli operation catalog v1.
+#
+# Machine-readable companion to `forge-cli-spec-v1.md`. The spec is
+# the source of truth for prose, rationale, and contract conformance;
+# this file enumerates every atom + macro for the v1 surface so the
+# Rust implementation, the backend wrappers, and the test fixtures
+# can be generated from a single declaration.
+#
+# Validation rule names referenced from `validations:` are defined
+# at the top of the file under `validations_catalog`. The spec
+# describes their semantics; the names below are the keys an
+# implementation can match on.
+
+version: 1
+binary: forge-cli
+schema_prefix: cli.forge-cli
+
+# ---------------------------------------------------------------------------
+# Shared validation catalog. Each op picks the subset it enforces.
+# ---------------------------------------------------------------------------
+validations_catalog:
+  branch_name:
+    rule: "^(feat|fix)/[a-z0-9][a-z0-9-]{1,63}$"
+    error_kind: branch_name_invalid
+    exit: DATA
+  branch_kind_matches:
+    rule: "feature -> feat/*, bug -> fix/*"
+    error_kind: branch_kind_mismatch
+    exit: DATA
+  body_summary:
+    rule: "non-empty H2 `## Summary` section"
+    error_kind: body_missing_summary
+    exit: DATA
+  body_test_plan:
+    rule: "non-empty H2 `## Test plan` section"
+    error_kind: body_missing_test_plan
+    exit: DATA
+  title_length:
+    rule: "len(title) <= 70 and no trailing whitespace"
+    error_kind: title_too_long
+    exit: DATA
+  worktree_clean:
+    rule: "git status --porcelain is empty"
+    error_kind: dirty_worktree
+    exit: DATA
+  head_pushed:
+    rule: "HEAD has upstream and matches remote-tracking ref"
+    error_kind: head_not_pushed
+    exit: DATA
+  default_branch_protected:
+    rule: "refuse force-push / direct merge to repo default branch"
+    error_kind: default_branch_protected
+    exit: DATA
+  draft_merge_refused:
+    rule: "pr.draft == false at merge time"
+    error_kind: draft_merge_refused
+    exit: DATA
+  required_checks_green:
+    rule: "every required check is success at merge time"
+    error_kind: checks_pending     # exit DATA when pending
+    failed_error_kind: checks_failed  # exit RUNTIME when failed
+  merge_method_supported:
+    rule: "method in {squash, merge, rebase} and backend supports it"
+    error_kind: merge_method_unsupported
+    exit: DATA
+  keep_branch_conflict:
+    rule: "--keep-branch and --delete-branch are mutually exclusive"
+    error_kind: keep_branch_conflict
+    exit: DATA
+
+# ---------------------------------------------------------------------------
+# Global flags every subcommand inherits.
+# ---------------------------------------------------------------------------
+global_flags:
+  - name: --format
+    type: enum<text|json>
+    default: text
+  - name: --remote
+    type: string
+    default: origin
+  - name: --provider
+    type: enum<github|gitlab>
+    default: auto
+  - name: --repo
+    type: string  # owner/name slug
+    default: derived-from-remote
+  - name: --dry-run
+    type: bool
+    default: false
+
+# ---------------------------------------------------------------------------
+# Atomic operations.
+# ---------------------------------------------------------------------------
+operations:
+
+  - id: pr.create
+    schema_version: cli.forge-cli.pr.create.v1
+    summary: Open a draft pull/merge request from the current branch.
+    inputs:
+      - { name: --head,        type: string,         default: current-branch }
+      - { name: --base,        type: string,         default: repo-default-branch }
+      - { name: --title,       type: string,         required: true }
+      - { name: --body,        type: string,         required: false }
+      - { name: --body-file,   type: path,           required: false }
+      - { name: --kind,        type: enum<feature|bug>, required: true }
+      - { name: --draft,       type: bool,           default: true }
+      - { name: --reviewer,    type: list<string>,   default: [] }
+      - { name: --label,       type: list<string>,   default: [] }
+    validations:
+      - branch_name
+      - branch_kind_matches
+      - title_length
+      - body_summary
+      - body_test_plan
+      - worktree_clean
+      - head_pushed
+    backends:
+      github:
+        program: gh
+        argv: [pr, create, "--draft", "--head", "{head}", "--base", "{base}", "--title", "{title}", "--body-file", "{body_file_or_temp}"]
+        json: { read_after: true, command: [pr, view, "{number}", --json, "number,url,headRefName,baseRefName,isDraft,title"] }
+      gitlab:
+        program: glab
+        argv: [mr, create, "--draft", "--source-branch", "{head}", "--target-branch", "{base}", "--title", "{title}", "--description", "{body_or_body_file}"]
+        json: { read_after: true, command: [mr, view, "{iid}", -F, json] }
+    output:
+      data:
+        number: integer
+        url: string
+        head: string
+        base: string
+        draft: bool
+        title: string
+        kind: enum<feature|bug>
+        provider: enum<github|gitlab>
+
+  - id: pr.view
+    schema_version: cli.forge-cli.pr.view.v1
+    summary: Fetch a single PR/MR with normalised fields.
+    inputs:
+      - { name: <id>, type: integer-or-branch, required: true }
+    validations: []
+    backends:
+      github: { program: gh,   argv: [pr,   view, "{id}", --json, "number,url,state,isDraft,title,headRefName,baseRefName,mergeable,mergedAt,labels"] }
+      gitlab: { program: glab, argv: [mr,   view, "{id}", -F, json] }
+    output:
+      data:
+        number: integer
+        url: string
+        state: enum<open|closed|merged>
+        draft: bool
+        title: string
+        head: string
+        base: string
+        mergeable: enum<yes|no|unknown>
+        merged_at: optional<string>
+        labels: list<string>
+
+  - id: pr.list
+    schema_version: cli.forge-cli.pr.list.v1
+    summary: List PRs/MRs filtered by author / state / branch.
+    inputs:
+      - { name: --state,  type: enum<open|closed|merged|all>, default: open }
+      - { name: --author, type: string,                       required: false }
+      - { name: --head,   type: string,                       required: false }
+      - { name: --limit,  type: integer,                      default: 30 }
+    validations: []
+    backends:
+      github: { program: gh,   argv: [pr, list, --json, "number,url,state,title,headRefName,author"] }
+      gitlab: { program: glab, argv: [mr, list, -F, json] }
+    output:
+      data:
+        items: list<{ number, url, state, title, head, author }>
+
+  - id: pr.edit
+    schema_version: cli.forge-cli.pr.edit.v1
+    summary: Mutate PR/MR title, body, base, labels, reviewers.
+    inputs:
+      - { name: <id>,        type: integer, required: true }
+      - { name: --title,     type: string,  required: false }
+      - { name: --body,      type: string,  required: false }
+      - { name: --body-file, type: path,    required: false }
+      - { name: --base,      type: string,  required: false }
+      - { name: --add-label,    type: list<string>, default: [] }
+      - { name: --remove-label, type: list<string>, default: [] }
+      - { name: --add-reviewer, type: list<string>, default: [] }
+    validations:
+      - title_length   # when --title supplied
+      - body_summary   # when --body or --body-file supplied
+      - body_test_plan # when --body or --body-file supplied
+    backends:
+      github: { program: gh,   argv: [pr, edit,   "{id}"] }
+      gitlab: { program: glab, argv: [mr, update, "{id}"] }
+
+  - id: pr.comment
+    schema_version: cli.forge-cli.pr.comment.v1
+    summary: Append a comment to a PR/MR.
+    inputs:
+      - { name: <id>,        type: integer, required: true }
+      - { name: --body,      type: string,  required: false }
+      - { name: --body-file, type: path,    required: false }
+    validations: []
+    backends:
+      github: { program: gh,   argv: [pr, comment, "{id}", --body, "{body_or_file}"] }
+      gitlab: { program: glab, argv: [mr, note,    "{id}", --message, "{body_or_file}"] }
+
+  - id: pr.ready
+    schema_version: cli.forge-cli.pr.ready.v1
+    summary: Promote a draft PR/MR to ready-for-review.
+    inputs:
+      - { name: <id>, type: integer, required: true }
+    validations:
+      - worktree_clean
+    backends:
+      github: { program: gh,   argv: [pr, ready,  "{id}"] }
+      gitlab: { program: glab, argv: [mr, update, "{id}", "--ready"] }
+
+  - id: pr.merge
+    schema_version: cli.forge-cli.pr.merge.v1
+    summary: Merge a ready PR/MR with the configured method.
+    inputs:
+      - { name: <id>,                       type: integer,                       required: true }
+      - { name: --method,                   type: enum<squash|merge|rebase>,     default: squash }
+      - { name: --keep-branch,              type: bool,                          default: false }
+      - { name: --allow-non-default-base,   type: bool,                          default: false }
+    validations:
+      - worktree_clean
+      - draft_merge_refused
+      - default_branch_protected
+      - required_checks_green   # TTL-zero re-check
+      - merge_method_supported
+      - keep_branch_conflict
+    backends:
+      github: { program: gh,   argv: [pr, merge, "{id}", "--{method}", "--delete-branch?"] }
+      gitlab: { program: glab, argv: [mr, merge, "{id}", "--squash?", "--remove-source-branch?"] }
+    output:
+      data:
+        number: integer
+        url: string
+        merge_sha: string
+        method: enum<squash|merge|rebase>
+        deleted_branch: bool
+
+  - id: pr.close
+    schema_version: cli.forge-cli.pr.close.v1
+    summary: Close a PR/MR without merging.
+    inputs:
+      - { name: <id>, type: integer, required: true }
+    validations: []
+    backends:
+      github: { program: gh,   argv: [pr, close, "{id}"] }
+      gitlab: { program: glab, argv: [mr, close, "{id}"] }
+
+  - id: pr.checks
+    schema_version: cli.forge-cli.pr.checks.v1
+    summary: One-shot snapshot of PR/MR check state.
+    inputs:
+      - { name: <id>,           type: integer-or-branch, required: true }
+      - { name: --required-only, type: bool,             default: true }
+    validations: []
+    backends:
+      github: { program: gh,   argv: [pr, checks, "{id}", --json, "name,state,conclusion,bucket,workflow,link,startedAt,completedAt,description,isRequired"] }
+      gitlab: { program: glab, argv: [ci, status,  "-b", "{branch}"] }   # text fallback parsed
+    output:
+      data:
+        state: enum<success|failure|pending|cancelled|neutral|skipped|timed_out>
+        required_count: integer
+        success_count: integer
+        failed: list<{ name, url, conclusion }>
+        pending: list<{ name, url }>
+
+  - id: pr.wait-checks
+    schema_version: cli.forge-cli.pr.checks.v1   # shares schema with pr.checks
+    summary: Block until every required check reaches a terminal state.
+    inputs:
+      - { name: <id>,            type: integer-or-branch, required: true }
+      - { name: --timeout,       type: duration,          default: 30m }
+      - { name: --interval,      type: duration,          default: 20s }
+      - { name: --required-only, type: bool,              default: true }
+    validations: []
+    behaviour: |
+      Polls pr.checks until every required check is terminal. Emits
+      a single envelope at the end. Maps results to exit code:
+        all success         -> SUCCESS 0
+        any failure         -> RUNTIME 1, error.kind=checks_failed
+        cancelled/timed_out -> RUNTIME 1, error.kind=checks_failed
+        deadline reached    -> UNAVAILABLE 69, error.kind=checks_timeout
+    backends: inherits-from-pr.checks
+    output: inherits-from-pr.checks
+
+  - id: issue.create
+    schema_version: cli.forge-cli.issue.create.v1
+    summary: Open a new issue.
+    inputs:
+      - { name: --title,     type: string, required: true }
+      - { name: --body,      type: string, required: false }
+      - { name: --body-file, type: path,   required: false }
+      - { name: --label,     type: list<string>, default: [] }
+      - { name: --assignee,  type: list<string>, default: [] }
+    validations:
+      - title_length
+    backends:
+      github: { program: gh,   argv: [issue, create, --title, "{title}", --body-file, "{body_file_or_temp}"] }
+      gitlab: { program: glab, argv: [issue, create, --title, "{title}", --description, "{body_or_file}"] }
+    output:
+      data: { number, url, title, state, provider }
+
+  - id: issue.view
+    schema_version: cli.forge-cli.issue.view.v1
+    summary: Fetch a single issue.
+    inputs:
+      - { name: <id>, type: integer, required: true }
+    backends:
+      github: { program: gh,   argv: [issue, view, "{id}", --json, "number,url,state,title,labels,assignees,body"] }
+      gitlab: { program: glab, argv: [issue, view, "{id}", -F, json] }
+
+  - id: issue.edit
+    schema_version: cli.forge-cli.issue.edit.v1
+    summary: Mutate issue title / body / labels / assignees.
+    inputs:
+      - { name: <id>,             type: integer,      required: true }
+      - { name: --title,          type: string,       required: false }
+      - { name: --body,           type: string,       required: false }
+      - { name: --body-file,      type: path,         required: false }
+      - { name: --add-label,      type: list<string>, default: [] }
+      - { name: --remove-label,   type: list<string>, default: [] }
+      - { name: --add-assignee,   type: list<string>, default: [] }
+    validations:
+      - title_length   # when --title supplied
+    backends:
+      github: { program: gh,   argv: [issue, edit,   "{id}"] }
+      gitlab: { program: glab, argv: [issue, update, "{id}"] }
+
+  - id: issue.comment
+    schema_version: cli.forge-cli.issue.comment.v1
+    summary: Append a comment to an issue.
+    inputs:
+      - { name: <id>,        type: integer, required: true }
+      - { name: --body,      type: string,  required: false }
+      - { name: --body-file, type: path,    required: false }
+    backends:
+      github: { program: gh,   argv: [issue, comment, "{id}", --body, "{body_or_file}"] }
+      gitlab: { program: glab, argv: [issue, note,    "{id}", --message, "{body_or_file}"] }
+
+  - id: issue.close
+    schema_version: cli.forge-cli.issue.close.v1
+    summary: Close an issue.
+    inputs:
+      - { name: <id>, type: integer, required: true }
+    backends:
+      github: { program: gh,   argv: [issue, close, "{id}"] }
+      gitlab: { program: glab, argv: [issue, close, "{id}"] }
+
+  - id: issue.reopen
+    schema_version: cli.forge-cli.issue.reopen.v1
+    summary: Reopen a closed issue.
+    inputs:
+      - { name: <id>, type: integer, required: true }
+    backends:
+      github: { program: gh,   argv: [issue, reopen, "{id}"] }
+      gitlab: { program: glab, argv: [issue, reopen, "{id}"] }
+
+  - id: repo.view
+    schema_version: cli.forge-cli.repo.view.v1
+    summary: Resolve repo slug, default branch, default merge method.
+    inputs: []
+    backends:
+      github: { program: gh,   argv: [repo, view, --json, "name,owner,defaultBranchRef,mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,url"] }
+      gitlab: { program: glab, argv: [repo, view, -F, json] }
+    output:
+      data:
+        owner: string
+        name: string
+        url: string
+        default_branch: string
+        merge_methods_allowed: list<enum<squash|merge|rebase>>
+
+  - id: auth.status
+    schema_version: cli.forge-cli.auth.status.v1
+    summary: Verify backend auth (gh / glab).
+    inputs: []
+    backends:
+      github: { program: gh,   argv: [auth, status] }
+      gitlab: { program: glab, argv: [auth, status] }
+    output:
+      data:
+        provider: enum<github|gitlab>
+        host: string
+        user: optional<string>
+        scopes: list<string>
+    notes: "Backend output is text, parsed into the structured envelope."
+
+# ---------------------------------------------------------------------------
+# Macro operations.
+# ---------------------------------------------------------------------------
+macros:
+
+  - id: pr.deliver
+    schema_version: cli.forge-cli.pr.deliver.v1
+    summary: End-to-end "open draft → CI green → ready → merge" flow.
+    inputs:
+      - { name: --kind,                     type: enum<feature|bug>,            required: true }
+      - { name: --title,                    type: string,                       required: false }
+      - { name: --body,                     type: string,                       required: false }
+      - { name: --body-file,                type: path,                         required: false }
+      - { name: --head,                     type: string,                       default: current-branch }
+      - { name: --base,                     type: string,                       default: repo-default-branch }
+      - { name: --method,                   type: enum<squash|merge|rebase>,    default: squash }
+      - { name: --reviewer,                 type: list<string>,                 default: [] }
+      - { name: --timeout,                  type: duration,                     default: 30m }
+      - { name: --no-merge,                 type: bool,                         default: false }
+      - { name: --allow-non-default-base,   type: bool,                         default: false }
+    sequence:
+      - { step: auth_status,        op: auth.status }
+      - { step: repo_view,          op: repo.view }
+      - { step: create,             op: pr.create }
+      - { step: wait_checks,        op: pr.wait-checks }
+      - { step: ready,              op: pr.ready,  skip_when: "--no-merge" }
+      - { step: merge,              op: pr.merge,  skip_when: "--no-merge" }
+    output:
+      data:
+        kind: enum<feature|bug>
+        provider: enum<github|gitlab>
+        pr:
+          number: integer
+          url: string
+          merged: bool
+          merge_sha: optional<string>
+        steps: "list of { step, ok, schema_version, payload }"
+    notes: |
+      Failure of any step short-circuits the macro. The outer exit
+      code is the failing step's exit code (no remapping). Steps
+      that did not run are omitted from `data.steps`.
+
+# ---------------------------------------------------------------------------
+# Output envelope (matches cli-output-contract-v1).
+# ---------------------------------------------------------------------------
+envelope:
+  fields:
+    schema_version: "cli.forge-cli.<op>.v<N>"
+    ok: bool
+    data: optional<object>
+    warnings: optional<list<string>>
+  error_extension:
+    data.error:
+      kind: string          # discriminator, e.g. branch_name_invalid
+      message: string       # short, human-readable
+      detail: optional<string>  # backend stderr tail, redacted, <=2 KiB
+
+# ---------------------------------------------------------------------------
+# Exit code map (aligned with cli-output-contract-v1 sysexits).
+# ---------------------------------------------------------------------------
+exit_codes:
+  SUCCESS:     { value: 0,  triggers: ["op completed; required state achieved"] }
+  RUNTIME:     { value: 1,  triggers: ["required checks failed", "merge conflict", "remote semantic failure"] }
+  USAGE:       { value: 64, triggers: ["bad CLI syntax", "unknown subcommand", "provider_unsupported"] }
+  DATA:        { value: 65, triggers: ["any lock-down policy violation", "body parse failed"] }
+  UNAVAILABLE: { value: 69, triggers: ["gh/glab missing", "auth required", "remote 5xx", "wait-checks timeout"] }
+  SOFTWARE:    { value: 70, triggers: ["backend JSON shape mismatch", "internal invariant violation"] }

--- a/docs/specs/forge-cli-spec-v1.md
+++ b/docs/specs/forge-cli-spec-v1.md
@@ -1,0 +1,499 @@
+# forge-cli Spec v1
+
+## Purpose
+
+This spec is the canonical contract for `forge-cli`, a new binary in the
+`nils-cli` workspace. `forge-cli` provides a provider-neutral surface for
+the remote forge operations that today are run directly against `gh` and
+`glab` from agent-kit skills (PR/MR lifecycle, Issue lifecycle, CI
+wait). Two backends ship together: GitHub (wraps `gh`) and GitLab
+(wraps `glab`). Behaviour, validation, and exit semantics are identical
+across backends; only the underlying subprocess and the rendered help
+text differ.
+
+Goals:
+
+- Replace ad-hoc `gh`/`glab` invocations scattered across agent-kit
+  skills with one binary that enforces branch / body / state policy at
+  the type level.
+- Make the GitHub and GitLab lanes byte-identical from the caller's
+  point of view (same flags, same envelope, same exit codes).
+- Codify defaults that were previously only described in skill
+  Markdown (PR body sections, branch naming, required-check gating,
+  draft → ready → merge ordering).
+- Stay a thin wrapper: every action delegates to `gh` or `glab` as a
+  subprocess. No direct REST client, no extra auth surface, no separate
+  rate-limit handling. Auth / SSO / enterprise hosts come from the
+  user's existing `gh auth login` and `glab auth login` state.
+
+Non-goals (v1):
+
+- Release management (`gh release`, GitLab releases).
+- Label management.
+- Arbitrary `gh api` / GitLab REST passthrough — no escape hatch in v1
+  on purpose; if a workflow needs it, the call belongs in a focused
+  follow-up op, not a generic shim. **Deferred to v2** — see "Open
+  questions / v2 candidates" for the re-evaluation criteria. v1
+  callers that need a non-CRUD call must keep using `gh api` / `glab
+  api` directly from the bash shell until then.
+- Issue *macros* beyond create/view/edit/comment/close/reopen — the
+  full plan-issue / dispatch-pr-review orchestration stays in
+  agent-kit skills for now.
+
+## Scope
+
+In scope (v1):
+
+- PR/MR lifecycle: `create`, `view`, `list`, `edit`, `comment`,
+  `ready`, `merge`, `close`.
+- PR/MR checks: `pr checks` (one-shot snapshot) and `pr wait-checks`
+  (blocking poll until terminal).
+- Issue lifecycle: `issue create`, `view`, `edit`, `comment`, `close`,
+  `reopen`.
+- Read-only helpers used by the macros: `auth status`, `repo view`.
+- Macro ops: `pr deliver` (kind = `feature` | `bug`), composing the
+  atoms above into the agent-kit standard "open draft → wait CI →
+  ready → merge → cleanup" flow.
+
+Out of scope (v1): release management, labels, raw REST passthrough,
+issue macros, repo creation, branch protection management, code review
+state mutation beyond `pr ready`. Each of these would either widen the
+parity gap (GitLab has no equivalent today) or remove the "lock down
+behaviour" value (REST passthrough = same as `gh api` + rename).
+
+## Provider parity model
+
+`forge-cli` is a *router + wrapper*, not a client.
+
+- Provider is auto-detected from the working tree's remote URL
+  (`origin` by default, configurable via `--remote`):
+  - `github.com` or matches `gh auth status` hosts → backend `github`,
+    subprocess `gh`.
+  - `gitlab.com` or matches `glab auth status` hosts → backend
+    `gitlab`, subprocess `glab`.
+  - Other hosts → `USAGE 64` with `error.kind = "provider_unsupported"`
+    and a hint to file a follow-up; v1 does not auto-fall-back to
+    HTTPS-only Gitea/Forgejo even though the URL shape would allow it.
+- All remote calls go through the backend subprocess. `forge-cli` does
+  not open HTTP sockets, does not hold tokens, and does not write to
+  the user's `~/.config/gh` or `~/.config/glab`.
+- Backend stdout (typically `--json` from `gh`/`glab`) is parsed and
+  re-rendered through the workspace's `cli_contract` envelope. Backend
+  stderr is captured; on failure the relevant tail is included in
+  `data.error.detail` with secrets redacted (see "Output contract"
+  below).
+- Backend invocations always force `--json <fields>` (gh) or
+  equivalent JSON-bearing flags (glab) where supported. When a `glab`
+  subcommand does not support `--json` in the installed version,
+  `forge-cli` falls back to text parsing wrapped behind a typed parser
+  module so that the brittle bit is isolated.
+
+Parity matrix (v1):
+
+| forge-cli op          | github backend                                                  | gitlab backend                                       | Parity                               |
+| --------------------- | --------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------ |
+| `pr create`           | `gh pr create --draft`                                          | `glab mr create --draft`                             | exact                                |
+| `pr view <id>`        | `gh pr view <id> --json …`                                      | `glab mr view <id> -F json`                          | exact                                |
+| `pr list`             | `gh pr list --json …`                                           | `glab mr list -F json`                               | exact                                |
+| `pr edit <id>`        | `gh pr edit <id> …`                                             | `glab mr update <id> …`                              | exact                                |
+| `pr comment <id>`     | `gh pr comment <id> --body …`                                   | `glab mr note <id> --message …`                      | exact                                |
+| `pr ready <id>`       | `gh pr ready <id>`                                              | `glab mr update <id> --ready`                        | exact                                |
+| `pr merge <id>`       | `gh pr merge <id> --squash --delete-branch`                     | `glab mr merge <id> --squash --remove-source-branch` | exact (method honoured per repo cfg) |
+| `pr close <id>`       | `gh pr close <id>`                                              | `glab mr close <id>`                                 | exact                                |
+| `pr checks <id>`      | `gh pr checks <id> --json …`                                    | `glab ci status -b <branch>` parsed                  | emulated on GitLab                   |
+| `pr wait-checks <id>` | poll `gh pr checks` + `gh run view`                             | poll `glab ci status` / pipeline view                | emulated; same envelope              |
+| `issue create`        | `gh issue create …`                                             | `glab issue create …`                                | exact                                |
+| `issue view <id>`     | `gh issue view <id> --json …`                                   | `glab issue view <id> -F json`                       | exact                                |
+| `issue edit <id>`     | `gh issue edit <id> …`                                          | `glab issue update <id> …`                           | exact                                |
+| `issue comment <id>`  | `gh issue comment <id> --body …`                                | `glab issue note <id> --message …`                   | exact                                |
+| `issue close <id>`    | `gh issue close <id>`                                           | `glab issue close <id>`                              | exact                                |
+| `issue reopen <id>`   | `gh issue reopen <id>`                                          | `glab issue reopen <id>`                             | exact                                |
+| `auth status`         | `gh auth status`                                                | `glab auth status`                                   | exact (text → typed)                 |
+| `repo view`           | `gh repo view --json …`                                         | `glab repo view -F json`                             | exact                                |
+| `pr deliver`          | macro: `pr create` → `pr wait-checks` → `pr ready` → `pr merge` | same composition with gitlab atoms                   | exact (same macro logic on both)     |
+
+"emulated" means the backend's native command differs in shape, but
+`forge-cli` normalises both into the same `cli.forge-cli.pr.checks.v1`
+payload so callers can branch on `data.state` regardless of host.
+
+## Naming and topology
+
+- Crate: `nils-forge-cli` (matches the `nils-*` package convention).
+- Binary: `forge-cli`.
+- Library entry: `crates/forge-cli/src/lib.rs`.
+- Wrapper (Homebrew formula bin): `wrappers/forge-cli`.
+- Completions: `completions/_forge-cli`, `completions/forge-cli.bash`.
+
+Command tree:
+
+```text
+forge-cli
+├── pr
+│   ├── create
+│   ├── view
+│   ├── list
+│   ├── edit
+│   ├── comment
+│   ├── ready
+│   ├── merge
+│   ├── close
+│   ├── checks
+│   ├── wait-checks
+│   └── deliver           (macro)
+├── issue
+│   ├── create
+│   ├── view
+│   ├── edit
+│   ├── comment
+│   ├── close
+│   └── reopen
+├── repo
+│   └── view
+├── auth
+│   └── status
+└── completion              (workspace standard)
+```
+
+Global flags (every subcommand):
+
+- `--format text|json` (workspace standard).
+- `--remote <name>` (default `origin`).
+- `--provider github|gitlab` (override auto-detect).
+- `--repo <owner/name>` (override remote-derived repo slug; passed to
+  backend's `--repo` / `-R` equivalent).
+- `--dry-run` — render the backend command that *would* run plus all
+  validation checks, but do not invoke it. Output envelope carries the
+  exact argv under `data.plan`.
+
+`forge-cli` itself does not expose `--token`, `--host`, or any auth
+override. Those belong to `gh`/`glab` and are configured there.
+
+## Atomic op surface
+
+The full machine-readable list lives in
+[`forge-cli-ops-v1.yaml`](forge-cli-ops-v1.yaml). The Markdown table
+below is the human-readable summary; the YAML is authoritative for
+backend mapping, validation rules, and output schema versions.
+
+### `pr create`
+
+- Input: `--head <branch>` (default current branch), `--base <branch>`
+  (default repo default branch), `--title <str>`, `--body-file <path>`
+  or `--body <str>`, `--kind feature|bug`, `--draft` (default `true`),
+  `--reviewer <user>...`, `--label <name>...`.
+- Validation (see "Lock-down policy" for the full list):
+  - branch name MUST match `^(feat|fix)/[a-z0-9][a-z0-9-]{1,63}$` and
+    align with `--kind`;
+  - title length ≤ 70 chars, no trailing whitespace;
+  - body MUST contain non-empty `## Summary` and `## Test plan`
+    sections;
+  - working tree MUST be clean (`git status --porcelain` empty);
+  - HEAD MUST be pushed and remote-tracked.
+- Output schema: `cli.forge-cli.pr.create.v1`,
+  `data = { number, url, head, base, draft, title, kind, provider }`.
+
+### `pr wait-checks`
+
+- Input: `<id>` (or `--head <branch>` to resolve PR by branch),
+  `--timeout <duration>` (default `30m`), `--interval <duration>`
+  (default `20s`), `--required-only` (default `true`).
+- Behaviour: polls the backend until every required check is in a
+  terminal state (`success`, `failure`, `cancelled`, `skipped`,
+  `neutral`). `--required-only=true` ignores non-required checks for
+  the gating decision but still reports them in `data.checks`.
+- Terminal states map to envelope `ok`:
+  - all required `success` → `ok = true`.
+  - any required `failure`/`cancelled`/`timed_out` → `ok = false`,
+    exit `RUNTIME 1`, `error.kind = "checks_failed"`.
+  - timeout reached → `ok = false`, exit `UNAVAILABLE 69`,
+    `error.kind = "checks_timeout"`.
+- Output schema: `cli.forge-cli.pr.checks.v1`,
+  `data = { state, required_count, success_count, failed:[…], pending:[…], duration_ms }`.
+
+### `pr merge`
+
+- Preconditions enforced before invoking the backend:
+  - PR exists and is not draft (call `pr ready` first if needed);
+  - working tree clean;
+  - required checks all green (re-checked even if `pr wait-checks`
+    succeeded earlier — TTL-zero gate);
+  - target branch is the repo default branch OR explicitly approved
+    via `--allow-non-default-base`;
+  - `--method squash|merge|rebase` (default `squash`, configurable
+    per repo).
+- Post-merge: deletes the remote branch (default `true`, disable via
+  `--keep-branch`).
+- Output schema: `cli.forge-cli.pr.merge.v1`,
+  `data = { number, url, merge_sha, method, deleted_branch }`.
+
+(See `forge-cli-ops-v1.yaml` for the remaining ops.)
+
+## Macro: `pr deliver`
+
+`pr deliver` is the canonical end-to-end flow agent-kit's
+`deliver-{feature,bug}-pr` skills compose today. It is implemented in
+Rust so behaviour is fixed at the type level and identical across
+providers.
+
+Synopsis:
+
+```text
+forge-cli pr deliver \
+  --kind feature|bug \
+  [--title <str>] [--body-file <path>] \
+  [--base <branch>] [--head <branch>] \
+  [--method squash|merge|rebase] \
+  [--reviewer <user>...] \
+  [--timeout <duration>] \
+  [--no-merge]        # stop after wait-checks; useful in CI
+```
+
+Steps:
+
+1. `auth status` — fail-fast on missing auth.
+2. `repo view` — resolve default branch, repo slug, default merge
+   method override.
+3. `pr create --draft` — atom; validates branch / title / body.
+4. `pr wait-checks` — atom; blocks until terminal.
+5. `pr ready` — atom; only if previous step is `success`.
+6. `pr merge` — atom; honours `--method` and repo override.
+7. Emit single envelope summarising all five sub-step outputs under
+   `data.steps[]`. The macro's own schema is
+   `cli.forge-cli.pr.deliver.v1`.
+
+Failure semantics:
+
+- A failing step short-circuits the macro. The envelope still lists
+  every step attempted, with the failing one's `ok = false` and the
+  remaining ones omitted (not present in the array).
+- The macro's outer exit code is the failing atom's exit code, not
+  remapped. So `checks_failed` propagates as `RUNTIME 1`, `policy`
+  violations propagate as `DATA 65`, and so on.
+
+## Lock-down policy
+
+These rules are enforced regardless of which backend runs. They are
+declared in `forge-cli-ops-v1.yaml` (`validations:` per op) so the
+backend implementations cannot diverge.
+
+1. **Branch naming.** Feature work MUST be on `feat/<slug>`, bug work
+   on `fix/<slug>`. Slug is `[a-z0-9][a-z0-9-]{1,63}`. Ticket prefix
+   `abc-123-` is allowed inside the slug. `--kind` and the branch
+   prefix MUST agree.
+2. **Body schema.** PR/MR body MUST contain non-empty `## Summary` and
+   `## Test plan` sections. Order is not enforced; presence and
+   non-emptiness are.
+3. **Title length.** ≤ 70 characters, no trailing whitespace, no
+   trailing punctuation other than `?`.
+4. **Working tree.** `git status --porcelain` MUST be empty for
+   `create`, `merge`, and `deliver`. (`view`/`list`/`comment` are
+   read/append-only and do not check.)
+5. **Push state.** HEAD MUST be pushed to a remote-tracking branch
+   before `create` runs.
+6. **Default-branch protection.** `forge-cli` refuses any operation
+   that would force-push, delete, or merge directly into the repo
+   default branch except via a merged PR/MR. `--allow-non-default-base`
+   exists for non-default *base* branches (e.g. release lanes); there
+   is no flag to bypass the default-branch force-push refusal.
+7. **Draft → ready → merge ordering.** `pr merge` refuses to merge a
+   draft. There is no `--merge-as-draft`. Callers MUST run `pr ready`
+   first (or use `pr deliver`, which sequences them).
+8. **Required-check gating.** `pr merge` re-checks required-check
+   state immediately before invoking the backend, even if
+   `pr wait-checks` was called earlier in the macro. This is the
+   TTL-zero re-check that addresses the
+   `github-pr-required-check-gating` operation record.
+9. **Merge method.** Default `squash`. Repo override allowed via
+   `.forge-cli.toml` `[merge] method = "squash" | "merge" | "rebase"`.
+   Per-invocation `--method` overrides the repo override; both are
+   logged in `data.method`.
+10. **Branch cleanup.** `pr merge` deletes the remote branch by
+    default (`--delete-branch` on `gh`, `--remove-source-branch` on
+    `glab`). Disable with `--keep-branch`. Local branch cleanup is
+    out of scope for `forge-cli` and remains the bash wrapper's job
+    in agent-kit skills.
+
+Violations map to `DATA 65` with one of these `data.error.kind` values:
+
+| `error.kind`               | Triggered by rule |
+| -------------------------- | ----------------- |
+| `branch_name_invalid`      | 1                 |
+| `branch_kind_mismatch`     | 1                 |
+| `body_missing_summary`     | 2                 |
+| `body_missing_test_plan`   | 2                 |
+| `title_too_long`           | 3                 |
+| `dirty_worktree`           | 4                 |
+| `head_not_pushed`          | 5                 |
+| `default_branch_protected` | 6                 |
+| `draft_merge_refused`      | 7                 |
+| `checks_pending`           | 8                 |
+| `checks_failed`            | 8 (`RUNTIME 1`)   |
+| `merge_method_unsupported` | 9                 |
+| `keep_branch_conflict`     | 10                |
+
+## CLI output contract conformance
+
+`forge-cli` follows
+[`cli-output-contract-v1`](cli-output-contract-v1.md) without
+exception:
+
+- Canonical flag is `--format text|json`. No `--json` boolean alias
+  is introduced (new binary, no migration debt).
+- Envelope: `{schema_version, ok, data, warnings}`. Snake_case
+  throughout. `data` omitted when no payload. `warnings` omitted when
+  empty.
+- Schema version literals follow `cli.forge-cli.<command>.v1`. Macro
+  steps embed their own atom schema versions inside `data.steps[].
+  payload.schema_version`.
+- Parse / unknown-subcommand errors go through
+  `nils_common::cli_contract::emit_parse_error` so `--format json`
+  works at the parse-error layer too.
+- Sensitive data: backend stderr is captured and tail-trimmed to 2 KiB
+  before being placed under `data.error.detail`. Token-shaped strings
+  (`gh[ps]_*`, `glpat-*`, `ghr_*`, `gho_*`) are redacted before
+  rendering. URLs are kept as-is — they are not secrets and the user
+  wants click-through.
+
+## Exit code map
+
+`forge-cli` uses only the six BSD sysexits-aligned constants from
+`nils_common::cli_contract::exit`. Discriminators go in
+`data.error.kind`, not in numeric exit codes.
+
+| Constant      | Value | `forge-cli` triggers                                                                  |
+| ------------- | ----- | ------------------------------------------------------------------------------------- |
+| `SUCCESS`     | `0`   | Op completed; required state achieved.                                                |
+| `RUNTIME`     | `1`   | Remote semantic failure: required checks failed, merge conflict, draft already ready. |
+| `USAGE`       | `64`  | Bad CLI syntax, unknown subcommand, unsupported provider.                             |
+| `DATA`        | `65`  | Lock-down policy violation (any rule above); body parse failure.                      |
+| `UNAVAILABLE` | `69`  | `gh`/`glab` missing, auth required, remote 5xx/network error, wait-checks timeout.    |
+| `SOFTWARE`    | `70`  | Internal invariant violation (backend JSON did not match expected shape).             |
+
+Callers (agent-kit skills, CI scripts) MUST branch on `error.kind`
+when finer granularity is needed. Numeric exit codes alone are
+intentionally not enough to distinguish "branch name invalid" from
+"missing Test plan section" — both are `DATA 65` because both are
+"the input did not meet the documented contract". The discriminator
+is in the envelope, where consumers parse it deliberately.
+
+## Configuration
+
+Per-repo overrides live in `.forge-cli.toml` at the repo root:
+
+```toml
+[merge]
+method = "squash"            # squash | merge | rebase
+delete_branch = true
+
+[body]
+summary_heading = "## Summary"
+test_plan_heading = "## Test plan"
+
+[branch]
+feature_prefix = "feat/"
+bug_prefix = "fix/"
+
+[checks]
+timeout = "30m"
+interval = "20s"
+required_only = true
+```
+
+Resolution order for any setting: explicit flag > `.forge-cli.toml` >
+spec default. Unknown keys produce a `warnings[]` entry, not an
+error — forward-compatibility for v2 fields.
+
+Environment variables (read once at startup, all optional):
+
+- `FORGE_CLI_GH_BIN` — override `gh` discovery path (testing).
+- `FORGE_CLI_GLAB_BIN` — override `glab` discovery path (testing).
+- `FORGE_CLI_DEFAULT_PROVIDER` — fallback provider when remote URL
+  doesn't auto-detect.
+
+## Provider detection
+
+```text
+explicit --provider flag
+  ↓ (else)
+remote URL parse from `git remote get-url <--remote>`
+  ↓
+host classification:
+  github.com OR matches `gh auth status` host  → github
+  gitlab.com OR matches `glab auth status` host → gitlab
+  any other host                                → USAGE 64
+                                                  error.kind=provider_unsupported
+```
+
+`gh auth status` and `glab auth status` are *cached* per `forge-cli`
+invocation (single call per provider, memoised). They are not refreshed
+mid-run.
+
+## Migration plan: agent-kit skills → forge-cli
+
+This is the v1 acceptance target. Every row below MUST be reachable
+through `forge-cli` before agent-kit can adopt the new CLI:
+
+| agent-kit skill                                | forge-cli op                                            |
+| ---------------------------------------------- | ------------------------------------------------------- |
+| `create-github-pr` / `create-feature-pr`       | `forge-cli pr create --kind feature`                    |
+| `create-bug-pr`                                | `forge-cli pr create --kind bug`                        |
+| `close-feature-pr` / `close-github-pr` feature | `forge-cli pr merge` (+ optional `pr ready`)            |
+| `close-bug-pr`                                 | `forge-cli pr merge`                                    |
+| `deliver-feature-pr` / `deliver-github-pr`     | `forge-cli pr deliver --kind feature`                   |
+| `deliver-bug-pr`                               | `forge-cli pr deliver --kind bug`                       |
+| `gh-fix-ci`                                    | `forge-cli pr wait-checks` + skill's fix-and-push loop  |
+| `gamania:create-feature-mr` / `-bug-mr`        | `forge-cli pr create` (provider auto-detected gitlab)   |
+| `gamania:close-*-mr` / `deliver-*-mr`          | same as github counterparts                             |
+| `issue-lifecycle`                              | `forge-cli issue create|view|edit|comment|close|reopen` |
+| `issue-follow-up`                              | `forge-cli issue create` (+ subsequent comments)        |
+
+Skills keep their bash shells. The shells:
+
+- Resolve / construct branch names, body content, ticket slugs.
+- Call `forge-cli`.
+- React to `forge-cli`'s envelope (parse `error.kind`, retry on
+  `UNAVAILABLE`, surface `policy` violations to the user verbatim).
+- Handle local git operations: `git push`, `git checkout`, branch
+  deletion locally, post-merge cleanup.
+
+The shells stop wrapping `gh` / `glab` directly. The `gh pr create …`
+and `glab mr create …` invocations are removed.
+
+## Testing strategy
+
+- **Atom unit tests.** Each op has a unit test pair: one against a
+  recorded `gh --json …` fixture and one against a recorded `glab …
+  -F json` fixture. Fixtures live under
+  `crates/forge-cli/tests/fixtures/{github,gitlab}/<op>/`.
+- **Exit-code matrix.** Per workspace policy, every binary ships an
+  exit-code matrix test covering `success`, `usage`, `data`, and
+  `runtime` paths. `forge-cli` extends it to cover `unavailable`
+  (forced via `FORGE_CLI_GH_BIN=/bin/false`) and one `software` path
+  (mangled fixture).
+- **Parity test.** A single test harness drives both backends through
+  the same op + the same logical input, then asserts the envelope is
+  byte-identical except for `data.provider` and `data.url` host.
+- **Dry-run smoke.** Every op supports `--dry-run`; integration tests
+  use `--dry-run` to verify the constructed backend argv without
+  actually contacting `github.com` or `gitlab.com`.
+- **End-to-end is opt-in.** Tests that hit real GitHub / GitLab are
+  gated behind `FORGE_CLI_E2E=1` and a designated sandbox repo.
+  Default CI does not run them.
+
+## Open questions / v2 candidates
+
+- Releases (`gh release create / view / edit`) — GitLab requires
+  glab + tag flow; could fit a `forge-cli release …` tree later.
+- Labels (`gh label create`) — currently used once in agent-kit
+  (label bootstrap on a new repo). Either v2 op or one-off script.
+- `gh api` passthrough — explicitly out of v1 because it defeats the
+  lock-down value. Re-evaluate if a real workflow needs a non-CRUD
+  call (e.g. CODEOWNERS, branch protection) and only then.
+- Repo creation (`gh repo create`) — out of v1; rarely called from
+  skills.
+- Issue macros (`issue deliver`, `issue close-when-prs-merged`,
+  `issue cross-link`) — depend on plan-issue / dispatch-pr-review
+  skills converging first; tracked separately.
+- Gitea / Forgejo backend — would require a new third backend or a
+  Forge-API client. Deliberately deferred until a concrete user
+  surfaces.


### PR DESCRIPTION
## Summary

Land the locked v1 contract for a new provider-neutral `forge-cli` binary plus its 8-sprint dispatch-ready execution plan. The contract covers PR/MR lifecycle, Issue lifecycle, and CI-wait atoms with one macro (`pr deliver`); both backends (`gh` and `glab`) ship in lock-step and the binary adopts `cli-output-contract-v1` from day one. This Sprint 0 PR is docs-only — no source code, no behaviour change. Sprints 1–8 (tracked in the same plan) implement atoms → macro → parity/exit-code tests → wrapper + brew + nils-cli minor bump.

## Changes

- Add `docs/specs/forge-cli-spec-v1.md` — v1 contract: parity matrix, lock-down rules, exit-code map, migration plan, output-contract conformance.
- Add `docs/specs/forge-cli-ops-v1.yaml` — machine-readable op catalog (validations, backend argv, output schemas, exit codes).
- Add `docs/plans/forge-cli/forge-cli-plan.md` — 8-sprint dispatch plan with per-task complexity scoring and explicit task-level dependencies.
- Add `docs/plans/forge-cli/forge-cli-discussion-source.md` — locked decisions (backend strategy, exit-code constants, provider precedence, glab parser version-pin, brew + minor-bump cadence) carried into execution.

## Test-First Evidence

- Change classification: docs/config/generated/visual-only waiver
- Failing test before fix: N/A — docs-only PR; no source under test, no behaviour to fail-test against.
- Final validation: `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` → PASS (plan-bundle-validate, markdown-lint, docs-hygiene strict, docs-placement strict). `plan-tooling validate --file docs/plans/forge-cli/forge-cli-plan.md` → OK.
- Waiver reason: docs-only commit; cli-output-contract conformance + per-op fixtures + parity/exit-code matrix tests land in Sprints 1–7 alongside the source code they exercise.

## Testing

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` (pass)
- `plan-tooling validate --file docs/plans/forge-cli/forge-cli-plan.md` (pass)
- `npx --yes rumdl@0.1.62 check --config .rumdl.toml` on the three new markdown files (pass)
- `cargo build` / `cargo test` — not run (reason: no source changes; workspace `cargo` gate would only re-build unchanged crates)

## Risk / Notes

- Locked v1 surface is intentionally narrow. `gh release`, label management, raw `gh api` / `glab api` passthrough, repo creation, branch protection, issue macros, and Gitea/Forgejo are explicitly deferred to v2 — spec documents the re-evaluation criteria for each.
- `glab ci status` JSON output does not exist in current installed minor; the spec pins the text parser to the currently installed `glab` minor and fails-fast with `UNAVAILABLE 69` on out-of-range versions. Out-of-band `glab` upgrades will surface as actionable errors, not silent misparses.
- Exit-code discriminator lives in `data.error.kind`, not in the numeric exit code — every lock-down violation is `DATA 65` and callers must branch on `error.kind`. This is documented in spec §"Exit code map" and is the v1 caller contract.
- `pr deliver` macro propagates the failing atom's exit code unchanged (no remapping). Callers reading only the outer exit code without `data.steps[]` will misclassify failures; behaviour is intentional and spec-documented.
- The same spec files (`docs/specs/forge-cli-*.md`) currently exist as untracked files on the user's `main` checkout. After this PR merges, those untracked copies become identical to tracked files; `git clean` or a simple `rm` will tidy the working tree without losing content.
