### PR TITLE
Forge-cli v1 Sprint 4: pr.merge with full lock-down + TTL-zero required-check re-check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,6 +1935,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `534aa7e12ce9605c1146fa10de58c7895b803ea182a16cdd959ba9455c86b80f`
+- Cargo.lock SHA256: `8ee4db4c06965010f76731e5a29cf906d9d1653c8eaa72ce99e7867cb94075f4`
 - Third-party crates (`source != null`): 438
 - Workspace crates (`source == null`, excluded below): 31
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `534aa7e12ce9605c1146fa10de58c7895b803ea182a16cdd959ba9455c86b80f`
+- Cargo.lock SHA256: `8ee4db4c06965010f76731e5a29cf906d9d1653c8eaa72ce99e7867cb94075f4`
 - Third-party crates (`source != null`): 438
 
 ## Notice Extraction Policy

--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -1612,12 +1612,16 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__merge)
-            opts="-h --format --remote --provider --repo --dry-run --help <ID>"
+            opts="-h --method --keep-branch --allow-non-default-base --format --remote --provider --repo --dry-run --help <ID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --method)
+                    COMPREPLY=($(compgen -W "squash merge rebase" -- "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -154,15 +154,18 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (merge)
 _arguments "${_arguments_options[@]}" : \
+'--method=[Merge method override. When omitted, falls back to \`.forge-cli.toml \[merge\].method\` then the spec default \`squash\`]:METHOD:(squash merge rebase)' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
 '--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
 '--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--keep-branch[Skip the post-merge branch deletion (\`--delete-branch\` on gh, \`--remove-source-branch\` on glab). Mutually exclusive with the implicit-true default; flagging both is \`keep_branch_conflict\`]' \
+'--allow-non-default-base[Allow merges where the PR'\''s base is not the repo'\''s default branch. Without this flag, mismatched bases trigger \`default_branch_protected\`]' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':id -- Numeric id:_default' \
+':id -- Numeric PR / MR id:_default' \
 && ret=0
 ;;
 (close)

--- a/crates/forge-cli/Cargo.toml
+++ b/crates/forge-cli/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 tempfile = "3"
 thiserror = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 nils-test-support = { version = "0.10.2", path = "../nils-test-support" }

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -234,6 +234,47 @@ pub struct PrReadyArgs {
     pub id: u64,
 }
 
+/// `pr merge` arguments. Maps to
+/// `forge-cli-ops-v1.yaml::operations.pr.merge` inputs.
+#[derive(Args, Debug, Clone)]
+pub struct PrMergeArgs {
+    /// Numeric PR / MR id.
+    pub id: u64,
+    /// Merge method override. When omitted, falls back to
+    /// `.forge-cli.toml [merge].method` then the spec default `squash`.
+    #[arg(long, value_enum)]
+    pub method: Option<MergeMethodFlag>,
+    /// Skip the post-merge branch deletion (`--delete-branch` on gh,
+    /// `--remove-source-branch` on glab). Mutually exclusive with the
+    /// implicit-true default; flagging both is `keep_branch_conflict`.
+    #[arg(long = "keep-branch", action = ArgAction::SetTrue)]
+    pub keep_branch: bool,
+    /// Allow merges where the PR's base is not the repo's default branch.
+    /// Without this flag, mismatched bases trigger `default_branch_protected`.
+    #[arg(long = "allow-non-default-base", action = ArgAction::SetTrue)]
+    pub allow_non_default_base: bool,
+}
+
+/// CLI-facing merge method enum so clap can render `--method squash|merge|rebase`
+/// without leaking the config crate's `MergeMethod` into the CLI layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum MergeMethodFlag {
+    Squash,
+    Merge,
+    Rebase,
+}
+
+impl MergeMethodFlag {
+    pub fn into_method(self) -> crate::config::MergeMethod {
+        match self {
+            Self::Squash => crate::config::MergeMethod::Squash,
+            Self::Merge => crate::config::MergeMethod::Merge,
+            Self::Rebase => crate::config::MergeMethod::Rebase,
+        }
+    }
+}
+
 /// `pr checks` arguments. Maps to
 /// `forge-cli-ops-v1.yaml::operations.pr.checks` inputs.
 #[derive(Args, Debug, Clone)]
@@ -369,10 +410,7 @@ pub enum PrCommand {
     /// Promote a draft PR / MR to ready-for-review.
     Ready(PrReadyArgs),
     /// Merge a ready PR / MR.
-    Merge {
-        /// Numeric id.
-        id: u64,
-    },
+    Merge(PrMergeArgs),
     /// Close a PR / MR without merging.
     Close {
         /// Numeric id.
@@ -491,6 +529,9 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
         Some(Command::Pr(PrArgs {
             command: Some(PrCommand::WaitChecks(args)),
         })) => ops::pr_wait_checks::run(&global, args, format),
+        Some(Command::Pr(PrArgs {
+            command: Some(PrCommand::Merge(args)),
+        })) => ops::pr_merge::run(&global, args, format),
         Some(Command::Completion(CompletionArgs { shell })) => emit_completion(shell),
         None
         | Some(Command::Auth(AuthArgs { command: None }))

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -278,7 +278,7 @@ pub struct PrWaitChecksArgs {
 
 /// Parse a duration string like `30m`, `20s`, `5h`, `500ms`. Accepts bare
 /// integers as seconds.
-fn parse_duration(s: &str) -> Result<Duration, String> {
+pub(crate) fn parse_duration(s: &str) -> Result<Duration, String> {
     let s = s.trim();
     if s.is_empty() {
         return Err("duration cannot be empty".into());

--- a/crates/forge-cli/src/config.rs
+++ b/crates/forge-cli/src/config.rs
@@ -1,0 +1,689 @@
+//! Per-repo `.forge-cli.toml` loader and setting resolver.
+//!
+//! Spec: `crates/forge-cli/docs/specs/forge-cli-spec-v1.md` §"Configuration".
+//! The loader walks the file system upward from the starting directory until
+//! it either finds a `.forge-cli.toml` or hits the git toplevel (inclusive).
+//! Unknown keys never error — they accumulate in `warnings` as
+//! `unknown-config-key:<section>.<key>` entries so the v1 binary stays
+//! forward-compatible with v2 fields documented later.
+//!
+//! Resolution order for any setting (per spec):
+//!
+//! ```text
+//! explicit flag > .forge-cli.toml > spec default
+//! ```
+//!
+//! Callers obtain a [`ForgeConfig`] from [`ForgeConfig::load_from`] (or
+//! [`ForgeConfig::default`] when no repo override applies) and then ask for a
+//! resolved value via the `resolve_*` helpers, passing the explicit flag (if
+//! any) as the first argument.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use toml::Value;
+
+use crate::cli::parse_duration;
+
+/// File name searched upward from CWD.
+pub const CONFIG_FILE_NAME: &str = ".forge-cli.toml";
+
+/// Top-level config sections recognised by this version.
+const KNOWN_SECTIONS: &[&str] = &["merge", "body", "branch", "checks"];
+
+/// Recognised keys per section.
+const KNOWN_MERGE_KEYS: &[&str] = &["method", "delete_branch"];
+const KNOWN_BODY_KEYS: &[&str] = &["summary_heading", "test_plan_heading"];
+const KNOWN_BRANCH_KEYS: &[&str] = &["feature_prefix", "bug_prefix"];
+const KNOWN_CHECKS_KEYS: &[&str] = &["timeout", "interval", "required_only"];
+
+/// Merge strategy choices supported by both backends. The string form matches
+/// the spec catalog and `[merge].method` in `.forge-cli.toml`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MergeMethod {
+    Squash,
+    Merge,
+    Rebase,
+}
+
+impl MergeMethod {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Squash => "squash",
+            Self::Merge => "merge",
+            Self::Rebase => "rebase",
+        }
+    }
+}
+
+impl fmt::Display for MergeMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for MergeMethod {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "squash" => Ok(Self::Squash),
+            "merge" => Ok(Self::Merge),
+            "rebase" => Ok(Self::Rebase),
+            other => Err(format!("unknown merge method {other:?}")),
+        }
+    }
+}
+
+/// Loaded `.forge-cli.toml` settings. Every field is optional; the resolver
+/// helpers fall back to the spec default when both the explicit override and
+/// this field are unset.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ForgeConfig {
+    pub merge_method: Option<MergeMethod>,
+    pub merge_delete_branch: Option<bool>,
+    pub body_summary_heading: Option<String>,
+    pub body_test_plan_heading: Option<String>,
+    pub branch_feature_prefix: Option<String>,
+    pub branch_bug_prefix: Option<String>,
+    pub checks_timeout: Option<Duration>,
+    pub checks_interval: Option<Duration>,
+    pub checks_required_only: Option<bool>,
+    /// Forward-compat warnings collected while parsing (unknown keys, bad
+    /// scalar types). Each entry is prefixed `unknown-config-key:` or
+    /// `invalid-config-value:` so callers can render them verbatim under
+    /// `data.warnings[]` in any envelope that surfaces config state.
+    pub warnings: Vec<String>,
+    /// Absolute path of the `.forge-cli.toml` that produced this config.
+    /// `None` when the loader returned defaults (no file found).
+    pub source_path: Option<PathBuf>,
+}
+
+impl ForgeConfig {
+    /// Search upward from `start_dir` (inclusive) for `.forge-cli.toml`,
+    /// stopping at `git_toplevel` (inclusive). Both paths must be absolute.
+    /// If `git_toplevel` is `None`, the loader walks all the way up to the
+    /// filesystem root.
+    ///
+    /// Returns `Ok(ForgeConfig::default())` when no file is found — that is
+    /// not an error condition.
+    ///
+    /// Read or parse failures are reported as warnings rather than errors so
+    /// the binary remains usable even with a malformed repo override; the
+    /// returned config falls back to spec defaults in that case.
+    pub fn load_from(start_dir: &Path, git_toplevel: Option<&Path>) -> Self {
+        let Some(found) = find_config_file(start_dir, git_toplevel) else {
+            return Self::default();
+        };
+        let contents = match std::fs::read_to_string(&found) {
+            Ok(s) => s,
+            Err(err) => {
+                let mut cfg = Self::default();
+                cfg.warnings
+                    .push(format!("invalid-config-value:read_error:{err}"));
+                cfg.source_path = Some(found);
+                return cfg;
+            }
+        };
+        let value: Value = match toml::from_str(&contents) {
+            Ok(v) => v,
+            Err(err) => {
+                let mut cfg = Self::default();
+                cfg.warnings
+                    .push(format!("invalid-config-value:parse_error:{err}"));
+                cfg.source_path = Some(found);
+                return cfg;
+            }
+        };
+        let mut cfg = parse_value(&value);
+        cfg.source_path = Some(found);
+        cfg
+    }
+
+    /// Resolve `[merge].method` against an optional explicit flag.
+    pub fn resolve_merge_method(&self, explicit: Option<MergeMethod>) -> MergeMethod {
+        explicit
+            .or(self.merge_method)
+            .unwrap_or(MergeMethod::Squash)
+    }
+
+    /// Resolve `[merge].delete_branch`. Default is `true` per spec.
+    pub fn resolve_delete_branch(&self, explicit: Option<bool>) -> bool {
+        explicit.or(self.merge_delete_branch).unwrap_or(true)
+    }
+
+    /// Resolve `[body].summary_heading`. Default is `## Summary` per spec.
+    pub fn resolve_summary_heading(&self, explicit: Option<&str>) -> String {
+        explicit
+            .map(|s| s.to_string())
+            .or_else(|| self.body_summary_heading.clone())
+            .unwrap_or_else(|| "## Summary".to_string())
+    }
+
+    /// Resolve `[body].test_plan_heading`. Default is `## Test plan` per spec.
+    pub fn resolve_test_plan_heading(&self, explicit: Option<&str>) -> String {
+        explicit
+            .map(|s| s.to_string())
+            .or_else(|| self.body_test_plan_heading.clone())
+            .unwrap_or_else(|| "## Test plan".to_string())
+    }
+
+    /// Resolve `[branch].feature_prefix`. Default is `feat/` per spec.
+    pub fn resolve_feature_prefix(&self, explicit: Option<&str>) -> String {
+        explicit
+            .map(|s| s.to_string())
+            .or_else(|| self.branch_feature_prefix.clone())
+            .unwrap_or_else(|| "feat/".to_string())
+    }
+
+    /// Resolve `[branch].bug_prefix`. Default is `fix/` per spec.
+    pub fn resolve_bug_prefix(&self, explicit: Option<&str>) -> String {
+        explicit
+            .map(|s| s.to_string())
+            .or_else(|| self.branch_bug_prefix.clone())
+            .unwrap_or_else(|| "fix/".to_string())
+    }
+
+    /// Resolve `[checks].timeout`. Default is `30m` per spec.
+    pub fn resolve_checks_timeout(&self, explicit: Option<Duration>) -> Duration {
+        explicit
+            .or(self.checks_timeout)
+            .unwrap_or_else(|| Duration::from_secs(30 * 60))
+    }
+
+    /// Resolve `[checks].interval`. Default is `20s` per spec.
+    pub fn resolve_checks_interval(&self, explicit: Option<Duration>) -> Duration {
+        explicit
+            .or(self.checks_interval)
+            .unwrap_or_else(|| Duration::from_secs(20))
+    }
+
+    /// Resolve `[checks].required_only`. Default is `true` per spec.
+    pub fn resolve_required_only(&self, explicit: Option<bool>) -> bool {
+        explicit.or(self.checks_required_only).unwrap_or(true)
+    }
+}
+
+fn find_config_file(start_dir: &Path, git_toplevel: Option<&Path>) -> Option<PathBuf> {
+    let toplevel = git_toplevel.map(canonical_or_path);
+    let mut cursor = Some(canonical_or_path(start_dir));
+    while let Some(dir) = cursor {
+        let candidate = dir.join(CONFIG_FILE_NAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if let Some(top) = toplevel.as_ref()
+            && &dir == top
+        {
+            return None;
+        }
+        cursor = dir.parent().map(Path::to_path_buf);
+    }
+    None
+}
+
+fn canonical_or_path(p: &Path) -> PathBuf {
+    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+fn parse_value(value: &Value) -> ForgeConfig {
+    let mut cfg = ForgeConfig::default();
+    let Value::Table(table) = value else {
+        cfg.warnings
+            .push("invalid-config-value:root_not_table".to_string());
+        return cfg;
+    };
+    for (section, section_value) in table {
+        if !KNOWN_SECTIONS.contains(&section.as_str()) {
+            cfg.warnings.push(format!("unknown-config-key:{section}"));
+            continue;
+        }
+        let Value::Table(section_table) = section_value else {
+            cfg.warnings
+                .push(format!("invalid-config-value:{section}:not_a_table"));
+            continue;
+        };
+        match section.as_str() {
+            "merge" => parse_merge(section_table, &mut cfg),
+            "body" => parse_body(section_table, &mut cfg),
+            "branch" => parse_branch(section_table, &mut cfg),
+            "checks" => parse_checks(section_table, &mut cfg),
+            _ => unreachable!("section filtered above"),
+        }
+    }
+    cfg
+}
+
+fn parse_merge(table: &toml::map::Map<String, Value>, cfg: &mut ForgeConfig) {
+    for (key, value) in table {
+        if !KNOWN_MERGE_KEYS.contains(&key.as_str()) {
+            cfg.warnings.push(format!("unknown-config-key:merge.{key}"));
+            continue;
+        }
+        match key.as_str() {
+            "method" => match value.as_str() {
+                Some(s) => match MergeMethod::from_str(s) {
+                    Ok(m) => cfg.merge_method = Some(m),
+                    Err(_) => cfg
+                        .warnings
+                        .push(format!("invalid-config-value:merge.method:{s}")),
+                },
+                None => cfg
+                    .warnings
+                    .push("invalid-config-value:merge.method:not_a_string".to_string()),
+            },
+            "delete_branch" => match value.as_bool() {
+                Some(b) => cfg.merge_delete_branch = Some(b),
+                None => cfg
+                    .warnings
+                    .push("invalid-config-value:merge.delete_branch:not_a_bool".to_string()),
+            },
+            _ => unreachable!("key filtered above"),
+        }
+    }
+}
+
+fn parse_body(table: &toml::map::Map<String, Value>, cfg: &mut ForgeConfig) {
+    for (key, value) in table {
+        if !KNOWN_BODY_KEYS.contains(&key.as_str()) {
+            cfg.warnings.push(format!("unknown-config-key:body.{key}"));
+            continue;
+        }
+        let Some(s) = value.as_str() else {
+            cfg.warnings
+                .push(format!("invalid-config-value:body.{key}:not_a_string"));
+            continue;
+        };
+        match key.as_str() {
+            "summary_heading" => cfg.body_summary_heading = Some(s.to_string()),
+            "test_plan_heading" => cfg.body_test_plan_heading = Some(s.to_string()),
+            _ => unreachable!("key filtered above"),
+        }
+    }
+}
+
+fn parse_branch(table: &toml::map::Map<String, Value>, cfg: &mut ForgeConfig) {
+    for (key, value) in table {
+        if !KNOWN_BRANCH_KEYS.contains(&key.as_str()) {
+            cfg.warnings
+                .push(format!("unknown-config-key:branch.{key}"));
+            continue;
+        }
+        let Some(s) = value.as_str() else {
+            cfg.warnings
+                .push(format!("invalid-config-value:branch.{key}:not_a_string"));
+            continue;
+        };
+        match key.as_str() {
+            "feature_prefix" => cfg.branch_feature_prefix = Some(s.to_string()),
+            "bug_prefix" => cfg.branch_bug_prefix = Some(s.to_string()),
+            _ => unreachable!("key filtered above"),
+        }
+    }
+}
+
+fn parse_checks(table: &toml::map::Map<String, Value>, cfg: &mut ForgeConfig) {
+    for (key, value) in table {
+        if !KNOWN_CHECKS_KEYS.contains(&key.as_str()) {
+            cfg.warnings
+                .push(format!("unknown-config-key:checks.{key}"));
+            continue;
+        }
+        match key.as_str() {
+            "timeout" | "interval" => match value.as_str() {
+                Some(s) => match parse_duration(s) {
+                    Ok(d) => {
+                        if key == "timeout" {
+                            cfg.checks_timeout = Some(d);
+                        } else {
+                            cfg.checks_interval = Some(d);
+                        }
+                    }
+                    Err(err) => cfg
+                        .warnings
+                        .push(format!("invalid-config-value:checks.{key}:{err}")),
+                },
+                None => cfg
+                    .warnings
+                    .push(format!("invalid-config-value:checks.{key}:not_a_string")),
+            },
+            "required_only" => match value.as_bool() {
+                Some(b) => cfg.checks_required_only = Some(b),
+                None => cfg
+                    .warnings
+                    .push("invalid-config-value:checks.required_only:not_a_bool".to_string()),
+            },
+            _ => unreachable!("key filtered above"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, body: &str) -> PathBuf {
+        let path = dir.join(CONFIG_FILE_NAME);
+        fs::write(&path, body).expect("write config");
+        path
+    }
+
+    #[test]
+    fn default_when_no_file_found() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = ForgeConfig::load_from(tmp.path(), Some(tmp.path()));
+        assert_eq!(cfg, ForgeConfig::default());
+    }
+
+    #[test]
+    fn parses_all_known_keys() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            r###"
+[merge]
+method = "rebase"
+delete_branch = false
+
+[body]
+summary_heading = "## Overview"
+test_plan_heading = "## Verification"
+
+[branch]
+feature_prefix = "feature/"
+bug_prefix = "bugfix/"
+
+[checks]
+timeout = "45m"
+interval = "5s"
+required_only = false
+"###,
+        );
+        let cfg = ForgeConfig::load_from(tmp.path(), Some(tmp.path()));
+        assert!(cfg.warnings.is_empty(), "warnings={:?}", cfg.warnings);
+        assert_eq!(cfg.merge_method, Some(MergeMethod::Rebase));
+        assert_eq!(cfg.merge_delete_branch, Some(false));
+        assert_eq!(cfg.body_summary_heading.as_deref(), Some("## Overview"));
+        assert_eq!(
+            cfg.body_test_plan_heading.as_deref(),
+            Some("## Verification")
+        );
+        assert_eq!(cfg.branch_feature_prefix.as_deref(), Some("feature/"));
+        assert_eq!(cfg.branch_bug_prefix.as_deref(), Some("bugfix/"));
+        assert_eq!(cfg.checks_timeout, Some(Duration::from_secs(45 * 60)));
+        assert_eq!(cfg.checks_interval, Some(Duration::from_secs(5)));
+        assert_eq!(cfg.checks_required_only, Some(false));
+    }
+
+    #[test]
+    fn loader_walks_upward_to_git_toplevel() {
+        let tmp = TempDir::new().unwrap();
+        let top = tmp.path();
+        let nested = top.join("crates/forge-cli/src");
+        fs::create_dir_all(&nested).unwrap();
+        write(
+            top,
+            r#"[merge]
+method = "merge"
+"#,
+        );
+        let cfg = ForgeConfig::load_from(&nested, Some(top));
+        assert_eq!(cfg.merge_method, Some(MergeMethod::Merge));
+        assert!(
+            cfg.source_path
+                .as_ref()
+                .map(|p| p.ends_with(CONFIG_FILE_NAME))
+                .unwrap_or(false),
+            "source_path should point at the discovered file, got {:?}",
+            cfg.source_path
+        );
+    }
+
+    #[test]
+    fn loader_stops_at_git_toplevel_even_if_higher_file_exists() {
+        // A higher ancestor outside the git toplevel must be ignored so
+        // unrelated parent repos cannot poison the loader.
+        let tmp = TempDir::new().unwrap();
+        let outer = tmp.path();
+        let toplevel = outer.join("repo");
+        let nested = toplevel.join("crates/forge-cli/src");
+        fs::create_dir_all(&nested).unwrap();
+        // File at outer should be invisible — toplevel is the boundary.
+        write(
+            outer,
+            r#"[merge]
+method = "rebase"
+"#,
+        );
+        let cfg = ForgeConfig::load_from(&nested, Some(&toplevel));
+        assert_eq!(cfg.merge_method, None);
+        assert!(cfg.source_path.is_none());
+    }
+
+    #[test]
+    fn unknown_top_level_key_emits_one_warning() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            r#"
+[merge]
+method = "squash"
+
+[experimental]
+flag = true
+"#,
+        );
+        let cfg = ForgeConfig::load_from(tmp.path(), Some(tmp.path()));
+        assert_eq!(cfg.merge_method, Some(MergeMethod::Squash));
+        assert_eq!(cfg.warnings, vec!["unknown-config-key:experimental"]);
+    }
+
+    #[test]
+    fn unknown_section_key_emits_one_warning_per_key() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            r#"
+[merge]
+method = "squash"
+mystery_key = 7
+another_unknown = "x"
+"#,
+        );
+        let cfg = ForgeConfig::load_from(tmp.path(), Some(tmp.path()));
+        let mut warnings = cfg.warnings.clone();
+        warnings.sort();
+        assert_eq!(
+            warnings,
+            vec![
+                "unknown-config-key:merge.another_unknown".to_string(),
+                "unknown-config-key:merge.mystery_key".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_merge_method_value_warns_and_falls_back() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            r#"[merge]
+method = "fast-forward"
+"#,
+        );
+        let cfg = ForgeConfig::load_from(tmp.path(), Some(tmp.path()));
+        assert_eq!(cfg.merge_method, None);
+        assert_eq!(
+            cfg.resolve_merge_method(None),
+            MergeMethod::Squash,
+            "must fall back to spec default"
+        );
+        assert!(
+            cfg.warnings
+                .iter()
+                .any(|w| w == "invalid-config-value:merge.method:fast-forward"),
+            "warnings={:?}",
+            cfg.warnings
+        );
+    }
+
+    #[test]
+    fn invalid_toml_yields_warning_not_error() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path(), "not = valid = toml\n");
+        let cfg = ForgeConfig::load_from(tmp.path(), Some(tmp.path()));
+        assert!(
+            cfg.warnings
+                .iter()
+                .any(|w| w.starts_with("invalid-config-value:parse_error:"))
+        );
+        // Resolution still falls back to spec defaults.
+        assert_eq!(cfg.resolve_merge_method(None), MergeMethod::Squash);
+    }
+
+    #[test]
+    fn resolution_precedence_explicit_wins_over_config_and_default() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            r###"
+[merge]
+method = "merge"
+delete_branch = false
+
+[body]
+summary_heading = "## Overview"
+test_plan_heading = "## Verification"
+
+[branch]
+feature_prefix = "feature/"
+bug_prefix = "bugfix/"
+
+[checks]
+timeout = "10m"
+interval = "5s"
+required_only = false
+"###,
+        );
+        let cfg = ForgeConfig::load_from(tmp.path(), Some(tmp.path()));
+        // merge.method: explicit > config > default
+        assert_eq!(
+            cfg.resolve_merge_method(Some(MergeMethod::Rebase)),
+            MergeMethod::Rebase
+        );
+        assert_eq!(cfg.resolve_merge_method(None), MergeMethod::Merge);
+        // merge.delete_branch
+        assert!(cfg.resolve_delete_branch(Some(true)));
+        assert!(!cfg.resolve_delete_branch(None));
+        // body headings
+        assert_eq!(
+            cfg.resolve_summary_heading(Some("## Why")),
+            "## Why".to_string()
+        );
+        assert_eq!(cfg.resolve_summary_heading(None), "## Overview".to_string());
+        assert_eq!(
+            cfg.resolve_test_plan_heading(Some("## How")),
+            "## How".to_string()
+        );
+        assert_eq!(
+            cfg.resolve_test_plan_heading(None),
+            "## Verification".to_string()
+        );
+        // branch prefixes
+        assert_eq!(
+            cfg.resolve_feature_prefix(Some("feat/")),
+            "feat/".to_string()
+        );
+        assert_eq!(cfg.resolve_feature_prefix(None), "feature/".to_string());
+        assert_eq!(cfg.resolve_bug_prefix(Some("fix/")), "fix/".to_string());
+        assert_eq!(cfg.resolve_bug_prefix(None), "bugfix/".to_string());
+        // checks timing
+        assert_eq!(
+            cfg.resolve_checks_timeout(Some(Duration::from_secs(120))),
+            Duration::from_secs(120)
+        );
+        assert_eq!(
+            cfg.resolve_checks_timeout(None),
+            Duration::from_secs(10 * 60)
+        );
+        assert_eq!(
+            cfg.resolve_checks_interval(Some(Duration::from_secs(2))),
+            Duration::from_secs(2)
+        );
+        assert_eq!(cfg.resolve_checks_interval(None), Duration::from_secs(5));
+        // checks.required_only
+        assert!(cfg.resolve_required_only(Some(true)));
+        assert!(!cfg.resolve_required_only(None));
+    }
+
+    #[test]
+    fn defaults_apply_when_neither_explicit_nor_config_set() {
+        let cfg = ForgeConfig::default();
+        assert_eq!(cfg.resolve_merge_method(None), MergeMethod::Squash);
+        assert!(cfg.resolve_delete_branch(None));
+        assert_eq!(cfg.resolve_summary_heading(None), "## Summary".to_string());
+        assert_eq!(
+            cfg.resolve_test_plan_heading(None),
+            "## Test plan".to_string()
+        );
+        assert_eq!(cfg.resolve_feature_prefix(None), "feat/".to_string());
+        assert_eq!(cfg.resolve_bug_prefix(None), "fix/".to_string());
+        assert_eq!(
+            cfg.resolve_checks_timeout(None),
+            Duration::from_secs(30 * 60)
+        );
+        assert_eq!(cfg.resolve_checks_interval(None), Duration::from_secs(20));
+        assert!(cfg.resolve_required_only(None));
+    }
+
+    #[test]
+    fn bad_scalar_type_yields_invalid_warning_not_panic() {
+        let tmp = TempDir::new().unwrap();
+        write(
+            tmp.path(),
+            r#"
+[merge]
+method = 42
+delete_branch = "yes"
+
+[checks]
+required_only = 1
+timeout = 42
+"#,
+        );
+        let cfg = ForgeConfig::load_from(tmp.path(), Some(tmp.path()));
+        let mut wanted = vec![
+            "invalid-config-value:merge.method:not_a_string".to_string(),
+            "invalid-config-value:merge.delete_branch:not_a_bool".to_string(),
+            "invalid-config-value:checks.required_only:not_a_bool".to_string(),
+            "invalid-config-value:checks.timeout:not_a_string".to_string(),
+        ];
+        wanted.sort();
+        let mut got = cfg.warnings.clone();
+        got.sort();
+        assert_eq!(got, wanted);
+        // All values fall back to defaults via resolver.
+        assert_eq!(cfg.resolve_merge_method(None), MergeMethod::Squash);
+        assert!(cfg.resolve_delete_branch(None));
+        assert!(cfg.resolve_required_only(None));
+        assert_eq!(
+            cfg.resolve_checks_timeout(None),
+            Duration::from_secs(30 * 60)
+        );
+    }
+
+    #[test]
+    fn merge_method_from_str_round_trip() {
+        for m in [MergeMethod::Squash, MergeMethod::Merge, MergeMethod::Rebase] {
+            assert_eq!(MergeMethod::from_str(m.as_str()), Ok(m));
+        }
+        assert!(MergeMethod::from_str("Squash").is_err());
+        assert!(MergeMethod::from_str("").is_err());
+    }
+}

