### PR TITLE
Add doctor filesystem probes

### DIFF
--- a/crates/agent-runtime-cli/src/commands/doctor.rs
+++ b/crates/agent-runtime-cli/src/commands/doctor.rs
@@ -1,0 +1,106 @@
+use crate::doctor::{self, DoctorFinding, DoctorOptions, DoctorSeverity};
+use crate::render::manifest::SourceRoot;
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+pub struct DoctorArgs {
+    /// Source root containing `manifests/`, `core/`, `targets/`, `build/`.
+    /// Defaults to the current working directory.
+    #[arg(long)]
+    pub source_root: Option<PathBuf>,
+    /// Product to diagnose (`codex` or `claude`).
+    #[arg(long)]
+    pub product: String,
+    /// Absolute path of the runtime home to inspect. Defaults to the
+    /// product's `live_home` from `manifests/runtime-roots.yaml`.
+    #[arg(long)]
+    pub live_home: Option<PathBuf>,
+    /// Absolute path of the state home to inspect. Defaults to the
+    /// product's `state_home` from `manifests/runtime-roots.yaml`.
+    #[arg(long)]
+    pub state_home: Option<PathBuf>,
+    /// Skip the optional `.private/link-map.overrides.yaml` overlay
+    /// merge. Default: merge if file exists, matching install/uninstall.
+    #[arg(long, default_value_t = false)]
+    pub no_overlay: bool,
+    /// Override the overlay file location. When set, the conventional
+    /// `<source-root>/.private/link-map.overrides.yaml` is ignored.
+    #[arg(long, conflicts_with = "no_overlay")]
+    pub overlay_path: Option<PathBuf>,
+}
+
+pub fn run(args: DoctorArgs) -> anyhow::Result<u8> {
+    if let Some(path) = args.live_home.as_deref()
+        && !path.is_absolute()
+    {
+        anyhow::bail!(
+            "agent-runtime doctor: --live-home must be absolute (got: {}); pass an absolute path such as /tmp/claude-sandbox or $HOME/.claude",
+            path.display()
+        );
+    }
+    if let Some(path) = args.state_home.as_deref()
+        && !path.is_absolute()
+    {
+        anyhow::bail!(
+            "agent-runtime doctor: --state-home must be absolute (got: {})",
+            path.display()
+        );
+    }
+
+    let root = SourceRoot::from_arg_or_cwd(args.source_root.as_deref())?;
+    let options = DoctorOptions {
+        overlay_enabled: !args.no_overlay,
+        overlay_path: args.overlay_path.clone(),
+    };
+    let outcome = doctor::run(
+        &args.product,
+        root.path(),
+        args.live_home.as_deref(),
+        args.state_home.as_deref(),
+        &options,
+    )?;
+
+    if let Some(summary) = outcome.overlay.as_ref() {
+        eprintln!(
+            "agent-runtime doctor: overlay merged (dropped={} replaced={} added={})",
+            summary.dropped, summary.replaced, summary.added,
+        );
+    }
+
+    eprintln!(
+        "agent-runtime doctor: product={} checks={} ok={} warn={} block={}",
+        outcome.product,
+        outcome.total_checks(),
+        outcome.ok,
+        outcome.warn,
+        outcome.block,
+    );
+    for finding in &outcome.findings {
+        print_finding(finding);
+    }
+
+    Ok(outcome.exit_code())
+}
+
+fn print_finding(finding: &DoctorFinding) {
+    let severity = match finding.severity {
+        DoctorSeverity::Ok => "ok",
+        DoctorSeverity::Warn => "warn",
+        DoctorSeverity::Block => "block",
+    };
+    let path = finding
+        .path
+        .as_ref()
+        .map(|p| format!(" {}", p.display()))
+        .unwrap_or_default();
+    let entry = finding
+        .entry_id
+        .as_ref()
+        .map(|id| format!(" ({id})"))
+        .unwrap_or_default();
+    eprintln!(
+        "  {severity} {}{}{}: {}",
+        finding.check, entry, path, finding.message,
+    );
+}

--- a/crates/agent-runtime-cli/src/commands/mod.rs
+++ b/crates/agent-runtime-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit_drift;
+pub mod doctor;
 pub mod gc_backups;
 pub mod install;
 pub mod purge_state;

