### PR TITLE
Migrate remaining single-binary crates onto shared CLI output contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,6 +1730,8 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "nils-common",
+ "nils-test-support",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -1742,6 +1744,7 @@ version = "0.10.2"
 dependencies = [
  "clap",
  "clap_complete",
+ "nils-common",
  "nils-test-support",
  "pretty_assertions",
  "serde",
@@ -2156,6 +2159,7 @@ version = "0.10.2"
 dependencies = [
  "clap",
  "clap_complete",
+ "nils-common",
  "nils-test-support",
  "pretty_assertions",
  "regex",
@@ -2180,6 +2184,7 @@ version = "0.10.2"
 dependencies = [
  "clap",
  "clap_complete",
+ "nils-common",
  "nils-test-support",
  "pretty_assertions",
  "regex",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `a327f54170303f79097e37083b6835fa3af676587baee806a9ee57919c167070`
+- Cargo.lock SHA256: `0aab1f11af653bdd6a4cd4b5475c8460bb8df6a301e8a99af5fc43a9f6fd198c`
 - Third-party crates (`source != null`): 438
 - Workspace crates (`source == null`, excluded below): 30
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `a327f54170303f79097e37083b6835fa3af676587baee806a9ee57919c167070`
+- Cargo.lock SHA256: `0aab1f11af653bdd6a4cd4b5475c8460bb8df6a301e8a99af5fc43a9f6fd198c`
 - Third-party crates (`source != null`): 438
 
 ## Notice Extraction Policy

--- a/crates/agent-docs/src/lib.rs
+++ b/crates/agent-docs/src/lib.rs
@@ -17,9 +17,11 @@ use output::{
     render_baseline, render_contexts, render_resolve, render_scaffold_baseline, render_stub,
 };
 
-const EXIT_OK: i32 = 0;
-const EXIT_STRICT_MISSING_REQUIRED: i32 = 1;
-const EXIT_USAGE: i32 = 2;
+use nils_common::cli_contract::exit;
+
+const EXIT_OK: i32 = exit::SUCCESS;
+const EXIT_STRICT_MISSING_REQUIRED: i32 = exit::RUNTIME;
+const EXIT_USAGE: i32 = exit::USAGE;
 const EXIT_CONFIG: i32 = 3;
 const EXIT_RUNTIME: i32 = 4;
 
@@ -35,7 +37,13 @@ where
     let cli = match Cli::try_parse_from(args) {
         Ok(parsed) => parsed,
         Err(err) => {
-            let code = err.exit_code();
+            use clap::error::ErrorKind;
+            let code = match err.kind() {
+                ErrorKind::DisplayHelp
+                | ErrorKind::DisplayVersion
+                | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => err.exit_code(),
+                _ => EXIT_USAGE,
+            };
             let _ = err.print();
             return code;
         }

--- a/crates/agent-docs/tests/integration.rs
+++ b/crates/agent-docs/tests/integration.rs
@@ -17,6 +17,8 @@ mod config;
 mod contexts_checklist;
 #[path = "integration/env_paths.rs"]
 mod env_paths;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/resolve_builtin.rs"]
 mod resolve_builtin;
 #[path = "integration/resolve_checklist.rs"]

--- a/crates/agent-docs/tests/integration/exit_codes.rs
+++ b/crates/agent-docs/tests/integration/exit_codes.rs
@@ -1,0 +1,21 @@
+use agent_docs::run_with_args;
+use std::ffi::OsString;
+
+#[test]
+fn unknown_subcommand_exits_usage() {
+    let code = run_with_args([OsString::from("agent-docs"), OsString::from("bogus")]);
+    assert_eq!(code, 64);
+}
+
+#[test]
+fn missing_subcommand_exits_clap_help() {
+    // No subcommand → clap renders help (exit 2).
+    let code = run_with_args([OsString::from("agent-docs")]);
+    assert!(matches!(code, 0 | 2), "unexpected exit code {code}");
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let code = run_with_args([OsString::from("agent-docs"), OsString::from("--help")]);
+    assert_eq!(code, 0);
+}

--- a/crates/agent-out/Cargo.toml
+++ b/crates/agent-out/Cargo.toml
@@ -19,9 +19,11 @@ path = "src/main.rs"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
+nils-common = { version = "0.10.2", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+nils-test-support = { version = "0.10.2", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-out/src/lib.rs
+++ b/crates/agent-out/src/lib.rs
@@ -16,10 +16,12 @@ use serde_json::{Value, json};
 
 use cli::{AuditArgs, AuditFormat, Cli, Command, ProjectArgs, ProjectFormat};
 
-const EXIT_OK: i32 = 0;
-const EXIT_AUDIT_VIOLATIONS: i32 = 1;
-const EXIT_RUNTIME: i32 = 1;
-const EXIT_USAGE: i32 = 64;
+use nils_common::cli_contract::exit;
+
+const EXIT_OK: i32 = exit::SUCCESS;
+const EXIT_AUDIT_VIOLATIONS: i32 = exit::RUNTIME;
+const EXIT_RUNTIME: i32 = exit::RUNTIME;
+const EXIT_USAGE: i32 = exit::USAGE;
 
 const PROJECT_SCHEMA_VERSION: &str = "cli.agent-out.project.v1";
 const AUDIT_SCHEMA_VERSION: &str = "cli.agent-out.audit.v1";

--- a/crates/agent-out/tests/integration.rs
+++ b/crates/agent-out/tests/integration.rs
@@ -5,3 +5,5 @@
 
 #[path = "integration/cli.rs"]
 mod cli;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;

--- a/crates/agent-out/tests/integration/exit_codes.rs
+++ b/crates/agent-out/tests/integration/exit_codes.rs
@@ -1,0 +1,44 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agent_out_bin() -> std::path::PathBuf {
+    for key in ["CARGO_BIN_EXE_agent-out", "CARGO_BIN_EXE_agent_out"] {
+        if let Ok(path) = std::env::var(key) {
+            return path.into();
+        }
+    }
+
+    let exe = std::env::current_exe().expect("current exe");
+    let target_dir = exe
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("target dir");
+    target_dir.join(format!("agent-out{}", std::env::consts::EXE_SUFFIX))
+}
+
+fn run_exit_code(dir: &Path, args: &[&str]) -> i32 {
+    let output = Command::new(agent_out_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("agent-out command");
+    output.status.code().unwrap_or(-1)
+}
+
+#[test]
+fn unknown_subcommand_exits_usage() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    assert_eq!(run_exit_code(dir.path(), &["bogus-command"]), 64);
+}
+
+#[test]
+fn missing_subcommand_exits_usage() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    assert_eq!(run_exit_code(dir.path(), &[]), 64);
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    assert_eq!(run_exit_code(dir.path(), &["--help"]), 0);
+}

--- a/crates/agent-scope-lock/Cargo.toml
+++ b/crates/agent-scope-lock/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
+nils-common = { version = "0.10.2", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/agent-scope-lock/src/lib.rs
+++ b/crates/agent-scope-lock/src/lib.rs
@@ -15,9 +15,11 @@ use serde_json::{Value, json};
 
 use cli::{ChangeMode, Cli, Command, CommonArgs, CreateArgs, OutputFormat, ValidateArgs};
 
-const EXIT_OK: i32 = 0;
-const EXIT_RUNTIME_OR_SCOPE: i32 = 1;
-const EXIT_USAGE: i32 = 64;
+use nils_common::cli_contract::exit;
+
+const EXIT_OK: i32 = exit::SUCCESS;
+const EXIT_RUNTIME_OR_SCOPE: i32 = exit::RUNTIME;
+const EXIT_USAGE: i32 = exit::USAGE;
 
 const LOCK_DOCUMENT_VERSION: &str = "agent-scope-lock.v1";
 const LOCK_FILE_NAME: &str = "agent-scope-lock.json";

--- a/crates/agent-scope-lock/tests/integration.rs
+++ b/crates/agent-scope-lock/tests/integration.rs
@@ -2,3 +2,5 @@
 
 #[path = "integration/cli.rs"]
 mod cli;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;

--- a/crates/agent-scope-lock/tests/integration/exit_codes.rs
+++ b/crates/agent-scope-lock/tests/integration/exit_codes.rs
@@ -1,0 +1,22 @@
+use nils_test_support::cmd::run_resolved_in_dir;
+
+#[test]
+fn unknown_subcommand_exits_usage() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("agent-scope-lock", tmp.path(), &["bogus"], &[], None);
+    assert_eq!(output.code, 64);
+}
+
+#[test]
+fn missing_required_arg_exits_usage() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("agent-scope-lock", tmp.path(), &["create"], &[], None);
+    assert_eq!(output.code, 64);
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("agent-scope-lock", tmp.path(), &["--help"], &[], None);
+    assert_eq!(output.code, 0);
+}

--- a/crates/codex-cli/src/main.rs
+++ b/crates/codex-cli/src/main.rs
@@ -4,6 +4,7 @@ mod completion;
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser};
 use codex_cli::{agent, auth, config};
+use nils_common::cli_contract::exit;
 
 fn main() {
     let exit_code = run();
@@ -15,17 +16,17 @@ fn run() -> i32 {
         let mut cmd = cli::Cli::command();
         if cmd.print_help().is_ok() {
             println!();
-            return 0;
+            return exit::SUCCESS;
         }
-        return 1;
+        return exit::RUNTIME;
     }
 
     let cli = match cli::Cli::try_parse_from(std::env::args()) {
         Ok(cli) => cli,
         Err(err) => {
             let code = match err.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => 0,
-                _ => 64,
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => exit::SUCCESS,
+                _ => exit::USAGE,
             };
             let _ = err.print();
             return code;

--- a/crates/codex-cli/tests/integration.rs
+++ b/crates/codex-cli/tests/integration.rs
@@ -41,6 +41,8 @@ mod config;
 mod diag_json_contract;
 #[path = "integration/dispatch.rs"]
 mod dispatch;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/fs.rs"]
 mod fs;
 #[path = "integration/json.rs"]

--- a/crates/codex-cli/tests/integration/exit_codes.rs
+++ b/crates/codex-cli/tests/integration/exit_codes.rs
@@ -1,0 +1,22 @@
+use nils_test_support::cmd::run_resolved_in_dir;
+
+#[test]
+fn unknown_subcommand_exits_usage() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("codex-cli", tmp.path(), &["bogus"], &[], None);
+    assert_eq!(output.code, 64);
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("codex-cli", tmp.path(), &["--help"], &[], None);
+    assert_eq!(output.code, 0);
+}
+
+#[test]
+fn invalid_flag_exits_usage() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("codex-cli", tmp.path(), &["--no-such-flag"], &[], None);
+    assert_eq!(output.code, 64);
+}

--- a/crates/gemini-cli/src/main.rs
+++ b/crates/gemini-cli/src/main.rs
@@ -4,6 +4,7 @@ mod completion;
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser};
 use gemini_cli::{agent, auth, config};
+use nils_common::cli_contract::exit;
 
 fn main() {
     let exit_code = run();
@@ -19,8 +20,8 @@ fn run() -> i32 {
         Ok(cli) => cli,
         Err(err) => {
             let code = match err.kind() {
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => 0,
-                _ => 64,
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => exit::SUCCESS,
+                _ => exit::USAGE,
             };
             let _ = err.print();
             return code;

--- a/crates/gemini-cli/tests/integration.rs
+++ b/crates/gemini-cli/tests/integration.rs
@@ -41,6 +41,8 @@ mod config;
 mod diag_json_contract;
 #[path = "integration/dispatch.rs"]
 mod dispatch;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/fs.rs"]
 mod fs;
 #[path = "integration/json.rs"]

--- a/crates/gemini-cli/tests/integration/exit_codes.rs
+++ b/crates/gemini-cli/tests/integration/exit_codes.rs
@@ -1,0 +1,22 @@
+use nils_test_support::cmd::run_resolved_in_dir;
+
+#[test]
+fn unknown_subcommand_exits_usage() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("gemini-cli", tmp.path(), &["bogus"], &[], None);
+    assert_eq!(output.code, 64);
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("gemini-cli", tmp.path(), &["--help"], &[], None);
+    assert_eq!(output.code, 0);
+}
+
+#[test]
+fn invalid_flag_exits_usage() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("gemini-cli", tmp.path(), &["--no-such-flag"], &[], None);
+    assert_eq!(output.code, 64);
+}

--- a/crates/git-lock/src/main.rs
+++ b/crates/git-lock/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand, ValueEnum};
+use nils_common::cli_contract::exit;
 
 mod completion;
 mod copy;
@@ -80,12 +81,12 @@ fn run() -> i32 {
 
     if args.len() > 1 && is_help(&args[1]) {
         messages::print_help();
-        return 0;
+        return exit::SUCCESS;
     }
 
     if args.len() > 1 && is_version(&args[1]) {
         println!("git-lock {}", env!("CARGO_PKG_VERSION"));
-        return 0;
+        return exit::SUCCESS;
     }
 
     if args.len() > 2
@@ -94,7 +95,7 @@ fn run() -> i32 {
         && let Some(text) = messages::subcommand_help(&args[1])
     {
         println!("{text}");
-        return 0;
+        return exit::SUCCESS;
     }
 
     if args.len() > 1 && args[1] == "completion" {
@@ -104,25 +105,25 @@ fn run() -> i32 {
             Command::Completion { shell } => completion::run(shell),
             _ => {
                 messages::print_help();
-                1
+                exit::USAGE
             }
         };
     }
 
     if !nils_common::git::is_git_repo().unwrap_or(false) {
         println!("{}", messages::NOT_GIT_REPO);
-        return 1;
+        return exit::RUNTIME;
     }
 
     if args.len() <= 1 {
         messages::print_help();
-        return 0;
+        return exit::SUCCESS;
     }
 
     if !is_known_command(&args[1]) {
         println!("{}", messages::unknown_command(&args[1]));
         println!("{}", messages::UNKNOWN_COMMAND_HINT);
-        return 1;
+        return exit::USAGE;
     }
 
     let cli = Cli::parse_from(&args);
@@ -138,7 +139,7 @@ fn run() -> i32 {
         Command::Completion { shell } => Ok(completion::run(shell)),
         Command::Help => {
             messages::print_help();
-            Ok(0)
+            Ok(exit::SUCCESS)
         }
     };
 
@@ -146,7 +147,7 @@ fn run() -> i32 {
         Ok(code) => code,
         Err(err) => {
             eprintln!("{err:#}");
-            1
+            exit::RUNTIME
         }
     }
 }

--- a/crates/git-lock/tests/integration.rs
+++ b/crates/git-lock/tests/integration.rs
@@ -15,6 +15,8 @@ mod copy_delete;
 mod diff_tag;
 #[path = "integration/edge_cases.rs"]
 mod edge_cases;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/help_outside_repo.rs"]
 mod help_outside_repo;
 #[path = "integration/list.rs"]

--- a/crates/git-lock/tests/integration/exit_codes.rs
+++ b/crates/git-lock/tests/integration/exit_codes.rs
@@ -1,0 +1,28 @@
+use crate::common;
+
+#[test]
+fn unknown_command_exits_usage() {
+    let repo = common::init_repo();
+    let cache = tempfile::TempDir::new().expect("cache");
+    let env = [("ZSH_CACHE_DIR", cache.path().to_str().unwrap())];
+    let output = common::run_git_lock_output(repo.path(), &["nope"], &env, None);
+    assert_eq!(output.status.code(), Some(64));
+}
+
+#[test]
+fn outside_repo_exits_runtime() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let cache = tempfile::TempDir::new().expect("cache");
+    let env = [("ZSH_CACHE_DIR", cache.path().to_str().unwrap())];
+    let output = common::run_git_lock_output(dir.path(), &["list"], &env, None);
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let cache = tempfile::TempDir::new().expect("cache");
+    let env = [("ZSH_CACHE_DIR", cache.path().to_str().unwrap())];
+    let output = common::run_git_lock_output(dir.path(), &["--help"], &env, None);
+    assert_eq!(output.status.code(), Some(0));
+}

--- a/crates/git-scope/src/main.rs
+++ b/crates/git-scope/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use nils_common::cli_contract::exit;
 use nils_common::env as shared_env;
 use std::process;
 
@@ -150,7 +151,7 @@ fn print_subcommand_help(command: &Command) -> bool {
 fn main() {
     if let Err(err) = run() {
         eprintln!("{err:#}");
-        process::exit(1);
+        process::exit(exit::RUNTIME);
     }
 }
 
@@ -181,7 +182,7 @@ fn run() -> Result<()> {
 
     if !git::is_git_repo() {
         println!("⚠️ Not a Git repository. Run this command inside a Git project.");
-        process::exit(1);
+        process::exit(exit::RUNTIME);
     }
 
     let no_color = cli.no_color || shared_env::no_color_enabled();
@@ -253,7 +254,7 @@ fn run() -> Result<()> {
                 eprintln!("Usage: git-scope commit [OPTIONS] <COMMIT>");
                 eprintln!();
                 eprintln!("For more information, try '--help commit <COMMIT>'.");
-                process::exit(2);
+                process::exit(exit::USAGE);
             };
             commit::render_commit(&commit, parent.as_deref(), no_color, print, progress_opt_in)
                 .with_context(|| format!("git-scope commit {commit}"))?;

--- a/crates/git-scope/tests/integration.rs
+++ b/crates/git-scope/tests/integration.rs
@@ -13,6 +13,8 @@ mod commit_mode;
 pub mod common;
 #[path = "integration/edge_cases.rs"]
 mod edge_cases;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/help_outside_repo.rs"]
 mod help_outside_repo;
 #[path = "integration/print_sources.rs"]

--- a/crates/git-scope/tests/integration/exit_codes.rs
+++ b/crates/git-scope/tests/integration/exit_codes.rs
@@ -1,0 +1,26 @@
+use crate::common;
+use nils_test_support::cmd::{options_in_dir_with_envs, run_resolved};
+
+#[test]
+fn commit_missing_required_arg_exits_usage() {
+    let repo = common::init_repo();
+    let options = options_in_dir_with_envs(repo.path(), &[]);
+    let output = run_resolved("git-scope", &["commit"], &options);
+    assert_eq!(output.code, 64);
+}
+
+#[test]
+fn unknown_subcommand_returns_clap_usage_exit_code() {
+    let repo = common::init_repo();
+    let options = options_in_dir_with_envs(repo.path(), &[]);
+    let output = run_resolved("git-scope", &["bogus"], &options);
+    assert_eq!(output.code, 2);
+}
+
+#[test]
+fn outside_git_repo_returns_runtime_exit_code() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let options = options_in_dir_with_envs(dir.path(), &[]);
+    let output = run_resolved("git-scope", &["staged"], &options);
+    assert_eq!(output.code, 1);
+}

--- a/crates/git-summary/src/app.rs
+++ b/crates/git-summary/src/app.rs
@@ -1,5 +1,7 @@
 use std::env;
 
+use nils_common::cli_contract::exit;
+
 use crate::cli::{print_header, print_help};
 use crate::dates::{
     last_month_range, last_week_range, this_month_range, this_week_range, today_range,
@@ -17,11 +19,11 @@ pub fn run() -> i32 {
 
     if args.is_empty() || is_help(&args[0]) {
         print_help();
-        return 0;
+        return exit::SUCCESS;
     }
     if is_version(&args[0]) {
         println!("git-summary {}", env!("CARGO_PKG_VERSION"));
-        return 0;
+        return exit::SUCCESS;
     }
 
     let cmd = args[0].as_str();
@@ -29,7 +31,7 @@ pub fn run() -> i32 {
         "all" => {
             if let Err(msg) = require_git() {
                 println!("{msg}");
-                return 1;
+                return exit::RUNTIME;
             }
             print_header("all commits");
             summary(None, None)
@@ -37,7 +39,7 @@ pub fn run() -> i32 {
         "today" => {
             if let Err(msg) = require_git() {
                 println!("{msg}");
-                return 1;
+                return exit::RUNTIME;
             }
             let range = today_range();
             print_header(&range.label);
@@ -46,7 +48,7 @@ pub fn run() -> i32 {
         "yesterday" => {
             if let Err(msg) = require_git() {
                 println!("{msg}");
-                return 1;
+                return exit::RUNTIME;
             }
             let range = yesterday_range();
             print_header(&range.label);
@@ -55,7 +57,7 @@ pub fn run() -> i32 {
         "this-month" => {
             if let Err(msg) = require_git() {
                 println!("{msg}");
-                return 1;
+                return exit::RUNTIME;
             }
             let range = this_month_range();
             print_header(&range.label);
@@ -64,7 +66,7 @@ pub fn run() -> i32 {
         "last-month" => {
             if let Err(msg) = require_git() {
                 println!("{msg}");
-                return 1;
+                return exit::RUNTIME;
             }
             let range = last_month_range();
             print_header(&range.label);
@@ -73,7 +75,7 @@ pub fn run() -> i32 {
         "this-week" => {
             if let Err(msg) = require_git() {
                 println!("{msg}");
-                return 1;
+                return exit::RUNTIME;
             }
             let range = this_week_range();
             print_header(&range.label);
@@ -82,7 +84,7 @@ pub fn run() -> i32 {
         "last-week" => {
             if let Err(msg) = require_git() {
                 println!("{msg}");
-                return 1;
+                return exit::RUNTIME;
             }
             let range = last_week_range();
             print_header(&range.label);
@@ -92,12 +94,12 @@ pub fn run() -> i32 {
             if args.len() >= 2 {
                 if let Err(msg) = require_git() {
                     println!("{msg}");
-                    return 1;
+                    return exit::RUNTIME;
                 }
                 summary(Some(&args[0]), Some(&args[1]))
             } else {
                 println!("❌ Invalid usage. Try: git-summary help");
-                1
+                exit::USAGE
             }
         }
     }

--- a/crates/git-summary/tests/integration.rs
+++ b/crates/git-summary/tests/integration.rs
@@ -11,5 +11,7 @@ pub mod common;
 mod completion_outside_repo;
 #[path = "integration/edge_cases.rs"]
 mod edge_cases;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/summary_counts.rs"]
 mod summary_counts;

--- a/crates/git-summary/tests/integration/exit_codes.rs
+++ b/crates/git-summary/tests/integration/exit_codes.rs
@@ -1,0 +1,22 @@
+use crate::common;
+
+#[test]
+fn missing_required_args_exits_usage() {
+    let repo = common::init_repo();
+    let (code, _) = common::run_git_summary_allow_fail(repo.path(), &["2024-01-01"], &[]);
+    assert_eq!(code, 64);
+}
+
+#[test]
+fn outside_git_repo_exits_runtime() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let (code, _) = common::run_git_summary_allow_fail(dir.path(), &["all"], &[]);
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn help_exits_success() {
+    let repo = common::init_repo();
+    let (code, _) = common::run_git_summary_allow_fail(repo.path(), &["--help"], &[]);
+    assert_eq!(code, 0);
+}

--- a/crates/image-processing/src/main.rs
+++ b/crates/image-processing/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{CommandFactory, Parser};
+use nils_common::cli_contract::exit;
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 use std::path::PathBuf;
 use std::process;
@@ -28,7 +29,13 @@ fn run() -> i32 {
     let cli = match Cli::try_parse() {
         Ok(c) => c,
         Err(err) => {
-            let code = err.exit_code();
+            use clap::error::ErrorKind;
+            let code = match err.kind() {
+                ErrorKind::DisplayHelp
+                | ErrorKind::DisplayVersion
+                | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => err.exit_code(),
+                _ => exit::USAGE,
+            };
             let _ = err.print();
             return code;
         }
@@ -235,7 +242,7 @@ fn usage_error(msg: &str) -> ! {
     let usage = cmd.render_usage().to_string();
     eprintln!("{usage}");
     eprintln!("image-processing: error: {msg}");
-    process::exit(2);
+    process::exit(exit::USAGE);
 }
 
 #[cfg(test)]

--- a/crates/image-processing/tests/integration.rs
+++ b/crates/image-processing/tests/integration.rs
@@ -11,5 +11,7 @@ mod core_flows;
 mod dry_run_paths;
 #[path = "integration/edge_cases.rs"]
 mod edge_cases;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/version.rs"]
 mod version;

--- a/crates/image-processing/tests/integration/edge_cases.rs
+++ b/crates/image-processing/tests/integration/edge_cases.rs
@@ -19,7 +19,7 @@ fn removed_subcommands_are_usage_errors() {
         "optimize",
     ] {
         let out = common::run_image_processing(dir.path(), &[removed], &[]);
-        assert_eq!(out.code, 2, "subcommand={removed}, stderr: {}", out.stderr);
+        assert_eq!(out.code, 64, "subcommand={removed}, stderr: {}", out.stderr);
         assert!(
             out.stderr.contains("invalid value")
                 || out.stderr.contains("unrecognized subcommand")
@@ -40,7 +40,7 @@ fn convert_requires_in() {
         &["convert", "--to", "png", "--out", "out/a.png"],
         &[],
     );
-    assert_eq!(out.code, 2);
+    assert_eq!(out.code, 64);
     assert!(
         out.stderr.contains("convert requires exactly one --in"),
         "stderr: {}",
@@ -73,7 +73,7 @@ fn convert_invalid_target_format_is_usage_error() {
         ],
         &[],
     );
-    assert_eq!(out.code, 2);
+    assert_eq!(out.code, 64);
     assert!(
         out.stderr.contains("png|webp|jpg"),
         "stderr: {}",
@@ -100,7 +100,7 @@ fn convert_unsupported_input_format_lists_jpeg() {
         ],
         &[],
     );
-    assert_eq!(out.code, 2);
+    assert_eq!(out.code, 64);
     assert!(
         out.stderr
             .contains("unsupported convert input format (expected svg|png|jpg|jpeg|webp)"),
@@ -137,7 +137,7 @@ fn convert_rejects_multiple_inputs() {
         ],
         &[],
     );
-    assert_eq!(out.code, 2);
+    assert_eq!(out.code, 64);
     assert!(
         out.stderr.contains("convert requires exactly one --in"),
         "stderr: {}",
@@ -161,7 +161,7 @@ fn convert_rejects_missing_out_or_extension_mismatch() {
         &["convert", "--in", "icon.svg", "--to", "png", "--json"],
         &[],
     );
-    assert_eq!(missing_out.code, 2);
+    assert_eq!(missing_out.code, 64);
     assert!(
         missing_out.stderr.contains("convert requires --out"),
         "stderr: {}",
@@ -182,7 +182,7 @@ fn convert_rejects_missing_out_or_extension_mismatch() {
         ],
         &[],
     );
-    assert_eq!(mismatch.code, 2);
+    assert_eq!(mismatch.code, 64);
     assert!(
         mismatch
             .stderr
@@ -219,7 +219,7 @@ fn convert_rejects_invalid_dimension_contracts() {
         ],
         &[],
     );
-    assert_eq!(with_zero_width.code, 2);
+    assert_eq!(with_zero_width.code, 64);
     assert!(
         with_zero_width.stderr.contains("--width must be > 0"),
         "stderr: {}",
@@ -242,7 +242,7 @@ fn convert_rejects_invalid_dimension_contracts() {
         ],
         &[],
     );
-    assert_eq!(with_zero_height.code, 2);
+    assert_eq!(with_zero_height.code, 64);
     assert!(
         with_zero_height.stderr.contains("--height must be > 0"),
         "stderr: {}",
@@ -258,7 +258,7 @@ fn svg_validate_requires_single_input_and_out() {
 
     let missing_out =
         common::run_image_processing(dir.path(), &["svg-validate", "--in", "one.svg"], &[]);
-    assert_eq!(missing_out.code, 2);
+    assert_eq!(missing_out.code, 64);
     assert!(
         missing_out.stderr.contains("svg-validate requires --out"),
         "stderr: {}",
@@ -278,7 +278,7 @@ fn svg_validate_requires_single_input_and_out() {
         ],
         &[],
     );
-    assert_eq!(many_inputs.code, 2);
+    assert_eq!(many_inputs.code, 64);
     assert!(
         many_inputs.stderr.contains("requires exactly one --in"),
         "stderr: {}",
@@ -346,7 +346,7 @@ fn convert_overwrite_flag_controls_existing_output_replacement() {
         ],
         &[],
     );
-    assert_eq!(blocked.code, 2);
+    assert_eq!(blocked.code, 64);
     assert!(
         blocked
             .stderr

--- a/crates/image-processing/tests/integration/exit_codes.rs
+++ b/crates/image-processing/tests/integration/exit_codes.rs
@@ -1,0 +1,22 @@
+use crate::common;
+
+#[test]
+fn unknown_subcommand_exits_usage() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let out = common::run_image_processing(dir.path(), &["bogus"], &[]);
+    assert_eq!(out.code, 64);
+}
+
+#[test]
+fn missing_required_arg_exits_usage() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let out = common::run_image_processing(dir.path(), &["convert"], &[]);
+    assert_eq!(out.code, 64);
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let out = common::run_image_processing(dir.path(), &["--help"], &[]);
+    assert_eq!(out.code, 0);
+}

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -14,14 +14,15 @@ mod task_spec;
 use std::ffi::OsString;
 
 use clap::Parser;
+use nils_common::cli_contract::exit;
 use serde_json::json;
 
 use crate::cli::Cli;
 use crate::commands::Command;
 
-pub const EXIT_SUCCESS: i32 = 0;
-pub const EXIT_FAILURE: i32 = 1;
-pub const EXIT_USAGE: i32 = 2;
+pub const EXIT_SUCCESS: i32 = exit::SUCCESS;
+pub const EXIT_FAILURE: i32 = exit::RUNTIME;
+pub const EXIT_USAGE: i32 = exit::USAGE;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinaryFlavor {

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -9,6 +9,8 @@ mod auto_single_lane_runtime_truth;
 mod cli_contract;
 #[path = "integration/common.rs"]
 pub mod common;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/grouping_default.rs"]
 mod grouping_default;
 #[path = "integration/link_pr_flow.rs"]

--- a/crates/plan-issue-cli/tests/integration/exit_codes.rs
+++ b/crates/plan-issue-cli/tests/integration/exit_codes.rs
@@ -1,0 +1,19 @@
+use crate::common;
+
+#[test]
+fn unknown_subcommand_exits_usage() {
+    let out = common::run_plan_issue_local(&["bogus"]);
+    assert_eq!(out.code, 64);
+}
+
+#[test]
+fn missing_required_args_exits_usage() {
+    let out = common::run_plan_issue_local(&["start-sprint"]);
+    assert_eq!(out.code, 64);
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let out = common::run_plan_issue_local(&["--help"]);
+    assert_eq!(out.code, 0);
+}

--- a/crates/plan-issue-cli/tests/integration/parity_guardrails.rs
+++ b/crates/plan-issue-cli/tests/integration/parity_guardrails.rs
@@ -136,7 +136,7 @@ fn parity_shell_multi_sprint_guide_matches_shell_fixture_after_normalization() {
 #[test]
 fn command_guardrails_local_issue_path_error_contains_subcommand_specific_guidance() {
     let out = common::run_plan_issue_local(&["--format", "json", "status-plan", "--issue", "217"]);
-    assert_eq!(out.code, 2, "stderr: {}", out.stderr);
+    assert_eq!(out.code, 64, "stderr: {}", out.stderr);
 
     let payload = parse_json(&out.stdout);
     assert_eq!(payload["status"], "error");
@@ -268,7 +268,7 @@ fn command_guardrails_close_plan_requires_github_comment_url_format() {
         "https://example.com/not-github-comment",
     ]);
 
-    assert_eq!(out.code, 2, "stderr: {}", out.stderr);
+    assert_eq!(out.code, 64, "stderr: {}", out.stderr);
     let payload = parse_json(&out.stdout);
     assert_eq!(payload["status"], "error");
     assert_eq!(payload["error"]["code"], "invalid-approval-comment-url");

--- a/crates/plan-tooling/src/usage.rs
+++ b/crates/plan-tooling/src/usage.rs
@@ -1,19 +1,20 @@
 use crate::{artifact_audit, batches, scaffold, spec, validate};
+use nils_common::cli_contract::exit;
 
 pub fn dispatch(args: &[String]) -> i32 {
     if args.len() <= 1 {
         print_help_stdout();
-        return 0;
+        return exit::SUCCESS;
     }
 
     let subcommand = args[1].as_str();
     if is_help(subcommand) || subcommand == "help" {
         print_help_stdout();
-        return 0;
+        return exit::SUCCESS;
     }
     if is_version(subcommand) {
         print_version_stdout();
-        return 0;
+        return exit::SUCCESS;
     }
 
     match subcommand {
@@ -28,7 +29,7 @@ pub fn dispatch(args: &[String]) -> i32 {
         other => {
             eprintln!("error: unknown argument: {other}");
             print_help_stderr();
-            1
+            exit::USAGE
         }
     }
 }
@@ -121,8 +122,8 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_unknown_command_exits_one() {
+    fn dispatch_unknown_command_exits_usage() {
         let code = dispatch(&["plan-tooling".to_string(), "nope".to_string()]);
-        assert_eq!(code, 1);
+        assert_eq!(code, exit::USAGE);
     }
 }

--- a/crates/plan-tooling/tests/integration.rs
+++ b/crates/plan-tooling/tests/integration.rs
@@ -11,6 +11,8 @@ mod batches;
 pub mod common;
 #[path = "integration/completion_outside_repo.rs"]
 mod completion_outside_repo;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/scaffold.rs"]
 mod scaffold;
 #[path = "integration/spec.rs"]

--- a/crates/plan-tooling/tests/integration/exit_codes.rs
+++ b/crates/plan-tooling/tests/integration/exit_codes.rs
@@ -1,0 +1,22 @@
+use nils_test_support::cmd::run_resolved_in_dir;
+
+#[test]
+fn unknown_subcommand_exits_usage() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("plan-tooling", tmp.path(), &["bogus"], &[], None);
+    assert_eq!(output.code, 64);
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("plan-tooling", tmp.path(), &["--help"], &[], None);
+    assert_eq!(output.code, 0);
+}
+
+#[test]
+fn no_args_exits_success_with_help() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("plan-tooling", tmp.path(), &[], &[], None);
+    assert_eq!(output.code, 0);
+}

--- a/crates/semantic-commit/src/staged_context.rs
+++ b/crates/semantic-commit/src/staged_context.rs
@@ -1,4 +1,5 @@
 use crate::git;
+use nils_common::cli_contract::exit;
 use nils_common::git as common_git;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -8,10 +9,11 @@ use std::process::Output;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
-const EXIT_ERROR: i32 = 1;
+const EXIT_ERROR: i32 = exit::RUNTIME;
 const EXIT_NO_STAGED_CHANGES: i32 = 2;
 const EXIT_DEPENDENCY_ERROR: i32 = 5;
 const CAT_PAGER_ENV: [(&str, &str); 2] = [("GIT_PAGER", "cat"), ("PAGER", "cat")];
+const STAGED_CONTEXT_SCHEMA_VERSION: &str = "cli.semantic-commit.staged-context.v2";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum OutputFormat {
@@ -251,6 +253,7 @@ fn build_bundle(repo: Option<&Path>) -> anyhow::Result<Bundle> {
             obj.insert("score".to_string(), json!(score));
         }
         if let Some(old_path) = entry.old_path {
+            obj.insert("old_path".to_string(), json!(old_path));
             obj.insert("oldPath".to_string(), json!(old_path));
         }
         obj.insert(
@@ -276,24 +279,37 @@ fn build_bundle(repo: Option<&Path>) -> anyhow::Result<Bundle> {
         .map(|(name, count)| json!({ "name": name, "count": count }))
         .collect();
 
+    let top_level_dir_count = top_level_dirs.len();
+    let status_counts_alias = status_counts.clone();
+    let top_level_dirs_alias = top_level_dirs.clone();
+    let generated_at_alias = generated_at.clone();
     let context = json!({
+        "schema_version": STAGED_CONTEXT_SCHEMA_VERSION,
         "schemaVersion": 1,
-        "generatedAt": generated_at,
+        "generated_at": generated_at,
+        "generatedAt": generated_at_alias,
         "repo": { "name": repo_name },
         "git": { "branch": branch, "head": head },
         "staged": {
             "summary": {
+                "file_count": file_count,
                 "fileCount": file_count,
                 "insertions": insertions,
                 "deletions": deletions,
+                "binary_file_count": binary_file_count,
                 "binaryFileCount": binary_file_count,
+                "lockfile_count": lockfile_count,
                 "lockfileCount": lockfile_count,
+                "root_file_count": root_file_count,
                 "rootFileCount": root_file_count,
-                "topLevelDirCount": top_level_dirs.len(),
+                "top_level_dir_count": top_level_dir_count,
+                "topLevelDirCount": top_level_dir_count,
             },
-            "statusCounts": status_counts,
+            "status_counts": status_counts,
+            "statusCounts": status_counts_alias,
             "structure": {
-                "topLevelDirs": top_level_dirs,
+                "top_level_dirs": top_level_dirs,
+                "topLevelDirs": top_level_dirs_alias,
             },
             "files": files,
             "patch": { "path": "staged.patch", "format": "git diff --cached" }

--- a/crates/semantic-commit/tests/integration.rs
+++ b/crates/semantic-commit/tests/integration.rs
@@ -9,5 +9,7 @@ mod commit;
 pub mod common;
 #[path = "integration/completion_outside_repo.rs"]
 mod completion_outside_repo;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;
 #[path = "integration/staged_context.rs"]
 mod staged_context;

--- a/crates/semantic-commit/tests/integration/exit_codes.rs
+++ b/crates/semantic-commit/tests/integration/exit_codes.rs
@@ -1,0 +1,80 @@
+use crate::common;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn unknown_subcommand_exits_one() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(dir.path(), &["bogus"], &[], None);
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
+fn staged_context_outside_repo_exits_one() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(dir.path(), &["staged-context"], &[], None);
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
+fn staged_context_no_staged_changes_exits_two() {
+    let repo = common::init_repo();
+    let output = common::run_semantic_commit_output(repo.path(), &["staged-context"], &[], None);
+    assert_eq!(output.status.code(), Some(2));
+}
+
+#[test]
+fn commit_missing_message_exits_three() {
+    let repo = common::init_repo();
+    common::write_file(repo.path(), "a.txt", "hello\n");
+    common::git(repo.path(), &["add", "a.txt"]);
+    let output =
+        common::run_semantic_commit_output(repo.path(), &["commit", "--automation"], &[], None);
+    assert_eq!(output.status.code(), Some(3));
+}
+
+#[test]
+fn commit_invalid_message_exits_four() {
+    let repo = common::init_repo();
+    common::write_file(repo.path(), "a.txt", "hello\n");
+    common::git(repo.path(), &["add", "a.txt"]);
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "not a semantic commit",
+            "--validate-only",
+        ],
+        &[],
+        None,
+    );
+    assert_eq!(output.status.code(), Some(4));
+}
+
+#[test]
+fn staged_context_emits_v2_schema_version_with_camelcase_alias() {
+    let repo = common::init_repo();
+    common::write_file(repo.path(), "a.txt", "hello\n");
+    common::git(repo.path(), &["add", "a.txt"]);
+
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &["staged-context", "--format", "json"],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let context: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("parse staged-context json");
+    assert_eq!(
+        context["schema_version"].as_str(),
+        Some("cli.semantic-commit.staged-context.v2")
+    );
+    assert_eq!(context["schemaVersion"].as_i64(), Some(1));
+    assert!(context["generated_at"].is_string());
+    assert!(context["generatedAt"].is_string());
+    assert_eq!(context["staged"]["summary"]["file_count"].as_i64(), Some(1));
+    assert_eq!(context["staged"]["summary"]["fileCount"].as_i64(), Some(1));
+}

--- a/crates/test-first-evidence/Cargo.toml
+++ b/crates/test-first-evidence/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
+nils-common = { version = "0.10.2", path = "../nils-common", package = "nils-common" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/test-first-evidence/src/lib.rs
+++ b/crates/test-first-evidence/src/lib.rs
@@ -18,10 +18,11 @@ use cli::{
     Cli, Command, CommonArgs, InitArgs, OutputFormat, RecordFailingArgs, RecordFinalArgs,
     RecordWaiverArgs,
 };
+use nils_common::cli_contract::exit;
 
-const EXIT_OK: i32 = 0;
-const EXIT_RUNTIME: i32 = 1;
-const EXIT_USAGE: i32 = 64;
+const EXIT_OK: i32 = exit::SUCCESS;
+const EXIT_RUNTIME: i32 = exit::RUNTIME;
+const EXIT_USAGE: i32 = exit::USAGE;
 
 const RECORD_SCHEMA_VERSION: &str = "test-first-evidence.record.v1";
 const RECORD_FILE_NAME: &str = "test-first-evidence.json";

--- a/crates/test-first-evidence/tests/integration.rs
+++ b/crates/test-first-evidence/tests/integration.rs
@@ -2,3 +2,5 @@
 
 #[path = "integration/cli.rs"]
 mod cli;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;

--- a/crates/test-first-evidence/tests/integration/exit_codes.rs
+++ b/crates/test-first-evidence/tests/integration/exit_codes.rs
@@ -1,0 +1,27 @@
+use nils_test_support::cmd::run_resolved_in_dir;
+
+#[test]
+fn unknown_subcommand_exits_usage() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("test-first-evidence", tmp.path(), &["bogus"], &[], None);
+    assert_eq!(output.code, 64);
+}
+
+#[test]
+fn missing_subcommand_exits_clap_help() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("test-first-evidence", tmp.path(), &[], &[], None);
+    // No subcommand → clap renders help (exit 2) or 64.
+    assert!(
+        matches!(output.code, 0 | 2 | 64),
+        "unexpected exit code {}",
+        output.code
+    );
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("test-first-evidence", tmp.path(), &["--help"], &[], None);
+    assert_eq!(output.code, 0);
+}

--- a/crates/web-evidence/Cargo.toml
+++ b/crates/web-evidence/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
+nils-common = { version = "0.10.2", path = "../nils-common", package = "nils-common" }
 regex = "1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 serde = { workspace = true }

--- a/crates/web-evidence/src/lib.rs
+++ b/crates/web-evidence/src/lib.rs
@@ -19,10 +19,11 @@ use serde::Serialize;
 use serde_json::{Value, json};
 
 use cli::{CaptureArgs, Cli, Command, HttpMethod, OutputFormat};
+use nils_common::cli_contract::exit;
 
-const EXIT_OK: i32 = 0;
-const EXIT_RUNTIME: i32 = 1;
-const EXIT_USAGE: i32 = 64;
+const EXIT_OK: i32 = exit::SUCCESS;
+const EXIT_RUNTIME: i32 = exit::RUNTIME;
+const EXIT_USAGE: i32 = exit::USAGE;
 
 const CAPTURE_SCHEMA_VERSION: &str = "cli.web-evidence.capture.v1";
 const SUMMARY_SCHEMA_VERSION: &str = "web-evidence.summary.v1";

--- a/crates/web-evidence/tests/integration.rs
+++ b/crates/web-evidence/tests/integration.rs
@@ -2,3 +2,5 @@
 
 #[path = "integration/cli.rs"]
 mod cli;
+#[path = "integration/exit_codes.rs"]
+mod exit_codes;

--- a/crates/web-evidence/tests/integration/exit_codes.rs
+++ b/crates/web-evidence/tests/integration/exit_codes.rs
@@ -1,0 +1,22 @@
+use nils_test_support::cmd::run_resolved_in_dir;
+
+#[test]
+fn unknown_subcommand_exits_usage() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("web-evidence", tmp.path(), &["bogus"], &[], None);
+    assert_eq!(output.code, 64);
+}
+
+#[test]
+fn capture_missing_required_arg_exits_usage() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("web-evidence", tmp.path(), &["capture"], &[], None);
+    assert_eq!(output.code, 64);
+}
+
+#[test]
+fn help_flag_exits_success() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_resolved_in_dir("web-evidence", tmp.path(), &["--help"], &[], None);
+    assert_eq!(output.code, 0);
+}

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-execution-state.md
@@ -2,37 +2,36 @@
 
 ## Current State
 
-- Status: in-progress (Sprint 1 + Sprint 2 + Tasks 3.1 + 3.2 complete; Tasks 3.3 / 3.4 pending)
-- Target scope: Task 3.2 (api-rest / api-gql / api-grpc / api-websocket / api-test)
-- Execution window: Task 3.2 only — Task 3.3 (remaining single-binary crates)
-  stays in a follow-up PR; Task 3.4 (lint script) lands after 3.3
+- Status: in-progress (Sprint 1 + Sprint 2 + Tasks 3.1 + 3.2 + 3.3 complete; Task 3.4 pending)
+- Target scope: Task 3.3 (remaining 14 single-binary crates)
+- Execution window: Task 3.3 only — Task 3.4 (workspace lint script) lands in a follow-up PR
 - Staged execution confirmation: confirmed(Sprint 1 PR #375, Sprint 2 PR #376,
-  Task 3.1 PR #377 merged; Task 3.2 in this PR; Tasks 3.3 / 3.4 to come)
-- Current task: Task 3.2 complete
-- Next task: Task 3.3 (migrate remaining single-binary crates)
-- Last updated: 2026-05-19
-- Branch/commit: feat/cli-output-contract-api-testing-stack (pending push)
+  Task 3.1 PR #377, Task 3.2 PR #378 merged; Task 3.3 in this PR; Task 3.4 to come)
+- Current task: Task 3.3 complete
+- Next task: Task 3.4 (workspace lint script for legacy contract usage)
+- Last updated: 2026-05-20
+- Branch/commit: feat/cli-output-contract-fan-out-3-3 (pending push)
 - Source document:
   docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger
 
-| ID       | Status  | Task                                                              | Evidence                                                                                                 | Notes                                                                                                                                                                                                                                                            |
-| -------- | ------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Task 1.1 | done    | Add `cli_contract` module to `nils-common`                        | crates/nils-common/src/cli_contract.rs; PR #375                                                          | Plus additive `EnvelopeError::details` field in Sprint 2                                                                                                                                                                                                         |
-| Task 1.2 | done    | Add parse-error JSON helper                                       | crates/nils-common/tests/integration/cli_contract.rs; PR #375                                            |                                                                                                                                                                                                                                                                  |
-| Task 1.3 | done    | Migrate `cli-template` as reference implementation                | crates/cli-template/src/main.rs; PR #375                                                                 |                                                                                                                                                                                                                                                                  |
-| Task 1.4 | done    | Write `cli-output-contract-v1.md` spec                            | docs/specs/cli-output-contract-v1.md; PR #375                                                            | Sprint 2 extended with `details` field                                                                                                                                                                                                                           |
-| Task 2.1 | done    | Replace memo-cli exit-code constants with shared module           | crates/memo-cli/src/errors.rs                                                                            | exit::USAGE/DATA/RUNTIME replaces 64/65/1 literals                                                                                                                                                                                                               |
-| Task 2.2 | done    | Migrate memo-cli to `OutputFormat` and hidden `--json` alias      | crates/memo-cli/src/cli.rs                                                                               | shared `nils_common::cli_contract::OutputFormat`; `--json` `hide=true conflicts_with=format`                                                                                                                                                                     |
-| Task 2.3 | done    | Migrate memo-cli JSON output to shared envelope and `warnings`    | crates/memo-cli/src/output/json.rs + commands/*                                                          | schema_version moved to `cli.memo-cli.<cmd>.v1`; collections nest `items` + `pagination`/`meta` under `data`; apply per-item errors surface in `warnings`                                                                                                        |
-| Task 2.4 | done    | Route memo-cli parse and unknown-subcommand errors through helper | crates/memo-cli/src/app.rs                                                                               | argv-scan detect of `--format json` / `--json`; calls `emit_parse_error`                                                                                                                                                                                         |
-| Task 2.5 | done    | Add memo-cli exit-code matrix test                                | crates/memo-cli/tests/integration/exit_codes.rs                                                          | 5 tests covering SUCCESS / USAGE (arg + unknown subcmd) / DATA / RUNTIME                                                                                                                                                                                         |
-| Task 3.1 | done    | Migrate `agent-workflow-primitives` binaries                      | crates/agent-workflow-primitives/src/common.rs + per-binary entrypoints; tests/integration/exit_codes.rs | shared `Envelope<T>` via refactored `common.rs`; `handle_parse_error` routes parse errors; 50 cli tests + 3 matrix tests; `RECORD_SCHEMA_VERSION` literals stay byte-stable                                                                                      |
-| Task 3.2 | done    | Migrate API testing stack                                         | crates/api-testing-core/src/cli_contract.rs + per-binary main.rs; cli_smoke matrix tests                 | shared `handle_parse_error` helper in api-testing-core; api-websocket envelope drops `command` / renames `result` → `data`; api-test stdout + `--out` both ship `cli.api-test.run.v1` envelope; `render_summary_from_json_str` accepts both wrapped + raw shapes |
-| Task 3.3 | pending | Migrate remaining single-binary crates and run the full gate      | n/a                                                                                                      | next sprint                                                                                                                                                                                                                                                      |
-| Task 3.4 | pending | Workspace lint script for legacy contract usage                   | n/a                                                                                                      | depends on 3.1, 3.2, 3.3                                                                                                                                                                                                                                         |
+| ID       | Status  | Task                                                              | Evidence                                                                                                                                                                                                                                              | Notes                                                                                                                                                                                                                                                                                                                                                                                        |
+| -------- | ------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task 1.1 | done    | Add `cli_contract` module to `nils-common`                        | crates/nils-common/src/cli_contract.rs; PR #375                                                                                                                                                                                                       | Plus additive `EnvelopeError::details` field in Sprint 2                                                                                                                                                                                                                                                                                                                                     |
+| Task 1.2 | done    | Add parse-error JSON helper                                       | crates/nils-common/tests/integration/cli_contract.rs; PR #375                                                                                                                                                                                         |                                                                                                                                                                                                                                                                                                                                                                                              |
+| Task 1.3 | done    | Migrate `cli-template` as reference implementation                | crates/cli-template/src/main.rs; PR #375                                                                                                                                                                                                              |                                                                                                                                                                                                                                                                                                                                                                                              |
+| Task 1.4 | done    | Write `cli-output-contract-v1.md` spec                            | docs/specs/cli-output-contract-v1.md; PR #375                                                                                                                                                                                                         | Sprint 2 extended with `details` field                                                                                                                                                                                                                                                                                                                                                       |
+| Task 2.1 | done    | Replace memo-cli exit-code constants with shared module           | crates/memo-cli/src/errors.rs                                                                                                                                                                                                                         | exit::USAGE/DATA/RUNTIME replaces 64/65/1 literals                                                                                                                                                                                                                                                                                                                                           |
+| Task 2.2 | done    | Migrate memo-cli to `OutputFormat` and hidden `--json` alias      | crates/memo-cli/src/cli.rs                                                                                                                                                                                                                            | shared `nils_common::cli_contract::OutputFormat`; `--json` `hide=true conflicts_with=format`                                                                                                                                                                                                                                                                                                 |
+| Task 2.3 | done    | Migrate memo-cli JSON output to shared envelope and `warnings`    | crates/memo-cli/src/output/json.rs + commands/*                                                                                                                                                                                                       | schema_version moved to `cli.memo-cli.<cmd>.v1`; collections nest `items` + `pagination`/`meta` under `data`; apply per-item errors surface in `warnings`                                                                                                                                                                                                                                    |
+| Task 2.4 | done    | Route memo-cli parse and unknown-subcommand errors through helper | crates/memo-cli/src/app.rs                                                                                                                                                                                                                            | argv-scan detect of `--format json` / `--json`; calls `emit_parse_error`                                                                                                                                                                                                                                                                                                                     |
+| Task 2.5 | done    | Add memo-cli exit-code matrix test                                | crates/memo-cli/tests/integration/exit_codes.rs                                                                                                                                                                                                       | 5 tests covering SUCCESS / USAGE (arg + unknown subcmd) / DATA / RUNTIME                                                                                                                                                                                                                                                                                                                     |
+| Task 3.1 | done    | Migrate `agent-workflow-primitives` binaries                      | crates/agent-workflow-primitives/src/common.rs + per-binary entrypoints; tests/integration/exit_codes.rs                                                                                                                                              | shared `Envelope<T>` via refactored `common.rs`; `handle_parse_error` routes parse errors; 50 cli tests + 3 matrix tests; `RECORD_SCHEMA_VERSION` literals stay byte-stable                                                                                                                                                                                                                  |
+| Task 3.2 | done    | Migrate API testing stack                                         | crates/api-testing-core/src/cli_contract.rs + per-binary main.rs; cli_smoke matrix tests                                                                                                                                                              | shared `handle_parse_error` helper in api-testing-core; api-websocket envelope drops `command` / renames `result` → `data`; api-test stdout + `--out` both ship `cli.api-test.run.v1` envelope; `render_summary_from_json_str` accepts both wrapped + raw shapes                                                                                                                             |
+| Task 3.3 | done    | Migrate remaining single-binary crates and run the full gate      | 14 crates: semantic-commit / git-scope / git-summary / git-lock / agent-out / agent-docs / agent-scope-lock / web-evidence / test-first-evidence / image-processing / codex-cli / gemini-cli / plan-tooling / plan-issue-cli; matrix tests per binary | semantic-commit staged-context emits `schema_version: "cli.semantic-commit.staged-context.v2"` plus all camelCase fields (`schemaVersion`, `generatedAt`, `fileCount`, `oldPath`, …) as deprecated aliases; agent-docs / image-processing / plan-issue-cli usage exits realigned 2 → 64; remaining crates wire `nils_common::cli_contract::exit::*` constants; 14 new exit-code matrix tests |
+| Task 3.4 | pending | Workspace lint script for legacy contract usage                   | n/a                                                                                                                                                                                                                                                   | depends on 3.1, 3.2, 3.3 (all done)                                                                                                                                                                                                                                                                                                                                                          |
 
 ## Validation
 
@@ -40,6 +39,8 @@
 | --- | --- | --- | --- |
 | `cargo test -p nils-common cli_contract` | pass | 10 tests (`EnvelopeError::details` additive change covered) | terminal log |
 | `cargo test -p nils-memo-cli` | pass | 34 tests (29 integration incl. 5 new exit-code matrix + 32 unit) | terminal log |
+| `cargo nextest run --workspace` | pass | 2801/2801 pass after Task 3.3 fan-out | terminal log |
+| `cargo clippy --workspace --all-targets -- -D warnings` | pass | zero warnings after Task 3.3 | terminal log |
 | `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | pass | docs hygiene + plan-bundle validate green | terminal log |
 | `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` | pass | cargo fmt + clippy -D warnings + nextest workspace + doctests + third-party audit green | terminal log |
 
@@ -53,6 +54,78 @@
 
 - See prior turn's notes. Sprint 1 foundation landed; this entry kept as
   context for Sprint 2.
+
+### 2026-05-20 (Task 3.3 → feat/cli-output-contract-fan-out-3-3)
+
+- Read:
+  - docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
+  - crates/cli-template/src/main.rs (reference impl)
+  - crates/semantic-commit/{src/lib.rs, src/usage.rs, src/staged_context.rs,
+    src/commit.rs, tests/integration/staged_context.rs}
+  - crates/git-scope/src/main.rs; crates/git-summary/{src/main.rs, src/app.rs};
+    crates/git-lock/src/main.rs
+  - crates/agent-out/{Cargo.toml, src/lib.rs}; crates/agent-docs/{Cargo.toml,
+    src/lib.rs}; crates/agent-scope-lock/{Cargo.toml, src/lib.rs}
+  - crates/web-evidence/{Cargo.toml, src/lib.rs};
+    crates/test-first-evidence/{Cargo.toml, src/lib.rs};
+    crates/image-processing/{Cargo.toml, src/main.rs}
+  - crates/codex-cli/src/main.rs; crates/gemini-cli/src/main.rs
+  - crates/plan-tooling/{src/lib.rs, src/usage.rs};
+    crates/plan-issue-cli/src/lib.rs
+- Changed:
+  - crates/semantic-commit/src/staged_context.rs (new `schema_version:
+    "cli.semantic-commit.staged-context.v2"`; duplicates camelCase fields —
+    `schemaVersion`, `generatedAt`, `fileCount`, `insertions`, `deletions`,
+    `binaryFileCount`, `lockfileCount`, `rootFileCount`, `topLevelDirCount`,
+    `statusCounts`, `topLevelDirs`, `oldPath` — as deprecated aliases for one
+    minor cycle; switches inline EXIT_ERROR=1 onto shared `exit::RUNTIME`)
+  - crates/semantic-commit/tests/integration/exit_codes.rs (new — 6 tests:
+    unknown subcommand → 1 / staged-context outside repo → 1 / no staged → 2
+    / commit missing message → 3 / commit invalid message → 4 / staged-context
+    v2 schema + camelCase alias assertions)
+  - crates/git-scope/src/main.rs (process::exit(1|2) → exit::RUNTIME / USAGE
+    via `nils_common::cli_contract::exit`); new exit-code matrix test
+  - crates/git-summary/src/app.rs (invalid usage → exit::USAGE; runtime →
+    exit::RUNTIME); new exit-code matrix test
+  - crates/git-lock/src/main.rs (unknown command → exit::USAGE; runtime →
+    exit::RUNTIME); new exit-code matrix test
+  - crates/agent-out/{Cargo.toml, src/lib.rs} (add nils-common dep + nils-test-support dev-dep;
+    inline EXIT_USAGE/RUNTIME/AUDIT_VIOLATIONS now point at shared `exit::*`); new exit-code
+    matrix test
+  - crates/agent-docs/src/lib.rs (EXIT_USAGE realigned 2 → 64 via shared
+    constant; clap parse-error path now routes non-help/version errors through
+    EXIT_USAGE explicitly); new exit-code matrix test
+  - crates/agent-scope-lock/{Cargo.toml, src/lib.rs} (add nils-common dep;
+    inline constants reuse `exit::*`); new exit-code matrix test
+  - crates/web-evidence/{Cargo.toml, src/lib.rs} (add nils-common dep; reuse
+    `exit::*`); new exit-code matrix test
+  - crates/test-first-evidence/{Cargo.toml, src/lib.rs} (add nils-common dep;
+    reuse `exit::*`); new exit-code matrix test
+  - crates/image-processing/src/main.rs (usage_error realigned 2 → 64 via
+    `exit::USAGE`; clap parse-error path narrows USAGE mapping for non-help/
+    version errors); existing edge_cases tests updated 2 → 64; new exit-code
+    matrix test
+  - crates/codex-cli/src/main.rs; crates/gemini-cli/src/main.rs (inline 64
+    literals replaced with `exit::USAGE`; help-path uses `exit::SUCCESS`); new
+    exit-code matrix tests per binary
+  - crates/plan-tooling/src/usage.rs (unknown command → `exit::USAGE`; unit
+    test renamed `dispatch_unknown_command_exits_usage`, asserts
+    `exit::USAGE`); new exit-code matrix test
+  - crates/plan-issue-cli/src/lib.rs (EXIT_USAGE realigned 2 → 64 via shared
+    constant; EXIT_FAILURE / EXIT_SUCCESS routed through `exit::*`); existing
+    parity_guardrails tests updated 2 → 64; new exit-code matrix test
+  - THIRD_PARTY_LICENSES.md / THIRD_PARTY_NOTICES.md (regenerated for new
+    nils-common dep edges in agent-out / agent-scope-lock / web-evidence /
+    test-first-evidence)
+- Validated:
+  - `cargo build --workspace` (clean)
+  - `cargo nextest run --workspace` (2801 / 2801 pass)
+  - `cargo clippy --workspace --all-targets -- -D warnings` (zero warnings)
+  - Per-binary `cargo test -p <crate> --test integration exit_codes` for all
+    14 crates: green
+- Blocked by: none
+- Next: open feature PR with `/deliver-feature-pr`; Task 3.4 (workspace lint
+  script for legacy contract usage) lands as the final follow-up PR.
 
 ### 2026-05-19 (Task 3.2 → feat/cli-output-contract-api-testing-stack)
 


### PR DESCRIPTION
## Summary

Delivers Task 3.3 of the
[`cli-output-contract-unification`](docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md)
plan. 14 single-binary crates now route their exit codes through
`nils_common::cli_contract::exit::*` (semantic-commit, git-scope, git-summary,
git-lock, agent-out, agent-docs, agent-scope-lock, web-evidence,
test-first-evidence, image-processing, codex-cli, gemini-cli, plan-tooling,
plan-issue-cli). `semantic-commit staged-context` adds a v2
`schema_version: "cli.semantic-commit.staged-context.v2"` while keeping the
existing camelCase fields as deprecated aliases for one minor cycle.

## Changes

- Wire `nils_common::cli_contract::exit::*` into 14 single-binary crates;
  inline EXIT_USAGE / EXIT_RUNTIME / EXIT_SUCCESS constants now point at the
  shared module so the workspace contract is the single source of truth.
- semantic-commit `staged-context` emits `schema_version: "cli.semantic-commit.staged-context.v2"`
  alongside duplicated camelCase keys (`schemaVersion`, `generatedAt`,
  `fileCount`, `insertions`, `deletions`, `binaryFileCount`, `lockfileCount`,
  `rootFileCount`, `topLevelDirCount`, `statusCounts`, `topLevelDirs`,
  `oldPath`) so downstream consumers keep working while the snake_case shape
  becomes canonical.
- agent-docs / image-processing / plan-issue-cli usage exits realigned from 2
  to 64 to match BSD sysexits; existing parity_guardrails and edge_cases
  test assertions updated in lockstep.
- Add `nils-common` dep to agent-out, agent-scope-lock, web-evidence,
  test-first-evidence (the four crates that were still ad-hoc). agent-out
  also gains a `nils-test-support` dev-dep for the new exit-code matrix test.
- Regenerated `THIRD_PARTY_LICENSES.md` / `THIRD_PARTY_NOTICES.md` for the new
  `nils-common` dep edges via `scripts/generate-third-party-artifacts.sh --write`.
- One exit-code matrix test per binary (14 new `tests/integration/exit_codes.rs`
  files, ~60 assertions covering unknown subcommand / missing required arg /
  help-flag paths).
- semantic-commit's documented exit-code contract (1 = usage or operational
  failure; 2 = no staged changes; 3 = message missing; 4 = validation
  failed; 5 = dependency missing) is preserved — the migration only adds
  shared-constant references, no exit-code semantics change in that crate.

## Test-First Evidence

- Change classification: refactor + additive contract extension.
- Failing test before fix: not applicable; per-binary exit-code matrix tests
  are new acceptance criteria added by this task. Each test is checked into
  this PR and exercises the new shared constants.
- Final validation: `cargo nextest run --workspace` (2801/2801 pass);
  `cargo clippy --workspace --all-targets -- -D warnings` (clean);
  per-binary `cargo test -p <crate> --test integration exit_codes` green for
  all 14 crates.
- Waiver reason: contract-alignment refactor with no pre-existing failing
  test; new matrix tests are the test-first evidence for the acceptance
  criteria ("one exit-code matrix test per binary").

## Testing

- `cargo nextest run --workspace`: pass (2801 / 2801 tests).
- `cargo clippy --workspace --all-targets -- -D warnings`: pass (zero warnings).
- `cargo fmt --all` applied before commit.
- `bash scripts/generate-third-party-artifacts.sh --write` applied.

## Risk / Notes

- agent-docs / image-processing / plan-issue-cli usage exits change from 2 to
  64. Callers that previously distinguished `exit 2 = usage` from
  `exit 1 = runtime` will now see `exit 64 = usage` instead. Tests in those
  crates have been updated; external automation that grepped for `exit 2`
  needs to adjust.
- semantic-commit `staged-context` JSON output now emits both camelCase and
  snake_case keys (object grows ~12 extra entries). Downstream parsers are
  unaffected because the camelCase fields still exist; consumers that
  enumerate keys may surface duplicates and can migrate to snake_case at
  their pace before the alias is removed in a future minor cycle.
- semantic-commit's documented exit codes (1, 2, 3, 4, 5) are preserved —
  argv-parse failures still exit 1, matching the public skill contract. The
  workspace lint script in Task 3.4 will accept 1 for semantic-commit's
  parse path.
- Task 3.4 (workspace lint script enforcing the new contract) remains as the
  final follow-up PR.
