### PR TITLE
Plan 04: implement agent-runtime gc-backups (Sprint 2 Task 2.4)

### DIFF
--- a/crates/agent-runtime-cli/src/commands/gc_backups.rs
+++ b/crates/agent-runtime-cli/src/commands/gc_backups.rs
@@ -1,0 +1,127 @@
+use crate::gc_backups::{
+    self, DEFAULT_RETENTION, GcChange, GcError, GcOptions, Mode, ProductFilter,
+};
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+pub struct GcBackupsArgs {
+    /// Absolute path of the state home whose `backups/` subtree is
+    /// subject to retention. Relative paths are rejected so gc-backups
+    /// never deletes outside an explicitly-chosen directory.
+    #[arg(long)]
+    pub state_home: PathBuf,
+    /// Product to prune (`codex` or `claude`). Default: both products.
+    #[arg(long)]
+    pub product: Option<String>,
+    /// Filter to a single link-map entry id. Runs whose root has no
+    /// `<surface>/` subdir are entirely skipped (never deleted).
+    #[arg(long)]
+    pub surface: Option<String>,
+    /// Number of newest install runs to retain per (product, surface)
+    /// bucket. Default: 5.
+    #[arg(long)]
+    pub retention: Option<usize>,
+    /// Print the planned deletions; do not mutate the filesystem.
+    #[arg(long, conflicts_with = "apply")]
+    pub dry_run: bool,
+    /// Delete the planned set under `<state_home>/backups/<product>/`.
+    #[arg(long, conflicts_with = "dry_run")]
+    pub apply: bool,
+}
+
+pub fn run(args: GcBackupsArgs) -> anyhow::Result<u8> {
+    if !args.state_home.is_absolute() {
+        anyhow::bail!(
+            "agent-runtime gc-backups: --state-home must be absolute (got: {})",
+            args.state_home.display()
+        );
+    }
+    if !args.dry_run && !args.apply {
+        anyhow::bail!("agent-runtime gc-backups: pass --dry-run or --apply");
+    }
+
+    let product = match args.product.as_deref() {
+        None => ProductFilter::All,
+        Some("claude") | Some("codex") => ProductFilter::One(args.product.unwrap()),
+        Some(other) => anyhow::bail!(
+            "agent-runtime gc-backups: --product must be `claude` or `codex` (got `{other}`)"
+        ),
+    };
+
+    let mode = if args.apply {
+        Mode::Apply
+    } else {
+        Mode::DryRun
+    };
+    let retention = args.retention.unwrap_or(DEFAULT_RETENTION);
+    let options = GcOptions {
+        product,
+        surface: args.surface.clone(),
+        retention,
+    };
+
+    let outcome = match gc_backups::run(&args.state_home, mode, &options) {
+        Ok(o) => o,
+        Err(GcError::InvalidSurface { value }) => {
+            anyhow::bail!(
+                "agent-runtime gc-backups: --surface `{value}` must be a single path component"
+            );
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    eprintln!(
+        "agent-runtime gc-backups: mode={} retention={} retained={} preserved-by-tag={} {}={}",
+        if matches!(mode, Mode::Apply) {
+            "apply"
+        } else {
+            "dry-run"
+        },
+        outcome.retention,
+        outcome.retained(),
+        outcome.preserved_by_tag(),
+        if matches!(mode, Mode::Apply) {
+            "deleted"
+        } else {
+            "would-delete"
+        },
+        if matches!(mode, Mode::Apply) {
+            outcome.deleted()
+        } else {
+            outcome.would_delete()
+        },
+    );
+
+    for change in &outcome.changes {
+        print_change(change);
+    }
+
+    Ok(0)
+}
+
+fn print_change(change: &GcChange) {
+    match change {
+        GcChange::Retained { product, ts, path } => {
+            eprintln!("  . retain {product} ts={ts} {}", path.display());
+        }
+        GcChange::PreservedByTag {
+            product,
+            ts,
+            path,
+            marker,
+        } => {
+            eprintln!(
+                "  # tagged {product} ts={ts} {} (marker: {})",
+                path.display(),
+                marker.display()
+            );
+        }
+        GcChange::WouldDelete { product, ts, path } => {
+            eprintln!("  - would-delete {product} ts={ts} {}", path.display());
+        }
+        GcChange::Deleted { product, ts, path } => {
+            eprintln!("  - deleted {product} ts={ts} {}", path.display());
+        }
+    }
+}

--- a/crates/agent-runtime-cli/src/commands/mod.rs
+++ b/crates/agent-runtime-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit_drift;
+pub mod gc_backups;
 pub mod install;
 pub mod purge_state;
 pub mod render;

--- a/crates/agent-runtime-cli/src/gc_backups.rs
+++ b/crates/agent-runtime-cli/src/gc_backups.rs
@@ -1,0 +1,647 @@
+//! `agent-runtime gc-backups` body. Plan 04 Sprint 2 Task 2.4.
+//!
+//! Prune aged backups under `<state_home>/backups/<product>/`. Retention
+//! defaults to 5 install runs; `--retention <N>` overrides. Runs whose
+//! root contains a `tag-<name>` marker file (written by
+//! `install --tag <name>`) are preserved regardless of where they fall in
+//! the timestamp ordering. `--surface <name>` restricts the sweep to runs
+//! that touched a specific link-map entry. `gc-backups` is the only
+//! sanctioned retention enforcer — `install` never prunes silently.
+//!
+//! ## Backup tree layout
+//!
+//! ```text
+//! <state_home>/backups/<product>/<unix_seconds>/
+//!     ├── <entry_id>/<filename>     (directory subtrees — one per entry)
+//!     └── tag-<name>                (regular file — the run-level marker)
+//! ```
+//!
+//! ## Canonical tag-marker vs entry_id disambiguation
+//!
+//! Per Plan 04 Sprint 1 Task 1.3 F-3 advisory, `gc-backups` owns the
+//! canonical [`is_tag_marker`] helper: a path is a tag marker iff its
+//! basename starts with `tag-` AND it is a regular file (per
+//! `symlink_metadata`). An entry-id subdir whose name happens to start
+//! with `tag-` is a directory, not a marker, and is not treated as a
+//! retention pin. This keeps the two namespaces collision-safe even when
+//! a future link-map entry chooses an unfortunate id.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Default install-runs retention when `--retention` is not passed.
+pub const DEFAULT_RETENTION: usize = 5;
+
+/// Products that gc-backups can scan when `--product` is not specified.
+/// Kept in deterministic order so test golden output stays stable.
+pub const ALL_PRODUCTS: &[&str] = &["claude", "codex"];
+
+/// Per-run dry-run / apply selector. Mirrors `install::Mode` /
+/// `uninstall::Mode` / `restore_backups::Mode` so the four lifecycle
+/// commands share an identical surface. Sprint 4 will fold these into
+/// one shared `Mode` (see Plan 04 Task 2.2 advisory R-10).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    DryRun,
+    Apply,
+}
+
+/// Product scope. `All` walks both `claude` and `codex` subtrees;
+/// `One` restricts to one product.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum ProductFilter {
+    #[default]
+    All,
+    One(String),
+}
+
+/// Per-invocation knobs. Defaults match the plan's stated defaults:
+/// every product, no surface filter, retention 5.
+#[derive(Debug, Clone)]
+pub struct GcOptions {
+    pub product: ProductFilter,
+    /// Filter to a single link-map entry id. When set, only runs whose
+    /// root contains a `<surface>/` subdirectory are considered for
+    /// retention — other runs are entirely skipped, never deleted.
+    pub surface: Option<String>,
+    pub retention: usize,
+}
+
+impl Default for GcOptions {
+    fn default() -> Self {
+        Self {
+            product: ProductFilter::All,
+            surface: None,
+            retention: DEFAULT_RETENTION,
+        }
+    }
+}
+
+/// One decision in the gc sweep. Records the (product, ts) pair plus the
+/// absolute path so the CLI can echo each disposition deterministically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GcChange {
+    /// Run was within the retention window (kept; no mutation).
+    Retained {
+        product: String,
+        ts: u64,
+        path: PathBuf,
+    },
+    /// Run carried at least one `tag-*` marker file (kept regardless of
+    /// retention; no mutation).
+    PreservedByTag {
+        product: String,
+        ts: u64,
+        path: PathBuf,
+        marker: PathBuf,
+    },
+    /// Run was beyond retention and deleted (`Mode::Apply` only).
+    Deleted {
+        product: String,
+        ts: u64,
+        path: PathBuf,
+    },
+    /// Run was beyond retention; `Mode::DryRun` would delete it.
+    WouldDelete {
+        product: String,
+        ts: u64,
+        path: PathBuf,
+    },
+}
+
+impl GcChange {
+    pub fn product(&self) -> &str {
+        match self {
+            GcChange::Retained { product, .. }
+            | GcChange::PreservedByTag { product, .. }
+            | GcChange::Deleted { product, .. }
+            | GcChange::WouldDelete { product, .. } => product,
+        }
+    }
+
+    pub fn ts(&self) -> u64 {
+        match self {
+            GcChange::Retained { ts, .. }
+            | GcChange::PreservedByTag { ts, .. }
+            | GcChange::Deleted { ts, .. }
+            | GcChange::WouldDelete { ts, .. } => *ts,
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        match self {
+            GcChange::Retained { path, .. }
+            | GcChange::PreservedByTag { path, .. }
+            | GcChange::Deleted { path, .. }
+            | GcChange::WouldDelete { path, .. } => path,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum GcError {
+    #[error("io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error(
+        "--surface `{value}` must be a single path component (no `/`, `\\`, `..`, or leading `.`)"
+    )]
+    InvalidSurface { value: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GcOutcome {
+    pub mode: Mode,
+    pub retention: usize,
+    pub changes: Vec<GcChange>,
+}
+
+impl GcOutcome {
+    pub fn deleted(&self) -> usize {
+        self.changes
+            .iter()
+            .filter(|c| matches!(c, GcChange::Deleted { .. }))
+            .count()
+    }
+    pub fn would_delete(&self) -> usize {
+        self.changes
+            .iter()
+            .filter(|c| matches!(c, GcChange::WouldDelete { .. }))
+            .count()
+    }
+    pub fn retained(&self) -> usize {
+        self.changes
+            .iter()
+            .filter(|c| matches!(c, GcChange::Retained { .. }))
+            .count()
+    }
+    pub fn preserved_by_tag(&self) -> usize {
+        self.changes
+            .iter()
+            .filter(|c| matches!(c, GcChange::PreservedByTag { .. }))
+            .count()
+    }
+}
+
+/// Canonical disambiguator between an `install --tag <name>` marker file
+/// and an entry-id subdirectory that happens to start with `tag-`.
+/// Returns `true` only when `path` exists as a regular file (the install
+/// executor always writes the marker as a zero-byte regular file).
+///
+/// Documented as part of Task 2.4 because gc-backups is the consumer that
+/// must protect tagged runs from retention sweeps — restore-backups uses
+/// the same shape but only as a "skip top-level files" filter where the
+/// outcome is the same regardless of marker / non-marker classification.
+pub fn is_tag_marker(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if !name.starts_with("tag-") {
+        return false;
+    }
+    fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_file())
+        .unwrap_or(false)
+}
+
+/// Execute one gc-backups sweep. Returns a deterministic, ordered set of
+/// per-run decisions:
+///
+/// - For each product (alphabetical when [`ProductFilter::All`]),
+/// - Walk `<state_home>/backups/<product>/<ts>/` directories,
+/// - Optionally retain only runs that contain a `<surface>/` subdir,
+/// - Tagged runs land as [`GcChange::PreservedByTag`] (deterministic),
+/// - Untagged runs sort by `ts` descending; the first `retention`
+///   become [`GcChange::Retained`], the rest become
+///   [`GcChange::Deleted`] / [`GcChange::WouldDelete`] depending on
+///   `mode`.
+///
+/// Returns `Ok` with an empty `changes` vec when `<state_home>/backups/`
+/// (or the product subtree) does not exist — gc-backups is idempotent
+/// across "never installed" / "already pruned" host states.
+pub fn run(state_home: &Path, mode: Mode, options: &GcOptions) -> Result<GcOutcome, GcError> {
+    if let Some(s) = options.surface.as_deref() {
+        validate_surface(s)?;
+    }
+
+    let products: Vec<&str> = match &options.product {
+        ProductFilter::All => ALL_PRODUCTS.to_vec(),
+        ProductFilter::One(p) => vec![p.as_str()],
+    };
+
+    let mut changes = Vec::new();
+    for product in products {
+        let product_root = state_home.join("backups").join(product);
+        if !product_root.is_dir() {
+            continue;
+        }
+        let runs = enumerate_runs(&product_root)?;
+        let runs = filter_by_surface(runs, options.surface.as_deref());
+
+        // Partition into (tagged, untagged) preserving deterministic order.
+        let mut tagged: Vec<RunRow> = Vec::new();
+        let mut untagged: Vec<RunRow> = Vec::new();
+        for row in runs {
+            match find_tag_marker(&row.path) {
+                Some(marker) => tagged.push(RunRow {
+                    marker: Some(marker),
+                    ..row
+                }),
+                None => untagged.push(row),
+            }
+        }
+
+        // Tagged: stable by ts ascending (matches enumerate order).
+        for row in tagged {
+            changes.push(GcChange::PreservedByTag {
+                product: product.to_string(),
+                ts: row.ts,
+                path: row.path,
+                marker: row.marker.expect("tagged row carries its marker"),
+            });
+        }
+
+        // Untagged: newest first.
+        untagged.sort_by_key(|row| std::cmp::Reverse(row.ts));
+        let keep_count = options.retention.min(untagged.len());
+        let to_delete: Vec<RunRow> = untagged.split_off(keep_count);
+
+        for row in untagged {
+            changes.push(GcChange::Retained {
+                product: product.to_string(),
+                ts: row.ts,
+                path: row.path,
+            });
+        }
+        for row in to_delete {
+            match mode {
+                Mode::DryRun => {
+                    changes.push(GcChange::WouldDelete {
+                        product: product.to_string(),
+                        ts: row.ts,
+                        path: row.path,
+                    });
+                }
+                Mode::Apply => {
+                    fs::remove_dir_all(&row.path).map_err(|source| GcError::Io {
+                        path: row.path.clone(),
+                        source,
+                    })?;
+                    changes.push(GcChange::Deleted {
+                        product: product.to_string(),
+                        ts: row.ts,
+                        path: row.path,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(GcOutcome {
+        mode,
+        retention: options.retention,
+        changes,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct RunRow {
+    ts: u64,
+    path: PathBuf,
+    marker: Option<PathBuf>,
+}
+
+fn enumerate_runs(product_root: &Path) -> Result<Vec<RunRow>, GcError> {
+    let read = fs::read_dir(product_root).map_err(|source| GcError::Io {
+        path: product_root.to_path_buf(),
+        source,
+    })?;
+    let mut rows = Vec::new();
+    for entry in read {
+        let entry = entry.map_err(|source| GcError::Io {
+            path: product_root.to_path_buf(),
+            source,
+        })?;
+        let file_type = entry.file_type().map_err(|source| GcError::Io {
+            path: entry.path(),
+            source,
+        })?;
+        if !file_type.is_dir() {
+            // Stray non-dir at the product root: not a run. Skip silently.
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Ok(ts) = name.parse::<u64>() else {
+            // Non-numeric subdir at the product root: not a run.
+            continue;
+        };
+        rows.push(RunRow {
+            ts,
+            path: entry.path(),
+            marker: None,
+        });
+    }
+    rows.sort_by_key(|row| row.ts);
+    Ok(rows)
+}
+
+fn filter_by_surface(rows: Vec<RunRow>, surface: Option<&str>) -> Vec<RunRow> {
+    let Some(name) = surface else {
+        return rows;
+    };
+    rows.into_iter()
+        .filter(|row| has_surface_subdir(&row.path, name))
+        .collect()
+}
+
+fn has_surface_subdir(run_dir: &Path, surface: &str) -> bool {
+    let target = run_dir.join(surface);
+    fs::symlink_metadata(&target)
+        .map(|m| m.file_type().is_dir())
+        .unwrap_or(false)
+}
+
+fn find_tag_marker(run_dir: &Path) -> Option<PathBuf> {
+    let read = fs::read_dir(run_dir).ok()?;
+    let mut markers: Vec<PathBuf> = read
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| is_tag_marker(p))
+        .collect();
+    markers.sort();
+    markers.into_iter().next()
+}
+
+fn validate_surface(s: &str) -> Result<(), GcError> {
+    if s.is_empty()
+        || s.contains('/')
+        || s.contains('\\')
+        || s == ".."
+        || s == "."
+        || s.starts_with('.')
+    {
+        return Err(GcError::InvalidSurface {
+            value: s.to_string(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn seed_run(state: &Path, product: &str, ts: u64, entry_id: &str) -> PathBuf {
+        let run = state
+            .join("backups")
+            .join(product)
+            .join(ts.to_string())
+            .join(entry_id);
+        fs::create_dir_all(&run).unwrap();
+        fs::write(run.join("plugin.json"), format!("BACKUP-{product}-{ts}")).unwrap();
+        state.join("backups").join(product).join(ts.to_string())
+    }
+
+    fn seed_tag(state: &Path, product: &str, ts: u64, name: &str) {
+        let path = state
+            .join("backups")
+            .join(product)
+            .join(ts.to_string())
+            .join(format!("tag-{name}"));
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, b"").unwrap();
+    }
+
+    #[test]
+    fn is_tag_marker_file_yes_dir_no() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("tag-pre-bump");
+        fs::write(&file, b"").unwrap();
+        assert!(is_tag_marker(&file), "regular file with tag- prefix");
+
+        let dir = tmp.path().join("tag-as-dir");
+        fs::create_dir_all(&dir).unwrap();
+        assert!(
+            !is_tag_marker(&dir),
+            "directory with tag- prefix is NOT a marker"
+        );
+
+        let other = tmp.path().join("not-a-tag");
+        fs::write(&other, b"").unwrap();
+        assert!(!is_tag_marker(&other), "non-tag- prefix");
+
+        let missing = tmp.path().join("tag-missing");
+        assert!(!is_tag_marker(&missing), "non-existent path");
+    }
+
+    #[test]
+    fn run_retains_five_of_seven_in_apply_mode() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        for ts in [100u64, 200, 300, 400, 500, 600, 700] {
+            seed_run(state, "claude", ts, "entry");
+        }
+        let outcome = run(
+            state,
+            Mode::Apply,
+            &GcOptions {
+                product: ProductFilter::One("claude".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome.retained(), 5);
+        assert_eq!(outcome.deleted(), 2);
+        assert_eq!(outcome.would_delete(), 0);
+
+        // Newest 5 survive on disk; oldest 2 deleted.
+        for keep in [300u64, 400, 500, 600, 700] {
+            assert!(
+                state.join("backups/claude").join(keep.to_string()).is_dir(),
+                "retained ts={keep}"
+            );
+        }
+        for gone in [100u64, 200] {
+            assert!(
+                !state.join("backups/claude").join(gone.to_string()).exists(),
+                "deleted ts={gone}"
+            );
+        }
+    }
+
+    #[test]
+    fn dry_run_classifies_without_mutating() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        for ts in [100u64, 200, 300, 400, 500, 600, 700] {
+            seed_run(state, "claude", ts, "entry");
+        }
+        let outcome = run(
+            state,
+            Mode::DryRun,
+            &GcOptions {
+                product: ProductFilter::One("claude".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome.would_delete(), 2);
+        assert_eq!(outcome.deleted(), 0);
+        // Every dir still on disk.
+        for ts in [100u64, 200, 300, 400, 500, 600, 700] {
+            assert!(state.join("backups/claude").join(ts.to_string()).is_dir());
+        }
+    }
+
+    #[test]
+    fn tag_marker_pins_run_even_outside_retention_window() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        // Oldest carries a tag — it MUST survive a default retention=5
+        // sweep against 7 runs.
+        for ts in [100u64, 200, 300, 400, 500, 600, 700] {
+            seed_run(state, "claude", ts, "entry");
+        }
+        seed_tag(state, "claude", 100, "pre-bump");
+
+        let outcome = run(
+            state,
+            Mode::Apply,
+            &GcOptions {
+                product: ProductFilter::One("claude".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome.preserved_by_tag(), 1);
+        assert!(state.join("backups/claude/100").is_dir(), "tagged survives");
+        // With 6 untagged runs and retention=5, exactly 1 gets deleted (ts=200).
+        assert_eq!(outcome.deleted(), 1);
+        assert!(!state.join("backups/claude/200").exists());
+    }
+
+    #[test]
+    fn retention_three_keeps_three() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        for ts in [100u64, 200, 300, 400, 500] {
+            seed_run(state, "claude", ts, "entry");
+        }
+        let outcome = run(
+            state,
+            Mode::Apply,
+            &GcOptions {
+                product: ProductFilter::One("claude".into()),
+                retention: 3,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome.retained(), 3);
+        assert_eq!(outcome.deleted(), 2);
+    }
+
+    #[test]
+    fn surface_filter_skips_runs_without_the_named_subdir() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        seed_run(state, "claude", 100, "alpha");
+        seed_run(state, "claude", 200, "beta");
+        seed_run(state, "claude", 300, "alpha");
+        // retention=1 with --surface alpha:
+        // candidate runs = {100,300}; newest kept = 300; 100 deleted.
+        // Run 200 has no `alpha/` subdir — must be untouched.
+        let outcome = run(
+            state,
+            Mode::Apply,
+            &GcOptions {
+                product: ProductFilter::One("claude".into()),
+                surface: Some("alpha".into()),
+                retention: 1,
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome.deleted(), 1);
+        assert!(state.join("backups/claude/200").is_dir(), "beta survives");
+        assert!(state.join("backups/claude/300").is_dir(), "newest alpha");
+        assert!(!state.join("backups/claude/100").exists());
+    }
+
+    #[test]
+    fn product_all_walks_both_subtrees() {
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        for ts in [100u64, 200, 300, 400, 500, 600] {
+            seed_run(state, "claude", ts, "entry");
+        }
+        for ts in [10u64, 20, 30] {
+            seed_run(state, "codex", ts, "entry");
+        }
+        let outcome = run(state, Mode::Apply, &GcOptions::default()).unwrap();
+        // claude: 6 runs, retain 5, delete 1.
+        // codex: 3 runs, retain 3, delete 0.
+        assert_eq!(outcome.retained(), 8);
+        assert_eq!(outcome.deleted(), 1);
+    }
+
+    #[test]
+    fn missing_state_or_product_root_is_clean_noop() {
+        let tmp = TempDir::new().unwrap();
+        let outcome = run(tmp.path(), Mode::Apply, &GcOptions::default()).unwrap();
+        assert!(outcome.changes.is_empty());
+    }
+
+    #[test]
+    fn entry_id_subdir_starting_with_tag_dash_is_not_treated_as_marker() {
+        // Plan 04 Task 1.3 F-3 namespace-overlap regression-pin.
+        // A link-map entry named `tag-pre-bump` would create
+        // `<ts>/tag-pre-bump/` (directory) — `is_tag_marker` must NOT
+        // classify it as a tag marker, so retention sweeps the run.
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        for ts in [100u64, 200] {
+            seed_run(state, "claude", ts, "tag-pre-bump");
+        }
+        let outcome = run(
+            state,
+            Mode::Apply,
+            &GcOptions {
+                product: ProductFilter::One("claude".into()),
+                retention: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome.preserved_by_tag(), 0, "subdir is not a marker");
+        assert_eq!(outcome.deleted(), 1);
+        assert!(!state.join("backups/claude/100").exists());
+    }
+
+    #[test]
+    fn invalid_surface_with_path_separators_is_rejected() {
+        let tmp = TempDir::new().unwrap();
+        for bad in ["", "..", ".", ".hidden", "a/b", "a\\b"] {
+            let err = run(
+                tmp.path(),
+                Mode::DryRun,
+                &GcOptions {
+                    surface: Some(bad.into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, GcError::InvalidSurface { .. }),
+                "expected InvalidSurface for {bad:?}, got {err:?}"
+            );
+        }
+    }
+}

--- a/crates/agent-runtime-cli/src/gc_backups.rs
+++ b/crates/agent-runtime-cli/src/gc_backups.rs
@@ -237,8 +237,16 @@ pub fn run(state_home: &Path, mode: Mode, options: &GcOptions) -> Result<GcOutco
     let mut changes = Vec::new();
     for product in products {
         let product_root = state_home.join("backups").join(product);
-        if !product_root.is_dir() {
-            continue;
+        // Defense-in-depth: refuse to enumerate / delete through a
+        // symlinked product_root. `Path::is_dir` follows symlinks, so
+        // without this guard an attacker who can plant a symlink at
+        // `<state_home>/backups/<product>` could redirect the
+        // `fs::remove_dir_all` below to a directory outside state_home.
+        // Mirrors the entry-level `file_type()` discipline in
+        // `enumerate_runs`. (Plan 04 Task 2.4 review S-1 / R-2.)
+        match fs::symlink_metadata(&product_root) {
+            Ok(meta) if meta.file_type().is_dir() => {}
+            _ => continue,
         }
         let runs = enumerate_runs(&product_root)?;
         let runs = filter_by_surface(runs, options.surface.as_deref());
@@ -440,6 +448,66 @@ mod tests {
 
         let missing = tmp.path().join("tag-missing");
         assert!(!is_tag_marker(&missing), "non-existent path");
+    }
+
+    #[test]
+    fn is_tag_marker_symlink_to_file_is_not_marker() {
+        // Plan 04 Task 2.4 review T-4 / S-1 positive-control regression
+        // pin. `is_tag_marker` must reject a symlink even when its target
+        // is a regular file — otherwise an attacker with write access at
+        // a run root could symlink `tag-evil -> /anywhere/regular-file`
+        // and force gc-backups to preserve the run.
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("real-file");
+        fs::write(&target, b"contents").unwrap();
+        let link = tmp.path().join("tag-evil");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(
+            !is_tag_marker(&link),
+            "symlink to a regular file must NOT be classified as a tag marker"
+        );
+    }
+
+    #[test]
+    fn product_root_symlink_is_refused_not_followed() {
+        // Plan 04 Task 2.4 review S-1 / R-2 regression pin.
+        // <state_home>/backups/<product> must not be a symlink — otherwise
+        // gc-backups would walk and `remove_dir_all` through the symlinked
+        // target. Defense-in-depth: even if the target is a real backup
+        // tree, refusing to traverse it is the safer default.
+        let tmp = TempDir::new().unwrap();
+        let state = tmp.path();
+        // Build a real backup tree elsewhere with one numeric run.
+        let real_tree = state.join("elsewhere");
+        fs::create_dir_all(real_tree.join("100").join("entry")).unwrap();
+        fs::write(real_tree.join("100/entry/plugin.json"), b"BACKUP").unwrap();
+        // Plant the product_root as a symlink at the canonical location.
+        let product_root = state.join("backups").join("claude");
+        fs::create_dir_all(product_root.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&real_tree, &product_root).unwrap();
+
+        let outcome = run(
+            state,
+            Mode::Apply,
+            &GcOptions {
+                product: ProductFilter::One("claude".into()),
+                retention: 0,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // Symlinked product_root yields zero changes, and the real tree
+        // is untouched.
+        assert!(
+            outcome.changes.is_empty(),
+            "symlinked product_root must produce no changes: {:?}",
+            outcome.changes
+        );
+        assert_eq!(
+            fs::read_to_string(real_tree.join("100/entry/plugin.json")).unwrap(),
+            "BACKUP",
+            "symlinked target must survive intact"
+        );
     }
 
     #[test]

--- a/crates/agent-runtime-cli/src/lib.rs
+++ b/crates/agent-runtime-cli/src/lib.rs
@@ -22,6 +22,7 @@ use std::process::ExitCode;
 
 pub mod audit_drift;
 pub mod commands;
+pub mod gc_backups;
 pub mod install;
 pub mod managed_block;
 pub mod purge_state;
@@ -53,7 +54,7 @@ pub enum Command {
     /// Detect source-vs-rendered, rendered-vs-live, and unsafe drift.
     AuditDrift(commands::audit_drift::AuditDriftArgs),
     /// Prune old backups under `<state_home>/backups/`.
-    GcBackups,
+    GcBackups(commands::gc_backups::GcBackupsArgs),
     /// Restore a runtime home from a recorded backup snapshot.
     RestoreBackups(commands::restore_backups::RestoreBackupsArgs),
     /// Purge runtime-managed state (use with caution).
@@ -68,7 +69,7 @@ impl Command {
             Command::Uninstall(_) => "uninstall",
             Command::Doctor => "doctor",
             Command::AuditDrift(_) => "audit-drift",
-            Command::GcBackups => "gc-backups",
+            Command::GcBackups(_) => "gc-backups",
             Command::RestoreBackups(_) => "restore-backups",
             Command::PurgeState(_) => "purge-state",
         }
@@ -118,6 +119,13 @@ pub fn run() -> ExitCode {
             Ok(code) => ExitCode::from(code),
             Err(err) => {
                 eprintln!("agent-runtime purge-state: {err:#}");
+                ExitCode::from(2)
+            }
+        },
+        Command::GcBackups(args) => match commands::gc_backups::run(args) {
+            Ok(code) => ExitCode::from(code),
+            Err(err) => {
+                eprintln!("agent-runtime gc-backups: {err:#}");
                 ExitCode::from(2)
             }
         },

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -9,6 +9,8 @@ mod audit_drift_classes;
 mod cli;
 #[path = "integration/determinism_gate.rs"]
 mod determinism_gate;
+#[path = "integration/gc_backups.rs"]
+mod gc_backups;
 #[path = "integration/install_flags.rs"]
 mod install_flags;
 #[path = "integration/install_pipeline.rs"]

--- a/crates/agent-runtime-cli/tests/integration/cli.rs
+++ b/crates/agent-runtime-cli/tests/integration/cli.rs
@@ -25,9 +25,9 @@ const ALL_SUBCOMMANDS: &[&str] = &[
 /// Subcommands whose body still prints `not implemented` and exits 1.
 /// `render` / `install` left after Plan 04 Sprint 1; `uninstall` after
 /// Sprint 2 Task 2.1; `restore-backups` after Sprint 2 Task 2.2;
-/// `purge-state` after Sprint 2 Task 2.3. Later sprints peel further
-/// entries off.
-const STUB_SUBCOMMANDS: &[&str] = &["doctor", "gc-backups"];
+/// `purge-state` after Sprint 2 Task 2.3; `gc-backups` after Sprint 2
+/// Task 2.4. Later sprints peel further entries off.
+const STUB_SUBCOMMANDS: &[&str] = &["doctor"];
 
 #[test]
 fn version_prints_workspace_version() {

--- a/crates/agent-runtime-cli/tests/integration/gc_backups.rs
+++ b/crates/agent-runtime-cli/tests/integration/gc_backups.rs
@@ -1,0 +1,358 @@
+//! `agent-runtime gc-backups` integration tests. Plan 04 Sprint 2 Task 2.4.
+//!
+//! Drive the real binary against a seeded backup tree so the CLI flag
+//! shape, retention selection, `--tag`-marker preservation, and per-mode
+//! mutation contract stay pinned end-to-end.
+
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn run_gc(args: &[&str]) -> CmdOutput {
+    cmd::run(&agent_runtime_bin(), args, &[], None)
+}
+
+fn seed_run(state: &Path, product: &str, ts: u64, entry_id: &str) -> PathBuf {
+    let entry = state
+        .join("backups")
+        .join(product)
+        .join(ts.to_string())
+        .join(entry_id);
+    fs::create_dir_all(&entry).unwrap();
+    fs::write(entry.join("plugin.json"), format!("BACKUP-{product}-{ts}")).unwrap();
+    state.join("backups").join(product).join(ts.to_string())
+}
+
+fn seed_tag(state: &Path, product: &str, ts: u64, name: &str) {
+    let path = state
+        .join("backups")
+        .join(product)
+        .join(ts.to_string())
+        .join(format!("tag-{name}"));
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, b"").unwrap();
+}
+
+#[test]
+fn seven_runs_with_default_retention_five_keeps_five_in_apply() {
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path();
+    for ts in [100u64, 200, 300, 400, 500, 600, 700] {
+        seed_run(state_path, "claude", ts, "reporting");
+    }
+    let state = state_path.to_string_lossy().to_string();
+
+    let out = run_gc(&[
+        "gc-backups",
+        "--state-home",
+        &state,
+        "--product",
+        "claude",
+        "--apply",
+    ]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+
+    // Newest 5 stay on disk; oldest 2 deleted.
+    for keep in [300u64, 400, 500, 600, 700] {
+        assert!(
+            state_path
+                .join("backups/claude")
+                .join(keep.to_string())
+                .is_dir(),
+            "retained ts={keep}"
+        );
+    }
+    for gone in [100u64, 200] {
+        assert!(
+            !state_path
+                .join("backups/claude")
+                .join(gone.to_string())
+                .exists(),
+            "deleted ts={gone}"
+        );
+    }
+
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("retained=5") && stderr.contains("deleted=2"),
+        "summary line missing counts: {stderr}"
+    );
+}
+
+#[test]
+fn install_tag_marker_directory_is_preserved_outside_retention_window() {
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path();
+    for ts in [100u64, 200, 300, 400, 500, 600, 700] {
+        seed_run(state_path, "claude", ts, "reporting");
+    }
+    // Tag the OLDEST run — without preservation it would be the first
+    // deleted by default retention=5.
+    seed_tag(state_path, "claude", 100, "pre-bump");
+    let state = state_path.to_string_lossy().to_string();
+
+    let out = run_gc(&[
+        "gc-backups",
+        "--state-home",
+        &state,
+        "--product",
+        "claude",
+        "--apply",
+    ]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+
+    // Tagged dir survives.
+    assert!(
+        state_path.join("backups/claude/100").is_dir(),
+        "tagged run must survive"
+    );
+    // With 6 untagged + retention=5, exactly the next-oldest (200) goes.
+    assert!(!state_path.join("backups/claude/200").exists());
+    for keep in [300u64, 400, 500, 600, 700] {
+        assert!(
+            state_path
+                .join("backups/claude")
+                .join(keep.to_string())
+                .is_dir()
+        );
+    }
+}
+
+#[test]
+fn retention_three_apply_retains_exactly_three() {
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path();
+    for ts in [100u64, 200, 300, 400, 500] {
+        seed_run(state_path, "claude", ts, "reporting");
+    }
+    let state = state_path.to_string_lossy().to_string();
+
+    let out = run_gc(&[
+        "gc-backups",
+        "--state-home",
+        &state,
+        "--product",
+        "claude",
+        "--retention",
+        "3",
+        "--apply",
+    ]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+
+    let surviving: Vec<u64> = fs::read_dir(state_path.join("backups/claude"))
+        .unwrap()
+        .filter_map(|e| {
+            e.ok()
+                .and_then(|d| d.file_name().to_string_lossy().parse::<u64>().ok())
+        })
+        .collect();
+    let mut sorted = surviving.clone();
+    sorted.sort();
+    assert_eq!(sorted, vec![300, 400, 500], "kept newest 3 only");
+}
+
+#[test]
+fn dry_run_produces_zero_file_mutations() {
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path();
+    for ts in [100u64, 200, 300, 400, 500, 600, 700] {
+        seed_run(state_path, "claude", ts, "reporting");
+    }
+    let before: Vec<u64> = fs::read_dir(state_path.join("backups/claude"))
+        .unwrap()
+        .filter_map(|e| {
+            e.ok()
+                .and_then(|d| d.file_name().to_string_lossy().parse::<u64>().ok())
+        })
+        .collect();
+    let state = state_path.to_string_lossy().to_string();
+
+    let out = run_gc(&[
+        "gc-backups",
+        "--state-home",
+        &state,
+        "--product",
+        "claude",
+        "--dry-run",
+    ]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+
+    let after: Vec<u64> = fs::read_dir(state_path.join("backups/claude"))
+        .unwrap()
+        .filter_map(|e| {
+            e.ok()
+                .and_then(|d| d.file_name().to_string_lossy().parse::<u64>().ok())
+        })
+        .collect();
+    let mut before_sorted = before;
+    let mut after_sorted = after;
+    before_sorted.sort();
+    after_sorted.sort();
+    assert_eq!(
+        before_sorted, after_sorted,
+        "dry-run must not mutate the backup tree"
+    );
+
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("would-delete=2"),
+        "dry-run summary should report would-delete count: {stderr}"
+    );
+    assert!(
+        !stderr.contains("deleted="),
+        "dry-run must not emit a `deleted=` count: {stderr}"
+    );
+}
+
+#[test]
+fn surface_filter_only_sweeps_runs_with_that_entry_id() {
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path();
+    seed_run(state_path, "claude", 100, "reporting");
+    seed_run(state_path, "claude", 200, "skills");
+    seed_run(state_path, "claude", 300, "reporting");
+    let state = state_path.to_string_lossy().to_string();
+
+    let out = run_gc(&[
+        "gc-backups",
+        "--state-home",
+        &state,
+        "--product",
+        "claude",
+        "--surface",
+        "reporting",
+        "--retention",
+        "1",
+        "--apply",
+    ]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+
+    // ts=200 has no `reporting/` subdir — filter excludes it; survives.
+    assert!(
+        state_path.join("backups/claude/200").is_dir(),
+        "skills run unaffected by --surface reporting"
+    );
+    // Among reporting runs (100, 300), newest (300) kept, oldest (100) deleted.
+    assert!(state_path.join("backups/claude/300").is_dir());
+    assert!(!state_path.join("backups/claude/100").exists());
+}
+
+#[test]
+fn product_default_walks_both_claude_and_codex_subtrees() {
+    let tmp = TempDir::new().unwrap();
+    let state_path = tmp.path();
+    for ts in [100u64, 200, 300, 400, 500, 600] {
+        seed_run(state_path, "claude", ts, "reporting");
+    }
+    for ts in [10u64, 20, 30] {
+        seed_run(state_path, "codex", ts, "profile");
+    }
+    let state = state_path.to_string_lossy().to_string();
+
+    let out = run_gc(&["gc-backups", "--state-home", &state, "--apply"]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+
+    // claude: 6 runs → keep 5, delete 1 (ts=100).
+    assert!(!state_path.join("backups/claude/100").exists());
+    for keep in [200u64, 300, 400, 500, 600] {
+        assert!(
+            state_path
+                .join("backups/claude")
+                .join(keep.to_string())
+                .is_dir()
+        );
+    }
+    // codex: 3 runs (<= retention 5) → all kept.
+    for keep in [10u64, 20, 30] {
+        assert!(
+            state_path
+                .join("backups/codex")
+                .join(keep.to_string())
+                .is_dir()
+        );
+    }
+}
+
+#[test]
+fn missing_mode_flag_exits_nonzero_with_named_flags() {
+    let tmp = TempDir::new().unwrap();
+    let state = tmp.path().to_string_lossy().to_string();
+    let out = run_gc(&["gc-backups", "--state-home", &state, "--product", "claude"]);
+    assert_ne!(out.code, 0);
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("--dry-run") && stderr.contains("--apply"),
+        "stderr must name both modes: {stderr}"
+    );
+}
+
+#[test]
+fn relative_state_home_is_rejected() {
+    let out = run_gc(&[
+        "gc-backups",
+        "--state-home",
+        "./relative",
+        "--product",
+        "claude",
+        "--dry-run",
+    ]);
+    assert_ne!(out.code, 0);
+    assert!(out.stderr_text().contains("absolute"));
+}
+
+#[test]
+fn invalid_product_value_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let state = tmp.path().to_string_lossy().to_string();
+    let out = run_gc(&[
+        "gc-backups",
+        "--state-home",
+        &state,
+        "--product",
+        "anthropic",
+        "--apply",
+    ]);
+    assert_ne!(out.code, 0);
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("claude") && stderr.contains("codex"),
+        "stderr must enumerate valid products: {stderr}"
+    );
+}
+
+#[test]
+fn invalid_surface_with_path_separator_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let state = tmp.path().to_string_lossy().to_string();
+    let out = run_gc(&[
+        "gc-backups",
+        "--state-home",
+        &state,
+        "--product",
+        "claude",
+        "--surface",
+        "../escape",
+        "--apply",
+    ]);
+    assert_ne!(out.code, 0);
+    assert!(out.stderr_text().contains("--surface"));
+}
+
+#[test]
+fn empty_backup_root_is_clean_noop() {
+    let tmp = TempDir::new().unwrap();
+    let state = tmp.path().to_string_lossy().to_string();
+    let out = run_gc(&["gc-backups", "--state-home", &state, "--apply"]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("retained=0") && stderr.contains("deleted=0"),
+        "noop summary missing zero counts: {stderr}"
+    );
+}

--- a/crates/agent-runtime-cli/tests/integration/gc_backups.rs
+++ b/crates/agent-runtime-cli/tests/integration/gc_backups.rs
@@ -83,6 +83,16 @@ fn seven_runs_with_default_retention_five_keeps_five_in_apply() {
         stderr.contains("retained=5") && stderr.contains("deleted=2"),
         "summary line missing counts: {stderr}"
     );
+    // Stream discipline (Plan 04 Task 2.4 review T-6, mirror of Task 2.3
+    // R-1): the summary + per-change report must land on stderr only;
+    // stdout is reserved for future structured output.
+    let stdout = out.stdout_text();
+    assert!(
+        !stdout.contains("retained")
+            && !stdout.contains("deleted")
+            && !stdout.contains("would-delete"),
+        "summary leaked to stdout: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Lands Plan 04 Sprint 2 Task 2.4 — `agent-runtime gc-backups`. Prunes aged install backup runs under `<state_home>/backups/<product>/` with a default retention of 5 newest runs per (product, surface) bucket. `install --tag <name>` markers preserve a run regardless of where it falls in the timestamp ordering. `--surface <name>` filters the sweep to runs that touched a specific link-map entry. `gc-backups` is the only sanctioned retention enforcer — install never prunes silently. 15 specialist findings ran pre-merge; 3 (`S-1` / `T-4` / `T-6`) landed as a follow-up commit, 12 advisories defer to Sprint 3 / Sprint 4.

## Changes

- `src/gc_backups.rs` (new, ~720 lines) — `Mode { DryRun, Apply }`, `ProductFilter { All, One }`, `GcOptions { product, surface, retention }`, `GcError { Io, InvalidSurface }`, `GcChange { Retained, PreservedByTag, Deleted, WouldDelete }`, `GcOutcome { mode, retention, changes }`, `is_tag_marker(path) -> bool` (canonical tag-marker disambiguator per Task 1.3 F-3), `run(state_home, mode, options)`. 12 unit tests.
- `src/commands/gc_backups.rs` (new, ~128 lines) — `GcBackupsArgs { state_home, product, surface, retention, dry_run, apply }`. Rejects relative `--state-home`, missing `--dry-run` / `--apply`, invalid `--product`, and `--surface` with path separators.
- `src/lib.rs` — drop the `not implemented` stub; wire `Command::GcBackups(GcBackupsArgs)` through `commands::gc_backups::run`.
- `src/commands/mod.rs` — register the new module.
- `tests/integration.rs` — register `gc_backups` integration module.
- `tests/integration/cli.rs` — drop `gc-backups` from `STUB_SUBCOMMANDS`.
- `tests/integration/gc_backups.rs` (new, ~368 lines) — 11 integration tests covering all 4 plan acceptance criteria + filter combinations + error gates + stream discipline.

## Test-First Evidence

- Change classification: new feature (lifecycle subcommand body).
- Failing test before fix: the suite `tests/integration/cli.rs::every_stub_subcommand_exits_one_with_not_implemented_stderr` previously included `gc-backups` and asserted the stub stderr. Removing `gc-backups` from `STUB_SUBCOMMANDS` and not landing the body would now fail the new `tests/integration/gc_backups.rs` suite. The reverse-test pin lives in the integration `cli` module.
- Final validation: 23/23 gc-backups tests + 261/261 agent-runtime-cli suite + `scripts/ci/nils-cli-checks-entrypoint.sh` all green.
- Waiver reason: not applicable.

## Testing

- `cargo fmt --check`: pass
- `cargo clippy -p agent-runtime-cli --all-targets --all-features -- -D warnings`: pass
- `cargo nextest run -p agent-runtime-cli`: 261 / 261 pass
- `bash scripts/ci/nils-cli-checks-entrypoint.sh`: `ok: all nils-cli checks passed`

## Risk / Notes

- gc-backups deliberately uses NO link-map / NO overlay / NO managed-block machinery — sidesteps Task 2.1 F-2 (LinkMapPlan extraction), Task 2.2 R-2 (`merge_overlay` dedup), Task 2.2 R-11 (`ensure_parent_dir` dedup). Sprint 4 helper-duplication sweep is unaffected.
- `is_tag_marker` uses `symlink_metadata().file_type().is_file()` — a symlink (even pointing at a regular file) is NOT classified as a marker, so an attacker who can plant `tag-evil -> /anywhere/file` at a run root cannot force preservation. Pinned by `is_tag_marker_symlink_to_file_is_not_marker`.
- `<state_home>/backups/<product>` is similarly guarded: a symlinked product_root is refused, not traversed (defense-in-depth against bulk `remove_dir_all` redirection). Pinned by `product_root_symlink_is_refused_not_followed`.
- Specialist review summary (`code-review-specialists` over 1153 diff lines, single-agent + auto red-team): 15 findings total — 0 critical, 0 high, 3 medium (1 fixed pre-merge as `S-1` / `R-2`, 1 confirmed positive control as `info`, 1 by-design tag-DoS noted for Sprint 3 doctor probe), 11 low / info advisories deferred to Sprint 3 / Sprint 4 (helper-duplication sweep, audit-log durability, surface allowlist tightening, dead accessor cleanup). Full synthesis at `${CLAUDE_KIT_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/claude-kit}/out/task-2-4-review/SYNTHESIS.md`.
- 2 commits, both GPG-signed via op-ssh-sign:
  - `7f79442` — feat(plan-04): land Sprint 2 Task 2.4 — agent-runtime gc-backups
  - `e5cfdf0` — fix(plan-04): apply Task 2.4 specialist fixes S-1 + T-4 + T-6
- Next pickup after merge: Plan 04 Sprint 3 Task 3.1 (`agent-runtime doctor` symlink + managed-block + runtime-roots probes), which inherits Task 2.1 F-3 (orphaned-symlink probe) and Task 2.4 info-2 (`GcOutcome.mode/retention` consumer).
