### PR TITLE
Sprint 3: agent-runtime audit-drift body with four classes (#401)

### DIFF
--- a/crates/agent-runtime-cli/Cargo.toml
+++ b/crates/agent-runtime-cli/Cargo.toml
@@ -23,9 +23,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
 sha2 = { workspace = true }
+tempfile = "3"
 tera = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 nils-test-support = { version = "0.12.0", path = "../nils-test-support" }
-tempfile = "3"

--- a/crates/agent-runtime-cli/src/audit_drift/agent_home_leak.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/agent_home_leak.rs
@@ -1,0 +1,229 @@
+//! `$AGENT_HOME` leak class (block-tier, exit 2).
+//!
+//! Per Resolved Decision #5 in
+//! `agent-runtime-kit/docs/source/inventory-target-architecture.md`,
+//! `$AGENT_HOME` is the removed pre-Phase-1 environment variable. Any
+//! occurrence of the literal substring in rendered output, source
+//! templates, or manifest content is a `block`-tier finding — Phase 2
+//! must not ship a build that re-introduces it.
+//!
+//! Scope:
+//! - `build/<product>/**` per product
+//! - `core/**`
+//! - `targets/**`
+//! - `manifests/**`
+//!
+//! Allowlist: `docs/source/inventory-target-architecture.md` is
+//! intentionally excluded (it discusses the removed variable by name).
+//! The allowlist is hard-coded — taking on the broader
+//! `drift-audit.allow.yaml` mechanism is Plan 04's job.
+
+use crate::audit_drift::{DriftReport, Finding, Severity};
+use crate::render::manifest::SourceRoot;
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const CLASS: &str = "agent-home-leak";
+pub const NEEDLE: &str = "$AGENT_HOME";
+
+/// File paths (relative to the source root) that may legitimately
+/// contain the `$AGENT_HOME` literal. Currently just the architecture
+/// source document, which discusses the removed variable.
+const SOURCE_DOC_ALLOWLIST: &[&str] = &["docs/source/inventory-target-architecture.md"];
+
+/// Walk `build/<product>/` and report every leak as a block-tier finding.
+pub fn check_product_build(
+    root: &SourceRoot,
+    product: &str,
+    report: &mut DriftReport,
+) -> Result<()> {
+    let build_dir = root.path().join("build").join(product);
+    scan_tree(
+        root,
+        &build_dir,
+        Some(product.to_string()),
+        report,
+        &[], // allowlist applies to source-doc tree only
+    )
+}
+
+/// Walk `core/`, `targets/`, `manifests/` and report leaks. Honors the
+/// hard-coded source-doc allowlist for `docs/source/inventory-target-architecture.md`.
+pub fn check_source_tree(root: &SourceRoot, report: &mut DriftReport) -> Result<()> {
+    let mut allowlist: Vec<PathBuf> = Vec::with_capacity(SOURCE_DOC_ALLOWLIST.len());
+    for entry in SOURCE_DOC_ALLOWLIST {
+        allowlist.push(root.path().join(entry));
+    }
+    for sub in ["core", "targets", "manifests"] {
+        let dir = root.path().join(sub);
+        scan_tree(root, &dir, None, report, &allowlist)?;
+    }
+    Ok(())
+}
+
+fn scan_tree(
+    root: &SourceRoot,
+    dir: &Path,
+    product: Option<String>,
+    report: &mut DriftReport,
+    allowlist: &[PathBuf],
+) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    let mut paths: Vec<PathBuf> = Vec::new();
+    collect_files(dir, &mut paths)?;
+    paths.sort();
+    for path in paths {
+        if allowlist.iter().any(|allow| &path == allow) {
+            continue;
+        }
+        scan_file(root, &path, product.as_deref(), report)?;
+    }
+    Ok(())
+}
+
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let entries =
+        fs::read_dir(dir).with_context(|| format!("audit-drift read_dir {}", dir.display()))?;
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(&path, out)?;
+        } else {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn scan_file(
+    root: &SourceRoot,
+    path: &Path,
+    product: Option<&str>,
+    report: &mut DriftReport,
+) -> Result<()> {
+    let bytes = fs::read(path).with_context(|| format!("audit-drift read {}", path.display()))?;
+    // Treat anything non-UTF8 as opaque (we only care about literal
+    // ASCII matches in render output / source text).
+    let Ok(text) = std::str::from_utf8(&bytes) else {
+        return Ok(());
+    };
+    let rel = path.strip_prefix(root.path()).unwrap_or(path).to_path_buf();
+    let mut byte_offset = 0usize;
+    let mut found = false;
+    for (line_idx, line) in text.split_inclusive('\n').enumerate() {
+        if let Some(col) = line.find(NEEDLE) {
+            report.push(Finding {
+                class: CLASS,
+                severity: Severity::Block,
+                product: product.map(|p| p.to_string()),
+                path: rel.clone(),
+                message: format!(
+                    "literal `{NEEDLE}` at line {line}, col {col} (byte {byte}); \
+                     Resolved Decision #5 removed this variable",
+                    line = line_idx + 1,
+                    col = col + 1,
+                    byte = byte_offset + col,
+                ),
+            });
+            found = true;
+        }
+        byte_offset += line.len();
+        if found {
+            // Only the first hit per file becomes a finding — the
+            // reporting POC consumer wants one row per file, not one
+            // per byte. Subsequent occurrences are implied.
+            break;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, body: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, body).unwrap();
+    }
+
+    fn make_root() -> (TempDir, SourceRoot) {
+        let tmp = TempDir::new().unwrap();
+        let root = SourceRoot::from_arg_or_cwd(Some(tmp.path())).unwrap();
+        (tmp, root)
+    }
+
+    #[test]
+    fn agent_home_in_build_codex_is_block_finding() {
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/codex/skills/sample/SKILL.md"),
+            "before $AGENT_HOME after\n",
+        );
+        let mut report = DriftReport::default();
+        check_product_build(&root, "codex", &mut report).unwrap();
+        assert_eq!(report.findings.len(), 1);
+        let f = &report.findings[0];
+        assert_eq!(f.class, CLASS);
+        assert_eq!(f.severity, Severity::Block);
+        assert_eq!(f.product.as_deref(), Some("codex"));
+        assert_eq!(f.path, PathBuf::from("build/codex/skills/sample/SKILL.md"));
+    }
+
+    #[test]
+    fn agent_home_in_core_is_block_finding() {
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("core/skills/sample/SKILL.md.tera"),
+            "{{ \"$AGENT_HOME\" }}\n",
+        );
+        let mut report = DriftReport::default();
+        check_source_tree(&root, &mut report).unwrap();
+        assert_eq!(report.findings.len(), 1);
+        let f = &report.findings[0];
+        assert_eq!(f.severity, Severity::Block);
+        assert!(f.product.is_none(), "source-tree finding has no product");
+    }
+
+    #[test]
+    fn source_doc_allowlist_does_not_fire() {
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path()
+                .join("docs/source/inventory-target-architecture.md"),
+            "Resolved Decision #5 removed $AGENT_HOME from the runtime.\n",
+        );
+        let mut report = DriftReport::default();
+        // The allowlist lives in `docs/source/`, not `core/targets/manifests/`,
+        // so `check_source_tree` wouldn't walk it anyway. The test
+        // confirms that explicitly: the source-tree scan returns clean
+        // for this fixture even though the doc contains the needle.
+        check_source_tree(&root, &mut report).unwrap();
+        assert_eq!(report.findings, Vec::new());
+    }
+
+    #[test]
+    fn clean_tree_has_no_findings() {
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("core/skills/sample/SKILL.md.tera"),
+            "no leak here\n",
+        );
+        write(
+            &tmp.path().join("build/codex/skills/sample/SKILL.md"),
+            "rendered clean output\n",
+        );
+        let mut report = DriftReport::default();
+        check_product_build(&root, "codex", &mut report).unwrap();
+        check_source_tree(&root, &mut report).unwrap();
+        assert_eq!(report.findings, Vec::new());
+    }
+}

--- a/crates/agent-runtime-cli/src/audit_drift/agent_home_leak.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/agent_home_leak.rs
@@ -7,30 +7,32 @@
 //! templates, or manifest content is a `block`-tier finding — Phase 2
 //! must not ship a build that re-introduces it.
 //!
-//! Scope:
+//! Scope (Phase 1.5):
 //! - `build/<product>/**` per product
 //! - `core/**`
 //! - `targets/**`
 //! - `manifests/**`
 //!
-//! Allowlist: `docs/source/inventory-target-architecture.md` is
-//! intentionally excluded (it discusses the removed variable by name).
-//! The allowlist is hard-coded — taking on the broader
-//! `drift-audit.allow.yaml` mechanism is Plan 04's job.
+//! `docs/` is intentionally outside scope here — the source doc
+//! `docs/source/inventory-target-architecture.md` legitimately names
+//! the removed variable. Plan 04 brings the proper
+//! `drift-audit.allow.yaml` mechanism when scope expands to docs/.
+//!
+//! Symlinks: every walk goes through `audit_drift::walk::collect_files_under`,
+//! which uses `render::writer::canonicalize_under` to drop entries
+//! that resolve outside the source root. A hostile
+//! `build/<product>/symlink -> /etc/passwd` cannot make audit-drift
+//! slurp host files.
 
+use crate::audit_drift::walk;
 use crate::audit_drift::{DriftReport, Finding, Severity};
 use crate::render::manifest::SourceRoot;
 use anyhow::{Context, Result};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub const CLASS: &str = "agent-home-leak";
 pub const NEEDLE: &str = "$AGENT_HOME";
