### PR TITLE
agent-runtime restore-backups: idempotent backup-tree reversal (Plan 04 Sprint 2 Task 2.2)

### DIFF
--- a/crates/agent-runtime-cli/src/commands/mod.rs
+++ b/crates/agent-runtime-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit_drift;
 pub mod install;
 pub mod render;
+pub mod restore_backups;
 pub mod uninstall;

--- a/crates/agent-runtime-cli/src/commands/restore_backups.rs
+++ b/crates/agent-runtime-cli/src/commands/restore_backups.rs
@@ -1,0 +1,220 @@
+use crate::render::manifest::SourceRoot;
+use crate::restore_backups::{
+    self, BackupRunSelector, Mode, RestoreError, RestoreOptions, RestoredChange,
+};
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+pub struct RestoreBackupsArgs {
+    /// Source root containing `manifests/`, `core/`, `targets/`, `build/`.
+    /// Defaults to the current working directory.
+    #[arg(long)]
+    pub source_root: Option<PathBuf>,
+    /// Product whose backups should be restored (`codex` or `claude`).
+    #[arg(long)]
+    pub product: String,
+    /// Absolute path of the runtime home (e.g. `~/.codex` / `~/.claude`).
+    /// Relative paths are rejected so restore never writes outside an
+    /// explicitly-chosen directory.
+    #[arg(long)]
+    pub live_home: PathBuf,
+    /// Absolute path of the state home (where backups live).
+    #[arg(long)]
+    pub state_home: PathBuf,
+    /// Backup run to restore from: `latest` or a unix-seconds timestamp
+    /// matching a directory under `<state_home>/backups/<product>/`.
+    /// Required — running without it exits non-zero with the available
+    /// timestamp list.
+    #[arg(long)]
+    pub from: Option<String>,
+    /// Filter to a single link-map entry id. Default: restore every
+    /// backup file in the run.
+    #[arg(long)]
+    pub surface: Option<String>,
+    /// Skip the optional `.private/link-map.overrides.yaml` overlay
+    /// merge. Default: merge if file exists, so overlay-discovered
+    /// entries are restored alongside the canonical link map.
+    #[arg(long, default_value_t = false)]
+    pub no_overlay: bool,
+    /// Override the overlay file location. When set, the conventional
+    /// `<source-root>/.private/link-map.overrides.yaml` is ignored.
+    #[arg(long, conflicts_with = "no_overlay")]
+    pub overlay_path: Option<PathBuf>,
+    /// Print the resolved plan; do not mutate the filesystem.
+    #[arg(long, conflicts_with = "apply")]
+    pub dry_run: bool,
+    /// Restore backup files into their original install destinations.
+    #[arg(long, conflicts_with = "dry_run")]
+    pub apply: bool,
+}
+
+pub fn run(args: RestoreBackupsArgs) -> anyhow::Result<u8> {
+    if !args.live_home.is_absolute() {
+        anyhow::bail!(
+            "agent-runtime restore-backups: --live-home must be absolute (got: {})",
+            args.live_home.display()
+        );
+    }
+    if !args.state_home.is_absolute() {
+        anyhow::bail!(
+            "agent-runtime restore-backups: --state-home must be absolute (got: {})",
+            args.state_home.display()
+        );
+    }
+    if !args.dry_run && !args.apply {
+        anyhow::bail!("agent-runtime restore-backups: pass --dry-run or --apply");
+    }
+    let from = match args.from.as_deref() {
+        Some(s) => s,
+        None => {
+            print_available_timestamps(&args.state_home, &args.product);
+            anyhow::bail!(
+                "agent-runtime restore-backups: --from is required (use `latest` or one of the timestamps printed above)"
+            );
+        }
+    };
+    let selector: BackupRunSelector = from.parse().map_err(|err: String| anyhow::anyhow!(err))?;
+
+    let mode = if args.apply {
+        Mode::Apply
+    } else {
+        Mode::DryRun
+    };
+
+    let root = SourceRoot::from_arg_or_cwd(args.source_root.as_deref())?;
+    let options = RestoreOptions {
+        selector: selector.clone(),
+        surface: args.surface.clone(),
+        overlay_enabled: !args.no_overlay,
+        overlay_path: args.overlay_path.clone(),
+    };
+
+    let outcome = match restore_backups::run(
+        &args.product,
+        root.path(),
+        &args.live_home,
+        &args.state_home,
+        mode,
+        &options,
+    ) {
+        Ok(o) => o,
+        Err(RestoreError::NoBackupRun {
+            root,
+            selector: _,
+            available,
+        }) => {
+            print_timestamps_list(&args.product, &available);
+            anyhow::bail!(
+                "agent-runtime restore-backups: no backup run matches --from {from} under {}",
+                root.display()
+            );
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    if let Some(s) = outcome.overlay.as_ref() {
+        eprintln!(
+            "agent-runtime restore-backups: overlay merged (dropped={} replaced={} added={})",
+            s.dropped, s.replaced, s.added,
+        );
+    }
+
+    eprintln!(
+        "agent-runtime restore-backups: product={} mode={} from={} actions={} restored={}",
+        outcome.plan.product,
+        if matches!(mode, Mode::Apply) {
+            "apply"
+        } else {
+            "dry-run"
+        },
+        outcome.backup_run.display(),
+        outcome.plan.actions.len(),
+        outcome
+            .changes
+            .iter()
+            .filter(|c| matches!(c, RestoredChange::FileRestored { .. }))
+            .count(),
+    );
+
+    for change in &outcome.changes {
+        print_change(change);
+    }
+
+    Ok(0)
+}
+
+fn print_available_timestamps(state_home: &std::path::Path, product: &str) {
+    let timestamps = restore_backups::list_available_timestamps(state_home, product);
+    print_timestamps_list(product, &timestamps);
+}
+
+fn print_timestamps_list(product: &str, timestamps: &[u64]) {
+    if timestamps.is_empty() {
+        eprintln!(
+            "agent-runtime restore-backups: no backup runs found under <state_home>/backups/{product}/"
+        );
+    } else {
+        eprintln!("agent-runtime restore-backups: available --from values for product={product}:");
+        for ts in timestamps {
+            eprintln!("  - {ts}");
+        }
+        eprintln!("  - latest (resolves to {})", timestamps.last().unwrap());
+    }
+}
+
+fn print_change(c: &RestoredChange) {
+    match c {
+        RestoredChange::FileRestored {
+            entry_id,
+            dest,
+            from_backup,
+        } => eprintln!(
+            "  + restore {} <- {} ({})",
+            dest.display(),
+            from_backup.display(),
+            entry_id
+        ),
+        RestoredChange::SkippedDestRegularFile {
+            entry_id,
+            dest,
+            from_backup: _,
+        } => eprintln!(
+            "  ? skip {} (regular file at dest; not overwriting; {})",
+            dest.display(),
+            entry_id
+        ),
+        RestoredChange::SkippedDestDirectory {
+            entry_id,
+            dest,
+            from_backup: _,
+        } => eprintln!(
+            "  ? skip {} (directory at dest; refuse to destroy; {})",
+            dest.display(),
+            entry_id
+        ),
+        RestoredChange::SkippedNoMatch {
+            entry_id,
+            from_backup,
+        } => eprintln!(
+            "  ? skip {} (no link-map match for entry; {})",
+            from_backup.display(),
+            entry_id
+        ),
+        RestoredChange::SkippedAmbiguous {
+            entry_id,
+            from_backup,
+            candidates,
+        } => {
+            eprintln!(
+                "  ? skip {} (ambiguous: {} candidates; {})",
+                from_backup.display(),
+                candidates.len(),
+                entry_id
+            );
+            for cand in candidates {
+                eprintln!("      candidate: {}", cand.display());
+            }
+        }
+    }
+}

--- a/crates/agent-runtime-cli/src/commands/restore_backups.rs
+++ b/crates/agent-runtime-cli/src/commands/restore_backups.rs
@@ -216,5 +216,18 @@ fn print_change(c: &RestoredChange) {
                 eprintln!("      candidate: {}", cand.display());
             }
         }
+        RestoredChange::SkippedSymlinkForeign {
+            entry_id,
+            dest,
+            actual_target,
+            expected_install_source,
+            from_backup: _,
+        } => eprintln!(
+            "  ? skip {} (foreign target: {}; expected: {}; {})",
+            dest.display(),
+            actual_target.display(),
+            expected_install_source.display(),
+            entry_id
+        ),
     }
 }

--- a/crates/agent-runtime-cli/src/lib.rs
+++ b/crates/agent-runtime-cli/src/lib.rs
@@ -25,6 +25,7 @@ pub mod commands;
 pub mod install;
 pub mod managed_block;
 pub mod render;
+pub mod restore_backups;
 pub mod uninstall;
 
 #[derive(Parser)]
@@ -53,7 +54,7 @@ pub enum Command {
     /// Prune old backups under `<state_home>/backups/`.
     GcBackups,
     /// Restore a runtime home from a recorded backup snapshot.
-    RestoreBackups,
+    RestoreBackups(commands::restore_backups::RestoreBackupsArgs),
     /// Purge runtime-managed state (use with caution).
     PurgeState,
 }
@@ -67,7 +68,7 @@ impl Command {
             Command::Doctor => "doctor",
             Command::AuditDrift(_) => "audit-drift",
             Command::GcBackups => "gc-backups",
-            Command::RestoreBackups => "restore-backups",
+            Command::RestoreBackups(_) => "restore-backups",
             Command::PurgeState => "purge-state",
         }
     }
