### PR TITLE
Forge-cli v1 Sprint 2: PR atoms (create/view/list/edit/comment/ready/close) + validation chain

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -1192,12 +1192,20 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__comment)
-            opts="-h --format --remote --provider --repo --dry-run --help <ID>"
+            opts="-h --body --body-file --format --remote --provider --repo --dry-run --help <ID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --body)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
@@ -1222,12 +1230,44 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__create)
-            opts="-h --format --remote --provider --repo --dry-run --help"
+            opts="-h --head --base --title --body --body-file --kind --no-draft --reviewer --label --format --remote --provider --repo --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --head)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --base)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --title)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --kind)
+                    COMPREPLY=($(compgen -W "feature bug" -- "${cur}"))
+                    return 0
+                    ;;
+                --reviewer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
@@ -1282,12 +1322,40 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__edit)
-            opts="-h --format --remote --provider --repo --dry-run --help <ID>"
+            opts="-h --title --body --body-file --base --add-label --remove-label --add-reviewer --format --remote --provider --repo --dry-run --help <ID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --title)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --base)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --add-label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --remove-label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --add-reviewer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
@@ -1494,12 +1562,28 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__list)
-            opts="-h --format --remote --provider --repo --dry-run --help"
+            opts="-h --state --author --head --limit --format --remote --provider --repo --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --state)
+                    COMPREPLY=($(compgen -W "open closed merged all" -- "${cur}"))
+                    return 0
+                    ;;
+                --author)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --head)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -56,11 +56,20 @@ json\:"Single-record JSON envelope (snake_case)"))' \
         case $line[1] in
             (create)
 _arguments "${_arguments_options[@]}" : \
+'--head=[Source branch (defaults to the current branch)]:HEAD:_default' \
+'--base=[Target / base branch (defaults to the repo'\''s default branch)]:BASE:_default' \
+'--title=[PR / MR title (required)]:TITLE:_default' \
+'(--body-file)--body=[PR / MR body / description text. Mutually exclusive with \`--body-file\`]:BODY:_default' \
+'--body-file=[Read PR / MR body from a file. Use \`-\` to read from stdin]:PATH:_default' \
+'--kind=[PR / MR kind (selects branch-prefix rule). Required]:KIND:(feature bug)' \
+'*--reviewer=[Add a reviewer (repeatable)]:USER:_default' \
+'*--label=[Add a label (repeatable)]:LABEL:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
 '--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
 '--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--no-draft[Open as ready-for-review instead of draft (default\: open as draft)]' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -81,6 +90,10 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (list)
 _arguments "${_arguments_options[@]}" : \
+'--state=[Filter by state (default\: open)]:STATE:(open closed merged all)' \
+'--author=[Filter by author handle]:AUTHOR:_default' \
+'--head=[Filter by head / source branch]:HEAD:_default' \
+'--limit=[Cap the number of returned PRs (default\: 30)]:LIMIT:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
@@ -93,6 +106,13 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (edit)
 _arguments "${_arguments_options[@]}" : \
+'--title=[Replace the title (revalidates \`title_length\`)]:TITLE:_default' \
+'(--body-file)--body=[Replace the body / description (revalidates body sections)]:BODY:_default' \
+'--body-file=[Read replacement body from a file. Use \`-\` for stdin]:PATH:_default' \
+'--base=[Re-target the PR / MR to this base branch]:BASE:_default' \
+'*--add-label=[Add a label (repeatable)]:LABEL:_default' \
+'*--remove-label=[Remove a label (repeatable)]:LABEL:_default' \
+'*--add-reviewer=[Add a reviewer (repeatable)]:USER:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
@@ -101,11 +121,13 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':id -- Numeric id:_default' \
+':id -- Numeric PR / MR id:_default' \
 && ret=0
 ;;
 (comment)
 _arguments "${_arguments_options[@]}" : \
+'(--body-file)--body=[Comment body. Mutually exclusive with \`--body-file\`]:BODY:_default' \
+'--body-file=[Read comment body from a file. Use \`-\` for stdin]:PATH:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
@@ -114,7 +136,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':id -- Numeric id:_default' \
+':id -- Numeric PR / MR id:_default' \
 && ret=0
 ;;
 (ready)
@@ -127,7 +149,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':id -- Numeric id:_default' \
+':id -- Numeric PR / MR id:_default' \
 && ret=0
 ;;
 (merge)

--- a/crates/forge-cli/Cargo.toml
+++ b/crates/forge-cli/Cargo.toml
@@ -22,9 +22,9 @@ clap_complete = { workspace = true }
 nils-common = { version = "0.10.2", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
+tempfile = "3"
 thiserror = { workspace = true }
 
 [dev-dependencies]
 nils-test-support = { version = "0.10.2", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
-tempfile = "3"

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -145,33 +145,163 @@ pub struct CompletionArgs {
     pub shell: Shell,
 }
 
+/// Clap-facing `--kind` enum. Maps 1:1 to [`crate::validations::PrKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum PrKindFlag {
+    Feature,
+    Bug,
+}
+
+impl PrKindFlag {
+    pub fn into_kind(self) -> crate::validations::PrKind {
+        match self {
+            PrKindFlag::Feature => crate::validations::PrKind::Feature,
+            PrKindFlag::Bug => crate::validations::PrKind::Bug,
+        }
+    }
+}
+
+/// `--state` filter shared by `pr list` and the close payload normaliser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum PrStateFilter {
+    Open,
+    Closed,
+    Merged,
+    All,
+}
+
+impl PrStateFilter {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PrStateFilter::Open => "open",
+            PrStateFilter::Closed => "closed",
+            PrStateFilter::Merged => "merged",
+            PrStateFilter::All => "all",
+        }
+    }
+}
+
+/// `pr edit` arguments. Maps to
+/// `forge-cli-ops-v1.yaml::operations.pr.edit` inputs.
+#[derive(Args, Debug, Clone)]
+pub struct PrEditArgs {
+    /// Numeric PR / MR id.
+    pub id: u64,
+    /// Replace the title (revalidates `title_length`).
+    #[arg(long)]
+    pub title: Option<String>,
+    /// Replace the body / description (revalidates body sections).
+    #[arg(long, conflicts_with = "body_file")]
+    pub body: Option<String>,
+    /// Read replacement body from a file. Use `-` for stdin.
+    #[arg(long = "body-file", value_name = "PATH")]
+    pub body_file: Option<String>,
+    /// Re-target the PR / MR to this base branch.
+    #[arg(long)]
+    pub base: Option<String>,
+    /// Add a label (repeatable).
+    #[arg(long = "add-label", value_name = "LABEL")]
+    pub add_labels: Vec<String>,
+    /// Remove a label (repeatable).
+    #[arg(long = "remove-label", value_name = "LABEL")]
+    pub remove_labels: Vec<String>,
+    /// Add a reviewer (repeatable).
+    #[arg(long = "add-reviewer", value_name = "USER")]
+    pub add_reviewers: Vec<String>,
+}
+
+/// `pr comment` arguments. Maps to
+/// `forge-cli-ops-v1.yaml::operations.pr.comment` inputs.
+#[derive(Args, Debug, Clone)]
+pub struct PrCommentArgs {
+    /// Numeric PR / MR id.
+    pub id: u64,
+    /// Comment body. Mutually exclusive with `--body-file`.
+    #[arg(long, conflicts_with = "body_file")]
+    pub body: Option<String>,
+    /// Read comment body from a file. Use `-` for stdin.
+    #[arg(long = "body-file", value_name = "PATH")]
+    pub body_file: Option<String>,
+}
+
+/// `pr ready` arguments.
+#[derive(Args, Debug, Clone)]
+pub struct PrReadyArgs {
+    /// Numeric PR / MR id.
+    pub id: u64,
+}
+
+/// `pr list` arguments. Maps to
+/// `forge-cli-ops-v1.yaml::operations.pr.list` inputs.
+#[derive(Args, Debug, Clone)]
+pub struct PrListArgs {
+    /// Filter by state (default: open).
+    #[arg(long, value_enum, default_value_t = PrStateFilter::Open)]
+    pub state: PrStateFilter,
+    /// Filter by author handle.
+    #[arg(long)]
+    pub author: Option<String>,
+    /// Filter by head / source branch.
+    #[arg(long)]
+    pub head: Option<String>,
+    /// Cap the number of returned PRs (default: 30).
+    #[arg(long, default_value_t = 30)]
+    pub limit: u32,
+}
+
+/// `pr create` arguments. Maps to the inputs declared in
+/// `crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml::operations.pr.create`.
+#[derive(Args, Debug, Clone)]
+pub struct PrCreateArgs {
+    /// Source branch (defaults to the current branch).
+    #[arg(long)]
+    pub head: Option<String>,
+    /// Target / base branch (defaults to the repo's default branch).
+    #[arg(long)]
+    pub base: Option<String>,
+    /// PR / MR title (required).
+    #[arg(long)]
+    pub title: String,
+    /// PR / MR body / description text. Mutually exclusive with `--body-file`.
+    #[arg(long, conflicts_with = "body_file")]
+    pub body: Option<String>,
+    /// Read PR / MR body from a file. Use `-` to read from stdin.
+    #[arg(long = "body-file", value_name = "PATH")]
+    pub body_file: Option<String>,
+    /// PR / MR kind (selects branch-prefix rule). Required.
+    #[arg(long, value_enum)]
+    pub kind: PrKindFlag,
+    /// Open as ready-for-review instead of draft (default: open as draft).
+    #[arg(long = "no-draft", action = ArgAction::SetTrue)]
+    pub no_draft: bool,
+    /// Add a reviewer (repeatable).
+    #[arg(long = "reviewer", value_name = "USER")]
+    pub reviewers: Vec<String>,
+    /// Add a label (repeatable).
+    #[arg(long = "label", value_name = "LABEL")]
+    pub labels: Vec<String>,
+}
+
 /// `pr` subtree.
 #[derive(Subcommand, Debug)]
 pub enum PrCommand {
     /// Open a draft pull / merge request from the current branch.
-    Create,
+    Create(PrCreateArgs),
     /// Fetch a single PR / MR with normalised fields.
     View {
         /// Numeric id or branch name.
         id: String,
     },
     /// List PRs / MRs.
-    List,
+    List(PrListArgs),
     /// Mutate PR / MR title, body, base, labels, reviewers.
-    Edit {
-        /// Numeric id.
-        id: u64,
-    },
+    Edit(PrEditArgs),
     /// Append a comment to a PR / MR.
-    Comment {
-        /// Numeric id.
-        id: u64,
-    },
+    Comment(PrCommentArgs),
     /// Promote a draft PR / MR to ready-for-review.
-    Ready {
-        /// Numeric id.
-        id: u64,
-    },
+    Ready(PrReadyArgs),
     /// Merge a ready PR / MR.
     Merge {
         /// Numeric id.
@@ -259,6 +389,27 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
         Some(Command::Repo(RepoArgs {
             command: Some(RepoCommand::View),
         })) => ops::repo_view::run(&global, format),
+        Some(Command::Pr(PrArgs {
+            command: Some(PrCommand::Create(args)),
+        })) => ops::pr_create::run(&global, args, format),
+        Some(Command::Pr(PrArgs {
+            command: Some(PrCommand::View { id }),
+        })) => ops::pr_view::run(&global, id, format),
+        Some(Command::Pr(PrArgs {
+            command: Some(PrCommand::List(args)),
+        })) => ops::pr_list::run(&global, args, format),
+        Some(Command::Pr(PrArgs {
+            command: Some(PrCommand::Close { id }),
+        })) => ops::pr_close::run(&global, id, format),
+        Some(Command::Pr(PrArgs {
+            command: Some(PrCommand::Edit(args)),
+        })) => ops::pr_edit::run(&global, args, format),
+        Some(Command::Pr(PrArgs {
+            command: Some(PrCommand::Comment(args)),
+        })) => ops::pr_comment::run(&global, args, format),
+        Some(Command::Pr(PrArgs {
+            command: Some(PrCommand::Ready(args)),
+        })) => ops::pr_ready::run(&global, args, format),
         Some(Command::Completion(CompletionArgs { shell })) => emit_completion(shell),
         None
         | Some(Command::Auth(AuthArgs { command: None }))
@@ -472,10 +623,64 @@ mod tests {
             match sub {
                 "view" | "checks" | "wait-checks" => argv.push("1"),
                 "edit" | "comment" | "ready" | "merge" | "close" => argv.push("1"),
+                "create" => {
+                    argv.extend(["--title", "demo", "--kind", "feature", "--body", "x"]);
+                }
                 _ => {}
             }
             let result = parse(&argv);
             assert!(result.is_ok(), "pr {sub} should parse, got {result:?}");
+        }
+    }
+
+    #[test]
+    fn pr_create_rejects_both_body_and_body_file() {
+        let result = parse(&[
+            "pr",
+            "create",
+            "--title",
+            "demo",
+            "--kind",
+            "feature",
+            "--body",
+            "inline",
+            "--body-file",
+            "-",
+        ]);
+        assert!(result.is_err(), "--body + --body-file must conflict");
+    }
+
+    #[test]
+    fn pr_create_parses_reviewer_and_label_lists() {
+        let cli = parse(&[
+            "pr",
+            "create",
+            "--title",
+            "demo",
+            "--kind",
+            "bug",
+            "--body",
+            "x",
+            "--reviewer",
+            "alice",
+            "--reviewer",
+            "bob",
+            "--label",
+            "p1",
+            "--label",
+            "needs-review",
+        ])
+        .expect("parse");
+        match cli.command {
+            Some(Command::Pr(PrArgs {
+                command: Some(PrCommand::Create(args)),
+            })) => {
+                assert_eq!(args.kind, PrKindFlag::Bug);
+                assert_eq!(args.reviewers, vec!["alice", "bob"]);
+                assert_eq!(args.labels, vec!["p1", "needs-review"]);
+                assert!(!args.no_draft);
+            }
+            other => panic!("expected pr create, got {other:?}"),
         }
     }
 

--- a/crates/forge-cli/src/error.rs
+++ b/crates/forge-cli/src/error.rs
@@ -52,6 +52,16 @@ pub enum ForgeError {
         message: String,
         detail: Option<String>,
     },
+    /// Lock-down policy violation (branch / title / body / worktree / push
+    /// state). Maps to `DATA 65` with the rule-specific `error.kind`
+    /// discriminator declared in spec §"Lock-down policy".
+    #[error("{message}")]
+    Validation {
+        schema_version: String,
+        kind: &'static str,
+        message: String,
+        detail: Option<String>,
+    },
 }
 
 impl ForgeError {
@@ -130,6 +140,23 @@ impl ForgeError {
         }
     }
 
+    /// Build a `DATA 65` validation error with the given rule-specific kind.
+    /// The `kind` literal MUST match one of the entries in spec §"Lock-down
+    /// policy" so callers can branch on `error.kind`.
+    pub fn validation(
+        schema_version: impl Into<String>,
+        kind: &'static str,
+        message: impl Into<String>,
+        detail: Option<String>,
+    ) -> Self {
+        Self::Validation {
+            schema_version: schema_version.into(),
+            kind,
+            message: message.into(),
+            detail,
+        }
+    }
+
     /// Map the error to its exit-code constant.
     pub fn exit_code(&self) -> i32 {
         match self {
@@ -138,6 +165,7 @@ impl ForgeError {
             Self::BackendError { .. } => exit::RUNTIME,
             Self::ProviderUnsupported { .. } => exit::USAGE,
             Self::SoftwareError { .. } => exit::SOFTWARE,
+            Self::Validation { .. } => exit::DATA,
         }
     }
 
@@ -149,6 +177,7 @@ impl ForgeError {
             Self::BackendError { .. } => "backend_error",
             Self::ProviderUnsupported { .. } => "provider_unsupported",
             Self::SoftwareError { .. } => "software_error",
+            Self::Validation { kind, .. } => kind,
         }
     }
 
@@ -158,7 +187,8 @@ impl ForgeError {
             | Self::BackendUnavailable { schema_version, .. }
             | Self::BackendError { schema_version, .. }
             | Self::ProviderUnsupported { schema_version, .. }
-            | Self::SoftwareError { schema_version, .. } => schema_version,
+            | Self::SoftwareError { schema_version, .. }
+            | Self::Validation { schema_version, .. } => schema_version,
         }
     }
 
@@ -168,7 +198,8 @@ impl ForgeError {
             | Self::BackendUnavailable { message, .. }
             | Self::BackendError { message, .. }
             | Self::ProviderUnsupported { message, .. }
-            | Self::SoftwareError { message, .. } => message,
+            | Self::SoftwareError { message, .. }
+            | Self::Validation { message, .. } => message,
         }
     }
 
