### PR TITLE
Retire visible --json aliases across remaining four crates

### DIFF
--- a/crates/codex-cli/src/cli.rs
+++ b/crates/codex-cli/src/cli.rs
@@ -95,8 +95,8 @@ pub struct OutputModeArgs {
     /// Output format (`text` or `json`)
     #[arg(long = "format", value_enum, value_name = "format")]
     pub format: Option<OutputFormat>,
-    /// Output machine-readable JSON
-    #[arg(long = "json", conflicts_with = "format")]
+    /// Hidden alias for `--format json` (kept for backwards compatibility).
+    #[arg(long = "json", hide = true, conflicts_with = "format")]
     pub json: bool,
 }
 
@@ -199,8 +199,8 @@ pub struct RateLimitsArgs {
     /// Output format (`text` or `json`)
     #[arg(long = "format", value_enum, value_name = "format")]
     pub format: Option<OutputFormat>,
-    /// Output raw JSON
-    #[arg(long = "json", conflicts_with = "format")]
+    /// Hidden alias for `--format json` (kept for backwards compatibility).
+    #[arg(long = "json", hide = true, conflicts_with = "format")]
     pub json: bool,
     /// Output a one-line summary
     #[arg(long = "one-line")]

--- a/crates/codex-cli/tests/integration/completion_contract.rs
+++ b/crates/codex-cli/tests/integration/completion_contract.rs
@@ -81,8 +81,7 @@ fn completion_contract_format_values_include_text_and_json() {
         script,
         &[
             "'--format=[Output format (\\`text\\` or \\`json\\`)]:format:(text json)' \\",
-            "'(--format)--json[Output machine-readable JSON]' \\",
-            "'(--format)--json[Output raw JSON]' \\",
+            "'(--format)--json[Hidden alias for \\`--format json\\` (kept for backwards compatibility)]' \\",
         ],
     );
 }

--- a/crates/codex-cli/tests/integration/main_entrypoint.rs
+++ b/crates/codex-cli/tests/integration/main_entrypoint.rs
@@ -99,19 +99,25 @@ fn main_help_excludes_provider_neutral_groups() {
 }
 
 #[test]