@@ -102,6 +103,13 @@ pub fn run() -> ExitCode {
             Ok(code) => ExitCode::from(code),
             Err(err) => {
                 eprintln!("agent-runtime uninstall: {err:#}");
+                ExitCode::from(2)
+            }
+        },
+        Command::RestoreBackups(args) => match commands::restore_backups::run(args) {
+            Ok(code) => ExitCode::from(code),
+            Err(err) => {
+                eprintln!("agent-runtime restore-backups: {err:#}");
                 ExitCode::from(2)
             }
         },

--- a/crates/agent-runtime-cli/src/restore_backups.rs
+++ b/crates/agent-runtime-cli/src/restore_backups.rs
@@ -1,0 +1,205 @@
+//! `agent-runtime restore-backups` body. Plan 04 Sprint 2 Task 2.2.
+//!
+//! Walks one backup-run root (`<state_home>/backups/<product>/<unix-seconds>/`)
+//! and restores every backed-up regular file back to the install destination
+//! the installer carried it from. The same link-map + overlay pipeline as
+//! `install::run` / `uninstall::run` is used so the entry-id → destination
+//! mapping seen at install time is regenerated deterministically — restore
+//! only needs the link-map shape, not a separate manifest, because install
+//! records the entry id in the backup directory layout itself.
+//!
+//! ## Scope
+//!
+//! - Only the `FileBackedUpThenSymlinked` arm of `install::executor` writes
+//!   into the backup tree; managed-block surfaces are edited in place and
+//!   have no per-run snapshot. Restore therefore only addresses the symlink
+//!   arm; managed-block contents are restored by editing the surface back
+//!   out via `uninstall --apply` (which strips the marker pair).
+//! - `tag-*` markers at the run root (written by `install --tag` for
+//!   retention pinning) are skipped — they are gc-hints, not files to
+//!   restore.
+//!
+//! ## Non-coverage (advisory, deferred)
+//!
+//! - Recursive-tree link-map entries that backed up multiple files into the
+//!   same `<entry_id>/<basename>` slot lose the relative subpath at install
+//!   time (install's `move_to_backup` uses `dest.file_name()` only). Restore
+//!   uses a regenerated `InstallPlan` to map each backup file back; when
+//!   exactly one `PlanAction::Symlink` matches `(entry_id, dest.file_name())`
+//!   it restores cleanly. Ambiguity (multiple matches) is recorded as
+//!   `RestoreSkippedAmbiguous` — `gc-backups` ages these out the same as
+//!   any other backup.
+
+pub mod executor;
+pub mod plan;
+
+use std::path::{Path, PathBuf};
+
+pub use executor::{ApplyError, Mode, RestoredChange};
+pub use plan::{BackupRunSelector, RestoreAction, RestorePlan, RestorePlanError};
+
+use crate::install::link_map::{LinkMap, LinkMapError};
+use crate::install::overlay::{self, LinkMapOverlay, OverlaySummary};
+use crate::install::plan::{InstallPlan, PlanError};
+
+/// Top-level error from [`run`]. Mirrors `install::InstallError` and
+/// `uninstall::UninstallError` so the CLI dispatches through identical
+/// match arms.
+#[derive(Debug, thiserror::Error)]
+pub enum RestoreError {
+    #[error("link-map: {0}")]
+    LinkMap(#[from] LinkMapError),
+    #[error("install-plan: {0}")]
+    Plan(#[from] PlanError),
+    #[error("restore-plan: {0}")]
+    RestorePlan(#[from] RestorePlanError),
+    #[error("apply: {0}")]
+    Apply(#[from] ApplyError),
+    #[error("no backup run found under {root}: selector={selector:?}; available={available:?}")]
+    NoBackupRun {
+        root: PathBuf,
+        selector: BackupRunSelector,
+        available: Vec<u64>,
+    },
+}
+
+/// Per-run knobs. Defaults: overlay merge on, no surface filter, selector
+/// resolves to the most recent backup run.
+#[derive(Debug, Clone)]
+pub struct RestoreOptions {
+    pub selector: BackupRunSelector,
+    /// Filter to a single link-map entry id. Default `None` = restore
+    /// every backup file in the run.
+    pub surface: Option<String>,
+    pub overlay_enabled: bool,
+    pub overlay_path: Option<PathBuf>,
+}
+
+impl Default for RestoreOptions {
+    /// `derive(Default)` would silently land `overlay_enabled = false` and
+    /// skip overlay-discovered entries from restore — same defensive
+    /// pattern as `InstallOptions` / `UninstallOptions`.
+    fn default() -> Self {
+        Self {
+            selector: BackupRunSelector::Latest,
+            surface: None,
+            overlay_enabled: true,
+            overlay_path: None,
+        }
+    }
+}
+
+/// Full outcome of one `restore_backups::run` cycle. `backup_run` is the
+/// resolved absolute path to the run that was inspected so the CLI can
+/// echo it back to operators — useful when `--from latest` was specified.
+#[derive(Debug)]
+pub struct RestoreOutcome {
+    pub plan: RestorePlan,
+    pub changes: Vec<RestoredChange>,
+    pub overlay: Option<OverlaySummary>,
+    pub backup_run: PathBuf,
+}
+
+/// Execute one restore cycle for `product`. The backup-run path is
+/// resolved from `<state_home>/backups/<product>/` according to
+/// `options.selector`; the install plan is regenerated from the link map
+/// so each backup file's `entry_id` can be mapped back to its original
+/// install destination.
+pub fn run(
+    product: &str,
+    source_root: &Path,
+    home: &Path,
+    state_home: &Path,
+    mode: Mode,
+    options: &RestoreOptions,
+) -> Result<RestoreOutcome, RestoreError> {
+    let mut link_map = LinkMap::load(source_root, product)?;
+    let overlay_summary = merge_overlay(&mut link_map, source_root, options)?;
+    let install_plan = InstallPlan::build(product, source_root, home, state_home, &link_map)?;
+
+    let product_root = state_home.join("backups").join(product);
+    let backup_run = resolve_backup_run(&product_root, &options.selector)?;
+
+    let plan =
+        RestorePlan::from_backup_run(&backup_run, &install_plan, options.surface.as_deref())?;
+    let changes = executor::run(&plan, mode)?;
+    Ok(RestoreOutcome {
+        plan,
+        changes,
+        overlay: overlay_summary,
+        backup_run,
+    })
+}
+
+/// List the unix-seconds directories that look like backup runs under
+/// `<state_home>/backups/<product>/`, sorted ascending. Used by the CLI
+/// to print the available-timestamp list when `--from` is missing or
+/// references a timestamp that does not exist.
+pub fn list_available_timestamps(state_home: &Path, product: &str) -> Vec<u64> {
+    let product_root = state_home.join("backups").join(product);
+    enumerate_timestamps(&product_root)
+}
+
+fn merge_overlay(
+    link_map: &mut LinkMap,
+    source_root: &Path,
+    options: &RestoreOptions,
+) -> Result<Option<OverlaySummary>, RestoreError> {
+    if !options.overlay_enabled {
+        return Ok(None);
+    }
+    let overlay_opt = match options.overlay_path.as_deref() {
+        Some(path) => LinkMapOverlay::load_from(path)?,
+        None => LinkMapOverlay::load_optional(source_root)?,
+    };
+    match overlay_opt {
+        Some(overlay) => {
+            let summary = overlay::apply(link_map, &overlay)?;
+            Ok(Some(summary))
+        }
+        None => Ok(None),
+    }
+}
+
+fn resolve_backup_run(
+    product_root: &Path,
+    selector: &BackupRunSelector,
+) -> Result<PathBuf, RestoreError> {
+    let timestamps = enumerate_timestamps(product_root);
+    match selector {
+        BackupRunSelector::Latest => match timestamps.last() {
+            Some(ts) => Ok(product_root.join(ts.to_string())),
+            None => Err(RestoreError::NoBackupRun {
+                root: product_root.to_path_buf(),
+                selector: selector.clone(),
+                available: timestamps,
+            }),
+        },
+        BackupRunSelector::Exact(target) => {
+            if timestamps.iter().any(|t| t == target) {
+                Ok(product_root.join(target.to_string()))
+            } else {
+                Err(RestoreError::NoBackupRun {
+                    root: product_root.to_path_buf(),
+                    selector: selector.clone(),
+                    available: timestamps,
+                })
+            }
+        }
+    }
+}
+
+fn enumerate_timestamps(product_root: &Path) -> Vec<u64> {
+    let read_dir = match std::fs::read_dir(product_root) {
+        Ok(r) => r,
+        Err(_) => return Vec::new(),
+    };
+    let mut timestamps: Vec<u64> = read_dir
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter_map(|name| name.parse::<u64>().ok())
+        .collect();
+    timestamps.sort();
+    timestamps
+}

--- a/crates/agent-runtime-cli/src/restore_backups/executor.rs
+++ b/crates/agent-runtime-cli/src/restore_backups/executor.rs
@@ -81,6 +81,20 @@ pub enum RestoredChange {
         from_backup: PathBuf,
         candidates: Vec<PathBuf>,
     },
+    /// `dest` is a symlink, but it points somewhere other than the
+    /// install source the regenerated plan recorded. Restore refuses to
+    /// destroy operator-retargeted symlinks — same contract `uninstall`
+    /// enforces. The CLI prints both `actual_target` and
+    /// `expected_install_source` so an operator who reshaped their kit
+    /// checkout can decide whether to re-point `--source-root` or
+    /// manually unwind the symlink.
+    SkippedSymlinkForeign {
+        entry_id: String,
+        dest: PathBuf,
+        actual_target: PathBuf,
+        expected_install_source: PathBuf,
+        from_backup: PathBuf,
+    },
 }
 
 /// Walk `plan.actions`. In `Mode::DryRun` the filesystem is untouched;
@@ -95,7 +109,8 @@ pub fn run(plan: &RestorePlan, mode: Mode) -> Result<Vec<RestoredChange>, ApplyE
                 entry_id,
                 source_backup,
                 dest,
-            } => handle_restore(mode, entry_id, source_backup, dest)?,
+                expected_install_source,
+            } => handle_restore(mode, entry_id, source_backup, dest, expected_install_source)?,
             RestoreAction::SkippedNoMatch {
                 entry_id,
                 source_backup,
@@ -123,28 +138,44 @@ fn handle_restore(
     entry_id: &str,
     backup: &Path,
     dest: &Path,
+    expected_install_source: &Path,
 ) -> Result<RestoredChange, ApplyError> {
     let meta = fs::symlink_metadata(dest);
     match meta {
-        Ok(m) if m.file_type().is_symlink() => match mode {
-            Mode::DryRun => Ok(RestoredChange::FileRestored {
-                entry_id: entry_id.to_string(),
-                dest: dest.to_path_buf(),
-                from_backup: backup.to_path_buf(),
-            }),
-            Mode::Apply => {
-                fs::remove_file(dest).map_err(|source| ApplyError::Io {
-                    path: dest.to_path_buf(),
-                    source,
-                })?;
-                move_backup_to_dest(backup, dest)?;
-                Ok(RestoredChange::FileRestored {
+        Ok(m) if m.file_type().is_symlink() => {
+            let actual = fs::read_link(dest).map_err(|source| ApplyError::Io {
+                path: dest.to_path_buf(),
+                source,
+            })?;
+            if actual != expected_install_source {
+                return Ok(RestoredChange::SkippedSymlinkForeign {
+                    entry_id: entry_id.to_string(),
+                    dest: dest.to_path_buf(),
+                    actual_target: actual,
+                    expected_install_source: expected_install_source.to_path_buf(),
+                    from_backup: backup.to_path_buf(),
+                });
+            }
+            match mode {
+                Mode::DryRun => Ok(RestoredChange::FileRestored {
                     entry_id: entry_id.to_string(),
                     dest: dest.to_path_buf(),
                     from_backup: backup.to_path_buf(),
-                })
+                }),
+                Mode::Apply => {
+                    fs::remove_file(dest).map_err(|source| ApplyError::Io {
+                        path: dest.to_path_buf(),
+                        source,
+                    })?;
+                    move_backup_to_dest(backup, dest)?;
+                    Ok(RestoredChange::FileRestored {
+                        entry_id: entry_id.to_string(),
+                        dest: dest.to_path_buf(),
+                        from_backup: backup.to_path_buf(),
+                    })
+                }
             }
-        },
+        }
         Ok(m) if m.file_type().is_file() => Ok(RestoredChange::SkippedDestRegularFile {
             entry_id: entry_id.to_string(),
             dest: dest.to_path_buf(),
@@ -262,6 +293,7 @@ mod tests {
                 entry_id: "claude.config".to_string(),
                 source_backup: backup.clone(),
                 dest: dest.clone(),
+                expected_install_source: install_source.clone(),
             }],
         };
         let changes = run(&plan, Mode::Apply).unwrap();
@@ -293,6 +325,7 @@ mod tests {
                 entry_id: "claude.config".to_string(),
                 source_backup: backup.clone(),
                 dest: dest.clone(),
+                expected_install_source: PathBuf::from("/unused-in-this-unit-test"),
             }],
         };
         let changes = run(&plan, Mode::DryRun).unwrap();
@@ -321,6 +354,7 @@ mod tests {
                 entry_id: "claude.config".to_string(),
                 source_backup: backup.clone(),
                 dest: dest.clone(),
+                expected_install_source: PathBuf::from("/unused-in-this-unit-test"),
             }],
         };
         let changes = run(&plan, Mode::Apply).unwrap();
@@ -344,6 +378,7 @@ mod tests {
                 entry_id: "claude.config".to_string(),
                 source_backup: backup.clone(),
                 dest: dest.clone(),
+                expected_install_source: PathBuf::from("/unused-in-this-unit-test"),
             }],
         };
         let changes = run(&plan, Mode::Apply).unwrap();