@@ -178,7 +209,8 @@ impl ForgeError {
             Self::BackendUnavailable { detail, .. }
             | Self::BackendError { detail, .. }
             | Self::ProviderUnsupported { detail, .. }
-            | Self::SoftwareError { detail, .. } => detail.as_deref(),
+            | Self::SoftwareError { detail, .. }
+            | Self::Validation { detail, .. } => detail.as_deref(),
         }
     }
 
@@ -252,6 +284,10 @@ mod tests {
             (
                 ForgeError::software("cli.forge-cli.error.v1", "x", None),
                 exit::SOFTWARE,
+            ),
+            (
+                ForgeError::validation("cli.forge-cli.error.v1", "branch_name_invalid", "x", None),
+                exit::DATA,
             ),
         ];
         for (err, expected) in cases {

--- a/crates/forge-cli/src/lib.rs
+++ b/crates/forge-cli/src/lib.rs
@@ -13,6 +13,7 @@ pub mod envelope;
 pub mod error;
 pub mod ops;
 pub mod provider;
+pub mod validations;
 
 use std::ffi::OsString;
 

--- a/crates/forge-cli/src/ops/mod.rs
+++ b/crates/forge-cli/src/ops/mod.rs
@@ -3,4 +3,12 @@
 //! returns `Result<i32, ForgeError>`.
 
 pub mod auth_status;
+pub mod pr_close;
+pub mod pr_comment;
+pub mod pr_create;
+pub mod pr_edit;
+pub mod pr_list;
+pub mod pr_ready;
+pub mod pr_state;
+pub mod pr_view;
 pub mod repo_view;

--- a/crates/forge-cli/src/ops/pr_close.rs
+++ b/crates/forge-cli/src/ops/pr_close.rs
@@ -1,0 +1,160 @@
+//! `pr close` atom.
+//!
+//! Spec / ops: `cli.forge-cli.pr.close.v1`. Closes a PR/MR without merging.
+//! Emits `{ number, url, state }` after the close call by re-fetching via
+//! `pr view`. Both backends print no envelope-ready JSON from the close
+//! call itself, so the follow-up view ensures the envelope reports the
+//! canonical post-close state (`closed`).
+
+use std::ffi::OsString;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{BackendCall, BackendProgram, BackendRunner, DryRunPayload, ProcessRunner};
+use crate::cli::{BINARY, GlobalFlags};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_view;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const SCHEMA: &str = "pr.close";
+const SCHEMA_VERSION: u32 = 1;
+
+/// Envelope payload for `cli.forge-cli.pr.close.v1`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrClosePayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub state: &'static str,
+}
+
+pub fn run(global: &GlobalFlags, id: u64, format: OutputFormat) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, id, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    id: u64,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let call = build_close_call(&ctx, id);
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let _ = runner.run(&call)?;
+
+    // Re-fetch via the canonical `pr view` to populate the envelope shape.
+    let view_call = build_view_call(&ctx, id);
+    let view_output = runner.run(&view_call)?;
+    let payload = pr_view::parse_view_output(&ctx, &view_output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        PrClosePayload {
+            provider: payload.provider,
+            number: payload.number,
+            url: payload.url,
+            state: payload.state,
+        },
+        format,
+        render_text,
+    ))
+}
+
+fn build_close_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("close"),
+            OsString::from(id.to_string()),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("close"),
+            OsString::from(id.to_string()),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn build_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("view"),
+            OsString::from(id.to_string()),
+            OsString::from("--json"),
+            OsString::from(
+                "number,url,state,isDraft,title,headRefName,baseRefName,mergeable,mergedAt,labels",
+            ),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("view"),
+            OsString::from(id.to_string()),
+            OsString::from("-F"),
+            OsString::from("json"),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn render_text(payload: &PrClosePayload) {
+    println!(
+        "closed {provider} #{number} ({state}): {url}",
+        provider = payload.provider,
+        number = payload.number,
+        state = payload.state,
+        url = payload.url,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "example.com".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    #[test]
+    fn build_close_call_github_emits_pr_close_id() {
+        let call = build_close_call(&ctx(Provider::GitHub), 42);
+        let plan = call.plan_argv();
+        assert_eq!(
+            plan[1..],
+            ["pr".to_string(), "close".to_string(), "42".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_close_call_gitlab_emits_mr_close_id() {
+        let call = build_close_call(&ctx(Provider::GitLab), 7);
+        let plan = call.plan_argv();
+        assert_eq!(
+            plan[1..],
+            ["mr".to_string(), "close".to_string(), "7".to_string()]
+        );
+    }
+}

--- a/crates/forge-cli/src/ops/pr_comment.rs
+++ b/crates/forge-cli/src/ops/pr_comment.rs
@@ -1,0 +1,224 @@
+//! `pr comment` atom.
+//!
+//! Spec / ops: `cli.forge-cli.pr.comment.v1`. Appends a comment to a PR/MR.
+//! Body can come from `--body`, `--body-file <path>`, or
+//! `--body-file -` (stdin). No lock-down validation runs — comments don't
+//! mutate PR state. The envelope payload reports `{ provider, number,
+//! url }` where `url` is the PR/MR URL (cheap re-fetch via `pr view`).
+
+use std::ffi::OsString;
+use std::fs;
+use std::io::Read as _;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{BackendCall, BackendProgram, BackendRunner, DryRunPayload, ProcessRunner};
+use crate::cli::{BINARY, GlobalFlags, PrCommentArgs};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_view;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const SCHEMA: &str = "pr.comment";
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrCommentPayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    args: PrCommentArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, args, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: PrCommentArgs,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let body = read_body(args.body.as_deref(), args.body_file.as_deref())?;
+    if body.trim().is_empty() {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "body_missing_summary",
+            "comment body is empty (supply --body or --body-file)",
+            None,
+        ));
+    }
+    let call = build_comment_call(&ctx, args.id, &body);
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let _ = runner.run(&call)?;
+
+    // Re-fetch the PR/MR URL via the canonical view call so consumers can
+    // chain the envelope into next steps. Body isn't included.
+    let view_call = pr_view_call(&ctx, args.id);
+    let view_output = runner.run(&view_call)?;
+    let view = pr_view::parse_view_output(&ctx, &view_output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        PrCommentPayload {
+            provider: view.provider,
+            number: view.number,
+            url: view.url,
+        },
+        format,
+        render_text,
+    ))
+}
+
+fn build_comment_call(ctx: &ProviderContext, id: u64, body: &str) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("comment"),
+            OsString::from(id.to_string()),
+            OsString::from("--body"),
+            OsString::from(body),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("note"),
+            OsString::from(id.to_string()),
+            OsString::from("--message"),
+            OsString::from(body),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("view"),
+            OsString::from(id.to_string()),
+            OsString::from("--json"),
+            OsString::from(
+                "number,url,state,isDraft,title,headRefName,baseRefName,mergeable,mergedAt,labels",
+            ),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("view"),
+            OsString::from(id.to_string()),
+            OsString::from("-F"),
+            OsString::from("json"),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn read_body(inline: Option<&str>, file: Option<&str>) -> Result<String, ForgeError> {
+    if let Some(s) = inline {
+        return Ok(s.to_string());
+    }
+    let Some(path) = file else {
+        return Ok(String::new());
+    };
+    if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "failed to read comment body from stdin",
+                Some(e.to_string()),
+            )
+        })?;
+        return Ok(buf);
+    }
+    fs::read_to_string(path).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            format!("failed to read --body-file '{path}'"),
+            Some(e.to_string()),
+        )
+    })
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &PrCommentPayload) {
+    println!(
+        "commented on {provider} #{number}: {url}",
+        provider = payload.provider,
+        number = payload.number,
+        url = payload.url,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{DetectionSource, Provider};
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "x".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    #[test]
+    fn build_comment_call_github_uses_pr_comment_body() {
+        let call = build_comment_call(&ctx(Provider::GitHub), 5, "hello");
+        let plan = call.plan_argv();
+        assert_eq!(
+            plan[1..4],
+            ["pr".to_string(), "comment".to_string(), "5".to_string()]
+        );
+        let b = plan.iter().position(|s| s == "--body").unwrap();
+        assert_eq!(plan[b + 1], "hello");
+    }
+
+    #[test]
+    fn build_comment_call_gitlab_uses_mr_note_message() {
+        let call = build_comment_call(&ctx(Provider::GitLab), 7, "hello");
+        let plan = call.plan_argv();
+        assert_eq!(
+            plan[1..4],
+            ["mr".to_string(), "note".to_string(), "7".to_string()]
+        );
+        let m = plan.iter().position(|s| s == "--message").unwrap();
+        assert_eq!(plan[m + 1], "hello");
+    }
+
+    #[test]
+    fn read_body_prefers_inline_over_file() {
+        assert_eq!(
+            read_body(Some("inline"), Some("/no/such")).unwrap(),
+            "inline"
+        );
+    }
+
+    #[test]
+    fn read_body_returns_empty_when_neither_set() {
+        assert_eq!(read_body(None, None).unwrap(), "");
+    }
+}

--- a/crates/forge-cli/src/ops/pr_create.rs
+++ b/crates/forge-cli/src/ops/pr_create.rs
@@ -1,0 +1,820 @@
+//! `pr create` atom.
+//!
+//! Spec: `crates/forge-cli/docs/specs/forge-cli-spec-v1.md` §"pr create" +
+//! `crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml::operations.pr.create`.
+//! Schema literal: `cli.forge-cli.pr.create.v1`.
+//!
+//! The atom carries the heaviest validation surface in v1. The orchestration
+//! is:
+//!
+//! 1. Parse `--kind` and resolve `--head` / `--body` source.
+//! 2. Detect provider context (`--provider` override or remote URL).
+//! 3. Run the shared validation chain from [`crate::validations`].
+//! 4. Materialize the body into a temp file so backend argv can use a
+//!    canonical `--body-file` form (gh) or the verbatim string (glab).
+//! 5. Build the create call, render `--dry-run` plan, or invoke the runner.
+//! 6. Parse the create call's stdout for the new PR/MR URL → number/iid.
+//! 7. Re-fetch the resulting PR/MR via the backend's view command and emit
+//!    the normalized envelope payload.
+
+use std::ffi::OsString;
+use std::fs;
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+use tempfile::NamedTempFile;
+
+use crate::backend::{
+    BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
+};
+use crate::cli::{BINARY, GlobalFlags, PrCreateArgs};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::repo_view;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+use crate::validations::{
+    BodyHeadings, PrKind, body_summary, body_test_plan, branch_kind_matches, branch_name,
+    git_head_state, git_status_porcelain, head_pushed, title_length, worktree_clean,
+};
+
+const SCHEMA: &str = "pr.create";
+const SCHEMA_VERSION: u32 = 1;
+
+type RemoteUrlFn<'a> = Box<dyn Fn(&str) -> Option<String> + 'a>;
+type CurrentBranchFn<'a> = Box<dyn Fn() -> Result<String, ForgeError> + 'a>;
+type DefaultBranchFn<'a> =
+    Box<dyn Fn(&dyn BackendRunner, &ProviderContext) -> Result<String, ForgeError> + 'a>;
+type GitStatusFn<'a> = Box<dyn Fn(&Path) -> Result<String, ForgeError> + 'a>;
+type HeadStateFn<'a> = Box<dyn Fn(&Path) -> Result<crate::validations::HeadState, ForgeError> + 'a>;
+
+/// Envelope payload for `cli.forge-cli.pr.create.v1`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrCreatePayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub head: String,
+    pub base: String,
+    pub draft: bool,
+    pub title: String,
+    pub kind: &'static str,
+}
+
+/// Production entrypoint. Pulls every external dependency from the real
+/// process / filesystem / git environment.
+pub fn run(
+    global: &GlobalFlags,
+    args: PrCreateArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    let env = Environment::production();
+    run_with(&runner, global, args, format, &env)
+}
+
+/// Resolver bundle injected by tests. Each closure stubs one external
+/// dependency: provider detection, git porcelain, head state, default base
+/// branch, and current branch name.
+pub struct Environment<'a> {
+    pub remote_url: RemoteUrlFn<'a>,
+    pub current_branch: CurrentBranchFn<'a>,
+    pub default_branch: DefaultBranchFn<'a>,
+    pub git_status: GitStatusFn<'a>,
+    pub head_state: HeadStateFn<'a>,
+    pub workdir: PathBuf,
+    pub headings: BodyHeadings,
+}
+
+impl<'a> Environment<'a> {
+    /// Real implementation that talks to git + the backend.
+    pub fn production() -> Self {
+        Self {
+            remote_url: Box::new(git_remote_url),
+            current_branch: Box::new(|| {
+                let out = std::process::Command::new("git")
+                    .args(["rev-parse", "--abbrev-ref", "HEAD"])
+                    .output()
+                    .map_err(|e| {
+                        ForgeError::software(
+                            schema_err(),
+                            "git rev-parse failed to spawn",
+                            Some(e.to_string()),
+                        )
+                    })?;
+                if !out.status.success() {
+                    return Err(ForgeError::software(
+                        schema_err(),
+                        "git rev-parse --abbrev-ref HEAD exited non-zero",
+                        Some(String::from_utf8_lossy(&out.stderr).into_owned()),
+                    ));
+                }
+                Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+            }),
+            default_branch: Box::new(|runner, ctx| {
+                let call = repo_view::build_call_for_default_branch(ctx);
+                let output = runner.run(&call)?;
+                let payload = repo_view::parse_backend_output(ctx, &output)?;
+                Ok(payload.default_branch)
+            }),
+            git_status: Box::new(git_status_porcelain),
+            head_state: Box::new(git_head_state),
+            workdir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            headings: BodyHeadings::default(),
+        }
+    }
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn schema_ok() -> String {
+    schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION)
+}
+
+/// Test-friendly entrypoint: caller injects the runner + environment.
+pub fn run_with<R: BackendRunner>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: PrCreateArgs,
+    format: OutputFormat,
+    env: &Environment<'_>,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, |r| {
+        (env.remote_url)(r)
+    })?;
+
+    // 1. Resolve head + base.
+    let head = match args.head.clone() {
+        Some(h) => h,
+        None => (env.current_branch)()?,
+    };
+    let base = match args.base.clone() {
+        Some(b) => b,
+        None => (env.default_branch)(runner as &dyn BackendRunner, &ctx)?,
+    };
+
+    // 2. Resolve body content. `--body` and `--body-file` cannot both be
+    //    set — clap rejects that at parse time with USAGE 64. If neither is
+    //    provided, the body is empty and the body_summary check will fail
+    //    with DATA 65 (body_missing_summary), which matches the spec.
+    let body = read_body(args.body.as_deref(), args.body_file.as_deref())?;
+
+    // 3. Validation chain — order matches spec §"pr create" so the most
+    //    obvious failure (bad branch name) is reported first.
+    let prefix = branch_name(&head)?;
+    let kind: PrKind = args.kind.into_kind();
+    branch_kind_matches(prefix, kind)?;
+    title_length(&args.title)?;
+    body_summary(&body, &env.headings)?;
+    body_test_plan(&body, &env.headings)?;
+    worktree_clean(&env.workdir, |w| (env.git_status)(w))?;
+    head_pushed(&env.workdir, |w| (env.head_state)(w))?;
+
+    let draft = !args.no_draft;
+
+    // 4. Materialize body into a temp file for argv handoff. The temp file
+    //    lives until the end of run_with(); the backend reads it before we
+    //    drop it.
+    let body_tempfile = write_body_tempfile(&body)?;
+    let body_path = body_tempfile.path().to_path_buf();
+
+    let create_call = build_create_call(
+        &ctx,
+        &head,
+        &base,
+        &args.title,
+        &body,
+        &body_path,
+        draft,
+        &args.reviewers,
+        &args.labels,
+    );
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &create_call);
+        return Ok(emit_success(schema_ok(), payload, format, |p| {
+            println!("would run: {plan}", plan = p.plan.join(" "));
+        }));
+    }
+
+    // 5. Create + parse the URL the backend prints back.
+    let create_output = runner.run(&create_call)?;
+    let (number, url) = parse_create_output(&ctx, &create_output)?;
+
+    // 6. Re-fetch full metadata via the view follow-up so the envelope
+    //    payload matches the spec's `data` shape exactly.
+    let view_call = build_view_call(&ctx, number);
+    let view_output = runner.run(&view_call)?;
+    let payload = parse_view_output(&ctx, &view_output, number, url, kind)?;
+
+    Ok(emit_success(schema_ok(), payload, format, render_text))
+}
+
+fn render_text(payload: &PrCreatePayload) {
+    println!(
+        "opened {provider} #{number} ({state}): {url}",
+        provider = payload.provider,
+        number = payload.number,
+        state = if payload.draft { "draft" } else { "ready" },
+        url = payload.url,
+    );
+}
+
+/// Read body content from `--body`, `--body-file`, or `--body-file -`
+/// (stdin). Returns an empty string when neither flag is set (the body
+/// validators then reject with `body_missing_summary`).
+fn read_body(inline: Option<&str>, file: Option<&str>) -> Result<String, ForgeError> {
+    if let Some(s) = inline {
+        return Ok(s.to_string());
+    }
+    let Some(path) = file else {
+        return Ok(String::new());
+    };
+    if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "failed to read PR body from stdin",
+                Some(e.to_string()),
+            )
+        })?;
+        return Ok(buf);
+    }
+    fs::read_to_string(path).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            format!("failed to read --body-file '{path}'"),
+            Some(e.to_string()),
+        )
+    })
+}
+
+/// Persist body content into a tempfile so backend argv has a stable
+/// `--body-file` path. The returned handle owns the file; dropping it
+/// deletes the temp.
+fn write_body_tempfile(body: &str) -> Result<NamedTempFile, ForgeError> {
+    let tmp = tempfile::Builder::new()
+        .prefix("forge-cli-body-")
+        .suffix(".md")
+        .tempfile()
+        .map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "failed to create PR body tempfile",
+                Some(e.to_string()),
+            )
+        })?;
+    fs::write(tmp.path(), body).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            "failed to write PR body tempfile",
+            Some(e.to_string()),
+        )
+    })?;
+    Ok(tmp)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_create_call(
+    ctx: &ProviderContext,
+    head: &str,
+    base: &str,
+    title: &str,
+    body: &str,
+    body_path: &Path,
+    draft: bool,
+    reviewers: &[String],
+    labels: &[String],
+) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let mut argv: Vec<OsString> = Vec::new();
+    match ctx.provider {
+        Provider::GitHub => {
+            argv.push(OsString::from("pr"));
+            argv.push(OsString::from("create"));
+            if draft {
+                argv.push(OsString::from("--draft"));
+            }
+            argv.push(OsString::from("--head"));
+            argv.push(OsString::from(head));
+            argv.push(OsString::from("--base"));
+            argv.push(OsString::from(base));
+            argv.push(OsString::from("--title"));
+            argv.push(OsString::from(title));
+            argv.push(OsString::from("--body-file"));
+            argv.push(OsString::from(body_path));
+            for r in reviewers {
+                argv.push(OsString::from("--reviewer"));
+                argv.push(OsString::from(r));
+            }
+            for l in labels {
+                argv.push(OsString::from("--label"));
+                argv.push(OsString::from(l));
+            }
+        }
+        Provider::GitLab => {
+            argv.push(OsString::from("mr"));
+            argv.push(OsString::from("create"));
+            if draft {
+                argv.push(OsString::from("--draft"));
+            }
+            argv.push(OsString::from("--source-branch"));
+            argv.push(OsString::from(head));
+            argv.push(OsString::from("--target-branch"));
+            argv.push(OsString::from(base));
+            argv.push(OsString::from("--title"));
+            argv.push(OsString::from(title));
+            argv.push(OsString::from("--description"));
+            argv.push(OsString::from(body));
+            if !reviewers.is_empty() {
+                argv.push(OsString::from("--reviewer"));
+                argv.push(OsString::from(reviewers.join(",")));
+            }
+            if !labels.is_empty() {
+                argv.push(OsString::from("--label"));
+                argv.push(OsString::from(labels.join(",")));
+            }
+        }
+    }
+    BackendCall::new(program, argv)
+}
+
+fn build_view_call(ctx: &ProviderContext, number: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("view"),
+            OsString::from(number.to_string()),
+            OsString::from("--json"),
+            OsString::from("number,url,headRefName,baseRefName,isDraft,title"),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("view"),
+            OsString::from(number.to_string()),
+            OsString::from("-F"),
+            OsString::from("json"),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+/// Extract `(number, url)` from `gh pr create` / `glab mr create` stdout.
+/// Both backends print the URL on the last non-blank line. The PR/MR id is
+/// the last path segment.
+pub fn parse_create_output(
+    ctx: &ProviderContext,
+    output: &BackendSuccess,
+) -> Result<(u64, String), ForgeError> {
+    let combined = format!("{}\n{}", output.stdout, output.stderr);
+    let url = combined
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .find_map(extract_pr_url)
+        .ok_or_else(|| {
+            ForgeError::software(
+                schema_err(),
+                "backend did not emit a recognizable PR/MR URL",
+                Some(format!("stdout={:?}", output.stdout)),
+            )
+        })?;
+    let number = parse_url_number(&url, ctx.provider).ok_or_else(|| {
+        ForgeError::software(
+            schema_err(),
+            "failed to parse PR/MR number from backend URL",
+            Some(format!("url={url}")),
+        )
+    })?;
+    Ok((number, url))
+}
+
+fn extract_pr_url(line: &str) -> Option<String> {
+    line.split_whitespace()
+        .find(|tok| {
+            (tok.starts_with("http://") || tok.starts_with("https://"))
+                && (tok.contains("/pull/") || tok.contains("/merge_requests/"))
+        })
+        .map(|s| s.trim_matches(|c: char| c == '.' || c == ',').to_string())
+}
+
+fn parse_url_number(url: &str, provider: Provider) -> Option<u64> {
+    let needle = match provider {
+        Provider::GitHub => "/pull/",
+        Provider::GitLab => "/merge_requests/",
+    };
+    let idx = url.find(needle)? + needle.len();
+    let rest = &url[idx..];
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
+}
+
+/// Parse `gh pr view --json …` / `glab mr view -F json` into the canonical
+/// envelope payload.
+pub fn parse_view_output(
+    ctx: &ProviderContext,
+    output: &BackendSuccess,
+    number: u64,
+    url_fallback: String,
+    kind: PrKind,
+) -> Result<PrCreatePayload, ForgeError> {
+    let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            format!(
+                "{program} {sub} view JSON is invalid",
+                program = match ctx.provider {
+                    Provider::GitHub => "gh pr",
+                    Provider::GitLab => "glab mr",
+                },
+                sub = "post-create"
+            ),
+            Some(e.to_string()),
+        )
+    })?;
+
+    match ctx.provider {
+        Provider::GitHub => Ok(PrCreatePayload {
+            provider: ctx.provider.as_str(),
+            number,
+            url: value
+                .get("url")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or(url_fallback),
+            head: required_str(&value, "headRefName")?,
+            base: required_str(&value, "baseRefName")?,
+            draft: value
+                .get("isDraft")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            title: required_str(&value, "title")?,
+            kind: kind.as_str(),
+        }),
+        Provider::GitLab => Ok(PrCreatePayload {
+            provider: ctx.provider.as_str(),
+            number,
+            url: value
+                .get("web_url")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .unwrap_or(url_fallback),
+            head: required_str(&value, "source_branch")?,
+            base: required_str(&value, "target_branch")?,
+            draft: gitlab_is_draft(&value),
+            title: required_str(&value, "title")?,
+            kind: kind.as_str(),
+        }),
+    }
+}
+
+fn required_str(value: &serde_json::Value, key: &str) -> Result<String, ForgeError> {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            ForgeError::software(
+                schema_err(),
+                format!("missing required field '{key}' in view JSON"),
+                None,
+            )
+        })
+}
+
+fn gitlab_is_draft(value: &serde_json::Value) -> bool {
+    // `glab mr view -F json` exposes either `draft: bool` (current glab)
+    // or `work_in_progress: bool` (older glab). We accept both.
+    if let Some(b) = value.get("draft").and_then(|v| v.as_bool()) {
+        return b;
+    }
+    if let Some(b) = value.get("work_in_progress").and_then(|v| v.as_bool()) {
+        return b;
+    }
+    if let Some(title) = value.get("title").and_then(|v| v.as_str()) {
+        let lower = title.to_ascii_lowercase();
+        return lower.starts_with("draft:") || lower.starts_with("wip:");
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::PrKindFlag;
+    use crate::provider::{DetectionSource, Provider};
+    use pretty_assertions::assert_eq;
+
+    fn github_ctx() -> ProviderContext {
+        ProviderContext {
+            provider: Provider::GitHub,
+            host: "github.com".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    fn gitlab_ctx() -> ProviderContext {
+        ProviderContext {
+            provider: Provider::GitLab,
+            host: "gitlab.com".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    #[test]
+    fn build_create_call_github_default_argv() {
+        let ctx = github_ctx();
+        let call = build_create_call(
+            &ctx,
+            "feat/x",
+            "main",
+            "demo",
+            "body",
+            Path::new("/tmp/body.md"),
+            true,
+            &[],
+            &[],
+        );
+        let plan = call.plan_argv();
+        assert_eq!(plan[1], "pr");
+        assert_eq!(plan[2], "create");
+        assert!(plan.contains(&"--draft".to_string()));
+        let head_idx = plan.iter().position(|s| s == "--head").unwrap();
+        assert_eq!(plan[head_idx + 1], "feat/x");
+        let body_idx = plan.iter().position(|s| s == "--body-file").unwrap();
+        assert_eq!(plan[body_idx + 1], "/tmp/body.md");
+    }
+
+    #[test]
+    fn build_create_call_skips_draft_when_off() {
+        let ctx = github_ctx();
+        let call = build_create_call(
+            &ctx,
+            "feat/x",
+            "main",
+            "demo",
+            "body",
+            Path::new("/tmp/body.md"),
+            false,
+            &[],
+            &[],
+        );
+        let plan = call.plan_argv();
+        assert!(!plan.contains(&"--draft".to_string()));
+    }
+
+    #[test]
+    fn build_create_call_gitlab_passes_description_inline() {
+        let ctx = gitlab_ctx();
+        let call = build_create_call(
+            &ctx,
+            "feat/x",
+            "main",
+            "demo",
+            "body-content",
+            Path::new("/tmp/body.md"),
+            true,
+            &["alice".into(), "bob".into()],
+            &["needs-review".into()],
+        );
+        let plan = call.plan_argv();
+        assert_eq!(plan[1], "mr");
+        assert_eq!(plan[2], "create");
+        let desc_idx = plan.iter().position(|s| s == "--description").unwrap();
+        assert_eq!(plan[desc_idx + 1], "body-content");
+        let reviewer_idx = plan.iter().position(|s| s == "--reviewer").unwrap();
+        assert_eq!(plan[reviewer_idx + 1], "alice,bob");
+    }
+
+    #[test]
+    fn parse_url_number_handles_github_and_gitlab() {
+        assert_eq!(
+            parse_url_number("https://github.com/o/r/pull/42", Provider::GitHub),
+            Some(42)
+        );
+        assert_eq!(
+            parse_url_number(
+                "https://gitlab.com/o/r/-/merge_requests/77",
+                Provider::GitLab
+            ),
+            Some(77)
+        );
+        assert_eq!(parse_url_number("not a url", Provider::GitHub), None);
+    }
+
+    #[test]
+    fn parse_create_output_extracts_url_from_stdout() {
+        let ctx = github_ctx();
+        let output = BackendSuccess {
+            stdout: "Creating draft pull request for feat/x into main in o/r\n\nhttps://github.com/o/r/pull/5\n".into(),
+            stderr: String::new(),
+        };
+        let (n, url) = parse_create_output(&ctx, &output).unwrap();
+        assert_eq!(n, 5);
+        assert_eq!(url, "https://github.com/o/r/pull/5");
+    }
+
+    #[test]
+    fn parse_view_output_github_shape() {
+        let ctx = github_ctx();
+        let output = BackendSuccess {
+            stdout: r#"{"number":5,"url":"https://github.com/o/r/pull/5","headRefName":"feat/x","baseRefName":"main","isDraft":true,"title":"demo"}"#.into(),
+            stderr: String::new(),
+        };
+        let payload = parse_view_output(
+            &ctx,
+            &output,
+            5,
+            "https://github.com/o/r/pull/5".into(),
+            PrKind::Feature,
+        )
+        .unwrap();
+        assert_eq!(payload.provider, "github");
+        assert_eq!(payload.number, 5);
+        assert_eq!(payload.head, "feat/x");
+        assert_eq!(payload.base, "main");
+        assert!(payload.draft);
+        assert_eq!(payload.kind, "feature");
+    }
+
+    #[test]
+    fn parse_view_output_gitlab_shape_with_draft_field() {
+        let ctx = gitlab_ctx();
+        let output = BackendSuccess {
+            stdout: r#"{"iid":7,"web_url":"https://gitlab.com/o/r/-/merge_requests/7","source_branch":"feat/y","target_branch":"main","draft":true,"title":"demo"}"#.into(),
+            stderr: String::new(),
+        };
+        let payload = parse_view_output(
+            &ctx,
+            &output,
+            7,
+            "https://gitlab.com/o/r/-/merge_requests/7".into(),
+            PrKind::Feature,
+        )
+        .unwrap();
+        assert!(payload.draft);
+        assert_eq!(payload.url, "https://gitlab.com/o/r/-/merge_requests/7");
+        assert_eq!(payload.base, "main");
+    }
+
+    #[test]
+    fn parse_view_output_gitlab_legacy_wip_field() {
+        let ctx = gitlab_ctx();
+        let output = BackendSuccess {
+            stdout: r#"{"iid":7,"web_url":"u","source_branch":"feat/y","target_branch":"main","work_in_progress":true,"title":"Draft: demo"}"#.into(),
+            stderr: String::new(),
+        };
+        let payload = parse_view_output(&ctx, &output, 7, "u".into(), PrKind::Feature).unwrap();
+        assert!(payload.draft);
+    }
+
+    #[test]
+    fn read_body_prefers_inline_over_file() {
+        let s = read_body(Some("inline"), Some("/dev/null")).unwrap();
+        assert_eq!(s, "inline");
+    }
+
+    #[test]
+    fn read_body_returns_empty_when_neither_set() {
+        assert_eq!(read_body(None, None).unwrap(), "");
+    }
+
+    // Helper so tests don't depend on PrKindFlag layout reordering.
+    fn args(title: &str, kind: PrKindFlag, body: Option<&str>) -> PrCreateArgs {
+        PrCreateArgs {
+            head: Some("feat/sample".into()),
+            base: Some("main".into()),
+            title: title.into(),
+            body: body.map(str::to_string),
+            body_file: None,
+            kind,
+            no_draft: false,
+            reviewers: Vec::new(),
+            labels: Vec::new(),
+        }
+    }
+
+    struct StubRunner;
+    impl BackendRunner for StubRunner {
+        fn run(&self, _: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+            unreachable!("dry-run path must not invoke the runner");
+        }
+    }
+
+    fn passthrough_env<'a>() -> Environment<'a> {
+        Environment {
+            remote_url: Box::new(|_| Some("git@github.com:o/r.git".into())),
+            current_branch: Box::new(|| Ok("feat/sample".into())),
+            default_branch: Box::new(|_, _| Ok("main".into())),
+            git_status: Box::new(|_| Ok(String::new())),
+            head_state: Box::new(|_| {
+                Ok(crate::validations::HeadState {
+                    head_sha: "abc".into(),
+                    upstream_sha: Some("abc".into()),
+                })
+            }),
+            workdir: PathBuf::from("."),
+            headings: BodyHeadings::default(),
+        }
+    }
+
+    #[test]
+    fn run_with_dry_run_returns_plan_envelope() {
+        let runner = StubRunner;
+        let env = passthrough_env();
+        let global = GlobalFlags {
+            format: Some(OutputFormat::Json),
+            remote: "origin".into(),
+            provider: None,
+            repo: None,
+            dry_run: true,
+        };
+        let body = "## Summary\n\nyes.\n\n## Test plan\n\nverified.\n";
+        let code = run_with(
+            &runner,
+            &global,
+            args("demo: ok", PrKindFlag::Feature, Some(body)),
+            OutputFormat::Json,
+            &env,
+        )
+        .expect("dry-run");
+        assert_eq!(code, nils_common::cli_contract::exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_rejects_dirty_worktree() {
+        let runner = StubRunner;
+        let env = Environment {
+            git_status: Box::new(|_| Ok(" M src/lib.rs\n".into())),
+            ..passthrough_env()
+        };
+        let global = GlobalFlags {
+            format: None,
+            remote: "origin".into(),
+            provider: None,
+            repo: None,
+            dry_run: true,
+        };
+        let body = "## Summary\n\nyes.\n\n## Test plan\n\nverified.\n";
+        let err = run_with(
+            &runner,
+            &global,
+            args("demo: ok", PrKindFlag::Feature, Some(body)),
+            OutputFormat::Json,
+            &env,
+        )
+        .expect_err("dirty");
+        assert_eq!(err.kind(), "dirty_worktree");
+    }
+
+    #[test]
+    fn run_with_rejects_branch_kind_mismatch() {
+        let runner = StubRunner;
+        let env = passthrough_env();
+        let global = GlobalFlags {
+            format: None,
+            remote: "origin".into(),
+            provider: None,
+            repo: None,
+            dry_run: true,
+        };
+        let body = "## Summary\n\nyes.\n\n## Test plan\n\nverified.\n";
+        let err = run_with(
+            &runner,
+            &global,
+            args("demo: ok", PrKindFlag::Bug, Some(body)),
+            OutputFormat::Json,
+            &env,
+        )
+        .expect_err("mismatch");
+        assert_eq!(err.kind(), "branch_kind_mismatch");
+    }
+
+    #[test]
+    fn run_with_rejects_missing_summary() {
+        let runner = StubRunner;
+        let env = passthrough_env();
+        let global = GlobalFlags {
+            format: None,
+            remote: "origin".into(),
+            provider: None,
+            repo: None,
+            dry_run: true,
+        };
+        let body = "## Test plan\n\nyes.\n";
+        let err = run_with(
+            &runner,
+            &global,
+            args("demo: ok", PrKindFlag::Feature, Some(body)),
+            OutputFormat::Json,
+            &env,
+        )
+        .expect_err("no summary");
+        assert_eq!(err.kind(), "body_missing_summary");
+    }
+}

--- a/crates/forge-cli/src/ops/pr_edit.rs
+++ b/crates/forge-cli/src/ops/pr_edit.rs
@@ -1,0 +1,340 @@
+//! `pr edit` atom.
+//!
+//! Spec / ops: `cli.forge-cli.pr.edit.v1`. Mutates PR/MR title, body, base,
+//! labels, reviewers. The `title_length` rule fires when `--title` is set;
+//! `body_summary` + `body_test_plan` fire when a new body is supplied via
+//! `--body` or `--body-file`. After mutation, the op re-fetches via
+//! `pr view` so the envelope payload carries the canonical post-edit state.
+
+use std::ffi::OsString;
+use std::fs;
+use std::io::Read as _;
+use std::path::Path;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use tempfile::NamedTempFile;
+
+use crate::backend::{BackendCall, BackendProgram, BackendRunner, DryRunPayload, ProcessRunner};
+use crate::cli::{BINARY, GlobalFlags, PrEditArgs};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_view::{self, PrViewPayload};
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+use crate::validations::{BodyHeadings, body_summary, body_test_plan, title_length};
+
+const SCHEMA: &str = "pr.edit";
+const SCHEMA_VERSION: u32 = 1;
+
+pub fn run(
+    global: &GlobalFlags,
+    args: PrEditArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, args, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: PrEditArgs,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+
+    // Read the replacement body once; keep around so the temp file stays
+    // alive through the backend call.
+    let new_body = if args.body.is_some() || args.body_file.is_some() {
+        Some(read_body(args.body.as_deref(), args.body_file.as_deref())?)
+    } else {
+        None
+    };
+
+    // Conditional validations per spec §"pr edit".
+    if let Some(title) = &args.title {
+        title_length(title)?;
+    }
+    if let Some(body) = &new_body {
+        let headings = BodyHeadings::default();
+        body_summary(body, &headings)?;
+        body_test_plan(body, &headings)?;
+    }
+
+    let body_tempfile = match (&ctx.provider, &new_body) {
+        (Provider::GitHub, Some(b)) => Some(write_body_tempfile(b)?),
+        _ => None,
+    };
+    let body_path = body_tempfile.as_ref().map(|t| t.path().to_path_buf());
+
+    let call = build_edit_call(&ctx, &args, new_body.as_deref(), body_path.as_deref());
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let _ = runner.run(&call)?;
+
+    // Re-fetch via canonical `pr view` so the envelope mirrors the
+    // post-edit state.
+    let view_call = pr_view_call(&ctx, args.id);
+    let view_output = runner.run(&view_call)?;
+    let payload: PrViewPayload = pr_view::parse_view_output(&ctx, &view_output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        payload,
+        format,
+        render_text,
+    ))
+}
+
+fn build_edit_call(
+    ctx: &ProviderContext,
+    args: &PrEditArgs,
+    body: Option<&str>,
+    body_path: Option<&Path>,
+) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let mut argv: Vec<OsString> = Vec::new();
+    match ctx.provider {
+        Provider::GitHub => {
+            argv.push(OsString::from("pr"));
+            argv.push(OsString::from("edit"));
+            argv.push(OsString::from(args.id.to_string()));
+            if let Some(t) = &args.title {
+                argv.push(OsString::from("--title"));
+                argv.push(OsString::from(t));
+            }
+            if let Some(p) = body_path {
+                argv.push(OsString::from("--body-file"));
+                argv.push(OsString::from(p));
+            }
+            if let Some(b) = &args.base {
+                argv.push(OsString::from("--base"));
+                argv.push(OsString::from(b));
+            }
+            for l in &args.add_labels {
+                argv.push(OsString::from("--add-label"));
+                argv.push(OsString::from(l));
+            }
+            for l in &args.remove_labels {
+                argv.push(OsString::from("--remove-label"));
+                argv.push(OsString::from(l));
+            }
+            for r in &args.add_reviewers {
+                argv.push(OsString::from("--add-reviewer"));
+                argv.push(OsString::from(r));
+            }
+        }
+        Provider::GitLab => {
+            argv.push(OsString::from("mr"));
+            argv.push(OsString::from("update"));
+            argv.push(OsString::from(args.id.to_string()));
+            if let Some(t) = &args.title {
+                argv.push(OsString::from("--title"));
+                argv.push(OsString::from(t));
+            }
+            if let Some(b) = body {
+                argv.push(OsString::from("--description"));
+                argv.push(OsString::from(b));
+            }
+            if let Some(b) = &args.base {
+                argv.push(OsString::from("--target-branch"));
+                argv.push(OsString::from(b));
+            }
+            if !args.add_labels.is_empty() {
+                argv.push(OsString::from("--label"));
+                argv.push(OsString::from(args.add_labels.join(",")));
+            }
+            if !args.remove_labels.is_empty() {
+                argv.push(OsString::from("--unlabel"));
+                argv.push(OsString::from(args.remove_labels.join(",")));
+            }
+            if !args.add_reviewers.is_empty() {
+                argv.push(OsString::from("--reviewer"));
+                argv.push(OsString::from(args.add_reviewers.join(",")));
+            }
+        }
+    }
+    BackendCall::new(program, argv)
+}
+
+fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("view"),
+            OsString::from(id.to_string()),
+            OsString::from("--json"),
+            OsString::from(
+                "number,url,state,isDraft,title,headRefName,baseRefName,mergeable,mergedAt,labels",
+            ),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("view"),
+            OsString::from(id.to_string()),
+            OsString::from("-F"),
+            OsString::from("json"),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn read_body(inline: Option<&str>, file: Option<&str>) -> Result<String, ForgeError> {
+    if let Some(s) = inline {
+        return Ok(s.to_string());
+    }
+    let Some(path) = file else {
+        return Ok(String::new());
+    };
+    if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "failed to read body from stdin",
+                Some(e.to_string()),
+            )
+        })?;
+        return Ok(buf);
+    }
+    fs::read_to_string(path).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            format!("failed to read --body-file '{path}'"),
+            Some(e.to_string()),
+        )
+    })
+}
+
+fn write_body_tempfile(body: &str) -> Result<NamedTempFile, ForgeError> {
+    let tmp = tempfile::Builder::new()
+        .prefix("forge-cli-edit-body-")
+        .suffix(".md")
+        .tempfile()
+        .map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "failed to create body tempfile",
+                Some(e.to_string()),
+            )
+        })?;
+    fs::write(tmp.path(), body).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            "failed to write body tempfile",
+            Some(e.to_string()),
+        )
+    })?;
+    Ok(tmp)
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &PrViewPayload) {
+    println!(
+        "edited #{n} [{state}{draft}]: {url}",
+        n = payload.number,
+        state = payload.state,
+        draft = if payload.draft { ",draft" } else { "" },
+        url = payload.url,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{DetectionSource, Provider};
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "x".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    fn args(id: u64) -> PrEditArgs {
+        PrEditArgs {
+            id,
+            title: None,
+            body: None,
+            body_file: None,
+            base: None,
+            add_labels: vec![],
+            remove_labels: vec![],
+            add_reviewers: vec![],
+        }
+    }
+
+    #[test]
+    fn build_edit_call_github_emits_add_remove_labels() {
+        let mut a = args(5);
+        a.add_labels = vec!["needs-review".into(), "p1".into()];
+        a.remove_labels = vec!["wip".into()];
+        let call = build_edit_call(&ctx(Provider::GitHub), &a, None, None);
+        let plan = call.plan_argv();
+        // --add-label appears once per label.
+        let adds: Vec<_> = plan
+            .windows(2)
+            .filter(|w| w[0] == "--add-label")
+            .map(|w| w[1].clone())
+            .collect();
+        assert_eq!(adds, vec!["needs-review".to_string(), "p1".to_string()]);
+        let removes: Vec<_> = plan
+            .windows(2)
+            .filter(|w| w[0] == "--remove-label")
+            .map(|w| w[1].clone())
+            .collect();
+        assert_eq!(removes, vec!["wip".to_string()]);
+    }
+
+    #[test]
+    fn build_edit_call_gitlab_collapses_labels_to_csv() {
+        let mut a = args(7);
+        a.add_labels = vec!["needs-review".into(), "p1".into()];
+        a.remove_labels = vec!["wip".into(), "ci-only".into()];
+        let call = build_edit_call(&ctx(Provider::GitLab), &a, None, None);
+        let plan = call.plan_argv();
+        let label_idx = plan.iter().position(|s| s == "--label").unwrap();
+        assert_eq!(plan[label_idx + 1], "needs-review,p1");
+        let unlabel_idx = plan.iter().position(|s| s == "--unlabel").unwrap();
+        assert_eq!(plan[unlabel_idx + 1], "wip,ci-only");
+    }
+
+    #[test]
+    fn build_edit_call_github_uses_body_file() {
+        let mut a = args(5);
+        a.body = Some("ignored".into());
+        let call = build_edit_call(
+            &ctx(Provider::GitHub),
+            &a,
+            Some("x"),
+            Some(Path::new("/tmp/body.md")),
+        );
+        let plan = call.plan_argv();
+        let bf_idx = plan.iter().position(|s| s == "--body-file").unwrap();
+        assert_eq!(plan[bf_idx + 1], "/tmp/body.md");
+    }
+
+    #[test]
+    fn build_edit_call_gitlab_uses_description_inline() {
+        let mut a = args(5);
+        a.body = Some("inline body".into());
+        let call = build_edit_call(&ctx(Provider::GitLab), &a, Some("inline body"), None);
+        let plan = call.plan_argv();
+        let d_idx = plan.iter().position(|s| s == "--description").unwrap();
+        assert_eq!(plan[d_idx + 1], "inline body");
+    }
+}

--- a/crates/forge-cli/src/ops/pr_list.rs
+++ b/crates/forge-cli/src/ops/pr_list.rs
@@ -1,0 +1,344 @@
+//! `pr list` atom.
+//!
+//! Spec / ops: `cli.forge-cli.pr.list.v1`. Returns a flat array of PR/MR
+//! summaries filtered by `--state`, `--author`, `--head`, `--limit`. Both
+//! backends emit a JSON array; the normalizer flattens the per-provider
+//! field names into the canonical envelope shape.
+
+use std::ffi::OsString;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{
+    BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
+};
+use crate::cli::{BINARY, GlobalFlags, PrListArgs, PrStateFilter};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_state::normalize_state;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const SCHEMA: &str = "pr.list";
+const SCHEMA_VERSION: u32 = 1;
+
+const GH_JSON_FIELDS: &str = "number,url,state,title,headRefName,author";
+
+/// Envelope payload for `cli.forge-cli.pr.list.v1`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrListPayload {
+    pub provider: &'static str,
+    pub items: Vec<PrListItem>,
+}
+
+/// One row in the list envelope.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrListItem {
+    pub number: u64,
+    pub url: String,
+    pub state: &'static str,
+    pub title: String,
+    pub head: String,
+    pub author: Option<String>,
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    args: PrListArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, args, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: PrListArgs,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let call = build_list_call(&ctx, &args);
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let output = runner.run(&call)?;
+    let payload = parse_list_output(&ctx, &output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        payload,
+        format,
+        render_text,
+    ))
+}
+
+fn build_list_call(ctx: &ProviderContext, args: &PrListArgs) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let limit = args.limit.max(1);
+    let mut argv: Vec<OsString> = Vec::new();
+    match ctx.provider {
+        Provider::GitHub => {
+            argv.push(OsString::from("pr"));
+            argv.push(OsString::from("list"));
+            argv.push(OsString::from("--state"));
+            argv.push(OsString::from(args.state.as_str()));
+            argv.push(OsString::from("--limit"));
+            argv.push(OsString::from(limit.to_string()));
+            if let Some(a) = &args.author {
+                argv.push(OsString::from("--author"));
+                argv.push(OsString::from(a));
+            }
+            if let Some(h) = &args.head {
+                argv.push(OsString::from("--head"));
+                argv.push(OsString::from(h));
+            }
+            argv.push(OsString::from("--json"));
+            argv.push(OsString::from(GH_JSON_FIELDS));
+        }
+        Provider::GitLab => {
+            argv.push(OsString::from("mr"));
+            argv.push(OsString::from("list"));
+            argv.push(OsString::from(gitlab_state_flag(args.state)));
+            argv.push(OsString::from("--per-page"));
+            argv.push(OsString::from(limit.to_string()));
+            if let Some(a) = &args.author {
+                argv.push(OsString::from("--author"));
+                argv.push(OsString::from(a));
+            }
+            if let Some(h) = &args.head {
+                argv.push(OsString::from("--source-branch"));
+                argv.push(OsString::from(h));
+            }
+            argv.push(OsString::from("-F"));
+            argv.push(OsString::from("json"));
+        }
+    }
+    BackendCall::new(program, argv)
+}
+
+fn gitlab_state_flag(state: PrStateFilter) -> &'static str {
+    // glab uses a positional-flag form for "all states"; the value is the
+    // same as the state literal.
+    match state {
+        PrStateFilter::Open => "--opened",
+        PrStateFilter::Closed => "--closed",
+        PrStateFilter::Merged => "--merged",
+        PrStateFilter::All => "--all",
+    }
+}
+
+pub fn parse_list_output(
+    ctx: &ProviderContext,
+    output: &BackendSuccess,
+) -> Result<PrListPayload, ForgeError> {
+    let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
+        ForgeError::software(schema_err(), "pr list JSON is invalid", Some(e.to_string()))
+    })?;
+    let arr = value.as_array().ok_or_else(|| {
+        ForgeError::software(
+            schema_err(),
+            "pr list JSON is not an array",
+            Some(format!("got: {value}")),
+        )
+    })?;
+    let items = arr
+        .iter()
+        .map(|raw| parse_item(raw, ctx))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(PrListPayload {
+        provider: ctx.provider.as_str(),
+        items,
+    })
+}
+
+fn parse_item(raw: &serde_json::Value, ctx: &ProviderContext) -> Result<PrListItem, ForgeError> {
+    match ctx.provider {
+        Provider::GitHub => Ok(PrListItem {
+            number: raw
+                .get("number")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| missing("number"))?,
+            url: required_str(raw, "url")?,
+            state: normalize_state(
+                raw.get("state").and_then(|v| v.as_str()).unwrap_or(""),
+                ctx.provider,
+            )?,
+            title: required_str(raw, "title")?,
+            head: required_str(raw, "headRefName")?,
+            author: raw
+                .get("author")
+                .and_then(|v| v.get("login").and_then(|n| n.as_str()))
+                .map(str::to_string),
+        }),
+        Provider::GitLab => Ok(PrListItem {
+            number: raw
+                .get("iid")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| missing("iid"))?,
+            url: required_str(raw, "web_url")?,
+            state: normalize_state(
+                raw.get("state").and_then(|v| v.as_str()).unwrap_or(""),
+                ctx.provider,
+            )?,
+            title: required_str(raw, "title")?,
+            head: required_str(raw, "source_branch")?,
+            author: raw
+                .get("author")
+                .and_then(|v| v.get("username").and_then(|n| n.as_str()))
+                .map(str::to_string),
+        }),
+    }
+}
+
+fn required_str(raw: &serde_json::Value, key: &str) -> Result<String, ForgeError> {
+    raw.get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| missing(key))
+}
+
+fn missing(key: &str) -> ForgeError {
+    ForgeError::software(
+        schema_err(),
+        format!("missing required field '{key}' in pr list item"),
+        None,
+    )
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &PrListPayload) {
+    for item in &payload.items {
+        let author = item.author.as_deref().unwrap_or("<unknown>");
+        println!(
+            "#{n} [{s}] {t} ({a}) — {u}",
+            n = item.number,
+            s = item.state,
+            t = item.title,
+            a = author,
+            u = item.url,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "example.com".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    fn default_args() -> PrListArgs {
+        PrListArgs {
+            state: PrStateFilter::Open,
+            author: None,
+            head: None,
+            limit: 30,
+        }
+    }
+
+    #[test]
+    fn build_list_call_github_passes_state_and_limit() {
+        let call = build_list_call(&ctx(Provider::GitHub), &default_args());
+        let plan = call.plan_argv();
+        let s_idx = plan.iter().position(|s| s == "--state").unwrap();
+        assert_eq!(plan[s_idx + 1], "open");
+        let l_idx = plan.iter().position(|s| s == "--limit").unwrap();
+        assert_eq!(plan[l_idx + 1], "30");
+    }
+
+    #[test]
+    fn build_list_call_github_includes_optional_filters() {
+        let mut args = default_args();
+        args.author = Some("alice".into());
+        args.head = Some("feat/x".into());
+        args.limit = 1;
+        args.state = PrStateFilter::Merged;
+        let call = build_list_call(&ctx(Provider::GitHub), &args);
+        let plan = call.plan_argv();
+        let a_idx = plan.iter().position(|s| s == "--author").unwrap();
+        assert_eq!(plan[a_idx + 1], "alice");
+        let h_idx = plan.iter().position(|s| s == "--head").unwrap();
+        assert_eq!(plan[h_idx + 1], "feat/x");
+        let l_idx = plan.iter().position(|s| s == "--limit").unwrap();
+        assert_eq!(plan[l_idx + 1], "1");
+        let s_idx = plan.iter().position(|s| s == "--state").unwrap();
+        assert_eq!(plan[s_idx + 1], "merged");
+    }
+
+    #[test]
+    fn build_list_call_gitlab_maps_state_to_flag() {
+        let mut args = default_args();
+        args.state = PrStateFilter::Merged;
+        let call = build_list_call(&ctx(Provider::GitLab), &args);
+        let plan = call.plan_argv();
+        assert!(plan.contains(&"--merged".to_string()));
+        assert!(plan.contains(&"--per-page".to_string()));
+        assert!(plan.contains(&"-F".to_string()));
+    }
+
+    #[test]
+    fn parse_list_output_github() {
+        let stdout = r#"[
+          {"number":1,"url":"u1","state":"OPEN","title":"a","headRefName":"feat/a","author":{"login":"alice"}},
+          {"number":2,"url":"u2","state":"CLOSED","title":"b","headRefName":"feat/b","author":{"login":"bob"}}
+        ]"#;
+        let payload = parse_list_output(
+            &ctx(Provider::GitHub),
+            &BackendSuccess {
+                stdout: stdout.into(),
+                stderr: String::new(),
+            },
+        )
+        .unwrap();
+        assert_eq!(payload.items.len(), 2);
+        assert_eq!(payload.items[0].state, "open");
+        assert_eq!(payload.items[1].state, "closed");
+        assert_eq!(payload.items[0].author.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn parse_list_output_gitlab() {
+        let stdout = r#"[
+          {"iid":7,"web_url":"u","state":"opened","title":"x","source_branch":"feat/x","author":{"username":"alice"}}
+        ]"#;
+        let payload = parse_list_output(
+            &ctx(Provider::GitLab),
+            &BackendSuccess {
+                stdout: stdout.into(),
+                stderr: String::new(),
+            },
+        )
+        .unwrap();
+        assert_eq!(payload.items[0].number, 7);
+        assert_eq!(payload.items[0].state, "open");
+    }
+
+    #[test]
+    fn build_list_call_clamps_zero_limit_to_one() {
+        let mut args = default_args();
+        args.limit = 0;
+        let call = build_list_call(&ctx(Provider::GitHub), &args);
+        let plan = call.plan_argv();
+        let l_idx = plan.iter().position(|s| s == "--limit").unwrap();
+        assert_eq!(plan[l_idx + 1], "1");
+    }
+}

--- a/crates/forge-cli/src/ops/pr_ready.rs
+++ b/crates/forge-cli/src/ops/pr_ready.rs
@@ -1,0 +1,170 @@
+//! `pr ready` atom.
+//!
+//! Spec / ops: `cli.forge-cli.pr.ready.v1`. Promotes a draft PR/MR to
+//! ready-for-review. Validation: `worktree_clean`. After mutation the op
+//! re-fetches via `pr view` so the envelope carries the canonical
+//! post-ready state (`draft: false`).
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+
+use crate::backend::{BackendCall, BackendProgram, BackendRunner, DryRunPayload, ProcessRunner};
+use crate::cli::{BINARY, GlobalFlags, PrReadyArgs};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_view::{self, PrViewPayload};
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+use crate::validations::{git_status_porcelain, worktree_clean};
+
+const SCHEMA: &str = "pr.ready";
+const SCHEMA_VERSION: u32 = 1;
+
+pub fn run(
+    global: &GlobalFlags,
+    args: PrReadyArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    let workdir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    run_with(
+        &runner,
+        global,
+        args,
+        format,
+        git_remote_url,
+        &workdir,
+        git_status_porcelain,
+    )
+}
+
+pub fn run_with<R, F, G>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: PrReadyArgs,
+    format: OutputFormat,
+    remote_url_lookup: F,
+    workdir: &std::path::Path,
+    git_status: G,
+) -> Result<i32, ForgeError>
+where
+    R: BackendRunner,
+    F: Fn(&str) -> Option<String>,
+    G: FnOnce(&std::path::Path) -> Result<String, ForgeError>,
+{
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    worktree_clean(workdir, git_status)?;
+
+    let call = build_ready_call(&ctx, args.id);
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+    let _ = runner.run(&call)?;
+
+    let view_call = pr_view_call(&ctx, args.id);
+    let view_output = runner.run(&view_call)?;
+    let payload: PrViewPayload = pr_view::parse_view_output(&ctx, &view_output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        payload,
+        format,
+        render_text,
+    ))
+}
+
+fn build_ready_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("ready"),
+            OsString::from(id.to_string()),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("update"),
+            OsString::from(id.to_string()),
+            OsString::from("--ready"),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("view"),
+            OsString::from(id.to_string()),
+            OsString::from("--json"),
+            OsString::from(
+                "number,url,state,isDraft,title,headRefName,baseRefName,mergeable,mergedAt,labels",
+            ),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("view"),
+            OsString::from(id.to_string()),
+            OsString::from("-F"),
+            OsString::from("json"),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn render_text(payload: &PrViewPayload) {
+    println!(
+        "ready #{n} [{state}]: {url}",
+        n = payload.number,
+        state = payload.state,
+        url = payload.url,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{DetectionSource, Provider};
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "x".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    #[test]
+    fn build_ready_call_github_emits_pr_ready_id() {
+        let call = build_ready_call(&ctx(Provider::GitHub), 5);
+        let plan = call.plan_argv();
+        assert_eq!(
+            plan[1..],
+            ["pr".to_string(), "ready".to_string(), "5".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_ready_call_gitlab_emits_mr_update_ready() {
+        let call = build_ready_call(&ctx(Provider::GitLab), 7);
+        let plan = call.plan_argv();
+        assert_eq!(
+            plan[1..],
+            [
+                "mr".to_string(),
+                "update".to_string(),
+                "7".to_string(),
+                "--ready".to_string()
+            ]
+        );
+    }
+}

--- a/crates/forge-cli/src/ops/pr_state.rs
+++ b/crates/forge-cli/src/ops/pr_state.rs
@@ -1,0 +1,115 @@
+//! Shared PR/MR state normalization for `pr view`, `pr list`, `pr close`,
+//! and the `pr deliver` macro.
+//!
+//! Spec: `crates/forge-cli/docs/specs/forge-cli-spec-v1.md` §"pr view" — the
+//! canonical envelope state enum is `open | closed | merged`. GitHub
+//! already uses these literals (uppercased). GitLab uses `opened` /
+//! `closed` / `merged` / `locked`. The mapping below is the only place
+//! state strings cross the wire.
+
+use nils_common::cli_contract::schema_version_for;
+
+use crate::cli::BINARY;
+use crate::error::ForgeError;
+use crate::provider::Provider;
+
+/// Convert a raw backend state into the canonical `open | closed | merged`
+/// literal. Unknown values produce a `SOFTWARE 70` error so consumers see a
+/// hard failure rather than a silent fallthrough.
+pub fn normalize_state(raw: &str, provider: Provider) -> Result<&'static str, ForgeError> {
+    let lower = raw.trim().to_ascii_lowercase();
+    let mapped = match provider {
+        Provider::GitHub => match lower.as_str() {
+            "open" => "open",
+            "closed" => "closed",
+            "merged" => "merged",
+            _ => return unknown(raw, provider),
+        },
+        Provider::GitLab => match lower.as_str() {
+            "opened" | "open" => "open",
+            "closed" | "locked" => "closed",
+            "merged" => "merged",
+            _ => return unknown(raw, provider),
+        },
+    };
+    Ok(mapped)
+}
+
+fn unknown(raw: &str, provider: Provider) -> Result<&'static str, ForgeError> {
+    Err(ForgeError::software(
+        schema_version_for(BINARY, "error", 1),
+        format!(
+            "{provider} returned an unknown state literal '{raw}'",
+            provider = provider.as_str()
+        ),
+        None,
+    ))
+}
+
+/// Convert GitHub's mergeable trio (`MERGEABLE`/`CONFLICTING`/`UNKNOWN`) or
+/// GitLab's `merge_status` shape into the canonical `yes | no | unknown`
+/// literal.
+pub fn normalize_mergeable_github(value: Option<&str>) -> &'static str {
+    match value.unwrap_or("").to_ascii_uppercase().as_str() {
+        "MERGEABLE" => "yes",
+        "CONFLICTING" => "no",
+        _ => "unknown",
+    }
+}
+
+pub fn normalize_mergeable_gitlab(value: Option<&str>) -> &'static str {
+    match value.unwrap_or("") {
+        "can_be_merged" | "mergeable" => "yes",
+        "cannot_be_merged" | "cannot_be_merged_recheck" => "no",
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn github_state_passthrough() {
+        assert_eq!(normalize_state("OPEN", Provider::GitHub).unwrap(), "open");
+        assert_eq!(
+            normalize_state("merged", Provider::GitHub).unwrap(),
+            "merged"
+        );
+    }
+
+    #[test]
+    fn gitlab_opened_becomes_open() {
+        assert_eq!(normalize_state("opened", Provider::GitLab).unwrap(), "open");
+    }
+
+    #[test]
+    fn gitlab_locked_becomes_closed() {
+        assert_eq!(
+            normalize_state("locked", Provider::GitLab).unwrap(),
+            "closed"
+        );
+    }
+
+    #[test]
+    fn unknown_state_errors_software() {
+        let err = normalize_state("invented", Provider::GitHub).expect_err("unknown");
+        assert_eq!(err.kind(), "software_error");
+    }
+
+    #[test]
+    fn mergeable_mapping_github() {
+        assert_eq!(normalize_mergeable_github(Some("MERGEABLE")), "yes");
+        assert_eq!(normalize_mergeable_github(Some("CONFLICTING")), "no");
+        assert_eq!(normalize_mergeable_github(Some("UNKNOWN")), "unknown");
+        assert_eq!(normalize_mergeable_github(None), "unknown");
+    }
+
+    #[test]
+    fn mergeable_mapping_gitlab() {
+        assert_eq!(normalize_mergeable_gitlab(Some("can_be_merged")), "yes");
+        assert_eq!(normalize_mergeable_gitlab(Some("cannot_be_merged")), "no");
+        assert_eq!(normalize_mergeable_gitlab(None), "unknown");
+    }
+}

--- a/crates/forge-cli/src/ops/pr_view.rs
+++ b/crates/forge-cli/src/ops/pr_view.rs
@@ -1,0 +1,400 @@
+//! `pr view` atom.
+//!
+//! Spec / ops: `cli.forge-cli.pr.view.v1`. Accepts either a numeric id or a
+//! branch name. Numeric ids are passed through to the backend directly;
+//! branch names are resolved upstream via `gh pr view <branch>` (GitHub
+//! handles this natively) or `glab mr list --source-branch <branch>` (which
+//! returns a JSON array whose first entry's `iid` is taken).
+
+use std::ffi::OsString;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{
+    BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
+};
+use crate::cli::{BINARY, GlobalFlags};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_state::{
+    normalize_mergeable_github, normalize_mergeable_gitlab, normalize_state,
+};
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const SCHEMA: &str = "pr.view";
+const SCHEMA_VERSION: u32 = 1;
+
+const GH_JSON_FIELDS: &str =
+    "number,url,state,isDraft,title,headRefName,baseRefName,mergeable,mergedAt,labels";
+
+/// Envelope payload for `cli.forge-cli.pr.view.v1`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrViewPayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub state: &'static str,
+    pub draft: bool,
+    pub title: String,
+    pub head: String,
+    pub base: String,
+    pub mergeable: &'static str,
+    pub merged_at: Option<String>,
+    pub labels: Vec<String>,
+}
+
+pub fn run(global: &GlobalFlags, id: String, format: OutputFormat) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, &id, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    id: &str,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+
+    // GitLab cannot resolve a branch name in a single view call; fan out to
+    // `mr list --source-branch <branch>` first.
+    let resolved_id = if id.chars().all(|c| c.is_ascii_digit()) {
+        id.to_string()
+    } else {
+        resolve_branch_id(runner, &ctx, id)?
+    };
+
+    let call = build_view_call(&ctx, &resolved_id);
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let output = runner.run(&call)?;
+    let payload = parse_view_output(&ctx, &output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        payload,
+        format,
+        render_text,
+    ))
+}
+
+fn build_view_call(ctx: &ProviderContext, id: &str) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("view"),
+            OsString::from(id),
+            OsString::from("--json"),
+            OsString::from(GH_JSON_FIELDS),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("view"),
+            OsString::from(id),
+            OsString::from("-F"),
+            OsString::from("json"),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn resolve_branch_id<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    branch: &str,
+) -> Result<String, ForgeError> {
+    match ctx.provider {
+        Provider::GitHub => Ok(branch.to_string()),
+        Provider::GitLab => {
+            let argv: Vec<OsString> = vec![
+                OsString::from("mr"),
+                OsString::from("list"),
+                OsString::from("--source-branch"),
+                OsString::from(branch),
+                OsString::from("-F"),
+                OsString::from("json"),
+            ];
+            let call = BackendCall::new(BackendProgram::Glab, argv);
+            let output = runner.run(&call)?;
+            extract_first_iid(&output.stdout).ok_or_else(|| {
+                ForgeError::software(
+                    schema_err(),
+                    format!("no GitLab MR matches source-branch '{branch}'"),
+                    Some(format!("stdout={:?}", output.stdout)),
+                )
+            })
+        }
+    }
+}
+
+fn extract_first_iid(stdout: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(stdout.trim()).ok()?;
+    let iid = value
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|first| first.get("iid"))
+        .and_then(|v| v.as_u64())?;
+    Some(iid.to_string())
+}
+
+pub fn parse_view_output(
+    ctx: &ProviderContext,
+    output: &BackendSuccess,
+) -> Result<PrViewPayload, ForgeError> {
+    let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
+        ForgeError::software(schema_err(), "pr view JSON is invalid", Some(e.to_string()))
+    })?;
+    match ctx.provider {
+        Provider::GitHub => parse_github(&value, ctx),
+        Provider::GitLab => parse_gitlab(&value, ctx),
+    }
+}
+
+fn parse_github(
+    value: &serde_json::Value,
+    ctx: &ProviderContext,
+) -> Result<PrViewPayload, ForgeError> {
+    let raw_state = value.get("state").and_then(|v| v.as_str()).unwrap_or("");
+    let merged_at = value
+        .get("mergedAt")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.is_empty());
+    let state = if merged_at.is_some() {
+        "merged"
+    } else {
+        normalize_state(raw_state, ctx.provider)?
+    };
+    let labels = github_label_names(value);
+    Ok(PrViewPayload {
+        provider: ctx.provider.as_str(),
+        number: value
+            .get("number")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| missing("number"))?,
+        url: required_str(value, "url")?,
+        state,
+        draft: value
+            .get("isDraft")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        title: required_str(value, "title")?,
+        head: required_str(value, "headRefName")?,
+        base: required_str(value, "baseRefName")?,
+        mergeable: normalize_mergeable_github(value.get("mergeable").and_then(|v| v.as_str())),
+        merged_at,
+        labels,
+    })
+}
+
+fn parse_gitlab(
+    value: &serde_json::Value,
+    ctx: &ProviderContext,
+) -> Result<PrViewPayload, ForgeError> {
+    let raw_state = value.get("state").and_then(|v| v.as_str()).unwrap_or("");
+    let state = normalize_state(raw_state, ctx.provider)?;
+    let merged_at = value
+        .get("merged_at")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.is_empty());
+    let draft = value
+        .get("draft")
+        .and_then(|v| v.as_bool())
+        .or_else(|| value.get("work_in_progress").and_then(|v| v.as_bool()))
+        .unwrap_or(false);
+    let labels = gitlab_label_names(value);
+    Ok(PrViewPayload {
+        provider: ctx.provider.as_str(),
+        number: value
+            .get("iid")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| missing("iid"))?,
+        url: required_str(value, "web_url")?,
+        state,
+        draft,
+        title: required_str(value, "title")?,
+        head: required_str(value, "source_branch")?,
+        base: required_str(value, "target_branch")?,
+        mergeable: normalize_mergeable_gitlab(value.get("merge_status").and_then(|v| v.as_str())),
+        merged_at,
+        labels,
+    })
+}
+
+fn github_label_names(value: &serde_json::Value) -> Vec<String> {
+    value
+        .get("labels")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    item.get("name")
+                        .and_then(|n| n.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn gitlab_label_names(value: &serde_json::Value) -> Vec<String> {
+    value
+        .get("labels")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    item.as_str().map(str::to_string).or_else(|| {
+                        item.get("name")
+                            .and_then(|n| n.as_str())
+                            .map(str::to_string)
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn required_str(value: &serde_json::Value, key: &str) -> Result<String, ForgeError> {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| missing(key))
+}
+
+fn missing(key: &str) -> ForgeError {
+    ForgeError::software(
+        schema_err(),
+        format!("missing required field '{key}' in pr view JSON"),
+        None,
+    )
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &PrViewPayload) {
+    println!(
+        "#{number} [{state}{draft}] {title}\n  {url}",
+        number = payload.number,
+        state = payload.state,
+        draft = if payload.draft { ",draft" } else { "" },
+        title = payload.title,
+        url = payload.url,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+
+    fn ctx(provider: Provider) -> ProviderContext {
+        ProviderContext {
+            provider,
+            host: "example.com".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    #[test]
+    fn build_view_call_github_uses_json_fields() {
+        let call = build_view_call(&ctx(Provider::GitHub), "5");
+        let plan = call.plan_argv();
+        assert_eq!(plan[1..3], ["pr".to_string(), "view".to_string()]);
+        let json_idx = plan.iter().position(|s| s == "--json").unwrap();
+        assert!(plan[json_idx + 1].contains("mergeable"));
+    }
+
+    #[test]
+    fn build_view_call_gitlab_uses_f_json() {
+        let call = build_view_call(&ctx(Provider::GitLab), "9");
+        let plan = call.plan_argv();
+        assert_eq!(plan[1..3], ["mr".to_string(), "view".to_string()]);
+        assert!(plan.iter().any(|s| s == "-F"));
+    }
+
+    #[test]
+    fn parse_github_open_pr() {
+        let output = BackendSuccess {
+            stdout: r#"{"number":5,"url":"u","state":"OPEN","isDraft":true,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[{"name":"a"},{"name":"b"}]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitHub), &output).unwrap();
+        assert_eq!(p.state, "open");
+        assert!(p.draft);
+        assert_eq!(p.mergeable, "yes");
+        assert_eq!(p.merged_at, None);
+        assert_eq!(p.labels, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn parse_github_merged_pr_overrides_state() {
+        // GitHub keeps state=CLOSED on merged PRs; mergedAt is the canonical
+        // signal so we promote to "merged".
+        let output = BackendSuccess {
+            stdout: r#"{"number":5,"url":"u","state":"CLOSED","isDraft":false,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"UNKNOWN","mergedAt":"2026-05-19T10:00:00Z","labels":[]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitHub), &output).unwrap();
+        assert_eq!(p.state, "merged");
+        assert_eq!(p.merged_at.as_deref(), Some("2026-05-19T10:00:00Z"));
+    }
+
+    #[test]
+    fn parse_gitlab_opened_normalises_to_open() {
+        let output = BackendSuccess {
+            stdout: r#"{"iid":7,"web_url":"u","state":"opened","draft":true,"title":"t","source_branch":"feat/x","target_branch":"main","merge_status":"can_be_merged","labels":["x","y"]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitLab), &output).unwrap();
+        assert_eq!(p.state, "open");
+        assert!(p.draft);
+        assert_eq!(p.mergeable, "yes");
+        assert_eq!(p.labels, vec!["x".to_string(), "y".to_string()]);
+    }
+
+    #[test]
+    fn parse_gitlab_locked_normalises_to_closed() {
+        let output = BackendSuccess {
+            stdout: r#"{"iid":7,"web_url":"u","state":"locked","draft":false,"title":"t","source_branch":"feat/x","target_branch":"main","merge_status":"cannot_be_merged","labels":[]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitLab), &output).unwrap();
+        assert_eq!(p.state, "closed");
+        assert_eq!(p.mergeable, "no");
+    }
+
+    #[test]
+    fn parse_gitlab_unknown_state_errors_software() {
+        let output = BackendSuccess {
+            stdout: r#"{"iid":1,"web_url":"u","state":"invented","draft":false,"title":"t","source_branch":"feat/x","target_branch":"main","merge_status":"unknown","labels":[]}"#.into(),
+            stderr: String::new(),
+        };
+        let err = parse_view_output(&ctx(Provider::GitLab), &output).expect_err("invented");
+        assert_eq!(err.kind(), "software_error");
+    }
+
+    #[test]
+    fn extract_first_iid_from_list_array() {
+        let s = r#"[{"iid":42,"title":"x"},{"iid":7}]"#;
+        assert_eq!(extract_first_iid(s), Some("42".into()));
+        assert_eq!(extract_first_iid("[]"), None);
+        assert_eq!(extract_first_iid("not json"), None);
+    }
+}

--- a/crates/forge-cli/src/ops/repo_view.rs
+++ b/crates/forge-cli/src/ops/repo_view.rs
@@ -98,6 +98,12 @@ fn build_call(ctx: &ProviderContext, repo_override: Option<&str>) -> BackendCall
     BackendCall::new(program, argv)
 }
 
+/// Re-export of the internal builder so `pr create` (and later atoms) can
+/// resolve the repo's default branch without duplicating the argv shape.
+pub fn build_call_for_default_branch(ctx: &ProviderContext) -> BackendCall {
+    build_call(ctx, None)
+}
+
 /// Parse the backend stdout into the normalized payload.
 pub fn parse_backend_output(
     ctx: &ProviderContext,

--- a/crates/forge-cli/src/validations.rs
+++ b/crates/forge-cli/src/validations.rs
@@ -1,0 +1,631 @@
+//! Shared lock-down validations consumed by every mutating PR / MR op.
+//!
+//! Spec: `crates/forge-cli/docs/specs/forge-cli-spec-v1.md` §"Lock-down
+//! policy" plus `crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml`
+//! `validations_catalog`. Each rule below maps 1:1 to a row in the catalog
+//! and returns a [`ForgeError::Validation`] with the rule's documented
+//! `error.kind` literal. The numeric exit class (`DATA 65`) lives in
+//! [`crate::error::ForgeError::exit_code`] — never inlined here.
+//!
+//! Body parsing rule (spec §"Lock-down policy" item 2): "non-empty H2
+//! `## Summary` / `## Test plan` section" means the H2 heading line itself
+//! does not count as content; only non-blank lines below the heading and
+//! above the next H2 (or end-of-body) count. Both "section absent" and
+//! "section present but empty" produce the same `error.kind` because the
+//! user-visible failure is identical.
+
+use std::path::Path;
+use std::process::Command;
+
+use nils_common::cli_contract::schema_version_for;
+
+use crate::cli::BINARY;
+use crate::error::ForgeError;
+
+/// PR/MR kind declared by the caller via `--kind`. Drives the
+/// `branch_kind_matches` rule plus the macro in Sprint 6.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrKind {
+    Feature,
+    Bug,
+}
+
+impl PrKind {
+    /// Render the kind to the lower-case enum literal used in envelopes and
+    /// argv (`feature`, `bug`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PrKind::Feature => "feature",
+            PrKind::Bug => "bug",
+        }
+    }
+
+    /// Parse the `--kind` flag value. Anything outside the spec's enum is a
+    /// usage error and is handled at the clap layer; this helper exists for
+    /// internal callers that already hold the string.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "feature" => Some(PrKind::Feature),
+            "bug" => Some(PrKind::Bug),
+            _ => None,
+        }
+    }
+}
+
+/// Branch prefix recovered from a branch name that matches the
+/// `branch_name` rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BranchPrefix {
+    Feat,
+    Fix,
+}
+
+impl BranchPrefix {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BranchPrefix::Feat => "feat",
+            BranchPrefix::Fix => "fix",
+        }
+    }
+}
+
+/// Configurable body H2 headings (set via `.forge-cli.toml` in later
+/// sprints). Defaults match the spec §"Lock-down policy" item 2.
+#[derive(Debug, Clone)]
+pub struct BodyHeadings {
+    pub summary: String,
+    pub test_plan: String,
+}
+
+impl Default for BodyHeadings {
+    fn default() -> Self {
+        Self {
+            summary: "## Summary".to_string(),
+            test_plan: "## Test plan".to_string(),
+        }
+    }
+}
+
+/// Hard cap on title length per spec §"Lock-down policy" item 3.
+pub const TITLE_MAX_LEN: usize = 70;
+
+fn schema() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+/// Rule 1a — branch name matches `^(feat|fix)/[a-z0-9][a-z0-9-]{1,63}$`.
+///
+/// Returns the matched prefix so callers can chain into
+/// [`branch_kind_matches`] without re-parsing.
+pub fn branch_name(branch: &str) -> Result<BranchPrefix, ForgeError> {
+    let (prefix, rest) = match branch.split_once('/') {
+        Some((p, r)) => (p, r),
+        None => return Err(branch_name_err(branch, "missing 'feat/' or 'fix/' prefix")),
+    };
+
+    let prefix = match prefix {
+        "feat" => BranchPrefix::Feat,
+        "fix" => BranchPrefix::Fix,
+        other => {
+            return Err(branch_name_err(
+                branch,
+                &format!("unknown prefix '{other}' (expected 'feat' or 'fix')"),
+            ));
+        }
+    };
+
+    if rest.is_empty() {
+        return Err(branch_name_err(branch, "slug is empty"));
+    }
+    if rest.len() > 64 {
+        return Err(branch_name_err(
+            branch,
+            &format!("slug is {len} chars; max 64", len = rest.len()),
+        ));
+    }
+    let bytes = rest.as_bytes();
+    let first = bytes[0];
+    if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+        return Err(branch_name_err(
+            branch,
+            "slug must start with a lowercase letter or digit",
+        ));
+    }
+    for &b in &bytes[1..] {
+        if !(b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-') {
+            return Err(branch_name_err(
+                branch,
+                "slug must be lowercase [a-z0-9-] only",
+            ));
+        }
+    }
+    Ok(prefix)
+}
+
+fn branch_name_err(branch: &str, why: &str) -> ForgeError {
+    ForgeError::validation(
+        schema(),
+        "branch_name_invalid",
+        format!("branch '{branch}' is invalid: {why}"),
+        Some("rule=^(feat|fix)/[a-z0-9][a-z0-9-]{1,63}$".to_string()),
+    )
+}
+
+/// Rule 1b — declared `--kind` matches the branch prefix
+/// (`feature` ↔ `feat/*`, `bug` ↔ `fix/*`).
+pub fn branch_kind_matches(prefix: BranchPrefix, kind: PrKind) -> Result<(), ForgeError> {
+    let ok = matches!(
+        (prefix, kind),
+        (BranchPrefix::Feat, PrKind::Feature) | (BranchPrefix::Fix, PrKind::Bug)
+    );
+    if ok {
+        Ok(())
+    } else {
+        Err(ForgeError::validation(
+            schema(),
+            "branch_kind_mismatch",
+            format!(
+                "branch prefix '{prefix}/' does not match --kind '{kind}'",
+                prefix = prefix.as_str(),
+                kind = kind.as_str(),
+            ),
+            Some(format!(
+                "feature -> feat/*, bug -> fix/* (branch_prefix={p}, kind={k})",
+                p = prefix.as_str(),
+                k = kind.as_str(),
+            )),
+        ))
+    }
+}
+
+/// Rule 3 — `len(title) <= 70` (codepoint count) and no trailing whitespace.
+pub fn title_length(title: &str) -> Result<(), ForgeError> {
+    if title.is_empty() {
+        return Err(ForgeError::validation(
+            schema(),
+            "title_too_long",
+            "title is empty",
+            Some("rule=len(title) in 1..=70".to_string()),
+        ));
+    }
+    let last = title.chars().next_back().expect("non-empty");
+    if last.is_whitespace() {
+        return Err(ForgeError::validation(
+            schema(),
+            "title_too_long",
+            "title has trailing whitespace",
+            Some("rule=len(title) <= 70 and no trailing whitespace".to_string()),
+        ));
+    }
+    let count = title.chars().count();
+    if count > TITLE_MAX_LEN {
+        return Err(ForgeError::validation(
+            schema(),
+            "title_too_long",
+            format!("title length {count} exceeds maximum {TITLE_MAX_LEN}"),
+            Some(format!("rule=len(title) <= {TITLE_MAX_LEN}")),
+        ));
+    }
+    Ok(())
+}
+
+/// Rule 2a — body contains a non-empty H2 `## Summary` section.
+pub fn body_summary(body: &str, headings: &BodyHeadings) -> Result<(), ForgeError> {
+    if has_non_empty_section(body, &headings.summary) {
+        Ok(())
+    } else {
+        Err(ForgeError::validation(
+            schema(),
+            "body_missing_summary",
+            format!(
+                "body is missing a non-empty '{heading}' section",
+                heading = headings.summary
+            ),
+            Some(format!("rule=non-empty H2 '{}' section", headings.summary)),
+        ))
+    }
+}
+
+/// Rule 2b — body contains a non-empty H2 `## Test plan` section.
+pub fn body_test_plan(body: &str, headings: &BodyHeadings) -> Result<(), ForgeError> {
+    if has_non_empty_section(body, &headings.test_plan) {
+        Ok(())
+    } else {
+        Err(ForgeError::validation(
+            schema(),
+            "body_missing_test_plan",
+            format!(
+                "body is missing a non-empty '{heading}' section",
+                heading = headings.test_plan
+            ),
+            Some(format!(
+                "rule=non-empty H2 '{}' section",
+                headings.test_plan
+            )),
+        ))
+    }
+}
+
+/// Walk `body` line-by-line. Find the configured H2 heading; collect
+/// non-blank lines beneath it until either the next H2 or end of input.
+/// Returns true iff at least one non-blank content line was found.
+fn has_non_empty_section(body: &str, heading: &str) -> bool {
+    let mut in_section = false;
+    let mut saw_content = false;
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if is_h2_heading(trimmed) {
+            if in_section {
+                return saw_content;
+            }
+            if trimmed == heading {
+                in_section = true;
+                continue;
+            }
+        }
+        if in_section && !trimmed.is_empty() {
+            saw_content = true;
+        }
+    }
+    in_section && saw_content
+}
+
+fn is_h2_heading(line: &str) -> bool {
+    // `## …` exactly — three or more `#` would be H3+ and must not collide
+    // with `## Summary`.
+    line.starts_with("## ") && !line.starts_with("### ")
+}
+
+/// Rule 4 — `git status --porcelain` is empty (no staged, unstaged, or
+/// untracked changes).
+///
+/// `git_status_fn` is injected so tests can stub the porcelain output
+/// without spawning git.
+pub fn worktree_clean<F>(workdir: &Path, git_status_fn: F) -> Result<(), ForgeError>
+where
+    F: FnOnce(&Path) -> Result<String, ForgeError>,
+{
+    let porcelain = git_status_fn(workdir)?;
+    if porcelain.lines().all(|l| l.trim().is_empty()) {
+        Ok(())
+    } else {
+        let preview: Vec<&str> = porcelain.lines().filter(|l| !l.trim().is_empty()).collect();
+        let detail = preview.join("\n");
+        Err(ForgeError::validation(
+            schema(),
+            "dirty_worktree",
+            "worktree is dirty (commit, stash, or discard local changes first)",
+            Some(detail),
+        ))
+    }
+}
+
+/// Rule 5 — HEAD has an upstream and matches the upstream's SHA. The
+/// `head_state_fn` returns `(head_sha, upstream_sha)` — `Ok(None)` for
+/// upstream means "no upstream configured".
+pub fn head_pushed<F>(workdir: &Path, head_state_fn: F) -> Result<(), ForgeError>
+where
+    F: FnOnce(&Path) -> Result<HeadState, ForgeError>,
+{
+    let state = head_state_fn(workdir)?;
+    match state.upstream_sha {
+        None => Err(ForgeError::validation(
+            schema(),
+            "head_not_pushed",
+            "HEAD has no upstream tracking branch (push the branch first)",
+            None,
+        )),
+        Some(upstream) if upstream == state.head_sha => Ok(()),
+        Some(upstream) => Err(ForgeError::validation(
+            schema(),
+            "head_not_pushed",
+            "HEAD differs from its upstream (push the branch first)",
+            Some(format!(
+                "head={head}\nupstream={upstream}",
+                head = state.head_sha
+            )),
+        )),
+    }
+}
+
+/// State pair consumed by [`head_pushed`]. `upstream_sha` is `None` when
+/// the branch has no `@{upstream}` tracking ref configured.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeadState {
+    pub head_sha: String,
+    pub upstream_sha: Option<String>,
+}
+
+/// Default porcelain reader used in production. Spawns `git -C <workdir>
+/// status --porcelain=v1`. Maps git failures to `SOFTWARE 70` because a
+/// missing or broken git binary is an environment invariant, not a
+/// lock-down violation.
+pub fn git_status_porcelain(workdir: &Path) -> Result<String, ForgeError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workdir)
+        .args(["status", "--porcelain=v1"])
+        .output()
+        .map_err(|e| {
+            ForgeError::software(
+                schema(),
+                "git status --porcelain failed to spawn",
+                Some(e.to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        return Err(ForgeError::software(
+            schema(),
+            "git status --porcelain exited non-zero",
+            Some(stderr),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Default head-state resolver. Reads `HEAD` and `@{upstream}` via git.
+pub fn git_head_state(workdir: &Path) -> Result<HeadState, ForgeError> {
+    let head_sha = run_git_capture(workdir, &["rev-parse", "HEAD"])?;
+    let head_sha = head_sha.trim().to_string();
+
+    let upstream = run_git_capture(workdir, &["rev-parse", "--abbrev-ref", "@{upstream}"]);
+    let upstream_sha = match upstream {
+        Ok(_) => Some(
+            run_git_capture(workdir, &["rev-parse", "@{upstream}"])?
+                .trim()
+                .to_string(),
+        ),
+        Err(_) => None,
+    };
+    Ok(HeadState {
+        head_sha,
+        upstream_sha,
+    })
+}
+
+fn run_git_capture(workdir: &Path, args: &[&str]) -> Result<String, ForgeError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workdir)
+        .args(args)
+        .output()
+        .map_err(|e| {
+            ForgeError::software(
+                schema(),
+                format!("git {} failed to spawn", args.join(" ")),
+                Some(e.to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        return Err(ForgeError::software(
+            schema(),
+            format!("git {} exited non-zero", args.join(" ")),
+            Some(stderr),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    fn ok_branch(name: &str) -> BranchPrefix {
+        branch_name(name).unwrap_or_else(|e| panic!("expected ok branch '{name}', got {e:?}"))
+    }
+
+    fn err_kind(err: ForgeError) -> &'static str {
+        err.kind()
+    }
+
+    #[test]
+    fn branch_name_accepts_feat_and_fix() {
+        assert_eq!(ok_branch("feat/forge-cli-v1"), BranchPrefix::Feat);
+        assert_eq!(ok_branch("fix/abc-123-mr-body"), BranchPrefix::Fix);
+        assert_eq!(ok_branch("feat/a"), BranchPrefix::Feat);
+    }
+
+    #[test]
+    fn branch_name_rejects_uppercase_slug() {
+        let err = branch_name("feat/Mixed-Case").expect_err("uppercase");
+        assert_eq!(err_kind(err), "branch_name_invalid");
+    }
+
+    #[test]
+    fn branch_name_rejects_missing_prefix() {
+        let err = branch_name("main").expect_err("no prefix");
+        assert_eq!(err_kind(err), "branch_name_invalid");
+    }
+
+    #[test]
+    fn branch_name_rejects_unknown_prefix() {
+        let err = branch_name("docs/release-notes").expect_err("docs/");
+        assert_eq!(err_kind(err), "branch_name_invalid");
+    }
+
+    #[test]
+    fn branch_name_rejects_leading_hyphen() {
+        let err = branch_name("feat/-leading-hyphen").expect_err("leading hyphen");
+        assert_eq!(err_kind(err), "branch_name_invalid");
+    }
+
+    #[test]
+    fn branch_name_rejects_empty_slug() {
+        let err = branch_name("feat/").expect_err("empty slug");
+        assert_eq!(err_kind(err), "branch_name_invalid");
+    }
+
+    #[test]
+    fn branch_name_rejects_oversized_slug() {
+        let slug = "a".repeat(65);
+        let err = branch_name(&format!("feat/{slug}")).expect_err("oversized");
+        assert_eq!(err_kind(err), "branch_name_invalid");
+    }
+
+    #[test]
+    fn branch_kind_matches_happy_paths() {
+        branch_kind_matches(BranchPrefix::Feat, PrKind::Feature).expect("feat+feature");
+        branch_kind_matches(BranchPrefix::Fix, PrKind::Bug).expect("fix+bug");
+    }
+
+    #[test]
+    fn branch_kind_matches_rejects_crossed_pair() {
+        let err = branch_kind_matches(BranchPrefix::Feat, PrKind::Bug).expect_err("feat+bug");
+        assert_eq!(err_kind(err), "branch_kind_mismatch");
+        let err = branch_kind_matches(BranchPrefix::Fix, PrKind::Feature).expect_err("fix+feat");
+        assert_eq!(err_kind(err), "branch_kind_mismatch");
+    }
+
+    #[test]
+    fn title_length_accepts_short_title() {
+        title_length("short and sweet").expect("ok");
+    }
+
+    #[test]
+    fn title_length_rejects_over_70_chars() {
+        let title: String = "a".repeat(71);
+        let err = title_length(&title).expect_err("too long");
+        assert_eq!(err_kind(err), "title_too_long");
+    }
+
+    #[test]
+    fn title_length_rejects_empty() {
+        let err = title_length("").expect_err("empty");
+        assert_eq!(err_kind(err), "title_too_long");
+    }
+
+    #[test]
+    fn title_length_rejects_trailing_whitespace() {
+        let err = title_length("hello ").expect_err("trailing space");
+        assert_eq!(err_kind(err), "title_too_long");
+    }
+
+    #[test]
+    fn title_length_counts_codepoints_not_bytes() {
+        // 70 CJK codepoints (each 3 UTF-8 bytes) — under the codepoint cap.
+        let title: String = "文".repeat(70);
+        title_length(&title).expect("ok at 70 codepoints");
+        // 71 codepoints → rejected.
+        let title: String = "文".repeat(71);
+        let err = title_length(&title).expect_err("71 codepoints");
+        assert_eq!(err_kind(err), "title_too_long");
+    }
+
+    #[test]
+    fn body_summary_accepts_well_formed_body() {
+        let body = "## Summary\n\nWhat this PR does.\n\n## Test plan\n\nHow it was verified.\n";
+        body_summary(body, &BodyHeadings::default()).expect("summary present");
+        body_test_plan(body, &BodyHeadings::default()).expect("test plan present");
+    }
+
+    #[test]
+    fn body_summary_rejects_when_section_absent() {
+        let body = "## Test plan\n\nOnly the test plan here.\n";
+        let err = body_summary(body, &BodyHeadings::default()).expect_err("no summary");
+        assert_eq!(err_kind(err), "body_missing_summary");
+    }
+
+    #[test]
+    fn body_summary_rejects_when_section_empty() {
+        // Heading present but no content before the next H2.
+        let body = "## Summary\n\n## Test plan\n\nthings.\n";
+        let err = body_summary(body, &BodyHeadings::default()).expect_err("empty section");
+        assert_eq!(err_kind(err), "body_missing_summary");
+    }
+
+    #[test]
+    fn body_test_plan_rejects_when_section_absent() {
+        let body = "## Summary\n\nDescribed it.\n";
+        let err = body_test_plan(body, &BodyHeadings::default()).expect_err("no test plan");
+        assert_eq!(err_kind(err), "body_missing_test_plan");
+    }
+
+    #[test]
+    fn body_test_plan_rejects_when_section_empty() {
+        let body = "## Summary\n\nDescribed it.\n\n## Test plan\n";
+        let err = body_test_plan(body, &BodyHeadings::default()).expect_err("empty test plan");
+        assert_eq!(err_kind(err), "body_missing_test_plan");
+    }
+
+    #[test]
+    fn body_summary_ignores_h3_headings() {
+        // `### Summary` must not satisfy the H2 rule.
+        let body = "### Summary\n\nNot an H2.\n\n## Test plan\n\nyes.\n";
+        let err = body_summary(body, &BodyHeadings::default()).expect_err("h3 not H2");
+        assert_eq!(err_kind(err), "body_missing_summary");
+    }
+
+    #[test]
+    fn body_headings_respect_custom_overrides() {
+        let custom = BodyHeadings {
+            summary: "## 摘要".to_string(),
+            test_plan: "## 驗證計畫".to_string(),
+        };
+        let body = "## 摘要\n\n做了什麼。\n\n## 驗證計畫\n\n怎麼驗。\n";
+        body_summary(body, &custom).expect("zh summary");
+        body_test_plan(body, &custom).expect("zh test plan");
+    }
+
+    #[test]
+    fn worktree_clean_accepts_empty_porcelain() {
+        worktree_clean(&PathBuf::from("."), |_| Ok(String::new())).expect("clean");
+        worktree_clean(&PathBuf::from("."), |_| Ok("\n  \n".to_string())).expect("clean+ws");
+    }
+
+    #[test]
+    fn worktree_clean_rejects_dirty_porcelain() {
+        let err = worktree_clean(&PathBuf::from("."), |_| {
+            Ok(" M src/lib.rs\n?? tmp/note.txt\n".to_string())
+        })
+        .expect_err("dirty");
+        assert_eq!(err_kind(err), "dirty_worktree");
+    }
+
+    #[test]
+    fn head_pushed_accepts_matching_shas() {
+        head_pushed(&PathBuf::from("."), |_| {
+            Ok(HeadState {
+                head_sha: "deadbeef".into(),
+                upstream_sha: Some("deadbeef".into()),
+            })
+        })
+        .expect("clean");
+    }
+
+    #[test]
+    fn head_pushed_rejects_missing_upstream() {
+        let err = head_pushed(&PathBuf::from("."), |_| {
+            Ok(HeadState {
+                head_sha: "deadbeef".into(),
+                upstream_sha: None,
+            })
+        })
+        .expect_err("no upstream");
+        assert_eq!(err_kind(err), "head_not_pushed");
+    }
+
+    #[test]
+    fn head_pushed_rejects_divergent_shas() {
+        let err = head_pushed(&PathBuf::from("."), |_| {
+            Ok(HeadState {
+                head_sha: "aaaaaaaa".into(),
+                upstream_sha: Some("bbbbbbbb".into()),
+            })
+        })
+        .expect_err("divergent");
+        assert_eq!(err_kind(err), "head_not_pushed");
+    }
+
+    #[test]
+    fn pr_kind_round_trips_strings() {
+        assert_eq!(PrKind::parse("feature"), Some(PrKind::Feature));
+        assert_eq!(PrKind::parse("bug"), Some(PrKind::Bug));
+        assert_eq!(PrKind::parse("nope"), None);
+        assert_eq!(PrKind::Feature.as_str(), "feature");
+        assert_eq!(PrKind::Bug.as_str(), "bug");
+    }
+}

--- a/crates/forge-cli/tests/fixtures/github/pr_create/create_stdout.txt
+++ b/crates/forge-cli/tests/fixtures/github/pr_create/create_stdout.txt
@@ -1,0 +1,3 @@
+Creating draft pull request for feat/sample into main in sympoies/nils-cli
+
+https://github.com/sympoies/nils-cli/pull/123

--- a/crates/forge-cli/tests/fixtures/github/pr_create/view_response.json
+++ b/crates/forge-cli/tests/fixtures/github/pr_create/view_response.json
@@ -1,0 +1,8 @@
+{
+  "number": 123,
+  "url": "https://github.com/sympoies/nils-cli/pull/123",
+  "headRefName": "feat/sample",
+  "baseRefName": "main",
+  "isDraft": true,
+  "title": "feat: sample feature"
+}

--- a/crates/forge-cli/tests/fixtures/gitlab/pr_create/create_stdout.txt
+++ b/crates/forge-cli/tests/fixtures/gitlab/pr_create/create_stdout.txt
@@ -1,0 +1,3 @@
+Creating draft merge request for feat/sample into main in sympoies/nils-cli
+
+https://gitlab.com/sympoies/nils-cli/-/merge_requests/77

--- a/crates/forge-cli/tests/fixtures/gitlab/pr_create/view_response.json
+++ b/crates/forge-cli/tests/fixtures/gitlab/pr_create/view_response.json
@@ -1,0 +1,8 @@
+{
+  "iid": 77,
+  "web_url": "https://gitlab.com/sympoies/nils-cli/-/merge_requests/77",
+  "source_branch": "feat/sample",
+  "target_branch": "main",
+  "draft": true,
+  "title": "feat: sample feature"
+}

--- a/crates/forge-cli/tests/integration.rs
+++ b/crates/forge-cli/tests/integration.rs
@@ -5,6 +5,8 @@ mod integration {
     mod auth_status;
     mod cli;
     mod exit_codes;
+    mod pr_create;
     mod repo_view;
     mod support;
+    mod validations;
 }

--- a/crates/forge-cli/tests/integration/pr_create.rs
+++ b/crates/forge-cli/tests/integration/pr_create.rs
@@ -1,0 +1,481 @@
+//! End-to-end `pr create` integration tests.
+//!
+//! These tests drive the real `forge-cli` binary against a temporary git
+//! work tree so the validation chain (branch / kind / body / worktree /
+//! head_pushed) runs against actual git output, plus a dispatching backend
+//! stub that branches on argv to mimic `gh` / `glab` for the create + view
+//! call chain. Token-shaped strings never appear in fixtures — see
+//! `tests/fixtures/{github,gitlab}/pr_create/`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+use super::support::{CmdOutput, StubEnv, parse_envelope, run_forge_cli_in};
+
+const FIXTURE_GH_CREATE_STDOUT: &str =
+    include_str!("../fixtures/github/pr_create/create_stdout.txt");
+const FIXTURE_GH_VIEW_JSON: &str = include_str!("../fixtures/github/pr_create/view_response.json");
+const FIXTURE_GLAB_CREATE_STDOUT: &str =
+    include_str!("../fixtures/gitlab/pr_create/create_stdout.txt");
+const FIXTURE_GLAB_VIEW_JSON: &str =
+    include_str!("../fixtures/gitlab/pr_create/view_response.json");
+
+/// Set up a temp git repo at `tempdir/repo`. Creates a single commit on
+/// `main`, then a `feat/sample` branch tracking a synthetic
+/// `refs/remotes/origin/feat/sample` ref pointing at the same SHA, and a
+/// matching `origin` remote URL. The repo is clean.
+fn make_git_repo(provider_host: &str, repo_slug: &str) -> TempDir {
+    let tempdir = TempDir::new().expect("tempdir");
+    let repo = tempdir.path().join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+
+    let git = |args: &[&str]| {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args(args)
+            .output()
+            .expect("git spawn");
+        if !out.status.success() {
+            panic!(
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        out
+    };
+
+    git(&["init", "-q", "-b", "main"]);
+    git(&["config", "user.email", "test@example.com"]);
+    git(&["config", "user.name", "Tester"]);
+    git(&["config", "commit.gpgsign", "false"]);
+    fs::write(repo.join("README.md"), "init\n").expect("readme");
+    git(&["add", "README.md"]);
+    git(&["commit", "-q", "-m", "initial"]);
+    git(&["checkout", "-q", "-b", "feat/sample"]);
+    git(&[
+        "remote",
+        "add",
+        "origin",
+        &format!("https://{provider_host}/{repo_slug}.git"),
+    ]);
+    // Synthesize the upstream ref by direct write — avoids needing a real
+    // remote.
+    let head_sha = String::from_utf8(git(&["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    let upstream_ref = repo.join(".git/refs/remotes/origin/feat/sample");
+    fs::create_dir_all(upstream_ref.parent().unwrap()).unwrap();
+    fs::write(&upstream_ref, format!("{head_sha}\n")).unwrap();
+    git(&[
+        "branch",
+        "-q",
+        "--set-upstream-to=origin/feat/sample",
+        "feat/sample",
+    ]);
+
+    tempdir
+}
+
+fn well_formed_body() -> &'static str {
+    "## Summary\n\nLand the new feature.\n\n## Test plan\n\nVerified via cargo test.\n"
+}
+
+#[test]
+fn pr_create_dry_run_renders_plan_envelope() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+    // No backend call needed when --base is provided (skips default-branch
+    // resolution).
+    let stub = StubEnv::new();
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: dry-run demo",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+        Some(&repo_path),
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["schema_version"], "cli.forge-cli.pr.create.v1");
+    assert_eq!(envelope["data"]["provider"], "github");
+    let plan = envelope["data"]["plan"].as_array().expect("plan array");
+    let plan_strings: Vec<String> = plan
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect();
+    assert!(plan_strings.contains(&"pr".to_string()), "{plan_strings:?}");
+    assert!(
+        plan_strings.contains(&"create".to_string()),
+        "{plan_strings:?}"
+    );
+    assert!(
+        plan_strings.contains(&"--draft".to_string()),
+        "{plan_strings:?}"
+    );
+}
+
+#[test]
+fn pr_create_rejects_dirty_worktree_with_data_exit() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+    // Create an untracked file to dirty the worktree.
+    fs::write(repo_path.join("dirty.txt"), "x\n").unwrap();
+
+    let stub = StubEnv::new();
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: dirty",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+        Some(&repo_path),
+    );
+    assert_eq!(out.code, 65, "expected DATA 65, stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["ok"], false);
+    assert_eq!(envelope["error"]["code"], "dirty_worktree");
+}
+
+#[test]
+fn pr_create_rejects_branch_kind_mismatch_with_data_exit() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: wrong-kind",
+            "--kind",
+            "bug",
+            "--body",
+            well_formed_body(),
+        ],
+        Some(&repo_path),
+    );
+    assert_eq!(out.code, 65, "expected DATA 65, stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["error"]["code"], "branch_kind_mismatch");
+}
+
+#[test]
+fn pr_create_rejects_body_without_summary_with_data_exit() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: missing summary",
+            "--kind",
+            "feature",
+            "--body",
+            "## Test plan\n\nfine.\n",
+        ],
+        Some(&repo_path),
+    );
+    assert_eq!(out.code, 65);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["error"]["code"], "body_missing_summary");
+}
+
+#[test]
+fn pr_create_rejects_title_over_70_chars_with_data_exit() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let too_long = "a".repeat(71);
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--title",
+            &too_long,
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+        Some(&repo_path),
+    );
+    assert_eq!(out.code, 65);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["error"]["code"], "title_too_long");
+}
+
+#[test]
+fn pr_create_rejects_body_and_body_file_conflict_with_usage_exit() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: conflict",
+            "--kind",
+            "feature",
+            "--body",
+            "inline",
+            "--body-file",
+            "-",
+        ],
+        Some(&repo_path),
+    );
+    assert_eq!(out.code, 64, "expected USAGE 64, stderr={}", out.stderr);
+}
+
+/// Dispatching gh stub: branches on the first arg-2 pair (`repo view`,
+/// `pr create`, `pr view`).
+fn write_gh_dispatch_stub(stub: &StubEnv) -> PathBuf {
+    let body = format!(
+        r#"#!/bin/sh
+set -e
+case "$1 $2" in
+  "repo view")
+    cat <<'EOF'
+{{
+  "name": "nils-cli",
+  "owner": {{ "login": "sympoies" }},
+  "url": "https://github.com/sympoies/nils-cli",
+  "defaultBranchRef": {{ "name": "main" }},
+  "mergeCommitAllowed": false,
+  "squashMergeAllowed": true,
+  "rebaseMergeAllowed": false
+}}
+EOF
+    ;;
+  "pr create")
+    cat <<'EOF'
+{create}
+EOF
+    ;;
+  "pr view")
+    cat <<'EOF'
+{view}
+EOF
+    ;;
+  *)
+    echo "stub: unexpected gh args: $*" >&2
+    exit 99
+    ;;
+esac
+"#,
+        create = FIXTURE_GH_CREATE_STDOUT,
+        view = FIXTURE_GH_VIEW_JSON,
+    );
+    stub.write_stub("gh", &body)
+}
+
+fn write_glab_dispatch_stub(stub: &StubEnv) -> PathBuf {
+    let body = format!(
+        r#"#!/bin/sh
+set -e
+case "$1 $2" in
+  "repo view")
+    cat <<'EOF'
+{{
+  "path": "nils-cli",
+  "namespace": {{ "full_path": "sympoies" }},
+  "web_url": "https://gitlab.com/sympoies/nils-cli",
+  "default_branch": "main",
+  "merge_method": "merge"
+}}
+EOF
+    ;;
+  "mr create")
+    cat <<'EOF'
+{create}
+EOF
+    ;;
+  "mr view")
+    cat <<'EOF'
+{view}
+EOF
+    ;;
+  *)
+    echo "stub: unexpected glab args: $*" >&2
+    exit 99
+    ;;
+esac
+"#,
+        create = FIXTURE_GLAB_CREATE_STDOUT,
+        view = FIXTURE_GLAB_VIEW_JSON,
+    );
+    stub.write_stub("glab", &body)
+}
+
+fn run_in_repo(stub: &StubEnv, repo: &Path, args: &[&str]) -> CmdOutput {
+    run_forge_cli_in(stub, args, Some(repo))
+}
+
+#[test]
+fn pr_create_github_full_chain_emits_canonical_envelope() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let gh_path = write_gh_dispatch_stub(&stub);
+    let stub = stub.env("FORGE_CLI_GH_BIN", gh_path.to_string_lossy());
+
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: sample feature",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["schema_version"], "cli.forge-cli.pr.create.v1");
+    assert_eq!(envelope["ok"], true);
+    assert_eq!(envelope["data"]["provider"], "github");
+    assert_eq!(envelope["data"]["number"], 123);
+    assert_eq!(envelope["data"]["head"], "feat/sample");
+    assert_eq!(envelope["data"]["base"], "main");
+    assert_eq!(envelope["data"]["draft"], true);
+    assert_eq!(envelope["data"]["kind"], "feature");
+    assert_eq!(
+        envelope["data"]["url"],
+        "https://github.com/sympoies/nils-cli/pull/123"
+    );
+}
+
+#[test]
+fn pr_create_gitlab_full_chain_emits_canonical_envelope() {
+    let tempdir = make_git_repo("gitlab.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let glab_path = write_glab_dispatch_stub(&stub);
+    let stub = stub.env("FORGE_CLI_GLAB_BIN", glab_path.to_string_lossy());
+
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: sample feature",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["schema_version"], "cli.forge-cli.pr.create.v1");
+    assert_eq!(envelope["data"]["provider"], "gitlab");
+    assert_eq!(envelope["data"]["number"], 77);
+    assert_eq!(envelope["data"]["base"], "main");
+    assert_eq!(envelope["data"]["draft"], true);
+    assert_eq!(
+        envelope["data"]["url"],
+        "https://gitlab.com/sympoies/nils-cli/-/merge_requests/77"
+    );
+}

--- a/crates/forge-cli/tests/integration/validations.rs
+++ b/crates/forge-cli/tests/integration/validations.rs
@@ -1,0 +1,58 @@
+//! End-to-end tests asserting that validation rules return the right
+//! `error.kind` discriminator when wired through the public surface.
+//!
+//! The pr-create / pr-edit integration suites (Tasks 2.2 / 2.4) exercise
+//! these rules from the CLI boundary. This module pins the contract at the
+//! library boundary instead: it is the canonical "validation `error.kind`
+//! catalog" reference that downstream sprints can grep when wiring new
+//! atoms.
+
+use forge_cli::validations::{
+    BodyHeadings, BranchPrefix, HeadState, PrKind, body_summary, body_test_plan,
+    branch_kind_matches, branch_name, head_pushed, title_length, worktree_clean,
+};
+
+#[test]
+fn validation_kinds_match_spec_catalog() {
+    // Each row encodes the spec §"Lock-down policy" mapping. If any
+    // discriminator drifts, this test fails so the spec / code pair stays
+    // honest.
+    let cases: &[(&str, &str)] = &[
+        ("branch_name (invalid)", "branch_name_invalid"),
+        ("branch_kind_matches (mismatch)", "branch_kind_mismatch"),
+        ("title_length (over cap)", "title_too_long"),
+        ("body_summary (missing)", "body_missing_summary"),
+        ("body_test_plan (missing)", "body_missing_test_plan"),
+        ("worktree_clean (dirty)", "dirty_worktree"),
+        ("head_pushed (no upstream)", "head_not_pushed"),
+    ];
+
+    let errs: Vec<&'static str> = vec![
+        branch_name("docs/release").unwrap_err().kind(),
+        branch_kind_matches(BranchPrefix::Feat, PrKind::Bug)
+            .unwrap_err()
+            .kind(),
+        title_length(&"a".repeat(71)).unwrap_err().kind(),
+        body_summary("## Test plan\n\ntext\n", &BodyHeadings::default())
+            .unwrap_err()
+            .kind(),
+        body_test_plan("## Summary\n\nx\n", &BodyHeadings::default())
+            .unwrap_err()
+            .kind(),
+        worktree_clean(std::path::Path::new("."), |_| Ok(" M f.rs\n".into()))
+            .unwrap_err()
+            .kind(),
+        head_pushed(std::path::Path::new("."), |_| {
+            Ok(HeadState {
+                head_sha: "abc".into(),
+                upstream_sha: None,
+            })
+        })
+        .unwrap_err()
+        .kind(),
+    ];
+
+    for ((label, expected), got) in cases.iter().zip(errs.iter()) {
+        assert_eq!(*got, *expected, "case={label}");
+    }
+}


