### PR TITLE
Add --live-home, --tag, and overlay merge to agent-runtime install (Plan 04 Sprint 1 Task 1.3)

### DIFF
--- a/crates/agent-runtime-cli/src/commands/install.rs
+++ b/crates/agent-runtime-cli/src/commands/install.rs
@@ -4,15 +4,6 @@ use clap::Args;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-/// Tag-name policy. Mirrors the `managed_block::is_trusted_surface` contract
-/// so backup-dir tags share the same ASCII-safe alphabet as managed-block
-/// surfaces. Plan 04 Sprint 1 Task 1.3.
-fn is_trusted_tag(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-}
-
 #[derive(Args, Debug)]
 pub struct InstallArgs {
     /// Source root containing `manifests/`, `core/`, `targets/`, `build/`.
@@ -69,8 +60,10 @@ pub fn run(args: InstallArgs) -> anyhow::Result<u8> {
         );
     }
     if let Some(tag) = args.tag.as_deref()
-        && !is_trusted_tag(tag)
+        && !install::is_trusted_tag(tag)
     {
+        // The executor re-validates as defense in depth; the CLI catches
+        // the same shape early so the error message can name the flag.
         anyhow::bail!(
             "agent-runtime install: --tag `{tag}` is not a trusted tag name (allowed: ASCII alphanumeric / `-` / `_`)"
         );
@@ -94,7 +87,7 @@ pub fn run(args: InstallArgs) -> anyhow::Result<u8> {
         overlay_path: args.overlay_path.clone(),
     };
 
-    let (plan, changes) = install::run(
+    let outcome = install::run(
         &args.product,
         root.path(),
         &args.live_home,
@@ -104,22 +97,33 @@ pub fn run(args: InstallArgs) -> anyhow::Result<u8> {
         &options,
     )?;
 
+    if let Some(s) = outcome.overlay.as_ref() {
+        // Operator-visible notice that the overlay was consumed; matches
+        // the architecture-doc requirement that dry-run print the
+        // post-merge effective state, not just the inputs.
+        eprintln!(
+            "agent-runtime install: overlay merged (dropped={} replaced={} added={})",
+            s.dropped, s.replaced, s.added,
+        );
+    }
+
     eprintln!(
         "agent-runtime install: product={} mode={} actions={} changes={}",
-        plan.product,
+        outcome.plan.product,
         if matches!(mode, Mode::Apply) {
             "apply"
         } else {
             "dry-run"
         },
-        plan.actions.len(),
-        changes
+        outcome.plan.actions.len(),
+        outcome
+            .changes
             .iter()
             .filter(|c| !matches!(c, AppliedChange::NoOp { .. }))
             .count(),
     );
 
-    for change in &changes {
+    for change in &outcome.changes {
         print_change(change);
     }
 
@@ -171,26 +175,5 @@ fn print_change(c: &AppliedChange) {
         AppliedChange::NoOp { entry_id, dest } => {
             eprintln!("  = no-op {} ({})", dest.display(), entry_id)
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::is_trusted_tag;
-
-    #[test]
-    fn trusted_tag_accepts_alnum_dash_underscore() {
-        assert!(is_trusted_tag("pre-bump"));
-        assert!(is_trusted_tag("rc_1"));
-        assert!(is_trusted_tag("0.2.0".replace('.', "-").as_str()));
-    }
-
-    #[test]
-    fn trusted_tag_rejects_empty_or_unsafe() {
-        assert!(!is_trusted_tag(""));
-        assert!(!is_trusted_tag("../escape"));
-        assert!(!is_trusted_tag("with space"));
-        assert!(!is_trusted_tag("dot.in.name"));
-        assert!(!is_trusted_tag("slash/in/name"));
     }
 }

--- a/crates/agent-runtime-cli/src/commands/install.rs
+++ b/crates/agent-runtime-cli/src/commands/install.rs
@@ -1,8 +1,17 @@
-use crate::install::{self, AppliedChange, Mode};
+use crate::install::{self, AppliedChange, InstallOptions, Mode};
 use crate::render::manifest::SourceRoot;
 use clap::Args;
 use std::path::PathBuf;
 use std::time::SystemTime;
+
+/// Tag-name policy. Mirrors the `managed_block::is_trusted_surface` contract
+/// so backup-dir tags share the same ASCII-safe alphabet as managed-block
+/// surfaces. Plan 04 Sprint 1 Task 1.3.
+fn is_trusted_tag(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
 
 #[derive(Args, Debug)]
 pub struct InstallArgs {
@@ -14,13 +23,26 @@ pub struct InstallArgs {
     #[arg(long)]
     pub product: String,
     /// Absolute path of the runtime home (e.g. `~/.codex` / `~/.claude`).
-    /// Plan 04 Sprint 1 Task 1.3 will add `--live-home` as the polished
-    /// alias plus env-var expansion of the runtime-roots template.
+    /// Relative paths are rejected so install never writes outside an
+    /// explicitly-chosen directory.
     #[arg(long)]
-    pub home: PathBuf,
+    pub live_home: PathBuf,
     /// Absolute path of the state home (where backups land).
     #[arg(long)]
     pub state_home: PathBuf,
+    /// Tag the backup-run root with a `tag-<name>` marker file so
+    /// `gc-backups` (Plan 04 Sprint 2 Task 2.4) can preserve it across
+    /// retention sweeps. Tag must be ASCII alphanumeric / `-` / `_`.
+    #[arg(long)]
+    pub tag: Option<String>,
+    /// Skip the optional `.private/link-map.overrides.yaml` overlay
+    /// merge. Default: merge if file exists.
+    #[arg(long, default_value_t = false)]
+    pub no_overlay: bool,
+    /// Override the overlay file location. When set, the conventional
+    /// `<source-root>/.private/link-map.overrides.yaml` is ignored.
+    #[arg(long, conflicts_with = "no_overlay")]
+    pub overlay_path: Option<PathBuf>,
     /// Print the resolved plan; do not mutate the filesystem.
     #[arg(long, conflicts_with = "apply")]
     pub dry_run: bool,
@@ -31,16 +53,26 @@ pub struct InstallArgs {
 }
 
 pub fn run(args: InstallArgs) -> anyhow::Result<u8> {
-    if !args.home.is_absolute() {
+    if !args.live_home.is_absolute() {
+        // Open question Q1 default (resolved 2026-05-21): `--live-home`
+        // must be absolute. Relative paths exit non-zero with a usage
+        // error naming the flag so callers can fix their invocation.
         anyhow::bail!(
-            "agent-runtime install: --home must be absolute (got: {})",
-            args.home.display()
+            "agent-runtime install: --live-home must be absolute (got: {}); pass an absolute path such as /tmp/claude-sandbox or $HOME/.claude",
+            args.live_home.display()
         );
     }
     if !args.state_home.is_absolute() {
         anyhow::bail!(
             "agent-runtime install: --state-home must be absolute (got: {})",
             args.state_home.display()
+        );
+    }
+    if let Some(tag) = args.tag.as_deref()
+        && !is_trusted_tag(tag)
+    {
+        anyhow::bail!(
+            "agent-runtime install: --tag `{tag}` is not a trusted tag name (allowed: ASCII alphanumeric / `-` / `_`)"
         );
     }
     if !args.dry_run && !args.apply {
@@ -56,13 +88,20 @@ pub fn run(args: InstallArgs) -> anyhow::Result<u8> {
     #[allow(clippy::disallowed_methods)]
     let now = SystemTime::now();
 
+    let options = InstallOptions {
+        tag: args.tag.clone(),
+        overlay_enabled: !args.no_overlay,
+        overlay_path: args.overlay_path.clone(),
+    };
+
     let (plan, changes) = install::run(
         &args.product,
         root.path(),
-        &args.home,
+        &args.live_home,
         &args.state_home,
         mode,
         now,
+        &options,
     )?;
 
     eprintln!(
@@ -132,5 +171,26 @@ fn print_change(c: &AppliedChange) {
         AppliedChange::NoOp { entry_id, dest } => {
             eprintln!("  = no-op {} ({})", dest.display(), entry_id)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_trusted_tag;
+
+    #[test]
+    fn trusted_tag_accepts_alnum_dash_underscore() {
+        assert!(is_trusted_tag("pre-bump"));
+        assert!(is_trusted_tag("rc_1"));
+        assert!(is_trusted_tag("0.2.0".replace('.', "-").as_str()));
+    }
+
+    #[test]
+    fn trusted_tag_rejects_empty_or_unsafe() {
+        assert!(!is_trusted_tag(""));
+        assert!(!is_trusted_tag("../escape"));
+        assert!(!is_trusted_tag("with space"));
+        assert!(!is_trusted_tag("dot.in.name"));
+        assert!(!is_trusted_tag("slash/in/name"));
     }
 }

--- a/crates/agent-runtime-cli/src/install.rs
+++ b/crates/agent-runtime-cli/src/install.rs
@@ -1,29 +1,33 @@
-//! `agent-runtime install` body. Plan 04 Sprint 1 Task 1.2.
+//! `agent-runtime install` body. Plan 04 Sprint 1 Tasks 1.2 / 1.3.
 //!
 //! Layout:
 //!
 //! - [`link_map`] — parser for `targets/<product>/link-map.yaml` with
 //!   per-entry validation that mirrors the JSON Schema in
 //!   `agent-runtime-kit/core/docs/schemas/link-map.schema.json`.
-//! - [`plan`] — builder that turns a `LinkMap` into a flat ordered
-//!   `InstallPlan`, expanding `recursive: true` directory entries into
-//!   one action per file.
+//! - [`overlay`] — optional `.private/link-map.overrides.yaml` parser plus
+//!   the per-entry-replace merge function. Applied before plan generation.
+//! - [`plan`] — builder that turns a (post-overlay-merge) `LinkMap` into a
+//!   flat ordered `InstallPlan`, expanding `recursive: true` directory
+//!   entries into one action per file.
 //! - [`executor`] — walks the plan and reconciles the runtime home to
 //!   the plan. Re-running on a clean install is a byte-identical no-op.
 //!
-//! The CLI wrapper lives in `commands::install`; Task 1.3 layers
-//! `--live-home` / `--tag` / overlay flags on top without rewriting any
-//! of this contract.
+//! The CLI wrapper lives in `commands::install`. Task 1.3 layers
+//! `--live-home`, `--tag`, and `--no-overlay` on top of the Task 1.2
+//! Rust API without rewriting the contract.
 
 pub mod executor;
 pub mod link_map;
+pub mod overlay;
 pub mod plan;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 pub use executor::{AppliedChange, ApplyError, Mode};
 pub use link_map::{LinkMap, LinkMapError};
+pub use overlay::{LinkMapOverlay, OVERLAY_REL_PATH};
 pub use plan::{InstallPlan, PlanError};
 
 /// Top-level error returned by [`run`]. Each variant wraps the typed
@@ -39,6 +43,41 @@ pub enum InstallError {
     Apply(#[from] ApplyError),
 }
 
+/// Per-run knobs threaded through to the executor. Plan 04 Sprint 1
+/// Task 1.3 introduces these; later sprints (gc-backups, doctor) keep
+/// extending the struct rather than the positional `run` signature.
+#[derive(Debug, Clone)]
+pub struct InstallOptions {
+    /// Optional backup-directory tag. When set and at least one backup
+    /// is created during apply, a `tag-<name>` marker file is written at
+    /// the backup-run root so `gc-backups` (Task 2.4) can preserve the
+    /// directory across retention sweeps.
+    pub tag: Option<String>,
+    /// When `false`, skip the `.private/link-map.overrides.yaml` read.
+    /// Defaults to `true` — overlay merge is the production path; the
+    /// `--no-overlay` flag wires this to `false` for tests and
+    /// reproducible drift baselines.
+    pub overlay_enabled: bool,
+    /// Explicit overlay file location. When `None` and `overlay_enabled`
+    /// is `true`, the conventional `<source_root>/.private/link-map.overrides.yaml`
+    /// is used.
+    pub overlay_path: Option<PathBuf>,
+}
+
+impl Default for InstallOptions {
+    /// Default knobs: overlay merge on, no tag, conventional overlay path.
+    /// Overlay-on is the production path — derive(Default) would land
+    /// `overlay_enabled = false` and silently turn the production behaviour
+    /// off for any caller using `InstallOptions::default()`.
+    fn default() -> Self {
+        Self {
+            tag: None,
+            overlay_enabled: true,
+            overlay_path: None,
+        }
+    }
+}
+
 /// Execute one install cycle. Builds the plan from the link-map at
 /// `<source_root>/targets/<product>/link-map.yaml`, then either prints
 /// it ([`Mode::DryRun`]) or applies it ([`Mode::Apply`]). `home` and
@@ -51,9 +90,19 @@ pub fn run(
     state_home: &Path,
     mode: Mode,
     now: SystemTime,
+    options: &InstallOptions,
 ) -> Result<(InstallPlan, Vec<AppliedChange>), InstallError> {
-    let link_map = LinkMap::load(source_root, product)?;
+    let mut link_map = LinkMap::load(source_root, product)?;
+    if options.overlay_enabled {
+        let overlay_opt = match options.overlay_path.as_deref() {
+            Some(path) => LinkMapOverlay::load_from(path)?,
+            None => LinkMapOverlay::load_optional(source_root)?,
+        };
+        if let Some(overlay) = overlay_opt {
+            overlay::apply(&mut link_map, &overlay)?;
+        }
+    }
     let plan = InstallPlan::build(product, source_root, home, state_home, &link_map)?;
-    let changes = executor::run(&plan, mode, now)?;
+    let changes = executor::run(&plan, mode, now, options.tag.as_deref())?;
     Ok((plan, changes))
 }

--- a/crates/agent-runtime-cli/src/install.rs
+++ b/crates/agent-runtime-cli/src/install.rs
@@ -25,9 +25,9 @@ pub mod plan;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-pub use executor::{AppliedChange, ApplyError, Mode};
+pub use executor::{AppliedChange, ApplyError, Mode, is_trusted_tag};
 pub use link_map::{LinkMap, LinkMapError};
-pub use overlay::{LinkMapOverlay, OVERLAY_REL_PATH};
+pub use overlay::{LinkMapOverlay, OVERLAY_REL_PATH, OverlaySummary};
 pub use plan::{InstallPlan, PlanError};
 
 /// Top-level error returned by [`run`]. Each variant wraps the typed
@@ -78,6 +78,20 @@ impl Default for InstallOptions {
     }
 }
 
+/// Full outcome of an `install::run` cycle. The CLI consumes the
+/// `overlay` field to print a one-line operator-visible notice when an
+/// overlay was merged (architecture-doc requirement: dry-run must expose
+/// the post-merge effective config).
+#[derive(Debug)]
+pub struct InstallOutcome {
+    pub plan: InstallPlan,
+    pub changes: Vec<AppliedChange>,
+    /// `None` when overlay merge was disabled or the overlay file was
+    /// absent; `Some(summary)` when an overlay was consumed (even if it
+    /// changed zero entries — the operator still wants to know it ran).
+    pub overlay: Option<OverlaySummary>,
+}
+
 /// Execute one install cycle. Builds the plan from the link-map at
 /// `<source_root>/targets/<product>/link-map.yaml`, then either prints
 /// it ([`Mode::DryRun`]) or applies it ([`Mode::Apply`]). `home` and
@@ -91,18 +105,24 @@ pub fn run(
     mode: Mode,
     now: SystemTime,
     options: &InstallOptions,
-) -> Result<(InstallPlan, Vec<AppliedChange>), InstallError> {
+) -> Result<InstallOutcome, InstallError> {
     let mut link_map = LinkMap::load(source_root, product)?;
+    let mut overlay_summary: Option<OverlaySummary> = None;
     if options.overlay_enabled {
         let overlay_opt = match options.overlay_path.as_deref() {
             Some(path) => LinkMapOverlay::load_from(path)?,
             None => LinkMapOverlay::load_optional(source_root)?,
         };
         if let Some(overlay) = overlay_opt {
-            overlay::apply(&mut link_map, &overlay)?;
+            let summary = overlay::apply(&mut link_map, &overlay)?;
+            overlay_summary = Some(summary);
         }
     }
     let plan = InstallPlan::build(product, source_root, home, state_home, &link_map)?;
     let changes = executor::run(&plan, mode, now, options.tag.as_deref())?;
-    Ok((plan, changes))
+    Ok(InstallOutcome {
+        plan,
+        changes,
+        overlay: overlay_summary,
+    })
 }

--- a/crates/agent-runtime-cli/src/install/executor.rs
+++ b/crates/agent-runtime-cli/src/install/executor.rs
@@ -77,11 +77,15 @@ pub enum Mode {
 /// Walk `plan.actions` and return the change set. In [`Mode::DryRun`]
 /// the filesystem is untouched. In [`Mode::Apply`] every divergence is
 /// reconciled. `now` is injected so the backup-directory timestamp is
-/// deterministic in tests.
+/// deterministic in tests. When `tag` is set and at least one backup
+/// directory was created during apply, a `tag-<name>` marker file is
+/// written at the backup-run root so `gc-backups` (Task 2.4) can
+/// preserve it across retention sweeps.
 pub fn run(
     plan: &InstallPlan,
     mode: Mode,
     now: SystemTime,
+    tag: Option<&str>,
 ) -> Result<Vec<AppliedChange>, ApplyError> {
     let backup_root = backup_root_for(plan, now);
     let mut changes = Vec::with_capacity(plan.actions.len());
@@ -102,6 +106,27 @@ pub fn run(
             } => handle_managed_block(mode, entry_id, config_file, surface, *comment_style, body)?,
         };
         changes.push(change);
+    }
+
+    // Write the tag marker only when we are in Apply mode AND at least one
+    // backup directory was created during this run. Dry-run never touches
+    // state_home; runs with zero backups produce no run root for the tag
+    // to live in.
+    if let (Mode::Apply, Some(name)) = (mode, tag) {
+        let had_backup = changes
+            .iter()
+            .any(|c| matches!(c, AppliedChange::FileBackedUpThenSymlinked { .. }));
+        if had_backup {
+            let marker = backup_root.join(format!("tag-{name}"));
+            fs::create_dir_all(&backup_root).map_err(|source| ApplyError::Io {
+                path: backup_root.clone(),
+                source,
+            })?;
+            fs::write(&marker, b"").map_err(|source| ApplyError::Io {
+                path: marker,
+                source,
+            })?;
+        }
     }
     Ok(changes)
 }

--- a/crates/agent-runtime-cli/src/install/executor.rs
+++ b/crates/agent-runtime-cli/src/install/executor.rs
@@ -35,6 +35,22 @@ pub enum ApplyError {
         #[source]
         source: crate::managed_block::ManagedBlockError,
     },
+    #[error(
+        "tag `{value}` is not a trusted tag name (allowed: ASCII alphanumeric / `-` / `_`, non-empty)"
+    )]
+    InvalidTag { value: String },
+}
+
+/// Tag-name trust contract: non-empty ASCII alphanumeric / `-` / `_`.
+/// Mirrors `crate::managed_block::is_trusted_surface` because both produce
+/// filesystem-visible names from user-controlled identifiers. Validated at
+/// the executor entry as defense in depth — the CLI also rejects bad tags,
+/// but library callers using `InstallOptions { tag, .. }` directly hit the
+/// same gate.
+pub fn is_trusted_tag(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
 /// Single applied change. The dry-run printer also emits a list of these
@@ -87,6 +103,13 @@ pub fn run(
     now: SystemTime,
     tag: Option<&str>,
 ) -> Result<Vec<AppliedChange>, ApplyError> {
+    if let Some(name) = tag
+        && !is_trusted_tag(name)
+    {
+        return Err(ApplyError::InvalidTag {
+            value: name.to_string(),
+        });
+    }
     let backup_root = backup_root_for(plan, now);
     let mut changes = Vec::with_capacity(plan.actions.len());
     for action in &plan.actions {
@@ -384,4 +407,55 @@ fn handle_managed_block(
         entry_id: entry_id.to_string(),
         config_file: config_file.to_path_buf(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::install::plan::InstallPlan;
+    use tempfile::TempDir;
+
+    #[test]
+    fn trusted_tag_accepts_alnum_dash_underscore() {
+        assert!(is_trusted_tag("pre-bump"));
+        assert!(is_trusted_tag("rc_1"));
+        assert!(is_trusted_tag("0-2-0"));
+        assert!(is_trusted_tag("A1B2C3"));
+    }
+
+    #[test]
+    fn trusted_tag_rejects_empty_or_unsafe() {
+        assert!(!is_trusted_tag(""));
+        assert!(!is_trusted_tag("../escape"));
+        assert!(!is_trusted_tag("with space"));
+        assert!(!is_trusted_tag("dot.in.name"));
+        assert!(!is_trusted_tag("slash/in/name"));
+        assert!(!is_trusted_tag("null\0byte"));
+    }
+
+    #[test]
+    fn run_rejects_untrusted_tag_before_walking_actions() {
+        // Pins the defense-in-depth gate so a library caller that bypasses
+        // the CLI cannot compose `InstallOptions { tag: "../escape", .. }`
+        // that sneaks past the friendly anyhow message in commands::install.
+        let tmp = TempDir::new().unwrap();
+        let plan = InstallPlan {
+            product: "claude".to_string(),
+            source_root: tmp.path().to_path_buf(),
+            home: tmp.path().join("home"),
+            state_home: tmp.path().join("state"),
+            actions: Vec::new(),
+        };
+        let err = run(
+            &plan,
+            Mode::Apply,
+            SystemTime::UNIX_EPOCH,
+            Some("../escape"),
+        )
+        .unwrap_err();
+        match err {
+            ApplyError::InvalidTag { value } => assert_eq!(value, "../escape"),
+            other => panic!("expected InvalidTag, got {other:?}"),
+        }
+    }
 }

--- a/crates/agent-runtime-cli/src/install/overlay.rs
+++ b/crates/agent-runtime-cli/src/install/overlay.rs
@@ -108,16 +108,38 @@ impl LinkMapOverlay {
     }
 }
 
+/// Per-run accounting of the overlay merge. The install pipeline echoes
+/// this in dry-run / apply output so reviewers see at a glance that an
+/// overlay is in play (the architecture doc requires dry-run to expose
+/// the post-merge effective config).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OverlaySummary {
+    pub dropped: usize,
+    pub replaced: usize,
+    pub added: usize,
+}
+
+impl OverlaySummary {
+    pub fn total(&self) -> usize {
+        self.dropped + self.replaced + self.added
+    }
+}
+
 /// Apply `overlay` to `base` per the per-entry-replace rule. Drops, replaces,
 /// and additions all happen in-place against `base.entries` so the caller's
 /// downstream plan builder consumes the merged result without knowing the
 /// overlay existed.
-pub fn apply(base: &mut LinkMap, overlay: &LinkMapOverlay) -> Result<(), LinkMapError> {
+pub fn apply(base: &mut LinkMap, overlay: &LinkMapOverlay) -> Result<OverlaySummary, LinkMapError> {
+    let mut summary = OverlaySummary::default();
     for ov in &overlay.entries {
         if !ov.enabled {
             // Drop matching tracked entry. Silently no-op when missing: the
             // overlay author may have already removed the entry upstream.
+            let before = base.entries.len();
             base.entries.retain(|e| e.id != ov.id);
+            if base.entries.len() < before {
+                summary.dropped += 1;
+            }
             continue;
         }
         let merged = build_full_entry(ov)?;
@@ -129,11 +151,17 @@ pub fn apply(base: &mut LinkMap, overlay: &LinkMapOverlay) -> Result<(), LinkMap
                 reason,
             })?;
         match base.entries.iter().position(|e| e.id == ov.id) {
-            Some(idx) => base.entries[idx] = merged,
-            None => base.entries.push(merged),
+            Some(idx) => {
+                base.entries[idx] = merged;
+                summary.replaced += 1;
+            }
+            None => {
+                base.entries.push(merged);
+                summary.added += 1;
+            }
         }
     }
-    Ok(())
+    Ok(summary)
 }
 
 fn build_full_entry(ov: &OverlayEntry) -> Result<LinkEntry, LinkMapError> {
@@ -284,9 +312,44 @@ entries:
                 body_template: None,
             }],
         };
-        apply(&mut base, &overlay).unwrap();
+        let summary = apply(&mut base, &overlay).unwrap();
         assert_eq!(base.entries.len(), 1);
         assert_eq!(base.entries[0].id, "keep");
+        assert_eq!(
+            summary,
+            OverlaySummary {
+                dropped: 1,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn apply_summary_counts_disabled_misses_as_zero_drop() {
+        // Disabled overlay for an id that does not exist in `base` is a
+        // no-op rather than an error (overlay author may have already
+        // removed it upstream). Make sure the summary reflects that — we
+        // should not lie about "1 drop" if nothing was dropped.
+        let mut base = LinkMap {
+            schema_version: 1,
+            entries: vec![tracked_entry("alpha")],
+        };
+        let overlay = LinkMapOverlay {
+            schema_version: 1,
+            entries: vec![OverlayEntry {
+                id: "does-not-exist".to_string(),
+                enabled: false,
+                kind: None,
+                source: None,
+                destination: None,
+                recursive: false,
+                surface: None,
+                comment_style: None,
+                body_template: None,
+            }],
+        };
+        let summary = apply(&mut base, &overlay).unwrap();
+        assert_eq!(summary, OverlaySummary::default());
     }
 
     #[test]

--- a/crates/agent-runtime-cli/src/install/overlay.rs
+++ b/crates/agent-runtime-cli/src/install/overlay.rs
@@ -1,0 +1,403 @@
+//! `.private/link-map.overrides.yaml` overlay parser. Plan 04 Sprint 1
+//! Task 1.3.
+//!
+//! Merge rule per
+//! `agent-runtime-kit/docs/source/inventory-target-architecture.md`
+//! `### Overlay Merge Semantics`:
+//!
+//! > Per-entry override. Entry id is the key; the `.private/` entry
+//! > **replaces** the tracked entry as a whole (no deep merge — avoids
+//! > subtle drift in nested install metadata). `enabled: false` in an
+//! > overlay entry drops that entry from the install plan.
+//!
+//! Overlay file is **optional**: when absent, [`LinkMapOverlay::load_optional`]
+//! returns `Ok(None)` and the tracked link-map flows through unchanged. When
+//! present, it MUST round-trip through the same schema gates as the tracked
+//! link-map (schema_version match, `deny_unknown_fields`, per-kind required
+//! / forbidden fields).
+
+use super::link_map::{CommentStyle, EntryKind, LinkEntry, LinkMap, LinkMapError, SCHEMA_VERSION};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+/// Conventional location of the overlay file, relative to the agent-runtime-kit
+/// source root.
+pub const OVERLAY_REL_PATH: &str = ".private/link-map.overrides.yaml";
+
+fn default_enabled() -> bool {
+    true
+}
+
+/// Single overlay entry. Mirrors [`LinkEntry`] plus an optional `enabled`
+/// flag: when `enabled: false`, the matching tracked entry is dropped from
+/// the merged plan and the other fields are ignored.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct OverlayEntry {
+    pub id: String,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub kind: Option<EntryKind>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub destination: Option<String>,
+    #[serde(default)]
+    pub recursive: bool,
+    #[serde(default)]
+    pub surface: Option<String>,
+    #[serde(default)]
+    pub comment_style: Option<CommentStyle>,
+    #[serde(default)]
+    pub body_template: Option<String>,
+}
+
+/// Parsed overlay file.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct LinkMapOverlay {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub entries: Vec<OverlayEntry>,
+}
+
+impl LinkMapOverlay {
+    /// Read `<source_root>/.private/link-map.overrides.yaml` if it exists.
+    /// Missing file is `Ok(None)`; any other failure (schema mismatch, parse
+    /// error, duplicate id) bubbles as a [`LinkMapError`] so the install
+    /// pipeline refuses to start rather than silently falling back to the
+    /// tracked map.
+    pub fn load_optional(source_root: &Path) -> Result<Option<Self>, LinkMapError> {
+        Self::load_from(&source_root.join(OVERLAY_REL_PATH))
+    }
+
+    /// Read the overlay from an explicit path. `Ok(None)` when the file is
+    /// absent; otherwise mirrors [`load_optional`] semantics. Used by
+    /// `commands::install` when a caller passes `--overlay-path`.
+    pub fn load_from(file: &Path) -> Result<Option<Self>, LinkMapError> {
+        if !file.exists() {
+            return Ok(None);
+        }
+        let raw = std::fs::read_to_string(file).map_err(|source| LinkMapError::Io {
+            file: file.to_path_buf(),
+            source,
+        })?;
+        let parsed: LinkMapOverlay =
+            serde_yaml_ng::from_str(&raw).map_err(|source| LinkMapError::Parse {
+                file: file.to_path_buf(),
+                source,
+            })?;
+        if parsed.schema_version != SCHEMA_VERSION {
+            return Err(LinkMapError::SchemaVersion {
+                file: file.to_path_buf(),
+                expected: SCHEMA_VERSION,
+                found: parsed.schema_version,
+            });
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for entry in &parsed.entries {
+            if !seen.insert(entry.id.clone()) {
+                return Err(LinkMapError::DuplicateId {
+                    file: file.to_path_buf(),
+                    id: entry.id.clone(),
+                });
+            }
+        }
+        Ok(Some(parsed))
+    }
+}
+
+/// Apply `overlay` to `base` per the per-entry-replace rule. Drops, replaces,
+/// and additions all happen in-place against `base.entries` so the caller's
+/// downstream plan builder consumes the merged result without knowing the
+/// overlay existed.
+pub fn apply(base: &mut LinkMap, overlay: &LinkMapOverlay) -> Result<(), LinkMapError> {
+    for ov in &overlay.entries {
+        if !ov.enabled {
+            // Drop matching tracked entry. Silently no-op when missing: the
+            // overlay author may have already removed the entry upstream.
+            base.entries.retain(|e| e.id != ov.id);
+            continue;
+        }
+        let merged = build_full_entry(ov)?;
+        merged
+            .validate()
+            .map_err(|reason| LinkMapError::InvalidEntry {
+                file: PathBuf::from(OVERLAY_REL_PATH),
+                id: merged.id.clone(),
+                reason,
+            })?;
+        match base.entries.iter().position(|e| e.id == ov.id) {
+            Some(idx) => base.entries[idx] = merged,
+            None => base.entries.push(merged),
+        }
+    }
+    Ok(())
+}
+
+fn build_full_entry(ov: &OverlayEntry) -> Result<LinkEntry, LinkMapError> {
+    // `enabled: true` overlay entries MUST declare a full entry shape; the
+    // overlay rule is replacement, not deep-merge, so missing required fields
+    // are a usage error.
+    let kind = ov.kind.ok_or_else(|| LinkMapError::InvalidEntry {
+        file: PathBuf::from(OVERLAY_REL_PATH),
+        id: ov.id.clone(),
+        reason: "overlay entry with enabled=true must declare `kind`".to_string(),
+    })?;
+    let destination = ov
+        .destination
+        .clone()
+        .ok_or_else(|| LinkMapError::InvalidEntry {
+            file: PathBuf::from(OVERLAY_REL_PATH),
+            id: ov.id.clone(),
+            reason: "overlay entry with enabled=true must declare `destination`".to_string(),
+        })?;
+    Ok(LinkEntry {
+        id: ov.id.clone(),
+        kind,
+        source: ov.source.clone(),
+        destination,
+        recursive: ov.recursive,
+        surface: ov.surface.clone(),
+        comment_style: ov.comment_style,
+        body_template: ov.body_template.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_overlay(root: &Path, body: &str) -> PathBuf {
+        let dir = root.join(".private");
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("link-map.overrides.yaml");
+        fs::write(&file, body).unwrap();
+        file
+    }
+
+    #[test]
+    fn load_optional_returns_none_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let result = LinkMapOverlay::load_optional(tmp.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_optional_returns_some_when_present() {
+        let tmp = TempDir::new().unwrap();
+        write_overlay(
+            tmp.path(),
+            "\
+schema_version: 1
+entries:
+  - id: reporting.skills-tree
+    enabled: false
+",
+        );
+        let overlay = LinkMapOverlay::load_optional(tmp.path()).unwrap().unwrap();
+        assert_eq!(overlay.entries.len(), 1);
+        assert!(!overlay.entries[0].enabled);
+    }
+
+    #[test]
+    fn load_optional_rejects_unknown_field() {
+        let tmp = TempDir::new().unwrap();
+        write_overlay(
+            tmp.path(),
+            "\
+schema_version: 1
+entries:
+  - id: x
+    bogus: 1
+",
+        );
+        let err = LinkMapOverlay::load_optional(tmp.path()).unwrap_err();
+        assert!(matches!(err, LinkMapError::Parse { .. }));
+    }
+
+    #[test]
+    fn load_optional_rejects_schema_mismatch() {
+        let tmp = TempDir::new().unwrap();
+        write_overlay(
+            tmp.path(),
+            "\
+schema_version: 99
+entries: []
+",
+        );
+        let err = LinkMapOverlay::load_optional(tmp.path()).unwrap_err();
+        assert!(matches!(err, LinkMapError::SchemaVersion { found: 99, .. }));
+    }
+
+    #[test]
+    fn load_optional_rejects_duplicate_id() {
+        let tmp = TempDir::new().unwrap();
+        write_overlay(
+            tmp.path(),
+            "\
+schema_version: 1
+entries:
+  - id: same
+    enabled: false
+  - id: same
+    enabled: false
+",
+        );
+        let err = LinkMapOverlay::load_optional(tmp.path()).unwrap_err();
+        assert!(matches!(err, LinkMapError::DuplicateId { id, .. } if id == "same"));
+    }
+
+    fn tracked_entry(id: &str) -> LinkEntry {
+        LinkEntry {
+            id: id.to_string(),
+            kind: EntryKind::SymlinkedFile,
+            source: Some("build/a".to_string()),
+            destination: "plugins/a".to_string(),
+            recursive: false,
+            surface: None,
+            comment_style: None,
+            body_template: None,
+        }
+    }
+
+    #[test]
+    fn apply_drops_disabled_entry() {
+        let mut base = LinkMap {
+            schema_version: 1,
+            entries: vec![tracked_entry("keep"), tracked_entry("drop")],
+        };
+        let overlay = LinkMapOverlay {
+            schema_version: 1,
+            entries: vec![OverlayEntry {
+                id: "drop".to_string(),
+                enabled: false,
+                kind: None,
+                source: None,
+                destination: None,
+                recursive: false,
+                surface: None,
+                comment_style: None,
+                body_template: None,
+            }],
+        };
+        apply(&mut base, &overlay).unwrap();
+        assert_eq!(base.entries.len(), 1);
+        assert_eq!(base.entries[0].id, "keep");
+    }
+
+    #[test]
+    fn apply_replaces_existing_entry() {
+        let mut base = LinkMap {
+            schema_version: 1,
+            entries: vec![tracked_entry("x")],
+        };
+        let overlay = LinkMapOverlay {
+            schema_version: 1,
+            entries: vec![OverlayEntry {
+                id: "x".to_string(),
+                enabled: true,
+                kind: Some(EntryKind::SymlinkedFile),
+                source: Some("build/replaced".to_string()),
+                destination: Some("plugins/replaced".to_string()),
+                recursive: false,
+                surface: None,
+                comment_style: None,
+                body_template: None,
+            }],
+        };
+        apply(&mut base, &overlay).unwrap();
+        assert_eq!(base.entries.len(), 1);
+        assert_eq!(base.entries[0].source.as_deref(), Some("build/replaced"));
+        assert_eq!(base.entries[0].destination, "plugins/replaced");
+    }
+
+    #[test]
+    fn apply_adds_new_entry() {
+        let mut base = LinkMap {
+            schema_version: 1,
+            entries: vec![tracked_entry("a")],
+        };
+        let overlay = LinkMapOverlay {
+            schema_version: 1,
+            entries: vec![OverlayEntry {
+                id: "b".to_string(),
+                enabled: true,
+                kind: Some(EntryKind::SymlinkedFile),
+                source: Some("build/b".to_string()),
+                destination: Some("plugins/b".to_string()),
+                recursive: false,
+                surface: None,
+                comment_style: None,
+                body_template: None,
+            }],
+        };
+        apply(&mut base, &overlay).unwrap();
+        assert_eq!(base.entries.len(), 2);
+        assert_eq!(base.entries[1].id, "b");
+    }
+
+    #[test]
+    fn apply_rejects_enabled_entry_missing_kind() {
+        let mut base = LinkMap {
+            schema_version: 1,
+            entries: vec![],
+        };
+        let overlay = LinkMapOverlay {
+            schema_version: 1,
+            entries: vec![OverlayEntry {
+                id: "x".to_string(),
+                enabled: true,
+                kind: None,
+                source: None,
+                destination: Some("plugins/x".to_string()),
+                recursive: false,
+                surface: None,
+                comment_style: None,
+                body_template: None,
+            }],
+        };
+        let err = apply(&mut base, &overlay).unwrap_err();
+        match err {
+            LinkMapError::InvalidEntry { reason, .. } => {
+                assert!(reason.contains("`kind`"), "got: {reason}");
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_rejects_enabled_entry_failing_kind_contract() {
+        // managed-block requires surface/comment_style/body_template; an
+        // overlay entry that names kind=managed-block but omits them must
+        // fail the same contract the tracked link-map enforces.
+        let mut base = LinkMap {
+            schema_version: 1,
+            entries: vec![],
+        };
+        let overlay = LinkMapOverlay {
+            schema_version: 1,
+            entries: vec![OverlayEntry {
+                id: "bad".to_string(),
+                enabled: true,
+                kind: Some(EntryKind::ManagedBlock),
+                source: None,
+                destination: Some("config.toml".to_string()),
+                recursive: false,
+                surface: None,
+                comment_style: None,
+                body_template: None,
+            }],
+        };
+        let err = apply(&mut base, &overlay).unwrap_err();
+        match err {
+            LinkMapError::InvalidEntry { reason, .. } => {
+                assert!(reason.contains("surface"), "got: {reason}");
+            }
+            other => panic!("expected InvalidEntry, got {other:?}"),
+        }
+    }
+}

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -9,6 +9,8 @@ mod audit_drift_classes;
 mod cli;
 #[path = "integration/determinism_gate.rs"]
 mod determinism_gate;
+#[path = "integration/install_flags.rs"]
+mod install_flags;
 #[path = "integration/install_pipeline.rs"]
 mod install_pipeline;
 #[path = "integration/managed_block.rs"]

--- a/crates/agent-runtime-cli/tests/integration/install_flags.rs
+++ b/crates/agent-runtime-cli/tests/integration/install_flags.rs
@@ -168,7 +168,7 @@ fn tag_writes_marker_into_backup_run_root_when_backup_happens() {
         tag: Some("pre-bump".to_string()),
         ..InstallOptions::default()
     };
-    let (_, _) = install::run(
+    let __outcome = install::run(
         "claude",
         &source_root,
         &home,
@@ -293,7 +293,7 @@ entries:
     let home = tmp.path().join("home");
     let state_home = tmp.path().join("state");
 
-    let (plan, _) = install::run(
+    let __outcome = install::run(
         "claude",
         &source_root,
         &home,
@@ -303,6 +303,7 @@ entries:
         &InstallOptions::default(),
     )
     .unwrap();
+    let plan = __outcome.plan;
 
     // Only the plugin-manifest entry survives — skills-tree was dropped.
     assert_eq!(
@@ -332,7 +333,7 @@ entries:
     let home = tmp.path().join("home");
     let state_home = tmp.path().join("state");
 
-    let (plan, _) = install::run(
+    let __outcome = install::run(
         "claude",
         &source_root,
         &home,
@@ -342,6 +343,7 @@ entries:
         &InstallOptions::default(),
     )
     .unwrap();
+    let plan = __outcome.plan;
 
     let dests: Vec<String> = plan
         .actions
@@ -381,7 +383,7 @@ entries:
         overlay_enabled: false,
         ..InstallOptions::default()
     };
-    let (plan, _) = install::run(
+    let __outcome = install::run(
         "claude",
         &source_root,
         &home,
@@ -391,6 +393,7 @@ entries:
         &options,
     )
     .unwrap();
+    let plan = __outcome.plan;
 
     // skills-tree drop is ignored → both initial entries flow through, so
     // the plan has >1 actions (manifest + every file under skills-tree).
@@ -426,7 +429,7 @@ entries:
         overlay_path: Some(custom.clone()),
         ..InstallOptions::default()
     };
-    let (plan, _) = install::run(
+    let __outcome = install::run(
         "claude",
         &source_root,
         &home,
@@ -436,11 +439,94 @@ entries:
         &options,
     )
     .unwrap();
+    let plan = __outcome.plan;
     assert_eq!(
         plan.actions.len(),
         1,
         "custom overlay path should have dropped skills-tree: {:?}",
         plan.actions
+    );
+}
+
+#[test]
+fn overlay_consumption_is_announced_on_stderr() {
+    // Architecture-doc requirement: `agent-runtime install --dry-run` must
+    // expose the post-overlay-merge effective config to reviewers. Pin the
+    // one-line summary naming dropped/replaced/added counts whenever an
+    // overlay is consumed.
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    write_overlay(
+        &source_root,
+        "\
+schema_version: 1
+entries:
+  - id: reporting.skills-tree
+    enabled: false
+",
+    );
+    let live_home = tmp.path().join("sandbox");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&live_home).unwrap();
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let live_arg = live_home.to_string_lossy().into_owned();
+    let state_arg = state_home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "install",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "claude",
+        "--live-home",
+        &live_arg,
+        "--state-home",
+        &state_arg,
+        "--dry-run",
+    ]);
+    assert_eq!(output.code, 0, "install dry-run should exit 0");
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.contains("overlay merged"),
+        "stderr should announce overlay consumption: {stderr}"
+    );
+    assert!(
+        stderr.contains("dropped=1"),
+        "stderr should name the drop count: {stderr}"
+    );
+}
+
+#[test]
+fn overlay_stays_silent_when_no_overlay_file_present() {
+    // Mirror of the above — when no overlay is loaded, the CLI must NOT
+    // print the overlay-merged line; otherwise the operator cannot tell
+    // at a glance whether an overlay was in play.
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let live_home = tmp.path().join("sandbox");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&live_home).unwrap();
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let live_arg = live_home.to_string_lossy().into_owned();
+    let state_arg = state_home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "install",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "claude",
+        "--live-home",
+        &live_arg,
+        "--state-home",
+        &state_arg,
+        "--dry-run",
+    ]);
+    assert_eq!(output.code, 0);
+    let stderr = output.stderr_text();
+    assert!(
+        !stderr.contains("overlay merged"),
+        "stderr must NOT announce overlay merge when no overlay file is present: {stderr}"
     );
 }
 

--- a/crates/agent-runtime-cli/tests/integration/install_flags.rs
+++ b/crates/agent-runtime-cli/tests/integration/install_flags.rs
@@ -1,0 +1,476 @@
+//! `agent-runtime install` flag tests. Plan 04 Sprint 1 Task 1.3.
+//!
+//! Covers:
+//!
+//! - `--live-home`: rejects relative paths with a usage error naming the
+//!   flag (Open Q1 resolved-default behaviour); accepts absolute paths.
+//! - `--tag`: writes a `tag-<name>` marker file at the backup-run root
+//!   when at least one backup is created; rejects unsafe characters.
+//! - `--no-overlay` / `--overlay-path`: the `.private/link-map.overrides.yaml`
+//!   merge runs before plan generation and can be redirected or skipped.
+
+use agent_runtime_cli::install::{self, InstallOptions, Mode};
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn run_cli(args: &[&str]) -> CmdOutput {
+    let bin = agent_runtime_bin();
+    cmd::run(&bin, args, &[], None)
+}
+
+fn fixed_time() -> SystemTime {
+    SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)
+}
+
+/// Build a source root matching the install_pipeline test fixture so the
+/// in-process install API has something realistic to run against.
+fn build_source_root(tmp: &Path, product: &str) -> PathBuf {
+    let root = tmp.join("src");
+    fs::create_dir_all(&root).unwrap();
+    let plugin_dir = root
+        .join("targets")
+        .join(product)
+        .join("plugins")
+        .join("reporting")
+        .join(format!(".{product}-plugin"));
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(
+        plugin_dir.join("plugin.json"),
+        r#"{"name":"reporting","version":"0.1.0"}"#,
+    )
+    .unwrap();
+    let build_dir = root
+        .join("build")
+        .join(product)
+        .join("plugins")
+        .join("reporting")
+        .join("skills");
+    fs::create_dir_all(build_dir.join("daily-brief")).unwrap();
+    fs::write(
+        build_dir.join("daily-brief").join("SKILL.md"),
+        "# daily-brief\n",
+    )
+    .unwrap();
+    let link_map = format!(
+        "schema_version: 1\nentries:\n  - id: reporting.plugin-manifest\n    kind: plugin-manifest-copy\n    source: targets/{product}/plugins/reporting/.{product}-plugin/plugin.json\n    destination: plugins/reporting/.{product}-plugin/plugin.json\n  - id: reporting.skills-tree\n    kind: symlinked-file\n    source: build/{product}/plugins/reporting/skills\n    destination: plugins/reporting/skills\n    recursive: true\n",
+    );
+    fs::write(
+        root.join("targets").join(product).join("link-map.yaml"),
+        link_map,
+    )
+    .unwrap();
+    fs::canonicalize(&root).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// --live-home
+// ---------------------------------------------------------------------------
+
+#[test]
+fn live_home_rejects_relative_path_with_usage_error() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&state_home).unwrap();
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let state_arg = state_home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "install",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "claude",
+        "--live-home",
+        "./relative-sandbox",
+        "--state-home",
+        &state_arg,
+        "--dry-run",
+    ]);
+    assert_ne!(
+        output.code, 0,
+        "expected non-zero exit for relative --live-home"
+    );
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.contains("--live-home"),
+        "stderr should name the offending flag: {stderr}"
+    );
+    assert!(
+        stderr.contains("absolute"),
+        "stderr should mention the absolute-path requirement: {stderr}"
+    );
+}
+
+#[test]
+fn live_home_accepts_absolute_path_dry_run() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let live_home = tmp.path().join("sandbox");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&live_home).unwrap();
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let live_arg = live_home.to_string_lossy().into_owned();
+    let state_arg = state_home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "install",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "claude",
+        "--live-home",
+        &live_arg,
+        "--state-home",
+        &state_arg,
+        "--dry-run",
+    ]);
+    assert_eq!(
+        output.code,
+        0,
+        "expected zero exit for absolute --live-home; stderr={}",
+        output.stderr_text()
+    );
+    // Dry-run must not have written into the sandbox.
+    let entries: Vec<_> = fs::read_dir(&live_home).unwrap().collect();
+    assert!(
+        entries.is_empty(),
+        "dry-run wrote into sandbox: {entries:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// --tag
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tag_writes_marker_into_backup_run_root_when_backup_happens() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    // Seed a regular file at one of the install destinations so the apply
+    // executor produces a FileBackedUpThenSymlinked change.
+    let pre_existing = home.join("plugins/reporting/skills/daily-brief/SKILL.md");
+    fs::create_dir_all(pre_existing.parent().unwrap()).unwrap();
+    fs::write(&pre_existing, b"user-edited content\n").unwrap();
+
+    let options = InstallOptions {
+        tag: Some("pre-bump".to_string()),
+        ..InstallOptions::default()
+    };
+    let (_, _) = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::Apply,
+        fixed_time(),
+        &options,
+    )
+    .unwrap();
+
+    let backup_run_root = state_home
+        .join("backups")
+        .join("claude")
+        .join(format!("{}", 1_700_000_000_u64));
+    let marker = backup_run_root.join("tag-pre-bump");
+    assert!(
+        marker.exists(),
+        "expected tag marker at {} after a backup-triggering apply",
+        marker.display()
+    );
+}
+
+#[test]
+fn tag_writes_no_marker_when_no_backup_happens() {
+    // Fresh home → no pre-existing files → no backups → no marker.
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let options = InstallOptions {
+        tag: Some("pre-bump".to_string()),
+        ..InstallOptions::default()
+    };
+    install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::Apply,
+        fixed_time(),
+        &options,
+    )
+    .unwrap();
+
+    let backup_run_root = state_home
+        .join("backups")
+        .join("claude")
+        .join(format!("{}", 1_700_000_000_u64));
+    assert!(
+        !backup_run_root.exists(),
+        "backup run root must not be created on a backup-free apply"
+    );
+}
+
+#[test]
+fn tag_rejects_unsafe_characters() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let live_home = tmp.path().join("sandbox");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&live_home).unwrap();
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let live_arg = live_home.to_string_lossy().into_owned();
+    let state_arg = state_home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "install",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "claude",
+        "--live-home",
+        &live_arg,
+        "--state-home",
+        &state_arg,
+        "--tag",
+        "../escape",
+        "--dry-run",
+    ]);
+    assert_ne!(output.code, 0, "expected non-zero exit for unsafe --tag");
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.contains("--tag"),
+        "stderr should name the offending flag: {stderr}"
+    );
+    assert!(
+        stderr.contains("trusted") || stderr.contains("allowed"),
+        "stderr should explain the trust contract: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Overlay merge
+// ---------------------------------------------------------------------------
+
+fn write_overlay(source_root: &Path, body: &str) {
+    let dir = source_root.join(".private");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("link-map.overrides.yaml"), body).unwrap();
+}
+
+#[test]
+fn overlay_drops_disabled_entry_before_plan_generation() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    write_overlay(
+        &source_root,
+        "\
+schema_version: 1
+entries:
+  - id: reporting.skills-tree
+    enabled: false
+",
+    );
+    let overlay_file = source_root.join(".private/link-map.overrides.yaml");
+    assert!(
+        overlay_file.exists(),
+        "overlay file should be readable from source_root: {}",
+        overlay_file.display()
+    );
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let (plan, _) = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::DryRun,
+        fixed_time(),
+        &InstallOptions::default(),
+    )
+    .unwrap();
+
+    // Only the plugin-manifest entry survives — skills-tree was dropped.
+    assert_eq!(
+        plan.actions.len(),
+        1,
+        "expected only the plugin-manifest action: {:?}",
+        plan.actions
+    );
+}
+
+#[test]
+fn overlay_replaces_existing_entry_destination() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    write_overlay(
+        &source_root,
+        "\
+schema_version: 1
+entries:
+  - id: reporting.plugin-manifest
+    enabled: true
+    kind: plugin-manifest-copy
+    source: targets/claude/plugins/reporting/.claude-plugin/plugin.json
+    destination: plugins/overridden/.claude-plugin/plugin.json
+",
+    );
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let (plan, _) = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::DryRun,
+        fixed_time(),
+        &InstallOptions::default(),
+    )
+    .unwrap();
+
+    let dests: Vec<String> = plan
+        .actions
+        .iter()
+        .map(|a| match a {
+            agent_runtime_cli::install::plan::PlanAction::Symlink { dest, .. } => {
+                dest.display().to_string()
+            }
+            agent_runtime_cli::install::plan::PlanAction::ManagedBlock { config_file, .. } => {
+                config_file.display().to_string()
+            }
+        })
+        .collect();
+    assert!(
+        dests.iter().any(|d| d.contains("plugins/overridden/")),
+        "overlay destination should appear in plan: {dests:?}"
+    );
+}
+
+#[test]
+fn no_overlay_skips_private_file_even_when_present() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    write_overlay(
+        &source_root,
+        "\
+schema_version: 1
+entries:
+  - id: reporting.skills-tree
+    enabled: false
+",
+    );
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let options = InstallOptions {
+        overlay_enabled: false,
+        ..InstallOptions::default()
+    };
+    let (plan, _) = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::DryRun,
+        fixed_time(),
+        &options,
+    )
+    .unwrap();
+
+    // skills-tree drop is ignored → both initial entries flow through, so
+    // the plan has >1 actions (manifest + every file under skills-tree).
+    assert!(
+        plan.actions.len() > 1,
+        "expected overlay-disabled run to include the skills-tree entries: {:?}",
+        plan.actions
+    );
+}
+
+#[test]
+fn overlay_path_redirects_to_explicit_file() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+
+    // Put the overlay somewhere *other* than the conventional .private/
+    // location so we can prove --overlay-path was honoured.
+    let custom = tmp.path().join("alt-overlay.yaml");
+    fs::write(
+        &custom,
+        "\
+schema_version: 1
+entries:
+  - id: reporting.skills-tree
+    enabled: false
+",
+    )
+    .unwrap();
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let options = InstallOptions {
+        overlay_path: Some(custom.clone()),
+        ..InstallOptions::default()
+    };
+    let (plan, _) = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::DryRun,
+        fixed_time(),
+        &options,
+    )
+    .unwrap();
+    assert_eq!(
+        plan.actions.len(),
+        1,
+        "custom overlay path should have dropped skills-tree: {:?}",
+        plan.actions
+    );
+}
+
+#[test]
+fn overlay_schema_mismatch_aborts_install() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    write_overlay(
+        &source_root,
+        "\
+schema_version: 99
+entries: []
+",
+    );
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let err = install::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        Mode::DryRun,
+        fixed_time(),
+        &InstallOptions::default(),
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("schema_version"),
+        "expected schema_version error, got: {msg}"
+    );
+}