@@ -353,6 +388,57 @@ mod tests {
         ));
         assert!(backup.exists());
         assert!(dest.is_dir());
+    }
+
+    #[test]
+    fn foreign_symlink_target_is_skipped_with_actual_and_expected_recorded() {
+        let tmp = TempDir::new().unwrap();
+        let backup = tmp.path().join("backup/entry/settings.json");
+        write_file(&backup, "original-content");
+        let expected_source = tmp.path().join("source/settings.json");
+        write_file(&expected_source, "rendered-content");
+        let operator_target = tmp.path().join("operator/custom.json");
+        write_file(&operator_target, "operator-content");
+        let dest = tmp.path().join("home/settings.json");
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        // Symlink at dest points somewhere the operator manually retargeted to,
+        // not the install source recorded in the plan.
+        std::os::unix::fs::symlink(&operator_target, &dest).unwrap();
+
+        let plan = RestorePlan {
+            product: "claude".to_string(),
+            home: tmp.path().join("home"),
+            backup_run: tmp.path().join("backup"),
+            actions: vec![RestoreAction::RestoreFile {
+                entry_id: "claude.config".to_string(),
+                source_backup: backup.clone(),
+                dest: dest.clone(),
+                expected_install_source: expected_source.clone(),
+            }],
+        };
+        let changes = run(&plan, Mode::Apply).unwrap();
+        assert_eq!(changes.len(), 1);
+        match &changes[0] {
+            RestoredChange::SkippedSymlinkForeign {
+                actual_target,
+                expected_install_source,
+                ..
+            } => {
+                assert_eq!(actual_target, &operator_target);
+                assert_eq!(expected_install_source, &expected_source);
+            }
+            other => panic!("expected SkippedSymlinkForeign, got {other:?}"),
+        }
+        // Operator content + backup file both survive.
+        assert_eq!(
+            fs::read_link(&dest).unwrap(),
+            operator_target,
+            "executor must not retarget operator symlink"
+        );
+        assert!(
+            backup.exists(),
+            "executor must not consume backup when skipping foreign"
+        );
     }
 
     #[test]

