### PR TITLE
Sprint 2: determinism gate + cross-process render test (#401)

### DIFF
--- a/crates/agent-runtime-cli/clippy.toml
+++ b/crates/agent-runtime-cli/clippy.toml
@@ -1,0 +1,22 @@
+# Determinism gate for the render engine. Per Resolved Decision #9 in
+# `agent-runtime-kit/docs/source/inventory-target-architecture.md`, render
+# output must be a pure function of the source-root contents — no
+# wall-clock time and no hash-randomized iteration order. The lints
+# below catch the two common sources of nondeterminism at compile time;
+# the matching `#![deny(...)]` attributes in `src/lib.rs` make every
+# violation a build failure.
+#
+# Tera's `Function` trait signature forces `&HashMap<String, Value>` on
+# helper closures, so `src/render/helpers/` opts out via a scoped
+# `#![allow(clippy::disallowed_types)]` and is the only place the lint
+# is silenced. See `docs/determinism.md` for the full contract.
+
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "Use IndexMap or BTreeMap for deterministic iteration; render output must be byte-stable across cold processes. See Resolved Decision #9." },
+]
+
+disallowed-methods = [
+    { path = "std::time::SystemTime::now", reason = "Render must not depend on wall-clock time; the only sanctioned time value is `render::time::source_commit_timestamp()`. See Resolved Decision #9." },
+    { path = "chrono::Utc::now", reason = "Render must not depend on wall-clock time; the only sanctioned time value is `render::time::source_commit_timestamp()`. See Resolved Decision #9." },
+    { path = "chrono::Local::now", reason = "Render must not depend on wall-clock time; the only sanctioned time value is `render::time::source_commit_timestamp()`. See Resolved Decision #9." },
+]

--- a/crates/agent-runtime-cli/clippy.toml
+++ b/crates/agent-runtime-cli/clippy.toml
@@ -13,10 +13,14 @@
 
 disallowed-types = [
     { path = "std::collections::HashMap", reason = "Use IndexMap or BTreeMap for deterministic iteration; render output must be byte-stable across cold processes. See Resolved Decision #9." },
+    { path = "std::collections::HashSet", reason = "Use BTreeSet or IndexSet for deterministic iteration; render output must be byte-stable across cold processes. See Resolved Decision #9." },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "DefaultHasher is randomly seeded per-process; render must not depend on per-process hash state. See Resolved Decision #9." },
+    { path = "std::collections::hash_map::RandomState", reason = "RandomState is per-process randomness; render must not depend on per-process hash state. See Resolved Decision #9." },
 ]
 
 disallowed-methods = [
     { path = "std::time::SystemTime::now", reason = "Render must not depend on wall-clock time; the only sanctioned time value is `render::time::source_commit_timestamp()`. See Resolved Decision #9." },
+    { path = "std::time::Instant::now", reason = "Render must not depend on monotonic-clock time; the only sanctioned time value is `render::time::source_commit_timestamp()`. See Resolved Decision #9." },
     { path = "chrono::Utc::now", reason = "Render must not depend on wall-clock time; the only sanctioned time value is `render::time::source_commit_timestamp()`. See Resolved Decision #9." },
     { path = "chrono::Local::now", reason = "Render must not depend on wall-clock time; the only sanctioned time value is `render::time::source_commit_timestamp()`. See Resolved Decision #9." },
 ]

