### PR TITLE
test(agent-runtime-cli): track workspace version via CARGO_PKG_VERSION

### DIFF
--- a/crates/agent-runtime-cli/tests/integration/cli.rs
+++ b/crates/agent-runtime-cli/tests/integration/cli.rs
@@ -23,13 +23,14 @@ const SUBCOMMANDS: &[&str] = &[
 ];
 
 #[test]
-fn version_prints_dev_release() {
+fn version_prints_workspace_version() {
     let output = run(&["--version"]);
     assert_eq!(output.code, 0);
     let stdout = output.stdout_text();
+    let expected = env!("CARGO_PKG_VERSION");
     assert!(
-        stdout.contains("0.0.1-dev"),
-        "version output should include 0.0.1-dev: {stdout}"
+        stdout.contains(expected),
+        "version output should include {expected}: {stdout}"
     );
 }
 


### PR DESCRIPTION
## Summary

Track the upcoming workspace version bump without per-release test edits. Replaces the hard-coded `"0.0.1-dev"` assertion in `crates/agent-runtime-cli/tests/integration/cli.rs` with `env!("CARGO_PKG_VERSION")`, so the test follows whatever the crate's Cargo.toml says.

## Why now

The next nils-cli release (`v0.12.0`) is a coupled-workspace bump that pulls every crate (including the new `agent-runtime-cli` stub) onto the workspace cadence — per the existing `chore(release): bump cli versions to X.Y.Z` convention. Without this fix, the release script would update `Cargo.toml` to `0.12.0` but the test would still assert `"0.0.1-dev"`, failing CI.

## Changes

- `crates/agent-runtime-cli/tests/integration/cli.rs`: rename `version_prints_dev_release` → `version_prints_workspace_version`; assert `stdout.contains(env!("CARGO_PKG_VERSION"))` instead of the literal.

## Testing

- `cargo test -p agent-runtime-cli --test integration` → 4/4 pass (still asserts `"0.0.1-dev"` matches the current Cargo.toml).