### PR DESCRIPTION
## Summary

Sprint 2 of the forge-cli v1 delivery lands all seven PR/MR lifecycle atoms (`create`,
`view`, `list`, `edit`, `comment`, `ready`, `close`) and the shared lock-down
validation chain they share with later sprints (`pr merge` in Sprint 4 and `pr
deliver` macro in Sprint 6). Sprint 1 left the binary with scaffolding, provider
detection, auth.status, and repo.view; this PR turns it into a usable PR/MR
front-end against both `gh` and `glab`.

## Changes

- `crates/forge-cli/src/validations.rs` (new): shared lock-down rules
  (`branch_name`, `branch_kind_matches`, `title_length`, `body_summary`,
  `body_test_plan`, `worktree_clean`, `head_pushed`) per spec §"Lock-down policy".
  Each rule returns a typed `ForgeError::Validation` with the rule's documented
  `error.kind`; numeric `DATA 65` lives in `ForgeError::exit_code`, never inlined.
- `crates/forge-cli/src/ops/pr_create.rs` (new, heaviest atom): full validation
  chain → backend create → URL parse → post-create view re-fetch → canonical
  envelope `cli.forge-cli.pr.create.v1` with
  `{ provider, number, url, head, base, draft, title, kind }`. Body materialises
  to a tempfile for `gh pr create --body-file`; GitLab gets the description
  inline. `--body` and `--body-file` conflict is rejected at the clap layer
  (`USAGE 64`).
