### PR TITLE
feat(plan-issue): add issue-backed record lifecycle

### DIFF
--- a/completions/bash/plan-issue
+++ b/completions/bash/plan-issue
@@ -46,6 +46,12 @@ _plan-issue() {
             plan__issue,ready-sprint)
                 cmd="plan__issue__ready__sprint"
                 ;;
+            plan__issue,record)
+                cmd="plan__issue__record"
+                ;;
+            plan__issue,resolve-approval)
+                cmd="plan__issue__resolve__approval"
+                ;;
             plan__issue,start-plan)
                 cmd="plan__issue__start__plan"
                 ;;
@@ -55,6 +61,21 @@ _plan-issue() {
             plan__issue,status-plan)
                 cmd="plan__issue__status__plan"
                 ;;
+            plan__issue__record,audit)
+                cmd="plan__issue__record__audit"
+                ;;
+            plan__issue__record,build-dispatch-ledger)
+                cmd="plan__issue__record__build__dispatch__ledger"
+                ;;
+            plan__issue__record,closeout-gate)
+                cmd="plan__issue__record__closeout__gate"
+                ;;
+            plan__issue__record,render-comment)
+                cmd="plan__issue__record__render__comment"
+                ;;
+            plan__issue__record,render-dashboard)
+                cmd="plan__issue__record__render__dashboard"
+                ;;
             *)
                 ;;
         esac
@@ -62,7 +83,7 @@ _plan-issue() {
 
     case "${cmd}" in
         plan__issue)
-            opts="-f -h -V --repo --dry-run --force --json --format --help --version build-task-spec build-plan-task-spec start-plan status-plan link-pr ready-plan close-plan cleanup-worktrees start-sprint ready-sprint accept-sprint multi-sprint-guide completion"
+            opts="-f -h -V --repo --dry-run --force --json --format --state-dir --help --version build-task-spec build-plan-task-spec start-plan status-plan link-pr ready-plan close-plan cleanup-worktrees start-sprint ready-sprint accept-sprint multi-sprint-guide resolve-approval record completion"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -76,6 +97,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -84,7 +109,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__accept__sprint)
-            opts="-f -h --plan --issue --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --approved-comment-url --summary --summary-file --comment --no-comment --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --issue --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --approved-comment-url --summary --summary-file --comment --no-comment --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -154,6 +179,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -162,7 +191,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__build__plan__task__spec)
-            opts="-f -h --plan --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -212,6 +241,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -220,7 +253,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__build__task__spec)
-            opts="-f -h --plan --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -274,6 +307,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -282,7 +319,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__cleanup__worktrees)
-            opts="-f -h --issue --repo --dry-run --force --json --format --help"
+            opts="-f -h --issue --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -300,6 +337,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -308,7 +349,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__close__plan)
-            opts="-f -h --issue --body-file --approved-comment-url --reason --comment --comment-file --allow-not-done --repo --dry-run --force --json --format --help"
+            opts="-f -h --issue --body-file --approved-comment-url --reason --comment --comment-file --allow-not-done --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -346,6 +387,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -354,7 +399,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__completion)
-            opts="-f -h --repo --dry-run --force --json --format --help bash zsh"
+            opts="-f -h --repo --dry-run --force --json --format --state-dir --help bash zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -368,6 +413,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -376,7 +425,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__link__pr)
-            opts="-f -h --issue --body-file --task --sprint --pr-group --pr --status --repo --dry-run --force --json --format --help"
+            opts="-f -h --issue --body-file --task --sprint --pr-group --pr --status --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -418,6 +467,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -426,7 +479,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__multi__sprint__guide)
-            opts="-f -h --plan --from-sprint --to-sprint --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --from-sprint --to-sprint --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -452,6 +505,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -460,7 +517,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__ready__plan)
-            opts="-f -h --issue --body-file --summary --summary-file --label-update --label --remove-label --comment --no-comment --repo --dry-run --force --json --format --help"
+            opts="-f -h --issue --body-file --summary --summary-file --label-update --label --remove-label --comment --no-comment --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -498,6 +555,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -506,7 +567,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__ready__sprint)
-            opts="-f -h --plan --issue --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --summary --summary-file --comment --no-comment --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --issue --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --summary --summary-file --comment --no-comment --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -572,6 +633,376 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__record)
+            opts="-f -h --repo --dry-run --force --json --format --state-dir --help render-dashboard render-comment audit closeout-gate build-dispatch-ledger"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__record__audit)
+            opts="-f -h --body-file --comments-json --profile --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --comments-json)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__record__build__dispatch__ledger)
+            opts="-f -h --plan --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --out --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --plan)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --owner-prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --branch-prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --worktree-prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --strategy)
+                    COMPREPLY=($(compgen -W "deterministic auto" -- "${cur}"))
+                    return 0
+                    ;;
+                --pr-grouping)
+                    COMPREPLY=($(compgen -W "per-sprint group" -- "${cur}"))
+                    return 0
+                    ;;
+                --default-pr-grouping)
+                    COMPREPLY=($(compgen -W "per-sprint group" -- "${cur}"))
+                    return 0
+                    ;;
+                --pr-group)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --out)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__record__closeout__gate)
+            opts="-f -h --body-file --comments-json --profile --require-complete --require-session --require-validation --require-review --require-closeout --approval --linked-pr --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --comments-json)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --approval)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --linked-pr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__record__render__comment)
+            opts="-f -h --profile --marker-family --kind --path --commit --content-file --title --details-summary --out --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --marker-family)
+                    COMPREPLY=($(compgen -W "shared compat" -- "${cur}"))
+                    return 0
+                    ;;
+                --kind)
+                    COMPREPLY=($(compgen -W "source plan state session validation review closeout" -- "${cur}"))
+                    return 0
+                    ;;
+                --path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --commit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --content-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --title)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --details-summary)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --out)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__record__render__dashboard)
+            opts="-f -h --profile --status --target-scope --current --next-action --validation --linked-pr --blocker --approval --source-url --plan-url --state-url --session-url --validation-url --review-url --closeout-url --title --issue-url --out --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --status)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --target-scope)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --current)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --next-action)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --validation)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --linked-pr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --blocker)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --approval)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --source-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --plan-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --state-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --session-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --validation-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --review-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --closeout-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --title)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --issue-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --out)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__resolve__approval)
+            opts="-f -h --pr --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --pr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -580,7 +1011,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__start__plan)
-            opts="-f -h --plan --title --task-spec-out --issue-body-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --label --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --title --task-spec-out --issue-body-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --label --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -642,6 +1073,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -650,7 +1085,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__start__sprint)
-            opts="-f -h --plan --issue --sprint --task-spec-out --subagent-prompts-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --comment --no-comment --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --issue --sprint --task-spec-out --subagent-prompts-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --comment --no-comment --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -712,6 +1147,10 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -720,7 +1159,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__status__plan)
-            opts="-f -h --issue --body-file --comment --no-comment --repo --dry-run --force --json --format --help"
+            opts="-f -h --issue --body-file --comment --no-comment --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -740,6 +1179,10 @@ _plan-issue() {
                     ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 *)

--- a/completions/bash/plan-issue-local
+++ b/completions/bash/plan-issue-local
@@ -46,6 +46,12 @@ _plan-issue-local() {
             plan__issue__local,ready-sprint)
                 cmd="plan__issue__local__ready__sprint"
                 ;;
+            plan__issue__local,record)
+                cmd="plan__issue__local__record"
+                ;;
+            plan__issue__local,resolve-approval)
+                cmd="plan__issue__local__resolve__approval"
+                ;;
             plan__issue__local,start-plan)
                 cmd="plan__issue__local__start__plan"
                 ;;
@@ -55,6 +61,21 @@ _plan-issue-local() {
             plan__issue__local,status-plan)
                 cmd="plan__issue__local__status__plan"
                 ;;
+            plan__issue__local__record,audit)
+                cmd="plan__issue__local__record__audit"
+                ;;
+            plan__issue__local__record,build-dispatch-ledger)
+                cmd="plan__issue__local__record__build__dispatch__ledger"
+                ;;
+            plan__issue__local__record,closeout-gate)
+                cmd="plan__issue__local__record__closeout__gate"
+                ;;
+            plan__issue__local__record,render-comment)
+                cmd="plan__issue__local__record__render__comment"
+                ;;
+            plan__issue__local__record,render-dashboard)
+                cmd="plan__issue__local__record__render__dashboard"
+                ;;
             *)
                 ;;
         esac
@@ -62,7 +83,7 @@ _plan-issue-local() {
 
     case "${cmd}" in
         plan__issue__local)
-            opts="-f -h -V --repo --dry-run --force --json --format --help --version build-task-spec build-plan-task-spec start-plan status-plan link-pr ready-plan close-plan cleanup-worktrees start-sprint ready-sprint accept-sprint multi-sprint-guide completion"
+            opts="-f -h -V --repo --dry-run --force --json --format --state-dir --help --version build-task-spec build-plan-task-spec start-plan status-plan link-pr ready-plan close-plan cleanup-worktrees start-sprint ready-sprint accept-sprint multi-sprint-guide resolve-approval record completion"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -76,6 +97,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -84,7 +109,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__accept__sprint)
-            opts="-f -h --plan --issue --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --approved-comment-url --summary --summary-file --comment --no-comment --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --issue --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --approved-comment-url --summary --summary-file --comment --no-comment --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -154,6 +179,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -162,7 +191,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__build__plan__task__spec)
-            opts="-f -h --plan --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -212,6 +241,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -220,7 +253,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__build__task__spec)
-            opts="-f -h --plan --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -274,6 +307,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -282,7 +319,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__cleanup__worktrees)
-            opts="-f -h --issue --repo --dry-run --force --json --format --help"
+            opts="-f -h --issue --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -300,6 +337,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -308,7 +349,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__close__plan)
-            opts="-f -h --issue --body-file --approved-comment-url --reason --comment --comment-file --allow-not-done --repo --dry-run --force --json --format --help"
+            opts="-f -h --issue --body-file --approved-comment-url --reason --comment --comment-file --allow-not-done --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -346,6 +387,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -354,7 +399,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__completion)
-            opts="-f -h --repo --dry-run --force --json --format --help bash zsh"
+            opts="-f -h --repo --dry-run --force --json --format --state-dir --help bash zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -368,6 +413,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -376,7 +425,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__link__pr)
-            opts="-f -h --issue --body-file --task --sprint --pr-group --pr --status --repo --dry-run --force --json --format --help"
+            opts="-f -h --issue --body-file --task --sprint --pr-group --pr --status --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -418,6 +467,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -426,7 +479,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__multi__sprint__guide)
-            opts="-f -h --plan --from-sprint --to-sprint --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --from-sprint --to-sprint --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -452,6 +505,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -460,7 +517,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__ready__plan)
-            opts="-f -h --issue --body-file --summary --summary-file --label-update --label --remove-label --comment --no-comment --repo --dry-run --force --json --format --help"
+            opts="-f -h --issue --body-file --summary --summary-file --label-update --label --remove-label --comment --no-comment --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -498,6 +555,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -506,7 +567,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__ready__sprint)
-            opts="-f -h --plan --issue --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --summary --summary-file --comment --no-comment --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --issue --sprint --task-spec-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --summary --summary-file --comment --no-comment --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -572,6 +633,376 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__local__record)
+            opts="-f -h --repo --dry-run --force --json --format --state-dir --help render-dashboard render-comment audit closeout-gate build-dispatch-ledger"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__local__record__audit)
+            opts="-f -h --body-file --comments-json --profile --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --comments-json)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__local__record__build__dispatch__ledger)
+            opts="-f -h --plan --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --out --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --plan)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --owner-prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --branch-prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --worktree-prefix)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --strategy)
+                    COMPREPLY=($(compgen -W "deterministic auto" -- "${cur}"))
+                    return 0
+                    ;;
+                --pr-grouping)
+                    COMPREPLY=($(compgen -W "per-sprint group" -- "${cur}"))
+                    return 0
+                    ;;
+                --default-pr-grouping)
+                    COMPREPLY=($(compgen -W "per-sprint group" -- "${cur}"))
+                    return 0
+                    ;;
+                --pr-group)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --out)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__local__record__closeout__gate)
+            opts="-f -h --body-file --comments-json --profile --require-complete --require-session --require-validation --require-review --require-closeout --approval --linked-pr --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --comments-json)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --approval)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --linked-pr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__local__record__render__comment)
+            opts="-f -h --profile --marker-family --kind --path --commit --content-file --title --details-summary --out --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --marker-family)
+                    COMPREPLY=($(compgen -W "shared compat" -- "${cur}"))
+                    return 0
+                    ;;
+                --kind)
+                    COMPREPLY=($(compgen -W "source plan state session validation review closeout" -- "${cur}"))
+                    return 0
+                    ;;
+                --path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --commit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --content-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --title)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --details-summary)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --out)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__local__record__render__dashboard)
+            opts="-f -h --profile --status --target-scope --current --next-action --validation --linked-pr --blocker --approval --source-url --plan-url --state-url --session-url --validation-url --review-url --closeout-url --title --issue-url --out --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --status)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --target-scope)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --current)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --next-action)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --validation)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --linked-pr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --blocker)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --approval)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --source-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --plan-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --state-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --session-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --validation-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --review-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --closeout-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --title)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --issue-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --out)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__local__resolve__approval)
+            opts="-f -h --pr --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --pr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -580,7 +1011,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__start__plan)
-            opts="-f -h --plan --title --task-spec-out --issue-body-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --label --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --title --task-spec-out --issue-body-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --label --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -642,6 +1073,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -650,7 +1085,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__start__sprint)
-            opts="-f -h --plan --issue --sprint --task-spec-out --subagent-prompts-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --comment --no-comment --repo --dry-run --force --json --format --help"
+            opts="-f -h --plan --issue --sprint --task-spec-out --subagent-prompts-out --owner-prefix --branch-prefix --worktree-prefix --strategy --pr-grouping --default-pr-grouping --pr-group --comment --no-comment --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -712,6 +1147,10 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
                     ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -720,7 +1159,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__status__plan)
