### PR TITLE
Harden git-lock destructive safety workflows

### DIFF
--- a/crates/git-cli/src/open.rs
+++ b/crates/git-cli/src/open.rs
@@ -182,6 +182,11 @@ fn open_commit(args: &[String]) -> i32 {
 }
 
 fn open_compare(args: &[String]) -> i32 {
+    if args.first().is_some_and(|arg| is_help_token(arg)) {
+        print_usage();
+        return 0;
+    }
+
     if args.len() > 2 {
         eprintln!("❌ git-cli open compare takes at most two refs");
         print_usage();
@@ -494,6 +499,11 @@ fn open_commits(args: &[String]) -> i32 {
 }
 
 fn open_file(args: &[String]) -> i32 {
+    if args.first().is_some_and(|arg| is_help_token(arg)) {
+        print_usage();
+        return 0;
+    }
+
     if args.is_empty() || args.len() > 2 {
         eprintln!("❌ Usage: git-cli open file <path> [ref]");
         return 2;
@@ -515,6 +525,11 @@ fn open_file(args: &[String]) -> i32 {
 }
 
 fn open_blame(args: &[String]) -> i32 {
+    if args.first().is_some_and(|arg| is_help_token(arg)) {
+        print_usage();
+        return 0;
+    }
+
     if args.is_empty() || args.len() > 2 {
         eprintln!("❌ Usage: git-cli open blame <path> [ref]");
         return 2;

--- a/crates/git-cli/src/utils.rs
+++ b/crates/git-cli/src/utils.rs
@@ -14,7 +14,21 @@ pub fn dispatch(cmd: &str, args: &[String]) -> Option<i32> {
     }
 }
 
-fn zip(_args: &[String]) -> i32 {
+fn zip(args: &[String]) -> i32 {
+    if args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "-h" | "--help" | "help"))
+    {
+        print_zip_help();
+        return 0;
+    }
+
+    if let Some(arg) = args.first() {
+        eprintln!("❗ Unknown argument: {arg}");
+        eprintln!("Usage: git-cli utils zip");
+        return 1;
+    }
+
     let short = match git_stdout_trimmed(&["rev-parse", "--short", "HEAD"]) {
         Ok(value) => value,
         Err(code) => return code,
@@ -30,6 +44,11 @@ fn zip(_args: &[String]) -> i32 {
         emit_output(&output);
         exit_code(&output)
     }
+}
+
+fn print_zip_help() {
+    println!("Usage: git-cli utils zip");
+    println!("Create backup-<short-sha>.zip from HEAD in the current directory.");
 }
 
 fn copy_staged(args: &[String]) -> i32 {

--- a/crates/git-cli/tests/integration/open.rs
+++ b/crates/git-cli/tests/integration/open.rs
@@ -93,6 +93,40 @@ fn open_file_encodes_path_spaces() {
 }
 
 #[test]
+fn open_leaf_help_does_not_launch_browser() {
+    let harness = GitCliHarness::new();
+    let dir = init_repo();
+    git(
+        dir.path(),
+        &["remote", "add", "origin", "git@github.com:acme/repo.git"],
+    );
+
+    for args in [
+        &["open", "compare", "--help"][..],
+        &["open", "file", "--help"][..],
+        &["open", "blame", "--help"][..],
+    ] {
+        let output = run_with_open_script(
+            &harness,
+            dir.path(),
+            args,
+            r#"#!/bin/bash
+echo "open should not be called" >&2
+exit 99
+"#,
+        );
+
+        assert_eq!(output.code, 0, "args: {args:?}");
+        assert_eq!(output.stderr_text(), "", "args: {args:?}");
+        assert!(
+            output.stdout_text().contains("Usage:\n  git-cli open"),
+            "args: {args:?}, stdout: {}",
+            output.stdout_text()
+        );
+    }
+}
+
+#[test]
 fn open_actions_rejects_non_github_provider() {
     let harness = GitCliHarness::new();
     let dir = init_repo();

--- a/crates/git-cli/tests/integration/utils.rs
+++ b/crates/git-cli/tests/integration/utils.rs
@@ -8,6 +8,10 @@ fn copy_staged_help() -> &'static str {
     "Usage: git-cli utils copy-staged [-p|--stdout|--both]\n  -p, --stdout, --print   Print staged diff to stdout (no status message)\n  --both                  Print to stdout and copy to clipboard\n"
 }
 
+fn zip_help() -> &'static str {
+    "Usage: git-cli utils zip\nCreate backup-<short-sha>.zip from HEAD in the current directory.\n"
+}
+
 fn trim_trailing_newlines(input: &str) -> &str {
     input.trim_end_matches(['\n', '\r'])
 }
@@ -59,6 +63,26 @@ fn utils_zip_creates_backup_zip() {
 
     let zip_path = dir.path().join(format!("backup-{short}.zip"));
     assert!(zip_path.exists(), "expected zip archive to exist");
+}
+
+#[test]
+fn utils_zip_help_does_not_create_backup_zip() {
+    let harness = GitCliHarness::new();
+    let dir = init_repo();
+
+    let output = harness.run(dir.path(), &["utils", "zip", "--help"]);
+
+    assert_eq!(output.code, 0);
+    assert_eq!(output.stderr_text(), "");
+    assert_eq!(output.stdout_text(), zip_help());
+
+    let entries: Vec<_> = fs::read_dir(dir.path())
+        .expect("read repo")
+        .filter_map(Result::ok)
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter(|name| name.starts_with("backup-") && name.ends_with(".zip"))
+        .collect();
+    assert!(entries.is_empty(), "unexpected backup files: {entries:?}");
 }
 
 #[test]

--- a/crates/git-lock/src/delete.rs
+++ b/crates/git-lock/src/delete.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
+use nils_common::cli_contract::exit;
 use std::fs;
+use std::io::{self, IsTerminal};
 
 use crate::git::DefaultGitBackend;
 use crate::lock_view::LockDetails;
@@ -8,6 +10,15 @@ use crate::prompt;
 use crate::store::LockStore;
 
 pub fn run(args: &[String]) -> Result<i32> {
+    let options = match DeleteOptions::parse(args) {
+        Ok(options) => options,
+        Err(message) => {
+            println!("{message}");
+            println!("{}", messages::DELETE_USAGE);
+            return Ok(exit::USAGE);
+        }
+    };
+
     let store = LockStore::open()?;
     let lock_dir = store.lock_dir().to_path_buf();
 
@@ -16,11 +27,12 @@ pub fn run(args: &[String]) -> Result<i32> {
         return Ok(1);
     }
 
-    let label_arg = args.first().map(String::as_str);
+    let label_arg = options.label.as_deref();
     let label = match store.resolve_label(label_arg)? {
         Some(label) => label,
         None => {
             println!("❌ No label provided and no latest git-lock exists");
+            println!("Hint: run `git-lock list` to see available locks.");
             return Ok(1);
         }
     };
@@ -28,6 +40,7 @@ pub fn run(args: &[String]) -> Result<i32> {
     let lock_file = store.lock_path(&label);
     if !lock_file.exists() {
         println!("❌ git-lock [{label}] not found");
+        println!("Hint: run `git-lock list` to see available locks.");
         return Ok(1);
     }
 
@@ -50,9 +63,17 @@ pub fn run(args: &[String]) -> Result<i32> {
     }
     println!();
 
-    let prompt = "⚠️  Delete this git-lock? [y/N] ";
-    if !prompt::confirm(prompt)? {
-        return Ok(1);
+    if !options.force {
+        if !io::stdin().is_terminal() {
+            eprintln!("error: git-lock delete requires --force when stdin is not a TTY");
+            return Ok(exit::USAGE);
+        }
+
+        println!("{}", delete_warning());
+        let prompt = "⚠️  Delete this git-lock? [y/N] ";
+        if !prompt::confirm(prompt)? {
+            return Ok(1);
+        }
     }
 
     fs::remove_file(&lock_file)?;
@@ -63,4 +84,63 @@ pub fn run(args: &[String]) -> Result<i32> {
     }
 
     Ok(0)
+}
+
+fn delete_warning() -> &'static str {
+    "WARNING: this permanently deletes the lock record from disk"
+}
+
+#[derive(Debug, Default)]
+struct DeleteOptions {
+    force: bool,
+    label: Option<String>,
+}
+
+impl DeleteOptions {
+    fn parse(args: &[String]) -> std::result::Result<Self, String> {
+        let mut options = Self::default();
+
+        for arg in args.iter().map(String::as_str) {
+            match arg {
+                "--force" | "-f" => options.force = true,
+                "--help" | "-h" => return Err(String::new()),
+                _ if arg.starts_with('-') => {
+                    return Err(format!("❗ Unknown delete option: {arg}"));
+                }
+                _ => {
+                    if options.label.is_some() {
+                        return Err("❗ Too many labels provided (expected at most 1)".to_string());
+                    }
+                    options.label = Some(arg.to_string());
+                }
+            }
+        }
+
+        Ok(options)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DeleteOptions, delete_warning};
+
+    #[test]
+    fn parses_force_and_label() {
+        let args = vec!["--force".to_string(), "wip".to_string()];
+        let parsed = DeleteOptions::parse(&args).expect("parse");
+        assert!(parsed.force);
+        assert_eq!(parsed.label.as_deref(), Some("wip"));
+    }
+
+    #[test]
+    fn rejects_unknown_flags() {
+        let args = vec!["--wat".to_string()];
+        let err = DeleteOptions::parse(&args).expect_err("reject");
+        assert!(err.contains("Unknown delete option"));
+    }
+
+    #[test]
+    fn warning_mentions_permanent_disk_delete() {
+        assert!(delete_warning().contains("permanently deletes the lock record from disk"));
+    }
 }

--- a/crates/git-lock/src/errors.rs
+++ b/crates/git-lock/src/errors.rs
@@ -1,0 +1,61 @@
+use anyhow::Error;
+
+pub fn format_error(err: &Error) -> String {
+    let rendered = format!("{err:#}");
+    match hint_for(&rendered) {
+        Some(hint) => format!("{rendered}\nHint: {hint}"),
+        None => rendered,
+    }
+}
+
+fn hint_for(rendered: &str) -> Option<&'static str> {
+    let lower = rendered.to_ascii_lowercase();
+
+    if lower.contains("git-lock") && lower.contains("not found") {
+        return Some("run `git-lock list` to see available locks.");
+    }
+
+    if lower.contains("ambiguous") && lower.contains("label") {
+        return Some("use the full git-lock label shown by `git-lock list`.");
+    }
+
+    if lower.contains("git ") && (lower.contains("failed") || lower.contains("not found")) {
+        return Some("ensure `git` is installed and run this command inside a Git repository.");
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_error;
+    use anyhow::anyhow;
+
+    #[test]
+    fn formats_label_not_found_hint() {
+        let err = anyhow!("git-lock [repo:missing] not found");
+        let rendered = format_error(&err);
+        assert!(rendered.contains("run `git-lock list`"));
+    }
+
+    #[test]
+    fn formats_ambiguous_label_hint() {
+        let err = anyhow!("ambiguous label: rel");
+        let rendered = format_error(&err);
+        assert!(rendered.contains("use the full git-lock label"));
+    }
+
+    #[test]
+    fn formats_git_command_hint() {
+        let err = anyhow!("git [\"diff\", \"--stat\"] failed");
+        let rendered = format_error(&err);
+        assert!(rendered.contains("ensure `git` is installed"));
+    }
+
+    #[test]
+    fn leaves_unknown_errors_unchanged() {
+        let err = anyhow!("something else failed");
+        let rendered = format_error(&err);
+        assert_eq!(rendered, "something else failed");
+    }
+}

--- a/crates/git-lock/src/git.rs
+++ b/crates/git-lock/src/git.rs
@@ -20,6 +20,10 @@ pub fn run_status_inherit(args: &[&str]) -> Result<i32> {
     Ok(status.code().unwrap_or(1))
 }
 
+pub fn run_output(args: &[&str]) -> Result<std::process::Output> {
+    common_git::run_output(args).with_context(|| format!("git {args:?}"))
+}
+
 pub fn rev_parse(value: &str) -> Result<Option<String>> {
     common_git::rev_parse(&[value]).with_context(|| format!("git rev-parse {value}"))
 }
@@ -40,7 +44,7 @@ pub fn tag_exists(tag: &str) -> Result<bool> {
 }
 
 fn run_git_trimmed_optional(args: &[&str]) -> Result<Option<String>> {
-    let output = common_git::run_output(args).with_context(|| format!("git {args:?}"))?;
+    let output = run_output(args)?;
 
     if !output.status.success() {
         return Ok(None);

--- a/crates/git-lock/src/main.rs
+++ b/crates/git-lock/src/main.rs
@@ -6,6 +6,7 @@ mod completion;
 mod copy;
 mod delete;
 mod diff;
+mod errors;
 mod fs;
 mod git;
 mod list;
@@ -139,7 +140,7 @@ fn run() -> i32 {
     match result {
         Ok(code) => code,
         Err(err) => {
-            eprintln!("{err:#}");
+            eprintln!("{}", errors::format_error(&err));
             exit::RUNTIME
         }
     }

--- a/crates/git-lock/src/messages.rs
+++ b/crates/git-lock/src/messages.rs
@@ -3,6 +3,9 @@ pub const UNKNOWN_COMMAND_HINT: &str = "Run 'git-lock help' for usage.";
 pub const COPY_USAGE: &str = "❗ Usage: git-lock copy <source-label> <target-label>";
 pub const TARGET_LABEL_MISSING: &str = "❗ Target label is missing";
 pub const NO_GIT_LOCKS_FOUND: &str = "❌ No git-locks found";
+pub const UNLOCK_USAGE: &str =
+    "❗ Usage: git-lock unlock [--dry-run] [--verbose|--show-diff] [label]";
+pub const DELETE_USAGE: &str = "❗ Usage: git-lock delete [--force] [label]";
 pub const DIFF_USAGE: &str = "❗ Usage: git-lock diff <label1> <label2> [--no-color]";
 pub const TAG_USAGE: &str =
     "❗ Usage: git-lock tag <git-lock-label> <tag-name> [-m <tag-message>] [--push]";

--- a/crates/git-lock/src/unlock.rs
+++ b/crates/git-lock/src/unlock.rs
@@ -1,13 +1,23 @@
 use anyhow::Result;
+use nils_common::cli_contract::exit;
 
 use crate::git;
 use crate::git::DefaultGitBackend;
 use crate::lock_view::LockDetails;
+use crate::messages;
 use crate::prompt;
 use crate::store::LockStore;
 
 pub fn run(args: &[String]) -> Result<i32> {
-    let label_arg = args.first().map(String::as_str);
+    let options = match UnlockOptions::parse(args) {
+        Ok(options) => options,
+        Err(message) => {
+            println!("{message}");
+            println!("{}", messages::UNLOCK_USAGE);
+            return Ok(exit::USAGE);
+        }
+    };
+    let label_arg = options.label.as_deref();
 
     let store = LockStore::open()?;
     store.ensure_dir()?;
@@ -16,6 +26,7 @@ pub fn run(args: &[String]) -> Result<i32> {
         Some(label) => label,
         None => {
             println!("❌ No recent git-lock found for {}", store.repo_id());
+            println!("Hint: run `git-lock list` to see available locks.");
             return Ok(1);
         }
     };
@@ -26,6 +37,7 @@ pub fn run(args: &[String]) -> Result<i32> {
             "❌ No git-lock named '{label}' found for {}",
             store.repo_id()
         );
+        println!("Hint: run `git-lock list` to see available locks.");
         return Ok(1);
     }
 
@@ -45,7 +57,24 @@ pub fn run(args: &[String]) -> Result<i32> {
     }
     println!();
 
-    let prompt = format!("⚠️  Hard reset to [{label}]? [y/N] ");
+    let preview = ResetPreview::load(&details.lock.hash, options.verbose)?;
+
+    if options.dry_run {
+        println!(
+            "Dry run: git-lock unlock [{label}] would reset HEAD to {}.",
+            details.lock.hash
+        );
+        preview.print(options.verbose);
+        return Ok(0);
+    }
+
+    preview.print(options.verbose);
+    println!();
+
+    let prompt = format!(
+        "⚠️  Hard reset to [{label}] ({}) and change {} files? [y/N] ",
+        details.lock.hash, preview.changed_files
+    );
     if !prompt::confirm(&prompt)? {
         return Ok(1);
     }
@@ -62,4 +91,147 @@ pub fn run(args: &[String]) -> Result<i32> {
     );
 
     Ok(0)
+}
+
+#[derive(Debug, Default)]
+struct UnlockOptions {
+    dry_run: bool,
+    verbose: bool,
+    label: Option<String>,
+}
+
+impl UnlockOptions {
+    fn parse(args: &[String]) -> std::result::Result<Self, String> {
+        let mut options = Self::default();
+
+        for arg in args.iter().map(String::as_str) {
+            match arg {
+                "--dry-run" => options.dry_run = true,
+                "--verbose" | "--show-diff" => options.verbose = true,
+                "--help" | "-h" => return Err(String::new()),
+                _ if arg.starts_with('-') => {
+                    return Err(format!("❗ Unknown unlock option: {arg}"));
+                }
+                _ => {
+                    if options.label.is_some() {
+                        return Err("❗ Too many labels provided (expected at most 1)".to_string());
+                    }
+                    options.label = Some(arg.to_string());
+                }
+            }
+        }
+
+        Ok(options)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResetPreview {
+    stat: String,
+    full_diff: Option<String>,
+    changed_files: usize,
+}
+
+impl ResetPreview {
+    fn load(hash: &str, include_full_diff: bool) -> Result<Self> {
+        let stat_output = git::run_output(&["diff", "--stat", "HEAD", hash])?;
+        if !stat_output.status.success() {
+            anyhow::bail!(
+                "git diff --stat HEAD {hash} failed: {}",
+                String::from_utf8_lossy(&stat_output.stderr).trim()
+            );
+        }
+
+        let stat = String::from_utf8_lossy(&stat_output.stdout).to_string();
+        let changed_files = count_changed_files(&stat);
+
+        let full_diff = if include_full_diff {
+            let diff_output = git::run_output(&["diff", "HEAD", hash])?;
+            if !diff_output.status.success() {
+                anyhow::bail!(
+                    "git diff HEAD {hash} failed: {}",
+                    String::from_utf8_lossy(&diff_output.stderr).trim()
+                );
+            }
+            Some(String::from_utf8_lossy(&diff_output.stdout).to_string())
+        } else {
+            None
+        };
+
+        Ok(Self {
+            stat,
+            full_diff,
+            changed_files,
+        })
+    }
+
+    fn print(&self, verbose: bool) {
+        println!("Reset preview:");
+        println!("   Changed files: {}", self.changed_files);
+        if self.stat.trim().is_empty() {
+            println!("   (no file changes)");
+        } else {
+            for line in self.stat.lines() {
+                println!("   {line}");
+            }
+        }
+
+        if verbose {
+            println!();
+            println!("Full diff:");
+            match self.full_diff.as_deref().map(str::trim_end) {
+                Some(diff) if !diff.is_empty() => println!("{diff}"),
+                _ => println!("(no diff)"),
+            }
+        }
+    }
+}
+
+fn count_changed_files(stat: &str) -> usize {
+    let non_empty: Vec<&str> = stat
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+    if non_empty.is_empty() {
+        return 0;
+    }
+
+    let last = non_empty.last().copied().unwrap_or_default();
+    if last.contains("file changed") || last.contains("files changed") {
+        non_empty.len().saturating_sub(1)
+    } else {
+        non_empty.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UnlockOptions, count_changed_files};
+
+    #[test]
+    fn parses_flags_and_label() {
+        let args = vec![
+            "--dry-run".to_string(),
+            "--verbose".to_string(),
+            "base".to_string(),
+        ];
+        let parsed = UnlockOptions::parse(&args).expect("parse");
+        assert!(parsed.dry_run);
+        assert!(parsed.verbose);
+        assert_eq!(parsed.label.as_deref(), Some("base"));
+    }
+
+    #[test]
+    fn rejects_unknown_flags() {
+        let args = vec!["--wat".to_string()];
+        let err = UnlockOptions::parse(&args).expect_err("reject");
+        assert!(err.contains("Unknown unlock option"));
+    }
+
+    #[test]
+    fn counts_git_stat_file_lines() {
+        let stat =
+            " a.txt | 2 +-\n b.txt | 1 +\n 2 files changed, 2 insertions(+), 1 deletion(-)\n";
+        assert_eq!(count_changed_files(stat), 2);
+    }
 }

--- a/crates/git-lock/tests/integration/copy_delete.rs
+++ b/crates/git-lock/tests/integration/copy_delete.rs
@@ -58,10 +58,42 @@ fn delete_latest() {
 
     run_git_lock(repo.path(), &["lock", "wip"], &env, None);
 
-    let output = run_git_lock_output(repo.path(), &["delete", "wip"], &env, Some("y\n"));
+    let output = run_git_lock_output(repo.path(), &["delete", "--force", "wip"], &env, None);
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(stdout.contains(&format!("🗑️  Deleted git-lock [{repo_name}:wip]")));
     assert!(stdout.contains("Removed latest marker"));
     assert!(!latest_file(&cache, &repo_name).exists());
+}
+
+#[test]
+fn delete_non_interactive_without_force_exits_usage() {
+    let repo = init_repo();
+    let cache = cache_dir();
+    let env = [("ZSH_CACHE_DIR", cache.path().to_str().unwrap())];
+
+    run_git_lock(repo.path(), &["lock", "wip"], &env, None);
+
+    let output = run_git_lock_output(repo.path(), &["delete", "wip"], &env, None);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(output.status.code(), Some(64));
+    assert!(stderr.contains("requires --force when stdin is not a TTY"));
+}
+
+#[test]
+fn delete_force_skips_prompt() {
+    let repo = init_repo();
+    let cache = cache_dir();
+    let repo_name = repo_id(repo.path());
+    let env = [("ZSH_CACHE_DIR", cache.path().to_str().unwrap())];
+
+    run_git_lock(repo.path(), &["lock", "wip"], &env, None);
+
+    let output = run_git_lock_output(repo.path(), &["delete", "--force", "wip"], &env, None);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success());
+    assert!(!stdout.contains("[y/N]"));
+    assert!(stdout.contains(&format!("🗑️  Deleted git-lock [{repo_name}:wip]")));
 }

--- a/crates/git-lock/tests/integration/edge_cases.rs
+++ b/crates/git-lock/tests/integration/edge_cases.rs
@@ -91,6 +91,7 @@ fn unlock_missing_label() {
     assert!(stdout.contains(&format!(
         "No git-lock named 'missing' found for {repo_name}"
     )));
+    assert!(stdout.contains("run `git-lock list`"));
     assert!(!output.status.success());
 }
 

--- a/crates/git-lock/tests/integration/lock_unlock.rs
+++ b/crates/git-lock/tests/integration/lock_unlock.rs
@@ -56,9 +56,76 @@ fn unlock_cancel() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains(&format!("🔐 Found [{repo_name}:wip]")));
-    assert!(stdout.contains("Hard reset to [wip]?"));
+    assert!(stdout.contains("Hard reset to [wip]"));
     assert!(stdout.contains("🚫 Aborted"));
     assert!(!output.status.success());
+}
+
+#[test]
+fn unlock_dry_run_prints_summary_and_keeps_head() {
+    let repo = init_repo();
+    let cache = cache_dir();
+    let env = [("ZSH_CACHE_DIR", cache.path().to_str().unwrap())];
+
+    let base_hash = common::git(repo.path(), &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+    commit_file(repo.path(), "change.txt", "second", "second");
+    let second_hash = common::git(repo.path(), &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+
+    run_git_lock(
+        repo.path(),
+        &["lock", "base", "note", &base_hash],
+        &env,
+        None,
+    );
+
+    let output = run_git_lock_output(repo.path(), &["unlock", "--dry-run", "base"], &env, None);
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Dry run"));
+    assert!(stdout.contains("Changed files: 1"));
+    assert!(stdout.contains("change.txt"));
+
+    let head_after = common::git(repo.path(), &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+    assert_eq!(head_after, second_hash);
+}
+
+#[test]
+fn unlock_verbose_prints_full_diff_before_prompt() {
+    let repo = init_repo();
+    let cache = cache_dir();
+    let env = [("ZSH_CACHE_DIR", cache.path().to_str().unwrap())];
+
+    let base_hash = common::git(repo.path(), &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+    commit_file(repo.path(), "change.txt", "second", "second");
+
+    run_git_lock(
+        repo.path(),
+        &["lock", "base", "note", &base_hash],
+        &env,
+        None,
+    );
+
+    let output = run_git_lock_output(
+        repo.path(),
+        &["unlock", "--verbose", "base"],
+        &env,
+        Some("n\n"),
+    );
+    assert!(!output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Full diff"));
+    assert!(stdout.contains("diff --git"));
+    assert!(stdout.contains("Hard reset to [base]"));
 }
 
 #[test]


### PR DESCRIPTION
# Harden git-lock destructive safety workflows

## Summary

Implements Sprint 1 of #384 by adding safer `git-lock` destructive-command behavior and fixes the validation side effects that produced root backup zips and opened GitHub `--help` pages during completion audits.

## Changes

- Add `git-lock unlock --dry-run` with reset preview and `--verbose` / `--show-diff` full diff output before prompting.
- Require `git-lock delete --force` for non-interactive deletion, add a permanent-delete warning for interactive deletion, and improve missing-label hints.
- Add `git-lock` remediation hints for common label and git runtime failures.
- Make `git-cli utils zip --help` print help without creating `backup-<sha>.zip`.
- Make `git-cli open compare|file|blame --help` print help without launching browser URLs.

## Test-First Evidence

- Change classification: behavior change
- Failing test before fix: `cargo test -p nils-git-lock unlock_ -- --nocapture` and `cargo test -p nils-git-lock delete_ -- --nocapture` failed for the new safety coverage before implementation.
- Final validation: `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` passed.
- Waiver reason: N/A

## Testing

- `cargo test -p nils-git-lock unlock_ -- --nocapture` (pass)
- `cargo test -p nils-git-lock delete_ -- --nocapture` (pass)
- `cargo test -p nils-git-lock` (pass)
- `cargo test -p nils-git-cli help -- --nocapture` (pass)
- `cargo test -p nils-git-cli utils_zip -- --nocapture` (pass)
- `bash scripts/ci/completion-flag-parity-audit.sh --strict` (pass)
- `cargo fmt --all -- --check` (pass)
- `cargo clippy -p nils-git-lock -p nils-git-cli --all-targets --all-features -- -D warnings` (pass)
- `cargo test -p nils-git-lock -p nils-git-cli` (pass)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` (pass; 3270 tests, coverage 85.72%)
- `git diff --check` (pass)

## Risk / Notes

- Refs #384. This PR completes Sprint 1 only; Sprint 2/3 tasks remain pending.
- Root artifact checks after the fix returned no `backup-*.zip` / zip files at repo root.