--- a/crates/agent-runtime-cli/src/doctor.rs
+++ b/crates/agent-runtime-cli/src/doctor.rs
@@ -268,7 +268,17 @@ fn resolve_runtime_roots(
     live_home_override: Option<&Path>,
     state_home_override: Option<&Path>,
 ) -> ResolvedRuntimeRoots {
-    let mut env: BTreeMap<String, String> = std::env::vars().collect();
+    let env: BTreeMap<String, String> = std::env::vars().collect();
+    resolve_runtime_roots_with_env(product, root, live_home_override, state_home_override, env)
+}
+
+fn resolve_runtime_roots_with_env(
+    product: &str,
+    root: &ProductRoot,
+    live_home_override: Option<&Path>,
+    state_home_override: Option<&Path>,
+    mut env: BTreeMap<String, String>,
+) -> ResolvedRuntimeRoots {
     if let Some(live_home) = live_home_override
         && product == "codex"
     {
@@ -285,10 +295,7 @@ fn resolve_runtime_roots(
     let state_home = state_home_override
         .map(Path::to_path_buf)
         .unwrap_or_else(|| PathBuf::from(expand_env_vars(&root.state_home, &env)));
-    let plugin_root = root
-        .plugin_root
-        .as_deref()
-        .map(|raw| resolve_product_path(product, raw, live_home_override, &env));
+    let plugin_root = resolve_plugin_root(product, root, live_home_override, &env);
 
     ResolvedRuntimeRoots {
         product: product.to_string(),
@@ -296,6 +303,24 @@ fn resolve_runtime_roots(
         docs_home,
         state_home,
         plugin_root,
+    }
+}
+
+fn resolve_plugin_root(
+    product: &str,
+    root: &ProductRoot,
+    live_home_override: Option<&Path>,
+    env: &BTreeMap<String, String>,
+) -> Option<PathBuf> {
+    if let Some(raw) = root.plugin_root.as_deref() {
+        return Some(resolve_product_path(product, raw, live_home_override, env));
+    }
+    let name = root.plugin_root_env.as_deref()?;
+    let value = env.get(name)?;
+    if value.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(value))
     }
 }
 
@@ -337,11 +362,11 @@ fn expand_env_vars(raw: &str, env: &BTreeMap<String, String>) -> String {
             continue;
         }
         if chars.get(i + 1) == Some(&'{')
-            && let Some(end) = chars[i + 2..].iter().position(|c| *c == '}')
+            && let Some(end) = find_matching_brace(&chars, i + 1)
         {
-            let expr: String = chars[i + 2..i + 2 + end].iter().collect();
+            let expr: String = chars[i + 2..end].iter().collect();
             out.push_str(&expand_braced_expr(&expr, env));
-            i += end + 3;
+            i = end + 1;
             continue;
         }
         let mut end = i + 1;
@@ -358,6 +383,26 @@ fn expand_env_vars(raw: &str, env: &BTreeMap<String, String>) -> String {
         i = end;
     }
     out
+}
+
+fn find_matching_brace(chars: &[char], open_brace: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut i = open_brace + 1;
+    while i < chars.len() {
+        if chars[i] == '$' && chars.get(i + 1) == Some(&'{') {
+            depth += 1;
+            i += 2;
+            continue;
+        }
+        if chars[i] == '}' {
+            if depth == 0 {
+                return Some(i);
+            }
+            depth -= 1;
+        }
+        i += 1;
+    }
+    None
 }
 
 fn expand_braced_expr(expr: &str, env: &BTreeMap<String, String>) -> String {
@@ -384,6 +429,69 @@ mod tests {
         assert_eq!(
             expand_env_vars("${CODEX_AGENT_STATE_HOME:-$HOME/.local/state}", &env),
             "/tmp/home/.local/state"
+        );
+    }
+
+    #[test]
+    fn env_expansion_supports_nested_braced_default_values() {
+        let mut env = BTreeMap::new();
+        env.insert("HOME".to_string(), "/tmp/home".to_string());
+        assert_eq!(
+            expand_env_vars(
+                "${CODEX_AGENT_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/codex}",
+                &env
+            ),
+            "/tmp/home/.local/state/agent-runtime-kit/codex"
+        );
+
+        env.insert("XDG_STATE_HOME".to_string(), "/tmp/state".to_string());
+        assert_eq!(
+            expand_env_vars(
+                "${CODEX_AGENT_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/codex}",
+                &env
+            ),
+            "/tmp/state/agent-runtime-kit/codex"
+        );
+
+        env.insert(
+            "CODEX_AGENT_STATE_HOME".to_string(),
+            "/tmp/codex-state".to_string(),
+        );
+        assert_eq!(
+            expand_env_vars(
+                "${CODEX_AGENT_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit/codex}",
+                &env
+            ),
+            "/tmp/codex-state"
+        );
+    }
+
+    #[test]
+    fn runtime_root_resolution_uses_plugin_root_env_when_set() {
+        let root = ProductRoot {
+            live_home: "$HOME/.claude".to_string(),
+            docs_home: "$HOME/.claude".to_string(),
+            state_home: "$HOME/.local/state/agent-runtime-kit/claude".to_string(),
+            plugin_root: None,
+            plugin_root_env: Some("CLAUDE_PLUGIN_ROOT".to_string()),
+            hook_config_strategy: None,
+            min_version: "0.0.0".to_string(),
+            recommended_version: "0.0.0".to_string(),
+            min_version_effective_from: "2099-01-01".to_string(),
+            version_probe: "claude --version".to_string(),
+        };
+        let mut env = BTreeMap::new();
+        env.insert("HOME".to_string(), "/tmp/home".to_string());
+        env.insert(
+            "CLAUDE_PLUGIN_ROOT".to_string(),
+            "/tmp/claude-plugin".to_string(),
+        );
+
+        let resolved = resolve_runtime_roots_with_env("claude", &root, None, None, env);
+
+        assert_eq!(
+            resolved.plugin_root,
+            Some(PathBuf::from("/tmp/claude-plugin"))
         );
     }
 }