--- a/crates/forge-cli/src/lib.rs
+++ b/crates/forge-cli/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod backend;
 pub mod cli;
+pub mod config;
 pub mod envelope;
 pub mod error;
 pub mod glab_version;

--- a/crates/forge-cli/src/ops/mod.rs
+++ b/crates/forge-cli/src/ops/mod.rs
@@ -10,6 +10,7 @@ pub mod pr_comment;
 pub mod pr_create;
 pub mod pr_edit;
 pub mod pr_list;
+pub mod pr_merge;
 pub mod pr_ready;
 pub mod pr_state;
 pub mod pr_view;

--- a/crates/forge-cli/src/ops/mod.rs
+++ b/crates/forge-cli/src/ops/mod.rs
@@ -15,3 +15,4 @@ pub mod pr_state;
 pub mod pr_view;
 pub mod pr_wait_checks;
 pub mod repo_view;
+pub mod required_check_gate;

--- a/crates/forge-cli/src/ops/pr_merge.rs
+++ b/crates/forge-cli/src/ops/pr_merge.rs
@@ -1,0 +1,541 @@
+//! `pr merge` atom — the heaviest single atom in the v1 surface.
+//!
+//! Spec / ops: `cli.forge-cli.pr.merge.v1`. Layers six lock-down policy rules
+//! on top of a backend invocation:
+//!
+//! | Rule                                | Triggered when                                              | Error kind                | Exit       |
+//! | ----------------------------------- | ----------------------------------------------------------- | ------------------------- | ---------- |
+//! | 4 — worktree_clean                  | local repo has uncommitted changes                          | `dirty_worktree`          | DATA 65    |
+//! | 6 — default_branch_protected        | PR base ≠ repo default branch, `--allow-non-default-base=0` | `default_branch_protected`| DATA 65    |
+//! | 7 — draft_merge_refused             | `pr view` returns `draft=true`                              | `draft_merge_refused`     | DATA 65    |
+//! | 8 — required_checks_green (TTL=0)   | fresh `pr.checks --required-only` not all green             | `checks_pending`/`failed` | DATA / RT  |
+//! | 9 — merge_method_supported          | resolved method not in `repo.view.merge_methods_allowed`    | `merge_method_unsupported`| DATA 65    |
+//! | 10 — keep_branch_conflict           | `--keep-branch` set while `[merge].delete_branch=true`      | `keep_branch_conflict`    | DATA 65    |
+//!
+//! Backend argv (per ops YAML):
+//! - GitHub: `gh pr merge <id> --{method} [--delete-branch]`
+//! - GitLab: `glab mr merge <id> [--squash] [--remove-source-branch]`
+//!
+//! Post-merge: re-fetches `pr.view` with `mergeCommit` / `merge_commit_sha`
+//! included so the envelope can surface `data.merge_sha`.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{
+    BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
+};
+use crate::cli::{BINARY, GlobalFlags, PrMergeArgs};
+use crate::config::{ForgeConfig, MergeMethod};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_view;
+use crate::ops::repo_view::{self, RepoViewPayload};
+use crate::ops::required_check_gate::ensure_required_checks_green;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+use crate::validations::{git_status_porcelain, worktree_clean};
+
+pub const SCHEMA: &str = "pr.merge";
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Envelope payload for `cli.forge-cli.pr.merge.v1`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrMergePayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub merge_sha: String,
+    pub method: &'static str,
+    pub deleted_branch: bool,
+    pub base: String,
+    pub head: String,
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    args: PrMergeArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    let workdir = std::env::current_dir().map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            "could not resolve current dir",
+            Some(e.to_string()),
+        )
+    })?;
+    run_with(&runner, global, &args, format, &workdir, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: &PrMergeArgs,
+    format: OutputFormat,
+    workdir: &std::path::Path,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+
+    // Load .forge-cli.toml so the method default + delete_branch default flow
+    // from the per-repo config when no explicit flag is set.
+    let cfg = ForgeConfig::load_from(workdir, find_git_toplevel(workdir).as_deref());
+    let method = cfg.resolve_merge_method(args.method.map(|m| m.into_method()));
+    let cfg_delete = cfg.resolve_delete_branch(None);
+    // --keep-branch flips the implicit-true default off; explicit conflict
+    // (rule 10) fires only when the user paired --keep-branch with an explicit
+    // [merge].delete_branch = true config in the same repo.
+    enforce_keep_branch_conflict(args.keep_branch, &cfg)?;
+    let delete_branch = if args.keep_branch { false } else { cfg_delete };
+
+    if global.dry_run {
+        let call = build_merge_call(&ctx, args.id, method, delete_branch);
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    // Rule 4 — clean worktree.
+    worktree_clean(workdir, git_status_porcelain)?;
+
+    // Rule 7 + base discovery — fetch pr.view once and reuse.
+    let pr = fetch_pr_view(runner, &ctx, args.id)?;
+    if pr.draft {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "draft_merge_refused",
+            "PR is still a draft; mark ready before merging",
+            None,
+        ));
+    }
+
+    // Rule 6 — default branch protection (unless explicitly overridden).
+    let repo = fetch_repo_view(runner, &ctx)?;
+    if !args.allow_non_default_base && pr.base != repo.default_branch {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "default_branch_protected",
+            format!(
+                "PR base {base:?} differs from repo default {default:?}; pass --allow-non-default-base to override",
+                base = pr.base,
+                default = repo.default_branch,
+            ),
+            None,
+        ));
+    }
+
+    // Rule 9 — method must be in the repo's allowed list.
+    enforce_method_supported(method, &repo)?;
+
+    // Rule 8 — TTL-zero required-check re-check.
+    ensure_required_checks_green(runner, global, &ctx, &args.id.to_string())?;
+
+    // All gates clear — invoke the backend.
+    let merge_call = build_merge_call(&ctx, args.id, method, delete_branch);
+    runner.run(&merge_call)?;
+
+    // Post-merge re-fetch for merge_sha.
+    let merge_sha = fetch_merge_sha(runner, &ctx, args.id)?;
+
+    let payload = PrMergePayload {
+        provider: ctx.provider.as_str(),
+        number: pr.number,
+        url: pr.url,
+        merge_sha,
+        method: method.as_str(),
+        deleted_branch: delete_branch,
+        base: pr.base,
+        head: pr.head,
+    };
+
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        payload,
+        format,
+        render_text,
+    ))
+}
+
+/// Build the backend merge invocation.
+pub fn build_merge_call(
+    ctx: &ProviderContext,
+    id: u64,
+    method: MergeMethod,
+    delete_branch: bool,
+) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let id_str = id.to_string();
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => {
+            let mut v = vec![
+                OsString::from("pr"),
+                OsString::from("merge"),
+                OsString::from(id_str),
+                OsString::from(format!("--{}", method.as_str())),
+            ];
+            if delete_branch {
+                v.push(OsString::from("--delete-branch"));
+            }
+            v
+        }
+        Provider::GitLab => {
+            let mut v = vec![
+                OsString::from("mr"),
+                OsString::from("merge"),
+                OsString::from(id_str),
+            ];
+            if matches!(method, MergeMethod::Squash) {
+                v.push(OsString::from("--squash"));
+            }
+            // glab does not have a dedicated `--rebase` boolean on the merge
+            // command in the pinned minor; rebase is achieved via repo-level
+            // merge method setup. We still surface `merge_method_unsupported`
+            // for unsupported choices at validation time (rule 9), so the
+            // argv here only diverges between squash and the default merge.
+            if delete_branch {
+                v.push(OsString::from("--remove-source-branch"));
+            }
+            v
+        }
+    };
+    BackendCall::new(program, argv)
+}
+
+fn fetch_pr_view<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    id: u64,
+) -> Result<PrView, ForgeError> {
+    let call = pr_view_call(ctx, id);
+    let output = runner.run(&call)?;
+    let payload = pr_view::parse_view_output(ctx, &output)?;
+    Ok(PrView {
+        number: payload.number,
+        url: payload.url,
+        draft: payload.draft,
+        base: payload.base,
+        head: payload.head,
+        state: payload.state.to_string(),
+    })
+}
+
+fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let id_str = id.to_string();
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("view"),
+            OsString::from(id_str),
+            OsString::from("--json"),
+            OsString::from(
+                "number,url,state,isDraft,title,headRefName,baseRefName,mergeable,mergedAt,labels",
+            ),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("view"),
+            OsString::from(id_str),
+            OsString::from("-F"),
+            OsString::from("json"),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn fetch_repo_view<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+) -> Result<RepoViewPayload, ForgeError> {
+    let call = repo_view::build_call_for_default_branch(ctx);
+    let output = runner.run(&call)?;
+    repo_view::parse_backend_output(ctx, &output)
+}
+
+fn fetch_merge_sha<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    id: u64,
+) -> Result<String, ForgeError> {
+    let call = merge_sha_call(ctx, id);
+    let output = runner.run(&call)?;
+    extract_merge_sha(ctx, &output)
+}
+
+fn merge_sha_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let id_str = id.to_string();
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("pr"),
+            OsString::from("view"),
+            OsString::from(id_str),
+            OsString::from("--json"),
+            OsString::from("mergeCommit"),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("mr"),
+            OsString::from("view"),
+            OsString::from(id_str),
+            OsString::from("-F"),
+            OsString::from("json"),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn extract_merge_sha(ctx: &ProviderContext, output: &BackendSuccess) -> Result<String, ForgeError> {
+    let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            "post-merge view returned invalid JSON",
+            Some(e.to_string()),
+        )
+    })?;
+    let sha = match ctx.provider {
+        Provider::GitHub => value
+            .get("mergeCommit")
+            .and_then(|v| v.get("oid"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        Provider::GitLab => value
+            .get("merge_commit_sha")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .filter(|s| !s.is_empty()),
+    };
+    sha.ok_or_else(|| {
+        ForgeError::software(
+            schema_err(),
+            "merge succeeded but merge_sha was missing from post-merge view",
+            Some(format!("stdout={:?}", output.stdout)),
+        )
+    })
+}
+
+fn enforce_keep_branch_conflict(keep_branch: bool, cfg: &ForgeConfig) -> Result<(), ForgeError> {
+    // Conflict surfaces when the user asks to keep the source branch AND the
+    // repo config explicitly opts into branch deletion. The implicit default
+    // (`delete_branch=true` when nothing is set) is silently overridden by
+    // `--keep-branch`; only an explicit collision is an error.
+    if keep_branch && matches!(cfg.merge_delete_branch, Some(true)) {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "keep_branch_conflict",
+            "--keep-branch conflicts with [merge].delete_branch = true in .forge-cli.toml",
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn enforce_method_supported(method: MergeMethod, repo: &RepoViewPayload) -> Result<(), ForgeError> {
+    if repo.merge_methods_allowed.is_empty() {
+        // repo view returned no info — pass through; the backend will fail
+        // loudly if the method really is unsupported.
+        return Ok(());
+    }
+    let wanted = method.as_str();
+    if repo.merge_methods_allowed.contains(&wanted) {
+        Ok(())
+    } else {
+        Err(ForgeError::validation(
+            schema_err(),
+            "merge_method_unsupported",
+            format!(
+                "merge method {wanted:?} is not enabled on the repo (allowed: {allowed:?})",
+                allowed = repo.merge_methods_allowed,
+            ),
+            None,
+        ))
+    }
+}
+
+fn find_git_toplevel(start: &std::path::Path) -> Option<PathBuf> {
+    let mut cursor = Some(start.to_path_buf());
+    while let Some(dir) = cursor {
+        if dir.join(".git").exists() {
+            return Some(dir);
+        }
+        cursor = dir.parent().map(std::path::Path::to_path_buf);
+    }
+    None
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &PrMergePayload) {
+    println!(
+        "merged #{number} via {method} → {sha}{deleted}\n  {url}",
+        number = payload.number,
+        method = payload.method,
+        sha = payload.merge_sha,
+        deleted = if payload.deleted_branch {
+            " (branch deleted)"
+        } else {
+            ""
+        },
+        url = payload.url,
+    );
+}
+
+/// Minimal post-pr.view projection used internally to wire base/draft into the
+/// lock-down chain without re-deriving every field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PrView {
+    number: u64,
+    url: String,
+    draft: bool,
+    base: String,
+    head: String,
+    #[allow(dead_code)]
+    state: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+
+    fn ctx(provider: Provider) -> ProviderContext {
+        ProviderContext {
+            provider,
+            host: "github.com".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    fn repo_with(default: &str, methods: Vec<&'static str>) -> RepoViewPayload {
+        RepoViewPayload {
+            provider: "github",
+            owner: "acme".into(),
+            name: "widgets".into(),
+            url: "https://github.com/acme/widgets".into(),
+            default_branch: default.into(),
+            merge_methods_allowed: methods,
+        }
+    }
+
+    #[test]
+    fn merge_call_gh_includes_method_flag_and_delete_branch() {
+        let call = build_merge_call(&ctx(Provider::GitHub), 7, MergeMethod::Squash, true);
+        let plan = call.plan_argv();
+        assert_eq!(plan[1..3], ["pr".to_string(), "merge".to_string()]);
+        assert!(plan.iter().any(|s| s == "--squash"));
+        assert!(plan.iter().any(|s| s == "--delete-branch"));
+    }
+
+    #[test]
+    fn merge_call_gh_drops_delete_branch_when_disabled() {
+        let call = build_merge_call(&ctx(Provider::GitHub), 7, MergeMethod::Merge, false);
+        let plan = call.plan_argv();
+        assert!(plan.iter().any(|s| s == "--merge"));
+        assert!(!plan.iter().any(|s| s == "--delete-branch"));
+    }
+
+    #[test]
+    fn merge_call_glab_includes_squash_and_remove_branch() {
+        let call = build_merge_call(&ctx(Provider::GitLab), 9, MergeMethod::Squash, true);
+        let plan = call.plan_argv();
+        assert_eq!(plan[1..3], ["mr".to_string(), "merge".to_string()]);
+        assert!(plan.iter().any(|s| s == "--squash"));
+        assert!(plan.iter().any(|s| s == "--remove-source-branch"));
+    }
+
+    #[test]
+    fn merge_call_glab_merge_method_omits_squash_flag() {
+        let call = build_merge_call(&ctx(Provider::GitLab), 9, MergeMethod::Merge, false);
+        let plan = call.plan_argv();
+        assert!(!plan.iter().any(|s| s == "--squash"));
+        assert!(!plan.iter().any(|s| s == "--remove-source-branch"));
+    }
+
+    #[test]
+    fn keep_branch_conflict_fires_only_on_explicit_config_collision() {
+        let mut cfg = ForgeConfig::default();
+        // Implicit default — no conflict.
+        assert!(enforce_keep_branch_conflict(true, &cfg).is_ok());
+        cfg.merge_delete_branch = Some(false);
+        assert!(enforce_keep_branch_conflict(true, &cfg).is_ok());
+        cfg.merge_delete_branch = Some(true);
+        let err = enforce_keep_branch_conflict(true, &cfg).expect_err("must fail");
+        assert_eq!(err.kind(), "keep_branch_conflict");
+        assert_eq!(err.exit_code(), 65);
+        // Without --keep-branch, no collision regardless of config.
+        assert!(enforce_keep_branch_conflict(false, &cfg).is_ok());
+    }
+
+    #[test]
+    fn method_supported_passes_through_when_repo_methods_unknown() {
+        let repo = repo_with("main", vec![]);
+        assert!(enforce_method_supported(MergeMethod::Rebase, &repo).is_ok());
+    }
+
+    #[test]
+    fn method_supported_accepts_listed_method() {
+        let repo = repo_with("main", vec!["squash", "merge"]);
+        assert!(enforce_method_supported(MergeMethod::Squash, &repo).is_ok());
+    }
+
+    #[test]
+    fn method_supported_rejects_unlisted_method_with_data_65() {
+        let repo = repo_with("main", vec!["merge"]);
+        let err = enforce_method_supported(MergeMethod::Rebase, &repo).expect_err("must fail");
+        assert_eq!(err.kind(), "merge_method_unsupported");
+        assert_eq!(err.exit_code(), 65);
+    }
+
+    #[test]
+    fn extract_merge_sha_github_pulls_oid() {
+        let output = BackendSuccess {
+            stdout: r#"{"mergeCommit":{"oid":"abc123"}}"#.into(),
+            stderr: String::new(),
+        };
+        assert_eq!(
+            extract_merge_sha(&ctx(Provider::GitHub), &output).unwrap(),
+            "abc123"
+        );
+    }
+
+    #[test]
+    fn extract_merge_sha_gitlab_pulls_merge_commit_sha() {
+        let output = BackendSuccess {
+            stdout: r#"{"merge_commit_sha":"def456"}"#.into(),
+            stderr: String::new(),
+        };
+        assert_eq!(
+            extract_merge_sha(&ctx(Provider::GitLab), &output).unwrap(),
+            "def456"
+        );
+    }
+
+    #[test]
+    fn extract_merge_sha_errors_software_when_missing() {
+        let output = BackendSuccess {
+            stdout: r#"{}"#.into(),
+            stderr: String::new(),
+        };
+        let err = extract_merge_sha(&ctx(Provider::GitHub), &output).expect_err("must fail");
+        assert_eq!(err.kind(), "software_error");
+    }
+
+    #[test]
+    fn extract_merge_sha_errors_on_empty_gitlab_sha() {
+        let output = BackendSuccess {
+            stdout: r#"{"merge_commit_sha":""}"#.into(),
+            stderr: String::new(),
+        };
+        let err = extract_merge_sha(&ctx(Provider::GitLab), &output).expect_err("must fail");
+        assert_eq!(err.kind(), "software_error");
+    }
+}

--- a/crates/forge-cli/src/ops/required_check_gate.rs
+++ b/crates/forge-cli/src/ops/required_check_gate.rs
@@ -1,0 +1,230 @@
+//! Required-check gate used by `pr merge` immediately before the backend
+//! invocation. Performs a fresh TTL-zero snapshot through
+//! [`pr_checks::snapshot`] and refuses to proceed when any required check is
+//! failing or pending.
+//!
+//! Spec: `crates/forge-cli/docs/specs/forge-cli-spec-v1.md` §"Lock-down policy"
+//! rule 8 (`required_checks_green`). Mirrors the
+//! `github-pr-required-check-gating` operation record: even when an upstream
+//! `pr wait-checks` finished < 1s ago, the gate re-fetches from the provider
+//! so stale "all green" answers cannot leak through into a destructive merge.
+//!
+//! Error surface:
+//!
+//! | Outcome           | Variant                                 | Exit         |
+//! | ----------------- | --------------------------------------- | ------------ |
+//! | All required pass | `Ok(PrChecksPayload)`                   | n/a          |
+//! | Any required fail | `Err(checks_failed)` → RuntimeFailure   | RUNTIME 1    |
+//! | Else any pending  | `Err(checks_pending)` → Validation      | DATA 65      |
+//!
+//! Failure dominates pending — if both are present the gate reports
+//! `checks_failed` because the spec terminal-state mapping puts failure ahead
+//! of pending.
+
+use crate::backend::BackendRunner;
+use crate::cli::{BINARY, GlobalFlags, PrChecksArgs};
+use crate::error::ForgeError;
+use crate::ops::pr_checks::{self, PrChecksPayload};
+use crate::provider::ProviderContext;
+use nils_common::cli_contract::schema_version_for;
+
+/// Schema literal used by the gate's failure envelopes. Re-uses the
+/// `pr.checks.v1` schema so failure envelopes carry the same shape that
+/// upstream consumers already parse — the only thing that changes is `ok` and
+/// the `error.kind` discriminator.
+fn schema() -> String {
+    schema_version_for(BINARY, pr_checks::SCHEMA, pr_checks::SCHEMA_VERSION)
+}
+
+/// Fetch the current required-check snapshot and assert all required checks
+/// are passing.
+///
+/// On success returns the populated snapshot so callers (e.g. `pr merge`) can
+/// surface counts under `data.checks_snapshot` if they choose. On failure the
+/// returned [`ForgeError`] already carries the discriminator + exit code; the
+/// caller just forwards it to the envelope emitter.
+pub fn ensure_required_checks_green<R: BackendRunner>(
+    runner: &R,
+    global: &GlobalFlags,
+    ctx: &ProviderContext,
+    pr_id: &str,
+) -> Result<PrChecksPayload, ForgeError> {
+    let args = PrChecksArgs {
+        id: pr_id.to_string(),
+        required_only: true,
+    };
+    let snapshot = pr_checks::snapshot(runner, global, ctx, &args)?;
+    classify(snapshot)
+}
+
+fn classify(snapshot: PrChecksPayload) -> Result<PrChecksPayload, ForgeError> {
+    if !snapshot.failed.is_empty() {
+        let names = snapshot
+            .failed
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(ForgeError::runtime_failure(
+            schema(),
+            "checks_failed",
+            format!(
+                "{} required check(s) failed: {}",
+                snapshot.failed.len(),
+                names
+            ),
+            None,
+        ));
+    }
+    if !snapshot.pending.is_empty() {
+        let names = snapshot
+            .pending
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(ForgeError::validation(
+            schema(),
+            "checks_pending",
+            format!(
+                "{} required check(s) still pending: {}",
+                snapshot.pending.len(),
+                names
+            ),
+            None,
+        ));
+    }
+    Ok(snapshot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::pr_checks::{CheckItem, FailedCheck, PendingCheck};
+    use nils_common::cli_contract::exit;
+    use pretty_assertions::assert_eq;
+
+    fn pass_snapshot() -> PrChecksPayload {
+        PrChecksPayload {
+            provider: "github",
+            state: "success",
+            required_count: 2,
+            success_count: 2,
+            failed: vec![],
+            pending: vec![],
+            checks: vec![
+                CheckItem {
+                    name: "test".into(),
+                    state: "success",
+                    url: None,
+                    conclusion: Some("success".into()),
+                    workflow: None,
+                    required: true,
+                    started_at: None,
+                    completed_at: None,
+                },
+                CheckItem {
+                    name: "lint".into(),
+                    state: "success",
+                    url: None,
+                    conclusion: Some("success".into()),
+                    workflow: None,
+                    required: true,
+                    started_at: None,
+                    completed_at: None,
+                },
+            ],
+            duration_ms: None,
+        }
+    }
+
+    fn with_failure(name: &str) -> PrChecksPayload {
+        let mut snap = pass_snapshot();
+        snap.state = "failure";
+        snap.success_count = 1;
+        snap.failed.push(FailedCheck {
+            name: name.into(),
+            url: None,
+            conclusion: Some("failure".into()),
+        });
+        snap
+    }
+
+    fn with_pending(name: &str) -> PrChecksPayload {
+        let mut snap = pass_snapshot();
+        snap.state = "pending";
+        snap.success_count = 1;
+        snap.pending.push(PendingCheck {
+            name: name.into(),
+            url: None,
+        });
+        snap
+    }
+
+    #[test]
+    fn all_green_returns_payload_untouched() {
+        let snap = pass_snapshot();
+        let result = classify(snap.clone()).expect("must pass");
+        assert_eq!(result.state, "success");
+        assert_eq!(result.success_count, 2);
+    }
+
+    #[test]
+    fn pending_only_yields_checks_pending_validation_with_data_65() {
+        let err = classify(with_pending("integration")).expect_err("must fail with pending");
+        assert_eq!(err.kind(), "checks_pending");
+        assert_eq!(err.exit_code(), exit::DATA);
+    }
+
+    #[test]
+    fn failure_yields_checks_failed_runtime_with_exit_1() {
+        let err = classify(with_failure("test")).expect_err("must fail with failure");
+        assert_eq!(err.kind(), "checks_failed");
+        assert_eq!(err.exit_code(), exit::RUNTIME);
+    }
+
+    #[test]
+    fn failure_dominates_pending_when_both_present() {
+        // Per spec terminal-state mapping (failure > pending), checks_failed
+        // wins so the merge atom surfaces the most actionable error first.
+        let mut snap = with_failure("compile");
+        snap.pending.push(PendingCheck {
+            name: "integration".into(),
+            url: None,
+        });
+        let err = classify(snap).expect_err("must fail with failure");
+        assert_eq!(err.kind(), "checks_failed");
+    }
+
+    #[test]
+    fn error_message_lists_offending_check_names() {
+        let snap = {
+            let mut s = pass_snapshot();
+            s.state = "failure";
+            s.success_count = 0;
+            s.failed.push(FailedCheck {
+                name: "test".into(),
+                url: None,
+                conclusion: Some("failure".into()),
+            });
+            s.failed.push(FailedCheck {
+                name: "lint".into(),
+                url: None,
+                conclusion: Some("failure".into()),
+            });
+            s
+        };
+        let err = classify(snap).expect_err("must fail");
+        let rendered = format!("{err}");
+        assert!(rendered.contains("test"), "got {rendered}");
+        assert!(rendered.contains("lint"), "got {rendered}");
+        assert!(rendered.starts_with("2 required check(s) failed"));
+    }
+
+    #[test]
+    fn schema_literal_matches_pr_checks_v1() {
+        // Failure envelopes from the gate share the pr.checks.v1 schema so
+        // upstream consumers parse one shape end-to-end across the merge flow.
+        assert_eq!(schema(), "cli.forge-cli.pr.checks.v1");
+    }
+}

--- a/crates/forge-cli/tests/integration.rs
+++ b/crates/forge-cli/tests/integration.rs
@@ -8,6 +8,7 @@ mod integration {
     mod pr_checks_github;
     mod pr_checks_gitlab;
     mod pr_create;
+    mod pr_merge;
     mod pr_wait_checks;
     mod repo_view;
     mod required_check_gate;

--- a/crates/forge-cli/tests/integration.rs
+++ b/crates/forge-cli/tests/integration.rs
@@ -10,6 +10,7 @@ mod integration {
     mod pr_create;
     mod pr_wait_checks;
     mod repo_view;
+    mod required_check_gate;
     mod support;
     mod validations;
 }

--- a/crates/forge-cli/tests/integration/pr_merge.rs
+++ b/crates/forge-cli/tests/integration/pr_merge.rs
@@ -1,0 +1,146 @@
+//! `pr merge` integration tests covering the dry-run plan envelope and the
+//! configuration-driven `keep_branch_conflict` rule. The wider lock-down chain
+//! (rules 4 / 6 / 7 / 8 / 9) is unit-tested in
+//! `crates/forge-cli/src/ops/pr_merge.rs` and the dedicated gate suite at
+//! `tests/integration/required_check_gate.rs`; this module pins the CLI surface
+//! and the per-repo `.forge-cli.toml` precedence end-to-end.
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+use super::support::{StubEnv, parse_envelope, run_forge_cli_in};
+
+const FORBIDDEN_STUB: &str = "#!/bin/sh\necho 'should not run during dry-run' >&2\nexit 99\n";
+
+#[test]
+fn pr_merge_dry_run_renders_squash_plan_with_delete_branch() {
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "42",
+        ],
+        None,
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.pr.merge.v1");
+    let plan: Vec<String> = env["data"]["plan"]
+        .as_array()
+        .expect("plan array")
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect();
+    assert!(plan.iter().any(|s| s == "merge"), "{plan:?}");
+    assert!(plan.iter().any(|s| s == "42"), "{plan:?}");
+    assert!(plan.iter().any(|s| s == "--squash"), "{plan:?}");
+    assert!(plan.iter().any(|s| s == "--delete-branch"), "{plan:?}");
+}
+
+#[test]
+fn pr_merge_dry_run_method_override_uses_merge_flag() {
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "1",
+            "--method",
+            "merge",
+        ],
+        None,
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let plan: Vec<String> = env["data"]["plan"]
+        .as_array()
+        .expect("plan array")
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect();
+    assert!(plan.iter().any(|s| s == "--merge"), "{plan:?}");
+    assert!(!plan.iter().any(|s| s == "--squash"), "{plan:?}");
+}
+
+#[test]
+fn pr_merge_keep_branch_drops_delete_branch_in_dry_run_plan() {
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "1",
+            "--keep-branch",
+        ],
+        None,
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let plan: Vec<String> = env["data"]["plan"]
+        .as_array()
+        .expect("plan array")
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect();
+    assert!(!plan.iter().any(|s| s == "--delete-branch"), "{plan:?}");
+}
+
+#[test]
+fn pr_merge_keep_branch_conflicts_with_config_delete_branch_true() {
+    // The lock-down rule (rule 10) requires an *explicit* config opting into
+    // branch deletion before --keep-branch becomes a hard error. We mock that
+    // by writing a .forge-cli.toml inside a tempdir and invoking the binary
+    // from there so the loader picks it up.
+    let repo = TempDir::new().expect("tempdir");
+    fs::write(
+        repo.path().join(".forge-cli.toml"),
+        "[merge]\ndelete_branch = true\n",
+    )
+    .expect("write config");
+    fs::create_dir_all(repo.path().join(".git")).expect("fake .git");
+
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "1",
+            "--keep-branch",
+        ],
+        Some(repo.path()),
+    );
+    assert_eq!(
+        out.code, 65,
+        "expected DATA 65 on keep_branch_conflict, stderr={}",
+        out.stderr
+    );
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["ok"], false);
+    assert_eq!(env["error"]["code"], "keep_branch_conflict");
+}

