### PR TITLE
Harden testing audits and CLI contracts

### DIFF
--- a/.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
+++ b/.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
@@ -12,6 +12,7 @@ Runs the required pre-delivery checks from DEVELOPMENT.md:
   - bash scripts/ci/markdownlint-audit.sh --strict
   - bash scripts/ci/plan-bundle-validate.sh --strict
   - bash scripts/ci/cli-output-contract-lint.sh --strict
+  - bash scripts/ci/tests/shared-helper-adoption-audit.test.sh
   - bash scripts/ci/test-stale-audit.sh --strict
   - bash scripts/ci/third-party-artifacts-audit.sh --strict
   - bash scripts/ci/completion-asset-audit.sh --strict
@@ -125,6 +126,7 @@ if [[ "$docs_only" -eq 1 ]]; then
   exit 0
 fi
 
+run bash scripts/ci/tests/shared-helper-adoption-audit.test.sh
 run bash scripts/ci/test-stale-audit.sh --strict
 run bash scripts/ci/third-party-artifacts-audit.sh --strict
 run bash scripts/ci/completion-asset-audit.sh --strict

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -137,6 +137,7 @@ NILS_CLI_COVERAGE_FAIL_UNDER_LINES=90 bash scripts/ci/nils-cli-checks-entrypoint
 - `bash scripts/ci/markdownlint-audit.sh --strict`
 - `bash scripts/ci/plan-bundle-validate.sh --strict`
 - `bash scripts/ci/cli-output-contract-lint.sh --strict`
+- `bash scripts/ci/tests/shared-helper-adoption-audit.test.sh`
 - `bash scripts/ci/test-stale-audit.sh --strict`
 - `bash scripts/ci/third-party-artifacts-audit.sh --strict`
 - `bash scripts/ci/completion-asset-audit.sh --strict`

--- a/crates/agent-runtime-cli/tests/integration/install_flags.rs
+++ b/crates/agent-runtime-cli/tests/integration/install_flags.rs
@@ -26,6 +26,14 @@ fn run_cli(args: &[&str]) -> CmdOutput {
     cmd::run(&bin, args, &[], None)
 }
 
+fn assert_dir_empty_or_absent(path: &Path, label: &str) {
+    if !path.exists() {
+        return;
+    }
+    let entries: Vec<_> = fs::read_dir(path).unwrap().collect();
+    assert!(entries.is_empty(), "{label} was mutated: {entries:?}");
+}
+
 fn fixed_time() -> SystemTime {
     SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)
 }
@@ -494,6 +502,16 @@ entries:
         stderr.contains("dropped=1"),
         "stderr should name the drop count: {stderr}"
     );
+    assert!(
+        stderr.contains("actions=1"),
+        "stderr should report the post-overlay effective plan action count: {stderr}"
+    );
+    assert!(
+        stderr.contains("changes=1"),
+        "dry-run should report the post-overlay planned change count: {stderr}"
+    );
+    assert_dir_empty_or_absent(&live_home, "dry-run live home");
+    assert_dir_empty_or_absent(&state_home, "dry-run state home");
 }
 
 #[test]

--- a/crates/agent-runtime-cli/tests/integration/uninstall.rs
+++ b/crates/agent-runtime-cli/tests/integration/uninstall.rs
@@ -16,10 +16,21 @@ use agent_runtime_cli::install::{self, InstallOptions, Mode as InstallMode};
 use agent_runtime_cli::uninstall::{
     self, Mode as UninstallMode, UninstallOptions, UninstalledChange,
 };
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn run_cli(args: &[&str]) -> CmdOutput {
+    let bin = agent_runtime_bin();
+    cmd::run(&bin, args, &[], None)
+}
 
 fn fixed_time() -> SystemTime {
     SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)
@@ -459,6 +470,65 @@ fn foreign_symlink_at_install_dest_is_skipped() {
 }
 
 #[test]