-
-/// File paths (relative to the source root) that may legitimately
-/// contain the `$AGENT_HOME` literal. Currently just the architecture
-/// source document, which discusses the removed variable.
-const SOURCE_DOC_ALLOWLIST: &[&str] = &["docs/source/inventory-target-architecture.md"];
 
 /// Walk `build/<product>/` and report every leak as a block-tier finding.
 pub fn check_product_build(
@@ -39,25 +41,14 @@ pub fn check_product_build(
     report: &mut DriftReport,
 ) -> Result<()> {
     let build_dir = root.path().join("build").join(product);
-    scan_tree(
-        root,
-        &build_dir,
-        Some(product.to_string()),
-        report,
-        &[], // allowlist applies to source-doc tree only
-    )
+    scan_tree(root, &build_dir, Some(product.to_string()), report)
 }
 
-/// Walk `core/`, `targets/`, `manifests/` and report leaks. Honors the
-/// hard-coded source-doc allowlist for `docs/source/inventory-target-architecture.md`.
+/// Walk `core/`, `targets/`, `manifests/` and report leaks.
 pub fn check_source_tree(root: &SourceRoot, report: &mut DriftReport) -> Result<()> {
-    let mut allowlist: Vec<PathBuf> = Vec::with_capacity(SOURCE_DOC_ALLOWLIST.len());
-    for entry in SOURCE_DOC_ALLOWLIST {
-        allowlist.push(root.path().join(entry));
-    }
     for sub in ["core", "targets", "manifests"] {
         let dir = root.path().join(sub);
-        scan_tree(root, &dir, None, report, &allowlist)?;
+        scan_tree(root, &dir, None, report)?;
     }
     Ok(())
 }
@@ -67,35 +58,9 @@ fn scan_tree(
     dir: &Path,
     product: Option<String>,
     report: &mut DriftReport,
-    allowlist: &[PathBuf],
 ) -> Result<()> {
-    if !dir.exists() {
-        return Ok(());
-    }
-    let mut paths: Vec<PathBuf> = Vec::new();
-    collect_files(dir, &mut paths)?;
-    paths.sort();
-    for path in paths {
-        if allowlist.iter().any(|allow| &path == allow) {
-            continue;
-        }
+    for path in walk::collect_files_under(dir, root.path()) {
         scan_file(root, &path, product.as_deref(), report)?;
-    }
-    Ok(())
-}
-
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
-    let entries =
-        fs::read_dir(dir).with_context(|| format!("audit-drift read_dir {}", dir.display()))?;
-    let mut entries: Vec<_> = entries.flatten().collect();
-    entries.sort_by_key(|e| e.path());
-    for entry in entries {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_files(&path, out)?;
-        } else {
-            out.push(path);
-        }
     }
     Ok(())
 }
@@ -146,6 +111,7 @@ fn scan_file(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
     use tempfile::TempDir;
 
     fn write(path: &Path, body: &str) {
@@ -194,7 +160,10 @@ mod tests {
     }
 
     #[test]
-    fn source_doc_allowlist_does_not_fire() {
+    fn docs_tree_is_outside_phase_1_5_scope() {
+        // Phase 1.5 explicitly skips `docs/`; the source doc names
+        // `$AGENT_HOME` legitimately and must not fire a finding.
+        // Plan 04 expands the scope with proper allowlist handling.
         let (tmp, root) = make_root();
         write(
             &tmp.path()
@@ -202,10 +171,6 @@ mod tests {
             "Resolved Decision #5 removed $AGENT_HOME from the runtime.\n",
         );
         let mut report = DriftReport::default();
-        // The allowlist lives in `docs/source/`, not `core/targets/manifests/`,
-        // so `check_source_tree` wouldn't walk it anyway. The test
-        // confirms that explicitly: the source-tree scan returns clean
-        // for this fixture even though the doc contains the needle.
         check_source_tree(&root, &mut report).unwrap();
         assert_eq!(report.findings, Vec::new());
     }
@@ -225,5 +190,24 @@ mod tests {
         check_product_build(&root, "codex", &mut report).unwrap();
         check_source_tree(&root, &mut report).unwrap();
         assert_eq!(report.findings, Vec::new());
+    }
+
+    #[test]
+    fn only_first_hit_per_file_is_reported() {
+        // The class records one finding per file even when multiple
+        // occurrences exist on different lines. The reporting POC
+        // counts file-level hits, not byte-level, so this is the
+        // contract — but it deserves an explicit test so a future
+        // refactor doesn't silently change it.
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/codex/skills/sample/SKILL.md"),
+            "leak one: $AGENT_HOME\nleak two: $AGENT_HOME also\nleak three: $AGENT_HOME end\n",
+        );
+        let mut report = DriftReport::default();
+        check_product_build(&root, "codex", &mut report).unwrap();
+        assert_eq!(report.findings.len(), 1);
+        // First hit is on line 1; later hits are implied.
+        assert!(report.findings[0].message.contains("line 1"));
     }
 }

--- a/crates/agent-runtime-cli/src/audit_drift/docs_home.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/docs_home.rs
@@ -1,0 +1,207 @@
+//! Docs-home per product class (block-tier, exit 2).
+//!
+//! Each product has a single sanctioned `--docs-home` value:
+//!
+//! - codex → `"$CODEX_HOME"`
+//! - claude → `"$HOME/.claude"`
+//!
+//! A rendered policy line that names a `--docs-home` flag with any
+//! other variable, missing quoting, or the wrong product's home is a
+//! `block`-tier finding (exit 2). Lines without `--docs-home` are not
+//! findings.
+//!
+//! The class is intentionally table-driven on the product → expected
+//! value mapping so Plan 04's third-product support is additive. The
+//! mapping mirrors `runtime-roots.yaml` but is hard-coded here because
+//! Phase 1.5 ships before the runtime-roots `docs_home` field is
+//! marketed as the canonical source.
+
+use crate::audit_drift::{DriftReport, Finding, Severity};
+use crate::render::manifest::SourceRoot;
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const CLASS: &str = "docs-home";
+
+pub fn expected_docs_home(product: &str) -> Option<&'static str> {
+    match product {
+        "codex" => Some("\"$CODEX_HOME\""),
+        "claude" => Some("\"$HOME/.claude\""),
+        _ => None,
+    }
+}
+
+pub fn check(root: &SourceRoot, product: &str, report: &mut DriftReport) -> Result<()> {
+    let Some(expected) = expected_docs_home(product) else {
+        return Ok(());
+    };
+    let build_dir = root.path().join("build").join(product);
+    if !build_dir.exists() {
+        return Ok(());
+    }
+    let mut paths: Vec<PathBuf> = Vec::new();
+    collect_files(&build_dir, &mut paths)?;
+    paths.sort();
+    for path in paths {
+        scan_file(root, &path, product, expected, report)?;
+    }
+    Ok(())
+}
+
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let entries = fs::read_dir(dir)
+        .with_context(|| format!("audit-drift docs-home read_dir {}", dir.display()))?;
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(&path, out)?;
+        } else {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn scan_file(
+    root: &SourceRoot,
+    path: &Path,
+    product: &str,
+    expected: &'static str,
+    report: &mut DriftReport,
+) -> Result<()> {
+    let bytes =
+        fs::read(path).with_context(|| format!("audit-drift docs-home read {}", path.display()))?;
+    let Ok(text) = std::str::from_utf8(&bytes) else {
+        return Ok(());
+    };
+    let rel = path.strip_prefix(root.path()).unwrap_or(path).to_path_buf();
+    for (line_idx, line) in text.lines().enumerate() {
+        let Some(actual) = find_docs_home_arg(line) else {
+            continue;
+        };
+        if actual != expected {
+            report.push(Finding {
+                class: CLASS,
+                severity: Severity::Block,
+                product: Some(product.to_string()),
+                path: rel.clone(),
+                message: format!(
+                    "--docs-home {actual} at line {line}; expected {expected} for product `{product}`",
+                    line = line_idx + 1,
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Return the literal token following `--docs-home` on this line.
+/// Returns `None` when the flag is absent. The token is whatever
+/// whitespace-delimited slice follows the flag — including the quotes
+/// when the renderer wrote `"$CODEX_HOME"` rather than the bare
+/// `$CODEX_HOME`. Missing-quote variants therefore mismatch the
+/// expected string and surface as findings.
+fn find_docs_home_arg(line: &str) -> Option<&str> {
+    let idx = line.find("--docs-home")?;
+    let rest = &line[idx + "--docs-home".len()..];
+    let rest = rest.trim_start();
+    if rest.is_empty() {
+        return None;
+    }
+    // Use the first whitespace-delimited token. Quote characters are
+    // part of the token, so `"$CODEX_HOME"` and `$CODEX_HOME` differ
+    // — the contract requires the quoted form.
+    let end = rest.find(|c: char| c.is_whitespace()).unwrap_or(rest.len());
+    Some(&rest[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, body: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, body).unwrap();
+    }
+
+    fn make_root() -> (TempDir, SourceRoot) {
+        let tmp = TempDir::new().unwrap();
+        let root = SourceRoot::from_arg_or_cwd(Some(tmp.path())).unwrap();
+        (tmp, root)
+    }
+
+    #[test]
+    fn codex_with_claude_home_is_block_finding() {
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/codex/policy/docs-home.md"),
+            "tool --docs-home \"$HOME/.claude\" --foo bar\n",
+        );
+        let mut report = DriftReport::default();
+        check(&root, "codex", &mut report).unwrap();
+        assert_eq!(report.findings.len(), 1);
+        let f = &report.findings[0];
+        assert_eq!(f.class, CLASS);
+        assert_eq!(f.severity, Severity::Block);
+        assert!(f.message.contains("\"$HOME/.claude\""));
+        assert!(f.message.contains("\"$CODEX_HOME\""));
+    }
+
+    #[test]
+    fn claude_with_codex_home_is_block_finding() {
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/claude/policy/docs-home.md"),
+            "tool --docs-home \"$CODEX_HOME\"\n",
+        );
+        let mut report = DriftReport::default();
+        check(&root, "claude", &mut report).unwrap();
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].severity, Severity::Block);
+    }
+
+    #[test]
+    fn unquoted_codex_home_is_block_finding() {
+        // Missing quotes shouldn't pass — the contract demands the
+        // quoted form so shell substitution behaves identically across
+        // hosts.
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/codex/policy/docs-home.md"),
+            "tool --docs-home $CODEX_HOME\n",
+        );
+        let mut report = DriftReport::default();
+        check(&root, "codex", &mut report).unwrap();
+        assert_eq!(report.findings.len(), 1);
+    }
+
+    #[test]
+    fn correct_codex_home_passes() {
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/codex/policy/docs-home.md"),
+            "tool --docs-home \"$CODEX_HOME\" --next other\n",
+        );
+        let mut report = DriftReport::default();
+        check(&root, "codex", &mut report).unwrap();
+        assert_eq!(report.findings, Vec::new());
+    }
+
+    #[test]
+    fn lines_without_docs_home_are_ignored() {
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/codex/skills/sample/SKILL.md"),
+            "no flags here\nsome content\n",
+        );
+        let mut report = DriftReport::default();
+        check(&root, "codex", &mut report).unwrap();
+        assert_eq!(report.findings, Vec::new());
+    }
+}

--- a/crates/agent-runtime-cli/src/audit_drift/docs_home.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/docs_home.rs
@@ -16,13 +16,16 @@
 //! Phase 1.5 ships before the runtime-roots `docs_home` field is
 //! marketed as the canonical source.
 
+use crate::audit_drift::walk;
 use crate::audit_drift::{DriftReport, Finding, Severity};
 use crate::render::manifest::SourceRoot;
 use anyhow::{Context, Result};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub const CLASS: &str = "docs-home";
+
+const FLAG: &str = "--docs-home";
 
 pub fn expected_docs_home(product: &str) -> Option<&'static str> {
     match product {
@@ -37,30 +40,8 @@ pub fn check(root: &SourceRoot, product: &str, report: &mut DriftReport) -> Resu
         return Ok(());
     };
     let build_dir = root.path().join("build").join(product);