-            opts="-f -h --issue --body-file --comment --no-comment --repo --dry-run --force --json --format --help"
+            opts="-f -h --issue --body-file --comment --no-comment --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -740,6 +1179,10 @@ _plan-issue-local() {
                     ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 *)

--- a/completions/zsh/_plan-issue
+++ b/completions/zsh/_plan-issue
@@ -17,12 +17,13 @@ _plan-issue() {
     _arguments "${_arguments_options[@]}" : \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
-'-h[Print help]' \
-'--help[Print help]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \
 '--version[Print version]' \
 ":: :_plan-issue_commands" \
@@ -48,10 +49,11 @@ _arguments "${_arguments_options[@]}" : \
 '*--pr-group=[Explicit task->group mapping (\`<task>=<group>\`). Repeatable]:task=group:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -69,10 +71,11 @@ _arguments "${_arguments_options[@]}" : \
 '*--pr-group=[Explicit task->group mapping (\`<task>=<group>\`). Repeatable]:task=group:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -93,10 +96,11 @@ _arguments "${_arguments_options[@]}" : \
 '*--label=[Labels to add at issue creation time]:name:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -107,12 +111,13 @@ _arguments "${_arguments_options[@]}" : \
 '--body-file=[Offline issue body path]:path:_files' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '(--no-comment)--comment[Emit comment output]' \
 '(--comment)--no-comment[Disable comment output]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -128,10 +133,11 @@ _arguments "${_arguments_options[@]}" : \
 '--status=[Row status to apply after linking PR (default\: \`in-progress\`)]:STATUS:(planned in-progress blocked)' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -146,13 +152,14 @@ _arguments "${_arguments_options[@]}" : \
 '*--remove-label=[Labels to remove when \`--label-update\` is set]:name:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--label-update[Apply label updates in live mode]' \
 '(--no-comment)--comment[Emit comment output]' \
 '(--comment)--no-comment[Disable comment output]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -167,11 +174,12 @@ _arguments "${_arguments_options[@]}" : \
 '(--comment)--comment-file=[Path to close comment markdown/text]:path:_files' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--allow-not-done[Allow closing when some tasks are not done]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -181,10 +189,11 @@ _arguments "${_arguments_options[@]}" : \
 '--issue=[Plan issue number (live \`plan-issue\` only)]:number:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -205,12 +214,13 @@ _arguments "${_arguments_options[@]}" : \
 '*--pr-group=[Explicit task->group mapping (\`<task>=<group>\`). Repeatable]:task=group:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '(--no-comment)--comment[Emit comment output]' \
 '(--comment)--no-comment[Disable comment output]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -232,12 +242,13 @@ _arguments "${_arguments_options[@]}" : \
 '(--summary)--summary-file=[Path to markdown/text review summary]:path:_files' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '(--no-comment)--comment[Emit comment output]' \
 '(--comment)--no-comment[Disable comment output]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -260,12 +271,13 @@ _arguments "${_arguments_options[@]}" : \
 '(--summary)--summary-file=[Path to markdown/text review summary]:path:_files' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '(--no-comment)--comment[Emit comment output]' \
 '(--comment)--no-comment[Disable comment output]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -277,22 +289,179 @@ _arguments "${_arguments_options[@]}" : \
 '--to-sprint=[Last sprint to include]:number:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
+;;
+(resolve-approval)
+_arguments "${_arguments_options[@]}" : \
+'--pr=[PR number (live \`plan-issue\` path only)]:number:_default' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(record)
+_arguments "${_arguments_options[@]}" : \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_plan-issue__subcmd__record_commands" \
+"*::: :->record" \
+&& ret=0
+
+    case $state in
+    (record)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:plan-issue-record-command-$line[1]:"
+        case $line[1] in
+            (render-dashboard)
+_arguments "${_arguments_options[@]}" : \
+'--profile=[Lifecycle profile for the issue record]:PROFILE:(tracking dispatch)' \
+'--status=[Current lifecycle status shown in the dashboard]:text:_default' \
+'--target-scope=[Target scope shown in the dashboard]:text:_default' \
+'--current=[Current task, lane, or closeout phase]:text:_default' \
+'--next-action=[Next action shown in the dashboard]:text:_default' \
+'--validation=[Latest validation summary or URL]:text:_default' \
+'*--linked-pr=[Linked PR reference. Repeatable]:ref:_default' \
+'*--blocker=[Current blocker. Repeatable]:text:_default' \
+'--approval=[Review or close approval state]:text:_default' \
+'--source-url=[Source snapshot URL]:url:_default' \
+'--plan-url=[Plan snapshot URL]:url:_default' \
+'--state-url=[Latest execution state URL]:url:_default' \
+'--session-url=[Latest execution session URL]:url:_default' \
+'--validation-url=[Latest validation evidence URL]:url:_default' \
+'--review-url=[Latest review evidence URL]:url:_default' \
+'--closeout-url=[Closeout comment URL]:url:_default' \
+'--title=[Original plan title]:text:_default' \
+'--issue-url=[Provider issue URL]:url:_default' \
+'--out=[Write rendered Markdown to this path]:path:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(render-comment)
+_arguments "${_arguments_options[@]}" : \
+'--profile=[Lifecycle profile for the comment marker and visible metadata]:PROFILE:(tracking dispatch)' \
+'--marker-family=[Marker family to emit]:MARKER_FAMILY:((shared\:"Emit the shared issue-backed-plan marker family"
+compat\:"Emit compatibility markers used by the existing tracking lifecycle"))' \
+'--kind=[Lifecycle comment kind]:KIND:(source plan state session validation review closeout)' \
+'--path=[Source file path represented by this comment]:path:_files' \
+'--commit=[Commit hash for snapshot comments]:sha:_default' \
+'--content-file=[Markdown content to embed in the comment]:path:_files' \
+'--title=[Override the visible heading]:text:_default' \
+'--details-summary=[Override the collapsed details summary for source/plan snapshots]:text:_default' \
+'--out=[Write rendered Markdown to this path]:path:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(audit)
+_arguments "${_arguments_options[@]}" : \
+'--body-file=[Provider issue body Markdown]:path:_files' \
+'--comments-json=[JSON containing either \`comments\` from \`gh issue view --json comments\` or a raw array of comment objects]:path:_files' \
+'--profile=[Expected profile. When omitted, all recognized markers are reported]:PROFILE:(tracking dispatch)' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(closeout-gate)
+_arguments "${_arguments_options[@]}" : \
+'--body-file=[Provider issue body Markdown]:path:_files' \
+'--comments-json=[JSON containing either \`comments\` from \`gh issue view --json comments\` or a raw array of comment objects]:path:_files' \
+'--profile=[Expected profile]:PROFILE:(tracking dispatch)' \
+'--approval=[Explicit approval comment URL or approval evidence text]:text:_default' \
+'*--linked-pr=[Linked PR reference. Repeatable; checked for presence in the body or comments, not for provider merge state]:ref:_default' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--require-complete[Require an execution state whose visible status is complete]' \
+'--require-session[Require a session comment]' \
+'--require-validation[Require validation evidence]' \
+'--require-review[Require review evidence]' \
+'--require-closeout[Require a closeout comment]' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(build-dispatch-ledger)
+_arguments "${_arguments_options[@]}" : \
+'--plan=[Plan markdown path]:path:_files' \
+'--owner-prefix=[Task owner prefix]:text:_default' \
+'--branch-prefix=[Branch prefix]:text:_default' \
+'--worktree-prefix=[Worktree prefix]:text:_default' \
+'--strategy=[Split strategy for group assignment]:strategy:(deterministic auto)' \
+'--pr-grouping=[PR grouping mode (deterministic only)]:mode:(per-sprint group)' \
+'--default-pr-grouping=[Auto fallback when sprint metadata omits grouping intent]:mode:(per-sprint group)' \
+'*--pr-group=[Explicit task->group mapping (\`<task>=<group>\`). Repeatable]:task=group:_default' \
+'--out=[Write rendered Markdown to this path]:path:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+        esac
+    ;;
+esac
 ;;
 (completion)
 _arguments "${_arguments_options[@]}" : \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 ':shell -- Shell to generate completion script for:(bash zsh)' \
@@ -318,72 +487,115 @@ _plan-issue_commands() {
 'ready-sprint:Post sprint-ready comment for main-agent review before merge' \
 'accept-sprint:Enforce merged-PR gate, sync sprint status=done, then post accepted comment' \
 'multi-sprint-guide:Print the full repeated command flow for a plan (1 plan = 1 issue)' \
+'resolve-approval:Resolve the URL of the most recent \`Decision\: merge\` review-evidence comment on a PR, suitable for \`accept-sprint --approved-comment-url\`' \
+'record:Render and audit issue-backed plan record dashboards and comments' \
 'completion:Export shell completion script' \
     )
     _describe -t commands 'plan-issue commands' commands "$@"
 }
-(( $+functions[_plan-issue__accept-sprint_commands] )) ||
-_plan-issue__accept-sprint_commands() {
+(( $+functions[_plan-issue__subcmd__accept-sprint_commands] )) ||
+_plan-issue__subcmd__accept-sprint_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue accept-sprint commands' commands "$@"
 }
-(( $+functions[_plan-issue__build-plan-task-spec_commands] )) ||
-_plan-issue__build-plan-task-spec_commands() {
+(( $+functions[_plan-issue__subcmd__build-plan-task-spec_commands] )) ||
+_plan-issue__subcmd__build-plan-task-spec_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue build-plan-task-spec commands' commands "$@"
 }
-(( $+functions[_plan-issue__build-task-spec_commands] )) ||
-_plan-issue__build-task-spec_commands() {
+(( $+functions[_plan-issue__subcmd__build-task-spec_commands] )) ||
+_plan-issue__subcmd__build-task-spec_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue build-task-spec commands' commands "$@"
 }
-(( $+functions[_plan-issue__cleanup-worktrees_commands] )) ||
-_plan-issue__cleanup-worktrees_commands() {
+(( $+functions[_plan-issue__subcmd__cleanup-worktrees_commands] )) ||
+_plan-issue__subcmd__cleanup-worktrees_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue cleanup-worktrees commands' commands "$@"
 }
-(( $+functions[_plan-issue__close-plan_commands] )) ||
-_plan-issue__close-plan_commands() {
+(( $+functions[_plan-issue__subcmd__close-plan_commands] )) ||
+_plan-issue__subcmd__close-plan_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue close-plan commands' commands "$@"
 }
-(( $+functions[_plan-issue__completion_commands] )) ||
-_plan-issue__completion_commands() {
+(( $+functions[_plan-issue__subcmd__completion_commands] )) ||
+_plan-issue__subcmd__completion_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue completion commands' commands "$@"
 }
-(( $+functions[_plan-issue__link-pr_commands] )) ||
-_plan-issue__link-pr_commands() {
+(( $+functions[_plan-issue__subcmd__link-pr_commands] )) ||
+_plan-issue__subcmd__link-pr_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue link-pr commands' commands "$@"
 }
-(( $+functions[_plan-issue__multi-sprint-guide_commands] )) ||
-_plan-issue__multi-sprint-guide_commands() {
+(( $+functions[_plan-issue__subcmd__multi-sprint-guide_commands] )) ||
+_plan-issue__subcmd__multi-sprint-guide_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue multi-sprint-guide commands' commands "$@"
 }
-(( $+functions[_plan-issue__ready-plan_commands] )) ||
-_plan-issue__ready-plan_commands() {
+(( $+functions[_plan-issue__subcmd__ready-plan_commands] )) ||
+_plan-issue__subcmd__ready-plan_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue ready-plan commands' commands "$@"
 }
-(( $+functions[_plan-issue__ready-sprint_commands] )) ||
-_plan-issue__ready-sprint_commands() {
+(( $+functions[_plan-issue__subcmd__ready-sprint_commands] )) ||
+_plan-issue__subcmd__ready-sprint_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue ready-sprint commands' commands "$@"
 }
-(( $+functions[_plan-issue__start-plan_commands] )) ||
-_plan-issue__start-plan_commands() {
+(( $+functions[_plan-issue__subcmd__record_commands] )) ||
+_plan-issue__subcmd__record_commands() {
+    local commands; commands=(
+'render-dashboard:Render a mutable issue dashboard for an issue-backed plan record' \
+'render-comment:Render one append-only lifecycle comment' \
+'audit:Audit issue body and comments for lifecycle markers' \
+'closeout-gate:Evaluate closeout readiness from lifecycle audit evidence' \
+'build-dispatch-ledger:Build a dispatch ledger from plan metadata and split grouping rules' \
+    )
+    _describe -t commands 'plan-issue record commands' commands "$@"
+}
+(( $+functions[_plan-issue__subcmd__record__subcmd__audit_commands] )) ||
+_plan-issue__subcmd__record__subcmd__audit_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue record audit commands' commands "$@"
+}
+(( $+functions[_plan-issue__subcmd__record__subcmd__build-dispatch-ledger_commands] )) ||
+_plan-issue__subcmd__record__subcmd__build-dispatch-ledger_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue record build-dispatch-ledger commands' commands "$@"
+}
+(( $+functions[_plan-issue__subcmd__record__subcmd__closeout-gate_commands] )) ||
+_plan-issue__subcmd__record__subcmd__closeout-gate_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue record closeout-gate commands' commands "$@"
+}
+(( $+functions[_plan-issue__subcmd__record__subcmd__render-comment_commands] )) ||
+_plan-issue__subcmd__record__subcmd__render-comment_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue record render-comment commands' commands "$@"
+}
+(( $+functions[_plan-issue__subcmd__record__subcmd__render-dashboard_commands] )) ||
+_plan-issue__subcmd__record__subcmd__render-dashboard_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue record render-dashboard commands' commands "$@"
+}
+(( $+functions[_plan-issue__subcmd__resolve-approval_commands] )) ||
+_plan-issue__subcmd__resolve-approval_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue resolve-approval commands' commands "$@"
+}
+(( $+functions[_plan-issue__subcmd__start-plan_commands] )) ||
+_plan-issue__subcmd__start-plan_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue start-plan commands' commands "$@"
 }
-(( $+functions[_plan-issue__start-sprint_commands] )) ||
-_plan-issue__start-sprint_commands() {
+(( $+functions[_plan-issue__subcmd__start-sprint_commands] )) ||
+_plan-issue__subcmd__start-sprint_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue start-sprint commands' commands "$@"
 }
-(( $+functions[_plan-issue__status-plan_commands] )) ||
-_plan-issue__status-plan_commands() {
+(( $+functions[_plan-issue__subcmd__status-plan_commands] )) ||
+_plan-issue__subcmd__status-plan_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue status-plan commands' commands "$@"
 }

--- a/completions/zsh/_plan-issue-local
+++ b/completions/zsh/_plan-issue-local
@@ -17,12 +17,13 @@ _plan-issue-local() {
     _arguments "${_arguments_options[@]}" : \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
-'-h[Print help]' \
-'--help[Print help]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \
 '--version[Print version]' \
 ":: :_plan-issue-local_commands" \
@@ -48,10 +49,11 @@ _arguments "${_arguments_options[@]}" : \
 '*--pr-group=[Explicit task->group mapping (\`<task>=<group>\`). Repeatable]:task=group:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -69,10 +71,11 @@ _arguments "${_arguments_options[@]}" : \
 '*--pr-group=[Explicit task->group mapping (\`<task>=<group>\`). Repeatable]:task=group:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -93,10 +96,11 @@ _arguments "${_arguments_options[@]}" : \
 '*--label=[Labels to add at issue creation time]:name:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -107,12 +111,13 @@ _arguments "${_arguments_options[@]}" : \
 '--body-file=[Offline issue body path]:path:_files' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '(--no-comment)--comment[Emit comment output]' \
 '(--comment)--no-comment[Disable comment output]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -128,10 +133,11 @@ _arguments "${_arguments_options[@]}" : \
 '--status=[Row status to apply after linking PR (default\: \`in-progress\`)]:STATUS:(planned in-progress blocked)' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -146,13 +152,14 @@ _arguments "${_arguments_options[@]}" : \
 '*--remove-label=[Labels to remove when \`--label-update\` is set]:name:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--label-update[Apply label updates in live mode]' \
 '(--no-comment)--comment[Emit comment output]' \
 '(--comment)--no-comment[Disable comment output]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -167,11 +174,12 @@ _arguments "${_arguments_options[@]}" : \
 '(--comment)--comment-file=[Path to close comment markdown/text]:path:_files' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--allow-not-done[Allow closing when some tasks are not done]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -181,10 +189,11 @@ _arguments "${_arguments_options[@]}" : \
 '--issue=[Plan issue number (live \`plan-issue\` only)]:number:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -205,12 +214,13 @@ _arguments "${_arguments_options[@]}" : \
 '*--pr-group=[Explicit task->group mapping (\`<task>=<group>\`). Repeatable]:task=group:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '(--no-comment)--comment[Emit comment output]' \
 '(--comment)--no-comment[Disable comment output]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -232,12 +242,13 @@ _arguments "${_arguments_options[@]}" : \
 '(--summary)--summary-file=[Path to markdown/text review summary]:path:_files' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '(--no-comment)--comment[Emit comment output]' \
 '(--comment)--no-comment[Disable comment output]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -260,12 +271,13 @@ _arguments "${_arguments_options[@]}" : \
 '(--summary)--summary-file=[Path to markdown/text review summary]:path:_files' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '(--no-comment)--comment[Emit comment output]' \
 '(--comment)--no-comment[Disable comment output]' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
@@ -277,22 +289,179 @@ _arguments "${_arguments_options[@]}" : \
 '--to-sprint=[Last sprint to include]:number:_default' \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
+;;
+(resolve-approval)
+_arguments "${_arguments_options[@]}" : \
+'--pr=[PR number (live \`plan-issue\` path only)]:number:_default' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(record)
+_arguments "${_arguments_options[@]}" : \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_plan-issue-local__subcmd__record_commands" \
+"*::: :->record" \
+&& ret=0
+
+    case $state in
+    (record)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:plan-issue-local-record-command-$line[1]:"
+        case $line[1] in
+            (render-dashboard)
+_arguments "${_arguments_options[@]}" : \
+'--profile=[Lifecycle profile for the issue record]:PROFILE:(tracking dispatch)' \
+'--status=[Current lifecycle status shown in the dashboard]:text:_default' \
+'--target-scope=[Target scope shown in the dashboard]:text:_default' \
+'--current=[Current task, lane, or closeout phase]:text:_default' \
+'--next-action=[Next action shown in the dashboard]:text:_default' \
+'--validation=[Latest validation summary or URL]:text:_default' \
+'*--linked-pr=[Linked PR reference. Repeatable]:ref:_default' \
+'*--blocker=[Current blocker. Repeatable]:text:_default' \
+'--approval=[Review or close approval state]:text:_default' \
+'--source-url=[Source snapshot URL]:url:_default' \
+'--plan-url=[Plan snapshot URL]:url:_default' \
+'--state-url=[Latest execution state URL]:url:_default' \
+'--session-url=[Latest execution session URL]:url:_default' \
+'--validation-url=[Latest validation evidence URL]:url:_default' \
+'--review-url=[Latest review evidence URL]:url:_default' \
+'--closeout-url=[Closeout comment URL]:url:_default' \
+'--title=[Original plan title]:text:_default' \
+'--issue-url=[Provider issue URL]:url:_default' \
+'--out=[Write rendered Markdown to this path]:path:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(render-comment)
+_arguments "${_arguments_options[@]}" : \
+'--profile=[Lifecycle profile for the comment marker and visible metadata]:PROFILE:(tracking dispatch)' \
+'--marker-family=[Marker family to emit]:MARKER_FAMILY:((shared\:"Emit the shared issue-backed-plan marker family"
+compat\:"Emit compatibility markers used by the existing tracking lifecycle"))' \
+'--kind=[Lifecycle comment kind]:KIND:(source plan state session validation review closeout)' \
+'--path=[Source file path represented by this comment]:path:_files' \
+'--commit=[Commit hash for snapshot comments]:sha:_default' \
+'--content-file=[Markdown content to embed in the comment]:path:_files' \
+'--title=[Override the visible heading]:text:_default' \
+'--details-summary=[Override the collapsed details summary for source/plan snapshots]:text:_default' \
+'--out=[Write rendered Markdown to this path]:path:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(audit)
+_arguments "${_arguments_options[@]}" : \
+'--body-file=[Provider issue body Markdown]:path:_files' \
+'--comments-json=[JSON containing either \`comments\` from \`gh issue view --json comments\` or a raw array of comment objects]:path:_files' \
+'--profile=[Expected profile. When omitted, all recognized markers are reported]:PROFILE:(tracking dispatch)' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(closeout-gate)
+_arguments "${_arguments_options[@]}" : \
+'--body-file=[Provider issue body Markdown]:path:_files' \
+'--comments-json=[JSON containing either \`comments\` from \`gh issue view --json comments\` or a raw array of comment objects]:path:_files' \
+'--profile=[Expected profile]:PROFILE:(tracking dispatch)' \
+'--approval=[Explicit approval comment URL or approval evidence text]:text:_default' \
+'*--linked-pr=[Linked PR reference. Repeatable; checked for presence in the body or comments, not for provider merge state]:ref:_default' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--require-complete[Require an execution state whose visible status is complete]' \
+'--require-session[Require a session comment]' \
+'--require-validation[Require validation evidence]' \
+'--require-review[Require review evidence]' \
+'--require-closeout[Require a closeout comment]' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(build-dispatch-ledger)
+_arguments "${_arguments_options[@]}" : \
+'--plan=[Plan markdown path]:path:_files' \
+'--owner-prefix=[Task owner prefix]:text:_default' \
+'--branch-prefix=[Branch prefix]:text:_default' \
+'--worktree-prefix=[Worktree prefix]:text:_default' \
+'--strategy=[Split strategy for group assignment]:strategy:(deterministic auto)' \
+'--pr-grouping=[PR grouping mode (deterministic only)]:mode:(per-sprint group)' \
+'--default-pr-grouping=[Auto fallback when sprint metadata omits grouping intent]:mode:(per-sprint group)' \
+'*--pr-group=[Explicit task->group mapping (\`<task>=<group>\`). Repeatable]:task=group:_default' \
+'--out=[Write rendered Markdown to this path]:path:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+        esac
+    ;;
+esac
 ;;
 (completion)
 _arguments "${_arguments_options[@]}" : \
 '--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
 '--dry-run[Print write actions without mutating GitHub state]' \
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
-'--json[Output machine-readable JSON (alias for --format json)]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
 '-h[Print help]' \
 '--help[Print help]' \
 ':shell -- Shell to generate completion script for:(bash zsh)' \
@@ -318,72 +487,115 @@ _plan-issue-local_commands() {
 'ready-sprint:Post sprint-ready comment for main-agent review before merge' \
 'accept-sprint:Enforce merged-PR gate, sync sprint status=done, then post accepted comment' \
 'multi-sprint-guide:Print the full repeated command flow for a plan (1 plan = 1 issue)' \
+'resolve-approval:Resolve the URL of the most recent \`Decision\: merge\` review-evidence comment on a PR, suitable for \`accept-sprint --approved-comment-url\`' \
+'record:Render and audit issue-backed plan record dashboards and comments' \
 'completion:Export shell completion script' \
     )
     _describe -t commands 'plan-issue-local commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__accept-sprint_commands] )) ||
-_plan-issue-local__accept-sprint_commands() {
+(( $+functions[_plan-issue-local__subcmd__accept-sprint_commands] )) ||
+_plan-issue-local__subcmd__accept-sprint_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local accept-sprint commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__build-plan-task-spec_commands] )) ||
-_plan-issue-local__build-plan-task-spec_commands() {
+(( $+functions[_plan-issue-local__subcmd__build-plan-task-spec_commands] )) ||
+_plan-issue-local__subcmd__build-plan-task-spec_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local build-plan-task-spec commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__build-task-spec_commands] )) ||
-_plan-issue-local__build-task-spec_commands() {
+(( $+functions[_plan-issue-local__subcmd__build-task-spec_commands] )) ||
+_plan-issue-local__subcmd__build-task-spec_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local build-task-spec commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__cleanup-worktrees_commands] )) ||
-_plan-issue-local__cleanup-worktrees_commands() {
+(( $+functions[_plan-issue-local__subcmd__cleanup-worktrees_commands] )) ||
+_plan-issue-local__subcmd__cleanup-worktrees_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local cleanup-worktrees commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__close-plan_commands] )) ||
-_plan-issue-local__close-plan_commands() {
+(( $+functions[_plan-issue-local__subcmd__close-plan_commands] )) ||
+_plan-issue-local__subcmd__close-plan_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local close-plan commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__completion_commands] )) ||
-_plan-issue-local__completion_commands() {
+(( $+functions[_plan-issue-local__subcmd__completion_commands] )) ||
+_plan-issue-local__subcmd__completion_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local completion commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__link-pr_commands] )) ||
-_plan-issue-local__link-pr_commands() {
+(( $+functions[_plan-issue-local__subcmd__link-pr_commands] )) ||
+_plan-issue-local__subcmd__link-pr_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local link-pr commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__multi-sprint-guide_commands] )) ||
-_plan-issue-local__multi-sprint-guide_commands() {
+(( $+functions[_plan-issue-local__subcmd__multi-sprint-guide_commands] )) ||
+_plan-issue-local__subcmd__multi-sprint-guide_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local multi-sprint-guide commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__ready-plan_commands] )) ||
-_plan-issue-local__ready-plan_commands() {
+(( $+functions[_plan-issue-local__subcmd__ready-plan_commands] )) ||
+_plan-issue-local__subcmd__ready-plan_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local ready-plan commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__ready-sprint_commands] )) ||
-_plan-issue-local__ready-sprint_commands() {
+(( $+functions[_plan-issue-local__subcmd__ready-sprint_commands] )) ||
+_plan-issue-local__subcmd__ready-sprint_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local ready-sprint commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__start-plan_commands] )) ||
-_plan-issue-local__start-plan_commands() {
+(( $+functions[_plan-issue-local__subcmd__record_commands] )) ||
+_plan-issue-local__subcmd__record_commands() {
+    local commands; commands=(
+'render-dashboard:Render a mutable issue dashboard for an issue-backed plan record' \
+'render-comment:Render one append-only lifecycle comment' \
+'audit:Audit issue body and comments for lifecycle markers' \
+'closeout-gate:Evaluate closeout readiness from lifecycle audit evidence' \
+'build-dispatch-ledger:Build a dispatch ledger from plan metadata and split grouping rules' \
+    )
+    _describe -t commands 'plan-issue-local record commands' commands "$@"
+}
+(( $+functions[_plan-issue-local__subcmd__record__subcmd__audit_commands] )) ||
+_plan-issue-local__subcmd__record__subcmd__audit_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue-local record audit commands' commands "$@"
+}
+(( $+functions[_plan-issue-local__subcmd__record__subcmd__build-dispatch-ledger_commands] )) ||
+_plan-issue-local__subcmd__record__subcmd__build-dispatch-ledger_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue-local record build-dispatch-ledger commands' commands "$@"
+}
+(( $+functions[_plan-issue-local__subcmd__record__subcmd__closeout-gate_commands] )) ||
+_plan-issue-local__subcmd__record__subcmd__closeout-gate_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue-local record closeout-gate commands' commands "$@"
+}
+(( $+functions[_plan-issue-local__subcmd__record__subcmd__render-comment_commands] )) ||
+_plan-issue-local__subcmd__record__subcmd__render-comment_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue-local record render-comment commands' commands "$@"
+}
+(( $+functions[_plan-issue-local__subcmd__record__subcmd__render-dashboard_commands] )) ||
+_plan-issue-local__subcmd__record__subcmd__render-dashboard_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue-local record render-dashboard commands' commands "$@"
+}
+(( $+functions[_plan-issue-local__subcmd__resolve-approval_commands] )) ||
+_plan-issue-local__subcmd__resolve-approval_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue-local resolve-approval commands' commands "$@"
+}
+(( $+functions[_plan-issue-local__subcmd__start-plan_commands] )) ||
+_plan-issue-local__subcmd__start-plan_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local start-plan commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__start-sprint_commands] )) ||
-_plan-issue-local__start-sprint_commands() {
+(( $+functions[_plan-issue-local__subcmd__start-sprint_commands] )) ||
+_plan-issue-local__subcmd__start-sprint_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local start-sprint commands' commands "$@"
 }
-(( $+functions[_plan-issue-local__status-plan_commands] )) ||
-_plan-issue-local__status-plan_commands() {
+(( $+functions[_plan-issue-local__subcmd__status-plan_commands] )) ||
+_plan-issue-local__subcmd__status-plan_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local status-plan commands' commands "$@"
 }

--- a/crates/plan-issue-cli/README.md
+++ b/crates/plan-issue-cli/README.md
@@ -4,9 +4,13 @@
 
 `plan-issue-cli` provides the Rust command contract for plan/issue delivery orchestration. It is the typed replacement lane for
 `plan-issue-delivery-loop.sh` behavior and is built around deterministic task-spec generation, issue-body rendering, and gate-enforced
-sprint transitions. `Task Decomposition` is the runtime-truth execution table; sprint task-spec/prompt artifacts are derived from those
-issue rows. `plan-tooling split-prs` provides grouping primitives only in the current model; `plan-issue-cli` materializes runtime
-`Owner/Branch/Worktree/Notes` metadata from plan content plus grouping results.
+sprint transitions. `Task Decomposition` is the runtime-truth execution table for the existing plan/sprint command family; sprint
+task-spec/prompt artifacts are derived from those issue rows. `plan-tooling split-prs` provides grouping primitives only in the current
+model; `plan-issue-cli` materializes runtime `Owner/Branch/Worktree/Notes` metadata from plan content plus grouping results.
+
+For issue-backed tracking and dispatch workflows whose provider issue body is a mutable dashboard, use `plan-issue record ...`. The record
+surface renders dashboards and append-only comments, audits lifecycle markers, evaluates closeout readiness, and builds dispatch ledgers
+without mutating provider issues.
 
 The crate ships two binaries with the same command surface:
 
@@ -42,6 +46,14 @@ Shell wrapper scripts are deprecated for this crate path. Use `plan-issue` / `pl
 ### Shell completion
 
 - `completion <bash|zsh>`: export completion script for each binary.
+
+### Issue-backed records
+
+- `record render-dashboard`: render the mutable dashboard body shared by tracking and dispatch profiles.
+- `record render-comment`: render source, plan, state, session, validation, review, or closeout comments with compat or shared markers.
+- `record audit`: inspect issue body Markdown plus provider comments JSON for recognized lifecycle markers.
+- `record closeout-gate`: evaluate closeout readiness from audit evidence.
+- `record build-dispatch-ledger`: render a dispatch ledger from plan metadata and split grouping rules.
 
 ## Global flags
 
@@ -109,6 +121,15 @@ plan-issue-local build-plan-task-spec \
   --plan docs/plans/example-plan.md \
   --strategy auto \
   --default-pr-grouping group
+
+# 6) Render a tracking dashboard without provider mutation
+plan-issue-local record render-dashboard \
+  --profile tracking \
+  --status in-progress \
+  --source-url "$SOURCE_COMMENT_URL" \
+  --plan-url "$PLAN_COMMENT_URL" \
+  --state-url "$STATE_COMMENT_URL" \
+  --out /tmp/tracking-dashboard.md
 ```
 
 ## Exit codes
@@ -144,6 +165,7 @@ for the upstream contract.
 ## Specifications
 
 - [CLI contract v2](docs/specs/plan-issue-cli-contract-v2.md)
+- [Issue-backed plan record contract v1](docs/specs/issue-backed-plan-record-contract-v1.md)
 - [State machine and gate invariants v1](docs/specs/plan-issue-state-machine-v1.md)
 - [Gate matrix v1](docs/specs/plan-issue-gate-matrix-v1.md)
 

--- a/crates/plan-issue-cli/docs/README.md
+++ b/crates/plan-issue-cli/docs/README.md
@@ -4,18 +4,29 @@
 
 Crate-local documentation for `nils-plan-issue-cli`.
 
-`Task Decomposition` is the crate's documented runtime-truth execution table for plan/sprint orchestration. Specs define `Owner` as a
-dispatch alias, document single-lane normalization to `per-sprint`, and treat task-spec/subagent prompts as derived artifacts (not a second
-issue-body dispatch table). `start-sprint` validates drift against plan-derived lanes and does not rewrite issue rows in runtime-truth mode.
+`Task Decomposition` is the crate's documented runtime-truth execution table for
+existing plan/sprint orchestration. Specs define `Owner` as a dispatch alias,
+document single-lane normalization to `per-sprint`, and treat
+task-spec/subagent prompts as derived artifacts (not a second issue-body
+dispatch table). `start-sprint` validates drift against plan-derived lanes and
+does not rewrite issue rows in runtime-truth mode.
+
+Issue-backed tracking and dispatch records that keep provider issue bodies as
+mutable dashboards use the newer `plan-issue record ...` surface. That surface
+renders/audits dashboards, append-only comments, dispatch ledgers, and closeout
+readiness locally; provider issue mutation remains outside this crate path.
 
 Current runtime ownership:
 
 - `plan-tooling split-prs` emits grouping primitives only.
 - `plan-issue-cli` materializes runtime `Owner/Branch/Worktree/Notes` metadata from plan content, grouping results, and prefixes.
+- `plan-issue record build-dispatch-ledger` consumes the same grouping
+  primitives without moving provider UI rendering into `plan-tooling`.
 - markdown table cell canonicalization is provided by `nils-common::markdown`.
 
 ## Specs
 
 - [plan-issue CLI contract v2](specs/plan-issue-cli-contract-v2.md)
+- [issue-backed plan record contract v1](specs/issue-backed-plan-record-contract-v1.md)
 - [plan-issue state machine and gates v1](specs/plan-issue-state-machine-v1.md)
 - [plan-issue gate matrix v1](specs/plan-issue-gate-matrix-v1.md)

--- a/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v1.md
+++ b/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v1.md
@@ -1,0 +1,83 @@
+# Issue-Backed Plan Record Contract v1
+
+## Scope
+
+`plan-issue record ...` is the deterministic rendering and audit surface for
+issue-backed plan records whose durable state lives in provider issue comments.
+It does not create, comment on, edit, or close provider issues. Provider CRUD
+remains owned by `forge-cli` or the active provider adapter.
+
+This contract is separate from the older `start-plan` / `status-plan` /
+`close-plan` Task Decomposition runtime. Those commands remain compatible for
+existing dispatch lanes, while `record` commands support lightweight tracking
+issues and dispatch issues that keep the provider issue body as a mutable
+dashboard.
+
+## Profiles
+
+- `tracking`: single-agent issue-backed plan execution.
+- `dispatch`: tracking plus subagent lanes, PR grouping, review state, and
+  dispatch closeout gates.
+
+Both profiles share the same visible dashboard and comment section names. The
+dispatch profile adds a dispatch ledger instead of making `## Task
+Decomposition` the top-level issue body truth.
+
+## Command Boundary
+
+- `plan-tooling`: plan parsing, validation, dependency batches, and PR split
+  modeling only.
+- `plan-issue record`: dashboard/comment rendering, lifecycle marker audit,
+  dispatch ledger rendering, and closeout readiness evaluation.
+- `forge-cli`: provider issue and PR create/comment/edit/close/read
+  operations.
+
+## Command Surface
+
+- `record render-dashboard`: renders the mutable issue body dashboard.
+- `record render-comment`: renders one append-only source, plan, state,
+  session, validation, review, or closeout comment.
+- `record audit`: reads issue body Markdown plus provider comments JSON and
+  reports recognized lifecycle markers.
+- `record closeout-gate`: evaluates closeout checks from audit evidence.
+- `record build-dispatch-ledger`: uses the same plan metadata and split
+  grouping rules as task-spec generation to render a dispatch ledger table.
+
+All commands are local and deterministic. They may write rendered Markdown to
+`--out`, but they never mutate a provider by themselves.
+
+## Marker Families
+
+`record render-comment` can emit two marker families:
+
+- `--marker-family compat`: compatibility markers used by existing tracking
+  and dispatch skills, including `plan-tracking-issue:*`,
+  `execute-from-tracking-issue:*`, `tracking-issue-closeout:*`, and
+  `deliver-dispatch-plan:*`.
+- `--marker-family shared`: profile-aware `issue-backed-plan:*` markers for a
+  future single-family migration.
+
+`record audit` recognizes both families and also accepts current lightweight
+v2 tracking markers such as `execute-plan-tracking-issue:*`.
+
+Marker detection only accepts a marker that is the first non-empty line in a
+comment. Markers quoted inside source or plan snapshots are ignored.
+
+## Dashboard Shape
+
+The dashboard body uses:
+
+- `## Current Dashboard` or `## Final Dashboard`
+- `## Durable Record`
+- `## Guardrails`
+- `## Original Tracker` when title or issue URL are available
+
+The body is a mutable dashboard only. Durable state comes from append-only
+comments.
+
+## Closeout Gate
+
+`record closeout-gate` reports structured checks and rendered Markdown. It can
+require source snapshot, plan snapshot, complete state, session, validation,
+review, closeout, explicit approval, and linked PR references. Provider merge
+state still belongs to the provider/PR tooling layer.

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod build;
 pub mod completion;
 pub mod plan;
+pub mod record;
 pub mod sprint;
 
 use clap::{Args, Subcommand, ValueEnum};
@@ -15,6 +16,7 @@ use self::plan::{
     CleanupWorktreesArgs, ClosePlanArgs, LinkPrArgs, ReadyPlanArgs, ResolveApprovalArgs,
     StartPlanArgs, StatusPlanArgs,
 };
+use self::record::RecordArgs;
 use self::sprint::{AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
@@ -178,6 +180,9 @@ pub enum Command {
     /// comment on a PR, suitable for `accept-sprint --approved-comment-url`.
     ResolveApproval(ResolveApprovalArgs),
 
+    /// Render and audit issue-backed plan record dashboards and comments.
+    Record(RecordArgs),
+
     /// Export shell completion script.
     Completion(CompletionArgs),
 }
@@ -198,6 +203,7 @@ impl Command {
             Self::AcceptSprint(_) => "accept-sprint",
             Self::MultiSprintGuide(_) => "multi-sprint-guide",
             Self::ResolveApproval(_) => "resolve-approval",
+            Self::Record(args) => args.command_id(),
             Self::Completion(_) => "completion",
         }
     }
@@ -218,6 +224,7 @@ impl Command {
             // (Task 1.3); dispatch records gain `worktree_abs_path`
             // (Task 1.4).
             Self::StartSprint(_) => "v2",
+            Self::Record(_) => "v1",
             _ => "v1",
         };
         format!(
@@ -241,6 +248,7 @@ impl Command {
             Self::AcceptSprint(args) => serde_json::to_value(args),
             Self::MultiSprintGuide(args) => serde_json::to_value(args),
             Self::ResolveApproval(args) => serde_json::to_value(args),
+            Self::Record(args) => serde_json::to_value(args),
             Self::Completion(args) => serde_json::to_value(args),
         };
 
@@ -263,11 +271,24 @@ impl Command {
             Self::ClosePlan(args) => validate_close_plan_args(args, dry_run),
             Self::LinkPr(args) => validate_link_pr_args(args),
             Self::MultiSprintGuide(args) => validate_multi_sprint_guide_args(args),
+            Self::Record(_) => Ok(()),
             Self::Completion(_)
             | Self::StatusPlan(_)
             | Self::ReadyPlan(_)
             | Self::ResolveApproval(_)
             | Self::CleanupWorktrees(_) => Ok(()),
+        }
+    }
+}
+
+impl RecordArgs {
+    pub fn command_id(&self) -> &'static str {
+        match &self.command {
+            record::RecordCommand::RenderDashboard(_) => "record.render-dashboard",
+            record::RecordCommand::RenderComment(_) => "record.render-comment",
+            record::RecordCommand::Audit(_) => "record.audit",
+            record::RecordCommand::CloseoutGate(_) => "record.closeout-gate",
+            record::RecordCommand::BuildDispatchLedger(_) => "record.build-dispatch-ledger",
         }
     }
 }

--- a/crates/plan-issue-cli/src/commands/record.rs
+++ b/crates/plan-issue-cli/src/commands/record.rs
@@ -1,0 +1,289 @@
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand, ValueEnum};
+use serde::Serialize;
+
+use super::{GroupingArgs, PrefixArgs};
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct RecordArgs {
+    #[command(subcommand)]
+    pub command: RecordCommand,
+}
+
+#[derive(Debug, Clone, Subcommand, Serialize)]
+pub enum RecordCommand {
+    /// Render a mutable issue dashboard for an issue-backed plan record.
+    RenderDashboard(Box<RenderDashboardArgs>),
+
+    /// Render one append-only lifecycle comment.
+    RenderComment(Box<RenderCommentArgs>),
+
+    /// Audit issue body and comments for lifecycle markers.
+    Audit(Box<RecordAuditArgs>),
+
+    /// Evaluate closeout readiness from lifecycle audit evidence.
+    CloseoutGate(Box<RecordCloseoutGateArgs>),
+
+    /// Build a dispatch ledger from plan metadata and split grouping rules.
+    BuildDispatchLedger(Box<BuildDispatchLedgerArgs>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
+pub enum RecordProfile {
+    Tracking,
+    Dispatch,
+}
+
+impl RecordProfile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Tracking => "tracking",
+            Self::Dispatch => "dispatch",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
+pub enum MarkerFamily {
+    /// Emit the shared issue-backed-plan marker family.
+    Shared,
+    /// Emit compatibility markers used by the existing tracking lifecycle.
+    Compat,
+}
+
+impl MarkerFamily {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Shared => "shared",
+            Self::Compat => "compat",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
+pub enum LifecycleCommentKind {
+    #[value(name = "source", alias = "source-snapshot")]
+    Source,
+    #[value(name = "plan", alias = "plan-snapshot")]
+    Plan,
+    State,
+    Session,
+    Validation,
+    Review,
+    Closeout,
+}
+
+impl LifecycleCommentKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Source => "source",
+            Self::Plan => "plan",
+            Self::State => "state",
+            Self::Session => "session",
+            Self::Validation => "validation",
+            Self::Review => "review",
+            Self::Closeout => "closeout",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct RenderDashboardArgs {
+    /// Lifecycle profile for the issue record.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Current lifecycle status shown in the dashboard.
+    #[arg(long, default_value = "in-progress", value_name = "text")]
+    pub status: String,
+
+    /// Target scope shown in the dashboard.
+    #[arg(
+        long = "target-scope",
+        default_value = "issue-backed plan execution",
+        value_name = "text"
+    )]
+    pub target_scope: String,
+
+    /// Current task, lane, or closeout phase.
+    #[arg(long = "current", default_value = "pending", value_name = "text")]
+    pub current: String,
+
+    /// Next action shown in the dashboard.
+    #[arg(long = "next-action", default_value = "pending", value_name = "text")]
+    pub next_action: String,
+
+    /// Latest validation summary or URL.
+    #[arg(long, default_value = "pending", value_name = "text")]
+    pub validation: String,
+
+    /// Linked PR reference. Repeatable.
+    #[arg(long = "linked-pr", value_name = "ref")]
+    pub linked_pr: Vec<String>,
+
+    /// Current blocker. Repeatable.
+    #[arg(long = "blocker", value_name = "text")]
+    pub blocker: Vec<String>,
+
+    /// Review or close approval state.
+    #[arg(long, default_value = "pending", value_name = "text")]
+    pub approval: String,
+
+    /// Source snapshot URL.
+    #[arg(long = "source-url", value_name = "url")]
+    pub source_url: Option<String>,
+
+    /// Plan snapshot URL.
+    #[arg(long = "plan-url", value_name = "url")]
+    pub plan_url: Option<String>,
+
+    /// Latest execution state URL.
+    #[arg(long = "state-url", value_name = "url")]
+    pub state_url: Option<String>,
+
+    /// Latest execution session URL.
+    #[arg(long = "session-url", value_name = "url")]
+    pub session_url: Option<String>,
+
+    /// Latest validation evidence URL.
+    #[arg(long = "validation-url", value_name = "url")]
+    pub validation_url: Option<String>,
+
+    /// Latest review evidence URL.
+    #[arg(long = "review-url", value_name = "url")]
+    pub review_url: Option<String>,
+
+    /// Closeout comment URL.
+    #[arg(long = "closeout-url", value_name = "url")]
+    pub closeout_url: Option<String>,
+
+    /// Original plan title.
+    #[arg(long, value_name = "text")]
+    pub title: Option<String>,
+
+    /// Provider issue URL.
+    #[arg(long = "issue-url", value_name = "url")]
+    pub issue_url: Option<String>,
+
+    /// Write rendered Markdown to this path.
+    #[arg(long, value_name = "path")]
+    pub out: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct RenderCommentArgs {
+    /// Lifecycle profile for the comment marker and visible metadata.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Marker family to emit.
+    #[arg(long = "marker-family", value_enum, default_value_t = MarkerFamily::Compat)]
+    pub marker_family: MarkerFamily,
+
+    /// Lifecycle comment kind.
+    #[arg(long, value_enum)]
+    pub kind: LifecycleCommentKind,
+
+    /// Source file path represented by this comment.
+    #[arg(long = "path", value_name = "path")]
+    pub path: Option<PathBuf>,
+
+    /// Commit hash for snapshot comments.
+    #[arg(long, value_name = "sha")]
+    pub commit: Option<String>,
+
+    /// Markdown content to embed in the comment.
+    #[arg(long = "content-file", value_name = "path")]
+    pub content_file: Option<PathBuf>,
+
+    /// Override the visible heading.
+    #[arg(long, value_name = "text")]
+    pub title: Option<String>,
+
+    /// Override the collapsed details summary for source/plan snapshots.
+    #[arg(long = "details-summary", value_name = "text")]
+    pub details_summary: Option<String>,
+
+    /// Write rendered Markdown to this path.
+    #[arg(long, value_name = "path")]
+    pub out: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct RecordAuditArgs {
+    /// Provider issue body Markdown.
+    #[arg(long = "body-file", value_name = "path")]
+    pub body_file: Option<PathBuf>,
+
+    /// JSON containing either `comments` from `gh issue view --json comments`
+    /// or a raw array of comment objects.
+    #[arg(long = "comments-json", value_name = "path")]
+    pub comments_json: PathBuf,
+
+    /// Expected profile. When omitted, all recognized markers are reported.
+    #[arg(long, value_enum)]
+    pub profile: Option<RecordProfile>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct RecordCloseoutGateArgs {
+    /// Provider issue body Markdown.
+    #[arg(long = "body-file", value_name = "path")]
+    pub body_file: Option<PathBuf>,
+
+    /// JSON containing either `comments` from `gh issue view --json comments`
+    /// or a raw array of comment objects.
+    #[arg(long = "comments-json", value_name = "path")]
+    pub comments_json: PathBuf,
+
+    /// Expected profile.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Require an execution state whose visible status is complete.
+    #[arg(long = "require-complete")]
+    pub require_complete: bool,
+
+    /// Require a session comment.
+    #[arg(long = "require-session")]
+    pub require_session: bool,
+
+    /// Require validation evidence.
+    #[arg(long = "require-validation")]
+    pub require_validation: bool,
+
+    /// Require review evidence.
+    #[arg(long = "require-review")]
+    pub require_review: bool,
+
+    /// Require a closeout comment.
+    #[arg(long = "require-closeout")]
+    pub require_closeout: bool,
+
+    /// Explicit approval comment URL or approval evidence text.
+    #[arg(long = "approval", value_name = "text")]
+    pub approval: Option<String>,
+
+    /// Linked PR reference. Repeatable; checked for presence in the body or
+    /// comments, not for provider merge state.
+    #[arg(long = "linked-pr", value_name = "ref")]
+    pub linked_pr: Vec<String>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct BuildDispatchLedgerArgs {
+    /// Plan markdown path.
+    #[arg(long, value_name = "path")]
+    pub plan: PathBuf,
+
+    #[command(flatten)]
+    pub prefixes: PrefixArgs,
+
+    #[command(flatten)]
+    pub grouping: GroupingArgs,
+
+    /// Write rendered Markdown to this path.
+    #[arg(long, value_name = "path")]
+    pub out: Option<PathBuf>,
+}

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -14,6 +14,10 @@ use crate::commands::plan::{
     CleanupWorktreesArgs, ClosePlanArgs, LinkPrArgs, LinkPrStatus, ReadyPlanArgs,
     ResolveApprovalArgs, StartPlanArgs, StatusPlanArgs,
 };
+use crate::commands::record::{
+    BuildDispatchLedgerArgs, RecordArgs, RecordAuditArgs, RecordCloseoutGateArgs, RecordCommand,
+    RenderCommentArgs, RenderDashboardArgs,
+};
 use crate::commands::sprint::{
     AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs,
 };
@@ -21,6 +25,9 @@ use crate::commands::{Command as CliCommand, SplitStrategy, SummaryArgs};
 use crate::dispatch_record::{self, DispatchRecord};
 use crate::github::{GhCliAdapter, GitHubAdapter};
 use crate::issue_body::{self, TaskRow};
+use crate::lifecycle_record::{
+    self, CloseoutGateInput, CommentInput, DashboardInput, render_closeout_checks,
+};
 use crate::render::{self, SprintCommentInput, SprintCommentMode};
 use crate::runtime_layout::{self, IssueRoot, SprintRoot};
 use crate::task_spec::{self, TaskSpecBuildOptions, TaskSpecRow, TaskSpecScope};
@@ -63,11 +70,152 @@ pub fn execute(binary: BinaryFlavor, cli: &Cli) -> Result<Value, CommandError> {
         CliCommand::ResolveApproval(args) => {
             run_resolve_approval_json(binary, cli.force, cli.repo.as_deref(), args)
         }
+        CliCommand::Record(args) => run_record(args),
         CliCommand::Completion(_) => Err(CommandError::usage(
             "completion-direct-output-only",
             "completion output is emitted directly; run `<binary> completion <bash|zsh>`",
         )),
     }
+}
+
+fn run_record(args: &RecordArgs) -> Result<Value, CommandError> {
+    match &args.command {
+        RecordCommand::RenderDashboard(args) => run_record_render_dashboard(args),
+        RecordCommand::RenderComment(args) => run_record_render_comment(args),
+        RecordCommand::Audit(args) => run_record_audit(args),
+        RecordCommand::CloseoutGate(args) => run_record_closeout_gate(args),
+        RecordCommand::BuildDispatchLedger(args) => run_record_build_dispatch_ledger(args),
+    }
+}
+
+fn run_record_render_dashboard(args: &RenderDashboardArgs) -> Result<Value, CommandError> {
+    let markdown = lifecycle_record::render_dashboard(DashboardInput {
+        profile: args.profile,
+        status: args.status.clone(),
+        target_scope: args.target_scope.clone(),
+        current: args.current.clone(),
+        next_action: args.next_action.clone(),
+        validation: args.validation.clone(),
+        linked_prs: args.linked_pr.clone(),
+        blockers: args.blocker.clone(),
+        approval: args.approval.clone(),
+        source_url: args.source_url.clone(),
+        plan_url: args.plan_url.clone(),
+        state_url: args.state_url.clone(),
+        session_url: args.session_url.clone(),
+        validation_url: args.validation_url.clone(),
+        review_url: args.review_url.clone(),
+        closeout_url: args.closeout_url.clone(),
+        title: args.title.clone(),
+        issue_url: args.issue_url.clone(),
+    });
+    let out_path = write_optional_record_output(args.out.as_ref(), &markdown)?;
+
+    Ok(json!({
+        "profile": args.profile.as_str(),
+        "operation": "render-dashboard",
+        "out_path": out_path,
+        "markdown": markdown,
+    }))
+}
+
+fn run_record_render_comment(args: &RenderCommentArgs) -> Result<Value, CommandError> {
+    let content = match &args.content_file {
+        Some(path) => Some(read_text_file(path, "comment-content-read-failed")?),
+        None => None,
+    };
+    let markdown = lifecycle_record::render_comment(CommentInput {
+        profile: args.profile,
+        marker_family: args.marker_family,
+        kind: args.kind,
+        path: args.path.as_ref().map(|path| path_text(path)),
+        commit: args.commit.clone(),
+        content,
+        title: args.title.clone(),
+        details_summary: args.details_summary.clone(),
+    })
+    .map_err(|err| CommandError::runtime("record-comment-render-failed", err))?;
+    let out_path = write_optional_record_output(args.out.as_ref(), &markdown)?;
+
+    Ok(json!({
+        "profile": args.profile.as_str(),
+        "marker_family": args.marker_family.as_str(),
+        "kind": args.kind.as_str(),
+        "operation": "render-comment",
+        "out_path": out_path,
+        "markdown": markdown,
+    }))
+}
+
+fn run_record_audit(args: &RecordAuditArgs) -> Result<Value, CommandError> {
+    let body = match &args.body_file {
+        Some(path) => Some(read_text_file(path, "record-body-read-failed")?),
+        None => None,
+    };
+    let comments_json = read_text_file(&args.comments_json, "record-comments-read-failed")?;
+    let audit = lifecycle_record::audit_record(body.as_deref(), &comments_json, args.profile)
+        .map_err(|err| CommandError::runtime("record-audit-failed", err))?;
+
+    Ok(json!({
+        "operation": "audit",
+        "audit": audit,
+    }))
+}
+
+fn run_record_closeout_gate(args: &RecordCloseoutGateArgs) -> Result<Value, CommandError> {
+    let body = match &args.body_file {
+        Some(path) => Some(read_text_file(path, "record-body-read-failed")?),
+        None => None,
+    };
+    let comments_json = read_text_file(&args.comments_json, "record-comments-read-failed")?;
+    let audit = lifecycle_record::audit_record(body.as_deref(), &comments_json, Some(args.profile))
+        .map_err(|err| CommandError::runtime("record-audit-failed", err))?;
+    let gate = lifecycle_record::evaluate_closeout_gate(
+        &audit,
+        CloseoutGateInput {
+            profile: args.profile,
+            require_complete: args.require_complete,
+            require_session: args.require_session,
+            require_validation: args.require_validation,
+            require_review: args.require_review,
+            require_closeout: args.require_closeout,
+            approval: args.approval.clone(),
+            linked_prs: args.linked_pr.clone(),
+        },
+    );
+    let checks_markdown = render_closeout_checks(&gate.checks);
+
+    Ok(json!({
+        "operation": "closeout-gate",
+        "profile": args.profile.as_str(),
+        "ready": gate.ready,
+        "checks": gate.checks,
+        "checks_markdown": checks_markdown,
+    }))
+}
+
+fn run_record_build_dispatch_ledger(args: &BuildDispatchLedgerArgs) -> Result<Value, CommandError> {
+    let options = to_build_options(
+        args.prefixes.owner_prefix.clone(),
+        args.prefixes.branch_prefix.clone(),
+        args.prefixes.worktree_prefix.clone(),
+        args.grouping.pr_grouping,
+        args.grouping.default_pr_grouping,
+        args.grouping.strategy,
+        args.grouping.pr_group.clone(),
+    );
+    let build = task_spec::build_task_spec(&args.plan, TaskSpecScope::Plan, &options)
+        .map_err(|err| CommandError::runtime("dispatch-ledger-generation-failed", err))?;
+    let markdown = render_dispatch_ledger(&build.rows);
+    let out_path = write_optional_record_output(args.out.as_ref(), &markdown)?;
+
+    Ok(json!({
+        "operation": "build-dispatch-ledger",
+        "plan_title": build.plan_title,
+        "record_count": build.rows.len(),
+        "out_path": out_path,
+        "markdown": markdown,
+    }))
 }
 
 fn run_build_task_spec(args: &BuildTaskSpecArgs) -> Result<Value, CommandError> {
@@ -1962,6 +2110,66 @@ fn load_summary(summary: &SummaryArgs) -> Result<Option<String>, CommandError> {
         return Ok(Some(text));
     }
     Ok(None)
+}
+
+fn read_text_file(path: &Path, code: &'static str) -> Result<String, CommandError> {
+    fs::read_to_string(path).map_err(|err| {
+        CommandError::runtime(code, format!("failed to read {}: {err}", path.display()))
+    })
+}
+
+fn write_optional_record_output(
+    path: Option<&PathBuf>,
+    markdown: &str,
+) -> Result<Option<String>, CommandError> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    render::write_rendered(path, markdown)
+        .map_err(|err| CommandError::runtime("record-output-write-failed", err))?;
+    Ok(Some(path_text(path)))
+}
+
+fn render_dispatch_ledger(rows: &[TaskSpecRow]) -> String {
+    let mut out = vec![
+        "## Dispatch Ledger".to_string(),
+        String::new(),
+        "| Task | Summary | Sprint | Owner/Subagent | Branch | Worktree | Execution Mode | PR Group | PR | Status | Validation | Review | Notes |".to_string(),
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+            .to_string(),
+    ];
+    for row in rows {
+        let execution_mode = dispatch_execution_mode(row);
+        out.push(format!(
+            "| {} | {} | S{} | {} | {} | {} | {} | {} | TBD | planned | pending | pending | {} |",
+            record_table_cell(&row.task_id),
+            record_table_cell(&row.summary),
+            row.sprint,
+            record_table_cell(&row.owner),
+            record_table_cell(&row.branch),
+            record_table_cell(&row.worktree),
+            record_table_cell(&execution_mode),
+            record_table_cell(&row.pr_group),
+            record_table_cell(&row.notes),
+        ));
+    }
+    let mut rendered = out.join("\n");
+    rendered.push('\n');
+    rendered
+}
+
+fn dispatch_execution_mode(row: &TaskSpecRow) -> String {
+    match row.grouping {
+        crate::commands::PrGrouping::PerSprint => "per-sprint".to_string(),
+        crate::commands::PrGrouping::Group if row.pr_group.trim().is_empty() => {
+            "pr-isolated".to_string()
+        }
+        crate::commands::PrGrouping::Group => "pr-shared".to_string(),
+    }
+}
+
+fn record_table_cell(value: &str) -> String {
+    common_markdown::canonicalize_table_cell(value)
 }
 
 fn load_close_comment(

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -5,6 +5,7 @@ pub mod dispatch_record;
 mod execute;
 mod github;
 mod issue_body;
+pub mod lifecycle_record;
 pub mod output;
 mod render;
 pub mod runtime_layout;

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -1,0 +1,737 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::commands::record::{LifecycleCommentKind, MarkerFamily, RecordProfile};
+
+#[derive(Debug, Clone)]
+pub struct DashboardInput {
+    pub profile: RecordProfile,
+    pub status: String,
+    pub target_scope: String,
+    pub current: String,
+    pub next_action: String,
+    pub validation: String,
+    pub linked_prs: Vec<String>,
+    pub blockers: Vec<String>,
+    pub approval: String,
+    pub source_url: Option<String>,
+    pub plan_url: Option<String>,
+    pub state_url: Option<String>,
+    pub session_url: Option<String>,
+    pub validation_url: Option<String>,
+    pub review_url: Option<String>,
+    pub closeout_url: Option<String>,
+    pub title: Option<String>,
+    pub issue_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CommentInput {
+    pub profile: RecordProfile,
+    pub marker_family: MarkerFamily,
+    pub kind: LifecycleCommentKind,
+    pub path: Option<String>,
+    pub commit: Option<String>,
+    pub content: Option<String>,
+    pub title: Option<String>,
+    pub details_summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MarkerHit {
+    pub role: String,
+    pub profile: String,
+    pub family: String,
+    pub url: Option<String>,
+    pub created_at: Option<String>,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RecordAudit {
+    pub profile_filter: Option<String>,
+    pub body_sections: BodySections,
+    pub markers: BTreeMap<String, MarkerHit>,
+    pub missing_required: Vec<String>,
+    pub recognized_count: usize,
+    #[serde(skip_serializing)]
+    pub evidence_text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BodySections {
+    pub current_dashboard: bool,
+    pub final_dashboard: bool,
+    pub durable_record: bool,
+    pub closeout_checks: bool,
+    pub task_decomposition: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CloseoutCheck {
+    pub check: String,
+    pub status: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CloseoutGateResult {
+    pub ready: bool,
+    pub checks: Vec<CloseoutCheck>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CloseoutGateInput {
+    pub profile: RecordProfile,
+    pub require_complete: bool,
+    pub require_session: bool,
+    pub require_validation: bool,
+    pub require_review: bool,
+    pub require_closeout: bool,
+    pub approval: Option<String>,
+    pub linked_prs: Vec<String>,
+}
+
+#[derive(Debug)]
+struct CommentJson {
+    body: Option<String>,
+    url: Option<String>,
+    html_url: Option<String>,
+    created_at: Option<String>,
+}
+
+pub fn render_dashboard(input: DashboardInput) -> String {
+    let linked_prs = non_empty_join(&input.linked_prs, "none yet");
+    let blockers = non_empty_join(&input.blockers, "none");
+
+    let mut out = Vec::new();
+    let dashboard_title = if input.status.trim().eq_ignore_ascii_case("complete") {
+        "## Final Dashboard"
+    } else {
+        "## Current Dashboard"
+    };
+    out.push(dashboard_title.to_string());
+    out.push(String::new());
+    out.push("This issue is the durable tracking surface for an issue-backed plan execution. The full source, plan, and execution logs remain in".to_string());
+    out.push("append-only issue comments.".to_string());
+    out.push(String::new());
+    out.push(format!("- Status: {}", input.status.trim()));
+    out.push(format!("- Profile: {}", input.profile.as_str()));
+    out.push(format!("- Target scope: {}", input.target_scope.trim()));
+    out.push(format!("- Current task: {}", input.current.trim()));
+    out.push(format!("- Next action: {}", input.next_action.trim()));
+    out.push(format!("- Validation: {}", input.validation.trim()));
+    out.push(format!("- Linked PRs: {linked_prs}"));
+    out.push(format!("- Blockers: {blockers}"));
+    out.push(format!("- Review approval: {}", input.approval.trim()));
+    out.push(String::new());
+    out.push("## Durable Record".to_string());
+    out.push(String::new());
+    out.push(format!(
+        "- Source snapshot: {}",
+        dashboard_link(input.source_url.as_deref(), "source snapshot")
+    ));
+    out.push(format!(
+        "- Plan snapshot: {}",
+        dashboard_link(input.plan_url.as_deref(), "plan snapshot")
+    ));
+    out.push(format!(
+        "- Execution state: {}",
+        dashboard_link(input.state_url.as_deref(), "execution state")
+    ));
+    out.push(format!(
+        "- Latest session: {}",
+        dashboard_link(input.session_url.as_deref(), "Execution Session")
+    ));
+    out.push(format!(
+        "- Latest validation: {}",
+        dashboard_link(input.validation_url.as_deref(), "Validation Evidence")
+    ));
+    if input.profile == RecordProfile::Dispatch || input.review_url.is_some() {
+        out.push(format!(
+            "- Latest review: {}",
+            dashboard_link(input.review_url.as_deref(), "Review Evidence")
+        ));
+    }
+    out.push(format!(
+        "- Closeout comment: {}",
+        dashboard_link(input.closeout_url.as_deref(), "closeout")
+    ));
+    out.push(String::new());
+    out.push("## Guardrails".to_string());
+    out.push(String::new());
+    out.push("- The issue body is a mutable dashboard only.".to_string());
+    out.push("- Append-only issue comments are the durable source of truth.".to_string());
+    out.push(
+        "- `plan-tooling` owns plan parsing, validation, batching, and PR split modeling only."
+            .to_string(),
+    );
+    out.push("- Provider create, comment, edit, and close operations remain owned by `forge-cli` or provider atoms.".to_string());
+
+    if input.title.is_some() || input.issue_url.is_some() {
+        out.push(String::new());
+        out.push("## Original Tracker".to_string());
+        out.push(String::new());
+        if let Some(title) = input
+            .title
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            out.push(format!("- Title: {}", title.trim()));
+        }
+        if let Some(url) = input
+            .issue_url
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            out.push(format!("- Issue: {}", url.trim()));
+        }
+    }
+
+    finalize_markdown(out)
+}
+
+pub fn render_comment(input: CommentInput) -> Result<String, String> {
+    let marker = marker_for(input.marker_family, input.profile, input.kind)?;
+    let heading = input
+        .title
+        .clone()
+        .unwrap_or_else(|| default_heading(input.profile, input.kind).to_string());
+    let content = input.content.unwrap_or_default();
+
+    let mut out = Vec::new();
+    out.push(marker);
+    out.push(String::new());
+    out.push(format!("## {heading}"));
+    out.push(String::new());
+
+    if input.marker_family == MarkerFamily::Shared || input.profile == RecordProfile::Dispatch {
+        out.push(format!("- Profile: {}", input.profile.as_str()));
+    }
+    if let Some(path) = input
+        .path
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        out.push(format!("- Path: `{}`", path.trim()));
+    }
+    if let Some(commit) = input
+        .commit
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        out.push(format!("- Commit: `{}`", commit.trim()));
+    }
+
+    if matches!(
+        input.kind,
+        LifecycleCommentKind::Source | LifecycleCommentKind::Plan
+    ) {
+        if !out.last().is_some_and(String::is_empty) {
+            out.push(String::new());
+        }
+        out.push("- Snapshot mode: local committed Markdown".to_string());
+        out.push(String::new());
+        out.push("<details>".to_string());
+        out.push(format!(
+            "<summary>{}</summary>",
+            input
+                .details_summary
+                .as_deref()
+                .unwrap_or_else(|| default_details_summary(input.kind))
+        ));
+        out.push(String::new());
+        out.push(content);
+        out.push(String::new());
+        out.push("</details>".to_string());
+    } else if !content.trim().is_empty() {
+        out.push(String::new());
+        out.push(content);
+    }
+
+    Ok(finalize_markdown(out))
+}
+
+pub fn audit_record(
+    body: Option<&str>,
+    comments_json: &str,
+    profile_filter: Option<RecordProfile>,
+) -> Result<RecordAudit, String> {
+    let comments = parse_comments_json(comments_json)?;
+    let mut markers = BTreeMap::new();
+    let mut recognized_count = 0usize;
+    let mut evidence_text = String::new();
+    if let Some(body) = body {
+        evidence_text.push_str(body);
+        evidence_text.push('\n');
+    }
+
+    for comment in comments {
+        let Some(body) = comment.body.as_deref() else {
+            continue;
+        };
+        evidence_text.push_str(body);
+        evidence_text.push('\n');
+        let Some(mut hit) = marker_hit(body) else {
+            continue;
+        };
+        if profile_filter.is_some_and(|profile| hit.profile != profile.as_str()) {
+            continue;
+        }
+        hit.url = comment.url.or(comment.html_url);
+        hit.created_at = comment.created_at;
+        hit.status = extract_status(body);
+        recognized_count += 1;
+        markers.insert(hit.role.clone(), hit);
+    }
+
+    let mut missing_required = Vec::new();
+    for role in ["source_snapshot", "plan_snapshot", "state"] {
+        if !markers.contains_key(role) {
+            missing_required.push(role.to_string());
+        }
+    }
+
+    Ok(RecordAudit {
+        profile_filter: profile_filter.map(|profile| profile.as_str().to_string()),
+        body_sections: inspect_body_sections(body.unwrap_or_default()),
+        markers,
+        missing_required,
+        recognized_count,
+        evidence_text,
+    })
+}
+
+pub fn evaluate_closeout_gate(audit: &RecordAudit, input: CloseoutGateInput) -> CloseoutGateResult {
+    let mut checks = Vec::new();
+
+    push_marker_check(&mut checks, audit, "source_snapshot", "source snapshot");
+    push_marker_check(&mut checks, audit, "plan_snapshot", "plan snapshot");
+    push_marker_check(&mut checks, audit, "state", "execution state");
+
+    if input.require_complete {
+        let (status, detail) = match audit
+            .markers
+            .get("state")
+            .and_then(|hit| hit.status.as_deref())
+        {
+            Some(value) if value.eq_ignore_ascii_case("complete") => {
+                ("pass", "complete".to_string())
+            }
+            Some(value) => ("fail", format!("latest state status is `{value}`")),
+            None => ("fail", "missing execution state".to_string()),
+        };
+        checks.push(CloseoutCheck {
+            check: "execution completion".to_string(),
+            status: status.to_string(),
+            detail,
+        });
+    }
+
+    if input.require_session {
+        push_marker_check(&mut checks, audit, "session", "completed session");
+    }
+    if input.require_validation {
+        push_marker_check(&mut checks, audit, "validation", "validation evidence");
+    }
+    if input.require_review || input.profile == RecordProfile::Dispatch {
+        push_marker_check(&mut checks, audit, "review", "review evidence");
+    }
+    if input.require_closeout {
+        push_marker_check(&mut checks, audit, "closeout", "closeout comment");
+    }
+
+    let approval = input.approval.as_deref().unwrap_or("").trim();
+    let (status, detail) = if approval.is_empty() {
+        ("fail", "missing explicit approval".to_string())
+    } else {
+        ("pass", approval.to_string())
+    };
+    checks.push(CloseoutCheck {
+        check: "close approval".to_string(),
+        status: status.to_string(),
+        detail,
+    });
+
+    if !input.linked_prs.is_empty() {
+        let body_text = audit_text_for_pr_search(audit);
+        let missing = input
+            .linked_prs
+            .iter()
+            .filter(|pr| !body_text.contains(pr.trim()))
+            .map(|pr| pr.trim().to_string())
+            .collect::<Vec<_>>();
+        let (status, detail) = if missing.is_empty() {
+            (
+                "pass",
+                format!("linked PRs referenced: {}", input.linked_prs.join(", ")),
+            )
+        } else {
+            (
+                "fail",
+                format!(
+                    "linked PRs not found in lifecycle evidence: {}",
+                    missing.join(", ")
+                ),
+            )
+        };
+        checks.push(CloseoutCheck {
+            check: "linked PRs".to_string(),
+            status: status.to_string(),
+            detail,
+        });
+    }
+
+    let ready = checks.iter().all(|check| check.status == "pass");
+    CloseoutGateResult { ready, checks }
+}
+
+pub fn render_closeout_checks(checks: &[CloseoutCheck]) -> String {
+    let mut out = Vec::new();
+    out.push("| Check | Status | Detail |".to_string());
+    out.push("| --- | --- | --- |".to_string());
+    for check in checks {
+        out.push(format!(
+            "| {} | {} | {} |",
+            table_cell(&check.check),
+            table_cell(&check.status),
+            table_cell(&check.detail)
+        ));
+    }
+    finalize_markdown(out)
+}
+
+fn non_empty_join(values: &[String], fallback: &str) -> String {
+    let joined = values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if joined.is_empty() {
+        fallback.to_string()
+    } else {
+        joined
+    }
+}
+
+fn dashboard_link(url: Option<&str>, label: &str) -> String {
+    match url.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(url) if url.starts_with("http://") || url.starts_with("https://") => {
+            format!("[{label}]({url})")
+        }
+        Some(value) => value.to_string(),
+        None => "pending".to_string(),
+    }
+}
+
+fn default_heading(profile: RecordProfile, kind: LifecycleCommentKind) -> &'static str {
+    match kind {
+        LifecycleCommentKind::Source => "Source Snapshot",
+        LifecycleCommentKind::Plan => "Plan Snapshot",
+        LifecycleCommentKind::State => "Execution State",
+        LifecycleCommentKind::Session => "Execution Session",
+        LifecycleCommentKind::Validation => "Validation Evidence",
+        LifecycleCommentKind::Review => "Review Evidence",
+        LifecycleCommentKind::Closeout => match profile {
+            RecordProfile::Tracking => "Tracking Issue Closeout",
+            RecordProfile::Dispatch => "Dispatch Issue Closeout",
+        },
+    }
+}
+
+fn default_details_summary(kind: LifecycleCommentKind) -> &'static str {
+    match kind {
+        LifecycleCommentKind::Source => "Source snapshot",
+        LifecycleCommentKind::Plan => "Plan snapshot",
+        _ => "Details",
+    }
+}
+
+fn marker_for(
+    family: MarkerFamily,
+    profile: RecordProfile,
+    kind: LifecycleCommentKind,
+) -> Result<String, String> {
+    let marker = match family {
+        MarkerFamily::Shared => match kind {
+            LifecycleCommentKind::Source | LifecycleCommentKind::Plan => format!(
+                "<!-- issue-backed-plan:snapshot:v1 kind={} profile={} -->",
+                kind.as_str(),
+                profile.as_str()
+            ),
+            _ => format!(
+                "<!-- issue-backed-plan:{}:v1 profile={} -->",
+                kind.as_str(),
+                profile.as_str()
+            ),
+        },
+        MarkerFamily::Compat => compat_marker(profile, kind)?,
+    };
+    Ok(marker)
+}
+
+fn compat_marker(profile: RecordProfile, kind: LifecycleCommentKind) -> Result<String, String> {
+    let marker = match (profile, kind) {
+        (RecordProfile::Tracking, LifecycleCommentKind::Source)
+        | (RecordProfile::Tracking, LifecycleCommentKind::Plan) => format!(
+            "<!-- plan-tracking-issue:snapshot:v1 kind={} -->",
+            kind.as_str()
+        ),
+        (RecordProfile::Tracking, LifecycleCommentKind::State) => {
+            "<!-- execute-from-tracking-issue:state:v1 -->".to_string()
+        }
+        (RecordProfile::Tracking, LifecycleCommentKind::Session) => {
+            "<!-- execute-from-tracking-issue:session:v1 -->".to_string()
+        }
+        (RecordProfile::Tracking, LifecycleCommentKind::Validation) => {
+            "<!-- execute-from-tracking-issue:validation:v1 -->".to_string()
+        }
+        (RecordProfile::Tracking, LifecycleCommentKind::Closeout) => {
+            "<!-- tracking-issue-closeout:v1 -->".to_string()
+        }
+        (RecordProfile::Tracking, LifecycleCommentKind::Review) => {
+            return Err("tracking profile does not emit compat review markers".to_string());
+        }
+        (RecordProfile::Dispatch, LifecycleCommentKind::Source)
+        | (RecordProfile::Dispatch, LifecycleCommentKind::Plan) => format!(
+            "<!-- deliver-dispatch-plan:snapshot:v1 kind={} -->",
+            kind.as_str()
+        ),
+        (RecordProfile::Dispatch, LifecycleCommentKind::State) => {
+            "<!-- deliver-dispatch-plan:state:v1 -->".to_string()
+        }
+        (RecordProfile::Dispatch, LifecycleCommentKind::Session) => {
+            "<!-- deliver-dispatch-plan:session:v1 -->".to_string()
+        }
+        (RecordProfile::Dispatch, LifecycleCommentKind::Validation) => {
+            "<!-- deliver-dispatch-plan:validation:v1 -->".to_string()
+        }
+        (RecordProfile::Dispatch, LifecycleCommentKind::Review) => {
+            "<!-- deliver-dispatch-plan:review:v1 -->".to_string()
+        }
+        (RecordProfile::Dispatch, LifecycleCommentKind::Closeout) => {
+            "<!-- deliver-dispatch-plan:closeout:v1 -->".to_string()
+        }
+    };
+    Ok(marker)
+}
+
+fn parse_comments_json(raw: &str) -> Result<Vec<CommentJson>, String> {
+    let value = serde_json::from_str::<Value>(raw)
+        .map_err(|err| format!("failed to parse comments JSON: {err}"))?;
+    let comments_value = match value {
+        Value::Object(mut object) => object
+            .remove("comments")
+            .ok_or_else(|| "comments JSON object is missing `comments`".to_string())?,
+        Value::Array(items) => Value::Array(items),
+        _ => {
+            return Err(
+                "comments JSON must be an array or an object with a `comments` array".to_string(),
+            );
+        }
+    };
+    let Value::Array(items) = comments_value else {
+        return Err("`comments` must be an array".to_string());
+    };
+
+    Ok(items
+        .into_iter()
+        .filter_map(|item| {
+            let Value::Object(mut object) = item else {
+                return None;
+            };
+            Some(CommentJson {
+                body: string_field(&mut object, "body"),
+                url: string_field(&mut object, "url"),
+                html_url: string_field(&mut object, "html_url"),
+                created_at: string_field(&mut object, "created_at")
+                    .or_else(|| string_field(&mut object, "createdAt")),
+            })
+        })
+        .collect())
+}
+
+fn string_field(object: &mut serde_json::Map<String, Value>, key: &str) -> Option<String> {
+    object
+        .remove(key)
+        .and_then(|value| value.as_str().map(ToString::to_string))
+}
+
+fn marker_hit(body: &str) -> Option<MarkerHit> {
+    let marker = first_comment_marker(body)?;
+    parse_marker_line(marker)
+}
+
+fn first_comment_marker(body: &str) -> Option<&str> {
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.starts_with("<!--") && trimmed.ends_with("-->") {
+            return Some(trimmed);
+        }
+        return None;
+    }
+    None
+}
+
+fn parse_marker_line(marker: &str) -> Option<MarkerHit> {
+    let inner = marker.strip_prefix("<!--")?.strip_suffix("-->")?.trim();
+    let attrs = parse_attrs(inner);
+
+    if inner.starts_with("issue-backed-plan:snapshot:v1") {
+        let kind = attrs.get("kind")?;
+        let profile = attrs
+            .get("profile")
+            .map(String::as_str)
+            .unwrap_or("tracking");
+        return Some(hit(format!("{kind}_snapshot"), profile, "shared"));
+    }
+    if let Some(rest) = inner.strip_prefix("issue-backed-plan:") {
+        let kind = rest.split(':').next()?;
+        let profile = attrs
+            .get("profile")
+            .map(String::as_str)
+            .unwrap_or("tracking");
+        return Some(hit(kind.to_string(), profile, "shared"));
+    }
+
+    if inner.starts_with("plan-tracking-issue:snapshot:v") {
+        let kind = attrs.get("kind")?;
+        return Some(hit(format!("{kind}_snapshot"), "tracking", "compat"));
+    }
+    if let Some(rest) = inner.strip_prefix("execute-from-tracking-issue:") {
+        let kind = rest.split(':').next()?;
+        return Some(hit(kind.to_string(), "tracking", "compat"));
+    }
+    if let Some(rest) = inner.strip_prefix("execute-plan-tracking-issue:") {
+        let kind = rest.split(':').next()?;
+        return Some(hit(kind.to_string(), "tracking", "compat"));
+    }
+    if inner.starts_with("tracking-issue-closeout:v")
+        || inner.starts_with("plan-tracking-issue-closeout:v")
+    {
+        return Some(hit("closeout".to_string(), "tracking", "compat"));
+    }
+
+    if inner.starts_with("deliver-dispatch-plan:snapshot:v") {
+        let kind = attrs.get("kind")?;
+        return Some(hit(format!("{kind}_snapshot"), "dispatch", "compat"));
+    }
+    if let Some(rest) = inner.strip_prefix("deliver-dispatch-plan:") {
+        let kind = rest.split(':').next()?;
+        return Some(hit(kind.to_string(), "dispatch", "compat"));
+    }
+    if let Some(rest) = inner.strip_prefix("dispatch-plan:") {
+        let kind = rest.split(':').next()?;
+        return Some(hit(kind.to_string(), "dispatch", "compat"));
+    }
+
+    None
+}
+
+fn hit(role: String, profile: &str, family: &str) -> MarkerHit {
+    MarkerHit {
+        role,
+        profile: profile.to_string(),
+        family: family.to_string(),
+        url: None,
+        created_at: None,
+        status: None,
+    }
+}
+
+fn parse_attrs(marker: &str) -> BTreeMap<String, String> {
+    let mut attrs = BTreeMap::new();
+    for token in marker.split_whitespace().skip(1) {
+        let Some((key, value)) = token.split_once('=') else {
+            continue;
+        };
+        attrs.insert(
+            key.trim().to_string(),
+            value
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string(),
+        );
+    }
+    attrs
+}
+
+fn extract_status(body: &str) -> Option<String> {
+    for line in body.lines() {
+        let trimmed = line.trim();
+        let Some(rest) = trimmed.strip_prefix("- Status:") else {
+            continue;
+        };
+        let status = rest.trim();
+        if !status.is_empty() {
+            return Some(status.to_string());
+        }
+    }
+    None
+}
+
+fn inspect_body_sections(body: &str) -> BodySections {
+    BodySections {
+        current_dashboard: body.contains("## Current Dashboard"),
+        final_dashboard: body.contains("## Final Dashboard"),
+        durable_record: body.contains("## Durable Record"),
+        closeout_checks: body.contains("## Closeout Checks"),
+        task_decomposition: body.contains("## Task Decomposition"),
+    }
+}
+
+fn push_marker_check(
+    checks: &mut Vec<CloseoutCheck>,
+    audit: &RecordAudit,
+    role: &str,
+    label: &str,
+) {
+    let (status, detail) = match audit.markers.get(role) {
+        Some(hit) => (
+            "pass",
+            hit.url
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("present")
+                .to_string(),
+        ),
+        None => ("fail", format!("missing {label}")),
+    };
+    checks.push(CloseoutCheck {
+        check: label.to_string(),
+        status: status.to_string(),
+        detail,
+    });
+}
+
+fn audit_text_for_pr_search(audit: &RecordAudit) -> String {
+    let mut values = BTreeSet::new();
+    if !audit.evidence_text.trim().is_empty() {
+        values.insert(audit.evidence_text.clone());
+    }
+    for hit in audit.markers.values() {
+        if let Some(url) = hit.url.as_deref() {
+            values.insert(url.to_string());
+        }
+    }
+    values.into_iter().collect::<Vec<_>>().join("\n")
+}
+
+fn table_cell(value: &str) -> String {
+    value.replace('|', "\\|").replace('\n', "<br>")
+}
+
+fn finalize_markdown(lines: Vec<String>) -> String {
+    let mut rendered = lines.join("\n");
+    if !rendered.ends_with('\n') {
+        rendered.push('\n');
+    }
+    rendered
+}

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -272,14 +272,14 @@ pub fn audit_record(
         let Some(body) = comment.body.as_deref() else {
             continue;
         };
-        evidence_text.push_str(body);
-        evidence_text.push('\n');
         let Some(mut hit) = marker_hit(body) else {
             continue;
         };
         if profile_filter.is_some_and(|profile| hit.profile != profile.as_str()) {
             continue;
         }
+        evidence_text.push_str(body);
+        evidence_text.push('\n');
         hit.url = comment.url.or(comment.html_url);
         hit.created_at = comment.created_at;
         hit.status = extract_status(body);

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -15,6 +15,8 @@ mod exit_codes;
 mod grouping_default;
 #[path = "integration/help_snapshot.rs"]
 mod help_snapshot;
+#[path = "integration/lifecycle_record.rs"]
+mod lifecycle_record;
 #[path = "integration/link_pr_flow.rs"]
 mod link_pr_flow;
 #[path = "integration/live_issue_ops.rs"]

--- a/crates/plan-issue-cli/tests/integration/cli_contract.rs
+++ b/crates/plan-issue-cli/tests/integration/cli_contract.rs
@@ -28,6 +28,7 @@ fn cli_help_lists_full_surface_for_live_and_local_bins() {
         "multi-sprint-guide",
         // Task 1.5
         "resolve-approval",
+        "record",
         "-V, --version",
         "USAGE PATHS",
         "plan-issue-local",

--- a/crates/plan-issue-cli/tests/integration/lifecycle_record.rs
+++ b/crates/plan-issue-cli/tests/integration/lifecycle_record.rs
@@ -165,6 +165,65 @@ fn issue_backed_lifecycle_closeout_gate_reports_ready_when_required_markers_pass
 }
 
 #[test]
+fn issue_backed_lifecycle_closeout_gate_filters_linked_prs_by_profile() {
+    let tmp = TempDir::new().expect("tmp");
+    let body = tmp.path().join("body.md");
+    let comments = tmp.path().join("comments.json");
+    fs::write(
+        &body,
+        "## Final Dashboard\n\n## Durable Record\n\n## Closeout Checks\n",
+    )
+    .expect("write body");
+    fs::write(
+        &comments,
+        r##"[
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-source","body":"<!-- issue-backed-plan:snapshot:v1 kind=source profile=dispatch -->\n\n## Source Snapshot\n"},
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-plan","body":"<!-- issue-backed-plan:snapshot:v1 kind=plan profile=dispatch -->\n\n## Plan Snapshot\n"},
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-state","body":"<!-- issue-backed-plan:state:v1 profile=dispatch -->\n\n## Execution State\n\n- Status: complete\n"},
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-session","body":"<!-- issue-backed-plan:session:v1 profile=dispatch -->\n\n## Execution Session\n"},
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-validation","body":"<!-- issue-backed-plan:validation:v1 profile=dispatch -->\n\n## Validation Evidence\n"},
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-review","body":"<!-- issue-backed-plan:review:v1 profile=dispatch -->\n\n## Review Evidence\n"},
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-tracking","body":"<!-- execute-from-tracking-issue:session:v1 -->\n\n## Execution Session\n\n- PR: #999\n"}
+]"##,
+    )
+    .expect("write comments");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "closeout-gate",
+        "--profile",
+        "dispatch",
+        "--require-complete",
+        "--require-session",
+        "--require-validation",
+        "--require-review",
+        "--approval",
+        "explicit dispatch approval",
+        "--linked-pr",
+        "#999",
+        "--body-file",
+        body.to_str().expect("body path"),
+        "--comments-json",
+        comments.to_str().expect("comments path"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = json_stdout(&out);
+    let result = &payload["payload"]["result"];
+    assert_eq!(result["ready"], false);
+    assert!(
+        result["checks_markdown"]
+            .as_str()
+            .unwrap()
+            .contains("| linked PRs | fail | linked PRs not found in lifecycle evidence: #999 |"),
+        "{}",
+        result["checks_markdown"]
+    );
+}
+
+#[test]
 fn issue_backed_lifecycle_build_dispatch_ledger_uses_plan_tooling_without_task_decomposition() {
     let tmp = TempDir::new().expect("tmp");
     let rendered = tmp.path().join("dispatch-ledger.md");

--- a/crates/plan-issue-cli/tests/integration/lifecycle_record.rs
+++ b/crates/plan-issue-cli/tests/integration/lifecycle_record.rs
@@ -1,0 +1,201 @@
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use crate::common;
+
+fn json_stdout(out: &common::CmdOut) -> Value {
+    serde_json::from_str(&out.stdout).expect("json stdout")
+}
+
+#[test]
+fn issue_backed_lifecycle_render_comment_emits_compat_tracking_snapshot() {
+    let tmp = TempDir::new().expect("tmp");
+    let content = tmp.path().join("source.md");
+    let rendered = tmp.path().join("comment.md");
+    fs::write(
+        &content,
+        "# Source\n\n<!-- execute-from-tracking-issue:validation:v1 -->\n",
+    )
+    .expect("write content");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "render-comment",
+        "--kind",
+        "source",
+        "--path",
+        "docs/source.md",
+        "--commit",
+        "abc123",
+        "--content-file",
+        content.to_str().expect("content path"),
+        "--out",
+        rendered.to_str().expect("rendered path"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let body = fs::read_to_string(&rendered).expect("read rendered");
+    assert!(
+        body.starts_with("<!-- plan-tracking-issue:snapshot:v1 kind=source -->"),
+        "{body}"
+    );
+    assert!(body.contains("## Source Snapshot"), "{body}");
+    assert!(body.contains("<details>"), "{body}");
+    assert!(!body.contains("## Task Decomposition"), "{body}");
+
+    let payload = json_stdout(&out);
+    assert_eq!(payload["command"], "record.render-comment");
+    assert_eq!(payload["payload"]["result"]["kind"], "source");
+}
+
+#[test]
+fn issue_backed_lifecycle_audit_uses_only_top_level_comment_markers() {
+    let tmp = TempDir::new().expect("tmp");
+    let body = tmp.path().join("body.md");
+    let comments = tmp.path().join("comments.json");
+    fs::write(
+        &body,
+        "## Current Dashboard\n\n## Durable Record\n\nNo task table here.\n",
+    )
+    .expect("write body");
+    fs::write(
+        &comments,
+        r##"{
+  "comments": [
+    {
+      "url": "https://github.com/owner/repo/issues/1#issuecomment-source",
+      "body": "<!-- plan-tracking-issue:snapshot:v1 kind=source -->\n\n## Source Snapshot\n\n<details>\n<summary>Source snapshot</summary>\n\n<!-- execute-from-tracking-issue:validation:v1 -->\n\n</details>\n"
+    },
+    {
+      "url": "https://github.com/owner/repo/issues/1#issuecomment-plan",
+      "body": "<!-- plan-tracking-issue:snapshot:v1 kind=plan -->\n\n## Plan Snapshot\n"
+    },
+    {
+      "url": "https://github.com/owner/repo/issues/1#issuecomment-state",
+      "body": "<!-- execute-from-tracking-issue:state:v1 -->\n\n## Execution State\n\n- Status: complete\n"
+    }
+  ]
+}"##,
+    )
+    .expect("write comments");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "audit",
+        "--profile",
+        "tracking",
+        "--body-file",
+        body.to_str().expect("body path"),
+        "--comments-json",
+        comments.to_str().expect("comments path"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = json_stdout(&out);
+    let audit = &payload["payload"]["result"]["audit"];
+    assert_eq!(audit["recognized_count"], 3);
+    assert_eq!(
+        audit["markers"]["source_snapshot"]["url"],
+        "https://github.com/owner/repo/issues/1#issuecomment-source"
+    );
+    assert!(audit["markers"]["validation"].is_null());
+    assert_eq!(audit["missing_required"].as_array().unwrap().len(), 0);
+    assert_eq!(audit["body_sections"]["task_decomposition"], false);
+}
+
+#[test]
+fn issue_backed_lifecycle_closeout_gate_reports_ready_when_required_markers_pass() {
+    let tmp = TempDir::new().expect("tmp");
+    let body = tmp.path().join("body.md");
+    let comments = tmp.path().join("comments.json");
+    fs::write(
+        &body,
+        "## Final Dashboard\n\n## Durable Record\n\n## Closeout Checks\n",
+    )
+    .expect("write body");
+    fs::write(
+        &comments,
+        r##"[
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-source","body":"<!-- plan-tracking-issue:snapshot:v1 kind=source -->\n\n## Source Snapshot\n"},
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-plan","body":"<!-- plan-tracking-issue:snapshot:v1 kind=plan -->\n\n## Plan Snapshot\n"},
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-state","body":"<!-- execute-from-tracking-issue:state:v1 -->\n\n## Execution State\n\n- Status: complete\n"},
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-session","body":"<!-- execute-from-tracking-issue:session:v1 -->\n\n## Execution Session\n"},
+  {"url":"https://github.com/owner/repo/issues/1#issuecomment-validation","body":"<!-- execute-from-tracking-issue:validation:v1 -->\n\n## Validation Evidence\n"}
+]"##,
+    )
+    .expect("write comments");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "closeout-gate",
+        "--profile",
+        "tracking",
+        "--require-complete",
+        "--require-session",
+        "--require-validation",
+        "--approval",
+        "explicit close approval flag",
+        "--body-file",
+        body.to_str().expect("body path"),
+        "--comments-json",
+        comments.to_str().expect("comments path"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = json_stdout(&out);
+    let result = &payload["payload"]["result"];
+    assert_eq!(result["ready"], true);
+    assert!(
+        result["checks_markdown"]
+            .as_str()
+            .unwrap()
+            .contains("| close approval | pass | explicit close approval flag |"),
+        "{}",
+        result["checks_markdown"]
+    );
+}
+
+#[test]
+fn issue_backed_lifecycle_build_dispatch_ledger_uses_plan_tooling_without_task_decomposition() {
+    let tmp = TempDir::new().expect("tmp");
+    let rendered = tmp.path().join("dispatch-ledger.md");
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "build-dispatch-ledger",
+        "--plan",
+        "crates/plan-issue-cli/tests/fixtures/plans/plan-issue-rust-cli-full-delivery-plan.md",
+        "--pr-grouping",
+        "per-sprint",
+        "--out",
+        rendered.to_str().expect("rendered path"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let ledger = fs::read_to_string(&rendered).expect("read ledger");
+    assert!(ledger.starts_with("## Dispatch Ledger"), "{ledger}");
+    assert!(
+        ledger.contains("| Task | Summary | Sprint | Owner/Subagent |"),
+        "{ledger}"
+    );
+    assert!(!ledger.contains("## Task Decomposition"), "{ledger}");
+
+    let payload = json_stdout(&out);
+    assert_eq!(payload["command"], "record.build-dispatch-ledger");
+    assert!(
+        payload["payload"]["result"]["record_count"]
+            .as_u64()
+            .unwrap()
+            > 0
+    );
+}

--- a/crates/plan-issue-cli/tests/integration/parity_guardrails.rs
+++ b/crates/plan-issue-cli/tests/integration/parity_guardrails.rs
@@ -47,6 +47,7 @@ fn parity_shell_help_surface_tracks_current_command_contract() {
         "accept-sprint         Enforce merged-PR gate, sync sprint status=done, then post accepted comment",
         "multi-sprint-guide    Print the full repeated command flow for a plan (1 plan = 1 issue)",
         "resolve-approval      Resolve the URL of the most recent `Decision: merge` review-evidence comment on a PR, suitable for `accept-sprint --approved-comment-url`",
+        "record                Render and audit issue-backed plan record dashboards and comments",
         "completion            Export shell completion script",
     ] {
         assert!(


### PR DESCRIPTION
## Summary

- Add `plan-issue record` primitives for shared issue-backed plan dashboards, durable comments, marker audit, closeout gates, and dispatch ledgers.
- Preserve the existing `plan-tooling` boundary: plan parsing, validation, batch analysis, and split modeling stay out of provider issue rendering.
- Add compatibility for legacy tracking markers and shared `issue-backed-plan:*` markers so runtime skills can migrate without waiting for a release.
- Fix closeout linked-PR evidence filtering so dispatch gates cannot pass from unrelated tracking comments.

## Test plan

- `cargo test -p nils-plan-issue-cli issue_backed_lifecycle --no-fail-fast`
- `cargo test -p nils-plan-issue-cli`
- `cargo test -p nils-plan-tooling`
- `cargo test -p nils-forge-cli`
- `cargo build -p nils-plan-issue-cli -p nils-forge-cli -p nils-plan-tooling`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- `bash -n completions/bash/plan-issue && bash -n completions/bash/plan-issue-local && zsh -n completions/zsh/_plan-issue && zsh -n completions/zsh/_plan-issue-local`
- `git diff --check`
