### PR TITLE
Finalize forge-cli v1 ledger + cli-output-contract conformance attestation

### DIFF
--- a/docs/plans/forge-cli/forge-cli-execution-state.md
+++ b/docs/plans/forge-cli/forge-cli-execution-state.md
@@ -2,67 +2,67 @@
 
 ## Current State
 
-- Status: in progress
+- Status: complete (Sprints 0–8 + Task 8.3 release flow delivered;
+  cli-output-contract-v1 conformance verified)
 - Target scope: whole plan (Sprints 0–8)
-- Execution window: 2026-05-19 → ongoing
+- Execution window: 2026-05-19 → 2026-05-20
 - Staged execution confirmation: not applicable (default-continue
   authorization: "Just keep doing it by default.")
-- Current task: Sprint 8 review (PR pending)
-- Next task: Task 8.3 (release flow — runs after PR merges via
-  `nils-cli-bump-version-tag-release`, not in this PR)
+- Current task: none — v1 delivered end to end
+- Next task: none
 - Last updated: 2026-05-20
-- Branch/commit: `feat/forge-cli-v1-sprint8-wrapper` cut from
-  `origin/main@3474555` (Sprint 7 PR #398 merge); Task 8.1 wrapper +
-  completion sync test and Task 8.2 README cross-link complete locally,
-  PR pending push and CI
+- Branch/commit: Sprint 8 landed via PR #399 (merge `3d08224`); release
+  flow shipped `chore(release): bump cli versions to 0.11.0` (`0e84c98`)
+  with tags `v0.11.0` (source) and `nils-cli-v0.11.0` (tap); local
+  Homebrew formula upgraded `0.10.2 → 0.11.0`
 - Source document: docs/plans/forge-cli/forge-cli-plan.md
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger
 
-| ID       | Status    | Task                                                        | Evidence                                   | Notes                                                          |
-| -------- | --------- | ----------------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------- |
-| Task 1.1 | completed | Scaffold `crates/forge-cli/` package and workspace wiring   | PR #381 (merged `eb92969`)                 | Sprint 1                                                       |
-| Task 1.2 | completed | Define clap command tree + global flags                     | PR #381                                    | Sprint 1                                                       |
-| Task 1.3 | completed | Implement provider detection                                | PR #381                                    | Sprint 1                                                       |
-| Task 1.4 | completed | Subprocess wrapper + envelope serializer + dry-run plumbing | PR #381                                    | Sprint 1                                                       |
-| Task 1.5 | completed | Implement `auth status` atom                                | PR #381                                    | Sprint 1                                                       |
-| Task 1.6 | completed | Implement `repo view` atom                                  | PR #381                                    | Sprint 1                                                       |
-| Task 1.7 | completed | Sprint 1 exit-code matrix + workspace gate                  | PR #381                                    | Sprint 1                                                       |
-| Task 2.1 | completed | PR body / title / branch validation module                  | PR #388 (merged `856797c`)                 | Sprint 2 — `crates/forge-cli/src/validations.rs`               |
-| Task 2.2 | completed | `pr create` atom                                            | PR #388                                    | Sprint 2                                                       |
-| Task 2.3 | completed | `pr view`, `pr list`, `pr close` atoms                      | PR #388                                    | Sprint 2                                                       |
-| Task 2.4 | completed | `pr edit`, `pr comment`, `pr ready` atoms                   | PR #388                                    | Sprint 2                                                       |
-| Task 3.1 | completed | `pr checks` GitHub backend                                  | PR #390 (merged `7d93d1a`)                 | Sprint 3                                                       |
-| Task 3.2 | completed | `pr checks` GitLab text parser with version fail-fast       | PR #390                                    | Pinned `glab` 1.45.x — `glab_version_unsupported` → UNAVAIL 69 |
-| Task 3.3 | completed | `pr wait-checks` polling loop                               | PR #390 + fix `1071cc6`                    | `checks_failed` RUNTIME 1 / `checks_timeout` UNAVAIL 69        |
-| Task 4.1 | completed | Merge-method resolution + `.forge-cli.toml` loader          | commit `cf45459`                           | Sprint 4 — 12 lib tests covering loader walk + warning surface |
-| Task 4.2 | completed | TTL-zero required-check re-check helper                     | commit `feae217`                           | Sprint 4 — 6 lib + 4 integration tests pin no-caching contract |
-| Task 4.3 | completed | `pr merge` atom                                             | commit `9094408`                           | Sprint 4 — full lock-down chain + 12 lib + 4 integration tests |
-| Task 5.1 | completed | `issue create`, `issue view`, `issue close`, `issue reopen` | branch `feat/forge-cli-v1-sprint5-issues`  | Sprint 5 — issue_view shared parser + 4 atoms + 9 integration  |
-| Task 5.2 | completed | `issue edit`, `issue comment`                               | branch `feat/forge-cli-v1-sprint5-issues`  | Sprint 5 — partial mutation + body-file stdin                  |
-| Task 6.1 | completed | `pr deliver` macro composition + step envelope              | branch `feat/forge-cli-v1-sprint6-deliver` | Sprint 6 — atom compute helpers + WaitOutcome enum, 6-step seq |
-| Task 6.2 | completed | Macro CLI surface + dry-run plan rendering                  | branch `feat/forge-cli-v1-sprint6-deliver` | Sprint 6 — 4 integration tests pin dry-run / no-merge / method |
-| Task 7.1 | completed | Parity harness                                              | branch `feat/forge-cli-v1-sprint7-parity`  | Sprint 7 — 11-row table + 5 cross-provider envelope assertions |
-| Task 7.2 | completed | Exit-code matrix completion                                 | branch `feat/forge-cli-v1-sprint7-parity`  | Sprint 7 — 12 tests covering every documented (exit, kind)     |
-| Task 7.3 | completed | Fixture redaction audit                                     | branch `feat/forge-cli-v1-sprint7-parity`  | Sprint 7 — lint script + planted-token regression test         |
-| Task 8.1 | completed | `wrappers/forge-cli` + shell completions                    | branch `feat/forge-cli-v1-sprint8-wrapper` | Sprint 8 — wrapper mirrors git-cli, 4 completion-sync tests    |
-| Task 8.2 | completed | Homebrew tap formula update                                 | branch `feat/forge-cli-v1-sprint8-wrapper` | Sprint 8 — workspace README cross-link + wrapper ready for tap |
-| Task 8.3 | pending   | `nils-cli` minor bump + tag + tap formula bump              | post-merge release flow                    | Runs via nils-cli-bump-version-tag-release after PR merges     |
+| ID       | Status    | Task                                                        | Evidence                                               | Notes                                                                                                         |
+| -------- | --------- | ----------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Task 1.1 | completed | Scaffold `crates/forge-cli/` package and workspace wiring   | PR #381 (merged `eb92969`)                             | Sprint 1                                                                                                      |
+| Task 1.2 | completed | Define clap command tree + global flags                     | PR #381                                                | Sprint 1                                                                                                      |
+| Task 1.3 | completed | Implement provider detection                                | PR #381                                                | Sprint 1                                                                                                      |
+| Task 1.4 | completed | Subprocess wrapper + envelope serializer + dry-run plumbing | PR #381                                                | Sprint 1                                                                                                      |
+| Task 1.5 | completed | Implement `auth status` atom                                | PR #381                                                | Sprint 1                                                                                                      |
+| Task 1.6 | completed | Implement `repo view` atom                                  | PR #381                                                | Sprint 1                                                                                                      |
+| Task 1.7 | completed | Sprint 1 exit-code matrix + workspace gate                  | PR #381                                                | Sprint 1                                                                                                      |
+| Task 2.1 | completed | PR body / title / branch validation module                  | PR #388 (merged `856797c`)                             | Sprint 2 — `crates/forge-cli/src/validations.rs`                                                              |
+| Task 2.2 | completed | `pr create` atom                                            | PR #388                                                | Sprint 2                                                                                                      |
+| Task 2.3 | completed | `pr view`, `pr list`, `pr close` atoms                      | PR #388                                                | Sprint 2                                                                                                      |
+| Task 2.4 | completed | `pr edit`, `pr comment`, `pr ready` atoms                   | PR #388                                                | Sprint 2                                                                                                      |
+| Task 3.1 | completed | `pr checks` GitHub backend                                  | PR #390 (merged `7d93d1a`)                             | Sprint 3                                                                                                      |
+| Task 3.2 | completed | `pr checks` GitLab text parser with version fail-fast       | PR #390                                                | Pinned `glab` 1.45.x — `glab_version_unsupported` → UNAVAIL 69                                                |
+| Task 3.3 | completed | `pr wait-checks` polling loop                               | PR #390 + fix `1071cc6`                                | `checks_failed` RUNTIME 1 / `checks_timeout` UNAVAIL 69                                                       |
+| Task 4.1 | completed | Merge-method resolution + `.forge-cli.toml` loader          | commit `cf45459`                                       | Sprint 4 — 12 lib tests covering loader walk + warning surface                                                |
+| Task 4.2 | completed | TTL-zero required-check re-check helper                     | commit `feae217`                                       | Sprint 4 — 6 lib + 4 integration tests pin no-caching contract                                                |
+| Task 4.3 | completed | `pr merge` atom                                             | commit `9094408`                                       | Sprint 4 — full lock-down chain + 12 lib + 4 integration tests                                                |
+| Task 5.1 | completed | `issue create`, `issue view`, `issue close`, `issue reopen` | PR #395 (merged `718b7dd`)                             | Sprint 5 — issue_view shared parser + 4 atoms + 9 integration                                                 |
+| Task 5.2 | completed | `issue edit`, `issue comment`                               | PR #395                                                | Sprint 5 — partial mutation + body-file stdin                                                                 |
+| Task 6.1 | completed | `pr deliver` macro composition + step envelope              | PR #397 (merged `15fcc73`)                             | Sprint 6 — atom compute helpers + WaitOutcome enum, 6-step seq                                                |
+| Task 6.2 | completed | Macro CLI surface + dry-run plan rendering                  | PR #397                                                | Sprint 6 — 4 integration tests pin dry-run / no-merge / method                                                |
+| Task 7.1 | completed | Parity harness                                              | PR #398 (merged `3474555`)                             | Sprint 7 — 11-row table + 5 cross-provider envelope assertions                                                |
+| Task 7.2 | completed | Exit-code matrix completion                                 | PR #398                                                | Sprint 7 — 12 tests covering every documented (exit, kind)                                                    |
+| Task 7.3 | completed | Fixture redaction audit                                     | PR #398                                                | Sprint 7 — lint script + planted-token regression test                                                        |
+| Task 8.1 | completed | `wrappers/forge-cli` + shell completions                    | PR #399 (merged `3d08224`)                             | Sprint 8 — wrapper mirrors git-cli, 4 completion-sync tests                                                   |
+| Task 8.2 | completed | Homebrew tap formula update                                 | PR #399 (merged `3d08224`)                             | Sprint 8 — workspace README cross-link + wrapper ready for tap                                                |
+| Task 8.3 | completed | `nils-cli` minor bump + tag + tap formula bump              | commit `0e84c98` + tags `v0.11.0` / `nils-cli-v0.11.0` | Ran `nils-cli-bump-version-tag-release` 2026-05-20; both `release.yml` runs green; local brew 0.10.2 → 0.11.0 |
 
 ## Validation
 
-| Command                                            | Status  | Summary                                              | Artifact                     |
-| -------------------------------------------------- | ------- | ---------------------------------------------------- | ---------------------------- |
-| `cargo test -p nils-forge-cli`                     | green   | 167 lib + 46 integration at end of Sprint 3          | local + PR #390 CI           |
-| `cargo clippy --all-targets`                       | green   | end of Sprint 3                                      | local + PR #390 CI           |
-| `bash scripts/ci/plan-bundle-validate.sh --strict` | green   | Sprint 0 docs-only gate (PR #379)                    | PR #379                      |
-| `bash scripts/ci/completion-asset-audit.sh`        | green   | bash + zsh regenerated each sprint                   | PR #381 / #388 / #390        |
-| `bash scripts/ci/completion-flag-parity-audit.sh`  | green   | parity with built-in `forge-cli` after each sprint   | PR #381 / #388 / #390        |
-| `bash scripts/ci/cli-output-contract-lint.sh`      | green   | each sprint                                          | PR #381 / #388 / #390        |
-| `bash scripts/ci/docs-placement-audit.sh`          | green   | docs co-located under `crates/forge-cli/docs/specs/` | PR #379                      |
-| `bash scripts/ci/docs-hygiene-audit.sh`            | green   | markdownlint / rumdl clean across plan bundle        | PR #379 / #381 / #388 / #390 |
-| `bash scripts/ci/nils-cli-checks-entrypoint.sh`    | pending | end-of-Sprint-8 workspace gate                       | n/a                          |
+| Command                                                | Status | Summary                                                         | Artifact                                  |
+| ------------------------------------------------------ | ------ | --------------------------------------------------------------- | ----------------------------------------- |
+| `cargo test -p nils-forge-cli`                         | green  | 219 lib + 93 integration at end of Sprint 8                     | local + PR #399 CI                        |
+| `cargo clippy --all-targets`                           | green  | end of Sprint 8                                                 | local + PR #399 CI                        |
+| `bash scripts/ci/plan-bundle-validate.sh --strict`     | green  | Sprint 0 docs-only gate (PR #379)                               | PR #379                                   |
+| `bash scripts/ci/completion-asset-audit.sh`            | green  | bash + zsh regenerated each sprint                              | PR #381 / #388 / #390 / #399              |
+| `bash scripts/ci/completion-flag-parity-audit.sh`      | green  | parity with built-in `forge-cli` after each sprint              | PR #381 / #388 / #390 / #399              |
+| `bash scripts/ci/cli-output-contract-lint.sh --strict` | green  | forge-cli passes shared envelope + exit + `--format` lint clean | local 2026-05-20 (attestation in PR #400) |
+| `bash scripts/ci/docs-placement-audit.sh`              | green  | docs co-located under `crates/forge-cli/docs/specs/`            | PR #379                                   |
+| `bash scripts/ci/docs-hygiene-audit.sh`                | green  | markdownlint / rumdl clean across plan bundle                   | PR #379 / #381 / #388 / #390 / #399       |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh`        | green  | Sprint 8 CI rerun after MD013 fix `d371b82`                     | PR #399 actions run                       |
 
 ## Blockers
 
@@ -140,3 +140,30 @@
   bump) runs post-merge via the `nils-cli-bump-version-tag-release`
   skill and is not part of this PR. Test surface grows to 219 lib +
   93 integration.
+- 2026-05-20 — Sprint 8 merged via PR #399 (`3d08224`); CI initially
+  tripped MD013 on the new workspace README forge-cli row (202 > 140
+  chars) and was healed by `d371b82` (wrap the bullet across three
+  lines), then merged on the rerun.
+- 2026-05-20 — Task 8.3 release flow executed end to end via
+  `nils-cli-bump-version-tag-release --version 0.11.0` from the parent
+  worktree: workspace bumped 0.10.2 → 0.11.0 (`0e84c98`), annotated
+  tag `v0.11.0` pushed, `sympoies/nils-cli` `release.yml` ran green,
+  Homebrew tap formula re-pointed to the v0.11.0 archives, tap-side
+  `chore(formula): bump nils-cli to v0.11.0` pushed + tagged
+  `nils-cli-v0.11.0`, tap `release.yml` ran green, local
+  `brew upgrade sympoies/tap/nils-cli` confirms `0.10.2 → 0.11.0`. v1
+  scope delivered end to end.
+- 2026-05-20 — Cross-plan attestation: forge-cli verified clean against
+  the cli-output-contract-unification plan
+  (`docs/plans/cli-output-contract-unification/`). forge-cli was
+  designed conformant from Sprint 1 — every op routes through
+  `nils_common::cli_contract::{Envelope, EnvelopeError, OutputFormat,
+  exit, schema_version_for, emit_parse_error}`, every schema literal
+  follows `cli.forge-cli.<op>.v1`, the only output flag is
+  `--format text|json` (no `--json` bool), and there are 33 `exit::*`
+  call sites with zero inline numeric exit literals in `main.rs`.
+  Verified by `bash scripts/ci/cli-output-contract-lint.sh --strict`
+  PASS plus `exit_codes.rs` (6 tests) and `exit_codes_full.rs`
+  (12 tests) covering the documented `(exit, kind)` matrix, and
+  42 schema-literal assertions across 13 integration test files. No
+  remediation required on this PR.

--- a/docs/plans/forge-cli/forge-cli-execution-state.md
+++ b/docs/plans/forge-cli/forge-cli-execution-state.md
@@ -6,7 +6,7 @@
 - Target scope: whole plan (Sprints 0–8)
 - Execution window: 2026-05-19 → ongoing
 - Staged execution confirmation: not applicable (default-continue
-  authorization: "默認就一直做下去")
+  authorization: "Just keep doing it by default.")
 - Current task: Sprint 8 review (PR pending)
 - Next task: Task 8.3 (release flow — runs after PR merges via
   `nils-cli-bump-version-tag-release`, not in this PR)


### PR DESCRIPTION
## Summary

Docs-only PR that finalizes the forge-cli v1 execution ledger now that Sprint 8 has merged
(PR #399 -> `3d08224`) and Task 8.3 has shipped end to end (workspace bumped to `0.11.0`,
tags `v0.11.0` / `nils-cli-v0.11.0` pushed, both `release.yml` runs green, local Homebrew
formula upgraded). Also folds in a conformance attestation against the parallel
`cli-output-contract-unification` plan — forge-cli was designed against the shared envelope
from Sprint 1, so no remediation is required.

## Changes

- `docs/plans/forge-cli/forge-cli-execution-state.md`
  - Flip `Status` to `complete (Sprints 0-8 + Task 8.3 release flow delivered;
    cli-output-contract-v1 conformance verified)`.
  - Update `Branch/commit` to record PR #399 merge `3d08224`, release commit `0e84c98`,
    and tags `v0.11.0` / `nils-cli-v0.11.0`.
  - Replace the loose Sprint 5-8 evidence ("branch ...") with the merged PR commit SHAs
    (`#395 -> 718b7dd`, `#397 -> 15fcc73`, `#398 -> 3474555`, `#399 -> 3d08224`).
  - Mark Task 8.3 `completed` with the release-flow evidence (`0e84c98` + both tags).
  - Bump the Validation table to record the Sprint 8 CI rerun (post-MD013 fix `d371b82`)
    and the strict `cli-output-contract-lint.sh` PASS.
  - Append two final session-log entries: Sprint 8 merge (including the MD013 healing
    follow-up) + Task 8.3 release flow + the cli-output-contract conformance attestation.

PR `a53f89b` (translation of the default-continue authorization line) was already on this
local branch when it was cut and is carried along unchanged.

## Test-First Evidence

- **Change classification**: docs-only follow-up. No production code or test surface
  touched in this PR.
- **Failing test before fix**: not applicable. The prior `Validation` row
  `bash scripts/ci/nils-cli-checks-entrypoint.sh - pending - end-of-Sprint-8 workspace
  gate` was the literal "evidence is missing" placeholder that this PR replaces with the
  Sprint 8 CI rerun's PASS line.
- **Final validation**:
  - `bash scripts/ci/markdownlint-audit.sh --strict` -> PASS (`rumdl fmt` re-aligned the
    widened Task Ledger table).
  - `bash scripts/ci/docs-hygiene-audit.sh --strict` -> PASS (warnings=0).
  - `bash scripts/ci/cli-output-contract-lint.sh --strict` -> PASS (clean, no allowlist
    additions required for forge-cli - it was conformant from Sprint 1).
- **Waiver reason**: not applicable.

### cli-output-contract conformance check (audit performed against merged forge-cli)

| Requirement | Status | Evidence |
| --- | --- | --- |
| `schema_version` via `nils_common::cli_contract::schema_version_for` (no inline literals) | clean | `crates/forge-cli/src/ops/*.rs`; 42 `cli.forge-cli.<op>.v1` assertions across 13 test files |
| snake_case JSON via shared `Envelope<T>` | clean | `crates/forge-cli/src/envelope.rs` wraps `nils_common::cli_contract::Envelope` |
| Shared `exit::*` constants only - no inline `process::exit(1\|2)` | clean | 33 `exit::*` call sites in `crates/forge-cli/src/`; 0 inline numeric exits in `main.rs` |
| `--format text\|json` (no `--json` bool) | clean | 0 `--json` long-flag declarations; `crates/forge-cli/src/cli.rs` uses shared `OutputFormat` |
| `emit_parse_error` for parse / unknown-subcommand | clean | `crates/forge-cli/src/cli.rs:706` |
| Per-binary exit-code matrix test | clean | `tests/integration/exit_codes.rs` (6) + `exit_codes_full.rs` (12) - 18 tests cover every documented `(exit, kind)` pair |
| Workspace lint `cli-output-contract-lint.sh --strict` | clean | local run 2026-05-20 |

No code changes required.

## Testing

- `bash scripts/ci/markdownlint-audit.sh --strict` - pass
- `bash scripts/ci/docs-hygiene-audit.sh --strict` - pass
- `bash scripts/ci/cli-output-contract-lint.sh --strict` - pass
- `npx --yes rumdl@0.1.62 fmt` - applied (table alignment after widening the ledger table)

Full workspace test run not exercised on this PR because no source files are touched;
CI will run the entire required-checks pipeline anyway.

## Risk / Notes

- Risk: minimal. Docs-only PR; the only writer is the ledger file itself.
- The `cli-output-contract` attestation is recorded inline in the ledger rather than as a
  separate spec doc - the existing `docs/specs/cli-output-contract-v1.md` already governs
  the contract, and forge-cli is a consumer, not a re-publisher.
- After this merges, the forge-cli plan bundle (plan + source + execution-state) is
  durable end-to-end and tracking issue #391 can be closed via the
  `dispatch-plan-delivery` close gate (out of scope for this PR).
