### PR TITLE
Plan 04: add doctor upgrade coverage

### DIFF
--- a/crates/agent-runtime-cli/src/commands/doctor.rs
+++ b/crates/agent-runtime-cli/src/commands/doctor.rs
@@ -1,4 +1,4 @@
-use crate::doctor::{self, DoctorFinding, DoctorOptions, DoctorSeverity};
+use crate::doctor::{self, DoctorFinding, DoctorOptions, DoctorSeverity, upgrade};
 use crate::render::manifest::SourceRoot;
 use clap::Args;
 use std::path::PathBuf;
@@ -28,6 +28,15 @@ pub struct DoctorArgs {
     /// `<source-root>/.private/link-map.overrides.yaml` is ignored.
     #[arg(long, conflicts_with = "no_overlay")]
     pub overlay_path: Option<PathBuf>,
+    /// Active cli-tools profile to check.
+    #[arg(long, default_value = "recommended")]
+    pub profile: String,
+    /// Print copy-pasteable Homebrew upgrade commands for non-ok probes.
+    #[arg(long, default_value_t = false)]
+    pub suggest_upgrade: bool,
+    /// Inspect a consuming repo's `.agents/scripts/` project-local overlays.
+    #[arg(long)]
+    pub check_project: Option<PathBuf>,
 }
 
 pub fn run(args: DoctorArgs) -> anyhow::Result<u8> {
@@ -52,6 +61,8 @@ pub fn run(args: DoctorArgs) -> anyhow::Result<u8> {
     let options = DoctorOptions {
         overlay_enabled: !args.no_overlay,
         overlay_path: args.overlay_path.clone(),
+        cli_tools_profile: args.profile.clone(),
+        check_project: args.check_project.clone(),
     };
     let outcome = doctor::run(
         &args.product,
@@ -90,8 +101,44 @@ pub fn run(args: DoctorArgs) -> anyhow::Result<u8> {
             probe.command,
         );
     }
+    for probe in &outcome.coverage_probes {
+        let parsed = probe.parsed_version.as_deref().unwrap_or("unknown");
+        let required = probe.required_version.as_deref().unwrap_or("n/a");
+        eprintln!(
+            "  {} {} status={} name={} command=`{}` required={} parsed={}",
+            match probe.severity {
+                DoctorSeverity::Ok => "ok",
+                DoctorSeverity::Warn => "warn",
+                DoctorSeverity::Block => "block",
+            },
+            probe.kind.check(),
+            probe.status.as_str(),
+            probe.name,
+            probe.command,
+            required,
+            parsed,
+        );
+    }
+    for probe in &outcome.project_probes {
+        eprintln!(
+            "  {} project-overlay status={} script={} path={}",
+            match probe.severity {
+                DoctorSeverity::Ok => "ok",
+                DoctorSeverity::Warn => "warn",
+                DoctorSeverity::Block => "block",
+            },
+            probe.status.as_str(),
+            probe.script,
+            probe.path.display(),
+        );
+    }
     for finding in &outcome.findings {
         print_finding(finding);
+    }
+    if args.suggest_upgrade {
+        for suggestion in upgrade::suggestions(&outcome) {
+            println!("{}", suggestion.command);
+        }
     }
 
     Ok(outcome.exit_code())

--- a/crates/agent-runtime-cli/src/doctor.rs
+++ b/crates/agent-runtime-cli/src/doctor.rs
@@ -4,7 +4,10 @@
 //! managed-block marker pairing, runtime-roots path readability, and
 //! product version posture.
 
+pub mod coverage;
 pub mod probes;
+pub mod project;
+pub mod upgrade;
 pub mod version;
 
 use crate::install::link_map::{LinkMap, LinkMapError};
@@ -19,6 +22,8 @@ use thiserror::Error;
 pub struct DoctorOptions {
     pub overlay_enabled: bool,
     pub overlay_path: Option<PathBuf>,
+    pub cli_tools_profile: String,
+    pub check_project: Option<PathBuf>,
 }
 
 impl Default for DoctorOptions {
@@ -26,6 +31,8 @@ impl Default for DoctorOptions {
         Self {
             overlay_enabled: true,
             overlay_path: None,
+            cli_tools_profile: "recommended".to_string(),
+            check_project: None,
         }
     }
 }
@@ -38,6 +45,8 @@ pub enum DoctorError {
     LinkMap(#[from] LinkMapError),
     #[error("plan: {0}")]
     Plan(#[from] PlanError),
+    #[error("coverage: {0}")]
+    Coverage(#[from] coverage::CoverageError),
     #[error("unknown product `{product}`; expected `codex` or `claude`")]
     UnknownProduct { product: String },
 }
@@ -143,6 +152,8 @@ pub struct DoctorOutcome {
     pub product: String,
     pub findings: Vec<DoctorFinding>,
     pub version_probes: Vec<version::VersionProbeFinding>,
+    pub coverage_probes: Vec<coverage::CoverageFinding>,
+    pub project_probes: Vec<project::ProjectOverlayFinding>,
     pub ok: usize,
     pub warn: usize,
     pub block: usize,
@@ -212,6 +223,28 @@ pub fn run(
             report.findings.push(version_probe.to_doctor_finding());
         }
     }
+    let coverage_probes = coverage::probe(source_root, &options.cli_tools_profile)?;
+    for probe in &coverage_probes {
+        match probe.severity {
+            DoctorSeverity::Ok => report.ok += 1,
+            DoctorSeverity::Warn | DoctorSeverity::Block => {
+                report.findings.push(probe.to_doctor_finding(product));
+            }
+        }
+    }
+    let project_probes = options
+        .check_project
+        .as_deref()
+        .map(project::probe_project)
+        .unwrap_or_default();
+    for probe in &project_probes {
+        match probe.severity {
+            DoctorSeverity::Ok => report.ok += 1,
+            DoctorSeverity::Warn | DoctorSeverity::Block => {
+                report.findings.push(probe.to_doctor_finding(product));
+            }
+        }
+    }
 
     let warn = report
         .findings
@@ -228,6 +261,8 @@ pub fn run(
         product: product.to_string(),
         findings: report.findings,
         version_probes: vec![version_probe],
+        coverage_probes,
+        project_probes,
         ok: report.ok,
         warn,
         block,

--- a/crates/agent-runtime-cli/src/doctor/coverage.rs
+++ b/crates/agent-runtime-cli/src/doctor/coverage.rs
@@ -1,0 +1,425 @@
+//! Required CLI and third-party tool coverage for `agent-runtime doctor`.
+
+use super::{DoctorFinding, DoctorSeverity};
+use crate::doctor::version::{self, Version};
+use crate::render::manifest::{CliToolsManifest, SCHEMA_VERSION, SkillsManifest};
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CoverageError {
+    #[error("missing manifest: {path}")]
+    Missing { path: PathBuf },
+    #[error("schema_version mismatch in {file}: expected {expected}, got {found}")]
+    SchemaVersion {
+        file: PathBuf,
+        expected: u32,
+        found: u32,
+    },
+    #[error("parse error in {file}: {source}")]
+    Parse {
+        file: PathBuf,
+        #[source]
+        source: serde_yaml_ng::Error,
+    },
+    #[error("io error reading {file}: {source}")]
+    Io {
+        file: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("unknown cli-tools profile `{profile}`; expected core, recommended, or full")]
+    UnknownProfile { profile: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverageKind {
+    RequiredCli,
+    CliTool,
+}
+
+impl CoverageKind {
+    pub fn check(self) -> &'static str {
+        match self {
+            CoverageKind::RequiredCli => "required-cli",
+            CoverageKind::CliTool => "cli-tool",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverageStatus {
+    Ok,
+    Missing,
+    Outdated,
+    Unparseable,
+}
+
+impl CoverageStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CoverageStatus::Ok => "ok",
+            CoverageStatus::Missing => "missing",
+            CoverageStatus::Outdated => "outdated",
+            CoverageStatus::Unparseable => "unparseable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoverageFinding {
+    pub kind: CoverageKind,
+    pub name: String,
+    pub command: String,
+    pub status: CoverageStatus,
+    pub severity: DoctorSeverity,
+    pub required_version: Option<String>,
+    pub parsed_version: Option<String>,
+    pub formula: Option<String>,
+    pub message: String,
+}
+
+impl CoverageFinding {
+    pub fn to_doctor_finding(&self, product: &str) -> DoctorFinding {
+        let mut message = format!("status={} command=`{}`", self.status.as_str(), self.command);
+        if let Some(required) = self.required_version.as_deref() {
+            message.push_str(&format!(" required={required}"));
+        }
+        if let Some(parsed) = self.parsed_version.as_deref() {
+            message.push_str(&format!(" parsed={parsed}"));
+        }
+        if let Some(formula) = self.formula.as_deref() {
+            message.push_str(&format!(" upgrade=`brew upgrade {formula}`"));
+        }
+        if !self.message.is_empty() {
+            message.push_str(&format!(": {}", self.message));
+        }
+
+        match self.severity {
+            DoctorSeverity::Ok => DoctorFinding {
+                product: product.to_string(),
+                check: self.kind.check(),
+                severity: DoctorSeverity::Ok,
+                entry_id: Some(self.name.clone()),
+                path: None,
+                message,
+            },
+            DoctorSeverity::Warn => DoctorFinding::warn(
+                product,
+                self.kind.check(),
+                Some(self.name.clone()),
+                None,
+                message,
+            ),
+            DoctorSeverity::Block => DoctorFinding::block(
+                product,
+                self.kind.check(),
+                Some(self.name.clone()),
+                None,
+                message,
+            ),
+        }
+    }
+}
+
+pub fn probe(source_root: &Path, profile: &str) -> Result<Vec<CoverageFinding>, CoverageError> {
+    let skills: SkillsManifest = load_manifest(&source_root.join("manifests").join("skills.yaml"))?;
+    let cli_tools: CliToolsManifest =
+        load_manifest(&source_root.join("manifests").join("cli-tools.yaml"))?;
+
+    let mut findings = Vec::new();
+    for (binary, floor) in required_cli_floors(&skills) {
+        findings.push(probe_required_cli(&binary, &floor));
+    }
+    for key in profile_tools(&cli_tools, profile)? {
+        let Some(formula) = cli_tools.formulas.get(key) else {
+            findings.push(CoverageFinding {
+                kind: CoverageKind::CliTool,
+                name: key.to_string(),
+                command: key.to_string(),
+                status: CoverageStatus::Missing,
+                severity: DoctorSeverity::Warn,
+                required_version: None,
+                parsed_version: None,
+                formula: None,
+                message: "profile references a formula key that is not declared".to_string(),
+            });
+            continue;
+        };
+        findings.push(probe_cli_tool(
+            key,
+            formula.command.as_str(),
+            formula.brew.as_str(),
+        ));
+    }
+    Ok(findings)
+}
+
+fn load_manifest<T>(file: &Path) -> Result<T, CoverageError>
+where
+    T: for<'de> serde::Deserialize<'de> + SchemaVersion,
+{
+    if !file.exists() {
+        return Err(CoverageError::Missing {
+            path: file.to_path_buf(),
+        });
+    }
+    let raw = std::fs::read_to_string(file).map_err(|source| CoverageError::Io {
+        file: file.to_path_buf(),
+        source,
+    })?;
+    let parsed: T = serde_yaml_ng::from_str(&raw).map_err(|source| CoverageError::Parse {
+        file: file.to_path_buf(),
+        source,
+    })?;
+    if parsed.schema_version() != SCHEMA_VERSION {
+        return Err(CoverageError::SchemaVersion {
+            file: file.to_path_buf(),
+            expected: SCHEMA_VERSION,
+            found: parsed.schema_version(),
+        });
+    }
+    Ok(parsed)
+}
+
+trait SchemaVersion {
+    fn schema_version(&self) -> u32;
+}
+
+impl SchemaVersion for SkillsManifest {
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+}
+
+impl SchemaVersion for CliToolsManifest {
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+}
+
+fn required_cli_floors(skills: &SkillsManifest) -> BTreeMap<String, String> {
+    let mut floors: BTreeMap<String, String> = BTreeMap::new();
+    for skill in &skills.skills {
+        for (binary, floor) in &skill.required_clis {
+            match floors.get(binary.as_str()) {
+                Some(existing) if floor_cmp(floor, existing).is_le() => {}
+                _ => {
+                    floors.insert(binary.clone(), floor.clone());
+                }
+            }
+        }
+    }
+    floors
+}
+
+fn floor_cmp(left: &str, right: &str) -> std::cmp::Ordering {
+    match (Version::parse(left), Version::parse(right)) {
+        (Some(left), Some(right)) => left.cmp(&right),
+        _ => left.cmp(right),
+    }
+}
+
+fn profile_tools<'a>(
+    cli_tools: &'a CliToolsManifest,
+    profile: &str,
+) -> Result<&'a [String], CoverageError> {
+    match profile {
+        "core" => Ok(&cli_tools.profiles.core),
+        "recommended" => Ok(&cli_tools.profiles.recommended),
+        "full" => Ok(&cli_tools.profiles.full),
+        _ => Err(CoverageError::UnknownProfile {
+            profile: profile.to_string(),
+        }),
+    }
+}
+
+fn probe_required_cli(binary: &str, floor: &str) -> CoverageFinding {
+    if find_in_path(binary).is_none() {
+        return CoverageFinding {
+            kind: CoverageKind::RequiredCli,
+            name: binary.to_string(),
+            command: binary.to_string(),
+            status: CoverageStatus::Missing,
+            severity: DoctorSeverity::Block,
+            required_version: Some(floor.to_string()),
+            parsed_version: None,
+            formula: Some("nils-cli".to_string()),
+            message: "required nils-cli binary is not on PATH".to_string(),
+        };
+    }
+
+    let raw = version::run_probe_command(&format!("{binary} --version"));
+    let Some(parsed) = Version::parse(&raw) else {
+        return CoverageFinding {
+            kind: CoverageKind::RequiredCli,
+            name: binary.to_string(),
+            command: binary.to_string(),
+            status: CoverageStatus::Unparseable,
+            severity: DoctorSeverity::Warn,
+            required_version: Some(floor.to_string()),
+            parsed_version: None,
+            formula: Some("nils-cli".to_string()),
+            message: format!("version output could not be parsed: {raw:?}"),
+        };
+    };
+    let Some(required) = Version::parse(floor) else {
+        return CoverageFinding {
+            kind: CoverageKind::RequiredCli,
+            name: binary.to_string(),
+            command: binary.to_string(),
+            status: CoverageStatus::Unparseable,
+            severity: DoctorSeverity::Warn,
+            required_version: Some(floor.to_string()),
+            parsed_version: Some(parsed.to_string()),
+            formula: Some("nils-cli".to_string()),
+            message: "required_clis floor could not be parsed".to_string(),
+        };
+    };
+
+    if parsed < required {
+        CoverageFinding {
+            kind: CoverageKind::RequiredCli,
+            name: binary.to_string(),
+            command: binary.to_string(),
+            status: CoverageStatus::Outdated,
+            severity: DoctorSeverity::Warn,
+            required_version: Some(floor.to_string()),
+            parsed_version: Some(parsed.to_string()),
+            formula: Some("nils-cli".to_string()),
+            message: "installed nils-cli binary is below the declared floor".to_string(),
+        }
+    } else {
+        CoverageFinding {
+            kind: CoverageKind::RequiredCli,
+            name: binary.to_string(),
+            command: binary.to_string(),
+            status: CoverageStatus::Ok,
+            severity: DoctorSeverity::Ok,
+            required_version: Some(floor.to_string()),
+            parsed_version: Some(parsed.to_string()),
+            formula: Some("nils-cli".to_string()),
+            message: "installed nils-cli binary meets the declared floor".to_string(),
+        }
+    }
+}
+
+fn probe_cli_tool(key: &str, command: &str, brew_formula: &str) -> CoverageFinding {
+    if find_in_path(command).is_none() {
+        return CoverageFinding {
+            kind: CoverageKind::CliTool,
+            name: key.to_string(),
+            command: command.to_string(),
+            status: CoverageStatus::Missing,
+            severity: DoctorSeverity::Warn,
+            required_version: None,
+            parsed_version: None,
+            formula: Some(brew_formula.to_string()),
+            message: format!(
+                "cli-tools binary is not on PATH; install with `brew install {brew_formula}`"
+            ),
+        };
+    }
+
+    if brew_reports_outdated(brew_formula) {
+        CoverageFinding {
+            kind: CoverageKind::CliTool,
+            name: key.to_string(),
+            command: command.to_string(),
+            status: CoverageStatus::Outdated,
+            severity: DoctorSeverity::Warn,
+            required_version: None,
+            parsed_version: None,
+            formula: Some(brew_formula.to_string()),
+            message: "Homebrew reports a newer formula is available".to_string(),
+        }
+    } else {
+        CoverageFinding {
+            kind: CoverageKind::CliTool,
+            name: key.to_string(),
+            command: command.to_string(),
+            status: CoverageStatus::Ok,
+            severity: DoctorSeverity::Ok,
+            required_version: None,
+            parsed_version: None,
+            formula: Some(brew_formula.to_string()),
+            message: "cli-tools binary is on PATH".to_string(),
+        }
+    }
+}
+
+fn brew_reports_outdated(formula: &str) -> bool {
+    if find_in_path("brew").is_none() {
+        return false;
+    }
+    let raw = version::run_probe_command(&format!("brew outdated --quiet {formula}"));
+    raw.lines().any(|line| line.trim() == formula)
+}
+
+fn find_in_path(program: &str) -> Option<PathBuf> {
+    if program.contains('/') || program.contains('\\') {
+        let path = PathBuf::from(program);
+        return is_executable_file(&path).then_some(path);
+    }
+    let path_var = std::env::var_os("PATH")?;
+    let windows_extensions = if cfg!(windows) {
+        Some(windows_pathext_extensions())
+    } else {
+        None
+    };
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(program);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+        if let Some(extensions) = windows_extensions.as_ref() {
+            for extension in extensions {
+                let mut file_name = OsString::from(program);
+                file_name.push(extension);
+                let candidate = dir.join(file_name);
+                if is_executable_file(&candidate) {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn windows_pathext_extensions() -> Vec<OsString> {
+    let raw = std::env::var_os("PATHEXT")
+        .unwrap_or_else(|| OsString::from(".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH"));
+    raw.to_string_lossy()
+        .split(';')
+        .filter_map(|segment| {
+            let segment = segment.trim();
+            if segment.is_empty() {
+                None
+            } else if segment.starts_with('.') {
+                Some(OsString::from(segment))
+            } else {
+                Some(OsString::from(format!(".{segment}")))
+            }
+        })
+        .collect()
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}

--- a/crates/agent-runtime-cli/src/doctor/project.rs
+++ b/crates/agent-runtime-cli/src/doctor/project.rs
@@ -1,0 +1,115 @@
+//! Project-local overlay coverage for `agent-runtime doctor --check-project`.
+
+use super::{DoctorFinding, DoctorSeverity};
+use std::path::{Path, PathBuf};
+
+const PROJECT_OVERLAY_SCRIPTS: &[&str] =
+    &["bench", "bootstrap", "demo", "deploy", "pre-pr", "release"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectOverlayStatus {
+    Wired,
+    Missing,
+}
+
+impl ProjectOverlayStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProjectOverlayStatus::Wired => "wired",
+            ProjectOverlayStatus::Missing => "missing",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectOverlayFinding {
+    pub script: String,
+    pub status: ProjectOverlayStatus,
+    pub severity: DoctorSeverity,
+    pub path: PathBuf,
+    pub message: String,
+}
+
+impl ProjectOverlayFinding {
+    pub fn to_doctor_finding(&self, product: &str) -> DoctorFinding {
+        let message = format!("status={}: {}", self.status.as_str(), self.message);
+        match self.severity {
+            DoctorSeverity::Ok => DoctorFinding {
+                product: product.to_string(),
+                check: "project-overlay",
+                severity: DoctorSeverity::Ok,
+                entry_id: Some(self.script.clone()),
+                path: Some(self.path.clone()),
+                message,
+            },
+            DoctorSeverity::Warn => DoctorFinding::warn(
+                product,
+                "project-overlay",
+                Some(self.script.clone()),
+                Some(self.path.clone()),
+                message,
+            ),
+            DoctorSeverity::Block => DoctorFinding::block(
+                product,
+                "project-overlay",
+                Some(self.script.clone()),
+                Some(self.path.clone()),
+                message,
+            ),
+        }
+    }
+}
+
+pub fn probe_project(project_root: &Path) -> Vec<ProjectOverlayFinding> {
+    PROJECT_OVERLAY_SCRIPTS
+        .iter()
+        .map(|script| probe_script(project_root, script))
+        .collect()
+}
+
+fn probe_script(project_root: &Path, script: &str) -> ProjectOverlayFinding {
+    let path = project_root
+        .join(".agents")
+        .join("scripts")
+        .join(format!("{script}.sh"));
+    if is_executable_file(&path) {
+        ProjectOverlayFinding {
+            script: script.to_string(),
+            status: ProjectOverlayStatus::Wired,
+            severity: DoctorSeverity::Ok,
+            path,
+            message: "project-local script exists and is executable".to_string(),
+        }
+    } else {
+        let message = if path.exists() {
+            "project-local script exists but is not executable"
+        } else {
+            "project-local script is missing"
+        };
+        ProjectOverlayFinding {
+            script: script.to_string(),
+            status: ProjectOverlayStatus::Missing,
+            severity: DoctorSeverity::Warn,
+            path,
+            message: message.to_string(),
+        }
+    }
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}

--- a/crates/agent-runtime-cli/src/doctor/upgrade.rs
+++ b/crates/agent-runtime-cli/src/doctor/upgrade.rs
@@ -1,0 +1,36 @@
+//! Copy-pasteable Homebrew upgrade suggestions for doctor findings.
+
+use super::coverage::CoverageStatus;
+use super::version::VersionStatus;
+use super::{DoctorOutcome, DoctorSeverity};
+use std::collections::BTreeSet;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpgradeSuggestion {
+    pub formula: String,
+    pub command: String,
+}
+
+pub fn suggestions(outcome: &DoctorOutcome) -> Vec<UpgradeSuggestion> {
+    let mut formulas = BTreeSet::new();
+    for probe in &outcome.version_probes {
+        if probe.status != VersionStatus::Ok {
+            formulas.insert(probe.product.clone());
+        }
+    }
+    for probe in &outcome.coverage_probes {
+        if probe.severity == DoctorSeverity::Ok || probe.status == CoverageStatus::Ok {
+            continue;
+        }
+        if let Some(formula) = probe.formula.as_deref() {
+            formulas.insert(formula.to_string());
+        }
+    }
+    formulas
+        .into_iter()
+        .map(|formula| UpgradeSuggestion {
+            command: format!("brew upgrade {formula}"),
+            formula,
+        })
+        .collect()
+}

--- a/crates/agent-runtime-cli/src/doctor/version.rs
+++ b/crates/agent-runtime-cli/src/doctor/version.rs
@@ -91,14 +91,14 @@ impl VersionProbeFinding {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct Version {
+pub(crate) struct Version {
     major: u64,
     minor: u64,
     patch: u64,
 }
 
 impl Version {
-    fn parse(raw: &str) -> Option<Self> {
+    pub(crate) fn parse(raw: &str) -> Option<Self> {
         let bytes = raw.as_bytes();
         for i in 0..bytes.len() {
             if !(bytes[i].is_ascii_digit()
@@ -239,7 +239,7 @@ fn finding(
     }
 }
 
-fn run_probe_command(command: &str) -> String {
+pub(crate) fn run_probe_command(command: &str) -> String {
     run_probe_command_with_timeout(command, PROBE_TIMEOUT_POLLS, PROBE_TIMEOUT_SLEEP)
 }
 

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -11,6 +11,8 @@ mod cli;
 mod determinism_gate;
 #[path = "integration/doctor_filesystem.rs"]
 mod doctor_filesystem;
+#[path = "integration/doctor_upgrade.rs"]
+mod doctor_upgrade;
 #[path = "integration/doctor_version.rs"]
 mod doctor_version;
 #[path = "integration/gc_backups.rs"]

--- a/crates/agent-runtime-cli/tests/integration/doctor_filesystem.rs
+++ b/crates/agent-runtime-cli/tests/integration/doctor_filesystem.rs
@@ -94,6 +94,16 @@ products:
         runtime_roots,
     )
     .unwrap();
+    fs::write(
+        root.join("manifests").join("skills.yaml"),
+        "schema_version: 1\nskills: []\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("manifests").join("cli-tools.yaml"),
+        "schema_version: 1\nprofiles:\n  core: []\n  recommended: []\n  full: []\nformulas: {}\n",
+    )
+    .unwrap();
 
     fs::canonicalize(&root).unwrap()
 }

--- a/crates/agent-runtime-cli/tests/integration/doctor_upgrade.rs
+++ b/crates/agent-runtime-cli/tests/integration/doctor_upgrade.rs
@@ -1,0 +1,262 @@
+//! Integration coverage for Plan 04 Sprint 3 Task 3.3 doctor upgrade,
+//! project-overlay, and CLI coverage probes.
+
+use agent_runtime_cli::doctor::project::{self, ProjectOverlayStatus};
+use nils_test_support::cmd::{self, CmdOutput};
+use nils_test_support::{StubBinDir, bin};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn run(args: &[&str], path: &str) -> CmdOutput {
+    cmd::run(&agent_runtime_bin(), args, &[("PATH", path)], None)
+}
+
+fn write_exe(path: &Path, body: &str) {
+    fs::write(path, body).unwrap();
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}
+
+fn write_source_root(
+    tmp: &TempDir,
+    home: &Path,
+    state_home: &Path,
+    required_clis: &str,
+    cli_tools: &str,
+) -> PathBuf {
+    let root = tmp.path().join("src");
+    fs::create_dir_all(home.join("plugins")).unwrap();
+    fs::create_dir_all(root.join("manifests")).unwrap();
+    fs::create_dir_all(root.join("targets").join("codex")).unwrap();
+    fs::write(
+        root.join("targets").join("codex").join("link-map.yaml"),
+        "schema_version: 1\nentries: []\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("manifests").join("runtime-roots.yaml"),
+        format!(
+            "\
+schema_version: 1
+products:
+  codex:
+    live_home: \"{home}\"
+    docs_home: \"{home}\"
+    state_home: \"{state_home}\"
+    plugin_root: \"{home}/plugins\"
+    hook_config_strategy: managed-block
+    min_version: \"0.1.0\"
+    recommended_version: \"0.2.0\"
+    min_version_effective_from: \"2099-01-01\"
+    version_probe: \"codex --version\"
+  claude:
+    live_home: \"{home}\"
+    docs_home: \"{home}\"
+    state_home: \"{state_home}\"
+    hook_config_strategy: settings-json
+    min_version: \"0.1.0\"
+    recommended_version: \"0.2.0\"
+    min_version_effective_from: \"2099-01-01\"
+    version_probe: \"claude --version\"
+",
+            home = home.display(),
+            state_home = state_home.display(),
+        ),
+    )
+    .unwrap();
+    fs::write(
+        root.join("manifests").join("skills.yaml"),
+        format!(
+            "\
+schema_version: 1
+skills:
+  - id: reporting.daily-brief
+    domain: reporting
+    source: core/skills/reporting/daily-brief
+    products:
+      codex:
+        name: daily-brief
+        render_to: plugins/reporting/skills/daily-brief/SKILL.md
+    required_clis:
+{required_clis}
+"
+        ),
+    )
+    .unwrap();
+    fs::write(root.join("manifests").join("cli-tools.yaml"), cli_tools).unwrap();
+    fs::canonicalize(&root).unwrap()
+}
+
+fn empty_cli_tools() -> &'static str {
+    "\
+schema_version: 1
+profiles:
+  core: []
+  recommended: []
+  full: []
+formulas: {}
+"
+}
+
+#[test]
+fn missing_required_cli_binary_blocks() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&state_home).unwrap();
+    let source_root = write_source_root(
+        &tmp,
+        &home,
+        &state_home,
+        "      agent-out: \">=0.13.0\"\n",
+        empty_cli_tools(),
+    );
+    let bin_dir = StubBinDir::new();
+    bin_dir.write_exe("codex", "#!/bin/sh\necho 'codex 0.2.0'\n");
+
+    let output = run(
+        &[
+            "doctor",
+            "--product",
+            "codex",
+            "--source-root",
+            source_root.to_str().unwrap(),
+            "--profile",
+            "core",
+        ],
+        &bin_dir.path_str(),
+    );
+
+    assert_eq!(output.code, 2);
+    let stderr = output.stderr_text();
+    assert!(stderr.contains("block required-cli"), "{stderr}");
+    assert!(stderr.contains("status=missing"), "{stderr}");
+    assert!(stderr.contains("agent-out"), "{stderr}");
+}
+
+#[test]
+fn outdated_required_cli_binary_warns() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&state_home).unwrap();
+    let source_root = write_source_root(
+        &tmp,
+        &home,
+        &state_home,
+        "      agent-out: \">=0.13.0\"\n",
+        empty_cli_tools(),
+    );
+    let bin_dir = StubBinDir::new();
+    bin_dir.write_exe("codex", "#!/bin/sh\necho 'codex 0.2.0'\n");
+    bin_dir.write_exe("agent-out", "#!/bin/sh\necho 'agent-out 0.12.0'\n");
+
+    let output = run(
+        &[
+            "doctor",
+            "--product",
+            "codex",
+            "--source-root",
+            source_root.to_str().unwrap(),
+            "--profile",
+            "core",
+        ],
+        &bin_dir.path_str(),
+    );
+
+    assert_eq!(output.code, 1);
+    let stderr = output.stderr_text();
+    assert!(stderr.contains("warn required-cli"), "{stderr}");
+    assert!(stderr.contains("status=outdated"), "{stderr}");
+    assert!(stderr.contains("agent-out"), "{stderr}");
+}
+
+#[test]
+fn suggest_upgrade_prints_one_brew_upgrade_line_per_formula() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let state_home = tmp.path().join("state");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&state_home).unwrap();
+    let source_root = write_source_root(
+        &tmp,
+        &home,
+        &state_home,
+        "      agent-out: \">=0.13.0\"\n      git-scope: \">=0.13.0\"\n",
+        "\
+schema_version: 1
+profiles:
+  core: [ripgrep]
+  recommended: [ripgrep]
+  full: [ripgrep]
+formulas:
+  ripgrep:
+    brew: ripgrep
+    command: rg
+    linux_only_alternative: null
+    categories: [search]
+",
+    );
+    let bin_dir = StubBinDir::new();
+    bin_dir.write_exe("codex", "#!/bin/sh\necho 'codex 0.1.0'\n");
+    bin_dir.write_exe("agent-out", "#!/bin/sh\necho 'agent-out 0.12.0'\n");
+    bin_dir.write_exe("git-scope", "#!/bin/sh\necho 'git-scope 0.12.0'\n");
+    bin_dir.write_exe("rg", "#!/bin/sh\necho 'ripgrep 14.1.0'\n");
+    bin_dir.write_exe(
+        "brew",
+        "#!/bin/sh\nif [ \"$1\" = \"outdated\" ]; then echo 'ripgrep'; fi\n",
+    );
+
+    let output = run(
+        &[
+            "doctor",
+            "--product",
+            "codex",
+            "--source-root",
+            source_root.to_str().unwrap(),
+            "--profile",
+            "core",
+            "--suggest-upgrade",
+        ],
+        &bin_dir.path_str(),
+    );
+
+    assert_eq!(output.code, 1);
+    let stdout = output.stdout_text();
+    let mut lines = stdout.lines().collect::<Vec<_>>();
+    lines.sort_unstable();
+    assert_eq!(
+        lines,
+        vec![
+            "brew upgrade codex",
+            "brew upgrade nils-cli",
+            "brew upgrade ripgrep",
+        ]
+    );
+}
+
+#[test]
+fn check_project_reports_missing_overlay_scripts() {
+    let tmp = TempDir::new().unwrap();
+    let scripts = tmp.path().join(".agents").join("scripts");
+    fs::create_dir_all(&scripts).unwrap();
+    write_exe(&scripts.join("bench.sh"), "#!/bin/sh\nexit 0\n");
+
+    let findings = project::probe_project(tmp.path());
+
+    assert!(findings.iter().any(|finding| {
+        finding.script == "bench" && finding.status == ProjectOverlayStatus::Wired
+    }));
+    assert!(findings.iter().any(|finding| {
+        finding.script == "deploy" && finding.status == ProjectOverlayStatus::Missing
+    }));
+}


### PR DESCRIPTION
# Plan 04: add doctor upgrade coverage

## Summary

Adds Sprint 3 Task 3.3 coverage to `agent-runtime doctor`: required nils-cli binary checks, active `cli-tools` profile checks, project-local `.agents/scripts` overlay checks, and copy-pasteable `brew upgrade <formula>` suggestions.

## Changes

- Adds `--suggest-upgrade`, `--profile`, and `--check-project` to `agent-runtime doctor`.
- Adds typed coverage/project/upgrade modules and wires their findings into the existing doctor exit-code aggregation.
- Adds integration coverage for missing/outdated `required_clis`, one-line upgrade suggestions, and project overlay scanning.

## Test-First Evidence

- Change classification: feature
- Failing test before fix: `cargo test -p agent-runtime-cli doctor_upgrade` exited 101 because `agent_runtime_cli::doctor::project` did not exist.
- Final validation: `cargo test -p agent-runtime-cli`, `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings`, and `git diff --check` passed.

## Testing

- `cargo test -p agent-runtime-cli doctor_upgrade` (pass)
- `cargo test -p agent-runtime-cli doctor_filesystem` (pass)
- `cargo test -p agent-runtime-cli doctor_version` (pass)
- `cargo test -p agent-runtime-cli doctor::` (pass)
- `cargo test -p agent-runtime-cli` (pass)
- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` (pass)
- `git diff --check` (pass)

## Risk / Notes

- Specialist review completed with testing, maintainability, API-contract, and red-team scope; no concrete unresolved findings.
- `cli-tools` latest checks use local Homebrew metadata via `brew outdated --quiet <formula>` when `brew` is present; missing profile tools report install guidance and warning severity.
- `--check-project` currently checks the six planned project-local overlay script names: `bench`, `bootstrap`, `demo`, `deploy`, `pre-pr`, and `release`.

Refs graysurf/agent-runtime-kit#3
