### PR TITLE
Surface CLI progress and default limits

### DIFF
--- a/crates/git-summary/src/summary.rs
+++ b/crates/git-summary/src/summary.rs
@@ -1,5 +1,3 @@
-use std::io::IsTerminal;
-
 use anyhow::Result;
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 
@@ -50,7 +48,7 @@ pub fn summary(since: Option<&str>, until: Option<&str>) -> i32 {
 
 fn render_summary(log_args: &[String]) -> Result<()> {
     let authors = collect_authors(log_args)?;
-    let progress = if !authors.is_empty() && std::io::stderr().is_terminal() {
+    let progress = if !authors.is_empty() {
         Some(Progress::new(
             authors.len() as u64,
             ProgressOptions::default().with_finish(ProgressFinish::Clear),

--- a/crates/memo-cli/README.md
+++ b/crates/memo-cli/README.md
@@ -51,7 +51,8 @@ Commands:
 - `fetch` and `apply` are machine-facing commands and support both `--json` and `--format json`.
 - `list`, `search`, and `report` also support JSON mode for automation and dashboards.
 - `list`/`search`/`fetch` may include additive metadata fields:
-  `content_type`, `validation_status`.
+  `content_type`, `validation_status`; `list` and `search` also expose
+  `truncated` pagination metadata.
 - `report` may include additive metadata aggregates:
   `top_content_types`, `validation_status_totals`.
 - In JSON mode, parse `stdout` only. `stderr` is diagnostic-only and not part of the data contract.

--- a/crates/memo-cli/docs/specs/memo-cli-command-contract-v1.md
+++ b/crates/memo-cli/docs/specs/memo-cli-command-contract-v1.md
@@ -210,6 +210,8 @@ Behavior:
 Text output (`stdout`):
 
 - table/list with id, timestamp, state, short preview.
+- when the returned row count reaches `--limit`, a footer names the active
+  limit and suggests `--limit` / `--offset` for follow-up paging.
 
 JSON output:
 
@@ -217,6 +219,8 @@ JSON output:
   fields when available:
   - `content_type`
   - `validation_status`
+- `pagination.truncated` is `true` when the returned row count reaches
+  `--limit`.
 
 ### `search`
 
@@ -242,6 +246,8 @@ Behavior:
 Text output (`stdout`):
 
 - ranked matches with score, id, timestamp, and preview.
+- when the returned match count reaches `--limit`, a footer names the active
+  limit and suggests increasing `--limit`.
 
 JSON output:
 
@@ -251,6 +257,8 @@ JSON output:
   - `validation_status`
 - JSON `meta` includes `fields[]` reflecting the effective field scope.
 - JSON `meta` includes `match` reflecting the effective match mode.
+- JSON `meta.truncated` is `true` when the returned match count reaches
+  `--limit`.
 
 ### `report`
 

--- a/crates/memo-cli/docs/specs/memo-cli-json-contract-v1.md
+++ b/crates/memo-cli/docs/specs/memo-cli-json-contract-v1.md
@@ -127,7 +127,7 @@ Semantics:
   - optional `content_type`
   - optional `validation_status`
 - optional `pagination`:
-  - `limit`, `offset`, `returned`
+  - `limit`, `offset`, `returned`, `truncated`
 
 ### `search` (`results`)
 
@@ -139,7 +139,7 @@ Semantics:
   - optional `content_type`
   - optional `validation_status`
 - optional `meta`:
-  - `query`, `limit`, `state`, `fields`, `match`
+  - `query`, `limit`, `state`, `fields`, `match`, `truncated`
 
 ### `report` (`result`)
 
@@ -274,7 +274,8 @@ Redaction example (conceptual):
   "pagination": {
     "limit": 20,
     "offset": 0,
-    "returned": 2
+    "returned": 2,
+    "truncated": false
   }
 }
 ```
@@ -305,7 +306,8 @@ Redaction example (conceptual):
     "limit": 20,
     "state": "all",
     "fields": ["raw_text", "derived_text", "tags_text"],
-    "match": "fts"
+    "match": "fts",
+    "truncated": false
   }
 }
 ```

--- a/crates/memo-cli/src/commands/list.rs
+++ b/crates/memo-cli/src/commands/list.rs
@@ -15,6 +15,7 @@ pub fn run(
 ) -> Result<(), AppError> {
     let rows =
         storage.with_connection(|conn| repository::list_items(conn, state, limit, offset))?;
+    let truncated = limit > 0 && rows.len() == limit;
 
     if format.is_json() {
         let items = rows
@@ -38,12 +39,13 @@ pub fn run(
                     "limit": limit,
                     "offset": offset,
                     "returned": rows.len(),
+                    "truncated": truncated,
                 },
             }),
         );
     }
 
-    text::print_list(&rows);
+    text::print_list(&rows, limit, offset, truncated);
 
     Ok(())
 }

--- a/crates/memo-cli/src/commands/search.rs
+++ b/crates/memo-cli/src/commands/search.rs
@@ -25,6 +25,7 @@ pub fn run(
     let rows = storage.with_connection(|conn| {
         search::search_items(conn, query, state, &search_fields, match_mode, limit)
     })?;
+    let truncated = limit > 0 && rows.len() == limit;
 
     if format.is_json() {
         let items = rows
@@ -51,12 +52,13 @@ pub fn run(
                     "state": query_state_label(state),
                     "fields": search_field_labels(&search_fields),
                     "match": search_match_mode_label(match_mode),
+                    "truncated": truncated,
                 },
             }),
         );
     }
 