- `crates/forge-cli/src/ops/pr_view.rs` (new): accepts numeric id or branch
  name; GitLab resolves branch names via `glab mr list --source-branch` first.
  Emits `cli.forge-cli.pr.view.v1` with normalized `state ∈ {open, closed,
  merged}`, `mergeable ∈ {yes, no, unknown}`, and labels.
- `crates/forge-cli/src/ops/pr_list.rs` (new): `--state`, `--author`, `--head`,
  `--limit` filters. GitHub uses `--state/--limit`, GitLab uses
  `--{opened,closed,merged,all}` + `--per-page`. Schema
  `cli.forge-cli.pr.list.v1`.
- `crates/forge-cli/src/ops/pr_close.rs` (new): close + re-fetch. Schema
  `cli.forge-cli.pr.close.v1`.
- `crates/forge-cli/src/ops/pr_edit.rs` (new): mutate title / body / base /
  labels / reviewers. `title_length` revalidates when `--title` set;
  `body_summary` + `body_test_plan` revalidate when new body is supplied via
  `--body` or `--body-file`. Schema `cli.forge-cli.pr.edit.v1`.
- `crates/forge-cli/src/ops/pr_comment.rs` (new): append comment with
  `--body` or `--body-file -` (stdin). Schema `cli.forge-cli.pr.comment.v1`
  with `{ provider, number, url }`.
