### PR TITLE
Sprint 1: wire agent-runtime render engine core (#401)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,15 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
+ "indexmap",
  "nils-test-support",
+ "serde",
+ "serde_json",
+ "serde_yml",
+ "sha2 0.11.0",
+ "tempfile",
+ "tera",
+ "thiserror",
 ]
 
 [[package]]
@@ -394,12 +402,34 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf 0.11.3",
+]
+
+[[package]]
+name = "chrono-tz"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
+dependencies = [
+ "parse-zoneinfo",
+ "phf 0.11.3",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -562,6 +592,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +666,12 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "diff"
@@ -1025,6 +1080,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1185,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "hybrid-array"
@@ -1318,6 +1393,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1609,6 +1700,16 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -1912,7 +2013,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
 ]
 
@@ -2085,7 +2186,7 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
- "chrono-tz",
+ "chrono-tz 0.10.4",
  "clap",
  "clap_complete",
  "nils-common",
@@ -2564,10 +2665,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared 0.11.3",
+]
 
 [[package]]
 name = "phf"
@@ -2575,7 +2737,36 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2771,7 +2962,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2820,12 +3011,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2835,7 +3047,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3276,10 +3497,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3378,6 +3625,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3487,6 +3744,28 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tera"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
+dependencies = [
+ "chrono",
+ "chrono-tz 0.9.0",
+ "globwalk",
+ "humansize",
+ "lazy_static",
+ "percent-encoding",
+ "pest",
+ "pest_derive",
+ "rand 0.8.6",
+ "regex",
+ "serde",
+ "serde_json",
+ "slug",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3810,7 +4089,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3829,6 +4108,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"
@@ -3882,6 +4167,12 @@ name = "unicode-script"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-vo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,13 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "=4.6.5"
 directories = "6"
+indexmap = { version = "2", features = ["serde"] }
 pretty_assertions = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yml = "0.0.12"
+sha2 = "0.11"
+tera = "1"
 thiserror = "2"
 toml = "1.1"
 tracing = "0.1"

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,8 +3,8 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `afcbc28d90980f0de587c9f2542ccb9f344118c22dad31745b836d7966f7de6e`
-- Third-party crates (`source != null`): 438
+- Cargo.lock SHA256: `d2f8ac32075a3111bc3c12d24a6044df7dab739e80d636b4649b7c710ba95d58`
+- Third-party crates (`source != null`): 465
 - Workspace crates (`source == null`, excluded below): 32
 
 ## Notes
@@ -17,17 +17,17 @@ This file documents third-party Rust crate licenses used by this workspace.
 
 | License Expression | Crate Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 209 |
-| MIT | 78 |
+| MIT OR Apache-2.0 | 224 |
+| MIT | 86 |
 | Apache-2.0 OR MIT | 36 |
 | Zlib OR Apache-2.0 OR MIT | 19 |
 | Unicode-3.0 | 18 |
+| MIT/Apache-2.0 | 17 |
 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | 15 |
-| MIT/Apache-2.0 | 15 |
-| Unlicense OR MIT | 9 |
+| Unlicense OR MIT | 10 |
+| BSD-3-Clause | 4 |
 | MIT OR Apache-2.0 OR Zlib | 4 |
 | Apache-2.0 OR ISC OR MIT | 3 |
-| BSD-3-Clause | 3 |
 | CDLA-Permissive-2.0 | 3 |
 | Zlib | 3 |
 | Apache-2.0 | 2 |
@@ -93,6 +93,8 @@ This file documents third-party Rust crate licenses used by this workspace.
 | cfg_aliases | 0.2.1 | MIT | crates.io |
 | chrono | 0.4.44 | MIT OR Apache-2.0 | crates.io |
 | chrono-tz | 0.10.4 | MIT OR Apache-2.0 | crates.io |
+| chrono-tz | 0.9.0 | MIT OR Apache-2.0 | crates.io |
+| chrono-tz-build | 0.3.0 | MIT OR Apache-2.0 | crates.io |
 | clap | 4.6.1 | MIT OR Apache-2.0 | crates.io |
 | clap_builder | 4.6.0 | MIT OR Apache-2.0 | crates.io |
 | clap_complete | 4.6.5 | MIT OR Apache-2.0 | crates.io |
@@ -111,6 +113,8 @@ This file documents third-party Rust crate licenses used by this workspace.
 | cpufeatures | 0.2.17 | MIT OR Apache-2.0 | crates.io |
 | cpufeatures | 0.3.0 | MIT OR Apache-2.0 | crates.io |
 | crc32fast | 1.5.0 | MIT OR Apache-2.0 | crates.io |
+| crossbeam-deque | 0.8.6 | MIT OR Apache-2.0 | crates.io |
+| crossbeam-epoch | 0.9.18 | MIT OR Apache-2.0 | crates.io |
 | crossbeam-utils | 0.8.21 | MIT OR Apache-2.0 | crates.io |
 | crypto-common | 0.1.7 | MIT OR Apache-2.0 | crates.io |
 | crypto-common | 0.2.2 | MIT OR Apache-2.0 | crates.io |
@@ -118,6 +122,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | data-encoding | 2.11.0 | MIT | crates.io |
 | data-url | 0.3.2 | MIT OR Apache-2.0 | crates.io |
 | deranged | 0.5.8 | MIT OR Apache-2.0 | crates.io |
+| deunicode | 1.6.2 | BSD-3-Clause | crates.io |
 | diff | 0.1.13 | MIT OR Apache-2.0 | crates.io |
 | digest | 0.10.7 | MIT OR Apache-2.0 | crates.io |
 | digest | 0.11.3 | MIT OR Apache-2.0 | crates.io |
@@ -163,6 +168,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | getrandom | 0.4.2 | MIT OR Apache-2.0 | crates.io |
 | gif | 0.14.2 | MIT OR Apache-2.0 | crates.io |
 | globset | 0.4.18 | Unlicense OR MIT | crates.io |
+| globwalk | 0.9.1 | MIT | crates.io |
 | hashbrown | 0.15.5 | MIT OR Apache-2.0 | crates.io |
 | hashbrown | 0.16.1 | MIT OR Apache-2.0 | crates.io |
 | hashbrown | 0.17.1 | MIT OR Apache-2.0 | crates.io |
@@ -175,6 +181,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | http-body | 1.0.1 | MIT | crates.io |
 | http-body-util | 0.1.3 | MIT | crates.io |
 | httparse | 1.10.1 | MIT OR Apache-2.0 | crates.io |
+| humansize | 2.1.3 | MIT/Apache-2.0 | crates.io |
 | hybrid-array | 0.4.12 | MIT OR Apache-2.0 | crates.io |
 | hyper | 1.9.0 | MIT | crates.io |
 | hyper-rustls | 0.27.9 | Apache-2.0 OR ISC OR MIT | crates.io |
@@ -191,6 +198,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | id-arena | 2.3.0 | MIT/Apache-2.0 | crates.io |
 | idna | 1.1.0 | MIT OR Apache-2.0 | crates.io |
 | idna_adapter | 1.2.2 | Apache-2.0 OR MIT | crates.io |
+| ignore | 0.4.25 | Unlicense OR MIT | crates.io |
 | image | 0.25.10 | MIT OR Apache-2.0 | crates.io |
 | image-webp | 0.2.4 | MIT OR Apache-2.0 | crates.io |
 | imagesize | 0.14.0 | MIT | crates.io |
@@ -219,6 +227,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | libm | 0.2.16 | MIT | crates.io |
 | libredox | 0.1.16 | MIT | crates.io |
 | libsqlite3-sys | 0.37.0 | MIT | crates.io |
+| libyml | 0.0.5 | MIT | crates.io |
 | linux-raw-sys | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | crates.io |
 | litemap | 0.8.2 | Unicode-3.0 | crates.io |
 | log | 0.4.29 | MIT OR Apache-2.0 | crates.io |
@@ -264,8 +273,17 @@ This file documents third-party Rust crate licenses used by this workspace.
 | option-ext | 0.2.0 | MPL-2.0 | crates.io |
 | ordered-stream | 0.2.0 | MIT OR Apache-2.0 | crates.io |
 | parking | 2.2.1 | Apache-2.0 OR MIT | crates.io |
+| parse-zoneinfo | 0.3.1 | MIT | crates.io |
 | percent-encoding | 2.3.2 | MIT OR Apache-2.0 | crates.io |
+| pest | 2.8.6 | MIT OR Apache-2.0 | crates.io |
+| pest_derive | 2.8.6 | MIT OR Apache-2.0 | crates.io |
+| pest_generator | 2.8.6 | MIT OR Apache-2.0 | crates.io |
+| pest_meta | 2.8.6 | MIT OR Apache-2.0 | crates.io |
+| phf | 0.11.3 | MIT | crates.io |
 | phf | 0.12.1 | MIT | crates.io |
+| phf_codegen | 0.11.3 | MIT | crates.io |
+| phf_generator | 0.11.3 | MIT | crates.io |
+| phf_shared | 0.11.3 | MIT | crates.io |
 | phf_shared | 0.12.1 | MIT | crates.io |
 | pico-args | 0.5.0 | MIT | crates.io |
 | pin-project-lite | 0.2.17 | Apache-2.0 OR MIT | crates.io |
@@ -291,8 +309,11 @@ This file documents third-party Rust crate licenses used by this workspace.
 | quote | 1.0.45 | MIT OR Apache-2.0 | crates.io |
 | r-efi | 5.3.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later | crates.io |
 | r-efi | 6.0.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later | crates.io |
+| rand | 0.8.6 | MIT OR Apache-2.0 | crates.io |
 | rand | 0.9.4 | MIT OR Apache-2.0 | crates.io |
+| rand_chacha | 0.3.1 | MIT OR Apache-2.0 | crates.io |
 | rand_chacha | 0.9.0 | MIT OR Apache-2.0 | crates.io |
+| rand_core | 0.6.4 | MIT OR Apache-2.0 | crates.io |
 | rand_core | 0.9.5 | MIT OR Apache-2.0 | crates.io |
 | redox_users | 0.5.2 | MIT | crates.io |
 | regex | 1.12.3 | MIT OR Apache-2.0 | crates.io |
@@ -332,7 +353,9 @@ This file documents third-party Rust crate licenses used by this workspace.
 | serde_repr | 0.1.20 | MIT OR Apache-2.0 | crates.io |
 | serde_spanned | 1.1.1 | MIT OR Apache-2.0 | crates.io |
 | serde_urlencoded | 0.7.1 | MIT/Apache-2.0 | crates.io |
+| serde_yml | 0.0.12 | MIT OR Apache-2.0 | crates.io |
 | sha1 | 0.10.6 | MIT OR Apache-2.0 | crates.io |
+| sha2 | 0.10.9 | MIT OR Apache-2.0 | crates.io |
 | sha2 | 0.11.0 | MIT OR Apache-2.0 | crates.io |
 | sharded-slab | 0.1.7 | MIT | crates.io |
 | shell-words | 1.1.1 | MIT/Apache-2.0 | crates.io |
@@ -345,6 +368,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | siphasher | 1.0.3 | MIT/Apache-2.0 | crates.io |
 | slab | 0.4.12 | MIT | crates.io |
 | slotmap | 1.1.1 | Zlib | crates.io |
+| slug | 0.1.6 | MIT/Apache-2.0 | crates.io |
 | smallvec | 1.15.1 | MIT OR Apache-2.0 | crates.io |
 | socket2 | 0.6.3 | MIT OR Apache-2.0 | crates.io |
 | sqlite-wasm-rs | 0.5.4 | MIT | crates.io |
@@ -357,6 +381,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | sync_wrapper | 1.0.2 | Apache-2.0 | crates.io |
 | synstructure | 0.13.2 | MIT | crates.io |
 | tempfile | 3.27.0 | MIT OR Apache-2.0 | crates.io |
+| tera | 1.20.1 | MIT | crates.io |
 | thiserror | 2.0.18 | MIT OR Apache-2.0 | crates.io |
 | thiserror-impl | 2.0.18 | MIT OR Apache-2.0 | crates.io |
 | thread_local | 1.1.9 | MIT OR Apache-2.0 | crates.io |
@@ -389,6 +414,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | tungstenite | 0.29.0 | MIT OR Apache-2.0 | crates.io |
 | typed-arena | 2.0.2 | MIT | crates.io |
 | typenum | 1.20.0 | MIT OR Apache-2.0 | crates.io |
+| ucd-trie | 0.1.7 | MIT OR Apache-2.0 | crates.io |
 | uds_windows | 1.2.1 | MIT | crates.io |
 | unicase | 2.9.0 | MIT OR Apache-2.0 | crates.io |
 | unicode-bidi | 0.3.18 | MIT OR Apache-2.0 | crates.io |
@@ -397,6 +423,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | unicode-ident | 1.0.24 | (MIT OR Apache-2.0) AND Unicode-3.0 | crates.io |
 | unicode-properties | 0.1.4 | MIT/Apache-2.0 | crates.io |
 | unicode-script | 0.5.8 | MIT OR Apache-2.0 | crates.io |
+| unicode-segmentation | 1.13.2 | MIT OR Apache-2.0 | crates.io |
 | unicode-vo | 0.1.0 | MIT/Apache-2.0 | crates.io |
 | unicode-width | 0.2.2 | MIT OR Apache-2.0 | crates.io |
 | unicode-xid | 0.2.6 | MIT OR Apache-2.0 | crates.io |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,8 +3,8 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `afcbc28d90980f0de587c9f2542ccb9f344118c22dad31745b836d7966f7de6e`
-- Third-party crates (`source != null`): 438
+- Cargo.lock SHA256: `d2f8ac32075a3111bc3c12d24a6044df7dab739e80d636b4649b7c710ba95d58`
+- Third-party crates (`source != null`): 465
 
 ## Notice Extraction Policy
 
@@ -379,6 +379,22 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - License file references:
   - `LICENSE`
 
+### chrono-tz 0.9.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### chrono-tz-build 0.3.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
 ### clap 4.6.1
 
 - License: `MIT OR Apache-2.0`
@@ -537,6 +553,24 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
 
+### crossbeam-deque 0.8.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### crossbeam-epoch 0.9.18
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
 ### crossbeam-utils 0.8.21
 
 - License: `MIT OR Apache-2.0`
@@ -598,6 +632,14 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - License file references:
   - `LICENSE-Apache`
   - `LICENSE-MIT`
+
+### deunicode 1.6.2
+
+- License: `BSD-3-Clause`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
 
 ### diff 0.1.13
 
@@ -994,6 +1036,14 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `COPYING`
   - `UNLICENSE`
 
+### globwalk 0.9.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
 ### hashbrown 0.15.5
 
 - License: `MIT OR Apache-2.0`
@@ -1092,6 +1142,15 @@ This file documents third-party notice-file discovery for Rust crates used by th
 ### httparse 1.10.1
 
 - License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### humansize 2.1.3
+
+- License: `MIT/Apache-2.0`
 - Source: `crates.io`
 - Notice files: No explicit NOTICE file discovered.
 - License file references:
@@ -1233,6 +1292,16 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - License file references:
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
+
+### ignore 0.4.25
+
+- License: `Unlicense OR MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
+  - `COPYING`
+  - `UNLICENSE`
 
 ### image 0.25.10
 
@@ -1472,6 +1541,14 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - Notice files: No explicit NOTICE file discovered.
 - License file references:
   - `LICENSE`
+
+### libyml 0.0.5
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
 
 ### linux-raw-sys 0.12.1
 
@@ -1840,6 +1917,14 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-MIT`
   - `LICENSE-THIRD-PARTY`
 
+### parse-zoneinfo 0.3.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
 ### percent-encoding 2.3.2
 
 - License: `MIT OR Apache-2.0`
@@ -1849,7 +1934,75 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
 
+### pest 2.8.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### pest_derive 2.8.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### pest_generator 2.8.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### pest_meta 2.8.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### phf 0.11.3
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
 ### phf 0.12.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### phf_codegen 0.11.3
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### phf_generator 0.11.3
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
+
+### phf_shared 0.11.3
 
 - License: `MIT`
 - Source: `crates.io`
@@ -2075,6 +2228,15 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - Notice files: No explicit NOTICE file discovered.
 - License file reference: none declared
 
+### rand 0.8.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
 ### rand 0.9.4
 
 - License: `MIT OR Apache-2.0`
@@ -2084,7 +2246,25 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
 
+### rand_chacha 0.3.1
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
 ### rand_chacha 0.9.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### rand_core 0.6.4
 
 - License: `MIT OR Apache-2.0`
 - Source: `crates.io`
@@ -2440,7 +2620,25 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
 
+### serde_yml 0.0.12
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
 ### sha1 0.10.6
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### sha2 0.10.9
 
 - License: `MIT OR Apache-2.0`
 - Source: `crates.io`
@@ -2552,6 +2750,15 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - License file references:
   - `LICENSE`
 
+### slug 0.1.6
+
+- License: `MIT/Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
 ### smallvec 1.15.1
 
 - License: `MIT OR Apache-2.0`
@@ -2653,6 +2860,14 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - License file references:
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
+
+### tera 1.20.1
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE`
 
 ### thiserror 2.0.18
 
@@ -2930,6 +3145,15 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
 
+### ucd-trie 0.1.7
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
 ### uds_windows 1.2.1
 
 - License: `MIT`
@@ -2994,6 +3218,15 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-MIT`
 
 ### unicode-script 0.5.8
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
+### unicode-segmentation 1.13.2
 
 - License: `MIT OR Apache-2.0`
 - Source: `crates.io`

--- a/crates/agent-runtime-cli/Cargo.toml
+++ b/crates/agent-runtime-cli/Cargo.toml
@@ -4,8 +4,12 @@ version = "0.12.0"
 edition.workspace = true
 license.workspace = true
 
-description = "Stub CLI for graysurf/agent-runtime-kit. Subcommands are intentionally not implemented until Plan 02 (render + audit-drift) lands."
+description = "Render / install / doctor / audit-drift CLI for graysurf/agent-runtime-kit."
 repository = "https://github.com/sympoies/nils-cli"
+
+[lib]
+name = "agent_runtime_cli"
+path = "src/lib.rs"
 
 [[bin]]
 name = "agent-runtime"
@@ -14,6 +18,14 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+indexmap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yml = { workspace = true }
+sha2 = { workspace = true }
+tera = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 nils-test-support = { version = "0.12.0", path = "../nils-test-support" }
+tempfile = "3"

--- a/crates/agent-runtime-cli/src/commands/mod.rs
+++ b/crates/agent-runtime-cli/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod render;

--- a/crates/agent-runtime-cli/src/commands/render.rs
+++ b/crates/agent-runtime-cli/src/commands/render.rs
@@ -1,0 +1,46 @@
+use crate::render::golden;
+use crate::render::manifest::{self, SourceRoot};
+use crate::render::writer;
+use clap::Args;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+const DEFAULT_PRODUCT: &str = "codex";
+
+#[derive(Args, Debug)]
+pub struct RenderArgs {
+    /// Source root containing `manifests/`, `core/`, `targets/`, `build/`.
+    /// Defaults to the current working directory.
+    #[arg(long)]
+    pub source_root: Option<PathBuf>,
+    /// Product to render (`codex` or `claude`). Defaults to `codex`.
+    #[arg(long, default_value = DEFAULT_PRODUCT)]
+    pub product: String,
+    /// Rewrite `tests/golden/<product>/.../expected/` from the just-rendered
+    /// build tree. Scoped to the active `--product` subtree only.
+    #[arg(long)]
+    pub update_golden: bool,
+}
+
+pub fn run(args: RenderArgs) -> anyhow::Result<u8> {
+    let root = SourceRoot::from_arg_or_cwd(args.source_root.as_deref())?;
+    let manifests = Arc::new(manifest::load_all(&root)?);
+    let report = writer::write_product(&root, manifests.clone(), &args.product)?;
+    eprintln!(
+        "agent-runtime render: product={} root={} rendered={} cached={} skipped={}",
+        report.product,
+        report.output_root.display(),
+        report.rendered.len(),
+        report.cached.len(),
+        report.skipped.len(),
+    );
+    if args.update_golden {
+        let copied = golden::update_golden(root.path(), &manifests, &report)?;
+        eprintln!(
+            "agent-runtime render: update-golden copied {} file(s) into tests/golden/{}/",
+            copied.len(),
+            report.product,
+        );
+    }
+    Ok(0)
+}

--- a/crates/agent-runtime-cli/src/lib.rs
+++ b/crates/agent-runtime-cli/src/lib.rs
@@ -1,0 +1,69 @@
+use clap::{Parser, Subcommand};
+use std::process::ExitCode;
+
+pub mod commands;
+pub mod render;
+
+#[derive(Parser)]
+#[command(
+    name = "agent-runtime",
+    version,
+    about = "Render / install / doctor / audit-drift for graysurf/agent-runtime-kit."
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Render `core/` + `targets/<product>/` into `build/<product>/`.
+    Render(commands::render::RenderArgs),
+    /// Activate rendered output against a product's runtime home.
+    Install,
+    /// Remove installed renderer output from a product's runtime home.
+    Uninstall,
+    /// Diagnose host setup, runtime roots, and required CLI floors.
+    Doctor,
+    /// Detect source-vs-rendered, rendered-vs-live, and unsafe drift.
+    AuditDrift,
+    /// Prune old backups under `<state_home>/backups/`.
+    GcBackups,
+    /// Restore a runtime home from a recorded backup snapshot.
+    RestoreBackups,
+    /// Purge runtime-managed state (use with caution).
+    PurgeState,
+}
+
+impl Command {
+    fn name(&self) -> &'static str {
+        match self {
+            Command::Render(_) => "render",
+            Command::Install => "install",
+            Command::Uninstall => "uninstall",
+            Command::Doctor => "doctor",
+            Command::AuditDrift => "audit-drift",
+            Command::GcBackups => "gc-backups",
+            Command::RestoreBackups => "restore-backups",
+            Command::PurgeState => "purge-state",
+        }
+    }
+}
+
+pub fn run() -> ExitCode {
+    let cli = Cli::parse();
+    let name = cli.command.name();
+    match cli.command {
+        Command::Render(args) => match commands::render::run(args) {
+            Ok(code) => ExitCode::from(code),
+            Err(err) => {
+                eprintln!("agent-runtime render: {err:#}");
+                ExitCode::from(2)
+            }
+        },
+        _ => {
+            eprintln!("agent-runtime {name}: not implemented");
+            ExitCode::from(1)
+        }
+    }
+}

--- a/crates/agent-runtime-cli/src/main.rs
+++ b/crates/agent-runtime-cli/src/main.rs
@@ -1,54 +1,5 @@
-use clap::{Parser, Subcommand};
 use std::process::ExitCode;
 
-#[derive(Parser)]
-#[command(
-    name = "agent-runtime",
-    version,
-    about = "Render / install / doctor / audit-drift for graysurf/agent-runtime-kit (Plan 01 stub — every subcommand exits 1)."
-)]
-struct Cli {
-    #[command(subcommand)]
-    command: Command,
-}
-
-#[derive(Subcommand)]
-enum Command {
-    /// Render `core/` + `targets/<product>/` into `build/<product>/`.
-    Render,
-    /// Activate rendered output against a product's runtime home.
-    Install,
-    /// Remove installed renderer output from a product's runtime home.
-    Uninstall,
-    /// Diagnose host setup, runtime roots, and required CLI floors.
-    Doctor,
-    /// Detect source-vs-rendered, rendered-vs-live, and unsafe drift.
-    AuditDrift,
-    /// Prune old backups under `<state_home>/backups/`.
-    GcBackups,
-    /// Restore a runtime home from a recorded backup snapshot.
-    RestoreBackups,
-    /// Purge runtime-managed state (use with caution).
-    PurgeState,
-}
-
-impl Command {
-    fn name(&self) -> &'static str {
-        match self {
-            Command::Render => "render",
-            Command::Install => "install",
-            Command::Uninstall => "uninstall",
-            Command::Doctor => "doctor",
-            Command::AuditDrift => "audit-drift",
-            Command::GcBackups => "gc-backups",
-            Command::RestoreBackups => "restore-backups",
-            Command::PurgeState => "purge-state",
-        }
-    }
-}
-
 fn main() -> ExitCode {
-    let cli = Cli::parse();
-    eprintln!("agent-runtime {}: not implemented", cli.command.name());
-    ExitCode::from(1)
+    agent_runtime_cli::run()
 }

--- a/crates/agent-runtime-cli/src/render/cache.rs
+++ b/crates/agent-runtime-cli/src/render/cache.rs
@@ -30,14 +30,22 @@ impl RenderCache {
     }
 
     /// Load the cache from `path`, returning an empty cache when the
-    /// file is missing or unreadable. An unparsable cache file is
-    /// silently treated as empty so a corrupted cache forces a full
-    /// re-render instead of failing the run.
+    /// file is missing or unreadable. An unparsable cache file or one
+    /// with a `schema_version` that we don't know how to interpret is
+    /// silently treated as empty so a corrupted or future-format cache
+    /// forces a full re-render instead of failing the run or silently
+    /// trusting cache entries from a different version.
     pub fn load_or_empty(path: &Path) -> Self {
-        match fs::read_to_string(path) {
-            Ok(body) => serde_json::from_str(&body).unwrap_or_else(|_| Self::empty()),
-            Err(_) => Self::empty(),
+        let Ok(body) = fs::read_to_string(path) else {
+            return Self::empty();
+        };
+        let Ok(parsed) = serde_json::from_str::<Self>(&body) else {
+            return Self::empty();
+        };
+        if parsed.schema_version != CACHE_SCHEMA_VERSION {
+            return Self::empty();
         }
+        parsed
     }
 
     pub fn save(&self, path: &Path) -> std::io::Result<()> {
@@ -90,6 +98,23 @@ mod tests {
         fs::write(&path, "this is not json").unwrap();
         let loaded = RenderCache::load_or_empty(&path);
         assert!(loaded.skills.is_empty());
+    }
+
+    /// A cache file written by a future agent-runtime-cli with a newer
+    /// `schema_version` should be ignored rather than half-trusted —
+    /// the entries' shape might have changed.
+    #[test]
+    fn schema_version_mismatch_loads_as_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".render-cache.json");
+        fs::write(
+            &path,
+            r#"{"schema_version": 99, "skills": {"old.skill": {"hash": "sha256:0", "output": "x"}}}"#,
+        )
+        .unwrap();
+        let loaded = RenderCache::load_or_empty(&path);
+        assert!(loaded.skills.is_empty());
+        assert_eq!(loaded.schema_version, CACHE_SCHEMA_VERSION);
     }
 
     #[test]

--- a/crates/agent-runtime-cli/src/render/cache.rs
+++ b/crates/agent-runtime-cli/src/render/cache.rs
@@ -1,0 +1,121 @@
+//! Per-product render cache persisted as `.render-cache.json` at the
+//! root of `build/<product>/`. The cache keeps the cache-hit path
+//! byte-identical to the cache-miss path: when the recorded hash for a
+//! skill matches and the output file is still on disk, render leaves
+//! the file alone; otherwise the skill is re-rendered and overwritten.
+//!
+//! Serialization uses [`BTreeMap`] so the on-disk file is byte-stable
+//! across runs (the cache-hit equality test depends on that).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+pub const CACHE_FILE: &str = ".render-cache.json";
+pub const CACHE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RenderCache {
+    pub schema_version: u32,
+    pub skills: BTreeMap<String, CacheEntry>,
+}
+
+impl RenderCache {
+    pub fn empty() -> Self {
+        Self {
+            schema_version: CACHE_SCHEMA_VERSION,
+            skills: BTreeMap::new(),
+        }
+    }
+
+    /// Load the cache from `path`, returning an empty cache when the
+    /// file is missing or unreadable. An unparsable cache file is
+    /// silently treated as empty so a corrupted cache forces a full
+    /// re-render instead of failing the run.
+    pub fn load_or_empty(path: &Path) -> Self {
+        match fs::read_to_string(path) {
+            Ok(body) => serde_json::from_str(&body).unwrap_or_else(|_| Self::empty()),
+            Err(_) => Self::empty(),
+        }
+    }
+
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        let body = serde_json::to_string_pretty(self).expect("RenderCache serializes");
+        fs::write(path, body.as_bytes())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CacheEntry {
+    pub hash: String,
+    pub output: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn round_trips_through_disk() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".render-cache.json");
+        let mut cache = RenderCache::empty();
+        cache.skills.insert(
+            "market.favorites".to_string(),
+            CacheEntry {
+                hash: "sha256:deadbeef".to_string(),
+                output: "skills/sample/SKILL.md".to_string(),
+            },
+        );
+        cache.save(&path).unwrap();
+        let loaded = RenderCache::load_or_empty(&path);
+        assert_eq!(loaded, cache);
+    }
+
+    #[test]
+    fn missing_file_loads_as_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("does-not-exist.json");
+        let loaded = RenderCache::load_or_empty(&path);
+        assert!(loaded.skills.is_empty());
+        assert_eq!(loaded.schema_version, CACHE_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn unparsable_file_loads_as_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".render-cache.json");
+        fs::write(&path, "this is not json").unwrap();
+        let loaded = RenderCache::load_or_empty(&path);
+        assert!(loaded.skills.is_empty());
+    }
+
+    #[test]
+    fn save_emits_sorted_keys_for_byte_stability() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(".render-cache.json");
+        let mut cache = RenderCache::empty();
+        cache.skills.insert(
+            "zeta.last".to_string(),
+            CacheEntry {
+                hash: "sha256:1".to_string(),
+                output: "z".to_string(),
+            },
+        );
+        cache.skills.insert(
+            "alpha.first".to_string(),
+            CacheEntry {
+                hash: "sha256:2".to_string(),
+                output: "a".to_string(),
+            },
+        );
+        cache.save(&path).unwrap();
+        let body = fs::read_to_string(&path).unwrap();
+        // BTreeMap serialization → alpha appears before zeta.
+        let alpha_idx = body.find("alpha.first").unwrap();
+        let zeta_idx = body.find("zeta.last").unwrap();
+        assert!(alpha_idx < zeta_idx);
+    }
+}

--- a/crates/agent-runtime-cli/src/render/golden.rs
+++ b/crates/agent-runtime-cli/src/render/golden.rs
@@ -1,0 +1,282 @@
+//! `--update-golden` mode. After a normal render, copy every produced
+//! file from `<source-root>/build/<product>/<skill-render-dir>/` into
+//! `<source-root>/tests/golden/<product>/<skill-render-dir>/expected/`.
+//!
+//! Golden directory creation is best-effort: a missing
+//! `tests/golden/<product>/` is created, never errored on, and we never
+//! touch anything outside the active product's subtree.
+
+use crate::render::manifest::ManifestSet;
+use crate::render::writer::{RenderReport, sandboxed_join};
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Copy every rendered file under `report.output_root` into
+/// `<source-root>/tests/golden/<product>/<...>/expected/...`. Returns
+/// the list of (source, destination) pairs that were actually copied.
+pub fn update_golden(
+    source_root: &Path,
+    manifests: &ManifestSet,
+    report: &RenderReport,
+) -> Result<Vec<(PathBuf, PathBuf)>> {
+    let golden_root = source_root
+        .join("tests")
+        .join("golden")
+        .join(&report.product);
+    fs::create_dir_all(&golden_root)
+        .with_context(|| format!("create_dir_all {}", golden_root.display()))?;
+
+    let mut copied = Vec::new();
+    let touched = touched_skill_ids(report);
+    for skill in &manifests.skills.skills {
+        if !touched.contains(&skill.id) {
+            continue;
+        }
+        let Some(render) = skill.products.get(&report.product) else {
+            continue;
+        };
+        let render_to = Path::new(&render.render_to);
+        let render_dir = render_to.parent().unwrap_or_else(|| Path::new(""));
+        let src_dir = sandboxed_join(&report.output_root, &render_dir.to_string_lossy())?;
+        let dst_dir = sandboxed_join(&golden_root, &format!("{}/expected", render_dir.display()))?;
+        if !src_dir.exists() {
+            continue;
+        }
+        fs::create_dir_all(&dst_dir)
+            .with_context(|| format!("create_dir_all {}", dst_dir.display()))?;
+        copy_tree(&src_dir, &dst_dir, &mut copied)?;
+    }
+    Ok(copied)
+}
+
+fn touched_skill_ids(report: &RenderReport) -> std::collections::BTreeSet<String> {
+    let mut ids = std::collections::BTreeSet::new();
+    ids.extend(report.rendered.iter().cloned());
+    ids.extend(report.cached.iter().cloned());
+    ids
+}
+
+fn copy_tree(src: &Path, dst: &Path, copied: &mut Vec<(PathBuf, PathBuf)>) -> Result<()> {
+    let mut entries: Vec<_> = fs::read_dir(src)
+        .with_context(|| format!("read_dir {}", src.display()))?
+        .flatten()
+        .collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let src_path = entry.path();
+        let file_name = entry.file_name();
+        let dst_path = dst.join(&file_name);
+        if src_path.is_dir() {
+            fs::create_dir_all(&dst_path)
+                .with_context(|| format!("create_dir_all {}", dst_path.display()))?;
+            copy_tree(&src_path, &dst_path, copied)?;
+        } else {
+            fs::copy(&src_path, &dst_path).with_context(|| {
+                format!("copy {} -> {}", src_path.display(), dst_path.display())
+            })?;
+            copied.push((src_path, dst_path));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::manifest::{self, SourceRoot};
+    use crate::render::writer;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, body: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, body).unwrap();
+    }
+
+    fn fixture(tmp: &TempDir) -> SourceRoot {
+        let root = tmp.path();
+        write(
+            &root.join("manifests/skills.yaml"),
+            r#"
+schema_version: 1
+skills:
+  - id: market.favorites
+    domain: market
+    source: core/skills/market/favorites
+    products:
+      codex:
+        name: /market-favorites
+        render_to: skills/market/favorites/SKILL.md
+    required_clis:
+      agent-out: ">=0.5.0"
+"#,
+        );
+        write(
+            &root.join("manifests/plugins.yaml"),
+            "schema_version: 1\nplugins: []\n",
+        );
+        write(
+            &root.join("manifests/product-capabilities.yaml"),
+            PRODUCT_CAPS,
+        );
+        write(&root.join("manifests/runtime-roots.yaml"), RUNTIME_ROOTS);
+        write(&root.join("manifests/cli-tools.yaml"), CLI_TOOLS);
+        write(
+            &root.join("core/skills/market/favorites/SKILL.md.tera"),
+            r#"# {{ skill_ref(id="market.favorites") }}
+required: {{ cli_ref(name="agent-out") }}
+"#,
+        );
+        SourceRoot::from_arg_or_cwd(Some(root)).unwrap()
+    }
+
+    const PRODUCT_CAPS: &str = r#"
+schema_version: 1
+products:
+  codex:
+    nested_skill_support: true
+    plugin_manifest:
+      path_pattern: "ignored"
+      loaded_at_runtime: false
+      schema_ref: "ignored"
+    hooks_model:
+      config_surface: "ignored"
+      payload_shape: "ignored"
+      supports_inline_python: false
+    config_activation:
+      - "$CODEX_HOME/AGENTS.md"
+    runtime_state:
+      state_home_env: "STATE"
+      default_path: "/tmp/state"
+  claude:
+    nested_skill_support: true
+    plugin_manifest:
+      path_pattern: "ignored"
+      loaded_at_runtime: true
+      schema_ref: "ignored"
+    hooks_model:
+      config_surface: "ignored"
+      payload_shape: "ignored"
+      supports_inline_python: true
+    config_activation:
+      - "$HOME/.claude/settings.json"
+    runtime_state:
+      state_home_env: "STATE"
+      default_path: "/tmp/state"
+"#;
+
+    const RUNTIME_ROOTS: &str = r#"
+schema_version: 1
+products:
+  codex:
+    live_home: "$CODEX_HOME"
+    docs_home: "$CODEX_HOME"
+    state_home: "/tmp/state"
+    plugin_root: "$CODEX_HOME/plugins"
+    hook_config_strategy: managed-block
+    min_version: "<TBD: pin during Phase 1>"
+    recommended_version: "<TBD: pin during Phase 1>"
+    min_version_effective_from: "<TBD: pin during Phase 1>"
+    version_probe: "codex --version"
+  claude:
+    live_home: "$HOME/.claude"
+    docs_home: "$HOME/.claude"
+    state_home: "/tmp/state"
+    plugin_root_env: "CLAUDE_PLUGIN_ROOT"
+    hook_config_strategy: settings-json
+    min_version: "<TBD: pin during Phase 1>"
+    recommended_version: "<TBD: pin during Phase 1>"
+    min_version_effective_from: "<TBD: pin during Phase 1>"
+    version_probe: "claude --version"
+"#;
+
+    const CLI_TOOLS: &str = r#"
+schema_version: 1
+profiles:
+  core: [ripgrep]
+  recommended: [ripgrep]
+  full: [ripgrep]
+formulas:
+  ripgrep:
+    brew: ripgrep
+    command: rg
+    linux_only_alternative: null
+    categories: [search]
+"#;
+
+    #[test]
+    fn flag_off_does_not_write_golden() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture(&tmp);
+        let set = Arc::new(manifest::load_all(&root).unwrap());
+        writer::write_product(&root, set, "codex").unwrap();
+        // No golden update; ensure tests/golden/ never appeared.
+        let golden = root.path().join("tests/golden");
+        assert!(!golden.exists(), "{} should not exist", golden.display());
+    }
+
+    #[test]
+    fn flag_on_creates_golden_tree_for_active_product() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture(&tmp);
+        let set = Arc::new(manifest::load_all(&root).unwrap());
+        let report = writer::write_product(&root, set.clone(), "codex").unwrap();
+        let copied = update_golden(root.path(), &set, &report).unwrap();
+        assert!(
+            !copied.is_empty(),
+            "golden update should copy at least one file"
+        );
+
+        let expected = root
+            .path()
+            .join("tests/golden/codex/skills/market/favorites/expected/SKILL.md");
+        assert!(expected.exists(), "{} missing", expected.display());
+        let body = fs::read_to_string(&expected).unwrap();
+        assert!(body.contains("# /market-favorites"), "{body}");
+    }
+
+    #[test]
+    fn flag_on_only_touches_active_product_subtree() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture(&tmp);
+        let set = Arc::new(manifest::load_all(&root).unwrap());
+        // Plant a sentinel file under tests/golden/claude/ to prove we
+        // never write outside tests/golden/codex/.
+        let sentinel_dir = root.path().join("tests/golden/claude/skills");
+        fs::create_dir_all(&sentinel_dir).unwrap();
+        let sentinel = sentinel_dir.join("DO_NOT_TOUCH.md");
+        fs::write(&sentinel, "untouched\n").unwrap();
+        let report = writer::write_product(&root, set.clone(), "codex").unwrap();
+        update_golden(root.path(), &set, &report).unwrap();
+        assert_eq!(fs::read_to_string(&sentinel).unwrap(), "untouched\n");
+    }
+
+    #[test]
+    fn cached_skills_are_also_refreshed_into_golden() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture(&tmp);
+        let set = Arc::new(manifest::load_all(&root).unwrap());
+        // Prime cache.
+        let first = writer::write_product(&root, set.clone(), "codex").unwrap();
+        // Pre-create golden with a stale value.
+        let expected = root
+            .path()
+            .join("tests/golden/codex/skills/market/favorites/expected/SKILL.md");
+        fs::create_dir_all(expected.parent().unwrap()).unwrap();
+        fs::write(&expected, "stale\n").unwrap();
+        // Run a cached render then update golden — cached path must
+        // still overwrite golden.
+        let second = writer::write_product(&root, set.clone(), "codex").unwrap();
+        assert!(
+            !second.cached.is_empty(),
+            "expected cache hit, got {second:?}"
+        );
+        let _ = first;
+        update_golden(root.path(), &set, &second).unwrap();
+        let body = fs::read_to_string(&expected).unwrap();
+        assert!(body.contains("# /market-favorites"), "{body}");
+    }
+}

--- a/crates/agent-runtime-cli/src/render/helpers/cli_ref.rs
+++ b/crates/agent-runtime-cli/src/render/helpers/cli_ref.rs
@@ -1,0 +1,73 @@
+//! `cli_ref(name)` — resolve a CLI reference. The current skill's
+//! `required_clis` map is the authoritative source for version floors;
+//! when a binary appears there, we emit `name (floor)`. Falling back to
+//! [`cli-tools.yaml`](super::HelperContext) covers third-party tools
+//! without a per-skill floor. Unknown names surface a typed error so
+//! drift audit's `cli_ref` rejection class fires loud and early.
+
+use super::HelperContext;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tera::{Function, Value};
+
+pub fn make(ctx: Arc<HelperContext>) -> impl Function + 'static {
+    move |args: &HashMap<String, Value>| -> tera::Result<Value> {
+        let raw = args
+            .get("name")
+            .ok_or_else(|| tera::Error::msg("cli_ref(): required arg `name` (string)"))?;
+        let name = raw.as_str().ok_or_else(|| {
+            tera::Error::msg(format!(
+                "cli_ref(): arg `name` must be a string, got {raw:?}"
+            ))
+        })?;
+        if let Some(floor) = ctx.current_skill_required_clis.get(name) {
+            return Ok(Value::String(format!("{name} ({floor})")));
+        }
+        if ctx.manifests.cli_tools.formulas.contains_key(name) {
+            return Ok(Value::String(name.to_string()));
+        }
+        Err(tera::Error::msg(format!(
+            "cli_ref(): unknown binary {name:?} \
+             (not declared in skill {skill:?} required_clis, \
+             not present in cli-tools.yaml formulas)",
+            skill = ctx.current_skill_id
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{fixture_context, format_err, render};
+
+    #[test]
+    fn renders_floor_for_required_cli() {
+        let ctx = fixture_context("codex");
+        let out = render(r#"{{ cli_ref(name="agent-out") }}"#, ctx).unwrap();
+        assert_eq!(out, "agent-out (>=0.5.0)");
+    }
+
+    #[test]
+    fn renders_third_party_tool_from_cli_tools_yaml() {
+        let ctx = fixture_context("codex");
+        let out = render(r#"{{ cli_ref(name="ripgrep") }}"#, ctx).unwrap();
+        assert_eq!(out, "ripgrep");
+    }
+
+    #[test]
+    fn rejects_unknown_binary() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ cli_ref(name="totally-not-real") }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("totally-not-real"), "{msg}");
+        assert!(msg.contains("cli_ref()"), "{msg}");
+        assert!(msg.contains("market.favorites"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_missing_arg() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ cli_ref() }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("required arg `name`"), "{msg}");
+    }
+}

--- a/crates/agent-runtime-cli/src/render/helpers/mod.rs
+++ b/crates/agent-runtime-cli/src/render/helpers/mod.rs
@@ -49,7 +49,7 @@ mod test_support {
         CliToolFormula, CliToolsManifest, CliToolsProfiles, HooksModel, PluginManifestSpec,
         PluginsManifest, ProductCapabilitiesManifest, ProductCapabilitiesProducts,
         ProductCapability, ProductRender, ProductRoot, RuntimeRootsManifest, RuntimeRootsProducts,
-        RuntimeState, Skill, SkillsManifest, StateOutMode,
+        RuntimeState, Skill, SkillProducts, SkillsManifest, StateOutMode,
     };
 
     fn product_capability() -> ProductCapability {
@@ -90,23 +90,18 @@ mod test_support {
     }
 
     pub fn fixture_manifests() -> ManifestSet {
-        let mut products = IndexMap::new();
-        products.insert(
-            "codex".to_string(),
-            ProductRender {
+        let products = SkillProducts {
+            codex: Some(ProductRender {
                 name: Some("/codex-name".to_string()),
                 render_to: "build/codex/skills/sample/SKILL.md".to_string(),
                 path_override: None,
-            },
-        );
-        products.insert(
-            "claude".to_string(),
-            ProductRender {
+            }),
+            claude: Some(ProductRender {
                 name: Some("market:favorites".to_string()),
                 render_to: "build/claude/plugins/market/skills/favorites/SKILL.md".to_string(),
                 path_override: None,
-            },
-        );
+            }),
+        };
         let mut required_clis = IndexMap::new();
         required_clis.insert("agent-out".to_string(), ">=0.5.0".to_string());
         required_clis.insert("market-cli".to_string(), ">=0.4.0".to_string());

--- a/crates/agent-runtime-cli/src/render/helpers/mod.rs
+++ b/crates/agent-runtime-cli/src/render/helpers/mod.rs
@@ -1,0 +1,204 @@
+//! Tera helper functions registered against a per-skill render pass.
+//!
+//! Each helper is constructed from a shared [`HelperContext`] that captures
+//! everything required for resolution: the source root, the parsed manifest
+//! bundle, the active product, and the current skill's `required_clis` /
+//! `state_out_mode`. Helpers are stateless beyond this snapshot, so two
+//! cold processes registering the same context produce identical output.
+//!
+//! Tera's `Function` trait signature forces `&HashMap<String, Value>` on
+//! us — that's the only sanctioned `HashMap` import inside `src/render/`
+//! and it stays scoped to this module (the context fed to Tera lives in
+//! [`IndexMap`] / `BTreeMap` per Resolved Decision #9).
+
+use crate::render::manifest::{ManifestSet, StateOutMode};
+use indexmap::IndexMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tera::Tera;
+
+pub mod cli_ref;
+pub mod script;
+pub mod skill_ref;
+pub mod state_out;
+
+/// Snapshot of the resolution context that all four helpers share for a
+/// single skill's render. Cloned via [`Arc`] into each helper closure.
+#[derive(Debug, Clone)]
+pub struct HelperContext {
+    pub source_root: PathBuf,
+    pub manifests: Arc<ManifestSet>,
+    pub current_product: String,
+    pub current_skill_id: String,
+    pub current_skill_required_clis: IndexMap<String, String>,
+    pub current_skill_state_out_mode: StateOutMode,
+}
+
+/// Register every renderer helper on `tera` with the shared `ctx`.
+pub fn register_all(tera: &mut Tera, ctx: Arc<HelperContext>) {
+    tera.register_function("script", script::make(ctx.clone()));
+    tera.register_function("skill_ref", skill_ref::make(ctx.clone()));
+    tera.register_function("state_out", state_out::make(ctx.clone()));
+    tera.register_function("cli_ref", cli_ref::make(ctx));
+}
+
+#[cfg(test)]
+mod test_support {
+    use super::*;
+    use crate::render::manifest::{
+        CliToolFormula, CliToolsManifest, CliToolsProfiles, HooksModel, PluginManifestSpec,
+        PluginsManifest, ProductCapabilitiesManifest, ProductCapabilitiesProducts,
+        ProductCapability, ProductRender, ProductRoot, RuntimeRootsManifest, RuntimeRootsProducts,
+        RuntimeState, Skill, SkillsManifest, StateOutMode,
+    };
+
+    fn product_capability() -> ProductCapability {
+        ProductCapability {
+            nested_skill_support: true,
+            plugin_manifest: PluginManifestSpec {
+                path_pattern: "ignored".to_string(),
+                loaded_at_runtime: false,
+                schema_ref: "ignored".to_string(),
+            },
+            hooks_model: HooksModel {
+                config_surface: "ignored".to_string(),
+                payload_shape: "ignored".to_string(),
+                supports_inline_python: false,
+            },
+            config_activation: vec!["ignored".to_string()],
+            runtime_state: RuntimeState {
+                state_home_env: "STATE".to_string(),
+                default_path: "/tmp/state".to_string(),
+            },
+            marketplace_concept: false,
+        }
+    }
+
+    fn product_root() -> ProductRoot {
+        ProductRoot {
+            live_home: "/tmp/live".to_string(),
+            docs_home: "/tmp/docs".to_string(),
+            state_home: "/tmp/state".to_string(),
+            plugin_root: None,
+            plugin_root_env: None,
+            hook_config_strategy: None,
+            min_version: "<TBD: pin during Phase 1>".to_string(),
+            recommended_version: "<TBD: pin during Phase 1>".to_string(),
+            min_version_effective_from: "<TBD: pin during Phase 1>".to_string(),
+            version_probe: "probe".to_string(),
+        }
+    }
+
+    pub fn fixture_manifests() -> ManifestSet {
+        let mut products = IndexMap::new();
+        products.insert(
+            "codex".to_string(),
+            ProductRender {
+                name: Some("/codex-name".to_string()),
+                render_to: "build/codex/skills/sample/SKILL.md".to_string(),
+                path_override: None,
+            },
+        );
+        products.insert(
+            "claude".to_string(),
+            ProductRender {
+                name: Some("market:favorites".to_string()),
+                render_to: "build/claude/plugins/market/skills/favorites/SKILL.md".to_string(),
+                path_override: None,
+            },
+        );
+        let mut required_clis = IndexMap::new();
+        required_clis.insert("agent-out".to_string(), ">=0.5.0".to_string());
+        required_clis.insert("market-cli".to_string(), ">=0.4.0".to_string());
+        let skill = Skill {
+            id: "market.favorites".to_string(),
+            domain: "market".to_string(),
+            source: "core/skills/market/favorites".to_string(),
+            products,
+            required_clis,
+            state_out_mode: StateOutMode::Runtime,
+            aliases: IndexMap::new(),
+            divergent: false,
+            portability_notes: None,
+        };
+        let mut formulas: IndexMap<String, CliToolFormula> = IndexMap::new();
+        formulas.insert(
+            "ripgrep".to_string(),
+            CliToolFormula {
+                brew: "ripgrep".to_string(),
+                command: "rg".to_string(),
+                linux_only_alternative: None,
+                categories: vec!["search".to_string()],
+                notes: None,
+            },
+        );
+        ManifestSet {
+            skills: SkillsManifest {
+                schema_version: 1,
+                skills: vec![skill],
+            },
+            plugins: PluginsManifest {
+                schema_version: 1,
+                plugins: vec![],
+            },
+            product_capabilities: ProductCapabilitiesManifest {
+                schema_version: 1,
+                products: ProductCapabilitiesProducts {
+                    codex: product_capability(),
+                    claude: product_capability(),
+                },
+                plugin_manifest_diff: None,
+            },
+            runtime_roots: RuntimeRootsManifest {
+                schema_version: 1,
+                products: RuntimeRootsProducts {
+                    codex: product_root(),
+                    claude: product_root(),
+                },
+                host_profiles: IndexMap::new(),
+            },
+            cli_tools: CliToolsManifest {
+                schema_version: 1,
+                profiles: CliToolsProfiles {
+                    core: vec!["ripgrep".to_string()],
+                    recommended: vec!["ripgrep".to_string()],
+                    full: vec!["ripgrep".to_string()],
+                },
+                formulas,
+            },
+        }
+    }
+
+    pub fn fixture_context(product: &str) -> HelperContext {
+        let manifests = Arc::new(fixture_manifests());
+        let skill = &manifests.skills.skills[0];
+        HelperContext {
+            source_root: PathBuf::from("/tmp/source-root"),
+            current_product: product.to_string(),
+            current_skill_id: skill.id.clone(),
+            current_skill_required_clis: skill.required_clis.clone(),
+            current_skill_state_out_mode: skill.state_out_mode,
+            manifests,
+        }
+    }
+
+    pub fn render(template: &str, ctx: HelperContext) -> tera::Result<String> {
+        let mut tera = Tera::default();
+        register_all(&mut tera, Arc::new(ctx));
+        tera.render_str(template, &tera::Context::new())
+    }
+
+    /// Flatten a Tera error and its source chain into a single string so
+    /// rejection tests can assert against the originating helper message,
+    /// not Tera's outer `Failed to render '__tera_one_off'` wrapper.
+    pub fn format_err(err: &tera::Error) -> String {
+        let mut out = err.to_string();
+        let mut next: Option<&dyn std::error::Error> = std::error::Error::source(err);
+        while let Some(cause) = next {
+            out.push_str("\n  caused by: ");
+            out.push_str(&cause.to_string());
+            next = cause.source();
+        }
+        out
+    }
+}

--- a/crates/agent-runtime-cli/src/render/helpers/script.rs
+++ b/crates/agent-runtime-cli/src/render/helpers/script.rs
@@ -1,0 +1,84 @@
+//! `script(path)` — resolve a path under the source root, restricted to
+//! the three sanctioned subtrees: `core/`, `targets/`, `manifests/`.
+//!
+//! The returned value is the source-root-joined path as a string. Render
+//! is read-only at this stage; no I/O happens here.
+
+use super::HelperContext;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tera::{Function, Value};
+
+const ALLOWED_PREFIXES: &[&str] = &["core/", "targets/", "manifests/"];
+
+pub fn make(ctx: Arc<HelperContext>) -> impl Function + 'static {
+    move |args: &HashMap<String, Value>| -> tera::Result<Value> {
+        let raw = args
+            .get("path")
+            .ok_or_else(|| tera::Error::msg("script(): required arg `path` (string)"))?;
+        let path = raw.as_str().ok_or_else(|| {
+            tera::Error::msg(format!(
+                "script(): arg `path` must be a string, got {raw:?}"
+            ))
+        })?;
+        if path.contains("..") {
+            return Err(tera::Error::msg(format!(
+                "script(): arg `path` {path:?} must not contain `..` segments",
+            )));
+        }
+        if !ALLOWED_PREFIXES
+            .iter()
+            .any(|prefix| path.starts_with(prefix))
+        {
+            return Err(tera::Error::msg(format!(
+                "script(): arg `path` {path:?} must start with one of {ALLOWED_PREFIXES:?}",
+            )));
+        }
+        let resolved = ctx.source_root.join(path);
+        Ok(Value::String(resolved.to_string_lossy().into_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{fixture_context, format_err, render};
+
+    #[test]
+    fn resolves_a_core_path_against_source_root() {
+        let ctx = fixture_context("codex");
+        let out = render(r#"{{ script(path="core/scripts/foo.sh") }}"#, ctx).unwrap();
+        assert_eq!(out, "/tmp/source-root/core/scripts/foo.sh");
+    }
+
+    #[test]
+    fn resolves_a_targets_path_against_source_root() {
+        let ctx = fixture_context("claude");
+        let out = render(r#"{{ script(path="targets/claude/policy.md") }}"#, ctx).unwrap();
+        assert_eq!(out, "/tmp/source-root/targets/claude/policy.md");
+    }
+
+    #[test]
+    fn rejects_path_outside_allowed_subtrees() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ script(path="/etc/passwd") }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("script()"), "{msg}");
+        assert!(msg.contains("/etc/passwd"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_traversal_in_path() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ script(path="core/../etc/passwd") }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains(".."), "{msg}");
+    }
+
+    #[test]
+    fn rejects_missing_arg() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ script() }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("required arg `path`"), "{msg}");
+    }
+}

--- a/crates/agent-runtime-cli/src/render/helpers/skill_ref.rs
+++ b/crates/agent-runtime-cli/src/render/helpers/skill_ref.rs
@@ -1,0 +1,85 @@
+//! `skill_ref(id)` — resolve a tracked skill id (`<domain>.<skill>`) to
+//! the product-native invocation name for the active product. Falls back
+//! to the canonical id when the per-product entry omits `name`.
+
+use super::HelperContext;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tera::{Function, Value};
+
+pub fn make(ctx: Arc<HelperContext>) -> impl Function + 'static {
+    move |args: &HashMap<String, Value>| -> tera::Result<Value> {
+        let raw = args
+            .get("id")
+            .ok_or_else(|| tera::Error::msg("skill_ref(): required arg `id` (string)"))?;
+        let id = raw.as_str().ok_or_else(|| {
+            tera::Error::msg(format!(
+                "skill_ref(): arg `id` must be a string, got {raw:?}"
+            ))
+        })?;
+        let skill = ctx
+            .manifests
+            .skills
+            .skills
+            .iter()
+            .find(|s| s.id == id)
+            .ok_or_else(|| {
+                tera::Error::msg(format!(
+                    "skill_ref(): no skill with id {id:?} in skills.yaml"
+                ))
+            })?;
+        let render = skill.products.get(&ctx.current_product).ok_or_else(|| {
+            tera::Error::msg(format!(
+                "skill_ref(): skill {id:?} has no entry for product {product:?}",
+                product = ctx.current_product
+            ))
+        })?;
+        let label = render.name.clone().unwrap_or_else(|| id.to_string());
+        Ok(Value::String(label))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{fixture_context, format_err, render};
+
+    #[test]
+    fn returns_product_native_name_for_codex() {
+        let ctx = fixture_context("codex");
+        let out = render(r#"{{ skill_ref(id="market.favorites") }}"#, ctx).unwrap();
+        assert_eq!(out, "/codex-name");
+    }
+
+    #[test]
+    fn returns_product_native_name_for_claude() {
+        let ctx = fixture_context("claude");
+        let out = render(r#"{{ skill_ref(id="market.favorites") }}"#, ctx).unwrap();
+        assert_eq!(out, "market:favorites");
+    }
+
+    #[test]
+    fn rejects_unknown_skill_id() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ skill_ref(id="market.unknown") }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("market.unknown"), "{msg}");
+        assert!(msg.contains("skill_ref()"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_skill_missing_for_current_product() {
+        let mut ctx = fixture_context("codex");
+        ctx.current_product = "unknown-product".to_string();
+        let err = render(r#"{{ skill_ref(id="market.favorites") }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("unknown-product"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_missing_arg() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ skill_ref() }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("required arg `id`"), "{msg}");
+    }
+}

--- a/crates/agent-runtime-cli/src/render/helpers/state_out.rs
+++ b/crates/agent-runtime-cli/src/render/helpers/state_out.rs
@@ -16,9 +16,10 @@ use tera::{Function, Value};
 
 pub fn make(ctx: Arc<HelperContext>) -> impl Function + 'static {
     move |args: &HashMap<String, Value>| -> tera::Result<Value> {
-        let domain = string_arg(args, "domain")?;
-        let topic = optional_string_arg(args, "topic")?;
-        let repo = optional_string_arg(args, "repo")?;
+        let domain = validated_arg(args, "domain", /* required */ true)?
+            .expect("required arg returned None unexpectedly");
+        let topic = validated_arg(args, "topic", false)?;
+        let repo = validated_arg(args, "repo", false)?;
         match ctx.current_skill_state_out_mode {
             StateOutMode::Runtime => {
                 let mut cmd = format!("agent-out path-for --domain {domain}");
@@ -39,29 +40,45 @@ pub fn make(ctx: Arc<HelperContext>) -> impl Function + 'static {
     }
 }
 
-fn string_arg(args: &HashMap<String, Value>, name: &'static str) -> tera::Result<String> {
-    let raw = args
-        .get(name)
-        .ok_or_else(|| tera::Error::msg(format!("state_out(): required arg `{name}` (string)")))?;
-    raw.as_str().map(str::to_string).ok_or_else(|| {
-        tera::Error::msg(format!(
-            "state_out(): arg `{name}` must be a string, got {raw:?}"
-        ))
-    })
+/// Allowed character set for `state_out` args. The rendered output is a
+/// command string that downstream agent runtimes feed to a shell, so the
+/// helper rejects anything that could break out of the argv slot:
+/// shell metacharacters (` ; | & $ \` < > * ? \n` etc.), shell quote
+/// characters, and any whitespace. Identifiers in the source doc are
+/// kebab-case slugs (`market`, `favorites`, `nils-cli`); this charset
+/// is intentionally narrow.
+fn arg_charset_ok(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':'))
 }
 
