### PR TITLE
Add unsafe drift scoring

### DIFF
--- a/crates/agent-runtime-cli/src/audit_drift/mod.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/mod.rs
@@ -24,12 +24,16 @@ pub mod agent_home_leak;
 pub mod docs_home;
 pub mod rendered_target;
 pub mod source_manifest;
+pub mod unsafe_score;
 pub mod walk;
 
 pub const PRODUCTS: &[&str] = &["codex", "claude"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
+    /// Drift that is only visible in verbose output and never affects
+    /// the exit code.
+    Suppressed,
     /// Drift that the reporting POC will surface but not block on.
     Warn,
     /// Drift that breaks an explicit Resolved Decision contract.
@@ -39,6 +43,7 @@ pub enum Severity {
 impl Severity {
     pub fn exit_code(self) -> u8 {
         match self {
+            Severity::Suppressed => 0,
             Severity::Warn => 1,
             Severity::Block => 2,
         }
@@ -46,6 +51,7 @@ impl Severity {
 
     pub fn label(self) -> &'static str {
         match self {
+            Severity::Suppressed => "suppressed",
             Severity::Warn => "warn",
             Severity::Block => "block",
         }
@@ -119,6 +125,7 @@ pub fn run(root: &SourceRoot) -> Result<DriftReport> {
         docs_home::check(root, product, &mut report)?;
     }
     agent_home_leak::check_source_tree(root, &mut report)?;
+    unsafe_score::check(root, &mut report)?;
 
     report.sort();
     Ok(report)
@@ -180,8 +187,10 @@ mod tests {
 
     #[test]
     fn severity_exit_codes_match_documented_policy() {
+        assert_eq!(Severity::Suppressed.exit_code(), 0);
         assert_eq!(Severity::Warn.exit_code(), 1);
         assert_eq!(Severity::Block.exit_code(), 2);
+        assert_eq!(Severity::Suppressed.label(), "suppressed");
         assert_eq!(Severity::Warn.label(), "warn");
         assert_eq!(Severity::Block.label(), "block");
     }

--- a/crates/agent-runtime-cli/src/audit_drift/unsafe_score.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/unsafe_score.rs
@@ -1,0 +1,336 @@
+//! Composite unsafe-score drift class.
+//!
+//! The score is intentionally small and explainable:
+//!
+//! - sensitive path match: 0.4
+//! - keyword prefix with a nearby value-shaped token: 0.4
+//! - high-entropy value run: 0.4
+//!
+//! Scores `>= 0.8` block, scores `>= 0.4` warn, and lower scores are
+//! suppressed. Suppressed findings stay in the in-memory report so
+//! `audit-drift --verbose` can explain why a keyword-only line did not
+//! become a warning.
+
+use crate::audit_drift::walk;
+use crate::audit_drift::{DriftReport, Finding, PRODUCTS, Severity};
+use crate::render::manifest::SourceRoot;
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+
+pub const CLASS: &str = "unsafe";
+
+const SIGNAL_WEIGHT: f64 = 0.4;
+const BLOCK_THRESHOLD: f64 = 0.8;
+const WARN_THRESHOLD: f64 = 0.4;
+const ENTROPY_THRESHOLD: f64 = 4.0;
+const MIN_VALUE_RUN: usize = 24;
+
+const KEYWORDS: &[&str] = &[
+    "token",
+    "api_key",
+    "password",
+    "bearer",
+    "secret",
+    "private_key",
+];
+
+pub fn check(root: &SourceRoot, report: &mut DriftReport) -> Result<()> {
+    for product in PRODUCTS {
+        let build_dir = root.path().join("build").join(product);
+        scan_tree(root, &build_dir, Some((*product).to_string()), report)?;
+    }
+    for sub in ["core", "targets", "manifests"] {
+        let dir = root.path().join(sub);
+        scan_tree(root, &dir, None, report)?;
+    }
+    Ok(())
+}
+
+fn scan_tree(
+    root: &SourceRoot,
+    dir: &Path,
+    product: Option<String>,
+    report: &mut DriftReport,
+) -> Result<()> {
+    for path in walk::collect_files_under(dir, root.path()) {
+        scan_file(root, &path, product.as_deref(), report)?;
+    }
+    Ok(())
+}
+
+fn scan_file(
+    root: &SourceRoot,
+    path: &Path,
+    product: Option<&str>,
+    report: &mut DriftReport,
+) -> Result<()> {
+    let bytes =
+        fs::read(path).with_context(|| format!("audit-drift unsafe read {}", path.display()))?;
+    let Ok(text) = std::str::from_utf8(&bytes) else {
+        return Ok(());
+    };
+    let rel = path.strip_prefix(root.path()).unwrap_or(path).to_path_buf();
+    let analysis = analyze_file(&rel, text);
+    if analysis.should_report() {
+        report.push(Finding {
+            class: CLASS,
+            severity: analysis.severity(),
+            product: product.map(str::to_string),
+            path: rel,
+            message: analysis.message(),
+        });
+    }
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct UnsafeAnalysis {
+    path_match: bool,
+    keyword_prefix: Option<usize>,
+    entropy_above_threshold: Option<usize>,
+    keyword_without_value: Option<usize>,
+}
+
+impl UnsafeAnalysis {
+    fn score(&self) -> f64 {
+        let mut score = 0.0;
+        if self.path_match {
+            score += SIGNAL_WEIGHT;
+        }
+        if self.keyword_prefix.is_some() {
+            score += SIGNAL_WEIGHT;
+        }
+        if self.entropy_above_threshold.is_some() {
+            score += SIGNAL_WEIGHT;
+        }
+        score
+    }
+
+    fn severity(&self) -> Severity {
+        let score = self.score();
+        if score >= BLOCK_THRESHOLD {
+            Severity::Block
+        } else if score >= WARN_THRESHOLD {
+            Severity::Warn
+        } else {
+            Severity::Suppressed
+        }
+    }
+
+    fn should_report(&self) -> bool {
+        self.score() >= WARN_THRESHOLD || self.keyword_without_value.is_some()
+    }
+
+    fn message(&self) -> String {
+        let mut signals = Vec::new();
+        if self.path_match {
+            signals.push("path_match".to_string());
+        }
+        if let Some(line) = self.keyword_prefix {
+            signals.push(format!("keyword_prefix(line {line})"));
+        }
+        if let Some(line) = self.entropy_above_threshold {
+            signals.push(format!("entropy_above_threshold(line {line})"));
+        }
+        if signals.is_empty()
+            && let Some(line) = self.keyword_without_value
+        {
+            signals.push(format!("keyword_without_value(line {line})"));
+        }
+        format!(
+            "score={score:.1} signals={signals}; thresholds: >=0.8 block, >=0.4 warn, <0.4 suppressed",
+            score = self.score(),
+            signals = signals.join(","),
+        )
+    }
+}
+
+fn analyze_file(path: &Path, text: &str) -> UnsafeAnalysis {
+    let mut analysis = UnsafeAnalysis {
+        path_match: matches_sensitive_path(path),
+        ..UnsafeAnalysis::default()
+    };
+
+    for (line_idx, line) in text.lines().enumerate() {
+        let line_number = line_idx + 1;
+        if analysis.keyword_prefix.is_none() && line_has_keyword_value(line) {
+            analysis.keyword_prefix = Some(line_number);
+        } else if analysis.keyword_without_value.is_none() && line_has_keyword(line) {
+            analysis.keyword_without_value = Some(line_number);
+        }
+
+        if analysis.entropy_above_threshold.is_none() && line_has_high_entropy_run(line) {
+            analysis.entropy_above_threshold = Some(line_number);
+        }
+
+        if analysis.keyword_prefix.is_some() && analysis.entropy_above_threshold.is_some() {
+            break;
+        }
+    }
+
+    analysis
+}
+
+fn matches_sensitive_path(path: &Path) -> bool {
+    let normalized = path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/");
+    if normalized == "auth.json" || normalized.ends_with("/auth.json") {
+        return true;
+    }
+    if path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with(".credentials"))
+    {
+        return true;
+    }
+    normalized.starts_with("sessions/") || normalized.contains("/sessions/")
+}
+
+fn line_has_keyword(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    KEYWORDS.iter().any(|keyword| lower.contains(keyword))
+}
+
+fn line_has_keyword_value(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    for keyword in KEYWORDS {
+        let mut search_from = 0usize;
+        while let Some(idx) = lower[search_from..].find(keyword) {
+            let after_idx = search_from + idx + keyword.len();
+            let after = &line[after_idx..];
+            if value_runs(after).any(|run| is_value_shaped(run, 8)) {
+                return true;
+            }
+            search_from = after_idx;
+        }
+    }
+    false
+}
+
+fn line_has_high_entropy_run(line: &str) -> bool {
+    value_runs(line).any(|run| {
+        is_entropy_candidate(run)
+            && run.len() >= MIN_VALUE_RUN
+            && shannon_entropy(run) >= ENTROPY_THRESHOLD
+    })
+}
+
+fn value_runs(line: &str) -> impl Iterator<Item = &str> {
+    line.split(|c: char| !is_value_char(c))
+        .filter(|run| !run.is_empty())
+}
+
+fn is_value_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '+' | '/' | '=')
+}
+
+fn is_value_shaped(run: &str, min_len: usize) -> bool {
+    if run.len() < min_len {
+        return false;
+    }
+    let has_digit = run.chars().any(|c| c.is_ascii_digit());
+    let has_symbol = run
+        .chars()
+        .any(|c| matches!(c, '_' | '-' | '.' | '+' | '/' | '='));
+    let has_upper = run.chars().any(|c| c.is_ascii_uppercase());
+    let has_lower = run.chars().any(|c| c.is_ascii_lowercase());
+    has_digit || has_symbol || (has_upper && has_lower)
+}
+
+fn is_entropy_candidate(run: &str) -> bool {
+    // Long path/template references can have high character variety
+    // while being ordinary source text. Requiring at least one digit
+    // keeps the entropy signal focused on token-like values and lets
+    // keyword/path signals handle lower-entropy secret names.
+    run.chars().any(|c| c.is_ascii_digit())
+}
+
+fn shannon_entropy(value: &str) -> f64 {
+    let bytes = value.as_bytes();
+    if bytes.is_empty() {
+        return 0.0;
+    }
+    let mut counts = [0usize; 256];
+    for byte in bytes {
+        counts[*byte as usize] += 1;
+    }
+    let len = bytes.len() as f64;
+    counts
+        .iter()
+        .filter(|count| **count > 0)
+        .map(|count| {
+            let p = *count as f64 / len;
+            -p * p.log2()
+        })
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn sensitive_path_patterns_match_documented_set() {
+        assert!(matches_sensitive_path(Path::new("core/auth.json")));
+        assert!(matches_sensitive_path(Path::new("core/.credentials.local")));
+        assert!(matches_sensitive_path(Path::new(
+            "build/codex/sessions/abc.json"
+        )));
+        assert!(!matches_sensitive_path(Path::new("core/skills/SKILL.md")));
+    }
+
+    #[test]
+    fn keyword_without_value_is_suppressed() {
+        let analysis = analyze_file(Path::new("core/notes.md"), "password rotation only\n");
+        assert_eq!(analysis.score(), 0.0);
+        assert_eq!(analysis.severity(), Severity::Suppressed);
+        assert!(analysis.should_report());
+    }
+
+    #[test]
+    fn path_keyword_entropy_scores_full_weight() {
+        let analysis = analyze_file(
+            Path::new("core/auth.json"),
+            "token: 4fK9zQm2Lp8sVx7Tn3Bc6Rj0WaYd\n",
+        );
+        assert!((analysis.score() - 1.2).abs() < 0.000_001);
+        assert_eq!(analysis.severity(), Severity::Block);
+    }
+
+    #[test]
+    fn entropy_threshold_uses_bits_per_byte() {
+        assert!(shannon_entropy("4fK9zQm2Lp8sVx7Tn3Bc6Rj0WaYd") >= ENTROPY_THRESHOLD);
+        assert!(shannon_entropy("aaaaaaaaaaaaaaaaaaaaaaaaaaaa") < ENTROPY_THRESHOLD);
+    }
+
+    #[test]
+    fn entropy_signal_ignores_long_path_like_runs_without_digits() {
+        assert!(!line_has_high_entropy_run(
+            r#"script(path="core/skills/codex_only/SKILL.md.tera")"#
+        ));
+    }
+
+    #[test]
+    fn signal_names_are_deduped_in_message_order() {
+        let analysis = analyze_file(
+            Path::new("core/auth.json"),
+            "token: 4fK9zQm2Lp8sVx7Tn3Bc6Rj0WaYd\n",
+        );
+        let message = analysis.message();
+        let signals = message
+            .split("signals=")
+            .nth(1)
+            .unwrap()
+            .split(';')
+            .next()
+            .unwrap();
+        let unique: BTreeSet<_> = signals.split(',').collect();
+        assert_eq!(signals.split(',').count(), unique.len());
+    }
+}

--- a/crates/agent-runtime-cli/src/commands/audit_drift.rs
+++ b/crates/agent-runtime-cli/src/commands/audit_drift.rs
@@ -9,12 +9,21 @@ pub struct AuditDriftArgs {
     /// Defaults to the current working directory.
     #[arg(long)]
     pub source_root: Option<PathBuf>,
+
+    /// Include suppressed drift findings in the report.
+    #[arg(long)]
+    pub verbose: bool,
 }
 
 pub fn run(args: AuditDriftArgs) -> anyhow::Result<u8> {
     let root = SourceRoot::from_arg_or_cwd(args.source_root.as_deref())?;
     let report = audit_drift::run(&root)?;
-    for f in &report.findings {
+    let visible_findings: Vec<_> = report
+        .findings
+        .iter()
+        .filter(|f| args.verbose || f.severity != audit_drift::Severity::Suppressed)
+        .collect();
+    for f in &visible_findings {
         eprintln!(
             "audit-drift [{class}/{severity}{product}] {path}: {msg}",
             class = f.class,
@@ -30,11 +39,11 @@ pub fn run(args: AuditDriftArgs) -> anyhow::Result<u8> {
     }
     let exit_code = report.exit_code();
     if exit_code == 0 {
-        eprintln!("audit-drift: clean ({} findings)", report.findings.len());
+        eprintln!("audit-drift: clean ({} findings)", visible_findings.len());
     } else {
         eprintln!(
             "audit-drift: {n} finding(s); highest-severity exit={exit}",
-            n = report.findings.len(),
+            n = visible_findings.len(),
             exit = exit_code,
         );
     }

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -5,6 +5,8 @@
 
 #[path = "integration/audit_drift_classes.rs"]
 mod audit_drift_classes;
+#[path = "integration/audit_drift_unsafe_score.rs"]
+mod audit_drift_unsafe_score;
 #[path = "integration/cli.rs"]
 mod cli;
 #[path = "integration/determinism_gate.rs"]

--- a/crates/agent-runtime-cli/tests/integration/audit_drift_unsafe_score.rs
+++ b/crates/agent-runtime-cli/tests/integration/audit_drift_unsafe_score.rs
@@ -1,0 +1,163 @@
+//! Integration coverage for Plan 04 Task 4.1 `audit-drift` unsafe scoring.
+//!
+//! The plan still names a standalone `crates/audit-drift` crate, but the
+//! current implementation lives inside `agent-runtime-cli::audit_drift`.
+//! These tests pin the user-facing `agent-runtime audit-drift` contract so
+//! the internal module layout can remain local to this repo.
+
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/render-determinism")
+}
+
+fn copy_tree(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_tree(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap();
+        }
+    }
+}
+
+fn copy_fixture() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    copy_tree(&fixture_root(), tmp.path());
+    tmp
+}
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn audit(root: &Path, extra_args: &[&str]) -> CmdOutput {
+    let mut args = vec!["audit-drift", "--source-root", root.to_str().unwrap()];
+    args.extend(extra_args);
+    cmd::run(&agent_runtime_bin(), &args, &[], None)
+}
+
+#[test]
+fn unsafe_score_path_keyword_entropy_blocks() {
+    let tmp = copy_fixture();
+    write(
+        &tmp.path().join("core/secrets/auth.json"),
+        "token: 4fK9zQm2Lp8sVx7Tn3Bc6Rj0WaYd\n",
+    );
+
+    let out = audit(tmp.path(), &[]);
+    assert_eq!(
+        out.code,
+        2,
+        "path + keyword + entropy should block; stderr=\n{}",
+        out.stderr_text(),
+    );
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("[unsafe/block"),
+        "expected unsafe/block finding; got\n{stderr}",
+    );
+    assert!(
+        stderr.contains("score=1.2"),
+        "expected composite score in finding; got\n{stderr}",
+    );
+}
+
+#[test]
+fn unsafe_score_path_only_warns() {
+    let tmp = copy_fixture();
+    write(&tmp.path().join("core/auth.json"), "{}\n");
+
+    let out = audit(tmp.path(), &[]);
+    assert_eq!(
+        out.code,
+        1,
+        "path-only unsafe score should warn; stderr=\n{}",
+        out.stderr_text(),
+    );
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("[unsafe/warn"),
+        "expected unsafe/warn finding; got\n{stderr}",
+    );
+    assert!(
+        stderr.contains("score=0.4"),
+        "expected path-only score; got\n{stderr}",
+    );
+}
+
+#[test]
+fn unsafe_score_entropy_only_warns() {
+    let tmp = copy_fixture();
+    write(
+        &tmp.path().join("core/skills/sample/high-entropy.txt"),
+        "opaque 4fK9zQm2Lp8sVx7Tn3Bc6Rj0WaYd\n",
+    );
+
+    let out = audit(tmp.path(), &[]);
+    assert_eq!(
+        out.code,
+        1,
+        "entropy-only unsafe score should warn; stderr=\n{}",
+        out.stderr_text(),
+    );
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("[unsafe/warn"),
+        "expected unsafe/warn finding; got\n{stderr}",
+    );
+    assert!(
+        stderr.contains("entropy_above_threshold"),
+        "expected entropy signal; got\n{stderr}",
+    );
+}
+
+#[test]
+fn unsafe_score_keyword_without_value_is_suppressed_until_verbose() {
+    let tmp = copy_fixture();
+    write(
+        &tmp.path().join("core/skills/sample/rotation-notes.md"),
+        "password rotation policy only; no value appears here\n",
+    );
+
+    let normal = audit(tmp.path(), &[]);
+    assert_eq!(
+        normal.code,
+        0,
+        "suppressed unsafe finding should not affect default exit; stderr=\n{}",
+        normal.stderr_text(),
+    );
+    assert!(
+        !normal.stderr_text().contains("[unsafe/suppressed"),
+        "suppressed finding should be hidden by default; stderr=\n{}",
+        normal.stderr_text(),
+    );
+
+    let verbose = audit(tmp.path(), &["--verbose"]);
+    assert_eq!(
+        verbose.code,
+        0,
+        "suppressed unsafe finding should still exit 0; stderr=\n{}",
+        verbose.stderr_text(),
+    );
+    assert!(
+        verbose.stderr_text().contains("[unsafe/suppressed"),
+        "suppressed finding should be visible with --verbose; stderr=\n{}",
+        verbose.stderr_text(),
+    );
+}


### PR DESCRIPTION
# Add unsafe drift scoring

## Summary

Implements Plan 04 Task 4.1 for `agent-runtime audit-drift`: composite unsafe scoring with path, keyword, and entropy signals, suppressed findings hidden by default, and `--verbose` reporting for suppressed keyword-only observations. Refs graysurf/agent-runtime-kit#3.

## Changes

- Add `audit_drift::unsafe_score` and wire it into the existing drift report aggregation.
- Add `Severity::Suppressed` with exit code `0` and default output filtering.
- Add `audit-drift --verbose` to show suppressed findings without changing exit behavior.
- Add integration coverage for block, warn, entropy-only, and suppressed/verbose behavior.

## Test-First Evidence

- Change classification: feature / behavior change.
- Failing test before fix: `cargo test -p agent-runtime-cli unsafe_score` failed before implementation; unsafe findings were missing and `audit-drift --verbose` was rejected as an unexpected argument.
- Final validation: focused unsafe score tests, existing audit-drift class tests, full `agent-runtime-cli` crate tests, clippy, and whitespace checks passed.
- Waiver reason: N/A.

## Testing

- `cargo test -p agent-runtime-cli unsafe_score` (pass)
- `cargo test -p agent-runtime-cli audit_drift_classes` (pass)
- `cargo test -p agent-runtime-cli audit_drift` (pass)
- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` (pass)
- `cargo test -p agent-runtime-cli` (pass)
- `git diff --check` (pass)

## Risk / Notes

- The plan path `crates/audit-drift` is stale; current implementation lives under `crates/agent-runtime-cli/src/audit_drift/`.
- Entropy detection requires a long value run with at least one digit to avoid path/template false positives; digit-free secrets still rely on path or keyword signals.
- Specialist review ran with testing, maintainability, API-contract, security, performance, and red-team lenses; no concrete unresolved findings.
