### PR TITLE
Add agent-runtime-cli stub crate for graysurf/agent-runtime-kit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "agent-runtime-cli"
+version = "0.0.1-dev"
+dependencies = [
+ "anyhow",
+ "clap",
+ "nils-test-support",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/nils-term",
   "crates/nils-test-support",
   "crates/cli-template",
+  "crates/agent-runtime-cli",
   "crates/memo-cli",
   "crates/codex-cli",
   "crates/fzf-cli",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,9 +3,9 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `a43ced0fc3c5f73e39311264ba2695e8d17fdefc12417e82e3e2df002a29cebc`
+- Cargo.lock SHA256: `276f9f9a751ce49f3ded0180db269cc0ee6e3c13bc621fe136f52833437e188f`
 - Third-party crates (`source != null`): 438
-- Workspace crates (`source == null`, excluded below): 31
+- Workspace crates (`source == null`, excluded below): 32
 
 ## Notes
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `a43ced0fc3c5f73e39311264ba2695e8d17fdefc12417e82e3e2df002a29cebc`
+- Cargo.lock SHA256: `276f9f9a751ce49f3ded0180db269cc0ee6e3c13bc621fe136f52833437e188f`
 - Third-party crates (`source != null`): 438
 
 ## Notice Extraction Policy

--- a/crates/agent-runtime-cli/Cargo.toml
+++ b/crates/agent-runtime-cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "agent-runtime-cli"
+version = "0.0.1-dev"
+edition.workspace = true
+license.workspace = true
+
+description = "Stub CLI for graysurf/agent-runtime-kit. Subcommands are intentionally not implemented until Plan 02 (render + audit-drift) lands."
+repository = "https://github.com/sympoies/nils-cli"
+
+[[bin]]
+name = "agent-runtime"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+
+[dev-dependencies]
+nils-test-support = { version = "0.11.0", path = "../nils-test-support" }

--- a/crates/agent-runtime-cli/README.md
+++ b/crates/agent-runtime-cli/README.md
@@ -1,0 +1,48 @@
+# agent-runtime-cli
+
+## Overview
+
+`agent-runtime-cli` is the Rust crate that ships the `agent-runtime` binary
+for [`graysurf/agent-runtime-kit`](https://github.com/graysurf/agent-runtime-kit).
+This Plan 01 release is a **stub**: every subcommand prints
+`agent-runtime <subcommand>: not implemented` to stderr and exits `1`.
+The crate exists so the rest of the install ladder — Homebrew tap,
+`scripts/setup.sh`, `required_clis` declarations — can be wired up against
+a real binary before Plan 02 lands the actual render / audit / install
+bodies.
+
+## Package vs binary name
+
+| Field        | Value                |
+| ------------ | -------------------- |
+| Package name | `agent-runtime-cli`  |
+| Binary name  | `agent-runtime`      |
+
+Use the package name (`-p agent-runtime-cli`) for cargo commands and the
+binary name (`agent-runtime`) for installed-binary invocations.
+
+## Subcommands (Plan 01 stub — all exit 1)
+
+Enumeration is pinned by
+[Resolved Decision #2 in `docs/source/inventory-target-architecture.md`](https://github.com/graysurf/agent-runtime-kit/blob/main/docs/source/inventory-target-architecture.md)
+of the consuming repo:
+
+- `render` — render `core/` + `targets/<product>/` into `build/<product>/`.
+- `install` — activate rendered output against a product's runtime home.
+- `uninstall` — remove installed renderer output from a product's runtime home.
+- `doctor` — diagnose host setup, runtime roots, and required CLI floors.
+- `audit-drift` — detect source-vs-rendered, rendered-vs-live, and unsafe drift.
+- `gc-backups` — prune old backups under `<state_home>/backups/`.
+- `restore-backups` — restore a runtime home from a recorded backup snapshot.
+- `purge-state` — purge runtime-managed state (use with caution).
+
+## Roadmap
+
+- Plan 02 (`02-nils-cli-render-and-drift-audit`): implement `render` +
+  `audit-drift` bodies; cut a `0.1.0` release and re-pin the Homebrew
+  formula.
+- Plan 04 (`04-install-and-bootstrap`): implement `install` / `uninstall`
+  / `doctor` / `gc-backups` / `restore-backups` / `purge-state` bodies.
+
+Track open work and discussion in
+[graysurf/agent-runtime-kit Issue #1](https://github.com/graysurf/agent-runtime-kit/issues/1).

--- a/crates/agent-runtime-cli/README.md
+++ b/crates/agent-runtime-cli/README.md
@@ -13,10 +13,10 @@ bodies.
 
 ## Package vs binary name
 
-| Field        | Value                |
-| ------------ | -------------------- |
-| Package name | `agent-runtime-cli`  |
-| Binary name  | `agent-runtime`      |
+| Field        | Value               |
+| ------------ | ------------------- |
+| Package name | `agent-runtime-cli` |
+| Binary name  | `agent-runtime`     |
 
 Use the package name (`-p agent-runtime-cli`) for cargo commands and the
 binary name (`agent-runtime`) for installed-binary invocations.

--- a/crates/agent-runtime-cli/docs/README.md
+++ b/crates/agent-runtime-cli/docs/README.md
@@ -1,0 +1,26 @@
+# agent-runtime-cli Docs Index
+
+> Ownership: Maintained by the `agent-runtime-cli` crate maintainers. Keep
+> this index updated when docs are added, moved, or removed.
+
+The Plan 01 stub ships with no crate-local specs / runbooks / reports.
+Authoritative architecture and migration plans live in the consuming repo
+[`graysurf/agent-runtime-kit`](https://github.com/graysurf/agent-runtime-kit).
+
+## Specs
+
+- None yet. Add documents under `docs/specs/` and register them here.
+
+## Runbooks
+
+- None yet. Add documents under `docs/runbooks/` and register them here.
+
+## Reports
+
+- None yet. Add documents under `docs/reports/` and register them here.
+
+## Links
+
+- Back to crate README: [`../README.md`](../README.md)
+- Consuming repo: [`graysurf/agent-runtime-kit`](https://github.com/graysurf/agent-runtime-kit)
+- Tracking issue: [`graysurf/agent-runtime-kit#1`](https://github.com/graysurf/agent-runtime-kit/issues/1)

--- a/crates/agent-runtime-cli/src/main.rs
+++ b/crates/agent-runtime-cli/src/main.rs
@@ -1,0 +1,54 @@
+use clap::{Parser, Subcommand};
+use std::process::ExitCode;
+
+#[derive(Parser)]
+#[command(
+    name = "agent-runtime",
+    version,
+    about = "Render / install / doctor / audit-drift for graysurf/agent-runtime-kit (Plan 01 stub — every subcommand exits 1)."
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Render `core/` + `targets/<product>/` into `build/<product>/`.
+    Render,
+    /// Activate rendered output against a product's runtime home.
+    Install,
+    /// Remove installed renderer output from a product's runtime home.
+    Uninstall,
+    /// Diagnose host setup, runtime roots, and required CLI floors.
+    Doctor,
+    /// Detect source-vs-rendered, rendered-vs-live, and unsafe drift.
+    AuditDrift,
+    /// Prune old backups under `<state_home>/backups/`.
+    GcBackups,
+    /// Restore a runtime home from a recorded backup snapshot.
+    RestoreBackups,
+    /// Purge runtime-managed state (use with caution).
+    PurgeState,
+}
+
+impl Command {
+    fn name(&self) -> &'static str {
+        match self {
+            Command::Render => "render",
+            Command::Install => "install",
+            Command::Uninstall => "uninstall",
+            Command::Doctor => "doctor",
+            Command::AuditDrift => "audit-drift",
+            Command::GcBackups => "gc-backups",
+            Command::RestoreBackups => "restore-backups",
+            Command::PurgeState => "purge-state",
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    eprintln!("agent-runtime {}: not implemented", cli.command.name());
+    ExitCode::from(1)
+}

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -1,0 +1,7 @@
+// Consolidated integration test target.
+// Each former `tests/*.rs` is declared as a submodule here so the crate
+// links one integration test binary instead of many. This keeps the
+// dev-loop link phase O(crates) instead of O(test-files).
+
+#[path = "integration/cli.rs"]
+mod cli;

--- a/crates/agent-runtime-cli/tests/integration/cli.rs
+++ b/crates/agent-runtime-cli/tests/integration/cli.rs
@@ -1,0 +1,67 @@
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::path::PathBuf;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn run(args: &[&str]) -> CmdOutput {
+    let bin = agent_runtime_bin();
+    cmd::run(&bin, args, &[], None)
+}
+
+const SUBCOMMANDS: &[&str] = &[
+    "render",
+    "install",
+    "uninstall",
+    "doctor",
+    "audit-drift",
+    "gc-backups",
+    "restore-backups",
+    "purge-state",
+];
+
+#[test]
+fn version_prints_dev_release() {
+    let output = run(&["--version"]);
+    assert_eq!(output.code, 0);
+    let stdout = output.stdout_text();
+    assert!(
+        stdout.contains("0.0.1-dev"),
+        "version output should include 0.0.1-dev: {stdout}"
+    );
+}
+
+#[test]
+fn help_lists_every_subcommand() {
+    let output = run(&["--help"]);
+    assert_eq!(output.code, 0);
+    let stdout = output.stdout_text();
+    for sub in SUBCOMMANDS {
+        assert!(
+            stdout.contains(sub),
+            "help should list `{sub}` subcommand: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn every_subcommand_stub_exits_one_with_not_implemented_stderr() {
+    for sub in SUBCOMMANDS {
+        let output = run(&[sub]);
+        assert_eq!(output.code, 1, "subcommand `{sub}` should exit 1");
+        let stderr = output.stderr_text();
+        let expected = format!("agent-runtime {sub}: not implemented");
+        assert!(
+            stderr.contains(&expected),
+            "subcommand `{sub}` stderr should contain `{expected}`: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn unknown_subcommand_exits_nonzero() {
+    let output = run(&["does-not-exist"]);
+    assert_ne!(output.code, 0);
+}

--- a/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
+++ b/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
@@ -16,22 +16,22 @@
 
 ## Task Ledger
 
-| ID       | Status  | Task                                                              | Evidence | Notes                                                              |
-| -------- | ------- | ----------------------------------------------------------------- | -------- | ------------------------------------------------------------------ |
-| Task 1.1 | pending | Wire manifest ingest and the `--source-root` flag                 | n/a      | depends on Plan 01 stub crate being present                        |
-| Task 1.2 | pending | Register the four Tera helpers                                    | n/a      | depends on 1.1                                                     |
-| Task 1.3 | pending | Write `build/<product>/` output and per-skill cache               | n/a      | depends on 1.2                                                     |
-| Task 1.4 | pending | Add `--update-golden` flag                                        | n/a      | depends on 1.3                                                     |
-| Task 2.1 | pending | Add determinism clippy lints to affected crates                   | n/a      | scoped per Open Question default                                   |
-| Task 2.2 | pending | Add cross-process render determinism integration test             | n/a      | depends on 1.3 and 2.1                                             |
-| Task 2.3 | pending | Document the only sanctioned time value                           | n/a      | depends on 2.1                                                     |
-| Task 3.1 | pending | Source-manifest validity and rendered-target diff classes         | n/a      | depends on 1.3                                                     |
-| Task 3.2 | pending | `$AGENT_HOME` leak class (blocking, exit 2)                       | n/a      | depends on 3.1                                                     |
-| Task 3.3 | pending | Docs-home per product class (blocking, exit 2)                    | n/a      | depends on 3.1                                                     |
-| Task 3.4 | pending | Audit-drift fixture set                                           | n/a      | depends on 3.1/3.2/3.3                                             |
-| Task 4.1 | pending | Tag `agent-runtime-cli` v0.1.0 and update release config          | n/a      | depends on 2.2 and 3.4                                             |
-| Task 4.2 | pending | Bump `homebrew-tap` formula                                       | n/a      | depends on 4.1                                                     |
-| Task 4.3 | pending | Cross-repo: bump `required_clis` floors in agent-runtime-kit      | n/a      | cross-repo PR against agent-runtime-kit; depends on 4.2            |
+| ID       | Status  | Task                                                         | Evidence | Notes                                                   |
+| -------- | ------- | ------------------------------------------------------------ | -------- | ------------------------------------------------------- |
+| Task 1.1 | pending | Wire manifest ingest and the `--source-root` flag            | n/a      | depends on Plan 01 stub crate being present             |
+| Task 1.2 | pending | Register the four Tera helpers                               | n/a      | depends on 1.1                                          |
+| Task 1.3 | pending | Write `build/<product>/` output and per-skill cache          | n/a      | depends on 1.2                                          |
+| Task 1.4 | pending | Add `--update-golden` flag                                   | n/a      | depends on 1.3                                          |
+| Task 2.1 | pending | Add determinism clippy lints to affected crates              | n/a      | scoped per Open Question default                        |
+| Task 2.2 | pending | Add cross-process render determinism integration test        | n/a      | depends on 1.3 and 2.1                                  |
+| Task 2.3 | pending | Document the only sanctioned time value                      | n/a      | depends on 2.1                                          |
+| Task 3.1 | pending | Source-manifest validity and rendered-target diff classes    | n/a      | depends on 1.3                                          |
+| Task 3.2 | pending | `$AGENT_HOME` leak class (blocking, exit 2)                  | n/a      | depends on 3.1                                          |
+| Task 3.3 | pending | Docs-home per product class (blocking, exit 2)               | n/a      | depends on 3.1                                          |
+| Task 3.4 | pending | Audit-drift fixture set                                      | n/a      | depends on 3.1/3.2/3.3                                  |
+| Task 4.1 | pending | Tag `agent-runtime-cli` v0.1.0 and update release config     | n/a      | depends on 2.2 and 3.4                                  |
+| Task 4.2 | pending | Bump `homebrew-tap` formula                                  | n/a      | depends on 4.1                                          |
+| Task 4.3 | pending | Cross-repo: bump `required_clis` floors in agent-runtime-kit | n/a      | cross-repo PR against agent-runtime-kit; depends on 4.2 |
 
 ## Validation
 

--- a/docs/specs/completion-coverage-matrix-v1.md
+++ b/docs/specs/completion-coverage-matrix-v1.md
@@ -6,6 +6,12 @@
 - Obligation rule for this matrix: all workspace binaries are `required` unless explicitly `excluded` as internal/example binaries.
 - Explicit exclusion: `cli-template` is `excluded` because it is an example/template CLI and is out of scope for user-facing release
   contract migration (`docs/plans/repo-completion-standard-rollout-plan.md`).
+- Explicit exclusion: `agent-runtime` is `excluded` while the crate ships as the Plan 01 stub for the consuming repo
+  [`graysurf/agent-runtime-kit`](https://github.com/graysurf/agent-runtime-kit) — every subcommand exits `1` with
+  `not implemented`, so generated completions would advertise unimplemented surface. Completion assets are deferred to
+  Plan 02 (`render` / `audit-drift`) and Plan 04 (`install` / `uninstall` / `doctor` / `gc-backups` / `restore-backups` /
+  `purge-state`), at which point this row flips to `required` and the crate begins exporting `completion <bash|zsh>` via
+  clap. Tracking: [`graysurf/agent-runtime-kit#1`](https://github.com/graysurf/agent-runtime-kit/issues/1).
 - Explicit treatment: `image-processing` is `required` (user-facing CLI in `README.md`) and must ship clap-first thin completion adapters in
   both shells.
 - Alias policy: alias families are required only for `git-scope` (`gs*`), `git-cli` (`gx*`), `codex-cli` (`cx*`), and `fzf-cli` (`fx*`) per
@@ -28,6 +34,7 @@
 | --------------------- | ---------- | ---------------------------------- | ------------------------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `agent-docs`          | `required` | `present` (`_agent-docs`)          | `present` (`agent-docs`)             | not required                                                   | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories.                                                                                                                     |
 | `agent-out`           | `required` | `present` (`_agent-out`)           | `present` (`agent-out`)              | not required                                                   | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories.                                                                                                                     |
+| `agent-runtime`       | `excluded` | `missing`                          | `missing`                            | not required                                                   | `not required (excluded)`                                                                                                                    | Plan 01 stub from `graysurf/agent-runtime-kit`; every subcommand exits `1` with `not implemented`, so completions are deferred until Plan 02 / Plan 04 land real bodies.                |
 | `agent-scope-lock`    | `required` | `present` (`_agent-scope-lock`)    | `present` (`agent-scope-lock`)       | not required                                                   | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion is exported by `agent-scope-lock completion <bash\|zsh>` and generated from clap metadata.                                                                 |
 | `api-gql`             | `required` | `present` (`_api-gql`)             | `present` (`api-gql`)                | not required                                                   | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories.                                                                                                                     |
 | `api-grpc`            | `required` | `present` (`_api-grpc`)            | `present` (`api-grpc`)               | not required                                                   | `completion_mode=clap-first; completion_mode_toggles=forbidden; alternate_completion_dispatch=forbidden; generated_load_failure=fail-closed` | Workspace binary; completion files exist in both shell directories.                                                                                                                     |
@@ -64,5 +71,5 @@
 
 ## Exclusion summary
 
-- `excluded`: `cli-template` (explicit staged exclusion).
-- No other workspace binary is excluded in this matrix.
+- `excluded`: `cli-template` (explicit staged exclusion), `agent-runtime` (Plan 01 stub from `graysurf/agent-runtime-kit`; completion
+  assets land in Plan 02 / Plan 04).


### PR DESCRIPTION
## Summary

Open `crates/agent-runtime-cli/` as a Plan 01 stub crate so the rest of the [`graysurf/agent-runtime-kit`](https://github.com/graysurf/agent-runtime-kit) install ladder — `manifests/`, `scripts/setup.sh`, the Homebrew tap formula — can wire up against a real binary before Plan 02 lands the render / install / audit-drift bodies. Cloned from `cli-template`, ships as `0.0.1-dev`, every subcommand exits 1 by design.

## Changes

- Add `crates/agent-runtime-cli/` (binary name `agent-runtime`, package name `agent-runtime-cli`, version `0.0.1-dev`).
- Wire the eight subcommands from Resolved Decision #2 of the consuming repo (`render`, `install`, `uninstall`, `doctor`, `audit-drift`, `gc-backups`, `restore-backups`, `purge-state`) — each prints `agent-runtime <sub>: not implemented` to stderr and exits 1; `--version` returns `0.0.1-dev`.
- Register `crates/agent-runtime-cli` in the workspace `members` list.
- Replace the cloned cli-template integration tests with four agent-runtime-specific tests: `--version`, `--help` lists every subcommand, every subcommand exits 1 with the expected stderr line, unknown subcommand exits non-zero.
- Refresh the crate README + docs index so they describe the stub and link to the consumer.

## Test-First Evidence

- Change classification: feature (new binary surface introduced).
- Failing test before fix: the four integration tests above (`tests/integration/cli.rs`) would fail against the cloned cli-template main; they are the contract for the stub.
- Final validation: `cargo test -p agent-runtime-cli --tests` → 4 passed; `cargo build --workspace` → ok; manual `target/debug/agent-runtime --version` → `agent-runtime 0.0.1-dev`; manual subcommand loop → all 8 exit 1 with the expected stderr.

## Testing

- `cargo build -p agent-runtime-cli` (pass).
- `cargo build --workspace` (pass).
- `cargo metadata --format-version 1 | jq -r '.packages[].name' | grep -Fx agent-runtime-cli` (pass).
- `cargo test -p agent-runtime-cli --tests` (pass, 4/4).
- `./target/debug/agent-runtime --version` → `agent-runtime 0.0.1-dev` (pass).
- `for sub in render install uninstall doctor audit-drift gc-backups restore-backups purge-state; do ./target/debug/agent-runtime "$sub"; done` — all exit 1 with `agent-runtime <sub>: not implemented` on stderr (pass).

## Risk / Notes

- Crate is intentionally namespaced as `agent-runtime-cli` (package) vs `agent-runtime` (binary) so brew users get `agent-runtime` on PATH. Matches the Plan 01 architecture doc rule.
- This PR does NOT cut a release tag or update the Homebrew tap; those are separate steps owned by [`graysurf/agent-runtime-kit#1`](https://github.com/graysurf/agent-runtime-kit/issues/1) Plan 01 Sprint 3 Tasks 3.3 + 3.4, which need a release-publish decision (current nils-cli tag is `v0.11.0-4-g6cb2877`; the plan asks for a literal `v0.0.1-dev` tag that lands as backwards-numbered in tag-sort order — pending tap-bump consequence review).
- The workspace package version stays at `0.11.0`; only this crate ships at `0.0.1-dev`, scoped to its own `[package]` block.