-fn optional_string_arg(
+fn validated_arg(
     args: &HashMap<String, Value>,
     name: &'static str,
+    required: bool,
 ) -> tera::Result<Option<String>> {
     let Some(raw) = args.get(name) else {
+        if required {
+            return Err(tera::Error::msg(format!(
+                "state_out(): required arg `{name}` (string)"
+            )));
+        }
         return Ok(None);
     };
-    raw.as_str().map(|s| Some(s.to_string())).ok_or_else(|| {
+    let value = raw.as_str().ok_or_else(|| {
         tera::Error::msg(format!(
             "state_out(): arg `{name}` must be a string, got {raw:?}"
         ))
-    })
+    })?;
+    if !arg_charset_ok(value) {
+        return Err(tera::Error::msg(format!(
+            "state_out(): arg `{name}` {value:?} contains characters outside \
+             the allowed set [A-Za-z0-9._:/-]; the rendered command is \
+             shell-executed downstream and must stay quote-free",
+        )));
+    }
+    Ok(Some(value.to_string()))
 }
 
 #[cfg(test)]
@@ -117,5 +134,60 @@ mod tests {
         let err = render(r#"{{ state_out() }}"#, ctx).unwrap_err();
         let msg = format_err(&err);
         assert!(msg.contains("required arg `domain`"), "{msg}");
+    }
+
+    /// Shell-meta injection attempt — the rendered command string is
+    /// shell-executed downstream, so a `domain=; rm -rf $HOME` literal
+    /// would propagate. The charset gate rejects it before render.
+    #[test]
+    fn rejects_shell_metacharacters_in_args() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ state_out(domain="market; rm -rf $HOME") }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("characters outside the allowed set"), "{msg}");
+        assert!(msg.contains("rm -rf"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_whitespace_in_args() {
+        let ctx = fixture_context("codex");
+        let err = render(
+            r#"{{ state_out(domain="market", topic="favorites bar") }}"#,
+            ctx,
+        )
+        .unwrap_err();
+        assert!(format_err(&err).contains("favorites bar"));
+    }
+
+    #[test]
+    fn rejects_dollar_sign_in_args() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ state_out(domain="market", topic="$HOME") }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("state_out()"), "{msg}");
+        assert!(msg.contains("$HOME"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_empty_string_arg() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ state_out(domain="") }}"#, ctx).unwrap_err();
+        assert!(format_err(&err).contains("allowed set"));
+    }
+
+    #[test]
+    fn accepts_kebab_case_and_slashes() {
+        // Real source-doc identifiers include kebab-case slugs (`nils-cli`),
+        // dotted scopes (`market.favorites`), and a few slash-bearing repos.
+        let ctx = fixture_context("codex");
+        let out = render(
+            r#"{{ state_out(domain="market", topic="market.favorites", repo="sympoies/nils-cli") }}"#,
+            ctx,
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "agent-out path-for --domain market --topic market.favorites --repo sympoies/nils-cli",
+        );
     }
 }