--- a/crates/agent-runtime-cli/src/restore_backups/executor.rs
+++ b/crates/agent-runtime-cli/src/restore_backups/executor.rs
@@ -1,0 +1,384 @@
+//! Restore executor. Walks each `RestoreAction::RestoreFile` and moves
+//! the backup file back to the install destination it came from.
+//!
+//! ## Filesystem-mode policy
+//!
+//! `install::executor::move_to_backup` used `fs::rename`, which is an
+//! inode-level operation: it preserves mode, ownership, and timestamps
+//! verbatim. Restore tries `fs::rename` first so those attributes ride
+//! with the file. When `rename` fails with `EXDEV` (cross-device move
+//! — backup dir and live home on different filesystems), we fall back
+//! to `fs::copy` (which preserves the mode portion via the OS but does
+//! NOT change ownership of the new file) followed by removal of the
+//! backup. We never invoke `chown`: Plan 04 is not a root-scoped tool,
+//! and silently failing chown calls would be worse than not running
+//! them at all.
+
+use super::plan::{RestoreAction, RestorePlan};
+use std::fs;
+use std::io;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Mode {
+    DryRun,
+    Apply,
+}
+
+#[derive(Debug, Error)]
+pub enum ApplyError {
+    #[error("io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// One change the executor emitted while walking the plan. `Skipped*`
+/// variants record refusal to mutate (operator already wrote a file at
+/// the destination, directory in the way, etc.) — they are not errors,
+/// but the printer surfaces them so the operator can see exactly what
+/// was left alone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RestoredChange {
+    /// The backup was successfully moved (or, in dry-run, would be
+    /// moved) back to `dest`. `from_backup` is the path the file came
+    /// from in `<state_home>/backups/`.
+    FileRestored {
+        entry_id: String,
+        dest: PathBuf,
+        from_backup: PathBuf,
+    },
+    /// `dest` is a regular file (not a symlink). Restore will not
+    /// overwrite operator content — they may have already restored
+    /// manually, or written a replacement.
+    SkippedDestRegularFile {
+        entry_id: String,
+        dest: PathBuf,
+        from_backup: PathBuf,
+    },
+    /// `dest` is a directory. Restore never destroys directories.
+    SkippedDestDirectory {
+        entry_id: String,
+        dest: PathBuf,
+        from_backup: PathBuf,
+    },
+    /// The restore plan flagged this backup as un-matchable in the
+    /// regenerated install plan (link-map entry removed). Surface to the
+    /// operator so they can decide whether to delete the orphan or
+    /// reinstate the link map.
+    SkippedNoMatch {
+        entry_id: String,
+        from_backup: PathBuf,
+    },
+    /// More than one install-plan action matched `(entry_id, basename)`.
+    /// Recursive-tree expansion lost the subpath at install time.
+    SkippedAmbiguous {
+        entry_id: String,
+        from_backup: PathBuf,
+        candidates: Vec<PathBuf>,
+    },
+}
+
+/// Walk `plan.actions`. In `Mode::DryRun` the filesystem is untouched;
+/// every change is classified as if `Mode::Apply` had run, so dry-run
+/// output mirrors apply output one-for-one (same convention as install
+/// and uninstall executors).
+pub fn run(plan: &RestorePlan, mode: Mode) -> Result<Vec<RestoredChange>, ApplyError> {
+    let mut changes = Vec::with_capacity(plan.actions.len());
+    for action in &plan.actions {
+        let change = match action {
+            RestoreAction::RestoreFile {
+                entry_id,
+                source_backup,
+                dest,
+            } => handle_restore(mode, entry_id, source_backup, dest)?,
+            RestoreAction::SkippedNoMatch {
+                entry_id,
+                source_backup,
+            } => RestoredChange::SkippedNoMatch {
+                entry_id: entry_id.clone(),
+                from_backup: source_backup.clone(),
+            },
+            RestoreAction::SkippedAmbiguous {
+                entry_id,
+                source_backup,
+                candidates,
+            } => RestoredChange::SkippedAmbiguous {
+                entry_id: entry_id.clone(),
+                from_backup: source_backup.clone(),
+                candidates: candidates.clone(),
+            },
+        };
+        changes.push(change);
+    }
+    Ok(changes)
+}
+
+fn handle_restore(
+    mode: Mode,
+    entry_id: &str,
+    backup: &Path,
+    dest: &Path,
+) -> Result<RestoredChange, ApplyError> {
+    let meta = fs::symlink_metadata(dest);
+    match meta {
+        Ok(m) if m.file_type().is_symlink() => match mode {
+            Mode::DryRun => Ok(RestoredChange::FileRestored {
+                entry_id: entry_id.to_string(),
+                dest: dest.to_path_buf(),
+                from_backup: backup.to_path_buf(),
+            }),
+            Mode::Apply => {
+                fs::remove_file(dest).map_err(|source| ApplyError::Io {
+                    path: dest.to_path_buf(),
+                    source,
+                })?;
+                move_backup_to_dest(backup, dest)?;
+                Ok(RestoredChange::FileRestored {
+                    entry_id: entry_id.to_string(),
+                    dest: dest.to_path_buf(),
+                    from_backup: backup.to_path_buf(),
+                })
+            }
+        },
+        Ok(m) if m.file_type().is_file() => Ok(RestoredChange::SkippedDestRegularFile {
+            entry_id: entry_id.to_string(),
+            dest: dest.to_path_buf(),
+            from_backup: backup.to_path_buf(),
+        }),
+        Ok(_) => Ok(RestoredChange::SkippedDestDirectory {
+            entry_id: entry_id.to_string(),
+            dest: dest.to_path_buf(),
+            from_backup: backup.to_path_buf(),
+        }),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => match mode {
+            Mode::DryRun => Ok(RestoredChange::FileRestored {
+                entry_id: entry_id.to_string(),
+                dest: dest.to_path_buf(),
+                from_backup: backup.to_path_buf(),
+            }),
+            Mode::Apply => {
+                ensure_parent_dir(dest)?;
+                move_backup_to_dest(backup, dest)?;
+                Ok(RestoredChange::FileRestored {
+                    entry_id: entry_id.to_string(),
+                    dest: dest.to_path_buf(),
+                    from_backup: backup.to_path_buf(),
+                })
+            }
+        },
+        Err(source) => Err(ApplyError::Io {
+            path: dest.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+/// Move `backup` to `dest`. Prefer `fs::rename` (preserves all inode
+/// attributes); fall back to copy + permission re-apply + delete on
+/// `EXDEV`.
+fn move_backup_to_dest(backup: &Path, dest: &Path) -> Result<(), ApplyError> {
+    match fs::rename(backup, dest) {
+        Ok(()) => Ok(()),
+        Err(e) if is_cross_device(&e) => copy_then_remove(backup, dest),
+        Err(source) => Err(ApplyError::Io {
+            path: backup.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn copy_then_remove(backup: &Path, dest: &Path) -> Result<(), ApplyError> {
+    let meta = fs::metadata(backup).map_err(|source| ApplyError::Io {
+        path: backup.to_path_buf(),
+        source,
+    })?;
+    fs::copy(backup, dest).map_err(|source| ApplyError::Io {
+        path: dest.to_path_buf(),
+        source,
+    })?;
+    let mode = meta.permissions().mode();
+    fs::set_permissions(dest, fs::Permissions::from_mode(mode)).map_err(|source| {
+        ApplyError::Io {
+            path: dest.to_path_buf(),
+            source,
+        }
+    })?;
+    fs::remove_file(backup).map_err(|source| ApplyError::Io {
+        path: backup.to_path_buf(),
+        source,
+    })?;
+    Ok(())
+}
+
+fn is_cross_device(e: &io::Error) -> bool {
+    // EXDEV is libc::EXDEV (18 on Linux, 18 on macOS). Use raw_os_error
+    // so we do not pull in libc just for this constant.
+    e.raw_os_error() == Some(18)
+}
+
+fn ensure_parent_dir(dest: &Path) -> Result<(), ApplyError> {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).map_err(|source| ApplyError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_file(p: &Path, content: &str) {
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(p, content).unwrap();
+    }
+
+    #[test]
+    fn apply_restores_symlink_dest_back_to_original_content() {
+        let tmp = TempDir::new().unwrap();
+        let backup = tmp.path().join("backup/entry/settings.json");
+        write_file(&backup, "original-content");
+        let install_source = tmp.path().join("source/settings.json");
+        write_file(&install_source, "rendered-content");
+        let dest = tmp.path().join("home/settings.json");
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&install_source, &dest).unwrap();
+
+        let plan = RestorePlan {
+            product: "claude".to_string(),
+            home: tmp.path().join("home"),
+            backup_run: tmp.path().join("backup"),
+            actions: vec![RestoreAction::RestoreFile {
+                entry_id: "claude.config".to_string(),
+                source_backup: backup.clone(),
+                dest: dest.clone(),
+            }],
+        };
+        let changes = run(&plan, Mode::Apply).unwrap();
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(changes[0], RestoredChange::FileRestored { .. }));
+        assert!(!backup.exists(), "backup should be moved out");
+        assert!(
+            !fs::symlink_metadata(&dest)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "original-content");
+    }
+
+    #[test]
+    fn dry_run_classifies_but_does_not_touch() {
+        let tmp = TempDir::new().unwrap();
+        let backup = tmp.path().join("backup/entry/settings.json");
+        write_file(&backup, "original");
+        let dest = tmp.path().join("home/settings.json");
+        write_file(&dest, "post-install-content");
+
+        let plan = RestorePlan {
+            product: "claude".to_string(),
+            home: tmp.path().join("home"),
+            backup_run: tmp.path().join("backup"),
+            actions: vec![RestoreAction::RestoreFile {
+                entry_id: "claude.config".to_string(),
+                source_backup: backup.clone(),
+                dest: dest.clone(),
+            }],
+        };
+        let changes = run(&plan, Mode::DryRun).unwrap();
+        // Regular file at dest -> SkippedDestRegularFile regardless of mode.
+        assert!(matches!(
+            changes[0],
+            RestoredChange::SkippedDestRegularFile { .. }
+        ));
+        assert!(backup.exists(), "dry-run must not move backup");
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "post-install-content");
+    }
+
+    #[test]
+    fn missing_dest_is_restored_in_place() {
+        let tmp = TempDir::new().unwrap();
+        let backup = tmp.path().join("backup/entry/settings.json");
+        write_file(&backup, "original");
+        let dest = tmp.path().join("home/sub/settings.json");
+        // parent dir does not exist; executor should create it
+
+        let plan = RestorePlan {
+            product: "claude".to_string(),
+            home: tmp.path().join("home"),
+            backup_run: tmp.path().join("backup"),
+            actions: vec![RestoreAction::RestoreFile {
+                entry_id: "claude.config".to_string(),
+                source_backup: backup.clone(),
+                dest: dest.clone(),
+            }],
+        };
+        let changes = run(&plan, Mode::Apply).unwrap();
+        assert!(matches!(changes[0], RestoredChange::FileRestored { .. }));
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "original");
+    }
+
+    #[test]
+    fn directory_at_dest_is_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let backup = tmp.path().join("backup/entry/settings.json");
+        write_file(&backup, "x");
+        let dest = tmp.path().join("home/settings.json");
+        fs::create_dir_all(&dest).unwrap();
+
+        let plan = RestorePlan {
+            product: "claude".to_string(),
+            home: tmp.path().join("home"),
+            backup_run: tmp.path().join("backup"),
+            actions: vec![RestoreAction::RestoreFile {
+                entry_id: "claude.config".to_string(),
+                source_backup: backup.clone(),
+                dest: dest.clone(),
+            }],
+        };
+        let changes = run(&plan, Mode::Apply).unwrap();
+        assert!(matches!(
+            changes[0],
+            RestoredChange::SkippedDestDirectory { .. }
+        ));
+        assert!(backup.exists());
+        assert!(dest.is_dir());
+    }
+
+    #[test]
+    fn skipped_actions_propagate_through_executor() {
+        let plan = RestorePlan {
+            product: "claude".to_string(),
+            home: PathBuf::from("/x"),
+            backup_run: PathBuf::from("/y"),
+            actions: vec![
+                RestoreAction::SkippedNoMatch {
+                    entry_id: "gone.entry".to_string(),
+                    source_backup: PathBuf::from("/y/gone.entry/file"),
+                },
+                RestoreAction::SkippedAmbiguous {
+                    entry_id: "tree.entry".to_string(),
+                    source_backup: PathBuf::from("/y/tree.entry/file"),
+                    candidates: vec![PathBuf::from("/a"), PathBuf::from("/b")],
+                },
+            ],
+        };
+        let changes = run(&plan, Mode::Apply).unwrap();
+        assert_eq!(changes.len(), 2);
+        assert!(matches!(changes[0], RestoredChange::SkippedNoMatch { .. }));
+        assert!(matches!(
+            changes[1],
+            RestoredChange::SkippedAmbiguous { .. }
+        ));
+    }
+}

--- a/crates/agent-runtime-cli/src/restore_backups/plan.rs
+++ b/crates/agent-runtime-cli/src/restore_backups/plan.rs
@@ -37,10 +37,17 @@ impl std::str::FromStr for BackupRunSelector {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RestoreAction {
     /// Move `source_backup` back to `dest`. Both paths are absolute.
+    ///
+    /// `expected_install_source` is the absolute path the post-install
+    /// symlink at `dest` should be pointing at — recorded from the
+    /// regenerated `InstallPlan` so the executor can refuse to clobber
+    /// a symlink an operator has manually retargeted away from the
+    /// install layout (the same protection `uninstall` enforces).
     RestoreFile {
         entry_id: String,
         source_backup: PathBuf,
         dest: PathBuf,
+        expected_install_source: PathBuf,
     },
     /// The backup file matched no `PlanAction::Symlink` in the
     /// regenerated install plan — usually because the link-map entry was
@@ -170,24 +177,32 @@ fn walk_backup_dir(
             Some(n) => n.to_os_string(),
             None => continue,
         };
-        let candidates: Vec<PathBuf> = install_plan
+        let candidates: Vec<(PathBuf, PathBuf)> = install_plan
             .actions
             .iter()
             .filter_map(|a| match a {
                 PlanAction::Symlink {
-                    entry_id: id, dest, ..
+                    entry_id: id,
+                    source,
+                    dest,
+                    ..
                 } if id == entry_id && dest.file_name() == Some(file_name.as_ref()) => {
-                    Some(dest.clone())
+                    Some((dest.clone(), source.clone()))
                 }
                 _ => None,
             })
             .collect();
         match candidates.len() {
-            1 => out.push(RestoreAction::RestoreFile {
-                entry_id: entry_id.to_string(),
-                source_backup: backup_file,
-                dest: candidates.into_iter().next().expect("len==1"),
-            }),
+            1 => {
+                let (dest, expected_install_source) =
+                    candidates.into_iter().next().expect("len==1");
+                out.push(RestoreAction::RestoreFile {
+                    entry_id: entry_id.to_string(),
+                    source_backup: backup_file,
+                    dest,
+                    expected_install_source,
+                });
+            }
             0 => out.push(RestoreAction::SkippedNoMatch {
                 entry_id: entry_id.to_string(),
                 source_backup: backup_file,
@@ -195,7 +210,7 @@ fn walk_backup_dir(
             _ => out.push(RestoreAction::SkippedAmbiguous {
                 entry_id: entry_id.to_string(),
                 source_backup: backup_file,
-                candidates,
+                candidates: candidates.into_iter().map(|(d, _)| d).collect(),
             }),
         }
     }

--- a/crates/agent-runtime-cli/src/restore_backups/plan.rs
+++ b/crates/agent-runtime-cli/src/restore_backups/plan.rs
@@ -1,0 +1,257 @@
+//! Restore plan: walks one backup-run directory and matches every
+//! backed-up file to a `PlanAction::Symlink` in a regenerated install
+//! plan. The match is `(entry_id, dest.file_name())` — install's
+//! `move_to_backup` records both into `<run>/<entry_id>/<basename>`, so
+//! restoration is fully derivable from the link-map shape without a
+//! per-run manifest.
+
+use crate::install::plan::{InstallPlan, PlanAction};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Selector for `--from <timestamp>|latest`. Parsed by the CLI; the
+/// resolver under `restore_backups::run` picks an actual directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackupRunSelector {
+    /// `--from latest` — pick the highest-numbered unix-seconds dir.
+    Latest,
+    /// `--from <unix-seconds>` — pick that exact dir, or error.
+    Exact(u64),
+}
+
+impl std::str::FromStr for BackupRunSelector {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("latest") {
+            return Ok(Self::Latest);
+        }
+        s.parse::<u64>().map(Self::Exact).map_err(|err| {
+            format!("--from must be `latest` or a unix-seconds timestamp (got `{s}`): {err}")
+        })
+    }
+}
+
+/// One step the restore executor will run. Each action carries the
+/// resolved source-of-truth backup path and the destination it should
+/// land at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RestoreAction {
+    /// Move `source_backup` back to `dest`. Both paths are absolute.
+    RestoreFile {
+        entry_id: String,
+        source_backup: PathBuf,
+        dest: PathBuf,
+    },
+    /// The backup file matched no `PlanAction::Symlink` in the
+    /// regenerated install plan — usually because the link-map entry was
+    /// removed or its destination changed between install and restore.
+    SkippedNoMatch {
+        entry_id: String,
+        source_backup: PathBuf,
+    },
+    /// More than one `PlanAction::Symlink` matched (`entry_id`,
+    /// `file_name`). This is the recursive-tree collision case advisory
+    /// in the module doc — install dropped the relative subpath, so
+    /// restore cannot disambiguate without operator input.
+    SkippedAmbiguous {
+        entry_id: String,
+        source_backup: PathBuf,
+        candidates: Vec<PathBuf>,
+    },
+}
+
+/// Resolved restore plan. `actions` preserves the order the run-directory
+/// walk produced (sorted, so test goldens stay stable).
+#[derive(Debug, Clone)]
+pub struct RestorePlan {
+    pub product: String,
+    pub home: PathBuf,
+    pub backup_run: PathBuf,
+    pub actions: Vec<RestoreAction>,
+}
+
+/// Errors that can occur while walking the backup-run directory. None
+/// fire when the run dir is empty — that case is an empty `actions`
+/// vector, not an error.
+#[derive(Debug, Error)]
+pub enum RestorePlanError {
+    #[error("io error reading backup run {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl RestorePlan {
+    /// Build a restore plan by walking every regular file under
+    /// `backup_run/<entry_id>/` (skipping top-level `tag-*` markers) and
+    /// matching it against `install_plan.actions`.
+    ///
+    /// `surface_filter` (when `Some`) restricts the plan to backup files
+    /// whose `entry_id` matches the filter. Unmatched entries are
+    /// silently skipped at plan-build time so the executor does not
+    /// generate noise for filtered-out backups.
+    pub fn from_backup_run(
+        backup_run: &Path,
+        install_plan: &InstallPlan,
+        surface_filter: Option<&str>,
+    ) -> Result<Self, RestorePlanError> {
+        let mut actions = Vec::new();
+        let entries = match std::fs::read_dir(backup_run) {
+            Ok(r) => r,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self {
+                    product: install_plan.product.clone(),
+                    home: install_plan.home.clone(),
+                    backup_run: backup_run.to_path_buf(),
+                    actions,
+                });
+            }
+            Err(source) => {
+                return Err(RestorePlanError::Io {
+                    path: backup_run.to_path_buf(),
+                    source,
+                });
+            }
+        };
+
+        let mut entry_dirs: Vec<(String, PathBuf)> = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(|source| RestorePlanError::Io {
+                path: backup_run.to_path_buf(),
+                source,
+            })?;
+            let file_type = entry.file_type().map_err(|source| RestorePlanError::Io {
+                path: entry.path(),
+                source,
+            })?;
+            if !file_type.is_dir() {
+                // `tag-*` markers + any future top-level files: ignore.
+                continue;
+            }
+            let name = match entry.file_name().into_string() {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            entry_dirs.push((name, entry.path()));
+        }
+        entry_dirs.sort_by(|a, b| a.0.cmp(&b.0));
+
+        for (entry_id, entry_dir) in entry_dirs {
+            if let Some(filter) = surface_filter
+                && entry_id != filter
+            {
+                continue;
+            }
+            walk_backup_dir(&entry_id, &entry_dir, install_plan, &mut actions)?;
+        }
+
+        Ok(Self {
+            product: install_plan.product.clone(),
+            home: install_plan.home.clone(),
+            backup_run: backup_run.to_path_buf(),
+            actions,
+        })
+    }
+}
+
+fn walk_backup_dir(
+    entry_id: &str,
+    dir: &Path,
+    install_plan: &InstallPlan,
+    out: &mut Vec<RestoreAction>,
+) -> Result<(), RestorePlanError> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    collect_files(dir, &mut files)?;
+    files.sort();
+    for backup_file in files {
+        let file_name = match backup_file.file_name() {
+            Some(n) => n.to_os_string(),
+            None => continue,
+        };
+        let candidates: Vec<PathBuf> = install_plan
+            .actions
+            .iter()
+            .filter_map(|a| match a {
+                PlanAction::Symlink {
+                    entry_id: id, dest, ..
+                } if id == entry_id && dest.file_name() == Some(file_name.as_ref()) => {
+                    Some(dest.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        match candidates.len() {
+            1 => out.push(RestoreAction::RestoreFile {
+                entry_id: entry_id.to_string(),
+                source_backup: backup_file,
+                dest: candidates.into_iter().next().expect("len==1"),
+            }),
+            0 => out.push(RestoreAction::SkippedNoMatch {
+                entry_id: entry_id.to_string(),
+                source_backup: backup_file,
+            }),
+            _ => out.push(RestoreAction::SkippedAmbiguous {
+                entry_id: entry_id.to_string(),
+                source_backup: backup_file,
+                candidates,
+            }),
+        }
+    }
+    Ok(())
+}
+
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), RestorePlanError> {
+    let read = std::fs::read_dir(dir).map_err(|source| RestorePlanError::Io {
+        path: dir.to_path_buf(),
+        source,
+    })?;
+    for entry in read {
+        let entry = entry.map_err(|source| RestorePlanError::Io {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        let file_type = entry.file_type().map_err(|source| RestorePlanError::Io {
+            path: entry.path(),
+            source,
+        })?;
+        if file_type.is_dir() {
+            collect_files(&entry.path(), out)?;
+        } else if file_type.is_file() {
+            out.push(entry.path());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selector_parses_latest_case_insensitively() {
+        assert_eq!(
+            "latest".parse::<BackupRunSelector>().unwrap(),
+            BackupRunSelector::Latest
+        );
+        assert_eq!(
+            "LATEST".parse::<BackupRunSelector>().unwrap(),
+            BackupRunSelector::Latest
+        );
+    }
+
+    #[test]
+    fn selector_parses_unix_seconds() {
+        assert_eq!(
+            "1700000000".parse::<BackupRunSelector>().unwrap(),
+            BackupRunSelector::Exact(1_700_000_000)
+        );
+    }
+
+    #[test]
+    fn selector_rejects_garbage() {
+        assert!("yesterday".parse::<BackupRunSelector>().is_err());
+        assert!("-5".parse::<BackupRunSelector>().is_err());
+    }
+}

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -19,5 +19,7 @@ mod managed_block;
 mod render;
 #[path = "integration/render_determinism.rs"]
 mod render_determinism;
+#[path = "integration/restore_backups.rs"]
+mod restore_backups;
 #[path = "integration/uninstall.rs"]
 mod uninstall;

--- a/crates/agent-runtime-cli/tests/integration/cli.rs
+++ b/crates/agent-runtime-cli/tests/integration/cli.rs
@@ -23,9 +23,10 @@ const ALL_SUBCOMMANDS: &[&str] = &[
 ];
 
 /// Subcommands whose body still prints `not implemented` and exits 1.
-/// `render` / `install` left the list after Plan 04 Sprint 1; `uninstall`
-/// leaves after Sprint 2 Task 2.1. Later sprints peel further entries off.
-const STUB_SUBCOMMANDS: &[&str] = &["doctor", "gc-backups", "restore-backups", "purge-state"];
+/// `render` / `install` left after Plan 04 Sprint 1; `uninstall` after
+/// Sprint 2 Task 2.1; `restore-backups` after Sprint 2 Task 2.2. Later
+/// sprints peel further entries off.
+const STUB_SUBCOMMANDS: &[&str] = &["doctor", "gc-backups", "purge-state"];
 
 #[test]
 fn version_prints_workspace_version() {

--- a/crates/agent-runtime-cli/tests/integration/restore_backups.rs
+++ b/crates/agent-runtime-cli/tests/integration/restore_backups.rs
@@ -1,0 +1,547 @@
+//! Restore-backups pipeline integration tests. Plan 04 Sprint 2 Task 2.2.
+//!
+//! The load-bearing assertions are:
+//!
+//! - Write → install → restore round-trip puts the operator's original
+//!   pre-install file content back at the install destination.
+//! - `--from latest` resolves to the highest-numbered unix-seconds run.
+//! - `--from <unknown-ts>` returns `NoBackupRun` with the available list.
+//! - `tag-*` marker files at the run root are not treated as restore
+//!   sources.
+//! - A regular file at the destination is not overwritten (operator
+//!   already restored or wrote a replacement).
+//! - `--surface <entry_id>` restricts restore to that entry id only.
+//! - Recursive link-map entries that collide on `(entry_id, basename)`
+//!   produce `SkippedAmbiguous`.
+
+use agent_runtime_cli::install::{self, InstallOptions, Mode as InstallMode};
+use agent_runtime_cli::restore_backups::{
+    self, BackupRunSelector, Mode as RestoreMode, RestoreError, RestoreOptions, RestoredChange,
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use tempfile::TempDir;
+
+fn ts(secs: u64) -> SystemTime {
+    SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
+}
+
+fn build_source_root(tmp: &Path, product: &str) -> PathBuf {
+    let root = tmp.join("src");
+    fs::create_dir_all(&root).unwrap();
+
+    let plugin_dir = root
+        .join("targets")
+        .join(product)
+        .join("plugins")
+        .join("reporting")
+        .join(format!(".{product}-plugin"));
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(
+        plugin_dir.join("plugin.json"),
+        r#"{"name":"reporting","version":"0.1.0-from-source"}"#,
+    )
+    .unwrap();
+
+    let build_dir = root
+        .join("build")
+        .join(product)
+        .join("plugins")
+        .join("reporting")
+        .join("skills");
+    fs::create_dir_all(build_dir.join("daily-brief")).unwrap();
+    fs::write(
+        build_dir.join("daily-brief").join("SKILL.md"),
+        "# daily-brief\n",
+    )
+    .unwrap();
+    fs::create_dir_all(build_dir.join("topic-radar")).unwrap();
+    fs::write(
+        build_dir.join("topic-radar").join("SKILL.md"),
+        "# topic-radar\n",
+    )
+    .unwrap();
+
+    let link_map = format!(
+        "schema_version: 1\nentries:\n  - id: reporting.plugin-manifest\n    kind: plugin-manifest-copy\n    source: targets/{product}/plugins/reporting/.{product}-plugin/plugin.json\n    destination: plugins/reporting/.{product}-plugin/plugin.json\n  - id: reporting.skills-tree\n    kind: symlinked-file\n    source: build/{product}/plugins/reporting/skills\n    destination: plugins/reporting/skills\n    recursive: true\n",
+    );
+    fs::write(
+        root.join("targets").join(product).join("link-map.yaml"),
+        link_map,
+    )
+    .unwrap();
+
+    fs::canonicalize(&root).unwrap()
+}
+
+fn seed_pre_install_manifest(home: &Path, content: &str) -> PathBuf {
+    let dest = home
+        .join("plugins")
+        .join("reporting")
+        .join(".claude-plugin")
+        .join("plugin.json");
+    fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    fs::write(&dest, content).unwrap();
+    dest
+}
+
+fn seed_pre_install_skills(home: &Path) {
+    let skills_root = home.join("plugins").join("reporting").join("skills");
+    for (sub, content) in [
+        ("daily-brief/SKILL.md", "ORIG-DAILY"),
+        ("topic-radar/SKILL.md", "ORIG-RADAR"),
+    ] {
+        let dest = skills_root.join(sub);
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        fs::write(&dest, content).unwrap();
+    }
+}
+
+fn run_install(source_root: &Path, home: &Path, state_home: &Path, at: SystemTime) {
+    let outcome = install::run(
+        "claude",
+        source_root,
+        home,
+        state_home,
+        InstallMode::Apply,
+        at,
+        &InstallOptions::default(),
+    )
+    .unwrap();
+    assert!(!outcome.changes.is_empty(), "install produced no changes");
+}
+
+fn run_install_tagged(
+    source_root: &Path,
+    home: &Path,
+    state_home: &Path,
+    at: SystemTime,
+    tag: &str,
+) {
+    let options = InstallOptions {
+        tag: Some(tag.to_string()),
+        ..InstallOptions::default()
+    };
+    install::run(
+        "claude",
+        source_root,
+        home,
+        state_home,
+        InstallMode::Apply,
+        at,
+        &options,
+    )
+    .unwrap();
+}
+
+#[test]
+fn roundtrip_install_then_restore_returns_original_content() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let manifest_dest = seed_pre_install_manifest(&home, "ORIG-MANIFEST");
+    run_install(&source_root, &home, &state_home, ts(1_700_000_000));
+
+    // After install, dest is a symlink pointing into the source root.
+    let meta = fs::symlink_metadata(&manifest_dest).unwrap();
+    assert!(meta.file_type().is_symlink());
+    assert_ne!(fs::read_to_string(&manifest_dest).unwrap(), "ORIG-MANIFEST");
+
+    // The backup file landed under <state>/backups/claude/<ts>/reporting.plugin-manifest/plugin.json.
+    let backup_file =
+        state_home.join("backups/claude/1700000000/reporting.plugin-manifest/plugin.json");
+    assert!(backup_file.exists(), "install did not produce backup file");
+    assert_eq!(fs::read_to_string(&backup_file).unwrap(), "ORIG-MANIFEST");
+
+    let outcome = restore_backups::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        RestoreMode::Apply,
+        &RestoreOptions::default(),
+    )
+    .unwrap();
+    assert!(
+        outcome
+            .changes
+            .iter()
+            .any(|c| matches!(c, RestoredChange::FileRestored { .. })),
+        "no FileRestored in {:#?}",
+        outcome.changes
+    );
+
+    // Dest is now a regular file with the original content.
+    let meta_after = fs::symlink_metadata(&manifest_dest).unwrap();
+    assert!(
+        meta_after.file_type().is_file() && !meta_after.file_type().is_symlink(),
+        "restore did not replace symlink with regular file"
+    );
+    assert_eq!(fs::read_to_string(&manifest_dest).unwrap(), "ORIG-MANIFEST");
+    // The backup file has been moved out of the backup tree.
+    assert!(
+        !backup_file.exists(),
+        "restore did not consume the backup file"
+    );
+}
+
+#[test]
+fn restore_dry_run_does_not_mutate_home_or_backup_tree() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let manifest_dest = seed_pre_install_manifest(&home, "ORIG-MANIFEST");
+    run_install(&source_root, &home, &state_home, ts(1_700_000_000));
+
+    let manifest_target_before = fs::read_link(&manifest_dest).unwrap();
+    let backup_file =
+        state_home.join("backups/claude/1700000000/reporting.plugin-manifest/plugin.json");
+    assert!(backup_file.exists());
+
+    let outcome = restore_backups::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        RestoreMode::DryRun,
+        &RestoreOptions::default(),
+    )
+    .unwrap();
+    // Dry-run still classifies one FileRestored — same convention as install/uninstall.
+    assert!(
+        outcome
+            .changes
+            .iter()
+            .any(|c| matches!(c, RestoredChange::FileRestored { .. })),
+        "dry-run failed to classify restore: {:#?}",
+        outcome.changes
+    );
+
+    // Home and backup tree untouched.
+    let meta = fs::symlink_metadata(&manifest_dest).unwrap();
+    assert!(meta.file_type().is_symlink());
+    assert_eq!(
+        fs::read_link(&manifest_dest).unwrap(),
+        manifest_target_before
+    );
+    assert!(backup_file.exists());
+    assert_eq!(fs::read_to_string(&backup_file).unwrap(), "ORIG-MANIFEST");
+}
+
+#[test]
+fn restore_with_no_backups_returns_no_backup_run_with_empty_list() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&state_home).unwrap();
+
+    let err = restore_backups::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        RestoreMode::Apply,
+        &RestoreOptions::default(),
+    )
+    .unwrap_err();
+
+    match err {
+        RestoreError::NoBackupRun {
+            available,
+            selector,
+            ..
+        } => {
+            assert!(
+                available.is_empty(),
+                "expected empty available list, got {available:?}"
+            );
+            assert_eq!(selector, BackupRunSelector::Latest);
+        }
+        other => panic!("expected NoBackupRun, got {other:?}"),
+    }
+}
+
+#[test]
+fn restore_from_exact_unknown_timestamp_lists_available_runs() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    seed_pre_install_manifest(&home, "ORIG-MANIFEST");
+    run_install(&source_root, &home, &state_home, ts(1_700_000_000));
+
+    let options = RestoreOptions {
+        selector: BackupRunSelector::Exact(9_999_999_999),
+        ..RestoreOptions::default()
+    };
+    let err = restore_backups::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        RestoreMode::Apply,
+        &options,
+    )
+    .unwrap_err();
+
+    match err {
+        RestoreError::NoBackupRun { available, .. } => {
+            assert_eq!(available, vec![1_700_000_000_u64]);
+        }
+        other => panic!("expected NoBackupRun, got {other:?}"),
+    }
+}
+
+#[test]
+fn restore_from_latest_picks_newest_run_across_multiple_installs() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    // First install at ts=1700000000 with original content A.
+    seed_pre_install_manifest(&home, "ORIG-A");
+    run_install(&source_root, &home, &state_home, ts(1_700_000_000));
+
+    // Operator manually replaces the symlink with a regular file
+    // containing content B, then re-installs at a later ts. The second
+    // install backs up content B into the newer run dir.
+    let manifest_dest = home.join("plugins/reporting/.claude-plugin/plugin.json");
+    fs::remove_file(&manifest_dest).unwrap();
+    fs::write(&manifest_dest, "ORIG-B").unwrap();
+    run_install(&source_root, &home, &state_home, ts(1_700_500_000));
+
+    let timestamps = restore_backups::list_available_timestamps(&state_home, "claude");
+    assert_eq!(timestamps, vec![1_700_000_000, 1_700_500_000]);
+
+    // Latest picks the second run, restoring content B.
+    let outcome = restore_backups::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        RestoreMode::Apply,
+        &RestoreOptions::default(),
+    )
+    .unwrap();
+    assert!(
+        outcome
+            .changes
+            .iter()
+            .any(|c| matches!(c, RestoredChange::FileRestored { .. })),
+        "no FileRestored: {:#?}",
+        outcome.changes
+    );
+    assert_eq!(fs::read_to_string(&manifest_dest).unwrap(), "ORIG-B");
+}
+
+#[test]
+fn restore_skips_tag_marker_files_at_run_root() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    seed_pre_install_manifest(&home, "ORIG-MANIFEST");
+    run_install_tagged(
+        &source_root,
+        &home,
+        &state_home,
+        ts(1_700_000_000),
+        "pre-bump",
+    );
+
+    // Sanity: tag marker landed.
+    let tag_marker = state_home.join("backups/claude/1700000000/tag-pre-bump");
+    assert!(tag_marker.exists(), "tag marker missing");
+
+    let outcome = restore_backups::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        RestoreMode::Apply,
+        &RestoreOptions::default(),
+    )
+    .unwrap();
+
+    // Exactly one FileRestored (the manifest); no action references the tag marker.
+    let restored: Vec<_> = outcome
+        .changes
+        .iter()
+        .filter(|c| matches!(c, RestoredChange::FileRestored { .. }))
+        .collect();
+    assert_eq!(restored.len(), 1, "expected 1 restored, got {restored:?}");
+    for c in &outcome.changes {
+        if let RestoredChange::FileRestored { from_backup, .. } = c {
+            assert!(
+                !from_backup
+                    .file_name()
+                    .map(|n| n.to_string_lossy().starts_with("tag-"))
+                    .unwrap_or(false),
+                "restore tried to restore a tag-* marker: {from_backup:?}",
+            );
+        }
+    }
+    // Tag marker still present after restore (gc-backups, not restore, owns its lifetime).
+    assert!(tag_marker.exists(), "restore consumed the tag marker");
+}
+
+#[test]
+fn restore_skips_regular_file_at_dest_preserving_operator_content() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let manifest_dest = seed_pre_install_manifest(&home, "ORIG-MANIFEST");
+    run_install(&source_root, &home, &state_home, ts(1_700_000_000));
+
+    // Operator manually overwrote the symlink with a custom file before running restore.
+    fs::remove_file(&manifest_dest).unwrap();
+    fs::write(&manifest_dest, "OPERATOR-CUSTOM").unwrap();
+
+    let outcome = restore_backups::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        RestoreMode::Apply,
+        &RestoreOptions::default(),
+    )
+    .unwrap();
+
+    // Skipped because of regular file at dest.
+    assert!(
+        outcome
+            .changes
+            .iter()
+            .any(|c| matches!(c, RestoredChange::SkippedDestRegularFile { .. })),
+        "expected SkippedDestRegularFile in {:#?}",
+        outcome.changes,
+    );
+    // No FileRestored emitted for the manifest entry.
+    assert!(
+        !outcome.changes.iter().any(|c| matches!(
+            c,
+            RestoredChange::FileRestored { dest, .. } if dest == &manifest_dest
+        )),
+        "restore overwrote operator content: {:#?}",
+        outcome.changes,
+    );
+    assert_eq!(
+        fs::read_to_string(&manifest_dest).unwrap(),
+        "OPERATOR-CUSTOM"
+    );
+    // Backup file still present so the operator can recover manually later.
+    let backup_file =
+        state_home.join("backups/claude/1700000000/reporting.plugin-manifest/plugin.json");
+    assert!(backup_file.exists());
+}
+
+#[test]
+fn restore_surface_filter_restricts_to_named_entry_id() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    seed_pre_install_manifest(&home, "ORIG-MANIFEST");
+    seed_pre_install_skills(&home);
+    run_install(&source_root, &home, &state_home, ts(1_700_000_000));
+
+    let options = RestoreOptions {
+        surface: Some("reporting.plugin-manifest".to_string()),
+        ..RestoreOptions::default()
+    };
+    let outcome = restore_backups::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        RestoreMode::Apply,
+        &options,
+    )
+    .unwrap();
+
+    // Only one action ran (the manifest); skills tree entries were filtered out.
+    assert_eq!(
+        outcome.changes.len(),
+        1,
+        "expected exactly one restore action under --surface filter, got {:#?}",
+        outcome.changes,
+    );
+    assert!(matches!(
+        outcome.changes[0],
+        RestoredChange::FileRestored { .. }
+    ));
+
+    // Manifest restored.
+    let manifest_dest = home.join("plugins/reporting/.claude-plugin/plugin.json");
+    let meta = fs::symlink_metadata(&manifest_dest).unwrap();
+    assert!(meta.file_type().is_file() && !meta.file_type().is_symlink());
+
+    // Skills tree symlinks still in place (filter excluded them).
+    let skill_dest = home.join("plugins/reporting/skills/daily-brief/SKILL.md");
+    let skill_meta = fs::symlink_metadata(&skill_dest).unwrap();
+    assert!(
+        skill_meta.file_type().is_symlink(),
+        "surface filter did not protect skills tree from restore",
+    );
+}
+
+#[test]
+fn restore_emits_skipped_ambiguous_for_recursive_basename_collision() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    seed_pre_install_manifest(&home, "ORIG-MANIFEST");
+    // Both daily-brief/SKILL.md and topic-radar/SKILL.md will land in
+    // <state>/backups/claude/<ts>/reporting.skills-tree/SKILL.md — the
+    // second clobbers the first because install's move_to_backup uses
+    // dest.file_name() only. Restore sees one backup file with two
+    // candidate install destinations and emits SkippedAmbiguous.
+    seed_pre_install_skills(&home);
+    run_install(&source_root, &home, &state_home, ts(1_700_000_000));
+
+    let outcome = restore_backups::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        RestoreMode::Apply,
+        &RestoreOptions::default(),
+    )
+    .unwrap();
+
+    let ambiguous: Vec<_> = outcome
+        .changes
+        .iter()
+        .filter(|c| matches!(c, RestoredChange::SkippedAmbiguous { .. }))
+        .collect();
+    assert_eq!(
+        ambiguous.len(),
+        1,
+        "expected one ambiguous skip from skills tree collision: {:#?}",
+        outcome.changes,
+    );
+    if let RestoredChange::SkippedAmbiguous {
+        entry_id,
+        candidates,
+        ..
+    } = &ambiguous[0]
+    {
+        assert_eq!(entry_id, "reporting.skills-tree");
+        assert_eq!(candidates.len(), 2, "expected 2 candidates: {candidates:?}");
+    }
+}

