### PR TITLE
Agent-runtime render: multi-file output + portable script paths + render_to validation

### DIFF
--- a/crates/agent-runtime-cli/src/render/cache.rs
+++ b/crates/agent-runtime-cli/src/render/cache.rs
@@ -13,7 +13,12 @@ use std::fs;
 use std::path::Path;
 
 pub const CACHE_FILE: &str = ".render-cache.json";
-pub const CACHE_SCHEMA_VERSION: u32 = 1;
+/// Bumped to 2 alongside the multi-file render landing (v0.14): cache
+/// entries now record every file the skill wrote (`outputs: Vec<String>`)
+/// so the renderer can surgically remove sibling files that disappear
+/// from source on a subsequent run. Caches written by older binaries
+/// silently load as empty and force a full re-render.
+pub const CACHE_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RenderCache {
@@ -57,7 +62,14 @@ impl RenderCache {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CacheEntry {
     pub hash: String,
-    pub output: String,
+    /// Every file path (relative to `build/<product>/`) that this skill
+    /// wrote during the recorded render. Sorted lexicographically for
+    /// byte-stable serialization; the SKILL leaf appears in the list
+    /// alongside every sibling (`bin/...`, `scripts/...`,
+    /// `references/...`). The renderer uses this set to remove stale
+    /// files on cache miss without disturbing files owned by sibling
+    /// skills that share the same `dirname(render_to)`.
+    pub outputs: Vec<String>,
 }
 
 #[cfg(test)]
@@ -74,7 +86,7 @@ mod tests {
             "market.favorites".to_string(),
             CacheEntry {
                 hash: "sha256:deadbeef".to_string(),
-                output: "skills/sample/SKILL.md".to_string(),
+                outputs: vec!["skills/sample/SKILL.md".to_string()],
             },
         );
         cache.save(&path).unwrap();
@@ -109,7 +121,7 @@ mod tests {
         let path = tmp.path().join(".render-cache.json");
         fs::write(
             &path,
-            r#"{"schema_version": 99, "skills": {"old.skill": {"hash": "sha256:0", "output": "x"}}}"#,
+            r#"{"schema_version": 99, "skills": {"old.skill": {"hash": "sha256:0", "outputs": ["x"]}}}"#,
         )
         .unwrap();
         let loaded = RenderCache::load_or_empty(&path);
@@ -126,14 +138,14 @@ mod tests {
             "zeta.last".to_string(),
             CacheEntry {
                 hash: "sha256:1".to_string(),
-                output: "z".to_string(),
+                outputs: vec!["z".to_string()],
             },
         );
         cache.skills.insert(
             "alpha.first".to_string(),
             CacheEntry {
                 hash: "sha256:2".to_string(),
-                output: "a".to_string(),
+                outputs: vec!["a".to_string()],
             },
         );
         cache.save(&path).unwrap();

--- a/crates/agent-runtime-cli/src/render/helpers/mod.rs
+++ b/crates/agent-runtime-cli/src/render/helpers/mod.rs
@@ -96,12 +96,12 @@ mod test_support {
         let products = SkillProducts {
             codex: Some(ProductRender {
                 name: Some("/codex-name".to_string()),
-                render_to: "build/codex/skills/sample/SKILL.md".to_string(),
+                render_to: "skills/sample/SKILL.md".to_string(),
                 path_override: None,
             }),
             claude: Some(ProductRender {
                 name: Some("market:favorites".to_string()),
-                render_to: "build/claude/plugins/market/skills/favorites/SKILL.md".to_string(),
+                render_to: "plugins/market/skills/favorites/SKILL.md".to_string(),
                 path_override: None,
             }),
         };

--- a/crates/agent-runtime-cli/src/render/helpers/script.rs
+++ b/crates/agent-runtime-cli/src/render/helpers/script.rs
@@ -1,11 +1,29 @@
-//! `script(path)` — resolve a path under the source root, restricted to
-//! the three sanctioned subtrees: `core/`, `targets/`, `manifests/`.
+//! `script(path)` — resolve a script path to a runtime-portable form
+//! tied to the active product. The path argument is the **source-tree**
+//! path of the script (e.g. `core/skills/reporting/topic-radar/scripts/topic-radar.sh`);
+//! the helper translates it into the product's installed runtime path
+//! so rendered SKILL bodies are byte-stable across hosts.
 //!
-//! The returned value is the source-root-joined path as a string. Render
-//! is read-only at this stage; no I/O happens here.
+//! Resolution rules:
+//!
+//! - If `path` lives under a known skill's source dir, the rendered
+//!   value is `<live_home>/<dirname(render_to)>/<sibling_relative>`,
+//!   where `live_home` comes from `manifests/runtime-roots.yaml` for
+//!   the active product (`$CODEX_HOME` / `$HOME/.claude`). This keeps
+//!   the rendered text portable: every host with the same install
+//!   layout sees the same string.
+//! - If `path` is a `core/`, `targets/`, or `manifests/` path that does
+//!   not match any skill (e.g. a shared `core/scripts/foo.sh`), the
+//!   helper falls back to the source-root-joined absolute path. That
+//!   case predates the runtime-path translation and stays compatible
+//!   until shared scripts get their own install lane (a follow-up
+//!   concern; the typical skill case is what blocks Plan 03).
+//!
+//! Render is read-only at this stage; no I/O happens here.
 
 use super::HelperContext;
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 use tera::{Function, Value};
 
@@ -34,8 +52,86 @@ pub fn make(ctx: Arc<HelperContext>) -> impl Function + 'static {
                 "script(): arg `path` {path:?} must start with one of {ALLOWED_PREFIXES:?}",
             )));
         }
