### PR TITLE
Add audit-drift extra and intentional classes

### DIFF
--- a/crates/agent-runtime-cli/src/audit_drift/allowlist.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/allowlist.rs
@@ -154,6 +154,7 @@ fn demote(severity: Severity) -> Severity {
     match severity {
         Severity::Block => Severity::Warn,
         Severity::Warn => Severity::Suppressed,
+        Severity::Info => Severity::Info,
         Severity::Suppressed => Severity::Suppressed,
     }
 }

--- a/crates/agent-runtime-cli/src/audit_drift/classes/extra.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/classes/extra.rs
@@ -1,0 +1,275 @@
+//! Extra live-surface drift class.
+//!
+//! The class compares the current product runtime home against the
+//! install map. It only scans roots that the install map owns, so a
+//! user's unrelated runtime state does not become audit input.
+
+use crate::audit_drift::{DriftReport, Finding, Severity};
+use crate::install::link_map::{EntryKind, LinkMap, LinkMapError};
+use crate::render::manifest::{ManifestSet, ProductRoot, RuntimeRootsManifest, SourceRoot};
+use anyhow::{Context, Result};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+pub const CLASS: &str = "extra";
+
+pub fn check(
+    root: &SourceRoot,
+    manifests: Option<&ManifestSet>,
+    product: &str,
+    report: &mut DriftReport,
+) -> Result<()> {
+    let Some(manifests) = manifests else {
+        return Ok(());
+    };
+    let Some(product_root) = product_root(&manifests.runtime_roots, product) else {
+        return Ok(());
+    };
+    let live_home = resolve_live_home(product_root);
+    if !live_home.is_absolute() || !live_home.exists() {
+        return Ok(());
+    }
+    let link_map = match LinkMap::load(root.path(), product) {
+        Ok(link_map) => link_map,
+        Err(LinkMapError::Missing { .. }) => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+
+    let expected = expected_live_paths(root.path(), &link_map);
+    let scan_roots = scan_roots(&link_map);
+    if scan_roots.is_empty() {
+        return Ok(());
+    }
+
+    let live_files = live_files_under_roots(&live_home, &scan_roots)?;
+    for rel in live_files {
+        if expected.contains(&rel) || ignored_live_file(&rel) {
+            continue;
+        }
+        report.push(Finding {
+            class: CLASS,
+            severity: Severity::Warn,
+            product: Some(product.to_string()),
+            path: rel.clone(),
+            message: format!(
+                "live runtime surface exists under an install-map root but is not tracked by the install map: {}",
+                rel.display()
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+fn product_root<'a>(
+    runtime_roots: &'a RuntimeRootsManifest,
+    product: &str,
+) -> Option<&'a ProductRoot> {
+    match product {
+        "codex" => Some(&runtime_roots.products.codex),
+        "claude" => Some(&runtime_roots.products.claude),
+        _ => None,
+    }
+}
+
+fn resolve_live_home(root: &ProductRoot) -> PathBuf {
+    let env: BTreeMap<String, String> = std::env::vars().collect();
+    PathBuf::from(expand_env_vars(&root.live_home, &env))
+}
+
+fn expected_live_paths(source_root: &Path, link_map: &LinkMap) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    for entry in &link_map.entries {
+        let Some(dest) = clean_rel_path(&entry.destination) else {
+            continue;
+        };
+        match entry.kind {
+            EntryKind::SymlinkedFile if entry.recursive => {
+                let Some(source) = entry.source.as_deref().and_then(clean_rel_path) else {
+                    continue;
+                };
+                let source_abs = source_root.join(source);
+                if source_abs.is_dir() {
+                    for rel in source_files(&source_abs) {
+                        out.insert(dest.join(rel));
+                    }
+                } else if source_abs.exists() {
+                    out.insert(dest);
+                }
+            }
+            EntryKind::SymlinkedFile
+            | EntryKind::PluginManifestCopy
+            | EntryKind::BackedUpOnReplace
+            | EntryKind::ManagedBlock => {
+                out.insert(dest);
+            }
+        }
+    }
+    out
+}
+
+fn scan_roots(link_map: &LinkMap) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    for entry in &link_map.entries {
+        let Some(dest) = clean_rel_path(&entry.destination) else {
+            continue;
+        };
+        match entry.kind {
+            EntryKind::SymlinkedFile if entry.recursive => {
+                out.insert(dest);
+            }
+            EntryKind::SymlinkedFile
+            | EntryKind::PluginManifestCopy
+            | EntryKind::BackedUpOnReplace => {
+                if let Some(parent) = dest.parent()
+                    && !parent.as_os_str().is_empty()
+                {
+                    out.insert(parent.to_path_buf());
+                }
+            }
+            EntryKind::ManagedBlock => {}
+        }
+    }
+    out
+}
+
+fn source_files(root: &Path) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    collect_source_files(root, root, &mut out);
+    out
+}
+
+fn collect_source_files(root: &Path, dir: &Path, out: &mut BTreeSet<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(kind) = entry.file_type() else {
+            continue;
+        };
+        if kind.is_dir() {
+            collect_source_files(root, &path, out);
+        } else if let Ok(rel) = path.strip_prefix(root) {
+            out.insert(rel.to_path_buf());
+        }
+    }
+}
+
+fn live_files_under_roots(
+    live_home: &Path,
+    roots: &BTreeSet<PathBuf>,
+) -> Result<BTreeSet<PathBuf>> {
+    let mut out = BTreeSet::new();
+    for rel_root in roots {
+        collect_live_files(live_home, rel_root, &mut out)?;
+    }
+    Ok(out)
+}
+
+fn collect_live_files(live_home: &Path, rel: &Path, out: &mut BTreeSet<PathBuf>) -> Result<()> {
+    let path = live_home.join(rel);
+    let Ok(meta) = fs::symlink_metadata(&path) else {
+        return Ok(());
+    };
+    if meta.file_type().is_symlink() || meta.is_file() {
+        out.insert(rel.to_path_buf());
+        return Ok(());
+    }
+    if !meta.is_dir() {
+        return Ok(());
+    }
+
+    let entries = fs::read_dir(&path).with_context(|| format!("read {}", path.display()))?;
+    for entry in entries {
+        let entry = entry.with_context(|| format!("read {}", path.display()))?;
+        collect_live_files(live_home, &rel.join(entry.file_name()), out)?;
+    }
+    Ok(())
+}
+
+fn clean_rel_path(path: impl AsRef<str>) -> Option<PathBuf> {
+    let path = Path::new(path.as_ref());
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return None;
+    }
+    if path
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+    Some(path.to_path_buf())
+}
+
+fn ignored_live_file(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()) == Some(".DS_Store")
+}
+
+fn expand_env_vars(raw: &str, env: &BTreeMap<String, String>) -> String {
+    let chars: Vec<char> = raw.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] != '$' {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        if chars.get(i + 1) == Some(&'{')
+            && let Some(end) = find_matching_brace(&chars, i + 1)
+        {
+            let expr: String = chars[i + 2..end].iter().collect();
+            out.push_str(&expand_braced_expr(&expr, env));
+            i = end + 1;
+            continue;
+        }
+        let mut end = i + 1;
+        while end < chars.len() && (chars[end].is_ascii_alphanumeric() || chars[end] == '_') {
+            end += 1;
+        }
+        if end == i + 1 {
+            out.push('$');
+            i += 1;
+            continue;
+        }
+        let name: String = chars[i + 1..end].iter().collect();
+        out.push_str(env.get(&name).map(String::as_str).unwrap_or(""));
+        i = end;
+    }
+    out
+}
+
+fn find_matching_brace(chars: &[char], open_brace: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut i = open_brace + 1;
+    while i < chars.len() {
+        if chars[i] == '$' && chars.get(i + 1) == Some(&'{') {
+            depth += 1;
+            i += 2;
+            continue;
+        }
+        if chars[i] == '}' {
+            if depth == 0 {
+                return Some(i);
+            }
+            depth -= 1;
+        }
+        i += 1;
+    }
+    None
+}
+
+fn expand_braced_expr(expr: &str, env: &BTreeMap<String, String>) -> String {
+    if let Some((name, fallback)) = expr.split_once(":-") {
+        if let Some(value) = env.get(name)
+            && !value.is_empty()
+        {
+            return value.clone();
+        }
+        expand_env_vars(fallback, env)
+    } else {
+        env.get(expr).cloned().unwrap_or_default()
+    }
+}