--- a/crates/agent-runtime-cli/tests/integration/install_pipeline.rs
+++ b/crates/agent-runtime-cli/tests/integration/install_pipeline.rs
@@ -123,7 +123,7 @@ fn dry_run_does_not_mutate_home() {
     fs::create_dir_all(&home).unwrap();
 
     let before = snapshot(&home);
-    let (plan, changes) = install::run(
+    let __outcome = install::run(
         "claude",
         &source_root,
         &home,
@@ -133,6 +133,8 @@ fn dry_run_does_not_mutate_home() {
         &InstallOptions::default(),
     )
     .unwrap();
+    let plan = __outcome.plan;
+    let changes = __outcome.changes;
 
     // Dry-run must not touch the filesystem.
     assert_eq!(snapshot(&home), before, "home was mutated by dry-run");
@@ -156,7 +158,7 @@ fn apply_writes_symlinks_and_is_byte_identical_on_second_run() {
     let home = tmp.path().join("home");
     let state_home = tmp.path().join("state");
 
-    let (_, changes_first) = install::run(
+    let __outcome = install::run(
         "claude",
         &source_root,
         &home,
@@ -166,6 +168,7 @@ fn apply_writes_symlinks_and_is_byte_identical_on_second_run() {
         &InstallOptions::default(),
     )
     .unwrap();
+    let changes_first = __outcome.changes;
     // First apply: every action is a SymlinkCreated (fresh home).
     for c in &changes_first {
         assert!(
@@ -189,7 +192,7 @@ fn apply_writes_symlinks_and_is_byte_identical_on_second_run() {
     assert_eq!(fs::read_to_string(&skill_dest).unwrap(), "# daily-brief\n",);
 
     // Second apply: byte-identical no-op.
-    let (_, changes_second) = install::run(
+    let __outcome = install::run(
         "claude",
         &source_root,
         &home,
@@ -199,6 +202,7 @@ fn apply_writes_symlinks_and_is_byte_identical_on_second_run() {
         &InstallOptions::default(),
     )
     .unwrap();
+    let changes_second = __outcome.changes;
     for c in &changes_second {
         assert!(
             matches!(c, AppliedChange::NoOp { .. }),
@@ -224,7 +228,7 @@ fn pre_existing_regular_file_is_backed_up_then_symlinked() {
     fs::create_dir_all(pre_existing.parent().unwrap()).unwrap();
     fs::write(&pre_existing, b"user-edited content\n").unwrap();
 
-    let (_, changes) = install::run(
+    let __outcome = install::run(
         "claude",
         &source_root,
         &home,
@@ -234,6 +238,7 @@ fn pre_existing_regular_file_is_backed_up_then_symlinked() {
         &InstallOptions::default(),
     )
     .unwrap();
+    let changes = __outcome.changes;
 
     let backed_up = changes
         .iter()
@@ -307,7 +312,7 @@ entries:
     let home = tmp.path().join("home");
     let state_home = tmp.path().join("state");
 
-    let (_, changes_first) = install::run(
+    let __outcome = install::run(
         "codex",
         &source_root,
         &home,
@@ -317,6 +322,7 @@ entries:
         &InstallOptions::default(),
     )
     .unwrap();
+    let changes_first = __outcome.changes;
     assert_eq!(changes_first.len(), 1);
     assert!(matches!(
         changes_first[0],
@@ -328,7 +334,7 @@ entries:
     assert!(config_after_first.contains("tag = \"agent-runtime\""));
     assert!(config_after_first.contains("# <<< agent-runtime-kit:install <<<"));
 
-    let (_, changes_second) = install::run(
+    let __outcome = install::run(
         "codex",
         &source_root,
         &home,
@@ -338,6 +344,7 @@ entries:
         &InstallOptions::default(),
     )
     .unwrap();
+    let changes_second = __outcome.changes;
     assert!(matches!(changes_second[0], AppliedChange::NoOp { .. }));
     let config_after_second = fs::read_to_string(home.join("config.toml")).unwrap();
     assert_eq!(config_after_first, config_after_second);

--- a/crates/agent-runtime-cli/tests/integration/install_pipeline.rs
+++ b/crates/agent-runtime-cli/tests/integration/install_pipeline.rs
@@ -5,7 +5,7 @@
 //! printer and apply executor both exercise the byte-identical
 //! idempotence guarantee the Plan 04 acceptance criteria require.
 
-use agent_runtime_cli::install::{self, AppliedChange, Mode};
+use agent_runtime_cli::install::{self, AppliedChange, InstallOptions, Mode};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
@@ -130,6 +130,7 @@ fn dry_run_does_not_mutate_home() {
         &state_home,
         Mode::DryRun,
         fixed_time(),
+        &InstallOptions::default(),
     )
     .unwrap();
 
@@ -162,6 +163,7 @@ fn apply_writes_symlinks_and_is_byte_identical_on_second_run() {
         &state_home,
         Mode::Apply,
         fixed_time(),
+        &InstallOptions::default(),
     )
     .unwrap();
     // First apply: every action is a SymlinkCreated (fresh home).
@@ -194,6 +196,7 @@ fn apply_writes_symlinks_and_is_byte_identical_on_second_run() {
         &state_home,
         Mode::Apply,
         fixed_time(),
+        &InstallOptions::default(),
     )
     .unwrap();
     for c in &changes_second {
@@ -228,6 +231,7 @@ fn pre_existing_regular_file_is_backed_up_then_symlinked() {
         &state_home,
         Mode::Apply,
         fixed_time(),
+        &InstallOptions::default(),
     )
     .unwrap();
 
@@ -310,6 +314,7 @@ entries:
         &state_home,
         Mode::Apply,
         fixed_time(),
+        &InstallOptions::default(),
     )
     .unwrap();
     assert_eq!(changes_first.len(), 1);
@@ -330,6 +335,7 @@ entries:
         &state_home,
         Mode::Apply,
         fixed_time(),
+        &InstallOptions::default(),
     )
     .unwrap();
     assert!(matches!(changes_second[0], AppliedChange::NoOp { .. }));
@@ -351,6 +357,7 @@ fn missing_link_map_returns_typed_error() {
         &state_home,
         Mode::DryRun,
         fixed_time(),
+        &InstallOptions::default(),
     )
     .unwrap_err();
     let msg = err.to_string();


### PR DESCRIPTION
## Summary

Lands Plan 04 Sprint 1 Task 1.3 — adds `--live-home <abs-path>` (relative
paths rejected with a flag-naming usage error per Open Q1 resolved default),
`--tag <name>` that writes a `tag-<name>` marker file at the backup-run root
so `gc-backups` (Sprint 2 Task 2.4) can preserve it across retention sweeps,
and a new `.private/link-map.overrides.yaml` overlay merge applied before
plan generation (per-entry replace; `enabled: false` drops; new entries are
added). A `/code-review-specialists` pass surfaced two material findings
(F-1 tag validation only at CLI boundary; F-2 overlay consumed silently);
both fixed in commit `e340719` pre-merge.

## Changes

- `crates/agent-runtime-cli/src/commands/install.rs` — rename `--home` to
  `--live-home`; add `--tag` / `--no-overlay` / `--overlay-path`; route
  through `install::is_trusted_tag` for an early friendly error message.
- `crates/agent-runtime-cli/src/install.rs` — `InstallOptions` (custom
  `Default` with `overlay_enabled = true`); `InstallOutcome { plan,
  changes, overlay: Option<OverlaySummary> }`.
- `crates/agent-runtime-cli/src/install/overlay.rs` (new) —
  `LinkMapOverlay` parser + `apply()` returning `OverlaySummary
  { dropped, replaced, added }`.
- `crates/agent-runtime-cli/src/install/executor.rs` — tag-name validation
  at executor entry (defense in depth) + `ApplyError::InvalidTag` + tag
  marker write at backup-run root.
- `crates/agent-runtime-cli/tests/integration/install_flags.rs` (new) —
  12 integration tests covering `--live-home` accept/reject, `--tag`
  marker write + unsafe-char rejection, overlay drop / replace /
  schema-mismatch / `--no-overlay` / `--overlay-path` / stderr
  announcement.
- `crates/agent-runtime-cli/tests/integration/install_pipeline.rs` — call
  sites updated for the new `InstallOutcome` return shape.

## Test-First Evidence

- **Change classification**: feature (Plan 04 Sprint 1 Task 1.3).
- **Failing test before fix**: not applicable — feature scope; covered by
  failing-fast assertions (`live_home_rejects_relative_path_with_usage_error`,
  `tag_rejects_unsafe_characters`,
  `overlay_drops_disabled_entry_before_plan_generation`,
  `overlay_consumption_is_announced_on_stderr`,
  `run_rejects_untrusted_tag_before_walking_actions`) that would have
  failed against the Task 1.2 baseline.
- **Final validation**: `cargo test -p agent-runtime-cli` 45/45 pass +
  full `nils-cli-verify-required-checks` gate stack green
  (`scripts/ci/nils-cli-checks-entrypoint.sh` → "ok: all nils-cli checks
  passed").
- **Waiver reason**: not applicable — every new behaviour is pinned by a
  passing test.

## Testing

- `cargo fmt --check`: pass.
- `cargo clippy -p agent-runtime-cli --all-targets --all-features -- -D warnings`: pass.
- `cargo test -p agent-runtime-cli`: pass (45/45).
- `bash scripts/ci/nils-cli-checks-entrypoint.sh`: pass.
- Both commits GPG-signed (`G G` via op-ssh-sign).

## Risk / Notes

- **Breaking CLI rename** `--home` → `--live-home`. No release shipped
  `--home` (Task 1.2 merged on the same day as this PR), so no external
  consumers exist. Will be called out in the Sprint 4 Task 4.4 0.2.0
  CHANGELOG.
- **F-3 advisory** (api-contract low, deferred): `<state_home>/backups/
  <product>/<unix-seconds>/tag-<name>` (marker file) and `<unix-seconds>/
  <entry_id>/` (backup subdir) share the same path namespace. Sprint 2
  Task 2.4 (`gc-backups`) should test file-type before treating a path
  as a tag marker, OR reserve `tag-*` prefix in the link-map schema's
  `id` pattern.
- Specialist review synthesis: see
  `/Users/terry/.local/state/claude-kit/out/task-1-3-review/SYNTHESIS.md`
  (2 mediums resolved pre-merge; 6 info / low advisories deferred to
  Sprint 2 / 4).
- Next pickup after this merges: Plan 04 Sprint 2 Task 2.1 — implement
  `agent-runtime uninstall`.
