### PR TITLE
Add drift audit allowlist

### DIFF
--- a/crates/agent-runtime-cli/src/audit_drift/allowlist.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/allowlist.rs
@@ -1,0 +1,275 @@
+//! `drift-audit.allow.yaml` support for unsafe finding demotion.
+//!
+//! Task 4.2 only defines `unsafe_allow`; each match demotes an unsafe
+//! finding by exactly one tier (`block` -> `warn`, `warn` ->
+//! `suppressed`). Suppressed findings remain in the report so verbose
+//! output can still show the evidence.
+
+use crate::audit_drift::unsafe_score;
+use crate::audit_drift::{DriftReport, Severity};
+use crate::render::manifest::SourceRoot;
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+const ALLOWLIST_FILE: &str = "drift-audit.allow.yaml";
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Error)]
+pub enum AllowlistError {
+    #[error("unsupported private audit-drift allowlist: {path}; put {file} at the source root")]
+    PrivateUnsupported { path: PathBuf, file: &'static str },
+    #[error("io error reading {file}: {source}")]
+    Io {
+        file: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("parse error in {file}: {source}")]
+    Parse {
+        file: PathBuf,
+        #[source]
+        source: serde_yaml_ng::Error,
+    },
+    #[error("schema_version mismatch in {file}: expected {expected}, got {found}")]
+    SchemaVersion {
+        file: PathBuf,
+        expected: u32,
+        found: u32,
+    },
+    #[error("{file}: unsafe_allow[{index}] path must be non-empty")]
+    EmptyPath { file: PathBuf, index: usize },
+    #[error("{file}: unsafe_allow[{index}] reason must be non-empty")]
+    EmptyReason { file: PathBuf, index: usize },
+}
+
+#[derive(Debug, Default)]
+pub struct Allowlist {
+    unsafe_allow: Vec<UnsafeAllow>,
+}
+
+impl Allowlist {
+    pub fn apply(&self, report: &mut DriftReport) {
+        if self.unsafe_allow.is_empty() {
+            return;
+        }
+        for finding in &mut report.findings {
+            if finding.class != unsafe_score::CLASS {
+                continue;
+            }
+            let path = finding.path.to_string_lossy();
+            let Some(entry) = self.unsafe_allow.iter().find(|entry| entry.matches(&path)) else {
+                continue;
+            };
+            let before = finding.severity;
+            let after = demote(before);
+            if after != before {
+                finding.severity = after;
+                finding.message.push_str(&format!(
+                    "; allowlist demoted {before}->{after}: {reason}",
+                    before = before.label(),
+                    after = after.label(),
+                    reason = entry.reason,
+                ));
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct UnsafeAllow {
+    path: String,
+    reason: String,
+}
+
+impl UnsafeAllow {
+    fn matches(&self, path: &str) -> bool {
+        glob_matches(&self.path, path)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawAllowlist {
+    schema_version: u32,
+    #[serde(default)]
+    unsafe_allow: Vec<RawUnsafeAllow>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawUnsafeAllow {
+    path: String,
+    reason: String,
+}
+
+pub fn load(root: &SourceRoot) -> Result<Allowlist, AllowlistError> {
+    if let Some(path) = find_private_allowlist(&root.path().join(".private")) {
+        return Err(AllowlistError::PrivateUnsupported {
+            path,
+            file: ALLOWLIST_FILE,
+        });
+    }
+
+    let file = root.path().join(ALLOWLIST_FILE);
+    if !file.exists() {
+        return Ok(Allowlist::default());
+    }
+
+    let raw = fs::read_to_string(&file).map_err(|source| AllowlistError::Io {
+        file: file.clone(),
+        source,
+    })?;
+    let parsed: RawAllowlist =
+        serde_yaml_ng::from_str(&raw).map_err(|source| AllowlistError::Parse {
+            file: file.clone(),
+            source,
+        })?;
+    if parsed.schema_version != SCHEMA_VERSION {
+        return Err(AllowlistError::SchemaVersion {
+            file,
+            expected: SCHEMA_VERSION,
+            found: parsed.schema_version,
+        });
+    }
+
+    let mut unsafe_allow = Vec::new();
+    for (index, entry) in parsed.unsafe_allow.into_iter().enumerate() {
+        if entry.path.trim().is_empty() {
+            return Err(AllowlistError::EmptyPath { file, index });
+        }
+        if entry.reason.trim().is_empty() {
+            return Err(AllowlistError::EmptyReason { file, index });
+        }
+        unsafe_allow.push(UnsafeAllow {
+            path: entry.path,
+            reason: entry.reason,
+        });
+    }
+    Ok(Allowlist { unsafe_allow })
+}
+
+fn demote(severity: Severity) -> Severity {
+    match severity {
+        Severity::Block => Severity::Warn,
+        Severity::Warn => Severity::Suppressed,
+        Severity::Suppressed => Severity::Suppressed,
+    }
+}
+
+fn find_private_allowlist(private_dir: &Path) -> Option<PathBuf> {
+    let mut stack = vec![private_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.file_name().and_then(|name| name.to_str()) == Some(ALLOWLIST_FILE) {
+                return Some(path);
+            }
+            if entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+                stack.push(path);
+            }
+        }
+    }
+    None
+}
+
+fn glob_matches(pattern: &str, path: &str) -> bool {
+    let pattern = normalize_path(pattern);
+    let path = normalize_path(path);
+    let pattern_parts: Vec<&str> = pattern.split('/').filter(|part| !part.is_empty()).collect();
+    let path_parts: Vec<&str> = path.split('/').filter(|part| !part.is_empty()).collect();
+    match_components(&pattern_parts, &path_parts)
+}
+
+fn normalize_path(path: &str) -> String {
+    path.trim().trim_matches('/').replace('\\', "/")
+}
+
+fn match_components(pattern: &[&str], path: &[&str]) -> bool {
+    if pattern.is_empty() {
+        return path.is_empty();
+    }
+    if pattern[0] == "**" {
+        return (0..=path.len()).any(|idx| match_components(&pattern[1..], &path[idx..]));
+    }
+    if path.is_empty() {
+        return false;
+    }
+    segment_matches(pattern[0], path[0]) && match_components(&pattern[1..], &path[1..])
+}
+
+fn segment_matches(pattern: &str, text: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return pattern == text;
+    }
+
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut remaining = text;
+    if let Some(first) = parts.first().filter(|part| !part.is_empty()) {
+        let Some(rest) = remaining.strip_prefix(first) else {
+            return false;
+        };
+        remaining = rest;
+    }
+    for part in parts
+        .iter()
+        .skip(1)
+        .take(parts.len().saturating_sub(2))
+        .filter(|part| !part.is_empty())
+    {
+        let Some(idx) = remaining.find(part) else {
+            return false;
+        };
+        remaining = &remaining[idx + part.len()..];
+    }
+    if let Some(last) = parts.last().filter(|part| !part.is_empty()) {
+        remaining.ends_with(last)
+    } else {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit_drift::{Finding, Severity};
+
+    #[test]
+    fn glob_matches_double_star_and_segment_wildcards() {
+        assert!(glob_matches(
+            "tests/drift/fixtures/**",
+            "tests/drift/fixtures/auth.json"
+        ));
+        assert!(glob_matches("core/*.json", "core/auth.json"));
+        assert!(!glob_matches("core/*.json", "core/nested/auth.json"));
+    }
+
+    #[test]
+    fn apply_demotes_unsafe_findings_only_one_tier() {
+        let allowlist = Allowlist {
+            unsafe_allow: vec![UnsafeAllow {
+                path: "core/auth.json".to_string(),
+                reason: "fixture".to_string(),
+            }],
+        };
+        let mut report = DriftReport {
+            findings: vec![Finding {
+                class: unsafe_score::CLASS,
+                severity: Severity::Block,
+                product: None,
+                path: PathBuf::from("core/auth.json"),
+                message: "score=1.2".to_string(),
+            }],
+        };
+        allowlist.apply(&mut report);
+        assert_eq!(report.findings[0].severity, Severity::Warn);
+        assert!(report.findings[0].message.contains("block->warn"));
+    }
+}

--- a/crates/agent-runtime-cli/src/audit_drift/mod.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/mod.rs
@@ -12,15 +12,15 @@
 //! - `2` — any `block`-tier finding (`$AGENT_HOME` leak, docs-home
 //!   per product).
 //!
-//! Plan 04 will expand the matrix (unsafe scoring, `extra`,
-//! `intentional-difference`, root-map). This module intentionally
-//! stops at the four classes Phase 2 needs.
+//! Plan 04 expands the matrix with unsafe scoring, unsafe allowlist
+//! demotion, `extra`, `intentional-difference`, and root-map checks.
 
 use crate::render::manifest::SourceRoot;
 use anyhow::Result;
 use std::path::PathBuf;
 
 pub mod agent_home_leak;
+pub mod allowlist;
 pub mod docs_home;
 pub mod rendered_target;
 pub mod source_manifest;
@@ -116,6 +116,7 @@ impl DriftReport {
 /// `$AGENT_HOME` substring) records it in the report and continues.
 pub fn run(root: &SourceRoot) -> Result<DriftReport> {
     let mut report = DriftReport::default();
+    let allowlist = allowlist::load(root)?;
 
     let manifests = source_manifest::check(root, &mut report)?;
 
@@ -126,6 +127,7 @@ pub fn run(root: &SourceRoot) -> Result<DriftReport> {
     }
     agent_home_leak::check_source_tree(root, &mut report)?;
     unsafe_score::check(root, &mut report)?;
+    allowlist.apply(&mut report);
 
     report.sort();
     Ok(report)

--- a/crates/agent-runtime-cli/src/audit_drift/unsafe_score.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/unsafe_score.rs
@@ -40,7 +40,7 @@ pub fn check(root: &SourceRoot, report: &mut DriftReport) -> Result<()> {
         let build_dir = root.path().join("build").join(product);
         scan_tree(root, &build_dir, Some((*product).to_string()), report)?;
     }
-    for sub in ["core", "targets", "manifests"] {
+    for sub in ["core", "targets", "manifests", "tests/drift"] {
         let dir = root.path().join(sub);
         scan_tree(root, &dir, None, report)?;
     }

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -3,6 +3,8 @@
 // links one integration test binary instead of many. This keeps the
 // dev-loop link phase O(crates) instead of O(test-files).
 
+#[path = "integration/audit_drift_allowlist.rs"]
+mod audit_drift_allowlist;
 #[path = "integration/audit_drift_classes.rs"]
 mod audit_drift_classes;
 #[path = "integration/audit_drift_unsafe_score.rs"]

--- a/crates/agent-runtime-cli/tests/integration/audit_drift_allowlist.rs
+++ b/crates/agent-runtime-cli/tests/integration/audit_drift_allowlist.rs
@@ -1,0 +1,163 @@
+//! Integration coverage for `drift-audit.allow.yaml` unsafe allowlist handling.
+
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/render-determinism")
+}
+
+fn copy_tree(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_tree(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap();
+        }
+    }
+}
+
+fn copy_fixture() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    copy_tree(&fixture_root(), tmp.path());
+    tmp
+}
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn audit(root: &Path, extra_args: &[&str]) -> CmdOutput {
+    let mut args = vec!["audit-drift", "--source-root", root.to_str().unwrap()];
+    args.extend(extra_args);
+    cmd::run(&agent_runtime_bin(), &args, &[], None)
+}
+
+#[test]
+fn allowlist_demotes_block_to_warn_under_tests_fixture_glob() {
+    let tmp = copy_fixture();
+    write(
+        &tmp.path().join("tests/drift/fixtures/auth.json"),
+        "token: 4fK9zQm2Lp8sVx7Tn3Bc6Rj0WaYd\n",
+    );
+    write(
+        &tmp.path().join("drift-audit.allow.yaml"),
+        r#"schema_version: 1
+unsafe_allow:
+  - path: "tests/drift/fixtures/**"
+    reason: "fixture intentionally contains fake token material"
+"#,
+    );
+
+    let out = audit(tmp.path(), &[]);
+    assert_eq!(
+        out.code,
+        1,
+        "allowlisted block finding should demote to warn; stderr=\n{}",
+        out.stderr_text(),
+    );
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("[unsafe/warn"),
+        "expected demoted unsafe/warn finding; got\n{stderr}",
+    );
+    assert!(
+        stderr.contains("allowlist demoted block->warn"),
+        "expected allowlist demotion note; got\n{stderr}",
+    );
+}
+
+#[test]
+fn allowlist_demotes_warn_to_suppressed_without_hiding_verbose_evidence() {
+    let tmp = copy_fixture();
+    write(&tmp.path().join("core/auth.json"), "{}\n");
+    write(
+        &tmp.path().join("drift-audit.allow.yaml"),
+        r#"schema_version: 1
+unsafe_allow:
+  - path: "core/auth.json"
+    reason: "empty fixture path only"
+"#,
+    );
+
+    let normal = audit(tmp.path(), &[]);
+    assert_eq!(
+        normal.code,
+        0,
+        "allowlisted warn should demote to suppressed by default; stderr=\n{}",
+        normal.stderr_text(),
+    );
+    assert!(
+        !normal.stderr_text().contains("[unsafe/suppressed"),
+        "suppressed finding should stay hidden by default; stderr=\n{}",
+        normal.stderr_text(),
+    );
+
+    let verbose = audit(tmp.path(), &["--verbose"]);
+    assert_eq!(verbose.code, 0, "stderr=\n{}", verbose.stderr_text());
+    let stderr = verbose.stderr_text();
+    assert!(
+        stderr.contains("[unsafe/suppressed"),
+        "expected verbose suppressed finding; got\n{stderr}",
+    );
+    assert!(
+        stderr.contains("allowlist demoted warn->suppressed"),
+        "expected allowlist demotion note; got\n{stderr}",
+    );
+}
+
+#[test]
+fn allowlist_entry_missing_reason_errors_at_audit_start() {
+    let tmp = copy_fixture();
+    write(&tmp.path().join("core/auth.json"), "{}\n");
+    write(
+        &tmp.path().join("drift-audit.allow.yaml"),
+        r#"schema_version: 1
+unsafe_allow:
+  - path: "core/auth.json"
+"#,
+    );
+
+    let out = audit(tmp.path(), &[]);
+    assert_ne!(out.code, 0, "missing reason should fail");
+    assert!(
+        out.stderr_text().contains("reason"),
+        "expected schema error naming reason; stderr=\n{}",
+        out.stderr_text(),
+    );
+}
+
+#[test]
+fn private_allowlist_is_rejected_at_config_load() {
+    let tmp = copy_fixture();
+    write(
+        &tmp.path().join(".private/drift-audit.allow.yaml"),
+        r#"schema_version: 1
+unsafe_allow:
+  - path: "core/auth.json"
+    reason: "not supported from private overlay"
+"#,
+    );
+
+    let out = audit(tmp.path(), &[]);
+    assert_ne!(out.code, 0, ".private allowlist should fail");
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains(".private") && stderr.contains("drift-audit.allow.yaml"),
+        "expected .private allowlist rejection; got\n{stderr}",
+    );
+}


### PR DESCRIPTION
# Add drift audit allowlist

## Summary

Implements Plan 04 Task 4.2 for `agent-runtime audit-drift`: a top-level `drift-audit.allow.yaml` schema that demotes `unsafe` findings by exactly one tier while preserving verbose evidence. Refs graysurf/agent-runtime-kit#3.

## Changes

- Add `audit_drift::allowlist` loader for `{ schema_version: 1, unsafe_allow: [...] }`.
- Demote matching `unsafe` findings `block -> warn` or `warn -> suppressed`.
- Reject `.private/drift-audit.allow.yaml` before audit scanning.
- Extend unsafe scanning to `tests/drift/` so planned fixture allowlist paths are covered.

## Test-First Evidence

- Change classification: feature / behavior change.
- Failing test before fix: `cargo test -p agent-runtime-cli allowlist` failed before implementation for block demotion, warn demotion, missing reason, and `.private` rejection.
- Final validation: focused allowlist tests, full audit-drift tests, full `agent-runtime-cli` crate tests, clippy, and whitespace checks passed.
- Waiver reason: N/A.

## Testing

- `cargo test -p agent-runtime-cli allowlist` (pass)
- `cargo test -p agent-runtime-cli audit_drift` (pass)
- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` (pass)
- `cargo test -p agent-runtime-cli` (pass)
- `git diff --check` (pass)

## Risk / Notes

- Glob support is intentionally small: `**` across path components and `*` within a component.
- Allowlists never remove findings from the in-memory report; `warn -> suppressed` remains visible with `--verbose`.
- Specialist review ran with testing, maintainability, API-contract, security, performance, and red-team lenses; no concrete unresolved findings.