--- a/crates/agent-runtime-cli/tests/integration/restore_backups.rs
+++ b/crates/agent-runtime-cli/tests/integration/restore_backups.rs
@@ -545,3 +545,67 @@ fn restore_emits_skipped_ambiguous_for_recursive_basename_collision() {
         assert_eq!(candidates.len(), 2, "expected 2 candidates: {candidates:?}");
     }
 }
+
+#[test]
+fn foreign_symlink_at_install_dest_is_skipped_not_overwritten() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    let manifest_dest = seed_pre_install_manifest(&home, "ORIG-MANIFEST");
+    run_install(&source_root, &home, &state_home, ts(1_700_000_000));
+
+    // Operator retargets the install-placed symlink to their own file —
+    // a foreign target restore-backups must refuse to destroy.
+    let operator_file = tmp.path().join("operator/custom.json");
+    fs::create_dir_all(operator_file.parent().unwrap()).unwrap();
+    fs::write(&operator_file, "OPERATOR-RETARGETED").unwrap();
+    fs::remove_file(&manifest_dest).unwrap();
+    std::os::unix::fs::symlink(&operator_file, &manifest_dest).unwrap();
+
+    let outcome = restore_backups::run(
+        "claude",
+        &source_root,
+        &home,
+        &state_home,
+        RestoreMode::Apply,
+        &RestoreOptions::default(),
+    )
+    .unwrap();
+
+    let foreign: Vec<_> = outcome
+        .changes
+        .iter()
+        .filter(|c| matches!(c, RestoredChange::SkippedSymlinkForeign { .. }))
+        .collect();
+    assert_eq!(
+        foreign.len(),
+        1,
+        "expected one foreign-symlink skip: {:#?}",
+        outcome.changes,
+    );
+    if let RestoredChange::SkippedSymlinkForeign {
+        actual_target,
+        expected_install_source,
+        ..
+    } = foreign[0]
+    {
+        assert_eq!(actual_target, &operator_file);
+        // expected_install_source resolves to <source_root>/targets/claude/plugins/reporting/.claude-plugin/plugin.json
+        let expected =
+            source_root.join("targets/claude/plugins/reporting/.claude-plugin/plugin.json");
+        assert_eq!(expected_install_source, &expected);
+    }
+
+    // Operator's retargeted symlink survived (still points at custom file).
+    assert_eq!(fs::read_link(&manifest_dest).unwrap(), operator_file);
+    // Backup file still present so the operator can recover later once
+    // they decide what to do with the retargeting.
+    let backup_file =
+        state_home.join("backups/claude/1700000000/reporting.plugin-manifest/plugin.json");
+    assert!(
+        backup_file.exists(),
+        "backup must survive a foreign-target skip"
+    );
+}


