### PR TITLE
Add forge-cli inbox discovery

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -25,6 +25,9 @@ _forge-cli() {
             forge__cli,help)
                 cmd="forge__cli__help"
                 ;;
+            forge__cli,inbox)
+                cmd="forge__cli__inbox"
+                ;;
             forge__cli,issue)
                 cmd="forge__cli__issue"
                 ;;
@@ -55,6 +58,9 @@ _forge-cli() {
             forge__cli__help,help)
                 cmd="forge__cli__help__help"
                 ;;
+            forge__cli__help,inbox)
+                cmd="forge__cli__help__inbox"
+                ;;
             forge__cli__help,issue)
                 cmd="forge__cli__help__issue"
                 ;;
@@ -66,6 +72,15 @@ _forge-cli() {
                 ;;
             forge__cli__help__auth,status)
                 cmd="forge__cli__help__auth__status"
+                ;;
+            forge__cli__help__inbox,list)
+                cmd="forge__cli__help__inbox__list"
+                ;;
+            forge__cli__help__inbox,next)
+                cmd="forge__cli__help__inbox__next"
+                ;;
+            forge__cli__help__inbox,status)
+                cmd="forge__cli__help__inbox__status"
                 ;;
             forge__cli__help__issue,close)
                 cmd="forge__cli__help__issue__close"
@@ -120,6 +135,30 @@ _forge-cli() {
                 ;;
             forge__cli__help__repo,view)
                 cmd="forge__cli__help__repo__view"
+                ;;
+            forge__cli__inbox,help)
+                cmd="forge__cli__inbox__help"
+                ;;
+            forge__cli__inbox,list)
+                cmd="forge__cli__inbox__list"
+                ;;
+            forge__cli__inbox,next)
+                cmd="forge__cli__inbox__next"
+                ;;
+            forge__cli__inbox,status)
+                cmd="forge__cli__inbox__status"
+                ;;
+            forge__cli__inbox__help,help)
+                cmd="forge__cli__inbox__help__help"
+                ;;
+            forge__cli__inbox__help,list)
+                cmd="forge__cli__inbox__help__list"
+                ;;
+            forge__cli__inbox__help,next)
+                cmd="forge__cli__inbox__help__next"
+                ;;
+            forge__cli__inbox__help,status)
+                cmd="forge__cli__inbox__help__status"
                 ;;
             forge__cli__issue,close)
                 cmd="forge__cli__issue__close"
@@ -254,7 +293,7 @@ _forge-cli() {
 
     case "${cmd}" in
         forge__cli)
-            opts="-h -V --format --remote --provider --repo --dry-run --help --version pr issue repo auth completion help"
+            opts="-h -V --format --remote --provider --repo --dry-run --help --version pr issue inbox repo auth completion help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -416,7 +455,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help)
-            opts="pr issue repo auth completion help"
+            opts="pr issue inbox repo auth completion help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -474,6 +513,62 @@ _forge-cli() {
         forge__cli__help__help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__inbox)
+            opts="status list next"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__inbox__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__inbox__next)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__inbox__status)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -772,6 +867,232 @@ _forge-cli() {
                 return 0
             fi
             case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__inbox)
+            opts="-h --format --remote --provider --repo --dry-run --help status list next help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__inbox__help)
+            opts="status list next help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__inbox__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__inbox__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__inbox__help__next)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__inbox__help__status)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__inbox__list)
+            opts="-h --gitlab-host --kind --limit --format --remote --provider --repo --dry-run --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --gitlab-host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --kind)
+                    COMPREPLY=($(compgen -W "review assigned todo authored involved" -- "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__inbox__next)
+            opts="-h --gitlab-host --kind --limit --format --remote --provider --repo --dry-run --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --gitlab-host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --kind)
+                    COMPREPLY=($(compgen -W "review assigned todo authored involved" -- "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__inbox__status)
+            opts="-h --gitlab-host --kind --limit --format --remote --provider --repo --dry-run --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --gitlab-host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --kind)
+                    COMPREPLY=($(compgen -W "review assigned todo authored involved" -- "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -460,6 +460,107 @@ esac
     ;;
 esac
 ;;
+(inbox)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_forge-cli__subcmd__inbox_commands" \
+"*::: :->inbox" \
+&& ret=0
+
+    case $state in
+    (inbox)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:forge-cli-inbox-command-$line[1]:"
+        case $line[1] in
+            (status)
+_arguments "${_arguments_options[@]}" : \
+'--gitlab-host=[GitLab host for inbox API calls]:HOST:_default' \
+'*--kind=[Restrict inbox reasons/kinds. Repeatable. Defaults to review, assigned, todo, and authored; \`involved\` is opt-in because it can be broad on GitHub]:KINDS:(review assigned todo authored involved)' \
+'--limit=[Per-provider, per-query-family bounded result limit (default\: 30)]:LIMIT:_default' \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(list)
+_arguments "${_arguments_options[@]}" : \
+'--gitlab-host=[GitLab host for inbox API calls]:HOST:_default' \
+'*--kind=[Restrict inbox reasons/kinds. Repeatable. Defaults to review, assigned, todo, and authored; \`involved\` is opt-in because it can be broad on GitHub]:KINDS:(review assigned todo authored involved)' \
+'--limit=[Per-provider, per-query-family bounded result limit (default\: 30)]:LIMIT:_default' \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(next)
+_arguments "${_arguments_options[@]}" : \
+'--gitlab-host=[GitLab host for inbox API calls]:HOST:_default' \
+'*--kind=[Restrict inbox reasons/kinds. Repeatable. Defaults to review, assigned, todo, and authored; \`involved\` is opt-in]:KINDS:(review assigned todo authored involved)' \
+'--limit=[Number of ranked items to return (default\: 5). Provider queries remain bounded at at least 30 candidates so ranking has enough input]:LIMIT:_default' \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_forge-cli__subcmd__inbox__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:forge-cli-inbox-help-command-$line[1]:"
+        case $line[1] in
+            (status)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(next)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
 (repo)
 _arguments "${_arguments_options[@]}" : \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
@@ -705,6 +806,34 @@ _arguments "${_arguments_options[@]}" : \
     ;;
 esac
 ;;
+(inbox)
+_arguments "${_arguments_options[@]}" : \
+":: :_forge-cli__subcmd__help__subcmd__inbox_commands" \
+"*::: :->inbox" \
+&& ret=0
+
+    case $state in
+    (inbox)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:forge-cli-help-inbox-command-$line[1]:"
+        case $line[1] in
+            (status)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(next)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
 (repo)
 _arguments "${_arguments_options[@]}" : \
 ":: :_forge-cli__subcmd__help__subcmd__repo_commands" \
@@ -767,6 +896,7 @@ _forge-cli_commands() {
     local commands; commands=(
 'pr:Pull / merge request lifecycle' \
 'issue:Issue lifecycle' \
+'inbox:Personal cross-repo work inbox' \
 'repo:Repository helpers' \
 'auth:Backend authentication helpers' \
 'completion:Emit shell-completion scripts' \
@@ -815,6 +945,7 @@ _forge-cli__subcmd__help_commands() {
     local commands; commands=(
 'pr:Pull / merge request lifecycle' \
 'issue:Issue lifecycle' \
+'inbox:Personal cross-repo work inbox' \
 'repo:Repository helpers' \
 'auth:Backend authentication helpers' \
 'completion:Emit shell-completion scripts' \
@@ -843,6 +974,30 @@ _forge-cli__subcmd__help__subcmd__completion_commands() {
 _forge-cli__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli help help commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__inbox_commands] )) ||
+_forge-cli__subcmd__help__subcmd__inbox_commands() {
+    local commands; commands=(
+'status:Summarize bounded personal work counts' \
+'list:List normalized inbox items' \
+'next:Return ranked next-action candidates' \
+    )
+    _describe -t commands 'forge-cli help inbox commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__inbox__subcmd__list_commands] )) ||
+_forge-cli__subcmd__help__subcmd__inbox__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli help inbox list commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__inbox__subcmd__next_commands] )) ||
+_forge-cli__subcmd__help__subcmd__inbox__subcmd__next_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli help inbox next commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__inbox__subcmd__status_commands] )) ||
+_forge-cli__subcmd__help__subcmd__inbox__subcmd__status_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli help inbox status commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__help__subcmd__issue_commands] )) ||
 _forge-cli__subcmd__help__subcmd__issue_commands() {
@@ -969,6 +1124,61 @@ _forge-cli__subcmd__help__subcmd__repo_commands() {
 _forge-cli__subcmd__help__subcmd__repo__subcmd__view_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli help repo view commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__inbox_commands] )) ||
