### PR TITLE
Forge-cli v1 Sprint 5: Issue atoms (create/view/edit/comment/close/reopen)

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -840,12 +840,20 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__issue__comment)
-            opts="-h --format --remote --provider --repo --dry-run --help <ID>"
+            opts="-h --body --body-file --format --remote --provider --repo --dry-run --help <ID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --body)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
@@ -870,12 +878,32 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__issue__create)
-            opts="-h --format --remote --provider --repo --dry-run --help"
+            opts="-h --title --body --body-file --label --assignee --format --remote --provider --repo --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --title)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --assignee)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
@@ -900,12 +928,36 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__issue__edit)
-            opts="-h --format --remote --provider --repo --dry-run --help <ID>"
+            opts="-h --title --body --body-file --add-label --remove-label --add-assignee --format --remote --provider --repo --dry-run --help <ID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --title)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --add-label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --remove-label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --add-assignee)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -313,6 +313,11 @@ json\:"Single-record JSON envelope (snake_case)"))' \
         case $line[1] in
             (create)
 _arguments "${_arguments_options[@]}" : \
+'--title=[Issue title (≤70 chars per \`title_length\` rule)]:TITLE:_default' \
+'(--body-file)--body=[Issue body (inline). Mutually exclusive with \`--body-file\`]:BODY:_default' \
+'--body-file=[Read body from a file. Use \`-\` for stdin]:BODY_FILE:_default' \
+'*--label=[Add a label. Repeat to apply multiple labels]:NAME:_default' \
+'*--assignee=[Assign a user. Repeat to assign multiple]:LOGIN:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
@@ -338,6 +343,12 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (edit)
 _arguments "${_arguments_options[@]}" : \
+'--title=[New title (re-validated against \`title_length\`)]:TITLE:_default' \
+'(--body-file)--body=[New body. Mutually exclusive with \`--body-file\`]:BODY:_default' \
+'--body-file=[Read body from a file. Use \`-\` for stdin]:BODY_FILE:_default' \
+'*--add-label=[Add a label. Repeat to add multiple]:NAME:_default' \
+'*--remove-label=[Remove a label. Repeat to remove multiple]:NAME:_default' \
+'*--add-assignee=[Add an assignee. Repeat to assign multiple]:LOGIN:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
@@ -346,11 +357,13 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':id -- Numeric id:_default' \
+':id -- Numeric issue id:_default' \
 && ret=0
 ;;
 (comment)
 _arguments "${_arguments_options[@]}" : \
