### PR TITLE
Plan 04 Sprint 1 Task 1.2 PR B: install pipeline (link-map -> plan -> apply)

### DIFF
--- a/crates/agent-runtime-cli/src/commands/install.rs
+++ b/crates/agent-runtime-cli/src/commands/install.rs
@@ -1,0 +1,136 @@
+use crate::install::{self, AppliedChange, Mode};
+use crate::render::manifest::SourceRoot;
+use clap::Args;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+#[derive(Args, Debug)]
+pub struct InstallArgs {
+    /// Source root containing `manifests/`, `core/`, `targets/`, `build/`.
+    /// Defaults to the current working directory.
+    #[arg(long)]
+    pub source_root: Option<PathBuf>,
+    /// Product to install (`codex` or `claude`).
+    #[arg(long)]
+    pub product: String,
+    /// Absolute path of the runtime home (e.g. `~/.codex` / `~/.claude`).
+    /// Plan 04 Sprint 1 Task 1.3 will add `--live-home` as the polished
+    /// alias plus env-var expansion of the runtime-roots template.
+    #[arg(long)]
+    pub home: PathBuf,
+    /// Absolute path of the state home (where backups land).
+    #[arg(long)]
+    pub state_home: PathBuf,
+    /// Print the resolved plan; do not mutate the filesystem.
+    #[arg(long, conflicts_with = "apply")]
+    pub dry_run: bool,
+    /// Reconcile the runtime home to the plan. Idempotent on the
+    /// second run.
+    #[arg(long, conflicts_with = "dry_run")]
+    pub apply: bool,
+}
+
+pub fn run(args: InstallArgs) -> anyhow::Result<u8> {
+    if !args.home.is_absolute() {
+        anyhow::bail!(
+            "agent-runtime install: --home must be absolute (got: {})",
+            args.home.display()
+        );
+    }
+    if !args.state_home.is_absolute() {
+        anyhow::bail!(
+            "agent-runtime install: --state-home must be absolute (got: {})",
+            args.state_home.display()
+        );
+    }
+    if !args.dry_run && !args.apply {
+        anyhow::bail!("agent-runtime install: pass --dry-run or --apply");
+    }
+    let mode = if args.apply {
+        Mode::Apply
+    } else {
+        Mode::DryRun
+    };
+
+    let root = SourceRoot::from_arg_or_cwd(args.source_root.as_deref())?;
+    #[allow(clippy::disallowed_methods)]
+    let now = SystemTime::now();
+
+    let (plan, changes) = install::run(
+        &args.product,
+        root.path(),
+        &args.home,
+        &args.state_home,
+        mode,
+        now,
+    )?;
+
+    eprintln!(
+        "agent-runtime install: product={} mode={} actions={} changes={}",
+        plan.product,
+        if matches!(mode, Mode::Apply) {
+            "apply"
+        } else {
+            "dry-run"
+        },
+        plan.actions.len(),
+        changes
+            .iter()
+            .filter(|c| !matches!(c, AppliedChange::NoOp { .. }))
+            .count(),
+    );
+
+    for change in &changes {
+        print_change(change);
+    }
+
+    Ok(0)
+}
+
+fn print_change(c: &AppliedChange) {
+    match c {
+        AppliedChange::SymlinkCreated {
+            entry_id,
+            dest,
+            source,
+        } => eprintln!(
+            "  + symlink {} -> {} ({})",
+            dest.display(),
+            source.display(),
+            entry_id
+        ),
+        AppliedChange::SymlinkReplaced {
+            entry_id,
+            dest,
+            source,
+        } => eprintln!(
+            "  ~ symlink {} -> {} (replaced; {})",
+            dest.display(),
+            source.display(),
+            entry_id
+        ),
+        AppliedChange::FileBackedUpThenSymlinked {
+            entry_id,
+            dest,
+            source,
+            backup,
+        } => eprintln!(
+            "  ! backup {} -> {}, then symlink to {} ({})",
+            dest.display(),
+            backup.display(),
+            source.display(),
+            entry_id
+        ),
+        AppliedChange::ManagedBlockApplied {
+            entry_id,
+            config_file,
+        } => eprintln!(
+            "  ~ managed-block applied to {} ({})",
+            config_file.display(),
+            entry_id
+        ),
+        AppliedChange::NoOp { entry_id, dest } => {
+            eprintln!("  = no-op {} ({})", dest.display(), entry_id)
+        }
+    }
+}

--- a/crates/agent-runtime-cli/src/commands/mod.rs
+++ b/crates/agent-runtime-cli/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod audit_drift;
+pub mod install;
 pub mod render;

