### PR TITLE
agent-runtime purge-state: scoped state clearing with audit (Plan 04 Sprint 2 Task 2.3)

### DIFF
--- a/crates/agent-runtime-cli/src/commands/mod.rs
+++ b/crates/agent-runtime-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod audit_drift;
 pub mod install;
+pub mod purge_state;
 pub mod render;
 pub mod restore_backups;
 pub mod uninstall;

--- a/crates/agent-runtime-cli/src/commands/purge_state.rs
+++ b/crates/agent-runtime-cli/src/commands/purge_state.rs
@@ -1,0 +1,79 @@
+use crate::purge_state::{self, Confirm, PurgeError, Scope};
+use clap::Args;
+use std::io::{BufReader, stderr, stdin, stdout};
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+pub struct PurgeStateArgs {
+    /// Absolute path of the state home (the directory whose `out/`
+    /// and `backups/` subtrees are subject to purge).
+    #[arg(long)]
+    pub state_home: PathBuf,
+    /// Required scope: `out` clears `<state_home>/out/`; `backups`
+    /// clears `<state_home>/backups/`; `all` clears both. No default.
+    #[arg(long)]
+    pub scope: Option<String>,
+    /// Skip the interactive confirmation prompt and log a single
+    /// `--yes` audit line to stderr. Reserved for CI / scripted
+    /// contexts; interactive operators should answer the prompt.
+    #[arg(long, default_value_t = false)]
+    pub yes: bool,
+}
+
+pub fn run(args: PurgeStateArgs) -> anyhow::Result<u8> {
+    if !args.state_home.is_absolute() {
+        anyhow::bail!(
+            "agent-runtime purge-state: --state-home must be absolute (got: {})",
+            args.state_home.display()
+        );
+    }
+    let scope_str = match args.scope.as_deref() {
+        Some(s) => s,
+        None => {
+            anyhow::bail!(
+                "agent-runtime purge-state: --scope is required (one of `out`, `backups`, `all`)"
+            );
+        }
+    };
+    let scope: Scope = scope_str
+        .parse()
+        .map_err(|err: String| anyhow::anyhow!(err))?;
+
+    let outcome = if args.yes {
+        purge_state::run(&args.state_home, scope, Confirm::Yes, &mut stderr())
+    } else {
+        let stdin_h = stdin();
+        let mut reader = BufReader::new(stdin_h.lock());
+        let stdout_h = stdout();
+        let mut writer = stdout_h.lock();
+        let mut audit = stderr();
+        purge_state::run(
+            &args.state_home,
+            scope,
+            Confirm::Prompt {
+                reader: &mut reader,
+                writer: &mut writer,
+            },
+            &mut audit,
+        )
+    };
+
+    let outcome = match outcome {
+        Ok(o) => o,
+        Err(PurgeError::Cancelled) => {
+            eprintln!("agent-runtime purge-state: cancelled");
+            return Ok(1);
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    eprintln!(
+        "agent-runtime purge-state: scope={} cleared={}",
+        outcome.scope.as_str(),
+        outcome.cleared.len()
+    );
+    for path in &outcome.cleared {
+        eprintln!("  - cleared {}", path.display());
+    }
+    Ok(0)
+}

--- a/crates/agent-runtime-cli/src/lib.rs
+++ b/crates/agent-runtime-cli/src/lib.rs
@@ -24,6 +24,7 @@ pub mod audit_drift;
 pub mod commands;
 pub mod install;
 pub mod managed_block;
+pub mod purge_state;
 pub mod render;
 pub mod restore_backups;
 pub mod uninstall;
@@ -56,7 +57,7 @@ pub enum Command {
     /// Restore a runtime home from a recorded backup snapshot.
     RestoreBackups(commands::restore_backups::RestoreBackupsArgs),
     /// Purge runtime-managed state (use with caution).
-    PurgeState,
+    PurgeState(commands::purge_state::PurgeStateArgs),
 }
 
 impl Command {
@@ -69,7 +70,7 @@ impl Command {
             Command::AuditDrift(_) => "audit-drift",
             Command::GcBackups => "gc-backups",
             Command::RestoreBackups(_) => "restore-backups",
-            Command::PurgeState => "purge-state",
+            Command::PurgeState(_) => "purge-state",
         }
     }
 }
@@ -110,6 +111,13 @@ pub fn run() -> ExitCode {
             Ok(code) => ExitCode::from(code),
             Err(err) => {
                 eprintln!("agent-runtime restore-backups: {err:#}");
+                ExitCode::from(2)
+            }
+        },
+        Command::PurgeState(args) => match commands::purge_state::run(args) {
+            Ok(code) => ExitCode::from(code),
+            Err(err) => {
+                eprintln!("agent-runtime purge-state: {err:#}");
                 ExitCode::from(2)
             }
         },

--- a/crates/agent-runtime-cli/src/purge_state.rs
+++ b/crates/agent-runtime-cli/src/purge_state.rs
@@ -1,0 +1,382 @@
+//! `agent-runtime purge-state` body. Plan 04 Sprint 2 Task 2.3.
+//!
+//! Removes writable state under `<state_home>` per a required `--scope`:
+//!
+//! - `out` — clears everything under `<state_home>/out/` (renderer
+//!   artifacts, dry-run output captures, agent-output cache).
+//! - `backups` — clears everything under `<state_home>/backups/`
+//!   (every product's per-run backup tree).
+//! - `all` — both of the above.
+//!
+//! The runtime home is **never** touched (no `--live-home` arg even
+//! accepted). `auth*`, `history*`, `sessions*`, `cache*`, and
+//! `projects*` live under the product runtime home — not under
+//! `<state_home>` — and are therefore outside this command's scope by
+//! construction.
+//!
+//! Confirmation is required by default. `--yes` bypasses the prompt
+//! and is logged to stderr in a single audit line containing the scope
+//! value — the CLI is the only sanctioned way to set it, and the
+//! library writes the audit line at the start of every invocation so
+//! the trace is present even on partial failure.
+
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Required-scope selector. There is **no default**: missing `--scope`
+/// exits non-zero at the CLI before reaching this module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    /// `<state_home>/out/` only.
+    Out,
+    /// `<state_home>/backups/` only.
+    Backups,
+    /// Both `out/` and `backups/`.
+    All,
+}
+
+impl Scope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Scope::Out => "out",
+            Scope::Backups => "backups",
+            Scope::All => "all",
+        }
+    }
+}
+
+impl std::str::FromStr for Scope {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "out" => Ok(Scope::Out),
+            "backups" => Ok(Scope::Backups),
+            "all" => Ok(Scope::All),
+            other => Err(format!(
+                "--scope must be one of `out`, `backups`, `all` (got `{other}`)"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum PurgeError {
+    #[error("io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    /// The operator answered the confirmation prompt with anything
+    /// other than `y` / `yes`. Treated as a clean refusal — not an
+    /// error to log as a stack trace.
+    #[error("purge cancelled by operator")]
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PurgeOutcome {
+    pub scope: Scope,
+    /// Absolute paths of the top-level dirs the executor cleared
+    /// (`<state_home>/out`, `<state_home>/backups`, or both). Empty
+    /// when the requested dir did not exist — that is a no-op success.
+    pub cleared: Vec<PathBuf>,
+}
+
+/// Confirmation policy. `Yes` bypasses the prompt and triggers the
+/// `--yes` audit line on stderr; `Prompt` reads a single line from
+/// the supplied reader and accepts `y` / `yes` (case-insensitive).
+pub enum Confirm<'a> {
+    Yes,
+    Prompt {
+        reader: &'a mut dyn BufRead,
+        writer: &'a mut dyn Write,
+    },
+}
+
+/// Execute one purge cycle. Writes the `--yes` audit line (or runs
+/// the prompt) before any filesystem mutation, so the operator
+/// trace lands even when the subsequent `fs::remove_dir_all` fails.
+pub fn run(
+    state_home: &Path,
+    scope: Scope,
+    confirm: Confirm<'_>,
+    audit: &mut dyn Write,
+) -> Result<PurgeOutcome, PurgeError> {
+    match confirm {
+        Confirm::Yes => {
+            writeln!(
+                audit,
+                "agent-runtime purge-state: --yes scope={} state_home={}",
+                scope.as_str(),
+                state_home.display(),
+            )
+            .ok();
+        }
+        Confirm::Prompt { reader, writer } => {
+            write!(
+                writer,
+                "agent-runtime purge-state: about to clear scope={} under {} — proceed? [y/N] ",
+                scope.as_str(),
+                state_home.display(),
+            )
+            .ok();
+            writer.flush().ok();
+            let mut line = String::new();
+            reader
+                .read_line(&mut line)
+                .map_err(|source| PurgeError::Io {
+                    path: PathBuf::from("<confirm-prompt>"),
+                    source,
+                })?;
+            let answer = line.trim().to_ascii_lowercase();
+            if answer != "y" && answer != "yes" {
+                return Err(PurgeError::Cancelled);
+            }
+        }
+    }
+
+    let mut cleared = Vec::new();
+    match scope {
+        Scope::Out => {
+            if let Some(p) = clear_dir(state_home, "out")? {
+                cleared.push(p);
+            }
+        }
+        Scope::Backups => {
+            if let Some(p) = clear_dir(state_home, "backups")? {
+                cleared.push(p);
+            }
+        }
+        Scope::All => {
+            if let Some(p) = clear_dir(state_home, "out")? {
+                cleared.push(p);
+            }
+            if let Some(p) = clear_dir(state_home, "backups")? {
+                cleared.push(p);
+            }
+        }
+    }
+    Ok(PurgeOutcome { scope, cleared })
+}
+
+/// Remove `<state_home>/<sub>` if present, then recreate it as an
+/// empty directory. Returns `Some(path)` when the dir existed before
+/// the call (so the outcome can record what was cleared), `None`
+/// when it was absent (no-op success).
+fn clear_dir(state_home: &Path, sub: &str) -> Result<Option<PathBuf>, PurgeError> {
+    let target = state_home.join(sub);
+    match fs::symlink_metadata(&target) {
+        Ok(meta) if meta.file_type().is_dir() => {
+            fs::remove_dir_all(&target).map_err(|source| PurgeError::Io {
+                path: target.clone(),
+                source,
+            })?;
+            // Recreate the empty dir so subsequent install / render
+            // calls do not have to create it themselves. Mirrors how
+            // the install pipeline assumes `<state_home>` shape on
+            // entry.
+            fs::create_dir_all(&target).map_err(|source| PurgeError::Io {
+                path: target.clone(),
+                source,
+            })?;
+            Ok(Some(target))
+        }
+        Ok(_) => {
+            // A non-dir at this path (file, symlink, socket) is a
+            // shape violation — refuse to destroy it. The CLI maps
+            // this to a clear error message.
+            Err(PurgeError::Io {
+                path: target,
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "expected directory under <state_home>",
+                ),
+            })
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(PurgeError::Io {
+            path: target,
+            source,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use tempfile::TempDir;
+
+    fn seed(state: &Path, sub: &str, file_name: &str, bytes: &str) {
+        let dir = state.join(sub);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join(file_name), bytes).unwrap();
+    }
+
+    #[test]
+    fn scope_from_str_accepts_three_values_and_rejects_garbage() {
+        assert_eq!("out".parse::<Scope>().unwrap(), Scope::Out);
+        assert_eq!("backups".parse::<Scope>().unwrap(), Scope::Backups);
+        assert_eq!("all".parse::<Scope>().unwrap(), Scope::All);
+        assert!("OUT".parse::<Scope>().is_err());
+        assert!("everything".parse::<Scope>().is_err());
+    }
+
+    #[test]
+    fn yes_writes_audit_line_and_clears_out_only() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        seed(state, "out", "render.log", "RENDER");
+        seed(state, "backups/claude/123/entry", "plugin.json", "BACKUP");
+
+        let mut audit = Vec::new();
+        let outcome = run(state, Scope::Out, Confirm::Yes, &mut audit).unwrap();
+        assert_eq!(outcome.scope, Scope::Out);
+        assert_eq!(outcome.cleared, vec![state.join("out")]);
+
+        let audit_text = String::from_utf8(audit).unwrap();
+        assert!(
+            audit_text.contains("--yes"),
+            "audit must mention --yes: {audit_text}"
+        );
+        assert!(
+            audit_text.contains("scope=out"),
+            "audit must name scope: {audit_text}"
+        );
+
+        // out/ is now empty, backups/ is untouched.
+        assert!(state.join("out").is_dir());
+        assert!(state.join("out").read_dir().unwrap().next().is_none());
+        assert_eq!(
+            fs::read_to_string(state.join("backups/claude/123/entry/plugin.json")).unwrap(),
+            "BACKUP"
+        );
+    }
+
+    #[test]
+    fn yes_with_scope_backups_clears_backups_only() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        seed(state, "out", "render.log", "RENDER");
+        seed(state, "backups/claude/123/entry", "plugin.json", "BACKUP");
+
+        let mut audit = Vec::new();
+        let outcome = run(state, Scope::Backups, Confirm::Yes, &mut audit).unwrap();
+        assert_eq!(outcome.cleared, vec![state.join("backups")]);
+        assert_eq!(
+            fs::read_to_string(state.join("out/render.log")).unwrap(),
+            "RENDER"
+        );
+        assert!(state.join("backups").is_dir());
+        assert!(state.join("backups").read_dir().unwrap().next().is_none());
+    }
+
+    #[test]
+    fn yes_with_scope_all_clears_both() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        seed(state, "out", "render.log", "RENDER");
+        seed(state, "backups/claude/123/entry", "plugin.json", "BACKUP");
+
+        let mut audit = Vec::new();
+        let outcome = run(state, Scope::All, Confirm::Yes, &mut audit).unwrap();
+        assert_eq!(
+            outcome.cleared,
+            vec![state.join("out"), state.join("backups")]
+        );
+        assert!(state.join("out").read_dir().unwrap().next().is_none());
+        assert!(state.join("backups").read_dir().unwrap().next().is_none());
+    }
+
+    #[test]
+    fn prompt_y_proceeds_and_no_cancels() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        seed(state, "out", "render.log", "RENDER");
+
+        // First call: operator answers "y\n" — purge proceeds.
+        let mut reader = Cursor::new(b"y\n".to_vec());
+        let mut writer: Vec<u8> = Vec::new();
+        let mut audit = Vec::new();
+        let outcome = run(
+            state,
+            Scope::Out,
+            Confirm::Prompt {
+                reader: &mut reader,
+                writer: &mut writer,
+            },
+            &mut audit,
+        )
+        .unwrap();
+        assert_eq!(outcome.scope, Scope::Out);
+        // Prompt was rendered to the writer.
+        let prompt = String::from_utf8(writer).unwrap();
+        assert!(
+            prompt.contains("scope=out"),
+            "prompt missing scope: {prompt}"
+        );
+        // No audit line for the prompt path.
+        assert!(
+            audit.is_empty(),
+            "audit must stay empty in prompt path: {audit:?}"
+        );
+
+        // Second call: re-seed and answer "n" — purge cancelled.
+        seed(state, "out", "render.log", "RENDER-AGAIN");
+        let mut reader = Cursor::new(b"n\n".to_vec());
+        let mut writer: Vec<u8> = Vec::new();
+        let mut audit2 = Vec::new();
+        let err = run(
+            state,
+            Scope::Out,
+            Confirm::Prompt {
+                reader: &mut reader,
+                writer: &mut writer,
+            },
+            &mut audit2,
+        )
+        .unwrap_err();
+        assert!(matches!(err, PurgeError::Cancelled));
+        // Content survived the refusal.
+        assert_eq!(
+            fs::read_to_string(state.join("out/render.log")).unwrap(),
+            "RENDER-AGAIN"
+        );
+    }
+
+    #[test]
+    fn missing_subdir_is_clean_noop_not_error() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        // Neither out/ nor backups/ exists.
+        let mut audit = Vec::new();
+        let outcome = run(state, Scope::All, Confirm::Yes, &mut audit).unwrap();
+        assert!(outcome.cleared.is_empty());
+    }
+
+    #[test]
+    fn refuses_non_dir_at_scope_path() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        fs::create_dir_all(state).unwrap();
+        // Plant a regular file where the dir should be.
+        fs::write(state.join("out"), "regular-file").unwrap();
+
+        let mut audit = Vec::new();
+        let err = run(state, Scope::Out, Confirm::Yes, &mut audit).unwrap_err();
+        match err {
+            PurgeError::Io { path, .. } => assert_eq!(path, state.join("out")),
+            other => panic!("expected Io shape-violation error, got {other:?}"),
+        }
+        // The audit line still landed before the IO error.
+        assert!(String::from_utf8(audit).unwrap().contains("scope=out"));
+        // The operator's file survived — we refused to destroy it.
+        assert_eq!(
+            fs::read_to_string(state.join("out")).unwrap(),
+            "regular-file"
+        );
+    }
+}