--- a/crates/agent-runtime-cli/docs/determinism.md
+++ b/crates/agent-runtime-cli/docs/determinism.md
@@ -1,0 +1,106 @@
+# agent-runtime determinism contract
+
+Render output must be a pure function of the source-root contents. Two
+cold processes running `agent-runtime render --source-root <root>
+--product <product>` against the same source tree MUST produce
+byte-identical output under `build/<product>/`. This document captures
+the three rules that enforce that contract and the single escape hatch
+the engine is allowed to take.
+
+Source: [`agent-runtime-kit/docs/source/inventory-target-architecture.md`
+→ Resolved Decision #9](https://github.com/graysurf/agent-runtime-kit/blob/main/docs/source/inventory-target-architecture.md#resolved-decisions).
+
+## Rule 1 — no `HashMap` at the Tera context entry point
+
+Rust's `std::collections::HashMap` randomises iteration order, so a
+context fed to Tera via `HashMap` would render the same source to
+different bytes on different processes (and on the same process across
+runs, when the underlying hasher seeds differ).
+
+Enforcement:
+
+- `crates/agent-runtime-cli/clippy.toml` and
+  `crates/nils-common/clippy.toml` list `std::collections::HashMap`
+  under `disallowed-types`.
+- The `#![deny(clippy::disallowed_types, clippy::disallowed_methods)]`
+  attribute at the top of each crate's `lib.rs` makes a violation a
+  build failure under `cargo clippy --all-targets -- -D warnings`.
+- The render code uses `IndexMap` (insertion-ordered) or `BTreeMap`
+  (key-sorted) for every map that crosses into Tera.
+
+Single exemption: `crates/agent-runtime-cli/src/render/helpers/` —
+Tera's `Function` trait signature is
+`fn call(&self, args: &HashMap<String, Value>) -> Result<Value>`, so
+the helper closures cannot avoid the type. The module-level
+`#![allow(clippy::disallowed_types)]` in `helpers/mod.rs` scopes the
+silence to exactly those files; no other module under `src/render/`
+imports `HashMap`.
+
+## Rule 2 — no wall-clock time
+
+`std::time::SystemTime::now()`, `chrono::Utc::now()`, and
+`chrono::Local::now()` all produce values that change on every call.
+If any of these landed in rendered output the determinism contract
+would break immediately.
+
+Enforcement: same clippy.toml + `#![deny(...)]` mechanism as Rule 1.
+
+Single exemption: [`render::time::source_commit_timestamp`]. This
+function shells out to `git -C <source-root> log -1 --format=%cI HEAD`
+and returns the ISO-8601 commit timestamp of the source-root's HEAD.
+The value changes only when the source tree itself changes, so it
+stays stable for any given source state.
+
+If a template needs a date value, this is the only sanctioned source.
+Render-path helpers may call it directly; the lint stays silent
+because `source_commit_timestamp` calls `Command::new("git")` rather
+than the disallowed `now()` methods.
+
+## Rule 3 — read only from `core/` / `targets/` / `manifests/`
+
+Render must not consult any path outside the source-root subtree. A
+helper that read `$HOME/.codex`, `$HOME/.claude`, or runtime state
+would couple render output to the host machine and break determinism.
+
+Enforcement:
+
+- `render::writer::sandboxed_join` rejects any path containing `..` or
+  starting with `/`, anchoring every render-time path to
+  `<source-root>/`.
+- `render::writer::canonicalize_under` and
+  `render::writer::guard_write_under` resolve the candidate path,
+  canonicalise it, and reject anything that resolves outside the
+  source root or build root. This closes the symlink-escape vector
+  where a hostile `SKILL.md.tera` could be a symlink pointing at
+  `/etc/passwd`.
+- `render::helpers::script` accepts only paths starting with `core/`,
+  `targets/`, or `manifests/`.
+
+## What this contract does NOT cover
+
+- Cross-platform path separator normalization (rendered output ships
+  Unix paths; no Windows-host support is in scope).
+- TOCTOU between `canonicalize_under` and the subsequent `fs::read`.
+  The brief race window is acceptable for the threat model — an
+  attacker with write access to the source root during render has
+  already compromised the system. Linux-only `openat2(RESOLVE_BENEATH)`
+  closes the race; we'll add it if/when the threat model expands.
+- Reproducible binary output (the renderer emits text files; binary
+  determinism is a build-system concern).
+
+## Verifying the contract locally
+
+```bash
+# Determinism gate
+cargo clippy -p agent-runtime-cli -p nils-common --all-targets -- -D warnings
+
+# Cross-process determinism integration test
+cargo test -p agent-runtime-cli render_determinism
+
+# Whole render unit + integration suite
+cargo test -p agent-runtime-cli
+```
+
+A failing clippy run, a non-byte-identical second render, or a leaked
+non-sanctioned time/HashMap import means the contract is broken — fix
+before merge.

--- a/crates/agent-runtime-cli/docs/determinism.md
+++ b/crates/agent-runtime-cli/docs/determinism.md
@@ -10,23 +10,32 @@ the engine is allowed to take.
 Source: [`agent-runtime-kit/docs/source/inventory-target-architecture.md`
 → Resolved Decision #9](https://github.com/graysurf/agent-runtime-kit/blob/main/docs/source/inventory-target-architecture.md#resolved-decisions).
 
-## Rule 1 — no `HashMap` at the Tera context entry point
+## Rule 1 — no hash-randomized iteration on the render path
 
-Rust's `std::collections::HashMap` randomises iteration order, so a
-context fed to Tera via `HashMap` would render the same source to
-different bytes on different processes (and on the same process across
-runs, when the underlying hasher seeds differ).
+Rust's `std::collections::HashMap` (and its `HashSet` sibling,
+`hash_map::DefaultHasher`, `hash_map::RandomState`) randomises
+iteration order, so a context fed to Tera via any of these would
+render the same source to different bytes on different processes
+(and on the same process across runs, when the underlying hasher
+seeds differ).
 
 Enforcement:
 
 - `crates/agent-runtime-cli/clippy.toml` and
-  `crates/nils-common/clippy.toml` list `std::collections::HashMap`
-  under `disallowed-types`.
+  `crates/nils-common/clippy.toml` list `std::collections::HashMap`,
+  `std::collections::HashSet`,
+  `std::collections::hash_map::DefaultHasher`, and
+  `std::collections::hash_map::RandomState` under `disallowed-types`.
 - The `#![deny(clippy::disallowed_types, clippy::disallowed_methods)]`
   attribute at the top of each crate's `lib.rs` makes a violation a
   build failure under `cargo clippy --all-targets -- -D warnings`.
 - The render code uses `IndexMap` (insertion-ordered) or `BTreeMap`
   (key-sorted) for every map that crosses into Tera.
+- Filesystem directory walks (`std::fs::read_dir`) sort their entries
+  before consumption — the OS returns them in arbitrary order on
+  most filesystems. The integration test in
+  `tests/integration/render_determinism.rs` and the production walk
+  in `render::golden::update_golden` both sort before iterating.
 
 Single exemption: `crates/agent-runtime-cli/src/render/helpers/` —
 Tera's `Function` trait signature is
@@ -34,14 +43,16 @@ Tera's `Function` trait signature is
 the helper closures cannot avoid the type. The module-level
 `#![allow(clippy::disallowed_types)]` in `helpers/mod.rs` scopes the
 silence to exactly those files; no other module under `src/render/`
-imports `HashMap`.
+imports `HashMap`. The `allowlist_is_exact` integration test asserts
+this scope cannot drift silently — adding `#[allow(...)]` to another
+module fails the test.
 
-## Rule 2 — no wall-clock time
+## Rule 2 — no wall-clock or monotonic time
 
-`std::time::SystemTime::now()`, `chrono::Utc::now()`, and
-`chrono::Local::now()` all produce values that change on every call.
-If any of these landed in rendered output the determinism contract
-would break immediately.
+`std::time::SystemTime::now()`, `std::time::Instant::now()`,
+`chrono::Utc::now()`, and `chrono::Local::now()` all produce values
+that change on every call. If any of these landed in rendered output
+the determinism contract would break immediately.
 
 Enforcement: same clippy.toml + `#![deny(...)]` mechanism as Rule 1.
 

--- a/crates/agent-runtime-cli/src/lib.rs
+++ b/crates/agent-runtime-cli/src/lib.rs
@@ -1,3 +1,22 @@
+//! `agent-runtime` CLI library. Render / install / doctor /
+//! audit-drift for graysurf/agent-runtime-kit.
+//!
+//! ## Determinism contract (Resolved Decision #9)
+//!
+//! Render output must be a pure function of the source-root contents:
+//! no wall-clock time, no hash-randomized iteration. The crate-wide
+//! `#![deny(...)]` attribute below pairs with `clippy.toml` to make
+//! `std::collections::HashMap`, `std::time::SystemTime::now`, and
+//! `chrono::Utc::now` build failures. The single sanctioned time
+//! value is `render::time::source_commit_timestamp()`. Helpers under
+//! `render::helpers` are the only sanctioned `HashMap` site — Tera's
+//! `Function` trait forces the signature, and the lint is silenced
+//! exactly there.
+//!
+//! Source: `agent-runtime-kit/docs/source/inventory-target-architecture.md`
+//! → Resolved Decision #9.
+#![deny(clippy::disallowed_types, clippy::disallowed_methods)]
+
 use clap::{Parser, Subcommand};
 use std::process::ExitCode;
 

--- a/crates/agent-runtime-cli/src/render/helpers/mod.rs
+++ b/crates/agent-runtime-cli/src/render/helpers/mod.rs
@@ -9,7 +9,10 @@
 //! Tera's `Function` trait signature forces `&HashMap<String, Value>` on
 //! us — that's the only sanctioned `HashMap` import inside `src/render/`
 //! and it stays scoped to this module (the context fed to Tera lives in
-//! [`IndexMap`] / `BTreeMap` per Resolved Decision #9).
+//! [`IndexMap`] / `BTreeMap` per Resolved Decision #9). The crate-wide
+//! `clippy::disallowed_types` gate on `HashMap` is silenced exactly here
+//! and nowhere else.
+#![allow(clippy::disallowed_types)]
 
 use crate::render::manifest::{ManifestSet, StateOutMode};
 use indexmap::IndexMap;

--- a/crates/agent-runtime-cli/src/render/mod.rs
+++ b/crates/agent-runtime-cli/src/render/mod.rs
@@ -2,4 +2,5 @@ pub mod cache;
 pub mod golden;
 pub mod helpers;
 pub mod manifest;
+pub mod time;
 pub mod writer;

--- a/crates/agent-runtime-cli/src/render/time.rs
+++ b/crates/agent-runtime-cli/src/render/time.rs
@@ -115,13 +115,65 @@ mod tests {
         (tmp, root)
     }
 
+    /// Strict RFC 3339 / ISO 8601 check. Matches `YYYY-MM-DDTHH:MM:SS`
+    /// followed by either `Z` or `±HH:MM`. This is what `--format=%cI`
+    /// produces and what downstream Tera helpers will assume.
+    fn is_strict_iso8601(s: &str) -> bool {
+        let bytes = s.as_bytes();
+        // Minimum length: "YYYY-MM-DDTHH:MM:SSZ" = 20.
+        if bytes.len() < 20 {
+            return false;
+        }
+        let digit = |i: usize| bytes[i].is_ascii_digit();
+        let sep = |i: usize, c: u8| bytes[i] == c;
+        if !(digit(0)
+            && digit(1)
+            && digit(2)
+            && digit(3)
+            && sep(4, b'-')
+            && digit(5)
+            && digit(6)
+            && sep(7, b'-')
+            && digit(8)
+            && digit(9)
+            && sep(10, b'T')
+            && digit(11)
+            && digit(12)
+            && sep(13, b':')
+            && digit(14)
+            && digit(15)
+            && sep(16, b':')
+            && digit(17)
+            && digit(18))
+        {
+            return false;
+        }
+        let tz = &bytes[19..];
+        match tz {
+            [b'Z'] => true,
+            [sign, h1, h2, b':', m1, m2]
+                if (*sign == b'+' || *sign == b'-')
+                    && h1.is_ascii_digit()
+                    && h2.is_ascii_digit()
+                    && m1.is_ascii_digit()
+                    && m2.is_ascii_digit() =>
+            {
+                true
+            }
+            _ => false,
+        }
+    }
+
     #[test]
     fn returns_iso8601_timestamp_for_head() {
         let (_tmp, root) = init_git_repo();
         let ts = source_commit_timestamp(&root).unwrap();
-        // ISO-8601 with timezone offset, e.g. "2026-05-21T00:00:00+00:00".
+        assert!(
+            is_strict_iso8601(&ts),
+            "expected strict ISO-8601 (YYYY-MM-DDTHH:MM:SS[Z|±HH:MM]), got {ts:?}",
+        );
+        // The fixed committer date pins this exact value.
         assert!(ts.starts_with("2026-05-21T00:00:00"), "got {ts:?}");
-        assert!(ts.ends_with("+00:00") || ts.ends_with("Z"), "got {ts:?}");
     }
 
     #[test]
@@ -143,5 +195,35 @@ mod tests {
             msg.contains("git log") || msg.contains("not a git"),
             "{msg}"
         );
+    }
+
+    #[test]
+    fn errors_when_repo_has_no_head_yet() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        run("git", &["init", "--quiet", "--initial-branch=main"], &root);
+        // No commits — `HEAD` is unborn.
+        let err = source_commit_timestamp(&root).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("git log") && !msg.is_empty(),
+            "expected git log error for unborn HEAD, got {msg:?}"
+        );
+    }
+
+    #[test]
+    fn iso8601_strictness_rejects_obvious_garbage() {
+        // Self-test for the matcher — protects against the matcher
+        // silently accepting non-ISO output if git ever changes its
+        // `%cI` format.
+        assert!(is_strict_iso8601("2026-05-21T00:00:00Z"));
+        assert!(is_strict_iso8601("2026-05-21T00:00:00+08:00"));
+        assert!(is_strict_iso8601("2026-05-21T00:00:00-05:30"));
+        assert!(!is_strict_iso8601(""));
+        assert!(!is_strict_iso8601("2026-05-21"));
+        assert!(!is_strict_iso8601("2026-05-21 00:00:00Z"));
+        assert!(!is_strict_iso8601("2026/05/21T00:00:00Z"));
+        assert!(!is_strict_iso8601("2026-05-21T00:00:00"));
+        assert!(!is_strict_iso8601("2026-05-21T00:00:00+0000"));
     }
 }

