### PR TITLE
Replace unmaintained serde_yml/libyml with serde_yaml_ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
  "nils-test-support",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "sha2 0.11.0",
  "tempfile",
  "tera",
@@ -1700,16 +1700,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -3497,18 +3487,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4197,6 +4185,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ indexmap = { version = "2", features = ["serde"] }
 pretty_assertions = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10"
 sha2 = "0.11"
 tera = "1"
 thiserror = "2"

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `d8530c845b68f74d56d8aa1a048af5c022ca416f917506f2dfe491718e4150a8`
+- Cargo.lock SHA256: `fcda8ef2b5cd0ce9de0926874ed0532571d2e15f1be4e46002a36cd83b32acd5`
 - Third-party crates (`source != null`): 465
 - Workspace crates (`source == null`, excluded below): 32
 
@@ -17,8 +17,8 @@ This file documents third-party Rust crate licenses used by this workspace.
 
 | License Expression | Crate Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 224 |
-| MIT | 86 |
+| MIT OR Apache-2.0 | 223 |
+| MIT | 87 |
 | Apache-2.0 OR MIT | 36 |
 | Zlib OR Apache-2.0 OR MIT | 19 |
 | Unicode-3.0 | 18 |
@@ -227,7 +227,6 @@ This file documents third-party Rust crate licenses used by this workspace.
 | libm | 0.2.16 | MIT | crates.io |
 | libredox | 0.1.16 | MIT | crates.io |
 | libsqlite3-sys | 0.37.0 | MIT | crates.io |
-| libyml | 0.0.5 | MIT | crates.io |
 | linux-raw-sys | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | crates.io |
 | litemap | 0.8.2 | Unicode-3.0 | crates.io |
 | log | 0.4.29 | MIT OR Apache-2.0 | crates.io |
@@ -353,7 +352,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | serde_repr | 0.1.20 | MIT OR Apache-2.0 | crates.io |
 | serde_spanned | 1.1.1 | MIT OR Apache-2.0 | crates.io |
 | serde_urlencoded | 0.7.1 | MIT/Apache-2.0 | crates.io |
-| serde_yml | 0.0.12 | MIT OR Apache-2.0 | crates.io |
+| serde_yaml_ng | 0.10.0 | MIT | crates.io |
 | sha1 | 0.10.6 | MIT OR Apache-2.0 | crates.io |
 | sha2 | 0.10.9 | MIT OR Apache-2.0 | crates.io |
 | sha2 | 0.11.0 | MIT OR Apache-2.0 | crates.io |
@@ -428,6 +427,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | unicode-width | 0.2.2 | MIT OR Apache-2.0 | crates.io |
 | unicode-xid | 0.2.6 | MIT OR Apache-2.0 | crates.io |
 | unit-prefix | 0.5.2 | MIT | crates.io |
+| unsafe-libyaml | 0.2.11 | MIT | crates.io |
 | untrusted | 0.9.0 | ISC | crates.io |
 | url | 2.5.8 | MIT OR Apache-2.0 | crates.io |
 | urlencoding | 2.1.3 | MIT | crates.io |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `d8530c845b68f74d56d8aa1a048af5c022ca416f917506f2dfe491718e4150a8`
+- Cargo.lock SHA256: `fcda8ef2b5cd0ce9de0926874ed0532571d2e15f1be4e46002a36cd83b32acd5`
 - Third-party crates (`source != null`): 465
 
 ## Notice Extraction Policy
@@ -1542,14 +1542,6 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - License file references:
   - `LICENSE`
 
-### libyml 0.0.5
-
-- License: `MIT`
-- Source: `crates.io`
-- Notice files: No explicit NOTICE file discovered.
-- License file references:
-  - `LICENSE-MIT`
-
 ### linux-raw-sys 0.12.1
 
 - License: `Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`
@@ -2620,14 +2612,13 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
 
-### serde_yml 0.0.12
+### serde_yaml_ng 0.10.0
 
-- License: `MIT OR Apache-2.0`
+- License: `MIT`
 - Source: `crates.io`
 - Notice files: No explicit NOTICE file discovered.
 - License file references:
-  - `LICENSE-APACHE`
-  - `LICENSE-MIT`
+  - `LICENSE`
 
 ### sha1 0.10.6
 
@@ -3269,6 +3260,14 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - Notice files: No explicit NOTICE file discovered.
 - License file references:
   - `LICENSE`