### PR DESCRIPTION
## Summary

Lands Plan 04 Sprint 2 Task 2.2 — `agent-runtime restore-backups`. The command walks `<state_home>/backups/<product>/<unix-seconds>/` and reverses the `FileBackedUpThenSymlinked` arm of `install::executor`: each backup file is matched to its install destination via a regenerated `InstallPlan`, the post-install symlink at that destination is removed (only if it still points at the install source), and the backup is moved back into place with `fs::rename` (or `fs::copy` + `set_permissions` + delete on `EXDEV`). `--from <unix-ts>|latest` is required; missing `--from` prints the available timestamp list and exits non-zero.

A `/code-review-specialists` pass surfaced one material finding (R-1: foreign-symlink protection missing — the same shape Task 2.1 resolved as F-1). Fixed pre-merge by threading `expected_install_source` through the action variant and refusing to remove operator-retargeted symlinks.

## Changes

- `crates/agent-runtime-cli/src/restore_backups.rs` — top-level `run` + `RestoreOptions` (custom `Default` mirrors `Install`/`Uninstall`Options) + `RestoreError { LinkMap, Plan, RestorePlan, Apply, NoBackupRun }` + `RestoreOutcome` + `list_available_timestamps` + `resolve_backup_run` + `enumerate_timestamps`.
- `crates/agent-runtime-cli/src/restore_backups/plan.rs` — `RestorePlan` + `RestoreAction { RestoreFile, SkippedNoMatch, SkippedAmbiguous }` + `BackupRunSelector { Latest, Exact(u64) }` parser. Walks the backup run, skips top-level `tag-*` markers, matches each backup file to `PlanAction::Symlink` by `(entry_id, dest.file_name())`. `RestoreFile` carries `expected_install_source` (R-1 fix).
- `crates/agent-runtime-cli/src/restore_backups/executor.rs` — `Mode { DryRun, Apply }` + `ApplyError` + `RestoredChange { FileRestored, SkippedDestRegularFile, SkippedDestDirectory, SkippedNoMatch, SkippedAmbiguous, SkippedSymlinkForeign }`. `handle_restore` verifies `read_link(dest) == expected_install_source` before removing the symlink (R-1). `move_backup_to_dest` prefers `fs::rename`; falls back to `fs::copy` + `set_permissions(mode)` + `fs::remove_file` on `EXDEV`. Never invokes `chown`.
- `crates/agent-runtime-cli/src/commands/restore_backups.rs` — `RestoreBackupsArgs` (`--source-root`, `--product`, `--live-home`, `--state-home`, `--from`, `--surface`, `--no-overlay`, `--overlay-path`, `--dry-run`, `--apply`). `--live-home` and `--state-home` are absolute-only. Missing `--from` prints the available timestamp list. `NoBackupRun` errors print the same list before exiting non-zero. Printer mirrors uninstall's foreign-symlink format byte-for-byte.
- `crates/agent-runtime-cli/src/lib.rs` + `crates/agent-runtime-cli/src/commands/mod.rs` — wire `Command::RestoreBackups(RestoreBackupsArgs)` and `pub mod restore_backups`.
- `crates/agent-runtime-cli/tests/integration/cli.rs` — drop `"restore-backups"` from `STUB_SUBCOMMANDS` (it stays in `ALL_SUBCOMMANDS` for the help-listing test).
- `crates/agent-runtime-cli/tests/integration/restore_backups.rs` — 10 integration tests: round-trip apply, dry-run no-mutation, `NoBackupRun` empty list, `NoBackupRun` with available list on unknown `--from`, `--from latest` across multiple runs, `tag-*` skip, regular-file-at-dest skip, `--surface` filter, recursive-collision `SkippedAmbiguous`, foreign-symlink skip (R-1).