--- a/crates/agent-runtime-cli/src/render/time.rs
+++ b/crates/agent-runtime-cli/src/render/time.rs
@@ -1,0 +1,147 @@
+//! The only sanctioned time value the render engine is allowed to use.
+//!
+//! Per Resolved Decision #9 in
+//! `agent-runtime-kit/docs/source/inventory-target-architecture.md`,
+//! render output must be a pure function of the source-root contents.
+//! `std::time::SystemTime::now()` and `chrono::Utc::now()` are
+//! clippy-banned inside `agent-runtime-cli` and `nils-common`. The
+//! single escape hatch is [`source_commit_timestamp`], which returns
+//! the ISO-8601 commit timestamp of the source-root's `HEAD` — a value
+//! that changes only when the source tree itself changes, so two cold
+//! processes rendering the same source produce identical output.
+//!
+//! See `crates/agent-runtime-cli/docs/determinism.md` for the full
+//! contract.
+
+use anyhow::{Context, Result, anyhow};
+use std::path::Path;
+use std::process::Command;
+
+/// Return the ISO-8601 commit timestamp of `HEAD` in the git repository
+/// at `source_root`. Equivalent to `git -C <source_root> log -1
+/// --format=%cI HEAD`. The output is the only time-shaped value
+/// permitted to land in rendered output.
+///
+/// Returns `Err` when:
+/// - `git` is missing from `PATH`,
+/// - `source_root` is not a git repository,
+/// - `HEAD` cannot be resolved (empty repo).
+pub fn source_commit_timestamp(source_root: &Path) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(source_root)
+        .args(["log", "-1", "--format=%cI", "HEAD"])
+        .output()
+        .with_context(|| {
+            format!(
+                "spawn `git -C {} log -1 --format=%cI HEAD`",
+                source_root.display()
+            )
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "git log -1 --format=%cI HEAD exited {status:?} at {root}: {stderr}",
+            status = output.status.code(),
+            root = source_root.display(),
+            stderr = stderr.trim(),
+        ));
+    }
+    let raw = String::from_utf8(output.stdout)
+        .context("git log -1 --format=%cI HEAD produced non-UTF8 output")?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!(
+            "git log -1 --format=%cI HEAD returned empty stdout at {}",
+            source_root.display(),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn run(cmd: &str, args: &[&str], cwd: &Path) {
+        let status = Command::new(cmd)
+            .args(args)
+            .current_dir(cwd)
+            .status()
+            .unwrap();
+        assert!(
+            status.success(),
+            "{cmd} {args:?} failed at {}",
+            cwd.display()
+        );
+    }
+
+    fn init_git_repo() -> (TempDir, PathBuf) {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        run("git", &["init", "--quiet", "--initial-branch=main"], &root);
+        run("git", &["config", "user.email", "test@example.com"], &root);
+        run("git", &["config", "user.name", "Test"], &root);
+        run("git", &["config", "commit.gpgsign", "false"], &root);
+        run("git", &["config", "tag.gpgsign", "false"], &root);
+        fs::write(root.join("README"), "seed\n").unwrap();
+        run("git", &["add", "README"], &root);
+        // Force a fixed committer date so the assertion below is stable.
+        let env_args = [
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "--quiet",
+            "--allow-empty-message",
+            "-m",
+            "seed",
+            "--date=2026-05-21T00:00:00+00:00",
+        ];
+        let status = Command::new("git")
+            .args(env_args)
+            .env("GIT_COMMITTER_DATE", "2026-05-21T00:00:00+00:00")
+            .env("GIT_AUTHOR_DATE", "2026-05-21T00:00:00+00:00")
+            .current_dir(&root)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        (tmp, root)
+    }
+
+    #[test]
+    fn returns_iso8601_timestamp_for_head() {
+        let (_tmp, root) = init_git_repo();
+        let ts = source_commit_timestamp(&root).unwrap();
+        // ISO-8601 with timezone offset, e.g. "2026-05-21T00:00:00+00:00".
+        assert!(ts.starts_with("2026-05-21T00:00:00"), "got {ts:?}");
+        assert!(ts.ends_with("+00:00") || ts.ends_with("Z"), "got {ts:?}");
+    }
+
+    #[test]
+    fn is_stable_across_calls_for_same_head() {
+        let (_tmp, root) = init_git_repo();
+        let first = source_commit_timestamp(&root).unwrap();
+        let second = source_commit_timestamp(&root).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn errors_when_source_root_is_not_a_git_repo() {
+        let tmp = TempDir::new().unwrap();
+        let err = source_commit_timestamp(tmp.path()).unwrap_err();
+        let msg = format!("{err:#}");
+        // git's error message contains "not a git repository"; we
+        // surface whatever git stderr said with the source root.
+        assert!(
+            msg.contains("git log") || msg.contains("not a git"),
+            "{msg}"
+        );
+    }
+}

--- a/crates/agent-runtime-cli/tests/fixtures/render-determinism/core/skills/codex_only/SKILL.md.tera
+++ b/crates/agent-runtime-cli/tests/fixtures/render-determinism/core/skills/codex_only/SKILL.md.tera
@@ -1,0 +1,8 @@
+# {{ skill_ref(id="sample.codex-only") }}
+
+This skill renders only for codex; the claude product render must not
+contain this template's output.
+
+state: {{ state_out(domain="sample", topic="codex-only") }}
+required: {{ cli_ref(name="agent-out") }}
+script: {{ script(path="core/skills/codex_only/SKILL.md.tera") }}

--- a/crates/agent-runtime-cli/tests/fixtures/render-determinism/core/skills/sample/SKILL.md.tera
+++ b/crates/agent-runtime-cli/tests/fixtures/render-determinism/core/skills/sample/SKILL.md.tera
@@ -1,0 +1,5 @@
+# {{ skill_ref(id="sample.determinism") }}
+
+state: {{ state_out(domain="sample", topic="determinism") }}
+required: {{ cli_ref(name="agent-out") }}
+script: {{ script(path="core/skills/sample/SKILL.md.tera") }}

--- a/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/cli-tools.yaml
+++ b/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/cli-tools.yaml
@@ -1,0 +1,11 @@
+schema_version: 1
+profiles:
+  core: [ripgrep]
+  recommended: [ripgrep]
+  full: [ripgrep]
+formulas:
+  ripgrep:
+    brew: ripgrep
+    command: rg
+    linux_only_alternative: null
+    categories: [search]

--- a/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/plugins.yaml
+++ b/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/plugins.yaml
@@ -1,0 +1,2 @@
+schema_version: 1
+plugins: []

--- a/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/product-capabilities.yaml
+++ b/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/product-capabilities.yaml
@@ -1,0 +1,34 @@
+schema_version: 1
+products:
+  codex:
+    nested_skill_support: true
+    plugin_manifest:
+      path_pattern: "$CODEX_HOME/plugins/<domain>/.codex-plugin/plugin.json"
+      loaded_at_runtime: false
+      schema_ref: "core/docs/schemas/codex-plugin.schema.json"
+    hooks_model:
+      config_surface: "$CODEX_HOME/config.toml"
+      payload_shape: "codex-toml-managed-block"
+      supports_inline_python: false
+    config_activation:
+      - "$CODEX_HOME/AGENTS.md"
+    runtime_state:
+      state_home_env: "CODEX_AGENT_STATE_HOME"
+      default_path: "${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/codex"
+    marketplace_concept: false
+  claude:
+    nested_skill_support: true
+    plugin_manifest:
+      path_pattern: "${CLAUDE_PLUGIN_ROOT}/<plugin>/.claude-plugin/plugin.json"
+      loaded_at_runtime: true
+      schema_ref: "core/docs/schemas/claude-plugin.schema.json"
+    hooks_model:
+      config_surface: "$HOME/.claude/settings.json"
+      payload_shape: "claude-pretool-v1"
+      supports_inline_python: true
+    config_activation:
+      - "$HOME/.claude/settings.json"
+    runtime_state:
+      state_home_env: "CLAUDE_KIT_STATE_HOME"
+      default_path: "${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/claude"
+    marketplace_concept: true

--- a/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/runtime-roots.yaml
+++ b/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/runtime-roots.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+products:
+  codex:
+    live_home: "$CODEX_HOME"
+    docs_home: "$CODEX_HOME"
+    state_home: "${CODEX_AGENT_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/codex}"
+    plugin_root: "$CODEX_HOME/plugins"
+    hook_config_strategy: managed-block
+    min_version: "<TBD: pin during Phase 1>"
+    recommended_version: "<TBD: pin during Phase 1>"
+    min_version_effective_from: "<TBD: pin during Phase 1>"
+    version_probe: "codex --version"
+  claude:
+    live_home: "$HOME/.claude"
+    docs_home: "$HOME/.claude"
+    state_home: "${CLAUDE_KIT_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/claude}"
+    plugin_root_env: "CLAUDE_PLUGIN_ROOT"
+    hook_config_strategy: settings-json
+    min_version: "<TBD: pin during Phase 1>"
+    recommended_version: "<TBD: pin during Phase 1>"
+    min_version_effective_from: "<TBD: pin during Phase 1>"
+    version_probe: "claude --version"

--- a/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/skills.yaml
+++ b/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/skills.yaml
@@ -12,3 +12,12 @@ skills:
         render_to: plugins/sample/skills/determinism/SKILL.md
     required_clis:
       agent-out: ">=0.5.0"
+  - id: sample.codex-only
+    domain: sample
+    source: core/skills/codex_only
+    products:
+      codex:
+        name: /sample-codex-only
+        render_to: skills/sample/CODEX_ONLY.md
+    required_clis:
+      agent-out: ">=0.5.0"

--- a/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/skills.yaml
+++ b/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/skills.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+skills:
+  - id: sample.determinism
+    domain: sample
+    source: core/skills/sample
+    products:
+      codex:
+        name: /sample-determinism
+        render_to: skills/sample/SKILL.md
+      claude:
+        name: sample:determinism
+        render_to: plugins/sample/skills/determinism/SKILL.md
+    required_clis:
+      agent-out: ">=0.5.0"

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -5,6 +5,8 @@
 
 #[path = "integration/cli.rs"]
 mod cli;
+#[path = "integration/determinism_gate.rs"]
+mod determinism_gate;
 #[path = "integration/render.rs"]
 mod render;
 #[path = "integration/render_determinism.rs"]

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -7,3 +7,5 @@
 mod cli;
 #[path = "integration/render.rs"]
 mod render;
+#[path = "integration/render_determinism.rs"]
+mod render_determinism;

--- a/crates/agent-runtime-cli/tests/integration/determinism_gate.rs
+++ b/crates/agent-runtime-cli/tests/integration/determinism_gate.rs
@@ -1,0 +1,154 @@
+//! Negative-control for the determinism gate.
+//!
+//! The cross-process determinism test in `render_determinism.rs`
+//! proves that *current* render output is byte-stable, but it cannot
+//! tell whether the clippy gate that protects future contributors
+//! is actually in place. If `#![deny(...)]` were silently removed
+//! from a `lib.rs` or the `disallowed-{types,methods}` list were
+//! emptied, the byte-equal test would still pass — and the next
+//! time someone introduced `HashMap` on the render path, the
+//! contract would break with no warning.
+//!
+//! This file asserts the gate's *presence*: the required clippy.toml
+//! entries exist, the `#![deny(...)]` attribute is in place on both
+//! crate libs, and the scoped `#![allow(...)]` exemption is exactly
+//! where `docs/determinism.md` claims it lives.
+
+const AGENT_RUNTIME_CLIPPY_TOML: &str = include_str!("../../clippy.toml");
+const NILS_COMMON_CLIPPY_TOML: &str = include_str!("../../../nils-common/clippy.toml");
+const AGENT_RUNTIME_LIB_RS: &str = include_str!("../../src/lib.rs");
+const NILS_COMMON_LIB_RS: &str = include_str!("../../../nils-common/src/lib.rs");
+const HELPERS_MOD_RS: &str = include_str!("../../src/render/helpers/mod.rs");
+
+const REQUIRED_DISALLOWED_TYPES: &[&str] = &[
+    "std::collections::HashMap",
+    "std::collections::HashSet",
+    "std::collections::hash_map::DefaultHasher",
+    "std::collections::hash_map::RandomState",
+];
+
+const REQUIRED_DISALLOWED_METHODS: &[&str] = &[
+    "std::time::SystemTime::now",
+    "std::time::Instant::now",
+    "chrono::Utc::now",
+    "chrono::Local::now",
+];
+
+fn assert_contains(haystack: &str, needle: &str, where_: &str) {
+    assert!(
+        haystack.contains(needle),
+        "{where_} is missing required token {needle:?}; \
+         determinism gate has drifted from docs/determinism.md"
+    );
+}
+
+#[test]
+fn agent_runtime_clippy_toml_lists_every_required_entry() {
+    for ty in REQUIRED_DISALLOWED_TYPES {
+        assert_contains(
+            AGENT_RUNTIME_CLIPPY_TOML,
+            ty,
+            "crates/agent-runtime-cli/clippy.toml",
+        );
+    }
+    for m in REQUIRED_DISALLOWED_METHODS {
+        assert_contains(
+            AGENT_RUNTIME_CLIPPY_TOML,
+            m,
+            "crates/agent-runtime-cli/clippy.toml",
+        );
+    }
+}
+
+#[test]
+fn nils_common_clippy_toml_lists_every_required_entry() {
+    for ty in REQUIRED_DISALLOWED_TYPES {
+        assert_contains(
+            NILS_COMMON_CLIPPY_TOML,
+            ty,
+            "crates/nils-common/clippy.toml",
+        );
+    }
+    for m in REQUIRED_DISALLOWED_METHODS {
+        assert_contains(NILS_COMMON_CLIPPY_TOML, m, "crates/nils-common/clippy.toml");
+    }
+}
+
+#[test]
+fn agent_runtime_lib_denies_the_determinism_lints() {
+    assert_contains(
+        AGENT_RUNTIME_LIB_RS,
+        "#![deny(clippy::disallowed_types, clippy::disallowed_methods)]",
+        "crates/agent-runtime-cli/src/lib.rs",
+    );
+}
+
+#[test]
+fn nils_common_lib_denies_the_determinism_lints() {
+    assert_contains(
+        NILS_COMMON_LIB_RS,
+        "#![deny(clippy::disallowed_types, clippy::disallowed_methods)]",
+        "crates/nils-common/src/lib.rs",
+    );
+}
+
+#[test]
+fn helpers_mod_carries_the_only_sanctioned_disallowed_types_allow() {
+    assert_contains(
+        HELPERS_MOD_RS,
+        "#![allow(clippy::disallowed_types)]",
+        "crates/agent-runtime-cli/src/render/helpers/mod.rs",
+    );
+}
+
+/// `helpers/mod.rs` is the only file under `src/render/` allowed to
+/// silence `disallowed_types`. Walk the render subtree and confirm no
+/// other file carries the inner attribute.
+///
+/// `disallowed_methods` may be silenced anywhere off the render path
+/// (and the explicit exemption in `nils-common::fs::temp_path` does
+/// so), but on the render path itself the only sanctioned escape
+/// hatch is `render::time::source_commit_timestamp`.
+#[test]
+fn render_subtree_has_no_unsanctioned_disallowed_types_allow() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let render_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/render");
+    let helpers_mod = render_dir.join("helpers/mod.rs");
+
+    let mut offenders: Vec<String> = Vec::new();
+    walk_rust_files(&render_dir, &mut |path| {
+        if path == helpers_mod {
+            return;
+        }
+        let body = fs::read_to_string(path).unwrap();
+        if body.contains("#![allow(clippy::disallowed_types")
+            || body.contains("#[allow(clippy::disallowed_types")
+        {
+            offenders.push(path.display().to_string());
+        }
+    });
+
+    assert!(
+        offenders.is_empty(),
+        "only `render/helpers/mod.rs` may silence `clippy::disallowed_types`; \
+         these files also carry the lint allow and would let a future \
+         HashMap import slip through the determinism gate: {offenders:#?}"
+    );
+}
+
+fn walk_rust_files(dir: &std::path::Path, f: &mut dyn FnMut(&std::path::Path)) {
+    let mut entries: Vec<_> = std::fs::read_dir(dir).unwrap().flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_rust_files(&path, f);
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+            f(&path);
+        }
+    }
+}