--- a/crates/forge-cli/tests/integration/required_check_gate.rs
+++ b/crates/forge-cli/tests/integration/required_check_gate.rs
@@ -1,0 +1,160 @@
+//! End-to-end tests for the TTL-zero required-check gate.
+//!
+//! These exercise [`forge_cli::ops::required_check_gate::ensure_required_checks_green`]
+//! against a real [`ProcessRunner`] backed by a generated gh stub. Each call
+//! to the helper must re-fetch from the provider — there is no caching across
+//! atoms — so the tests pin that property by counting stub invocations.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use forge_cli::backend::ProcessRunner;
+use forge_cli::cli::GlobalFlags;
+use forge_cli::ops::required_check_gate::ensure_required_checks_green;
+use forge_cli::provider::{DetectionSource, Provider, ProviderContext};
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+/// FORGE_CLI_GH_BIN is process-wide; serialize tests that mutate it so
+/// parallel test execution can't cross-contaminate stub paths.
+fn lock_env() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+fn write_stub(dir: &TempDir, body: &str) -> PathBuf {
+    let path = dir.path().join("gh");
+    fs::write(&path, body).expect("write gh stub");
+    let mut perm = fs::metadata(&path).expect("metadata").permissions();
+    perm.set_mode(0o755);
+    fs::set_permissions(&path, perm).expect("chmod");
+    path
+}
+
+fn github_ctx() -> ProviderContext {
+    ProviderContext {
+        provider: Provider::GitHub,
+        host: "github.com".into(),
+        source: DetectionSource::Flag,
+    }
+}
+
+fn run_globals() -> GlobalFlags {
+    GlobalFlags {
+        format: None,
+        remote: "origin".into(),
+        provider: None,
+        repo: None,
+        dry_run: false,
+    }
+}
+
+const SUCCESS_JSON: &str = r#"[{"name":"build","bucket":"pass","conclusion":"success","isRequired":true,"link":"https://ci/1"},{"name":"test","bucket":"pass","conclusion":"success","isRequired":true,"link":"https://ci/2"}]"#;
+const PENDING_JSON: &str = r#"[{"name":"build","bucket":"pass","conclusion":"success","isRequired":true,"link":"https://ci/1"},{"name":"test","bucket":"pending","conclusion":"","isRequired":true,"link":"https://ci/2"}]"#;
+const FAILURE_JSON: &str = r#"[{"name":"build","bucket":"pass","conclusion":"success","isRequired":true,"link":"https://ci/1"},{"name":"test","bucket":"fail","conclusion":"failure","isRequired":true,"link":"https://ci/2"}]"#;
+
+#[test]
+fn all_required_green_returns_payload_with_runtime_runner() {
+    let tmp = TempDir::new().unwrap();
+    write_stub(
+        &tmp,
+        &format!(
+            "#!/bin/sh\nset -e\ncase \"$1 $2\" in\n  \"pr checks\")\n    cat <<'EOF'\n{SUCCESS_JSON}\nEOF\n    ;;\n  *)\n    echo \"stub: unexpected gh args: $*\" >&2; exit 99;;\nesac\n"
+        ),
+    );
+    // SAFETY: process-wide env var; tests within this binary share state but
+    // the helper reads the var each time the runner spawns gh, so a stale
+    // value would only break parallel tests in this module.
+    let _guard = lock_env();
+    unsafe {
+        std::env::set_var("FORGE_CLI_GH_BIN", tmp.path().join("gh"));
+    }
+
+    let runner = ProcessRunner;
+    let globals = run_globals();
+    let ctx = github_ctx();
+    let snap = ensure_required_checks_green(&runner, &globals, &ctx, "42")
+        .expect("required checks must be green");
+
+    assert_eq!(snap.state, "success");
+    assert_eq!(snap.required_count, 2);
+    assert_eq!(snap.success_count, 2);
+}
+
+#[test]
+fn pending_required_check_exits_data_with_kind_checks_pending() {
+    let tmp = TempDir::new().unwrap();
+    write_stub(
+        &tmp,
+        &format!(
+            "#!/bin/sh\nset -e\ncase \"$1 $2\" in\n  \"pr checks\")\n    cat <<'EOF'\n{PENDING_JSON}\nEOF\n    ;;\n  *)\n    echo \"stub: unexpected gh args: $*\" >&2; exit 99;;\nesac\n"
+        ),
+    );
+    let _guard = lock_env();
+    unsafe {
+        std::env::set_var("FORGE_CLI_GH_BIN", tmp.path().join("gh"));
+    }
+
+    let runner = ProcessRunner;
+    let err = ensure_required_checks_green(&runner, &run_globals(), &github_ctx(), "42")
+        .expect_err("must surface pending");
+    assert_eq!(err.kind(), "checks_pending");
+    assert_eq!(err.exit_code(), 65);
+}
+
+#[test]
+fn failing_required_check_exits_runtime_with_kind_checks_failed() {
+    let tmp = TempDir::new().unwrap();
+    write_stub(
+        &tmp,
+        &format!(
+            "#!/bin/sh\nset -e\ncase \"$1 $2\" in\n  \"pr checks\")\n    cat <<'EOF'\n{FAILURE_JSON}\nEOF\n    ;;\n  *)\n    echo \"stub: unexpected gh args: $*\" >&2; exit 99;;\nesac\n"
+        ),
+    );
+    let _guard = lock_env();
+    unsafe {
+        std::env::set_var("FORGE_CLI_GH_BIN", tmp.path().join("gh"));
+    }
+
+    let runner = ProcessRunner;
+    let err = ensure_required_checks_green(&runner, &run_globals(), &github_ctx(), "42")
+        .expect_err("must surface failure");
+    assert_eq!(err.kind(), "checks_failed");
+    assert_eq!(err.exit_code(), 1);
+}
+
+#[test]
+fn helper_refetches_every_call_no_caching_across_atoms() {
+    // Sprint 4's contract: even if pr.wait-checks finished <1s ago, the gate
+    // must re-fetch. We prove that by counting stub invocations: two helper
+    // calls in the same test should produce two spawns of gh.
+    let tmp = TempDir::new().unwrap();
+    let counter = tmp.path().join("counter");
+    fs::write(&counter, "0").unwrap();
+    let stub_dir = tmp.path().to_string_lossy().to_string();
+    let body = format!(
+        "#!/bin/sh\nset -e\ncase \"$1 $2\" in\n  \"pr checks\")\n    n=$(cat \"{stub_dir}/counter\")\n    echo $((n + 1)) > \"{stub_dir}/counter\"\n    cat <<'EOF'\n{SUCCESS_JSON}\nEOF\n    ;;\n  *)\n    echo \"stub: unexpected gh args: $*\" >&2; exit 99;;\nesac\n"
+    );
+    write_stub(&tmp, &body);
+    let _guard = lock_env();
+    unsafe {
+        std::env::set_var("FORGE_CLI_GH_BIN", tmp.path().join("gh"));
+    }
+
+    let runner = ProcessRunner;
+    let globals = run_globals();
+    let ctx = github_ctx();
+    ensure_required_checks_green(&runner, &globals, &ctx, "42").expect("call 1 must pass");
+    ensure_required_checks_green(&runner, &globals, &ctx, "42").expect("call 2 must pass");
+
+    let final_count: u32 = fs::read_to_string(&counter)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_eq!(final_count, 2, "gh must be re-invoked on every gate call");
+}