-    text::print_search(&rows);
+    text::print_search(&rows, limit, truncated);
 
     Ok(())
 }

--- a/crates/memo-cli/src/output/text.rs
+++ b/crates/memo-cli/src/output/text.rs
@@ -38,7 +38,7 @@ pub fn print_delete(
     );
 }
 
-pub fn print_list(rows: &[ListItem]) {
+pub fn print_list(rows: &[ListItem], limit: usize, offset: usize, truncated: bool) {
     if rows.is_empty() {
         println!("(no items)");
         return;
@@ -60,9 +60,17 @@ pub fn print_list(rows: &[ListItem]) {
             row.text_preview
         );
     }
+
+    if truncated {
+        println!(
+            "(showing {} items with --limit {limit}; use --limit <N> to show more or --offset {} for the next page)",
+            rows.len(),
+            offset.saturating_add(limit),
+        );
+    }
 }
 
-pub fn print_search(rows: &[SearchItem]) {
+pub fn print_search(rows: &[SearchItem], limit: usize, truncated: bool) {
     if rows.is_empty() {
         println!("(no matches)");
         return;
@@ -82,6 +90,13 @@ pub fn print_search(rows: &[SearchItem]) {
             row.created_at,
             row.score,
             row.preview
+        );
+    }
+
+    if truncated {
+        println!(
+            "(showing {} matches with --limit {limit}; use --limit <N> to show more)",
+            rows.len(),
         );
     }
 }
@@ -271,11 +286,11 @@ mod tests {
         print_add(1, "2026-02-12T10:00:00Z");
         print_update(1, "2026-02-12T10:30:00Z", 2, 1);
         print_delete(1, "2026-02-12T10:40:00Z", 2, 1);
-        print_list(&[]);
-        print_list(&sample_list_rows());
+        print_list(&[], 20, 0, false);
+        print_list(&sample_list_rows(), 20, 0, false);
 
-        print_search(&[]);
-        print_search(&sample_search_rows());
+        print_search(&[], 20, false);
+        print_search(&sample_search_rows(), 20, false);
 
         print_report(&sample_report());
         print_report(&ReportSummary {

--- a/crates/memo-cli/tests/integration.rs
+++ b/crates/memo-cli/tests/integration.rs
@@ -23,6 +23,8 @@ mod help_snapshot;
 mod item_id_allocator;
 #[path = "integration/json_contract.rs"]
 mod json_contract;
+#[path = "integration/list_search_footer.rs"]
+mod list_search_footer;
 #[path = "integration/memo_flow.rs"]
 mod memo_flow;
 #[path = "integration/metadata_projection.rs"]

--- a/crates/memo-cli/tests/integration/json_contract.rs
+++ b/crates/memo-cli/tests/integration/json_contract.rs
@@ -64,6 +64,7 @@ fn json_contract() {
     assert_eq!(list_json["data"]["pagination"]["limit"], 20);
     assert_eq!(list_json["data"]["pagination"]["offset"], 0);
     assert_eq!(list_json["data"]["pagination"]["returned"], 1);
+    assert_eq!(list_json["data"]["pagination"]["truncated"], false);
     let first_list_item = &list_json["data"]["items"][0];
     assert!(
         first_list_item.get("content_type").is_some(),
@@ -96,6 +97,7 @@ fn json_contract() {
     assert_eq!(search_json["data"]["meta"]["limit"], 5);
     assert_eq!(search_json["data"]["meta"]["state"], "all");
     assert_eq!(search_json["data"]["meta"]["match"], "fts");
+    assert_eq!(search_json["data"]["meta"]["truncated"], false);
     assert_eq!(
         search_json["data"]["meta"]["fields"],
         json!(["raw_text", "derived_text", "tags_text"])

--- a/crates/memo-cli/tests/integration/list_search_footer.rs
+++ b/crates/memo-cli/tests/integration/list_search_footer.rs
@@ -1,0 +1,112 @@
+use pretty_assertions::assert_eq;
+
+use crate::support::{parse_json_stdout, run_memo_cli, test_db_path};
+
+fn add_items(db_path: &std::path::Path, count: usize, prefix: &str) {
+    for idx in 0..count {
+        let output = run_memo_cli(db_path, &["add", &format!("{prefix} item {idx}")], None);
+        assert_eq!(output.code, 0, "add failed: {}", output.stderr_text());
+    }
+}
+
+#[test]
+fn list_text_footer_appears_only_when_limit_is_reached() {
+    let db_path = test_db_path("list_text_footer");
+    add_items(&db_path, 3, "visible");
+
+    let truncated = run_memo_cli(&db_path, &["list", "--limit", "2"], None);
+    assert_eq!(
+        truncated.code,
+        0,
+        "list failed: {}",
+        truncated.stderr_text()
+    );
+    let stdout = truncated.stdout_text();
+    assert!(stdout.contains("(showing 2 items with --limit 2;"));
+    assert!(stdout.contains("--offset 2"));
+
+    let complete = run_memo_cli(&db_path, &["list", "--limit", "5"], None);
+    assert_eq!(complete.code, 0, "list failed: {}", complete.stderr_text());
+    assert!(!complete.stdout_text().contains("(showing"));
+}
+
+#[test]
+fn list_json_reports_truncation_state() {
+    let db_path = test_db_path("list_json_truncated");
+    add_items(&db_path, 3, "json");
+
+    let truncated = run_memo_cli(&db_path, &["--json", "list", "--limit", "2"], None);
+    assert_eq!(
+        truncated.code,
+        0,
+        "list failed: {}",
+        truncated.stderr_text()
+    );
+    let truncated_json = parse_json_stdout(&truncated);
+    assert_eq!(truncated_json["data"]["pagination"]["truncated"], true);
+
+    let complete = run_memo_cli(&db_path, &["--json", "list", "--limit", "5"], None);
+    assert_eq!(complete.code, 0, "list failed: {}", complete.stderr_text());
+    let complete_json = parse_json_stdout(&complete);
+    assert_eq!(complete_json["data"]["pagination"]["truncated"], false);
+}
+
+#[test]
+fn search_text_footer_appears_only_when_limit_is_reached() {
+    let db_path = test_db_path("search_text_footer");
+    add_items(&db_path, 3, "needle");
+
+    let truncated = run_memo_cli(&db_path, &["search", "needle", "--limit", "2"], None);
+    assert_eq!(
+        truncated.code,
+        0,
+        "search failed: {}",
+        truncated.stderr_text()
+    );
+    let stdout = truncated.stdout_text();
+    assert!(stdout.contains("(showing 2 matches with --limit 2;"));
+    assert!(stdout.contains("use --limit <N>"));
+
+    let complete = run_memo_cli(&db_path, &["search", "needle", "--limit", "5"], None);
+    assert_eq!(
+        complete.code,
+        0,
+        "search failed: {}",
+        complete.stderr_text()
+    );
+    assert!(!complete.stdout_text().contains("(showing"));
+}
+
+#[test]
+fn search_json_reports_truncation_state() {
+    let db_path = test_db_path("search_json_truncated");
+    add_items(&db_path, 3, "target");
+
+    let truncated = run_memo_cli(
+        &db_path,
+        &["--json", "search", "target", "--limit", "2"],
+        None,
+    );
+    assert_eq!(
+        truncated.code,
+        0,
+        "search failed: {}",
+        truncated.stderr_text()
+    );
+    let truncated_json = parse_json_stdout(&truncated);
+    assert_eq!(truncated_json["data"]["meta"]["truncated"], true);
+
+    let complete = run_memo_cli(
+        &db_path,
+        &["--json", "search", "target", "--limit", "5"],
+        None,
+    );
+    assert_eq!(
+        complete.code,
+        0,
+        "search failed: {}",
+        complete.stderr_text()
+    );
+    let complete_json = parse_json_stdout(&complete);
+    assert_eq!(complete_json["data"]["meta"]["truncated"], false);
+}

--- a/crates/semantic-commit/README.md
+++ b/crates/semantic-commit/README.md
@@ -61,6 +61,8 @@ Flags:
 - `--summary <git-scope|git-show|none>` (default: `git-scope` with fallback to `git-show`)
 - `--no-summary` — equivalent to `--summary none`
 - `--repo <path>` — run git commands against the repository path
+- `--max-header-width <N>` — override the commit header width (default: `100`). When the flag is
+  absent, `SEMANTIC_COMMIT_HEADER_WIDTH` may set the default; the flag wins when both are present.
 - `--automation` (alias: `--non-interactive`) — disallow stdin message fallback
 - `--validate-only` — validate the commit message format and exit without committing
 - `--dry-run` — run validation and staged-change checks, then skip `git commit`
@@ -83,7 +85,8 @@ semantic-commit completion <bash|zsh>
 
 ## Commit Message Validation
 
-- Header must be non-empty, `<= 100` characters, and use a lowercase type.
+- Header must be non-empty, no longer than the active header width, and use a lowercase type. The
+  default active header width is `100`.
 - Header format: `type(scope): subject` or `type: subject`.
 - If a body exists, line 2 must be blank and each body line must start with `-` + space, followed by an
   uppercase letter and be `<= 100` characters. A bullet may wrap onto a following line by prefixing that

--- a/crates/semantic-commit/src/commit.rs
+++ b/crates/semantic-commit/src/commit.rs
@@ -44,6 +44,7 @@ struct CommitOptions {
     dry_run: bool,
     auto_fix: bool,
     repo: Option<PathBuf>,
+    max_header_width: usize,
 }
 
 impl Default for CommitOptions {
@@ -60,6 +61,7 @@ impl Default for CommitOptions {
             dry_run: false,
             auto_fix: false,
             repo: None,
+            max_header_width: DEFAULT_MAX_HEADER_WIDTH,
         }
     }
 }
@@ -109,7 +111,8 @@ pub fn run(args: &[String]) -> i32 {
         return EXIT_ERROR;
     }
 
-    if let Err(code) = validate_commit_message(tmpfile.path()) {
+    if let Err(code) = validate_commit_message_with_width(tmpfile.path(), options.max_header_width)
+    {
         return code;
     }
 
@@ -138,8 +141,7 @@ pub fn run(args: &[String]) -> i32 {
         return 0;
     }
 
-    let show_progress = !options.no_progress && std::io::stderr().is_terminal();
-    let progress = if show_progress {
+    let progress = if !options.no_progress {
         Some(Progress::spinner(
             ProgressOptions::default()
                 .with_prefix("semantic-commit ")
@@ -178,6 +180,7 @@ pub fn run(args: &[String]) -> i32 {
 
 fn parse_args(args: &[String]) -> Result<CommitOptions, i32> {
     let mut options = CommitOptions::default();
+    let mut max_header_width_from_flag = false;
 
     let mut i = 0;
     while i < args.len() {
@@ -283,6 +286,19 @@ fn parse_args(args: &[String]) -> Result<CommitOptions, i32> {
                 options.repo = Some(PathBuf::from(value));
                 i += 2;
             }
+            "--max-header-width" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value,
+                    None => {
+                        eprintln!("error: --max-header-width requires a value");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.max_header_width = parse_header_width_flag(value)?;
+                max_header_width_from_flag = true;
+                i += 2;
+            }
             other => {
                 eprintln!("error: unknown argument: {other}");
                 print_usage_stderr();
@@ -296,7 +312,42 @@ fn parse_args(args: &[String]) -> Result<CommitOptions, i32> {
         return Err(EXIT_ERROR);
     }
 
+    if !max_header_width_from_flag {
+        options.max_header_width = env_header_width()?;
+    }
+
     Ok(options)
+}
+
+fn env_header_width() -> Result<usize, i32> {
+    match std::env::var("SEMANTIC_COMMIT_HEADER_WIDTH") {
+        Ok(value) => parse_header_width_env(&value),
+        Err(std::env::VarError::NotPresent) => Ok(DEFAULT_MAX_HEADER_WIDTH),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            eprintln!("error: SEMANTIC_COMMIT_HEADER_WIDTH must be valid UTF-8");
+            Err(EXIT_ERROR)
+        }
+    }
+}
+
+fn parse_header_width_flag(value: &str) -> Result<usize, i32> {
+    parse_positive_width(value, "--max-header-width")
+}
+
+fn parse_header_width_env(value: &str) -> Result<usize, i32> {
+    parse_positive_width(value, "SEMANTIC_COMMIT_HEADER_WIDTH")
+}
+
+fn parse_positive_width(value: &str, label: &str) -> Result<usize, i32> {
+    let Ok(parsed) = value.parse::<usize>() else {
+        eprintln!("error: {label} must be a positive integer");
+        return Err(EXIT_ERROR);
+    };
+    if parsed == 0 {
+        eprintln!("error: {label} must be a positive integer");
+        return Err(EXIT_ERROR);
+    }
+    Ok(parsed)
 }
 
 fn read_message_contents(options: &CommitOptions) -> Result<String, i32> {
@@ -454,7 +505,12 @@ fn write_message_file(path: &Path, contents: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn validate_commit_message(path: &Path) -> Result<(), i32> {
+    validate_commit_message_with_width(path, DEFAULT_MAX_HEADER_WIDTH)
+}
+
+fn validate_commit_message_with_width(path: &Path, max_header_width: usize) -> Result<(), i32> {
     let file = File::open(path).map_err(|_| {
         eprintln!("error: commit message validation failed");
         EXIT_VALIDATION_FAILED
@@ -479,8 +535,10 @@ fn validate_commit_message(path: &Path) -> Result<(), i32> {
     if header.is_empty() {
         return fail_validation("commit header is empty");
     }
-    if header.chars().count() > MAX_LINE_WIDTH {
-        return fail_validation("commit header exceeds 100 characters (max 100)");
+    if header.chars().count() > max_header_width {
+        return fail_validation(&format!(
+            "commit header exceeds {max_header_width} characters (max {max_header_width})"
+        ));
     }
     if !is_valid_header(header) {
         return fail_validation(
@@ -502,9 +560,9 @@ fn validate_commit_message(path: &Path) -> Result<(), i32> {
                     "commit body line {line_no} is empty; body lines must start with '- ' followed by uppercase letter (or '  ' to continue the previous bullet)"
                 ));
             }
-            if line.chars().count() > MAX_LINE_WIDTH {
+            if line.chars().count() > BODY_LINE_WIDTH {
                 return fail_validation(&format!(
-                    "commit body line {line_no} exceeds 100 characters (max 100)"
+                    "commit body line {line_no} exceeds {BODY_LINE_WIDTH} characters (max {BODY_LINE_WIDTH})"
                 ));
             }
 
@@ -574,7 +632,8 @@ fn is_valid_header(header: &str) -> bool {
     true
 }
 
-const MAX_LINE_WIDTH: usize = 100;
+const DEFAULT_MAX_HEADER_WIDTH: usize = 100;
+const BODY_LINE_WIDTH: usize = 100;
 
 fn normalize_message(input: &str) -> String {
     let lines: Vec<&str> = input.lines().collect();
@@ -596,7 +655,7 @@ fn normalize_message(input: &str) -> String {
         out.push(String::new());
         for line in body {
             let cased = capitalize_bullet_first_char(line);
-            for wrapped in wrap_body_line(&cased, MAX_LINE_WIDTH) {
+            for wrapped in wrap_body_line(&cased, BODY_LINE_WIDTH) {
                 out.push(wrapped);
             }
         }
@@ -750,6 +809,10 @@ fn print_usage(stderr: bool) {
     let _ = writeln!(
         out,
         "      --repo <path>            Run git commands against repo path"
+    );
+    let _ = writeln!(
+        out,
+        "      --max-header-width <N>   Override commit header width (default: {DEFAULT_MAX_HEADER_WIDTH}; env: SEMANTIC_COMMIT_HEADER_WIDTH)"
     );
     let _ = writeln!(
         out,

--- a/crates/semantic-commit/src/completion.rs
+++ b/crates/semantic-commit/src/completion.rs
@@ -120,6 +120,12 @@ fn build_completion_command() -> Command {
                         .value_hint(ValueHint::DirPath),
                 )
                 .arg(
+                    Arg::new("max-header-width")
+                        .long("max-header-width")
+                        .help("Override commit header width")
+                        .value_name("N"),
+                )
+                .arg(
                     Arg::new("automation")
                         .long("automation")
                         .help("Disable interactive prompts and stdin input")

--- a/crates/semantic-commit/tests/integration/commit.rs
+++ b/crates/semantic-commit/tests/integration/commit.rs
@@ -334,6 +334,106 @@ fn commit_validate_only_invalid_message_returns_4() {
     assert_eq!(output.status.code(), Some(4));
 }
 
+fn header_with_total_len(total_len: usize) -> String {
+    let prefix = "feat: ";
+    assert!(total_len > prefix.len());
+    format!("{prefix}{}", "a".repeat(total_len - prefix.len()))
+}
+
+#[test]
+fn commit_max_header_width_flag_rejects_header_over_active_limit() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let message = header_with_total_len(73);
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--max-header-width",
+            "72",
+            "--message",
+            &message,
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    assert!(
+        as_str(&output.stderr).contains("commit header exceeds 72 characters (max 72)"),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+}
+
+#[test]
+fn commit_max_header_width_env_sets_default_when_flag_absent() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let message = header_with_total_len(81);
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &["commit", "--validate-only", "--message", &message],
+        &[("SEMANTIC_COMMIT_HEADER_WIDTH", "80")],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    assert!(
+        as_str(&output.stderr).contains("commit header exceeds 80 characters (max 80)"),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+}
+
+#[test]
+fn commit_max_header_width_flag_wins_over_env_default() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let message = header_with_total_len(79);
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--max-header-width",
+            "80",
+            "--message",
+            &message,
+        ],
+        &[("SEMANTIC_COMMIT_HEADER_WIDTH", "72")],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+}
+
+#[test]
+fn commit_max_header_width_env_rejects_non_positive_values() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing",
+        ],
+        &[("SEMANTIC_COMMIT_HEADER_WIDTH", "0")],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        as_str(&output.stderr).contains("SEMANTIC_COMMIT_HEADER_WIDTH must be a positive integer"),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+}
+
 #[test]
 fn commit_dry_run_validates_and_checks_staged_without_committing() {
     let repo = common::init_repo();


### PR DESCRIPTION
# Surface CLI progress and default limits

## Summary

Implements issue #387 by routing progress call sites through `nils-term::progress`, surfacing memo pagination truncation in text and JSON outputs, and adding configurable `semantic-commit` header-width validation.

## Changes

- Let `git-summary` and `semantic-commit` rely on `nils-term::progress` auto TTY behavior instead of duplicating inline progress gating.
- Add `memo-cli list/search` truncation footers and JSON `truncated` metadata, with command/JSON contract docs updated.
- Add `semantic-commit commit --max-header-width <N>` plus `SEMANTIC_COMMIT_HEADER_WIDTH`, where the flag wins over the environment default.
- Update semantic-commit completion metadata for the new flag.

## Test-First Evidence

- Change classification: feature / behavior change.
- Failing test before fix: N/A; waived for additive CLI behavior where new integration coverage was added with the implementation and final validation exercises the new behavior.
- Final validation: `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` passed with 3353 nextest tests and 85.65% line coverage.
- Waiver reason: the issue requested new defaults/contract behavior rather than a pre-existing failing regression.

## Testing

- `cargo test -p nils-term progress` (pass)
- `cargo test -p nils-git-summary` (pass)
- `cargo test -p nils-memo-cli list_search_footer` (pass)
- `cargo test -p nils-semantic-commit max_header_width` (pass)
- `cargo test -p nils-memo-cli` (pass)
- `cargo test -p nils-semantic-commit` (pass)
- `cargo test -p nils-api-gql` (pass)
- `git diff --check` (pass)
- `bash scripts/ci/completion-flag-parity-audit.sh --strict` (pass)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` (pass)

## Risk / Notes

- Refs #387. Tracking issue closure is handled by the issue closeout workflow after merge.
- Plan package selectors for focused checks were stale; actual package IDs are `nils-git-summary`, `nils-memo-cli`, and `nils-semantic-commit`.