+_forge-cli__subcmd__inbox_commands() {
+    local commands; commands=(
+'status:Summarize bounded personal work counts' \
+'list:List normalized inbox items' \
+'next:Return ranked next-action candidates' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'forge-cli inbox commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__inbox__subcmd__help_commands] )) ||
+_forge-cli__subcmd__inbox__subcmd__help_commands() {
+    local commands; commands=(
+'status:Summarize bounded personal work counts' \
+'list:List normalized inbox items' \
+'next:Return ranked next-action candidates' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'forge-cli inbox help commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__inbox__subcmd__help__subcmd__help_commands] )) ||
+_forge-cli__subcmd__inbox__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli inbox help help commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__inbox__subcmd__help__subcmd__list_commands] )) ||
+_forge-cli__subcmd__inbox__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli inbox help list commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__inbox__subcmd__help__subcmd__next_commands] )) ||
+_forge-cli__subcmd__inbox__subcmd__help__subcmd__next_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli inbox help next commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__inbox__subcmd__help__subcmd__status_commands] )) ||
+_forge-cli__subcmd__inbox__subcmd__help__subcmd__status_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli inbox help status commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__inbox__subcmd__list_commands] )) ||
+_forge-cli__subcmd__inbox__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli inbox list commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__inbox__subcmd__next_commands] )) ||
+_forge-cli__subcmd__inbox__subcmd__next_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli inbox next commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__inbox__subcmd__status_commands] )) ||
+_forge-cli__subcmd__inbox__subcmd__status_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli inbox status commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__issue_commands] )) ||
 _forge-cli__subcmd__issue_commands() {

--- a/crates/forge-cli/README.md
+++ b/crates/forge-cli/README.md
@@ -1,8 +1,9 @@
 # forge-cli
 
-Provider-neutral CLI for remote forge operations (PR/MR lifecycle, Issue
-lifecycle, CI wait). Two backends ship together: GitHub (wraps `gh`) and
-GitLab (wraps `glab`). Adopts `cli-output-contract-v1` from day one.
+Provider-neutral CLI for remote forge operations (personal inbox discovery,
+PR/MR lifecycle, Issue lifecycle, CI wait). Two backends ship together: GitHub
+(wraps `gh`) and GitLab (wraps `glab`). Adopts `cli-output-contract-v1` from
+day one.
 
 ## Read first
 
@@ -16,12 +17,30 @@ GitLab (wraps `glab`). Adopts `cli-output-contract-v1` from day one.
 
 ```sh
 cargo run -p nils-forge-cli -- --help
+cargo run -p nils-forge-cli -- inbox status --format json
 cargo run -p nils-forge-cli -- auth status --format json
 cargo run -p nils-forge-cli -- pr deliver --kind feature --dry-run --format json
 ```
 
 `forge-cli` does NOT introduce a `--json` boolean flag. Use
 `--format text|json` exclusively.
+
+## Inbox discovery
+
+`forge-cli inbox` is a read-only personal work inbox for agents, scheduled jobs,
+and Alfred-style consumers:
+
+```sh
+forge-cli inbox list --format json
+forge-cli inbox status --provider gitlab --gitlab-host gitlab.example.com --format json
+forge-cli inbox next --limit 5 --format json
+```
+
+With no `--provider`, inbox queries GitHub and GitLab and keeps successful
+provider results when another provider fails. GitLab inbox calls always pass
+`--hostname <host>` to `glab api`; use `--gitlab-host` for self-managed hosts.
+`status` reports bounded counts, and `next` returns a ranked bounded subset
+without mutating PRs, issues, merge requests, or todos.
 
 ## GitHub checks compatibility
 

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -391,6 +391,76 @@ operations:
         scopes: list<string>
     notes: "Backend output is text, parsed into the structured envelope."
 
+  - id: inbox.list
+    schema_version: cli.forge-cli.inbox.list.v1
+    summary: List normalized personal inbox items across selected providers.
+    inputs:
+      - { name: --gitlab-host, type: string, default: gitlab.com, scope: inbox-only }
+      - { name: --kind,        type: list<enum<review|assigned|todo|authored|involved>>, default: [review, assigned, todo, authored] }
+      - { name: --limit,       type: integer, default: 30, semantics: "per provider and per query family" }
+    validations: []
+    backends:
+      github:
+        program: gh
+        argv:
+          - [search, prs, "--review-requested", "@me", --state, open, --sort, updated, --order, desc, --limit, "{limit}", --json, "number,url,title,updatedAt,author,repository"]
+          - [search, prs, "--assignee", "@me", --state, open, --sort, updated, --order, desc, --limit, "{limit}", --json, "number,url,title,updatedAt,author,repository"]
+          - [search, issues, "--assignee", "@me", --state, open, --sort, updated, --order, desc, --limit, "{limit}", --json, "number,url,title,updatedAt,author,repository"]
+          - [search, prs, "--author", "@me", --state, open, --sort, updated, --order, desc, --limit, "{limit}", --json, "number,url,title,updatedAt,author,repository"]
+          - [search, issues, "--author", "@me", --state, open, --sort, updated, --order, desc, --limit, "{limit}", --json, "number,url,title,updatedAt,author,repository"]
+      gitlab:
+        program: glab
+        argv:
+          - [api, user, --hostname, "{gitlab_host}"]
+          - [api, --hostname, "{gitlab_host}", "merge_requests?scope=assigned_to_me&state=opened&order_by=updated_at&sort=desc&per_page={limit}"]
+          - [api, --hostname, "{gitlab_host}", "merge_requests?reviewer_username={username}&state=opened&order_by=updated_at&sort=desc&per_page={limit}"]
+          - [api, --hostname, "{gitlab_host}", "merge_requests?author_id={user_id}&state=opened&order_by=updated_at&sort=desc&per_page={limit}"]
+          - [api, --hostname, "{gitlab_host}", "issues?scope=assigned_to_me&state=opened&order_by=updated_at&sort=desc&per_page={limit}"]
+          - [api, --hostname, "{gitlab_host}", "issues?author_id={user_id}&state=opened&order_by=updated_at&sort=desc&per_page={limit}"]
+          - [api, --hostname, "{gitlab_host}", "todos?state=pending&order_by=updated_at&sort=desc&per_page={limit}"]
+    output:
+      data:
+        providers: "list of { provider, host, ok, item_count, limited, error? }"
+        limit: integer
+        items: "list of normalized inbox items"
+    notes: "Partial provider success exits 0 with provider errors in data.providers[] and string warnings[]; all selected providers failing exits non-zero."
+
+  - id: inbox.status
+    schema_version: cli.forge-cli.inbox.status.v1
+    summary: Summarize bounded inbox counts by provider, host, kind, and reason.
+    inputs:
+      - { name: --gitlab-host, type: string, default: gitlab.com, scope: inbox-only }
+      - { name: --kind,        type: list<enum<review|assigned|todo|authored|involved>>, default: [review, assigned, todo, authored] }
+      - { name: --limit,       type: integer, default: 30, semantics: "per provider and per query family" }
+    validations: []
+    backends:
+      github: { derives_from: inbox.list }
+      gitlab: { derives_from: inbox.list }
+    output:
+      data:
+        providers: "list of provider status rows"
+        limit: integer
+        item_count: integer
+        counts: "list of { provider, host, kind, reason, count, limited }"
+
+  - id: inbox.next
+    schema_version: cli.forge-cli.inbox.next.v1
+    summary: Return ranked next-action candidates from the normalized inbox.
+    inputs:
+      - { name: --gitlab-host, type: string, default: gitlab.com, scope: inbox-only }
+      - { name: --kind,        type: list<enum<review|assigned|todo|authored|involved>>, default: [review, assigned, todo, authored] }
+      - { name: --limit,       type: integer, default: 5, semantics: "returned ranked item count" }
+    validations: []
+    backends:
+      github: { derives_from: inbox.list, query_limit_floor: 30 }
+      gitlab: { derives_from: inbox.list, query_limit_floor: 30 }
+    output:
+      data:
+        providers: "list of provider status rows"
+        limit: integer
+        query_limit: integer
+        items: "ranked normalized inbox items"
+
 # ---------------------------------------------------------------------------
 # Macro operations.
 # ---------------------------------------------------------------------------

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -44,6 +44,8 @@ Non-goals (v1):
 
 In scope (v1):
 
+- Personal work discovery: `inbox list`, `inbox status`, and
+  `inbox next` across GitHub and GitLab.
 - PR/MR lifecycle: `create`, `view`, `list`, `edit`, `comment`,
   `ready`, `merge`, `close`.
 - PR/MR checks: `pr checks` (one-shot snapshot) and `pr wait-checks`
@@ -55,11 +57,11 @@ In scope (v1):
   atoms above into the agent-kit standard "open draft → wait CI →
   ready → merge → cleanup" flow.
 
-Out of scope (v1): release management, labels, raw REST passthrough,
-issue macros, repo creation, branch protection management, code review
-state mutation beyond `pr ready`. Each of these would either widen the
-parity gap (GitLab has no equivalent today) or remove the "lock down
-behaviour" value (REST passthrough = same as `gh api` + rename).
+Out of scope (v1): inbox mutations, release management, labels, raw REST
+passthrough, issue macros, repo creation, branch protection management, code
+review state mutation beyond `pr ready`. Each of these would either widen the
+parity gap (GitLab has no equivalent today) or remove the "lock down behaviour"
+value (REST passthrough = same as `gh api` + rename).
 
 ## Provider parity model
 
@@ -110,6 +112,9 @@ Parity matrix (v1):
 | `issue reopen <id>`   | `gh issue reopen <id>`                                          | `glab issue reopen <id>`                             | exact                                |
 | `auth status`         | `gh auth status`                                                | `glab auth status`                                   | exact (text → typed)                 |
 | `repo view`           | `gh repo view --json …`                                         | `glab repo view -F json`                             | exact                                |
+| `inbox list`          | `gh search prs/issues --json …`                                 | `glab api --hostname <host> …`                       | normalized aggregation               |
+| `inbox status`        | same provider reads as `inbox list`                             | same provider reads as `inbox list`                  | bounded counts                       |
+| `inbox next`          | same provider reads as `inbox list`                             | same provider reads as `inbox list`                  | ranked bounded subset                |
 | `pr deliver`          | macro: `pr create` → `pr wait-checks` → `pr ready` → `pr merge` | same composition with gitlab atoms                   | exact (same macro logic on both)     |
 
 "emulated" means the backend's native command differs in shape, but
@@ -147,6 +152,10 @@ forge-cli
 │   ├── comment
 │   ├── close
 │   └── reopen
+├── inbox
+│   ├── status
+│   ├── list
+│   └── next
 ├── repo
 │   └── view
 ├── auth
@@ -167,6 +176,20 @@ Global flags (every subcommand):
 
 `forge-cli` itself does not expose `--token`, `--host`, or any auth
 override. Those belong to `gh`/`glab` and are configured there.
+
+Inbox-local flags:
+
+- `forge-cli inbox list|status --limit <n>` bounds each provider query family
+  (default `30`).
+- `forge-cli inbox next --limit <n>` bounds the returned ranked candidates
+  (default `5`); provider reads still use at least `30` candidates.
+- `--kind review|assigned|todo|authored|involved` is repeatable. `involved` is
+  opt-in because it can be broad on GitHub.
+- `--gitlab-host <host>` is scoped to inbox commands only and is passed to
+  every GitLab `glab api` invocation as `--hostname <host>`.
+- With no `--provider`, inbox queries both default providers. `--provider
+  github|gitlab` narrows the inbox just as it narrows lifecycle commands, but
+  inbox does not reuse the single-provider remote resolver internally.
 
 ## Atomic op surface
 
@@ -334,6 +357,34 @@ Violations map to `DATA 65` with one of these `data.error.kind` values:
 | `checks_failed`            | 8 (`RUNTIME 1`)   |
 | `merge_method_unsupported` | 9                 |
 | `keep_branch_conflict`     | 10                |
+
+## Inbox output contract
+
+`inbox` is read-only and aggregates personal work discovery across selected
+providers:
+
+- `inbox list` emits `cli.forge-cli.inbox.list.v1` with
+  `data.providers[]`, `data.limit`, and normalized `data.items[]`.
+- `inbox status` emits `cli.forge-cli.inbox.status.v1` with bounded count rows
+  grouped by provider, host, kind, and reason. Counts are bounded by the
+  effective query limit, not guaranteed global totals.
+- `inbox next` emits `cli.forge-cli.inbox.next.v1` with ranked candidates;
+  review-requested work ranks ahead of assigned, todo, authored, and broad
+  involved work.
+- Every item includes `provider`, `host`, `kind`, `reasons`, `repo`, `number`,
+  `title`, `url`, `updated_at`, `author`, and `source`.
+- `reasons` is a deterministic de-duplicated array. Allowed v1 values are
+  `review`, `assigned`, `todo`, `authored`, and `involved`.
+- Partial provider success exits `SUCCESS 0`: successful provider items remain
+  in `data.items[]`, failed providers are represented in `data.providers[].
+  error`, and top-level `warnings[]` carries string warnings under the shared
+  workspace envelope contract.
+- If every selected provider fails, `inbox` exits non-zero through the normal
+  `ForgeError` / `cli_contract` failure envelope instead of returning an empty
+  successful inbox.
+- GitLab rows come from host-aware `glab api --hostname <host>` calls. The user
+  id and username are discovered with `glab api user --hostname <host>` for the
+  current invocation and are not persisted.
 
 ## CLI output contract conformance
 

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -107,6 +107,8 @@ pub enum Command {
     Pr(PrArgs),
     /// Issue lifecycle.
     Issue(IssueArgs),
+    /// Personal cross-repo work inbox.
+    Inbox(InboxArgs),
     /// Repository helpers.
     Repo(RepoArgs),
     /// Backend authentication helpers.
@@ -125,6 +127,12 @@ pub struct PrArgs {
 pub struct IssueArgs {
     #[command(subcommand)]
     pub command: Option<IssueCommand>,
+}
+
+#[derive(Args, Debug)]
+pub struct InboxArgs {
+    #[command(subcommand)]
+    pub command: Option<InboxCommand>,
 }
 
 #[derive(Args, Debug)]
@@ -178,6 +186,29 @@ pub enum PrStateFilter {
     Closed,
     Merged,
     All,
+}
+
+/// Inbox item-kind / reason filter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum InboxKindFlag {
+    Review,
+    Assigned,
+    Todo,
+    Authored,
+    Involved,
+}
+
+impl InboxKindFlag {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            InboxKindFlag::Review => "review",
+            InboxKindFlag::Assigned => "assigned",
+            InboxKindFlag::Todo => "todo",
+            InboxKindFlag::Authored => "authored",
+            InboxKindFlag::Involved => "involved",
+        }
+    }
 }
 
 impl PrStateFilter {
@@ -496,6 +527,57 @@ pub enum IssueCommand {
     },
 }
 