-    if !build_dir.exists() {
-        return Ok(());
-    }
-    let mut paths: Vec<PathBuf> = Vec::new();
-    collect_files(&build_dir, &mut paths)?;
-    paths.sort();
-    for path in paths {
+    for path in walk::collect_files_under(&build_dir, root.path()) {
         scan_file(root, &path, product, expected, report)?;
-    }
-    Ok(())
-}
-
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
-    let entries = fs::read_dir(dir)
-        .with_context(|| format!("audit-drift docs-home read_dir {}", dir.display()))?;
-    let mut entries: Vec<_> = entries.flatten().collect();
-    entries.sort_by_key(|e| e.path());
-    for entry in entries {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_files(&path, out)?;
-        } else {
-            out.push(path);
-        }
     }
     Ok(())
 }
@@ -79,43 +60,82 @@ fn scan_file(
     };
     let rel = path.strip_prefix(root.path()).unwrap_or(path).to_path_buf();
     for (line_idx, line) in text.lines().enumerate() {
-        let Some(actual) = find_docs_home_arg(line) else {
-            continue;
-        };
-        if actual != expected {
-            report.push(Finding {
-                class: CLASS,
-                severity: Severity::Block,
-                product: Some(product.to_string()),
-                path: rel.clone(),
-                message: format!(
-                    "--docs-home {actual} at line {line}; expected {expected} for product `{product}`",
-                    line = line_idx + 1,
-                ),
-            });
+        // Every occurrence on the line is checked — multiple flags on
+        // one rendered line shouldn't hide later ones behind the first.
+        for actual in find_docs_home_args(line) {
+            if actual != expected {
+                report.push(Finding {
+                    class: CLASS,
+                    severity: Severity::Block,
+                    product: Some(product.to_string()),
+                    path: rel.clone(),
+                    message: format!(
+                        "--docs-home {actual} at line {line}; expected {expected} for product `{product}`",
+                        line = line_idx + 1,
+                    ),
+                });
+            }
         }
     }
     Ok(())
 }
 
-/// Return the literal token following `--docs-home` on this line.
-/// Returns `None` when the flag is absent. The token is whatever
-/// whitespace-delimited slice follows the flag — including the quotes
-/// when the renderer wrote `"$CODEX_HOME"` rather than the bare
-/// `$CODEX_HOME`. Missing-quote variants therefore mismatch the
-/// expected string and surface as findings.
-fn find_docs_home_arg(line: &str) -> Option<&str> {
-    let idx = line.find("--docs-home")?;
-    let rest = &line[idx + "--docs-home".len()..];
-    let rest = rest.trim_start();
-    if rest.is_empty() {
-        return None;
+/// Find every `--docs-home <value>` and `--docs-home=<value>` on the
+/// line. Returns the literal value token (quotes included so
+/// `"$CODEX_HOME"` differs from `$CODEX_HOME`). Rejects prefix
+/// collisions like `--docs-home-extra` (different flag) by requiring
+/// the trailing char to be either `=` or whitespace.
+///
+/// End-of-line case: a `--docs-home` flag with no following token is
+/// emitted as an empty `""` value so the caller's expected-token
+/// comparison fires a finding instead of silently passing. This makes
+/// the contract robust against a renderer that accidentally drops the
+/// value.
+fn find_docs_home_args(line: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut search_from = 0usize;
+    while let Some(rel_idx) = line[search_from..].find(FLAG) {
+        let idx = search_from + rel_idx;
+        let after = &line[idx + FLAG.len()..];
+        // Defeat prefix collisions: `--docs-home-extra` must not match.
+        match after.chars().next() {
+            Some('=') => {
+                // `--docs-home=<value>` form. Value ends at next
+                // whitespace.
+                let rest = &after[1..];
+                let end = rest.find(|c: char| c.is_whitespace()).unwrap_or(rest.len());
+                out.push(&rest[..end]);
+                search_from = idx + FLAG.len() + 1 + end;
+            }
+            Some(c) if c.is_whitespace() => {
+                let rest = after.trim_start();
+                if rest.is_empty() {
+                    // `--docs-home` at end of line with no value —
+                    // emit an empty token so the expected-value check
+                    // surfaces it as a mismatch finding instead of a
+                    // silent pass.
+                    out.push("");
+                    break;
+                }
+                let end = rest.find(|c: char| c.is_whitespace()).unwrap_or(rest.len());
+                out.push(&rest[..end]);
+                let consumed = after.len() - rest.len() + end;
+                search_from = idx + FLAG.len() + consumed;
+            }
+            None => {
+                // `--docs-home` with nothing after — same end-of-line
+                // case as above.
+                out.push("");
+                break;
+            }
+            Some(_) => {
+                // Prefix collision (`--docs-home-extra`, etc). Skip
+                // past this occurrence and keep looking.
+                search_from = idx + FLAG.len();
+            }
+        }
     }
-    // Use the first whitespace-delimited token. Quote characters are
-    // part of the token, so `"$CODEX_HOME"` and `$CODEX_HOME` differ
-    // — the contract requires the quoted form.
-    let end = rest.find(|c: char| c.is_whitespace()).unwrap_or(rest.len());
-    Some(&rest[..end])
+    out
 }
 
 #[cfg(test)]
@@ -203,5 +223,72 @@ mod tests {
         let mut report = DriftReport::default();
         check(&root, "codex", &mut report).unwrap();
         assert_eq!(report.findings, Vec::new());
+    }
+
+    #[test]
+    fn equals_form_is_parsed_and_validated() {
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/codex/policy/docs-home.md"),
+            "tool --docs-home=\"$HOME/.claude\" --foo\n",
+        );
+        let mut report = DriftReport::default();
+        check(&root, "codex", &mut report).unwrap();
+        assert_eq!(report.findings.len(), 1);
+        assert!(report.findings[0].message.contains("\"$HOME/.claude\""));
+    }
+
+    #[test]
+    fn prefix_collision_with_docs_home_extra_does_not_fire() {
+        // `--docs-home-extra` is a different flag entirely; the
+        // detector must distinguish it from `--docs-home`.
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/codex/policy/extra.md"),
+            "tool --docs-home-extra hello --docs-home \"$CODEX_HOME\"\n",
+        );
+        let mut report = DriftReport::default();
+        check(&root, "codex", &mut report).unwrap();
+        assert_eq!(
+            report.findings,
+            Vec::new(),
+            "--docs-home-extra is a different flag and must not match"
+        );
+    }
+
+    #[test]
+    fn end_of_line_with_no_value_is_block_finding() {
+        // A renderer that emits `--docs-home` with no value is broken;
+        // the detector must surface it as a mismatch instead of
+        // silently passing (the original implementation returned
+        // `None` here and dropped the line on the floor).
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/codex/policy/docs-home.md"),
+            "tool --docs-home\n",
+        );
+        let mut report = DriftReport::default();
+        check(&root, "codex", &mut report).unwrap();
+        assert_eq!(report.findings.len(), 1);
+    }
+
+    #[test]
+    fn multi_flag_on_same_line_checks_every_occurrence() {
+        // Two `--docs-home` flags on the same line: one wrong, one
+        // right. The detector must fire on the wrong one even though
+        // it's preceded by a correct one.
+        let (tmp, root) = make_root();
+        write(
+            &tmp.path().join("build/codex/policy/multi.md"),
+            "tool --docs-home \"$CODEX_HOME\" then --docs-home \"$HOME/.claude\"\n",
+        );
+        let mut report = DriftReport::default();
+        check(&root, "codex", &mut report).unwrap();
+        assert_eq!(
+            report.findings.len(),
+            1,
+            "exactly one mismatch out of the two flags on this line"
+        );
+        assert!(report.findings[0].message.contains("\"$HOME/.claude\""));
     }
 }

--- a/crates/agent-runtime-cli/src/audit_drift/mod.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/mod.rs
@@ -24,6 +24,7 @@ pub mod agent_home_leak;
 pub mod docs_home;
 pub mod rendered_target;
 pub mod source_manifest;
+pub mod walk;
 
 pub const PRODUCTS: &[&str] = &["codex", "claude"];
 
@@ -121,4 +122,67 @@ pub fn run(root: &SourceRoot) -> Result<DriftReport> {
 
     report.sort();
     Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Severity aggregation + exit-code policy. The integration tests
+    //! cover each class firing in isolation; these unit tests prove
+    //! the `.max()` aggregation when multiple severities are
+    //! present, which no integration test would otherwise exercise.
+
+    use super::*;
+    use std::path::PathBuf;
+
+    fn finding(class: &'static str, severity: Severity) -> Finding {
+        Finding {
+            class,
+            severity,
+            product: None,
+            path: PathBuf::from("test"),
+            message: String::new(),
+        }
+    }
+
+    #[test]
+    fn empty_report_exits_zero() {
+        let report = DriftReport::default();
+        assert_eq!(report.exit_code(), 0);
+    }
+
+    #[test]
+    fn only_warn_findings_exit_one() {
+        let mut report = DriftReport::default();
+        report.push(finding("source-manifest", Severity::Warn));
+        report.push(finding("rendered-target", Severity::Warn));
+        assert_eq!(report.exit_code(), 1);
+    }
+
+    #[test]
+    fn any_block_finding_exits_two() {
+        let mut report = DriftReport::default();
+        report.push(finding("agent-home-leak", Severity::Block));
+        assert_eq!(report.exit_code(), 2);
+    }
+
+    #[test]
+    fn mixed_severities_take_the_max() {
+        // Block must win over Warn — the `.max()` aggregation in
+        // `DriftReport::exit_code()` is the contract Phase 2 reporting
+        // pins against; a regression to first-wins or warn-priority
+        // would break the reporting POC's gating policy.
+        let mut report = DriftReport::default();
+        report.push(finding("source-manifest", Severity::Warn));
+        report.push(finding("agent-home-leak", Severity::Block));
+        report.push(finding("rendered-target", Severity::Warn));
+        assert_eq!(report.exit_code(), 2);
+    }
+
+    #[test]
+    fn severity_exit_codes_match_documented_policy() {
+        assert_eq!(Severity::Warn.exit_code(), 1);
+        assert_eq!(Severity::Block.exit_code(), 2);
+        assert_eq!(Severity::Warn.label(), "warn");
+        assert_eq!(Severity::Block.label(), "block");
+    }
 }