--- a/crates/agent-runtime-cli/src/audit_drift/classes/intentional.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/classes/intentional.rs
@@ -1,0 +1,131 @@
+//! Documented product-difference drift class.
+//!
+//! `product-capabilities.yaml` records product-specific plugin manifest
+//! fields. When the target plugin manifests actually diverge along
+//! those documented fields, audit-drift reports the surface as
+//! informational instead of treating the difference as hidden drift.
+
+use crate::audit_drift::{DriftReport, Finding, Severity};
+use crate::render::manifest::{ManifestSet, PluginManifestDiff, SourceRoot};
+use anyhow::{Context, Result};
+use serde_json::{Map, Value};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const CLASS: &str = "intentional-difference";
+
+pub fn check(
+    root: &SourceRoot,
+    manifests: Option<&ManifestSet>,
+    report: &mut DriftReport,
+) -> Result<()> {
+    let Some(manifests) = manifests else {
+        return Ok(());
+    };
+    let Some(diff) = manifests.product_capabilities.plugin_manifest_diff.as_ref() else {
+        return Ok(());
+    };
+    if diff.codex_only_fields.is_empty() && diff.claude_only_fields.is_empty() {
+        return Ok(());
+    }
+
+    for domain in plugin_domains(root.path())? {
+        let codex_path = plugin_manifest_path(root.path(), "codex", &domain);
+        let claude_path = plugin_manifest_path(root.path(), "claude", &domain);
+        let Some(codex) = read_object(&codex_path)? else {
+            continue;
+        };
+        let Some(claude) = read_object(&claude_path)? else {
+            continue;
+        };
+
+        let ctx = PluginDiffContext {
+            source_root: root.path(),
+            domain: &domain,
+            diff,
+        };
+
+        push_documented_fields(&ctx, "codex", report, &codex_path, &codex, &claude);
+        push_documented_fields(&ctx, "claude", report, &claude_path, &claude, &codex);
+    }
+    Ok(())
+}
+
+struct PluginDiffContext<'a> {
+    source_root: &'a Path,
+    domain: &'a str,
+    diff: &'a PluginManifestDiff,
+}
+
+fn push_documented_fields(
+    ctx: &PluginDiffContext<'_>,
+    product: &str,
+    report: &mut DriftReport,
+    path: &Path,
+    product_manifest: &Map<String, Value>,
+    other_manifest: &Map<String, Value>,
+) {
+    let fields = match product {
+        "codex" => &ctx.diff.codex_only_fields,
+        "claude" => &ctx.diff.claude_only_fields,
+        _ => return,
+    };
+
+    for field in fields {
+        if product_manifest.contains_key(field) && !other_manifest.contains_key(field) {
+            report.push(Finding {
+                class: CLASS,
+                severity: Severity::Info,
+                product: Some(product.to_string()),
+                path: rel(ctx.source_root, path),
+                message: format!(
+                    "documented plugin manifest divergence for domain `{domain}`: field `{field}` is {product}-only",
+                    domain = ctx.domain
+                ),
+            });
+        }
+    }
+}
+
+fn plugin_domains(root: &Path) -> Result<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+    for product in ["codex", "claude"] {
+        let dir = root.join("targets").join(product).join("plugins");
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries {
+            let entry = entry.with_context(|| format!("read {}", dir.display()))?;
+            if entry.file_type().is_ok_and(|kind| kind.is_dir())
+                && let Some(name) = entry.file_name().to_str()
+            {
+                out.insert(name.to_string());
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn plugin_manifest_path(root: &Path, product: &str, domain: &str) -> PathBuf {
+    root.join("targets")
+        .join(product)
+        .join("plugins")
+        .join(domain)
+        .join(format!(".{product}-plugin"))
+        .join("plugin.json")
+}
+
+fn read_object(path: &Path) -> Result<Option<Map<String, Value>>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let value: Value =
+        serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
+    Ok(value.as_object().cloned())
+}
+
+fn rel(source_root: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(source_root).unwrap_or(path).to_path_buf()
+}

--- a/crates/agent-runtime-cli/src/audit_drift/classes/mod.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/classes/mod.rs
@@ -1,0 +1,4 @@
+//! Remaining Plan 04 drift classes.
+
+pub mod extra;
+pub mod intentional;

--- a/crates/agent-runtime-cli/src/audit_drift/mod.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/mod.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 
 pub mod agent_home_leak;
 pub mod allowlist;
+pub mod classes;
 pub mod docs_home;
 pub mod rendered_target;
 pub mod source_manifest;
@@ -34,6 +35,8 @@ pub enum Severity {
     /// Drift that is only visible in verbose output and never affects
     /// the exit code.
     Suppressed,
+    /// Drift that should be reported but never affects the exit code.
+    Info,
     /// Drift that the reporting POC will surface but not block on.
     Warn,
     /// Drift that breaks an explicit Resolved Decision contract.
@@ -44,6 +47,7 @@ impl Severity {
     pub fn exit_code(self) -> u8 {
         match self {
             Severity::Suppressed => 0,
+            Severity::Info => 0,
             Severity::Warn => 1,
             Severity::Block => 2,
         }
@@ -52,6 +56,7 @@ impl Severity {
     pub fn label(self) -> &'static str {
         match self {
             Severity::Suppressed => "suppressed",
+            Severity::Info => "info",
             Severity::Warn => "warn",
             Severity::Block => "block",
         }
@@ -124,7 +129,9 @@ pub fn run(root: &SourceRoot) -> Result<DriftReport> {
         rendered_target::check(root, manifests.as_deref(), product, &mut report)?;
         agent_home_leak::check_product_build(root, product, &mut report)?;
         docs_home::check(root, product, &mut report)?;
+        classes::extra::check(root, manifests.as_deref(), product, &mut report)?;
     }
+    classes::intentional::check(root, manifests.as_deref(), &mut report)?;
     agent_home_leak::check_source_tree(root, &mut report)?;
     unsafe_score::check(root, &mut report)?;
     allowlist.apply(&mut report);
@@ -190,9 +197,11 @@ mod tests {
     #[test]
     fn severity_exit_codes_match_documented_policy() {
         assert_eq!(Severity::Suppressed.exit_code(), 0);
+        assert_eq!(Severity::Info.exit_code(), 0);
         assert_eq!(Severity::Warn.exit_code(), 1);
         assert_eq!(Severity::Block.exit_code(), 2);
         assert_eq!(Severity::Suppressed.label(), "suppressed");
+        assert_eq!(Severity::Info.label(), "info");
         assert_eq!(Severity::Warn.label(), "warn");
         assert_eq!(Severity::Block.label(), "block");
     }

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -7,6 +7,8 @@
 mod audit_drift_allowlist;
 #[path = "integration/audit_drift_classes.rs"]
 mod audit_drift_classes;
+#[path = "integration/audit_drift_extra_intentional.rs"]
+mod audit_drift_extra_intentional;
 #[path = "integration/audit_drift_unsafe_score.rs"]
 mod audit_drift_unsafe_score;
 #[path = "integration/cli.rs"]

--- a/crates/agent-runtime-cli/tests/integration/audit_drift_extra_intentional.rs
+++ b/crates/agent-runtime-cli/tests/integration/audit_drift_extra_intentional.rs
@@ -1,0 +1,210 @@
+//! Integration coverage for Plan 04 Task 4.3 `audit-drift` intentional
+//! product differences and extra live surfaces.
+
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn fixture_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/render-determinism")
+}
+
+fn copy_tree(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            copy_tree(&src_path, &dst_path);
+        } else {
+            fs::copy(&src_path, &dst_path).unwrap();
+        }
+    }
+}
+
+fn copy_fixture() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    copy_tree(&fixture_root(), tmp.path());
+    tmp
+}
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn run(args: &[&str], envs: &[(&str, &str)]) -> CmdOutput {
+    cmd::run(&agent_runtime_bin(), args, envs, None)
+}
+
+fn render_both_products(root: &Path) {
+    for product in ["codex", "claude"] {
+        let out = run(
+            &[
+                "render",
+                "--source-root",
+                root.to_str().unwrap(),
+                "--product",
+                product,
+            ],
+            &[],
+        );
+        assert_eq!(
+            out.code,
+            0,
+            "render {product} exit={code} stderr={stderr}",
+            code = out.code,
+            stderr = out.stderr_text(),
+        );
+    }
+}
+
+fn audit(root: &Path, extra_args: &[&str], envs: &[(&str, &str)]) -> CmdOutput {
+    let mut args = vec!["audit-drift", "--source-root", root.to_str().unwrap()];
+    args.extend(extra_args);
+    run(&args, envs)
+}
+
+fn add_product_capability_diff(root: &Path) {
+    let file = root.join("manifests/product-capabilities.yaml");
+    let body = fs::read_to_string(&file).unwrap();
+    write(
+        &file,
+        &format!(
+            "{body}\nplugin_manifest_diff:\n  shared_fields:\n    - \"name\"\n  codex_only_fields:\n    - \"skills\"\n  claude_only_fields:\n    - \"homepage\"\n"
+        ),
+    );
+}
+
+fn add_plugin_manifests(root: &Path) {
+    write(
+        &root.join("targets/codex/plugins/reporting/.codex-plugin/plugin.json"),
+        r#"{
+  "name": "reporting",
+  "skills": [
+    {
+      "id": "sample",
+      "source": "core/skills/sample"
+    }
+  ]
+}
+"#,
+    );
+    write(
+        &root.join("targets/claude/plugins/reporting/.claude-plugin/plugin.json"),
+        r#"{
+  "name": "reporting",
+  "homepage": "https://github.com/graysurf/agent-runtime-kit"
+}
+"#,
+    );
+}
+
+fn add_claude_link_map(root: &Path) {
+    write(
+        &root.join("targets/claude/link-map.yaml"),
+        r#"schema_version: 1
+entries:
+  - id: reporting.plugin-manifest
+    kind: plugin-manifest-copy
+    source: targets/claude/plugins/reporting/.claude-plugin/plugin.json
+    destination: plugins/reporting/.claude-plugin/plugin.json
+  - id: reporting.skills-tree
+    kind: symlinked-file
+    source: build/claude/plugins/reporting/skills
+    destination: plugins/reporting/skills
+    recursive: true
+"#,
+    );
+}
+
+#[test]
+fn documented_plugin_manifest_divergence_reports_intentional_difference_exit_zero() {
+    let tmp = copy_fixture();
+    add_product_capability_diff(tmp.path());
+    add_plugin_manifests(tmp.path());
+
+    let out = audit(tmp.path(), &[], &[]);
+    assert_eq!(
+        out.code,
+        0,
+        "intentional differences should not affect exit code; stderr=\n{}",
+        out.stderr_text(),
+    );
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("[intentional-difference/info/codex]"),
+        "expected codex intentional difference; stderr=\n{stderr}",
+    );
+    assert!(
+        stderr.contains("[intentional-difference/info/claude]"),
+        "expected claude intentional difference; stderr=\n{stderr}",
+    );
+}
+
+#[test]
+fn untracked_file_under_live_home_install_root_reports_extra_exit_one() {
+    let tmp = copy_fixture();
+    add_plugin_manifests(tmp.path());
+    add_claude_link_map(tmp.path());
+    render_both_products(tmp.path());
+
+    let home = tmp.path().join("home");
+    let live_file = home.join(".claude/plugins/reporting/skills/unmanaged.txt");
+    write(&live_file, "local unmanaged file\n");
+
+    let home_str = home.to_str().unwrap();
+    let out = audit(tmp.path(), &[], &[("HOME", home_str)]);
+    assert_eq!(
+        out.code,
+        1,
+        "extra live surface should warn; stderr=\n{}",
+        out.stderr_text(),
+    );
+    let stderr = out.stderr_text();
+    assert!(
+        stderr.contains("[extra/warn/claude]"),
+        "expected extra/warn finding; stderr=\n{stderr}",
+    );
+    assert!(
+        stderr.contains("plugins/reporting/skills/unmanaged.txt"),
+        "expected extra finding to name unmanaged live file; stderr=\n{stderr}",
+    );
+}
+
+#[test]
+fn unrelated_live_home_sibling_outside_owned_link_map_roots_is_ignored() {
+    let tmp = copy_fixture();
+    add_plugin_manifests(tmp.path());
+    add_claude_link_map(tmp.path());
+    render_both_products(tmp.path());
+
+    let home = tmp.path().join("home");
+    write(
+        &home.join(".claude/plugins/unrelated-plugin/notes.txt"),
+        "operator-owned plugin file\n",
+    );
+
+    let home_str = home.to_str().unwrap();
+    let out = audit(tmp.path(), &[], &[("HOME", home_str)]);
+    assert_eq!(
+        out.code,
+        0,
+        "unrelated plugin sibling should stay outside extra scan scope; stderr=\n{}",
+        out.stderr_text(),
+    );
+    assert!(
+        !out.stderr_text().contains("[extra/warn"),
+        "unexpected extra finding for unrelated sibling; stderr=\n{}",
+        out.stderr_text(),
+    );
+}