+fn foreign_symlink_recovery_is_reported_by_cli() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_source_root(tmp.path(), "claude");
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+
+    run_install(&source_root, &home, &state_home);
+
+    let foreign = tmp.path().join("operator-managed-file.json");
+    fs::write(&foreign, b"{}").unwrap();
+    let manifest_dest = home.join("plugins/reporting/.claude-plugin/plugin.json");
+    fs::remove_file(&manifest_dest).unwrap();
+    std::os::unix::fs::symlink(&foreign, &manifest_dest).unwrap();
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let home_arg = home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "uninstall",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "claude",
+        "--live-home",
+        &home_arg,
+        "--apply",
+    ]);
+    assert_eq!(
+        output.code,
+        0,
+        "uninstall CLI should recover from a foreign symlink; stderr={}",
+        output.stderr_text()
+    );
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.contains("? skip"),
+        "foreign symlink should be reported as a skipped change: {stderr}"
+    );
+    assert!(
+        stderr.contains(&manifest_dest.display().to_string()),
+        "stderr should name the skipped destination: {stderr}"
+    );
+    assert!(
+        stderr.contains(&foreign.display().to_string()),
+        "stderr should name the actual foreign target: {stderr}"
+    );
+    assert!(
+        stderr.contains("expected:"),
+        "stderr should introduce the expected source recovery hint: {stderr}"
+    );
+    assert!(
+        fs::symlink_metadata(&manifest_dest)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "operator's foreign symlink was removed by CLI uninstall"
+    );
+}
+
+#[test]
 fn missing_link_map_returns_typed_error() {
     let tmp = TempDir::new().unwrap();
     let source_root = tmp.path().join("src");
@@ -474,4 +544,36 @@ fn missing_link_map_returns_typed_error() {
     .unwrap_err();
     let msg = err.to_string();
     assert!(msg.contains("link-map"), "expected link-map error: {msg}");
+}
+
+#[test]
+fn missing_link_map_error_is_reported_by_cli() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = tmp.path().join("src");
+    fs::create_dir_all(&source_root).unwrap();
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let home_arg = home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "uninstall",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "claude",
+        "--live-home",
+        &home_arg,
+        "--apply",
+    ]);
+    assert_ne!(output.code, 0, "missing link-map should fail");
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.contains("link-map"),
+        "stderr should map the missing link-map error: {stderr}"
+    );
+    assert!(
+        stderr.contains("targets/claude/link-map.yaml") || stderr.contains("No such file"),
+        "stderr should include enough path or OS detail to recover: {stderr}"
+    );
 }