- `crates/forge-cli/src/ops/pr_ready.rs` (new): promote draft → ready;
  validation `worktree_clean`. Schema `cli.forge-cli.pr.ready.v1` carries the
  post-ready `PrViewPayload` shape so consumers see `draft: false`.
- `crates/forge-cli/src/ops/pr_state.rs` (new): shared state / mergeable
  normalization. GitLab `opened → open`, `locked → closed`, unknown literals
  hard-fail `SOFTWARE 70`.
- `crates/forge-cli/src/error.rs`: new `Validation { kind, schema_version,
  message, detail }` variant mapping to `exit::DATA`.
- `crates/forge-cli/src/cli.rs`: new `PrCreateArgs`, `PrListArgs`,
  `PrEditArgs`, `PrCommentArgs`, `PrReadyArgs`, `PrKindFlag`, `PrStateFilter`;
  dispatch wired for every new op.
- `crates/forge-cli/Cargo.toml`: promote `tempfile` from `dev-dependencies` to
  `dependencies` so `pr create` / `pr edit` can materialise body files.
- Fixture pair files under
  `crates/forge-cli/tests/fixtures/{github,gitlab}/pr_create/` capturing
  canonical create stdout and view JSON shapes. No token-shaped strings.

## Test-First Evidence

- Change classification: feature (substantial new functionality, multiple new
  envelope schemas).