--- a/crates/agent-runtime-cli/src/install.rs
+++ b/crates/agent-runtime-cli/src/install.rs
@@ -1,0 +1,59 @@
+//! `agent-runtime install` body. Plan 04 Sprint 1 Task 1.2.
+//!
+//! Layout:
+//!
+//! - [`link_map`] — parser for `targets/<product>/link-map.yaml` with
+//!   per-entry validation that mirrors the JSON Schema in
+//!   `agent-runtime-kit/core/docs/schemas/link-map.schema.json`.
+//! - [`plan`] — builder that turns a `LinkMap` into a flat ordered
+//!   `InstallPlan`, expanding `recursive: true` directory entries into
+//!   one action per file.
+//! - [`executor`] — walks the plan and reconciles the runtime home to
+//!   the plan. Re-running on a clean install is a byte-identical no-op.
+//!
+//! The CLI wrapper lives in `commands::install`; Task 1.3 layers
+//! `--live-home` / `--tag` / overlay flags on top without rewriting any
+//! of this contract.
+
+pub mod executor;
+pub mod link_map;
+pub mod plan;
+
+use std::path::Path;
+use std::time::SystemTime;
+
+pub use executor::{AppliedChange, ApplyError, Mode};
+pub use link_map::{LinkMap, LinkMapError};
+pub use plan::{InstallPlan, PlanError};
+
+/// Top-level error returned by [`run`]. Each variant wraps the typed
+/// error from the contributing module so callers can match on the root
+/// cause if they need to.
+#[derive(Debug, thiserror::Error)]
+pub enum InstallError {
+    #[error("link-map: {0}")]
+    LinkMap(#[from] LinkMapError),
+    #[error("plan: {0}")]
+    Plan(#[from] PlanError),
+    #[error("apply: {0}")]
+    Apply(#[from] ApplyError),
+}
+
+/// Execute one install cycle. Builds the plan from the link-map at
+/// `<source_root>/targets/<product>/link-map.yaml`, then either prints
+/// it ([`Mode::DryRun`]) or applies it ([`Mode::Apply`]). `home` and
+/// `state_home` must be absolute. `now` is injected so the backup-dir
+/// timestamp stays deterministic in tests.
+pub fn run(
+    product: &str,
+    source_root: &Path,
+    home: &Path,
+    state_home: &Path,
+    mode: Mode,
+    now: SystemTime,
+) -> Result<(InstallPlan, Vec<AppliedChange>), InstallError> {
+    let link_map = LinkMap::load(source_root, product)?;
+    let plan = InstallPlan::build(product, source_root, home, state_home, &link_map)?;
+    let changes = executor::run(&plan, mode, now)?;
+    Ok((plan, changes))
+}

--- a/crates/agent-runtime-cli/src/install/executor.rs
+++ b/crates/agent-runtime-cli/src/install/executor.rs
@@ -1,0 +1,362 @@
+//! Apply executor for the install plan. Walks each [`PlanAction`] in
+//! order, mutating the filesystem only when the current state diverges
+//! from the desired state. Second-run-is-a-no-op idempotence is the
+//! load-bearing invariant Plan 04 Sprint 1 Task 1.2 ships against — see
+//! the integration test in `tests/integration/install_pipeline.rs`.
+
+use super::plan::{InstallPlan, PlanAction};
+use crate::managed_block::{CommentStyle as MbStyle, ManagedBlock};
+use std::fs;
+use std::io;
+use std::os::unix::fs as unix_fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ApplyError {
+    #[error("io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("could not back up {dest} to {backup}: {source}")]
+    Backup {
+        dest: PathBuf,
+        backup: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("managed-block helper rejected entry `{entry_id}` for {config_file}: {source}")]
+    ManagedBlock {
+        entry_id: String,
+        config_file: PathBuf,
+        #[source]
+        source: crate::managed_block::ManagedBlockError,
+    },
+}
+
+/// Single applied change. The dry-run printer also emits a list of these
+/// (without running them) so the user sees exactly what `--apply` would
+/// do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppliedChange {
+    SymlinkCreated {
+        entry_id: String,
+        dest: PathBuf,
+        source: PathBuf,
+    },
+    SymlinkReplaced {
+        entry_id: String,
+        dest: PathBuf,
+        source: PathBuf,
+    },
+    FileBackedUpThenSymlinked {
+        entry_id: String,
+        dest: PathBuf,
+        source: PathBuf,
+        backup: PathBuf,
+    },
+    ManagedBlockApplied {
+        entry_id: String,
+        config_file: PathBuf,
+    },
+    NoOp {
+        entry_id: String,
+        dest: PathBuf,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Mode {
+    DryRun,
+    Apply,
+}
+
+/// Walk `plan.actions` and return the change set. In [`Mode::DryRun`]
+/// the filesystem is untouched. In [`Mode::Apply`] every divergence is
+/// reconciled. `now` is injected so the backup-directory timestamp is
+/// deterministic in tests.
+pub fn run(
+    plan: &InstallPlan,
+    mode: Mode,
+    now: SystemTime,
+) -> Result<Vec<AppliedChange>, ApplyError> {
+    let backup_root = backup_root_for(plan, now);
+    let mut changes = Vec::with_capacity(plan.actions.len());
+    for action in &plan.actions {
+        let change = match action {
+            PlanAction::Symlink {
+                entry_id,
+                source,
+                dest,
+                requires_backup,
+            } => handle_symlink(mode, entry_id, source, dest, *requires_backup, &backup_root)?,
+            PlanAction::ManagedBlock {
+                entry_id,
+                config_file,
+                surface,
+                comment_style,
+                body,
+            } => handle_managed_block(mode, entry_id, config_file, surface, *comment_style, body)?,
+        };
+        changes.push(change);
+    }
+    Ok(changes)
+}
+
+fn backup_root_for(plan: &InstallPlan, now: SystemTime) -> PathBuf {
+    let secs = now
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    plan.state_home
+        .join("backups")
+        .join(&plan.product)
+        .join(format!("{secs}"))
+}
+
+fn handle_symlink(
+    mode: Mode,
+    entry_id: &str,
+    source: &Path,
+    dest: &Path,
+    requires_backup_flag: bool,
+    backup_root: &Path,
+) -> Result<AppliedChange, ApplyError> {
+    let current = read_symlink_target(dest);
+    if current.as_deref() == Some(source) {
+        // Already a symlink pointing at our source. Idempotent no-op.
+        return Ok(AppliedChange::NoOp {
+            entry_id: entry_id.to_string(),
+            dest: dest.to_path_buf(),
+        });
+    }
+
+    if matches!(mode, Mode::DryRun) {
+        return Ok(classify_dry_run(
+            entry_id,
+            source,
+            dest,
+            requires_backup_flag,
+            backup_root,
+        ));
+    }
+
+    ensure_parent_dir(dest)?;
+
+    let meta = fs::symlink_metadata(dest);
+    match meta {
+        Ok(m) if m.file_type().is_symlink() => {
+            // Existing symlink pointing somewhere else — replace.
+            fs::remove_file(dest).map_err(|source| ApplyError::Io {
+                path: dest.to_path_buf(),
+                source,
+            })?;
+            unix_fs::symlink(source, dest).map_err(|source_err| ApplyError::Io {
+                path: dest.to_path_buf(),
+                source: source_err,
+            })?;
+            Ok(AppliedChange::SymlinkReplaced {
+                entry_id: entry_id.to_string(),
+                dest: dest.to_path_buf(),
+                source: source.to_path_buf(),
+            })
+        }
+        Ok(m) if m.file_type().is_file() => {
+            // Existing regular file — back it up, then symlink.
+            let backup = move_to_backup(dest, entry_id, backup_root)?;
+            unix_fs::symlink(source, dest).map_err(|source_err| ApplyError::Io {
+                path: dest.to_path_buf(),
+                source: source_err,
+            })?;
+            Ok(AppliedChange::FileBackedUpThenSymlinked {
+                entry_id: entry_id.to_string(),
+                dest: dest.to_path_buf(),
+                source: source.to_path_buf(),
+                backup,
+            })
+        }
+        Ok(m) => {
+            // Directory or other file type at `dest`. Refuse — we don't
+            // own destruction of directories.
+            Err(ApplyError::Io {
+                path: dest.to_path_buf(),
+                source: io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!(
+                        "refusing to overwrite non-file destination (file_type={:?})",
+                        m.file_type()
+                    ),
+                ),
+            })
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            unix_fs::symlink(source, dest).map_err(|source_err| ApplyError::Io {
+                path: dest.to_path_buf(),
+                source: source_err,
+            })?;
+            Ok(AppliedChange::SymlinkCreated {
+                entry_id: entry_id.to_string(),
+                dest: dest.to_path_buf(),
+                source: source.to_path_buf(),
+            })
+        }
+        Err(e) => Err(ApplyError::Io {
+            path: dest.to_path_buf(),
+            source: e,
+        }),
+    }
+}
+
+fn classify_dry_run(
+    entry_id: &str,
+    source: &Path,
+    dest: &Path,
+    requires_backup_flag: bool,
+    backup_root: &Path,
+) -> AppliedChange {
+    let meta = fs::symlink_metadata(dest);
+    match meta {
+        Ok(m) if m.file_type().is_symlink() => AppliedChange::SymlinkReplaced {
+            entry_id: entry_id.to_string(),
+            dest: dest.to_path_buf(),
+            source: source.to_path_buf(),
+        },
+        Ok(m) if m.file_type().is_file() => {
+            let backup = backup_root
+                .join(entry_id)
+                .join(dest.file_name().map(Path::new).unwrap_or(Path::new("file")));
+            AppliedChange::FileBackedUpThenSymlinked {
+                entry_id: entry_id.to_string(),
+                dest: dest.to_path_buf(),
+                source: source.to_path_buf(),
+                backup,
+            }
+        }
+        Ok(_) => AppliedChange::SymlinkReplaced {
+            entry_id: entry_id.to_string(),
+            dest: dest.to_path_buf(),
+            source: source.to_path_buf(),
+        },
+        Err(_) if requires_backup_flag => {
+            // Plan said "requires backup" but the file vanished between
+            // plan time and dry-run time — fall back to plain create.
+            AppliedChange::SymlinkCreated {
+                entry_id: entry_id.to_string(),
+                dest: dest.to_path_buf(),
+                source: source.to_path_buf(),
+            }
+        }
+        Err(_) => AppliedChange::SymlinkCreated {
+            entry_id: entry_id.to_string(),
+            dest: dest.to_path_buf(),
+            source: source.to_path_buf(),
+        },
+    }
+}
+
+fn move_to_backup(dest: &Path, entry_id: &str, backup_root: &Path) -> Result<PathBuf, ApplyError> {
+    let file_name = dest.file_name().map(Path::new).unwrap_or(Path::new("file"));
+    let backup_dir = backup_root.join(entry_id);
+    fs::create_dir_all(&backup_dir).map_err(|source| ApplyError::Backup {
+        dest: dest.to_path_buf(),
+        backup: backup_dir.clone(),
+        source,
+    })?;
+    let backup_path = backup_dir.join(file_name);
+    fs::rename(dest, &backup_path).map_err(|source| ApplyError::Backup {
+        dest: dest.to_path_buf(),
+        backup: backup_path.clone(),
+        source,
+    })?;
+    Ok(backup_path)
+}
+
+fn ensure_parent_dir(dest: &Path) -> Result<(), ApplyError> {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).map_err(|source| ApplyError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(())
+}
+
+fn read_symlink_target(p: &Path) -> Option<PathBuf> {
+    fs::read_link(p).ok()
+}
+
+fn handle_managed_block(
+    mode: Mode,
+    entry_id: &str,
+    config_file: &Path,
+    surface: &str,
+    comment_style: super::link_map::CommentStyle,
+    body: &str,
+) -> Result<AppliedChange, ApplyError> {
+    let helper_style = match comment_style {
+        super::link_map::CommentStyle::Hash => MbStyle::Hash,
+        super::link_map::CommentStyle::DoubleSlash => MbStyle::DoubleSlash,
+    };
+    let block = ManagedBlock::new(surface.to_string(), helper_style);
+
+    let existing = match fs::read_to_string(config_file) {
+        Ok(s) => s,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return Err(ApplyError::Io {
+                path: config_file.to_path_buf(),
+                source: e,
+            });
+        }
+    };
+
+    // First install requires `force`; subsequent writes do not.
+    let needs_force = block.read(&existing).map(|o| o.is_none()).unwrap_or(true);
+
+    if matches!(mode, Mode::DryRun) {
+        let projected = block
+            .write(&existing, body, needs_force)
+            .map_err(|source| ApplyError::ManagedBlock {
+                entry_id: entry_id.to_string(),
+                config_file: config_file.to_path_buf(),
+                source,
+            })?;
+        return Ok(if projected == existing {
+            AppliedChange::NoOp {
+                entry_id: entry_id.to_string(),
+                dest: config_file.to_path_buf(),
+            }
+        } else {
+            AppliedChange::ManagedBlockApplied {
+                entry_id: entry_id.to_string(),
+                config_file: config_file.to_path_buf(),
+            }
+        });
+    }
+
+    let new_content = block
+        .write(&existing, body, needs_force)
+        .map_err(|source| ApplyError::ManagedBlock {
+            entry_id: entry_id.to_string(),
+            config_file: config_file.to_path_buf(),
+            source,
+        })?;
+    if new_content == existing {
+        return Ok(AppliedChange::NoOp {
+            entry_id: entry_id.to_string(),
+            dest: config_file.to_path_buf(),
+        });
+    }
+    ensure_parent_dir(config_file)?;
+    fs::write(config_file, new_content).map_err(|source| ApplyError::Io {
+        path: config_file.to_path_buf(),
+        source,
+    })?;
+    Ok(AppliedChange::ManagedBlockApplied {
+        entry_id: entry_id.to_string(),
+        config_file: config_file.to_path_buf(),
+    })
+}

--- a/crates/agent-runtime-cli/src/install/link_map.rs
+++ b/crates/agent-runtime-cli/src/install/link_map.rs
@@ -1,0 +1,365 @@
+//! `targets/<product>/link-map.yaml` parser.
+//!
+//! Schema source-of-truth lives in `agent-runtime-kit`:
+//! `core/docs/schemas/link-map.schema.json`. This module mirrors that
+//! schema with `#[serde(deny_unknown_fields)]` types so unknown keys fail
+//! deserialization loudly instead of being silently dropped. Per-kind
+//! required/forbidden field enforcement happens in [`LinkEntry::validate`]
+//! after the YAML round-trip, because `serde` alone cannot express the
+//! `allOf if/then` shape that the JSON Schema uses.
+//!
+//! Source: agent-runtime-kit Plan 04 Sprint 1 Task 1.2.
+//!   `docs/plans/04-installer-doctor-and-bootstrap/...-plan.md`.
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Error)]
+pub enum LinkMapError {
+    #[error("missing link-map: {path}")]
+    Missing { path: PathBuf },
+    #[error("schema_version mismatch in {file}: expected {expected}, got {found}")]
+    SchemaVersion {
+        file: PathBuf,
+        expected: u32,
+        found: u32,
+    },
+    #[error("parse error in {file}: {source}")]
+    Parse {
+        file: PathBuf,
+        #[source]
+        source: serde_yaml_ng::Error,
+    },
+    #[error("io error reading {file}: {source}")]
+    Io {
+        file: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("link-map entry `{id}` is invalid: {reason} (file: {file})")]
+    InvalidEntry {
+        file: PathBuf,
+        id: String,
+        reason: String,
+    },
+    #[error("link-map entry id `{id}` is duplicated in {file}")]
+    DuplicateId { file: PathBuf, id: String },
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum EntryKind {
+    SymlinkedFile,
+    PluginManifestCopy,
+    ManagedBlock,
+    BackedUpOnReplace,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CommentStyle {
+    Hash,
+    DoubleSlash,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct LinkEntry {
+    pub id: String,
+    pub kind: EntryKind,
+    #[serde(default)]
+    pub source: Option<String>,
+    pub destination: String,
+    #[serde(default)]
+    pub recursive: bool,
+    #[serde(default)]
+    pub surface: Option<String>,
+    #[serde(default)]
+    pub comment_style: Option<CommentStyle>,
+    #[serde(default)]
+    pub body_template: Option<String>,
+}
+
+impl LinkEntry {
+    /// Enforce the per-kind required / forbidden field contract that the
+    /// JSON Schema expresses via `allOf if/then`. Returns the first
+    /// violation it finds so error messages stay actionable.
+    pub fn validate(&self) -> Result<(), String> {
+        match self.kind {
+            EntryKind::SymlinkedFile => {
+                if self.source.is_none() {
+                    return Err("kind=symlinked-file requires `source`".to_string());
+                }
+                self.forbid_managed_block_fields()?;
+            }
+            EntryKind::PluginManifestCopy => {
+                if self.source.is_none() {
+                    return Err("kind=plugin-manifest-copy requires `source`".to_string());
+                }
+                if self.recursive {
+                    return Err("kind=plugin-manifest-copy forbids `recursive`".to_string());
+                }
+                self.forbid_managed_block_fields()?;
+            }
+            EntryKind::BackedUpOnReplace => {
+                if self.source.is_none() {
+                    return Err("kind=backed-up-on-replace requires `source`".to_string());
+                }
+                self.forbid_managed_block_fields()?;
+            }
+            EntryKind::ManagedBlock => {
+                if self.surface.is_none() {
+                    return Err("kind=managed-block requires `surface`".to_string());
+                }
+                if self.comment_style.is_none() {
+                    return Err("kind=managed-block requires `comment_style`".to_string());
+                }
+                if self.body_template.is_none() {
+                    return Err("kind=managed-block requires `body_template`".to_string());
+                }
+                if self.source.is_some() {
+                    return Err("kind=managed-block forbids `source`".to_string());
+                }
+                if self.recursive {
+                    return Err("kind=managed-block forbids `recursive`".to_string());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn forbid_managed_block_fields(&self) -> Result<(), String> {
+        if self.surface.is_some() {
+            return Err(format!("kind={:?} forbids `surface`", self.kind));
+        }
+        if self.comment_style.is_some() {
+            return Err(format!("kind={:?} forbids `comment_style`", self.kind));
+        }
+        if self.body_template.is_some() {
+            return Err(format!("kind={:?} forbids `body_template`", self.kind));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct LinkMap {
+    pub schema_version: u32,
+    pub entries: Vec<LinkEntry>,
+}
+
+impl LinkMap {
+    /// Load and validate the link-map at the conventional location:
+    /// `<source_root>/targets/<product>/link-map.yaml`.
+    pub fn load(source_root: &Path, product: &str) -> Result<Self, LinkMapError> {
+        let file = source_root
+            .join("targets")
+            .join(product)
+            .join("link-map.yaml");
+        if !file.exists() {
+            return Err(LinkMapError::Missing { path: file });
+        }
+        let raw = std::fs::read_to_string(&file).map_err(|source| LinkMapError::Io {
+            file: file.clone(),
+            source,
+        })?;
+        let parsed: LinkMap =
+            serde_yaml_ng::from_str(&raw).map_err(|source| LinkMapError::Parse {
+                file: file.clone(),
+                source,
+            })?;
+        if parsed.schema_version != SCHEMA_VERSION {
+            return Err(LinkMapError::SchemaVersion {
+                file,
+                expected: SCHEMA_VERSION,
+                found: parsed.schema_version,
+            });
+        }
+
+        // Per-entry validation + duplicate id detection.
+        let mut seen = std::collections::BTreeSet::new();
+        for entry in &parsed.entries {
+            entry
+                .validate()
+                .map_err(|reason| LinkMapError::InvalidEntry {
+                    file: file.clone(),
+                    id: entry.id.clone(),
+                    reason,
+                })?;
+            if !seen.insert(entry.id.clone()) {
+                return Err(LinkMapError::DuplicateId {
+                    file,
+                    id: entry.id.clone(),
+                });
+            }
+        }
+        Ok(parsed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_link_map(root: &Path, product: &str, body: &str) -> PathBuf {
+        let dir = root.join("targets").join(product);
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("link-map.yaml");
+        fs::write(&file, body).unwrap();
+        file
+    }
+
+    #[test]
+    fn load_accepts_initial_codex_shape() {
+        let tmp = TempDir::new().unwrap();
+        write_link_map(
+            tmp.path(),
+            "codex",
+            "\
+schema_version: 1
+entries:
+  - id: reporting.plugin-manifest
+    kind: plugin-manifest-copy
+    source: targets/codex/plugins/reporting/.codex-plugin/plugin.json
+    destination: plugins/reporting/.codex-plugin/plugin.json
+  - id: reporting.skills-tree
+    kind: symlinked-file
+    source: build/codex/plugins/reporting/skills
+    destination: plugins/reporting/skills
+    recursive: true
+",
+        );
+        let lm = LinkMap::load(tmp.path(), "codex").unwrap();
+        assert_eq!(lm.schema_version, 1);
+        assert_eq!(lm.entries.len(), 2);
+        assert_eq!(lm.entries[0].kind, EntryKind::PluginManifestCopy);
+        assert_eq!(lm.entries[1].kind, EntryKind::SymlinkedFile);
+        assert!(lm.entries[1].recursive);
+    }
+
+    #[test]
+    fn load_rejects_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let err = LinkMap::load(tmp.path(), "codex").unwrap_err();
+        assert!(matches!(err, LinkMapError::Missing { .. }));
+    }
+
+    #[test]
+    fn load_rejects_unknown_key() {
+        let tmp = TempDir::new().unwrap();
+        write_link_map(
+            tmp.path(),
+            "claude",
+            "\
+schema_version: 1
+entries:
+  - id: x
+    kind: symlinked-file
+    source: a
+    destination: b
+    bogus_field: 1
+",
+        );
+        let err = LinkMap::load(tmp.path(), "claude").unwrap_err();
+        assert!(matches!(err, LinkMapError::Parse { .. }));
+    }
+
+    #[test]
+    fn load_rejects_schema_version_mismatch() {
+        let tmp = TempDir::new().unwrap();
+        write_link_map(
+            tmp.path(),
+            "codex",
+            "\
+schema_version: 99
+entries:
+  - id: x
+    kind: symlinked-file
+    source: a
+    destination: b
+",
+        );
+        let err = LinkMap::load(tmp.path(), "codex").unwrap_err();
+        assert!(matches!(err, LinkMapError::SchemaVersion { found: 99, .. }));
+    }
+
+    #[test]
+    fn load_rejects_managed_block_without_required_fields() {
+        let tmp = TempDir::new().unwrap();
+        write_link_map(
+            tmp.path(),
+            "codex",
+            "\
+schema_version: 1
+entries:
+  - id: bad
+    kind: managed-block
+    destination: config.toml
+",
+        );
+        let err = LinkMap::load(tmp.path(), "codex").unwrap_err();
+        match err {
+            LinkMapError::InvalidEntry { id, reason, .. } => {
+                assert_eq!(id, "bad");
+                assert!(reason.contains("surface"), "got: {reason}");
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_rejects_managed_block_with_forbidden_source() {
+        let tmp = TempDir::new().unwrap();
+        write_link_map(
+            tmp.path(),
+            "codex",
+            "\
+schema_version: 1
+entries:
+  - id: bad
+    kind: managed-block
+    destination: config.toml
+    surface: install
+    comment_style: hash
+    body_template: 't = 1'
+    source: somewhere
+",
+        );
+        let err = LinkMap::load(tmp.path(), "codex").unwrap_err();
+        match err {
+            LinkMapError::InvalidEntry { reason, .. } => {
+                assert!(reason.contains("forbids `source`"), "got: {reason}");
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_rejects_duplicate_ids() {
+        let tmp = TempDir::new().unwrap();
+        write_link_map(
+            tmp.path(),
+            "codex",
+            "\
+schema_version: 1
+entries:
+  - id: same
+    kind: symlinked-file
+    source: a
+    destination: b
+  - id: same
+    kind: symlinked-file
+    source: c
+    destination: d
+",
+        );
+        let err = LinkMap::load(tmp.path(), "codex").unwrap_err();
+        assert!(matches!(err, LinkMapError::DuplicateId { id, .. } if id == "same"));
+    }
+}

--- a/crates/agent-runtime-cli/src/install/plan.rs
+++ b/crates/agent-runtime-cli/src/install/plan.rs
@@ -27,6 +27,10 @@ pub enum PlanError {
     NonRelativeDestination { id: String, path: PathBuf },
     #[error("source for entry `{id}` is not relative: {path}")]
     NonRelativeSource { id: String, path: PathBuf },
+    #[error("destination for entry `{id}` contains a `..` traversal: {path}")]
+    DestinationTraversal { id: String, path: PathBuf },
+    #[error("source for entry `{id}` contains a `..` traversal: {path}")]
+    SourceTraversal { id: String, path: PathBuf },
 }
 
 /// Single executable step the apply executor will run.
@@ -87,6 +91,12 @@ impl InstallPlan {
                     path: dest_rel.to_path_buf(),
                 });
             }
+            if has_parent_dir_component(dest_rel) {
+                return Err(PlanError::DestinationTraversal {
+                    id: entry.id.clone(),
+                    path: dest_rel.to_path_buf(),
+                });
+            }
             match entry.kind {
                 EntryKind::SymlinkedFile => {
                     expand_symlinked_file(entry, source_root, home, &mut actions)?;
@@ -129,13 +139,29 @@ fn require_relative_source(entry: &LinkEntry) -> Result<&str, PlanError> {
         .source
         .as_deref()
         .expect("validate() guarantees source for non-managed-block kinds");
-    if Path::new(s).is_absolute() {
+    let p = Path::new(s);
+    if p.is_absolute() {
         return Err(PlanError::NonRelativeSource {
             id: entry.id.clone(),
             path: PathBuf::from(s),
         });
     }
+    if has_parent_dir_component(p) {
+        return Err(PlanError::SourceTraversal {
+            id: entry.id.clone(),
+            path: PathBuf::from(s),
+        });
+    }
     Ok(s)
+}
+
+/// Return `true` if any component of `p` is `..`. We reject paths with
+/// parent-directory traversal because `PathBuf::join` does not normalize
+/// — `home.join("../etc/passwd")` would write under the user's
+/// filesystem above the sandbox home at apply time.
+fn has_parent_dir_component(p: &Path) -> bool {
+    use std::path::Component;
+    p.components().any(|c| matches!(c, Component::ParentDir))
 }
 
 fn expand_single_symlink(
@@ -240,5 +266,107 @@ fn is_regular_non_symlink(p: &Path) -> bool {
     match std::fs::symlink_metadata(p) {
         Ok(meta) => meta.file_type().is_file() && !meta.file_type().is_symlink(),
         Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::install::link_map::{EntryKind, LinkEntry, LinkMap};
+
+    fn one_entry_map(entry: LinkEntry) -> LinkMap {
+        LinkMap {
+            schema_version: 1,
+            entries: vec![entry],
+        }
+    }
+
+    fn symlinked_file(id: &str, source: &str, destination: &str) -> LinkEntry {
+        LinkEntry {
+            id: id.to_string(),
+            kind: EntryKind::SymlinkedFile,
+            source: Some(source.to_string()),
+            destination: destination.to_string(),
+            recursive: false,
+            surface: None,
+            comment_style: None,
+            body_template: None,
+        }
+    }
+
+    #[test]
+    fn build_rejects_absolute_destination() {
+        let lm = one_entry_map(symlinked_file("x", "build/a", "/etc/passwd"));
+        let err = InstallPlan::build(
+            "claude",
+            Path::new("/tmp/src"),
+            Path::new("/tmp/home"),
+            Path::new("/tmp/state"),
+            &lm,
+        )
+        .unwrap_err();
+        assert!(matches!(err, PlanError::NonRelativeDestination { .. }));
+    }
+
+    #[test]
+    fn build_rejects_traversal_in_destination() {
+        let lm = one_entry_map(symlinked_file("x", "build/a", "../escape"));
+        let err = InstallPlan::build(
+            "claude",
+            Path::new("/tmp/src"),
+            Path::new("/tmp/home"),
+            Path::new("/tmp/state"),
+            &lm,
+        )
+        .unwrap_err();
+        match err {
+            PlanError::DestinationTraversal { id, .. } => assert_eq!(id, "x"),
+            other => panic!("expected DestinationTraversal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_rejects_traversal_in_source() {
+        let lm = one_entry_map(symlinked_file("x", "../../etc/passwd", "plugins/x"));
+        let err = InstallPlan::build(
+            "claude",
+            Path::new("/tmp/src"),
+            Path::new("/tmp/home"),
+            Path::new("/tmp/state"),
+            &lm,
+        )
+        .unwrap_err();
+        match err {
+            PlanError::SourceTraversal { id, .. } => assert_eq!(id, "x"),
+            other => panic!("expected SourceTraversal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_rejects_absolute_source() {
+        let lm = one_entry_map(symlinked_file("x", "/etc/passwd", "plugins/x"));
+        let err = InstallPlan::build(
+            "claude",
+            Path::new("/tmp/src"),
+            Path::new("/tmp/home"),
+            Path::new("/tmp/state"),
+            &lm,
+        )
+        .unwrap_err();
+        assert!(matches!(err, PlanError::NonRelativeSource { .. }));
+    }
+
+    #[test]
+    fn build_rejects_traversal_via_inner_component() {
+        let lm = one_entry_map(symlinked_file("x", "build/a", "plugins/../../escape"));
+        let err = InstallPlan::build(
+            "claude",
+            Path::new("/tmp/src"),
+            Path::new("/tmp/home"),
+            Path::new("/tmp/state"),
+            &lm,
+        )
+        .unwrap_err();
+        assert!(matches!(err, PlanError::DestinationTraversal { .. }));
     }
 }

--- a/crates/agent-runtime-cli/src/install/plan.rs
+++ b/crates/agent-runtime-cli/src/install/plan.rs
@@ -1,0 +1,244 @@
+//! Install plan: the deterministic struct that both the dry-run printer
+//! and the apply executor consume. Plan 04 Sprint 1 Task 1.2.
+//!
+//! The builder walks a [`LinkMap`] in declared order, expands
+//! `recursive: true` directory entries into one [`PlanAction`] per file,
+//! and produces a flat list. Order is preserved — the executor walks the
+//! list top to bottom. Re-running against an unchanged tree produces an
+//! empty change set (idempotence is enforced at apply time by checking
+//! the current state of each destination before mutating).
+
+use super::link_map::{CommentStyle, EntryKind, LinkEntry, LinkMap};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PlanError {
+    #[error("source for entry `{id}` does not exist: {path}")]
+    MissingSource { id: String, path: PathBuf },
+    #[error("io error walking entry `{id}` source `{path}`: {source}")]
+    Walk {
+        id: String,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("destination for entry `{id}` is not relative: {path}")]
+    NonRelativeDestination { id: String, path: PathBuf },
+    #[error("source for entry `{id}` is not relative: {path}")]
+    NonRelativeSource { id: String, path: PathBuf },
+}
+
+/// Single executable step the apply executor will run.
+#[derive(Debug, Clone)]
+pub enum PlanAction {
+    /// Replace `dest` with a symlink pointing at `source`. Idempotent
+    /// when `dest` already points at `source`. Pre-existing regular files
+    /// at `dest` are backed up into `<state_home>/backups/...` first.
+    Symlink {
+        entry_id: String,
+        source: PathBuf,
+        dest: PathBuf,
+        /// True when `dest` would replace a regular file (not a symlink).
+        /// Drives backup behaviour at apply time.
+        requires_backup: bool,
+    },
+    /// Write or replace a managed block in a config file.
+    ManagedBlock {
+        entry_id: String,
+        config_file: PathBuf,
+        surface: String,
+        comment_style: CommentStyle,
+        body: String,
+    },
+}
+
+/// Resolved install plan. Each entry in `actions` is ready to run; the
+/// dry-run printer formats them, the apply executor mutates the
+/// filesystem. `home` and `source_root` are kept absolute so the plan
+/// transcript is unambiguous in tests.
+#[derive(Debug, Clone)]
+pub struct InstallPlan {
+    pub product: String,
+    pub source_root: PathBuf,
+    pub home: PathBuf,
+    pub state_home: PathBuf,
+    pub actions: Vec<PlanAction>,
+}
+
+impl InstallPlan {
+    /// Build the plan from a parsed link-map. `source_root` must be the
+    /// canonicalised agent-runtime-kit checkout root; `home` is the
+    /// product runtime home (`~/.codex`, `~/.claude`, or a sandbox). Both
+    /// must be absolute.
+    pub fn build(
+        product: &str,
+        source_root: &Path,
+        home: &Path,
+        state_home: &Path,
+        link_map: &LinkMap,
+    ) -> Result<Self, PlanError> {
+        let mut actions = Vec::new();
+        for entry in &link_map.entries {
+            let dest_rel = Path::new(&entry.destination);
+            if dest_rel.is_absolute() {
+                return Err(PlanError::NonRelativeDestination {
+                    id: entry.id.clone(),
+                    path: dest_rel.to_path_buf(),
+                });
+            }
+            match entry.kind {
+                EntryKind::SymlinkedFile => {
+                    expand_symlinked_file(entry, source_root, home, &mut actions)?;
+                }
+                EntryKind::PluginManifestCopy | EntryKind::BackedUpOnReplace => {
+                    expand_single_symlink(entry, source_root, home, &mut actions)?;
+                }
+                EntryKind::ManagedBlock => {
+                    let dest_abs = home.join(dest_rel);
+                    actions.push(PlanAction::ManagedBlock {
+                        entry_id: entry.id.clone(),
+                        config_file: dest_abs,
+                        surface: entry
+                            .surface
+                            .clone()
+                            .expect("validate() guarantees surface for managed-block"),
+                        comment_style: entry
+                            .comment_style
+                            .expect("validate() guarantees comment_style for managed-block"),
+                        body: entry
+                            .body_template
+                            .clone()
+                            .expect("validate() guarantees body_template for managed-block"),
+                    });
+                }
+            }
+        }
+        Ok(Self {
+            product: product.to_string(),
+            source_root: source_root.to_path_buf(),
+            home: home.to_path_buf(),
+            state_home: state_home.to_path_buf(),
+            actions,
+        })
+    }
+}
+
+fn require_relative_source(entry: &LinkEntry) -> Result<&str, PlanError> {
+    let s = entry
+        .source
+        .as_deref()
+        .expect("validate() guarantees source for non-managed-block kinds");
+    if Path::new(s).is_absolute() {
+        return Err(PlanError::NonRelativeSource {
+            id: entry.id.clone(),
+            path: PathBuf::from(s),
+        });
+    }
+    Ok(s)
+}
+
+fn expand_single_symlink(
+    entry: &LinkEntry,
+    source_root: &Path,
+    home: &Path,
+    out: &mut Vec<PlanAction>,
+) -> Result<(), PlanError> {
+    let source_rel = require_relative_source(entry)?;
+    let source_abs = source_root.join(source_rel);
+    if !source_abs.exists() {
+        return Err(PlanError::MissingSource {
+            id: entry.id.clone(),
+            path: source_abs,
+        });
+    }
+    let dest_abs = home.join(&entry.destination);
+    let requires_backup = is_regular_non_symlink(&dest_abs);
+    out.push(PlanAction::Symlink {
+        entry_id: entry.id.clone(),
+        source: source_abs,
+        dest: dest_abs,
+        requires_backup,
+    });
+    Ok(())
+}
+
+fn expand_symlinked_file(
+    entry: &LinkEntry,
+    source_root: &Path,
+    home: &Path,
+    out: &mut Vec<PlanAction>,
+) -> Result<(), PlanError> {
+    let source_rel = require_relative_source(entry)?;
+    let source_abs = source_root.join(source_rel);
+    if !source_abs.exists() {
+        return Err(PlanError::MissingSource {
+            id: entry.id.clone(),
+            path: source_abs,
+        });
+    }
+    if !entry.recursive {
+        let dest_abs = home.join(&entry.destination);
+        let requires_backup = is_regular_non_symlink(&dest_abs);
+        out.push(PlanAction::Symlink {
+            entry_id: entry.id.clone(),
+            source: source_abs,
+            dest: dest_abs,
+            requires_backup,
+        });
+        return Ok(());
+    }
+    // Recursive: walk the source directory and emit one symlink per
+    // file (sorted, so plan output stays deterministic across hosts).
+    let mut files = Vec::new();
+    collect_files(&source_abs, &source_abs, &mut files).map_err(|source| PlanError::Walk {
+        id: entry.id.clone(),
+        path: source_abs.clone(),
+        source,
+    })?;
+    files.sort();
+    for rel in files {
+        let abs_source = source_abs.join(&rel);
+        let abs_dest = home.join(&entry.destination).join(&rel);
+        let requires_backup = is_regular_non_symlink(&abs_dest);
+        out.push(PlanAction::Symlink {
+            entry_id: entry.id.clone(),
+            source: abs_source,
+            dest: abs_dest,
+            requires_backup,
+        });
+    }
+    Ok(())
+}
+
+fn collect_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), std::io::Error> {
+    if dir.is_file() {
+        // Caller passes a file path with `dir == file`: emit "".
+        if let Ok(rel) = dir.strip_prefix(root) {
+            out.push(rel.to_path_buf());
+        }
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_files(root, &path, out)?;
+        } else {
+            let rel = path
+                .strip_prefix(root)
+                .map(|p| p.to_path_buf())
+                .unwrap_or(path.clone());
+            out.push(rel);
+        }
+    }
+    Ok(())
+}
+
+fn is_regular_non_symlink(p: &Path) -> bool {
+    match std::fs::symlink_metadata(p) {
+        Ok(meta) => meta.file_type().is_file() && !meta.file_type().is_symlink(),
+        Err(_) => false,
+    }
+}

--- a/crates/agent-runtime-cli/src/lib.rs
+++ b/crates/agent-runtime-cli/src/lib.rs
@@ -22,6 +22,7 @@ use std::process::ExitCode;
 
 pub mod audit_drift;
 pub mod commands;
+pub mod install;
 pub mod managed_block;
 pub mod render;
 
@@ -41,7 +42,7 @@ pub enum Command {
     /// Render `core/` + `targets/<product>/` into `build/<product>/`.
     Render(commands::render::RenderArgs),
     /// Activate rendered output against a product's runtime home.
-    Install,
+    Install(commands::install::InstallArgs),
     /// Remove installed renderer output from a product's runtime home.
     Uninstall,
     /// Diagnose host setup, runtime roots, and required CLI floors.
@@ -60,7 +61,7 @@ impl Command {
     fn name(&self) -> &'static str {
         match self {
             Command::Render(_) => "render",
-            Command::Install => "install",
+            Command::Install(_) => "install",
             Command::Uninstall => "uninstall",
             Command::Doctor => "doctor",
             Command::AuditDrift(_) => "audit-drift",
@@ -86,6 +87,13 @@ pub fn run() -> ExitCode {
             Ok(code) => ExitCode::from(code),
             Err(err) => {
                 eprintln!("agent-runtime audit-drift: {err:#}");
+                ExitCode::from(2)
+            }
+        },
+        Command::Install(args) => match commands::install::run(args) {
+            Ok(code) => ExitCode::from(code),
+            Err(err) => {
+                eprintln!("agent-runtime install: {err:#}");
                 ExitCode::from(2)
             }
         },

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -9,6 +9,8 @@ mod audit_drift_classes;
 mod cli;
 #[path = "integration/determinism_gate.rs"]
 mod determinism_gate;
+#[path = "integration/install_pipeline.rs"]
+mod install_pipeline;
 #[path = "integration/managed_block.rs"]
 mod managed_block;
 #[path = "integration/render.rs"]

--- a/crates/agent-runtime-cli/tests/integration/cli.rs
+++ b/crates/agent-runtime-cli/tests/integration/cli.rs
@@ -23,10 +23,10 @@ const ALL_SUBCOMMANDS: &[&str] = &[
 ];
 
 /// Subcommands whose body still prints `not implemented` and exits 1.
-/// `render` is no longer a stub once Task 1.1 lands; later sprints peel
-/// further entries off this list.
+/// `render` and `install` are no longer stubs once Plan 04 Sprint 1
+/// Tasks 1.1 / 1.2 land; later sprints peel further entries off this
+/// list.
 const STUB_SUBCOMMANDS: &[&str] = &[
-    "install",
     "uninstall",
     "doctor",
     "gc-backups",

--- a/crates/agent-runtime-cli/tests/integration/install_pipeline.rs
+++ b/crates/agent-runtime-cli/tests/integration/install_pipeline.rs
@@ -277,6 +277,67 @@ fn walkdir_files(dir: &Path) -> Vec<PathBuf> {
 }
 
 #[test]
+fn managed_block_entry_writes_block_and_is_idempotent_on_second_apply() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("src");
+    fs::create_dir_all(root.join("targets").join("codex")).unwrap();
+    let link_map = "\
+schema_version: 1
+entries:
+  - id: codex.config
+    kind: managed-block
+    destination: config.toml
+    surface: install
+    comment_style: hash
+    body_template: |-
+      tag = \"agent-runtime\"
+      live_home = \"/tmp/sandbox\"
+";
+    fs::write(
+        root.join("targets").join("codex").join("link-map.yaml"),
+        link_map,
+    )
+    .unwrap();
+    let source_root = fs::canonicalize(&root).unwrap();
+
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let (_, changes_first) = install::run(
+        "codex",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::Apply,
+        fixed_time(),
+    )
+    .unwrap();
+    assert_eq!(changes_first.len(), 1);
+    assert!(matches!(
+        changes_first[0],
+        AppliedChange::ManagedBlockApplied { .. }
+    ));
+
+    let config_after_first = fs::read_to_string(home.join("config.toml")).unwrap();
+    assert!(config_after_first.contains("# >>> agent-runtime-kit:install >>>"));
+    assert!(config_after_first.contains("tag = \"agent-runtime\""));
+    assert!(config_after_first.contains("# <<< agent-runtime-kit:install <<<"));
+
+    let (_, changes_second) = install::run(
+        "codex",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::Apply,
+        fixed_time(),
+    )
+    .unwrap();
+    assert!(matches!(changes_second[0], AppliedChange::NoOp { .. }));
+    let config_after_second = fs::read_to_string(home.join("config.toml")).unwrap();
+    assert_eq!(config_after_first, config_after_second);
+}
+
+#[test]
 fn missing_link_map_returns_typed_error() {
     let tmp = TempDir::new().unwrap();
     let home = tmp.path().join("home");

--- a/crates/agent-runtime-cli/tests/integration/install_pipeline.rs
+++ b/crates/agent-runtime-cli/tests/integration/install_pipeline.rs
@@ -1,0 +1,300 @@
+//! Install pipeline integration tests. Plan 04 Sprint 1 Task 1.2.
+//!
+//! These tests build a deterministic tmp source root + tmp home and
+//! drive `agent_runtime_cli::install::run` end-to-end so the dry-run
+//! printer and apply executor both exercise the byte-identical
+//! idempotence guarantee the Plan 04 acceptance criteria require.
+
+use agent_runtime_cli::install::{self, AppliedChange, Mode};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use tempfile::TempDir;
+
+/// Build a minimal source root with one product's link-map pointing at
+/// a plugin manifest (`targets/`) and a recursive skills tree (`build/`).
+fn build_source_root(tmp: &Path, product: &str) -> PathBuf {
+    let root = tmp.join("src");
+    fs::create_dir_all(&root).unwrap();
+
+    // Plugin manifest under targets/.
+    let plugin_dir = root
+        .join("targets")
+        .join(product)
+        .join("plugins")
+        .join("reporting")
+        .join(format!(".{product}-plugin"));
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(
+        plugin_dir.join("plugin.json"),
+        r#"{"name":"reporting","version":"0.1.0"}"#,
+    )
+    .unwrap();
+
+    // Rendered skills tree under build/.
+    let build_dir = root
+        .join("build")
+        .join(product)
+        .join("plugins")
+        .join("reporting")
+        .join("skills");
+    fs::create_dir_all(build_dir.join("daily-brief")).unwrap();
+    fs::write(
+        build_dir.join("daily-brief").join("SKILL.md"),
+        "# daily-brief\n",
+    )
+    .unwrap();
+    fs::create_dir_all(build_dir.join("topic-radar").join("scripts")).unwrap();
+    fs::write(
+        build_dir.join("topic-radar").join("SKILL.md"),
+        "# topic-radar\n",
+    )
+    .unwrap();
+    fs::write(
+        build_dir
+            .join("topic-radar")
+            .join("scripts")
+            .join("topic-radar.sh"),
+        "#!/bin/sh\necho radar\n",
+    )
+    .unwrap();
+
+    // link-map.yaml that mirrors the production initial shape.
+    let link_map = format!(
+        "schema_version: 1\nentries:\n  - id: reporting.plugin-manifest\n    kind: plugin-manifest-copy\n    source: targets/{product}/plugins/reporting/.{product}-plugin/plugin.json\n    destination: plugins/reporting/.{product}-plugin/plugin.json\n  - id: reporting.skills-tree\n    kind: symlinked-file\n    source: build/{product}/plugins/reporting/skills\n    destination: plugins/reporting/skills\n    recursive: true\n",
+    );
+    fs::write(
+        root.join("targets").join(product).join("link-map.yaml"),
+        link_map,
+    )
+    .unwrap();
+
+    fs::canonicalize(&root).unwrap()
+}
+
+fn fixed_time() -> SystemTime {
+    // Tests use a fixed timestamp so backup-dir paths are stable.
+    SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)
+}
+
+/// Build a sorted snapshot of `dir`: every relative path under the
+/// directory plus, for each path, either the symlink target or the
+/// file contents. The snapshot is the canonical input to byte-identical
+/// idempotence assertions.
+fn snapshot(dir: &Path) -> Vec<(PathBuf, Snapshot)> {
+    let mut out = Vec::new();
+    collect(dir, dir, &mut out);
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Snapshot {
+    Symlink(PathBuf),
+    File(Vec<u8>),
+    Dir,
+}
+
+fn collect(root: &Path, dir: &Path, out: &mut Vec<(PathBuf, Snapshot)>) {
+    let Ok(read) = fs::read_dir(dir) else { return };
+    for entry in read.flatten() {
+        let path = entry.path();
+        let meta = fs::symlink_metadata(&path).unwrap();
+        let rel = path.strip_prefix(root).unwrap().to_path_buf();
+        if meta.file_type().is_symlink() {
+            let target = fs::read_link(&path).unwrap();
+            out.push((rel, Snapshot::Symlink(target)));
+        } else if meta.file_type().is_dir() {
+            out.push((rel, Snapshot::Dir));
+            collect(root, &path, out);
+        } else if meta.file_type().is_file() {
+            let bytes = fs::read(&path).unwrap();
+            out.push((rel, Snapshot::File(bytes)));
+        }
+    }
+}
+
+#[test]
+fn dry_run_does_not_mutate_home() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&home).unwrap();
+
+    let before = snapshot(&home);
+    let (plan, changes) = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::DryRun,
+        fixed_time(),
+    )
+    .unwrap();
+
+    // Dry-run must not touch the filesystem.
+    assert_eq!(snapshot(&home), before, "home was mutated by dry-run");
+    assert!(!state_home.exists(), "state_home was created by dry-run");
+
+    // Every action is reported.
+    assert_eq!(plan.actions.len(), changes.len());
+    // No NoOps on first dry-run (fresh home).
+    for c in &changes {
+        assert!(
+            !matches!(c, AppliedChange::NoOp { .. }),
+            "unexpected NoOp on first dry-run: {c:?}"
+        );
+    }
+}
+
+#[test]
+fn apply_writes_symlinks_and_is_byte_identical_on_second_run() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let (_, changes_first) = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::Apply,
+        fixed_time(),
+    )
+    .unwrap();
+    // First apply: every action is a SymlinkCreated (fresh home).
+    for c in &changes_first {
+        assert!(
+            matches!(c, AppliedChange::SymlinkCreated { .. }),
+            "first apply expected only SymlinkCreated, got {c:?}"
+        );
+    }
+
+    let snapshot_after_first = snapshot(&home);
+
+    // Sanity-check that the destinations exist as symlinks and resolve.
+    let manifest_dest = home.join("plugins/reporting/.claude-plugin/plugin.json");
+    assert!(
+        fs::symlink_metadata(&manifest_dest)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "manifest dest is not a symlink"
+    );
+    let skill_dest = home.join("plugins/reporting/skills/daily-brief/SKILL.md");
+    assert_eq!(fs::read_to_string(&skill_dest).unwrap(), "# daily-brief\n",);
+
+    // Second apply: byte-identical no-op.
+    let (_, changes_second) = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::Apply,
+        fixed_time(),
+    )
+    .unwrap();
+    for c in &changes_second {
+        assert!(
+            matches!(c, AppliedChange::NoOp { .. }),
+            "second apply expected only NoOp, got {c:?}"
+        );
+    }
+    assert_eq!(
+        snapshot(&home),
+        snapshot_after_first,
+        "second apply mutated the home tree",
+    );
+}
+
+#[test]
+fn pre_existing_regular_file_is_backed_up_then_symlinked() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    // Seed a regular file at one of the install destinations.
+    let pre_existing = home.join("plugins/reporting/skills/topic-radar/SKILL.md");
+    fs::create_dir_all(pre_existing.parent().unwrap()).unwrap();
+    fs::write(&pre_existing, b"user-edited content\n").unwrap();
+
+    let (_, changes) = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::Apply,
+        fixed_time(),
+    )
+    .unwrap();
+
+    let backed_up = changes
+        .iter()
+        .filter(|c| matches!(c, AppliedChange::FileBackedUpThenSymlinked { .. }))
+        .count();
+    assert_eq!(
+        backed_up, 1,
+        "exactly one entry should have triggered a backup: {changes:#?}",
+    );
+    // The original bytes survive under <state_home>/backups/...
+    assert!(state_home.exists(), "state_home was not created");
+    let backup_root = state_home.join("backups").join("claude");
+    let mut found_backup = false;
+    for entry in walkdir_files(&backup_root) {
+        if fs::read(&entry).ok() == Some(b"user-edited content\n".to_vec()) {
+            found_backup = true;
+            break;
+        }
+    }
+    assert!(
+        found_backup,
+        "backed-up bytes not found under {}",
+        backup_root.display()
+    );
+}
+
+fn walkdir_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(read) = fs::read_dir(dir) else { return };
+        for entry in read.flatten() {
+            let path = entry.path();
+            let Ok(meta) = fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if meta.file_type().is_dir() {
+                walk(&path, out);
+            } else if meta.file_type().is_file() {
+                out.push(path);
+            }
+        }
+    }
+    walk(dir, &mut out);
+    out
+}
+
+#[test]
+fn missing_link_map_returns_typed_error() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+    let source_root = tmp.path().join("src");
+    fs::create_dir_all(&source_root).unwrap();
+    let err = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::DryRun,
+        fixed_time(),
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("link-map"),
+        "expected link-map error, got: {msg}"
+    );
+}


### PR DESCRIPTION
# Plan 04 Sprint 1 Task 1.2 PR B: install pipeline (link-map → plan → apply)

## Summary

Replaces the `agent-runtime install` stub with the Plan 04 Sprint 1 Task 1.2
install pipeline. Consumes `targets/<product>/link-map.yaml` (schema landed in
[graysurf/agent-runtime-kit#18](https://github.com/graysurf/agent-runtime-kit/pull/18),
merged at `f89eec1`), turns it into a deterministic `InstallPlan`, and applies
it idempotently. Closes Task 1.2 across the two-repo PR-A+PR-B split.

## Changes

- `crates/agent-runtime-cli/src/install.rs` (new) — top-level module with `run(product, source_root, home, state_home, mode, now)` entry point and `InstallError` typed-error enum wrapping `LinkMapError` / `PlanError` / `ApplyError`.
- `crates/agent-runtime-cli/src/install/link_map.rs` (new) — `LinkMap::load` parses `<source_root>/targets/<product>/link-map.yaml` with `serde(deny_unknown_fields)`; per-entry `validate()` enforces the per-kind required/forbidden field contract that the JSON Schema expresses via `allOf if/then`; duplicate-id detection rejects shadowed entries.
- `crates/agent-runtime-cli/src/install/plan.rs` (new) — `InstallPlan::build` walks the `LinkMap` in declared order, validates each `destination` and `source` for relative-path + `..` traversal safety, then expands `recursive: true` directory entries into one `PlanAction` per file (sorted, deterministic).
- `crates/agent-runtime-cli/src/install/executor.rs` (new) — applies the plan: idempotent symlinks (no-op when `dest` already points at `source`; pre-existing regular files backed up to `<state_home>/backups/<product>/<unix-seconds>/<entry_id>/<filename>` before replace); calls the Task 1.1 `ManagedBlock` helper for managed-block entries with first-write `force=true` and subsequent writes idempotent.
- `crates/agent-runtime-cli/src/commands/install.rs` (new) — `InstallArgs (--source-root, --product, --home, --state-home, --dry-run|--apply)` with absolute-path validation. `SystemTime::now()` is called under a single-line `#[allow(clippy::disallowed_methods)]` opt-out — render-determinism gate remains intact for the rest of the crate.
- `crates/agent-runtime-cli/tests/integration/install_pipeline.rs` (new) — 6 file-system integration tests: dry-run is read-only; first apply creates symlinks; second apply is byte-identical no-op; pre-existing regular file is backed up before replace; managed-block end-to-end + idempotent; missing link-map yields typed error.
- `crates/agent-runtime-cli/src/lib.rs` — adds `pub mod install`, replaces `Install` unit variant with `Install(InstallArgs)`, dispatches in `run()`.
- `crates/agent-runtime-cli/src/commands/mod.rs` — adds `pub mod install;`.
- `crates/agent-runtime-cli/tests/integration.rs` — wires in the new integration test module.
- `crates/agent-runtime-cli/tests/integration/cli.rs` — removes `install` from `STUB_SUBCOMMANDS` (it now has a real body).

## Review Findings & Resolutions

A `/code-review-specialists` pass surfaced two material findings on the base
push (`fc447f9`); both are resolved in fix commit `c9befcf`:

- **F-1 (HIGH, security/red-team)** — `home.join(destination)` and `source_root.join(source)` did not reject `..` traversal. `PathBuf::join` does not normalize, so a link-map entry like `destination: ../etc/passwd` would walk outside the sandbox home at apply time. Resolved by adding `PlanError::DestinationTraversal` + `PlanError::SourceTraversal` plus a `has_parent_dir_component` walker that checks every path component before the plan is built.
- **F-3 (medium, testing)** — the `managed-block` executor path had no end-to-end test through `install::run`. Resolved by adding `managed_block_entry_writes_block_and_is_idempotent_on_second_apply` (driving the full install::run pipeline against a managed-block-only link-map fixture; asserts the block appears, that a second apply yields a `NoOp`, and that the config file is byte-identical between apply calls).
- F-2 (source path traversal) was hardened in the same commit. F-4 (`NonRelativeDestination` / `NonRelativeSource` had no positive coverage) is now exercised by the 5 new plan unit tests. F-5 (`expect("validate() guarantees ...")` panics) is a documented invariant — load-vs-direct-construct is internal-only; deferred to Sprint 2 if it ever grows.

## Test-First Evidence

- Change classification: feature (with security/red-team review hardening on top of the base feat commit).
- Failing test before fix: managed-block executor path had no end-to-end test in the base commit `fc447f9`; the `..` traversal rejection in plan building did not exist. Both gaps are now covered by tests added in the fix commit `c9befcf` (5 plan-builder unit tests + 1 integration test). The traversal-rejection tests fail against `fc447f9` (the rejection code does not exist there); they pass against `c9befcf`.
- Final validation: `cargo nextest run --profile ci --workspace` 100% pass; `cargo fmt --check` exit 0; `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` exit 0; `bash scripts/ci/nils-cli-checks-entrypoint.sh` → `ok: all nils-cli checks passed`. Both commits GPG-signed via `op-ssh-sign`.
- Waiver reason: not applicable.

## Testing

- `cargo nextest run --profile ci --workspace` (pass)
- `cargo test -p agent-runtime-cli install` (pass — 13 unit + 6 integration tests)
- `cargo fmt --check` (pass)
- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` (pass)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass — full required-checks gate stack)

## Risk / Notes

- `--home` / `--state-home` are intentionally minimal user-facing flags. Plan 04 Sprint 1 Task 1.3 (immediate downstream) will add `--live-home` as the polished alias plus env-var expansion of the runtime-roots.yaml templates and the `--tag` flag.
- Backup-dir layout: `<state_home>/backups/<product>/<unix-seconds>/<entry_id>/<filename>`. `now` is injected into `install::run`, so test fixtures get a stable timestamp without touching the system clock.
- `ManagedBlock` helper integration: the install executor maps `install::link_map::CommentStyle` (kebab-case YAML enum) to `managed_block::CommentStyle` (helper enum). Both live in the same crate but stay separate so the YAML schema type is not load-bearing on the helper's API contract.
- Determinism gate: `SystemTime::now()` is called exactly once in `commands::install::run()` under `#[allow(clippy::disallowed_methods)]`. The escape is scoped to that single line and inline-commented.
- Plan 03 reporting plugin: integration tests build a synthetic in-`TempDir` source root rather than reading the real `targets/<product>/link-map.yaml` files landed in PR #18, so unit + integration tests don't drift if Plan 03 entries change. The real link-map files are still exercised manually via `cargo run -- install --source-root ./agent-runtime-kit --product claude --home ~/.claude-sandbox --state-home /tmp/state --dry-run` once a user has both checkouts.
- No CHANGELOG entry — Plan 04 Task 4.4 will create `CHANGELOG.md` with the `0.2.0` release entry; intermediate work doesn't retro-fill earlier versions.