--- a/crates/agent-runtime-cli/tests/integration/render_determinism.rs
+++ b/crates/agent-runtime-cli/tests/integration/render_determinism.rs
@@ -69,13 +69,10 @@ fn walk(base: &Path, dir: &Path, out: &mut BTreeMap<String, Vec<u8>>) {
             walk(base, &path, out);
             continue;
         }
-        // The cache file changes between cache-miss and cache-hit runs
-        // by design (the recorded hash and on-disk pretty-print may
-        // shift across versions). The determinism contract covers the
-        // rendered output tree, not the cache scratchpad.
-        if path.file_name().and_then(|n| n.to_str()) == Some(".render-cache.json") {
-            continue;
-        }
+        // `.render-cache.json` is included in the comparison. The cache
+        // is BTreeMap-backed (see `render::cache`) and its on-disk form
+        // is documented as byte-stable, so two cold processes must emit
+        // byte-equal cache files when the source tree is unchanged.
         let bytes = fs::read(&path).unwrap();
         let rel = path
             .strip_prefix(base)

--- a/crates/agent-runtime-cli/tests/integration/render_determinism.rs
+++ b/crates/agent-runtime-cli/tests/integration/render_determinism.rs
@@ -1,0 +1,129 @@
+//! Cross-process determinism gate. Spawns the `agent-runtime` binary
+//! twice against `tests/fixtures/render-determinism/`, deleting
+//! `.render-cache.json` between runs so the second invocation is a
+//! cache-miss rather than a cache-hit. A byte-level walk over both
+//! `build/<product>/` trees must compare equal — if it ever diverges,
+//! something inside the render pipeline started depending on
+//! per-process state (HashMap iteration order, wall-clock time, env).
+//!
+//! Negative-control reminder: injecting a `SystemTime::now()`-derived
+//! value into any helper or writer path makes this test diverge on
+//! the second run. The crate-wide `clippy::disallowed_methods` gate
+//! is the first line of defense; this test is the byte-level proof
+//! that the gate's intent holds end-to-end.
+
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/render-determinism")
+}
+
+/// Copy the read-only on-disk fixture into a tempdir so each test run
+/// gets a private working tree (render writes `build/` next to the
+/// manifests).
+fn copy_fixture_to_tempdir() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    copy_tree(&fixture_root(), tmp.path());
+    tmp
+}
+
+fn copy_tree(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_tree(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap();
+        }
+    }
+}
+
+fn run(args: &[&str]) -> CmdOutput {
+    cmd::run(&agent_runtime_bin(), args, &[], None)
+}
+
+fn snapshot(root: &Path) -> BTreeMap<String, Vec<u8>> {
+    let mut out = BTreeMap::new();
+    walk(root, root, &mut out);
+    out
+}
+
+fn walk(base: &Path, dir: &Path, out: &mut BTreeMap<String, Vec<u8>>) {
+    let mut entries: Vec<_> = fs::read_dir(dir).unwrap().flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(base, &path, out);
+            continue;
+        }
+        // The cache file changes between cache-miss and cache-hit runs
+        // by design (the recorded hash and on-disk pretty-print may
+        // shift across versions). The determinism contract covers the
+        // rendered output tree, not the cache scratchpad.
+        if path.file_name().and_then(|n| n.to_str()) == Some(".render-cache.json") {
+            continue;
+        }
+        let bytes = fs::read(&path).unwrap();
+        let rel = path
+            .strip_prefix(base)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        out.insert(rel, bytes);
+    }
+}
+
+fn assert_cross_process_byte_equal(product: &str) {
+    let tmp = copy_fixture_to_tempdir();
+    let root_str = tmp.path().to_str().unwrap();
+
+    // First run — populates `build/<product>/` and `.render-cache.json`.
+    let first = run(&["render", "--source-root", root_str, "--product", product]);
+    assert_eq!(first.code, 0, "first render exit: {}", first.stderr_text());
+
+    let build_dir = tmp.path().join("build").join(product);
+    let cache_path = build_dir.join(".render-cache.json");
+    assert!(
+        cache_path.exists(),
+        "cache file should exist after first run"
+    );
+    let snapshot_first = snapshot(&build_dir);
+
+    // Force a cache-miss path on the second run by deleting the cache.
+    fs::remove_file(&cache_path).unwrap();
+    let second = run(&["render", "--source-root", root_str, "--product", product]);
+    assert_eq!(
+        second.code,
+        0,
+        "second render exit: {}",
+        second.stderr_text()
+    );
+    let snapshot_second = snapshot(&build_dir);
+    assert_eq!(
+        snapshot_second, snapshot_first,
+        "cross-process render for product={product} was not byte-identical",
+    );
+}
+
+#[test]
+fn cross_process_render_is_byte_identical_for_codex() {
+    assert_cross_process_byte_equal("codex");
+}
+
+#[test]
+fn cross_process_render_is_byte_identical_for_claude() {
+    assert_cross_process_byte_equal("claude");
+}

