### PR TITLE
Plan 04 Sprint 1 Task 1.1: managed-block helper module

### DIFF
--- a/crates/agent-runtime-cli/src/lib.rs
+++ b/crates/agent-runtime-cli/src/lib.rs
@@ -22,6 +22,7 @@ use std::process::ExitCode;
 
 pub mod audit_drift;
 pub mod commands;
+pub mod managed_block;
 pub mod render;
 
 #[derive(Parser)]

--- a/crates/agent-runtime-cli/src/managed_block.rs
+++ b/crates/agent-runtime-cli/src/managed_block.rs
@@ -1,0 +1,475 @@
+//! Managed-block helper for paired install markers.
+//!
+//! The installer (Plan 04 Sprint 1 Task 1.2) writes small managed blocks
+//! into product config files (`~/.codex/config.toml`,
+//! `~/.claude/settings.json`). This module owns the paired-marker contract
+//! so install / uninstall / restore-backups stay byte-consistent.
+//!
+//! Contract:
+//!
+//! - Markers are paired, comment-prefixed, and live on their own lines:
+//!   - `<prefix> >>> agent-runtime-kit:<surface> >>>` (open)
+//!   - `<prefix> <<< agent-runtime-kit:<surface> <<<` (close)
+//!
+//!   `<prefix>` is `#` for TOML surfaces and `//` for JSONC surfaces.
+//! - Bytes outside the marker pair are preserved verbatim across read /
+//!   write / remove. Inside the markers, the helper canonicalises layout
+//!   so repeated writes are idempotent.
+//! - Writing into a file with no markers refuses unless the caller passes
+//!   `force = true`; this keeps the first install opt-in explicit.
+//! - Unbalanced markers (one half present, the other missing) refuse with
+//!   a typed error naming the surface.
+//!
+//! Source: `agent-runtime-kit/docs/plans/04-installer-doctor-and-bootstrap/
+//! 04-installer-doctor-and-bootstrap-plan.md` Sprint 1 Task 1.1.
+
+use thiserror::Error;
+
+/// Comment syntax used by a surface's file format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentStyle {
+    /// `#` — TOML (Codex `config.toml`).
+    Hash,
+    /// `//` — JSONC (Claude `settings.json`).
+    DoubleSlash,
+}
+
+impl CommentStyle {
+    fn prefix(self) -> &'static str {
+        match self {
+            CommentStyle::Hash => "#",
+            CommentStyle::DoubleSlash => "//",
+        }
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ManagedBlockError {
+    /// File has no marker pair, and the caller did not opt in via `force`.
+    #[error("managed block for surface `{surface}` not present; pass force=true to add it")]
+    NotPresent { surface: String },
+    /// Marker counts do not balance (one half present, the other missing,
+    /// or more than one of either kind).
+    #[error(
+        "managed block markers for surface `{surface}` are unbalanced: {open} open / {close} close"
+    )]
+    Unbalanced {
+        surface: String,
+        open: usize,
+        close: usize,
+    },
+    /// Close marker precedes its paired open marker.
+    #[error("managed block close marker for surface `{surface}` precedes its open marker")]
+    OutOfOrder { surface: String },
+    /// More than one complete block for the same surface in one file.
+    #[error("managed block for surface `{surface}` appears multiple times in one file")]
+    Duplicate { surface: String },
+}
+
+/// Owns the marker syntax for one (surface, comment-style) pair.
+#[derive(Debug, Clone)]
+pub struct ManagedBlock {
+    surface: String,
+    style: CommentStyle,
+}
+
+impl ManagedBlock {
+    pub fn new(surface: impl Into<String>, style: CommentStyle) -> Self {
+        Self {
+            surface: surface.into(),
+            style,
+        }
+    }
+
+    pub fn surface(&self) -> &str {
+        &self.surface
+    }
+
+    pub fn style(&self) -> CommentStyle {
+        self.style
+    }
+
+    pub fn open_marker(&self) -> String {
+        format!(
+            "{prefix} >>> agent-runtime-kit:{surface} >>>",
+            prefix = self.style.prefix(),
+            surface = self.surface,
+        )
+    }
+
+    pub fn close_marker(&self) -> String {
+        format!(
+            "{prefix} <<< agent-runtime-kit:{surface} <<<",
+            prefix = self.style.prefix(),
+            surface = self.surface,
+        )
+    }
+
+    /// Return the block body if a complete marker pair is present, else
+    /// `Ok(None)`. Errors when markers are unbalanced or duplicated.
+    pub fn read(&self, text: &str) -> Result<Option<String>, ManagedBlockError> {
+        match self.locate(text)? {
+            None => Ok(None),
+            Some(span) => Ok(Some(text[span.body_start..span.body_end].to_string())),
+        }
+    }
+
+    /// Write `body` into the managed block. When markers already exist,
+    /// only bytes between the markers are replaced. When markers are
+    /// missing, the block is appended to the end of the file — but only
+    /// when `force` is true.
+    pub fn write(&self, text: &str, body: &str, force: bool) -> Result<String, ManagedBlockError> {
+        let body = canonicalize_body(body);
+        match self.locate(text)? {
+            None => {
+                if !force {
+                    return Err(ManagedBlockError::NotPresent {
+                        surface: self.surface.clone(),
+                    });
+                }
+                Ok(append_block(
+                    text,
+                    &self.open_marker(),
+                    &self.close_marker(),
+                    &body,
+                ))
+            }
+            Some(span) => Ok(replace_block(
+                text,
+                &span,
+                &self.open_marker(),
+                &self.close_marker(),
+                &body,
+            )),
+        }
+    }
+
+    /// Remove the managed block in full. No-op when no markers are
+    /// present. Errors on unbalanced markers.
+    pub fn remove(&self, text: &str) -> Result<String, ManagedBlockError> {
+        match self.locate(text)? {
+            None => Ok(text.to_string()),
+            Some(span) => Ok(remove_block(text, &span)),
+        }
+    }
+
+    fn locate(&self, text: &str) -> Result<Option<BlockSpan>, ManagedBlockError> {
+        let open = self.open_marker();
+        let close = self.close_marker();
+
+        let open_hits = line_anchored_matches(text, &open);
+        let close_hits = line_anchored_matches(text, &close);
+
+        if open_hits.len() != close_hits.len() {
+            return Err(ManagedBlockError::Unbalanced {
+                surface: self.surface.clone(),
+                open: open_hits.len(),
+                close: close_hits.len(),
+            });
+        }
+        if open_hits.is_empty() {
+            return Ok(None);
+        }
+        if open_hits.len() > 1 {
+            return Err(ManagedBlockError::Duplicate {
+                surface: self.surface.clone(),
+            });
+        }
+
+        let open_start = open_hits[0];
+        let close_start = close_hits[0];
+        let open_end = open_start + open.len();
+        if close_start < open_end {
+            return Err(ManagedBlockError::OutOfOrder {
+                surface: self.surface.clone(),
+            });
+        }
+        let close_end = close_start + close.len();
+
+        // Trim one `\n` immediately after the open marker and one `\n`
+        // immediately before the close marker so the body is the
+        // interior lines without their framing terminators. If those
+        // newlines are absent the markers are on the same line as body
+        // content — unusual but tolerated.
+        let body_start = if text.as_bytes().get(open_end) == Some(&b'\n') {
+            open_end + 1
+        } else {
+            open_end
+        };
+        let body_end = if close_start > 0 && text.as_bytes()[close_start - 1] == b'\n' {
+            close_start - 1
+        } else {
+            close_start
+        };
+        let body_end = body_end.max(body_start);
+
+        Ok(Some(BlockSpan {
+            open_start,
+            body_start,
+            body_end,
+            close_end,
+        }))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BlockSpan {
+    open_start: usize,
+    body_start: usize,
+    body_end: usize,
+    close_end: usize,
+}
+
+/// Locate every position in `text` where `needle` appears at the start of
+/// a line (column 0). Anchoring matches to line starts prevents false
+/// positives from a marker substring quoted inside string literals.
+fn line_anchored_matches(text: &str, needle: &str) -> Vec<usize> {
+    let mut out = Vec::new();
+    let bytes = text.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    if needle_bytes.is_empty() {
+        return out;
+    }
+    let mut idx = 0usize;
+    while idx + needle_bytes.len() <= bytes.len() {
+        if bytes[idx..idx + needle_bytes.len()] == *needle_bytes {
+            let at_line_start = idx == 0 || bytes[idx - 1] == b'\n';
+            let line_end_pos = idx + needle_bytes.len();
+            let line_terminates = line_end_pos == bytes.len() || bytes[line_end_pos] == b'\n';
+            if at_line_start && line_terminates {
+                out.push(idx);
+                idx = line_end_pos;
+                continue;
+            }
+        }
+        idx += 1;
+    }
+    out
+}
+
+fn canonicalize_body(body: &str) -> String {
+    let trimmed = body.trim_end_matches('\n');
+    trimmed.to_string()
+}
+
+fn append_block(text: &str, open: &str, close: &str, body: &str) -> String {
+    let mut out = String::with_capacity(text.len() + open.len() + body.len() + close.len() + 4);
+    out.push_str(text);
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(open);
+    out.push('\n');
+    if !body.is_empty() {
+        out.push_str(body);
+        out.push('\n');
+    }
+    out.push_str(close);
+    out.push('\n');
+    out
+}
+
+fn replace_block(text: &str, span: &BlockSpan, open: &str, close: &str, body: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    out.push_str(&text[..span.open_start]);
+    out.push_str(open);
+    out.push('\n');
+    if !body.is_empty() {
+        out.push_str(body);
+        out.push('\n');
+    }
+    out.push_str(close);
+    out.push_str(&text[span.close_end..]);
+    out
+}
+
+fn remove_block(text: &str, span: &BlockSpan) -> String {
+    let mut start = span.open_start;
+    let mut end = span.close_end;
+    // Absorb the single newline that follows the close marker so we do
+    // not leave a stranded blank line behind. Bytes further out are
+    // preserved verbatim.
+    if text.as_bytes().get(end) == Some(&b'\n') {
+        end += 1;
+    } else if start > 0 && text.as_bytes()[start - 1] == b'\n' {
+        // The block was the last line and had no trailing newline; pull
+        // the leading newline in instead so we still close the gap.
+        start -= 1;
+    }
+    let mut out = String::with_capacity(text.len());
+    out.push_str(&text[..start]);
+    out.push_str(&text[end..]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn toml_block() -> ManagedBlock {
+        ManagedBlock::new("install", CommentStyle::Hash)
+    }
+
+    fn json_block() -> ManagedBlock {
+        ManagedBlock::new("install", CommentStyle::DoubleSlash)
+    }
+
+    #[test]
+    fn marker_strings_match_resolved_contract() {
+        let b = toml_block();
+        assert_eq!(b.open_marker(), "# >>> agent-runtime-kit:install >>>");
+        assert_eq!(b.close_marker(), "# <<< agent-runtime-kit:install <<<");
+        let j = json_block();
+        assert_eq!(j.open_marker(), "// >>> agent-runtime-kit:install >>>");
+        assert_eq!(j.close_marker(), "// <<< agent-runtime-kit:install <<<");
+    }
+
+    #[test]
+    fn read_returns_none_when_no_markers_present() {
+        let b = toml_block();
+        assert_eq!(b.read("plain config").unwrap(), None);
+        assert_eq!(b.read("").unwrap(), None);
+    }
+
+    #[test]
+    fn read_returns_body_between_paired_markers() {
+        let b = toml_block();
+        let text = "leading\n# >>> agent-runtime-kit:install >>>\nfoo = 1\nbar = 2\n# <<< agent-runtime-kit:install <<<\ntrailing\n";
+        assert_eq!(b.read(text).unwrap(), Some("foo = 1\nbar = 2".to_string()));
+    }
+
+    #[test]
+    fn write_with_no_markers_requires_force() {
+        let b = toml_block();
+        let err = b.write("[plain]\n", "tag = 1", false).unwrap_err();
+        assert_eq!(
+            err,
+            ManagedBlockError::NotPresent {
+                surface: "install".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn write_with_force_appends_a_fresh_block() {
+        let b = toml_block();
+        let out = b.write("[plain]\n", "tag = 1", true).unwrap();
+        let expected = "[plain]\n# >>> agent-runtime-kit:install >>>\ntag = 1\n# <<< agent-runtime-kit:install <<<\n";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn write_preserves_bytes_outside_the_markers() {
+        let b = toml_block();
+        let before = "alpha\n# >>> agent-runtime-kit:install >>>\nold body\n# <<< agent-runtime-kit:install <<<\nbeta\n";
+        let after = b.write(before, "new body", false).unwrap();
+        // Outside the markers, both halves must be byte-identical.
+        let outside_before = "alpha\n";
+        let outside_after_tail = "\nbeta\n";
+        assert!(after.starts_with(outside_before));
+        assert!(after.ends_with(outside_after_tail));
+    }
+
+    #[test]
+    fn write_then_write_is_idempotent_on_same_body() {
+        let b = toml_block();
+        let base = "alpha\n# >>> agent-runtime-kit:install >>>\nold\n# <<< agent-runtime-kit:install <<<\nbeta\n";
+        let once = b.write(base, "next", false).unwrap();
+        let twice = b.write(&once, "next", false).unwrap();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn write_then_write_force_creates_block_idempotently() {
+        let b = toml_block();
+        let base = "[plain]\n";
+        let once = b.write(base, "tag = 1", true).unwrap();
+        let twice = b.write(&once, "tag = 1", true).unwrap();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn remove_strips_block_and_collapses_trailing_newline() {
+        let b = toml_block();
+        let before = "alpha\n# >>> agent-runtime-kit:install >>>\nfoo\n# <<< agent-runtime-kit:install <<<\nbeta\n";
+        let after = b.remove(before).unwrap();
+        assert_eq!(after, "alpha\nbeta\n");
+    }
+
+    #[test]
+    fn remove_is_a_noop_when_block_absent() {
+        let b = toml_block();
+        assert_eq!(b.remove("plain config").unwrap(), "plain config");
+    }
+
+    #[test]
+    fn unbalanced_markers_refuse() {
+        let b = toml_block();
+        let text = "alpha\n# >>> agent-runtime-kit:install >>>\nfoo\nbeta\n";
+        let err = b.read(text).unwrap_err();
+        match err {
+            ManagedBlockError::Unbalanced { open, close, .. } => {
+                assert_eq!((open, close), (1, 0));
+            }
+            other => panic!("expected Unbalanced, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn out_of_order_markers_refuse() {
+        let b = toml_block();
+        let text =
+            "# <<< agent-runtime-kit:install <<<\nfoo\n# >>> agent-runtime-kit:install >>>\n";
+        let err = b.read(text).unwrap_err();
+        assert!(matches!(err, ManagedBlockError::OutOfOrder { .. }));
+    }
+
+    #[test]
+    fn duplicate_blocks_refuse() {
+        let b = toml_block();
+        let text = "# >>> agent-runtime-kit:install >>>\na\n# <<< agent-runtime-kit:install <<<\n# >>> agent-runtime-kit:install >>>\nb\n# <<< agent-runtime-kit:install <<<\n";
+        let err = b.read(text).unwrap_err();
+        assert!(matches!(err, ManagedBlockError::Duplicate { .. }));
+    }
+
+    #[test]
+    fn markers_inside_string_literals_are_ignored() {
+        // Marker substrings that are not at column 0 must not be picked
+        // up — line anchoring is what keeps the helper safe to use
+        // against settings.json values that may contain similar text.
+        let b = json_block();
+        let text = "{\n  \"note\": \"// >>> agent-runtime-kit:install >>> inline string\"\n}\n";
+        assert_eq!(b.read(text).unwrap(), None);
+    }
+
+    #[test]
+    fn round_trip_preserves_outside_bytes_across_seeds() {
+        // Property-style sweep: a handful of deterministic seeds exercise
+        // body shapes that have historically tripped marker handlers —
+        // empty bodies, multi-line bodies, bodies that themselves contain
+        // marker-like substrings, and bodies with trailing newlines.
+        let b = toml_block();
+        let outside_prefix = "alpha\nbeta\n";
+        let outside_suffix = "gamma\ndelta\n";
+        let bodies = [
+            "",
+            "x = 1",
+            "x = 1\ny = 2\nz = 3",
+            "still text\n", // trailing newline canonicalised
+            "marker-like text >>> agent-runtime-kit:other", // not column 0
+            "k = \"# >>> agent-runtime-kit:install >>>\"", // marker inside a string
+        ];
+        for body in bodies {
+            let base = format!(
+                "{outside_prefix}# >>> agent-runtime-kit:install >>>\nseed\n# <<< agent-runtime-kit:install <<<\n{outside_suffix}"
+            );
+            let once = b.write(&base, body, false).unwrap();
+            let twice = b.write(&once, body, false).unwrap();
+            assert_eq!(once, twice, "body={body:?}");
+            assert!(once.starts_with(outside_prefix), "body={body:?}");
+            assert!(once.ends_with(outside_suffix), "body={body:?}");
+            let read_back = b.read(&once).unwrap().unwrap();
+            assert_eq!(read_back, canonicalize_body(body), "body={body:?}");
+        }
+    }
+}

--- a/crates/agent-runtime-cli/src/managed_block.rs
+++ b/crates/agent-runtime-cli/src/managed_block.rs
@@ -19,6 +19,18 @@
 //!   `force = true`; this keeps the first install opt-in explicit.
 //! - Unbalanced markers (one half present, the other missing) refuse with
 //!   a typed error naming the surface.
+//! - The `body` passed to `write` must not itself contain a line that
+//!   matches our open or close marker — that would write a file that
+//!   refuses to round-trip. The helper validates and refuses.
+//!
+//! Caller contract:
+//!
+//! - `surface` is a trusted identifier. The helper accepts ASCII
+//!   alphanumeric / `-` / `_` only and `debug_assert!`s the shape; release
+//!   builds trust the caller. Embedding newlines or marker tokens in the
+//!   surface name will produce well-formed but surprising markers.
+//! - Inputs are assumed to use LF (`\n`) line endings. CRLF files are out
+//!   of scope for Plan 04 and may silently no-op on `read`.
 //!
 //! Source: `agent-runtime-kit/docs/plans/04-installer-doctor-and-bootstrap/
 //! 04-installer-doctor-and-bootstrap-plan.md` Sprint 1 Task 1.1.
@@ -64,6 +76,17 @@ pub enum ManagedBlockError {
     /// More than one complete block for the same surface in one file.
     #[error("managed block for surface `{surface}` appears multiple times in one file")]
     Duplicate { surface: String },
+    /// The provided body contains a line that matches our own open or
+    /// close marker — writing it would corrupt the file so the next read
+    /// or write fails with `Unbalanced` or `Duplicate`. Refused at the
+    /// write boundary so the file on disk stays intact.
+    #[error(
+        "managed block body for surface `{surface}` contains its own marker line ({which}); refused"
+    )]
+    BodyContainsMarker {
+        surface: String,
+        which: &'static str,
+    },
 }
 
 /// Owns the marker syntax for one (surface, comment-style) pair.
@@ -75,10 +98,12 @@ pub struct ManagedBlock {
 
 impl ManagedBlock {
     pub fn new(surface: impl Into<String>, style: CommentStyle) -> Self {
-        Self {
-            surface: surface.into(),
-            style,
-        }
+        let surface = surface.into();
+        debug_assert!(
+            is_trusted_surface(&surface),
+            "surface name `{surface}` must be ASCII alphanumeric / `-` / `_` and non-empty",
+        );
+        Self { surface, style }
     }
 
     pub fn surface(&self) -> &str {
@@ -120,6 +145,20 @@ impl ManagedBlock {
     /// when `force` is true.
     pub fn write(&self, text: &str, body: &str, force: bool) -> Result<String, ManagedBlockError> {
         let body = canonicalize_body(body);
+        let open = self.open_marker();
+        let close = self.close_marker();
+        if !line_anchored_matches(&body, &open).is_empty() {
+            return Err(ManagedBlockError::BodyContainsMarker {
+                surface: self.surface.clone(),
+                which: "open",
+            });
+        }
+        if !line_anchored_matches(&body, &close).is_empty() {
+            return Err(ManagedBlockError::BodyContainsMarker {
+                surface: self.surface.clone(),
+                which: "close",
+            });
+        }
         match self.locate(text)? {
             None => {
                 if !force {
@@ -127,20 +166,9 @@ impl ManagedBlock {
                         surface: self.surface.clone(),
                     });
                 }
-                Ok(append_block(
-                    text,
-                    &self.open_marker(),
-                    &self.close_marker(),
-                    &body,
-                ))
+                Ok(append_block(text, &open, &close, &body))
             }
-            Some(span) => Ok(replace_block(
-                text,
-                &span,
-                &self.open_marker(),
-                &self.close_marker(),
-                &body,
-            )),
+            Some(span) => Ok(replace_block(text, &span, &open, &close, &body)),
         }
     }
 
@@ -250,6 +278,12 @@ fn line_anchored_matches(text: &str, needle: &str) -> Vec<usize> {
 fn canonicalize_body(body: &str) -> String {
     let trimmed = body.trim_end_matches('\n');
     trimmed.to_string()
+}
+
+fn is_trusted_surface(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
 fn append_block(text: &str, open: &str, close: &str, body: &str) -> String {
@@ -440,6 +474,58 @@ mod tests {
         let b = json_block();
         let text = "{\n  \"note\": \"// >>> agent-runtime-kit:install >>> inline string\"\n}\n";
         assert_eq!(b.read(text).unwrap(), None);
+    }
+
+    #[test]
+    fn write_rejects_body_that_contains_open_marker_line_on_append() {
+        let b = toml_block();
+        let evil = "# >>> agent-runtime-kit:install >>>";
+        let err = b.write("[plain]\n", evil, true).unwrap_err();
+        match err {
+            ManagedBlockError::BodyContainsMarker { surface, which } => {
+                assert_eq!(surface, "install");
+                assert_eq!(which, "open");
+            }
+            other => panic!("expected BodyContainsMarker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn write_rejects_body_that_contains_close_marker_line_on_replace() {
+        let b = toml_block();
+        let base = "alpha\n# >>> agent-runtime-kit:install >>>\nold\n# <<< agent-runtime-kit:install <<<\nbeta\n";
+        let evil = "innocent = 1\n# <<< agent-runtime-kit:install <<<\nmore = 2";
+        let err = b.write(base, evil, false).unwrap_err();
+        match err {
+            ManagedBlockError::BodyContainsMarker { surface, which } => {
+                assert_eq!(surface, "install");
+                assert_eq!(which, "close");
+            }
+            other => panic!("expected BodyContainsMarker, got {other:?}"),
+        }
+        // File on disk is untouched after a refused write.
+        // (The caller controls disk; this assertion just confirms the
+        // helper returns without producing a corrupted string.)
+    }
+
+    #[test]
+    fn write_accepts_body_containing_marker_substring_off_column_zero() {
+        // Same fingerprint, but not at the start of a line — must pass.
+        let b = toml_block();
+        let body = "    # >>> agent-runtime-kit:install >>> nested";
+        let out = b.write("[plain]\n", body, true).unwrap();
+        assert_eq!(b.read(&out).unwrap().as_deref(), Some(body));
+    }
+
+    #[test]
+    fn is_trusted_surface_accepts_canonical_identifiers() {
+        assert!(is_trusted_surface("install"));
+        assert!(is_trusted_surface("link-map"));
+        assert!(is_trusted_surface("agent_runtime_v2"));
+        assert!(!is_trusted_surface(""));
+        assert!(!is_trusted_surface("install\nmore"));
+        assert!(!is_trusted_surface("install >>>"));
+        assert!(!is_trusted_surface("install:tag"));
     }
 
     #[test]

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -9,6 +9,8 @@ mod audit_drift_classes;
 mod cli;
 #[path = "integration/determinism_gate.rs"]
 mod determinism_gate;
+#[path = "integration/managed_block.rs"]
+mod managed_block;
 #[path = "integration/render.rs"]
 mod render;
 #[path = "integration/render_determinism.rs"]

--- a/crates/agent-runtime-cli/tests/integration/managed_block.rs
+++ b/crates/agent-runtime-cli/tests/integration/managed_block.rs
@@ -102,6 +102,29 @@ fn remove_strips_block_and_leaves_outside_bytes_intact() {
 }
 
 #[test]
+fn write_refuses_when_body_contains_close_marker_line() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("config.toml");
+    let initial = "alpha\n# >>> agent-runtime-kit:install >>>\nold = 1\n# <<< agent-runtime-kit:install <<<\nbeta\n";
+    fs::write(&path, initial).unwrap();
+
+    let block = ManagedBlock::new("install", CommentStyle::Hash);
+    let before = fs::read_to_string(&path).unwrap();
+    let body = "tag = 1\n# <<< agent-runtime-kit:install <<<\nmore = 2";
+    let err = block.write(&before, body, true).unwrap_err();
+    match err {
+        ManagedBlockError::BodyContainsMarker { surface, which } => {
+            assert_eq!(surface, "install");
+            assert_eq!(which, "close");
+        }
+        other => panic!("expected BodyContainsMarker, got {other:?}"),
+    }
+
+    // File on disk must be byte-for-byte unchanged after the refusal.
+    assert_eq!(fs::read_to_string(&path).unwrap(), initial);
+}
+
+#[test]
 fn unbalanced_markers_refuse_and_do_not_mutate_file() {
     let tmp = TempDir::new().unwrap();
     let path = tmp.path().join("config.toml");

--- a/crates/agent-runtime-cli/tests/integration/managed_block.rs
+++ b/crates/agent-runtime-cli/tests/integration/managed_block.rs
@@ -1,0 +1,157 @@
+//! Integration tests for the `managed_block` helper that drive the
+//! contract through real on-disk read / write / remove cycles. The
+//! in-tree unit tests in `src/managed_block.rs` cover marker math and
+//! error variants; this suite focuses on the file-system level
+//! idempotence guarantees the installer (Sprint 1 Task 1.2) depends on.
+
+use agent_runtime_cli::managed_block::{CommentStyle, ManagedBlock, ManagedBlockError};
+use std::fs;
+use tempfile::TempDir;
+
+fn write_then_read(path: &std::path::Path, body: &str, force: bool, block: &ManagedBlock) {
+    let before = fs::read_to_string(path).unwrap();
+    let after = block.write(&before, body, force).unwrap();
+    fs::write(path, &after).unwrap();
+}
+
+#[test]
+fn first_install_appends_block_and_round_trips() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("config.toml");
+    fs::write(&path, "model = \"sonnet\"\n").unwrap();
+
+    let block = ManagedBlock::new("install", CommentStyle::Hash);
+    let body = "tag = \"agent-runtime\"\nlive_home = \"/tmp/sandbox\"";
+
+    // First install requires `force` because no markers exist yet.
+    write_then_read(&path, body, true, &block);
+    let installed = fs::read_to_string(&path).unwrap();
+    assert!(installed.starts_with("model = \"sonnet\"\n"));
+    assert!(
+        installed.contains("# >>> agent-runtime-kit:install >>>\n"),
+        "open marker missing: {installed:?}"
+    );
+    assert!(
+        installed.contains("# <<< agent-runtime-kit:install <<<\n"),
+        "close marker missing: {installed:?}"
+    );
+    assert_eq!(block.read(&installed).unwrap().as_deref(), Some(body));
+
+    // Re-running the install with the same body is byte-identical
+    // (idempotence on the apply path).
+    let second = block.write(&installed, body, false).unwrap();
+    assert_eq!(second, installed);
+}
+
+#[test]
+fn write_without_force_fails_on_clean_file() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("settings.json");
+    fs::write(&path, "{\n  \"model\": \"sonnet\"\n}\n").unwrap();
+
+    let block = ManagedBlock::new("install", CommentStyle::DoubleSlash);
+    let before = fs::read_to_string(&path).unwrap();
+    let err = block.write(&before, "{}", false).unwrap_err();
+    assert_eq!(
+        err,
+        ManagedBlockError::NotPresent {
+            surface: "install".to_string()
+        }
+    );
+
+    // File is untouched after a refused write.
+    let after = fs::read_to_string(&path).unwrap();
+    assert_eq!(before, after);
+}
+
+#[test]
+fn replace_preserves_outside_bytes_byte_for_byte() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("config.toml");
+    let outside_head = "[server]\nport = 4242\n\n";
+    let outside_tail = "\n[client]\nlanguage = \"en\"\n";
+    let initial = format!(
+        "{outside_head}# >>> agent-runtime-kit:install >>>\nold = 1\n# <<< agent-runtime-kit:install <<<{outside_tail}"
+    );
+    fs::write(&path, &initial).unwrap();
+
+    let block = ManagedBlock::new("install", CommentStyle::Hash);
+    let before = fs::read_to_string(&path).unwrap();
+    let after = block.write(&before, "fresh = 1\nmore = 2", false).unwrap();
+
+    assert!(after.starts_with(outside_head));
+    assert!(after.ends_with(outside_tail));
+    assert_eq!(
+        block.read(&after).unwrap().as_deref(),
+        Some("fresh = 1\nmore = 2")
+    );
+}
+
+#[test]
+fn remove_strips_block_and_leaves_outside_bytes_intact() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("config.toml");
+    let initial = "alpha\n# >>> agent-runtime-kit:install >>>\ngarbage\n# <<< agent-runtime-kit:install <<<\nbeta\n";
+    fs::write(&path, initial).unwrap();
+
+    let block = ManagedBlock::new("install", CommentStyle::Hash);
+    let cleaned = block.remove(&fs::read_to_string(&path).unwrap()).unwrap();
+    fs::write(&path, &cleaned).unwrap();
+
+    assert_eq!(fs::read_to_string(&path).unwrap(), "alpha\nbeta\n");
+}
+
+#[test]
+fn unbalanced_markers_refuse_and_do_not_mutate_file() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("config.toml");
+    // Open marker without a paired close — must refuse with a typed error.
+    let initial = "model = \"sonnet\"\n# >>> agent-runtime-kit:install >>>\nfoo = 1\n";
+    fs::write(&path, initial).unwrap();
+
+    let block = ManagedBlock::new("install", CommentStyle::Hash);
+    let before = fs::read_to_string(&path).unwrap();
+    let err = block.write(&before, "next = 2", true).unwrap_err();
+    match err {
+        ManagedBlockError::Unbalanced {
+            open,
+            close,
+            surface,
+        } => {
+            assert_eq!(surface, "install");
+            assert_eq!((open, close), (1, 0));
+        }
+        other => panic!("expected Unbalanced, got {other:?}"),
+    }
+    // Original file must still be byte-for-byte identical.
+    assert_eq!(fs::read_to_string(&path).unwrap(), initial);
+}
+
+#[test]
+fn jsonc_surface_round_trips_through_settings_file() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("settings.json");
+    let initial = "{\n  \"model\": \"sonnet\"\n}\n";
+    fs::write(&path, initial).unwrap();
+
+    let block = ManagedBlock::new("install", CommentStyle::DoubleSlash);
+    let body = "\"tag\": \"agent-runtime\",\n\"live_home\": \"/tmp/sandbox\"";
+
+    let installed = block
+        .write(&fs::read_to_string(&path).unwrap(), body, true)
+        .unwrap();
+    fs::write(&path, &installed).unwrap();
+    assert!(installed.contains("// >>> agent-runtime-kit:install >>>\n"));
+    assert_eq!(
+        block
+            .read(&fs::read_to_string(&path).unwrap())
+            .unwrap()
+            .as_deref(),
+        Some(body)
+    );
+
+    // Removing it must restore the original file byte-for-byte.
+    let cleaned = block.remove(&fs::read_to_string(&path).unwrap()).unwrap();
+    fs::write(&path, &cleaned).unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), initial);
+}


### PR DESCRIPTION
# Plan 04 Sprint 1 Task 1.1: managed-block helper module

## Summary

Lands the `managed_block` helper module under `agent-runtime-cli` that owns the
paired-marker contract for Plan 04's install pipeline (Sprint 1 Task 1.2) and
the Sprint 2 lifecycle siblings. The module guarantees byte-for-byte
preservation outside markers, idempotent re-writes, refusal to re-add without
`force = true`, refusal to write a body containing its own markers, and typed
errors on unbalanced / out-of-order / duplicate markers — covering both Codex
`config.toml` (`#`-prefixed markers) and Claude `settings.json` (`//`-prefixed
JSONC markers).

## Changes

- `crates/agent-runtime-cli/src/managed_block.rs` (new) — `ManagedBlock` struct with `read` / `write` / `remove`, `CommentStyle::{Hash,DoubleSlash}` for TOML / JSONC, `ManagedBlockError` typed error enum (`NotPresent` / `Unbalanced` / `OutOfOrder` / `Duplicate` / `BodyContainsMarker`), `is_trusted_surface` invariant with `debug_assert!` in `new()`, line-anchored marker matching that ignores marker substrings inside string literals, body canonicalisation (strips trailing newlines) for stable idempotence, and 19 in-crate unit tests.
- `crates/agent-runtime-cli/src/lib.rs` — exports `pub mod managed_block`.
- `crates/agent-runtime-cli/tests/integration/managed_block.rs` (new) — 7 file-system integration tests: first-install-with-force round-trip, refusal-without-force, byte-for-byte replacement preservation, remove-strips-block, body-contains-close-marker refuses without mutating file, unbalanced-markers-do-not-mutate-file, jsonc-settings round-trip.
- `crates/agent-runtime-cli/tests/integration.rs` — wires the new integration test file into the consolidated test target.

## Review Findings & Resolutions

A `/code-review-specialists` pass surfaced two material defects on the first
push. Both are resolved in the follow-up fix commit:

- **F-2 (medium, security/red-team)** — `write()` did not validate `body` against the surface's own open/close markers. A caller passing a body whose canonicalised content contains a line matching `# >>> agent-runtime-kit:install >>>` (or the close form) would silently produce a file with unbalanced markers, after which every subsequent `read`/`write` errors. Resolved by adding `ManagedBlockError::BodyContainsMarker` and short-circuiting in `write()` before any side effect.
- **F-1 (medium → documented invariant)** — `ManagedBlock::new` accepted arbitrary `String` surfaces, allowing newline / marker tokens that would produce well-formed but surprising multi-line markers. All callers in this codebase pass hardcoded identifiers ("install", future "uninstall" / "link-map"), so this is downgraded to a `debug_assert!` invariant in `new()` backed by `is_trusted_surface` (ASCII alphanumeric + `-`/`_`, non-empty) and explicit module-doc contract.
- **F-3 (testing)** — LF-only line-ending assumption is now documented in the module-level docs. CRLF support is out of scope for Plan 04 Sprint 1 Task 1.1.

## Test-First Evidence

- Change classification: feature (with security/red-team review hardening)
- Failing test before fix: prior to this PR the `managed_block` module did not exist, so `cargo test -p agent-runtime-cli managed_block` selected zero tests (compile-only baseline). This PR adds 26 tests that exercise the contract — all pass on the new module. The 4 newly-added unit tests + 1 integration test for the F-1/F-2 hardening would have failed against the first push (which lacked `BodyContainsMarker` and the `is_trusted_surface` invariant).
- Final validation: `cargo nextest run -p agent-runtime-cli` → 142/142 pass. `cargo fmt --check` → exit 0. `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` → exit 0. `bash scripts/ci/nils-cli-checks-entrypoint.sh` → `ok: all nils-cli checks passed` (entire repo gate stack: docs-placement / docs-hygiene / markdownlint / plan-bundle-validate / cli-output-contract-lint / forge-cli-fixture-lint / test-stale-audit / third-party-artifacts-audit / completion-asset-audit / completion-flag-parity-audit / zsh completion test / `cargo fmt --all --check` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo nextest run --profile ci --workspace` / `cargo test --workspace --doc`).
- Waiver reason: not applicable.

## Testing

- `cargo nextest run -p agent-runtime-cli` (pass — 142/142)
- `cargo test -p agent-runtime-cli managed_block` (pass — 19 unit + 7 integration tests)
- `cargo fmt --check` (pass)
- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` (pass)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass)

## Risk / Notes

- Pure addition — no existing module is touched besides the two-line export in `lib.rs` and the one-line wire-in in `tests/integration.rs`. Risk surface is the new module's contract.
- Body canonicalisation strips trailing newlines: a caller that writes `body = "foo\n"` and then `read` returns `"foo"`. This keeps idempotence guarantees clean but is worth knowing for Sprint 1 Task 1.2 (install pipeline) which will be the first real caller.
- Marker matching is line-anchored: only matches that begin at column 0 and end at column-after-marker-or-EOL count. A marker substring inside a JSON string literal value will NOT trigger; the `markers_inside_string_literals_are_ignored` unit test pins that behavior.
- LF line endings only. CRLF files are out of scope for Plan 04 Sprint 1 Task 1.1; documented in the module-level docs.
- Surface names are trusted ASCII identifiers (`[A-Za-z0-9_-]+`); enforced by `debug_assert!` in `new()`. All call sites in this codebase pass hardcoded values.
- Plan 04 source-of-truth document was aligned in agent-runtime-kit PR #16 (merged 2026-05-21) so this Sprint 1 PR follows the corrected layout. Sprint 1 Task 1.2 (install pipeline) is the immediate downstream consumer.