+/// `inbox` subtree.
+#[derive(Subcommand, Debug)]
+pub enum InboxCommand {
+    /// Summarize bounded personal work counts.
+    Status(InboxQueryArgs),
+    /// List normalized inbox items.
+    List(InboxQueryArgs),
+    /// Return ranked next-action candidates.
+    Next(InboxNextArgs),
+}
+
+/// Shared inbox query arguments for list/status.
+#[derive(Args, Debug, Clone)]
+pub struct InboxQueryArgs {
+    /// GitLab host for inbox API calls.
+    #[arg(
+        long = "gitlab-host",
+        value_name = "HOST",
+        default_value = "gitlab.com"
+    )]
+    pub gitlab_host: String,
+    /// Restrict inbox reasons/kinds. Repeatable. Defaults to review,
+    /// assigned, todo, and authored; `involved` is opt-in because it can be
+    /// broad on GitHub.
+    #[arg(long = "kind", value_enum)]
+    pub kinds: Vec<InboxKindFlag>,
+    /// Per-provider, per-query-family bounded result limit (default: 30).
+    #[arg(long, default_value_t = 30)]
+    pub limit: u32,
+}
+
+/// `inbox next` arguments.
+#[derive(Args, Debug, Clone)]
+pub struct InboxNextArgs {
+    /// GitLab host for inbox API calls.
+    #[arg(
+        long = "gitlab-host",
+        value_name = "HOST",
+        default_value = "gitlab.com"
+    )]
+    pub gitlab_host: String,
+    /// Restrict inbox reasons/kinds. Repeatable. Defaults to review,
+    /// assigned, todo, and authored; `involved` is opt-in.
+    #[arg(long = "kind", value_enum)]
+    pub kinds: Vec<InboxKindFlag>,
+    /// Number of ranked items to return (default: 5). Provider queries remain
+    /// bounded at at least 30 candidates so ranking has enough input.
+    #[arg(long, default_value_t = 5)]
+    pub limit: u32,
+}
+
 /// `issue create` arguments.
 #[derive(Args, Debug, Clone)]
 pub struct IssueCreateArgs {
@@ -651,12 +733,16 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
         Some(Command::Issue(IssueArgs {
             command: Some(IssueCommand::Reopen { id }),
         })) => ops::issue_reopen::run(&global, id, format),
+        Some(Command::Inbox(InboxArgs {
+            command: Some(command),
+        })) => ops::inbox::run(&global, command, format),
         Some(Command::Completion(CompletionArgs { shell })) => emit_completion(shell),
         None
         | Some(Command::Auth(AuthArgs { command: None }))
         | Some(Command::Repo(RepoArgs { command: None }))
         | Some(Command::Pr(PrArgs { command: None }))
-        | Some(Command::Issue(IssueArgs { command: None })) => {
+        | Some(Command::Issue(IssueArgs { command: None }))
+        | Some(Command::Inbox(InboxArgs { command: None })) => {
             // No subcommand: print help and exit USAGE so callers don't
             // mistake the no-op for success.
             let _ = <Cli as clap::CommandFactory>::command().print_help();
@@ -932,6 +1018,50 @@ mod tests {
             let result = parse(&argv);
             assert!(result.is_ok(), "issue {sub} should parse, got {result:?}");
         }
+    }
+
+    #[test]
+    fn lists_every_inbox_v1_subcommand() {
+        for sub in ["status", "list", "next"] {
+            let result = parse(&["inbox", sub]);
+            assert!(result.is_ok(), "inbox {sub} should parse, got {result:?}");
+        }
+    }
+
+    #[test]
+    fn inbox_cli_parses_gitlab_host_kind_and_limit() {
+        let cli = parse(&[
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+            "--kind",
+            "review",
+            "--kind",
+            "assigned",
+            "--limit",
+            "7",
+        ])
+        .expect("parse");
+        match cli.command {
+            Some(Command::Inbox(InboxArgs {
+                command: Some(InboxCommand::List(args)),
+            })) => {
+                assert_eq!(args.gitlab_host, "gitlab.example.com");
+                assert_eq!(
+                    args.kinds,
+                    vec![InboxKindFlag::Review, InboxKindFlag::Assigned]
+                );
+                assert_eq!(args.limit, 7);
+            }
+            other => panic!("expected inbox list, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gitlab_host_is_not_global() {
+        let result = parse(&["--gitlab-host", "gitlab.example.com", "repo", "view"]);
+        assert!(result.is_err(), "--gitlab-host must stay inbox-local");
     }
 
     #[test]

--- a/crates/forge-cli/src/envelope.rs
+++ b/crates/forge-cli/src/envelope.rs
@@ -61,6 +61,39 @@ where
     }
 }
 
+/// Emit a success envelope with non-fatal warning strings attached.
+pub fn emit_success_with_warnings<T, F>(
+    schema_version: impl Into<String>,
+    data: T,
+    warnings: Vec<String>,
+    format: OutputFormat,
+    render_text: F,
+) -> i32
+where
+    T: Serialize,
+    F: FnOnce(&T),
+{
+    let envelope = Envelope::success(schema_version, data).with_warnings(warnings);
+    match format {
+        OutputFormat::Json => match serde_json::to_string(&envelope) {
+            Ok(serialized) => {
+                println!("{serialized}");
+                exit::SUCCESS
+            }
+            Err(_) => exit::SOFTWARE,
+        },
+        OutputFormat::Text => {
+            if let Some(payload) = envelope.data.as_ref() {
+                render_text(payload);
+            }
+            for warning in envelope.warnings {
+                eprintln!("warning: {warning}");
+            }
+            exit::SUCCESS
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/forge-cli/src/ops/inbox.rs
+++ b/crates/forge-cli/src/ops/inbox.rs
@@ -773,10 +773,10 @@ fn parse_gitlab_todo(
             .or_else(|| optional_str(raw, "updated_at"))
             .or_else(|| optional_str(raw, "created_at"))
             .unwrap_or_default(),
-        author: raw
+        author: target_obj
             .get("author")
             .and_then(gitlab_author_from_value)
-            .or_else(|| target_obj.get("author").and_then(gitlab_author_from_value)),
+            .or_else(|| raw.get("author").and_then(gitlab_author_from_value)),
         source: query.source,
     })
 }

--- a/crates/forge-cli/src/ops/inbox.rs
+++ b/crates/forge-cli/src/ops/inbox.rs
@@ -1,0 +1,1166 @@
+//! Cross-repo personal work inbox.
+//!
+//! `forge-cli inbox` is intentionally separate from repo-local lifecycle
+//! commands. It can query more than one provider in a single invocation,
+//! normalize items into one JSON contract, and report provider-local failures
+//! without hiding successful results from another provider.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::ffi::OsString;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{BackendCall, BackendProgram, BackendRunner, BackendSuccess, ProcessRunner};
+use crate::cli::{BINARY, GlobalFlags, InboxCommand, InboxKindFlag, InboxNextArgs, InboxQueryArgs};
+use crate::envelope::emit_success_with_warnings;
+use crate::error::ForgeError;
+use crate::provider::{Provider, classify_host, git_remote_url, parse_host};
+
+const LIST_SCHEMA: &str = "inbox.list";
+const STATUS_SCHEMA: &str = "inbox.status";
+const NEXT_SCHEMA: &str = "inbox.next";
+const SCHEMA_VERSION: u32 = 1;
+const DEFAULT_QUERY_LIMIT: u32 = 30;
+const GH_JSON_FIELDS: &str = "number,url,title,updatedAt,author,repository";
+
+#[derive(Debug, Clone)]
+struct ProviderTarget {
+    provider: Provider,
+    host: String,
+}
+
+#[derive(Debug, Clone)]
+struct QueryConfig {
+    reasons: Vec<InboxKindFlag>,
+    query_limit: u32,
+}
+
+#[derive(Debug, Clone)]
+struct ProviderSuccess {
+    items: Vec<InboxItem>,
+    limited: bool,
+}
+
+#[derive(Debug, Clone)]
+struct InboxCollection {
+    providers: Vec<InboxProviderStatus>,
+    items: Vec<InboxItem>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct InboxProviderStatus {
+    pub provider: &'static str,
+    pub host: String,
+    pub ok: bool,
+    pub item_count: usize,
+    pub limited: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<InboxProviderError>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct InboxProviderError {
+    pub kind: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct InboxItem {
+    pub provider: &'static str,
+    pub host: String,
+    pub kind: String,
+    pub reasons: Vec<String>,
+    pub repo: String,
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub updated_at: String,
+    pub author: Option<String>,
+    pub source: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct InboxListPayload {
+    providers: Vec<InboxProviderStatus>,
+    limit: u32,
+    items: Vec<InboxItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct InboxStatusPayload {
+    providers: Vec<InboxProviderStatus>,
+    limit: u32,
+    item_count: usize,
+    counts: Vec<InboxCount>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct InboxCount {
+    provider: &'static str,
+    host: String,
+    kind: String,
+    reason: String,
+    count: usize,
+    limited: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct InboxNextPayload {
+    providers: Vec<InboxProviderStatus>,
+    limit: u32,
+    query_limit: u32,
+    items: Vec<InboxItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct InboxDryRunPayload {
+    providers: Vec<InboxDryRunProvider>,
+    limit: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    query_limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct InboxDryRunProvider {
+    provider: &'static str,
+    host: String,
+    plans: Vec<Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+struct ProviderQuery {
+    reason: InboxKindFlag,
+    source: &'static str,
+    call: BackendCall,
+}
+
+#[derive(Debug, Clone)]
+struct GitlabIdentity {
+    id: String,
+    username: String,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct ItemKey {
+    provider: &'static str,
+    host: String,
+    repo: String,
+    number: u64,
+    url: String,
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    command: InboxCommand,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, command, format)
+}
+
+pub fn run_with<R: BackendRunner>(
+    runner: &R,
+    global: &GlobalFlags,
+    command: InboxCommand,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    match command {
+        InboxCommand::List(args) => run_list(runner, global, args, format),
+        InboxCommand::Status(args) => run_status(runner, global, args, format),
+        InboxCommand::Next(args) => run_next(runner, global, args, format),
+    }
+}
+
+fn run_list<R: BackendRunner>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: InboxQueryArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let targets = resolve_targets(global, &args.gitlab_host);
+    let config = QueryConfig::new(args.kinds, args.limit.max(1));
+    if global.dry_run {
+        return Ok(emit_dry_run(
+            schema_version_for(BINARY, LIST_SCHEMA, SCHEMA_VERSION),
+            &targets,
+            &config,
+            args.limit.max(1),
+            None,
+            format,
+        ));
+    }
+
+    let collection = collect_inbox(runner, &targets, &config)?;
+    let payload = InboxListPayload {
+        providers: collection.providers,
+        limit: config.query_limit,
+        items: collection.items,
+    };
+    Ok(emit_success_with_warnings(
+        schema_version_for(BINARY, LIST_SCHEMA, SCHEMA_VERSION),
+        payload,
+        collection.warnings,
+        format,
+        render_list_text,
+    ))
+}
+
+fn run_status<R: BackendRunner>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: InboxQueryArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let targets = resolve_targets(global, &args.gitlab_host);
+    let config = QueryConfig::new(args.kinds, args.limit.max(1));
+    if global.dry_run {
+        return Ok(emit_dry_run(
+            schema_version_for(BINARY, STATUS_SCHEMA, SCHEMA_VERSION),
+            &targets,
+            &config,
+            args.limit.max(1),
+            None,
+            format,
+        ));
+    }
+
+    let collection = collect_inbox(runner, &targets, &config)?;
+    let counts = summarize_counts(&collection.providers, &collection.items);
+    let payload = InboxStatusPayload {
+        providers: collection.providers,
+        limit: config.query_limit,
+        item_count: collection.items.len(),
+        counts,
+    };
+    Ok(emit_success_with_warnings(
+        schema_version_for(BINARY, STATUS_SCHEMA, SCHEMA_VERSION),
+        payload,
+        collection.warnings,
+        format,
+        render_status_text,
+    ))
+}
+
+fn run_next<R: BackendRunner>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: InboxNextArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let targets = resolve_targets(global, &args.gitlab_host);
+    let result_limit = args.limit.max(1);
+    let query_limit = result_limit.max(DEFAULT_QUERY_LIMIT);
+    let config = QueryConfig::new(args.kinds, query_limit);
+    if global.dry_run {
+        return Ok(emit_dry_run(
+            schema_version_for(BINARY, NEXT_SCHEMA, SCHEMA_VERSION),
+            &targets,
+            &config,
+            result_limit,
+            Some(query_limit),
+            format,
+        ));
+    }
+
+    let mut collection = collect_inbox(runner, &targets, &config)?;
+    collection.items.truncate(result_limit as usize);
+    let payload = InboxNextPayload {
+        providers: collection.providers,
+        limit: result_limit,
+        query_limit,
+        items: collection.items,
+    };
+    Ok(emit_success_with_warnings(
+        schema_version_for(BINARY, NEXT_SCHEMA, SCHEMA_VERSION),
+        payload,
+        collection.warnings,
+        format,
+        render_next_text,
+    ))
+}
+
+impl QueryConfig {
+    fn new(kinds: Vec<InboxKindFlag>, query_limit: u32) -> Self {
+        let mut reasons = if kinds.is_empty() {
+            vec![
+                InboxKindFlag::Review,
+                InboxKindFlag::Assigned,
+                InboxKindFlag::Todo,
+                InboxKindFlag::Authored,
+            ]
+        } else {
+            kinds
+        };
+        reasons.sort_by_key(|r| reason_rank(r.as_str()));
+        reasons.dedup();
+        Self {
+            reasons,
+            query_limit,
+        }
+    }
+
+    fn wants(&self, reason: InboxKindFlag) -> bool {
+        self.reasons.contains(&reason)
+    }
+}
+
+fn resolve_targets(global: &GlobalFlags, gitlab_host: &str) -> Vec<ProviderTarget> {
+    match global.provider {
+        Some(crate::cli::ProviderFlag::Github) => vec![ProviderTarget {
+            provider: Provider::GitHub,
+            host: github_host(global),
+        }],
+        Some(crate::cli::ProviderFlag::Gitlab) => vec![ProviderTarget {
+            provider: Provider::GitLab,
+            host: gitlab_host_for(global, gitlab_host),
+        }],
+        None => vec![
+            ProviderTarget {
+                provider: Provider::GitHub,
+                host: github_host(global),
+            },
+            ProviderTarget {
+                provider: Provider::GitLab,
+                host: gitlab_host_for(global, gitlab_host),
+            },
+        ],
+    }
+}
+
+fn github_host(global: &GlobalFlags) -> String {
+    host_from_remote(global, Provider::GitHub).unwrap_or_else(|| "github.com".to_string())
+}
+
+fn gitlab_host_for(global: &GlobalFlags, explicit: &str) -> String {
+    let trimmed = explicit.trim();
+    if !trimmed.is_empty() && trimmed != "gitlab.com" {
+        return trimmed.to_string();
+    }
+    host_from_remote(global, Provider::GitLab).unwrap_or_else(|| "gitlab.com".to_string())
+}
+
+fn host_from_remote(global: &GlobalFlags, provider: Provider) -> Option<String> {
+    let url = git_remote_url(&global.remote)?;
+    let host = parse_host(&url)?;
+    if classify_host(&host) == Some(provider) {
+        Some(host)
+    } else {
+        None
+    }
+}
+
+fn collect_inbox<R: BackendRunner>(
+    runner: &R,
+    targets: &[ProviderTarget],
+    config: &QueryConfig,
+) -> Result<InboxCollection, ForgeError> {
+    let mut providers = Vec::new();
+    let mut items = Vec::new();
+    let mut warnings = Vec::new();
+    let mut failures = Vec::new();
+    let mut successes = 0usize;
+
+    for target in targets {
+        match query_provider(runner, target, config) {
+            Ok(success) => {
+                successes += 1;
+                let item_count = success.items.len();
+                providers.push(InboxProviderStatus {
+                    provider: target.provider.as_str(),
+                    host: target.host.clone(),
+                    ok: true,
+                    item_count,
+                    limited: success.limited,
+                    error: None,
+                });
+                items.extend(success.items);
+            }
+            Err(err) => {
+                let provider_error = InboxProviderError {
+                    kind: err.kind(),
+                    message: err.to_string(),
+                };
+                failures.push(format!(
+                    "{} {}: {}",
+                    target.provider.as_str(),
+                    target.host,
+                    provider_error.message
+                ));
+                warnings.push(format!(
+                    "provider_failed: {} {}: {}",
+                    target.provider.as_str(),
+                    target.host,
+                    provider_error.message
+                ));
+                providers.push(InboxProviderStatus {
+                    provider: target.provider.as_str(),
+                    host: target.host.clone(),
+                    ok: false,
+                    item_count: 0,
+                    limited: false,
+                    error: Some(provider_error),
+                });
+            }
+        }
+    }
+
+    if successes == 0 {
+        return Err(ForgeError::backend_error(
+            schema_err(),
+            "all selected inbox providers failed",
+            Some(failures.join("; ")),
+        ));
+    }
+
+    let mut items = dedupe_items(items);
+    sort_items(&mut items);
+    for provider in &mut providers {
+        if provider.ok {
+            provider.item_count = items
+                .iter()
+                .filter(|item| item.provider == provider.provider && item.host == provider.host)
+                .count();
+        }
+    }
+
+    Ok(InboxCollection {
+        providers,
+        items,
+        warnings,
+    })
+}
+
+fn query_provider<R: BackendRunner>(
+    runner: &R,
+    target: &ProviderTarget,
+    config: &QueryConfig,
+) -> Result<ProviderSuccess, ForgeError> {
+    match target.provider {
+        Provider::GitHub => query_github(runner, target, config),
+        Provider::GitLab => query_gitlab(runner, target, config),
+    }
+}
+
+fn query_github<R: BackendRunner>(
+    runner: &R,
+    target: &ProviderTarget,
+    config: &QueryConfig,
+) -> Result<ProviderSuccess, ForgeError> {
+    let queries = github_queries(config);
+    let mut items = Vec::new();
+    let mut limited = false;
+    for query in queries {
+        let output = runner.run(&query.call)?;
+        let parsed = parse_github_items(target, &query, &output)?;
+        if parsed.len() as u32 >= config.query_limit {
+            limited = true;
+        }
+        items.extend(parsed);
+    }
+    Ok(ProviderSuccess {
+        items: dedupe_items(items),
+        limited,
+    })
+}
+
+fn query_gitlab<R: BackendRunner>(
+    runner: &R,
+    target: &ProviderTarget,
+    config: &QueryConfig,
+) -> Result<ProviderSuccess, ForgeError> {
+    let identity = parse_gitlab_identity(&runner.run(&gitlab_identity_call(&target.host))?)?;
+    let queries = gitlab_queries(&target.host, &identity, config);
+    let mut items = Vec::new();
+    let mut limited = false;
+    for query in queries {
+        let output = runner.run(&query.call)?;
+        let parsed = parse_gitlab_items(target, &query, &output)?;
+        if parsed.len() as u32 >= config.query_limit {
+            limited = true;
+        }
+        items.extend(parsed);
+    }
+    Ok(ProviderSuccess {
+        items: dedupe_items(items),
+        limited,
+    })
+}
+
+fn github_queries(config: &QueryConfig) -> Vec<ProviderQuery> {
+    let mut queries = Vec::new();
+    if config.wants(InboxKindFlag::Review) {
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Review,
+            source: "github_search_prs",
+            call: github_search_call("prs", "--review-requested", config.query_limit),
+        });
+    }
+    if config.wants(InboxKindFlag::Assigned) {
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Assigned,
+            source: "github_search_prs",
+            call: github_search_call("prs", "--assignee", config.query_limit),
+        });
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Assigned,
+            source: "github_search_issues",
+            call: github_search_call("issues", "--assignee", config.query_limit),
+        });
+    }
+    if config.wants(InboxKindFlag::Authored) {
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Authored,
+            source: "github_search_prs",
+            call: github_search_call("prs", "--author", config.query_limit),
+        });
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Authored,
+            source: "github_search_issues",
+            call: github_search_call("issues", "--author", config.query_limit),
+        });
+    }
+    if config.wants(InboxKindFlag::Involved) {
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Involved,
+            source: "github_search_prs",
+            call: github_search_call("prs", "--involves", config.query_limit),
+        });
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Involved,
+            source: "github_search_issues",
+            call: github_search_call("issues", "--involves", config.query_limit),
+        });
+    }
+    queries
+}
+
+fn github_search_call(kind: &str, qualifier: &str, limit: u32) -> BackendCall {
+    BackendCall::new(
+        BackendProgram::Gh,
+        [
+            OsString::from("search"),
+            OsString::from(kind),
+            OsString::from(qualifier),
+            OsString::from("@me"),
+            OsString::from("--state"),
+            OsString::from("open"),
+            OsString::from("--sort"),
+            OsString::from("updated"),
+            OsString::from("--order"),
+            OsString::from("desc"),
+            OsString::from("--limit"),
+            OsString::from(limit.to_string()),
+            OsString::from("--json"),
+            OsString::from(GH_JSON_FIELDS),
+        ],
+    )
+}
+
+fn gitlab_identity_call(host: &str) -> BackendCall {
+    BackendCall::new(
+        BackendProgram::Glab,
+        [
+            OsString::from("api"),
+            OsString::from("user"),
+            OsString::from("--hostname"),
+            OsString::from(host),
+        ],
+    )
+}
+
+fn gitlab_queries(
+    host: &str,
+    identity: &GitlabIdentity,
+    config: &QueryConfig,
+) -> Vec<ProviderQuery> {
+    let mut queries = Vec::new();
+    if config.wants(InboxKindFlag::Assigned) {
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Assigned,
+            source: "gitlab_merge_requests",
+            call: gitlab_api_call(
+                host,
+                format!(
+                    "merge_requests?scope=assigned_to_me&state=opened&order_by=updated_at&sort=desc&per_page={}",
+                    config.query_limit
+                ),
+            ),
+        });
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Assigned,
+            source: "gitlab_issues",
+            call: gitlab_api_call(
+                host,
+                format!(
+                    "issues?scope=assigned_to_me&state=opened&order_by=updated_at&sort=desc&per_page={}",
+                    config.query_limit
+                ),
+            ),
+        });
+    }
+    if config.wants(InboxKindFlag::Review) {
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Review,
+            source: "gitlab_merge_requests",
+            call: gitlab_api_call(
+                host,
+                format!(
+                    "merge_requests?reviewer_username={}&state=opened&order_by=updated_at&sort=desc&per_page={}",
+                    identity.username, config.query_limit
+                ),
+            ),
+        });
+    }
+    if config.wants(InboxKindFlag::Authored) {
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Authored,
+            source: "gitlab_merge_requests",
+            call: gitlab_api_call(
+                host,
+                format!(
+                    "merge_requests?author_id={}&state=opened&order_by=updated_at&sort=desc&per_page={}",
+                    identity.id, config.query_limit
+                ),
+            ),
+        });
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Authored,
+            source: "gitlab_issues",
+            call: gitlab_api_call(
+                host,
+                format!(
+                    "issues?author_id={}&state=opened&order_by=updated_at&sort=desc&per_page={}",
+                    identity.id, config.query_limit
+                ),
+            ),
+        });
+    }
+    if config.wants(InboxKindFlag::Todo) {
+        queries.push(ProviderQuery {
+            reason: InboxKindFlag::Todo,
+            source: "gitlab_todos",
+            call: gitlab_api_call(
+                host,
+                format!(
+                    "todos?state=pending&order_by=updated_at&sort=desc&per_page={}",
+                    config.query_limit
+                ),
+            ),
+        });
+    }
+    queries
+}
+
+fn gitlab_api_call(host: &str, path: String) -> BackendCall {
+    BackendCall::new(
+        BackendProgram::Glab,
+        [
+            OsString::from("api"),
+            OsString::from("--hostname"),
+            OsString::from(host),
+            OsString::from(path),
+        ],
+    )
+}
+
+fn parse_github_items(
+    target: &ProviderTarget,
+    query: &ProviderQuery,
+    output: &BackendSuccess,
+) -> Result<Vec<InboxItem>, ForgeError> {
+    let values = parse_array(output, "GitHub inbox JSON is invalid")?;
+    values
+        .iter()
+        .map(|raw| {
+            let number = required_u64(raw, "number")?;
+            let url = required_str(raw, "url")?;
+            let repo = github_repo(raw).unwrap_or_else(|| repo_from_url(&url));
+            Ok(InboxItem {
+                provider: Provider::GitHub.as_str(),
+                host: target.host.clone(),
+                kind: query.reason.as_str().to_string(),
+                reasons: vec![query.reason.as_str().to_string()],
+                repo,
+                number,
+                title: required_str(raw, "title")?,
+                url,
+                updated_at: optional_str(raw, "updatedAt").unwrap_or_default(),
+                author: github_author(raw),
+                source: query.source,
+            })
+        })
+        .collect()
+}
+
+fn parse_gitlab_items(
+    target: &ProviderTarget,
+    query: &ProviderQuery,
+    output: &BackendSuccess,
+) -> Result<Vec<InboxItem>, ForgeError> {
+    let values = parse_array(output, "GitLab inbox JSON is invalid")?;
+    values
+        .iter()
+        .map(|raw| {
+            if query.source == "gitlab_todos" {
+                parse_gitlab_todo(target, query, raw)
+            } else {
+                parse_gitlab_work_item(target, query, raw)
+            }
+        })
+        .collect()
+}
+
+fn parse_gitlab_work_item(
+    target: &ProviderTarget,
+    query: &ProviderQuery,
+    raw: &serde_json::Value,
+) -> Result<InboxItem, ForgeError> {
+    let number = raw
+        .get("iid")
+        .and_then(|v| v.as_u64())
+        .or_else(|| raw.get("id").and_then(|v| v.as_u64()))
+        .ok_or_else(|| missing("iid"))?;
+    let url = required_str(raw, "web_url")?;
+    Ok(InboxItem {
+        provider: Provider::GitLab.as_str(),
+        host: target.host.clone(),
+        kind: query.reason.as_str().to_string(),
+        reasons: vec![query.reason.as_str().to_string()],
+        repo: gitlab_repo(raw).unwrap_or_else(|| repo_from_url(&url)),
+        number,
+        title: required_str(raw, "title")?,
+        url,
+        updated_at: optional_str(raw, "updated_at").unwrap_or_default(),
+        author: gitlab_author(raw),
+        source: query.source,
+    })
+}
+
+fn parse_gitlab_todo(
+    target: &ProviderTarget,
+    query: &ProviderQuery,
+    raw: &serde_json::Value,
+) -> Result<InboxItem, ForgeError> {
+    let target_obj = raw.get("target").unwrap_or(raw);
+    let url = optional_str(target_obj, "web_url")
+        .or_else(|| optional_str(raw, "target_url"))
+        .ok_or_else(|| missing("target.web_url"))?;
+    let number = target_obj
+        .get("iid")
+        .and_then(|v| v.as_u64())
+        .or_else(|| target_obj.get("id").and_then(|v| v.as_u64()))
+        .or_else(|| raw.get("id").and_then(|v| v.as_u64()))
+        .ok_or_else(|| missing("target.iid"))?;
+    Ok(InboxItem {
+        provider: Provider::GitLab.as_str(),
+        host: target.host.clone(),
+        kind: query.reason.as_str().to_string(),
+        reasons: vec![query.reason.as_str().to_string()],
+        repo: raw
+            .get("project")
+            .and_then(|p| optional_str(p, "path_with_namespace"))
+            .or_else(|| gitlab_repo(target_obj))
+            .unwrap_or_else(|| repo_from_url(&url)),
+        number,
+        title: optional_str(target_obj, "title")
+            .or_else(|| optional_str(raw, "body"))
+            .unwrap_or_else(|| "GitLab todo".to_string()),
+        url,
+        updated_at: optional_str(target_obj, "updated_at")
+            .or_else(|| optional_str(raw, "updated_at"))
+            .or_else(|| optional_str(raw, "created_at"))
+            .unwrap_or_default(),
+        author: raw
+            .get("author")
+            .and_then(gitlab_author_from_value)
+            .or_else(|| target_obj.get("author").and_then(gitlab_author_from_value)),
+        source: query.source,
+    })
+}
+
+fn parse_gitlab_identity(output: &BackendSuccess) -> Result<GitlabIdentity, ForgeError> {
+    let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            "GitLab user JSON is invalid",
+            Some(e.to_string()),
+        )
+    })?;
+    let id = value
+        .get("id")
+        .and_then(|v| v.as_u64())
+        .map(|v| v.to_string())
+        .or_else(|| optional_str(&value, "id"))
+        .ok_or_else(|| missing("id"))?;
+    let username = required_str(&value, "username")?;
+    Ok(GitlabIdentity { id, username })
+}
+
+fn parse_array(
+    output: &BackendSuccess,
+    message: &'static str,
+) -> Result<Vec<serde_json::Value>, ForgeError> {
+    let value: serde_json::Value = serde_json::from_str(output.stdout.trim())
+        .map_err(|e| ForgeError::software(schema_err(), message, Some(e.to_string())))?;
+    value
+        .as_array()
+        .cloned()
+        .ok_or_else(|| ForgeError::software(schema_err(), message, Some(format!("got: {value}"))))
+}
+
+fn github_repo(raw: &serde_json::Value) -> Option<String> {
+    let repo = raw.get("repository")?;
+    optional_str(repo, "nameWithOwner")
+        .or_else(|| optional_str(repo, "fullName"))
+        .or_else(|| optional_str(repo, "name_with_owner"))
+        .or_else(|| {
+            let owner = repo
+                .get("owner")
+                .and_then(|v| optional_str(v, "login").or_else(|| optional_str(v, "name")))?;
+            let name = optional_str(repo, "name")?;
+            Some(format!("{owner}/{name}"))
+        })
+}
+
+fn github_author(raw: &serde_json::Value) -> Option<String> {
+    raw.get("author")
+        .and_then(|v| optional_str(v, "login").or_else(|| optional_str(v, "name")))
+}
+
+fn gitlab_repo(raw: &serde_json::Value) -> Option<String> {
+    raw.get("project")
+        .and_then(|p| optional_str(p, "path_with_namespace"))
+        .or_else(|| {
+            raw.get("references")
+                .and_then(|r| optional_str(r, "full"))
+                .map(|full| strip_gitlab_reference(&full))
+        })
+        .or_else(|| {
+            raw.get("web_url")
+                .and_then(|v| v.as_str())
+                .map(repo_from_url)
+        })
+}
+
+fn strip_gitlab_reference(full: &str) -> String {
+    full.split_once('!')
+        .map(|(repo, _)| repo)
+        .or_else(|| full.split_once('#').map(|(repo, _)| repo))
+        .unwrap_or(full)
+        .to_string()
+}
+
+fn gitlab_author(raw: &serde_json::Value) -> Option<String> {
+    raw.get("author").and_then(gitlab_author_from_value)
+}
+
+fn gitlab_author_from_value(raw: &serde_json::Value) -> Option<String> {
+    optional_str(raw, "username").or_else(|| optional_str(raw, "name"))
+}
+
+fn repo_from_url(url: &str) -> String {
+    let without_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let path = without_scheme
+        .split_once('/')
+        .map(|(_, path)| path)
+        .unwrap_or(without_scheme);
+    let (path, gitlab_style) = path
+        .split_once("/-/")
+        .map(|(repo, _)| (repo, true))
+        .unwrap_or((path, false));
+    let mut parts = path.split('/').filter(|p| !p.is_empty());
+    let first = parts.next().unwrap_or("unknown");
+    let second = parts.next().unwrap_or("unknown");
+    if gitlab_style {
+        path.to_string()
+    } else {
+        format!("{first}/{second}")
+    }
+}
+
+fn required_str(raw: &serde_json::Value, key: &str) -> Result<String, ForgeError> {
+    optional_str(raw, key).ok_or_else(|| missing(key))
+}
+
+fn optional_str(raw: &serde_json::Value, key: &str) -> Option<String> {
+    raw.get(key).and_then(|v| v.as_str()).map(str::to_string)
+}
+
+fn required_u64(raw: &serde_json::Value, key: &str) -> Result<u64, ForgeError> {
+    raw.get(key)
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| missing(key))
+}
+
+fn missing(key: &str) -> ForgeError {
+    ForgeError::software(
+        schema_err(),
+        format!("missing required field '{key}' in inbox JSON"),
+        None,
+    )
+}
+
+fn dedupe_items(items: Vec<InboxItem>) -> Vec<InboxItem> {
+    let mut map: HashMap<ItemKey, InboxItem> = HashMap::new();
+    for item in items {
+        let key = ItemKey {
+            provider: item.provider,
+            host: item.host.clone(),
+            repo: item.repo.clone(),
+            number: item.number,
+            url: item.url.clone(),
+        };
+        match map.get_mut(&key) {
+            Some(existing) => merge_item(existing, item),
+            None => {
+                map.insert(key, item);
+            }
+        }
+    }
+    map.into_values().collect()
+}
+
+fn merge_item(existing: &mut InboxItem, incoming: InboxItem) {
+    let previous_primary_rank = reason_rank(existing.kind.as_str());
+    let incoming_rank = reason_rank(incoming.kind.as_str());
+    for reason in incoming.reasons {
+        if !existing.reasons.iter().any(|r| r == &reason) {
+            existing.reasons.push(reason);
+        }
+    }
+    existing.reasons.sort_by_key(|r| reason_rank(r));
+    if let Some(primary) = existing.reasons.first() {
+        existing.kind = primary.clone();
+    }
+    if incoming_rank < previous_primary_rank {
+        existing.source = incoming.source;
+    }
+    if incoming.updated_at > existing.updated_at {
+        existing.updated_at = incoming.updated_at;
+    }
+    if existing.author.is_none() {
+        existing.author = incoming.author;
+    }
+}
+
+fn sort_items(items: &mut [InboxItem]) {
+    items.sort_by(|a, b| {
+        reason_rank(a.kind.as_str())
+            .cmp(&reason_rank(b.kind.as_str()))
+            .then_with(|| b.updated_at.cmp(&a.updated_at))
+            .then_with(|| a.provider.cmp(b.provider))
+            .then_with(|| a.host.cmp(&b.host))
+            .then_with(|| a.repo.cmp(&b.repo))
+            .then_with(|| a.number.cmp(&b.number))
+            .then_with(|| a.url.cmp(&b.url))
+    });
+}
+
+fn reason_rank(reason: &str) -> u8 {
+    match reason {
+        "review" => 0,
+        "assigned" => 1,
+        "todo" => 2,
+        "authored" => 3,
+        "involved" => 4,
+        _ => 9,
+    }
+}
+
+fn summarize_counts(providers: &[InboxProviderStatus], items: &[InboxItem]) -> Vec<InboxCount> {
+    let mut limited_by_provider: HashMap<(&'static str, &str), bool> = HashMap::new();
+    for provider in providers {
+        limited_by_provider.insert(
+            (provider.provider, provider.host.as_str()),
+            provider.limited,
+        );
+    }
+
+    let mut counts: HashMap<(&'static str, String, String), usize> = HashMap::new();
+    for item in items {
+        for reason in &item.reasons {
+            *counts
+                .entry((item.provider, item.host.clone(), reason.clone()))
+                .or_insert(0) += 1;
+        }
+    }
+
+    let mut rows: Vec<InboxCount> = counts
+        .into_iter()
+        .map(|((provider, host, reason), count)| InboxCount {
+            provider,
+            host: host.clone(),
+            kind: reason.clone(),
+            reason,
+            count,
+            limited: *limited_by_provider
+                .get(&(provider, host.as_str()))
+                .unwrap_or(&false),
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        a.provider
+            .cmp(b.provider)
+            .then_with(|| a.host.cmp(&b.host))
+            .then_with(|| reason_rank(a.reason.as_str()).cmp(&reason_rank(b.reason.as_str())))
+            .then_with(|| {
+                if a.count == b.count {
+                    Ordering::Equal
+                } else {
+                    b.count.cmp(&a.count)
+                }
+            })
+    });
+    rows
+}
+
+fn emit_dry_run(
+    schema_version: String,
+    targets: &[ProviderTarget],
+    config: &QueryConfig,
+    limit: u32,
+    query_limit: Option<u32>,
+    format: OutputFormat,
+) -> i32 {
+    let providers = targets
+        .iter()
+        .map(|target| InboxDryRunProvider {
+            provider: target.provider.as_str(),
+            host: target.host.clone(),
+            plans: dry_run_plans(target, config),
+        })
+        .collect();
+    let payload = InboxDryRunPayload {
+        providers,
+        limit,
+        query_limit,
+    };
+    emit_success_with_warnings(schema_version, payload, Vec::new(), format, |payload| {
+        for provider in &payload.providers {
+            for plan in &provider.plans {
+                println!("would run: {}", plan.join(" "));
+            }
+        }
+    })
+}
+
+fn dry_run_plans(target: &ProviderTarget, config: &QueryConfig) -> Vec<Vec<String>> {
+    match target.provider {
+        Provider::GitHub => github_queries(config)
+            .into_iter()
+            .map(|query| query.call.plan_argv())
+            .collect(),
+        Provider::GitLab => {
+            let identity = GitlabIdentity {
+                id: "<user_id>".to_string(),
+                username: "<username>".to_string(),
+            };
+            let mut plans = vec![gitlab_identity_call(&target.host).plan_argv()];
+            plans.extend(
+                gitlab_queries(&target.host, &identity, config)
+                    .into_iter()
+                    .map(|query| query.call.plan_argv()),
+            );
+            plans
+        }
+    }
+}
+
+fn render_list_text(payload: &InboxListPayload) {
+    render_items_text(&payload.items);
+}
+
+fn render_next_text(payload: &InboxNextPayload) {
+    render_items_text(&payload.items);
+}
+
+fn render_items_text(items: &[InboxItem]) {
+    for item in items {
+        println!(
+            "[{provider}:{kind}] {repo}#{number} {title} - {url}",
+            provider = item.provider,
+            kind = item.kind,
+            repo = item.repo,
+            number = item.number,
+            title = item.title,
+            url = item.url,
+        );
+    }
+}
+
+fn render_status_text(payload: &InboxStatusPayload) {
+    for provider in &payload.providers {
+        println!(
+            "{provider}@{host}: {count} item(s){limited}",
+            provider = provider.provider,
+            host = provider.host,
+            count = provider.item_count,
+            limited = if provider.limited { " (limited)" } else { "" },
+        );
+    }
+    for count in &payload.counts {
+        println!(
+            "  {reason}: {count}",
+            reason = count.reason,
+            count = count.count
+        );
+    }
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn inbox_provider_resolver_defaults_to_both_providers() {
+        let global = GlobalFlags {
+            format: None,
+            remote: "missing-remote".into(),
+            provider: None,
+            repo: None,
+            dry_run: false,
+        };
+        let targets = resolve_targets(&global, "gitlab.example.com");
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0].provider, Provider::GitHub);
+        assert_eq!(targets[1].provider, Provider::GitLab);
+        assert_eq!(targets[1].host, "gitlab.example.com");
+    }
+
+    #[test]
+    fn inbox_contract_dedupes_reasons_by_priority() {
+        let item = InboxItem {
+            provider: "github",
+            host: "github.com".into(),
+            kind: "assigned".into(),
+            reasons: vec!["assigned".into()],
+            repo: "acme/widgets".into(),
+            number: 7,
+            title: "demo".into(),
+            url: "https://github.com/acme/widgets/pull/7".into(),
+            updated_at: "2026-05-21T00:00:00Z".into(),
+            author: Some("alice".into()),
+            source: "github_search_prs",
+        };
+        let mut duplicate = item.clone();
+        duplicate.kind = "review".into();
+        duplicate.reasons = vec!["review".into()];
+        duplicate.source = "github_review_search";
+        duplicate.updated_at = "2026-05-22T00:00:00Z".into();
+
+        let items = dedupe_items(vec![item, duplicate]);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].kind, "review");
+        assert_eq!(items[0].reasons, vec!["review", "assigned"]);
+        assert_eq!(items[0].source, "github_review_search");
+        assert_eq!(items[0].updated_at, "2026-05-22T00:00:00Z");
+    }
+}