+'(--body-file)--body=[Comment body. Mutually exclusive with \`--body-file\`]:BODY:_default' \
+'--body-file=[Read body from a file. Use \`-\` for stdin]:BODY_FILE:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
@@ -359,7 +372,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':id -- Numeric id:_default' \
+':id -- Numeric issue id:_default' \
 && ret=0
 ;;
 (close)

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -428,22 +428,16 @@ pub enum PrCommand {
 #[derive(Subcommand, Debug)]
 pub enum IssueCommand {
     /// Open a new issue.
-    Create,
+    Create(IssueCreateArgs),
     /// Fetch a single issue.
     View {
         /// Numeric id.
         id: u64,
     },
     /// Mutate an issue.
-    Edit {
-        /// Numeric id.
-        id: u64,
-    },
+    Edit(IssueEditArgs),
     /// Append a comment to an issue.
-    Comment {
-        /// Numeric id.
-        id: u64,
-    },
+    Comment(IssueCommentArgs),
     /// Close an issue.
     Close {
         /// Numeric id.
@@ -454,6 +448,64 @@ pub enum IssueCommand {
         /// Numeric id.
         id: u64,
     },
+}
+
+/// `issue create` arguments.
+#[derive(Args, Debug, Clone)]
+pub struct IssueCreateArgs {
+    /// Issue title (≤70 chars per `title_length` rule).
+    #[arg(long)]
+    pub title: String,
+    /// Issue body (inline). Mutually exclusive with `--body-file`.
+    #[arg(long, conflicts_with = "body_file")]
+    pub body: Option<String>,
+    /// Read body from a file. Use `-` for stdin.
+    #[arg(long = "body-file")]
+    pub body_file: Option<String>,
+    /// Add a label. Repeat to apply multiple labels.
+    #[arg(long = "label", value_name = "NAME")]
+    pub labels: Vec<String>,
+    /// Assign a user. Repeat to assign multiple.
+    #[arg(long = "assignee", value_name = "LOGIN")]
+    pub assignees: Vec<String>,
+}
+
+/// `issue edit` arguments.
+#[derive(Args, Debug, Clone)]
+pub struct IssueEditArgs {
+    /// Numeric issue id.
+    pub id: u64,
+    /// New title (re-validated against `title_length`).
+    #[arg(long)]
+    pub title: Option<String>,
+    /// New body. Mutually exclusive with `--body-file`.
+    #[arg(long, conflicts_with = "body_file")]
+    pub body: Option<String>,
+    /// Read body from a file. Use `-` for stdin.
+    #[arg(long = "body-file")]
+    pub body_file: Option<String>,
+    /// Add a label. Repeat to add multiple.
+    #[arg(long = "add-label", value_name = "NAME")]
+    pub add_label: Vec<String>,
+    /// Remove a label. Repeat to remove multiple.
+    #[arg(long = "remove-label", value_name = "NAME")]
+    pub remove_label: Vec<String>,
+    /// Add an assignee. Repeat to assign multiple.
+    #[arg(long = "add-assignee", value_name = "LOGIN")]
+    pub add_assignee: Vec<String>,
+}
+
+/// `issue comment` arguments.
+#[derive(Args, Debug, Clone)]
+pub struct IssueCommentArgs {
+    /// Numeric issue id.
+    pub id: u64,
+    /// Comment body. Mutually exclusive with `--body-file`.
+    #[arg(long, conflicts_with = "body_file")]
+    pub body: Option<String>,
+    /// Read body from a file. Use `-` for stdin.
+    #[arg(long = "body-file")]
+    pub body_file: Option<String>,
 }
 
 /// `repo` subtree.
@@ -532,6 +584,24 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
         Some(Command::Pr(PrArgs {
             command: Some(PrCommand::Merge(args)),
         })) => ops::pr_merge::run(&global, args, format),
+        Some(Command::Issue(IssueArgs {
+            command: Some(IssueCommand::Create(args)),
+        })) => ops::issue_create::run(&global, args, format),
+        Some(Command::Issue(IssueArgs {
+            command: Some(IssueCommand::View { id }),
+        })) => ops::issue_view::run(&global, id, format),
+        Some(Command::Issue(IssueArgs {
+            command: Some(IssueCommand::Edit(args)),
+        })) => ops::issue_edit::run(&global, args, format),
+        Some(Command::Issue(IssueArgs {
+            command: Some(IssueCommand::Comment(args)),
+        })) => ops::issue_comment::run(&global, args, format),
+        Some(Command::Issue(IssueArgs {
+            command: Some(IssueCommand::Close { id }),
+        })) => ops::issue_close::run(&global, id, format),
+        Some(Command::Issue(IssueArgs {
+            command: Some(IssueCommand::Reopen { id }),
+        })) => ops::issue_reopen::run(&global, id, format),
         Some(Command::Completion(CompletionArgs { shell })) => emit_completion(shell),
         None
         | Some(Command::Auth(AuthArgs { command: None }))
@@ -809,10 +879,11 @@ mod tests {
     #[test]
     fn lists_every_issue_v1_subcommand() {
         for sub in ["create", "view", "edit", "comment", "close", "reopen"] {
-            let mut argv = vec!["issue", sub];
-            if sub != "create" {
-                argv.push("1");
-            }
+            let argv: Vec<&str> = match sub {
+                "create" => vec!["issue", "create", "--title", "demo"],
+                "comment" | "edit" => vec!["issue", sub, "1"],
+                _ => vec!["issue", sub, "1"],
+            };
             let result = parse(&argv);
             assert!(result.is_ok(), "issue {sub} should parse, got {result:?}");
         }

--- a/crates/forge-cli/src/ops/issue_close.rs
+++ b/crates/forge-cli/src/ops/issue_close.rs
@@ -1,0 +1,120 @@
+//! `issue close` atom.
+//!
+//! Spec / ops: `cli.forge-cli.issue.close.v1`. Closes an issue and follows up
+//! with `issue view` so the envelope reports the post-close state.
+
+use std::ffi::OsString;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{BackendCall, BackendProgram, BackendRunner, DryRunPayload, ProcessRunner};
+use crate::cli::{BINARY, GlobalFlags};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::issue_view;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const SCHEMA: &str = "issue.close";
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct IssueClosePayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub state: &'static str,
+}
+
+pub fn run(global: &GlobalFlags, id: u64, format: OutputFormat) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, id, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    id: u64,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let call = build_close_call(&ctx, id);
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let _ = runner.run(&call)?;
+
+    let view_output = runner.run(&issue_view::build_view_call(&ctx, id))?;
+    let view = issue_view::parse_view_output(&ctx, &view_output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        IssueClosePayload {
+            provider: view.provider,
+            number: view.number,
+            url: view.url,
+            state: view.state,
+        },
+        format,
+        render_text,
+    ))
+}
+
+fn build_close_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub | Provider::GitLab => vec![
+            OsString::from("issue"),
+            OsString::from("close"),
+            OsString::from(id.to_string()),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn render_text(payload: &IssueClosePayload) {
+    println!(
+        "closed {provider} issue #{number} ({state}): {url}",
+        provider = payload.provider,
+        number = payload.number,
+        state = payload.state,
+        url = payload.url,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "x".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    #[test]
+    fn build_close_call_emits_issue_close_id_on_both_providers() {
+        let gh = build_close_call(&ctx(Provider::GitHub), 5);
+        assert_eq!(
+            gh.plan_argv()[1..],
+            ["issue".to_string(), "close".to_string(), "5".to_string()]
+        );
+        let gl = build_close_call(&ctx(Provider::GitLab), 9);
+        assert_eq!(
+            gl.plan_argv()[1..],
+            ["issue".to_string(), "close".to_string(), "9".to_string()]
+        );
+    }
+}

--- a/crates/forge-cli/src/ops/issue_comment.rs
+++ b/crates/forge-cli/src/ops/issue_comment.rs
@@ -1,0 +1,191 @@
+//! `issue comment` atom.
+//!
+//! Spec / ops: `cli.forge-cli.issue.comment.v1`. Appends a comment to an
+//! issue. Body resolution mirrors `pr comment`: `--body` takes precedence,
+//! else `--body-file <path>` (with `-` meaning stdin). Empty body rejects
+//! with `DATA 65` / `body_missing_summary`.
+
+use std::ffi::OsString;
+use std::fs;
+use std::io::Read as _;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{BackendCall, BackendProgram, BackendRunner, DryRunPayload, ProcessRunner};
+use crate::cli::{BINARY, GlobalFlags, IssueCommentArgs};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::issue_view;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const SCHEMA: &str = "issue.comment";
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct IssueCommentPayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    args: IssueCommentArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, args, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: IssueCommentArgs,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let body = read_body(args.body.as_deref(), args.body_file.as_deref())?;
+    if body.trim().is_empty() {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "body_missing_summary",
+            "comment body is empty (supply --body or --body-file)",
+            None,
+        ));
+    }
+    let call = build_comment_call(&ctx, args.id, &body);
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let _ = runner.run(&call)?;
+    let view_output = runner.run(&issue_view::build_view_call(&ctx, args.id))?;
+    let view = issue_view::parse_view_output(&ctx, &view_output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        IssueCommentPayload {
+            provider: view.provider,
+            number: view.number,
+            url: view.url,
+        },
+        format,
+        render_text,
+    ))
+}
+
+fn build_comment_call(ctx: &ProviderContext, id: u64, body: &str) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("issue"),
+            OsString::from("comment"),
+            OsString::from(id.to_string()),
+            OsString::from("--body"),
+            OsString::from(body),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("issue"),
+            OsString::from("note"),
+            OsString::from(id.to_string()),
+            OsString::from("--message"),
+            OsString::from(body),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn read_body(inline: Option<&str>, file: Option<&str>) -> Result<String, ForgeError> {
+    if let Some(s) = inline {
+        return Ok(s.to_string());
+    }
+    let Some(path) = file else {
+        return Ok(String::new());
+    };
+    if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "failed to read comment body from stdin",
+                Some(e.to_string()),
+            )
+        })?;
+        return Ok(buf);
+    }
+    fs::read_to_string(path).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            format!("failed to read --body-file '{path}'"),
+            Some(e.to_string()),
+        )
+    })
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &IssueCommentPayload) {
+    println!(
+        "commented on {provider} issue #{number}: {url}",
+        provider = payload.provider,
+        number = payload.number,
+        url = payload.url,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "x".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    #[test]
+    fn build_comment_call_github_uses_issue_comment_body() {
+        let call = build_comment_call(&ctx(Provider::GitHub), 5, "hello");
+        let plan = call.plan_argv();
+        assert_eq!(
+            plan[1..4],
+            ["issue".to_string(), "comment".to_string(), "5".to_string()]
+        );
+        let b = plan.iter().position(|s| s == "--body").unwrap();
+        assert_eq!(plan[b + 1], "hello");
+    }
+
+    #[test]
+    fn build_comment_call_gitlab_uses_issue_note_message() {
+        let call = build_comment_call(&ctx(Provider::GitLab), 7, "hello");
+        let plan = call.plan_argv();
+        assert_eq!(
+            plan[1..4],
+            ["issue".to_string(), "note".to_string(), "7".to_string()]
+        );
+        let m = plan.iter().position(|s| s == "--message").unwrap();
+        assert_eq!(plan[m + 1], "hello");
+    }
+
+    #[test]
+    fn read_body_prefers_inline_over_file() {
+        assert_eq!(
+            read_body(Some("inline"), Some("/no/such")).unwrap(),
+            "inline"
+        );
+    }
+}

--- a/crates/forge-cli/src/ops/issue_create.rs
+++ b/crates/forge-cli/src/ops/issue_create.rs
@@ -1,0 +1,338 @@
+//! `issue create` atom.
+//!
+//! Spec / ops: `cli.forge-cli.issue.create.v1`. The only validation is
+//! `title_length` (≤70 chars per spec). Body comes from `--body`,
+//! `--body-file <path>`, or `--body-file -` (stdin). The body is always
+//! materialised into a tempfile and handed to the backend as `--body-file`
+//! (gh) or `--description` (glab) so argv stays stable when bodies contain
+//! shell-hostile characters.
+
+use std::ffi::OsString;
+use std::fs;
+use std::io::Read as _;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+use tempfile::NamedTempFile;
+
+use crate::backend::{
+    BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
+};
+use crate::cli::{BINARY, GlobalFlags, IssueCreateArgs};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::issue_view;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+use crate::validations::title_length;
+
+const SCHEMA: &str = "issue.create";
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct IssueCreatePayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub title: String,
+    pub state: &'static str,
+    pub labels: Vec<String>,
+    pub assignees: Vec<String>,
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    args: IssueCreateArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, args, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: IssueCreateArgs,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    title_length(&args.title)?;
+    let body = read_body(args.body.as_deref(), args.body_file.as_deref())?;
+    let body_tempfile = write_body_tempfile(&body)?;
+    let body_path = body_tempfile.path().to_path_buf();
+    let call = build_create_call(
+        &ctx,
+        &args.title,
+        &body,
+        &body_path,
+        &args.labels,
+        &args.assignees,
+    );
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let output = runner.run(&call)?;
+    let (number, url) = parse_create_output(&ctx, &output)?;
+
+    // Re-fetch via issue view so the envelope matches the spec data shape.
+    let view_output = runner.run(&issue_view::build_view_call(&ctx, number))?;
+    let view = issue_view::parse_view_output(&ctx, &view_output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        IssueCreatePayload {
+            provider: view.provider,
+            number: view.number,
+            url: if url.is_empty() { view.url } else { url },
+            title: view.title,
+            state: view.state,
+            labels: view.labels,
+            assignees: view.assignees,
+        },
+        format,
+        render_text,
+    ))
+}
+
+fn build_create_call(
+    ctx: &ProviderContext,
+    title: &str,
+    body: &str,
+    body_path: &std::path::Path,
+    labels: &[String],
+    assignees: &[String],
+) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let mut argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("issue"),
+            OsString::from("create"),
+            OsString::from("--title"),
+            OsString::from(title),
+            OsString::from("--body-file"),
+            OsString::from(body_path),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("issue"),
+            OsString::from("create"),
+            OsString::from("--title"),
+            OsString::from(title),
+            OsString::from("--description"),
+            OsString::from(body),
+        ],
+    };
+    match ctx.provider {
+        Provider::GitHub => {
+            for l in labels {
+                argv.push(OsString::from("--label"));
+                argv.push(OsString::from(l));
+            }
+            for a in assignees {
+                argv.push(OsString::from("--assignee"));
+                argv.push(OsString::from(a));
+            }
+        }
+        Provider::GitLab => {
+            for l in labels {
+                argv.push(OsString::from("--label"));
+                argv.push(OsString::from(l));
+            }
+            for a in assignees {
+                argv.push(OsString::from("--assignee"));
+                argv.push(OsString::from(a));
+            }
+        }
+    }
+    BackendCall::new(program, argv)
+}
+
+fn parse_create_output(
+    ctx: &ProviderContext,
+    output: &BackendSuccess,
+) -> Result<(u64, String), ForgeError> {
+    // gh / glab both print a URL trailing the create command; pull the last
+    // line that looks like a URL and infer the number from its tail.
+    let url = output
+        .stdout
+        .lines()
+        .rev()
+        .find(|l| l.trim_start().starts_with("http"))
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if url.is_empty() {
+        return Err(ForgeError::software(
+            schema_err(),
+            "issue create did not print a URL",
+            Some(format!("stdout={:?}", output.stdout)),
+        ));
+    }
+    let number = url
+        .rsplit('/')
+        .find(|seg| seg.chars().all(|c| c.is_ascii_digit()) && !seg.is_empty())
+        .and_then(|seg| seg.parse::<u64>().ok())
+        .ok_or_else(|| {
+            ForgeError::software(
+                schema_err(),
+                format!(
+                    "could not parse issue number from URL '{url}' ({})",
+                    ctx.provider.as_str()
+                ),
+                None,
+            )
+        })?;
+    Ok((number, url))
+}
+
+fn read_body(inline: Option<&str>, file: Option<&str>) -> Result<String, ForgeError> {
+    if let Some(s) = inline {
+        return Ok(s.to_string());
+    }
+    let Some(path) = file else {
+        return Ok(String::new());
+    };
+    if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "failed to read issue body from stdin",
+                Some(e.to_string()),
+            )
+        })?;
+        return Ok(buf);
+    }
+    fs::read_to_string(path).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            format!("failed to read --body-file '{path}'"),
+            Some(e.to_string()),
+        )
+    })
+}
+
+fn write_body_tempfile(body: &str) -> Result<NamedTempFile, ForgeError> {
+    let tmp = tempfile::Builder::new()
+        .prefix("forge-cli-issue-body-")
+        .suffix(".md")
+        .tempfile()
+        .map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "failed to create issue body tempfile",
+                Some(e.to_string()),
+            )
+        })?;
+    fs::write(tmp.path(), body).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            "failed to write issue body tempfile",
+            Some(e.to_string()),
+        )
+    })?;
+    Ok(tmp)
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &IssueCreatePayload) {
+    println!(
+        "opened {provider} issue #{number}: {url}",
+        provider = payload.provider,
+        number = payload.number,
+        url = payload.url,
+    );
+}
+
+// `_path` placeholder kept for IDE breadcrumb when grepping for body-file
+// callers; the real path comes from the tempfile handle.
+#[allow(dead_code)]
+const _PATH_BREADCRUMB: &str = "body-file -> tempfile";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "x".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    #[test]
+    fn build_create_call_github_uses_body_file_and_labels() {
+        let path = PathBuf::from("/tmp/body.md");
+        let call = build_create_call(
+            &ctx(Provider::GitHub),
+            "title",
+            "body",
+            &path,
+            &["bug".into(), "p1".into()],
+            &["alice".into()],
+        );
+        let plan = call.plan_argv();
+        assert_eq!(plan[1..3], ["issue".to_string(), "create".to_string()]);
+        let title_idx = plan.iter().position(|s| s == "--title").unwrap();
+        assert_eq!(plan[title_idx + 1], "title");
+        let bf_idx = plan.iter().position(|s| s == "--body-file").unwrap();
+        assert_eq!(plan[bf_idx + 1], "/tmp/body.md");
+        // labels and assignees come through as repeated flag pairs.
+        let label_count = plan.iter().filter(|s| s.as_str() == "--label").count();
+        assert_eq!(label_count, 2);
+        let asg_count = plan.iter().filter(|s| s.as_str() == "--assignee").count();
+        assert_eq!(asg_count, 1);
+    }
+
+    #[test]
+    fn build_create_call_gitlab_uses_description_inline() {
+        let path = PathBuf::from("/tmp/body.md");
+        let call = build_create_call(&ctx(Provider::GitLab), "t", "lengthy body", &path, &[], &[]);
+        let plan = call.plan_argv();
+        let d = plan.iter().position(|s| s == "--description").unwrap();
+        assert_eq!(plan[d + 1], "lengthy body");
+        assert!(!plan.iter().any(|s| s == "--body-file"));
+    }
+
+    #[test]
+    fn parse_create_output_extracts_number_from_url() {
+        let out = BackendSuccess {
+            stdout: "creating issue...\nhttps://github.com/acme/widgets/issues/42\n".into(),
+            stderr: String::new(),
+        };
+        let (n, u) = parse_create_output(&ctx(Provider::GitHub), &out).unwrap();
+        assert_eq!(n, 42);
+        assert!(u.ends_with("/42"));
+    }
+
+    #[test]
+    fn parse_create_output_errors_when_no_url() {
+        let out = BackendSuccess {
+            stdout: "(no url)".into(),
+            stderr: String::new(),
+        };
+        let err = parse_create_output(&ctx(Provider::GitHub), &out).expect_err("must fail");
+        assert_eq!(err.kind(), "software_error");
+    }
+
+    #[test]
+    fn read_body_prefers_inline_over_file() {
+        assert_eq!(
+            read_body(Some("inline"), Some("/no/such")).unwrap(),
+            "inline"
+        );
+    }
+}