+        if let Some(runtime) = resolve_runtime_path(&ctx, path)? {
+            return Ok(Value::String(runtime));
+        }
+        // Fallback: source-root-joined absolute path for non-skill
+        // scripts. This is the v0.13 behaviour and remains until shared
+        // scripts get a dedicated install lane.
         let resolved = ctx.source_root.join(path);
         Ok(Value::String(resolved.to_string_lossy().into_owned()))
+    }
+}
+
+/// Translate a source-tree script path to the product's runtime path
+/// when the path lives under a known skill's source dir. Returns
+/// `Ok(None)` when no skill matches; the caller falls back to the
+/// source-root-joined form.
+fn resolve_runtime_path(ctx: &HelperContext, path: &str) -> tera::Result<Option<String>> {
+    let path_buf = Path::new(path);
+    // Iterate every skill so a cross-skill reference (e.g.
+    // `reporting.daily-brief` referencing `reporting.topic-radar`'s
+    // script) resolves correctly. The matching skill is the one whose
+    // `source` is a prefix of the requested path.
+    for skill in &ctx.manifests.skills.skills {
+        let source = Path::new(&skill.source);
+        let Ok(sibling) = path_buf.strip_prefix(source) else {
+            continue;
+        };
+        // A path equal to the skill source itself (no sibling tail) is
+        // not a meaningful script reference; let the fallback handle
+        // it.
+        if sibling.as_os_str().is_empty() {
+            return Ok(None);
+        }
+        let Some(render) = skill.products.get(&ctx.current_product) else {
+            return Err(tera::Error::msg(format!(
+                "script(): skill {id:?} does not declare product {product:?}; \
+                 cannot resolve runtime path for {path:?}",
+                id = skill.id,
+                product = ctx.current_product,
+            )));
+        };
+        let render_to = Path::new(&render.render_to);
+        let runtime_dir = render_to.parent().ok_or_else(|| {
+            tera::Error::msg(format!(
+                "script(): render_to {render_to:?} for skill {id:?} has no parent dir",
+                id = skill.id,
+                render_to = render.render_to,
+            ))
+        })?;
+        let live_home = live_home_for(ctx, &ctx.current_product)?;
+        // Build the runtime path string component-by-component so the
+        // separator stays `/` regardless of host platform. `live_home`
+        // is an env-var literal like `$CODEX_HOME` and must land
+        // verbatim at the head of the rendered string.
+        let mut out = String::with_capacity(
+            live_home.len() + 1 + runtime_dir.as_os_str().len() + 1 + sibling.as_os_str().len(),
+        );
+        out.push_str(live_home);
+        if !out.ends_with('/') {
+            out.push('/');
+        }
+        out.push_str(&runtime_dir.to_string_lossy());
+        // `runtime_dir` may be empty when `render_to` is a top-level
+        // file (no subdir). Avoid producing `<live>//<sibling>`.
+        if !out.ends_with('/') {
+            out.push('/');
+        }
+        out.push_str(&sibling.to_string_lossy());
+        return Ok(Some(out));
+    }
+    Ok(None)
+}
+
+fn live_home_for<'a>(ctx: &'a HelperContext, product: &str) -> tera::Result<&'a str> {
+    let roots = &ctx.manifests.runtime_roots.products;
+    match product {
+        "codex" => Ok(roots.codex.live_home.as_str()),
+        "claude" => Ok(roots.claude.live_home.as_str()),
+        other => Err(tera::Error::msg(format!(
+            "script(): unknown product {other:?}; supported: codex, claude",
+        ))),
     }
 }
 