--- a/crates/forge-cli/src/ops/mod.rs
+++ b/crates/forge-cli/src/ops/mod.rs
@@ -3,6 +3,7 @@
 //! returns `Result<i32, ForgeError>`.
 
 pub mod auth_status;
+pub mod inbox;
 pub mod issue_close;
 pub mod issue_comment;
 pub mod issue_create;

--- a/crates/forge-cli/tests/integration.rs
+++ b/crates/forge-cli/tests/integration.rs
@@ -8,6 +8,7 @@ mod integration {
     mod exit_codes;
     mod exit_codes_full;
     mod fixture_lint;
+    mod inbox;
     mod issue_atoms;
     mod parity;
     mod pr_checks_github;

--- a/crates/forge-cli/tests/integration/cli.rs
+++ b/crates/forge-cli/tests/integration/cli.rs
@@ -10,7 +10,7 @@ fn help_lists_every_top_level_subcommand() {
     let stub = StubEnv::new();
     let out = run_forge_cli(&stub, &["--help"]);
     assert_eq!(out.code, 0, "stderr={}", out.stderr);
-    for sub in ["pr", "issue", "repo", "auth", "completion"] {
+    for sub in ["pr", "issue", "inbox", "repo", "auth", "completion"] {
         assert!(
             out.stdout.contains(sub),
             "--help missing {sub}: stdout={}",
@@ -21,6 +21,20 @@ fn help_lists_every_top_level_subcommand() {
         !out.stdout.contains("--json"),
         "must not surface --json flag"
     );
+}
+
+#[test]
+fn inbox_cli_help_lists_every_v1_subcommand() {
+    let stub = StubEnv::new();
+    let out = run_forge_cli(&stub, &["inbox", "--help"]);
+    assert_eq!(out.code, 0);
+    for sub in ["status", "list", "next"] {
+        assert!(
+            out.stdout.contains(sub),
+            "inbox --help missing {sub}: stdout={}",
+            out.stdout
+        );
+    }
 }
 
 #[test]

--- a/crates/forge-cli/tests/integration/inbox.rs
+++ b/crates/forge-cli/tests/integration/inbox.rs
@@ -1,0 +1,263 @@
+//! `forge-cli inbox` integration tests. Provider calls are fully stubbed so
+//! cross-repo aggregation, partial success, and host propagation are tested
+//! without live GitHub/GitLab access.
+
+use pretty_assertions::assert_eq;
+
+use super::support::{StubEnv, parse_envelope, run_forge_cli};
+
+const GH_INBOX_STUB: &str = r#"#!/bin/sh
+set -e
+case "$1 $2 $3" in
+  "search prs --review-requested")
+    cat <<'EOF'
+[{"number":7,"url":"https://github.com/acme/widgets/pull/7","title":"Review me","updatedAt":"2026-05-22T10:00:00Z","author":{"login":"alice"},"repository":{"nameWithOwner":"acme/widgets"}}]
+EOF
+    ;;
+  "search prs --assignee")
+    cat <<'EOF'
+[{"number":7,"url":"https://github.com/acme/widgets/pull/7","title":"Review me","updatedAt":"2026-05-22T10:30:00Z","author":{"login":"alice"},"repository":{"nameWithOwner":"acme/widgets"}}]
+EOF
+    ;;
+  "search issues --assignee")
+    cat <<'EOF'
+[{"number":8,"url":"https://github.com/acme/widgets/issues/8","title":"Assigned issue","updatedAt":"2026-05-22T09:00:00Z","author":{"login":"bob"},"repository":{"nameWithOwner":"acme/widgets"}}]
+EOF
+    ;;
+  "search prs --author")
+    cat <<'EOF'
+[{"number":9,"url":"https://github.com/acme/widgets/pull/9","title":"Authored PR","updatedAt":"2026-05-21T09:00:00Z","author":{"login":"me"},"repository":{"nameWithOwner":"acme/widgets"}}]
+EOF
+    ;;
+  "search issues --author")
+    echo '[]'
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 99
+    ;;
+esac
+"#;
+
+const GH_EMPTY_STUB: &str = r#"#!/bin/sh
+set -e
+case "$1 $2" in
+  "search prs"|"search issues")
+    echo '[]'
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 99
+    ;;
+esac
+"#;
+
+const GH_FAIL_STUB: &str = r#"#!/bin/sh
+echo "gh unavailable" >&2
+exit 7
+"#;
+
+const GLAB_INBOX_STUB: &str = r#"#!/bin/sh
+set -e
+case "$*" in
+  *"--hostname gitlab.example.com"*) ;;
+  *)
+    echo "missing hostname: $*" >&2
+    exit 98
+    ;;
+esac
+
+case "$*" in
+  "api user --hostname gitlab.example.com")
+    cat <<'EOF'
+{"id":1435,"username":"terrylin"}
+EOF
+    ;;
+  *"merge_requests"*"scope=assigned_to_me"*)
+    cat <<'EOF'
+[{"iid":21,"web_url":"https://gitlab.example.com/team/api/-/merge_requests/21","title":"Assigned MR","updated_at":"2026-05-22T08:00:00Z","author":{"username":"carol"},"references":{"full":"team/api!21"}}]
+EOF
+    ;;
+  *"merge_requests"*"reviewer_username=terrylin"*)
+    cat <<'EOF'
+[{"iid":22,"web_url":"https://gitlab.example.com/team/api/-/merge_requests/22","title":"Review MR","updated_at":"2026-05-22T11:00:00Z","author":{"username":"dave"},"references":{"full":"team/api!22"}}]
+EOF
+    ;;
+  *"merge_requests"*"author_id=1435"*)
+    echo '[]'
+    ;;
+  *"issues"*"scope=assigned_to_me"*)
+    cat <<'EOF'
+[{"iid":31,"web_url":"https://gitlab.example.com/team/api/-/issues/31","title":"Assigned issue","updated_at":"2026-05-22T07:00:00Z","author":{"username":"erin"},"references":{"full":"team/api#31"}}]
+EOF
+    ;;
+  *"issues"*"author_id=1435"*)
+    echo '[]'
+    ;;
+  *"todos"*"state=pending"*)
+    cat <<'EOF'
+[{"id":55,"body":"todo body","created_at":"2026-05-22T06:00:00Z","target_url":"https://gitlab.example.com/team/api/-/issues/32","target":{"iid":32,"title":"Todo issue","web_url":"https://gitlab.example.com/team/api/-/issues/32","updated_at":"2026-05-22T06:30:00Z","author":{"username":"frank"}},"project":{"path_with_namespace":"team/api"},"author":{"username":"frank"}}]
+EOF
+    ;;
+  *)
+    echo "unexpected glab args: $*" >&2
+    exit 99
+    ;;
+esac
+"#;
+
+const GLAB_FAIL_STUB: &str = r#"#!/bin/sh
+echo "glab unavailable" >&2
+exit 8
+"#;
+
+#[test]
+fn inbox_github_dedupes_reasons_and_normalizes_items() {
+    let stub = StubEnv::new().gh_stub(GH_INBOX_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "inbox",
+            "list",
+            "--limit",
+            "9",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.inbox.list.v1");
+    assert_eq!(env["data"]["providers"][0]["provider"], "github");
+    assert_eq!(env["data"]["limit"], 9);
+    let items = env["data"]["items"].as_array().expect("items");
+    assert_eq!(items.len(), 3, "dedupe should collapse review+assigned PR");
+    assert_eq!(items[0]["kind"], "review");
+    assert_eq!(items[0]["reasons"][0], "review");
+    assert_eq!(items[0]["reasons"][1], "assigned");
+    assert_eq!(items[0]["repo"], "acme/widgets");
+}
+
+#[test]
+fn inbox_gitlab_passes_hostname_and_normalizes_api_rows() {
+    let stub = StubEnv::new().glab_stub(GLAB_INBOX_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+            "--limit",
+            "7",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["data"]["providers"][0]["host"], "gitlab.example.com");
+    assert_eq!(env["data"]["providers"][0]["item_count"], 4);
+    assert_eq!(env["data"]["items"][0]["kind"], "review");
+    assert_eq!(env["data"]["items"][0]["repo"], "team/api");
+    assert_eq!(env["data"]["items"][0]["source"], "gitlab_merge_requests");
+}
+
+#[test]
+fn inbox_list_partial_success_keeps_successful_provider() {
+    let stub = StubEnv::new()
+        .gh_stub(GH_EMPTY_STUB)
+        .glab_stub(GLAB_FAIL_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["ok"], true);
+    assert_eq!(env["data"]["providers"][0]["ok"], true);
+    assert_eq!(env["data"]["providers"][1]["ok"], false);
+    assert_eq!(
+        env["data"]["providers"][1]["error"]["kind"],
+        "backend_error"
+    );
+    assert!(
+        env["warnings"][0]
+            .as_str()
+            .unwrap()
+            .contains("provider_failed: gitlab gitlab.example.com")
+    );
+}
+
+#[test]
+fn inbox_contract_all_selected_providers_failed_is_nonzero() {
+    let stub = StubEnv::new()
+        .gh_stub(GH_FAIL_STUB)
+        .glab_stub(GLAB_FAIL_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+        ],
+    );
+    assert_eq!(out.code, 1, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["ok"], false);
+    assert_eq!(env["error"]["code"], "backend_error");
+}
+
+#[test]
+fn inbox_status_reports_bounded_reason_counts() {
+    let stub = StubEnv::new().gh_stub(GH_INBOX_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "inbox",
+            "status",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.inbox.status.v1");
+    assert_eq!(env["data"]["limit"], 30);
+    let counts = env["data"]["counts"].as_array().expect("counts");
+    assert!(counts.iter().any(|row| row["reason"] == "review"));
+    assert!(counts.iter().any(|row| row["reason"] == "assigned"));
+}
+
+#[test]
+fn inbox_next_returns_ranked_review_items_first() {
+    let stub = StubEnv::new().gh_stub(GH_INBOX_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &["--provider", "github", "--format", "json", "inbox", "next"],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.inbox.next.v1");
+    assert_eq!(env["data"]["limit"], 5);
+    assert_eq!(env["data"]["query_limit"], 30);
+    let items = env["data"]["items"].as_array().expect("items");
+    assert!(items.len() <= 5);
+    assert_eq!(items[0]["kind"], "review");
+}

--- a/crates/forge-cli/tests/integration/inbox.rs
+++ b/crates/forge-cli/tests/integration/inbox.rs
@@ -96,7 +96,7 @@ EOF
     ;;
   *"todos"*"state=pending"*)
     cat <<'EOF'
-[{"id":55,"body":"todo body","created_at":"2026-05-22T06:00:00Z","target_url":"https://gitlab.example.com/team/api/-/issues/32","target":{"iid":32,"title":"Todo issue","web_url":"https://gitlab.example.com/team/api/-/issues/32","updated_at":"2026-05-22T06:30:00Z","author":{"username":"frank"}},"project":{"path_with_namespace":"team/api"},"author":{"username":"frank"}}]
+[{"id":55,"body":"todo body","created_at":"2026-05-22T06:00:00Z","target_url":"https://gitlab.example.com/team/api/-/issues/32","target":{"iid":32,"title":"Todo issue","web_url":"https://gitlab.example.com/team/api/-/issues/32","updated_at":"2026-05-22T06:30:00Z","author":{"username":"frank"}},"project":{"path_with_namespace":"team/api"},"author":{"username":"notifier"}}]
 EOF
     ;;
   *)