- Failing test before fix: not practical — Sprint 2 is the first land of these
  atoms, no prior test could meaningfully fail.
- Waiver reason: greenfield atoms; the implementation is itself the contract
  surface, so tests are written alongside implementation.
- Final validation:
  - `cargo test -p nils-forge-cli` → **123 lib tests pass + 26 integration tests
    pass** (was 75 / 18 in Sprint 1).
  - Integration coverage includes the full git-tempdir + dispatching gh/glab
    stub chain that exercises `pr create` → `pr view` round-trip on both
    backends.
  - `cargo fmt --all -- --check` clean.
  - `cargo clippy --all-targets --all-features --workspace -- -D warnings`
    clean.
  - `bash scripts/ci/completion-asset-audit.sh` PASS.
  - `bash scripts/ci/completion-flag-parity-audit.sh` PASS.
  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` PASS
    (docs-placement, docs-hygiene, markdownlint, plan-bundle-validate,
    cli-output-contract-lint).
  - `bash scripts/generate-third-party-artifacts.sh --check` PASS (no SHA drift;
    `tempfile` moved from `dev-dependencies` to `dependencies` but version
    stayed at `3`).

## Testing

`pass` — all of the above gates run locally on
`feat/forge-cli-v1-sprint2-pr-atoms` before the push.

## Risk / Notes

- Spec uses the wording `data.error.kind` for the discriminator, while the
  workspace `cli-output-contract-v1` puts it under `error.code` in the wire
  envelope. The implementation correctly emits under `error.code` (the field
  that callers actually read). Spec wording cleanup is deferred to Sprint 7
  (parity / exit-code matrix work) to avoid spec churn in the middle of
  delivery.
- `pr create` validation order matches spec §"pr create"; failures short-circuit
  before any backend call so dirty-worktree etc. can't leak through.
- The end-to-end PR create test uses a dispatching shell stub
  (`case "$1 $2" in ...`) — it's the first stub in the suite that branches on
  argv. Sprint 7's parity harness will likely lift this into a shared helper.
- No new `--json` boolean alias introduced; `--format text|json` only.
