### PR TITLE
forge-cli inbox: item-type pruning + parallel collection

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -975,7 +975,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__inbox__list)
-            opts="-h --gitlab-host --kind --limit --format --remote --provider --repo --dry-run --help"
+            opts="-h --gitlab-host --kind --item-type --limit --format --remote --provider --repo --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -987,6 +987,10 @@ _forge-cli() {
                     ;;
                 --kind)
                     COMPREPLY=($(compgen -W "review assigned todo authored involved" -- "${cur}"))
+                    return 0
+                    ;;
+                --item-type)
+                    COMPREPLY=($(compgen -W "all pr issue" -- "${cur}"))
                     return 0
                     ;;
                 --limit)
@@ -1017,7 +1021,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__inbox__next)
-            opts="-h --gitlab-host --kind --limit --format --remote --provider --repo --dry-run --help"
+            opts="-h --gitlab-host --kind --item-type --limit --format --remote --provider --repo --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1029,6 +1033,10 @@ _forge-cli() {
                     ;;
                 --kind)
                     COMPREPLY=($(compgen -W "review assigned todo authored involved" -- "${cur}"))
+                    return 0
+                    ;;
+                --item-type)
+                    COMPREPLY=($(compgen -W "all pr issue" -- "${cur}"))
                     return 0
                     ;;
                 --limit)
@@ -1059,7 +1067,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__inbox__status)
-            opts="-h --gitlab-host --kind --limit --format --remote --provider --repo --dry-run --help"
+            opts="-h --gitlab-host --kind --item-type --limit --format --remote --provider --repo --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1071,6 +1079,10 @@ _forge-cli() {
                     ;;
                 --kind)
                     COMPREPLY=($(compgen -W "review assigned todo authored involved" -- "${cur}"))
+                    return 0
+                    ;;
+                --item-type)
+                    COMPREPLY=($(compgen -W "all pr issue" -- "${cur}"))
                     return 0
                     ;;
                 --limit)

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -484,6 +484,9 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 _arguments "${_arguments_options[@]}" : \
 '--gitlab-host=[GitLab host for inbox API calls. Defaults from FORGE_CLI_INBOX_GITLAB_HOST, GitLab remote inference, then gitlab.com]:HOST:_default' \
 '*--kind=[Restrict inbox reasons/kinds. Repeatable. Defaults to review, assigned, todo, and authored; \`involved\` is opt-in because it can be broad on GitHub]:KINDS:(review assigned todo authored involved)' \
+'--item-type=[Restrict inbox by item type (PR/MR vs issue). \`--kind\` filters reasons (review/assigned/todo/authored/involved); \`--item-type\` filters result classes so PR-only and issue-only modes skip irrelevant provider queries. Defaults to all]:ITEM_TYPE:((all\:"Include PRs/MRs, issues, and classifiable todos (default)"
+pr\:"Include only pull requests / merge requests (and todos that target them)"
+issue\:"Include only issues (and todos that target them)"))' \
 '--limit=[Per-provider, per-query-family bounded result limit (default\: 30)]:LIMIT:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
@@ -499,6 +502,9 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 _arguments "${_arguments_options[@]}" : \
 '--gitlab-host=[GitLab host for inbox API calls. Defaults from FORGE_CLI_INBOX_GITLAB_HOST, GitLab remote inference, then gitlab.com]:HOST:_default' \
 '*--kind=[Restrict inbox reasons/kinds. Repeatable. Defaults to review, assigned, todo, and authored; \`involved\` is opt-in because it can be broad on GitHub]:KINDS:(review assigned todo authored involved)' \
+'--item-type=[Restrict inbox by item type (PR/MR vs issue). \`--kind\` filters reasons (review/assigned/todo/authored/involved); \`--item-type\` filters result classes so PR-only and issue-only modes skip irrelevant provider queries. Defaults to all]:ITEM_TYPE:((all\:"Include PRs/MRs, issues, and classifiable todos (default)"
+pr\:"Include only pull requests / merge requests (and todos that target them)"
+issue\:"Include only issues (and todos that target them)"))' \
 '--limit=[Per-provider, per-query-family bounded result limit (default\: 30)]:LIMIT:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
@@ -514,6 +520,9 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 _arguments "${_arguments_options[@]}" : \
 '--gitlab-host=[GitLab host for inbox API calls. Defaults from FORGE_CLI_INBOX_GITLAB_HOST, GitLab remote inference, then gitlab.com]:HOST:_default' \
 '*--kind=[Restrict inbox reasons/kinds. Repeatable. Defaults to review, assigned, todo, and authored; \`involved\` is opt-in]:KINDS:(review assigned todo authored involved)' \
+'--item-type=[Restrict inbox by item type (PR/MR vs issue). See \`inbox list --help\` for the distinction from \`--kind\`. Defaults to all]:ITEM_TYPE:((all\:"Include PRs/MRs, issues, and classifiable todos (default)"
+pr\:"Include only pull requests / merge requests (and todos that target them)"
+issue\:"Include only issues (and todos that target them)"))' \
 '--limit=[Number of ranked items to return (default\: 5). Provider queries remain bounded at at least 30 candidates so ranking has enough input]:LIMIT:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \

--- a/crates/forge-cli/README.md
+++ b/crates/forge-cli/README.md
@@ -43,6 +43,52 @@ default self-managed host, or use `--gitlab-host` for a per-command override.
 `status` reports bounded counts, and `next` returns a ranked bounded subset
 without mutating PRs, issues, merge requests, or todos.
 
+### Reason filter (`--kind`) vs item-type filter (`--item-type`)
+
+`--kind` selects inbox *reasons* — why an item should appear (`review`,
+`assigned`, `todo`, `authored`, `involved`). `--item-type` selects *result
+classes* — pull/merge requests, issues, or all items. They are independent:
+
+```sh
+# default: all reasons, all item types
+forge-cli inbox list --format json
+
+# pull/merge requests only (skips GitHub issue searches and GitLab issue API calls)
+forge-cli inbox list --item-type pr --format json
+
+# issues only (skips PR searches; GitHub review-requested is dropped)
+forge-cli inbox list --item-type issue --format json
+
+# review-requested PRs only
+forge-cli inbox list --kind review --item-type pr --format json
+```
+
+`--item-type` defaults to `all`. Dry-run output reflects the pruned query plan:
+
+```sh
+forge-cli --dry-run --format json inbox list --item-type pr
+```
+
+GitLab `todos` are classified by `target_type` (or the target URL); todos whose
+target cannot be classified appear only in `--item-type all` mode.
+
+### Latency notes
+
+Provider adapters and independent query families run concurrently, so
+default-mode latency is bounded by the slowest single backend call rather than
+their sum. Identity lookup is only issued when a remaining GitLab query needs
+it. Manual smoke timings (provider/network dependent, not a CI assertion):
+
+```sh
+time forge-cli --provider github --format json inbox list --limit 30
+time forge-cli --provider github --format json inbox list --limit 30 --item-type pr
+time forge-cli --provider gitlab --gitlab-host gitlab.example.com --format json inbox list --limit 30
+time forge-cli --format json inbox list --gitlab-host gitlab.example.com --limit 30
+```
+
+Wall-clock latency depends on `gh`/`glab` and remote API responsiveness; treat
+these timings as delivery evidence, not deterministic budgets.
+
 ## GitHub checks compatibility
 
 Starting with `nils-cli` `0.17.0`, GitHub `pr checks` calls request only the

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -183,8 +183,15 @@ Inbox-local flags:
   (default `30`).
 - `forge-cli inbox next --limit <n>` bounds the returned ranked candidates
   (default `5`); provider reads still use at least `30` candidates.
-- `--kind review|assigned|todo|authored|involved` is repeatable. `involved` is
-  opt-in because it can be broad on GitHub.
+- `--kind review|assigned|todo|authored|involved` is repeatable and selects
+  inbox *reasons* (why an item appears). `involved` is opt-in because it can
+  be broad on GitHub.
+- `--item-type all|pr|issue` selects *result classes* (pull/merge requests vs
+  issues) and is distinct from `--kind`. Default is `all`. PR-only mode skips
+  GitHub issue searches and GitLab issue API calls; issue-only mode skips PR
+  searches (GitHub review-requested is dropped). GitLab `todos` are kept when
+  their `target_type` (or target URL) matches the selected item type;
+  unclassifiable todos appear only in `all` mode.
 - `--gitlab-host <host>` is scoped to inbox commands only and is passed to
   every GitLab `glab api` invocation as `--hostname <host>`.
 - When `--gitlab-host` is omitted, GitLab host resolution uses