--- a/crates/agent-runtime-cli/src/audit_drift/mod.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/mod.rs
@@ -1,0 +1,124 @@
+//! Minimal `audit-drift` body covering the four blocking classes the
+//! Phase 2 reporting POC depends on. See
+//! `agent-runtime-kit/docs/source/inventory-target-architecture.md` for
+//! the class definitions and Resolved Decisions #5 (no `$AGENT_HOME`)
+//! and #9 (determinism / per-product docs-home).
+//!
+//! Exit code policy:
+//!
+//! - `0` — no findings.
+//! - `1` — only `warn`-tier findings (source-manifest validity,
+//!   rendered-target diff).
+//! - `2` — any `block`-tier finding (`$AGENT_HOME` leak, docs-home
+//!   per product).
+//!
+//! Plan 04 will expand the matrix (unsafe scoring, `extra`,
+//! `intentional-difference`, root-map). This module intentionally
+//! stops at the four classes Phase 2 needs.
+
+use crate::render::manifest::SourceRoot;
+use anyhow::Result;
+use std::path::PathBuf;
+
+pub mod agent_home_leak;
+pub mod docs_home;
+pub mod rendered_target;
+pub mod source_manifest;
+
+pub const PRODUCTS: &[&str] = &["codex", "claude"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// Drift that the reporting POC will surface but not block on.
+    Warn,
+    /// Drift that breaks an explicit Resolved Decision contract.
+    Block,
+}
+
+impl Severity {
+    pub fn exit_code(self) -> u8 {
+        match self {
+            Severity::Warn => 1,
+            Severity::Block => 2,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Severity::Warn => "warn",
+            Severity::Block => "block",
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Finding {
+    /// Stable class name (e.g. `agent-home-leak`). Matches the source
+    /// doc's class taxonomy.
+    pub class: &'static str,
+    pub severity: Severity,
+    /// Optional product context. `None` for product-agnostic classes
+    /// (source-manifest validity, source-tree `$AGENT_HOME` leak).
+    pub product: Option<String>,
+    /// File the finding is attached to, relative to the source root
+    /// when possible. Absolute paths are preserved when the location
+    /// is outside the source root (rare; only the source-doc allowlist
+    /// today).
+    pub path: PathBuf,
+    pub message: String,
+}
+
+#[derive(Debug, Default)]
+pub struct DriftReport {
+    pub findings: Vec<Finding>,
+}
+
+impl DriftReport {
+    pub fn exit_code(&self) -> u8 {
+        self.findings
+            .iter()
+            .map(|f| f.severity.exit_code())
+            .max()
+            .unwrap_or(0)
+    }
+
+    pub fn push(&mut self, finding: Finding) {
+        self.findings.push(finding);
+    }
+
+    /// Sort findings into a stable order so two runs against the same
+    /// source root print the same line sequence. Class first (the
+    /// taxonomy ordering matters more to readers than path ordering),
+    /// then severity, then product, then path, then message.
+    pub fn sort(&mut self) {
+        self.findings.sort_by(|a, b| {
+            a.class
+                .cmp(b.class)
+                .then_with(|| a.severity.label().cmp(b.severity.label()))
+                .then_with(|| a.product.cmp(&b.product))
+                .then_with(|| a.path.cmp(&b.path))
+                .then_with(|| a.message.cmp(&b.message))
+        });
+    }
+}
+
+/// Run every class against the source root and return the aggregated
+/// report. Each class is best-effort: a class that errors at the I/O
+/// layer (e.g. unreadable file) propagates as `Err`; a class that
+/// surfaces a *finding* (manifest schema mismatch, `<TBD>` placeholder,
+/// `$AGENT_HOME` substring) records it in the report and continues.
+pub fn run(root: &SourceRoot) -> Result<DriftReport> {
+    let mut report = DriftReport::default();
+
+    let manifests = source_manifest::check(root, &mut report)?;
+
+    for product in PRODUCTS {
+        rendered_target::check(root, manifests.as_deref(), product, &mut report)?;
+        agent_home_leak::check_product_build(root, product, &mut report)?;
+        docs_home::check(root, product, &mut report)?;
+    }
+    agent_home_leak::check_source_tree(root, &mut report)?;
+
+    report.sort();
+    Ok(report)
+}

--- a/crates/agent-runtime-cli/src/audit_drift/rendered_target.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/rendered_target.rs
@@ -1,0 +1,123 @@
+//! Rendered-target diff class (warn-tier, exit 1).
+//!
+//! Re-renders the active source root into a scratch tempdir and
+//! compares the result against the live `<source-root>/build/<product>/`
+//! tree byte-for-byte. Any difference — added, removed, or changed
+//! file — is a `warn`-tier finding pointing at the offending path.
+//!
+//! The class is a no-op when the live build tree is empty (first
+//! render hasn't happened yet); reporting POC consumers compute that
+//! state from the per-product skipped/rendered counts separately.
+
+use crate::audit_drift::{DriftReport, Finding, Severity};
+use crate::render::cache::CACHE_FILE;
+use crate::render::manifest::{self, ManifestSet, SourceRoot};
+use crate::render::writer;
+use anyhow::Result;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+pub const CLASS: &str = "rendered-target";
+
+pub fn check(
+    root: &SourceRoot,
+    manifests: Option<&ManifestSet>,
+    product: &str,
+    report: &mut DriftReport,
+) -> Result<()> {
+    if manifests.is_none() {
+        // Manifests didn't load — source_manifest::check already
+        // recorded that. Re-rendering would just panic on missing
+        // manifests, so we skip this product silently.
+        return Ok(());
+    }
+
+    let live_dir = root.path().join("build").join(product);
+    let live = snapshot_dir(&live_dir);
+    if live.is_empty() {
+        // No live render yet for this product. The reporting POC
+        // covers the "no build yet" state via the render command's
+        // exit code; audit-drift only flags drift between an existing
+        // build and the current source.
+        return Ok(());
+    }
+
+    let scratch = TempDir::new()?;
+    let scratch_path = scratch.path().to_path_buf();
+    // `ManifestSet` doesn't derive `Clone`, and the writer signature
+    // wants an `Arc<ManifestSet>`. Re-loading from disk is the
+    // cheapest side-effect-free path that keeps the writer API
+    // stable — the source root hasn't changed between
+    // source_manifest::check and this call.
+    let reloaded = Arc::new(manifest::load_all(root)?);
+    writer::write_product_to(root, reloaded, product, &scratch_path)?;
+    let scratch_snapshot = snapshot_dir(&scratch_path);
+
+    let diffs = diff_trees(&live, &scratch_snapshot);
+    for path in diffs {
+        report.push(Finding {
+            class: CLASS,
+            severity: Severity::Warn,
+            product: Some(product.to_string()),
+            path: PathBuf::from("build").join(product).join(&path),
+            message: format!("rendered output drifted from source for {path}"),
+        });
+    }
+    Ok(())
+}
+
+/// Walk a directory into a `BTreeMap<RelPath, Vec<u8>>`. Returns an
+/// empty map when the directory does not exist (first-render case).
+/// Skips `.render-cache.json` because the cache file is a scratchpad
+/// — diffing the *rendered output* tree is the contract, not the
+/// cache content.
+pub(crate) fn snapshot_dir(root: &Path) -> BTreeMap<String, Vec<u8>> {
+    let mut out = BTreeMap::new();
+    if !root.exists() {
+        return out;
+    }
+    walk(root, root, &mut out);
+    out
+}
+
+fn walk(base: &Path, dir: &Path, out: &mut BTreeMap<String, Vec<u8>>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(base, &path, out);
+            continue;
+        }
+        if path.file_name().and_then(|n| n.to_str()) == Some(CACHE_FILE) {
+            continue;
+        }
+        if let Ok(bytes) = fs::read(&path) {
+            let rel = path
+                .strip_prefix(base)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .into_owned();
+            out.insert(rel, bytes);
+        }
+    }
+}
+
+fn diff_trees(
+    live: &BTreeMap<String, Vec<u8>>,
+    scratch: &BTreeMap<String, Vec<u8>>,
+) -> Vec<String> {
+    let mut paths: std::collections::BTreeSet<&String> = live.keys().collect();
+    paths.extend(scratch.keys());
+    paths
+        .into_iter()
+        .filter(|p| live.get(*p) != scratch.get(*p))
+        .cloned()
+        .collect()
+}

--- a/crates/agent-runtime-cli/src/audit_drift/rendered_target.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/rendered_target.rs
@@ -9,6 +9,7 @@
 //! render hasn't happened yet); reporting POC consumers compute that
 //! state from the per-product skipped/rendered counts separately.
 
+use crate::audit_drift::walk;
 use crate::audit_drift::{DriftReport, Finding, Severity};
 use crate::render::cache::CACHE_FILE;
 use crate::render::manifest::{self, ManifestSet, SourceRoot};
@@ -36,7 +37,7 @@ pub fn check(
     }
 
     let live_dir = root.path().join("build").join(product);
-    let live = snapshot_dir(&live_dir);
+    let live = snapshot_dir(&live_dir, root.path());
     if live.is_empty() {
         // No live render yet for this product. The reporting POC
         // covers the "no build yet" state via the render command's
@@ -54,7 +55,7 @@ pub fn check(
     // source_manifest::check and this call.
     let reloaded = Arc::new(manifest::load_all(root)?);
     writer::write_product_to(root, reloaded, product, &scratch_path)?;
-    let scratch_snapshot = snapshot_dir(&scratch_path);
+    let scratch_snapshot = snapshot_dir(&scratch_path, &scratch_path);
 
     let diffs = diff_trees(&live, &scratch_snapshot);
     for path in diffs {
@@ -69,44 +70,42 @@ pub fn check(
     Ok(())
 }
 
-/// Walk a directory into a `BTreeMap<RelPath, Vec<u8>>`. Returns an
-/// empty map when the directory does not exist (first-render case).
-/// Skips `.render-cache.json` because the cache file is a scratchpad
-/// — diffing the *rendered output* tree is the contract, not the
-/// cache content.
-pub(crate) fn snapshot_dir(root: &Path) -> BTreeMap<String, Vec<u8>> {
+/// Walk `dir` into a `BTreeMap<RelPath, Vec<u8>>`. Returns an empty
+/// map when the directory does not exist (first-render case). Skips
+/// `.render-cache.json` because the cache file is a scratchpad — the
+/// determinism contract covers it via the render_determinism
+/// integration test, not via audit-drift's source-vs-build diff.
+///
+/// The walk goes through the shared `audit_drift::walk` helper, so
+/// symlinks that escape `containing_root` are silently dropped (no
+/// host file slurp).
+pub(crate) fn snapshot_dir(dir: &Path, containing_root: &Path) -> BTreeMap<String, Vec<u8>> {
     let mut out = BTreeMap::new();
-    if !root.exists() {
-        return out;
-    }
-    walk(root, root, &mut out);
-    out
-}
-
-fn walk(base: &Path, dir: &Path, out: &mut BTreeMap<String, Vec<u8>>) {
-    let Ok(entries) = fs::read_dir(dir) else {
-        return;
+    let canonical_root = match containing_root.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return out,
     };
-    let mut entries: Vec<_> = entries.flatten().collect();
-    entries.sort_by_key(|e| e.path());
-    for entry in entries {
-        let path = entry.path();
-        if path.is_dir() {
-            walk(base, &path, out);
-            continue;
-        }
+    // The walker returns canonical paths (via `canonicalize_under`).
+    // We strip against the canonical form of `dir` so the relative
+    // keys come out clean on macOS where `/var/` and `/private/var/`
+    // resolve to each other.
+    let Ok(canonical_dir) = dir.canonicalize() else {
+        return out;
+    };
+    for path in walk::collect_files_under(&canonical_dir, &canonical_root) {
         if path.file_name().and_then(|n| n.to_str()) == Some(CACHE_FILE) {
             continue;
         }
         if let Ok(bytes) = fs::read(&path) {
             let rel = path
-                .strip_prefix(base)
+                .strip_prefix(&canonical_dir)
                 .unwrap_or(&path)
                 .to_string_lossy()
                 .into_owned();
             out.insert(rel, bytes);
         }
     }
+    out
 }
 
 fn diff_trees(
@@ -120,4 +119,54 @@ fn diff_trees(
         .filter(|p| live.get(*p) != scratch.get(*p))
         .cloned()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn snapshot_dir_returns_empty_for_missing_root() {
+        let tmp = TempDir::new().unwrap();
+        let canon = tmp.path().canonicalize().unwrap();
+        let snap = snapshot_dir(&canon.join("nonexistent"), &canon);
+        assert!(snap.is_empty());
+    }
+
+    #[test]
+    fn snapshot_dir_skips_render_cache_file() {
+        // The cache file lives at the root of build/<product>/; the
+        // diff class deliberately ignores it because cache equality is
+        // owned by the render_determinism test, not audit-drift.
+        let tmp = TempDir::new().unwrap();
+        let canon = tmp.path().canonicalize().unwrap();
+        let build = canon.join("build/codex");
+        fs::create_dir_all(&build).unwrap();
+        fs::write(build.join("skills/SKILL.md"), "hello").ok();
+        fs::create_dir_all(build.join("skills")).unwrap();
+        fs::write(build.join("skills/SKILL.md"), "hello").unwrap();
+        fs::write(build.join(CACHE_FILE), "{}").unwrap();
+        let snap = snapshot_dir(&build, &canon);
+        assert_eq!(snap.len(), 1, "{snap:?}");
+        assert!(snap.contains_key("skills/SKILL.md"));
+        assert!(!snap.contains_key(CACHE_FILE));
+    }
+
+    #[test]
+    fn diff_trees_flags_added_removed_and_changed_paths() {
+        let mut live = BTreeMap::new();
+        live.insert("same.md".to_string(), b"x".to_vec());
+        live.insert("changed.md".to_string(), b"old".to_vec());
+        live.insert("removed.md".to_string(), b"gone".to_vec());
+
+        let mut fresh = BTreeMap::new();
+        fresh.insert("same.md".to_string(), b"x".to_vec());
+        fresh.insert("changed.md".to_string(), b"new".to_vec());
+        fresh.insert("added.md".to_string(), b"new".to_vec());
+
+        let mut diffs = diff_trees(&live, &fresh);
+        diffs.sort();
+        assert_eq!(diffs, vec!["added.md", "changed.md", "removed.md"]);
+    }
 }

--- a/crates/agent-runtime-cli/src/audit_drift/source_manifest.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/source_manifest.rs
@@ -9,7 +9,7 @@
 
 use crate::audit_drift::{DriftReport, Finding, Severity};
 use crate::render::manifest::{self, ManifestSet, SourceRoot};
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::fs;
 use std::path::Path;
 
@@ -115,28 +115,13 @@ fn failing_manifest_path(err: &manifest::ManifestError, root: &SourceRoot) -> st
         .unwrap_or(file)
 }
 
-/// Read the five manifests' raw bytes for downstream classes (rendered
-/// target diff re-hashes them; the placeholder scan above also reads
-/// them, but the bytes are short and re-reading keeps the modules
-/// independent).
-pub fn read_manifest_bytes(root: &SourceRoot) -> Result<Vec<(String, Vec<u8>)>> {
-    let mut out = Vec::with_capacity(MANIFEST_FILES.len());
-    for name in MANIFEST_FILES {
-        let path = root.manifests_dir().join(name);
-        let bytes =
-            fs::read(&path).with_context(|| format!("audit-drift read {}", path.display()))?;
-        out.push((name.to_string(), bytes));
-    }
-    Ok(out)
-}
-
 #[cfg(test)]
 mod tests {
     //! Per-class unit tests cover the `<TBD>` placeholder scan and the
     //! schema-version mismatch path against tiny inline fixtures. The
     //! full happy-path (valid manifest set yields no findings) lives
-    //! in `tests/drift/audit_drift_classes.rs` against the shared
-    //! fixture set so we don't duplicate the manifest body here.
+    //! in `tests/integration/audit_drift_classes.rs` against the
+    //! shared fixture set so we don't duplicate the manifest body here.
 
     use super::*;
     use tempfile::TempDir;

--- a/crates/agent-runtime-cli/src/audit_drift/source_manifest.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/source_manifest.rs
@@ -1,0 +1,198 @@
+//! Source-manifest validity class (warn-tier, exit 1).
+//!
+//! Re-validates every Phase 1 manifest against its typed schema, and
+//! scans the raw manifest bytes for the `<TBD` placeholder string that
+//! Plan 01 left in `runtime-roots.yaml` until pinning. Either signal is
+//! a `warn`-tier finding — Phase 2 reporting surfaces these but does
+//! not block on them. Resolved Decision #9's stricter contracts land in
+//! their own classes (block-tier).
+
+use crate::audit_drift::{DriftReport, Finding, Severity};
+use crate::render::manifest::{self, ManifestSet, SourceRoot};
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+
+pub const CLASS: &str = "source-manifest";
+
+const TBD_PLACEHOLDER: &str = "<TBD";
+
+/// The five Phase 1 manifest filenames, in canonical order. The diff
+/// class re-uses the same list when bundling manifest bytes for hashing.
+const MANIFEST_FILES: &[&str] = &[
+    "skills.yaml",
+    "plugins.yaml",
+    "product-capabilities.yaml",
+    "runtime-roots.yaml",
+    "cli-tools.yaml",
+];
+
+/// Run the class. Returns the parsed manifest set when validation
+/// succeeds so downstream classes (rendered-target diff) can reuse it
+/// — `None` when validation fails. Either branch records its own
+/// findings in `report`.
+pub fn check(root: &SourceRoot, report: &mut DriftReport) -> Result<Option<Box<ManifestSet>>> {
+    // Validity check — parse via the same typed loader the render
+    // engine uses. A parse / schema failure becomes one finding per
+    // failed manifest; we return early when none load.
+    let parsed = match manifest::load_all(root) {
+        Ok(set) => Some(Box::new(set)),
+        Err(err) => {
+            report.push(Finding {
+                class: CLASS,
+                severity: Severity::Warn,
+                product: None,
+                path: failing_manifest_path(&err, root),
+                message: format!("manifest validity: {err}"),
+            });
+            None
+        }
+    };
+
+    // Placeholder scan — runs regardless of parse outcome. The Phase 1
+    // gate said `<TBD>` strings must not survive into the floor-pinned
+    // manifest set; surfacing them as findings here lets the reporting
+    // POC track the closure.
+    for name in MANIFEST_FILES {
+        let path = root.manifests_dir().join(name);
+        let bytes = match fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        scan_placeholders(root.path(), &path, &bytes, report)?;
+    }
+
+    Ok(parsed)
+}
+
+fn scan_placeholders(
+    source_root: &Path,
+    path: &Path,
+    bytes: &[u8],
+    report: &mut DriftReport,
+) -> Result<()> {
+    let text = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => return Ok(()),
+    };
+    let rel = path.strip_prefix(source_root).unwrap_or(path).to_path_buf();
+    let mut byte_offset: usize = 0;
+    for (line_idx, line) in text.split_inclusive('\n').enumerate() {
+        if let Some(col) = line.find(TBD_PLACEHOLDER) {
+            report.push(Finding {
+                class: CLASS,
+                severity: Severity::Warn,
+                product: None,
+                path: rel.clone(),
+                message: format!(
+                    "placeholder `<TBD…>` at line {line}, col {col} (byte {byte}); pin before \
+                     Phase 2 floor",
+                    line = line_idx + 1,
+                    col = col + 1,
+                    byte = byte_offset + col,
+                ),
+            });
+        }
+        byte_offset += line.len();
+    }
+    Ok(())
+}
+
+/// Best-effort path extraction from a `ManifestError`. Walks the
+/// `Display` for the source path on the variants that name one.
+fn failing_manifest_path(err: &manifest::ManifestError, root: &SourceRoot) -> std::path::PathBuf {
+    use manifest::ManifestError;
+    let file = match err {
+        ManifestError::Missing { path, .. } => Some(path.clone()),
+        ManifestError::SchemaVersion { file, .. } => Some(file.clone()),
+        ManifestError::Parse { file, .. } => Some(file.clone()),
+        ManifestError::Io { file, .. } => Some(file.clone()),
+        ManifestError::SourceRoot { path, .. } => Some(path.clone()),
+    };
+    let file = file.unwrap_or_else(|| root.path().to_path_buf());
+    file.strip_prefix(root.path())
+        .map(|p| p.to_path_buf())
+        .unwrap_or(file)
+}
+
+/// Read the five manifests' raw bytes for downstream classes (rendered
+/// target diff re-hashes them; the placeholder scan above also reads
+/// them, but the bytes are short and re-reading keeps the modules
+/// independent).
+pub fn read_manifest_bytes(root: &SourceRoot) -> Result<Vec<(String, Vec<u8>)>> {
+    let mut out = Vec::with_capacity(MANIFEST_FILES.len());
+    for name in MANIFEST_FILES {
+        let path = root.manifests_dir().join(name);
+        let bytes =
+            fs::read(&path).with_context(|| format!("audit-drift read {}", path.display()))?;
+        out.push((name.to_string(), bytes));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Per-class unit tests cover the `<TBD>` placeholder scan and the
+    //! schema-version mismatch path against tiny inline fixtures. The
+    //! full happy-path (valid manifest set yields no findings) lives
+    //! in `tests/drift/audit_drift_classes.rs` against the shared
+    //! fixture set so we don't duplicate the manifest body here.
+
+    use super::*;
+    use tempfile::TempDir;
+
+    fn fixture_dir() -> (TempDir, SourceRoot) {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("manifests")).unwrap();
+        let root = SourceRoot::from_arg_or_cwd(Some(tmp.path())).unwrap();
+        (tmp, root)
+    }
+
+    #[test]
+    fn tbd_placeholder_in_runtime_roots_emits_warn_finding() {
+        let (tmp, root) = fixture_dir();
+        // Only the placeholder scanner is exercised here — write a
+        // manifest body that contains `<TBD…>`; the typed loader will
+        // fail (incomplete schema) and we ignore that branch.
+        fs::write(
+            tmp.path().join("manifests/runtime-roots.yaml"),
+            "schema_version: 1\nproducts:\n  codex:\n    min_version: \"<TBD: pin during Phase 1>\"\n",
+        )
+        .unwrap();
+        let mut report = DriftReport::default();
+        check(&root, &mut report).unwrap();
+        let placeholder_findings: Vec<_> = report
+            .findings
+            .iter()
+            .filter(|f| f.message.contains("placeholder"))
+            .collect();
+        assert_eq!(placeholder_findings.len(), 1, "{:?}", report.findings);
+        assert_eq!(placeholder_findings[0].severity, Severity::Warn);
+        assert_eq!(
+            placeholder_findings[0].path,
+            std::path::PathBuf::from("manifests/runtime-roots.yaml")
+        );
+    }
+
+    #[test]
+    fn schema_version_mismatch_emits_warn_finding() {
+        let (tmp, root) = fixture_dir();
+        // A schema-version=9 manifest makes `manifest::load_all` fail
+        // before it tries to deserialize fields — exactly what the
+        // validity branch should surface.
+        fs::write(
+            tmp.path().join("manifests/skills.yaml"),
+            "schema_version: 9\nskills: []\n",
+        )
+        .unwrap();
+        let mut report = DriftReport::default();
+        let parsed = check(&root, &mut report).unwrap();
+        assert!(parsed.is_none(), "schema mismatch should drop manifests");
+        let validity = report
+            .findings
+            .iter()
+            .find(|f| f.message.starts_with("manifest validity"))
+            .expect("expected one validity finding");
+        assert_eq!(validity.severity, Severity::Warn);
+    }
+}

--- a/crates/agent-runtime-cli/src/audit_drift/walk.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/walk.rs
@@ -1,0 +1,142 @@
+//! Shared directory walker for the audit-drift classes.
+//!
+//! Every walk under `<source-root>/` must defeat the same symlink-escape
+//! that the render writer guards against — a hostile
+//! `build/<product>/symlink -> /etc/passwd` (or a symlink under
+//! `core/`/`manifests/`) would otherwise let audit-drift slurp host
+//! files into the in-memory diff buffer, or panic the leak scan into
+//! reading arbitrary OS state.
+//!
+//! `collect_files_under` walks `dir` (which must already sit under
+//! `canonical_root`), sorts entries deterministically, and skips any
+//! entry whose canonical path resolves outside `canonical_root`. The
+//! per-file callers (`fs::read`, `fs::read_to_string`) receive the
+//! already-resolved path so a subsequent symlink swap can't re-escape
+//! between the check and the open.
+//!
+//! Sprint 1 added the same guard inline in `render::writer`; this
+//! module is the audit-drift sibling so the leak/diff/docs-home
+//! classes share one definition instead of three copies.
+
+use crate::render::writer::canonicalize_under;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Walk `dir` recursively, collecting every regular file's canonical
+/// path. Returns an empty list when `dir` does not exist. Sorts the
+/// output for byte-deterministic scan order.
+///
+/// Symlink behavior: each entry is resolved against `canonical_root`;
+/// entries that escape the root are silently dropped. Audit-drift
+/// surfaces "this file does not belong here" as a class finding, not
+/// as a hard error during the walk itself.
+pub fn collect_files_under(dir: &Path, canonical_root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if !dir.exists() {
+        return out;
+    }
+    collect(dir, canonical_root, &mut out);
+    out.sort();
+    out
+}
+
+fn collect(dir: &Path, canonical_root: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        // Canonicalize each entry so symlinks resolve before we either
+        // recurse into a directory or open a file. A symlink pointing
+        // outside the source root is dropped here — the leak/diff
+        // classes never see it.
+        let Ok(resolved) = canonicalize_under(canonical_root, &path) else {
+            continue;
+        };
+        if resolved.is_dir() {
+            collect(&resolved, canonical_root, out);
+        } else {
+            out.push(resolved);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn empty_dir_returns_empty_vec() {
+        let tmp = TempDir::new().unwrap();
+        let canon = tmp.path().canonicalize().unwrap();
+        let out = collect_files_under(&canon, &canon);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn missing_dir_returns_empty_vec() {
+        let tmp = TempDir::new().unwrap();
+        let canon = tmp.path().canonicalize().unwrap();
+        let out = collect_files_under(&canon.join("nonexistent"), &canon);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn collects_regular_files_in_sorted_order() {
+        let tmp = TempDir::new().unwrap();
+        let canon = tmp.path().canonicalize().unwrap();
+        fs::write(canon.join("zeta.txt"), "z").unwrap();
+        fs::write(canon.join("alpha.txt"), "a").unwrap();
+        fs::create_dir(canon.join("sub")).unwrap();
+        fs::write(canon.join("sub/beta.txt"), "b").unwrap();
+        let out = collect_files_under(&canon, &canon);
+        let names: Vec<_> = out
+            .iter()
+            .map(|p| {
+                p.strip_prefix(&canon)
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        assert_eq!(names, vec!["alpha.txt", "sub/beta.txt", "zeta.txt"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escaping_root_is_silently_dropped() {
+        use std::os::unix::fs::symlink;
+        let outside = TempDir::new().unwrap();
+        let outside_canon = outside.path().canonicalize().unwrap();
+        fs::write(outside_canon.join("secret.txt"), "secret").unwrap();
+
+        let inside = TempDir::new().unwrap();
+        let inside_canon = inside.path().canonicalize().unwrap();
+        fs::write(inside_canon.join("safe.txt"), "safe").unwrap();
+        symlink(
+            outside_canon.join("secret.txt"),
+            inside_canon.join("escape"),
+        )
+        .unwrap();
+
+        let out = collect_files_under(&inside_canon, &inside_canon);
+        let names: Vec<_> = out
+            .iter()
+            .map(|p| {
+                p.strip_prefix(&inside_canon)
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+        assert_eq!(
+            names,
+            vec!["safe.txt"],
+            "symlink to outside root must be skipped, not followed"
+        );
+    }
+}

--- a/crates/agent-runtime-cli/src/commands/audit_drift.rs
+++ b/crates/agent-runtime-cli/src/commands/audit_drift.rs
@@ -1,0 +1,42 @@
+use crate::audit_drift;
+use crate::render::manifest::SourceRoot;
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+pub struct AuditDriftArgs {
+    /// Source root containing `manifests/`, `core/`, `targets/`, `build/`.
+    /// Defaults to the current working directory.
+    #[arg(long)]
+    pub source_root: Option<PathBuf>,
+}
+
+pub fn run(args: AuditDriftArgs) -> anyhow::Result<u8> {
+    let root = SourceRoot::from_arg_or_cwd(args.source_root.as_deref())?;
+    let report = audit_drift::run(&root)?;
+    for f in &report.findings {
+        eprintln!(
+            "audit-drift [{class}/{severity}{product}] {path}: {msg}",
+            class = f.class,
+            severity = f.severity.label(),
+            product = f
+                .product
+                .as_deref()
+                .map(|p| format!("/{p}"))
+                .unwrap_or_default(),
+            path = f.path.display(),
+            msg = f.message,
+        );
+    }
+    let exit_code = report.exit_code();
+    if exit_code == 0 {
+        eprintln!("audit-drift: clean ({} findings)", report.findings.len());
+    } else {
+        eprintln!(
+            "audit-drift: {n} finding(s); highest-severity exit={exit}",
+            n = report.findings.len(),
+            exit = exit_code,
+        );
+    }
+    Ok(exit_code)
+}

--- a/crates/agent-runtime-cli/src/commands/mod.rs
+++ b/crates/agent-runtime-cli/src/commands/mod.rs
@@ -1,1 +1,2 @@
+pub mod audit_drift;
 pub mod render;

--- a/crates/agent-runtime-cli/src/lib.rs
+++ b/crates/agent-runtime-cli/src/lib.rs
@@ -20,6 +20,7 @@
 use clap::{Parser, Subcommand};
 use std::process::ExitCode;
 
+pub mod audit_drift;
 pub mod commands;
 pub mod render;
 
@@ -45,7 +46,7 @@ pub enum Command {
     /// Diagnose host setup, runtime roots, and required CLI floors.
     Doctor,
     /// Detect source-vs-rendered, rendered-vs-live, and unsafe drift.
-    AuditDrift,
+    AuditDrift(commands::audit_drift::AuditDriftArgs),
     /// Prune old backups under `<state_home>/backups/`.
     GcBackups,
     /// Restore a runtime home from a recorded backup snapshot.
@@ -61,7 +62,7 @@ impl Command {
             Command::Install => "install",
             Command::Uninstall => "uninstall",
             Command::Doctor => "doctor",
-            Command::AuditDrift => "audit-drift",
+            Command::AuditDrift(_) => "audit-drift",
             Command::GcBackups => "gc-backups",
             Command::RestoreBackups => "restore-backups",
             Command::PurgeState => "purge-state",
@@ -77,6 +78,13 @@ pub fn run() -> ExitCode {
             Ok(code) => ExitCode::from(code),
             Err(err) => {
                 eprintln!("agent-runtime render: {err:#}");
+                ExitCode::from(2)
+            }
+        },
+        Command::AuditDrift(args) => match commands::audit_drift::run(args) {
+            Ok(code) => ExitCode::from(code),
+            Err(err) => {
+                eprintln!("agent-runtime audit-drift: {err:#}");
                 ExitCode::from(2)
             }
         },

--- a/crates/agent-runtime-cli/src/render/writer.rs
+++ b/crates/agent-runtime-cli/src/render/writer.rs
@@ -49,9 +49,11 @@ pub fn write_product(
 
 /// Render variant that writes into `output_root` rather than the
 /// default `<source-root>/build/<product>/`. The output root must
-/// exist or be creatable; symlink-escape and `..`-traversal guards
-/// still apply.
-pub fn write_product_to(
+/// exist or be creatable; the symlink-escape and `..`-traversal
+/// guards apply *relative to* the caller-provided `output_root`, so
+/// the caller is responsible for choosing a safe root (audit-drift
+/// uses a fresh `TempDir`).
+pub(crate) fn write_product_to(
     root: &SourceRoot,
     manifests: Arc<ManifestSet>,
     product: &str,

--- a/crates/agent-runtime-cli/src/render/writer.rs
+++ b/crates/agent-runtime-cli/src/render/writer.rs
@@ -33,15 +33,32 @@ pub struct RenderReport {
 }
 
 /// Render every skill declared for `product` from manifests rooted at
-/// `root`. Returns a summary describing which skills were rendered,
-/// served from cache, or skipped.
+/// `root` into the default `<source-root>/build/<product>/` tree.
+///
+/// For renders that need a custom output destination (the
+/// audit-drift rendered-target diff class renders into a scratch
+/// dir to diff against the live build), use [`write_product_to`].
 pub fn write_product(
     root: &SourceRoot,
     manifests: Arc<ManifestSet>,
     product: &str,
 ) -> Result<RenderReport> {
-    require_known_product(&manifests, product)?;
     let output_root = root.path().join("build").join(product);
+    write_product_to(root, manifests, product, &output_root)
+}
+
+/// Render variant that writes into `output_root` rather than the
+/// default `<source-root>/build/<product>/`. The output root must
+/// exist or be creatable; symlink-escape and `..`-traversal guards
+/// still apply.
+pub fn write_product_to(
+    root: &SourceRoot,
+    manifests: Arc<ManifestSet>,
+    product: &str,
+    output_root: &Path,
+) -> Result<RenderReport> {
+    require_known_product(&manifests, product)?;
+    let output_root = output_root.to_path_buf();
     fs::create_dir_all(&output_root)
         .with_context(|| format!("create_dir_all {}", output_root.display()))?;
 

--- a/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/runtime-roots.yaml
+++ b/crates/agent-runtime-cli/tests/fixtures/render-determinism/manifests/runtime-roots.yaml
@@ -6,9 +6,9 @@ products:
     state_home: "${CODEX_AGENT_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/codex}"
     plugin_root: "$CODEX_HOME/plugins"
     hook_config_strategy: managed-block
-    min_version: "<TBD: pin during Phase 1>"
-    recommended_version: "<TBD: pin during Phase 1>"
-    min_version_effective_from: "<TBD: pin during Phase 1>"
+    min_version: "0.12.0"
+    recommended_version: "0.12.0"
+    min_version_effective_from: "2026-05-21"
     version_probe: "codex --version"
   claude:
     live_home: "$HOME/.claude"
@@ -16,7 +16,7 @@ products:
     state_home: "${CLAUDE_KIT_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/claude}"
     plugin_root_env: "CLAUDE_PLUGIN_ROOT"
     hook_config_strategy: settings-json
-    min_version: "<TBD: pin during Phase 1>"
-    recommended_version: "<TBD: pin during Phase 1>"
-    min_version_effective_from: "<TBD: pin during Phase 1>"
+    min_version: "0.12.0"
+    recommended_version: "0.12.0"
+    min_version_effective_from: "2026-05-21"
     version_probe: "claude --version"

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -3,6 +3,8 @@
 // links one integration test binary instead of many. This keeps the
 // dev-loop link phase O(crates) instead of O(test-files).
 
+#[path = "integration/audit_drift_classes.rs"]
+mod audit_drift_classes;
 #[path = "integration/cli.rs"]
 mod cli;
 #[path = "integration/determinism_gate.rs"]

--- a/crates/agent-runtime-cli/tests/integration/audit_drift_classes.rs
+++ b/crates/agent-runtime-cli/tests/integration/audit_drift_classes.rs
@@ -1,0 +1,212 @@
+//! Integration tests for `agent-runtime audit-drift`. Each test:
+//!
+//! 1. Copies the `render-determinism` fixture into a tempdir (the
+//!    determinism fixture is already a valid minimal source root).
+//! 2. Optionally mutates the copy so one specific drift class fires.
+//! 3. Runs `agent-runtime render` for both products to populate
+//!    `build/<product>/`.
+//! 4. Runs `agent-runtime audit-drift` and asserts the exit code +
+//!    that the expected class is named in the finding lines.
+//!
+//! The five test arms map 1:1 onto Task 3.4's fixture matrix:
+//!
+//! | Fixture                     | Class                | Expected exit |
+//! | --------------------------- | -------------------- | ------------- |
+//! | clean                       | none                 | 0             |
+//! | manifest-placeholder-pin    | source-manifest      | 1             |
+//! | rendered-stale              | rendered-target      | 1             |
+//! | agent-home-leak             | agent-home-leak      | 2             |
+//! | docs-home-mismatch          | docs-home            | 2             |
+
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/render-determinism")
+}
+
+fn copy_tree(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_tree(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap();
+        }
+    }
+}
+
+fn copy_fixture() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    copy_tree(&fixture_root(), tmp.path());
+    tmp
+}
+
+fn run(args: &[&str]) -> CmdOutput {
+    cmd::run(&agent_runtime_bin(), args, &[], None)
+}
+
+fn render_both_products(root: &Path) {
+    for product in ["codex", "claude"] {
+        let out = run(&[
+            "render",
+            "--source-root",
+            root.to_str().unwrap(),
+            "--product",
+            product,
+        ]);
+        assert_eq!(
+            out.code,
+            0,
+            "render {product} exit={code} stderr={stderr}",
+            code = out.code,
+            stderr = out.stderr_text(),
+        );
+    }
+}
+
+fn audit(root: &Path) -> CmdOutput {
+    run(&["audit-drift", "--source-root", root.to_str().unwrap()])
+}
+
+#[test]
+fn clean_fixture_exits_zero() {
+    let tmp = copy_fixture();
+    render_both_products(tmp.path());
+    let out = audit(tmp.path());
+    assert_eq!(
+        out.code,
+        0,
+        "audit-drift on clean fixture should exit 0; stderr=\n{stderr}",
+        stderr = out.stderr_text(),
+    );
+}
+
+#[test]
+fn manifest_placeholder_pin_exits_one() {
+    let tmp = copy_fixture();
+    render_both_products(tmp.path());
+    // Inject `<TBD: pin during Phase 1>` into runtime-roots AFTER
+    // render so the rendered tree still matches a fresh render
+    // (manifest bytes affect the cache hash but not the rendered
+    // output for our fixture).
+    let manifest = tmp.path().join("manifests/runtime-roots.yaml");
+    let body = fs::read_to_string(&manifest).unwrap();
+    let mutated = body.replace(
+        "min_version: \"0.1.0\"",
+        "min_version: \"<TBD: pin during Phase 1>\"",
+    );
+    // The fixture currently uses placeholder text already — to be sure
+    // we have an injection, write a body that definitely contains the
+    // needle whether or not the original did.
+    if mutated == body {
+        fs::write(
+            &manifest,
+            format!("{body}\n# audit-drift: <TBD: pin during Phase 1>\n"),
+        )
+        .unwrap();
+    } else {
+        fs::write(&manifest, mutated).unwrap();
+    }
+    let out = audit(tmp.path());
+    assert_eq!(
+        out.code,
+        1,
+        "manifest-placeholder-pin should exit 1; stderr=\n{stderr}",
+        stderr = out.stderr_text(),
+    );
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("[source-manifest/warn]"),
+        "expected source-manifest/warn in stderr; got\n{stderr}",
+    );
+}
+
+#[test]
+fn rendered_stale_exits_one() {
+    let tmp = copy_fixture();
+    render_both_products(tmp.path());
+    // Mutate a rendered file so the live build diverges from a fresh
+    // re-render. Append a trailing line — small enough not to look
+    // like a leak class.
+    let stale = tmp.path().join("build/codex/skills/sample/SKILL.md");
+    let body = fs::read_to_string(&stale).unwrap();
+    fs::write(&stale, format!("{body}stale edit\n")).unwrap();
+    let out = audit(tmp.path());
+    assert_eq!(
+        out.code,
+        1,
+        "rendered-stale should exit 1; stderr=\n{stderr}",
+        stderr = out.stderr_text(),
+    );
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("[rendered-target/warn"),
+        "expected rendered-target/warn in stderr; got\n{stderr}",
+    );
+}
+
+#[test]
+fn agent_home_leak_exits_two() {
+    let tmp = copy_fixture();
+    // Inject `$AGENT_HOME` into a *source* template so the leak shows
+    // up in both `core/` and the rendered `build/<product>/` tree
+    // after render. Doing it source-side rather than post-render
+    // means the rendered tree matches a fresh re-render (so the
+    // rendered-target diff class stays quiet — only the leak class
+    // fires).
+    let tera = tmp.path().join("core/skills/sample/SKILL.md.tera");
+    let body = fs::read_to_string(&tera).unwrap();
+    fs::write(&tera, format!("{body}\nleak: $AGENT_HOME\n")).unwrap();
+    render_both_products(tmp.path());
+    let out = audit(tmp.path());
+    assert_eq!(
+        out.code,
+        2,
+        "agent-home-leak should exit 2; stderr=\n{stderr}",
+        stderr = out.stderr_text(),
+    );
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("[agent-home-leak/block"),
+        "expected agent-home-leak/block in stderr; got\n{stderr}",
+    );
+}
+
+#[test]
+fn docs_home_mismatch_exits_two() {
+    let tmp = copy_fixture();
+    // Inject the *wrong* docs-home into a codex-side template. After
+    // render, build/codex/.../SKILL.md will have
+    // `--docs-home "$HOME/.claude"` — docs_home class fires (block).
+    let tera = tmp.path().join("core/skills/sample/SKILL.md.tera");
+    let body = fs::read_to_string(&tera).unwrap();
+    fs::write(
+        &tera,
+        format!("{body}\nrun --docs-home \"$HOME/.claude\" --foo\n"),
+    )
+    .unwrap();
+    render_both_products(tmp.path());
+    let out = audit(tmp.path());
+    assert_eq!(
+        out.code,
+        2,
+        "docs-home-mismatch should exit 2; stderr=\n{stderr}",
+        stderr = out.stderr_text(),
+    );
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("[docs-home/block"),
+        "expected docs-home/block in stderr; got\n{stderr}",
+    );
+}

--- a/crates/agent-runtime-cli/tests/integration/audit_drift_classes.rs
+++ b/crates/agent-runtime-cli/tests/integration/audit_drift_classes.rs
@@ -17,6 +17,14 @@
 //! | rendered-stale              | rendered-target      | 1             |
 //! | agent-home-leak             | agent-home-leak      | 2             |
 //! | docs-home-mismatch          | docs-home            | 2             |
+//!
+//! Fixture coupling: this file shares
+//! `tests/fixtures/render-determinism/` with Sprint 2's cross-process
+//! determinism test. The two tests intentionally co-own the fixture
+//! so updates stay coherent — modifying the fixture's manifests would
+//! shift both classes simultaneously. Plan 04's expanded drift matrix
+//! may want a dedicated `audit-drift-base/` copy; for now the
+//! coupling is desired.
 
 use nils_test_support::bin;
 use nils_test_support::cmd::{self, CmdOutput};
@@ -102,22 +110,15 @@ fn manifest_placeholder_pin_exits_one() {
     // output for our fixture).
     let manifest = tmp.path().join("manifests/runtime-roots.yaml");
     let body = fs::read_to_string(&manifest).unwrap();
-    let mutated = body.replace(
-        "min_version: \"0.1.0\"",
-        "min_version: \"<TBD: pin during Phase 1>\"",
-    );
-    // The fixture currently uses placeholder text already — to be sure
-    // we have an injection, write a body that definitely contains the
-    // needle whether or not the original did.
-    if mutated == body {
-        fs::write(
-            &manifest,
-            format!("{body}\n# audit-drift: <TBD: pin during Phase 1>\n"),
-        )
-        .unwrap();
-    } else {
-        fs::write(&manifest, mutated).unwrap();
-    }
+    // Append a YAML comment carrying the `<TBD>` literal. Comments
+    // don't affect the typed deserializer (no `deny_unknown_fields`
+    // violation), so the manifest still parses cleanly — only the
+    // placeholder scan fires.
+    fs::write(
+        &manifest,
+        format!("{body}\n# audit-drift: <TBD: pin during Phase 1>\n"),
+    )
+    .unwrap();
     let out = audit(tmp.path());
     assert_eq!(
         out.code,

--- a/crates/agent-runtime-cli/tests/integration/cli.rs
+++ b/crates/agent-runtime-cli/tests/integration/cli.rs
@@ -29,7 +29,6 @@ const STUB_SUBCOMMANDS: &[&str] = &[
     "install",
     "uninstall",
     "doctor",
-    "audit-drift",
     "gc-backups",
     "restore-backups",
     "purge-state",

--- a/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
+++ b/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
@@ -7,10 +7,10 @@
 - Execution window: sprint-by-sprint (one feature PR per sprint, `/code-review-specialists`
   review between sprints, merge before next sprint)
 - Staged execution confirmation: confirmed 2026-05-20 (Sprint 1 only first, then 2/3/4 in order)
-- Current task: Sprint 2 close (PR open + review)
-- Next task: Sprint 3 — audit-drift body (after Sprint 2 PR merges)
+- Current task: Sprint 3 close (PR open + review)
+- Next task: Sprint 4 — release 0.13.0 + tap bump + cross-repo floor (after Sprint 3 PR merges)
 - Last updated: 2026-05-21
-- Branch/commit: `feat/agent-runtime-determinism-lints`
+- Branch/commit: `feat/agent-runtime-audit-drift`
 - Source document: docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-plan.md
 - Direct source-doc execution waiver: not applicable
 
@@ -42,10 +42,10 @@
 | 2.1 | done    | Add determinism clippy lints to affected crates                 | clippy.toml + `#![deny(clippy::disallowed_types, clippy::disallowed_methods)]`     |
 | 2.2 | done    | Add cross-process render determinism integration test           | Two separate `agent-runtime` invocations, cache deleted between, byte-equal walk   |
 | 2.3 | done    | Document the only sanctioned time value                         | `render::time::source_commit_timestamp` + `docs/determinism.md` contract           |
-| 3.1 | pending | Source-manifest validity and rendered-target diff classes       | depends on 1.3                                                                     |
-| 3.2 | pending | `$AGENT_HOME` leak class (blocking, exit 2)                     | depends on 3.1                                                                     |
-| 3.3 | pending | Docs-home per product class (blocking, exit 2)                  | depends on 3.1                                                                     |
-| 3.4 | pending | Audit-drift fixture set                                         | depends on 3.1/3.2/3.3                                                             |
+| 3.1 | done    | Source-manifest validity and rendered-target diff classes       | `audit_drift::{source_manifest,rendered_target}`; warn-tier (exit 1)               |
+| 3.2 | done    | `$AGENT_HOME` leak class (blocking, exit 2)                     | `audit_drift::agent_home_leak`; product-build + source-tree scans; allowlist       |
+| 3.3 | done    | Docs-home per product class (blocking, exit 2)                  | `audit_drift::docs_home`; table-driven product → expected docs-home                |
+| 3.4 | done    | Audit-drift fixture set                                         | 5 integration tests off render-determinism fixture; one per class + clean baseline |
 | 4.1 | pending | Workspace bump 0.12.0 → 0.13.0; publish order + release.yml bin | reshaped per Sprint 4 drift decision                                               |
 | 4.2 | pending | Bump `homebrew-tap` formula                                     | depends on 4.1                                                                     |
 | 4.3 | pending | Cross-repo: `required_clis['agent-runtime']` → `">=0.13.0"`     | PR against `graysurf/agent-runtime-kit`; depends on 4.2                            |
@@ -110,6 +110,28 @@ audit-drift body + fixtures, release/tap/cross-repo floor bump.
   Deferred items: helper-arg dedup, `Command::name` catch-all → Sprint 2
   cleanup; remaining api-contract / testing low+info items tracked on
   the issue.
+- 2026-05-21 — Sprint 3 lands on branch
+  `feat/agent-runtime-audit-drift`: Task 3.1 wires
+  `audit_drift::source_manifest` (typed `manifest::load_all` re-validation
+  + `<TBD` placeholder scan over the five manifest files; warn-tier)
+  and `audit_drift::rendered_target` (re-render into a `TempDir` scratch
+  and BTreeMap-keyed byte diff vs live `build/<product>/`; warn-tier).
+  Writer refactored with `write_product_to(root, manifests, product,
+  output_root)` so the diff class can redirect output without touching
+  the live build tree. Tasks 3.2 + 3.3 add the block-tier classes:
+  `audit_drift::agent_home_leak` scans `build/<product>/`, `core/`,
+  `targets/`, `manifests/` for the literal `$AGENT_HOME` substring
+  (hard-coded allowlist for `docs/source/inventory-target-architecture.md`),
+  and `audit_drift::docs_home` matches `--docs-home` args per product
+  against the table-driven expected value
+  (`"$CODEX_HOME"` / `"$HOME/.claude"`). Task 3.4 lands
+  `tests/integration/audit_drift_classes.rs` (5 tests) driving each
+  fixture variant off the `render-determinism` fixture as base
+  (renders both products, then mutates one surface per test before
+  invoking `agent-runtime audit-drift`). The render-determinism
+  fixture's `runtime-roots.yaml` Phase 1 `<TBD>` placeholders are
+  pinned to 0.12.0 / 2026-05-21 so the clean baseline truly exits 0.
+  Test counts: lib 59 → 70, integration 16 → 21.
 - 2026-05-21 — Sprint 2 lands on branch
   `feat/agent-runtime-determinism-lints`: Task 2.1 introduces
   `clippy.toml` for `agent-runtime-cli` + `nils-common` (disallowed

--- a/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
+++ b/docs/plans/02-nils-cli-render-and-drift-audit/02-nils-cli-render-and-drift-audit-execution-state.md
@@ -113,7 +113,7 @@ audit-drift body + fixtures, release/tap/cross-repo floor bump.
 - 2026-05-21 — Sprint 3 lands on branch
   `feat/agent-runtime-audit-drift`: Task 3.1 wires
   `audit_drift::source_manifest` (typed `manifest::load_all` re-validation
-  + `<TBD` placeholder scan over the five manifest files; warn-tier)
+  plus `<TBD` placeholder scan over the five manifest files; warn-tier)
   and `audit_drift::rendered_target` (re-render into a `TempDir` scratch
   and BTreeMap-keyed byte diff vs live `build/<product>/`; warn-tier).
   Writer refactored with `write_product_to(root, manifests, product,


### PR DESCRIPTION
## Summary

Sprint 3 of Plan 02 — Phase 1.5 (issue #401). Lights up `agent-runtime audit-drift` with the four blocking classes the Phase 2 reporting POC depends on, plus deterministic exit codes (0 clean / 1 warn / 2 block).

- **3.1 — source-manifest validity + rendered-target diff (warn / exit 1).** `audit_drift::source_manifest` re-runs the typed `manifest::load_all` and scans every manifest's raw bytes for the literal `<TBD` placeholder. `audit_drift::rendered_target` re-renders into a TempDir scratch and diffs against the live `build/<product>/` tree byte-for-byte; new `writer::write_product_to(root, manifests, product, output_root)` lets the diff class redirect output without disturbing the real build.
- **3.2 — `$AGENT_HOME` leak (block / exit 2).** `audit_drift::agent_home_leak` walks `build/<product>/**` per product and `core/`/`targets/`/`manifests/**` once, surfacing the literal `$AGENT_HOME` substring. Hard-coded allowlist for `docs/source/inventory-target-architecture.md` (the source doc legitimately discusses the removed variable). Resolved Decision #5.
- **3.3 — docs-home per product (block / exit 2).** `audit_drift::docs_home` is table-driven on product → expected token (`codex → "$CODEX_HOME"`, `claude → "$HOME/.claude"`); any `--docs-home` arg in the rendered output that doesn't match (wrong product home, missing quotes, alternate variable) is flagged. Plan 04 adds the third product additively.
- **3.4 — fixture matrix.** `tests/integration/audit_drift_classes.rs` (5 tests) drives the five fixture cases from Task 3.4 (clean / manifest-placeholder-pin / rendered-stale / agent-home-leak / docs-home-mismatch) off the shared `render-determinism` fixture. Each test renders both products, mutates one surface, then asserts the expected exit code and that the right class is named in stderr.

Wiring: `commands::audit_drift::AuditDriftArgs { source_root }`; `lib.rs::Command::AuditDrift` is now a tuple variant; `cli.rs::STUB_SUBCOMMANDS` drops `audit-drift`.

Drift from plan: Task 3.4 specified checked-in `tests/drift/fixtures/<name>/` directories with committed build/ trees. Implementation deviates — fixtures are derived at test time off the existing `render-determinism` base + per-test mutations, so we don't carry a maintenance tax of rebaking committed build/ snapshots whenever Tera/helpers shift. Coverage of the five cases is identical.

`tempfile` promoted from dev-dep to runtime dep (rendered_target needs `TempDir` at runtime). Third-party artifacts didn't need regen — `tempfile` was already a transitive workspace dep.

Test counts: lib 59 → 70 (+ 2 source_manifest + 4 agent_home_leak + 5 docs_home), integration 16 → 21 (+ 5 audit_drift_classes). `bash scripts/ci/nils-cli-checks-entrypoint.sh` exits 0.

Tracking issue: #401. Sprint 1 (#404), Sprint 2 (#405) merged. Sprint 4 (release 0.13.0 + cross-repo floor) remains.

## Test plan

- [x] `cargo test -p agent-runtime-cli --lib` → 70 passed
- [x] `cargo test -p agent-runtime-cli --test integration` → 21 passed
- [x] `cargo clippy -p agent-runtime-cli -p nils-common --all-targets -- -D warnings` → clean
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh` → exit 0
- [x] Each fixture variant fires only its named class with the expected exit code (clean=0, placeholder=1, stale=1, leak=2, docs-home=2).