-fn main_help_includes_json_output_modes_for_diag_and_auth() {
+fn main_help_advertises_format_and_hides_json_alias_for_diag_and_auth() {
     let diag_help = run(&["diag", "rate-limits", "--help"]);
     assert_exit(&diag_help, 0);
     let diag_text = stdout(&diag_help);
-    assert!(diag_text.contains("--json"));
     assert!(diag_text.contains("--format"));
     assert!(diag_text.contains("--clear-cache"));
+    assert!(
+        !diag_text.contains("--json"),
+        "diag rate-limits --help leaked the hidden --json alias: {diag_text}"
+    );
 
     let auth_help = run(&["auth", "current", "--help"]);
     assert_exit(&auth_help, 0);
     let auth_text = stdout(&auth_help);
-    assert!(auth_text.contains("--json"));
     assert!(auth_text.contains("--format"));
+    assert!(
+        !auth_text.contains("--json"),
+        "auth current --help leaked the hidden --json alias: {auth_text}"
+    );
 }
 
 #[test]

--- a/crates/codex-cli/tests/integration/parity_oracle.rs
+++ b/crates/codex-cli/tests/integration/parity_oracle.rs
@@ -64,17 +64,17 @@ fn parity_oracle_topology_matches_gemini() {
 }
 
 #[test]
-fn parity_oracle_json_flags_match_gemini_for_auth_and_diag_help() {
+fn parity_oracle_format_flag_visibility_matches_gemini_for_auth_and_diag_help() {
     let codex_auth = run_codex(&["auth", "current", "--help"]);
     let gemini_auth = run_gemini(&["auth", "current", "--help"]);
     assert_eq!(codex_auth.code, 0);
     assert_eq!(gemini_auth.code, 0);
     let codex_auth_text = codex_auth.stdout_text();
     let gemini_auth_text = gemini_auth.stdout_text();
-    for token in ["--format", "--json"] {
-        assert!(codex_auth_text.contains(token));
-        assert!(gemini_auth_text.contains(token));
-    }
+    assert!(codex_auth_text.contains("--format"));
+    assert!(gemini_auth_text.contains("--format"));
+    assert!(!codex_auth_text.contains("--json"));
+    assert!(!gemini_auth_text.contains("--json"));
 
     let codex_diag = run_codex(&["diag", "rate-limits", "--help"]);
     let gemini_diag = run_gemini(&["diag", "rate-limits", "--help"]);
@@ -82,10 +82,12 @@ fn parity_oracle_json_flags_match_gemini_for_auth_and_diag_help() {
     assert_eq!(gemini_diag.code, 0);
     let codex_diag_text = codex_diag.stdout_text();
     let gemini_diag_text = gemini_diag.stdout_text();
-    for token in ["--format", "--json", "--cached", "--async"] {
+    for token in ["--format", "--cached", "--async"] {
         assert!(codex_diag_text.contains(token));
         assert!(gemini_diag_text.contains(token));
     }
+    assert!(!codex_diag_text.contains("--json"));
+    assert!(!gemini_diag_text.contains("--json"));
 }
 
 #[test]

--- a/crates/gemini-cli/src/cli.rs
+++ b/crates/gemini-cli/src/cli.rs
@@ -83,8 +83,8 @@ pub struct OutputModeArgs {
     /// Output format (`text` or `json`)
     #[arg(long = "format", value_enum, value_name = "format")]
     pub format: Option<OutputFormat>,
-    /// Output machine-readable JSON
-    #[arg(long = "json", conflicts_with = "format")]
+    /// Hidden alias for `--format json` (kept for backwards compatibility).
+    #[arg(long = "json", hide = true, conflicts_with = "format")]
     pub json: bool,
 }
 
@@ -187,8 +187,8 @@ pub struct RateLimitsArgs {
     /// Output format (`text` or `json`)
     #[arg(long = "format", value_enum, value_name = "format")]
     pub format: Option<OutputFormat>,
-    /// Output raw JSON
-    #[arg(long = "json", conflicts_with = "format")]
+    /// Hidden alias for `--format json` (kept for backwards compatibility).
+    #[arg(long = "json", hide = true, conflicts_with = "format")]
     pub json: bool,
     /// Output a one-line summary
     #[arg(long = "one-line")]

--- a/crates/gemini-cli/tests/integration/completion_contract.rs
+++ b/crates/gemini-cli/tests/integration/completion_contract.rs
@@ -81,8 +81,7 @@ fn completion_contract_format_values_include_text_and_json() {
         script,
         &[
             "'--format=[Output format (\\`text\\` or \\`json\\`)]:format:(text json)' \\",
-            "'(--format)--json[Output machine-readable JSON]' \\",
-            "'(--format)--json[Output raw JSON]' \\",
+            "'(--format)--json[Hidden alias for \\`--format json\\` (kept for backwards compatibility)]' \\",
         ],
     );
 }

--- a/crates/gemini-cli/tests/integration/main_entrypoint.rs
+++ b/crates/gemini-cli/tests/integration/main_entrypoint.rs
@@ -99,18 +99,24 @@ fn main_help_excludes_provider_neutral_groups() {
 }
 
 #[test]
-fn main_help_includes_json_output_modes_for_diag_and_auth() {
+fn main_help_advertises_format_and_hides_json_alias_for_diag_and_auth() {
     let diag_help = run(&["diag", "rate-limits", "--help"]);
     assert_exit(&diag_help, 0);
     let diag_text = stdout(&diag_help);
-    assert!(diag_text.contains("--json"));
     assert!(diag_text.contains("--format"));
+    assert!(
+        !diag_text.contains("--json"),
+        "diag rate-limits --help leaked the hidden --json alias: {diag_text}"
+    );
 
     let auth_help = run(&["auth", "current", "--help"]);
     assert_exit(&auth_help, 0);
     let auth_text = stdout(&auth_help);
-    assert!(auth_text.contains("--json"));
     assert!(auth_text.contains("--format"));
+    assert!(
+        !auth_text.contains("--json"),
+        "auth current --help leaked the hidden --json alias: {auth_text}"
+    );
 }
 
 #[test]

--- a/crates/gemini-cli/tests/integration/parity_oracle.rs
+++ b/crates/gemini-cli/tests/integration/parity_oracle.rs
@@ -64,17 +64,17 @@ fn parity_oracle_topology_matches_codex() {
 }
 
 #[test]
-fn parity_oracle_json_flags_match_codex_for_auth_and_diag_help() {
+fn parity_oracle_format_flag_visibility_matches_codex_for_auth_and_diag_help() {
     let gemini_auth = run_gemini(&["auth", "current", "--help"]);
     let codex_auth = run_codex(&["auth", "current", "--help"]);
     assert_eq!(gemini_auth.code, 0);
     assert_eq!(codex_auth.code, 0);
     let gemini_auth_text = gemini_auth.stdout_text();
     let codex_auth_text = codex_auth.stdout_text();
-    for token in ["--format", "--json"] {
-        assert!(gemini_auth_text.contains(token));
-        assert!(codex_auth_text.contains(token));
-    }
+    assert!(gemini_auth_text.contains("--format"));
+    assert!(codex_auth_text.contains("--format"));
+    assert!(!gemini_auth_text.contains("--json"));
+    assert!(!codex_auth_text.contains("--json"));
 
     let gemini_diag = run_gemini(&["diag", "rate-limits", "--help"]);
     let codex_diag = run_codex(&["diag", "rate-limits", "--help"]);
@@ -82,10 +82,12 @@ fn parity_oracle_json_flags_match_codex_for_auth_and_diag_help() {
     assert_eq!(codex_diag.code, 0);
     let gemini_diag_text = gemini_diag.stdout_text();
     let codex_diag_text = codex_diag.stdout_text();
-    for token in ["--format", "--json", "--cached", "--async"] {
+    for token in ["--format", "--cached", "--async"] {
         assert!(gemini_diag_text.contains(token));
         assert!(codex_diag_text.contains(token));
     }
+    assert!(!gemini_diag_text.contains("--json"));
+    assert!(!codex_diag_text.contains("--json"));
 }
 
 #[test]

--- a/crates/image-processing/src/cli.rs
+++ b/crates/image-processing/src/cli.rs
@@ -43,7 +43,11 @@ pub struct Cli {
     pub overwrite: bool,
     #[arg(long = "dry-run", help = "Validate and plan without writing output")]
     pub dry_run: bool,
-    #[arg(long, help = "Emit machine-readable JSON to stdout")]
+    #[arg(
+        long,
+        hide = true,
+        help = "Hidden alias for `--format json` (kept for backwards compatibility)"
+    )]
     pub json: bool,
     #[arg(long, help = "Print per-item processing report")]
     pub report: bool,

--- a/crates/plan-issue-cli/src/cli.rs
+++ b/crates/plan-issue-cli/src/cli.rs
@@ -31,8 +31,8 @@ pub struct Cli {
     #[arg(short = 'f', long, global = true)]
     pub force: bool,
 
-    /// Output machine-readable JSON (alias for --format json).
-    #[arg(long, global = true)]
+    /// Hidden alias for `--format json` (kept for backwards compatibility).
+    #[arg(long, global = true, hide = true)]
     pub json: bool,
 
     /// Output format.

--- a/scripts/ci/cli-output-contract-lint.sh
+++ b/scripts/ci/cli-output-contract-lint.sh
@@ -71,14 +71,10 @@ fi
 # ----------------------------------------------------------------------------
 
 # Files with grandfathered `--json` boolean flags lacking `hide = true`.
-# These predate the contract's hidden-alias requirement; remove once their
-# one-minor-cycle migration completes.
-declare -a JSON_ALLOWED_FILES=(
-  "crates/codex-cli/src/cli.rs"
-  "crates/gemini-cli/src/cli.rs"
-  "crates/image-processing/src/cli.rs"
-  "crates/plan-issue-cli/src/cli.rs"
-)
+# Empty post-migration: every `--json` flag in the workspace now carries
+# `hide = true`. Re-introductions are caught by check (a) and require an
+# explicit entry here with justification.
+declare -a JSON_ALLOWED_FILES=()
 
 # Files where camelCase serde renames are intentional (non-CLI-envelope
 # persistent records: AWP, JUnit-compat suite schemas, documented v2 alias).


### PR DESCRIPTION
## Summary

Closes out the one-minor-cycle deprecation window for the visible `--json`
flag in the four crates that were grandfathered by the `cli-output-contract`
lint allowlist (codex-cli, gemini-cli, image-processing, plan-issue-cli).
After this PR the workspace's `JSON_ALLOWED_FILES` allowlist is empty —
every `--json` flag in the workspace now carries `hide = true`.

## Changes

- `crates/codex-cli/src/cli.rs`, `crates/gemini-cli/src/cli.rs`: both
  `OutputModeArgs` (`auth …`) and `RateLimitsArgs` (`diag rate-limits`)
  switch `#[arg(long = "json", conflicts_with = "format")]` to
  `#[arg(long = "json", hide = true, conflicts_with = "format")]`. Doc
  comments updated to match the contract's "hidden alias" phrasing.
- `crates/image-processing/src/cli.rs`, `crates/plan-issue-cli/src/cli.rs`:
  add `hide = true` to the global `--json` flag; doc comment updated.
- `scripts/ci/cli-output-contract-lint.sh`: drop all four entries from
  `JSON_ALLOWED_FILES`; the array is now empty and any future visible
  `--json` re-introduction fails check (a) immediately.
- Test fixups for the four affected help / parity / completion-contract
  tests in codex-cli and gemini-cli:
  - `main_help_includes_json_output_modes_for_diag_and_auth` renamed to
    `main_help_advertises_format_and_hides_json_alias_for_diag_and_auth`,
    flipped to assert `--format` is shown and `--json` is NOT shown.
  - `parity_oracle_json_flags_match_*_for_auth_and_diag_help` renamed to
    `parity_oracle_format_flag_visibility_matches_*_for_auth_and_diag_help`,
    drops `--json` from the visible-token set and adds a not-contains
    assertion.
  - `completion_contract_format_values_include_text_and_json` updated to
    expect the single new completion line carrying the hidden-alias
    description (zsh completion still includes the alias as a context-
    aware option, just with the "Hidden alias for …" label).

## Test-First Evidence

- **Change classification**: deprecation cleanup. No new public surface;
  every consumer that already used `--json` keeps working (the alias is
  hidden, not removed).
- **Failing test before fix**: not applicable; the change deliberately
  flips a set of negative invariants, and the existing tests served as
  the failing oracle before they were updated to match the new contract.
- **Final validation**:
  - `cargo nextest run -p nils-codex-cli -p nils-gemini-cli -p nils-image-processing -p nils-plan-issue-cli` → 810/810 pass.
  - `bash scripts/ci/cli-output-contract-lint.sh` → PASS (empty allowlist).
  - `bash scripts/ci/tests/cli-output-contract-lint.test.sh` → baseline + 3 regressions all fire.
  - `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` → PASS (fmt + clippy + nextest workspace + doctests + audits all green).
- **Waiver reason**: n/a.

## Testing

- `cargo nextest run -p nils-codex-cli -p nils-gemini-cli -p nils-image-processing -p nils-plan-issue-cli` → 810/810 pass
- `bash scripts/ci/cli-output-contract-lint.sh` → pass
- `bash scripts/ci/tests/cli-output-contract-lint.test.sh` → pass
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` → pass

## Risk / Notes

- `--json` continues to work at runtime as a hidden alias. No CLI
  contract is broken; only the `--help` output for these binaries no
  longer advertises `--json` (per the v1 contract).
- Downstream completion files that hardcoded `--json` are unaffected —
  clap_complete still emits the alias in the generated zsh / bash
  completion (the only change is the description string).
- This is the final cleanup item for the
  `cli-output-contract-unification` plan; no follow-ups remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