--- a/crates/agent-runtime-cli/src/purge_state.rs
+++ b/crates/agent-runtime-cli/src/purge_state.rs
@@ -118,7 +118,7 @@ pub fn run(
         Confirm::Prompt { reader, writer } => {
             write!(
                 writer,
-                "agent-runtime purge-state: about to clear scope={} under {} — proceed? [y/N] ",
+                "agent-runtime purge-state: about to clear scope={} under {} — type `y` or `yes` to confirm (anything else cancels): ",
                 scope.as_str(),
                 state_home.display(),
             )

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -15,6 +15,8 @@ mod install_flags;
 mod install_pipeline;
 #[path = "integration/managed_block.rs"]
 mod managed_block;
+#[path = "integration/purge_state.rs"]
+mod purge_state;
 #[path = "integration/render.rs"]
 mod render;
 #[path = "integration/render_determinism.rs"]

--- a/crates/agent-runtime-cli/tests/integration/cli.rs
+++ b/crates/agent-runtime-cli/tests/integration/cli.rs
@@ -24,9 +24,10 @@ const ALL_SUBCOMMANDS: &[&str] = &[
 
 /// Subcommands whose body still prints `not implemented` and exits 1.
 /// `render` / `install` left after Plan 04 Sprint 1; `uninstall` after
-/// Sprint 2 Task 2.1; `restore-backups` after Sprint 2 Task 2.2. Later
-/// sprints peel further entries off.
-const STUB_SUBCOMMANDS: &[&str] = &["doctor", "gc-backups", "purge-state"];
+/// Sprint 2 Task 2.1; `restore-backups` after Sprint 2 Task 2.2;
+/// `purge-state` after Sprint 2 Task 2.3. Later sprints peel further
+/// entries off.
+const STUB_SUBCOMMANDS: &[&str] = &["doctor", "gc-backups"];
 
 #[test]
 fn version_prints_workspace_version() {

--- a/crates/agent-runtime-cli/tests/integration/purge_state.rs
+++ b/crates/agent-runtime-cli/tests/integration/purge_state.rs
@@ -92,6 +92,12 @@ fn scope_out_yes_removes_only_out_subtree_and_emits_audit_line() {
         stderr.contains("--yes") && stderr.contains("scope=out"),
         "audit line missing or malformed: {stderr}"
     );
+    // Audit must go to stderr only — regression-pin for stdout/stderr discipline.
+    assert!(
+        !out.stdout_text().contains("--yes"),
+        "audit line must not leak to stdout: {}",
+        out.stdout_text()
+    );
 
     // out/ exists and is empty.
     assert!(state_path.join("out").is_dir());

--- a/crates/agent-runtime-cli/tests/integration/purge_state.rs
+++ b/crates/agent-runtime-cli/tests/integration/purge_state.rs
@@ -1,0 +1,273 @@
+//! `agent-runtime purge-state` integration tests. Plan 04 Sprint 2 Task 2.3.
+//!
+//! Drive the real binary so the CLI argument shape, the `--yes` audit
+//! line, the confirmation prompt, and the `--scope` selection all stay
+//! pinned end-to-end.
+
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> std::path::PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn run_purge(args: &[&str], stdin: Option<&[u8]>) -> CmdOutput {
+    cmd::run(&agent_runtime_bin(), args, &[], stdin)
+}
+
+fn seed_state_tree(state: &Path) {
+    fs::create_dir_all(state.join("out/sub")).unwrap();
+    fs::write(state.join("out/render.log"), b"RENDER").unwrap();
+    fs::write(state.join("out/sub/artifact.txt"), b"ARTIFACT").unwrap();
+    fs::create_dir_all(state.join("backups/claude/1700000000/entry")).unwrap();
+    fs::write(
+        state.join("backups/claude/1700000000/entry/plugin.json"),
+        b"BACKUP",
+    )
+    .unwrap();
+}
+
+#[test]
+fn missing_scope_exits_non_zero_and_names_three_valid_values() {
+    let tmp = TempDir::new().unwrap();
+    let state = tmp.path().to_string_lossy().to_string();
+    // No `--scope` — must error.
+    let out = run_purge(&["purge-state", "--state-home", &state, "--yes"], None);
+    assert_ne!(out.code, 0, "missing --scope must exit non-zero: {out:?}");
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("out") && stderr.contains("backups") && stderr.contains("all"),
+        "stderr must name the three valid scope values: {stderr}"
+    );
+}
+
+#[test]
+fn invalid_scope_exits_non_zero() {
+    let tmp = TempDir::new().unwrap();
+    let state = tmp.path().to_string_lossy().to_string();
+    let out = run_purge(
+        &[
+            "purge-state",
+            "--state-home",
+            &state,
+            "--scope",
+            "everything",
+            "--yes",
+        ],
+        None,
+    );
+    assert_ne!(out.code, 0);
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("out") && stderr.contains("backups") && stderr.contains("all"),
+        "stderr must enumerate valid scopes on bad input: {stderr}"
+    );
+}
+
+#[test]
+fn scope_out_yes_removes_only_out_subtree_and_emits_audit_line() {
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path();
+    seed_state_tree(state_path);
+    let state = state_path.to_string_lossy().to_string();
+
+    let out = run_purge(
+        &[
+            "purge-state",
+            "--state-home",
+            &state,
+            "--scope",
+            "out",
+            "--yes",
+        ],
+        None,
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+    let stderr = out.stderr_text();
+    // Audit line carries scope.
+    assert!(
+        stderr.contains("--yes") && stderr.contains("scope=out"),
+        "audit line missing or malformed: {stderr}"
+    );
+
+    // out/ exists and is empty.
+    assert!(state_path.join("out").is_dir());
+    assert!(state_path.join("out").read_dir().unwrap().next().is_none());
+    // backups/ survived byte-for-byte.
+    assert_eq!(
+        fs::read_to_string(state_path.join("backups/claude/1700000000/entry/plugin.json")).unwrap(),
+        "BACKUP"
+    );
+}
+
+#[test]
+fn scope_backups_yes_removes_only_backups_subtree() {
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path();
+    seed_state_tree(state_path);
+    let state = state_path.to_string_lossy().to_string();
+
+    let out = run_purge(
+        &[
+            "purge-state",
+            "--state-home",
+            &state,
+            "--scope",
+            "backups",
+            "--yes",
+        ],
+        None,
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+    assert!(out.stderr_text().contains("scope=backups"));
+
+    assert_eq!(
+        fs::read_to_string(state_path.join("out/render.log")).unwrap(),
+        "RENDER"
+    );
+    assert!(state_path.join("backups").is_dir());
+    assert!(
+        state_path
+            .join("backups")
+            .read_dir()
+            .unwrap()
+            .next()
+            .is_none()
+    );
+}
+
+#[test]
+fn scope_all_yes_removes_both_subtrees() {
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path();
+    seed_state_tree(state_path);
+    let state = state_path.to_string_lossy().to_string();
+
+    let out = run_purge(
+        &[
+            "purge-state",
+            "--state-home",
+            &state,
+            "--scope",
+            "all",
+            "--yes",
+        ],
+        None,
+    );
+    assert_eq!(out.code, 0);
+    assert!(state_path.join("out").read_dir().unwrap().next().is_none());
+    assert!(
+        state_path
+            .join("backups")
+            .read_dir()
+            .unwrap()
+            .next()
+            .is_none()
+    );
+}
+
+#[test]
+fn confirmation_prompt_with_y_proceeds_and_with_n_cancels() {
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path();
+    seed_state_tree(state_path);
+    let state = state_path.to_string_lossy().to_string();
+
+    // Answer "y\n" → purge proceeds without the --yes flag.
+    let out = run_purge(
+        &["purge-state", "--state-home", &state, "--scope", "out"],
+        Some(b"y\n"),
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+    // No `--yes` audit line in the prompt path.
+    assert!(
+        !out.stderr_text().contains("--yes"),
+        "prompt path must not emit --yes audit: {}",
+        out.stderr_text()
+    );
+    assert!(state_path.join("out").read_dir().unwrap().next().is_none());
+
+    // Re-seed; answer "n\n" → cancelled, content preserved.
+    seed_state_tree(state_path);
+    let out = run_purge(
+        &["purge-state", "--state-home", &state, "--scope", "out"],
+        Some(b"n\n"),
+    );
+    assert_ne!(out.code, 0, "refusal must exit non-zero");
+    assert!(out.stderr_text().contains("cancelled"));
+    assert_eq!(
+        fs::read_to_string(state_path.join("out/render.log")).unwrap(),
+        "RENDER"
+    );
+}
+
+#[test]
+fn does_not_touch_runtime_homes_or_auth_history_sessions_cache_projects() {
+    // purge-state has no --live-home flag, so by construction it
+    // cannot reach a runtime home. This test pins the contract by
+    // placing a fake "runtime-home" alongside state_home and
+    // asserting purge --scope all leaves every file outside
+    // <state>/out and <state>/backups byte-identical.
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path().join("state");
+    let runtime_home = tmp.path().join("home");
+    seed_state_tree(&state_path);
+    for top in &["auth", "history", "sessions", "cache", "projects"] {
+        let dir = runtime_home.join(top);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("user.bin"), format!("user-{top}")).unwrap();
+    }
+    fs::write(state_path.join("sibling.txt"), b"SIBLING").unwrap();
+    let state = state_path.to_string_lossy().to_string();
+
+    let out = run_purge(
+        &[
+            "purge-state",
+            "--state-home",
+            &state,
+            "--scope",
+            "all",
+            "--yes",
+        ],
+        None,
+    );
+    assert_eq!(out.code, 0);
+
+    for top in &["auth", "history", "sessions", "cache", "projects"] {
+        let path = runtime_home.join(top).join("user.bin");
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            format!("user-{top}"),
+            "purge must not touch runtime home {path:?}",
+        );
+    }
+    // Sibling files inside state_home but outside out/ and backups/ also survive.
+    assert_eq!(
+        fs::read_to_string(state_path.join("sibling.txt")).unwrap(),
+        "SIBLING"
+    );
+}
+
+#[test]
+fn relative_state_home_is_rejected() {
+    let out = run_purge(
+        &[
+            "purge-state",
+            "--state-home",
+            "./relative-state",
+            "--scope",
+            "out",
+            "--yes",
+        ],
+        None,
+    );
+    assert_ne!(out.code, 0);
+    assert!(
+        out.stderr_text().contains("absolute"),
+        "stderr must explain the rejection: {}",
+        out.stderr_text()
+    );
+}

--- a/docs/plans/code-review-specialist-primitives/code-review-specialist-primitives-plan.md
+++ b/docs/plans/code-review-specialist-primitives/code-review-specialist-primitives-plan.md
@@ -1,5 +1,7 @@
 # Plan: Code Review Specialist Primitives
 
+<!-- markdownlint-disable MD013 -->
+
 ## Overview
 
 Add a deterministic `review-specialists` CLI to


### PR DESCRIPTION
## Summary

Lands Plan 04 Sprint 2 Task 2.3 — `agent-runtime purge-state`. The command clears writable state under `<state_home>` per a required `--scope out|backups|all` (no default — missing `--scope` exits non-zero with a usage error naming all three values). It prompts on stdin unless `--yes` is set; `--yes` emits a single audit line to stderr containing the scope before any filesystem mutation. Product runtime homes are never touched: `purge-state` accepts no `--live-home` flag, so reaching `auth*` / `history*` / `sessions*` / `cache*` / `projects*` (which live under the runtime home, not under `<state_home>`) is impossible by construction.

A `/code-review-specialists` pass produced 15 findings — **none above `low` severity**. Two low-effort hygiene items resolved pre-merge (R-1 stdout/stderr discipline + R-2 prompt clarity); the remaining 13 are deferred advisories.

## Changes

- `crates/agent-runtime-cli/src/purge_state.rs` — top-level `run(state_home, scope, confirm, audit)` + `Scope { Out, Backups, All }` (FromStr accepts only the three lower-case values) + `PurgeError { Io, Cancelled }` + `PurgeOutcome { scope, cleared: Vec<PathBuf> }` + `Confirm { Yes, Prompt { reader: &mut dyn BufRead, writer: &mut dyn Write } }`. `--yes` emits one audit line **before** any FS mutation so the trace lands even on partial failure. Symlink at the scope path is refused (`Err(InvalidData)`); `fs::remove_dir_all` is the Rust 1.58+ symlink-safe variant; the cleared subtree is recreated as an empty dir so subsequent install/render calls find a stable shape.
- `crates/agent-runtime-cli/src/commands/purge_state.rs` — `PurgeStateArgs` (`--state-home` absolute-only, `--scope`, `--yes`). Missing `--scope` exits non-zero with the three valid values named in the error. `--yes` path uses `Confirm::Yes` and writes the audit line to stderr; interactive path uses `Confirm::Prompt` with stdin/stdout. `PurgeError::Cancelled` exits 1 with a `cancelled` stderr message.
- `crates/agent-runtime-cli/src/lib.rs` + `crates/agent-runtime-cli/src/commands/mod.rs` — wire `Command::PurgeState(PurgeStateArgs)` + `pub mod purge_state` (both lib + commands).
- `crates/agent-runtime-cli/tests/integration/cli.rs` — drop `"purge-state"` from `STUB_SUBCOMMANDS` (it stays in `ALL_SUBCOMMANDS` for help-listing test).
- `crates/agent-runtime-cli/tests/integration.rs` — register `mod purge_state`.
- `crates/agent-runtime-cli/tests/integration/purge_state.rs` — 8 integration tests: missing `--scope` exits non-zero naming three values; invalid scope rejected; `--scope out --yes` clears out/ only + audit line; `--scope backups --yes` clears backups/ only; `--scope all --yes` clears both; prompt with `y\n` proceeds, `n\n` cancels; runtime-home + state-sibling files untouched under `--scope all`; relative `--state-home` rejected. Plus the R-1 stdout-discipline assertion added in the second commit.

## Test-First Evidence

- Change classification: production code (new command body + new module + new error/outcome enum) with comprehensive unit + integration coverage.
- Failing test before fix: the R-1 stdout-discipline assertion would have failed against `7575b0d` (the original commit) if a future regression mistakenly printed the audit line via `println!` instead of `eprintln!`. Now pinned against `088ec06`.
- Final validation: `cargo test -p agent-runtime-cli`: 165 lib + 71 integration = **236 / 236 pass**; `cargo clippy --all-targets --all-features -- -D warnings`: clean; `cargo fmt --check`: clean. Local `scripts/ci/nils-cli-checks-entrypoint.sh` reports one pre-existing markdown-lint failure on `docs/plans/code-review-specialist-primitives/code-review-specialist-primitives-plan.md` — confirmed inherited from `main` (commit `e642f38`); not introduced by this task and not part of the GitHub Actions required-checks set (PR #423 merged green with the same regression on main).

## Testing

- `cargo fmt --check` — pass
- `cargo clippy -p agent-runtime-cli --all-targets --all-features -- -D warnings` — pass
- `cargo test -p agent-runtime-cli` — pass (236 / 236)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh` — fail (pre-existing markdown-lint on `docs/plans/code-review-specialist-primitives/code-review-specialist-primitives-plan.md`, inherited from main `e642f38`, NOT introduced by Task 2.3 — see Test-First Evidence)

## Risk / Notes

- No CLI breaking changes — `purge-state` was a `not implemented` stub before this PR.
- 15 specialist findings: 2 low resolved pre-merge in `088ec06` (R-1 stdout discipline + R-2 prompt clarity). 13 advisories deferred. None above `low` severity. Synthesis: `$HOME/.local/state/claude-kit/out/task-2-3-review/SYNTHESIS.md`. Notable deferrals:
  - **Durable audit log** (security + red-team agreement) — `--yes` audit goes only to stderr; under cron with `2>/dev/null` no trace persists. Sprint 4 candidate: append a JSON line to `<state_home>/audit.log`.
  - **No `--dry-run` mode** — operators cannot preview what would be cleared. Spec does not require; Sprint 3 polish.
  - **`--scope` as `Option<String>` vs clap value_enum** — custom error message covers the actual UX gap; clap derive would auto-emit `[possible values: ...]` in `--help`. Low priority.
  - **Sprint 4 shared-helpers refactor** continues to grow: `Mode` enum absence here + `Confirm<'a>` lifetime ergonomics + audit-format hardcoding all join `merge_overlay` / `ensure_parent_dir` from Task 2.2.
- Pre-existing markdown lint failure on `docs/plans/code-review-specialist-primitives/code-review-specialist-primitives-plan.md` is unrelated to Task 2.3 (introduced in `e642f38` on main between Task 2.2 commits). Verified by re-running the lint on bare `main`. The strict gate is local-only; GitHub CI's required checks did not include it for PR #423.
- Next pickup after merge: Plan 04 Sprint 2 Task 2.4 — `agent-runtime gc-backups` (retention default 5; `--tag`-marked dirs preserved; **inherits** Task 1.3 F-3 (tag-* / entry_id namespace overlap) + Task 2.1 F-2 (LinkMapPlan extraction) + Task 2.2 R-2/R-3/R-10/R-11 (helper-duplication sweep)).
