### PR TITLE
Fix forge-cli GitHub checks for gh 2.92

### DIFF
--- a/crates/forge-cli/README.md
+++ b/crates/forge-cli/README.md
@@ -22,3 +22,11 @@ cargo run -p nils-forge-cli -- pr deliver --kind feature --dry-run --format json
 
 `forge-cli` does NOT introduce a `--json` boolean flag. Use
 `--format text|json` exclusively.
+
+## GitHub checks compatibility
+
+Starting with `nils-cli` `0.17.0`, GitHub `pr checks` calls request only the
+`gh 2.92.0` supported JSON fields. Required-check gates use an explicit
+`gh pr checks --required` snapshot instead of the removed `isRequired` JSON
+field, so `pr checks`, `pr wait-checks`, `pr merge`, and `pr deliver` share the
+same compatibility path.

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -259,7 +259,8 @@ operations:
       - { name: --required-only, type: bool,             default: true }
     validations: []
     backends:
-      github: { program: gh,   argv: [pr, checks, "{id}", --json, "name,state,conclusion,bucket,workflow,link,startedAt,completedAt,description,isRequired"] }
+      github: { program: gh,   argv: [pr, checks, "{id}", --json, "name,state,bucket,workflow,link,startedAt,completedAt,description"] }
+      github_required: { program: gh, argv: [pr, checks, "{id}", --required, --json, "name,state,bucket,workflow,link,startedAt,completedAt,description"] }
       gitlab: { program: glab, argv: [ci, status,  "-b", "{branch}"] }   # text fallback parsed
     output:
       data:

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -100,8 +100,8 @@ Parity matrix (v1):
 | `pr ready <id>`       | `gh pr ready <id>`                                              | `glab mr update <id> --ready`                        | exact                                |
 | `pr merge <id>`       | `gh pr merge <id> --squash --delete-branch`                     | `glab mr merge <id> --squash --remove-source-branch` | exact (method honoured per repo cfg) |
 | `pr close <id>`       | `gh pr close <id>`                                              | `glab mr close <id>`                                 | exact                                |
-| `pr checks <id>`      | `gh pr checks <id> --json …`                                    | `glab ci status -b <branch>` parsed                  | emulated on GitLab                   |
-| `pr wait-checks <id>` | poll `gh pr checks` + `gh run view`                             | poll `glab ci status` / pipeline view                | emulated; same envelope              |
+| `pr checks <id>`      | `gh pr checks <id> --json …` plus `--required` for gating       | `glab ci status -b <branch>` parsed                  | emulated on GitLab                   |
+| `pr wait-checks <id>` | poll `gh pr checks` / `gh pr checks --required`                 | poll `glab ci status` / pipeline view                | emulated; same envelope              |
 | `issue create`        | `gh issue create …`                                             | `glab issue create …`                                | exact                                |
 | `issue view <id>`     | `gh issue view <id> --json …`                                   | `glab issue view <id> -F json`                       | exact                                |
 | `issue edit <id>`     | `gh issue edit <id> …`                                          | `glab issue update <id> …`                           | exact                                |
@@ -200,7 +200,11 @@ backend mapping, validation rules, and output schema versions.
 - Behaviour: polls the backend until every required check is in a
   terminal state (`success`, `failure`, `cancelled`, `skipped`,
   `neutral`). `--required-only=true` ignores non-required checks for
-  the gating decision but still reports them in `data.checks`.
+  the gating decision but still reports them in `data.checks`. On
+  GitHub, required-check classification comes from an explicit
+  `gh pr checks --required` call; the JSON field set is
+  `name,state,bucket,workflow,link,startedAt,completedAt,description`
+  so the backend stays compatible with `gh 2.92.0`.
 - Terminal states map to envelope `ok`:
   - all required `success` → `ok = true`.
   - any required `failure`/`cancelled`/`timed_out` → `ok = false`,

--- a/crates/forge-cli/src/macros/pr_deliver.rs
+++ b/crates/forge-cli/src/macros/pr_deliver.rs
@@ -27,7 +27,7 @@ use crate::config::ForgeConfig;
 use crate::error::ForgeError;
 use crate::ops::pr_create::{self, Environment};
 use crate::ops::pr_wait_checks::{Clock, SystemClock, WaitOutcome};
-use crate::ops::{auth_status, pr_merge, pr_ready, pr_wait_checks, repo_view};
+use crate::ops::{auth_status, pr_checks, pr_merge, pr_ready, pr_wait_checks, repo_view};
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::validations::git_status_porcelain;
 
