### PR TITLE
Add local fast changed-scope checks

### DIFF
--- a/.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
+++ b/.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
@@ -12,6 +12,8 @@ Runs the required pre-delivery checks from DEVELOPMENT.md:
   - bash scripts/ci/markdownlint-audit.sh --strict
   - bash scripts/ci/plan-bundle-validate.sh --strict
   - bash scripts/ci/cli-output-contract-lint.sh --strict
+  - bash scripts/ci/forge-cli-fixture-lint.sh --strict
+  - bash scripts/ci/tests/local-fast-checks.test.sh
   - bash scripts/ci/tests/shared-helper-adoption-audit.test.sh
   - bash scripts/ci/test-stale-audit.sh --strict
   - bash scripts/ci/third-party-artifacts-audit.sh --strict
@@ -67,7 +69,7 @@ done
 
 required_cmds=(git npx)
 if [[ "$docs_only" -eq 0 ]]; then
-  required_cmds+=(cargo zsh rg)
+  required_cmds+=(cargo python3 zsh rg)
 fi
 
 for cmd in "${required_cmds[@]}"; do
@@ -126,6 +128,7 @@ if [[ "$docs_only" -eq 1 ]]; then
   exit 0
 fi
 
+run bash scripts/ci/tests/local-fast-checks.test.sh
 run bash scripts/ci/tests/shared-helper-adoption-audit.test.sh
 run bash scripts/ci/test-stale-audit.sh --strict
 run bash scripts/ci/third-party-artifacts-audit.sh --strict

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,9 +35,14 @@ Docs-only checks require:
 - `npx`
 - `plan-tooling`
 
+Local fast changed-scope checks also require:
+
+- `python3`
+
 Full required checks also require:
 
 - `cargo`
+- `python3`
 - `zsh`
 - `rg`
 - `cargo-nextest` when `NILS_CLI_TEST_RUNNER=nextest`
@@ -58,7 +63,31 @@ For optional runtime tools used by individual CLIs, see `BINARY_DEPENDENCIES.md`
 
 ## 3. Canonical local test flows
 
-Primary local entrypoint:
+Primary local entrypoint for day-to-day implementation work:
+
+```bash
+bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast
+```
+
+This runs changed-scope validation against `origin/main` by default:
+
+- documentation-only changes use the docs-only lane
+- non-shared crate changes run package-scoped `fmt`, `clippy`, and tests
+- shared crates and workspace-level files escalate to the workspace Rust gate
+
+Override the base ref when needed:
+
+```bash
+bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast --base main
+```
+
+Use `--plan-only` to inspect the selected validation scope without running it:
+
+```bash
+bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast --plan-only
+```
+
+The canonical CI/full-check entrypoint remains:
 
 ```bash
 bash scripts/ci/nils-cli-checks-entrypoint.sh
@@ -92,7 +121,24 @@ The lint has a self-test under
 `scripts/ci/tests/cli-output-contract-lint.test.sh` that exercises every
 regression class against synthetic fixtures.
 
-### 3.2 CI-like required checks (recommended before push)
+### 3.2 Local fast changed-scope checks
+
+For most local implementation loops:
+
+```bash
+bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast
+```
+
+Set `NILS_CLI_TEST_RUNNER=nextest` to require `cargo-nextest`; otherwise the
+local fast gate auto-selects `cargo nextest` when available and falls back to
+`cargo test`.
+
+The local fast gate is conservative. Changes to `nils-common`, `nils-term`,
+`nils-test-support`, root manifests, CI scripts, completions, `.agents/`,
+`.github/`, or other workspace-level paths use a workspace Rust gate because
+package-scoped checks can miss reverse-dependency breakage.
+
+### 3.3 CI-like required checks (optional local parity / CI gate)
 
 ```bash
 NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh
@@ -104,9 +150,10 @@ Notes:
 - Because doctests are not included in nextest, the entrypoint also runs
   `cargo test --workspace --doc` when `NILS_CLI_TEST_RUNNER=nextest`.
 
-### 3.3 Full pre-delivery flow (required for non-docs changes)
+### 3.4 Full coverage flow (CI/release gate)
 