@@ -165,6 +165,12 @@ fn inbox_gitlab_passes_hostname_and_normalizes_api_rows() {
     assert_eq!(env["data"]["items"][0]["kind"], "review");
     assert_eq!(env["data"]["items"][0]["repo"], "team/api");
     assert_eq!(env["data"]["items"][0]["source"], "gitlab_merge_requests");
+    let items = env["data"]["items"].as_array().expect("items");
+    let todo = items
+        .iter()
+        .find(|item| item["title"] == "Todo issue")
+        .expect("todo item");
+    assert_eq!(todo["author"], "frank");
 }
 
 #[test]


### PR DESCRIPTION
# Add forge-cli inbox discovery

## Summary

Adds the read-only `forge-cli inbox` command group for cross-repo personal work discovery across GitHub and GitLab. The implementation keeps existing repo-local lifecycle commands unchanged, adds inbox-local multi-provider resolution, and exposes stable JSON/text output for agents, schedulers, and Alfred-style consumers.

## Changes

- Adds `inbox status`, `inbox list`, and `inbox next` with inbox-scoped `--gitlab-host`, repeatable `--kind`, and bounded `--limit` controls.
- Implements GitHub `gh search` and GitLab `glab api --hostname <host>` adapters with normalized items, deterministic `reasons`, provider status rows, partial-success warnings, and all-provider-failure errors.
- Covers the new behavior with offline `gh`/`glab` integration fixtures, docs/spec updates, and regenerated bash/zsh completion assets.

## Test-First Evidence

- Change classification: feature
- Failing test before fix: N/A; this is a new CLI surface with no existing inbox command, so pre-existing failing-test capture was waived in issue #441.
- Final validation: `cargo test -p nils-forge-cli inbox -- --nocapture` (pass); `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (pass)
- Waiver reason: new additive command group; validation is covered by new unit/integration tests and the repository changed-scope gate.

## Testing

- `cargo fmt --all -- --check` (pass)
- `cargo test -p nils-forge-cli inbox -- --nocapture` (pass)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (pass)

## Risk / Notes

- `status` counts remain bounded by the effective provider/query limit and are not global exact counts.
- Live GitLab self-managed smoke is optional follow-up because offline fixtures cover the command contract without requiring provider state.
- Refs #441