--- a/docs/plans/forge-cli/forge-cli-execution-state.md
+++ b/docs/plans/forge-cli/forge-cli-execution-state.md
@@ -1,0 +1,86 @@
+# Forge-CLI v1 Execution State
+
+## Current State
+
+- Status: in progress
+- Target scope: whole plan (Sprints 0–8)
+- Execution window: 2026-05-19 → ongoing
+- Staged execution confirmation: not applicable (default-continue
+  authorization: "默認就一直做下去")
+- Current task: Task 4.1
+- Next task: Task 4.2
+- Last updated: 2026-05-20
+- Branch/commit: `feat/forge-cli-v1-sprint4-merge` cut from
+  `origin/main@7d93d1a` (PR #390 merge commit)
+- Source document: docs/plans/forge-cli/forge-cli-plan.md
+- Direct source-doc execution waiver: not applicable
+
+## Task Ledger
+
+| ID       | Status      | Task                                                        | Evidence                                 | Notes                                                          |
+| -------- | ----------- | ----------------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------- |
+| Task 1.1 | completed   | Scaffold `crates/forge-cli/` package and workspace wiring   | PR #381 (merged `eb92969`)               | Sprint 1                                                       |
+| Task 1.2 | completed   | Define clap command tree + global flags                     | PR #381                                  | Sprint 1                                                       |
+| Task 1.3 | completed   | Implement provider detection                                | PR #381                                  | Sprint 1                                                       |
+| Task 1.4 | completed   | Subprocess wrapper + envelope serializer + dry-run plumbing | PR #381                                  | Sprint 1                                                       |
+| Task 1.5 | completed   | Implement `auth status` atom                                | PR #381                                  | Sprint 1                                                       |
+| Task 1.6 | completed   | Implement `repo view` atom                                  | PR #381                                  | Sprint 1                                                       |
+| Task 1.7 | completed   | Sprint 1 exit-code matrix + workspace gate                  | PR #381                                  | Sprint 1                                                       |
+| Task 2.1 | completed   | PR body / title / branch validation module                  | PR #388 (merged `856797c`)               | Sprint 2 — `crates/forge-cli/src/validations.rs`               |
+| Task 2.2 | completed   | `pr create` atom                                            | PR #388                                  | Sprint 2                                                       |
+| Task 2.3 | completed   | `pr view`, `pr list`, `pr close` atoms                      | PR #388                                  | Sprint 2                                                       |
+| Task 2.4 | completed   | `pr edit`, `pr comment`, `pr ready` atoms                   | PR #388                                  | Sprint 2                                                       |
+| Task 3.1 | completed   | `pr checks` GitHub backend                                  | PR #390 (merged `7d93d1a`)               | Sprint 3                                                       |
+| Task 3.2 | completed   | `pr checks` GitLab text parser with version fail-fast       | PR #390                                  | Pinned `glab` 1.45.x — `glab_version_unsupported` → UNAVAIL 69 |
+| Task 3.3 | completed   | `pr wait-checks` polling loop                               | PR #390 + fix `1071cc6`                  | `checks_failed` RUNTIME 1 / `checks_timeout` UNAVAIL 69        |
+| Task 4.1 | in_progress | Merge-method resolution + `.forge-cli.toml` loader          | branch `feat/forge-cli-v1-sprint4-merge` | Current task                                                   |
+| Task 4.2 | pending     | TTL-zero required-check re-check helper                     | n/a                                      | Re-uses `pr_checks::snapshot()`                                |
+| Task 4.3 | pending     | `pr merge` atom                                             | n/a                                      | Implements lock-down rules 4 / 6 / 7 / 8 / 9 / 10              |
+| Task 5.1 | pending     | `issue create`, `issue view`, `issue close`, `issue reopen` | n/a                                      | Sprint 5 — mirrors Sprint 2 layout                             |
+| Task 5.2 | pending     | `issue edit`, `issue comment`                               | n/a                                      | Sprint 5                                                       |
+| Task 6.1 | pending     | `pr deliver` macro composition + step envelope              | n/a                                      | Sprint 6                                                       |
+| Task 6.2 | pending     | Macro CLI surface + dry-run plan rendering                  | n/a                                      | Sprint 6                                                       |
+| Task 7.1 | pending     | Parity harness                                              | n/a                                      | Sprint 7                                                       |
+| Task 7.2 | pending     | Exit-code matrix completion                                 | n/a                                      | Sprint 7                                                       |
+| Task 7.3 | pending     | Fixture redaction audit                                     | n/a                                      | Sprint 7                                                       |
+| Task 8.1 | pending     | `wrappers/forge-cli` + shell completions                    | n/a                                      | Sprint 8                                                       |
+| Task 8.2 | pending     | Homebrew tap formula update                                 | n/a                                      | Sprint 8                                                       |
+| Task 8.3 | pending     | `nils-cli` minor bump + tag + tap formula bump              | n/a                                      | Sprint 8                                                       |
+
+## Validation
+
+| Command                                            | Status  | Summary                                              | Artifact                     |
+| -------------------------------------------------- | ------- | ---------------------------------------------------- | ---------------------------- |
+| `cargo test -p nils-forge-cli`                     | green   | 167 lib + 46 integration at end of Sprint 3          | local + PR #390 CI           |
+| `cargo clippy --all-targets`                       | green   | end of Sprint 3                                      | local + PR #390 CI           |
+| `bash scripts/ci/plan-bundle-validate.sh --strict` | green   | Sprint 0 docs-only gate (PR #379)                    | PR #379                      |
+| `bash scripts/ci/completion-asset-audit.sh`        | green   | bash + zsh regenerated each sprint                   | PR #381 / #388 / #390        |
+| `bash scripts/ci/completion-flag-parity-audit.sh`  | green   | parity with built-in `forge-cli` after each sprint   | PR #381 / #388 / #390        |
+| `bash scripts/ci/cli-output-contract-lint.sh`      | green   | each sprint                                          | PR #381 / #388 / #390        |
+| `bash scripts/ci/docs-placement-audit.sh`          | green   | docs co-located under `crates/forge-cli/docs/specs/` | PR #379                      |
+| `bash scripts/ci/docs-hygiene-audit.sh`            | green   | markdownlint / rumdl clean across plan bundle        | PR #379 / #381 / #388 / #390 |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh`    | pending | end-of-Sprint-8 workspace gate                       | n/a                          |
+
+## Blockers
+
+- none
+
+## Session Log
+
+- 2026-05-19 — Sprint 0 merged (PR #379 / `f5eba86`): spec v1 + ops
+  catalog + dispatch plan + discussion source. Docs-only gate green.
+- 2026-05-19 — Sprint 1 merged (PR #381 / `eb92969`): crate scaffold,
+  global flags, provider detection, `auth status`, `repo view`,
+  `--dry-run`, exit-code matrix.
+- 2026-05-19 — Sprint 2 merged (PR #388 / `856797c`): seven PR atoms +
+  shared validation chain. Test surface jumps to 123 lib + 26
+  integration.
+- 2026-05-19 — Sprint 3 merged (PR #390 / `7d93d1a`): `pr checks` (gh
+  JSON + glab text parser with pinned-minor fail-fast) and
+  `pr wait-checks` polling loop with `Clock` trait. Caught a Linux CI
+  flake in the `gh_sequence_stub` helper (timeout test) and shipped a
+  follow-up fix `1071cc6` clamping the stub index to the trailing
+  snapshot.
+- 2026-05-20 — Cut `feat/forge-cli-v1-sprint4-merge` from `origin/main`
+  for Sprint 4 (`pr merge` lock-down + TTL-zero required-check
+  re-check). Tracking issue opened on `sympoies/nils-cli`.

--- a/docs/plans/forge-cli/forge-cli-execution-state.md
+++ b/docs/plans/forge-cli/forge-cli-execution-state.md
@@ -7,45 +7,46 @@
 - Execution window: 2026-05-19 → ongoing
 - Staged execution confirmation: not applicable (default-continue
   authorization: "默認就一直做下去")
-- Current task: Task 4.1
-- Next task: Task 4.2
+- Current task: Sprint 4 review (PR pending)
+- Next task: Task 5.1
 - Last updated: 2026-05-20
-- Branch/commit: `feat/forge-cli-v1-sprint4-merge` cut from
-  `origin/main@7d93d1a` (PR #390 merge commit)
+- Branch/commit: `feat/forge-cli-v1-sprint4-merge` HEAD at `9094408`
+  (Task 4.3); PR open and awaiting CI green + merge before cutting
+  Sprint 5 branch off updated `origin/main`
 - Source document: docs/plans/forge-cli/forge-cli-plan.md
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger
 
-| ID       | Status      | Task                                                        | Evidence                                 | Notes                                                          |
-| -------- | ----------- | ----------------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------- |
-| Task 1.1 | completed   | Scaffold `crates/forge-cli/` package and workspace wiring   | PR #381 (merged `eb92969`)               | Sprint 1                                                       |
-| Task 1.2 | completed   | Define clap command tree + global flags                     | PR #381                                  | Sprint 1                                                       |
-| Task 1.3 | completed   | Implement provider detection                                | PR #381                                  | Sprint 1                                                       |
-| Task 1.4 | completed   | Subprocess wrapper + envelope serializer + dry-run plumbing | PR #381                                  | Sprint 1                                                       |
-| Task 1.5 | completed   | Implement `auth status` atom                                | PR #381                                  | Sprint 1                                                       |
-| Task 1.6 | completed   | Implement `repo view` atom                                  | PR #381                                  | Sprint 1                                                       |
-| Task 1.7 | completed   | Sprint 1 exit-code matrix + workspace gate                  | PR #381                                  | Sprint 1                                                       |
-| Task 2.1 | completed   | PR body / title / branch validation module                  | PR #388 (merged `856797c`)               | Sprint 2 — `crates/forge-cli/src/validations.rs`               |
-| Task 2.2 | completed   | `pr create` atom                                            | PR #388                                  | Sprint 2                                                       |
-| Task 2.3 | completed   | `pr view`, `pr list`, `pr close` atoms                      | PR #388                                  | Sprint 2                                                       |
-| Task 2.4 | completed   | `pr edit`, `pr comment`, `pr ready` atoms                   | PR #388                                  | Sprint 2                                                       |
-| Task 3.1 | completed   | `pr checks` GitHub backend                                  | PR #390 (merged `7d93d1a`)               | Sprint 3                                                       |
-| Task 3.2 | completed   | `pr checks` GitLab text parser with version fail-fast       | PR #390                                  | Pinned `glab` 1.45.x — `glab_version_unsupported` → UNAVAIL 69 |
-| Task 3.3 | completed   | `pr wait-checks` polling loop                               | PR #390 + fix `1071cc6`                  | `checks_failed` RUNTIME 1 / `checks_timeout` UNAVAIL 69        |
-| Task 4.1 | in_progress | Merge-method resolution + `.forge-cli.toml` loader          | branch `feat/forge-cli-v1-sprint4-merge` | Current task                                                   |
-| Task 4.2 | pending     | TTL-zero required-check re-check helper                     | n/a                                      | Re-uses `pr_checks::snapshot()`                                |
-| Task 4.3 | pending     | `pr merge` atom                                             | n/a                                      | Implements lock-down rules 4 / 6 / 7 / 8 / 9 / 10              |
-| Task 5.1 | pending     | `issue create`, `issue view`, `issue close`, `issue reopen` | n/a                                      | Sprint 5 — mirrors Sprint 2 layout                             |
-| Task 5.2 | pending     | `issue edit`, `issue comment`                               | n/a                                      | Sprint 5                                                       |
-| Task 6.1 | pending     | `pr deliver` macro composition + step envelope              | n/a                                      | Sprint 6                                                       |
-| Task 6.2 | pending     | Macro CLI surface + dry-run plan rendering                  | n/a                                      | Sprint 6                                                       |
-| Task 7.1 | pending     | Parity harness                                              | n/a                                      | Sprint 7                                                       |
-| Task 7.2 | pending     | Exit-code matrix completion                                 | n/a                                      | Sprint 7                                                       |
-| Task 7.3 | pending     | Fixture redaction audit                                     | n/a                                      | Sprint 7                                                       |
-| Task 8.1 | pending     | `wrappers/forge-cli` + shell completions                    | n/a                                      | Sprint 8                                                       |
-| Task 8.2 | pending     | Homebrew tap formula update                                 | n/a                                      | Sprint 8                                                       |
-| Task 8.3 | pending     | `nils-cli` minor bump + tag + tap formula bump              | n/a                                      | Sprint 8                                                       |
+| ID       | Status    | Task                                                        | Evidence                   | Notes                                                          |
+| -------- | --------- | ----------------------------------------------------------- | -------------------------- | -------------------------------------------------------------- |
+| Task 1.1 | completed | Scaffold `crates/forge-cli/` package and workspace wiring   | PR #381 (merged `eb92969`) | Sprint 1                                                       |
+| Task 1.2 | completed | Define clap command tree + global flags                     | PR #381                    | Sprint 1                                                       |
+| Task 1.3 | completed | Implement provider detection                                | PR #381                    | Sprint 1                                                       |
+| Task 1.4 | completed | Subprocess wrapper + envelope serializer + dry-run plumbing | PR #381                    | Sprint 1                                                       |
+| Task 1.5 | completed | Implement `auth status` atom                                | PR #381                    | Sprint 1                                                       |
+| Task 1.6 | completed | Implement `repo view` atom                                  | PR #381                    | Sprint 1                                                       |
+| Task 1.7 | completed | Sprint 1 exit-code matrix + workspace gate                  | PR #381                    | Sprint 1                                                       |
+| Task 2.1 | completed | PR body / title / branch validation module                  | PR #388 (merged `856797c`) | Sprint 2 — `crates/forge-cli/src/validations.rs`               |
+| Task 2.2 | completed | `pr create` atom                                            | PR #388                    | Sprint 2                                                       |
+| Task 2.3 | completed | `pr view`, `pr list`, `pr close` atoms                      | PR #388                    | Sprint 2                                                       |
+| Task 2.4 | completed | `pr edit`, `pr comment`, `pr ready` atoms                   | PR #388                    | Sprint 2                                                       |
+| Task 3.1 | completed | `pr checks` GitHub backend                                  | PR #390 (merged `7d93d1a`) | Sprint 3                                                       |
+| Task 3.2 | completed | `pr checks` GitLab text parser with version fail-fast       | PR #390                    | Pinned `glab` 1.45.x — `glab_version_unsupported` → UNAVAIL 69 |
+| Task 3.3 | completed | `pr wait-checks` polling loop                               | PR #390 + fix `1071cc6`    | `checks_failed` RUNTIME 1 / `checks_timeout` UNAVAIL 69        |
+| Task 4.1 | completed | Merge-method resolution + `.forge-cli.toml` loader          | commit `cf45459`           | Sprint 4 — 12 lib tests covering loader walk + warning surface |
+| Task 4.2 | completed | TTL-zero required-check re-check helper                     | commit `feae217`           | Sprint 4 — 6 lib + 4 integration tests pin no-caching contract |
+| Task 4.3 | completed | `pr merge` atom                                             | commit `9094408`           | Sprint 4 — full lock-down chain + 12 lib + 4 integration tests |
+| Task 5.1 | pending   | `issue create`, `issue view`, `issue close`, `issue reopen` | n/a                        | Sprint 5 — mirrors Sprint 2 layout                             |
+| Task 5.2 | pending   | `issue edit`, `issue comment`                               | n/a                        | Sprint 5                                                       |
+| Task 6.1 | pending   | `pr deliver` macro composition + step envelope              | n/a                        | Sprint 6                                                       |
+| Task 6.2 | pending   | Macro CLI surface + dry-run plan rendering                  | n/a                        | Sprint 6                                                       |
+| Task 7.1 | pending   | Parity harness                                              | n/a                        | Sprint 7                                                       |
+| Task 7.2 | pending   | Exit-code matrix completion                                 | n/a                        | Sprint 7                                                       |
+| Task 7.3 | pending   | Fixture redaction audit                                     | n/a                        | Sprint 7                                                       |
+| Task 8.1 | pending   | `wrappers/forge-cli` + shell completions                    | n/a                        | Sprint 8                                                       |
+| Task 8.2 | pending   | Homebrew tap formula update                                 | n/a                        | Sprint 8                                                       |
+| Task 8.3 | pending   | `nils-cli` minor bump + tag + tap formula bump              | n/a                        | Sprint 8                                                       |
 
 ## Validation
 
@@ -83,4 +84,10 @@
   snapshot.
 - 2026-05-20 — Cut `feat/forge-cli-v1-sprint4-merge` from `origin/main`
   for Sprint 4 (`pr merge` lock-down + TTL-zero required-check
-  re-check). Tracking issue opened on `sympoies/nils-cli`.
+  re-check). Tracking issue #391 opened on `sympoies/nils-cli` with
+  source / plan / execution-state snapshot comments.
+- 2026-05-20 — Sprint 4 production code complete locally: Task 4.1
+  config loader (`cf45459`), Task 4.2 TTL-zero gate (`feae217`),
+  Task 4.3 `pr merge` atom with six lock-down rules (`9094408`).
+  Workspace test surface: 197 lib + 54 integration. PR pending push +
+  CI green.


### PR DESCRIPTION
## Summary

Sprint 4 of the [forge-cli v1 plan](https://github.com/sympoies/nils-cli/issues/391) lands the heaviest single atom in the v1 surface: `pr merge` with the full lock-down chain. The PR also lands the per-repo `.forge-cli.toml` loader and the TTL-zero required-check re-check helper that the merge atom and the future `pr deliver` macro share.

## Changes

- **`crates/forge-cli/src/config.rs`** — new `.forge-cli.toml` loader. Walks upward from CWD to the git toplevel (inclusive), maps `[merge]` / `[body]` / `[branch]` / `[checks]` to typed fields, and pushes unknown keys to `warnings[]` (prefixed `unknown-config-key:` or `invalid-config-value:`) so v1 stays forward-compatible with v2 keys. `resolve_*` helpers encode the spec precedence `explicit flag > .forge-cli.toml > spec default`.
- **`crates/forge-cli/src/ops/required_check_gate.rs`** — new TTL-zero gate. Re-fetches via `pr_checks::snapshot()` and returns `Ok` / `Err(checks_pending)` DATA 65 / `Err(checks_failed)` RUNTIME 1, with `checks_failed` dominating when both fail and pending are present. Integration tests count stub spawns to pin the no-caching contract.
- **`crates/forge-cli/src/ops/pr_merge.rs`** — new atom wiring six lock-down rules: `dirty_worktree` (Sprint 2 helper), `draft_merge_refused`, `default_branch_protected` (compared against `repo.view.default_branch` unless `--allow-non-default-base`), `required_checks_green` (Sprint 4.2 gate), `merge_method_unsupported` (intersect with `repo.view.merge_methods_allowed`), `keep_branch_conflict`. Backend argv per ops YAML: `gh pr merge <id> --{method} [--delete-branch]` and `glab mr merge <id> [--squash] [--remove-source-branch]`. Post-merge re-fetch surfaces `data.merge_sha`. Schema: `cli.forge-cli.pr.merge.v1`.
- **CLI surface** — adds `pr merge <id> [--method squash|merge|rebase] [--keep-branch] [--allow-non-default-base]`. Regenerated bash + zsh completions.
- **Execution ledger** — `docs/plans/forge-cli/forge-cli-execution-state.md` tracks Sprints 0–4 with commit-SHA evidence; new tracking issue `#391` carries source / plan / execution-state snapshots.

## Test-First Evidence

- **Change classification**: new feature (Sprint 4 atom delivery).
- **Failing test before fix**: not applicable — Sprint 4 is greenfield atom + helper work, not a bugfix.
- **Final validation**:
  - `cargo test -p nils-forge-cli` — 197 lib + 54 integration green (was 167 + 46 at end of Sprint 3).
  - `cargo clippy -p nils-forge-cli --all-targets -- -D warnings` — clean.
  - `bash scripts/ci/plan-bundle-validate.sh --strict` — pass.
  - `bash scripts/ci/completion-asset-audit.sh` + `completion-flag-parity-audit.sh` — pass; bash + zsh regenerated from compiled binary.
  - `bash scripts/ci/cli-output-contract-lint.sh` — pass.
  - `bash scripts/ci/docs-hygiene-audit.sh` + `docs-placement-audit.sh` — pass.
- **Waiver reason**: n/a.

## Testing

- pass: `cargo test -p nils-forge-cli` (251 total).
- pass: `cargo clippy -p nils-forge-cli --all-targets -- -D warnings`.
- pass: workspace CI gates (plan-bundle, docs, completion, cli-output-contract).
- not run (defer to Sprint 7): cross-provider parity harness and exit-code matrix completion.

## Risk / Notes

- `pr merge` is the riskiest single atom in v1 because its happy path actually mutates the remote. The lock-down chain refuses merges when any of the six rules trips, but real-world coverage of the happy path lands with Sprint 7's parity harness and Sprint 6's `pr deliver` macro; this PR ships the gates first.
- GitLab `glab mr merge` in the pinned 1.45 minor exposes only `--squash` as a merge-method flag; `rebase` is governed by the repo-level merge method config. Rule 9 (`merge_method_unsupported`) catches that mismatch at validation time so callers don't run into a silent glab fallback.
- `.forge-cli.toml` parse errors and unknown keys degrade gracefully to spec defaults plus `warnings[]` so a malformed repo override can't brick the binary.
- Sprint 5 (Issue atoms) is the next milestone and is unblocked by this merge.