--- a/crates/cli-template/src/main.rs
+++ b/crates/cli-template/src/main.rs
@@ -66,7 +66,10 @@ fn init_tracing(level: &str) {
         .or_else(|_| EnvFilter::try_from_default_env())
         .unwrap_or_else(|_| EnvFilter::new("info"));
 
-    fmt().with_env_filter(filter).init();
+    fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .init();
 }
 
 fn detect_format_from_argv() -> OutputFormat {

--- a/crates/cli-template/tests/integration/cli.rs
+++ b/crates/cli-template/tests/integration/cli.rs
@@ -21,6 +21,13 @@ fn run_without_rust_log(args: &[&str]) -> CmdOutput {
 fn cli_template_runs_without_subcommand() {
     let output = run(&[]);
     assert_eq!(output.code, 0);
+    let stdout = output.stdout_text();
+    assert_eq!(stdout, "", "no-subcommand path should not print stdout");
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.contains("no subcommand selected"),
+        "stderr should log the no-subcommand default path: {stderr}"
+    );
 }
 
 #[test]

--- a/docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-plan.md
+++ b/docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-plan.md
@@ -1,0 +1,205 @@
+# Plan: Testing Audits and CLI Contracts
+
+<!-- markdownlint-disable MD013 -->
+
+## Overview
+
+Restore confidence in the testing and audit surfaces called out by issue #421.
+The work starts with the shared-helper adoption audit because stale seeded
+paths make its output unreliable for future helper extraction, then adds narrow
+CLI contract tests for `cli-template` and `agent-runtime-cli`. Runtime behavior
+changes are allowed only when the new tests reveal a contract mismatch.
+
+## Read First
+
+- Primary source: docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-review-source.md
+- Source type: review-to-improvement-doc
+- Open questions carried into execution: none
+
+## Scope
+
+- In scope:
+  - Refresh `shared-helper-adoption-audit.sh` so seeded candidates match the
+    current workspace layout or are generated from current inventory.
+  - Add a regression self-test that fails when the shared-helper audit seeds a
+    missing file.
+  - Strengthen the `cli-template` no-subcommand integration test.
+  - Add `agent-runtime-cli` install overlay dry-run CLI coverage for
+    no-mutation and effective-plan behavior.
+  - Add `agent-runtime-cli` uninstall CLI coverage for foreign symlink recovery
+    output and missing link-map error mapping.
+- Out of scope:
+  - Broad helper extraction or migration work.
+  - Reworking the installer or uninstaller beyond fixes required by the new
+    operator-facing contract tests.
+  - Changing the issue lifecycle for #421 before implementation closeout.
+
+## Assumptions
+
+1. The intended shape is mostly tests and audit-script hardening.
+2. The `cli-template` no-subcommand path may intentionally emit no stdout; if
+   so, the test should pin that silence rather than inventing output.
+3. Non-doc implementation PRs must run the full required gate with coverage.
+
+## Sprint 1: Audit reliability and baseline CLI contract
+
+**Goal**: Make the shared-helper audit trustworthy and pin the weakest
+`cli-template` happy path before touching `agent-runtime-cli`.
+
+**Demo/Validation**:
+
+- Commands:
+  - `bash scripts/dev/shared-helper-adoption-audit.sh --format tsv --out target/testing-audits-cli-contracts/shared-helper-adoption.tsv`
+  - `bash scripts/ci/test-stale-audit.sh --strict`
+  - `cargo test -p nils-cli-template --test integration cli_template_runs_without_subcommand`
+- Verify: the audit reports against current files, stale seed paths fail a
+  deterministic self-test, and the no-subcommand CLI path has meaningful
+  stdout/stderr assertions.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 1.1: Refresh shared-helper adoption audit seeds
+
+- **Location**:
+  - scripts/dev/shared-helper-adoption-audit.sh
+  - scripts/ci/tests/shared-helper-adoption-audit.test.sh
+  - scripts/ci/nils-cli-checks-entrypoint.sh
+- **Description**: Replace stale seeded test paths with current workspace paths
+  or generate candidate rows from current inventory where practical. Add a
+  shell self-test that fails when a seeded candidate path does not exist, and
+  wire it into the smallest appropriate CI entrypoint if it should guard future
+  drift.
+- **Dependencies**:
+  - none
+- **Complexity**:
+  - 4
+- **Acceptance criteria**:
+  - The audit no longer reports `missing-file` for stale seeded integration
+    paths that moved to `tests/integration/...`.
+  - The self-test fails on a synthetic missing seeded path.
+  - `scripts/dev/shared-helper-adoption-audit.sh --format tsv` still writes the
+    documented TSV columns.
+  - `scripts/ci/test-stale-audit.sh --strict` continues to pass.
+- **Validation**:
+  - `bash scripts/ci/tests/shared-helper-adoption-audit.test.sh`
+  - `bash scripts/dev/shared-helper-adoption-audit.sh --format tsv --out target/testing-audits-cli-contracts/shared-helper-adoption.tsv`
+  - `bash scripts/ci/test-stale-audit.sh --strict`
+
+### Task 1.2: Pin cli-template no-subcommand output
+
+- **Location**:
+  - crates/cli-template/tests/integration/cli.rs
+  - crates/cli-template/src/main.rs
+- **Description**: Update `cli_template_runs_without_subcommand` so it asserts
+  the intended no-subcommand stdout/stderr contract in addition to exit code 0.
+  Change `main.rs` only if the current behavior is not the intended
+  operator-facing contract.
+- **Dependencies**:
+  - none
+- **Complexity**:
+  - 2
+- **Acceptance criteria**:
+  - The no-subcommand test asserts stdout and stderr explicitly.
+  - The assertion makes the intended default behavior clear to future
+    maintainers.
+  - Existing `hello`, `status`, help, and parse-error tests keep their current
+    contract.
+- **Validation**:
+  - `cargo test -p nils-cli-template --test integration cli_template_runs_without_subcommand`
+  - `cargo test -p nils-cli-template --test integration`
+
+## Sprint 2: Agent-runtime CLI contract coverage
+
+**Goal**: Add operator-facing install/uninstall tests for behavior already
+covered only partially or only at the library layer.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p agent-runtime-cli --test integration`
+  - `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage`
+- Verify: overlay dry-run no-mutation, effective-plan reporting, foreign
+  symlink recovery output, and missing link-map error mapping are all pinned at
+  the CLI boundary.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 2.1: Add overlay dry-run CLI no-mutation assertions
+
+- **Location**:
+  - crates/agent-runtime-cli/tests/integration/install_flags.rs
+  - crates/agent-runtime-cli/src/commands/install.rs
+- **Description**: Extend overlay dry-run coverage beyond the stderr
+  announcement. Assert that dry-run does not mutate live or state homes and
+  that the CLI-visible plan/action summary reflects the overlay-dropped
+  effective config.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**:
+  - 3
+- **Acceptance criteria**:
+  - The overlay dry-run test proves no symlink, managed-block, or backup output
+    is written.
+  - The CLI summary reflects the post-overlay action count.
+  - No-overlay and explicit-overlay-path tests remain distinct.
+- **Validation**:
+  - `cargo test -p agent-runtime-cli --test integration overlay`
+
+### Task 2.2: Add uninstall CLI recovery and error contract tests
+
+- **Location**:
+  - crates/agent-runtime-cli/tests/integration/uninstall.rs
+  - crates/agent-runtime-cli/src/commands/uninstall.rs
+  - crates/agent-runtime-cli/src/uninstall.rs
+- **Description**: Add CLI-level tests that pin foreign symlink recovery output
+  and missing link-map error mapping. Reuse the existing library fixtures where
+  possible so the new tests prove formatting and exit behavior instead of
+  duplicating low-level uninstall logic.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**:
+  - 3
+- **Acceptance criteria**:
+  - Foreign symlink CLI output names the skipped destination, actual target,
+    and expected source.
+  - Missing link-map failure exits with the intended code and message shape.
+  - Existing library-level recovery tests still pass.
+- **Validation**:
+  - `cargo test -p agent-runtime-cli --test integration uninstall`
+
+## Final Integration
+
+- Run `cargo fmt --all -- --check`.
+- Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- Run `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage`.
+- Update issue #421 or the plan-tracking issue with the validation summary and
+  any intentionally deferred findings.
+
+## Testing Strategy
+
+- Unit: add shell self-test coverage for the shared-helper adoption audit seed
+  integrity.
+- Integration: strengthen existing Rust integration tests for `cli-template`
+  and `agent-runtime-cli`.
+- E2E/manual: no browser or manual QA required; this is CLI/test tooling work.
+
+## Risks & gotchas
+
+- `test-stale-audit.sh` and `shared-helper-adoption-audit.sh` are related but
+  not equivalent. Passing stale-test audit must not be used as proof that
+  shared-helper adoption seeds are current.
+- Adding CLI output assertions can overfit incidental formatting. Assert the
+  operator-facing contract and avoid pinning temp paths or unstable ordering.
+- If production code changes are needed, keep them narrow and rerun the full
+  coverage gate because this stops being docs/test-only work.
+- New shell tests should be Bash 3.2 compatible because macOS CI may use
+  `/bin/bash`.
+
+## Rollback plan
+
+- Revert the plan implementation PR if audit or CLI contract tests prove
+  unstable.
+- If only the shared-helper self-test is noisy, remove it from the required
+  entrypoint while keeping the refreshed seed paths and open a follow-up issue.

--- a/docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-review-source.md
+++ b/docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-review-source.md
@@ -1,0 +1,84 @@
+# Testing Audits and CLI Contracts Improvement Record
+
+<!-- markdownlint-disable MD013 -->
+
+## Status
+
+- Date: 2026-05-21
+- Status: ready for implementation planning
+- Source issue: https://github.com/sympoies/nils-cli/issues/421
+- Retention intent: plan-source artifact; eligible for cleanup after execution
+  if the tracking issue keeps the durable closeout record.
+
+## Purpose
+
+Capture the testing specialist findings from issue #421 as the primary source
+for an execution plan. The goal is to make the shared-helper audit trustworthy
+again and add narrow CLI-level tests where current coverage proves only partial
+behavior.
+
+## Current Judgment
+
+The findings are implementation-ready and should be handled as focused testing
+and audit-hardening work. The shared-helper audit should be fixed first because
+its stale seeded paths make the report unreliable as a source of truth for
+future helper extraction. The remaining items are targeted CLI contract coverage
+gaps and should not expand into broad behavior rewrites unless a new test proves
+the current implementation violates the intended contract.
+
+## Findings
+
+| Priority | Issue | Evidence | Fix location | Acceptance |
+| --- | --- | --- | --- | --- |
+| P1 | `shared-helper-adoption-audit.sh` seeds stale integration-test paths, so adoption evidence misses current files. | Issue #421 reports 37 rows with 32 detection misses; local inspection shows stale paths such as `crates/gemini-cli/tests/paths.rs` in the seed manifest while the tree now uses `tests/integration/...` for many crates. | `scripts/dev/shared-helper-adoption-audit.sh`; add or wire a self-test under `scripts/ci/tests/`. | Seeded paths are current or deliberately generated, missing seeded files fail a self-test, and the audit output can be trusted before helper extraction work. |
+| P2 | `cli_template_runs_without_subcommand` checks only exit code 0. | `crates/cli-template/tests/integration/cli.rs` asserts `output.code == 0` without pinning stdout/stderr for the no-subcommand path. | `crates/cli-template/tests/integration/cli.rs`; implementation only if current output is not the intended contract. | The no-subcommand happy path pins meaningful stdout/stderr or explicit silence, plus the exit code. |
+| P2 | Overlay dry-run CLI coverage proves the stderr announcement but not no-mutation or the post-overlay effective plan. | `crates/agent-runtime-cli/tests/integration/install_flags.rs` has `overlay_consumption_is_announced_on_stderr` but no CLI boundary assertion that dry-run avoids filesystem mutation and reflects overlay-dropped entries in the resolved plan. | `crates/agent-runtime-cli/tests/integration/install_flags.rs`; `crates/agent-runtime-cli/src/commands/install.rs` only if output is insufficient. | CLI tests prove overlay dry-run consumes the overlay, does not mutate live/state homes, and reports the effective plan/action count after overlay merge. |
+| P2 | Uninstall recovery evidence is covered at the library layer, not the operator-facing CLI output/error contract. | `crates/agent-runtime-cli/tests/integration/uninstall.rs` verifies `SymlinkSkippedForeign` recovery data in `uninstall::run`, while CLI printing/error mapping remains unpinned. | `crates/agent-runtime-cli/tests/integration/uninstall.rs`; `crates/agent-runtime-cli/src/commands/uninstall.rs` only if output or error mapping drifts. | CLI tests prove foreign symlink recovery output names actual and expected targets, and missing link-map errors map to the intended operator-facing failure contract. |
+
+## Ownership Boundary
+
+- Runtime behavior is in scope only when a new contract test exposes a real
+  mismatch. The preferred change shape is test and audit hardening.
+- Shared helper extraction is out of scope; this work only restores the audit
+  that will guide later extraction.
+- Issue #421 remains the original review finding source. The sibling plan owns
+  task sequencing and validation gates.
+
+## Executable Backlog
+
+1. Refresh or generate shared-helper audit candidates and add a regression
+   self-test for stale seeded paths.
+2. Strengthen the `cli-template` no-subcommand test to assert the intended text
+   or silence contract.
+3. Add overlay dry-run CLI tests for no-mutation and post-overlay effective
+   plan behavior.
+4. Add uninstall CLI tests for foreign symlink recovery output and missing
+   link-map error mapping.
+
+## Validation Gates
+
+- `bash scripts/dev/shared-helper-adoption-audit.sh --format tsv --out target/testing-audits-cli-contracts/shared-helper-adoption.tsv`
+- `bash scripts/ci/test-stale-audit.sh --strict`
+- `cargo test -p nils-cli-template --test integration cli_template_runs_without_subcommand`
+- `cargo test -p agent-runtime-cli --test integration`
+- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage`
+
+## Execution
+
+- Recommended plan: docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-plan.md
+- Recommended execution state: docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-execution-state.md
+- Recommended next task source: start with the shared-helper audit fix before
+  adding CLI contract tests.
+
+## Guardrails
+
+- Do not treat a passing `test-stale-audit.sh` as proof that
+  `shared-helper-adoption-audit.sh` has no stale seed paths; they answer
+  different questions.
+- Do not widen the plan into helper extraction or runtime installer redesign.
+- If a CLI contract is ambiguous, pin the intended operator-facing behavior in
+  the test name and assertion before changing production code.
+
+## Open Questions
+
+- None. The defaults above are sufficient for execution.

--- a/docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-review-source.md
+++ b/docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-review-source.md
@@ -6,7 +6,7 @@
 
 - Date: 2026-05-21
 - Status: ready for implementation planning
-- Source issue: https://github.com/sympoies/nils-cli/issues/421
+- Source issue: <https://github.com/sympoies/nils-cli/issues/421>
 - Retention intent: plan-source artifact; eligible for cleanup after execution
   if the tracking issue keeps the durable closeout record.
 

--- a/scripts/ci/tests/shared-helper-adoption-audit.test.sh
+++ b/scripts/ci/tests/shared-helper-adoption-audit.test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Self-test for scripts/dev/shared-helper-adoption-audit.sh.
+#
+# Guards the seed manifest against path drift:
+#   (a) the real repo must not contain missing seeded paths
+#   (b) --check-seeds must fail when run against a synthetic workspace whose
+#       seeded files are absent
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
+  echo "error: must run inside the nils-cli git work tree" >&2
+  exit 2
+fi
+
+audit_script="$repo_root/scripts/dev/shared-helper-adoption-audit.sh"
+if [[ ! -x "$audit_script" ]]; then
+  echo "error: missing audit script: $audit_script" >&2
+  exit 2
+fi
+
+assert_real_repo_seed_paths_exist() {
+  echo "== baseline: real repo seed paths should exist =="
+  if ! bash "$audit_script" --check-seeds --format tsv >/dev/null; then
+    echo "FAIL: real repo contains missing shared-helper audit seed paths"
+    bash "$audit_script" --check-seeds --format tsv || true
+    exit 1
+  fi
+  echo "ok"
+}
+
+assert_check_seeds_keeps_tsv_stdout() {
+  echo "== contract: --check-seeds keeps TSV stdout clean =="
+  local output
+  output="$(bash "$audit_script" --check-seeds --format tsv 2>/dev/null)"
+  local first_line
+  first_line="$(printf '%s\n' "$output" | sed -n '1p')"
+  if [[ "$first_line" != $'path\tcategory\thelper_target\tstatus\ttask_id\trisk\tdetection_regex\tmatch_count\tmatch_preview\tnote' ]]; then
+    echo "FAIL: --check-seeds polluted TSV stdout"
+    printf '%s\n' "$output" | sed -n '1,5p'
+    exit 1
+  fi
+  echo "ok"
+}
+
+assert_missing_seed_paths_fail() {
+  echo "== regression: missing seeded paths should fail =="
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp:-}"' EXIT
+
+  mkdir -p "$tmp/crates"
+  printf '[workspace]\nmembers = []\n' >"$tmp/Cargo.toml"
+
+  set +e
+  output="$(bash "$audit_script" --root "$tmp" --check-seeds --format tsv 2>&1)"
+  status=$?
+  set -e
+
+  if [[ "$status" -eq 0 ]]; then
+    echo "FAIL: expected --check-seeds to fail for missing seeded paths"
+    echo "$output"
+    exit 1
+  fi
+  if ! grep -qF "missing seeded paths" <<<"$output"; then
+    echo "FAIL: missing-path failure did not name the seed-path problem"
+    echo "$output"
+    exit 1
+  fi
+  echo "ok ($status)"
+}
+
+assert_real_repo_seed_paths_exist
+assert_check_seeds_keeps_tsv_stdout
+assert_missing_seed_paths_fail
+
+echo
+echo "PASS: shared-helper-adoption-audit.test.sh"