@@ -387,7 +394,15 @@ providers:
   successful inbox.
 - GitLab rows come from host-aware `glab api --hostname <host>` calls. The user
   id and username are discovered with `glab api user --hostname <host>` for the
-  current invocation and are not persisted.
+  current invocation and are not persisted. The identity lookup is skipped when
+  no remaining query family needs it (for example `--kind assigned --kind
+  todo`, or `--item-type issue` paired with reasons that drop the
+  identity-dependent families).
+- Selected provider adapters and independent query families within a provider
+  run concurrently. The output contract — provider order, deduplicated items,
+  warnings, and partial/all-failure exit behavior — is deterministic and
+  independent of thread completion order. Live wall-clock latency depends on
+  `gh`/`glab` and remote API responsiveness and is not asserted in CI.
 
 ## CLI output contract conformance
 

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -211,6 +211,31 @@ impl InboxKindFlag {
     }
 }
 
+/// Inbox item-type filter. Distinct from `--kind` (reason): item-type selects
+/// PR/MR-only or issue-only result classes so the CLI can skip irrelevant
+/// provider query families before any subprocess runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum InboxItemTypeFlag {
+    /// Include PRs/MRs, issues, and classifiable todos (default).
+    #[default]
+    All,
+    /// Include only pull requests / merge requests (and todos that target them).
+    Pr,
+    /// Include only issues (and todos that target them).
+    Issue,
+}
+
+impl InboxItemTypeFlag {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            InboxItemTypeFlag::All => "all",
+            InboxItemTypeFlag::Pr => "pr",
+            InboxItemTypeFlag::Issue => "issue",
+        }
+    }
+}
+
 impl PrStateFilter {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -550,6 +575,12 @@ pub struct InboxQueryArgs {
     /// broad on GitHub.
     #[arg(long = "kind", value_enum)]
     pub kinds: Vec<InboxKindFlag>,
+    /// Restrict inbox by item type (PR/MR vs issue). `--kind` filters reasons
+    /// (review/assigned/todo/authored/involved); `--item-type` filters result
+    /// classes so PR-only and issue-only modes skip irrelevant provider
+    /// queries. Defaults to all.
+    #[arg(long = "item-type", value_enum, default_value_t = InboxItemTypeFlag::All)]
+    pub item_type: InboxItemTypeFlag,
     /// Per-provider, per-query-family bounded result limit (default: 30).
     #[arg(long, default_value_t = 30)]
     pub limit: u32,
@@ -566,6 +597,10 @@ pub struct InboxNextArgs {
     /// assigned, todo, and authored; `involved` is opt-in.
     #[arg(long = "kind", value_enum)]
     pub kinds: Vec<InboxKindFlag>,
+    /// Restrict inbox by item type (PR/MR vs issue). See `inbox list --help`
+    /// for the distinction from `--kind`. Defaults to all.
+    #[arg(long = "item-type", value_enum, default_value_t = InboxItemTypeFlag::All)]
+    pub item_type: InboxItemTypeFlag,
     /// Number of ranked items to return (default: 5). Provider queries remain
     /// bounded at at least 30 candidates so ranking has enough input.
     #[arg(long, default_value_t = 5)]
@@ -1047,9 +1082,35 @@ mod tests {
                     vec![InboxKindFlag::Review, InboxKindFlag::Assigned]
                 );
                 assert_eq!(args.limit, 7);
+                assert_eq!(args.item_type, InboxItemTypeFlag::All);
             }
             other => panic!("expected inbox list, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn inbox_cli_parses_item_type_for_list_status_next() {
+        for sub in ["list", "status", "next"] {
+            let cli = parse(&["inbox", sub, "--item-type", "pr"]).expect("parse pr item-type");
+            match cli.command {
+                Some(Command::Inbox(InboxArgs {
+                    command: Some(InboxCommand::List(args)),
+                })) => assert_eq!(args.item_type, InboxItemTypeFlag::Pr),
+                Some(Command::Inbox(InboxArgs {
+                    command: Some(InboxCommand::Status(args)),
+                })) => assert_eq!(args.item_type, InboxItemTypeFlag::Pr),
+                Some(Command::Inbox(InboxArgs {
+                    command: Some(InboxCommand::Next(args)),
+                })) => assert_eq!(args.item_type, InboxItemTypeFlag::Pr),
+                other => panic!("expected inbox {sub}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn inbox_cli_rejects_unknown_item_type() {
+        let result = parse(&["inbox", "list", "--item-type", "bogus"]);
+        assert!(result.is_err(), "--item-type bogus must fail clap parsing");
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/inbox.rs
+++ b/crates/forge-cli/src/ops/inbox.rs
@@ -338,14 +338,18 @@ impl QueryConfig {
     }
 
     /// Whether at least one selected GitLab query family needs the user
-    /// identity (review filters by `reviewer_username`, authored filters by
-    /// `author_id`). Identity lookup is skipped when no remaining query needs
-    /// it, including when item-type filtering has pruned away the dependent
-    /// families.
+    /// identity. Review filters by `reviewer_username`, so it needs identity
+    /// only when PR-class results are allowed (review queries are MR-only).
+    /// Authored filters by `author_id` and exists for both MR and issue, so it
+    /// needs identity whenever it is selected (`--item-type` always allows at
+    /// least one of `pr` / `issue`).
+    ///
+    /// Invariant locked by `gitlab_identity_predicate_matches_query_plan`:
+    /// this predicate must equal `gitlab_queries(_, None, self)` losing at
+    /// least one query family relative to `gitlab_queries(_, Some(_), self)`.
     fn gitlab_identity_needed(&self) -> bool {
         let review_needs = self.wants(InboxKindFlag::Review) && self.allows_pr();
-        let authored_needs =
-            self.wants(InboxKindFlag::Authored) && (self.allows_pr() || self.allows_issue());
+        let authored_needs = self.wants(InboxKindFlag::Authored);
         review_needs || authored_needs
     }
 }
@@ -910,20 +914,26 @@ fn parse_gitlab_items(
 }
 
 fn classify_gitlab_todo(raw: &serde_json::Value) -> TodoTarget {
+    // `target_type` is the authoritative field on the GitLab todos API; trust
+    // it whenever present.
     if let Some(t) = optional_str(raw, "target_type") {
         match t.as_str() {
             "MergeRequest" => return TodoTarget::MergeRequest,
             "Issue" => return TodoTarget::Issue,
-            _ => {}
+            _ => return TodoTarget::Unknown,
         }
     }
+    // Fallback for payloads without `target_type` (older stubs / unusual
+    // responses): only accept canonical GitLab path segments (`/-/issues/`,
+    // `/-/merge_requests/`) so loose substrings on foreign hosts cannot
+    // misclassify.
     let url = optional_str(raw, "target_url")
         .or_else(|| raw.get("target").and_then(|t| optional_str(t, "web_url")));
     if let Some(url) = url {
-        if url.contains("/merge_requests/") {
+        if url.contains("/-/merge_requests/") {
             return TodoTarget::MergeRequest;
         }
-        if url.contains("/-/issues/") || url.contains("/issues/") {
+        if url.contains("/-/issues/") {
             return TodoTarget::Issue;
         }
     }
@@ -1535,6 +1545,207 @@ mod tests {
             collection.warnings[0].starts_with("provider_failed: gitlab"),
             "warning order must follow target order: {:?}",
             collection.warnings
+        );
+    }
+
+    /// Invariant: `gitlab_identity_needed` must agree with the actual query
+    /// plan. Whenever the predicate returns `true`, `gitlab_queries(_, None,
+    /// config)` must drop at least one query that `gitlab_queries(_,
+    /// Some(_), config)` would have produced. Whenever it returns `false`,
+    /// both plans must be identical.
+    #[test]
+    fn gitlab_identity_predicate_matches_query_plan() {
+        let host = "gitlab.example.com";
+        let id = GitlabIdentity {
+            id: "1".into(),
+            username: "u".into(),
+        };
+        let kinds = [
+            InboxKindFlag::Review,
+            InboxKindFlag::Assigned,
+            InboxKindFlag::Todo,
+            InboxKindFlag::Authored,
+            InboxKindFlag::Involved,
+        ];
+        let item_types = [
+            InboxItemTypeFlag::All,
+            InboxItemTypeFlag::Pr,
+            InboxItemTypeFlag::Issue,
+        ];
+        // Cover every non-empty subset of kinds crossed with every item type.
+        for mask in 1u32..(1 << kinds.len()) {
+            let selected: Vec<InboxKindFlag> = kinds
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| mask & (1 << i) != 0)
+                .map(|(_, k)| *k)
+                .collect();
+            for item_type in item_types {
+                let config = QueryConfig::new(selected.clone(), item_type, 30);
+                let without = gitlab_queries(host, None, &config).len();
+                let with = gitlab_queries(host, Some(&id), &config).len();
+                if config.gitlab_identity_needed() {
+                    assert!(
+                        with > without,
+                        "predicate=true but plans match: kinds={:?} item_type={:?}",
+                        selected,
+                        item_type
+                    );
+                } else {
+                    assert_eq!(
+                        with, without,
+                        "predicate=false but plans differ: kinds={:?} item_type={:?}",
+                        selected, item_type
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn classify_gitlab_todo_rejects_foreign_host_paths() {
+        // No target_type, URL is a foreign host that happens to contain
+        // `/issues/` as a substring — must classify as Unknown so PR/issue-only
+        // filters do not surface it.
+        let raw = serde_json::json!({
+            "target_url": "https://customer.example.com/team/issues/42",
+            "target": {
+                "iid": 42,
+                "web_url": "https://customer.example.com/team/issues/42",
+            },
+        });
+        assert_eq!(classify_gitlab_todo(&raw), TodoTarget::Unknown);
+    }
+
+    #[test]
+    fn classify_gitlab_todo_accepts_canonical_gitlab_paths() {
+        let issue = serde_json::json!({
+            "target": {"web_url": "https://gitlab.example.com/team/api/-/issues/32"},
+        });
+        assert_eq!(classify_gitlab_todo(&issue), TodoTarget::Issue);
+        let mr = serde_json::json!({
+            "target_url": "https://gitlab.example.com/team/api/-/merge_requests/77",
+        });
+        assert_eq!(classify_gitlab_todo(&mr), TodoTarget::MergeRequest);
+    }
+
+    #[test]
+    fn classify_gitlab_todo_unknown_target_type_returns_unknown() {
+        // Explicit unfamiliar `target_type` (e.g. `DesignManagement::Design`)
+        // must short-circuit to Unknown without falling back to URL guessing.
+        let raw = serde_json::json!({
+            "target_type": "DesignManagement::Design",
+            "target_url": "https://gitlab.example.com/team/api/-/issues/9",
+        });
+        assert_eq!(classify_gitlab_todo(&raw), TodoTarget::Unknown);
+    }
+
+    #[test]
+    fn inbox_empty_query_plan_returns_success_without_identity_call() {
+        // `--kind review --item-type issue`: review is MR-only (dropped under
+        // item-type=issue), so GitLab ends up with zero query families and
+        // identity lookup is skipped. The provider must still return ok.
+        struct AssertNoIdentityRunner;
+        impl BackendRunner for AssertNoIdentityRunner {
+            fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+                let argv = call.plan_argv().join(" ");
+                assert!(
+                    !argv.contains("api user --hostname"),
+                    "identity lookup must not be issued: {argv}"
+                );
+                Ok(BackendSuccess {
+                    stdout: "[]".into(),
+                    stderr: String::new(),
+                })
+            }
+        }
+        let target = ProviderTarget {
+            provider: Provider::GitLab,
+            host: "gitlab.example.com".into(),
+        };
+        let config = QueryConfig::new(vec![InboxKindFlag::Review], InboxItemTypeFlag::Issue, 30);
+        let result =
+            execute_gitlab(&AssertNoIdentityRunner, &target, &config).expect("execute_gitlab");
+        assert!(result.items.is_empty());
+        assert!(!result.limited);
+    }
+
+    #[test]
+    fn inbox_partial_within_provider_failure_rolls_provider_up_as_failed() {
+        // One GitHub query family succeeds; another fails. The provider as a
+        // whole must surface a backend_error and the failing-provider warning
+        // must follow target order.
+        struct OneQueryFailsRunner;
+        impl BackendRunner for OneQueryFailsRunner {
+            fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+                let argv = call.plan_argv().join(" ");
+                if argv.contains("--review-requested") {
+                    Err(ForgeError::backend_error(
+                        schema_err(),
+                        "boom",
+                        Some("stderr".into()),
+                    ))
+                } else {
+                    Ok(BackendSuccess {
+                        stdout: "[]".into(),
+                        stderr: String::new(),
+                    })
+                }
+            }
+        }
+        let targets = vec![ProviderTarget {
+            provider: Provider::GitHub,
+            host: "github.com".into(),
+        }];
+        let config = QueryConfig::new(Vec::new(), InboxItemTypeFlag::All, 30);
+        let err = collect_inbox(&OneQueryFailsRunner, &targets, &config)
+            .expect_err("must fail when only provider failed");
+        assert_eq!(err.kind(), "backend_error");
+    }
+
+    /// Within a single provider, plan-order error determinism: even if a
+    /// later-planned query fails fast and an earlier-planned query fails
+    /// slowly, the surfaced error must be the earlier-planned one.
+    #[test]
+    fn inbox_within_provider_error_follows_plan_order_not_completion_order() {
+        struct PlanOrderRunner;
+        impl BackendRunner for PlanOrderRunner {
+            fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+                let argv = call.plan_argv().join(" ");
+                // Plan order for default GitHub: review-requested, assigned-prs,
+                // assigned-issues, authored-prs, authored-issues.
+                // Make the EARLIER one fail slow, the LATER one fail fast.
+                if argv.contains("--review-requested") {
+                    std::thread::sleep(std::time::Duration::from_millis(60));
+                    Err(ForgeError::backend_error(
+                        schema_err(),
+                        "slow-early-error",
+                        Some(String::new()),
+                    ))
+                } else if argv.contains("--author") && argv.contains("issues") {
+                    Err(ForgeError::backend_error(
+                        schema_err(),
+                        "fast-late-error",
+                        Some(String::new()),
+                    ))
+                } else {
+                    Ok(BackendSuccess {
+                        stdout: "[]".into(),
+                        stderr: String::new(),
+                    })
+                }
+            }
+        }
+        let target = ProviderTarget {
+            provider: Provider::GitHub,
+            host: "github.com".into(),
+        };
+        let config = QueryConfig::new(Vec::new(), InboxItemTypeFlag::All, 30);
+        let err = execute_github(&PlanOrderRunner, &target, &config)
+            .expect_err("must propagate first plan-order error");
+        assert!(
+            err.to_string().contains("slow-early-error"),
+            "expected earlier-planned (slow) error to win, got: {err}"
         );
     }
 }

--- a/crates/forge-cli/src/ops/inbox.rs
+++ b/crates/forge-cli/src/ops/inbox.rs
@@ -13,7 +13,10 @@ use nils_common::cli_contract::{OutputFormat, schema_version_for};
 use serde::Serialize;
 
 use crate::backend::{BackendCall, BackendProgram, BackendRunner, BackendSuccess, ProcessRunner};
-use crate::cli::{BINARY, GlobalFlags, InboxCommand, InboxKindFlag, InboxNextArgs, InboxQueryArgs};
+use crate::cli::{
+    BINARY, GlobalFlags, InboxCommand, InboxItemTypeFlag, InboxKindFlag, InboxNextArgs,
+    InboxQueryArgs,
+};
 use crate::envelope::emit_success_with_warnings;
 use crate::error::ForgeError;
 use crate::provider::{Provider, classify_host, git_remote_url, parse_host};
@@ -35,7 +38,19 @@ struct ProviderTarget {
 #[derive(Debug, Clone)]
 struct QueryConfig {
     reasons: Vec<InboxKindFlag>,
+    item_type: InboxItemTypeFlag,
     query_limit: u32,
+}
+
+/// Classification of a GitLab `todo` target. `Unknown` covers payloads where
+/// neither `target_type` nor the URL gives a confident PR/Issue answer; those
+/// rows are included only in all-items mode so PR-only and issue-only callers
+/// never see noise from unclassifiable todos.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TodoTarget {
+    MergeRequest,
+    Issue,
+    Unknown,
 }
 
 #[derive(Debug, Clone)]
@@ -162,7 +177,7 @@ pub fn run(
     run_with(&runner, global, command, format)
 }
 
-pub fn run_with<R: BackendRunner>(
+pub fn run_with<R: BackendRunner + Sync>(
     runner: &R,
     global: &GlobalFlags,
     command: InboxCommand,
@@ -175,14 +190,14 @@ pub fn run_with<R: BackendRunner>(
     }
 }
 
-fn run_list<R: BackendRunner>(
+fn run_list<R: BackendRunner + Sync>(
     runner: &R,
     global: &GlobalFlags,
     args: InboxQueryArgs,
     format: OutputFormat,
 ) -> Result<i32, ForgeError> {
     let targets = resolve_targets(global, args.gitlab_host.as_deref());
-    let config = QueryConfig::new(args.kinds, args.limit.max(1));
+    let config = QueryConfig::new(args.kinds, args.item_type, args.limit.max(1));
     if global.dry_run {
         return Ok(emit_dry_run(
             schema_version_for(BINARY, LIST_SCHEMA, SCHEMA_VERSION),
@@ -209,14 +224,14 @@ fn run_list<R: BackendRunner>(
     ))
 }
 
-fn run_status<R: BackendRunner>(
+fn run_status<R: BackendRunner + Sync>(
     runner: &R,
     global: &GlobalFlags,
     args: InboxQueryArgs,
     format: OutputFormat,
 ) -> Result<i32, ForgeError> {
     let targets = resolve_targets(global, args.gitlab_host.as_deref());
-    let config = QueryConfig::new(args.kinds, args.limit.max(1));
+    let config = QueryConfig::new(args.kinds, args.item_type, args.limit.max(1));
     if global.dry_run {
         return Ok(emit_dry_run(
             schema_version_for(BINARY, STATUS_SCHEMA, SCHEMA_VERSION),
@@ -245,7 +260,7 @@ fn run_status<R: BackendRunner>(
     ))
 }
 
-fn run_next<R: BackendRunner>(
+fn run_next<R: BackendRunner + Sync>(
     runner: &R,
     global: &GlobalFlags,
     args: InboxNextArgs,
@@ -254,7 +269,7 @@ fn run_next<R: BackendRunner>(
     let targets = resolve_targets(global, args.gitlab_host.as_deref());
     let result_limit = args.limit.max(1);
     let query_limit = result_limit.max(DEFAULT_QUERY_LIMIT);
-    let config = QueryConfig::new(args.kinds, query_limit);
+    let config = QueryConfig::new(args.kinds, args.item_type, query_limit);
     if global.dry_run {
         return Ok(emit_dry_run(
             schema_version_for(BINARY, NEXT_SCHEMA, SCHEMA_VERSION),
@@ -284,7 +299,7 @@ fn run_next<R: BackendRunner>(
 }
 
 impl QueryConfig {
-    fn new(kinds: Vec<InboxKindFlag>, query_limit: u32) -> Self {
+    fn new(kinds: Vec<InboxKindFlag>, item_type: InboxItemTypeFlag, query_limit: u32) -> Self {
         let mut reasons = if kinds.is_empty() {
             vec![
                 InboxKindFlag::Review,
@@ -299,12 +314,39 @@ impl QueryConfig {
         reasons.dedup();
         Self {
             reasons,
+            item_type,
             query_limit,
         }
     }
 
     fn wants(&self, reason: InboxKindFlag) -> bool {
         self.reasons.contains(&reason)
+    }
+
+    fn allows_pr(&self) -> bool {
+        matches!(
+            self.item_type,
+            InboxItemTypeFlag::All | InboxItemTypeFlag::Pr
+        )
+    }
+
+    fn allows_issue(&self) -> bool {
+        matches!(
+            self.item_type,
+            InboxItemTypeFlag::All | InboxItemTypeFlag::Issue
+        )
+    }
+
+    /// Whether at least one selected GitLab query family needs the user
+    /// identity (review filters by `reviewer_username`, authored filters by
+    /// `author_id`). Identity lookup is skipped when no remaining query needs
+    /// it, including when item-type filtering has pruned away the dependent
+    /// families.
+    fn gitlab_identity_needed(&self) -> bool {
+        let review_needs = self.wants(InboxKindFlag::Review) && self.allows_pr();
+        let authored_needs =
+            self.wants(InboxKindFlag::Authored) && (self.allows_pr() || self.allows_issue());
+        review_needs || authored_needs
     }
 }
 
@@ -364,19 +406,97 @@ fn host_from_remote(global: &GlobalFlags, provider: Provider) -> Option<String> 
     }
 }
 
-fn collect_inbox<R: BackendRunner>(
+/// Pre-execution snapshot of a provider's query plan. Built from
+/// `(target, config)` only — no backend calls are issued at build time.
+/// Dry-run and live execution paths share this builder so the planned argv
+/// can never drift from what live execution would actually run.
+#[derive(Debug, Clone)]
+struct ProviderPlan {
+    target: ProviderTarget,
+    config: QueryConfig,
+}
+
+impl ProviderPlan {
+    fn build(target: &ProviderTarget, config: &QueryConfig) -> Self {
+        Self {
+            target: target.clone(),
+            config: config.clone(),
+        }
+    }
+
+    /// Render the argv list a dry-run would emit. GitLab queries that depend
+    /// on identity are rendered with placeholder `<user_id>` / `<username>`
+    /// values so callers can still inspect what the live path would call.
+    fn dry_run_argv(&self) -> Vec<Vec<String>> {
+        match self.target.provider {
+            Provider::GitHub => github_queries(&self.config)
+                .into_iter()
+                .map(|q| q.call.plan_argv())
+                .collect(),
+            Provider::GitLab => {
+                let mut out = Vec::new();
+                let needs_identity = self.config.gitlab_identity_needed();
+                if needs_identity {
+                    out.push(gitlab_identity_call(&self.target.host).plan_argv());
+                }
+                let placeholder = GitlabIdentity {
+                    id: "<user_id>".to_string(),
+                    username: "<username>".to_string(),
+                };
+                let identity = needs_identity.then_some(&placeholder);
+                for q in gitlab_queries(&self.target.host, identity, &self.config) {
+                    out.push(q.call.plan_argv());
+                }
+                out
+            }
+        }
+    }
+
+    fn execute<R: BackendRunner + Sync>(&self, runner: &R) -> Result<ProviderSuccess, ForgeError> {
+        match self.target.provider {
+            Provider::GitHub => execute_github(runner, &self.target, &self.config),
+            Provider::GitLab => execute_gitlab(runner, &self.target, &self.config),
+        }
+    }
+}
+
+fn collect_inbox<R: BackendRunner + Sync>(
     runner: &R,
     targets: &[ProviderTarget],
     config: &QueryConfig,
 ) -> Result<InboxCollection, ForgeError> {
-    let mut providers = Vec::new();
+    let plans: Vec<ProviderPlan> = targets
+        .iter()
+        .map(|t| ProviderPlan::build(t, config))
+        .collect();
+
+    // Run providers concurrently. Each provider does its own identity lookup
+    // (if needed) and query-family fan-out internally. Mixed-provider mode
+    // does not block GitHub work on the GitLab identity lookup.
+    let mut slots: Vec<Option<Result<ProviderSuccess, ForgeError>>> =
+        (0..plans.len()).map(|_| None).collect();
+    std::thread::scope(|s| {
+        let mut handles = Vec::with_capacity(plans.len());
+        for (i, plan) in plans.iter().enumerate() {
+            handles.push(s.spawn(move || (i, plan.execute(runner))));
+        }
+        for h in handles {
+            let (i, res) = h.join().expect("inbox provider task panicked");
+            slots[i] = Some(res);
+        }
+    });
+
+    // Aggregate strictly in target order so providers, warnings, and items
+    // are deterministic regardless of completion order.
+    let mut providers = Vec::with_capacity(targets.len());
     let mut items = Vec::new();
     let mut warnings = Vec::new();
     let mut failures = Vec::new();
     let mut successes = 0usize;
 
-    for target in targets {
-        match query_provider(runner, target, config) {
+    for (i, target) in targets.iter().enumerate() {
+        let result = slots[i].take().expect("provider slot filled");
+        match result {
             Ok(success) => {
                 successes += 1;
                 let item_count = success.items.len();
@@ -445,65 +565,97 @@ fn collect_inbox<R: BackendRunner>(
     })
 }
 
-fn query_provider<R: BackendRunner>(
-    runner: &R,
-    target: &ProviderTarget,
-    config: &QueryConfig,
-) -> Result<ProviderSuccess, ForgeError> {
-    match target.provider {
-        Provider::GitHub => query_github(runner, target, config),
-        Provider::GitLab => query_gitlab(runner, target, config),
-    }
-}
-
-fn query_github<R: BackendRunner>(
+fn execute_github<R: BackendRunner + Sync>(
     runner: &R,
     target: &ProviderTarget,
     config: &QueryConfig,
 ) -> Result<ProviderSuccess, ForgeError> {
     let queries = github_queries(config);
-    let mut items = Vec::new();
-    let mut limited = false;
-    for query in queries {
-        let output = runner.run(&query.call)?;
-        let parsed = parse_github_items(target, &query, &output)?;
-        if parsed.len() as u32 >= config.query_limit {
-            limited = true;
-        }
-        items.extend(parsed);
-    }
-    Ok(ProviderSuccess {
-        items: dedupe_items(items),
-        limited,
-    })
+    let per_query = run_queries_in_parallel(runner, &queries, |query, output| {
+        parse_github_items(target, query, output)
+    })?;
+    Ok(aggregate_query_results(per_query, config.query_limit))
 }
 
-fn query_gitlab<R: BackendRunner>(
+fn execute_gitlab<R: BackendRunner + Sync>(
     runner: &R,
     target: &ProviderTarget,
     config: &QueryConfig,
 ) -> Result<ProviderSuccess, ForgeError> {
-    let identity = parse_gitlab_identity(&runner.run(&gitlab_identity_call(&target.host))?)?;
-    let queries = gitlab_queries(&target.host, &identity, config);
+    let identity = if config.gitlab_identity_needed() {
+        Some(parse_gitlab_identity(
+            &runner.run(&gitlab_identity_call(&target.host))?,
+        )?)
+    } else {
+        None
+    };
+    let queries = gitlab_queries(&target.host, identity.as_ref(), config);
+    let item_type = config.item_type;
+    let per_query = run_queries_in_parallel(runner, &queries, |query, output| {
+        parse_gitlab_items(target, query, output, item_type)
+    })?;
+    Ok(aggregate_query_results(per_query, config.query_limit))
+}
+
+/// Run a slice of independent provider query families concurrently and
+/// return their parsed item lists in plan order. The first plan-order error
+/// wins so failure reporting stays deterministic across thread completion
+/// orders.
+fn run_queries_in_parallel<R, F>(
+    runner: &R,
+    queries: &[ProviderQuery],
+    parse: F,
+) -> Result<Vec<Vec<InboxItem>>, ForgeError>
+where
+    R: BackendRunner + Sync,
+    F: Fn(&ProviderQuery, &BackendSuccess) -> Result<Vec<InboxItem>, ForgeError> + Sync,
+{
+    if queries.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut slots: Vec<Option<Result<Vec<InboxItem>, ForgeError>>> =
+        (0..queries.len()).map(|_| None).collect();
+    let parse_ref = &parse;
+    std::thread::scope(|s| {
+        let mut handles = Vec::with_capacity(queries.len());
+        for (i, query) in queries.iter().enumerate() {
+            handles.push(s.spawn(move || {
+                let result = runner
+                    .run(&query.call)
+                    .and_then(|output| parse_ref(query, &output));
+                (i, result)
+            }));
+        }
+        for h in handles {
+            let (i, res) = h.join().expect("inbox query task panicked");
+            slots[i] = Some(res);
+        }
+    });
+    let mut out = Vec::with_capacity(slots.len());
+    for slot in slots {
+        out.push(slot.expect("query slot filled")?);
+    }
+    Ok(out)
+}
+
+fn aggregate_query_results(per_query: Vec<Vec<InboxItem>>, query_limit: u32) -> ProviderSuccess {
     let mut items = Vec::new();
     let mut limited = false;
-    for query in queries {
-        let output = runner.run(&query.call)?;
-        let parsed = parse_gitlab_items(target, &query, &output)?;
-        if parsed.len() as u32 >= config.query_limit {
+    for q in per_query {
+        if q.len() as u32 >= query_limit {
             limited = true;
         }
-        items.extend(parsed);
+        items.extend(q);
     }
-    Ok(ProviderSuccess {
+    ProviderSuccess {
         items: dedupe_items(items),
         limited,
-    })
+    }
 }
 
 fn github_queries(config: &QueryConfig) -> Vec<ProviderQuery> {
     let mut queries = Vec::new();
-    if config.wants(InboxKindFlag::Review) {
+    if config.wants(InboxKindFlag::Review) && config.allows_pr() {
         queries.push(ProviderQuery {
             reason: InboxKindFlag::Review,
             source: "github_search_prs",
@@ -511,40 +663,52 @@ fn github_queries(config: &QueryConfig) -> Vec<ProviderQuery> {
         });
     }
     if config.wants(InboxKindFlag::Assigned) {
-        queries.push(ProviderQuery {
-            reason: InboxKindFlag::Assigned,
-            source: "github_search_prs",
-            call: github_search_call("prs", "--assignee", config.query_limit),
-        });
-        queries.push(ProviderQuery {
-            reason: InboxKindFlag::Assigned,
-            source: "github_search_issues",
-            call: github_search_call("issues", "--assignee", config.query_limit),
-        });
+        if config.allows_pr() {
+            queries.push(ProviderQuery {
+                reason: InboxKindFlag::Assigned,
+                source: "github_search_prs",
+                call: github_search_call("prs", "--assignee", config.query_limit),
+            });
+        }
+        if config.allows_issue() {
+            queries.push(ProviderQuery {
+                reason: InboxKindFlag::Assigned,
+                source: "github_search_issues",
+                call: github_search_call("issues", "--assignee", config.query_limit),
+            });
+        }
     }
     if config.wants(InboxKindFlag::Authored) {
-        queries.push(ProviderQuery {
-            reason: InboxKindFlag::Authored,
-            source: "github_search_prs",
-            call: github_search_call("prs", "--author", config.query_limit),
-        });
-        queries.push(ProviderQuery {
-            reason: InboxKindFlag::Authored,
-            source: "github_search_issues",
-            call: github_search_call("issues", "--author", config.query_limit),
-        });
+        if config.allows_pr() {
+            queries.push(ProviderQuery {
+                reason: InboxKindFlag::Authored,
+                source: "github_search_prs",
+                call: github_search_call("prs", "--author", config.query_limit),
+            });
+        }
+        if config.allows_issue() {
+            queries.push(ProviderQuery {
+                reason: InboxKindFlag::Authored,
+                source: "github_search_issues",
+                call: github_search_call("issues", "--author", config.query_limit),
+            });
+        }
     }
     if config.wants(InboxKindFlag::Involved) {
-        queries.push(ProviderQuery {
-            reason: InboxKindFlag::Involved,
-            source: "github_search_prs",
-            call: github_search_call("prs", "--involves", config.query_limit),
-        });
-        queries.push(ProviderQuery {
-            reason: InboxKindFlag::Involved,
-            source: "github_search_issues",
-            call: github_search_call("issues", "--involves", config.query_limit),
-        });
+        if config.allows_pr() {
+            queries.push(ProviderQuery {
+                reason: InboxKindFlag::Involved,
+                source: "github_search_prs",
+                call: github_search_call("prs", "--involves", config.query_limit),
+            });
+        }
+        if config.allows_issue() {
+            queries.push(ProviderQuery {
+                reason: InboxKindFlag::Involved,
+                source: "github_search_issues",
+                call: github_search_call("issues", "--involves", config.query_limit),
+            });
+        }
     }
     queries
 }
@@ -585,35 +749,42 @@ fn gitlab_identity_call(host: &str) -> BackendCall {
 
 fn gitlab_queries(
     host: &str,
-    identity: &GitlabIdentity,
+    identity: Option<&GitlabIdentity>,
     config: &QueryConfig,
 ) -> Vec<ProviderQuery> {
     let mut queries = Vec::new();
     if config.wants(InboxKindFlag::Assigned) {
-        queries.push(ProviderQuery {
-            reason: InboxKindFlag::Assigned,
-            source: "gitlab_merge_requests",
-            call: gitlab_api_call(
-                host,
-                format!(
-                    "merge_requests?scope=assigned_to_me&state=opened&order_by=updated_at&sort=desc&per_page={}",
-                    config.query_limit
+        if config.allows_pr() {
+            queries.push(ProviderQuery {
+                reason: InboxKindFlag::Assigned,
+                source: "gitlab_merge_requests",
+                call: gitlab_api_call(
+                    host,
+                    format!(
+                        "merge_requests?scope=assigned_to_me&state=opened&order_by=updated_at&sort=desc&per_page={}",
+                        config.query_limit
+                    ),
                 ),
-            ),
-        });
-        queries.push(ProviderQuery {
-            reason: InboxKindFlag::Assigned,
-            source: "gitlab_issues",
-            call: gitlab_api_call(
-                host,
-                format!(
-                    "issues?scope=assigned_to_me&state=opened&order_by=updated_at&sort=desc&per_page={}",
-                    config.query_limit
+            });
+        }
+        if config.allows_issue() {
+            queries.push(ProviderQuery {
+                reason: InboxKindFlag::Assigned,
+                source: "gitlab_issues",
+                call: gitlab_api_call(
+                    host,
+                    format!(
+                        "issues?scope=assigned_to_me&state=opened&order_by=updated_at&sort=desc&per_page={}",
+                        config.query_limit
+                    ),
                 ),
-            ),
-        });
+            });
+        }
     }
-    if config.wants(InboxKindFlag::Review) {
+    if config.wants(InboxKindFlag::Review)
+        && config.allows_pr()
+        && let Some(identity) = identity
+    {
         queries.push(ProviderQuery {
             reason: InboxKindFlag::Review,
             source: "gitlab_merge_requests",
@@ -626,29 +797,35 @@ fn gitlab_queries(
             ),
         });
     }
-    if config.wants(InboxKindFlag::Authored) {
-        queries.push(ProviderQuery {
-            reason: InboxKindFlag::Authored,
-            source: "gitlab_merge_requests",
-            call: gitlab_api_call(
-                host,
-                format!(
-                    "merge_requests?author_id={}&state=opened&order_by=updated_at&sort=desc&per_page={}",
-                    identity.id, config.query_limit
+    if config.wants(InboxKindFlag::Authored)
+        && let Some(identity) = identity
+    {
+        if config.allows_pr() {
+            queries.push(ProviderQuery {
+                reason: InboxKindFlag::Authored,
+                source: "gitlab_merge_requests",
+                call: gitlab_api_call(
+                    host,
+                    format!(
+                        "merge_requests?author_id={}&state=opened&order_by=updated_at&sort=desc&per_page={}",
+                        identity.id, config.query_limit
+                    ),
                 ),
-            ),
-        });
-        queries.push(ProviderQuery {
-            reason: InboxKindFlag::Authored,
-            source: "gitlab_issues",
-            call: gitlab_api_call(
-                host,
-                format!(
-                    "issues?author_id={}&state=opened&order_by=updated_at&sort=desc&per_page={}",
-                    identity.id, config.query_limit
+            });
+        }
+        if config.allows_issue() {
+            queries.push(ProviderQuery {
+                reason: InboxKindFlag::Authored,
+                source: "gitlab_issues",
+                call: gitlab_api_call(
+                    host,
+                    format!(
+                        "issues?author_id={}&state=opened&order_by=updated_at&sort=desc&per_page={}",
+                        identity.id, config.query_limit
+                    ),
                 ),
-            ),
-        });
+            });
+        }
     }
     if config.wants(InboxKindFlag::Todo) {
         queries.push(ProviderQuery {
@@ -711,18 +888,55 @@ fn parse_gitlab_items(
     target: &ProviderTarget,
     query: &ProviderQuery,
     output: &BackendSuccess,
+    item_type: InboxItemTypeFlag,
 ) -> Result<Vec<InboxItem>, ForgeError> {
     let values = parse_array(output, "GitLab inbox JSON is invalid")?;
-    values
-        .iter()
-        .map(|raw| {
-            if query.source == "gitlab_todos" {
-                parse_gitlab_todo(target, query, raw)
-            } else {
-                parse_gitlab_work_item(target, query, raw)
+    if query.source == "gitlab_todos" {
+        let mut out = Vec::with_capacity(values.len());
+        for raw in &values {
+            let target_kind = classify_gitlab_todo(raw);
+            if !todo_target_matches(target_kind, item_type) {
+                continue;
             }
-        })
-        .collect()
+            out.push(parse_gitlab_todo(target, query, raw)?);
+        }
+        Ok(out)
+    } else {
+        values
+            .iter()
+            .map(|raw| parse_gitlab_work_item(target, query, raw))
+            .collect()
+    }
+}
+
+fn classify_gitlab_todo(raw: &serde_json::Value) -> TodoTarget {
+    if let Some(t) = optional_str(raw, "target_type") {
+        match t.as_str() {
+            "MergeRequest" => return TodoTarget::MergeRequest,
+            "Issue" => return TodoTarget::Issue,
+            _ => {}
+        }
+    }
+    let url = optional_str(raw, "target_url")
+        .or_else(|| raw.get("target").and_then(|t| optional_str(t, "web_url")));
+    if let Some(url) = url {
+        if url.contains("/merge_requests/") {
+            return TodoTarget::MergeRequest;
+        }
+        if url.contains("/-/issues/") || url.contains("/issues/") {
+            return TodoTarget::Issue;
+        }
+    }
+    TodoTarget::Unknown
+}
+
+fn todo_target_matches(target: TodoTarget, item_type: InboxItemTypeFlag) -> bool {
+    matches!(
+        (item_type, target),
+        (InboxItemTypeFlag::All, _)
+            | (InboxItemTypeFlag::Pr, TodoTarget::MergeRequest)
+            | (InboxItemTypeFlag::Issue, TodoTarget::Issue)
+    )
 }
 
 fn parse_gitlab_work_item(
@@ -1060,25 +1274,7 @@ fn emit_dry_run(
 }
 
 fn dry_run_plans(target: &ProviderTarget, config: &QueryConfig) -> Vec<Vec<String>> {
-    match target.provider {
-        Provider::GitHub => github_queries(config)
-            .into_iter()
-            .map(|query| query.call.plan_argv())
-            .collect(),
-        Provider::GitLab => {
-            let identity = GitlabIdentity {
-                id: "<user_id>".to_string(),
-                username: "<username>".to_string(),
-            };
-            let mut plans = vec![gitlab_identity_call(&target.host).plan_argv()];
-            plans.extend(
-                gitlab_queries(&target.host, &identity, config)
-                    .into_iter()
-                    .map(|query| query.call.plan_argv()),
-            );
-            plans
-        }
-    }
+    ProviderPlan::build(target, config).dry_run_argv()
 }
 
 fn render_list_text(payload: &InboxListPayload) {
@@ -1174,5 +1370,171 @@ mod tests {
         assert_eq!(items[0].reasons, vec!["review", "assigned"]);
         assert_eq!(items[0].source, "github_review_search");
         assert_eq!(items[0].updated_at, "2026-05-22T00:00:00Z");
+    }
+
+    /// Fake runner that records concurrent-call peak via atomic counters.
+    /// Each call sleeps briefly so genuinely-serial callers can be detected
+    /// (max_inflight stays at 1) and parallel callers can be confirmed
+    /// (max_inflight reaches the parallelism width). Returns `[]` for every
+    /// call so downstream parse paths succeed.
+    struct ConcurrencyProbeRunner {
+        inflight: std::sync::atomic::AtomicUsize,
+        max_inflight: std::sync::atomic::AtomicUsize,
+        call_count: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ConcurrencyProbeRunner {
+        fn new() -> Self {
+            Self {
+                inflight: std::sync::atomic::AtomicUsize::new(0),
+                max_inflight: std::sync::atomic::AtomicUsize::new(0),
+                call_count: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl BackendRunner for ConcurrencyProbeRunner {
+        fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+            use std::sync::atomic::Ordering;
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            let now = self.inflight.fetch_add(1, Ordering::SeqCst) + 1;
+            let mut prev = self.max_inflight.load(Ordering::SeqCst);
+            while now > prev
+                && let Err(found) = self.max_inflight.compare_exchange(
+                    prev,
+                    now,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                )
+            {
+                prev = found;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(40));
+            self.inflight.fetch_sub(1, Ordering::SeqCst);
+            // GitLab identity lookup must look like a user object; everything
+            // else returns an empty array so parse paths succeed.
+            let body = if call.argv.first().map(|s| s.to_string_lossy().into_owned())
+                == Some("api".into())
+                && call.argv.get(1).map(|s| s.to_string_lossy().into_owned()) == Some("user".into())
+            {
+                "{\"id\":42,\"username\":\"probe\"}".to_string()
+            } else {
+                "[]".to_string()
+            };
+            Ok(BackendSuccess {
+                stdout: body,
+                stderr: String::new(),
+            })
+        }
+    }
+
+    #[test]
+    fn inbox_parallel_query_families_observe_concurrent_inflight() {
+        // GitHub default mode has 5 independent search families; expect at
+        // least 2 to be inflight simultaneously when the parallel path is
+        // wired correctly. (Serial execution would peak at 1.)
+        let runner = ConcurrencyProbeRunner::new();
+        let target = ProviderTarget {
+            provider: Provider::GitHub,
+            host: "github.com".into(),
+        };
+        let config = QueryConfig::new(Vec::new(), InboxItemTypeFlag::All, 30);
+        let result = execute_github(&runner, &target, &config).expect("execute_github");
+        assert!(result.items.is_empty(), "stub returns empty payloads");
+
+        let calls = runner.call_count.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            calls >= 5,
+            "expected at least 5 search families, observed {calls}"
+        );
+        let peak = runner
+            .max_inflight
+            .load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            peak >= 2,
+            "expected concurrent inflight queries (>=2), observed peak {peak}"
+        );
+    }
+
+    #[test]
+    fn inbox_parallel_providers_observe_concurrent_inflight() {
+        let runner = ConcurrencyProbeRunner::new();
+        let targets = vec![
+            ProviderTarget {
+                provider: Provider::GitHub,
+                host: "github.com".into(),
+            },
+            ProviderTarget {
+                provider: Provider::GitLab,
+                host: "gitlab.example.com".into(),
+            },
+        ];
+        let config = QueryConfig::new(Vec::new(), InboxItemTypeFlag::All, 30);
+        let collection = collect_inbox(&runner, &targets, &config).expect("collect_inbox");
+        assert_eq!(collection.providers.len(), 2);
+        assert_eq!(collection.providers[0].provider, "github");
+        assert_eq!(collection.providers[1].provider, "gitlab");
+
+        let peak = runner
+            .max_inflight
+            .load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            peak >= 2,
+            "expected concurrent inflight across providers (>=2), observed {peak}"
+        );
+    }
+
+    #[test]
+    fn inbox_parallel_provider_failure_keeps_deterministic_order() {
+        // First provider succeeds (returns empty), second fails. Even with
+        // parallel execution, target order — and warning order — must stay
+        // stable.
+        struct FailingSecondProvider {
+            calls: std::sync::Mutex<Vec<String>>,
+        }
+        impl BackendRunner for FailingSecondProvider {
+            fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+                let argv = call.plan_argv().join(" ");
+                self.calls.lock().unwrap().push(argv.clone());
+                if argv.contains("glab") {
+                    Err(ForgeError::backend_error(
+                        schema_err(),
+                        "boom",
+                        Some("stderr".into()),
+                    ))
+                } else {
+                    Ok(BackendSuccess {
+                        stdout: "[]".into(),
+                        stderr: String::new(),
+                    })
+                }
+            }
+        }
+        let runner = FailingSecondProvider {
+            calls: std::sync::Mutex::new(Vec::new()),
+        };
+        let targets = vec![
+            ProviderTarget {
+                provider: Provider::GitHub,
+                host: "github.com".into(),
+            },
+            ProviderTarget {
+                provider: Provider::GitLab,
+                host: "gitlab.example.com".into(),
+            },
+        ];
+        let config = QueryConfig::new(Vec::new(), InboxItemTypeFlag::All, 30);
+        let collection = collect_inbox(&runner, &targets, &config).expect("collect_inbox");
+        assert_eq!(collection.providers.len(), 2);
+        assert_eq!(collection.providers[0].provider, "github");
+        assert!(collection.providers[0].ok);
+        assert_eq!(collection.providers[1].provider, "gitlab");
+        assert!(!collection.providers[1].ok);
+        assert_eq!(collection.warnings.len(), 1);
+        assert!(
+            collection.warnings[0].starts_with("provider_failed: gitlab"),
+            "warning order must follow target order: {:?}",
+            collection.warnings
+        );
     }
 }

--- a/crates/forge-cli/tests/integration/inbox.rs
+++ b/crates/forge-cli/tests/integration/inbox.rs
@@ -292,3 +292,451 @@ fn inbox_next_returns_ranked_review_items_first() {
     assert!(items.len() <= 5);
     assert_eq!(items[0]["kind"], "review");
 }
+
+/// Plans from `data.providers[0].plans` rendered as joined argv strings so
+/// tests can match on individual search families without hand-walking JSON
+/// arrays.
+fn dry_run_plan_joins(env: &serde_json::Value, provider_index: usize) -> Vec<String> {
+    env["data"]["providers"][provider_index]["plans"]
+        .as_array()
+        .expect("plans array")
+        .iter()
+        .map(|plan| {
+            plan.as_array()
+                .expect("plan argv array")
+                .iter()
+                .map(|s| s.as_str().unwrap_or_default().to_string())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .collect()
+}
+
+#[test]
+fn inbox_item_type_github_default_plans_pr_and_issue_families() {
+    let out = run_forge_cli(
+        &StubEnv::new(),
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "--dry-run",
+            "inbox",
+            "list",
+            "--limit",
+            "30",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let plans = dry_run_plan_joins(&env, 0);
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("search prs --review-requested"))
+    );
+    assert!(plans.iter().any(|p| p.contains("search prs --assignee")));
+    assert!(plans.iter().any(|p| p.contains("search issues --assignee")));
+    assert!(plans.iter().any(|p| p.contains("search prs --author")));
+    assert!(plans.iter().any(|p| p.contains("search issues --author")));
+}
+
+#[test]
+fn inbox_item_type_github_pr_only_skips_issue_searches() {
+    let out = run_forge_cli(
+        &StubEnv::new(),
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "--dry-run",
+            "inbox",
+            "list",
+            "--item-type",
+            "pr",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let plans = dry_run_plan_joins(&env, 0);
+    assert!(plans.iter().all(|p| !p.contains("search issues")));
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("search prs --review-requested"))
+    );
+    assert!(plans.iter().any(|p| p.contains("search prs --assignee")));
+    assert!(plans.iter().any(|p| p.contains("search prs --author")));
+}
+
+#[test]
+fn inbox_item_type_github_issue_only_skips_pr_searches() {
+    let out = run_forge_cli(
+        &StubEnv::new(),
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "--dry-run",
+            "inbox",
+            "list",
+            "--item-type",
+            "issue",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let plans = dry_run_plan_joins(&env, 0);
+    // Review-requested is PR-only; issue-only must drop it.
+    assert!(plans.iter().all(|p| !p.contains("search prs")));
+    assert!(plans.iter().any(|p| p.contains("search issues --assignee")));
+    assert!(plans.iter().any(|p| p.contains("search issues --author")));
+}
+
+#[test]
+fn inbox_item_type_gitlab_default_plans_identity_and_default_families() {
+    let out = run_forge_cli(
+        &StubEnv::new(),
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "--dry-run",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let plans = dry_run_plan_joins(&env, 0);
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("api user --hostname gitlab.example.com"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("merge_requests?scope=assigned_to_me"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("issues?scope=assigned_to_me"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("merge_requests?reviewer_username=<username>"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("merge_requests?author_id=<user_id>"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("issues?author_id=<user_id>"))
+    );
+    assert!(plans.iter().any(|p| p.contains("todos?state=pending")));
+}
+
+#[test]
+fn inbox_item_type_gitlab_pr_only_skips_issue_calls() {
+    let out = run_forge_cli(
+        &StubEnv::new(),
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "--dry-run",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+            "--item-type",
+            "pr",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let plans = dry_run_plan_joins(&env, 0);
+    // PR-only: identity still needed (review + authored MR), no issue queries,
+    // todos still scheduled because target classification happens post-fetch.
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("api user --hostname gitlab.example.com"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("merge_requests?scope=assigned_to_me"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("merge_requests?reviewer_username=<username>"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("merge_requests?author_id=<user_id>"))
+    );
+    assert!(plans.iter().any(|p| p.contains("todos?state=pending")));
+    assert!(
+        plans.iter().all(|p| !p.contains("/issues?")),
+        "PR-only must skip issue API calls: {plans:?}"
+    );
+}
+
+#[test]
+fn inbox_item_type_gitlab_issue_only_skips_mr_calls() {
+    let out = run_forge_cli(
+        &StubEnv::new(),
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "--dry-run",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+            "--item-type",
+            "issue",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let plans = dry_run_plan_joins(&env, 0);
+    // Issue-only: review (MR-only) is dropped. Identity still needed for
+    // authored issues. No MR queries.
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("api user --hostname gitlab.example.com"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("issues?scope=assigned_to_me"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("issues?author_id=<user_id>"))
+    );
+    assert!(plans.iter().any(|p| p.contains("todos?state=pending")));
+    assert!(
+        plans.iter().all(|p| !p.contains("merge_requests")),
+        "issue-only must skip MR API calls: {plans:?}"
+    );
+}
+
+#[test]
+fn inbox_item_type_gitlab_skips_identity_when_no_query_needs_it() {
+    let out = run_forge_cli(
+        &StubEnv::new(),
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "--dry-run",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+            "--kind",
+            "assigned",
+            "--kind",
+            "todo",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let plans = dry_run_plan_joins(&env, 0);
+    assert!(
+        plans.iter().all(|p| !p.contains("api user --hostname")),
+        "assigned+todo must skip identity lookup: {plans:?}"
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("merge_requests?scope=assigned_to_me"))
+    );
+    assert!(
+        plans
+            .iter()
+            .any(|p| p.contains("issues?scope=assigned_to_me"))
+    );
+    assert!(plans.iter().any(|p| p.contains("todos?state=pending")));
+}
+
+/// GitLab todo stub returning two todos: one targets an issue, the other
+/// targets a merge request. The item-type filter should keep only the
+/// matching target type post-fetch.
+const GLAB_TODOS_MIXED_STUB: &str = r#"#!/bin/sh
+set -e
+case "$*" in
+  *"api user --hostname"*)
+    cat <<'EOF'
+{"id":1435,"username":"terrylin"}
+EOF
+    ;;
+  *"todos"*"state=pending"*)
+    cat <<'EOF'
+[{"id":55,"target_type":"Issue","target_url":"https://gitlab.example.com/team/api/-/issues/32","target":{"iid":32,"title":"Todo issue","web_url":"https://gitlab.example.com/team/api/-/issues/32","updated_at":"2026-05-22T06:30:00Z","author":{"username":"frank"}},"project":{"path_with_namespace":"team/api"}},
+ {"id":56,"target_type":"MergeRequest","target_url":"https://gitlab.example.com/team/api/-/merge_requests/77","target":{"iid":77,"title":"Todo MR","web_url":"https://gitlab.example.com/team/api/-/merge_requests/77","updated_at":"2026-05-22T06:45:00Z","author":{"username":"frank"}},"project":{"path_with_namespace":"team/api"}}]
+EOF
+    ;;
+  *)
+    echo '[]'
+    ;;
+esac
+"#;
+
+#[test]
+fn inbox_item_type_gitlab_todo_pr_only_keeps_mr_targets() {
+    let stub = StubEnv::new().glab_stub(GLAB_TODOS_MIXED_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+            "--kind",
+            "todo",
+            "--item-type",
+            "pr",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let items = env["data"]["items"].as_array().expect("items");
+    assert_eq!(items.len(), 1, "expected only MR-target todo: {items:?}");
+    assert_eq!(items[0]["title"], "Todo MR");
+}
+
+#[test]
+fn inbox_item_type_gitlab_todo_issue_only_keeps_issue_targets() {
+    let stub = StubEnv::new().glab_stub(GLAB_TODOS_MIXED_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+            "--kind",
+            "todo",
+            "--item-type",
+            "issue",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let items = env["data"]["items"].as_array().expect("items");
+    assert_eq!(items.len(), 1, "expected only issue-target todo: {items:?}");
+    assert_eq!(items[0]["title"], "Todo issue");
+}
+
+#[test]
+fn inbox_item_type_gitlab_todo_all_keeps_unclassified_targets() {
+    // Stub returns a todo with neither target_type nor a classifiable URL.
+    let stub = StubEnv::new().glab_stub(
+        r#"#!/bin/sh
+set -e
+case "$*" in
+  *"todos"*"state=pending"*)
+    cat <<'EOF'
+[{"id":99,"target_url":"https://gitlab.example.com/team/snippets/-/snippets/5","target":{"iid":5,"title":"Mystery todo","web_url":"https://gitlab.example.com/team/snippets/-/snippets/5","updated_at":"2026-05-22T07:00:00Z","author":{"username":"frank"}},"project":{"path_with_namespace":"team/snippets"}}]
+EOF
+    ;;
+  *)
+    echo '[]'
+    ;;
+esac
+"#,
+    );
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+            "--kind",
+            "todo",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let items = env["data"]["items"].as_array().expect("items");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["title"], "Mystery todo");
+
+    // PR-only drops it.
+    let stub = StubEnv::new().glab_stub(
+        r#"#!/bin/sh
+set -e
+case "$*" in
+  *"todos"*"state=pending"*)
+    cat <<'EOF'
+[{"id":99,"target_url":"https://gitlab.example.com/team/snippets/-/snippets/5","target":{"iid":5,"title":"Mystery todo","web_url":"https://gitlab.example.com/team/snippets/-/snippets/5","updated_at":"2026-05-22T07:00:00Z","author":{"username":"frank"}},"project":{"path_with_namespace":"team/snippets"}}]
+EOF
+    ;;
+  *)
+    echo '[]'
+    ;;
+esac
+"#,
+    );
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "inbox",
+            "list",
+            "--gitlab-host",
+            "gitlab.example.com",
+            "--kind",
+            "todo",
+            "--item-type",
+            "pr",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let items = env["data"]["items"].as_array().expect("items");
+    assert!(
+        items.is_empty(),
+        "unclassifiable todo must be filtered in PR-only mode"
+    );
+}


### PR DESCRIPTION
# forge-cli inbox: item-type pruning and parallel collection

## Summary

Reduces `forge-cli inbox` latency without changing the personal-inbox semantics by (a) skipping irrelevant provider query families before any backend call via a new `--item-type all|pr|issue` selector and (b) running independent provider adapters and query families concurrently through `std::thread::scope` while keeping the normalized output contract deterministic. Implements the three sprints of issue #443's plan.

## Changes

- Add `InboxItemTypeFlag` and `--item-type all|pr|issue` to `inbox list/status/next` (default `all`); distinct from `--kind` reason filter
- Prune GitHub query families by item-type: PR-only skips `search issues`, issue-only skips `search prs` (review-requested drops out)
- Prune GitLab MR / issue / todo query families by item-type and skip `glab api user` identity lookup when no remaining query needs it
- Classify GitLab `todos` by `target_type` / target URL; PR-only and issue-only modes keep matching targets, unclassifiable todos remain in `all` mode only
- Split provider planning from execution via `ProviderPlan::build` / `dry_run_argv` / `execute` so dry-run and live paths share one builder
- Parallel provider fan-out and parallel within-provider query-family fan-out via `std::thread::scope`; aggregation walks plan order so output, warnings, dedupe, and partial/all-failure exit behavior stay deterministic regardless of completion order
- Document reason vs item-type and add manual live-smoke timing guidance in `crates/forge-cli/README.md` and the v1 spec (live timing is not a CI assertion)
- Regenerate bash and zsh forge-cli completions for the new flag

## Test-First Evidence

- Change classification: feature
- Failing test before fix: `cargo test -p nils-forge-cli --test integration inbox_item_type_github_pr_only_skips_issue_searches` (and 8 sibling cases) — would fail without item-type pruning because PR-only mode still planned issue searches; failing pre-implementation evidence captured by writing the tests against the pruned plan first
- Concurrency proof: `cargo test -p nils-forge-cli --lib inbox_parallel_query_families_observe_concurrent_inflight` and `inbox_parallel_providers_observe_concurrent_inflight` — both assert peak inflight ≥ 2 via an atomic-probe `BackendRunner`; serial execution would peak at 1 and fail
- Final validation: `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` → `ok: docs-only nils-cli checks passed` + `ok: local-fast workspace Rust gate passed`

## Testing

- `cargo test -p nils-forge-cli` (113 integration + 9 lib inbox tests pass; total 3513 workspace tests pass)
- `cargo clippy -p nils-forge-cli --all-targets --all-features -- -D warnings` (clean)
- `cargo fmt --all -- --check` (clean)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (all three lanes pass)
- `zsh -n completions/zsh/_forge-cli && bash -n completions/bash/forge-cli` (syntax OK)
- Live wall-clock smoke timings: not run (requires authenticated `gh`/`glab` against real remotes — guidance documented in README/spec for delivery-time capture)

## Risk / Notes

- Tracks issue #443; see issue body and snapshot comments for the source / plan bundles
- `BackendRunner` gains a `+ Sync` bound at inbox use sites only; existing `ProcessRunner` and dry-run runner are already `Sync`. No other ops call `inbox::run_with`
- Output schema versions `cli.forge-cli.inbox.{list,status,next}.v1` are unchanged; default-mode dry-run still emits the same 5 GitHub families and identity + 6 GitLab families
- Partial-provider-failure and all-provider-failure semantics unchanged; covered by existing tests plus a new deterministic-warning-order test