### PR DESCRIPTION
# Add audit-drift extra and intentional classes

## Summary

Adds the remaining Plan 04 Task 4.3 audit-drift classes: informational `intentional-difference` findings for documented product plugin-manifest divergence, and warn-tier `extra` findings for unmanaged live runtime surfaces under install-map-owned paths.

## Changes

- Adds `audit_drift::classes::{intentional, extra}` and wires both into the aggregate drift pipeline.
- Adds `info` severity so documented intentional differences are visible while preserving exit `0`.
- Narrows `extra` live-home scanning to install-map-owned roots and avoids following live-home symlinked directories.
- Adds integration coverage for intentional divergence, extra unmanaged live files, and unrelated plugin sibling suppression.

## Test-First Evidence

- Change classification: feature / behavior change.
- Failing test before fix: `cargo test -p agent-runtime-cli extra_intentional` failed with `audit-drift: clean (0 findings)` for both missing Task 4.3 classes.
- Final validation: focused, audit-drift, clippy, full package tests, and `git diff --check` passed after implementation and review fix.
- Waiver reason: N/A.

## Testing

- `cargo test -p agent-runtime-cli extra_intentional` (pass)
- `cargo test -p agent-runtime-cli audit_drift` (pass)
- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` (pass)
- `cargo test -p agent-runtime-cli` (pass)
- `git diff --check` (pass)

## Risk / Notes

- `intentional-difference` currently covers plugin manifest field divergence declared in `product-capabilities.yaml`; broader product-capability surfaces remain future expansion.
- `extra` only scans install-map-owned live-home roots to avoid reporting unrelated user runtime state.