+
+### unsafe-libyaml 0.2.11
+
+- License: `MIT`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-MIT`
 
 ### untrusted 0.9.0
 

--- a/crates/agent-runtime-cli/Cargo.toml
+++ b/crates/agent-runtime-cli/Cargo.toml
@@ -21,7 +21,7 @@ clap = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yml = { workspace = true }
+serde_yaml_ng = { workspace = true }
 sha2 = { workspace = true }
 tempfile = "3"
 tera = { workspace = true }

--- a/crates/agent-runtime-cli/src/render/manifest.rs
+++ b/crates/agent-runtime-cli/src/render/manifest.rs
@@ -25,7 +25,7 @@ pub enum ManifestError {
     Parse {
         file: PathBuf,
         #[source]
-        source: serde_yml::Error,
+        source: serde_yaml_ng::Error,
     },
     #[error("io error reading {file}: {source}")]
     Io {
@@ -124,7 +124,7 @@ where
         file: file.to_path_buf(),
         source,
     })?;
-    let parsed: T = serde_yml::from_str(&raw).map_err(|source| ManifestError::Parse {
+    let parsed: T = serde_yaml_ng::from_str(&raw).map_err(|source| ManifestError::Parse {
         file: file.to_path_buf(),
         source,
     })?;
@@ -355,7 +355,7 @@ pub struct RuntimeRootsManifest {
     pub schema_version: u32,
     pub products: RuntimeRootsProducts,
     #[serde(default)]
-    pub host_profiles: IndexMap<String, IndexMap<String, serde_yml::Value>>,
+    pub host_profiles: IndexMap<String, IndexMap<String, serde_yaml_ng::Value>>,
 }
 
 impl WithSchemaVersion for RuntimeRootsManifest {
@@ -635,7 +635,7 @@ skills:
     required_clis:
       agent-runtime: ">=0.13.0"
 "#;
-        let parsed: SkillsManifest = serde_yml::from_str(yaml).unwrap();
+        let parsed: SkillsManifest = serde_yaml_ng::from_str(yaml).unwrap();
         let skill = parsed.skills.first().unwrap();
         assert_eq!(skill.state_out_mode, StateOutMode::Runtime);
         assert!(!skill.divergent);
@@ -652,7 +652,7 @@ plugins:
     product_manifests: {}
     install_policy: opt-in
 "#;
-        let parsed: PluginsManifest = serde_yml::from_str(yaml).unwrap();
+        let parsed: PluginsManifest = serde_yaml_ng::from_str(yaml).unwrap();
         assert_eq!(
             parsed.plugins.first().unwrap().install_policy,
             InstallPolicy::OptIn,
@@ -688,7 +688,7 @@ skills:
     required_clis:
       agent-runtime: ">=0.13.0"
 "#;
-        let err = serde_yml::from_str::<SkillsManifest>(yaml).unwrap_err();
+        let err = serde_yaml_ng::from_str::<SkillsManifest>(yaml).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("code"), "{msg}");
     }
@@ -707,7 +707,7 @@ skills:
     required_clis:
       agent-runtime: ">=0.13.0"
 "#;
-        let err = serde_yml::from_str::<SkillsManifest>(yaml).unwrap_err();
+        let err = serde_yaml_ng::from_str::<SkillsManifest>(yaml).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("products"), "{msg}");
     }
@@ -723,7 +723,7 @@ plugins:
     product_manifests:
       cluade: "targets/claude/.claude-plugin/plugin.json"
 "#;
-        let err = serde_yml::from_str::<PluginsManifest>(yaml).unwrap_err();
+        let err = serde_yaml_ng::from_str::<PluginsManifest>(yaml).unwrap_err();
         assert!(format!("{err}").contains("cluade"));
     }
 }


### PR DESCRIPTION
# Replace unmaintained serde_yml/libyml with serde_yaml_ng

## Summary

Resolves both open Dependabot alerts on `main` by swapping `agent-runtime-cli`'s YAML stack off the unmaintained `serde_yml` (which transitively pulls in the unsound `libyml`) and onto `serde_yaml_ng`, the actively maintained fork of `serde_yaml`. The replacement is API-compatible (`from_str`, `Value`, `Error`), so the change is a one-line crate swap plus regenerated `Cargo.lock` / `THIRD_PARTY_*` artifacts.

## Problem

The repository carried two open Dependabot security alerts on `main`, both of which are "unmaintained crate" advisories with **no upstream patch version**:

- [Alert #11 — High](https://github.com/sympoies/nils-cli/security/dependabot/11): `libyml` `>= 0.0.4, <= 0.0.5` — `yaml_string_extend` is unsound and the crate is unmaintained (`GHSA-gfxp-f68g-8x78`).
- [Alert #12 — Medium](https://github.com/sympoies/nils-cli/security/dependabot/12): `serde_yml` `<= 0.0.12` — crate is unsound and unmaintained (`GHSA-hhw4-xg65-fp2x`).

`serde_yml` is the only direct consumer (`agent-runtime-cli`), and it pulls `libyml` transitively, so both alerts share a single root cause.

## Reproduction

1. `gh api repos/sympoies/nils-cli/dependabot/alerts --jq '[.[] | select(.state == "open")]'`
2. `cargo tree -p agent-runtime-cli -i serde_yml`

Expected: zero open security alerts; YAML stack on a maintained crate with no open advisories.
Actual (before this PR): two open alerts; `agent-runtime-cli v0.12.0 -> serde_yml v0.0.12 -> libyml v0.0.5`.

## Issues Found

- Unmaintained, unsound transitive `libyml 0.0.5` — pre-fix `Cargo.lock` entry pulled in via `serde_yml`.
- Unmaintained, unsound direct dep `serde_yml 0.0.12` — pre-fix [Cargo.toml:53](Cargo.toml) and [crates/agent-runtime-cli/Cargo.toml:24](crates/agent-runtime-cli/Cargo.toml).

## Fix Approach

- Replace the workspace dep `serde_yml = "0.0.12"` with `serde_yaml_ng = "0.10"` (the actively maintained fork of `serde_yaml`; API-compatible drop-in for the surface we use: `from_str`, `Value`, `Error`).
- Update [crates/agent-runtime-cli/Cargo.toml](crates/agent-runtime-cli/Cargo.toml) to consume the new workspace dep.
- Rename every `serde_yml::*` reference in [crates/agent-runtime-cli/src/render/manifest.rs](crates/agent-runtime-cli/src/render/manifest.rs) to `serde_yaml_ng::*` (8 sites: `Error`, `from_str`, `Value`, plus 5 test call sites).
- Regenerate `Cargo.lock`, [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md), and [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) via `scripts/generate-third-party-artifacts.sh --write` so the deterministic artifacts contract stays satisfied.
- New transitive `unsafe-libyaml 0.2.11` was verified via GitHub Security Advisories API to have no open vulnerabilities (only a historic `< 0.2.10` issue, already patched).

## Test-First Evidence

- Change classification: `bug fix` (security: removes unmaintained / unsound deps flagged by Dependabot).
- Failing test before fix: N/A with waiver — the "failure" is the two open Dependabot advisories themselves (linked above); there is no in-repo test that can fail for an external advisory, and the crate swap is a mechanical rename with no behavior delta.
- Final validation:
  - `cargo build -p agent-runtime-cli` → ok, new dep tree: `agent-runtime-cli -> serde_yaml_ng v0.10.0 -> unsafe-libyaml v0.2.11` (libyml and serde_yml fully removed from `Cargo.lock`).
  - `cargo test -p agent-runtime-cli` → 21 integration tests + all unit tests pass.
  - `bash $HOME/.claude/scripts/pre-pr.sh` → `ok: required checks + coverage gate passed` (full nextest + clippy + docs gates + third-party-artifacts check + coverage gate).
- Waiver reason: external advisory cannot be expressed as a repo-local failing test; the manifest deserialization tests in `render::manifest::tests` exercise the new crate end-to-end and constitute the behaviour regression net.

## Testing

- `cargo build -p agent-runtime-cli` (pass)
- `cargo test -p agent-runtime-cli` (pass — 21 integration tests + all units)
- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` (pass)
- `scripts/generate-third-party-artifacts.sh --check` (pass)
- `bash $HOME/.claude/scripts/pre-pr.sh` (pass — full required-checks + coverage gate)

## Risk / Notes

- Pure dependency swap; no public API of `agent-runtime-cli` changes. The `serde_yaml_ng` crate is the most-used maintained fork of `serde_yaml` (which dtolnay archived) and preserves the original API surface — there is no migration delta for the eight call sites beyond the identifier rename.
- `serde_yaml_ng` is built on `unsafe-libyaml 0.2.11`; checked against the GitHub Security Advisories API — only a `< 0.2.10` advisory, already patched.
- `Cargo.lock` and `THIRD_PARTY_{LICENSES,NOTICES}.md` are regenerated via the repo's own `scripts/generate-third-party-artifacts.sh --write`; the `--check` mode passes, so the third-party-artifacts CI gate will not drift.