--- a/crates/nils-common/clippy.toml
+++ b/crates/nils-common/clippy.toml
@@ -1,0 +1,17 @@
+# `nils-common` is on the determinism gate because the render engine in
+# `agent-runtime-cli` reaches into it for path-resolution primitives and
+# shared utilities. Resolved Decision #9 in
+# `agent-runtime-kit/docs/source/inventory-target-architecture.md` requires
+# that any code on the render path stay free of hash-randomized iteration
+# and wall-clock time. Scope is intentionally narrow — only crates whose
+# output Tera consumes — per the plan's Open Question default.
+
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "Use IndexMap or BTreeMap; agent-runtime-cli consumes this crate on the render path and must stay deterministic. See Resolved Decision #9." },
+]
+
+disallowed-methods = [
+    { path = "std::time::SystemTime::now", reason = "Wall-clock time forbidden on the render path. See Resolved Decision #9." },
+    { path = "chrono::Utc::now", reason = "Wall-clock time forbidden on the render path. See Resolved Decision #9." },
+    { path = "chrono::Local::now", reason = "Wall-clock time forbidden on the render path. See Resolved Decision #9." },
+]

--- a/crates/nils-common/clippy.toml
+++ b/crates/nils-common/clippy.toml
@@ -8,10 +8,14 @@
 
 disallowed-types = [
     { path = "std::collections::HashMap", reason = "Use IndexMap or BTreeMap; agent-runtime-cli consumes this crate on the render path and must stay deterministic. See Resolved Decision #9." },
+    { path = "std::collections::HashSet", reason = "Use BTreeSet or IndexSet; agent-runtime-cli consumes this crate on the render path and must stay deterministic. See Resolved Decision #9." },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "DefaultHasher is randomly seeded per-process; render must not depend on per-process hash state. See Resolved Decision #9." },
+    { path = "std::collections::hash_map::RandomState", reason = "RandomState is per-process randomness; render must not depend on per-process hash state. See Resolved Decision #9." },
 ]
 
 disallowed-methods = [
     { path = "std::time::SystemTime::now", reason = "Wall-clock time forbidden on the render path. See Resolved Decision #9." },
+    { path = "std::time::Instant::now", reason = "Monotonic-clock time forbidden on the render path. See Resolved Decision #9." },
     { path = "chrono::Utc::now", reason = "Wall-clock time forbidden on the render path. See Resolved Decision #9." },
     { path = "chrono::Local::now", reason = "Wall-clock time forbidden on the render path. See Resolved Decision #9." },
 ]