@@ -439,14 +439,7 @@ fn pr_create_dry_plan(ctx: &ProviderContext, args: &PrDeliverArgs) -> Vec<String
 fn pr_wait_checks_dry_plan(ctx: &ProviderContext) -> Vec<String> {
     let prog = BackendProgram::for_provider(ctx.provider).default_executable();
     match ctx.provider {
-        Provider::GitHub => vec![
-            prog.into(),
-            "pr".into(),
-            "checks".into(),
-            "<pr-number>".into(),
-            "--json".into(),
-            "name,state,conclusion,bucket,workflow,link,startedAt,completedAt,description,isRequired".into(),
-        ],
+        Provider::GitHub => pr_checks::build_github_required_call("<pr-number>").plan_argv(),
         Provider::GitLab => vec![
             prog.into(),
             "ci".into(),

--- a/crates/forge-cli/src/ops/pr_checks.rs
+++ b/crates/forge-cli/src/ops/pr_checks.rs
@@ -1,8 +1,9 @@
 //! `pr checks` atom — one-shot snapshot of PR/MR check state.
 //!
 //! Spec / ops: `cli.forge-cli.pr.checks.v1`. GitHub uses
-//! `gh pr checks <id> --json name,state,conclusion,bucket,workflow,link,
-//! startedAt,completedAt,description,isRequired`. GitLab is delegated to
+//! `gh pr checks <id> --json name,state,bucket,workflow,link,startedAt,
+//! completedAt,description` plus a separate `--required` call for required-only
+//! gating. GitLab is delegated to
 //! [`crate::ops::pr_checks_gitlab`] which parses `glab ci status` text after
 //! probing `glab --version`.
 //!
@@ -10,6 +11,7 @@
 //! for the gating decision but still reports them under `data.checks`. The
 //! aggregate `data.state` derives from the gating subset.
 
+use std::collections::HashSet;
 use std::ffi::OsString;
 
 use nils_common::cli_contract::{OutputFormat, schema_version_for};
@@ -27,8 +29,8 @@ use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 pub const SCHEMA: &str = "pr.checks";
 pub const SCHEMA_VERSION: u32 = 1;
 
-const GH_JSON_FIELDS: &str =
-    "name,state,conclusion,bucket,workflow,link,startedAt,completedAt,description,isRequired";
+pub const GH_JSON_FIELDS: &str =
+    "name,state,bucket,workflow,link,startedAt,completedAt,description";
 
 /// Canonical normalized check state. Spec enum:
 /// `success | failure | pending | cancelled | neutral | skipped | timed_out`.
@@ -190,7 +192,12 @@ fn snapshot_github<R: BackendRunner>(
 ) -> Result<PrChecksPayload, ForgeError> {
     let call = build_github_call(&args.id);
     let output = runner.run(&call)?;
-    parse_github_snapshot(ctx, &output, args.required_only)
+    if args.required_only {
+        let required_call = build_github_required_call(&args.id);
+        let required_output = run_required_github_call(runner, &required_call)?;
+        return parse_github_snapshot_with_required_output(ctx, &output, &required_output);
+    }
+    parse_github_snapshot(ctx, &output, false)
 }
 
 /// Build the `gh pr checks <id> --json …` call. Public so the dry-run helper
@@ -208,13 +215,65 @@ pub fn build_github_call(id: &str) -> BackendCall {
     )
 }
 
+/// Build the `gh pr checks <id> --required --json …` call used for GitHub
+/// required-check gating because `gh 2.92.0` no longer exposes `isRequired`
+/// through the JSON field set.
+pub fn build_github_required_call(id: &str) -> BackendCall {
+    BackendCall::new(
+        BackendProgram::Gh,
+        [
+            OsString::from("pr"),
+            OsString::from("checks"),
+            OsString::from(id),
+            OsString::from("--required"),
+            OsString::from("--json"),
+            OsString::from(GH_JSON_FIELDS),
+        ],
+    )
+}
+
 /// Build the dry-run preview call for the current provider — public so
 /// downstream atoms (e.g. `pr wait-checks` dry-run) can reuse it.
 pub fn build_dry_run_call(ctx: &ProviderContext, args: &PrChecksArgs) -> BackendCall {
     match ctx.provider {
+        Provider::GitHub if args.required_only => build_github_required_call(&args.id),
         Provider::GitHub => build_github_call(&args.id),
         Provider::GitLab => pr_checks_gitlab::build_status_call(&args.id),
     }
+}
+
+fn run_required_github_call<R: BackendRunner>(
+    runner: &R,
+    call: &BackendCall,
+) -> Result<BackendSuccess, ForgeError> {
+    match runner.run(call) {
+        Ok(output) => Ok(output),
+        Err(ForgeError::BackendError {
+            schema_version: _,
+            message,
+            detail,
+        }) if is_no_required_checks(detail.as_deref()) => Ok(BackendSuccess {
+            stdout: "[]".into(),
+            stderr: format!(
+                "{}{}",
+                message,
+                detail
+                    .as_deref()
+                    .map(|d| format!("\n{d}"))
+                    .unwrap_or_default()
+            ),
+        }),
+        Err(err) => Err(err),
+    }
+}
+
+fn is_no_required_checks(detail: Option<&str>) -> bool {
+    detail
+        .map(|d| {
+            d.to_ascii_lowercase()
+                .contains("no required checks reported")
+        })
+        .unwrap_or(false)
 }
 
 fn parse_github_snapshot(
@@ -222,11 +281,50 @@ fn parse_github_snapshot(
     output: &BackendSuccess,
     required_only: bool,
 ) -> Result<PrChecksPayload, ForgeError> {
+    let checks = parse_github_checks(output, None, false)?;
+    Ok(aggregate(ctx, checks, required_only, None))
+}
+
+fn parse_github_snapshot_with_required_output(
+    ctx: &ProviderContext,
+    all_output: &BackendSuccess,
+    required_output: &BackendSuccess,
+) -> Result<PrChecksPayload, ForgeError> {
+    let required_entries = parse_github_checks(required_output, None, true)?;
+    let required_names = required_entries
+        .iter()
+        .map(|c| c.name.clone())
+        .collect::<HashSet<_>>();
+    let mut checks = parse_github_checks(all_output, Some(&required_names), false)?;
+
+    if checks.is_empty() {
+        checks = required_entries;
+    } else if !required_names.is_empty() {
+        let present_required = checks
+            .iter()
+            .filter(|c| c.required)
+            .map(|c| c.name.clone())
+            .collect::<HashSet<_>>();
+        for required in required_entries {
+            if !present_required.contains(required.name.as_str()) {
+                checks.push(required);
+            }
+        }
+    }
+
+    Ok(aggregate(ctx, checks, true, None))
+}
+
+fn parse_github_checks(
+    output: &BackendSuccess,
+    required_names: Option<&HashSet<String>>,
+    force_required: bool,
+) -> Result<Vec<CheckItem>, ForgeError> {
     let trimmed = output.stdout.trim();
     // Empty stdout: GitHub historically prints nothing when there are no
     // checks; tolerate the empty case as "no checks".
     if trimmed.is_empty() {
-        return Ok(empty_payload(ctx));
+        return Ok(Vec::new());
     }
     let value: serde_json::Value = serde_json::from_str(trimmed).map_err(|e| {
         ForgeError::software(
@@ -244,12 +342,16 @@ fn parse_github_snapshot(
     })?;
     let mut checks = Vec::with_capacity(arr.len());
     for entry in arr {
-        checks.push(parse_github_entry(entry)?);
+        checks.push(parse_github_entry(entry, required_names, force_required)?);
     }
-    Ok(aggregate(ctx, checks, required_only, None))
+    Ok(checks)
 }
 
-fn parse_github_entry(value: &serde_json::Value) -> Result<CheckItem, ForgeError> {
+fn parse_github_entry(
+    value: &serde_json::Value,
+    required_names: Option<&HashSet<String>>,
+    force_required: bool,
+) -> Result<CheckItem, ForgeError> {
     let name = value
         .get("name")
         .and_then(|v| v.as_str())
@@ -264,7 +366,11 @@ fn parse_github_entry(value: &serde_json::Value) -> Result<CheckItem, ForgeError
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(str::to_string);
-    let state = normalize_github_state(bucket.as_deref(), conclusion.as_deref());
+    let raw_state = value
+        .get("state")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
+    let state = normalize_github_state(bucket.as_deref(), conclusion.as_deref(), raw_state);
     let url = value
         .get("link")
         .and_then(|v| v.as_str())
@@ -275,10 +381,16 @@ fn parse_github_entry(value: &serde_json::Value) -> Result<CheckItem, ForgeError
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(str::to_string);
-    let required = value
-        .get("isRequired")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let required = if force_required {
+        true
+    } else if let Some(names) = required_names {
+        names.contains(&name)
+    } else {
+        value
+            .get("isRequired")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    };
     let started_at = value
         .get("startedAt")
         .and_then(|v| v.as_str())
@@ -301,11 +413,17 @@ fn parse_github_entry(value: &serde_json::Value) -> Result<CheckItem, ForgeError
     })
 }
 
-/// Normalize a GitHub `(bucket, conclusion)` pair to a canonical [`CheckState`].
-/// Conclusion takes precedence when populated; otherwise the bucket drives it.
-pub fn normalize_github_state(bucket: Option<&str>, conclusion: Option<&str>) -> CheckState {
+/// Normalize a GitHub `(bucket, conclusion, state)` triple to a canonical
+/// [`CheckState`]. `conclusion` is accepted for compatibility with older
+/// fixture/output shapes, but the `gh 2.92.0` request path relies on `bucket`
+/// and `state`.
+pub fn normalize_github_state(
+    bucket: Option<&str>,
+    conclusion: Option<&str>,
+    raw_state: Option<&str>,
+) -> CheckState {
     if let Some(c) = conclusion {
-        match c {
+        match c.to_ascii_lowercase().as_str() {
             "success" => return CheckState::Success,
             "failure" | "action_required" | "stale" | "startup_failure" => {
                 return CheckState::Failure;
@@ -317,13 +435,27 @@ pub fn normalize_github_state(bucket: Option<&str>, conclusion: Option<&str>) ->
             _ => {}
         }
     }
-    match bucket {
+    let bucket = bucket.map(str::to_ascii_lowercase);
+    match bucket.as_deref() {
         Some("pass") => CheckState::Success,
         Some("fail") => CheckState::Failure,
         Some("pending") => CheckState::Pending,
         Some("skipping") => CheckState::Skipped,
         Some("cancel") => CheckState::Cancelled,
-        _ => CheckState::Pending,
+        _ => match raw_state.map(str::to_ascii_lowercase).as_deref() {
+            Some("success" | "pass" | "completed") => CheckState::Success,
+            Some(
+                "failure" | "failed" | "error" | "action_required" | "stale" | "startup_failure",
+            ) => CheckState::Failure,
+            Some("pending" | "queued" | "in_progress" | "waiting" | "requested" | "expected") => {
+                CheckState::Pending
+            }
+            Some("cancelled" | "canceled") => CheckState::Cancelled,
+            Some("skipped" | "skipping") => CheckState::Skipped,
+            Some("neutral") => CheckState::Neutral,
+            Some("timed_out" | "timeout") => CheckState::TimedOut,
+            _ => CheckState::Pending,
+        },
     }
 }
 
@@ -410,19 +542,6 @@ pub fn aggregate(
         pending,
         checks,
         duration_ms,
-    }
-}
-
-fn empty_payload(ctx: &ProviderContext) -> PrChecksPayload {
-    PrChecksPayload {
-        provider: ctx.provider.as_str(),
-        state: CheckState::Success.as_str(),
-        required_count: 0,
-        success_count: 0,
-        failed: Vec::new(),
-        pending: Vec::new(),
-        checks: Vec::new(),
-        duration_ms: None,
     }
 }
 
@@ -532,23 +651,23 @@ mod tests {
     #[test]
     fn normalize_prefers_conclusion_over_bucket() {
         assert_eq!(
-            normalize_github_state(Some("pass"), Some("success")),
+            normalize_github_state(Some("pass"), Some("success"), None),
             CheckState::Success
         );
         assert_eq!(
-            normalize_github_state(Some("fail"), Some("timed_out")),
+            normalize_github_state(Some("fail"), Some("timed_out"), None),
             CheckState::TimedOut
         );
         assert_eq!(
-            normalize_github_state(Some("pass"), Some("neutral")),
+            normalize_github_state(Some("pass"), Some("neutral"), None),
             CheckState::Neutral
         );
         assert_eq!(
-            normalize_github_state(Some("pass"), Some("skipped")),
+            normalize_github_state(Some("pass"), Some("skipped"), None),
             CheckState::Skipped
         );
         assert_eq!(
-            normalize_github_state(Some("fail"), Some("action_required")),
+            normalize_github_state(Some("fail"), Some("action_required"), None),
             CheckState::Failure
         );
     }
@@ -556,14 +675,37 @@ mod tests {
     #[test]
     fn normalize_falls_back_to_bucket_when_no_conclusion() {
         assert_eq!(
-            normalize_github_state(Some("pending"), None),
+            normalize_github_state(Some("pending"), None, None),
             CheckState::Pending
         );
         assert_eq!(
-            normalize_github_state(Some("cancel"), None),
+            normalize_github_state(Some("cancel"), None, None),
             CheckState::Cancelled
         );
-        assert_eq!(normalize_github_state(None, None), CheckState::Pending);
+        assert_eq!(
+            normalize_github_state(None, None, None),
+            CheckState::Pending
+        );
+    }
+
+    #[test]
+    fn normalize_falls_back_to_state_when_bucket_is_unknown() {
+        assert_eq!(
+            normalize_github_state(None, None, Some("SUCCESS")),
+            CheckState::Success
+        );
+        assert_eq!(
+            normalize_github_state(None, None, Some("FAILURE")),
+            CheckState::Failure
+        );
+        assert_eq!(
+            normalize_github_state(None, None, Some("IN_PROGRESS")),
+            CheckState::Pending
+        );
+        assert_eq!(
+            normalize_github_state(None, None, Some("CANCELLED")),
+            CheckState::Cancelled
+        );
     }
 
     #[test]
@@ -691,9 +833,20 @@ mod tests {
             ["pr".to_string(), "checks".to_string(), "42".to_string()]
         );
         let json_idx = plan.iter().position(|s| s == "--json").expect("--json arg");
-        assert!(plan[json_idx + 1].contains("isRequired"));
         assert!(plan[json_idx + 1].contains("bucket"));
-        assert!(plan[json_idx + 1].contains("conclusion"));
+        assert!(!plan[json_idx + 1].contains("isRequired"));
+        assert!(!plan[json_idx + 1].contains("conclusion"));
+    }
+
+    #[test]
+    fn build_github_required_call_uses_required_flag_and_supported_json_fields() {
+        let call = build_github_required_call("42");
+        let plan = call.plan_argv();
+        assert!(plan.iter().any(|s| s == "--required"), "{plan:?}");
+        let json_idx = plan.iter().position(|s| s == "--json").expect("--json arg");
+        assert_eq!(plan[json_idx + 1], GH_JSON_FIELDS);
+        assert!(!plan[json_idx + 1].contains("isRequired"));
+        assert!(!plan[json_idx + 1].contains("conclusion"));
     }
 
     #[test]
@@ -730,14 +883,14 @@ mod tests {
     #[test]
     fn parse_github_snapshot_full_success_fixture() {
         let stdout = r#"[
-            {"name":"build","bucket":"pass","conclusion":"success","state":"COMPLETED","link":"https://ci/1","workflow":"CI","isRequired":true,"startedAt":"2026-05-19T10:00:00Z","completedAt":"2026-05-19T10:05:00Z","description":""},
-            {"name":"lint","bucket":"pass","conclusion":"success","state":"COMPLETED","link":"https://ci/2","workflow":"CI","isRequired":true,"startedAt":"2026-05-19T10:00:00Z","completedAt":"2026-05-19T10:02:00Z","description":""}
+            {"name":"build","bucket":"pass","state":"COMPLETED","link":"https://ci/1","workflow":"CI","startedAt":"2026-05-19T10:00:00Z","completedAt":"2026-05-19T10:05:00Z","description":""},
+            {"name":"lint","bucket":"pass","state":"COMPLETED","link":"https://ci/2","workflow":"CI","startedAt":"2026-05-19T10:00:00Z","completedAt":"2026-05-19T10:02:00Z","description":""}
         ]"#;
         let out = BackendSuccess {
             stdout: stdout.into(),
             stderr: String::new(),
         };
-        let p = parse_github_snapshot(&ctx(Provider::GitHub), &out, true).unwrap();
+        let p = parse_github_snapshot(&ctx(Provider::GitHub), &out, false).unwrap();
         assert_eq!(p.state, "success");
         assert_eq!(p.required_count, 2);
         assert_eq!(p.success_count, 2);
@@ -747,17 +900,26 @@ mod tests {
     }
 
     #[test]
-    fn parse_github_snapshot_mixed_failure_fixture() {
-        let stdout = r#"[
-            {"name":"build","bucket":"pass","conclusion":"success","link":"https://ci/1","isRequired":true},
-            {"name":"test","bucket":"fail","conclusion":"failure","link":"https://ci/2","isRequired":true},
-            {"name":"flaky","bucket":"pending","conclusion":"","link":"https://ci/3","isRequired":false}
+    fn parse_github_snapshot_with_required_output_marks_only_required_names() {
+        let all_stdout = r#"[
+            {"name":"build","bucket":"pass","state":"COMPLETED","link":"https://ci/1"},
+            {"name":"test","bucket":"fail","state":"COMPLETED","link":"https://ci/2"},
+            {"name":"flaky","bucket":"pending","state":"IN_PROGRESS","link":"https://ci/3"}
         ]"#;
-        let out = BackendSuccess {
-            stdout: stdout.into(),
+        let required_stdout = r#"[
+            {"name":"build","bucket":"pass","state":"COMPLETED","link":"https://ci/1"},
+            {"name":"test","bucket":"fail","state":"COMPLETED","link":"https://ci/2"}
+        ]"#;
+        let all = BackendSuccess {
+            stdout: all_stdout.into(),
             stderr: String::new(),
         };
-        let p = parse_github_snapshot(&ctx(Provider::GitHub), &out, true).unwrap();
+        let required = BackendSuccess {
+            stdout: required_stdout.into(),
+            stderr: String::new(),
+        };
+        let p = parse_github_snapshot_with_required_output(&ctx(Provider::GitHub), &all, &required)
+            .unwrap();
         assert_eq!(p.state, "failure");
         assert_eq!(p.required_count, 2);
         assert_eq!(p.failed.len(), 1);

--- a/crates/forge-cli/tests/fixtures/github/pr_checks/all_pending.json
+++ b/crates/forge-cli/tests/fixtures/github/pr_checks/all_pending.json
@@ -2,25 +2,21 @@
   {
     "name": "build",
     "state": "IN_PROGRESS",
-    "conclusion": "",
     "bucket": "pending",
     "workflow": "CI",
     "link": "https://github.com/sympoies/nils-cli/actions/runs/3001",
     "startedAt": "2026-05-19T10:00:00Z",
     "completedAt": "",
-    "description": "",
-    "isRequired": true
+    "description": ""
   },
   {
     "name": "test",
     "state": "QUEUED",
-    "conclusion": "",
     "bucket": "pending",
     "workflow": "CI",
     "link": "https://github.com/sympoies/nils-cli/actions/runs/3002",
     "startedAt": "",
     "completedAt": "",
-    "description": "",
-    "isRequired": true
+    "description": ""
   }
 ]

--- a/crates/forge-cli/tests/fixtures/github/pr_checks/all_success.json
+++ b/crates/forge-cli/tests/fixtures/github/pr_checks/all_success.json
@@ -2,37 +2,31 @@
   {
     "name": "build",
     "state": "COMPLETED",
-    "conclusion": "success",
     "bucket": "pass",
     "workflow": "CI",
     "link": "https://github.com/sympoies/nils-cli/actions/runs/1001",
     "startedAt": "2026-05-19T10:00:00Z",
     "completedAt": "2026-05-19T10:05:00Z",
-    "description": "Build the workspace",
-    "isRequired": true
+    "description": "Build the workspace"
   },
   {
     "name": "test",
     "state": "COMPLETED",
-    "conclusion": "success",
     "bucket": "pass",
     "workflow": "CI",
     "link": "https://github.com/sympoies/nils-cli/actions/runs/1002",
     "startedAt": "2026-05-19T10:00:00Z",
     "completedAt": "2026-05-19T10:07:00Z",
-    "description": "Run cargo test",
-    "isRequired": true
+    "description": "Run cargo test"
   },
   {
     "name": "lint",
     "state": "COMPLETED",
-    "conclusion": "success",
     "bucket": "pass",
     "workflow": "CI",
     "link": "https://github.com/sympoies/nils-cli/actions/runs/1003",
     "startedAt": "2026-05-19T10:00:00Z",
     "completedAt": "2026-05-19T10:01:30Z",
-    "description": "rumdl + rustfmt",
-    "isRequired": true
+    "description": "rumdl + rustfmt"
   }
 ]

--- a/crates/forge-cli/tests/fixtures/github/pr_checks/mixed_failure.json
+++ b/crates/forge-cli/tests/fixtures/github/pr_checks/mixed_failure.json
@@ -2,37 +2,31 @@
   {
     "name": "build",
     "state": "COMPLETED",
-    "conclusion": "success",
     "bucket": "pass",
     "workflow": "CI",
     "link": "https://github.com/sympoies/nils-cli/actions/runs/2001",
     "startedAt": "2026-05-19T10:00:00Z",
     "completedAt": "2026-05-19T10:05:00Z",
-    "description": "",
-    "isRequired": true
+    "description": ""
   },
   {
     "name": "test",
     "state": "COMPLETED",
-    "conclusion": "failure",
     "bucket": "fail",
     "workflow": "CI",
     "link": "https://github.com/sympoies/nils-cli/actions/runs/2002",
     "startedAt": "2026-05-19T10:00:00Z",
     "completedAt": "2026-05-19T10:07:30Z",
-    "description": "cargo test failed",
-    "isRequired": true
+    "description": "cargo test failed"
   },
   {
     "name": "optional-flaky",
     "state": "IN_PROGRESS",
-    "conclusion": "",
     "bucket": "pending",
     "workflow": "Nightly",
     "link": "https://github.com/sympoies/nils-cli/actions/runs/2003",
     "startedAt": "2026-05-19T10:00:00Z",
     "completedAt": "",
-    "description": "",
-    "isRequired": false
+    "description": ""
   }
 ]

--- a/crates/forge-cli/tests/fixtures/github/pr_checks/mixed_failure_required.json
+++ b/crates/forge-cli/tests/fixtures/github/pr_checks/mixed_failure_required.json
@@ -4,7 +4,7 @@
     "state": "COMPLETED",
     "bucket": "pass",
     "workflow": "CI",
-    "link": "https://github.com/sympoies/nils-cli/actions/runs/4001",
+    "link": "https://github.com/sympoies/nils-cli/actions/runs/2001",
     "startedAt": "2026-05-19T10:00:00Z",
     "completedAt": "2026-05-19T10:05:00Z",
     "description": ""
@@ -12,11 +12,11 @@
   {
     "name": "test",
     "state": "COMPLETED",
-    "bucket": "cancel",
+    "bucket": "fail",
     "workflow": "CI",
-    "link": "https://github.com/sympoies/nils-cli/actions/runs/4002",
+    "link": "https://github.com/sympoies/nils-cli/actions/runs/2002",
     "startedAt": "2026-05-19T10:00:00Z",
-    "completedAt": "2026-05-19T10:03:00Z",
-    "description": "cancelled by user"
+    "completedAt": "2026-05-19T10:07:30Z",
+    "description": "cargo test failed"
   }
 ]

--- a/crates/forge-cli/tests/integration/pr_checks_github.rs
+++ b/crates/forge-cli/tests/integration/pr_checks_github.rs
@@ -12,19 +12,30 @@ use super::support::{StubEnv, parse_envelope, run_forge_cli};
 
 const FIXTURE_ALL_SUCCESS: &str = include_str!("../fixtures/github/pr_checks/all_success.json");
 const FIXTURE_MIXED_FAILURE: &str = include_str!("../fixtures/github/pr_checks/mixed_failure.json");
+const FIXTURE_MIXED_FAILURE_REQUIRED: &str =
+    include_str!("../fixtures/github/pr_checks/mixed_failure_required.json");
 const FIXTURE_ALL_PENDING: &str = include_str!("../fixtures/github/pr_checks/all_pending.json");
 const FIXTURE_CANCELLED: &str = include_str!("../fixtures/github/pr_checks/cancelled.json");
 const FIXTURE_EMPTY: &str = include_str!("../fixtures/github/pr_checks/empty.json");
 
-fn gh_dispatch_stub(checks_json: &str) -> String {
+fn gh_dispatch_stub(all_checks_json: &str, required_checks_json: &str) -> String {
     format!(
         r#"#!/bin/sh
 set -e
 case "$1 $2" in
   "pr checks")
-    cat <<'EOF'
-{json}
+    case " $* " in
+      *" --required "*)
+        cat <<'EOF'
+{required_json}
 EOF
+        ;;
+      *)
+        cat <<'EOF'
+{all_json}
+EOF
+        ;;
+    esac
     ;;
   *)
     echo "stub: unexpected gh args: $*" >&2
@@ -32,12 +43,17 @@ EOF
     ;;
 esac
 "#,
-        json = checks_json,
+        all_json = all_checks_json,
+        required_json = required_checks_json,
     )
 }
 
-fn run_checks(checks_json: &str, extra_args: &[&str]) -> (i32, serde_json::Value) {
-    let stub = StubEnv::new().gh_stub(&gh_dispatch_stub(checks_json));
+fn run_checks(
+    all_checks_json: &str,
+    required_checks_json: &str,
+    extra_args: &[&str],
+) -> (i32, serde_json::Value) {
+    let stub = StubEnv::new().gh_stub(&gh_dispatch_stub(all_checks_json, required_checks_json));
     let mut argv = vec![
         "--provider",
         "github",
@@ -56,7 +72,7 @@ fn run_checks(checks_json: &str, extra_args: &[&str]) -> (i32, serde_json::Value
 
 #[test]
 fn pr_checks_all_success_emits_success_state() {
-    let (_, env) = run_checks(FIXTURE_ALL_SUCCESS, &[]);
+    let (_, env) = run_checks(FIXTURE_ALL_SUCCESS, FIXTURE_ALL_SUCCESS, &[]);
     assert_eq!(env["schema_version"], "cli.forge-cli.pr.checks.v1");
     assert_eq!(env["ok"], true);
     assert_eq!(env["data"]["provider"], "github");
@@ -70,14 +86,14 @@ fn pr_checks_all_success_emits_success_state() {
 
 #[test]
 fn pr_checks_mixed_failure_marks_required_failed() {
-    let (_, env) = run_checks(FIXTURE_MIXED_FAILURE, &[]);
+    let (_, env) = run_checks(FIXTURE_MIXED_FAILURE, FIXTURE_MIXED_FAILURE_REQUIRED, &[]);
     assert_eq!(env["data"]["state"], "failure");
     assert_eq!(env["data"]["required_count"], 2);
     assert_eq!(env["data"]["success_count"], 1);
     let failed = env["data"]["failed"].as_array().expect("failed array");
     assert_eq!(failed.len(), 1);
     assert_eq!(failed[0]["name"], "test");
-    assert_eq!(failed[0]["conclusion"], "failure");
+    assert!(failed[0]["conclusion"].is_null());
     // Non-required pending check stays in data.checks but not in gating.
     let checks = env["data"]["checks"].as_array().expect("checks array");
     assert_eq!(checks.len(), 3);
@@ -86,7 +102,11 @@ fn pr_checks_mixed_failure_marks_required_failed() {
 
 #[test]
 fn pr_checks_mixed_failure_required_only_false_includes_optional_in_gating() {
-    let (_, env) = run_checks(FIXTURE_MIXED_FAILURE, &["--required-only", "false"]);
+    let (_, env) = run_checks(
+        FIXTURE_MIXED_FAILURE,
+        FIXTURE_MIXED_FAILURE_REQUIRED,
+        &["--required-only", "false"],
+    );
     // Required-only=false: the optional pending check is now part of the
     // gating set, so required_count grows to 3 and pending becomes part of
     // the aggregate.
@@ -100,7 +120,7 @@ fn pr_checks_mixed_failure_required_only_false_includes_optional_in_gating() {
 
 #[test]
 fn pr_checks_all_pending_reports_pending_state() {
-    let (_, env) = run_checks(FIXTURE_ALL_PENDING, &[]);
+    let (_, env) = run_checks(FIXTURE_ALL_PENDING, FIXTURE_ALL_PENDING, &[]);
     assert_eq!(env["data"]["state"], "pending");
     assert_eq!(env["data"]["required_count"], 2);
     assert_eq!(env["data"]["success_count"], 0);
@@ -110,22 +130,69 @@ fn pr_checks_all_pending_reports_pending_state() {
 
 #[test]
 fn pr_checks_cancelled_marks_failure_lane() {
-    let (_, env) = run_checks(FIXTURE_CANCELLED, &[]);
+    let (_, env) = run_checks(FIXTURE_CANCELLED, FIXTURE_CANCELLED, &[]);
     // Cancelled is a failure-class terminal state.
     assert_eq!(env["data"]["state"], "cancelled");
     let failed = env["data"]["failed"].as_array().expect("failed");
     assert_eq!(failed.len(), 1);
     assert_eq!(failed[0]["name"], "test");
-    assert_eq!(failed[0]["conclusion"], "cancelled");
+    assert!(failed[0]["conclusion"].is_null());
 }
 
 #[test]
 fn pr_checks_empty_array_is_success_zero_count() {
-    let (_, env) = run_checks(FIXTURE_EMPTY, &[]);
+    let (_, env) = run_checks(FIXTURE_EMPTY, FIXTURE_EMPTY, &[]);
     assert_eq!(env["data"]["state"], "success");
     assert_eq!(env["data"]["required_count"], 0);
     assert_eq!(env["data"]["success_count"], 0);
     assert!(env["data"]["checks"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn pr_checks_no_required_checks_backend_message_is_success_zero_required() {
+    let stub = StubEnv::new().gh_stub(&format!(
+        r#"#!/bin/sh
+set -e
+case "$1 $2" in
+  "pr checks")
+    case " $* " in
+      *" --required "*)
+        echo "no required checks reported on the 'feat/example' branch" >&2
+        exit 1
+        ;;
+      *)
+        cat <<'EOF'
+{all_json}
+EOF
+        ;;
+    esac
+    ;;
+  *)
+    echo "stub: unexpected gh args: $*" >&2
+    exit 99
+    ;;
+esac
+"#,
+        all_json = FIXTURE_ALL_SUCCESS,
+    ));
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "checks",
+            "1",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["data"]["state"], "success");
+    assert_eq!(env["data"]["required_count"], 0);
+    assert_eq!(env["data"]["success_count"], 0);
+    assert_eq!(env["data"]["checks"].as_array().unwrap().len(), 3);
 }
 
 #[test]
@@ -156,9 +223,12 @@ fn pr_checks_dry_run_renders_plan_with_json_fields() {
         .collect();
     assert!(plan.contains(&"checks".to_string()), "{plan:?}");
     assert!(plan.contains(&"42".to_string()), "{plan:?}");
+    assert!(plan.contains(&"--required".to_string()), "{plan:?}");
     let json_idx = plan
         .iter()
         .position(|s| s == "--json")
         .expect("--json present");
-    assert!(plan[json_idx + 1].contains("isRequired"), "{plan:?}");
+    assert!(plan[json_idx + 1].contains("bucket"), "{plan:?}");
+    assert!(!plan[json_idx + 1].contains("isRequired"), "{plan:?}");
+    assert!(!plan[json_idx + 1].contains("conclusion"), "{plan:?}");
 }

--- a/crates/forge-cli/tests/integration/pr_deliver.rs
+++ b/crates/forge-cli/tests/integration/pr_deliver.rs
@@ -53,6 +53,31 @@ fn pr_deliver_dry_run_lists_all_six_steps_in_order() {
     );
     assert_eq!(env["data"]["no_merge"], false);
     assert_eq!(env["data"]["kind"], "feature");
+    let wait_plan = env["data"]["plan_steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["step"] == "wait_checks")
+        .expect("wait_checks step present")["plan"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect::<Vec<_>>();
+    assert!(wait_plan.iter().any(|s| s == "--required"), "{wait_plan:?}");
+    let json_idx = wait_plan
+        .iter()
+        .position(|s| s == "--json")
+        .expect("--json present");
+    assert!(wait_plan[json_idx + 1].contains("bucket"), "{wait_plan:?}");
+    assert!(
+        !wait_plan[json_idx + 1].contains("conclusion"),
+        "{wait_plan:?}"
+    );
+    assert!(
+        !wait_plan[json_idx + 1].contains("isRequired"),
+        "{wait_plan:?}"
+    );
 }
 
 #[test]

--- a/crates/forge-cli/tests/integration/pr_wait_checks.rs
+++ b/crates/forge-cli/tests/integration/pr_wait_checks.rs
@@ -34,13 +34,23 @@ case "$1 $2" in
   "pr checks")
     counter="{dir}/counter"
     idx=$(cat "$counter")
+    case " $* " in
+      *" --required "*)
+        idx=$((idx - 1))
+        if [ "$idx" -lt 0 ]; then
+            idx=0
+        fi
+        ;;
+      *)
+        next=$((idx + 1))
+        echo "$next" > "$counter"
+        ;;
+    esac
     if [ "$idx" -ge "{max_idx}" ]; then
         eff="{max_idx}"
     else
         eff="$idx"
     fi
-    next=$((idx + 1))
-    echo "$next" > "$counter"
     cat "{dir}/snap-$eff.json"
     ;;
   *)
@@ -53,9 +63,12 @@ esac
     stub.write_stub("gh", &body);
 }
 
-const PENDING_SNAP: &str = r#"[{"name":"build","bucket":"pending","conclusion":"","isRequired":true,"link":"https://ci/1"}]"#;
-const SUCCESS_SNAP: &str = r#"[{"name":"build","bucket":"pass","conclusion":"success","isRequired":true,"link":"https://ci/1"}]"#;
-const FAILURE_SNAP: &str = r#"[{"name":"build","bucket":"fail","conclusion":"failure","isRequired":true,"link":"https://ci/1"}]"#;
+const PENDING_SNAP: &str =
+    r#"[{"name":"build","bucket":"pending","state":"IN_PROGRESS","link":"https://ci/1"}]"#;
+const SUCCESS_SNAP: &str =
+    r#"[{"name":"build","bucket":"pass","state":"COMPLETED","link":"https://ci/1"}]"#;
+const FAILURE_SNAP: &str =
+    r#"[{"name":"build","bucket":"fail","state":"COMPLETED","link":"https://ci/1"}]"#;
 
 #[test]
 fn pr_wait_checks_succeeds_when_terminal_on_third_poll() {

--- a/crates/forge-cli/tests/integration/required_check_gate.rs
+++ b/crates/forge-cli/tests/integration/required_check_gate.rs
@@ -53,9 +53,9 @@ fn run_globals() -> GlobalFlags {
     }
 }
 
-const SUCCESS_JSON: &str = r#"[{"name":"build","bucket":"pass","conclusion":"success","isRequired":true,"link":"https://ci/1"},{"name":"test","bucket":"pass","conclusion":"success","isRequired":true,"link":"https://ci/2"}]"#;
-const PENDING_JSON: &str = r#"[{"name":"build","bucket":"pass","conclusion":"success","isRequired":true,"link":"https://ci/1"},{"name":"test","bucket":"pending","conclusion":"","isRequired":true,"link":"https://ci/2"}]"#;
-const FAILURE_JSON: &str = r#"[{"name":"build","bucket":"pass","conclusion":"success","isRequired":true,"link":"https://ci/1"},{"name":"test","bucket":"fail","conclusion":"failure","isRequired":true,"link":"https://ci/2"}]"#;
+const SUCCESS_JSON: &str = r#"[{"name":"build","bucket":"pass","state":"COMPLETED","link":"https://ci/1"},{"name":"test","bucket":"pass","state":"COMPLETED","link":"https://ci/2"}]"#;
+const PENDING_JSON: &str = r#"[{"name":"build","bucket":"pass","state":"COMPLETED","link":"https://ci/1"},{"name":"test","bucket":"pending","state":"IN_PROGRESS","link":"https://ci/2"}]"#;
+const FAILURE_JSON: &str = r#"[{"name":"build","bucket":"pass","state":"COMPLETED","link":"https://ci/1"},{"name":"test","bucket":"fail","state":"COMPLETED","link":"https://ci/2"}]"#;
 
 #[test]
 fn all_required_green_returns_payload_with_runtime_runner() {
@@ -137,7 +137,7 @@ fn helper_refetches_every_call_no_caching_across_atoms() {
     fs::write(&counter, "0").unwrap();
     let stub_dir = tmp.path().to_string_lossy().to_string();
     let body = format!(
-        "#!/bin/sh\nset -e\ncase \"$1 $2\" in\n  \"pr checks\")\n    n=$(cat \"{stub_dir}/counter\")\n    echo $((n + 1)) > \"{stub_dir}/counter\"\n    cat <<'EOF'\n{SUCCESS_JSON}\nEOF\n    ;;\n  *)\n    echo \"stub: unexpected gh args: $*\" >&2; exit 99;;\nesac\n"
+        "#!/bin/sh\nset -e\ncase \"$1 $2\" in\n  \"pr checks\")\n    case \" $* \" in\n      *\" --required \"*) ;;\n      *)\n        n=$(cat \"{stub_dir}/counter\")\n        echo $((n + 1)) > \"{stub_dir}/counter\"\n        ;;\n    esac\n    cat <<'EOF'\n{SUCCESS_JSON}\nEOF\n    ;;\n  *)\n    echo \"stub: unexpected gh args: $*\" >&2; exit 99;;\nesac\n"
     );
     write_stub(&tmp, &body);
     let _guard = lock_env();

--- a/docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-discussion-source.md
+++ b/docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-discussion-source.md
@@ -1,0 +1,146 @@
+# forge-cli GitHub Checks Compatibility Implementation Handoff
+
+- Status: open, ready for plan tracking
+- Date: 2026-05-22
+- Source: `graysurf/agent-runtime-kit` issue #26 Sprint 5 validation, local
+  `forge-cli` and `gh` command output, and the current `forge-cli` GitHub checks
+  implementation.
+- Intended next step: execute the paired plan and release `nils-cli` `0.17.0`.
+
+## Purpose
+
+Fix the `forge-cli` GitHub checks backend so released `forge-cli` works with
+`gh 2.92.0` during PR close and delivery workflows, then cut `nils-cli`
+`0.17.0` as the downstream compatibility boundary for `agent-runtime-kit` Plan
+05 Sprint 6.
+
+## Confirmed Facts
+
+- Released `forge-cli 0.16.0` fails live GitHub check operations with
+  `gh 2.92.0` because it requests unsupported `gh pr checks --json` fields.
+- The reproduced failure is:
+  `Unknown JSON field: "conclusion"`.
+- `gh 2.92.0` reports the supported `gh pr checks --json` fields as:
+  `bucket`, `completedAt`, `description`, `event`, `link`, `name`,
+  `startedAt`, `state`, and `workflow`.
+- A direct `gh pr checks 37 --repo graysurf/agent-runtime-kit --json ...`
+  using the supported fields returned a successful check snapshot.
+- A direct `gh pr checks 37 --repo graysurf/agent-runtime-kit --required ...`
+  returned `no required checks reported on the 'feat/plan-05-pr-domain' branch`
+  for the already-merged PR branch.
+- The current `forge-cli` implementation requests:
+  `name,state,conclusion,bucket,workflow,link,startedAt,completedAt,description,isRequired`.
+- `forge-cli pr merge` and `forge-cli pr deliver` depend on the same checks
+  backend through required-check gating, so the compatibility fix must cover the
+  shared backend, not only the standalone `pr checks` command.
+- `agent-runtime-kit` recorded this as extraction backlog item `P5-S5-G1` and
+  used provider-native `gh pr checks` / `gh pr merge` as a temporary operator
+  fallback.
+
+## Decisions
+
+- Fix this in `nils-cli` / `forge-cli`; do not add raw `gh` lifecycle logic to
+  `agent-runtime-kit` skill bodies.
+- Release the fix as `nils-cli` `0.17.0`.
+- Preserve `forge-cli` as the provider lifecycle primitive used by downstream
+  runtime skill bodies.
+- Keep provider-native `gh` commands as an explicitly recorded temporary
+  fallback only until the fixed release is available.
+
+## Scope
+
+- Update the GitHub `pr checks` backend to work with the `gh 2.92.0` field set.
+- Preserve the existing normalized `PrChecksPayload` contract where possible.
+- Keep `--required-only` behavior deterministic for `pr checks`,
+  `pr wait-checks`, `pr merge`, and `pr deliver`.
+- Add regression tests that reproduce the `gh 2.92.0` field set and the
+  provider error around unsupported fields.
+- Cut the `nils-cli` `0.17.0` release after the compatibility fix passes the
+  workspace release gates.
+- Update the downstream `agent-runtime-kit` issue with the nils-cli tracking
+  issue link and later release handoff.
+
+## Non-Scope
+
+- Do not rewrite `forge-cli` to call GitHub REST or GraphQL directly.
+- Do not add Gitea, Forgejo, release, label, or branch protection support.
+- Do not change GitLab checks behavior except where shared tests or docs need
+  harmless clarification.
+- Do not complete the `agent-runtime-kit` Plan 05 Sprint 6 migration in this
+  plan.
+
+## Implementation Boundaries
+
+- `nils-cli`: owns `forge-cli` backend behavior, tests, docs, version bump, and
+  release.
+- `agent-runtime-kit`: owns downstream skill floors and extraction backlog
+  closeout after `nils-cli 0.17.0` is released.
+- GitHub CLI: remains the subprocess backend; the wrapper must adapt to its
+  current supported JSON field set instead of assuming older fields.
+
+## Requirements
+
+- `forge-cli pr checks` must not request unsupported `gh 2.92.0` JSON fields.
+- `forge-cli pr wait-checks` must successfully gate passing checks through the
+  same normalized payload.
+- `forge-cli pr merge` must not fail before merge solely because the checks
+  backend requests unsupported fields.
+- `forge-cli pr deliver` must use the fixed checks path.
+- Required-check handling must not silently treat a real failed required check as
+  success.
+- No network access should be required for the default automated test suite;
+  live behavior is characterized through recorded/stubbed `gh` fixtures.
+
+## Acceptance Criteria
+
+- A regression test fails on the old `conclusion` / `isRequired` field request
+  and passes with the fixed field request.
+- GitHub checks fixtures model the `gh 2.92.0` field set.
+- `cargo test -p nils-forge-cli pr_checks` passes.
+- `cargo test -p nils-forge-cli pr_wait_checks required_check_gate pr_deliver`
+  passes or the equivalent targeted test set is recorded.
+- `bash scripts/ci/nils-cli-checks-entrypoint.sh` passes locally before release.
+- `nils-cli 0.17.0` is tagged and published through the standard release
+  workflow.
+- A post-release `forge-cli --version` check reports `0.17.0`.
+
+## Validation Plan
+
+- Targeted forge-cli tests for GitHub checks parsing and backend argv.
+- Integration tests for `pr wait-checks`, required-check gate, `pr merge`, and
+  `pr deliver` paths.
+- Workspace CI entrypoint before release.
+- Release verification after `0.17.0` is available on the local PATH.
+
+## Risks And Guardrails
+
+- `gh pr checks --required` can return no rows or a non-zero status when no
+  required checks are configured; the implementation must classify that case
+  intentionally instead of surfacing a generic backend failure.
+- Removing `isRequired` from the default field set means gating semantics need a
+  deliberate source of truth, such as a required-only backend call or equivalent
+  fixture-backed classification.
+- `state` values from `gh` are uppercase in current output; normalization must
+  be case-insensitive or explicitly mapped.
+- Release work should not update downstream `agent-runtime-kit` skill floors
+  until `forge-cli --version` confirms the released binary boundary.
+
+## Execution
+
+- Recommended plan: docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-plan.md
+- Recommended execution state: docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-execution-state.md
+
+## Retention Intent
+
+This source document is execution coordination for the `0.17.0` compatibility
+release. It can be cleaned up after the tracking issue is closed and downstream
+`agent-runtime-kit` has recorded the fixed release handoff.
+
+## Open Questions
+
+- Whether required-only gating should use one `gh pr checks --required` call plus
+  one all-checks call, or a single call with documented loss of optional-check
+  reporting. Default: preserve full reporting and use a separate required-only
+  call for gating.
+- Whether `0.17.0` should include any unrelated queued fixes. Default: no; keep
+  this release focused on the GitHub checks compatibility fix.

--- a/docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-execution-state.md
+++ b/docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-execution-state.md
@@ -1,0 +1,87 @@
+<!-- execute-from-tracking-issue:state:v1 -->
+# forge-cli GitHub Checks Compatibility Execution State
+
+## Execution State
+
+- Status: validating
+- Target scope: whole issue
+- Execution window: whole issue
+- Current task: PR delivery for Tasks 1.1 through 3.2
+- Next task: Task 4.1 release `nils-cli` `0.17.0` after PR merge
+- Last updated: 2026-05-22 19:17 Asia/Taipei
+- Branch/commit/PR: `feat/issue-439-gh-checks-compat`; PR not opened yet
+- Source document:
+  docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-plan.md
+- Direct source-doc execution waiver: not applicable
+
+<details>
+<summary>Full task ledger</summary>
+
+| ID | Status | Task | Evidence | Notes |
+| --- | --- | --- | --- | --- |
+| Task 1.1 | done | Add gh 2.92.0 field-set fixtures | `cargo test -p nils-forge-cli pr_checks_github` pass | Fixtures omit `conclusion` and `isRequired`; added required-only fixture. |
+| Task 1.2 | done | Pin required-only behavior expectations | `cargo test -p nils-forge-cli pr_wait_checks`; `cargo test -p nils-forge-cli required_check_gate` pass | Required-only gating uses explicit `gh pr checks --required` evidence. |
+| Task 2.1 | done | Replace unsupported GitHub checks fields | `cargo test -p nils-forge-cli pr_checks` pass | Backend command no longer requests `conclusion` or `isRequired`; state normalization handles bucket/state. |
+| Task 2.2 | done | Implement required-only gating source | Targeted forge-cli tests pass | No-required-check backend errors are normalized to zero required checks. |
+| Task 2.3 | done | Verify merge and deliver consumers | `cargo test -p nils-forge-cli pr_merge`; `cargo test -p nils-forge-cli pr_deliver` pass | `pr deliver` dry-run now uses the fixed required checks command shape. |
+| Task 3.1 | done | Update docs and changelog for compatibility fix | `rg -n "gh 2\\.92\\.0|0\\.17\\.0|checks" crates/forge-cli docs` pass | No root `CHANGELOG.md` exists; recorded release note in forge-cli README/specs. |
+| Task 3.2 | done | Run full local gate | `bash scripts/ci/nils-cli-checks-entrypoint.sh` pass | Includes nextest 3484/3484 and workspace doc tests. |
+| Task 4.1 | pending | Cut nils-cli 0.17.0 | Planned: standard release workflow; `forge-cli --version`; `gh release view v0.17.0 --repo sympoies/nils-cli` | Release only after merged fix and green gates. |
+| Task 4.2 | pending | Record downstream handoff | Planned: comment on `graysurf/agent-runtime-kit` issue #26 | Downstream owns skill floor/backlog update after release evidence exists. |
+
+</details>
+
+## Validation
+
+| Command | Status | Summary | Artifact |
+| --- | --- | --- | --- |
+| `agent-docs --docs-home "$HOME/.config/agent-kit" resolve --context startup --strict --format checklist` | pass | Required startup preflight passed earlier in this execution session. | terminal log |
+| `agent-docs --docs-home "$HOME/.config/agent-kit" resolve --context project-dev --strict --format checklist` | pass | Project-dev preflight passed earlier in this execution session. | terminal log |
+| `agent-docs --docs-home "$HOME/.config/agent-kit" resolve --context task-tools --strict --format checklist` | pass | Task-tools preflight passed earlier in this execution session before GitHub operations. | terminal log |
+| `cargo test -p nils-forge-cli pr_checks_github` | pass | 8 GitHub checks integration tests passed. | terminal log |
+| `cargo test -p nils-forge-cli pr_wait_checks` | pass | `pr wait-checks` unit/integration filter passed. | terminal log |
+| `cargo test -p nils-forge-cli required_check_gate` | pass | Required-check gate unit/integration filter passed. | terminal log |
+| `cargo test -p nils-forge-cli pr_merge` | pass | Merge dry-run/unit integration filter passed. | terminal log |
+| `cargo test -p nils-forge-cli pr_deliver` | pass | Deliver dry-run/full-chain integration filter passed. | terminal log |
+| `cargo test -p nils-forge-cli pr_checks` | pass | 33 unit + 16 integration checks tests passed. | terminal log |
+| `cargo test -p nils-forge-cli` | pass | 221 unit + 94 integration + doc-test pass. | terminal log |
+| `cargo clippy -p nils-forge-cli --all-targets -- -D warnings` | pass | No warnings. | terminal log |
+| `bash scripts/ci/plan-bundle-validate.sh --strict` | pass | Plan bundle validation passed after adding `Source document` to execution state. | terminal log |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh` | pass | All required checks passed; nextest 3484/3484, workspace doc tests pass. | terminal log |
+
+## Runtime Findings
+
+- `fix-now`: released `forge-cli 0.16.0` requests unsupported GitHub checks JSON
+  fields with `gh 2.92.0`; fixed in the current PR branch.
+- `fix-now`: local gate found markdown table alignment drift in the forge-cli
+  spec after docs edits; fixed with `rumdl fmt`.
+- `fix-now`: plan-bundle gate required the new execution state to include
+  `Source document`; fixed in this ledger.
+
+## Blockers
+
+- none
+
+## Session Log
+
+### 2026-05-22 18:08 Asia/Taipei
+
+- Read issue #439 source and plan snapshots.
+- Confirmed no prior `execute-from-tracking-issue:state:v1` comment existed.
+- Confirmed branch `feat/issue-439-gh-checks-compat` contains local plan commit
+  `b7b5e45` and one working-tree production edit in `pr_checks.rs`.
+- Initialized issue-backed execution state before continuing tests and PR work.
+
+### 2026-05-22 19:17 Asia/Taipei
+
+- Changed GitHub checks backend to request only the `gh 2.92.0` supported
+  fields and to use `gh pr checks --required` for required-only gating.
+- Updated fixtures/tests for all-success, mixed-failure, pending, cancelled,
+  empty, and no-required-check cases without `conclusion` / `isRequired`.
+- Updated `pr deliver` dry-run planning and forge-cli docs/specs to use the
+  fixed checks command shape.
+- Validated targeted forge-cli filters, full `nils-forge-cli`, and full
+  `bash scripts/ci/nils-cli-checks-entrypoint.sh`.
+- Fixed two small local gate issues: markdown table alignment and missing
+  execution-state `Source document`.
+- Next: commit, open PR, run mandatory specialist review and remote checks.

--- a/docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-execution-state.md
+++ b/docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-execution-state.md
@@ -8,14 +8,14 @@
 - Execution window: whole issue
 - Current task: PR delivery for Tasks 1.1 through 3.2
 - Next task: Task 4.1 release `nils-cli` `0.17.0` after PR merge
-- Last updated: 2026-05-22 19:17 Asia/Taipei
-- Branch/commit/PR: `feat/issue-439-gh-checks-compat`; PR not opened yet
+- Last updated: 2026-05-22 19:29 Asia/Taipei
+- Branch/commit/PR: `feat/issue-439-gh-checks-compat`; PR
+  [#440](https://github.com/sympoies/nils-cli/pull/440)
 - Source document:
   docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-plan.md
 - Direct source-doc execution waiver: not applicable
 
-<details>
-<summary>Full task ledger</summary>
+## Task Ledger
 
 | ID | Status | Task | Evidence | Notes |
 | --- | --- | --- | --- | --- |
@@ -28,8 +28,6 @@
 | Task 3.2 | done | Run full local gate | `bash scripts/ci/nils-cli-checks-entrypoint.sh` pass | Includes nextest 3484/3484 and workspace doc tests. |
 | Task 4.1 | pending | Cut nils-cli 0.17.0 | Planned: standard release workflow; `forge-cli --version`; `gh release view v0.17.0 --repo sympoies/nils-cli` | Release only after merged fix and green gates. |
 | Task 4.2 | pending | Record downstream handoff | Planned: comment on `graysurf/agent-runtime-kit` issue #26 | Downstream owns skill floor/backlog update after release evidence exists. |
-
-</details>
 
 ## Validation
 
@@ -57,6 +55,8 @@
   spec after docs edits; fixed with `rumdl fmt`.
 - `fix-now`: plan-bundle gate required the new execution state to include
   `Source document`; fixed in this ledger.
+- `fix-now`: remote CI found MD033 inline HTML in this execution-state ledger;
+  replaced the collapsible ledger with pure Markdown.
 
 ## Blockers
 
@@ -85,3 +85,12 @@
 - Fixed two small local gate issues: markdown table alignment and missing
   execution-state `Source document`.
 - Next: commit, open PR, run mandatory specialist review and remote checks.
+
+### 2026-05-22 19:29 Asia/Taipei
+
+- Opened draft PR
+  [#440](https://github.com/sympoies/nils-cli/pull/440)
+  for Tasks 1.1 through 3.2.
+- Remote CI exposed strict markdown lint failure on this execution-state file
+  (`MD033` for `<details>/<summary>`); fixed by converting the ledger to plain
+  Markdown.

--- a/docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-plan.md
+++ b/docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-plan.md
@@ -1,0 +1,312 @@
+# Plan: forge-cli GitHub Checks Compatibility and 0.17.0 Release
+
+## Overview
+
+Fix the `forge-cli` GitHub checks backend for `gh 2.92.0`, verify every
+downstream checks consumer (`pr checks`, `pr wait-checks`, `pr merge`, and
+`pr deliver`), then cut `nils-cli` `0.17.0` as the compatibility release needed
+by `agent-runtime-kit` Plan 05 Sprint 6.
+
+## Read First
+
+- Primary source: docs/plans/forge-cli-gh-292-checks/forge-cli-gh-292-checks-discussion-source.md
+- Source type: discussion-to-implementation-doc
+- Open questions carried into execution:
+  - Required-only gating implementation should preserve full check reporting
+    when practical; default to separate all-checks and required-only calls.
+  - Keep the `0.17.0` release focused on this compatibility fix unless a release
+    blocker is discovered.
+
+## Scope
+
+- In scope:
+  - Update `crates/forge-cli/src/ops/pr_checks.rs` GitHub backend field usage and
+    parsing for the `gh 2.92.0` field set.
+  - Keep `PrChecksPayload` stable where possible, deriving normalized state from
+    `bucket` and `state` when `conclusion` is unavailable.
+  - Preserve deterministic required-check gating for `pr wait-checks`,
+    `required_check_gate`, `pr merge`, and `pr deliver`.
+  - Add fixtures and tests for supported-field output, required-only output,
+    no-required-check behavior, passing checks, failing checks, and pending
+    checks.
+  - Update docs or changelog entries needed for the `0.17.0` release.
+  - Run the standard release workflow for `nils-cli 0.17.0`.
+  - Post downstream handoff evidence back to `agent-runtime-kit` issue #26.
+- Out of scope:
+  - Replacing `gh` subprocess usage with REST or GraphQL clients.
+  - Changing GitLab check parsing unless a shared abstraction requires a small
+    test or comment update.
+  - Updating `agent-runtime-kit` skill manifests or completing its Sprint 6 work.
+
+## Assumptions
+
+1. `gh 2.92.0` is the compatibility target because it is the currently observed
+   version that broke released `forge-cli 0.16.0`.
+2. Default automated tests must stay network-free through backend stubs.
+3. The standard nils-cli release path is still the source of truth for version
+   bump, tag, GitHub release, and local PATH verification.
+4. Downstream `agent-runtime-kit` will update `required_clis` and close
+   `P5-S5-G1` only after `forge-cli --version` reports the fixed release.
+
+## Sprint 1: Characterize GitHub Checks Compatibility
+
+**Goal**: Reproduce the `gh 2.92.0` field-set breakage in tests and pin the
+expected backend command shapes before changing production behavior.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-forge-cli pr_checks_github`
+  - `cargo test -p nils-forge-cli pr_wait_checks`
+- Verify: tests fail against the old unsupported `conclusion` / `isRequired`
+  field request and fixtures cover the supported `gh 2.92.0` fields.
+
+**PR grouping intent**: group
+**Execution Profile**: serial
+
+### Task 1.1: Add gh 2.92.0 field-set fixtures
+
+- **Location**:
+  - `crates/forge-cli/tests/fixtures/github/pr_checks/`
+  - `crates/forge-cli/tests/integration/pr_checks_github.rs`
+- **Description**: Add fixtures for the `gh 2.92.0` supported field set,
+  including passing, failing, pending, and no-required-check cases.
+- **Dependencies**:
+  - none
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - Fixtures omit `conclusion` and `isRequired`.
+  - Tests assert the current implementation still requests unsupported fields.
+  - The intended supported-field command shape is visible in test failure or
+    assertion output.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_checks_github`
+
+### Task 1.2: Pin required-only behavior expectations
+
+- **Location**:
+  - `crates/forge-cli/tests/integration/pr_wait_checks.rs`
+  - `crates/forge-cli/tests/integration/required_check_gate.rs`
+  - `crates/forge-cli/tests/integration/pr_deliver_chain.rs`
+- **Description**: Add or update tests showing how required-only gating should
+  behave when GitHub exposes required checks through `gh pr checks --required`
+  instead of an `isRequired` JSON field.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - Passing required checks produce `state=success`.
+  - Failed required checks produce `checks_failed`.
+  - Pending required checks remain pending or timeout through the existing wait
+    path.
+  - No-required-check behavior is classified deliberately.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_wait_checks required_check_gate`
+
+## Sprint 2: Fix forge-cli GitHub Checks Backend
+
+**Goal**: Make the GitHub checks backend compatible with `gh 2.92.0` while
+preserving the normalized payload and downstream gating behavior.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-forge-cli pr_checks_github`
+  - `cargo test -p nils-forge-cli pr_wait_checks required_check_gate`
+  - `cargo test -p nils-forge-cli pr_merge pr_deliver`
+- Verify: all checks consumers use the fixed backend and no command requests
+  unsupported GitHub JSON fields.
+
+**PR grouping intent**: group
+**Execution Profile**: serial
+
+### Task 2.1: Replace unsupported GitHub checks fields
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_checks.rs`
+- **Description**: Change the GitHub backend command builder to request only
+  fields supported by `gh 2.92.0`, and normalize payload state from `bucket` and
+  `state`.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - No GitHub checks command requests `conclusion` or `isRequired`.
+  - `state` normalization handles current `gh` values such as `SUCCESS`,
+    `FAILURE`, `PENDING`, and `CANCELLED`.
+  - Existing payload fields that cannot be sourced from `gh 2.92.0` are omitted
+    or derived through documented logic, not guessed.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_checks_github`
+
+### Task 2.2: Implement required-only gating source
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_checks.rs`
+  - `crates/forge-cli/src/ops/pr_wait_checks.rs`
+  - `crates/forge-cli/src/ops/required_check_gate.rs`
+- **Description**: Route required-check gating through a `gh pr checks
+  --required` snapshot or equivalent explicit path, while preserving all-check
+  reporting for the normal payload when possible.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - `required_only=true` gates only required checks.
+  - `required_only=false` gates all reported checks.
+  - No-required-check cases have a clear success or no-checks classification
+    backed by tests.
+  - Backend non-zero statuses caused by no required checks do not leak as generic
+    backend failures.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_wait_checks required_check_gate`
+
+### Task 2.3: Verify merge and deliver consumers
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_merge.rs`
+  - `crates/forge-cli/src/macros/pr_deliver.rs`
+  - `crates/forge-cli/tests/integration/pr_merge.rs`
+  - `crates/forge-cli/tests/integration/pr_deliver_chain.rs`
+- **Description**: Ensure `pr merge` and `pr deliver` call the fixed checks
+  backend and keep their existing lock-down semantics.
+- **Dependencies**:
+  - Task 2.2
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - Merge re-check no longer fails on unsupported fields.
+  - Deliver macro wait step records fixed checks payloads.
+  - Existing draft/base/method safeguards remain intact.
+- **Validation**:
+  - `cargo test -p nils-forge-cli pr_merge pr_deliver`
+
+## Sprint 3: Workspace Gate And Release Preparation
+
+**Goal**: Run the broader nils-cli validation stack, update release metadata, and
+prepare a focused `0.17.0` release boundary.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo fmt -p nils-forge-cli`
+  - `cargo clippy -p nils-forge-cli --all-targets -- -D warnings`
+  - `cargo test -p nils-forge-cli`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh`
+- Verify: local gates pass and release notes describe the GitHub checks
+  compatibility fix.
+
+**PR grouping intent**: per-sprint
+**Execution Profile**: serial
+
+### Task 3.1: Update docs and changelog for the compatibility fix
+
+- **Location**:
+  - `crates/forge-cli/README.md`
+  - `crates/forge-cli/CHANGELOG.md` if present
+  - root release/changelog files used by the current release workflow
+- **Description**: Record the `gh 2.92.0` compatibility fix and downstream
+  reason for the `0.17.0` release.
+- **Dependencies**:
+  - Task 2.3
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - Release notes identify the checks backend compatibility fix.
+  - Downstream `agent-runtime-kit` Plan 05 dependency is referenced without
+    making `agent-runtime-kit` changes in this repo.
+- **Validation**:
+  - `rg -n "gh 2\\.92\\.0|0\\.17\\.0|checks" crates/forge-cli CHANGELOG.md docs`
+
+### Task 3.2: Run full local gate
+
+- **Location**:
+  - workspace root
+  - `scripts/ci/nils-cli-checks-entrypoint.sh`
+- **Description**: Run targeted and full workspace validation before release.
+- **Dependencies**:
+  - Task 3.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - Targeted forge-cli tests pass.
+  - The canonical workspace entrypoint passes.
+  - Any skipped optional check is recorded with its reason.
+- **Validation**:
+  - `cargo test -p nils-forge-cli`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh`
+
+## Sprint 4: Release 0.17.0 And Downstream Handoff
+
+**Goal**: Cut the focused `nils-cli 0.17.0` release and record the handoff back
+to the downstream `agent-runtime-kit` issue.
+
+**Demo/Validation**:
+
+- Commands:
+  - standard nils-cli release workflow for `0.17.0`
+  - `forge-cli --version`
+  - `gh release view v0.17.0 --repo sympoies/nils-cli`
+- Verify: released binary reports `0.17.0`, GitHub release exists, and
+  downstream issue #26 has the handoff comment.
+
+**PR grouping intent**: per-sprint
+**Execution Profile**: serial
+
+### Task 4.1: Cut nils-cli 0.17.0
+
+- **Location**:
+  - workspace version files
+  - release scripts and generated release artifacts
+  - `sympoies/homebrew-tap` if the standard release workflow requires it
+- **Description**: Execute the existing nils-cli release workflow for `0.17.0`.
+- **Dependencies**:
+  - Task 3.2
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Source tag and GitHub release for `v0.17.0` exist.
+  - Local installed `forge-cli --version` reports `0.17.0` after release
+    verification.
+  - Homebrew tap state is updated if that is part of the current release
+    contract.
+- **Validation**:
+  - `forge-cli --version`
+  - `gh release view v0.17.0 --repo sympoies/nils-cli`
+
+### Task 4.2: Record downstream handoff
+
+- **Location**:
+  - `graysurf/agent-runtime-kit` issue #26
+  - `graysurf/agent-runtime-kit` extraction backlog in a downstream follow-up,
+    not this nils-cli plan
+- **Description**: Comment on the downstream issue with the `0.17.0` release
+  evidence and the next expected `agent-runtime-kit` action.
+- **Dependencies**:
+  - Task 4.1
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - Issue #26 links the nils-cli tracking issue.
+  - Issue #26 links or names `nils-cli 0.17.0` as the fixed release once
+    available.
+  - Downstream work remains responsible for bumping skill floors and closing
+    `P5-S5-G1`.
+- **Validation**:
+  - `gh issue view 26 --repo graysurf/agent-runtime-kit --comments`
+
+## Risks And Gotchas
+
+- Required-check semantics are the risky part of this fix. Removing `isRequired`
+  from the JSON payload without adding an explicit required-check source would
+  make gating unsafe.
+- `gh pr checks --required` behavior may differ for merged PRs, branches with no
+  required checks, and branches with pending checks. Tests should cover these as
+  separate cases.
+- Keep this release focused. Mixing unrelated fixes into `0.17.0` makes the
+  downstream compatibility boundary harder to audit.
+- Do not claim `agent-runtime-kit` Plan 05 Sprint 6 is unblocked until the
+  released `forge-cli` binary is verified on PATH.
+
+## Completion Criteria
+
+- The GitHub checks compatibility fix is merged in `sympoies/nils-cli`.
+- `nils-cli 0.17.0` is released and verified locally.
+- The nils-cli tracking issue records validation and release evidence.
+- `agent-runtime-kit` issue #26 records that the nils-cli fix issue and release
+  handoff exist.


### PR DESCRIPTION
# Fix forge-cli GitHub checks for gh 2.92

## Summary

Updates `forge-cli` GitHub PR checks handling so `gh 2.92.0` no longer rejects unsupported JSON fields, while preserving required-check gating for `pr checks`, `pr wait-checks`, `pr merge`, and `pr deliver`. Refs #439.

## Problem

- Expected: `forge-cli` should read GitHub PR checks through fields supported by the installed `gh` CLI and gate required checks deterministically.
- Actual: released `forge-cli 0.16.0` requests `conclusion` and `isRequired`, which `gh 2.92.0` rejects with `Unknown JSON field: "conclusion"`.
- Impact: downstream delivery workflows can fail before checks/merge on current GitHub CLI installs.

## Reproduction

1. Run a `forge-cli` GitHub checks path with `gh 2.92.0`, such as PR delivery or required-check gating.
2. Observe the backend `gh pr checks --json ...` rejection for unsupported fields.

- Expected result: checks parse into the normalized `PrChecksPayload` and required-only gating uses explicit required-check evidence.
- Actual result: the backend fails before returning checks because the JSON field list is invalid.

## Issues Found

|ID|Severity|Confidence|Area|Summary|Evidence|Status|
|---|---|---|---|---|---|---|
|`439-BUG-01`|high|high|`crates/forge-cli/src/ops/pr_checks.rs`|GitHub checks backend requested fields unsupported by `gh 2.92.0`.|Issue #439 source snapshot and updated regression tests.|fixed|
|`439-BUG-02`|high|high|`required-check gating`|Removing `isRequired` required an explicit source for required-only checks.|`gh pr checks --required` fixtures and tests.|fixed|

## Fix Approach

- Request only `gh 2.92.0` supported fields for GitHub checks snapshots.
- Add a required-only `gh pr checks --required` call and merge that evidence into normalized payloads for required gating.
- Normalize current uppercase GitHub states through bucket/state fallback.
- Update fixtures, consumer tests, `pr deliver` dry-run planning, and forge-cli docs/specs.
- Record the issue-backed execution state and validation evidence for #439.

## Test-First Evidence

- Change classification: bug fix.
- Failing test before fix: targeted tests were updated to assert unsupported fields are absent and required-only output is explicit; the old implementation failed those command-shape expectations.
- Final validation: targeted forge-cli tests, clippy, plan bundle validation, and full `bash scripts/ci/nils-cli-checks-entrypoint.sh` passed locally.
- Waiver reason: direct live `gh` repro was already captured in issue #439 source; automated coverage uses offline fixtures/stubs to keep CI credential-free.

## Testing

- `cargo test -p nils-forge-cli pr_checks_github` (pass)
- `cargo test -p nils-forge-cli pr_wait_checks` (pass)
- `cargo test -p nils-forge-cli required_check_gate` (pass)
- `cargo test -p nils-forge-cli pr_merge` (pass)
- `cargo test -p nils-forge-cli pr_deliver` (pass)
- `cargo test -p nils-forge-cli pr_checks` (pass)
- `cargo test -p nils-forge-cli` (pass)
- `cargo clippy -p nils-forge-cli --all-targets -- -D warnings` (pass)
- `bash scripts/ci/plan-bundle-validate.sh --strict` (pass)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh` (pass)

## Risk / Notes

- This keeps GitHub CLI as the backend and does not introduce REST/GraphQL behavior.
- No-required-check responses from `gh pr checks --required` are classified intentionally as an empty required set instead of a generic backend failure.
- Release task `0.17.0` remains pending until this PR merges.