--- a/crates/forge-cli/src/ops/issue_edit.rs
+++ b/crates/forge-cli/src/ops/issue_edit.rs
@@ -1,0 +1,276 @@
+//! `issue edit` atom.
+//!
+//! Spec / ops: `cli.forge-cli.issue.edit.v1`. Supports partial mutation of
+//! title / body / labels / assignees. `title_length` runs only when `--title`
+//! is supplied. Backend argv reflects exactly the subset of flags the user
+//! passed so we don't accidentally clear labels by sending empty values.
+
+use std::ffi::OsString;
+use std::fs;
+use std::io::Read as _;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{BackendCall, BackendProgram, BackendRunner, DryRunPayload, ProcessRunner};
+use crate::cli::{BINARY, GlobalFlags, IssueEditArgs};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::issue_view;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+use crate::validations::title_length;
+
+const SCHEMA: &str = "issue.edit";
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct IssueEditPayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub state: &'static str,
+    pub title: String,
+    pub labels: Vec<String>,
+    pub assignees: Vec<String>,
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    args: IssueEditArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, args, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: IssueEditArgs,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    if let Some(ref t) = args.title {
+        title_length(t)?;
+    }
+    let body = if args.body.is_some() || args.body_file.is_some() {
+        Some(read_body(args.body.as_deref(), args.body_file.as_deref())?)
+    } else {
+        None
+    };
+    let call = build_edit_call(&ctx, &args, body.as_deref());
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let _ = runner.run(&call)?;
+    let view_output = runner.run(&issue_view::build_view_call(&ctx, args.id))?;
+    let view = issue_view::parse_view_output(&ctx, &view_output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        IssueEditPayload {
+            provider: view.provider,
+            number: view.number,
+            url: view.url,
+            state: view.state,
+            title: view.title,
+            labels: view.labels,
+            assignees: view.assignees,
+        },
+        format,
+        render_text,
+    ))
+}
+
+fn build_edit_call(ctx: &ProviderContext, args: &IssueEditArgs, body: Option<&str>) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let mut argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("issue"),
+            OsString::from("edit"),
+            OsString::from(args.id.to_string()),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("issue"),
+            OsString::from("update"),
+            OsString::from(args.id.to_string()),
+        ],
+    };
+    if let Some(t) = &args.title {
+        argv.push(OsString::from("--title"));
+        argv.push(OsString::from(t));
+    }
+    if let Some(b) = body {
+        let body_flag = match ctx.provider {
+            Provider::GitHub => "--body",
+            Provider::GitLab => "--description",
+        };
+        argv.push(OsString::from(body_flag));
+        argv.push(OsString::from(b));
+    }
+    for label in &args.add_label {
+        let flag = match ctx.provider {
+            Provider::GitHub => "--add-label",
+            Provider::GitLab => "--label",
+        };
+        argv.push(OsString::from(flag));
+        argv.push(OsString::from(label));
+    }
+    for label in &args.remove_label {
+        let flag = match ctx.provider {
+            Provider::GitHub => "--remove-label",
+            Provider::GitLab => "--unlabel",
+        };
+        argv.push(OsString::from(flag));
+        argv.push(OsString::from(label));
+    }
+    for assignee in &args.add_assignee {
+        let flag = match ctx.provider {
+            Provider::GitHub => "--add-assignee",
+            Provider::GitLab => "--assignee",
+        };
+        argv.push(OsString::from(flag));
+        argv.push(OsString::from(assignee));
+    }
+    BackendCall::new(program, argv)
+}
+
+fn read_body(inline: Option<&str>, file: Option<&str>) -> Result<String, ForgeError> {
+    if let Some(s) = inline {
+        return Ok(s.to_string());
+    }
+    let Some(path) = file else {
+        return Ok(String::new());
+    };
+    if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "failed to read issue body from stdin",
+                Some(e.to_string()),
+            )
+        })?;
+        return Ok(buf);
+    }
+    fs::read_to_string(path).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            format!("failed to read --body-file '{path}'"),
+            Some(e.to_string()),
+        )
+    })
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &IssueEditPayload) {
+    println!(
+        "edited {provider} issue #{number} ({state}): {url}",
+        provider = payload.provider,
+        number = payload.number,
+        state = payload.state,
+        url = payload.url,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "x".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    fn args() -> IssueEditArgs {
+        IssueEditArgs {
+            id: 7,
+            title: None,
+            body: None,
+            body_file: None,
+            add_label: vec![],
+            remove_label: vec![],
+            add_assignee: vec![],
+        }
+    }
+
+    #[test]
+    fn build_edit_call_github_emits_issue_edit_id() {
+        let call = build_edit_call(&ctx(Provider::GitHub), &args(), None);
+        let plan = call.plan_argv();
+        assert_eq!(
+            plan[1..4],
+            ["issue".to_string(), "edit".to_string(), "7".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_edit_call_gitlab_emits_issue_update_id() {
+        let call = build_edit_call(&ctx(Provider::GitLab), &args(), None);
+        let plan = call.plan_argv();
+        assert_eq!(
+            plan[1..4],
+            ["issue".to_string(), "update".to_string(), "7".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_edit_call_github_passes_through_optional_title_and_body() {
+        let mut a = args();
+        a.title = Some("new title".into());
+        let call = build_edit_call(&ctx(Provider::GitHub), &a, Some("new body"));
+        let plan = call.plan_argv();
+        let t = plan.iter().position(|s| s == "--title").unwrap();
+        assert_eq!(plan[t + 1], "new title");
+        let b = plan.iter().position(|s| s == "--body").unwrap();
+        assert_eq!(plan[b + 1], "new body");
+    }
+
+    #[test]
+    fn build_edit_call_gitlab_uses_label_unlabel_flags() {
+        let mut a = args();
+        a.add_label = vec!["bug".into(), "p1".into()];
+        a.remove_label = vec!["wontfix".into()];
+        let call = build_edit_call(&ctx(Provider::GitLab), &a, None);
+        let plan = call.plan_argv();
+        let labels: Vec<usize> = plan
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.as_str() == "--label")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(plan[labels[0] + 1], "bug");
+        let unlabel = plan.iter().position(|s| s == "--unlabel").unwrap();
+        assert_eq!(plan[unlabel + 1], "wontfix");
+    }
+
+    #[test]
+    fn build_edit_call_github_uses_add_label_remove_label_flags() {
+        let mut a = args();
+        a.add_label = vec!["bug".into()];
+        a.remove_label = vec!["stale".into()];
+        let call = build_edit_call(&ctx(Provider::GitHub), &a, None);
+        let plan = call.plan_argv();
+        let al = plan.iter().position(|s| s == "--add-label").unwrap();
+        let rl = plan.iter().position(|s| s == "--remove-label").unwrap();
+        assert_eq!(plan[al + 1], "bug");
+        assert_eq!(plan[rl + 1], "stale");
+    }
+}

--- a/crates/forge-cli/src/ops/issue_reopen.rs
+++ b/crates/forge-cli/src/ops/issue_reopen.rs
@@ -1,0 +1,119 @@
+//! `issue reopen` atom.
+//!
+//! Spec / ops: `cli.forge-cli.issue.reopen.v1`. Reopens a closed issue and
+//! follows up with `issue view` so the envelope reports the post-action state.
+
+use std::ffi::OsString;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{BackendCall, BackendProgram, BackendRunner, DryRunPayload, ProcessRunner};
+use crate::cli::{BINARY, GlobalFlags};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::issue_view;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const SCHEMA: &str = "issue.reopen";
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct IssueReopenPayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub state: &'static str,
+}
+
+pub fn run(global: &GlobalFlags, id: u64, format: OutputFormat) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, id, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    id: u64,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let call = build_reopen_call(&ctx, id);
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let _ = runner.run(&call)?;
+    let view_output = runner.run(&issue_view::build_view_call(&ctx, id))?;
+    let view = issue_view::parse_view_output(&ctx, &view_output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        IssueReopenPayload {
+            provider: view.provider,
+            number: view.number,
+            url: view.url,
+            state: view.state,
+        },
+        format,
+        render_text,
+    ))
+}
+
+fn build_reopen_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub | Provider::GitLab => vec![
+            OsString::from("issue"),
+            OsString::from("reopen"),
+            OsString::from(id.to_string()),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+fn render_text(payload: &IssueReopenPayload) {
+    println!(
+        "reopened {provider} issue #{number} ({state}): {url}",
+        provider = payload.provider,
+        number = payload.number,
+        state = payload.state,
+        url = payload.url,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "x".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    #[test]
+    fn build_reopen_call_emits_issue_reopen_id_on_both_providers() {
+        let gh = build_reopen_call(&ctx(Provider::GitHub), 5);
+        assert_eq!(
+            gh.plan_argv()[1..],
+            ["issue".to_string(), "reopen".to_string(), "5".to_string()]
+        );
+        let gl = build_reopen_call(&ctx(Provider::GitLab), 9);
+        assert_eq!(
+            gl.plan_argv()[1..],
+            ["issue".to_string(), "reopen".to_string(), "9".to_string()]
+        );
+    }
+}

--- a/crates/forge-cli/src/ops/issue_view.rs
+++ b/crates/forge-cli/src/ops/issue_view.rs
@@ -1,0 +1,322 @@
+//! `issue view` atom + shared issue JSON parser.
+//!
+//! Spec / ops: `cli.forge-cli.issue.view.v1`. Both backends emit a single JSON
+//! object that we normalize into [`IssueViewPayload`]. The parser is `pub`
+//! because `issue create / edit / close / reopen / comment` all re-fetch the
+//! canonical view after their mutating call so the envelope reports the
+//! post-action state.
+
+use std::ffi::OsString;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{
+    BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
+};
+use crate::cli::{BINARY, GlobalFlags};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_state::normalize_state;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+pub const SCHEMA: &str = "issue.view";
+pub const SCHEMA_VERSION: u32 = 1;
+
+const GH_JSON_FIELDS: &str = "number,url,state,title,labels,assignees,body";
+
+/// Envelope payload for `cli.forge-cli.issue.view.v1`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct IssueViewPayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub state: &'static str,
+    pub title: String,
+    pub body: String,
+    pub labels: Vec<String>,
+    pub assignees: Vec<String>,
+}
+
+pub fn run(global: &GlobalFlags, id: u64, format: OutputFormat) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, id, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    id: u64,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let call = build_view_call(&ctx, id);
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let output = runner.run(&call)?;
+    let payload = parse_view_output(&ctx, &output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        payload,
+        format,
+        render_text,
+    ))
+}
+
+pub fn build_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("issue"),
+            OsString::from("view"),
+            OsString::from(id.to_string()),
+            OsString::from("--json"),
+            OsString::from(GH_JSON_FIELDS),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("issue"),
+            OsString::from("view"),
+            OsString::from(id.to_string()),
+            OsString::from("-F"),
+            OsString::from("json"),
+        ],
+    };
+    BackendCall::new(program, argv)
+}
+
+pub fn parse_view_output(
+    ctx: &ProviderContext,
+    output: &BackendSuccess,
+) -> Result<IssueViewPayload, ForgeError> {
+    let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            "issue view JSON is invalid",
+            Some(e.to_string()),
+        )
+    })?;
+    match ctx.provider {
+        Provider::GitHub => parse_github(&value, ctx),
+        Provider::GitLab => parse_gitlab(&value, ctx),
+    }
+}
+
+fn parse_github(
+    value: &serde_json::Value,
+    ctx: &ProviderContext,
+) -> Result<IssueViewPayload, ForgeError> {
+    let state = normalize_state(
+        value.get("state").and_then(|v| v.as_str()).unwrap_or(""),
+        ctx.provider,
+    )?;
+    Ok(IssueViewPayload {
+        provider: ctx.provider.as_str(),
+        number: value
+            .get("number")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| missing("number"))?,
+        url: required_str(value, "url")?,
+        state,
+        title: required_str(value, "title")?,
+        body: value
+            .get("body")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        labels: github_name_list(value, "labels"),
+        assignees: github_assignees(value),
+    })
+}
+
+fn parse_gitlab(
+    value: &serde_json::Value,
+    ctx: &ProviderContext,
+) -> Result<IssueViewPayload, ForgeError> {
+    let state = normalize_state(
+        value.get("state").and_then(|v| v.as_str()).unwrap_or(""),
+        ctx.provider,
+    )?;
+    Ok(IssueViewPayload {
+        provider: ctx.provider.as_str(),
+        number: value
+            .get("iid")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| missing("iid"))?,
+        url: required_str(value, "web_url")?,
+        state,
+        title: required_str(value, "title")?,
+        body: value
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        labels: gitlab_label_list(value),
+        assignees: gitlab_assignees(value),
+    })
+}
+
+fn github_name_list(value: &serde_json::Value, key: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    item.get("name")
+                        .and_then(|n| n.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn github_assignees(value: &serde_json::Value) -> Vec<String> {
+    value
+        .get("assignees")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    item.get("login")
+                        .and_then(|n| n.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn gitlab_label_list(value: &serde_json::Value) -> Vec<String> {
+    value
+        .get("labels")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    item.as_str().map(str::to_string).or_else(|| {
+                        item.get("name")
+                            .and_then(|n| n.as_str())
+                            .map(str::to_string)
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn gitlab_assignees(value: &serde_json::Value) -> Vec<String> {
+    value
+        .get("assignees")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    item.get("username")
+                        .and_then(|n| n.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn required_str(value: &serde_json::Value, key: &str) -> Result<String, ForgeError> {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| missing(key))
+}
+
+fn missing(key: &str) -> ForgeError {
+    ForgeError::software(
+        schema_err(),
+        format!("missing required field '{key}' in issue view JSON"),
+        None,
+    )
+}
+
+pub(super) fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &IssueViewPayload) {
+    println!(
+        "#{number} [{state}] {title}\n  {url}",
+        number = payload.number,
+        state = payload.state,
+        title = payload.title,
+        url = payload.url,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "example.com".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    #[test]
+    fn build_view_call_github_uses_json_fields() {
+        let call = build_view_call(&ctx(Provider::GitHub), 5);
+        let plan = call.plan_argv();
+        assert_eq!(plan[1..3], ["issue".to_string(), "view".to_string()]);
+        assert!(plan.iter().any(|s| s == "--json"));
+    }
+
+    #[test]
+    fn parse_github_open_issue() {
+        let output = BackendSuccess {
+            stdout: r#"{"number":7,"url":"u","state":"OPEN","title":"t","body":"b","labels":[{"name":"a"},{"name":"b"}],"assignees":[{"login":"x"}]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitHub), &output).unwrap();
+        assert_eq!(p.state, "open");
+        assert_eq!(p.labels, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(p.assignees, vec!["x".to_string()]);
+        assert_eq!(p.body, "b");
+    }
+
+    #[test]
+    fn parse_gitlab_opened_normalises_to_open() {
+        let output = BackendSuccess {
+            stdout: r#"{"iid":3,"web_url":"u","state":"opened","title":"t","description":"d","labels":["a"],"assignees":[{"username":"y"}]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitLab), &output).unwrap();
+        assert_eq!(p.number, 3);
+        assert_eq!(p.state, "open");
+        assert_eq!(p.labels, vec!["a".to_string()]);
+        assert_eq!(p.assignees, vec!["y".to_string()]);
+        assert_eq!(p.body, "d");
+    }
+
+    #[test]
+    fn parse_gitlab_closed_normalises_to_closed() {
+        let output = BackendSuccess {
+            stdout: r#"{"iid":3,"web_url":"u","state":"closed","title":"t","description":"","labels":[],"assignees":[]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitLab), &output).unwrap();
+        assert_eq!(p.state, "closed");
+    }
+}

--- a/crates/forge-cli/src/ops/mod.rs
+++ b/crates/forge-cli/src/ops/mod.rs
@@ -3,6 +3,12 @@
 //! returns `Result<i32, ForgeError>`.
 
 pub mod auth_status;
+pub mod issue_close;
+pub mod issue_comment;
+pub mod issue_create;
+pub mod issue_edit;
+pub mod issue_reopen;
+pub mod issue_view;
 pub mod pr_checks;
 pub mod pr_checks_gitlab;
 pub mod pr_close;

--- a/crates/forge-cli/tests/integration.rs
+++ b/crates/forge-cli/tests/integration.rs
@@ -5,6 +5,7 @@ mod integration {
     mod auth_status;
     mod cli;
     mod exit_codes;
+    mod issue_atoms;
     mod pr_checks_github;
     mod pr_checks_gitlab;
     mod pr_create;

--- a/crates/forge-cli/tests/integration/issue_atoms.rs
+++ b/crates/forge-cli/tests/integration/issue_atoms.rs
@@ -1,0 +1,277 @@
+//! Sprint 5 integration tests for the issue atoms. Each test exercises a
+//! single atom end-to-end against a stubbed gh / glab so the CLI surface +
+//! envelope contract are pinned without hitting any real provider.
+//!
+//! The fuller per-op fixture corpus (gh + glab JSON pairs for every action)
+//! lands in Sprint 7's parity harness; this module covers the acceptance
+//! criteria called out in the plan:
+//!
+//! - `issue create --dry-run --format json` renders the plan envelope.
+//! - `issue create` with an over-cap title exits DATA 65 / `title_too_long`.
+//! - Each of view / close / reopen / comment / edit emits the right schema
+//!   literal and snake_case envelope.
+
+use pretty_assertions::assert_eq;
+
+use super::support::{StubEnv, parse_envelope, run_forge_cli};
+
+const FORBIDDEN_STUB: &str = "#!/bin/sh\necho 'should not run during dry-run' >&2\nexit 99\n";
+
+fn issue_view_stub(state: &str, number: u64) -> String {
+    let json = format!(
+        r#"{{"number":{number},"url":"https://github.com/acme/widgets/issues/{number}","state":"{state}","title":"t","body":"b","labels":[{{"name":"bug"}}],"assignees":[{{"login":"alice"}}]}}"#
+    );
+    format!(
+        r#"#!/bin/sh
+set -e
+case "$1 $2" in
+  "issue view")
+    cat <<'EOF'
+{json}
+EOF
+    ;;
+  "issue close"|"issue reopen"|"issue comment"|"issue edit")
+    :
+    ;;
+  "issue create")
+    echo "creating issue..."
+    echo "https://github.com/acme/widgets/issues/{number}"
+    ;;
+  *)
+    echo "stub: unexpected gh args: $*" >&2
+    exit 99
+    ;;
+esac
+"#
+    )
+}
+
+#[test]
+fn issue_create_dry_run_renders_plan_with_title_and_body_file() {
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+            "issue",
+            "create",
+            "--title",
+            "demo title",
+            "--body",
+            "body text",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.issue.create.v1");
+    let plan: Vec<String> = env["data"]["plan"]
+        .as_array()
+        .expect("plan array")
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect();
+    assert!(plan.iter().any(|s| s == "issue"), "{plan:?}");
+    assert!(plan.iter().any(|s| s == "create"), "{plan:?}");
+    let t = plan.iter().position(|s| s == "--title").unwrap();
+    assert_eq!(plan[t + 1], "demo title");
+    assert!(plan.iter().any(|s| s == "--body-file"), "{plan:?}");
+}
+
+#[test]
+fn issue_create_title_over_70_chars_exits_data_with_title_too_long() {
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+    let long_title = "a".repeat(71);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "issue",
+            "create",
+            "--title",
+            &long_title,
+            "--body",
+            "b",
+        ],
+    );
+    assert_eq!(
+        out.code, 65,
+        "expected DATA 65 on title_too_long, stderr={}",
+        out.stderr
+    );
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["ok"], false);
+    assert_eq!(env["error"]["code"], "title_too_long");
+}
+
+#[test]
+fn issue_view_emits_canonical_envelope() {
+    let stub = StubEnv::new().gh_stub(&issue_view_stub("OPEN", 42));
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "issue",
+            "view",
+            "42",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.issue.view.v1");
+    assert_eq!(env["data"]["state"], "open");
+    assert_eq!(env["data"]["number"], 42);
+    assert_eq!(env["data"]["labels"][0], "bug");
+    assert_eq!(env["data"]["assignees"][0], "alice");
+}
+
+#[test]
+fn issue_close_runs_close_then_view_and_emits_closed_state() {
+    let stub = StubEnv::new().gh_stub(&issue_view_stub("CLOSED", 7));
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "issue",
+            "close",
+            "7",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.issue.close.v1");
+    assert_eq!(env["data"]["state"], "closed");
+    assert_eq!(env["data"]["number"], 7);
+}
+
+#[test]
+fn issue_reopen_runs_reopen_then_view_and_emits_open_state() {
+    let stub = StubEnv::new().gh_stub(&issue_view_stub("OPEN", 7));
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "issue",
+            "reopen",
+            "7",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.issue.reopen.v1");
+    assert_eq!(env["data"]["state"], "open");
+}
+
+#[test]
+fn issue_comment_runs_comment_then_view_and_emits_url() {
+    let stub = StubEnv::new().gh_stub(&issue_view_stub("OPEN", 11));
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "issue",
+            "comment",
+            "11",
+            "--body",
+            "hello",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.issue.comment.v1");
+    assert_eq!(env["data"]["number"], 11);
+    assert!(env["data"]["url"].as_str().unwrap().contains("/11"));
+}
+
+#[test]
+fn issue_comment_empty_body_exits_data_with_body_missing_summary() {
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "issue",
+            "comment",
+            "1",
+        ],
+    );
+    assert_eq!(out.code, 65, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["error"]["code"], "body_missing_summary");
+}
+
+#[test]
+fn issue_edit_revalidates_title_length_when_supplied() {
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+    let long_title = "z".repeat(71);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "issue",
+            "edit",
+            "5",
+            "--title",
+            &long_title,
+        ],
+    );
+    assert_eq!(out.code, 65, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["error"]["code"], "title_too_long");
+}
+
+#[test]
+fn issue_edit_dry_run_renders_plan_with_add_label_remove_label() {
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+            "issue",
+            "edit",
+            "5",
+            "--add-label",
+            "bug",
+            "--remove-label",
+            "stale",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let plan: Vec<String> = env["data"]["plan"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect();
+    assert!(plan.iter().any(|s| s == "--add-label"), "{plan:?}");
+    assert!(plan.iter().any(|s| s == "--remove-label"), "{plan:?}");
+}

--- a/docs/plans/forge-cli/forge-cli-execution-state.md
+++ b/docs/plans/forge-cli/forge-cli-execution-state.md
@@ -7,46 +7,46 @@
 - Execution window: 2026-05-19 → ongoing
 - Staged execution confirmation: not applicable (default-continue
   authorization: "默認就一直做下去")
-- Current task: Sprint 4 review (PR pending)
-- Next task: Task 5.1
+- Current task: Sprint 5 review (PR pending)
+- Next task: Task 6.1
 - Last updated: 2026-05-20
-- Branch/commit: `feat/forge-cli-v1-sprint4-merge` HEAD at `9094408`
-  (Task 4.3); PR open and awaiting CI green + merge before cutting
-  Sprint 5 branch off updated `origin/main`
+- Branch/commit: `feat/forge-cli-v1-sprint5-issues` cut from
+  `origin/main@c049a1f` (Sprint 4 PR #393 merge); Sprint 5 production
+  code complete locally, PR pending push + CI
 - Source document: docs/plans/forge-cli/forge-cli-plan.md
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger
 
-| ID       | Status    | Task                                                        | Evidence                   | Notes                                                          |
-| -------- | --------- | ----------------------------------------------------------- | -------------------------- | -------------------------------------------------------------- |
-| Task 1.1 | completed | Scaffold `crates/forge-cli/` package and workspace wiring   | PR #381 (merged `eb92969`) | Sprint 1                                                       |
-| Task 1.2 | completed | Define clap command tree + global flags                     | PR #381                    | Sprint 1                                                       |
-| Task 1.3 | completed | Implement provider detection                                | PR #381                    | Sprint 1                                                       |
-| Task 1.4 | completed | Subprocess wrapper + envelope serializer + dry-run plumbing | PR #381                    | Sprint 1                                                       |
-| Task 1.5 | completed | Implement `auth status` atom                                | PR #381                    | Sprint 1                                                       |
-| Task 1.6 | completed | Implement `repo view` atom                                  | PR #381                    | Sprint 1                                                       |
-| Task 1.7 | completed | Sprint 1 exit-code matrix + workspace gate                  | PR #381                    | Sprint 1                                                       |
-| Task 2.1 | completed | PR body / title / branch validation module                  | PR #388 (merged `856797c`) | Sprint 2 — `crates/forge-cli/src/validations.rs`               |
-| Task 2.2 | completed | `pr create` atom                                            | PR #388                    | Sprint 2                                                       |
-| Task 2.3 | completed | `pr view`, `pr list`, `pr close` atoms                      | PR #388                    | Sprint 2                                                       |
-| Task 2.4 | completed | `pr edit`, `pr comment`, `pr ready` atoms                   | PR #388                    | Sprint 2                                                       |
-| Task 3.1 | completed | `pr checks` GitHub backend                                  | PR #390 (merged `7d93d1a`) | Sprint 3                                                       |
-| Task 3.2 | completed | `pr checks` GitLab text parser with version fail-fast       | PR #390                    | Pinned `glab` 1.45.x — `glab_version_unsupported` → UNAVAIL 69 |
-| Task 3.3 | completed | `pr wait-checks` polling loop                               | PR #390 + fix `1071cc6`    | `checks_failed` RUNTIME 1 / `checks_timeout` UNAVAIL 69        |
-| Task 4.1 | completed | Merge-method resolution + `.forge-cli.toml` loader          | commit `cf45459`           | Sprint 4 — 12 lib tests covering loader walk + warning surface |
-| Task 4.2 | completed | TTL-zero required-check re-check helper                     | commit `feae217`           | Sprint 4 — 6 lib + 4 integration tests pin no-caching contract |
-| Task 4.3 | completed | `pr merge` atom                                             | commit `9094408`           | Sprint 4 — full lock-down chain + 12 lib + 4 integration tests |
-| Task 5.1 | pending   | `issue create`, `issue view`, `issue close`, `issue reopen` | n/a                        | Sprint 5 — mirrors Sprint 2 layout                             |
-| Task 5.2 | pending   | `issue edit`, `issue comment`                               | n/a                        | Sprint 5                                                       |
-| Task 6.1 | pending   | `pr deliver` macro composition + step envelope              | n/a                        | Sprint 6                                                       |
-| Task 6.2 | pending   | Macro CLI surface + dry-run plan rendering                  | n/a                        | Sprint 6                                                       |
-| Task 7.1 | pending   | Parity harness                                              | n/a                        | Sprint 7                                                       |
-| Task 7.2 | pending   | Exit-code matrix completion                                 | n/a                        | Sprint 7                                                       |
-| Task 7.3 | pending   | Fixture redaction audit                                     | n/a                        | Sprint 7                                                       |
-| Task 8.1 | pending   | `wrappers/forge-cli` + shell completions                    | n/a                        | Sprint 8                                                       |
-| Task 8.2 | pending   | Homebrew tap formula update                                 | n/a                        | Sprint 8                                                       |
-| Task 8.3 | pending   | `nils-cli` minor bump + tag + tap formula bump              | n/a                        | Sprint 8                                                       |
+| ID       | Status    | Task                                                        | Evidence                                  | Notes                                                          |
+| -------- | --------- | ----------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------- |
+| Task 1.1 | completed | Scaffold `crates/forge-cli/` package and workspace wiring   | PR #381 (merged `eb92969`)                | Sprint 1                                                       |
+| Task 1.2 | completed | Define clap command tree + global flags                     | PR #381                                   | Sprint 1                                                       |
+| Task 1.3 | completed | Implement provider detection                                | PR #381                                   | Sprint 1                                                       |
+| Task 1.4 | completed | Subprocess wrapper + envelope serializer + dry-run plumbing | PR #381                                   | Sprint 1                                                       |
+| Task 1.5 | completed | Implement `auth status` atom                                | PR #381                                   | Sprint 1                                                       |
+| Task 1.6 | completed | Implement `repo view` atom                                  | PR #381                                   | Sprint 1                                                       |
+| Task 1.7 | completed | Sprint 1 exit-code matrix + workspace gate                  | PR #381                                   | Sprint 1                                                       |
+| Task 2.1 | completed | PR body / title / branch validation module                  | PR #388 (merged `856797c`)                | Sprint 2 — `crates/forge-cli/src/validations.rs`               |
+| Task 2.2 | completed | `pr create` atom                                            | PR #388                                   | Sprint 2                                                       |
+| Task 2.3 | completed | `pr view`, `pr list`, `pr close` atoms                      | PR #388                                   | Sprint 2                                                       |
+| Task 2.4 | completed | `pr edit`, `pr comment`, `pr ready` atoms                   | PR #388                                   | Sprint 2                                                       |
+| Task 3.1 | completed | `pr checks` GitHub backend                                  | PR #390 (merged `7d93d1a`)                | Sprint 3                                                       |
+| Task 3.2 | completed | `pr checks` GitLab text parser with version fail-fast       | PR #390                                   | Pinned `glab` 1.45.x — `glab_version_unsupported` → UNAVAIL 69 |
+| Task 3.3 | completed | `pr wait-checks` polling loop                               | PR #390 + fix `1071cc6`                   | `checks_failed` RUNTIME 1 / `checks_timeout` UNAVAIL 69        |
+| Task 4.1 | completed | Merge-method resolution + `.forge-cli.toml` loader          | commit `cf45459`                          | Sprint 4 — 12 lib tests covering loader walk + warning surface |
+| Task 4.2 | completed | TTL-zero required-check re-check helper                     | commit `feae217`                          | Sprint 4 — 6 lib + 4 integration tests pin no-caching contract |
+| Task 4.3 | completed | `pr merge` atom                                             | commit `9094408`                          | Sprint 4 — full lock-down chain + 12 lib + 4 integration tests |
+| Task 5.1 | completed | `issue create`, `issue view`, `issue close`, `issue reopen` | branch `feat/forge-cli-v1-sprint5-issues` | Sprint 5 — issue_view shared parser + 4 atoms + 9 integration  |
+| Task 5.2 | completed | `issue edit`, `issue comment`                               | branch `feat/forge-cli-v1-sprint5-issues` | Sprint 5 — partial mutation + body-file stdin                  |
+| Task 6.1 | pending   | `pr deliver` macro composition + step envelope              | n/a                                       | Sprint 6                                                       |
+| Task 6.2 | pending   | Macro CLI surface + dry-run plan rendering                  | n/a                                       | Sprint 6                                                       |
+| Task 7.1 | pending   | Parity harness                                              | n/a                                       | Sprint 7                                                       |
+| Task 7.2 | pending   | Exit-code matrix completion                                 | n/a                                       | Sprint 7                                                       |
+| Task 7.3 | pending   | Fixture redaction audit                                     | n/a                                       | Sprint 7                                                       |
+| Task 8.1 | pending   | `wrappers/forge-cli` + shell completions                    | n/a                                       | Sprint 8                                                       |
+| Task 8.2 | pending   | Homebrew tap formula update                                 | n/a                                       | Sprint 8                                                       |
+| Task 8.3 | pending   | `nils-cli` minor bump + tag + tap formula bump              | n/a                                       | Sprint 8                                                       |
 
 ## Validation
 
@@ -91,3 +91,14 @@
   Task 4.3 `pr merge` atom with six lock-down rules (`9094408`).
   Workspace test surface: 197 lib + 54 integration. PR pending push +
   CI green.
+- 2026-05-20 — Sprint 4 merged via PR #393 (`c049a1f`); cut Sprint 5
+  branch `feat/forge-cli-v1-sprint5-issues` from updated `origin/main`.
+  Initial CI failed strict third-party-artifacts-audit because adding
+  `toml = 1.1` to forge-cli changed `Cargo.lock`'s SHA256; pushed
+  `379eb20` regenerating `THIRD_PARTY_LICENSES.md` /
+  `THIRD_PARTY_NOTICES.md` and CI came back green.
+- 2026-05-20 — Sprint 5 production code complete locally: 6 issue
+  atoms (`create` / `view` / `edit` / `comment` / `close` / `reopen`)
+  sharing `issue_view::parse_view_output`. Test surface grows to 216
+  lib + 63 integration (was 197 + 54 at end of Sprint 4). PR pending
+  push + CI green.


### PR DESCRIPTION
## Summary

Sprint 5 of the [forge-cli v1 plan](https://github.com/sympoies/nils-cli/issues/391) completes the Issue surface with six atoms (`issue create / view / edit / comment / close / reopen`). Issue ops have a much smaller validation footprint than PRs (no branch / body / push state), so this sprint is the lightest of Sprints 2–5 and is mostly a structural mirror of Sprint 2's PR atoms.

## Changes

- **`crates/forge-cli/src/ops/issue_view.rs`** — shared parser. `parse_view_output` is `pub` so the other five atoms can re-fetch via the canonical view after their mutating call. Normalizes GitHub state literals (`OPEN`/`CLOSED`) and GitLab state literals (`opened`/`closed`) through `pr_state::normalize_state`.
- **`crates/forge-cli/src/ops/issue_create.rs`** — runs `title_length` only, materializes body to a tempfile, passes `--body-file` (gh) or `--description` (glab), then re-fetches via `issue view` for the envelope payload.
- **`crates/forge-cli/src/ops/issue_close.rs`** / **`issue_reopen.rs`** — simple passthrough + follow-up `issue view` so the envelope reports the canonical post-action state.
- **`crates/forge-cli/src/ops/issue_edit.rs`** — partial mutation. Re-validates `title_length` only when `--title` is supplied. Emits provider-specific label / assignee flags (`--add-label`/`--remove-label` for gh, `--label`/`--unlabel` for glab).
- **`crates/forge-cli/src/ops/issue_comment.rs`** — body resolution mirrors `pr comment`; empty body rejects with `DATA 65` / `body_missing_summary`.
- **CLI surface** — adds `issue create --title --body --body-file --label --assignee`, `issue edit <id> --title --body --body-file --add-label --remove-label --add-assignee`, `issue comment <id> --body --body-file`, plus `issue view/close/reopen <id>`. Regenerated bash + zsh completions.
- **Execution ledger** — `docs/plans/forge-cli/forge-cli-execution-state.md` records Tasks 5.1 + 5.2 with commit-SHA evidence.

## Test-First Evidence

- **Change classification**: new feature (Sprint 5 atom delivery).
- **Failing test before fix**: not applicable — Sprint 5 is greenfield atom work, not a bugfix.
- **Final validation**:
  - `cargo test -p nils-forge-cli` — 216 lib + 63 integration green (was 197 + 54 at end of Sprint 4).
  - `cargo clippy -p nils-forge-cli --all-targets -- -D warnings` — clean.
  - `bash scripts/ci/cli-output-contract-lint.sh` — pass.
  - `bash scripts/ci/completion-flag-parity-audit.sh` — pass; bash + zsh regenerated from compiled binary.
  - `bash scripts/ci/third-party-artifacts-audit.sh --strict` — pass (no new deps).
- **Waiver reason**: n/a.

## Testing

- pass: `cargo test -p nils-forge-cli` (279 total).
- pass: `cargo clippy -p nils-forge-cli --all-targets -- -D warnings`.
- pass: workspace CI gates (cli-output-contract, completion, third-party-artifacts, docs).
- not run (defer to Sprint 7): per-op gh + glab fixture pairs and the cross-provider parity harness.

## Risk / Notes

- Each mutating issue op (`create / edit / close / reopen / comment`) calls `issue view` for its envelope payload. That's one extra subprocess per op, mirroring Sprint 2's PR atoms — Sprint 7's parity harness will assert byte-equality across providers based on those view payloads.
- GitLab uses `issue update` / `issue note` / `--label` / `--unlabel` where GitHub uses `issue edit` / `issue comment` / `--add-label` / `--remove-label`. The build_call helpers branch per-provider so the spec's `op_id` stays provider-neutral while the wire shape stays faithful to each backend.
- Sprint 6 (`pr deliver` macro) is the next milestone and is now unblocked.