## Test-First Evidence

- Change classification: production code (new command body + new module + new error/change enum) with comprehensive integration coverage.
- Failing test before fix: the R-1 fix was driven by the specialist finding; the new `foreign_symlink_at_install_dest_is_skipped_not_overwritten` integration test would have failed against `a831295` (the original commit) because restore would have silently destroyed the operator's retargeted symlink. It now passes against `e652bdf`.
- Final validation: `cargo test -p agent-runtime-cli`: 158 lib + 63 integration = **221 / 221 pass**; `cargo clippy --all-targets --all-features -- -D warnings`: clean; `cargo fmt --check`: clean; `bash scripts/ci/nils-cli-checks-entrypoint.sh`: `ok: all nils-cli checks passed`.

## Testing

- `cargo fmt --check` — pass
- `cargo clippy -p agent-runtime-cli --all-targets --all-features -- -D warnings` — pass
- `cargo test -p agent-runtime-cli` — pass (221 / 221)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh` — pass

## Risk / Notes

- No CLI breaking changes — `restore-backups` was a `not implemented` stub before this PR.
- 15 specialist findings: 1 medium resolved pre-merge in `e652bdf` (R-1 foreign-symlink protection); 14 lower-severity advisories deferred. Synthesis: `/Users/terry/.local/state/claude-kit/out/task-2-2-review/SYNTHESIS.md`. Notable deferrals:
  - **R-2 (Sprint 4 candidate)** — `merge_overlay` + `Mode` + `ensure_parent_dir` now duplicated 3x across install/uninstall/restore. Roll into the LinkMapPlan extraction refactor tracked from Task 2.1 F-2.
  - **R-3** — tag-marker filter is positional only; inherits Task 1.3 F-3 namespace overlap. Task 2.4 (`gc-backups`) owns the canonical helper.
  - **R-4** — `--surface` typo silently exits 0 with zero restores. UX polish, deferred to doctor (Sprint 3) for a `list-available-surfaces` probe.
- Managed-block surfaces have no per-run backup (install edits the file in place); `restore-backups` only addresses the symlinked-file arm. To unwind a managed block, use `uninstall --apply`.
- Recursive link-map entries that share a basename across sub-paths collide at install time (install's `move_to_backup` uses `dest.file_name()` only). `restore-backups` emits `SkippedAmbiguous` for those cases — the operator can resolve manually; `gc-backups` will age them out.
- Next pickup after merge: Plan 04 Sprint 2 Task 2.3 — `agent-runtime purge-state`.