--- a/crates/agent-runtime-cli/src/doctor.rs
+++ b/crates/agent-runtime-cli/src/doctor.rs
@@ -1,0 +1,389 @@
+//! Read-only `agent-runtime doctor` probes. Plan 04 Sprint 3 Task 3.1.
+//!
+//! This sprint covers filesystem posture only: link-map symlinks,
+//! managed-block marker pairing, and runtime-roots path readability.
+//! Version probes and upgrade suggestions land in later Sprint 3 tasks.
+
+pub mod probes;
+
+use crate::install::link_map::{LinkMap, LinkMapError};
+use crate::install::overlay::{self, LinkMapOverlay, OverlaySummary};
+use crate::install::plan::{InstallPlan, PlanError};
+use crate::render::manifest::{ProductRoot, RuntimeRootsManifest, SCHEMA_VERSION};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub struct DoctorOptions {
+    pub overlay_enabled: bool,
+    pub overlay_path: Option<PathBuf>,
+}
+
+impl Default for DoctorOptions {
+    fn default() -> Self {
+        Self {
+            overlay_enabled: true,
+            overlay_path: None,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DoctorError {
+    #[error("runtime-roots: {0}")]
+    RuntimeRoots(#[from] RuntimeRootsError),
+    #[error("link-map: {0}")]
+    LinkMap(#[from] LinkMapError),
+    #[error("plan: {0}")]
+    Plan(#[from] PlanError),
+    #[error("unknown product `{product}`; expected `codex` or `claude`")]
+    UnknownProduct { product: String },
+}
+
+#[derive(Debug, Error)]
+pub enum RuntimeRootsError {
+    #[error("missing runtime-roots manifest: {path}")]
+    Missing { path: PathBuf },
+    #[error("schema_version mismatch in {file}: expected {expected}, got {found}")]
+    SchemaVersion {
+        file: PathBuf,
+        expected: u32,
+        found: u32,
+    },
+    #[error("parse error in {file}: {source}")]
+    Parse {
+        file: PathBuf,
+        #[source]
+        source: serde_yaml_ng::Error,
+    },
+    #[error("io error reading {file}: {source}")]
+    Io {
+        file: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DoctorSeverity {
+    Ok,
+    Warn,
+    Block,
+}
+
+impl DoctorSeverity {
+    pub fn exit_code(self) -> u8 {
+        match self {
+            DoctorSeverity::Ok => 0,
+            DoctorSeverity::Warn => 1,
+            DoctorSeverity::Block => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DoctorFinding {
+    pub product: String,
+    pub check: &'static str,
+    pub severity: DoctorSeverity,
+    pub entry_id: Option<String>,
+    pub path: Option<PathBuf>,
+    pub message: String,
+}
+
+impl DoctorFinding {
+    pub fn warn(
+        product: &str,
+        check: &'static str,
+        entry_id: Option<String>,
+        path: Option<PathBuf>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            product: product.to_string(),
+            check,
+            severity: DoctorSeverity::Warn,
+            entry_id,
+            path,
+            message: message.into(),
+        }
+    }
+
+    pub fn block(
+        product: &str,
+        check: &'static str,
+        entry_id: Option<String>,
+        path: Option<PathBuf>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            product: product.to_string(),
+            check,
+            severity: DoctorSeverity::Block,
+            entry_id,
+            path,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedRuntimeRoots {
+    pub product: String,
+    pub live_home: PathBuf,
+    pub docs_home: PathBuf,
+    pub state_home: PathBuf,
+    pub plugin_root: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+pub struct DoctorOutcome {
+    pub product: String,
+    pub findings: Vec<DoctorFinding>,
+    pub ok: usize,
+    pub warn: usize,
+    pub block: usize,
+    pub overlay: Option<OverlaySummary>,
+}
+
+impl DoctorOutcome {
+    pub fn total_checks(&self) -> usize {
+        self.ok + self.warn + self.block
+    }
+
+    pub fn exit_code(&self) -> u8 {
+        if self.block > 0 {
+            DoctorSeverity::Block.exit_code()
+        } else if self.warn > 0 {
+            DoctorSeverity::Warn.exit_code()
+        } else {
+            DoctorSeverity::Ok.exit_code()
+        }
+    }
+}
+
+pub fn run(
+    product: &str,
+    source_root: &Path,
+    live_home_override: Option<&Path>,
+    state_home_override: Option<&Path>,
+    options: &DoctorOptions,
+) -> Result<DoctorOutcome, DoctorError> {
+    let runtime_roots = load_runtime_roots(source_root)?;
+    let product_root = product_root(&runtime_roots, product)?;
+    let resolved_roots = resolve_runtime_roots(
+        product,
+        product_root,
+        live_home_override,
+        state_home_override,
+    );
+
+    let mut link_map = LinkMap::load(source_root, product)?;
+    let mut overlay_summary = None;
+    if options.overlay_enabled {
+        let overlay_opt = match options.overlay_path.as_deref() {
+            Some(path) => LinkMapOverlay::load_from(path)?,
+            None => LinkMapOverlay::load_optional(source_root)?,
+        };
+        if let Some(overlay) = overlay_opt {
+            let summary = overlay::apply(&mut link_map, &overlay)?;
+            overlay_summary = Some(summary);
+        }
+    }
+
+    let plan = InstallPlan::build(
+        product,
+        source_root,
+        &resolved_roots.live_home,
+        &resolved_roots.state_home,
+        &link_map,
+    )?;
+
+    let mut report = probes::ProbeReport::default();
+    report.extend(probes::runtime_roots(&resolved_roots));
+    report.extend(probes::install_plan(product, &plan));
+
+    let warn = report
+        .findings
+        .iter()
+        .filter(|f| f.severity == DoctorSeverity::Warn)
+        .count();
+    let block = report
+        .findings
+        .iter()
+        .filter(|f| f.severity == DoctorSeverity::Block)
+        .count();
+
+    Ok(DoctorOutcome {
+        product: product.to_string(),
+        findings: report.findings,
+        ok: report.ok,
+        warn,
+        block,
+        overlay: overlay_summary,
+    })
+}
+
+fn load_runtime_roots(source_root: &Path) -> Result<RuntimeRootsManifest, RuntimeRootsError> {
+    let file = source_root.join("manifests").join("runtime-roots.yaml");
+    if !file.exists() {
+        return Err(RuntimeRootsError::Missing { path: file });
+    }
+    let raw = std::fs::read_to_string(&file).map_err(|source| RuntimeRootsError::Io {
+        file: file.clone(),
+        source,
+    })?;
+    let parsed: RuntimeRootsManifest =
+        serde_yaml_ng::from_str(&raw).map_err(|source| RuntimeRootsError::Parse {
+            file: file.clone(),
+            source,
+        })?;
+    if parsed.schema_version != SCHEMA_VERSION {
+        return Err(RuntimeRootsError::SchemaVersion {
+            file,
+            expected: SCHEMA_VERSION,
+            found: parsed.schema_version,
+        });
+    }
+    Ok(parsed)
+}
+
+fn product_root<'a>(
+    runtime_roots: &'a RuntimeRootsManifest,
+    product: &str,
+) -> Result<&'a ProductRoot, DoctorError> {
+    match product {
+        "codex" => Ok(&runtime_roots.products.codex),
+        "claude" => Ok(&runtime_roots.products.claude),
+        other => Err(DoctorError::UnknownProduct {
+            product: other.to_string(),
+        }),
+    }
+}
+
+fn resolve_runtime_roots(
+    product: &str,
+    root: &ProductRoot,
+    live_home_override: Option<&Path>,
+    state_home_override: Option<&Path>,
+) -> ResolvedRuntimeRoots {
+    let mut env: BTreeMap<String, String> = std::env::vars().collect();
+    if let Some(live_home) = live_home_override
+        && product == "codex"
+    {
+        env.insert(
+            "CODEX_HOME".to_string(),
+            live_home.to_string_lossy().into_owned(),
+        );
+    }
+
+    let live_home = live_home_override
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from(expand_env_vars(&root.live_home, &env)));
+    let docs_home = resolve_product_path(product, &root.docs_home, live_home_override, &env);
+    let state_home = state_home_override
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from(expand_env_vars(&root.state_home, &env)));
+    let plugin_root = root
+        .plugin_root
+        .as_deref()
+        .map(|raw| resolve_product_path(product, raw, live_home_override, &env));
+
+    ResolvedRuntimeRoots {
+        product: product.to_string(),
+        live_home,
+        docs_home,
+        state_home,
+        plugin_root,
+    }
+}
+
+fn resolve_product_path(
+    product: &str,
+    raw: &str,
+    live_home_override: Option<&Path>,
+    env: &BTreeMap<String, String>,
+) -> PathBuf {
+    if let Some(live_home) = live_home_override {
+        if product == "claude" {
+            if raw == "$HOME/.claude" {
+                return live_home.to_path_buf();
+            }
+            if let Some(rest) = raw.strip_prefix("$HOME/.claude/") {
+                return live_home.join(rest);
+            }
+        }
+        if product == "codex" {
+            if raw == "$CODEX_HOME" {
+                return live_home.to_path_buf();
+            }
+            if let Some(rest) = raw.strip_prefix("$CODEX_HOME/") {
+                return live_home.join(rest);
+            }
+        }
+    }
+    PathBuf::from(expand_env_vars(raw, env))
+}
+
+fn expand_env_vars(raw: &str, env: &BTreeMap<String, String>) -> String {
+    let chars: Vec<char> = raw.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] != '$' {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        if chars.get(i + 1) == Some(&'{')
+            && let Some(end) = chars[i + 2..].iter().position(|c| *c == '}')
+        {
+            let expr: String = chars[i + 2..i + 2 + end].iter().collect();
+            out.push_str(&expand_braced_expr(&expr, env));
+            i += end + 3;
+            continue;
+        }
+        let mut end = i + 1;
+        while end < chars.len() && (chars[end].is_ascii_alphanumeric() || chars[end] == '_') {
+            end += 1;
+        }
+        if end == i + 1 {
+            out.push('$');
+            i += 1;
+            continue;
+        }
+        let name: String = chars[i + 1..end].iter().collect();
+        out.push_str(env.get(&name).map(String::as_str).unwrap_or(""));
+        i = end;
+    }
+    out
+}
+
+fn expand_braced_expr(expr: &str, env: &BTreeMap<String, String>) -> String {
+    if let Some((name, fallback)) = expr.split_once(":-") {
+        if let Some(value) = env.get(name)
+            && !value.is_empty()
+        {
+            return value.clone();
+        }
+        expand_env_vars(fallback, env)
+    } else {
+        env.get(expr).cloned().unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_expansion_supports_nested_default_values() {
+        let mut env = BTreeMap::new();
+        env.insert("HOME".to_string(), "/tmp/home".to_string());
+        assert_eq!(
+            expand_env_vars("${CODEX_AGENT_STATE_HOME:-$HOME/.local/state}", &env),
+            "/tmp/home/.local/state"
+        );
+    }
+}

--- a/crates/agent-runtime-cli/src/doctor/probes.rs
+++ b/crates/agent-runtime-cli/src/doctor/probes.rs
@@ -1,0 +1,318 @@
+use super::{DoctorFinding, ResolvedRuntimeRoots};
+use crate::doctor::DoctorSeverity;
+use crate::install::link_map::CommentStyle;
+use crate::install::plan::{InstallPlan, PlanAction};
+use crate::managed_block::{CommentStyle as ManagedBlockStyle, ManagedBlock};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Default)]
+pub struct ProbeReport {
+    pub ok: usize,
+    pub findings: Vec<DoctorFinding>,
+}
+
+impl ProbeReport {
+    pub fn extend(&mut self, other: ProbeReport) {
+        self.ok += other.ok;
+        self.findings.extend(other.findings);
+    }
+
+    fn ok(&mut self) {
+        self.ok += 1;
+    }
+
+    fn push(&mut self, finding: DoctorFinding) {
+        self.findings.push(finding);
+    }
+}
+
+pub fn runtime_roots(roots: &ResolvedRuntimeRoots) -> ProbeReport {
+    let mut report = ProbeReport::default();
+    check_dir(
+        &mut report,
+        &roots.product,
+        "runtime-root.live_home",
+        &roots.live_home,
+        DoctorSeverity::Block,
+    );
+    check_dir(
+        &mut report,
+        &roots.product,
+        "runtime-root.docs_home",
+        &roots.docs_home,
+        DoctorSeverity::Warn,
+    );
+    check_dir(
+        &mut report,
+        &roots.product,
+        "runtime-root.state_home",
+        &roots.state_home,
+        DoctorSeverity::Warn,
+    );
+    if let Some(plugin_root) = roots.plugin_root.as_ref() {
+        check_dir(
+            &mut report,
+            &roots.product,
+            "runtime-root.plugin_root",
+            plugin_root,
+            DoctorSeverity::Warn,
+        );
+    }
+    report
+}
+
+pub fn install_plan(product: &str, plan: &InstallPlan) -> ProbeReport {
+    let mut report = ProbeReport::default();
+    for action in &plan.actions {
+        match action {
+            PlanAction::Symlink {
+                entry_id,
+                source,
+                dest,
+                requires_backup: _,
+            } => check_symlink(&mut report, product, entry_id, source, dest),
+            PlanAction::ManagedBlock {
+                entry_id,
+                config_file,
+                surface,
+                comment_style,
+                body: _,
+            } => check_managed_block(
+                &mut report,
+                product,
+                entry_id,
+                config_file,
+                surface,
+                *comment_style,
+            ),
+        }
+    }
+    report
+}
+
+fn check_dir(
+    report: &mut ProbeReport,
+    product: &str,
+    check: &'static str,
+    path: &Path,
+    missing_severity: DoctorSeverity,
+) {
+    if !path.is_absolute() {
+        report.push(finding_for_severity(
+            missing_severity,
+            product,
+            check,
+            None,
+            Some(path.to_path_buf()),
+            "runtime-root path is not absolute after environment expansion",
+        ));
+        return;
+    }
+
+    match fs::metadata(path) {
+        Ok(meta) if !meta.is_dir() => report.push(finding_for_severity(
+            missing_severity,
+            product,
+            check,
+            None,
+            Some(path.to_path_buf()),
+            "runtime-root path exists but is not a directory",
+        )),
+        Ok(_) => match fs::read_dir(path) {
+            Ok(_) => report.ok(),
+            Err(source) => report.push(finding_for_io(
+                missing_severity,
+                product,
+                check,
+                None,
+                path,
+                "runtime-root path is not readable",
+                source,
+            )),
+        },
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {
+            report.push(finding_for_severity(
+                missing_severity,
+                product,
+                check,
+                None,
+                Some(path.to_path_buf()),
+                "runtime-root path does not exist",
+            ));
+        }
+        Err(source) => report.push(finding_for_io(
+            missing_severity,
+            product,
+            check,
+            None,
+            path,
+            "runtime-root path could not be inspected",
+            source,
+        )),
+    }
+}
+
+fn check_symlink(
+    report: &mut ProbeReport,
+    product: &str,
+    entry_id: &str,
+    source: &Path,
+    dest: &Path,
+) {
+    if !source.exists() {
+        report.push(DoctorFinding::block(
+            product,
+            "link-map.symlink",
+            Some(entry_id.to_string()),
+            Some(source.to_path_buf()),
+            "tracked source file does not exist",
+        ));
+        return;
+    }
+
+    match fs::symlink_metadata(dest) {
+        Ok(meta) if !meta.file_type().is_symlink() => report.push(DoctorFinding::block(
+            product,
+            "link-map.symlink",
+            Some(entry_id.to_string()),
+            Some(dest.to_path_buf()),
+            "destination exists but is not a symlink",
+        )),
+        Ok(_) => match fs::read_link(dest) {
+            Ok(actual) if actual == source => report.ok(),
+            Ok(actual) => report.push(DoctorFinding::block(
+                product,
+                "link-map.symlink",
+                Some(entry_id.to_string()),
+                Some(dest.to_path_buf()),
+                format!(
+                    "destination points at {}; expected {}",
+                    actual.display(),
+                    source.display()
+                ),
+            )),
+            Err(source) => report.push(DoctorFinding::block(
+                product,
+                "link-map.symlink",
+                Some(entry_id.to_string()),
+                Some(dest.to_path_buf()),
+                format!("could not read symlink target: {source}"),
+            )),
+        },
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {
+            report.push(DoctorFinding::block(
+                product,
+                "link-map.symlink",
+                Some(entry_id.to_string()),
+                Some(dest.to_path_buf()),
+                "destination symlink is missing",
+            ));
+        }
+        Err(source) => report.push(DoctorFinding::block(
+            product,
+            "link-map.symlink",
+            Some(entry_id.to_string()),
+            Some(dest.to_path_buf()),
+            format!("could not inspect destination: {source}"),
+        )),
+    }
+}
+
+fn check_managed_block(
+    report: &mut ProbeReport,
+    product: &str,
+    entry_id: &str,
+    config_file: &Path,
+    surface: &str,
+    comment_style: CommentStyle,
+) {
+    let style = match comment_style {
+        CommentStyle::Hash => ManagedBlockStyle::Hash,
+        CommentStyle::DoubleSlash => ManagedBlockStyle::DoubleSlash,
+    };
+    let block = ManagedBlock::new(surface.to_string(), style);
+    let existing = match fs::read_to_string(config_file) {
+        Ok(text) => text,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {
+            report.push(DoctorFinding::block(
+                product,
+                "managed-block",
+                Some(entry_id.to_string()),
+                Some(config_file.to_path_buf()),
+                "config file is missing",
+            ));
+            return;
+        }
+        Err(source) => {
+            report.push(DoctorFinding::block(
+                product,
+                "managed-block",
+                Some(entry_id.to_string()),
+                Some(config_file.to_path_buf()),
+                format!("could not read config file: {source}"),
+            ));
+            return;
+        }
+    };
+
+    match block.read(&existing) {
+        Ok(Some(_)) => report.ok(),
+        Ok(None) => report.push(DoctorFinding::block(
+            product,
+            "managed-block",
+            Some(entry_id.to_string()),
+            Some(config_file.to_path_buf()),
+            format!("managed-block markers for surface `{surface}` are missing"),
+        )),
+        Err(source) => report.push(DoctorFinding::block(
+            product,
+            "managed-block",
+            Some(entry_id.to_string()),
+            Some(config_file.to_path_buf()),
+            source.to_string(),
+        )),
+    }
+}
+
+fn finding_for_io(
+    severity: DoctorSeverity,
+    product: &str,
+    check: &'static str,
+    entry_id: Option<String>,
+    path: &Path,
+    prefix: &str,
+    source: io::Error,
+) -> DoctorFinding {
+    finding_for_severity(
+        severity,
+        product,
+        check,
+        entry_id,
+        Some(path.to_path_buf()),
+        format!("{prefix}: {source}"),
+    )
+}
+
+fn finding_for_severity(
+    severity: DoctorSeverity,
+    product: &str,
+    check: &'static str,
+    entry_id: Option<String>,
+    path: Option<PathBuf>,
+    message: impl Into<String>,
+) -> DoctorFinding {
+    match severity {
+        DoctorSeverity::Ok => DoctorFinding {
+            product: product.to_string(),
+            check,
+            severity,
+            entry_id,
+            path,
+            message: message.into(),
+        },
+        DoctorSeverity::Warn => DoctorFinding::warn(product, check, entry_id, path, message),
+        DoctorSeverity::Block => DoctorFinding::block(product, check, entry_id, path, message),
+    }
+}

--- a/crates/agent-runtime-cli/src/lib.rs
+++ b/crates/agent-runtime-cli/src/lib.rs
@@ -22,6 +22,7 @@ use std::process::ExitCode;
 
 pub mod audit_drift;
 pub mod commands;
+pub mod doctor;
 pub mod gc_backups;
 pub mod install;
 pub mod managed_block;
@@ -50,7 +51,7 @@ pub enum Command {
     /// Remove installed renderer output from a product's runtime home.
     Uninstall(commands::uninstall::UninstallArgs),
     /// Diagnose host setup, runtime roots, and required CLI floors.
-    Doctor,
+    Doctor(commands::doctor::DoctorArgs),
     /// Detect source-vs-rendered, rendered-vs-live, and unsafe drift.
     AuditDrift(commands::audit_drift::AuditDriftArgs),
     /// Prune old backups under `<state_home>/backups/`.
@@ -67,7 +68,7 @@ impl Command {
             Command::Render(_) => "render",
             Command::Install(_) => "install",
             Command::Uninstall(_) => "uninstall",
-            Command::Doctor => "doctor",
+            Command::Doctor(_) => "doctor",
             Command::AuditDrift(_) => "audit-drift",
             Command::GcBackups(_) => "gc-backups",
             Command::RestoreBackups(_) => "restore-backups",
@@ -129,9 +130,12 @@ pub fn run() -> ExitCode {
                 ExitCode::from(2)
             }
         },
-        _ => {
-            eprintln!("agent-runtime {name}: not implemented");
-            ExitCode::from(1)
-        }
+        Command::Doctor(args) => match commands::doctor::run(args) {
+            Ok(code) => ExitCode::from(code),
+            Err(err) => {
+                eprintln!("agent-runtime {name}: {err:#}");
+                ExitCode::from(2)
+            }
+        },
     }
 }

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -9,6 +9,8 @@ mod audit_drift_classes;
 mod cli;
 #[path = "integration/determinism_gate.rs"]
 mod determinism_gate;
+#[path = "integration/doctor_filesystem.rs"]
+mod doctor_filesystem;
 #[path = "integration/gc_backups.rs"]
 mod gc_backups;
 #[path = "integration/install_flags.rs"]

--- a/crates/agent-runtime-cli/tests/integration/cli.rs
+++ b/crates/agent-runtime-cli/tests/integration/cli.rs
@@ -23,11 +23,9 @@ const ALL_SUBCOMMANDS: &[&str] = &[
 ];
 
 /// Subcommands whose body still prints `not implemented` and exits 1.
-/// `render` / `install` left after Plan 04 Sprint 1; `uninstall` after
-/// Sprint 2 Task 2.1; `restore-backups` after Sprint 2 Task 2.2;
-/// `purge-state` after Sprint 2 Task 2.3; `gc-backups` after Sprint 2
-/// Task 2.4. Later sprints peel further entries off.
-const STUB_SUBCOMMANDS: &[&str] = &["doctor"];
+/// All root `agent-runtime` subcommands have an owned body as of Plan 04
+/// Sprint 3 Task 3.1.
+const STUB_SUBCOMMANDS: &[&str] = &[];
 
 #[test]
 fn version_prints_workspace_version() {

--- a/crates/agent-runtime-cli/tests/integration/doctor_filesystem.rs
+++ b/crates/agent-runtime-cli/tests/integration/doctor_filesystem.rs
@@ -1,0 +1,216 @@
+//! Integration coverage for Plan 04 Sprint 3 Task 3.1 doctor probes.
+
+use agent_runtime_cli::doctor::{self, DoctorOptions, DoctorSeverity};
+use agent_runtime_cli::install::{self, InstallOptions, Mode};
+use agent_runtime_cli::managed_block::{CommentStyle, ManagedBlock};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use tempfile::TempDir;
+
+fn fixed_time() -> SystemTime {
+    SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000)
+}
+
+fn build_source_root(tmp: &Path, product: &str, home: &Path, state_home: &Path) -> PathBuf {
+    let root = tmp.join("src");
+    fs::create_dir_all(root.join("manifests")).unwrap();
+
+    let skill = root
+        .join("build")
+        .join(product)
+        .join("plugins")
+        .join("reporting")
+        .join("skills")
+        .join("daily-brief")
+        .join("SKILL.md");
+    fs::create_dir_all(skill.parent().unwrap()).unwrap();
+    fs::write(&skill, "# daily-brief\n").unwrap();
+
+    let target_dir = root.join("targets").join(product);
+    fs::create_dir_all(&target_dir).unwrap();
+    fs::write(
+        target_dir.join("link-map.yaml"),
+        format!(
+            "\
+schema_version: 1
+entries:
+  - id: reporting.daily-brief
+    kind: symlinked-file
+    source: build/{product}/plugins/reporting/skills/daily-brief/SKILL.md
+    destination: plugins/reporting/skills/daily-brief/SKILL.md
+  - id: {product}.hooks
+    kind: managed-block
+    destination: settings.json
+    surface: hooks
+    comment_style: double-slash
+    body_template: '\"hooks\": []'
+",
+        ),
+    )
+    .unwrap();
+
+    let runtime_roots = format!(
+        "\
+schema_version: 1
+products:
+  codex:
+    live_home: \"{home}\"
+    docs_home: \"{home}\"
+    state_home: \"{state_home}\"
+    plugin_root: \"{home}/plugins\"
+    hook_config_strategy: managed-block
+    min_version: \"0.0.0\"
+    recommended_version: \"0.0.0\"
+    min_version_effective_from: \"2099-01-01\"
+    version_probe: \"codex --version\"
+  claude:
+    live_home: \"{home}\"
+    docs_home: \"{home}\"
+    state_home: \"{state_home}\"
+    hook_config_strategy: settings-json
+    min_version: \"0.0.0\"
+    recommended_version: \"0.0.0\"
+    min_version_effective_from: \"2099-01-01\"
+    version_probe: \"claude --version\"
+",
+        home = home.display(),
+        state_home = state_home.display(),
+    );
+    fs::write(
+        root.join("manifests").join("runtime-roots.yaml"),
+        runtime_roots,
+    )
+    .unwrap();
+
+    fs::canonicalize(&root).unwrap()
+}
+
+fn install_clean(product: &str, source_root: &Path, home: &Path, state_home: &Path) {
+    install::run(
+        product,
+        source_root,
+        home,
+        state_home,
+        Mode::Apply,
+        fixed_time(),
+        &InstallOptions::default(),
+    )
+    .unwrap();
+}
+
+fn run_doctor(
+    product: &str,
+    source_root: &Path,
+    home: &Path,
+    state_home: &Path,
+) -> doctor::DoctorOutcome {
+    doctor::run(
+        product,
+        source_root,
+        Some(home),
+        Some(state_home),
+        &DoctorOptions::default(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn clean_install_produces_zero_findings_and_exit_zero() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&state_home).unwrap();
+    let source_root = build_source_root(tmp.path(), "claude", &home, &state_home);
+
+    install_clean("claude", &source_root, &home, &state_home);
+
+    let outcome = run_doctor("claude", &source_root, &home, &state_home);
+    assert_eq!(outcome.exit_code(), 0);
+    assert_eq!(outcome.findings, Vec::new());
+    assert!(outcome.ok > 0, "doctor should count successful probes");
+}
+
+#[test]
+fn broken_tracked_symlink_blocks_and_exits_two() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&state_home).unwrap();
+    let source_root = build_source_root(tmp.path(), "claude", &home, &state_home);
+
+    install_clean("claude", &source_root, &home, &state_home);
+    fs::remove_file(
+        home.join("plugins")
+            .join("reporting")
+            .join("skills")
+            .join("daily-brief")
+            .join("SKILL.md"),
+    )
+    .unwrap();
+
+    let outcome = run_doctor("claude", &source_root, &home, &state_home);
+    assert_eq!(outcome.exit_code(), 2);
+    assert!(
+        outcome.findings.iter().any(|finding| {
+            finding.severity == DoctorSeverity::Block
+                && finding.check == "link-map.symlink"
+                && finding.entry_id.as_deref() == Some("reporting.daily-brief")
+        }),
+        "expected broken symlink block finding: {:#?}",
+        outcome.findings
+    );
+}
+
+#[test]
+fn unbalanced_managed_block_marker_blocks_and_exits_two() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&state_home).unwrap();
+    let source_root = build_source_root(tmp.path(), "claude", &home, &state_home);
+
+    install_clean("claude", &source_root, &home, &state_home);
+    let config = home.join("settings.json");
+    let block = ManagedBlock::new("hooks", CommentStyle::DoubleSlash);
+    let edited = fs::read_to_string(&config)
+        .unwrap()
+        .replace(&(block.close_marker() + "\n"), "");
+    fs::write(&config, edited).unwrap();
+
+    let outcome = run_doctor("claude", &source_root, &home, &state_home);
+    assert_eq!(outcome.exit_code(), 2);
+    assert!(
+        outcome.findings.iter().any(|finding| {
+            finding.severity == DoctorSeverity::Block
+                && finding.check == "managed-block"
+                && finding.message.contains("unbalanced")
+        }),
+        "expected unbalanced managed-block finding: {:#?}",
+        outcome.findings
+    );
+}
+
+#[test]
+fn missing_state_home_warns_and_exits_one() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&home).unwrap();
+    let source_root = build_source_root(tmp.path(), "claude", &home, &state_home);
+
+    install_clean("claude", &source_root, &home, &state_home);
+
+    let outcome = run_doctor("claude", &source_root, &home, &state_home);
+    assert_eq!(outcome.exit_code(), 1);
+    assert!(
+        outcome.findings.iter().any(|finding| {
+            finding.severity == DoctorSeverity::Warn && finding.check == "runtime-root.state_home"
+        }),
+        "expected missing state_home warning: {:#?}",
+        outcome.findings
+    );
+}


### PR DESCRIPTION
# Add doctor filesystem probes

## Summary

Adds the Plan 04 Sprint 3 Task 3.1 `agent-runtime doctor` body for read-only filesystem posture checks. The command now inspects a selected product's runtime home against `runtime-roots.yaml`, the effective link map, and managed-block marker pairs, then returns the documented 0 / 1 / 2 severity exit policy.

Tracks graysurf/agent-runtime-kit#3.

## Changes

- Wire `agent-runtime doctor --product <codex|claude>` through a new command wrapper and library module.
- Reuse runtime-roots parsing, link-map overlay merge, install-plan expansion, and managed-block marker validation for read-only probes.
- Report blocking findings for broken tracked symlinks and unbalanced or missing managed blocks, and warnings for missing readable state/docs/plugin roots.
- Add Task 3.1 integration coverage for clean installs, broken symlinks, unbalanced markers, and missing `state_home` warnings.

## Test-First Evidence

- Change classification: feature / behavior change
- Failing test before fix: not captured; `doctor` was a stub and this task introduced the new acceptance test target with the implementation.
- Final validation: `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` passed; coverage 85.40%.
- Waiver reason: no pre-existing `doctor_filesystem` target existed before Task 3.1, so validation was substituted with focused and full gates after adding the new tests.

## Testing

- `cargo test -p agent-runtime-cli doctor_filesystem` (pass)
- `cargo test -p agent-runtime-cli` (pass)
- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` (pass)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` (pass; 85.40% line coverage)

## Risk / Notes

- Scope is intentionally limited to Task 3.1 filesystem probes; version probes, `--suggest-upgrade`, `--check-project`, and CLI coverage remain in Tasks 3.2 and 3.3.