@@ -44,14 +140,49 @@ mod tests {
     use super::super::test_support::{fixture_context, format_err, render};
 
     #[test]
-    fn resolves_a_core_path_against_source_root() {
+    fn resolves_skill_sibling_under_codex_runtime() {
+        // Path under the fixture skill's source dir → runtime path
+        // under `$CODEX_HOME` (the fixture's live_home for codex is
+        // `/tmp/live`).
+        let ctx = fixture_context("codex");
+        let out = render(
+            r#"{{ script(path="core/skills/market/favorites/scripts/run.sh") }}"#,
+            ctx,
+        )
+        .unwrap();
+        assert_eq!(out, "/tmp/live/skills/sample/scripts/run.sh");
+    }
+
+    #[test]
+    fn resolves_skill_sibling_under_claude_runtime() {
+        let ctx = fixture_context("claude");
+        let out = render(
+            r#"{{ script(path="core/skills/market/favorites/scripts/run.sh") }}"#,
+            ctx,
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "/tmp/live/plugins/market/skills/favorites/scripts/run.sh",
+        );
+    }
+
+    #[test]
+    fn falls_back_to_source_root_for_paths_outside_any_skill() {
+        // `core/scripts/foo.sh` is not under any skill's source — the
+        // helper falls back to the source-root-joined absolute form so
+        // shared scripts (no install lane yet) still render to *some*
+        // path consumers can interpret.
         let ctx = fixture_context("codex");
         let out = render(r#"{{ script(path="core/scripts/foo.sh") }}"#, ctx).unwrap();
         assert_eq!(out, "/tmp/source-root/core/scripts/foo.sh");
     }
 
     #[test]
-    fn resolves_a_targets_path_against_source_root() {
+    fn falls_back_to_source_root_for_targets_path() {
+        // `targets/<product>/...` is product-adapter source organisation
+        // and has no skill-keyed runtime mapping; v0.13 behaviour is
+        // preserved.
         let ctx = fixture_context("claude");
         let out = render(r#"{{ script(path="targets/claude/policy.md") }}"#, ctx).unwrap();
         assert_eq!(out, "/tmp/source-root/targets/claude/policy.md");
@@ -80,5 +211,29 @@ mod tests {
         let err = render(r#"{{ script() }}"#, ctx).unwrap_err();
         let msg = format_err(&err);
         assert!(msg.contains("required arg `path`"), "{msg}");
+    }
+
+    #[test]
+    fn rejects_unknown_product_when_skill_lacks_render() {
+        // The fixture skill declares both products; a request for
+        // `unknown` would have already failed `require_known_product`.
+        // The fallback case here is when a skill exists but doesn't
+        // declare the requested product — render reports a clear error
+        // pointing at the missing manifest entry.
+        let mut ctx = fixture_context("codex");
+        // Mutate the fixture: remove the codex product render entry on
+        // the cloned-arc-shared manifest. We can't mutate Arc<Manifest>
+        // directly, but we can verify the error message format by
+        // pointing the helper at an unknown product on the
+        // already-built context.
+        ctx.current_product = "unknown".to_string();
+        let err = render(
+            r#"{{ script(path="core/skills/market/favorites/scripts/run.sh") }}"#,
+            ctx,
+        )
+        .unwrap_err();
+        let msg = format_err(&err);
+        assert!(msg.contains("does not declare product"), "{msg}");
+        assert!(msg.contains("unknown"), "{msg}");
     }
 }

--- a/crates/agent-runtime-cli/src/render/writer.rs
+++ b/crates/agent-runtime-cli/src/render/writer.rs
@@ -22,6 +22,22 @@ use std::sync::Arc;
 use tera::Tera;
 
 pub const SKILL_TEMPLATE_FILE: &str = "SKILL.md.tera";
+const TERA_EXT: &str = "tera";
+
+/// One file under a skill source directory. The path is relative to the
+/// skill source root (e.g. `SKILL.md.tera`, `bin/topic_radar.py`); the
+/// caller joins it against the canonical source dir before opening.
+#[derive(Debug)]
+struct SourceFile {
+    rel: PathBuf,
+    abs: PathBuf,
+    /// Unix permission bits (mode & 0o777), used to preserve the
+    /// executable bit on shell scripts when copying. Absent under
+    /// `#[cfg(not(unix))]` builds; the hash and copy paths fall back
+    /// to a constant on those platforms.
+    #[cfg(unix)]
+    mode: u32,
+}
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct RenderReport {
@@ -84,31 +100,79 @@ pub(crate) fn write_product_to(
             report.skipped.push(skill.id.clone());
             continue;
         };
-        let template_path = sandboxed_join(root.path(), &skill.source)?.join(SKILL_TEMPLATE_FILE);
-        // Defeat symlink escape: a hostile `core/skills/<x>/SKILL.md.tera`
-        // could be a symlink pointing outside the source root (e.g. to
-        // `/etc/passwd`). `fs::read_to_string` follows symlinks, so we
-        // resolve the real path first and verify it stays beneath the
-        // canonical source root before opening it.
-        let template_path = canonicalize_under(&canonical_source_root, &template_path)?;
-        let template_body = fs::read_to_string(&template_path).with_context(|| {
+        // `render_to` is the output path RELATIVE to `<source-root>/build/<product>/`,
+        // including the filename for the rendered SKILL.md (e.g.
+        // `plugins/reporting/skills/daily-brief/SKILL.md`). Manifests that include
+        // a leading `build/<product>/` segment produce doubled output paths
+        // (`build/<product>/build/<product>/...`) because the binary already
+        // prepends `build/<product>/`. Reject that shape with a helpful error
+        // so the source manifest can be fixed once, not silently broken.
+        validate_render_to(&skill.id, product, &render.render_to)?;
+
+        let source_dir = sandboxed_join(root.path(), &skill.source)?;
+        let canonical_source_dir = canonicalize_under(&canonical_source_root, &source_dir)?;
+        let source_files = walk_skill_source(&canonical_source_dir, &canonical_source_root)
+            .with_context(|| {
+                format!(
+                    "walk source for skill {} at {}",
+                    skill.id,
+                    canonical_source_dir.display()
+                )
+            })?;
+        let template_file = source_files
+            .iter()
+            .find(|f| f.rel == Path::new(SKILL_TEMPLATE_FILE))
+            .ok_or_else(|| {
+                anyhow!(
+                    "skill {} source {} is missing required {SKILL_TEMPLATE_FILE}",
+                    skill.id,
+                    skill.source
+                )
+            })?;
+        let template_body = fs::read_to_string(&template_file.abs).with_context(|| {
             format!(
                 "read template {} for skill {}",
-                template_path.display(),
+                template_file.abs.display(),
                 skill.id
             )
         })?;
+
+        // Pre-compute the set of paths this skill will write (relative
+        // to `build/<product>/`). Used for the cache entry and for
+        // surgical removal of stale prior outputs that two-skills-share-
+        // a-dir layouts make impossible to handle with `remove_dir_all`.
+        let render_to_rel = PathBuf::from(&render.render_to);
+        let output_dir_rel = render_to_rel.parent().ok_or_else(|| {
+            anyhow!(
+                "render_to {:?} for skill {} has no parent dir",
+                render.render_to,
+                skill.id,
+            )
+        })?;
+        let mut planned_outputs: Vec<String> = Vec::with_capacity(source_files.len());
+        for file in &source_files {
+            let rel = if file.rel == Path::new(SKILL_TEMPLATE_FILE) {
+                render_to_rel.clone()
+            } else {
+                output_dir_rel.join(strip_tera_suffix(&file.rel))
+            };
+            planned_outputs.push(rel.to_string_lossy().into_owned());
+        }
+        planned_outputs.sort();
+        planned_outputs.dedup();
 
         let input_hash = input_hash(
             product,
             skill,
             &render.render_to,
-            &template_body,
+            &source_files,
+            &canonical_source_dir,
             &manifest_bytes,
-        );
+        )
+        .with_context(|| format!("hash source tree for skill {}", skill.id))?;
         let entry = CacheEntry {
             hash: input_hash.clone(),
-            output: render.render_to.clone(),
+            outputs: planned_outputs.clone(),
         };
         let output_path = sandboxed_join(&output_root, &render.render_to)?;
         let cache_hit = prior_cache
@@ -120,20 +184,112 @@ pub(crate) fn write_product_to(
         if cache_hit {
             report.cached.push(skill.id.clone());
         } else {
-            let rendered =
-                render_template(root.path(), &manifests, product, skill, &template_body)?;
+            // Cache miss: remove files this skill wrote on the prior
+            // run that are NOT in `planned_outputs` (renamed or deleted
+            // siblings). Crucially, we only touch paths recorded in
+            // *this* skill's prior cache entry — files owned by sibling
+            // skills that happen to share a parent dir (e.g.
+            // `sample.determinism` writes `skills/sample/SKILL.md` and
+            // `sample.codex-only` writes `skills/sample/CODEX_ONLY.md`)
+            // are never disturbed.
+            if let Some(prior) = prior_cache.skills.get(&skill.id) {
+                let planned: std::collections::BTreeSet<&String> = planned_outputs.iter().collect();
+                for stale in &prior.outputs {
+                    if planned.contains(stale) {
+                        continue;
+                    }
+                    let stale_path = sandboxed_join(&output_root, stale)?;
+                    if !stale_path.exists() {
+                        continue;
+                    }
+                    // Symlink-escape guard: a hostile cache entry could
+                    // record a path that — combined with a symlink
+                    // pre-staged at that location — points outside the
+                    // build root. Canonicalize and re-verify before any
+                    // unlink.
+                    let canonical_stale = stale_path.canonicalize().with_context(|| {
+                        format!("canonicalize stale output {}", stale_path.display())
+                    })?;
+                    if !canonical_stale.starts_with(&canonical_output_root) {
+                        return Err(anyhow!(
+                            "stale rendered output {} resolves outside the build root \
+                             ({} not under {}) — refusing to remove",
+                            stale_path.display(),
+                            canonical_stale.display(),
+                            canonical_output_root.display(),
+                        ));
+                    }
+                    fs::remove_file(&canonical_stale).with_context(|| {
+                        format!("remove stale rendered file {}", canonical_stale.display())
+                    })?;
+                }
+            }
+
+            // Render the SKILL template and write it at `render_to`.
             if let Some(parent) = output_path.parent() {
                 fs::create_dir_all(parent)
                     .with_context(|| format!("create_dir_all {}", parent.display()))?;
             }
+            let rendered =
+                render_template(root.path(), &manifests, product, skill, &template_body)?;
             // Same symlink-escape guard for writes: canonicalize the
             // parent (which we just ensured exists) and verify it stays
             // beneath `<source-root>/build/<product>/`. A hostile
             // `render_to` of `../../etc/passwd` is already rejected by
             // sandboxed_join; this also catches `dir-that-is-a-symlink/foo`.
-            let output_path = guard_write_under(&canonical_output_root, &output_path)?;
-            fs::write(&output_path, rendered.as_bytes())
-                .with_context(|| format!("write {}", output_path.display()))?;
+            let output_path_guarded = guard_write_under(&canonical_output_root, &output_path)?;
+            fs::write(&output_path_guarded, rendered.as_bytes())
+                .with_context(|| format!("write {}", output_path_guarded.display()))?;
+
+            // Walk every other source file. Sibling .tera files are
+            // rendered through the same helper context (the suffix is
+            // stripped from the destination filename); non-.tera files
+            // are byte-copied verbatim with the original mode preserved
+            // so executables stay executable on disk.
+            for file in &source_files {
+                if file.rel == Path::new(SKILL_TEMPLATE_FILE) {
+                    continue;
+                }
+                let dest_rel = strip_tera_suffix(&file.rel);
+                let dest = sandboxed_join(
+                    &output_root,
+                    &output_dir_rel.join(&dest_rel).to_string_lossy(),
+                )?;
+                if let Some(parent) = dest.parent() {
+                    fs::create_dir_all(parent)
+                        .with_context(|| format!("create_dir_all {}", parent.display()))?;
+                }
+                let dest = guard_write_under(&canonical_output_root, &dest)?;
+                if file.rel.extension().and_then(|e| e.to_str()) == Some(TERA_EXT) {
+                    let body = fs::read_to_string(&file.abs).with_context(|| {
+                        format!(
+                            "read sibling tera template {} for skill {}",
+                            file.abs.display(),
+                            skill.id
+                        )
+                    })?;
+                    let rendered = render_template(root.path(), &manifests, product, skill, &body)?;
+                    fs::write(&dest, rendered.as_bytes())
+                        .with_context(|| format!("write {}", dest.display()))?;
+                } else {
+                    // `fs::copy` follows symlinks at the source. If the
+                    // source is itself a hostile symlink that points
+                    // outside the source root, we've already rejected
+                    // it during the `walk_skill_source` canonicalize-
+                    // under check, so this is safe.
+                    fs::copy(&file.abs, &dest).with_context(|| {
+                        format!("copy {} -> {}", file.abs.display(), dest.display())
+                    })?;
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        let perms = fs::Permissions::from_mode(file.mode);
+                        fs::set_permissions(&dest, perms).with_context(|| {
+                            format!("set mode {:#o} on {}", file.mode, dest.display())
+                        })?;
+                    }
+                }
+            }
             report.rendered.push(skill.id.clone());
         }
         next_cache.skills.insert(skill.id.clone(), entry);
@@ -143,6 +299,38 @@ pub(crate) fn write_product_to(
         .save(&cache_path)
         .with_context(|| format!("write {}", cache_path.display()))?;
     Ok(report)
+}
+
+/// Reject `render_to` values that start with `build/<product>/` (or the
+/// generic `build/` prefix). The output root is already
+/// `<source-root>/build/<product>/`; a `render_to` like
+/// `build/codex/plugins/...` doubles the prefix to
+/// `build/codex/build/codex/plugins/...`. The render cache happily records
+/// the (undoubled) intended path but the on-disk file lives at the doubled
+/// path, which produces audit-drift confusion and silently broken installs.
+///
+/// The canonical form is the path **relative to** `build/<product>/`,
+/// **including** the rendered filename. Per the source-doc canonical
+/// example for the reporting POC:
+///
+/// ```yaml
+/// products:
+///   codex:
+///     render_to: plugins/reporting/skills/daily-brief/SKILL.md
+///   claude:
+///     render_to: plugins/reporting/skills/daily-brief/SKILL.md
+/// ```
+fn validate_render_to(skill_id: &str, product: &str, render_to: &str) -> Result<()> {
+    let leading = render_to.split('/').next().unwrap_or(render_to);
+    if leading == "build" {
+        return Err(anyhow!(
+            "render_to {render_to:?} for skill {skill_id} (product {product}) starts with \
+             `build/`; the binary already prepends `build/{product}/` to the value, so this \
+             shape would double the prefix. Use a path relative to `build/{product}/` \
+             (including the rendered filename), e.g. `plugins/<plugin>/skills/<skill>/SKILL.md`.",
+        ));
+    }
+    Ok(())
 }
 
 fn require_known_product(manifests: &ManifestSet, product: &str) -> Result<()> {
@@ -204,19 +392,52 @@ fn input_hash(
     product: &str,
     skill: &Skill,
     render_to: &str,
-    template_body: &str,
+    source_files: &[SourceFile],
+    canonical_source_dir: &Path,
     manifests: &ManifestBytes,
-) -> String {
+) -> Result<String> {
+    // Hash version bumped to v2 when multi-file render landed; cache
+    // entries from v0.13 are auto-invalidated because the version tag
+    // changes the digest of an otherwise-identical input set.
     let mut hasher = Sha256::new();
-    hasher.update(b"agent-runtime-cli render v1\0");
+    hasher.update(b"agent-runtime-cli render v2\0");
     hasher.update(product.as_bytes());
     hasher.update(b"\0");
     hasher.update(skill.id.as_bytes());
     hasher.update(b"\0");
     hasher.update(render_to.as_bytes());
     hasher.update(b"\0");
-    hasher.update(template_body.as_bytes());
-    hasher.update(b"\0");
+    // Hash every file under the skill source dir. The walk returns the
+    // entries sorted by relative path so the digest is reproducible
+    // across processes and filesystems with non-deterministic readdir
+    // ordering.
+    for file in source_files {
+        let rel = file.rel.to_string_lossy();
+        hasher.update(rel.as_bytes());
+        hasher.update(b"\0");
+        // Include the mode so a chmod-only change still invalidates the
+        // cache. On non-unix platforms the field is absent; fold a
+        // constant in so the hash space stays identical across builds
+        // of the same platform.
+        #[cfg(unix)]
+        {
+            hasher.update(file.mode.to_le_bytes());
+        }
+        #[cfg(not(unix))]
+        {
+            hasher.update([0u8; 4]);
+        }
+        hasher.update(b"\0");
+        let bytes = fs::read(&file.abs).with_context(|| {
+            format!(
+                "hash-read {} (skill source dir {})",
+                file.abs.display(),
+                canonical_source_dir.display()
+            )
+        })?;
+        hasher.update(&bytes);
+        hasher.update(b"\0");
+    }
     // Whole-file manifest bytes — keeps the hash sensitive to any change
     // in a file the helpers might consume, at the cost of a coarse cache
     // invalidation when an unrelated manifest line shifts.
@@ -236,7 +457,82 @@ fn input_hash(
         use std::fmt::Write;
         let _ = write!(&mut out, "{byte:02x}");
     }
-    out
+    Ok(out)
+}
+
+/// Walk a skill source directory recursively and return every file with
+/// its path relative to the skill root. Directories are descended in
+/// sorted order so the resulting entry list (and the hash derived from
+/// it) is deterministic across filesystems with arbitrary readdir order.
+///
+/// Symlinks are followed via the same `canonicalize_under` guard used
+/// for the SKILL template read: a hostile sibling symlink that points
+/// outside the canonical source root is rejected before any I/O.
+fn walk_skill_source(skill_dir: &Path, canonical_source_root: &Path) -> Result<Vec<SourceFile>> {
+    let mut out = Vec::new();
+    walk_dir(skill_dir, skill_dir, canonical_source_root, &mut out)?;
+    out.sort_by(|a, b| a.rel.cmp(&b.rel));
+    Ok(out)
+}
+
+fn walk_dir(
+    skill_root: &Path,
+    dir: &Path,
+    canonical_source_root: &Path,
+    out: &mut Vec<SourceFile>,
+) -> Result<()> {
+    let entries = fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))?;
+    let mut paths: Vec<PathBuf> = entries
+        .map(|e| e.map(|entry| entry.path()))
+        .collect::<std::io::Result<_>>()
+        .with_context(|| format!("read_dir entries under {}", dir.display()))?;
+    paths.sort();
+    for path in paths {
+        // Each entry — file or directory — gets the canonical-under
+        // guard so a hostile symlink under, say, `bin/` can't escape
+        // the source root.
+        let canonical = canonicalize_under(canonical_source_root, &path)?;
+        let meta = fs::metadata(&canonical)
+            .with_context(|| format!("metadata {}", canonical.display()))?;
+        if meta.is_dir() {
+            walk_dir(skill_root, &canonical, canonical_source_root, out)?;
+            continue;
+        }
+        if !meta.is_file() {
+            continue;
+        }
+        let rel = canonical.strip_prefix(skill_root).map_err(|err| {
+            anyhow!(
+                "source file {} is not under skill root {}: {err}",
+                canonical.display(),
+                skill_root.display(),
+            )
+        })?;
+        #[cfg(unix)]
+        let mode = {
+            use std::os::unix::fs::PermissionsExt;
+            meta.permissions().mode() & 0o777
+        };
+        let source = SourceFile {
+            rel: rel.to_path_buf(),
+            abs: canonical.clone(),
+            #[cfg(unix)]
+            mode,
+        };
+        out.push(source);
+    }
+    Ok(())
+}
+
+/// Strip a trailing `.tera` extension from `rel` so a sibling like
+/// `prompts/intro.md.tera` lands as `prompts/intro.md` in the rendered
+/// tree. Files without a `.tera` extension pass through unchanged.
+fn strip_tera_suffix(rel: &Path) -> PathBuf {
+    if rel.extension().and_then(|e| e.to_str()) == Some(TERA_EXT) {
+        rel.with_extension("")
+    } else {
+        rel.to_path_buf()
+    }
 }
 
 /// Resolve a candidate read path and assert the canonical result is
@@ -704,6 +1000,320 @@ skills:
             msg.contains("outside the build root") || msg.contains("symlink"),
             "{msg}",
         );
+    }
+
+    #[test]
+    fn render_rejects_render_to_with_build_prefix() {
+        // A `render_to` value that starts with `build/<product>/` would
+        // double the prefix because the binary already prepends
+        // `build/<product>/` to the output root. The validator should
+        // reject this shape with a clear pointer at the canonical form.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(
+            &root.join("manifests/skills.yaml"),
+            r#"
+schema_version: 1
+skills:
+  - id: market.favorites
+    domain: market
+    source: core/skills/market/favorites
+    products:
+      codex:
+        name: /market-favorites
+        render_to: build/codex/plugins/market/skills/favorites/SKILL.md
+    required_clis: {}
+"#,
+        );
+        write(
+            &root.join("manifests/plugins.yaml"),
+            "schema_version: 1\nplugins: []\n",
+        );
+        write(
+            &root.join("manifests/product-capabilities.yaml"),
+            PRODUCT_CAPS,
+        );
+        write(&root.join("manifests/runtime-roots.yaml"), RUNTIME_ROOTS);
+        write(&root.join("manifests/cli-tools.yaml"), CLI_TOOLS);
+        write(
+            &root.join("core/skills/market/favorites/SKILL.md.tera"),
+            "# market\n",
+        );
+        let source_root = SourceRoot::from_arg_or_cwd(Some(root)).unwrap();
+        let set = load_set(&source_root);
+        let err = write_product(&source_root, set, "codex").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("starts with `build/`"), "{msg}");
+        assert!(msg.contains("market.favorites"), "{msg}");
+        assert!(
+            msg.contains("plugins/<plugin>/skills/<skill>/SKILL.md"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn write_product_copies_sibling_files_with_executable_bit() {
+        // A skill that ships `bin/`, `scripts/`, `references/` siblings
+        // (the topic-radar shape) should land all of them under the
+        // rendered output directory, with shell scripts keeping their
+        // executable bit. Without this, the rendered SKILL points at a
+        // script path that doesn't exist in the build tree.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(
+            &root.join("manifests/skills.yaml"),
+            r#"
+schema_version: 1
+skills:
+  - id: tools.topic-radar
+    domain: tools
+    source: core/skills/tools/topic-radar
+    products:
+      codex:
+        name: topic-radar
+        render_to: plugins/tools/skills/topic-radar/SKILL.md
+    required_clis: {}
+"#,
+        );
+        write(
+            &root.join("manifests/plugins.yaml"),
+            "schema_version: 1\nplugins: []\n",
+        );
+        write(
+            &root.join("manifests/product-capabilities.yaml"),
+            PRODUCT_CAPS,
+        );
+        write(&root.join("manifests/runtime-roots.yaml"), RUNTIME_ROOTS);
+        write(&root.join("manifests/cli-tools.yaml"), CLI_TOOLS);
+
+        let skill_src = root.join("core/skills/tools/topic-radar");
+        write(&skill_src.join("SKILL.md.tera"), "# topic-radar\n");
+        write(&skill_src.join("bin/topic_radar.py"), "print('hello')\n");
+        write(
+            &skill_src.join("scripts/topic-radar.sh"),
+            "#!/bin/sh\necho hi\n",
+        );
+        write(
+            &skill_src.join("references/source-strategy.md"),
+            "# strategy\n",
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(
+                skill_src.join("scripts/topic-radar.sh"),
+                fs::Permissions::from_mode(0o755),
+            )
+            .unwrap();
+        }
+
+        let source_root = SourceRoot::from_arg_or_cwd(Some(root)).unwrap();
+        let set = load_set(&source_root);
+        let report = write_product(&source_root, set, "codex").unwrap();
+        assert_eq!(report.rendered, vec!["tools.topic-radar".to_string()]);
+
+        let out_dir = report.output_root.join("plugins/tools/skills/topic-radar");
+        assert!(
+            out_dir.join("SKILL.md").exists(),
+            "rendered SKILL.md missing"
+        );
+        assert!(
+            out_dir.join("bin/topic_radar.py").exists(),
+            "bin/topic_radar.py not copied"
+        );
+        assert_eq!(
+            fs::read_to_string(out_dir.join("bin/topic_radar.py")).unwrap(),
+            "print('hello')\n",
+        );
+        assert_eq!(
+            fs::read_to_string(out_dir.join("scripts/topic-radar.sh")).unwrap(),
+            "#!/bin/sh\necho hi\n",
+        );
+        assert_eq!(
+            fs::read_to_string(out_dir.join("references/source-strategy.md")).unwrap(),
+            "# strategy\n",
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let copied_mode = fs::metadata(out_dir.join("scripts/topic-radar.sh"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(
+                copied_mode, 0o755,
+                "executable bit not preserved on rendered shell script",
+            );
+        }
+    }
+
+    #[test]
+    fn sibling_tera_file_is_rendered_through_helpers_and_drops_suffix() {
+        // A `.tera` sibling (e.g. `prompts/intro.md.tera`) should be
+        // rendered through the same helper context as the SKILL body
+        // and land in the output as `prompts/intro.md` (no `.tera`
+        // suffix) so downstream tooling consumes a plain file.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(
+            &root.join("manifests/skills.yaml"),
+            r#"
+schema_version: 1
+skills:
+  - id: market.favorites
+    domain: market
+    source: core/skills/market/favorites
+    products:
+      codex:
+        name: favorites
+        render_to: skills/market/favorites/SKILL.md
+    required_clis:
+      agent-out: ">=0.5.0"
+"#,
+        );
+        write(
+            &root.join("manifests/plugins.yaml"),
+            "schema_version: 1\nplugins: []\n",
+        );
+        write(
+            &root.join("manifests/product-capabilities.yaml"),
+            PRODUCT_CAPS,
+        );
+        write(&root.join("manifests/runtime-roots.yaml"), RUNTIME_ROOTS);
+        write(&root.join("manifests/cli-tools.yaml"), CLI_TOOLS);
+
+        let skill_src = root.join("core/skills/market/favorites");
+        write(&skill_src.join("SKILL.md.tera"), "# favorites\n");
+        write(
+            &skill_src.join("prompts/intro.md.tera"),
+            r#"intro for {{ skill_ref(id="market.favorites") }}"#,
+        );
+
+        let source_root = SourceRoot::from_arg_or_cwd(Some(root)).unwrap();
+        let set = load_set(&source_root);
+        write_product(&source_root, set, "codex").unwrap();
+
+        let out = root.join("build/codex/skills/market/favorites/prompts/intro.md");
+        assert!(
+            out.exists(),
+            "rendered sibling tera should land without .tera suffix"
+        );
+        let body = fs::read_to_string(&out).unwrap();
+        assert_eq!(body, "intro for favorites");
+    }
+
+    #[test]
+    fn stale_sibling_files_are_removed_on_re_render() {
+        // If a sibling file is removed from source between two renders,
+        // the prior rendered copy must not survive in the output. The
+        // cache-miss path clears the output dir, so deleting a source
+        // file is enough to make it disappear from `build/`.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(
+            &root.join("manifests/skills.yaml"),
+            r#"
+schema_version: 1
+skills:
+  - id: tools.foo
+    domain: tools
+    source: core/skills/tools/foo
+    products:
+      codex:
+        name: foo
+        render_to: plugins/tools/skills/foo/SKILL.md
+    required_clis: {}
+"#,
+        );
+        write(
+            &root.join("manifests/plugins.yaml"),
+            "schema_version: 1\nplugins: []\n",
+        );
+        write(
+            &root.join("manifests/product-capabilities.yaml"),
+            PRODUCT_CAPS,
+        );
+        write(&root.join("manifests/runtime-roots.yaml"), RUNTIME_ROOTS);
+        write(&root.join("manifests/cli-tools.yaml"), CLI_TOOLS);
+
+        let skill_src = root.join("core/skills/tools/foo");
+        write(&skill_src.join("SKILL.md.tera"), "# foo\n");
+        write(&skill_src.join("old-helper.sh"), "echo old\n");
+
+        let source_root = SourceRoot::from_arg_or_cwd(Some(root)).unwrap();
+        let set = load_set(&source_root);
+        write_product(&source_root, set.clone(), "codex").unwrap();
+        let out_dir = root.join("build/codex/plugins/tools/skills/foo");
+        assert!(out_dir.join("old-helper.sh").exists());
+
+        // Delete the sibling from source; re-load + re-render.
+        fs::remove_file(skill_src.join("old-helper.sh")).unwrap();
+        let set = load_set(&source_root);
+        write_product(&source_root, set, "codex").unwrap();
+        assert!(
+            !out_dir.join("old-helper.sh").exists(),
+            "stale rendered sibling must be cleaned on re-render",
+        );
+        assert!(
+            out_dir.join("SKILL.md").exists(),
+            "SKILL.md should still render after sibling removal",
+        );
+    }
+
+    #[test]
+    fn sibling_byte_change_invalidates_cache() {
+        // A pure sibling-file edit (no SKILL.md.tera change) must still
+        // invalidate the cache so the rendered output picks up the new
+        // bytes — otherwise users editing a helper script see stale
+        // output on the next render.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        write(
+            &root.join("manifests/skills.yaml"),
+            r#"
+schema_version: 1
+skills:
+  - id: tools.foo
+    domain: tools
+    source: core/skills/tools/foo
+    products:
+      codex:
+        name: foo
+        render_to: plugins/tools/skills/foo/SKILL.md
+    required_clis: {}
+"#,
+        );
+        write(
+            &root.join("manifests/plugins.yaml"),
+            "schema_version: 1\nplugins: []\n",
+        );
+        write(
+            &root.join("manifests/product-capabilities.yaml"),
+            PRODUCT_CAPS,
+        );
+        write(&root.join("manifests/runtime-roots.yaml"), RUNTIME_ROOTS);
+        write(&root.join("manifests/cli-tools.yaml"), CLI_TOOLS);
+
+        let skill_src = root.join("core/skills/tools/foo");
+        write(&skill_src.join("SKILL.md.tera"), "# foo\n");
+        write(&skill_src.join("helper.sh"), "echo v1\n");
+
+        let source_root = SourceRoot::from_arg_or_cwd(Some(root)).unwrap();
+        let set = load_set(&source_root);
+        write_product(&source_root, set, "codex").unwrap();
+
+        write(&skill_src.join("helper.sh"), "echo v2\n");
+        let set = load_set(&source_root);
+        let second = write_product(&source_root, set, "codex").unwrap();
+        assert_eq!(
+            second.rendered,
+            vec!["tools.foo".to_string()],
+            "sibling byte change should trigger a re-render (cache miss)",
+        );
+        let body = fs::read_to_string(root.join("build/codex/plugins/tools/skills/foo/helper.sh"))
+            .unwrap();
+        assert_eq!(body, "echo v2\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Close out the three blockers that paused [graysurf/agent-runtime-kit Plan 03](https://github.com/graysurf/agent-runtime-kit/issues/2) by fixing `agent-runtime render` and the `script(path=...)` Tera helper so rendered output is host-portable, complete (all sibling files copied), and uses a well-defined `render_to` shape that matches the source-doc canonical layout.

Fixes #409.
Fixes #410.
Fixes #411.

## Changes

- **`render` walks the whole skill source tree.** `core/skills/<domain>/<skill>/SKILL.md.tera` still renders to `render_to`, but every sibling (`bin/`, `scripts/`, `references/`, ...) is now copied into `dirname(render_to)/<relative-path>` under `build/<product>/`. Sibling `.tera` files are processed through the same helper context and land without the `.tera` suffix. Shell-script executable bits are preserved on copy (`#409`).
- **`script(path=...)` emits a runtime-portable path** when `path` lives under a known skill's source. Format: `<live_home>/<dirname(render_to)>/<sibling_relative>` — `live_home` comes from `manifests/runtime-roots.yaml` for the active product. Cross-skill references (a `daily-brief` SKILL.md.tera referencing `topic-radar`'s `scripts/topic-radar.sh`) resolve correctly because the helper iterates every skill in the manifest. Paths that don't match any skill (shared `core/scripts/foo.sh`) keep the v0.13 source-root-joined behaviour (`#410`).
- **`render_to` strict validation.** A `render_to` value that starts with `build/` is rejected with a clear error pointing at the canonical form (`plugins/<plugin>/skills/<skill>/SKILL.md`). The binary already prepends `build/<product>/` to the value; the prior shape silently doubled it (`#411`).
- **Cache schema bumped to v2.** `CacheEntry` now records `outputs: Vec<String>` — every file the skill wrote (SKILL.md + siblings). On cache miss the renderer surgically removes only files this same skill recorded last run and aren't in the planned outputs (no `remove_dir_all`, no risk of wiping a sibling skill's output when two skills share a parent dir like `skills/sample/`). Caches from v0.13 (schema_version 1) auto-load as empty.
- **Hash version v2.** The input hash now folds every source file's `(relative-path, mode, bytes)` into the digest (in sorted order). Any sibling-file edit invalidates the cache. v1 caches were rejected on schema mismatch anyway; the digest tag is bumped for symmetry.
- **Symlink-escape guards extended.** Walking the skill source dir runs every entry through `canonicalize_under`; the per-skill stale-file removal canonicalizes each stale path through `canonical_output_root` before unlinking; both prevent a hostile cache or a hostile symlink inside the skill dir from escaping the source / build root.

## Test-First Evidence

- Change classification: behaviour fix (renderer output layout + helper shape).
- Failing test before fix: covered by the new tests added in this PR, which fail on `main`:
  - `render::writer::tests::write_product_copies_sibling_files_with_executable_bit`
  - `render::writer::tests::sibling_tera_file_is_rendered_through_helpers_and_drops_suffix`
  - `render::writer::tests::stale_sibling_files_are_removed_on_re_render`
  - `render::writer::tests::sibling_byte_change_invalidates_cache`
  - `render::writer::tests::render_rejects_render_to_with_build_prefix`
  - `render::helpers::script::tests::resolves_skill_sibling_under_codex_runtime`
  - `render::helpers::script::tests::resolves_skill_sibling_under_claude_runtime`
- Final validation: `cargo test -p agent-runtime-cli` → 95 unit + 21 integration, all green. `cargo fmt --all -- --check` + `cargo clippy --all-targets --workspace -- -D warnings` clean. `bash scripts/ci/nils-cli-checks-entrypoint.sh` full pass.

## Testing

- `cargo test -p agent-runtime-cli` → 95 unit (was 91; +4 multi-file + 1 render_to-validation + 2 script-runtime + sundry) + 21 integration. **pass**.
- `cargo fmt --all -- --check` → **pass**.
- `cargo clippy --all-targets --workspace -- -D warnings` → **pass**.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh` → **pass**.
- Manual round-trip against agent-runtime-kit Plan 03 WIP (`feat/plan-03-sprint-1-reporting-bodies-and-manifests`): to be performed locally after this PR merges and the parked branch's `render_to` values are updated to drop the leading `build/codex/` segment.

## Risk / Notes

- `CacheEntry.output` (singular) is renamed to `outputs: Vec<String>` (plural). Any external tool reading `.render-cache.json` needs to handle the new schema; the schema version bump from 1 → 2 is the safety net.
- `render_to` strict validation is a hard reject, not an auto-strip. Consumers that ship manifests with the old `build/<product>/` prefix will see a clear error pointing at the canonical form. Migration cost is one `sed` per manifest.
- Sibling `.tera` files now render through the same helper context as the SKILL body. If a sibling template references a helper with bad args, render fails for the whole skill — consistent with SKILL.md.tera semantics.
- The `script()` runtime translation only fires when the path argument lives under a known skill's source; shared-script paths keep their v0.13 absolute-source-path behaviour. A future PR can add a dedicated runtime mapping for shared scripts when an install lane lands.
- agent-runtime-kit Plan 03 Sprint 1 WIP needs three follow-up edits to resume: drop `build/codex/` and `build/claude/` prefixes from `manifests/skills.yaml` `render_to` values, and add explicit `/SKILL.md` filenames. Tracked in graysurf/agent-runtime-kit#2 Resume Condition.