-Coverage gate is mandatory for non-doc changes (total line coverage must stay `>= 85.00%`):
+Coverage gate is mandatory in CI and release-quality verification for non-doc
+changes (total line coverage must stay `>= 85.00%`):
 
 ```bash
 NILS_CLI_TEST_RUNNER=nextest \
@@ -137,6 +184,8 @@ NILS_CLI_COVERAGE_FAIL_UNDER_LINES=90 bash scripts/ci/nils-cli-checks-entrypoint
 - `bash scripts/ci/markdownlint-audit.sh --strict`
 - `bash scripts/ci/plan-bundle-validate.sh --strict`
 - `bash scripts/ci/cli-output-contract-lint.sh --strict`
+- `bash scripts/ci/forge-cli-fixture-lint.sh --strict`
+- `bash scripts/ci/tests/local-fast-checks.test.sh`
 - `bash scripts/ci/tests/shared-helper-adoption-audit.test.sh`
 - `bash scripts/ci/test-stale-audit.sh --strict`
 - `bash scripts/ci/third-party-artifacts-audit.sh --strict`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,6 +38,7 @@ Docs-only checks require:
 Local fast changed-scope checks also require:
 
 - `python3`
+- `cargo` for non-document changes
 
 Full required checks also require:
 

--- a/scripts/ci/nils-cli-checks-entrypoint.sh
+++ b/scripts/ci/nils-cli-checks-entrypoint.sh
@@ -4,17 +4,22 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  scripts/ci/nils-cli-checks-entrypoint.sh [--xvfb] [--with-coverage] [verify-script args...]
+  scripts/ci/nils-cli-checks-entrypoint.sh [--xvfb] [--local-fast] [--with-coverage] [verify-script args...]
 
 Description:
   Canonical cross-platform entrypoint for CI verification jobs.
   - Runs ./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
   - Reuses the current Bash interpreter so nested audit scripts run with the same shell version.
   - Optionally wraps execution with xvfb-run for Linux runners.
+  - Optionally runs the local fast changed-scope gate.
   - Optionally runs the local coverage gate and summary after required checks.
 
 Options:
   --xvfb             Run checks under `xvfb-run -a`
+  --local-fast       Run fast local changed-scope validation instead of the
+                     full required-checks script. Pass --base <ref>,
+                     --plan-only, or --changed-file <path> through to
+                     scripts/ci/nils-cli-local-fast.sh.
   --with-coverage    Run coverage gate after required checks:
                      cargo llvm-cov nextest --profile ci --workspace --lcov \
                        --output-path target/coverage/lcov.info --fail-under-lines <N>
@@ -31,7 +36,10 @@ USAGE
 use_xvfb=0
 with_coverage=0
 docs_only=0
+local_fast=0
+local_fast_arg_seen=0
 declare -a verify_args=()
+declare -a local_fast_args=()
 while [[ $# -gt 0 ]]; do
   case "${1:-}" in
     --xvfb)
@@ -40,6 +48,24 @@ while [[ $# -gt 0 ]]; do
       ;;
     --with-coverage)
       with_coverage=1
+      shift
+      ;;
+    --local-fast)
+      local_fast=1
+      shift
+      ;;
+    --base|--changed-file)
+      if [[ $# -lt 2 ]]; then
+        echo "error: ${1:-} requires a value" >&2
+        exit 2
+      fi
+      local_fast_arg_seen=1
+      local_fast_args+=("${1:-}" "${2:-}")
+      shift 2
+      ;;
+    --base=*|--changed-file=*|--plan-only)
+      local_fast_arg_seen=1
+      local_fast_args+=("${1:-}")
       shift
       ;;
     --docs-only)
@@ -57,6 +83,11 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ "$local_fast" -eq 0 && "$local_fast_arg_seen" -eq 1 ]]; then
+  echo "error: --base, --changed-file, and --plan-only require --local-fast" >&2
+  exit 2
+fi
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
@@ -91,6 +122,24 @@ run() {
     exit 1
   fi
 }
+
+if [[ "$local_fast" -eq 1 ]]; then
+  if [[ "$with_coverage" -eq 1 ]]; then
+    echo "error: --local-fast cannot be used with --with-coverage" >&2
+    exit 2
+  fi
+  if [[ "$docs_only" -eq 1 ]]; then
+    echo "error: --local-fast cannot be used with --docs-only" >&2
+    exit 2
+  fi
+  local_fast_script="./scripts/ci/nils-cli-local-fast.sh"
+  if [[ ! -f "$local_fast_script" ]]; then
+    echo "error: missing local fast checks script: $local_fast_script" >&2
+    exit 2
+  fi
+  run "$bash_bin" "$local_fast_script" "${local_fast_args[@]}"
+  exit 0
+fi
 
 declare -a cmd=( "$bash_bin" "$verify_script" "${verify_args[@]}" )
 if [[ "$use_xvfb" -eq 1 ]]; then

--- a/scripts/ci/nils-cli-local-fast.sh
+++ b/scripts/ci/nils-cli-local-fast.sh
@@ -86,7 +86,6 @@ require_cmd() {
 }
 
 require_cmd git
-require_cmd cargo
 require_cmd python3
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
@@ -139,6 +138,7 @@ collect_changed_files >"$changed_file_list"
 python3 - "$repo_root" "$changed_file_list" >"$plan_file" <<'PY'
 import json
 import pathlib
+import shutil
 import subprocess
 import sys
 
@@ -149,6 +149,37 @@ changed = [
     for line in changed_path.read_text(encoding="utf-8").splitlines()
     if line.strip()
 ]
+
+def emit(key, value):
+    print(f"{key}\t{value}")
+
+
+def is_doc_path(path):
+    return (
+        path.endswith(".md")
+        or path.startswith("docs/")
+        or "/docs/" in path
+        or path in {"README", "LICENSE", "NOTICE"}
+    )
+
+
+if not changed:
+    emit("mode", "none")
+    emit("docs_checks", "0")
+    emit("changed_count", "0")
+    sys.exit(0)
+
+if all(is_doc_path(path) for path in changed):
+    emit("mode", "docs-only")
+    emit("docs_checks", "1")
+    emit("changed_count", str(len(changed)))
+    for path in changed:
+        emit("changed", path)
+    sys.exit(0)
+
+if shutil.which("cargo") is None:
+    print("error: cargo is required for non-document local-fast planning", file=sys.stderr)
+    sys.exit(2)
 
 metadata_raw = subprocess.check_output(
     ["cargo", "metadata", "--no-deps", "--format-version", "1"],
@@ -165,19 +196,6 @@ for package in metadata["packages"]:
 crate_roots.sort(key=lambda item: len(item[0]), reverse=True)
 
 shared_packages = {"nils-common", "nils-term", "nils-test-support"}
-
-
-def emit(key, value):
-    print(f"{key}\t{value}")
-
-
-def is_doc_path(path):
-    return (
-        path.endswith(".md")
-        or path.startswith("docs/")
-        or "/docs/" in path
-        or path in {"README", "LICENSE", "NOTICE"}
-    )
 
 
 def package_for_path(path):

--- a/scripts/ci/nils-cli-local-fast.sh
+++ b/scripts/ci/nils-cli-local-fast.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ci/nils-cli-local-fast.sh [--base <ref>] [--plan-only] [--changed-file <path>]...
+
+Description:
+  Fast local validation for day-to-day development.
+  - Detects changed files against a merge-base with <ref> plus staged,
+    unstaged, and untracked files.
+  - Runs docs-only checks for documentation-only changes.
+  - Runs package-scoped fmt/clippy/tests for non-shared crate changes.
+  - Escalates to a workspace Rust gate for shared crates or workspace-level
+    files where package-scoped checks can miss reverse-dependency breakage.
+
+Options:
+  --base <ref>            Diff base for committed changes.
+                          Default: NILS_CLI_LOCAL_FAST_BASE or origin/main.
+  --plan-only             Print the detected validation plan and do not run it.
+  --changed-file <path>   Override changed-file detection. Repeatable.
+                          Intended for regression tests and explicit scopes.
+  -h, --help              Show this help.
+
+Environment:
+  NILS_CLI_LOCAL_FAST_BASE
+    Default base ref when --base is not supplied.
+  NILS_CLI_TEST_RUNNER
+    auto, nextest, cargo, or cargo-test. Default: auto.
+USAGE
+}
+
+base="${NILS_CLI_LOCAL_FAST_BASE:-origin/main}"
+plan_only=0
+declare -a forced_changed_files=()
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --base)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --base requires a value" >&2
+        exit 2
+      fi
+      base="${2:-}"
+      shift 2
+      ;;
+    --base=*)
+      base="${1#--base=}"
+      shift
+      ;;
+    --plan-only)
+      plan_only=1
+      shift
+      ;;
+    --changed-file)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --changed-file requires a value" >&2
+        exit 2
+      fi
+      forced_changed_files+=("${2:-}")
+      shift 2
+      ;;
+    --changed-file=*)
+      forced_changed_files+=("${1#--changed-file=}")
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: ${1:-}" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: missing required tool on PATH: $cmd" >&2
+    exit 2
+  fi
+}
+
+require_cmd git
+require_cmd cargo
+require_cmd python3
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
+  echo "error: must run inside a git work tree" >&2
+  exit 2
+fi
+cd "$repo_root"
+
+run() {
+  local -a cmd=( "$@" )
+  echo "+ ${cmd[*]}"
+  if "${cmd[@]}"; then
+    return 0
+  else
+    local code=$?
+    echo "error: local-fast check failed (exit $code): ${cmd[*]}" >&2
+    exit 1
+  fi
+}
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/nils-cli-local-fast.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+changed_file_list="$tmp_dir/changed-files.txt"
+plan_file="$tmp_dir/plan.tsv"
+
+collect_changed_files() {
+  if [[ "${#forced_changed_files[@]}" -gt 0 ]]; then
+    printf '%s\n' "${forced_changed_files[@]}" | sed '/^$/d' | sort -u
+    return 0
+  fi
+
+  if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
+    echo "error: base ref does not resolve to a commit: $base" >&2
+    exit 2
+  fi
+
+  local merge_base
+  merge_base="$(git merge-base HEAD "$base")"
+  {
+    git diff --name-only --diff-filter=ACMRT "$merge_base"...HEAD
+    git diff --name-only --diff-filter=ACMRT
+    git diff --name-only --cached --diff-filter=ACMRT
+    git ls-files --others --exclude-standard
+  } | sed '/^$/d' | sort -u
+}
+
+collect_changed_files >"$changed_file_list"
+
+python3 - "$repo_root" "$changed_file_list" >"$plan_file" <<'PY'
+import json
+import pathlib
+import subprocess
+import sys
+
+repo = pathlib.Path(sys.argv[1])
+changed_path = pathlib.Path(sys.argv[2])
+changed = [
+    line.strip()
+    for line in changed_path.read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+
+metadata_raw = subprocess.check_output(
+    ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+    cwd=repo,
+    text=True,
+)
+metadata = json.loads(metadata_raw)
+
+crate_roots = []
+for package in metadata["packages"]:
+    manifest = pathlib.Path(package["manifest_path"])
+    root = manifest.parent.relative_to(repo).as_posix()
+    crate_roots.append((root, package["name"]))
+crate_roots.sort(key=lambda item: len(item[0]), reverse=True)
+
+shared_packages = {"nils-common", "nils-term", "nils-test-support"}
+
+
+def emit(key, value):
+    print(f"{key}\t{value}")
+
+
+def is_doc_path(path):
+    return (
+        path.endswith(".md")
+        or path.startswith("docs/")
+        or "/docs/" in path
+        or path in {"README", "LICENSE", "NOTICE"}
+    )
+
+
+def package_for_path(path):
+    for root, name in crate_roots:
+        if path == root or path.startswith(root + "/"):
+            return root, name
+    return None
+
+
+packages = set()
+workspace_reasons = []
+shell_files = []
+docs_checks = False
+
+for path in changed:
+    if path.endswith(".sh"):
+        shell_files.append(path)
+
+    if is_doc_path(path):
+        docs_checks = True
+        continue
+
+    package = package_for_path(path)
+    if package is not None:
+        _root, package_name = package
+        if package_name in shared_packages:
+            workspace_reasons.append(f"shared package changed: {package_name}")
+        else:
+            packages.add(package_name)
+        continue
+
+    if path in {"Cargo.toml", "Cargo.lock"}:
+        workspace_reasons.append(f"workspace manifest changed: {path}")
+    elif path.startswith((".agents/", ".github/", ".cargo/", ".config/", "scripts/", "tests/", "completions/")):
+        workspace_reasons.append(f"workspace-level path changed: {path}")
+    else:
+        workspace_reasons.append(f"unclassified workspace path changed: {path}")
+
+if not changed:
+    mode = "none"
+elif workspace_reasons:
+    mode = "workspace"
+elif packages:
+    mode = "packages"
+elif docs_checks:
+    mode = "docs-only"
+else:
+    mode = "workspace"
+    workspace_reasons.append("fallback workspace mode")
+
+emit("mode", mode)
+emit("docs_checks", "1" if docs_checks else "0")
+emit("changed_count", str(len(changed)))
+for path in changed:
+    emit("changed", path)
+for package_name in sorted(packages):
+    emit("package", package_name)
+for reason in sorted(set(workspace_reasons)):
+    emit("reason", reason)
+for shell_file in sorted(set(shell_files)):
+    emit("shell", shell_file)
+PY
+
+mode=""
+docs_checks=0
+changed_count=0
+declare -a packages=()
+declare -a reasons=()
+declare -a changed_files=()
+declare -a shell_files=()
+
+while IFS=$'\t' read -r key value; do
+  case "$key" in
+    mode) mode="$value" ;;
+    docs_checks) docs_checks="$value" ;;
+    changed_count) changed_count="$value" ;;
+    package) packages+=("$value") ;;
+    reason) reasons+=("$value") ;;
+    changed) changed_files+=("$value") ;;
+    shell) shell_files+=("$value") ;;
+  esac
+done <"$plan_file"
+
+if [[ -z "$mode" ]]; then
+  echo "error: local-fast planner did not emit a mode" >&2
+  exit 1
+fi
+
+print_plan() {
+  echo "LOCAL_FAST_MODE=$mode"
+  echo "LOCAL_FAST_BASE=$base"
+  echo "LOCAL_FAST_DOCS_CHECKS=$docs_checks"
+  echo "LOCAL_FAST_CHANGED_COUNT=$changed_count"
+  for path in "${changed_files[@]}"; do
+    echo "LOCAL_FAST_CHANGED=$path"
+  done
+  for package in "${packages[@]}"; do
+    echo "LOCAL_FAST_PACKAGE=$package"
+  done
+  for reason in "${reasons[@]}"; do
+    echo "LOCAL_FAST_REASON=$reason"
+  done
+  for shell_file in "${shell_files[@]}"; do
+    echo "LOCAL_FAST_SHELL=$shell_file"
+  done
+}
+
+print_plan
+
+if [[ "$plan_only" -eq 1 ]]; then
+  exit 0
+fi
+
+bash_bin="${BASH:-}"
+if [[ -z "$bash_bin" || ! -x "$bash_bin" ]]; then
+  bash_bin="$(command -v bash || true)"
+fi
+if [[ -z "$bash_bin" || ! -x "$bash_bin" ]]; then
+  echo "error: bash not found on PATH" >&2
+  exit 2
+fi
+
+verify_script="./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh"
+if [[ ! -f "$verify_script" ]]; then
+  echo "error: missing required checks script: $verify_script" >&2
+  exit 2
+fi
+
+run_docs_checks() {
+  run "$bash_bin" "$verify_script" --docs-only
+}
+
+select_test_runner() {
+  local requested="${NILS_CLI_TEST_RUNNER:-auto}"
+  case "$requested" in
+    ""|auto)
+      if command -v cargo-nextest >/dev/null 2>&1; then
+        echo "nextest"
+      else
+        echo "cargo"
+      fi
+      ;;
+    nextest)
+      if ! command -v cargo-nextest >/dev/null 2>&1; then
+        echo "error: NILS_CLI_TEST_RUNNER=nextest requires cargo-nextest on PATH" >&2
+        exit 2
+      fi
+      echo "nextest"
+      ;;
+    cargo|cargo-test)
+      echo "cargo"
+      ;;
+    *)
+      echo "error: unsupported NILS_CLI_TEST_RUNNER value: $requested (expected auto, cargo, or nextest)" >&2
+      exit 2
+      ;;
+  esac
+}
+
+case "$mode" in
+  none)
+    echo "ok: local-fast found no changed files"
+    exit 0
+    ;;
+  docs-only)
+    run_docs_checks
+    echo "ok: local-fast docs-only checks passed"
+    exit 0
+    ;;
+  packages|workspace)
+    ;;
+  *)
+    echo "error: unsupported local-fast mode: $mode" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$docs_checks" -eq 1 ]]; then
+  run_docs_checks
+fi
+
+for shell_file in "${shell_files[@]}"; do
+  run bash -n "$shell_file"
+done
+
+test_runner="$(select_test_runner)"
+echo "LOCAL_FAST_TEST_RUNNER=$test_runner"
+
+run cargo fmt --all -- --check
+
+if [[ "$mode" == "workspace" ]]; then
+  run cargo clippy --all-targets --all-features -- -D warnings
+  if [[ "$test_runner" == "nextest" ]]; then
+    run cargo nextest run --profile ci --workspace
+    run cargo test --workspace --doc
+  else
+    run cargo test --workspace
+  fi
+  echo "ok: local-fast workspace Rust gate passed"
+  exit 0
+fi
+
+for package in "${packages[@]}"; do
+  run cargo clippy -p "$package" --all-targets --all-features -- -D warnings
+done
+
+for package in "${packages[@]}"; do
+  if [[ "$test_runner" == "nextest" ]]; then
+    run cargo nextest run --profile ci -p "$package"
+    run cargo test -p "$package" --doc
+  else
+    run cargo test -p "$package"
+  fi
+done
+
+echo "ok: local-fast package checks passed (${#packages[@]} package(s))"

--- a/scripts/ci/tests/local-fast-checks.test.sh
+++ b/scripts/ci/tests/local-fast-checks.test.sh
@@ -62,6 +62,31 @@ assert_docs_only_uses_docs_mode() {
   echo "ok"
 }
 
+assert_docs_only_plan_does_not_require_cargo() {
+  echo "== docs-only plan does not require cargo =="
+  local tmp_bin
+  tmp_bin="$(mktemp -d)"
+  for cmd in bash git python3 sed sort mktemp rm; do
+    ln -s "$(command -v "$cmd")" "$tmp_bin/$cmd"
+  done
+
+  local output status
+  set +e
+  output="$(PATH="$tmp_bin" bash "$script" --plan-only --changed-file docs/runbooks/example.md 2>&1)"
+  status=$?
+  set -e
+  rm -rf "$tmp_bin"
+  if [[ "$status" -ne 0 ]]; then
+    echo "FAIL: $FUNCNAME"
+    echo "$output"
+    exit 1
+  fi
+
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_MODE=docs-only"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_DOCS_CHECKS=1"
+  echo "ok"
+}
+
 assert_workspace_manifest_escalates_to_workspace() {
   echo "== workspace manifest escalates to workspace =="
   local output
@@ -95,6 +120,7 @@ assert_shell_script_is_reported() {
 assert_package_crate_uses_package_mode
 assert_shared_crate_escalates_to_workspace
 assert_docs_only_uses_docs_mode
+assert_docs_only_plan_does_not_require_cargo
 assert_workspace_manifest_escalates_to_workspace
 assert_docs_plus_package_runs_both
 assert_shell_script_is_reported

--- a/scripts/ci/tests/local-fast-checks.test.sh
+++ b/scripts/ci/tests/local-fast-checks.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Self-test for scripts/ci/nils-cli-local-fast.sh plan detection.
+#
+# The local fast gate is intentionally conservative: package-scoped validation
+# is only used for non-shared crate changes, while shared crates and
+# workspace-level files escalate to the workspace Rust gate.
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
+  echo "error: must run inside the nils-cli git work tree" >&2
+  exit 2
+fi
+
+script="$repo_root/scripts/ci/nils-cli-local-fast.sh"
+if [[ ! -f "$script" ]]; then
+  echo "error: missing local fast script: $script" >&2
+  exit 2
+fi
+
+plan_for() {
+  bash "$script" --plan-only "$@"
+}
+
+assert_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  if ! grep -qF "$needle" <<<"$haystack"; then
+    echo "FAIL: $label"
+    echo "missing: $needle"
+    echo "$haystack"
+    exit 1
+  fi
+}
+
+assert_package_crate_uses_package_mode() {
+  echo "== package crate uses package mode =="
+  local output
+  output="$(plan_for --changed-file crates/plan-tooling/src/validate.rs)"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_MODE=packages"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_PACKAGE=nils-plan-tooling"
+  echo "ok"
+}
+
+assert_shared_crate_escalates_to_workspace() {
+  echo "== shared crate escalates to workspace =="
+  local output
+  output="$(plan_for --changed-file crates/nils-common/src/lib.rs)"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_MODE=workspace"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_REASON=shared package changed: nils-common"
+  echo "ok"
+}
+
+assert_docs_only_uses_docs_mode() {
+  echo "== docs-only changes use docs mode =="
+  local output
+  output="$(plan_for --changed-file docs/runbooks/example.md)"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_MODE=docs-only"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_DOCS_CHECKS=1"
+  echo "ok"
+}
+
+assert_workspace_manifest_escalates_to_workspace() {
+  echo "== workspace manifest escalates to workspace =="
+  local output
+  output="$(plan_for --changed-file Cargo.toml)"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_MODE=workspace"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_REASON=workspace manifest changed: Cargo.toml"
+  echo "ok"
+}
+
+assert_docs_plus_package_runs_both() {
+  echo "== docs plus package requests docs and package checks =="
+  local output
+  output="$(plan_for \
+    --changed-file docs/runbooks/example.md \
+    --changed-file crates/plan-tooling/src/validate.rs)"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_MODE=packages"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_DOCS_CHECKS=1"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_PACKAGE=nils-plan-tooling"
+  echo "ok"
+}
+
+assert_shell_script_is_reported() {
+  echo "== shell script changes are reported for syntax checks =="
+  local output
+  output="$(plan_for --changed-file scripts/ci/nils-cli-local-fast.sh)"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_MODE=workspace"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_SHELL=scripts/ci/nils-cli-local-fast.sh"
+  echo "ok"
+}
+
+assert_package_crate_uses_package_mode
+assert_shared_crate_escalates_to_workspace
+assert_docs_only_uses_docs_mode
+assert_workspace_manifest_escalates_to_workspace
+assert_docs_plus_package_runs_both
+assert_shell_script_is_reported
+
+echo
+echo "PASS: local-fast-checks.test.sh"


### PR DESCRIPTION
# Add local fast changed-scope checks

## Summary

Adds a first-class local fast gate so day-to-day nils-cli development can validate only the changed scope while CI remains responsible for full workspace and coverage gates.

## Changes

- Adds `scripts/ci/nils-cli-local-fast.sh` to plan docs-only, package-scoped, or workspace fallback validation from changed files.
- Wires `--local-fast` through `scripts/ci/nils-cli-checks-entrypoint.sh` with `--base`, `--plan-only`, and explicit changed-file passthrough.
- Adds regression coverage for local-fast planning and documents the local-vs-CI validation flow in `DEVELOPMENT.md`.

## Test-First Evidence

- Change classification: feature / developer workflow
- Failing test before fix: N/A; this adds a new local validation surface with new regression coverage.
- Final validation: shell syntax checks, local-fast plan tests, docs-only gate, package-scoped local-fast, and `git diff --check` passed.
- Waiver reason: no pre-existing failing behavior; regression tests were added with the feature.

## Testing

- `bash -n scripts/ci/nils-cli-local-fast.sh scripts/ci/nils-cli-checks-entrypoint.sh scripts/ci/tests/local-fast-checks.test.sh .agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` (pass)
- `bash scripts/ci/tests/local-fast-checks.test.sh` (pass)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast --plan-only` (pass)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast --changed-file crates/plan-tooling/src/validate.rs --plan-only` (pass)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` (pass)
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast --changed-file crates/plan-tooling/src/validate.rs` (pass; 197 nextest tests)
- `git diff --check` (pass)

## Risk / Notes

- Shared crates and workspace-level paths intentionally escalate to workspace Rust validation to avoid missing reverse-dependency breakage.