--- a/crates/nils-common/src/fs.rs
+++ b/crates/nils-common/src/fs.rs
@@ -308,6 +308,14 @@ fn set_permissions(_path: &Path, _mode: u32) -> io::Result<()> {
     Ok(())
 }
 
+// Atomic-write helper, off the render path: produces a unique tempfile
+// name for the write-temp-then-rename pattern used by `atomic_write`.
+// The Resolved Decision #9 determinism gate covers the render pipeline
+// (agent-runtime-cli's `src/render/`), which never touches this helper
+// — `agent-runtime render` writes through `std::fs::write` directly.
+// Allowing `SystemTime::now()` exactly here keeps the gate green
+// without weakening the rule for any new render-path code.
+#[allow(clippy::disallowed_methods)]
 fn temp_path(path: &Path, attempt: u32) -> PathBuf {
     let filename = path
         .file_name()

--- a/crates/nils-common/src/lib.rs
+++ b/crates/nils-common/src/lib.rs
@@ -10,6 +10,18 @@
 //! - APIs stay domain-neutral and must not encode crate-specific UX policies.
 //! - Quoting and ANSI differences are expressed via explicit mode/policy parameters.
 //!
+//! ## Determinism contract (Resolved Decision #9)
+//!
+//! `agent-runtime-cli` consumes this crate on its render path, so
+//! `std::collections::HashMap`, `std::time::SystemTime::now`, and
+//! `chrono::Utc::now` are forbidden inside this crate. The crate-wide
+//! `#![deny(...)]` below pairs with `clippy.toml` to make every
+//! violation a build failure. Use `IndexMap` or `BTreeMap` for any map
+//! that wants stable iteration. Source:
+//! `agent-runtime-kit/docs/source/inventory-target-architecture.md`
+//! → Resolved Decision #9.
+#![deny(clippy::disallowed_types, clippy::disallowed_methods)]
+
 pub mod cli_contract;
 pub mod clipboard;
 pub mod env;

--- a/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
+++ b/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
@@ -7,10 +7,10 @@
 - Execution window: sprint-by-sprint (one feature PR per sprint, `/code-review-specialists`
   review between sprints, merge before next sprint)
 - Staged execution confirmation: confirmed 2026-05-20 (Sprint 1 only first, then 2/3/4 in order)
-- Current task: Sprint 1 close (PR open + review)
-- Next task: Task 2.1 (after Sprint 1 PR merges)
+- Current task: Sprint 2 close (PR open + review)
+- Next task: Sprint 3 — audit-drift body (after Sprint 2 PR merges)
 - Last updated: 2026-05-21
-- Branch/commit: `feat/agent-runtime-render-engine`
+- Branch/commit: `feat/agent-runtime-determinism-lints`
 - Source document: docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md
 - Direct source-doc execution waiver: not applicable
 
@@ -39,9 +39,9 @@
 | 1.2 | done    | Register the four Tera helpers                                  | script / skill_ref / state_out (runtime) / cli_ref; literal-mode errors to Plan 04 |
 | 1.3 | done    | Write `build/<product>/` output and per-skill cache             | SHA-256 keyed `.render-cache.json`; cache hit byte-identical to cache miss         |
 | 1.4 | done    | Add `--update-golden` flag                                      | Per-product subtree scope; sentinel test confirms no writes outside active product |
-| 2.1 | pending | Add determinism clippy lints to affected crates                 | scoped per Open Question default                                                   |
-| 2.2 | pending | Add cross-process render determinism integration test           | depends on 1.3 and 2.1                                                             |
-| 2.3 | pending | Document the only sanctioned time value                         | depends on 2.1                                                                     |
+| 2.1 | done    | Add determinism clippy lints to affected crates                 | clippy.toml + `#![deny(clippy::disallowed_types, clippy::disallowed_methods)]`     |
+| 2.2 | done    | Add cross-process render determinism integration test           | Two separate `agent-runtime` invocations, cache deleted between, byte-equal walk   |
+| 2.3 | done    | Document the only sanctioned time value                         | `render::time::source_commit_timestamp` + `docs/determinism.md` contract           |
 | 3.1 | pending | Source-manifest validity and rendered-target diff classes       | depends on 1.3                                                                     |
 | 3.2 | pending | `$AGENT_HOME` leak class (blocking, exit 2)                     | depends on 3.1                                                                     |
 | 3.3 | pending | Docs-home per product class (blocking, exit 2)                  | depends on 3.1                                                                     |
@@ -110,3 +110,27 @@ audit-drift body + fixtures, release/tap/cross-repo floor bump.
   Deferred items: helper-arg dedup, `Command::name` catch-all → Sprint 2
   cleanup; remaining api-contract / testing low+info items tracked on
   the issue.
+- 2026-05-21 — Sprint 2 lands on branch
+  `feat/agent-runtime-determinism-lints`: Task 2.1 introduces
+  `clippy.toml` for `agent-runtime-cli` + `nils-common` (disallowed
+  `HashMap` + `SystemTime::now` + `chrono::{Utc,Local}::now`) plus
+  crate-level `#![deny(clippy::disallowed_types,
+  clippy::disallowed_methods)]`. The Tera helper module gets a
+  scoped `allow` (Tera forces `&HashMap` at its trait surface);
+  `nils-common::fs::temp_path` gets a scoped `allow` with a comment
+  marking it off the render path. Task 2.2 adds
+  `tests/integration/render_determinism.rs` — two
+  `std::process::Command` invocations of `agent-runtime render`
+  with `.render-cache.json` deleted between runs, walking
+  `build/<product>/` with `BTreeMap` and asserting byte-equal for
+  both `codex` and `claude`. Fixture lives under
+  `tests/fixtures/render-determinism/` (5 manifests + one
+  Tera template exercising every helper). Task 2.3 adds
+  `render::time::source_commit_timestamp(source_root)` (shells out
+  to `git -C <root> log -1 --format=%cI HEAD`; 3 unit tests) plus
+  `docs/determinism.md` documenting the 3 rules + the single
+  sanctioned wall-clock escape hatch + the single sanctioned
+  `HashMap` exemption. Test counts: lib 54 → 57, integration 8 →
+  10. Determinism gate verified to actually fire on a temporary
+  HashMap injection. `bash scripts/ci/nils-cli-checks-entrypoint.sh`
+  exits 0.


### PR DESCRIPTION
## Summary

Sprint 2 of Plan 02 — Phase 1.5 (issue #401). Locks down render determinism with a compile-time clippy gate and adds the cross-process byte-equality test that verifies the contract end-to-end.

- **2.1 — determinism clippy gate.** New `clippy.toml` in both `agent-runtime-cli` and `nils-common` (the render path's two upstream crates): `disallowed-types = [HashMap]`, `disallowed-methods = [SystemTime::now, chrono::{Utc,Local}::now]`, each with a `reason` string pointing at Resolved Decision #9. Both crate libs now carry `#![deny(clippy::disallowed_types, clippy::disallowed_methods)]`. The Tera helper module gets a scoped `#![allow(clippy::disallowed_types)]` (the only sanctioned `HashMap` site — Tera's `Function` trait signature forces `&HashMap`). `nils-common::fs::temp_path` gets a scoped `#[allow]` with a comment marking it off the render path.
- **2.2 — cross-process determinism test.** New `tests/integration/render_determinism.rs` copies `tests/fixtures/render-determinism/` to a tempdir, runs `agent-runtime render` via `std::process::Command`, deletes `.render-cache.json`, runs it again, and walks `build/<product>/` with sorted traversal asserting byte equality. Runs for both `codex` and `claude` products. Gate verified to actually fire by temporarily injecting a `HashMap` use into `manifest.rs` — clippy errored with the expected reason — then reverted.
- **2.3 — sanctioned time + contract doc.** New `render::time::source_commit_timestamp(source_root)` shells out to `git -C <root> log -1 --format=%cI HEAD` (3 unit tests covering happy path, stability across calls, non-git-repo error). New `docs/determinism.md` documents the 3 rules and the single sanctioned wall-clock escape hatch.

Test counts: lib 54 → 57 (3 new for `render::time`), integration 8 → 10 (2 new cross-process determinism). `bash scripts/ci/nils-cli-checks-entrypoint.sh` exits 0.

Tracking issue: #401. Sprint 1 landed in #404 (commit d4104fa). Sprint 3 (audit-drift body) and Sprint 4 (release 0.13.0 + cross-repo floor) remain.

## Test plan

- [x] `cargo test -p agent-runtime-cli --lib` → 57 passed
- [x] `cargo test -p agent-runtime-cli --test integration` → 10 passed
- [x] `cargo clippy -p agent-runtime-cli -p nils-common --all-targets -- -D warnings` → clean
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh` → exit 0
- [x] Determinism gate live-fire: injecting `use std::collections::HashMap;` into `manifest.rs` errors with the disallowed-types reason; reverted.