--- a/scripts/dev/shared-helper-adoption-audit.sh
+++ b/scripts/dev/shared-helper-adoption-audit.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  shared-helper-adoption-audit.sh [--format tsv] [--out <manifest.tsv>] [--root <repo>]
+  shared-helper-adoption-audit.sh [--format tsv] [--out <manifest.tsv>] [--root <repo>] [--check-seeds]
 
 Scans for known maintainability candidates where code/tests duplicate primitives that should use
 `nils-common` or `nils-test-support`, then writes an issue-centric manifest.
@@ -16,6 +16,7 @@ Options:
   --format <tsv>   Output format (currently only `tsv` is supported)
   --out <file>     Write manifest TSV to file (also writes summary.md in the same directory)
   --root <dir>     Repo root (defaults to current git worktree root)
+  --check-seeds    Fail if any seeded candidate path is missing
   -h, --help       Show this help
 USAGE
 }
@@ -23,6 +24,7 @@ USAGE
 format="tsv"
 out_file=""
 repo_root=""
+check_seeds=0
 
 while [[ $# -gt 0 ]]; do
   case "${1:-}" in
@@ -37,6 +39,10 @@ while [[ $# -gt 0 ]]; do
     --root)
       repo_root="${2:-}"
       shift 2
+      ;;
+    --check-seeds)
+      check_seeds=1
+      shift
       ;;
     -h|--help)
       usage
@@ -185,14 +191,14 @@ seed_manifest() {
     'resolve_secret_dir_from_env|CODEX_SECRET_DIR' \
     "Duplicated env-only secret-dir resolver; parity-sensitive behavior."
 
-  add_row "crates/codex-cli/src/fs.rs" \
+  add_row "crates/codex-cli/tests/integration/fs.rs" \
     "runtime.fs_primitives" "nils-common::fs (extended)" "candidate" "Task 3.2" "high" \
-    'fn write_atomic|fn write_timestamp|fn sha256_file' \
-    "Codex-specific fs primitives overlap gemini and should be shared."
-  add_row "crates/gemini-cli/src/fs.rs" \
+    'sha256_file|write_atomic|write_timestamp|nils_common::fs' \
+    "Codex fs coverage records the shared primitive migration boundary."
+  add_row "crates/gemini-cli/tests/integration/fs.rs" \
     "runtime.fs_primitives" "nils-common::fs (extended)" "candidate" "Task 3.2" "high" \
-    'pub fn write_atomic|pub fn write_timestamp|pub fn sha256_file' \
-    "Gemini fs primitives overlap codex and should be shared."
+    'sha256_file|write_atomic|write_timestamp|nils_common::fs' \
+    "Gemini fs coverage records the shared primitive migration boundary."
   add_row "crates/gemini-cli/src/auth/mod.rs" \
     "runtime.auth_fs_primitives" "nils-common::fs/json helpers (via adapter)" "candidate" "Task 3.3" "high" \
     'pub\(crate\) fn (write_atomic|write_timestamp|strip_newlines|normalize_iso)' \
@@ -211,97 +217,108 @@ seed_manifest() {
     'fn env_lock|struct EnvGuard' \
     "Source tests define custom env guard pattern."
 
-  add_row "crates/gemini-cli/tests/paths.rs" \
+  add_row "crates/gemini-cli/tests/integration/paths.rs" \
     "integration-test.env_guard" "nils-test-support::EnvGuard/GlobalStateLock" "candidate" "Task 5.1" "medium" \
     'struct EnvVarGuard|fn env_lock|unsafe \{ std::env::(set_var|remove_var)' \
     "Integration tests define custom env guards and raw unsafe env mutation."
-  add_row "crates/gemini-cli/tests/prompts.rs" \
+  add_row "crates/gemini-cli/tests/integration/prompts.rs" \
     "integration-test.env_guard+fs" "nils-test-support::EnvGuard/GlobalStateLock + fs" "candidate" "Task 5.1" "medium" \
     'struct EnvVarGuard|fn env_lock|set_mode\(|unsafe \{ std::env::(set_var|remove_var)' \
     "Integration tests define custom env guards and manual chmod helper."
-  add_row "crates/gemini-cli/tests/agent_prompt.rs" \
+  add_row "crates/gemini-cli/tests/integration/agent_prompt.rs" \
     "integration-test.tempdir+fs" "nils-test-support::StubBinDir/fs + tempfile::TempDir" "candidate" "Task 5.1" "medium" \
     'fn temp_dir|fn write_executable\(' \
     "Custom tempdir and executable writer overlap shared helpers."
-  add_row "crates/gemini-cli/tests/auth_refresh.rs" \
+  add_row "crates/gemini-cli/tests/integration/auth_refresh.rs" \
     "integration-test.path_prepend+fs" "nils-test-support::CmdOptions::with_path_prepend + fs" "candidate" "Task 5.1" "medium" \
     'fn write_curl_stub|fn path_with_stub|set_mode\(|std::env::var\("PATH"\)' \
     "Manual stub writer and PATH prepend helper."
 
-  add_row "crates/codex-cli/tests/agent_commit.rs" \
+  add_row "crates/codex-cli/tests/integration/agent_commit.rs" \
     "integration-test.git_setup" "nils-test-support::git + fs" "candidate" "Task 5.2" "medium" \
     'Command::new\("git"\)|fn init_repo' \
     "Manual repo init/config/git calls in fallback commit tests."
-  add_row "crates/gemini-cli/tests/agent_commit_fallback.rs" \
+  add_row "crates/gemini-cli/tests/integration/agent_commit_fallback.rs" \
     "integration-test.git_setup" "nils-test-support::git + fs" "candidate" "Task 5.2" "medium" \
     'Command::new\("git"\)|fn init_repo|fn git_stdout' \
     "Manual repo init/config/git calls in fallback commit tests."
 
-  add_row "crates/agent-docs/tests/env_paths.rs" \
+  add_row "crates/agent-docs/tests/integration/env_paths.rs" \
     "integration-test.git_setup+fs" "nils-test-support::git/fs" "candidate" "Task 5.3" "medium" \
     'Command::new\("git"\)' \
     "Repeated git repo/worktree setup sequences and local fixture writers."
 
-  add_row "crates/git-scope/tests/help_outside_repo.rs" \
+  add_row "crates/git-scope/tests/integration/help_outside_repo.rs" \
     "integration-test.bin_resolve" "nils-test-support::bin + cmd" "candidate" "Task 5.4" "low" \
     'CARGO_BIN_EXE_|fn git_scope_bin' \
     "Manual binary resolution duplicates nils-test-support::bin::resolve."
-  add_row "crates/git-scope/tests/edge_cases.rs" \
+  add_row "crates/git-scope/tests/integration/edge_cases.rs" \
     "integration-test.allow_fail_runner" "nils-test-support::cmd" "candidate" "Task 5.4" "low" \
     'run_git_scope_allow_fail|std::process::Command::new\(common::git_scope_bin\(\)\)' \
     "Ad-hoc allow-fail command runner duplicates shared cmd helper behavior."
-  add_row "crates/git-scope/tests/common.rs" \
+  add_row "crates/git-scope/tests/integration/common.rs" \
     "integration-test.harness_consolidation" "nils-test-support::cmd/bin (thin wrappers only)" "candidate" "Task 5.4" "low" \
     'run_git_scope_output|run_resolved' \
     "Harness should remain thin and own shared wrappers for allow-fail path."
 
-  add_row "crates/api-grpc/tests/integration.rs" \
+  add_row "crates/api-grpc/tests/integration/integration.rs" \
     "integration-test.stub_executable" "nils-test-support::fs::write_executable" "candidate" "Task 5.5" "low" \
     'fn write_executable_script|set_mode\(0o755\)|set_permissions\(path, perms\)' \
     "Manual script chmod helper overlaps nils-test-support::fs."
-  add_row "crates/api-test/tests/grpc_integration.rs" \
+  add_row "crates/api-test/tests/integration/grpc_integration.rs" \
     "integration-test.stub_executable" "nils-test-support::fs::write_executable" "candidate" "Task 5.5" "low" \
     'set_mode\(0o755\)|set_permissions\(&mock, perms\)' \
     "Manual grpc mock chmod helper overlaps nils-test-support::fs."
-  add_row "crates/api-testing-core/tests/suite_runner_grpc_matrix.rs" \
+  add_row "crates/api-testing-core/tests/integration/suite_runner_grpc_matrix.rs" \
     "integration-test.stub_executable+env_guard" "nils-test-support::fs + EnvGuard/GlobalStateLock" "candidate" "Task 5.5" "medium" \
     'unsafe \{ std::env::(set_var|remove_var)|set_mode\(0o755\)' \
     "Manual chmod and raw env mutation in test."
 
-  add_row "crates/screen-record/tests/linux_request_permission.rs" \
+  add_row "crates/screen-record/tests/integration/linux_request_permission.rs" \
     "integration-test.stub_executable" "nils-test-support::fs::write_executable" "candidate" "Task 5.6" "low" \
     'ffmpeg_stub_dir|set_mode\(0o755\)|set_permissions\(&ffmpeg_path, perms\)' \
     "Manual ffmpeg stub writer duplicates executable helper."
 
-  add_row "crates/codex-cli/tests/agent_templates.rs" \
+  add_row "crates/codex-cli/tests/integration/agent_templates.rs" \
     "integration-test.path_prepend" "nils-test-support::CmdOptions::with_path_prepend" "candidate" "Task 5.7" "low" \
     'std::env::var\("PATH"\)|combined_path = format!' \
     "Manual PATH prepend string composition."
-  add_row "crates/codex-cli/tests/auth_json_contract.rs" \
+  add_row "crates/codex-cli/tests/integration/auth_json_contract.rs" \
     "integration-test.path_prepend" "nils-test-support::CmdOptions::with_path_prepend" "candidate" "Task 5.7" "low" \
     'current_path = std::env::var\("PATH"\)|path = format!\("\{\}:\{current_path\}"' \
     "Manual PATH prepend string composition."
-  add_row "crates/gemini-cli/tests/agent_templates.rs" \
+  add_row "crates/gemini-cli/tests/integration/agent_templates.rs" \
     "integration-test.path_prepend" "nils-test-support::CmdOptions::with_path_prepend" "candidate" "Task 5.7" "low" \
     'std::env::var\("PATH"\)|combined_path = format!' \
     "Manual PATH prepend string composition."
 
-  add_row "crates/fzf-cli/tests/open_and_file.rs" \
+  add_row "crates/fzf-cli/tests/integration/open_and_file.rs" \
     "integration-test.path_prepend" "nils-test-support::CmdOptions::with_path_prepend (via harness)" "candidate" "Task 5.7" "low" \
     'fn path_with_stub|std::env::var\("PATH"\)' \
     "Repeated PATH prepend helper."
-  add_row "crates/fzf-cli/tests/git_commands.rs" \
+  add_row "crates/fzf-cli/tests/integration/git_commands.rs" \
     "integration-test.path_prepend" "nils-test-support::CmdOptions::with_path_prepend (via harness)" "candidate" "Task 5.7" "low" \
     'fn path_with_stub|std::env::var\("PATH"\)' \
     "Repeated PATH prepend helper."
-  add_row "crates/fzf-cli/tests/git_commit.rs" \
+  add_row "crates/fzf-cli/tests/integration/git_commit.rs" \
     "integration-test.path_prepend" "nils-test-support::CmdOptions::with_path_prepend (via harness)" "candidate" "Task 5.7" "low" \
     'fn path_with_stub|std::env::var\("PATH"\)' \
     "Repeated PATH prepend helper."
-  add_row "crates/fzf-cli/tests/common.rs" \
+  add_row "crates/fzf-cli/tests/integration/common.rs" \
     "integration-test.harness_consolidation" "nils-test-support::cmd (thin wrappers only)" "candidate" "Task 5.7" "low" \
     'run_fzf_cli|StubBinDir|CmdOptions' \
     "Central harness file likely owns path-prepend helper after sweep."
+}
+
+check_seed_paths() {
+  local missing
+  missing="$(awk -F '\t' 'NR>1 && $9=="missing-file" {print $1}' "$tmp_rows")"
+  if [[ -n "$missing" ]]; then
+    echo "FAIL: shared-helper adoption audit has missing seeded paths:" >&2
+    echo "$missing" >&2
+    return 1
+  fi
+  echo "PASS: shared-helper adoption audit seed paths exist" >&2
 }
 
 render_summary_markdown() {
@@ -360,6 +377,10 @@ write_manifest() {
 }
 
 seed_manifest
+
+if [[ "$check_seeds" -eq 1 ]]; then
+  check_seed_paths
+fi
 
 if [[ -n "$out_file" ]]; then
   mkdir -p "$(dirname "$out_file")"


### PR DESCRIPTION
# Harden testing audits and CLI contracts

## Summary

Harden the Plan 04 testing-audit and CLI-contract surfaces by making shared-helper seed drift fail in required checks, pinning CLI stdout/stderr behavior, and covering agent-runtime install/uninstall recovery paths.

## Changes

- Add `--check-seeds` to `scripts/dev/shared-helper-adoption-audit.sh`, refresh stale seed paths, and add a CI self-test for real seed coverage, synthetic missing-path failure, and clean TSV stdout.
- Add the shared-helper adoption audit self-test to the nils-cli required check entrypoint and `DEVELOPMENT.md`.
- Strengthen `nils-cli-template` no-subcommand behavior so stdout stays empty and the default-path log goes to stderr.
- Expand `agent-runtime` integration coverage for overlay dry-runs, foreign symlink uninstall recovery, and missing link-map CLI errors.
- Apply the requested `code-review-specialists` repair for the `--check-seeds --format tsv` output contract.

## Test-First Evidence

- Change classification: behavior/test coverage change.
- Failing test before fix: `cargo test -p nils-cli-template --test integration cli_template_runs_without_subcommand` and the new shared-helper self-test cover the contract gaps introduced by this issue-backed plan; the seed-path and clean-TSV assertions were added before the final implementation gate.
- Final validation: `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` passed after the review repair.
- Waiver reason: N/A.

## Testing

- `bash scripts/ci/tests/shared-helper-adoption-audit.test.sh` (pass)
- `cargo test -p nils-cli-template --test integration cli_template_runs_without_subcommand` (pass)
- `cargo test -p agent-runtime-cli --test integration overlay_consumption_is_announced_on_stderr` (pass)
- `cargo test -p agent-runtime-cli --test integration uninstall` (pass)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` (pass, 85.40% line coverage)

## Risk / Notes

- Tracks #427.
- Specialist review found one output-contract issue in the audit script; the fix keeps TSV stdout clean by moving the seed success message to stderr and covering it in the self-test.