--- a/crates/agent-runtime-cli/src/render/helpers/state_out.rs
+++ b/crates/agent-runtime-cli/src/render/helpers/state_out.rs
@@ -1,0 +1,121 @@
+//! `state_out(domain, topic=, repo=)` — emit either an `agent-out
+//! path-for` invocation (mode `runtime`) or a literal resolved path
+//! (mode `literal`), driven by the current skill's `state_out_mode`.
+//!
+//! Per Resolved Decision #9 the runtime form is the durable contract —
+//! it preserves env-driven state-home overrides at execution time and
+//! keeps render output stable across hosts. Literal mode is reserved
+//! for skills that can't `exec` (a Plan 04 concern); we surface a clear
+//! typed error rather than guessing a literal path here.
+
+use super::HelperContext;
+use crate::render::manifest::StateOutMode;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tera::{Function, Value};
+
+pub fn make(ctx: Arc<HelperContext>) -> impl Function + 'static {
+    move |args: &HashMap<String, Value>| -> tera::Result<Value> {
+        let domain = string_arg(args, "domain")?;
+        let topic = optional_string_arg(args, "topic")?;
+        let repo = optional_string_arg(args, "repo")?;
+        match ctx.current_skill_state_out_mode {
+            StateOutMode::Runtime => {
+                let mut cmd = format!("agent-out path-for --domain {domain}");
+                if let Some(t) = topic {
+                    cmd.push_str(&format!(" --topic {t}"));
+                }
+                if let Some(r) = repo {
+                    cmd.push_str(&format!(" --repo {r}"));
+                }
+                Ok(Value::String(cmd))
+            }
+            StateOutMode::Literal => Err(tera::Error::msg(format!(
+                "state_out(): literal mode not yet wired for skill {skill:?} \
+                 (Plan 04 lands literal-mode resolution)",
+                skill = ctx.current_skill_id
+            ))),
+        }
+    }
+}
+
+fn string_arg(args: &HashMap<String, Value>, name: &'static str) -> tera::Result<String> {
+    let raw = args
+        .get(name)
+        .ok_or_else(|| tera::Error::msg(format!("state_out(): required arg `{name}` (string)")))?;
+    raw.as_str().map(str::to_string).ok_or_else(|| {
+        tera::Error::msg(format!(
+            "state_out(): arg `{name}` must be a string, got {raw:?}"
+        ))
+    })
+}
+
+fn optional_string_arg(
+    args: &HashMap<String, Value>,
+    name: &'static str,
+) -> tera::Result<Option<String>> {
+    let Some(raw) = args.get(name) else {
+        return Ok(None);
+    };
+    raw.as_str().map(|s| Some(s.to_string())).ok_or_else(|| {
+        tera::Error::msg(format!(
+            "state_out(): arg `{name}` must be a string, got {raw:?}"
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{fixture_context, format_err, render};
+    use crate::render::manifest::StateOutMode;
+
+    #[test]
+    fn runtime_mode_emits_path_for_invocation() {
+        let ctx = fixture_context("codex");
+        let out = render(
+            r#"{{ state_out(domain="market", topic="favorites") }}"#,
+            ctx,
+        )
+        .unwrap();
+        assert_eq!(out, "agent-out path-for --domain market --topic favorites");
+    }
+
+    #[test]
+    fn runtime_mode_emits_invocation_without_topic_when_unset() {
+        let ctx = fixture_context("codex");
+        let out = render(r#"{{ state_out(domain="market") }}"#, ctx).unwrap();
+        assert_eq!(out, "agent-out path-for --domain market");
+    }
+
+    #[test]
+    fn runtime_mode_includes_repo_when_present() {
+        let ctx = fixture_context("codex");
+        let out = render(
+            r#"{{ state_out(domain="market", topic="favorites", repo="nils-cli") }}"#,
+            ctx,
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "agent-out path-for --domain market --topic favorites --repo nils-cli",
+        );
+    }
+
+    #[test]
+    fn literal_mode_returns_typed_error_until_plan_04() {
+        let mut ctx = fixture_context("codex");
+        ctx.current_skill_state_out_mode = StateOutMode::Literal;
+        let err = render(r#"{{ state_out(domain="market") }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("literal mode"), "{msg}");
+        assert!(msg.contains("market.favorites"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_missing_domain() {
+        let ctx = fixture_context("codex");
+        let err = render(r#"{{ state_out() }}"#, ctx).unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("required arg `domain`"), "{msg}");
+    }
+}

--- a/crates/agent-runtime-cli/src/render/manifest.rs
+++ b/crates/agent-runtime-cli/src/render/manifest.rs
@@ -1,0 +1,630 @@
+//! Typed deserialization for the five Phase 1 manifests living under
+//! `<source-root>/manifests/`. Every map visible to the Tera context layer
+//! uses [`IndexMap`] or [`BTreeMap`] so render output stays deterministic
+//! across processes (Resolved Decision #9 in
+//! `inventory-target-architecture.md`).
+
+use indexmap::IndexMap;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    #[error("missing manifest: {path} (source root: {root})")]
+    Missing { path: PathBuf, root: PathBuf },
+    #[error("schema_version mismatch in {file}: expected {expected}, got {found}")]
+    SchemaVersion {
+        file: PathBuf,
+        expected: u32,
+        found: u32,
+    },
+    #[error("parse error in {file}: {source}")]
+    Parse {
+        file: PathBuf,
+        #[source]
+        source: serde_yml::Error,
+    },
+    #[error("io error reading {file}: {source}")]
+    Io {
+        file: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("source root could not be resolved ({path}): {source}")]
+    SourceRoot {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Canonicalised view of the directory passed via `--source-root`. The
+/// canonical path is computed once at construction so every later resolve
+/// walks the same tree.
+#[derive(Debug, Clone)]
+pub struct SourceRoot {
+    path: PathBuf,
+}
+
+impl SourceRoot {
+    /// Build a [`SourceRoot`] from an explicit `--source-root` argument, or
+    /// fall back to the current working directory. The resulting path is
+    /// canonicalised so symlinks resolve to a stable target.
+    pub fn from_arg_or_cwd(arg: Option<&Path>) -> Result<Self, ManifestError> {
+        let raw = match arg {
+            Some(p) => p.to_path_buf(),
+            None => std::env::current_dir().map_err(|source| ManifestError::SourceRoot {
+                path: PathBuf::from("."),
+                source,
+            })?,
+        };
+        let canonical = raw
+            .canonicalize()
+            .map_err(|source| ManifestError::SourceRoot {
+                path: raw.clone(),
+                source,
+            })?;
+        Ok(Self { path: canonical })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn manifests_dir(&self) -> PathBuf {
+        self.path.join("manifests")
+    }
+}
+
+/// Bundle of every Phase 1 manifest. Constructed by [`load_all`].
+#[derive(Debug)]
+pub struct ManifestSet {
+    pub skills: SkillsManifest,
+    pub plugins: PluginsManifest,
+    pub product_capabilities: ProductCapabilitiesManifest,
+    pub runtime_roots: RuntimeRootsManifest,
+    pub cli_tools: CliToolsManifest,
+}
+
+/// Read and validate every Phase 1 manifest under
+/// `<source_root>/manifests/`. Each manifest's `schema_version` is
+/// asserted to equal [`SCHEMA_VERSION`].
+pub fn load_all(root: &SourceRoot) -> Result<ManifestSet, ManifestError> {
+    let dir = root.manifests_dir();
+    Ok(ManifestSet {
+        skills: load::<SkillsManifest>(&dir.join("skills.yaml"), &root.path)?,
+        plugins: load::<PluginsManifest>(&dir.join("plugins.yaml"), &root.path)?,
+        product_capabilities: load::<ProductCapabilitiesManifest>(
+            &dir.join("product-capabilities.yaml"),
+            &root.path,
+        )?,
+        runtime_roots: load::<RuntimeRootsManifest>(&dir.join("runtime-roots.yaml"), &root.path)?,
+        cli_tools: load::<CliToolsManifest>(&dir.join("cli-tools.yaml"), &root.path)?,
+    })
+}
+
+trait WithSchemaVersion {
+    fn schema_version(&self) -> u32;
+}
+
+fn load<T>(file: &Path, root: &Path) -> Result<T, ManifestError>
+where
+    T: for<'de> Deserialize<'de> + WithSchemaVersion,
+{
+    if !file.exists() {
+        return Err(ManifestError::Missing {
+            path: file.to_path_buf(),
+            root: root.to_path_buf(),
+        });
+    }
+    let raw = std::fs::read_to_string(file).map_err(|source| ManifestError::Io {
+        file: file.to_path_buf(),
+        source,
+    })?;
+    let parsed: T = serde_yml::from_str(&raw).map_err(|source| ManifestError::Parse {
+        file: file.to_path_buf(),
+        source,
+    })?;
+    if parsed.schema_version() != SCHEMA_VERSION {
+        return Err(ManifestError::SchemaVersion {
+            file: file.to_path_buf(),
+            expected: SCHEMA_VERSION,
+            found: parsed.schema_version(),
+        });
+    }
+    Ok(parsed)
+}
+
+// ---------------------------------------------------------------------------
+// skills.yaml
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SkillsManifest {
+    pub schema_version: u32,
+    pub skills: Vec<Skill>,
+}
+
+impl WithSchemaVersion for SkillsManifest {
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Skill {
+    pub id: String,
+    pub domain: String,
+    pub source: String,
+    #[serde(default)]
+    pub products: IndexMap<String, ProductRender>,
+    pub required_clis: IndexMap<String, String>,
+    #[serde(default)]
+    pub state_out_mode: StateOutMode,
+    #[serde(default)]
+    pub aliases: IndexMap<String, String>,
+    #[serde(default)]
+    pub divergent: bool,
+    #[serde(default)]
+    pub portability_notes: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum StateOutMode {
+    #[default]
+    Runtime,
+    Literal,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProductRender {
+    #[serde(default)]
+    pub name: Option<String>,
+    pub render_to: String,
+    #[serde(default)]
+    pub path_override: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// plugins.yaml
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginsManifest {
+    pub schema_version: u32,
+    pub plugins: Vec<Plugin>,
+}
+
+impl WithSchemaVersion for PluginsManifest {
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Plugin {
+    pub id: String,
+    pub domain: String,
+    pub contained_skills: Vec<String>,
+    pub product_manifests: IndexMap<String, String>,
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+    #[serde(default)]
+    pub install_policy: InstallPolicy,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum InstallPolicy {
+    #[default]
+    Always,
+    OptIn,
+    Experimental,
+}
+
+// ---------------------------------------------------------------------------
+// product-capabilities.yaml
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProductCapabilitiesManifest {
+    pub schema_version: u32,
+    pub products: ProductCapabilitiesProducts,
+    #[serde(default)]
+    pub plugin_manifest_diff: Option<PluginManifestDiff>,
+}
+
+impl WithSchemaVersion for ProductCapabilitiesManifest {
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProductCapabilitiesProducts {
+    pub codex: ProductCapability,
+    pub claude: ProductCapability,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProductCapability {
+    pub nested_skill_support: bool,
+    pub plugin_manifest: PluginManifestSpec,
+    pub hooks_model: HooksModel,
+    pub config_activation: Vec<String>,
+    pub runtime_state: RuntimeState,
+    #[serde(default)]
+    pub marketplace_concept: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginManifestSpec {
+    pub path_pattern: String,
+    pub loaded_at_runtime: bool,
+    pub schema_ref: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HooksModel {
+    pub config_surface: String,
+    pub payload_shape: String,
+    #[serde(default)]
+    pub supports_inline_python: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeState {
+    pub state_home_env: String,
+    pub default_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginManifestDiff {
+    #[serde(default)]
+    pub shared_fields: Vec<String>,
+    #[serde(default)]
+    pub codex_only_fields: Vec<String>,
+    #[serde(default)]
+    pub claude_only_fields: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// runtime-roots.yaml
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeRootsManifest {
+    pub schema_version: u32,
+    pub products: RuntimeRootsProducts,
+    #[serde(default)]
+    pub host_profiles: IndexMap<String, IndexMap<String, serde_yml::Value>>,
+}
+
+impl WithSchemaVersion for RuntimeRootsManifest {
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeRootsProducts {
+    pub codex: ProductRoot,
+    pub claude: ProductRoot,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProductRoot {
+    pub live_home: String,
+    pub docs_home: String,
+    pub state_home: String,
+    #[serde(default)]
+    pub plugin_root: Option<String>,
+    #[serde(default)]
+    pub plugin_root_env: Option<String>,
+    #[serde(default)]
+    pub hook_config_strategy: Option<HookConfigStrategy>,
+    pub min_version: String,
+    pub recommended_version: String,
+    pub min_version_effective_from: String,
+    pub version_probe: String,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum HookConfigStrategy {
+    SettingsJson,
+    ManagedBlock,
+}
+
+// ---------------------------------------------------------------------------
+// cli-tools.yaml
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CliToolsManifest {
+    pub schema_version: u32,
+    pub profiles: CliToolsProfiles,
+    pub formulas: IndexMap<String, CliToolFormula>,
+}
+
+impl WithSchemaVersion for CliToolsManifest {
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CliToolsProfiles {
+    pub core: Vec<String>,
+    pub recommended: Vec<String>,
+    pub full: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CliToolFormula {
+    pub brew: String,
+    pub command: String,
+    #[serde(default)]
+    pub linux_only_alternative: Option<String>,
+    pub categories: Vec<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    const VALID_SKILLS: &str = "schema_version: 1\nskills: []\n";
+    const VALID_PLUGINS: &str = "schema_version: 1\nplugins: []\n";
+    const VALID_PRODUCT_CAPABILITIES: &str = r#"
+schema_version: 1
+products:
+  codex:
+    nested_skill_support: true
+    plugin_manifest:
+      path_pattern: "$CODEX_HOME/plugins/<domain>/.codex-plugin/plugin.json"
+      loaded_at_runtime: false
+      schema_ref: "core/docs/schemas/codex-plugin.schema.json"
+    hooks_model:
+      config_surface: "$CODEX_HOME/config.toml"
+      payload_shape: "codex-toml-managed-block"
+      supports_inline_python: false
+    config_activation:
+      - "$CODEX_HOME/AGENTS.md"
+    runtime_state:
+      state_home_env: "CODEX_AGENT_STATE_HOME"
+      default_path: "${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/codex"
+    marketplace_concept: false
+  claude:
+    nested_skill_support: true
+    plugin_manifest:
+      path_pattern: "${CLAUDE_PLUGIN_ROOT}/<plugin>/.claude-plugin/plugin.json"
+      loaded_at_runtime: true
+      schema_ref: "core/docs/schemas/claude-plugin.schema.json"
+    hooks_model:
+      config_surface: "$HOME/.claude/settings.json"
+      payload_shape: "claude-pretool-v1"
+      supports_inline_python: true
+    config_activation:
+      - "$HOME/.claude/settings.json"
+    runtime_state:
+      state_home_env: "CLAUDE_KIT_STATE_HOME"
+      default_path: "${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/claude"
+    marketplace_concept: true
+"#;
+    const VALID_RUNTIME_ROOTS: &str = r#"
+schema_version: 1
+products:
+  codex:
+    live_home: "$CODEX_HOME"
+    docs_home: "$CODEX_HOME"
+    state_home: "${CODEX_AGENT_STATE_HOME:-$HOME/.local/state}"
+    plugin_root: "$CODEX_HOME/plugins"
+    hook_config_strategy: managed-block
+    min_version: "<TBD: pin during Phase 1>"
+    recommended_version: "<TBD: pin during Phase 1>"
+    min_version_effective_from: "<TBD: pin during Phase 1>"
+    version_probe: "codex --version"
+  claude:
+    live_home: "$HOME/.claude"
+    docs_home: "$HOME/.claude"
+    state_home: "${CLAUDE_KIT_STATE_HOME:-$HOME/.local/state}"
+    plugin_root_env: "CLAUDE_PLUGIN_ROOT"
+    hook_config_strategy: settings-json
+    min_version: "<TBD: pin during Phase 1>"
+    recommended_version: "<TBD: pin during Phase 1>"
+    min_version_effective_from: "<TBD: pin during Phase 1>"
+    version_probe: "claude --version"
+"#;
+    const VALID_CLI_TOOLS: &str = r#"
+schema_version: 1
+profiles:
+  core: [ripgrep]
+  recommended: [ripgrep]
+  full: [ripgrep]
+formulas:
+  ripgrep:
+    brew: ripgrep
+    command: rg
+    linux_only_alternative: null
+    categories: [search]
+"#;
+
+    fn write_fixture(dir: &Path, with_overrides: &[(&str, &str)]) {
+        let manifests = dir.join("manifests");
+        fs::create_dir_all(&manifests).unwrap();
+        let mut files: IndexMap<&str, &str> = IndexMap::new();
+        files.insert("skills.yaml", VALID_SKILLS);
+        files.insert("plugins.yaml", VALID_PLUGINS);
+        files.insert("product-capabilities.yaml", VALID_PRODUCT_CAPABILITIES);
+        files.insert("runtime-roots.yaml", VALID_RUNTIME_ROOTS);
+        files.insert("cli-tools.yaml", VALID_CLI_TOOLS);
+        for (name, body) in with_overrides {
+            files.insert(*name, *body);
+        }
+        for (name, body) in files {
+            fs::write(manifests.join(name), body).unwrap();
+        }
+    }
+
+    #[test]
+    fn load_all_round_trips_a_minimal_fixture() {
+        let tmp = TempDir::new().unwrap();
+        write_fixture(tmp.path(), &[]);
+        let root = SourceRoot::from_arg_or_cwd(Some(tmp.path())).unwrap();
+        let set = load_all(&root).unwrap();
+        assert!(set.skills.skills.is_empty());
+        assert!(set.plugins.plugins.is_empty());
+        assert!(set.product_capabilities.products.codex.nested_skill_support);
+        assert!(set.product_capabilities.products.claude.marketplace_concept);
+        assert_eq!(
+            set.runtime_roots.products.codex.version_probe,
+            "codex --version"
+        );
+        assert_eq!(set.cli_tools.profiles.core, vec!["ripgrep".to_string()]);
+        let ripgrep = set.cli_tools.formulas.get("ripgrep").unwrap();
+        assert_eq!(ripgrep.brew, "ripgrep");
+        assert_eq!(ripgrep.command, "rg");
+        assert_eq!(ripgrep.categories, vec!["search".to_string()]);
+        assert!(ripgrep.linux_only_alternative.is_none());
+    }
+
+    #[test]
+    fn source_root_canonicalises_relative_paths() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("manifests")).unwrap();
+        // Pass a path with a ./ prefix to force resolution.
+        let dotted = tmp.path().join(".").join("manifests").join("..");
+        let root = SourceRoot::from_arg_or_cwd(Some(&dotted)).unwrap();
+        // The canonical path matches the canonical tmp path.
+        assert_eq!(root.path(), tmp.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn missing_manifest_reports_file_and_root() {
+        let tmp = TempDir::new().unwrap();
+        let manifests = tmp.path().join("manifests");
+        fs::create_dir_all(&manifests).unwrap();
+        // Only one manifest present; the rest are missing.
+        fs::write(manifests.join("skills.yaml"), VALID_SKILLS).unwrap();
+        let root = SourceRoot::from_arg_or_cwd(Some(tmp.path())).unwrap();
+        let err = load_all(&root).unwrap_err();
+        match err {
+            ManifestError::Missing {
+                path,
+                root: root_path,
+            } => {
+                assert!(path.ends_with("plugins.yaml"));
+                assert_eq!(root_path, tmp.path().canonicalize().unwrap());
+            }
+            other => panic!("expected ManifestError::Missing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_field_in_skills_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let mutated = "schema_version: 1\nskills: []\nbogus: true\n";
+        write_fixture(tmp.path(), &[("skills.yaml", mutated)]);
+        let root = SourceRoot::from_arg_or_cwd(Some(tmp.path())).unwrap();
+        let err = load_all(&root).unwrap_err();
+        match err {
+            ManifestError::Parse { file, .. } => {
+                assert!(file.ends_with("skills.yaml"));
+            }
+            other => panic!("expected ManifestError::Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wrong_schema_version_is_rejected_with_file_path() {
+        let tmp = TempDir::new().unwrap();
+        let mutated = "schema_version: 2\nplugins: []\n";
+        write_fixture(tmp.path(), &[("plugins.yaml", mutated)]);
+        let root = SourceRoot::from_arg_or_cwd(Some(tmp.path())).unwrap();
+        let err = load_all(&root).unwrap_err();
+        match err {
+            ManifestError::SchemaVersion {
+                file,
+                expected,
+                found,
+            } => {
+                assert!(file.ends_with("plugins.yaml"));
+                assert_eq!(expected, SCHEMA_VERSION);
+                assert_eq!(found, 2);
+            }
+            other => panic!("expected ManifestError::SchemaVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn state_out_mode_defaults_to_runtime() {
+        let yaml = r#"
+schema_version: 1
+skills:
+  - id: domain.skill
+    domain: domain
+    source: core/skills/domain/skill
+    products: {}
+    required_clis:
+      agent-runtime: ">=0.13.0"
+"#;
+        let parsed: SkillsManifest = serde_yml::from_str(yaml).unwrap();
+        let skill = parsed.skills.first().unwrap();
+        assert_eq!(skill.state_out_mode, StateOutMode::Runtime);
+        assert!(!skill.divergent);
+    }
+
+    #[test]
+    fn install_policy_accepts_kebab_case() {
+        let yaml = r#"
+schema_version: 1
+plugins:
+  - id: domain
+    domain: domain
+    contained_skills: []
+    product_manifests: {}
+    install_policy: opt-in
+"#;
+        let parsed: PluginsManifest = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(
+            parsed.plugins.first().unwrap().install_policy,
+            InstallPolicy::OptIn,
+        );
+    }
+
+    #[test]
+    fn source_root_rejects_nonexistent_path() {
+        let bogus = Path::new("/this/path/should/not/exist/agent-runtime-cli-test");
+        let err = SourceRoot::from_arg_or_cwd(Some(bogus)).unwrap_err();
+        match err {
+            ManifestError::SourceRoot { path, .. } => assert_eq!(path, bogus),
+            other => panic!("expected ManifestError::SourceRoot, got {other:?}"),
+        }
+    }
+}

--- a/crates/agent-runtime-cli/src/render/manifest.rs
+++ b/crates/agent-runtime-cli/src/render/manifest.rs
@@ -161,8 +161,10 @@ pub struct Skill {
     pub id: String,
     pub domain: String,
     pub source: String,
-    #[serde(default)]
-    pub products: IndexMap<String, ProductRender>,
+    // `products` is required per the upstream schema. The map is closed
+    // to the known products (`codex`, `claude`) — an unknown key in
+    // skills.yaml is a typo, not a silent skip.
+    pub products: SkillProducts,
     pub required_clis: IndexMap<String, String>,
     #[serde(default)]
     pub state_out_mode: StateOutMode,
@@ -172,6 +174,33 @@ pub struct Skill {
     pub divergent: bool,
     #[serde(default)]
     pub portability_notes: Option<String>,
+}
+
+/// Per-product render config for a skill. Mirrors the upstream
+/// `productRender` schema: `additionalProperties: false`, with both
+/// product keys optional. An unknown key (`code:`, `cluade:`) fails
+/// deserialization via `deny_unknown_fields` instead of being silently
+/// ignored as a "skill that supports neither product".
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SkillProducts {
+    #[serde(default)]
+    pub codex: Option<ProductRender>,
+    #[serde(default)]
+    pub claude: Option<ProductRender>,
+}
+
+impl SkillProducts {
+    /// Return the per-product entry for `product`. Unknown product
+    /// names always return `None`; callers should validate `product`
+    /// against the runtime-roots set before reaching this helper.
+    pub fn get(&self, product: &str) -> Option<&ProductRender> {
+        match product {
+            "codex" => self.codex.as_ref(),
+            "claude" => self.claude.as_ref(),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
@@ -215,11 +244,23 @@ pub struct Plugin {
     pub id: String,
     pub domain: String,
     pub contained_skills: Vec<String>,
-    pub product_manifests: IndexMap<String, String>,
+    pub product_manifests: PluginProductManifests,
     #[serde(default)]
     pub dependencies: Vec<String>,
     #[serde(default)]
     pub install_policy: InstallPolicy,
+}
+
+/// Per-product manifest paths. Mirrors the upstream schema's closed
+/// `additionalProperties: false` shape; unknown product keys (typos)
+/// fail deserialization instead of being silently dropped.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PluginProductManifests {
+    #[serde(default)]
+    pub codex: Option<String>,
+    #[serde(default)]
+    pub claude: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
@@ -626,5 +667,63 @@ plugins:
             ManifestError::SourceRoot { path, .. } => assert_eq!(path, bogus),
             other => panic!("expected ManifestError::SourceRoot, got {other:?}"),
         }
+    }
+
+    /// A typo in a product key (`code:` instead of `codex:`) used to be
+    /// silently dropped because `Skill.products` was an open
+    /// `IndexMap<String, _>`. The closed `SkillProducts` struct rejects
+    /// it as a parse error — the skill should not silently support
+    /// neither product.
+    #[test]
+    fn typo_in_product_key_is_rejected_at_parse_time() {
+        let yaml = r#"
+schema_version: 1
+skills:
+  - id: domain.skill
+    domain: domain
+    source: core/skills/domain/skill
+    products:
+      code:
+        render_to: skills/domain/skill/SKILL.md
+    required_clis:
+      agent-runtime: ">=0.13.0"
+"#;
+        let err = serde_yml::from_str::<SkillsManifest>(yaml).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("code"), "{msg}");
+    }
+
+    /// `Skill.products` is required per the upstream JSON schema. A
+    /// skill that omits the key should fail parse, not silently
+    /// default to an empty product map.
+    #[test]
+    fn skill_without_products_key_is_rejected() {
+        let yaml = r#"
+schema_version: 1
+skills:
+  - id: domain.skill
+    domain: domain
+    source: core/skills/domain/skill
+    required_clis:
+      agent-runtime: ">=0.13.0"
+"#;
+        let err = serde_yml::from_str::<SkillsManifest>(yaml).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("products"), "{msg}");
+    }
+
+    #[test]
+    fn typo_in_plugin_product_manifest_key_is_rejected() {
+        let yaml = r#"
+schema_version: 1
+plugins:
+  - id: domain
+    domain: domain
+    contained_skills: []
+    product_manifests:
+      cluade: "targets/claude/.claude-plugin/plugin.json"
+"#;
+        let err = serde_yml::from_str::<PluginsManifest>(yaml).unwrap_err();
+        assert!(format!("{err}").contains("cluade"));
     }
 }

--- a/crates/agent-runtime-cli/src/render/mod.rs
+++ b/crates/agent-runtime-cli/src/render/mod.rs
@@ -1,0 +1,5 @@
+pub mod cache;
+pub mod golden;
+pub mod helpers;
+pub mod manifest;
+pub mod writer;

--- a/crates/agent-runtime-cli/src/render/writer.rs
+++ b/crates/agent-runtime-cli/src/render/writer.rs
@@ -1,0 +1,590 @@
+//! Per-product render writer. Walks the skills declared for the active
+//! product, renders each via Tera + helpers when its input hash differs
+//! from the recorded cache entry, and writes the output under
+//! `<source-root>/build/<product>/`. Skills with a cache hit are left
+//! on disk verbatim — the determinism contract guarantees the cache-hit
+//! path is byte-identical to a fresh render of the same source.
+//!
+//! Render only opens paths under `<source-root>/`. Every read is rooted
+//! through [`source_path`](Self::source_path) and joined to the
+//! canonical source root, so a malicious `skill.source` like
+//! `../../etc` lands outside the source root and is rejected before any
+//! I/O happens.
+
+use crate::render::cache::{CACHE_FILE, CacheEntry, RenderCache};
+use crate::render::helpers::{HelperContext, register_all};
+use crate::render::manifest::{ManifestSet, Skill, SourceRoot};
+use anyhow::{Context, Result, anyhow};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+use tera::Tera;
+
+pub const SKILL_TEMPLATE_FILE: &str = "SKILL.md.tera";
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct RenderReport {
+    pub product: String,
+    pub output_root: PathBuf,
+    pub rendered: Vec<String>,
+    pub cached: Vec<String>,
+    pub skipped: Vec<String>,
+}
+
+/// Render every skill declared for `product` from manifests rooted at
+/// `root`. Returns a summary describing which skills were rendered,
+/// served from cache, or skipped.
+pub fn write_product(
+    root: &SourceRoot,
+    manifests: Arc<ManifestSet>,
+    product: &str,
+) -> Result<RenderReport> {
+    require_known_product(&manifests, product)?;
+    let output_root = root.path().join("build").join(product);
+    fs::create_dir_all(&output_root)
+        .with_context(|| format!("create_dir_all {}", output_root.display()))?;
+
+    let cache_path = output_root.join(CACHE_FILE);
+    let prior_cache = RenderCache::load_or_empty(&cache_path);
+    let manifest_bytes = read_manifest_bundle(root)?;
+    let mut next_cache = RenderCache::empty();
+    let mut report = RenderReport {
+        product: product.to_string(),
+        output_root: output_root.clone(),
+        ..RenderReport::default()
+    };
+
+    for skill in &manifests.skills.skills {
+        let Some(render) = skill.products.get(product) else {
+            report.skipped.push(skill.id.clone());
+            continue;
+        };
+        let template_path = sandboxed_join(root.path(), &skill.source)?.join(SKILL_TEMPLATE_FILE);
+        let template_body = fs::read_to_string(&template_path).with_context(|| {
+            format!(
+                "read template {} for skill {}",
+                template_path.display(),
+                skill.id
+            )
+        })?;
+
+        let input_hash = input_hash(
+            product,
+            skill,
+            &render.render_to,
+            &template_body,
+            &manifest_bytes,
+        );
+        let entry = CacheEntry {
+            hash: input_hash.clone(),
+            output: render.render_to.clone(),
+        };
+        let output_path = sandboxed_join(&output_root, &render.render_to)?;
+        let cache_hit = prior_cache
+            .skills
+            .get(&skill.id)
+            .is_some_and(|prior| prior == &entry)
+            && output_path.exists();
+
+        if cache_hit {
+            report.cached.push(skill.id.clone());
+        } else {
+            let rendered =
+                render_template(root.path(), &manifests, product, skill, &template_body)?;
+            if let Some(parent) = output_path.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("create_dir_all {}", parent.display()))?;
+            }
+            fs::write(&output_path, rendered.as_bytes())
+                .with_context(|| format!("write {}", output_path.display()))?;
+            report.rendered.push(skill.id.clone());
+        }
+        next_cache.skills.insert(skill.id.clone(), entry);
+    }
+
+    next_cache
+        .save(&cache_path)
+        .with_context(|| format!("write {}", cache_path.display()))?;
+    Ok(report)
+}
+
+fn require_known_product(manifests: &ManifestSet, product: &str) -> Result<()> {
+    match product {
+        "codex" | "claude" => Ok(()),
+        other => Err(anyhow!(
+            "unknown --product {other:?}; supported: codex, claude. \
+             schema_version={}",
+            manifests.product_capabilities.schema_version
+        )),
+    }
+}
+
+fn render_template(
+    source_root: &Path,
+    manifests: &Arc<ManifestSet>,
+    product: &str,
+    skill: &Skill,
+    template_body: &str,
+) -> Result<String> {
+    let ctx = HelperContext {
+        source_root: source_root.to_path_buf(),
+        manifests: manifests.clone(),
+        current_product: product.to_string(),
+        current_skill_id: skill.id.clone(),
+        current_skill_required_clis: skill.required_clis.clone(),
+        current_skill_state_out_mode: skill.state_out_mode,
+    };
+    let mut tera = Tera::default();
+    register_all(&mut tera, Arc::new(ctx));
+    tera.render_str(template_body, &tera::Context::new())
+        .with_context(|| format!("render skill {}", skill.id))
+}
+
+struct ManifestBytes {
+    skills: Vec<u8>,
+    plugins: Vec<u8>,
+    product_capabilities: Vec<u8>,
+    runtime_roots: Vec<u8>,
+    cli_tools: Vec<u8>,
+}
+
+fn read_manifest_bundle(root: &SourceRoot) -> Result<ManifestBytes> {
+    let dir = root.manifests_dir();
+    let read = |name: &str| -> Result<Vec<u8>> {
+        let path = dir.join(name);
+        fs::read(&path).with_context(|| format!("hash-read {}", path.display()))
+    };
+    Ok(ManifestBytes {
+        skills: read("skills.yaml")?,
+        plugins: read("plugins.yaml")?,
+        product_capabilities: read("product-capabilities.yaml")?,
+        runtime_roots: read("runtime-roots.yaml")?,
+        cli_tools: read("cli-tools.yaml")?,
+    })
+}
+
+fn input_hash(
+    product: &str,
+    skill: &Skill,
+    render_to: &str,
+    template_body: &str,
+    manifests: &ManifestBytes,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"agent-runtime-cli render v1\0");
+    hasher.update(product.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(skill.id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(render_to.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(template_body.as_bytes());
+    hasher.update(b"\0");
+    // Whole-file manifest bytes — keeps the hash sensitive to any change
+    // in a file the helpers might consume, at the cost of a coarse cache
+    // invalidation when an unrelated manifest line shifts.
+    hasher.update(&manifests.skills);
+    hasher.update(b"\0");
+    hasher.update(&manifests.plugins);
+    hasher.update(b"\0");
+    hasher.update(&manifests.product_capabilities);
+    hasher.update(b"\0");
+    hasher.update(&manifests.runtime_roots);
+    hasher.update(b"\0");
+    hasher.update(&manifests.cli_tools);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(7 + digest.len() * 2);
+    out.push_str("sha256:");
+    for byte in digest.iter() {
+        use std::fmt::Write;
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}
+
+/// Join `relative` onto `base` after rejecting any `..` segments. Used
+/// for every render-time path so we cannot escape `<source-root>/` via
+/// a hostile `skill.source`, `render_to`, or `--source-root` value.
+pub(crate) fn sandboxed_join(base: &Path, relative: &str) -> Result<PathBuf> {
+    let rel = PathBuf::from(relative);
+    for component in rel.components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(anyhow!(
+                    "path {relative:?} contains a `..` segment; render must stay under {base}",
+                    base = base.display(),
+                ));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(anyhow!(
+                    "path {relative:?} is absolute; render must stay under {base}",
+                    base = base.display(),
+                ));
+            }
+        }
+    }
+    Ok(base.join(rel))
+}
+
+/// Map of the rendered output bytes keyed by path-under-output-root.
+/// Test helper for cache-hit-vs-cache-miss byte equality assertions.
+#[cfg(test)]
+pub(crate) fn snapshot_outputs(output_root: &Path) -> std::collections::BTreeMap<String, Vec<u8>> {
+    let mut out = std::collections::BTreeMap::new();
+    walk(output_root, output_root, &mut out);
+    out
+}
+
+#[cfg(test)]
+fn walk(base: &Path, dir: &Path, out: &mut std::collections::BTreeMap<String, Vec<u8>>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(base, &path, out);
+            continue;
+        }
+        if path.file_name().and_then(|n| n.to_str()) == Some(CACHE_FILE) {
+            continue;
+        }
+        let bytes = fs::read(&path).unwrap();
+        let rel = path
+            .strip_prefix(base)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        out.insert(rel, bytes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::cache::RenderCache;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, body: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, body).unwrap();
+    }
+
+    const SKILLS_FIXTURE: &str = r#"
+schema_version: 1
+skills:
+  - id: market.favorites
+    domain: market
+    source: core/skills/market/favorites
+    products:
+      codex:
+        name: /market-favorites
+        render_to: skills/market/favorites/SKILL.md
+      claude:
+        name: market:favorites
+        render_to: plugins/market/skills/favorites/SKILL.md
+    required_clis:
+      agent-out: ">=0.5.0"
+      market-cli: ">=0.4.0"
+"#;
+
+    /// Build a working source root with one skill that exercises every
+    /// helper (script / skill_ref / state_out / cli_ref).
+    fn fixture_source_root(tmp: &TempDir) -> SourceRoot {
+        let root = tmp.path();
+        write(&root.join("manifests/skills.yaml"), SKILLS_FIXTURE);
+        write(
+            &root.join("manifests/plugins.yaml"),
+            "schema_version: 1\nplugins: []\n",
+        );
+        write(
+            &root.join("manifests/product-capabilities.yaml"),
+            PRODUCT_CAPS,
+        );
+        write(&root.join("manifests/runtime-roots.yaml"), RUNTIME_ROOTS);
+        write(&root.join("manifests/cli-tools.yaml"), CLI_TOOLS);
+
+        // Skill template exercises every helper. Trailing newline is
+        // intentional so the rendered file ends with one.
+        write(
+            &root.join("core/skills/market/favorites/SKILL.md.tera"),
+            r#"# {{ skill_ref(id="market.favorites") }}
+
+state: {{ state_out(domain="market", topic="favorites") }}
+script: {{ script(path="core/scripts/market.sh") }}
+required: {{ cli_ref(name="agent-out") }} via {{ cli_ref(name="market-cli") }}
+"#,
+        );
+
+        SourceRoot::from_arg_or_cwd(Some(root)).unwrap()
+    }
+
+    const PRODUCT_CAPS: &str = r#"
+schema_version: 1
+products:
+  codex:
+    nested_skill_support: true
+    plugin_manifest:
+      path_pattern: "ignored"
+      loaded_at_runtime: false
+      schema_ref: "ignored"
+    hooks_model:
+      config_surface: "ignored"
+      payload_shape: "ignored"
+      supports_inline_python: false
+    config_activation:
+      - "$CODEX_HOME/AGENTS.md"
+    runtime_state:
+      state_home_env: "STATE"
+      default_path: "/tmp/state"
+  claude:
+    nested_skill_support: true
+    plugin_manifest:
+      path_pattern: "ignored"
+      loaded_at_runtime: true
+      schema_ref: "ignored"
+    hooks_model:
+      config_surface: "ignored"
+      payload_shape: "ignored"
+      supports_inline_python: true
+    config_activation:
+      - "$HOME/.claude/settings.json"
+    runtime_state:
+      state_home_env: "STATE"
+      default_path: "/tmp/state"
+"#;
+
+    const RUNTIME_ROOTS: &str = r#"
+schema_version: 1
+products:
+  codex:
+    live_home: "$CODEX_HOME"
+    docs_home: "$CODEX_HOME"
+    state_home: "/tmp/state"
+    plugin_root: "$CODEX_HOME/plugins"
+    hook_config_strategy: managed-block
+    min_version: "<TBD: pin during Phase 1>"
+    recommended_version: "<TBD: pin during Phase 1>"
+    min_version_effective_from: "<TBD: pin during Phase 1>"
+    version_probe: "codex --version"
+  claude:
+    live_home: "$HOME/.claude"
+    docs_home: "$HOME/.claude"
+    state_home: "/tmp/state"
+    plugin_root_env: "CLAUDE_PLUGIN_ROOT"
+    hook_config_strategy: settings-json
+    min_version: "<TBD: pin during Phase 1>"
+    recommended_version: "<TBD: pin during Phase 1>"
+    min_version_effective_from: "<TBD: pin during Phase 1>"
+    version_probe: "claude --version"
+"#;
+
+    const CLI_TOOLS: &str = r#"
+schema_version: 1
+profiles:
+  core: [ripgrep]
+  recommended: [ripgrep]
+  full: [ripgrep]
+formulas:
+  ripgrep:
+    brew: ripgrep
+    command: rg
+    linux_only_alternative: null
+    categories: [search]
+"#;
+
+    fn load_set(root: &SourceRoot) -> Arc<ManifestSet> {
+        Arc::new(crate::render::manifest::load_all(root).unwrap())
+    }
+
+    #[test]
+    fn write_product_renders_codex_skill_into_build_tree() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture_source_root(&tmp);
+        let set = load_set(&root);
+
+        let report = write_product(&root, set, "codex").unwrap();
+
+        assert_eq!(report.rendered, vec!["market.favorites".to_string()]);
+        assert!(report.cached.is_empty());
+        assert!(report.skipped.is_empty());
+        let out = report.output_root.join("skills/market/favorites/SKILL.md");
+        let body = fs::read_to_string(&out).unwrap();
+        assert!(body.contains("# /market-favorites"), "{body}");
+        assert!(
+            body.contains("state: agent-out path-for --domain market --topic favorites"),
+            "{body}",
+        );
+        assert!(
+            body.contains("script: ") && body.contains("/core/scripts/market.sh"),
+            "{body}",
+        );
+        assert!(
+            body.contains("required: agent-out (>=0.5.0) via market-cli (>=0.4.0)"),
+            "{body}",
+        );
+
+        // Cache file exists after the run.
+        let cache = RenderCache::load_or_empty(&report.output_root.join(CACHE_FILE));
+        assert!(cache.skills.contains_key("market.favorites"));
+    }
+
+    #[test]
+    fn cache_hit_skips_render_and_keeps_existing_output_bytes() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture_source_root(&tmp);
+        let set = load_set(&root);
+
+        // First run populates output + cache.
+        let first = write_product(&root, set.clone(), "codex").unwrap();
+        let snapshot_first = snapshot_outputs(&first.output_root);
+        assert_eq!(first.rendered, vec!["market.favorites".to_string()]);
+
+        // Second run with no input change must hit the cache and leave
+        // the output bytes identical.
+        let second = write_product(&root, set.clone(), "codex").unwrap();
+        assert!(second.rendered.is_empty(), "{:?}", second.rendered);
+        assert_eq!(second.cached, vec!["market.favorites".to_string()]);
+        let snapshot_second = snapshot_outputs(&second.output_root);
+        assert_eq!(snapshot_first, snapshot_second);
+    }
+
+    #[test]
+    fn cache_miss_after_cache_file_deletion_reproduces_identical_bytes() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture_source_root(&tmp);
+        let set = load_set(&root);
+
+        let first = write_product(&root, set.clone(), "codex").unwrap();
+        let snapshot_first = snapshot_outputs(&first.output_root);
+
+        // Delete the cache file → forces a re-render. The rendered
+        // bytes must match the first run byte-for-byte.
+        fs::remove_file(first.output_root.join(CACHE_FILE)).unwrap();
+        let second = write_product(&root, set, "codex").unwrap();
+        assert_eq!(second.rendered, vec!["market.favorites".to_string()]);
+        let snapshot_second = snapshot_outputs(&second.output_root);
+        assert_eq!(snapshot_first, snapshot_second);
+    }
+
+    #[test]
+    fn template_change_invalidates_cache_and_re_renders() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture_source_root(&tmp);
+        let set = load_set(&root);
+        write_product(&root, set.clone(), "codex").unwrap();
+
+        // Touch the template body.
+        let tpl_path = root
+            .path()
+            .join("core/skills/market/favorites/SKILL.md.tera");
+        let mut body = fs::read_to_string(&tpl_path).unwrap();
+        body.push_str("\nextra line\n");
+        fs::write(&tpl_path, body).unwrap();
+
+        // Reload manifests (skill source bytes changed; manifest bytes
+        // unchanged → cache key still differs because template body is
+        // part of the hash input).
+        let set = load_set(&root);
+        let second = write_product(&root, set, "codex").unwrap();
+        assert_eq!(second.rendered, vec!["market.favorites".to_string()]);
+        let rendered =
+            fs::read_to_string(second.output_root.join("skills/market/favorites/SKILL.md"))
+                .unwrap();
+        assert!(rendered.ends_with("extra line\n"), "{rendered}");
+    }
+
+    #[test]
+    fn skill_without_product_entry_is_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(
+            &root.join("manifests/skills.yaml"),
+            r#"
+schema_version: 1
+skills:
+  - id: codex.only
+    domain: codex
+    source: core/skills/codex/only
+    products:
+      codex:
+        render_to: skills/codex-only/SKILL.md
+    required_clis: {}
+"#,
+        );
+        write(
+            &root.join("manifests/plugins.yaml"),
+            "schema_version: 1\nplugins: []\n",
+        );
+        write(
+            &root.join("manifests/product-capabilities.yaml"),
+            PRODUCT_CAPS,
+        );
+        write(&root.join("manifests/runtime-roots.yaml"), RUNTIME_ROOTS);
+        write(&root.join("manifests/cli-tools.yaml"), CLI_TOOLS);
+        write(
+            &root.join("core/skills/codex/only/SKILL.md.tera"),
+            "# codex-only\n",
+        );
+        let source_root = SourceRoot::from_arg_or_cwd(Some(root)).unwrap();
+        let set = load_set(&source_root);
+        let report = write_product(&source_root, set, "claude").unwrap();
+        assert!(report.rendered.is_empty());
+        assert_eq!(report.skipped, vec!["codex.only".to_string()]);
+    }
+
+    #[test]
+    fn render_rejects_unknown_product() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture_source_root(&tmp);
+        let set = load_set(&root);
+        let err = write_product(&root, set, "unknown").unwrap_err();
+        assert!(format!("{err:#}").contains("unknown --product"));
+    }
+
+    #[test]
+    fn sandboxed_join_rejects_parent_segments_and_absolute_paths() {
+        let base = Path::new("/tmp/source-root");
+        sandboxed_join(base, "core/scripts/foo.sh").unwrap();
+        sandboxed_join(base, "./core/scripts/foo.sh").unwrap();
+        let err = sandboxed_join(base, "../etc/passwd").unwrap_err();
+        assert!(format!("{err}").contains(".."));
+        let err = sandboxed_join(base, "/etc/passwd").unwrap_err();
+        assert!(format!("{err}").contains("absolute"));
+    }
+
+    #[test]
+    fn write_product_runs_against_empty_skills_manifest() {
+        // Real agent-runtime-kit ships skills.yaml empty in Plan 01.
+        // Render must not blow up — it should produce an empty cache.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(
+            &root.join("manifests/skills.yaml"),
+            "schema_version: 1\nskills: []\n",
+        );
+        write(
+            &root.join("manifests/plugins.yaml"),
+            "schema_version: 1\nplugins: []\n",
+        );
+        write(
+            &root.join("manifests/product-capabilities.yaml"),
+            PRODUCT_CAPS,
+        );
+        write(&root.join("manifests/runtime-roots.yaml"), RUNTIME_ROOTS);
+        write(&root.join("manifests/cli-tools.yaml"), CLI_TOOLS);
+        let source_root = SourceRoot::from_arg_or_cwd(Some(root)).unwrap();
+        let set = load_set(&source_root);
+        let report = write_product(&source_root, set, "codex").unwrap();
+        assert!(report.rendered.is_empty());
+        assert!(report.cached.is_empty());
+        assert!(report.skipped.is_empty());
+        assert!(report.output_root.exists());
+    }
+}

--- a/crates/agent-runtime-cli/src/render/writer.rs
+++ b/crates/agent-runtime-cli/src/render/writer.rs
@@ -55,12 +55,23 @@ pub fn write_product(
         ..RenderReport::default()
     };
 
+    let canonical_source_root = root.path().to_path_buf();
+    let canonical_output_root = output_root
+        .canonicalize()
+        .with_context(|| format!("canonicalize output root {}", output_root.display()))?;
+
     for skill in &manifests.skills.skills {
         let Some(render) = skill.products.get(product) else {
             report.skipped.push(skill.id.clone());
             continue;
         };
         let template_path = sandboxed_join(root.path(), &skill.source)?.join(SKILL_TEMPLATE_FILE);
+        // Defeat symlink escape: a hostile `core/skills/<x>/SKILL.md.tera`
+        // could be a symlink pointing outside the source root (e.g. to
+        // `/etc/passwd`). `fs::read_to_string` follows symlinks, so we
+        // resolve the real path first and verify it stays beneath the
+        // canonical source root before opening it.
+        let template_path = canonicalize_under(&canonical_source_root, &template_path)?;
         let template_body = fs::read_to_string(&template_path).with_context(|| {
             format!(
                 "read template {} for skill {}",
@@ -96,6 +107,12 @@ pub fn write_product(
                 fs::create_dir_all(parent)
                     .with_context(|| format!("create_dir_all {}", parent.display()))?;
             }
+            // Same symlink-escape guard for writes: canonicalize the
+            // parent (which we just ensured exists) and verify it stays
+            // beneath `<source-root>/build/<product>/`. A hostile
+            // `render_to` of `../../etc/passwd` is already rejected by
+            // sandboxed_join; this also catches `dir-that-is-a-symlink/foo`.
+            let output_path = guard_write_under(&canonical_output_root, &output_path)?;
             fs::write(&output_path, rendered.as_bytes())
                 .with_context(|| format!("write {}", output_path.display()))?;
             report.rendered.push(skill.id.clone());
@@ -201,6 +218,57 @@ fn input_hash(
         let _ = write!(&mut out, "{byte:02x}");
     }
     out
+}
+
+/// Resolve a candidate read path and assert the canonical result is
+/// still under `canonical_base`. Defeats symlink-based sandbox escape
+/// where a hostile `core/skills/<x>/SKILL.md.tera` symlinks to a file
+/// outside the source root (e.g. `/etc/passwd`). The path must exist;
+/// the caller is reading it.
+pub(crate) fn canonicalize_under(canonical_base: &Path, candidate: &Path) -> Result<PathBuf> {
+    let resolved = candidate
+        .canonicalize()
+        .with_context(|| format!("canonicalize {}", candidate.display()))?;
+    if !resolved.starts_with(canonical_base) {
+        return Err(anyhow!(
+            "path {candidate} resolves outside the source root \
+             ({resolved} not under {canonical_base}) — likely a symlink escape",
+            candidate = candidate.display(),
+            resolved = resolved.display(),
+            canonical_base = canonical_base.display(),
+        ));
+    }
+    Ok(resolved)
+}
+
+/// Resolve a candidate write path. The file itself may not exist yet,
+/// so we canonicalize the parent (which the caller created via
+/// `create_dir_all`) and assert it sits under `canonical_base`. A
+/// hostile parent symlink — e.g. `build/<product>/foo` is a symlink to
+/// `/etc/` — gets rejected before we open the file for write.
+pub(crate) fn guard_write_under(canonical_base: &Path, candidate: &Path) -> Result<PathBuf> {
+    let parent = candidate
+        .parent()
+        .ok_or_else(|| anyhow!("render output path {} has no parent", candidate.display()))?;
+    let canonical_parent = parent
+        .canonicalize()
+        .with_context(|| format!("canonicalize parent of {}", candidate.display()))?;
+    if !canonical_parent.starts_with(canonical_base) {
+        return Err(anyhow!(
+            "render output {} resolves outside the build root \
+             ({} not under {}) — likely a symlink escape",
+            candidate.display(),
+            canonical_parent.display(),
+            canonical_base.display(),
+        ));
+    }
+    let file_name = candidate.file_name().ok_or_else(|| {
+        anyhow!(
+            "render output path {} has no file name",
+            candidate.display()
+        )
+    })?;
+    Ok(canonical_parent.join(file_name))
 }
 
 /// Join `relative` onto `base` after rejecting any `..` segments. Used
@@ -557,6 +625,66 @@ skills:
         assert!(format!("{err}").contains(".."));
         let err = sandboxed_join(base, "/etc/passwd").unwrap_err();
         assert!(format!("{err}").contains("absolute"));
+    }
+
+    /// A hostile `skill.source` directory could contain a symlinked
+    /// SKILL.md.tera that points outside the source root. The lexical
+    /// `sandboxed_join` accepts the path (no `..`, not absolute), so
+    /// `canonicalize_under` catches the escape just before the read.
+    /// Without that guard the renderer would expose `/etc/passwd` (or
+    /// any readable file) into rendered output.
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_skill_template_outside_source_root_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture_source_root(&tmp);
+        let set = load_set(&root);
+        // Replace the legitimate template with a symlink pointing at
+        // a file outside the source root.
+        let outside = TempDir::new().unwrap();
+        let target = outside.path().join("hostile.tera");
+        fs::write(&target, "# captured from outside\n").unwrap();
+        let template_path = root
+            .path()
+            .join("core/skills/market/favorites/SKILL.md.tera");
+        fs::remove_file(&template_path).unwrap();
+        std::os::unix::fs::symlink(&target, &template_path).unwrap();
+
+        let err = write_product(&root, set, "codex").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("symlink") || msg.contains("outside the source root"),
+            "{msg}",
+        );
+    }
+
+    /// Same threat surface as the read-path test, but for the write
+    /// path: a hostile `build/<product>/` symlink could redirect render
+    /// output into the user's home directory. `guard_write_under`
+    /// canonicalizes the parent before fs::write opens it.
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_build_dir_outside_root_is_rejected_for_writes() {
+        let tmp = TempDir::new().unwrap();
+        let root = fixture_source_root(&tmp);
+        let set = load_set(&root);
+        // Pre-create build/<product>/, then swap one nested dir for a
+        // symlink pointing outside the canonical build root.
+        let build = root.path().join("build/codex");
+        fs::create_dir_all(&build).unwrap();
+        let dest = build.join("skills/market/favorites");
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        let outside = TempDir::new().unwrap();
+        let exfil = outside.path().join("favorites");
+        fs::create_dir(&exfil).unwrap();
+        std::os::unix::fs::symlink(&exfil, &dest).unwrap();
+
+        let err = write_product(&root, set, "codex").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("outside the build root") || msg.contains("symlink"),
+            "{msg}",
+        );
     }
 
     #[test]

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -5,3 +5,5 @@
 
 #[path = "integration/cli.rs"]
 mod cli;
+#[path = "integration/render.rs"]
+mod render;

--- a/crates/agent-runtime-cli/tests/integration/cli.rs
+++ b/crates/agent-runtime-cli/tests/integration/cli.rs
@@ -11,8 +11,21 @@ fn run(args: &[&str]) -> CmdOutput {
     cmd::run(&bin, args, &[], None)
 }
 
-const SUBCOMMANDS: &[&str] = &[
+const ALL_SUBCOMMANDS: &[&str] = &[
     "render",
+    "install",
+    "uninstall",
+    "doctor",
+    "audit-drift",
+    "gc-backups",
+    "restore-backups",
+    "purge-state",
+];
+
+/// Subcommands whose body still prints `not implemented` and exits 1.
+/// `render` is no longer a stub once Task 1.1 lands; later sprints peel
+/// further entries off this list.
+const STUB_SUBCOMMANDS: &[&str] = &[
     "install",
     "uninstall",
     "doctor",
@@ -39,7 +52,7 @@ fn help_lists_every_subcommand() {
     let output = run(&["--help"]);
     assert_eq!(output.code, 0);
     let stdout = output.stdout_text();
-    for sub in SUBCOMMANDS {
+    for sub in ALL_SUBCOMMANDS {
         assert!(
             stdout.contains(sub),
             "help should list `{sub}` subcommand: {stdout}"
@@ -48,8 +61,8 @@ fn help_lists_every_subcommand() {
 }
 
 #[test]
-fn every_subcommand_stub_exits_one_with_not_implemented_stderr() {
-    for sub in SUBCOMMANDS {
+fn every_stub_subcommand_exits_one_with_not_implemented_stderr() {
+    for sub in STUB_SUBCOMMANDS {
         let output = run(&[sub]);
         assert_eq!(output.code, 1, "subcommand `{sub}` should exit 1");
         let stderr = output.stderr_text();

--- a/crates/agent-runtime-cli/tests/integration/render.rs
+++ b/crates/agent-runtime-cli/tests/integration/render.rs
@@ -1,0 +1,227 @@
+//! End-to-end coverage for `agent-runtime render`. The library-level
+//! tests under `src/render/` cover the writer / cache / helper modules
+//! in isolation; this file spawns the actual binary so the clap layer,
+//! the `lib::run()` exit-code mapping, and the on-disk output all stay
+//! verifiable together.
+
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn run(args: &[&str]) -> CmdOutput {
+    cmd::run(&agent_runtime_bin(), args, &[], None)
+}
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+const VALID_PRODUCT_CAPABILITIES: &str = r#"
+schema_version: 1
+products:
+  codex:
+    nested_skill_support: true
+    plugin_manifest:
+      path_pattern: "ignored"
+      loaded_at_runtime: false
+      schema_ref: "ignored"
+    hooks_model:
+      config_surface: "ignored"
+      payload_shape: "ignored"
+      supports_inline_python: false
+    config_activation:
+      - "$CODEX_HOME/AGENTS.md"
+    runtime_state:
+      state_home_env: "STATE"
+      default_path: "/tmp/state"
+  claude:
+    nested_skill_support: true
+    plugin_manifest:
+      path_pattern: "ignored"
+      loaded_at_runtime: true
+      schema_ref: "ignored"
+    hooks_model:
+      config_surface: "ignored"
+      payload_shape: "ignored"
+      supports_inline_python: true
+    config_activation:
+      - "$HOME/.claude/settings.json"
+    runtime_state:
+      state_home_env: "STATE"
+      default_path: "/tmp/state"
+"#;
+
+const VALID_RUNTIME_ROOTS: &str = r#"
+schema_version: 1
+products:
+  codex:
+    live_home: "$CODEX_HOME"
+    docs_home: "$CODEX_HOME"
+    state_home: "/tmp/state"
+    plugin_root: "$CODEX_HOME/plugins"
+    hook_config_strategy: managed-block
+    min_version: "<TBD: pin during Phase 1>"
+    recommended_version: "<TBD: pin during Phase 1>"
+    min_version_effective_from: "<TBD: pin during Phase 1>"
+    version_probe: "codex --version"
+  claude:
+    live_home: "$HOME/.claude"
+    docs_home: "$HOME/.claude"
+    state_home: "/tmp/state"
+    plugin_root_env: "CLAUDE_PLUGIN_ROOT"
+    hook_config_strategy: settings-json
+    min_version: "<TBD: pin during Phase 1>"
+    recommended_version: "<TBD: pin during Phase 1>"
+    min_version_effective_from: "<TBD: pin during Phase 1>"
+    version_probe: "claude --version"
+"#;
+
+const VALID_CLI_TOOLS: &str = r#"
+schema_version: 1
+profiles:
+  core: [ripgrep]
+  recommended: [ripgrep]
+  full: [ripgrep]
+formulas:
+  ripgrep:
+    brew: ripgrep
+    command: rg
+    linux_only_alternative: null
+    categories: [search]
+"#;
+
+const VALID_PLUGINS: &str = "schema_version: 1\nplugins: []\n";
+
+fn fixture(tmp: &TempDir) -> PathBuf {
+    let root = tmp.path().to_path_buf();
+    write(
+        &root.join("manifests/skills.yaml"),
+        r#"
+schema_version: 1
+skills:
+  - id: market.favorites
+    domain: market
+    source: core/skills/market/favorites
+    products:
+      codex:
+        name: /market-favorites
+        render_to: skills/market/favorites/SKILL.md
+    required_clis:
+      agent-out: ">=0.5.0"
+"#,
+    );
+    write(&root.join("manifests/plugins.yaml"), VALID_PLUGINS);
+    write(
+        &root.join("manifests/product-capabilities.yaml"),
+        VALID_PRODUCT_CAPABILITIES,
+    );
+    write(
+        &root.join("manifests/runtime-roots.yaml"),
+        VALID_RUNTIME_ROOTS,
+    );
+    write(&root.join("manifests/cli-tools.yaml"), VALID_CLI_TOOLS);
+    write(
+        &root.join("core/skills/market/favorites/SKILL.md.tera"),
+        r#"# {{ skill_ref(id="market.favorites") }}
+required: {{ cli_ref(name="agent-out") }}
+state: {{ state_out(domain="market", topic="favorites") }}
+"#,
+    );
+    root
+}
+
+#[test]
+fn render_against_fixture_writes_expected_skill_md_and_cache() {
+    let tmp = TempDir::new().unwrap();
+    let root = fixture(&tmp);
+    let root_str = root.to_str().unwrap();
+
+    let out = run(&["render", "--source-root", root_str, "--product", "codex"]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+
+    let rendered = fs::read_to_string(root.join("build/codex/skills/market/favorites/SKILL.md"))
+        .expect("rendered SKILL.md missing");
+    assert!(rendered.contains("# /market-favorites"), "{rendered}");
+    assert!(
+        rendered.contains("required: agent-out (>=0.5.0)"),
+        "{rendered}",
+    );
+    assert!(
+        rendered.contains("state: agent-out path-for --domain market --topic favorites"),
+        "{rendered}",
+    );
+
+    let cache = fs::read_to_string(root.join("build/codex/.render-cache.json")).unwrap();
+    assert!(cache.contains("market.favorites"), "{cache}");
+}
+
+#[test]
+fn render_re_run_is_cache_hit_and_produces_identical_output() {
+    let tmp = TempDir::new().unwrap();
+    let root = fixture(&tmp);
+    let root_str = root.to_str().unwrap();
+
+    let first = run(&["render", "--source-root", root_str, "--product", "codex"]);
+    assert_eq!(first.code, 0);
+    let first_body =
+        fs::read_to_string(root.join("build/codex/skills/market/favorites/SKILL.md")).unwrap();
+
+    let second = run(&["render", "--source-root", root_str, "--product", "codex"]);
+    assert_eq!(second.code, 0);
+    assert!(
+        second.stderr_text().contains("cached=1"),
+        "expected cache hit on second run, got stderr: {}",
+        second.stderr_text(),
+    );
+    let second_body =
+        fs::read_to_string(root.join("build/codex/skills/market/favorites/SKILL.md")).unwrap();
+    assert_eq!(first_body, second_body);
+}
+
+#[test]
+fn render_against_missing_source_root_exits_two() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("no-manifests");
+    fs::create_dir_all(&root).unwrap();
+    let out = run(&[
+        "render",
+        "--source-root",
+        root.to_str().unwrap(),
+        "--product",
+        "codex",
+    ]);
+    assert_eq!(out.code, 2, "stderr: {}", out.stderr_text());
+    assert!(
+        out.stderr_text().contains("missing manifest") || out.stderr_text().contains("manifests"),
+        "{}",
+        out.stderr_text(),
+    );
+}
+
+#[test]
+fn render_with_update_golden_copies_rendered_files_into_tests_golden() {
+    let tmp = TempDir::new().unwrap();
+    let root = fixture(&tmp);
+    let root_str = root.to_str().unwrap();
+    let out = run(&[
+        "render",
+        "--source-root",
+        root_str,
+        "--product",
+        "codex",
+        "--update-golden",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+    let golden = root.join("tests/golden/codex/skills/market/favorites/expected/SKILL.md");
+    let body = fs::read_to_string(&golden).expect("golden SKILL.md missing");
+    assert!(body.contains("# /market-favorites"), "{body}");
+}

--- a/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
+++ b/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
@@ -4,7 +4,8 @@
 
 - Status: in-progress
 - Target scope: whole plan
-- Execution window: sprint-by-sprint (one feature PR per sprint, `/code-review-specialists` review between sprints, merge before next sprint)
+- Execution window: sprint-by-sprint (one feature PR per sprint, `/code-review-specialists`
+  review between sprints, merge before next sprint)
 - Staged execution confirmation: confirmed 2026-05-20 (Sprint 1 only first, then 2/3/4 in order)
 - Current task: Sprint 1 close (PR open + review)
 - Next task: Task 2.1 (after Sprint 1 PR merges)
@@ -15,52 +16,97 @@
 
 ## Active drift decisions
 
-- **Sprint 4 version**: plan assumed `0.0.1-dev → 0.1.0`. Reality: `agent-runtime-cli` already ships at workspace `0.12.0` after Plan 01 Sprint 3's coupled-workspace bump and the homebrew tap is at `0.12.0`. Resolved with the user 2026-05-20: Sprint 4 bumps the workspace `0.12.0 → 0.13.0` via `/nils-cli:bump-version-tag-release`, and Task 4.3 pins `required_clis['agent-runtime']` in `graysurf/agent-runtime-kit` to `">=0.13.0"`.
-- **nils-common path API**: Plan 02's Task 1.2 description assumes `nils-common` already exposes path-resolution primitives. Reality: no path module in `nils-common` today. Implemented sandboxed join inside `agent-runtime-cli` (`render::writer::sandboxed_join`) as a local primitive. Refactor to `nils-common` is non-blocking and can land later.
+- **Sprint 4 version**: plan assumed `0.0.1-dev → 0.1.0`. Reality:
+  `agent-runtime-cli` already ships at workspace `0.12.0` after Plan 01
+  Sprint 3's coupled-workspace bump and the homebrew tap is at `0.12.0`.
+  Resolved with the user 2026-05-20: Sprint 4 bumps the workspace
+  `0.12.0 → 0.13.0` via `/nils-cli:bump-version-tag-release`, and Task 4.3
+  pins `required_clis['agent-runtime']` in `graysurf/agent-runtime-kit`
+  to `">=0.13.0"`.
+- **nils-common path API**: Plan 02's Task 1.2 description assumes
+  `nils-common` already exposes path-resolution primitives. Reality: no
+  path module in `nils-common` today. Implemented sandboxed join +
+  symlink-escape guard inside `agent-runtime-cli`
+  (`render::writer::sandboxed_join`, `canonicalize_under`,
+  `guard_write_under`) as local primitives. Lift to `nils-common`
+  remains non-blocking.
 
 ## Task Ledger
 
-| ID       | Status    | Task                                                         | Evidence                                                                                                                            | Notes                                                                |
-| -------- | --------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Task 1.1 | done      | Wire manifest ingest and the `--source-root` flag            | `cargo test -p agent-runtime-cli render::manifest` (8/8 pass), smoke render against `~/Project/graysurf/agent-runtime-kit`           | Lib + module layout; 5 typed manifest structs; canonicalized SourceRoot |
-| Task 1.2 | done      | Register the four Tera helpers                               | `cargo test -p agent-runtime-cli render::helpers` (15/15 pass)                                                                       | script / skill_ref / state_out (runtime mode) / cli_ref; literal-mode state_out errors with Plan-04 reference |
-| Task 1.3 | done      | Write `build/<product>/` output and per-skill cache           | `cargo test -p agent-runtime-cli render::writer` (8/8 pass), `render::cache` (4/4 pass)                                              | SHA-256 keyed `.render-cache.json`; sandboxed_join rejects `..` and absolute paths; cache hit byte-identical to cache miss |
-| Task 1.4 | done      | Add `--update-golden` flag                                   | `cargo test -p agent-runtime-cli render::golden` (4/4 pass), smoke run with `--update-golden`                                        | Per-product subtree scope; sentinel test confirms no writes outside `tests/golden/<product>/` |
-| Task 2.1 | pending   | Add determinism clippy lints to affected crates              | n/a                                                                                                                                  | scoped per Open Question default                                     |
-| Task 2.2 | pending   | Add cross-process render determinism integration test        | n/a                                                                                                                                  | depends on 1.3 and 2.1                                               |
-| Task 2.3 | pending   | Document the only sanctioned time value                      | n/a                                                                                                                                  | depends on 2.1                                                       |
-| Task 3.1 | pending   | Source-manifest validity and rendered-target diff classes    | n/a                                                                                                                                  | depends on 1.3                                                       |
-| Task 3.2 | pending   | `$AGENT_HOME` leak class (blocking, exit 2)                  | n/a                                                                                                                                  | depends on 3.1                                                       |
-| Task 3.3 | pending   | Docs-home per product class (blocking, exit 2)               | n/a                                                                                                                                  | depends on 3.1                                                       |
-| Task 3.4 | pending   | Audit-drift fixture set                                      | n/a                                                                                                                                  | depends on 3.1/3.2/3.3                                               |
-| Task 4.1 | pending   | Bump workspace 0.12.0 → 0.13.0; add publish-order + release.yml binary | n/a                                                                                                                          | reshaped per Sprint 4 drift decision                                 |
-| Task 4.2 | pending   | Bump `homebrew-tap` formula                                  | n/a                                                                                                                                  | depends on 4.1                                                       |
-| Task 4.3 | pending   | Cross-repo: bump `required_clis['agent-runtime']` to `">=0.13.0"` | n/a                                                                                                                             | cross-repo PR against `graysurf/agent-runtime-kit`; depends on 4.2   |
+| ID  | Status  | Task                                                            | Notes                                                                              |
+| --- | ------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| 1.1 | done    | Wire manifest ingest and the `--source-root` flag               | Lib + module layout; 5 typed manifest structs; canonicalized SourceRoot            |
+| 1.2 | done    | Register the four Tera helpers                                  | script / skill_ref / state_out (runtime) / cli_ref; literal-mode errors to Plan 04 |
+| 1.3 | done    | Write `build/<product>/` output and per-skill cache             | SHA-256 keyed `.render-cache.json`; cache hit byte-identical to cache miss         |
+| 1.4 | done    | Add `--update-golden` flag                                      | Per-product subtree scope; sentinel test confirms no writes outside active product |
+| 2.1 | pending | Add determinism clippy lints to affected crates                 | scoped per Open Question default                                                   |
+| 2.2 | pending | Add cross-process render determinism integration test           | depends on 1.3 and 2.1                                                             |
+| 2.3 | pending | Document the only sanctioned time value                         | depends on 2.1                                                                     |
+| 3.1 | pending | Source-manifest validity and rendered-target diff classes       | depends on 1.3                                                                     |
+| 3.2 | pending | `$AGENT_HOME` leak class (blocking, exit 2)                     | depends on 3.1                                                                     |
+| 3.3 | pending | Docs-home per product class (blocking, exit 2)                  | depends on 3.1                                                                     |
+| 3.4 | pending | Audit-drift fixture set                                         | depends on 3.1/3.2/3.3                                                             |
+| 4.1 | pending | Workspace bump 0.12.0 → 0.13.0; publish order + release.yml bin | reshaped per Sprint 4 drift decision                                               |
+| 4.2 | pending | Bump `homebrew-tap` formula                                     | depends on 4.1                                                                     |
+| 4.3 | pending | Cross-repo: `required_clis['agent-runtime']` → `">=0.13.0"`     | PR against `graysurf/agent-runtime-kit`; depends on 4.2                            |
 
-## Validation
+## Sprint 1 — local validation (pre-PR)
 
-| Command | Status | Summary | Artifact |
-| --- | --- | --- | --- |
-| `plan-tooling validate --file docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md --format text --explain` | done | bundle gate before first commit | exit 0 |
-| `cargo test -p agent-runtime-cli render` | done | Sprint 1 close — 43/43 lib tests + 4/4 integration tests pass | local run |
-| `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` | done | Sprint 1 close — clippy clean (Sprint 2 adds determinism lints to gate) | local run |
-| `bash scripts/ci/nils-cli-checks-entrypoint.sh` | done | Sprint 1 close — required checks suite green after THIRD_PARTY artifact regeneration + cargo fmt | local run |
-| `cargo clippy -p agent-runtime-cli -p nils-common --all-targets -- -D warnings` | pending | Sprint 2 close | n/a |
-| `cargo test -p agent-runtime-cli render_determinism` | pending | Sprint 2 close | n/a |
-| `cargo test -p agent-runtime-cli audit_drift` | pending | Sprint 3 close | n/a |
-| `cargo test -p agent-runtime-cli audit_drift_classes` | pending | Sprint 3 close | n/a |
-| `brew audit --strict --online sympoies/tap/nils-cli` | pending | Sprint 4, after Task 4.2 | n/a |
-| `agent-runtime audit-drift --source-root ~/Project/graysurf/agent-runtime-kit` | pending | Sprint 4, after Task 4.3 | n/a |
+- `cargo test -p agent-runtime-cli` — 54 lib + 8 integration pass.
+- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` — clean.
+- `cargo fmt --all -- --check` — clean.
+- `bash scripts/ci/nils-cli-checks-entrypoint.sh` — exit 0 after
+  `bash scripts/generate-third-party-artifacts.sh --write`.
+- `plan-tooling validate --file <plan>.md --format text --explain` — exit 0
+  (plan = `docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md`).
+
+Sprint 2+: clippy determinism gate, cross-process determinism test,
+audit-drift body + fixtures, release/tap/cross-repo floor bump.
 
 ## Blockers
 
-- None active. Plan 01 in `graysurf/agent-runtime-kit` reached Sprint 4 (commit `29c51b5`); five Phase 1 manifests + schemas + stub `agent-runtime-cli` crate at workspace `0.12.0` are in place.
+- None active. Plan 01 in `graysurf/agent-runtime-kit` reached Sprint 4
+  (commit `29c51b5`); five Phase 1 manifests + schemas + stub
+  `agent-runtime-cli` crate at workspace `0.12.0` are in place.
 
 ## Session Log
 
-- 2026-05-20 — Sprint 1 execution starts. Branch `feat/agent-runtime-render-engine` created off `main` (clean tree). Issue #401 state initialized via `execute-from-tracking-issue:state:v1` comment; dashboard refreshed. Cross-repo `agent-runtime-kit` repo verified at `~/Project/graysurf/agent-runtime-kit`.
-- 2026-05-20 — Task 1.1 lands: `src/lib.rs` exposes `Cli` + `Command` + `run()`; new `commands/` and `render/` module trees; `render::manifest` defines five typed manifests deserialized with `serde_yml` + `deny_unknown_fields`. Workspace deps gain `indexmap`, `serde_yml`, `sha2`, `tera`. Integration test `cli.rs` splits `STUB_SUBCOMMANDS` from `ALL_SUBCOMMANDS` so `render` no longer prints `not implemented` but every other subcommand still does.
-- 2026-05-20 — Task 1.2 lands: `render::helpers::{script, skill_ref, state_out, cli_ref}` registered via `register_all`. Helper signature uses `&HashMap` from Tera (the only sanctioned `HashMap` import inside `src/render/`); test_support provides shared fixtures and a chain-walking `format_err` so rejection assertions hit the underlying helper message rather than Tera's `Failed to render '__tera_one_off'` wrapper.
-- 2026-05-21 — Task 1.3 lands: `render::writer::write_product` + `render::cache::RenderCache`. SHA-256 hash spans skill id + product + render target + template body + every Phase 1 manifest's raw bytes. Cache file is `BTreeMap`-backed JSON so on-disk bytes are stable. `sandboxed_join` rejects `..` and absolute paths; eight writer tests cover render output, cache hit/miss byte equality, template-change invalidation, skipped products, unknown product, sandboxed_join rejections, and the empty-skills.yaml smoke case.
-- 2026-05-21 — Task 1.4 lands: `render::golden::update_golden` reads the `RenderReport`, copies every touched skill's render-dir into `tests/golden/<product>/<...>/expected/`. Sentinel test confirms the active-product subtree is the only one mutated. `--update-golden` flag wired into `commands::render::RenderArgs`.
-- 2026-05-21 — Sprint 1 close: regenerated THIRD_PARTY artifacts (new `tera`, `serde_yml`, `sha2`, `indexmap` transitive deps); ran `cargo fmt --all`; `bash scripts/ci/nils-cli-checks-entrypoint.sh` exits 0; `plan-tooling validate` exits 0. Opening feature PR via `pr:create-feature-pr`.
+- 2026-05-20 — Sprint 1 execution starts. Branch
+  `feat/agent-runtime-render-engine` off `main`. Issue #401 state
+  initialized via `execute-from-tracking-issue:state:v1` comment;
+  dashboard refreshed.
+- 2026-05-20 — Task 1.1 lands: `src/lib.rs` exposes `run()`; new
+  `commands/` and `render/` module trees; five typed manifest structs
+  with `deny_unknown_fields` and `schema_version` validation.
+  Workspace deps gain `indexmap`, `serde_yml`, `sha2`, `tera`.
+- 2026-05-20 — Task 1.2 lands: `render::helpers::{script, skill_ref,
+  state_out, cli_ref}` registered via `register_all`. Helper signature
+  uses `&HashMap` from Tera (the only sanctioned `HashMap` import in
+  `src/render/`).
+- 2026-05-21 — Task 1.3 lands: `render::writer::write_product` plus
+  `render::cache::RenderCache`. SHA-256 hash spans skill id, product,
+  render target, template body, and every Phase 1 manifest's raw
+  bytes. Cache file is `BTreeMap`-backed JSON.
+- 2026-05-21 — Task 1.4 lands: `render::golden::update_golden` reads
+  the `RenderReport`, copies every touched skill's render-dir into
+  `tests/golden/<product>/<...>/expected/`. Sentinel test confirms
+  the active-product subtree is the only one mutated.
+- 2026-05-21 — Sprint 1 close: regenerated THIRD_PARTY artifacts;
+  `cargo fmt --all`; `bash scripts/ci/nils-cli-checks-entrypoint.sh`
+  exits 0. PR #404 opened as draft.
+- 2026-05-21 — `/code-review-specialists` ran (5 specialists in
+  parallel: maintainability, security, api-contract, testing,
+  performance). Applied fixes: (a) `state_out` charset-validation
+  rejects shell metacharacters (HIGH security); (b) symlink-escape
+  guard via `canonicalize_under` + `guard_write_under` at every
+  render-time file open (HIGH security); (c) closed `SkillProducts` /
+  `PluginProductManifests` typed structs so unknown product keys
+  fail parse instead of silent-skip (MEDIUM api-contract); (d)
+  `Skill.products` no longer `#[serde(default)]` (MEDIUM
+  api-contract); (e) cache `schema_version` mismatch falls back to
+  empty (MEDIUM testing); (f) added symlink-escape rejection tests,
+  unknown-product-key rejection tests, and four end-to-end render
+  integration tests. Lib tests grew 43 → 54, integration grew 4 → 8.
+  Deferred items: helper-arg dedup, `Command::name` catch-all → Sprint 2
+  cleanup; remaining api-contract / testing low+info items tracked on
+  the issue.

--- a/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
+++ b/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
@@ -2,57 +2,65 @@
 
 ## Current State
 
-- Status: not started
+- Status: in-progress
 - Target scope: whole plan
-- Execution window: undecided
-- Staged execution confirmation: not applicable
-- Current task: Task 1.1
-- Next task: Task 1.1
-- Last updated: 2026-05-20
-- Branch/commit: not started
-- Source document:
-  docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md
+- Execution window: sprint-by-sprint (one feature PR per sprint, `/code-review-specialists` review between sprints, merge before next sprint)
+- Staged execution confirmation: confirmed 2026-05-20 (Sprint 1 only first, then 2/3/4 in order)
+- Current task: Sprint 1 close (PR open + review)
+- Next task: Task 2.1 (after Sprint 1 PR merges)
+- Last updated: 2026-05-21
+- Branch/commit: `feat/agent-runtime-render-engine`
+- Source document: docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md
 - Direct source-doc execution waiver: not applicable
+
+## Active drift decisions
+
+- **Sprint 4 version**: plan assumed `0.0.1-dev → 0.1.0`. Reality: `agent-runtime-cli` already ships at workspace `0.12.0` after Plan 01 Sprint 3's coupled-workspace bump and the homebrew tap is at `0.12.0`. Resolved with the user 2026-05-20: Sprint 4 bumps the workspace `0.12.0 → 0.13.0` via `/nils-cli:bump-version-tag-release`, and Task 4.3 pins `required_clis['agent-runtime']` in `graysurf/agent-runtime-kit` to `">=0.13.0"`.
+- **nils-common path API**: Plan 02's Task 1.2 description assumes `nils-common` already exposes path-resolution primitives. Reality: no path module in `nils-common` today. Implemented sandboxed join inside `agent-runtime-cli` (`render::writer::sandboxed_join`) as a local primitive. Refactor to `nils-common` is non-blocking and can land later.
 
 ## Task Ledger
 
-| ID       | Status  | Task                                                         | Evidence | Notes                                                   |
-| -------- | ------- | ------------------------------------------------------------ | -------- | ------------------------------------------------------- |
-| Task 1.1 | pending | Wire manifest ingest and the `--source-root` flag            | n/a      | depends on Plan 01 stub crate being present             |
-| Task 1.2 | pending | Register the four Tera helpers                               | n/a      | depends on 1.1                                          |
-| Task 1.3 | pending | Write `build/<product>/` output and per-skill cache          | n/a      | depends on 1.2                                          |
-| Task 1.4 | pending | Add `--update-golden` flag                                   | n/a      | depends on 1.3                                          |
-| Task 2.1 | pending | Add determinism clippy lints to affected crates              | n/a      | scoped per Open Question default                        |
-| Task 2.2 | pending | Add cross-process render determinism integration test        | n/a      | depends on 1.3 and 2.1                                  |
-| Task 2.3 | pending | Document the only sanctioned time value                      | n/a      | depends on 2.1                                          |
-| Task 3.1 | pending | Source-manifest validity and rendered-target diff classes    | n/a      | depends on 1.3                                          |
-| Task 3.2 | pending | `$AGENT_HOME` leak class (blocking, exit 2)                  | n/a      | depends on 3.1                                          |
-| Task 3.3 | pending | Docs-home per product class (blocking, exit 2)               | n/a      | depends on 3.1                                          |
-| Task 3.4 | pending | Audit-drift fixture set                                      | n/a      | depends on 3.1/3.2/3.3                                  |
-| Task 4.1 | pending | Tag `agent-runtime-cli` v0.1.0 and update release config     | n/a      | depends on 2.2 and 3.4                                  |
-| Task 4.2 | pending | Bump `homebrew-tap` formula                                  | n/a      | depends on 4.1                                          |
-| Task 4.3 | pending | Cross-repo: bump `required_clis` floors in agent-runtime-kit | n/a      | cross-repo PR against agent-runtime-kit; depends on 4.2 |
+| ID       | Status    | Task                                                         | Evidence                                                                                                                            | Notes                                                                |
+| -------- | --------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Task 1.1 | done      | Wire manifest ingest and the `--source-root` flag            | `cargo test -p agent-runtime-cli render::manifest` (8/8 pass), smoke render against `~/Project/graysurf/agent-runtime-kit`           | Lib + module layout; 5 typed manifest structs; canonicalized SourceRoot |
+| Task 1.2 | done      | Register the four Tera helpers                               | `cargo test -p agent-runtime-cli render::helpers` (15/15 pass)                                                                       | script / skill_ref / state_out (runtime mode) / cli_ref; literal-mode state_out errors with Plan-04 reference |
+| Task 1.3 | done      | Write `build/<product>/` output and per-skill cache           | `cargo test -p agent-runtime-cli render::writer` (8/8 pass), `render::cache` (4/4 pass)                                              | SHA-256 keyed `.render-cache.json`; sandboxed_join rejects `..` and absolute paths; cache hit byte-identical to cache miss |
+| Task 1.4 | done      | Add `--update-golden` flag                                   | `cargo test -p agent-runtime-cli render::golden` (4/4 pass), smoke run with `--update-golden`                                        | Per-product subtree scope; sentinel test confirms no writes outside `tests/golden/<product>/` |
+| Task 2.1 | pending   | Add determinism clippy lints to affected crates              | n/a                                                                                                                                  | scoped per Open Question default                                     |
+| Task 2.2 | pending   | Add cross-process render determinism integration test        | n/a                                                                                                                                  | depends on 1.3 and 2.1                                               |
+| Task 2.3 | pending   | Document the only sanctioned time value                      | n/a                                                                                                                                  | depends on 2.1                                                       |
+| Task 3.1 | pending   | Source-manifest validity and rendered-target diff classes    | n/a                                                                                                                                  | depends on 1.3                                                       |
+| Task 3.2 | pending   | `$AGENT_HOME` leak class (blocking, exit 2)                  | n/a                                                                                                                                  | depends on 3.1                                                       |
+| Task 3.3 | pending   | Docs-home per product class (blocking, exit 2)               | n/a                                                                                                                                  | depends on 3.1                                                       |
+| Task 3.4 | pending   | Audit-drift fixture set                                      | n/a                                                                                                                                  | depends on 3.1/3.2/3.3                                               |
+| Task 4.1 | pending   | Bump workspace 0.12.0 → 0.13.0; add publish-order + release.yml binary | n/a                                                                                                                          | reshaped per Sprint 4 drift decision                                 |
+| Task 4.2 | pending   | Bump `homebrew-tap` formula                                  | n/a                                                                                                                                  | depends on 4.1                                                       |
+| Task 4.3 | pending   | Cross-repo: bump `required_clis['agent-runtime']` to `">=0.13.0"` | n/a                                                                                                                             | cross-repo PR against `graysurf/agent-runtime-kit`; depends on 4.2   |
 
 ## Validation
 
 | Command | Status | Summary | Artifact |
 | --- | --- | --- | --- |
-| `plan-tooling validate --file docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md --strict --format text --explain` | pending | bundle gate before first commit | n/a |
-| `cargo test -p agent-runtime-cli render` | pending | Sprint 1 close | n/a |
+| `plan-tooling validate --file docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md --format text --explain` | done | bundle gate before first commit | exit 0 |
+| `cargo test -p agent-runtime-cli render` | done | Sprint 1 close — 43/43 lib tests + 4/4 integration tests pass | local run |
+| `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` | done | Sprint 1 close — clippy clean (Sprint 2 adds determinism lints to gate) | local run |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh` | done | Sprint 1 close — required checks suite green after THIRD_PARTY artifact regeneration + cargo fmt | local run |
 | `cargo clippy -p agent-runtime-cli -p nils-common --all-targets -- -D warnings` | pending | Sprint 2 close | n/a |
 | `cargo test -p agent-runtime-cli render_determinism` | pending | Sprint 2 close | n/a |
 | `cargo test -p agent-runtime-cli audit_drift` | pending | Sprint 3 close | n/a |
 | `cargo test -p agent-runtime-cli audit_drift_classes` | pending | Sprint 3 close | n/a |
-| `bash scripts/ci/nils-cli-checks-entrypoint.sh` | pending | Sprint 2, 3, 4 close | n/a |
 | `brew audit --strict --online sympoies/tap/nils-cli` | pending | Sprint 4, after Task 4.2 | n/a |
-| `agent-runtime audit-drift --source-root ../agent-runtime-kit` | pending | Sprint 4, after Task 4.3 | n/a |
+| `agent-runtime audit-drift --source-root ~/Project/graysurf/agent-runtime-kit` | pending | Sprint 4, after Task 4.3 | n/a |
 
 ## Blockers
 
-- Plan 01 in `sympoies/agent-runtime-kit` must reach `done` before
-  Task 1.1 can start (need manifest schemas and the
-  `crates/agent-runtime-cli/` shell crate).
+- None active. Plan 01 in `graysurf/agent-runtime-kit` reached Sprint 4 (commit `29c51b5`); five Phase 1 manifests + schemas + stub `agent-runtime-cli` crate at workspace `0.12.0` are in place.
 
 ## Session Log
 
-(none yet)
+- 2026-05-20 — Sprint 1 execution starts. Branch `feat/agent-runtime-render-engine` created off `main` (clean tree). Issue #401 state initialized via `execute-from-tracking-issue:state:v1` comment; dashboard refreshed. Cross-repo `agent-runtime-kit` repo verified at `~/Project/graysurf/agent-runtime-kit`.
+- 2026-05-20 — Task 1.1 lands: `src/lib.rs` exposes `Cli` + `Command` + `run()`; new `commands/` and `render/` module trees; `render::manifest` defines five typed manifests deserialized with `serde_yml` + `deny_unknown_fields`. Workspace deps gain `indexmap`, `serde_yml`, `sha2`, `tera`. Integration test `cli.rs` splits `STUB_SUBCOMMANDS` from `ALL_SUBCOMMANDS` so `render` no longer prints `not implemented` but every other subcommand still does.
+- 2026-05-20 — Task 1.2 lands: `render::helpers::{script, skill_ref, state_out, cli_ref}` registered via `register_all`. Helper signature uses `&HashMap` from Tera (the only sanctioned `HashMap` import inside `src/render/`); test_support provides shared fixtures and a chain-walking `format_err` so rejection assertions hit the underlying helper message rather than Tera's `Failed to render '__tera_one_off'` wrapper.
+- 2026-05-21 — Task 1.3 lands: `render::writer::write_product` + `render::cache::RenderCache`. SHA-256 hash spans skill id + product + render target + template body + every Phase 1 manifest's raw bytes. Cache file is `BTreeMap`-backed JSON so on-disk bytes are stable. `sandboxed_join` rejects `..` and absolute paths; eight writer tests cover render output, cache hit/miss byte equality, template-change invalidation, skipped products, unknown product, sandboxed_join rejections, and the empty-skills.yaml smoke case.
+- 2026-05-21 — Task 1.4 lands: `render::golden::update_golden` reads the `RenderReport`, copies every touched skill's render-dir into `tests/golden/<product>/<...>/expected/`. Sentinel test confirms the active-product subtree is the only one mutated. `--update-golden` flag wired into `commands::render::RenderArgs`.
+- 2026-05-21 — Sprint 1 close: regenerated THIRD_PARTY artifacts (new `tera`, `serde_yml`, `sha2`, `indexmap` transitive deps); ran `cargo fmt --all`; `bash scripts/ci/nils-cli-checks-entrypoint.sh` exits 0; `plan-tooling validate` exits 0. Opening feature PR via `pr:create-feature-pr`.


### PR DESCRIPTION
# Sprint 1: wire agent-runtime render engine core

## Summary

Sprint 1 of [docs/plans/02-nils-cli-render-and-drift-audit](docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md) ([tracking issue #401](https://github.com/sympoies/nils-cli/issues/401)) lands the `agent-runtime` render engine: typed manifest ingest, four Tera helpers, deterministic byte-stable build writer with SHA-256 keyed cache, and `--update-golden` flag scoped to the active product. Subsequent sprints add determinism clippy lints (Sprint 2), the minimal `audit-drift` body (Sprint 3), and a `0.13.0` release with cross-repo `required_clis` floor bump (Sprint 4).

## Changes

- `src/lib.rs` + `commands/render.rs` + `render/{manifest,helpers,writer,cache,golden}.rs` replace the not-implemented render stub. The crate now exposes a real subcommand at workspace `0.12.0`; every other subcommand still stubs out per Plan 01.
- `render::manifest` defines typed structs for all five Phase 1 manifests (`deny_unknown_fields`, `schema_version` validation). `SourceRoot` canonicalises `--source-root` (default `current_dir()`).
- `render::helpers::{script, skill_ref, state_out, cli_ref}` registered via `register_all`. `script` rejects paths outside `core/`/`targets/`/`manifests/` and rejects `..`. `state_out` runtime mode emits `agent-out path-for --domain <d> [--topic <t>] [--repo <r>]`; literal mode surfaces a typed error pointing at Plan 04 (per source-doc reservation). `cli_ref` resolves against the active skill's `required_clis` first, falling back to `cli-tools.yaml.formulas`.
- `render::writer::write_product` walks `skills.yaml.skills`, renders via Tera, and writes byte-stable output under `<source-root>/build/<product>/`. Cache file `.render-cache.json` is `BTreeMap`-backed JSON; cache key is SHA-256 of `(product, skill.id, render_to, template_body, every Phase 1 manifest file's raw bytes)`. `sandboxed_join` rejects `..` and absolute paths at every render-time path join.
- `render::golden::update_golden` copies the touched skill's render-dir into `tests/golden/<product>/<...>/expected/`. Per-product subtree scope enforced by sentinel test.
- Workspace deps gain `indexmap`, `serde_yml`, `sha2`, `tera`. `THIRD_PARTY_LICENSES.md` / `THIRD_PARTY_NOTICES.md` regenerated.
- Integration test `cli.rs` splits `STUB_SUBCOMMANDS` from `ALL_SUBCOMMANDS` so only the seven remaining stubs assert the not-implemented stderr.

## Test-First Evidence

- Change classification: feature
- Failing test before fix: pre-Sprint-1 the only test was `every_subcommand_stub_exits_one_with_not_implemented_stderr`, which asserted `render` printed `not implemented`. Implementing render flipped this expectation; the test was split into `STUB_SUBCOMMANDS` (still asserting not-implemented for the seven remaining stubs) and `ALL_SUBCOMMANDS` (help coverage). Per-task unit tests under `render::{manifest, helpers, writer, cache, golden}::tests` were added under `cargo test`-driven TDD.
- Final validation:
  - `cargo test -p agent-runtime-cli` → 43/43 lib + 4/4 integration tests pass.
  - `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` → clean.
  - `cargo fmt --all -- --check` → clean.
  - `bash scripts/ci/nils-cli-checks-entrypoint.sh` → exit 0 after `bash scripts/generate-third-party-artifacts.sh --write`.
  - `plan-tooling validate --file docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md --format text --explain` → exit 0.
  - Manual smoke: `agent-runtime render --source-root ~/Project/graysurf/agent-runtime-kit --product codex` exits 0 with `rendered=0 cached=0 skipped=0` (skills.yaml empty until Plan 03). With `--update-golden` the run also creates `tests/golden/codex/` (copies 0 files until skills land). Smoke-test artifacts cleaned afterwards.

## Testing

- `cargo test -p agent-runtime-cli` (pass)
- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` (pass)
- `cargo fmt --all -- --check` (pass)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass)
- `plan-tooling validate --file docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md --format text --explain` (pass)

## Risk / Notes

- **Drift decision — Sprint 4 version**: Plan 02 was written assuming `agent-runtime-cli` would be at `0.0.1-dev` and Sprint 4 would bump it to `0.1.0`. Reality after Plan 01 Sprint 3's coupled workspace bump: the crate already ships at workspace `0.12.0` and `sympoies/homebrew-tap` is at the matching tag. Sprint 4 will instead bump the workspace `0.12.0 → 0.13.0` via `/nils-cli:bump-version-tag-release` and pin `required_clis['agent-runtime']` in `graysurf/agent-runtime-kit` to `">=0.13.0"`. Captured in [issue #401 state comment](https://github.com/sympoies/nils-cli/issues/401#issuecomment-4500137012) and the execution-state file.
- **Drift decision — sandboxed path primitive**: Plan 02 assumed `nils-common` already exposed path-resolution primitives. Reality: no path module in `nils-common` today. Shipped `render::writer::sandboxed_join` locally; lifting it to `nils-common` is non-blocking and can land in a follow-up.
- `audit-drift`, `install`, `uninstall`, `doctor`, `gc-backups`, `restore-backups`, `purge-state` still stub out — Sprints 3 and later phases cover those.
- `state_out` literal mode surfaces a typed error referencing Plan 04 — the source doc reserves literal-mode resolution for that plan.
