### PR TITLE
Add Codex skill surface doctor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "clap",
  "indexmap",
  "nils-test-support",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,6 +62,15 @@ For optional runtime tools used by individual CLIs, see `BINARY_DEPENDENCIES.md`
   - `cargo run -p nils-cli-template -- --help`
   - `cargo run -p nils-git-scope -- --help`
 
+### 2.1 Codex skill-surface shape checks
+
+`agent-runtime doctor --class skill-surface --product codex` validates
+install-map shape only. A passing shape check is not Codex Desktop acceptance;
+live acceptance still requires `codex debug prompt-input` in a fresh Codex
+Desktop session with `$HOME/.agents` absent and legacy skill environment
+variables unset. Rationale:
+`docs/plans/codex-skill-surface-primitives/codex-skill-surface-primitives-discussion-source.md`.
+
 ## 3. Canonical local test flows
 
 Primary local entrypoint for day-to-day implementation work:

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `86626a2e5939b67451831ba2957d3bac8c49b4c09a52034f7fda3b00ed3a2dae`
+- Cargo.lock SHA256: `1e92408930a5356c8ec6fd5e5a2ef67348a3e37513e006a1b8a1db69640a70df`
 - Third-party crates (`source != null`): 465
 - Workspace crates (`source == null`, excluded below): 31
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `86626a2e5939b67451831ba2957d3bac8c49b4c09a52034f7fda3b00ed3a2dae`
+- Cargo.lock SHA256: `1e92408930a5356c8ec6fd5e5a2ef67348a3e37513e006a1b8a1db69640a70df`
 - Third-party crates (`source != null`): 465
 
 ## Notice Extraction Policy

--- a/crates/agent-runtime-cli/Cargo.toml
+++ b/crates/agent-runtime-cli/Cargo.toml
@@ -29,3 +29,4 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 nils-test-support = { version = "0.17.4", path = "../nils-test-support" }
+pretty_assertions = { workspace = true }

--- a/crates/agent-runtime-cli/src/commands/doctor.rs
+++ b/crates/agent-runtime-cli/src/commands/doctor.rs
@@ -1,6 +1,7 @@
-use crate::doctor::{self, DoctorFinding, DoctorOptions, DoctorSeverity, upgrade};
+use crate::doctor::{self, DoctorClass, DoctorFinding, DoctorOptions, DoctorSeverity, upgrade};
 use crate::render::manifest::SourceRoot;
-use clap::Args;
+use clap::{Args, ValueEnum};
+use serde::Serialize;
 use std::path::PathBuf;
 
 #[derive(Args, Debug)]
@@ -37,6 +38,33 @@ pub struct DoctorArgs {
     /// Inspect a consuming repo's `.agents/scripts/` project-local overlays.
     #[arg(long)]
     pub check_project: Option<PathBuf>,
+    /// Run a single doctor class instead of the default host/runtime probes.
+    #[arg(long = "class", value_enum)]
+    pub class: Option<DoctorClassArg>,
+    /// Output format.
+    #[arg(long, value_enum, default_value = "text")]
+    pub format: OutputFormat,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum DoctorClassArg {
+    SkillSurface,
+}
+
+impl From<DoctorClassArg> for DoctorClass {
+    fn from(value: DoctorClassArg) -> Self {
+        match value {
+            DoctorClassArg::SkillSurface => DoctorClass::SkillSurface,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum OutputFormat {
+    Text,
+    Json,
 }
 
 pub fn run(args: DoctorArgs) -> anyhow::Result<u8> {
@@ -63,6 +91,7 @@ pub fn run(args: DoctorArgs) -> anyhow::Result<u8> {
         overlay_path: args.overlay_path.clone(),
         cli_tools_profile: args.profile.clone(),
         check_project: args.check_project.clone(),
+        class_filter: args.class.map(Into::into),
     };
     let outcome = doctor::run(
         &args.product,
@@ -72,6 +101,16 @@ pub fn run(args: DoctorArgs) -> anyhow::Result<u8> {
         &options,
     )?;
 
+    if args.format == OutputFormat::Json {
+        print_json(&outcome, args.suggest_upgrade)?;
+        return Ok(outcome.exit_code());
+    }
+
+    print_text(&outcome, args.suggest_upgrade);
+    Ok(outcome.exit_code())
+}
+
+fn print_text(outcome: &doctor::DoctorOutcome, suggest_upgrade: bool) {
     if let Some(summary) = outcome.overlay.as_ref() {
         eprintln!(
             "agent-runtime doctor: overlay merged (dropped={} replaced={} added={})",
@@ -135,13 +174,58 @@ pub fn run(args: DoctorArgs) -> anyhow::Result<u8> {
     for finding in &outcome.findings {
         print_finding(finding);
     }
-    if args.suggest_upgrade {
-        for suggestion in upgrade::suggestions(&outcome) {
+    if suggest_upgrade {
+        for suggestion in upgrade::suggestions(outcome) {
             println!("{}", suggestion.command);
         }
     }
+    if let Some(boundary) = outcome.acceptance_boundary.as_deref() {
+        eprintln!("agent-runtime doctor: acceptance-boundary: {boundary}");
+    }
+}
 
-    Ok(outcome.exit_code())
+#[derive(Serialize)]
+struct DoctorJson<'a> {
+    schema_version: &'static str,
+    product: &'a str,
+    checks: usize,
+    ok: usize,
+    warn: usize,
+    block: usize,
+    exit_code: u8,
+    findings: &'a [DoctorFinding],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skill_surface: Option<&'a doctor::skill_surface::SkillSurfaceReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    acceptance_boundary: Option<&'a str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    upgrade_suggestions: Vec<String>,
+}
+
+fn print_json(outcome: &doctor::DoctorOutcome, suggest_upgrade: bool) -> anyhow::Result<()> {
+    let upgrade_suggestions = if suggest_upgrade {
+        upgrade::suggestions(outcome)
+            .into_iter()
+            .map(|suggestion| suggestion.command)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let envelope = DoctorJson {
+        schema_version: "agent-runtime-cli.doctor.v1",
+        product: &outcome.product,
+        checks: outcome.total_checks(),
+        ok: outcome.ok,
+        warn: outcome.warn,
+        block: outcome.block,
+        exit_code: outcome.exit_code(),
+        findings: &outcome.findings,
+        skill_surface: outcome.skill_surface.as_ref(),
+        acceptance_boundary: outcome.acceptance_boundary.as_deref(),
+        upgrade_suggestions,
+    };
+    println!("{}", serde_json::to_string_pretty(&envelope)?);
+    Ok(())
 }
 
 fn print_finding(finding: &DoctorFinding) {

--- a/crates/agent-runtime-cli/src/commands/install.rs
+++ b/crates/agent-runtime-cli/src/commands/install.rs
@@ -131,13 +131,19 @@ pub fn run(args: InstallArgs) -> anyhow::Result<u8> {
 }
 
 fn print_change(c: &AppliedChange) {
+    eprintln!("{}", format_change(c));
+}
+
+fn format_change(c: &AppliedChange) -> String {
     match c {
         AppliedChange::SymlinkCreated {
             entry_id,
             dest,
             source,
-        } => eprintln!(
-            "  + symlink {} -> {} ({})",
+            link_mode,
+        } => format!(
+            "  + {} {} -> {} ({})",
+            link_mode.label(),
             dest.display(),
             source.display(),
             entry_id
@@ -146,8 +152,10 @@ fn print_change(c: &AppliedChange) {
             entry_id,
             dest,
             source,
-        } => eprintln!(
-            "  ~ symlink {} -> {} (replaced; {})",
+            link_mode,
+        } => format!(
+            "  ~ {} {} -> {} (replaced; {})",
+            link_mode.label(),
             dest.display(),
             source.display(),
             entry_id
@@ -156,24 +164,64 @@ fn print_change(c: &AppliedChange) {
             entry_id,
             dest,
             source,
+            link_mode,
             backup,
-        } => eprintln!(
-            "  ! backup {} -> {}, then symlink to {} ({})",
+        } => format!(
+            "  ! backup {} -> {}, then {} to {} ({})",
             dest.display(),
             backup.display(),
+            link_mode.label(),
             source.display(),
             entry_id
         ),
         AppliedChange::ManagedBlockApplied {
             entry_id,
             config_file,
-        } => eprintln!(
+        } => format!(
             "  ~ managed-block applied to {} ({})",
             config_file.display(),
             entry_id
         ),
         AppliedChange::NoOp { entry_id, dest } => {
-            eprintln!("  = no-op {} ({})", dest.display(), entry_id)
+            format!("  = no-op {} ({})", dest.display(), entry_id)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::install::plan::SymlinkLinkMode;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    #[test]
+    fn format_change_names_directory_symlink_mode() {
+        let line = format_change(&AppliedChange::SymlinkCreated {
+            entry_id: "reporting.daily-brief".to_string(),
+            dest: PathBuf::from("/tmp/home/skills/reporting/daily-brief"),
+            source: PathBuf::from("/tmp/source/daily-brief"),
+            link_mode: SymlinkLinkMode::Directory,
+        });
+
+        assert_eq!(
+            line,
+            "  + directory symlink /tmp/home/skills/reporting/daily-brief -> /tmp/source/daily-brief (reporting.daily-brief)"
+        );
+    }
+
+    #[test]
+    fn format_change_names_recursive_file_symlink_mode() {
+        let line = format_change(&AppliedChange::SymlinkReplaced {
+            entry_id: "reporting.skills-tree".to_string(),
+            dest: PathBuf::from("/tmp/home/plugins/reporting/skills/foo/SKILL.md"),
+            source: PathBuf::from("/tmp/source/build/skills/foo/SKILL.md"),
+            link_mode: SymlinkLinkMode::RecursiveFile,
+        });
+
+        assert_eq!(
+            line,
+            "  ~ recursive file symlink /tmp/home/plugins/reporting/skills/foo/SKILL.md -> /tmp/source/build/skills/foo/SKILL.md (replaced; reporting.skills-tree)"
+        );
     }
 }

--- a/crates/agent-runtime-cli/src/doctor.rs
+++ b/crates/agent-runtime-cli/src/doctor.rs
@@ -7,6 +7,7 @@
 pub mod coverage;
 pub mod probes;
 pub mod project;
+pub mod skill_surface;
 pub mod upgrade;
 pub mod version;
 
@@ -14,6 +15,7 @@ use crate::install::link_map::{LinkMap, LinkMapError};
 use crate::install::overlay::{self, LinkMapOverlay, OverlaySummary};
 use crate::install::plan::{InstallPlan, PlanError};
 use crate::render::manifest::{ProductRoot, RuntimeRootsManifest, SCHEMA_VERSION};
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -24,6 +26,7 @@ pub struct DoctorOptions {
     pub overlay_path: Option<PathBuf>,
     pub cli_tools_profile: String,
     pub check_project: Option<PathBuf>,
+    pub class_filter: Option<DoctorClass>,
 }
 
 impl Default for DoctorOptions {
@@ -33,8 +36,14 @@ impl Default for DoctorOptions {
             overlay_path: None,
             cli_tools_profile: "recommended".to_string(),
             check_project: None,
+            class_filter: None,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DoctorClass {
+    SkillSurface,
 }
 
 #[derive(Debug, Error)]
@@ -75,7 +84,8 @@ pub enum RuntimeRootsError {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum DoctorSeverity {
     Ok,
     Warn,
@@ -92,7 +102,7 @@ impl DoctorSeverity {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DoctorFinding {
     pub product: String,
     pub check: &'static str,
@@ -154,6 +164,8 @@ pub struct DoctorOutcome {
     pub version_probes: Vec<version::VersionProbeFinding>,
     pub coverage_probes: Vec<coverage::CoverageFinding>,
     pub project_probes: Vec<project::ProjectOverlayFinding>,
+    pub skill_surface: Option<skill_surface::SkillSurfaceReport>,
+    pub acceptance_boundary: Option<String>,
     pub ok: usize,
     pub warn: usize,
     pub block: usize,
@@ -183,6 +195,10 @@ pub fn run(
     state_home_override: Option<&Path>,
     options: &DoctorOptions,
 ) -> Result<DoctorOutcome, DoctorError> {
+    if matches!(options.class_filter, Some(DoctorClass::SkillSurface)) {
+        return run_skill_surface_only(product, source_root, options);
+    }
+
     let runtime_roots = load_runtime_roots(source_root)?;
     let product_root = product_root(&runtime_roots, product)?;
     let resolved_roots = resolve_runtime_roots(
@@ -263,11 +279,91 @@ pub fn run(
         version_probes: vec![version_probe],
         coverage_probes,
         project_probes,
+        skill_surface: None,
+        acceptance_boundary: None,
         ok: report.ok,
         warn,
         block,
         overlay: overlay_summary,
     })
+}
+
+fn run_skill_surface_only(
+    product: &str,
+    source_root: &Path,
+    options: &DoctorOptions,
+) -> Result<DoctorOutcome, DoctorError> {
+    let link_map = match load_effective_link_map(source_root, product, options)? {
+        Some(link_map) => link_map,
+        None => {
+            return Ok(DoctorOutcome {
+                product: product.to_string(),
+                findings: Vec::new(),
+                version_probes: Vec::new(),
+                coverage_probes: Vec::new(),
+                project_probes: Vec::new(),
+                skill_surface: Some(skill_surface::SkillSurfaceReport::empty(product)),
+                acceptance_boundary: skill_surface::acceptance_boundary(product)
+                    .map(str::to_string),
+                ok: 0,
+                warn: 0,
+                block: 0,
+                overlay: None,
+            });
+        }
+    };
+    let report = skill_surface::check(product, source_root, &link_map);
+    let warn = report
+        .findings
+        .iter()
+        .filter(|finding| finding.severity == DoctorSeverity::Warn)
+        .count();
+    let block = report
+        .findings
+        .iter()
+        .filter(|finding| finding.severity == DoctorSeverity::Block)
+        .count();
+    let ok = report
+        .items
+        .iter()
+        .filter(|item| item.warnings.is_empty())
+        .count();
+    let acceptance_boundary = report.acceptance_boundary.clone();
+    Ok(DoctorOutcome {
+        product: product.to_string(),
+        findings: report.findings.clone(),
+        version_probes: Vec::new(),
+        coverage_probes: Vec::new(),
+        project_probes: Vec::new(),
+        skill_surface: Some(report),
+        acceptance_boundary,
+        ok,
+        warn,
+        block,
+        overlay: None,
+    })
+}
+
+fn load_effective_link_map(
+    source_root: &Path,
+    product: &str,
+    options: &DoctorOptions,
+) -> Result<Option<LinkMap>, DoctorError> {
+    let mut link_map = match LinkMap::load(source_root, product) {
+        Ok(link_map) => link_map,
+        Err(LinkMapError::Missing { .. }) => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    if options.overlay_enabled {
+        let overlay_opt = match options.overlay_path.as_deref() {
+            Some(path) => LinkMapOverlay::load_from(path)?,
+            None => LinkMapOverlay::load_optional(source_root)?,
+        };
+        if let Some(overlay) = overlay_opt {
+            overlay::apply(&mut link_map, &overlay)?;
+        }
+    }
+    Ok(Some(link_map))
 }
 
 fn load_runtime_roots(source_root: &Path) -> Result<RuntimeRootsManifest, RuntimeRootsError> {

--- a/crates/agent-runtime-cli/src/doctor/probes.rs
+++ b/crates/agent-runtime-cli/src/doctor/probes.rs
@@ -71,6 +71,7 @@ pub fn install_plan(product: &str, plan: &InstallPlan) -> ProbeReport {
                 entry_id,
                 source,
                 dest,
+                link_mode: _,
                 requires_backup: _,
             } => check_symlink(&mut report, product, entry_id, source, dest),
             PlanAction::ManagedBlock {

--- a/crates/agent-runtime-cli/src/doctor/skill_surface.rs
+++ b/crates/agent-runtime-cli/src/doctor/skill_surface.rs
@@ -1,0 +1,354 @@
+//! Codex active skill-surface classifier for `agent-runtime doctor`.
+//!
+//! This diagnostic is shape-only. It reads the rendered link map and
+//! source tree to classify install intent; it deliberately does not stat
+//! `$CODEX_HOME` or attempt to reproduce Codex Desktop discovery.
+
+use super::{DoctorFinding, DoctorSeverity};
+use crate::install::link_map::{EntryKind, LinkEntry, LinkMap};
+use serde::Serialize;
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
+
+pub const CLASS: &str = "skill-surface";
+pub const FILE_SYMLINK_WARNING: &str = "codex.active-skill.file-symlink";
+pub const CODEX_ACCEPTANCE_BOUNDARY: &str = "shape validation only; live Codex Desktop discovery still requires `codex debug prompt-input` in a fresh session";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SkillSurfaceReport {
+    pub product: String,
+    pub items: Vec<SkillSurfaceItem>,
+    pub findings: Vec<DoctorFinding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acceptance_boundary: Option<String>,
+}
+
+impl SkillSurfaceReport {
+    pub fn empty(product: &str) -> Self {
+        Self {
+            product: product.to_string(),
+            items: Vec::new(),
+            findings: Vec::new(),
+            acceptance_boundary: acceptance_boundary(product).map(str::to_string),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SkillSurfaceItem {
+    pub id: String,
+    pub source: String,
+    pub destination: String,
+    pub link_mode: SkillSurfaceLinkMode,
+    pub expected_codex_discoverable: CodexDiscoverability,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<SkillSurfaceWarning>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SkillSurfaceLinkMode {
+    File,
+    Directory,
+    RecursiveFile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexDiscoverability {
+    Yes,
+    No,
+    NotApplicable,
+}
+
+impl Serialize for CodexDiscoverability {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Yes => serializer.serialize_bool(true),
+            Self::No => serializer.serialize_bool(false),
+            Self::NotApplicable => serializer.serialize_str("not-applicable"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SkillSurfaceWarning {
+    pub code: &'static str,
+    pub message: String,
+    pub remediation: &'static str,
+}
+
+pub fn acceptance_boundary(product: &str) -> Option<&'static str> {
+    (product == "codex").then_some(CODEX_ACCEPTANCE_BOUNDARY)
+}
+
+pub fn check(product: &str, source_root: &Path, link_map: &LinkMap) -> SkillSurfaceReport {
+    let mut items = Vec::new();
+    let mut findings = Vec::new();
+    for entry in &link_map.entries {
+        let Some(item) = classify_entry(product, source_root, entry) else {
+            continue;
+        };
+        for warning in &item.warnings {
+            findings.push(DoctorFinding {
+                product: product.to_string(),
+                check: CLASS,
+                severity: DoctorSeverity::Warn,
+                entry_id: Some(item.id.clone()),
+                path: Some(PathBuf::from(&item.destination)),
+                message: format!(
+                    "{}: {}; {}",
+                    warning.code, warning.message, warning.remediation
+                ),
+            });
+        }
+        items.push(item);
+    }
+    SkillSurfaceReport {
+        product: product.to_string(),
+        items,
+        findings,
+        acceptance_boundary: acceptance_boundary(product).map(str::to_string),
+    }
+}
+
+fn classify_entry(
+    product: &str,
+    source_root: &Path,
+    entry: &LinkEntry,
+) -> Option<SkillSurfaceItem> {
+    let source = entry.source.as_deref()?;
+    let source_abs = source_root.join(source);
+    let link_mode = link_mode(&source_abs, entry);
+    let destination = clean_rel_path(&entry.destination);
+    let expected_codex_discoverable =
+        expected_codex_discoverable(product, destination.as_deref(), link_mode, entry);
+    let warnings = warnings(product, destination.as_deref(), &entry.id);
+    Some(SkillSurfaceItem {
+        id: entry.id.clone(),
+        source: source.to_string(),
+        destination: entry.destination.clone(),
+        link_mode,
+        expected_codex_discoverable,
+        warnings,
+    })
+}
+
+fn link_mode(source_abs: &Path, entry: &LinkEntry) -> SkillSurfaceLinkMode {
+    if entry.kind == EntryKind::SymlinkedFile && entry.recursive {
+        return SkillSurfaceLinkMode::RecursiveFile;
+    }
+    match std::fs::symlink_metadata(source_abs) {
+        Ok(meta) if meta.is_dir() => SkillSurfaceLinkMode::Directory,
+        _ => SkillSurfaceLinkMode::File,
+    }
+}
+
+fn expected_codex_discoverable(
+    product: &str,
+    destination: Option<&Path>,
+    link_mode: SkillSurfaceLinkMode,
+    entry: &LinkEntry,
+) -> CodexDiscoverability {
+    if product != "codex" {
+        return CodexDiscoverability::NotApplicable;
+    }
+    let Some(destination) = destination else {
+        return CodexDiscoverability::NotApplicable;
+    };
+    if !is_skills_prefixed(destination) {
+        return CodexDiscoverability::NotApplicable;
+    }
+    if entry.kind == EntryKind::SymlinkedFile
+        && !entry.recursive
+        && link_mode == SkillSurfaceLinkMode::Directory
+        && is_domain_nested_skill_leaf(destination)
+    {
+        CodexDiscoverability::Yes
+    } else {
+        CodexDiscoverability::No
+    }
+}
+
+fn warnings(
+    product: &str,
+    destination: Option<&Path>,
+    _entry_id: &str,
+) -> Vec<SkillSurfaceWarning> {
+    let Some(destination) = destination else {
+        return Vec::new();
+    };
+    if product == "codex" && is_skill_md_leaf(destination) {
+        vec![SkillSurfaceWarning {
+            code: FILE_SYMLINK_WARNING,
+            message: format!(
+                "Codex active skill destination `{}` is a SKILL.md file symlink",
+                destination.display()
+            ),
+            remediation: "use a directory-symlink leaf at `skills/<domain>/<skill>`",
+        }]
+    } else {
+        Vec::new()
+    }
+}
+
+fn clean_rel_path(raw: &str) -> Option<PathBuf> {
+    let path = Path::new(raw);
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return None;
+    }
+    if path
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+    Some(path.to_path_buf())
+}
+
+fn is_skills_prefixed(path: &Path) -> bool {
+    matches!(path.components().next(), Some(Component::Normal(first)) if first == OsStr::new("skills"))
+}
+
+fn is_domain_nested_skill_leaf(path: &Path) -> bool {
+    let components: Vec<_> = path.components().collect();
+    components.len() >= 3
+        && matches!(components[0], Component::Normal(first) if first == OsStr::new("skills"))
+        && !matches!(components.last(), Some(Component::Normal(last)) if *last == OsStr::new("SKILL.md"))
+}
+
+fn is_skill_md_leaf(path: &Path) -> bool {
+    is_skills_prefixed(path)
+        && matches!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("SKILL.md")
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::install::link_map::LinkEntry;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn entry(id: &str, source: &str, destination: &str, recursive: bool) -> LinkEntry {
+        LinkEntry {
+            id: id.to_string(),
+            kind: EntryKind::SymlinkedFile,
+            source: Some(source.to_string()),
+            destination: destination.to_string(),
+            recursive,
+            surface: None,
+            comment_style: None,
+            body_template: None,
+        }
+    }
+
+    #[test]
+    fn classifies_domain_nested_directory_skill_as_codex_discoverable() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp
+            .path()
+            .join("build/codex/plugins/reporting/skills/daily-brief");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "# daily brief\n").unwrap();
+
+        let item = classify_entry(
+            "codex",
+            tmp.path(),
+            &entry(
+                "reporting.daily-brief",
+                "build/codex/plugins/reporting/skills/daily-brief",
+                "skills/reporting/daily-brief",
+                false,
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(item.link_mode, SkillSurfaceLinkMode::Directory);
+        assert_eq!(item.expected_codex_discoverable, CodexDiscoverability::Yes);
+        assert_eq!(item.warnings, Vec::new());
+    }
+
+    #[test]
+    fn classifies_skill_md_file_leaf_as_not_discoverable_with_warning() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp
+            .path()
+            .join("build/codex/plugins/reporting/skills/daily-brief/SKILL.md");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(&source, "# daily brief\n").unwrap();
+
+        let item = classify_entry(
+            "codex",
+            tmp.path(),
+            &entry(
+                "reporting.daily-brief",
+                "build/codex/plugins/reporting/skills/daily-brief/SKILL.md",
+                "skills/reporting/daily-brief/SKILL.md",
+                false,
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(item.link_mode, SkillSurfaceLinkMode::File);
+        assert_eq!(item.expected_codex_discoverable, CodexDiscoverability::No);
+        assert_eq!(item.warnings.len(), 1);
+        assert_eq!(item.warnings[0].code, FILE_SYMLINK_WARNING);
+    }
+
+    #[test]
+    fn classifies_recursive_skill_entry_as_not_discoverable() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp.path().join("build/codex/plugins/reporting/skills");
+        fs::create_dir_all(source.join("daily-brief")).unwrap();
+        fs::write(source.join("daily-brief/SKILL.md"), "# daily brief\n").unwrap();
+
+        let item = classify_entry(
+            "codex",
+            tmp.path(),
+            &entry(
+                "reporting.skills-tree",
+                "build/codex/plugins/reporting/skills",
+                "skills/reporting",
+                true,
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(item.link_mode, SkillSurfaceLinkMode::RecursiveFile);
+        assert_eq!(item.expected_codex_discoverable, CodexDiscoverability::No);
+    }
+
+    #[test]
+    fn classifies_non_skills_destination_as_not_applicable() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp
+            .path()
+            .join("targets/codex/plugins/reporting/.codex-plugin/plugin.json");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(&source, "{}\n").unwrap();
+
+        let item = classify_entry(
+            "codex",
+            tmp.path(),
+            &entry(
+                "reporting.plugin-manifest",
+                "targets/codex/plugins/reporting/.codex-plugin/plugin.json",
+                "plugins/reporting/.codex-plugin/plugin.json",
+                false,
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(item.link_mode, SkillSurfaceLinkMode::File);
+        assert_eq!(
+            item.expected_codex_discoverable,
+            CodexDiscoverability::NotApplicable
+        );
+    }
+}

--- a/crates/agent-runtime-cli/src/install.rs
+++ b/crates/agent-runtime-cli/src/install.rs
@@ -9,7 +9,9 @@
 //!   the per-entry-replace merge function. Applied before plan generation.
 //! - [`plan`] — builder that turns a (post-overlay-merge) `LinkMap` into a
 //!   flat ordered `InstallPlan`, expanding `recursive: true` directory
-//!   entries into one action per file.
+//!   entries into one action per file. Non-recursive `symlinked-file`
+//!   entries intentionally accept either file or directory sources and
+//!   become one symlink action at the declared destination.
 //! - [`executor`] — walks the plan and reconciles the runtime home to
 //!   the plan. Re-running on a clean install is a byte-identical no-op.
 //!

--- a/crates/agent-runtime-cli/src/install/executor.rs
+++ b/crates/agent-runtime-cli/src/install/executor.rs
@@ -4,7 +4,7 @@
 //! load-bearing invariant Plan 04 Sprint 1 Task 1.2 ships against — see
 //! the integration test in `tests/integration/install_pipeline.rs`.
 
-use super::plan::{InstallPlan, PlanAction};
+use super::plan::{InstallPlan, PlanAction, SymlinkLinkMode};
 use crate::managed_block::{CommentStyle as MbStyle, ManagedBlock};
 use std::fs;
 use std::io;
@@ -62,16 +62,19 @@ pub enum AppliedChange {
         entry_id: String,
         dest: PathBuf,
         source: PathBuf,
+        link_mode: SymlinkLinkMode,
     },
     SymlinkReplaced {
         entry_id: String,
         dest: PathBuf,
         source: PathBuf,
+        link_mode: SymlinkLinkMode,
     },
     FileBackedUpThenSymlinked {
         entry_id: String,
         dest: PathBuf,
         source: PathBuf,
+        link_mode: SymlinkLinkMode,
         backup: PathBuf,
     },
     ManagedBlockApplied {
@@ -118,8 +121,17 @@ pub fn run(
                 entry_id,
                 source,
                 dest,
+                link_mode,
                 requires_backup,
-            } => handle_symlink(mode, entry_id, source, dest, *requires_backup, &backup_root)?,
+            } => handle_symlink(
+                mode,
+                entry_id,
+                source,
+                dest,
+                *link_mode,
+                *requires_backup,
+                &backup_root,
+            )?,
             PlanAction::ManagedBlock {
                 entry_id,
                 config_file,
@@ -170,6 +182,7 @@ fn handle_symlink(
     entry_id: &str,
     source: &Path,
     dest: &Path,
+    link_mode: SymlinkLinkMode,
     requires_backup_flag: bool,
     backup_root: &Path,
 ) -> Result<AppliedChange, ApplyError> {
@@ -187,6 +200,7 @@ fn handle_symlink(
             entry_id,
             source,
             dest,
+            link_mode,
             requires_backup_flag,
             backup_root,
         ));
@@ -210,6 +224,7 @@ fn handle_symlink(
                 entry_id: entry_id.to_string(),
                 dest: dest.to_path_buf(),
                 source: source.to_path_buf(),
+                link_mode,
             })
         }
         Ok(m) if m.file_type().is_file() => {
@@ -223,6 +238,7 @@ fn handle_symlink(
                 entry_id: entry_id.to_string(),
                 dest: dest.to_path_buf(),
                 source: source.to_path_buf(),
+                link_mode,
                 backup,
             })
         }
@@ -249,6 +265,7 @@ fn handle_symlink(
                 entry_id: entry_id.to_string(),
                 dest: dest.to_path_buf(),
                 source: source.to_path_buf(),
+                link_mode,
             })
         }
         Err(e) => Err(ApplyError::Io {
@@ -262,6 +279,7 @@ fn classify_dry_run(
     entry_id: &str,
     source: &Path,
     dest: &Path,
+    link_mode: SymlinkLinkMode,
     requires_backup_flag: bool,
     backup_root: &Path,
 ) -> AppliedChange {
@@ -271,6 +289,7 @@ fn classify_dry_run(
             entry_id: entry_id.to_string(),
             dest: dest.to_path_buf(),
             source: source.to_path_buf(),
+            link_mode,
         },
         Ok(m) if m.file_type().is_file() => {
             let backup = backup_root
@@ -280,6 +299,7 @@ fn classify_dry_run(
                 entry_id: entry_id.to_string(),
                 dest: dest.to_path_buf(),
                 source: source.to_path_buf(),
+                link_mode,
                 backup,
             }
         }
@@ -287,6 +307,7 @@ fn classify_dry_run(
             entry_id: entry_id.to_string(),
             dest: dest.to_path_buf(),
             source: source.to_path_buf(),
+            link_mode,
         },
         Err(_) if requires_backup_flag => {
             // Plan said "requires backup" but the file vanished between
@@ -295,12 +316,14 @@ fn classify_dry_run(
                 entry_id: entry_id.to_string(),
                 dest: dest.to_path_buf(),
                 source: source.to_path_buf(),
+                link_mode,
             }
         }
         Err(_) => AppliedChange::SymlinkCreated {
             entry_id: entry_id.to_string(),
             dest: dest.to_path_buf(),
             source: source.to_path_buf(),
+            link_mode,
         },
     }
 }
@@ -412,7 +435,9 @@ fn handle_managed_block(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::install::plan::InstallPlan;
+    use crate::install::plan::{InstallPlan, SymlinkLinkMode};
+    use pretty_assertions::assert_eq;
+    use std::fs;
     use tempfile::TempDir;
 
     #[test]
@@ -456,6 +481,79 @@ mod tests {
         match err {
             ApplyError::InvalidTag { value } => assert_eq!(value, "../escape"),
             other => panic!("expected InvalidTag, got {other:?}"),
+        }
+    }
+
+    fn directory_symlink_plan(tmp: &TempDir) -> (InstallPlan, PathBuf, PathBuf) {
+        let source = tmp.path().join("source/skills/reporting/daily-brief");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "# daily brief\n").unwrap();
+        let dest = tmp.path().join("home/skills/reporting/daily-brief");
+        let plan = InstallPlan {
+            product: "codex".to_string(),
+            source_root: tmp.path().join("source"),
+            home: tmp.path().join("home"),
+            state_home: tmp.path().join("state"),
+            actions: vec![PlanAction::Symlink {
+                entry_id: "reporting.daily-brief".to_string(),
+                source: source.clone(),
+                dest: dest.clone(),
+                link_mode: SymlinkLinkMode::Directory,
+                requires_backup: false,
+            }],
+        };
+        (plan, source, dest)
+    }
+
+    #[test]
+    fn apply_creates_directory_symlink_and_second_apply_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let (plan, source, dest) = directory_symlink_plan(&tmp);
+
+        let first = run(&plan, Mode::Apply, SystemTime::UNIX_EPOCH, None).unwrap();
+
+        assert_eq!(
+            first,
+            vec![AppliedChange::SymlinkCreated {
+                entry_id: "reporting.daily-brief".to_string(),
+                dest: dest.clone(),
+                source: source.clone(),
+                link_mode: SymlinkLinkMode::Directory,
+            }]
+        );
+        assert!(
+            fs::symlink_metadata(&dest)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(fs::read_link(&dest).unwrap(), source);
+
+        let second = run(&plan, Mode::Apply, SystemTime::UNIX_EPOCH, None).unwrap();
+
+        assert_eq!(
+            second,
+            vec![AppliedChange::NoOp {
+                entry_id: "reporting.daily-brief".to_string(),
+                dest,
+            }]
+        );
+    }
+
+    #[test]
+    fn apply_refuses_to_overwrite_existing_real_directory() {
+        let tmp = TempDir::new().unwrap();
+        let (plan, _source, dest) = directory_symlink_plan(&tmp);
+        fs::create_dir_all(&dest).unwrap();
+
+        let err = run(&plan, Mode::Apply, SystemTime::UNIX_EPOCH, None).unwrap_err();
+
+        match err {
+            ApplyError::Io { path, source } => {
+                assert_eq!(path, dest);
+                assert_eq!(source.kind(), io::ErrorKind::AlreadyExists);
+            }
+            other => panic!("expected AlreadyExists io error, got {other:?}"),
         }
     }
 }

--- a/crates/agent-runtime-cli/src/install/link_map.rs
+++ b/crates/agent-runtime-cli/src/install/link_map.rs
@@ -7,6 +7,11 @@
 //! required/forbidden field enforcement happens in [`LinkEntry::validate`]
 //! after the YAML round-trip, because `serde` alone cannot express the
 //! `allOf if/then` shape that the JSON Schema uses.
+//! `kind=symlinked-file` is a compatibility name: with
+//! `recursive: false`, its `source` may be a file or a directory and the
+//! installer creates exactly one symlink at `destination`. With
+//! `recursive: true`, directory sources expand into one file symlink per
+//! source file.
 //!
 //! Source: agent-runtime-kit Plan 04 Sprint 1 Task 1.2.
 //!   `docs/plans/04-installer-doctor-and-bootstrap/...-plan.md`.
@@ -91,7 +96,9 @@ impl LinkEntry {
         match self.kind {
             EntryKind::SymlinkedFile => {
                 if self.source.is_none() {
-                    return Err("kind=symlinked-file requires `source`".to_string());
+                    return Err(
+                        "kind=symlinked-file requires `source` (file or directory)".to_string()
+                    );
                 }
                 self.forbid_managed_block_fields()?;
             }

--- a/crates/agent-runtime-cli/src/install/plan.rs
+++ b/crates/agent-runtime-cli/src/install/plan.rs
@@ -3,10 +3,14 @@
 //!
 //! The builder walks a [`LinkMap`] in declared order, expands
 //! `recursive: true` directory entries into one [`PlanAction`] per file,
-//! and produces a flat list. Order is preserved — the executor walks the
-//! list top to bottom. Re-running against an unchanged tree produces an
-//! empty change set (idempotence is enforced at apply time by checking
-//! the current state of each destination before mutating).
+//! leaves `recursive: false` entries as one symlink action, and produces
+//! a flat list. A non-recursive `kind=symlinked-file` entry may point at
+//! either a file or a directory; directory sources intentionally become
+//! directory symlinks at the entry's destination. Order is preserved —
+//! the executor walks the list top to bottom. Re-running against an
+//! unchanged tree produces an empty change set (idempotence is enforced
+//! at apply time by checking the current state of each destination before
+//! mutating).
 
 use super::link_map::{CommentStyle, EntryKind, LinkEntry, LinkMap};
 use std::path::{Path, PathBuf};
@@ -43,6 +47,7 @@ pub enum PlanAction {
         entry_id: String,
         source: PathBuf,
         dest: PathBuf,
+        link_mode: SymlinkLinkMode,
         /// True when `dest` would replace a regular file (not a symlink).
         /// Drives backup behaviour at apply time.
         requires_backup: bool,
@@ -55,6 +60,23 @@ pub enum PlanAction {
         comment_style: CommentStyle,
         body: String,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymlinkLinkMode {
+    File,
+    Directory,
+    RecursiveFile,
+}
+
+impl SymlinkLinkMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            SymlinkLinkMode::File => "file symlink",
+            SymlinkLinkMode::Directory => "directory symlink",
+            SymlinkLinkMode::RecursiveFile => "recursive file symlink",
+        }
+    }
 }
 
 /// Resolved install plan. Each entry in `actions` is ready to run; the
@@ -180,10 +202,12 @@ fn expand_single_symlink(
     }
     let dest_abs = home.join(&entry.destination);
     let requires_backup = is_regular_non_symlink(&dest_abs);
+    let link_mode = link_mode_for_source(&source_abs);
     out.push(PlanAction::Symlink {
         entry_id: entry.id.clone(),
         source: source_abs,
         dest: dest_abs,
+        link_mode,
         requires_backup,
     });
     Ok(())
@@ -206,10 +230,12 @@ fn expand_symlinked_file(
     if !entry.recursive {
         let dest_abs = home.join(&entry.destination);
         let requires_backup = is_regular_non_symlink(&dest_abs);
+        let link_mode = link_mode_for_source(&source_abs);
         out.push(PlanAction::Symlink {
             entry_id: entry.id.clone(),
             source: source_abs,
             dest: dest_abs,
+            link_mode,
             requires_backup,
         });
         return Ok(());
@@ -231,10 +257,18 @@ fn expand_symlinked_file(
             entry_id: entry.id.clone(),
             source: abs_source,
             dest: abs_dest,
+            link_mode: SymlinkLinkMode::RecursiveFile,
             requires_backup,
         });
     }
     Ok(())
+}
+
+fn link_mode_for_source(source: &Path) -> SymlinkLinkMode {
+    match std::fs::symlink_metadata(source) {
+        Ok(meta) if meta.is_dir() => SymlinkLinkMode::Directory,
+        _ => SymlinkLinkMode::File,
+    }
 }
 
 fn collect_files(root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), std::io::Error> {
@@ -273,6 +307,9 @@ fn is_regular_non_symlink(p: &Path) -> bool {
 mod tests {
     use super::*;
     use crate::install::link_map::{EntryKind, LinkEntry, LinkMap};
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::TempDir;
 
     fn one_entry_map(entry: LinkEntry) -> LinkMap {
         LinkMap {
@@ -368,5 +405,42 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, PlanError::DestinationTraversal { .. }));
+    }
+
+    #[test]
+    fn build_keeps_non_recursive_directory_source_as_one_symlink_action() {
+        let tmp = TempDir::new().unwrap();
+        let source_root = tmp.path().join("src");
+        let source_dir = source_root.join("build/codex/plugins/reporting/skills/daily-brief");
+        fs::create_dir_all(&source_dir).unwrap();
+        fs::write(source_dir.join("SKILL.md"), "# daily brief\n").unwrap();
+
+        let home = tmp.path().join("home");
+        let state_home = tmp.path().join("state");
+        let lm = one_entry_map(symlinked_file(
+            "reporting.daily-brief",
+            "build/codex/plugins/reporting/skills/daily-brief",
+            "skills/reporting/daily-brief",
+        ));
+
+        let plan = InstallPlan::build("codex", &source_root, &home, &state_home, &lm).unwrap();
+
+        assert_eq!(plan.actions.len(), 1);
+        match &plan.actions[0] {
+            PlanAction::Symlink {
+                entry_id,
+                source,
+                dest,
+                link_mode,
+                requires_backup,
+            } => {
+                assert_eq!(entry_id, "reporting.daily-brief");
+                assert_eq!(source, &source_dir);
+                assert_eq!(dest, &home.join("skills/reporting/daily-brief"));
+                assert_eq!(*link_mode, SymlinkLinkMode::Directory);
+                assert!(!requires_backup);
+            }
+            other => panic!("expected symlink action, got {other:?}"),
+        }
     }
 }

--- a/crates/agent-runtime-cli/src/uninstall/plan.rs
+++ b/crates/agent-runtime-cli/src/uninstall/plan.rs
@@ -55,6 +55,7 @@ impl UninstallPlan {
                     entry_id,
                     source,
                     dest,
+                    link_mode: _,
                     requires_backup: _,
                 } => {
                     actions.push(UninstallAction::RemoveSymlink {

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -17,6 +17,8 @@ mod cli;
 mod determinism_gate;
 #[path = "integration/doctor_filesystem.rs"]
 mod doctor_filesystem;
+#[path = "integration/doctor_skill_surface.rs"]
+mod doctor_skill_surface;
 #[path = "integration/doctor_upgrade.rs"]
 mod doctor_upgrade;
 #[path = "integration/doctor_version.rs"]

--- a/crates/agent-runtime-cli/tests/integration/audit_drift_extra_intentional.rs
+++ b/crates/agent-runtime-cli/tests/integration/audit_drift_extra_intentional.rs
@@ -127,6 +127,19 @@ entries:
     );
 }
 
+fn add_codex_directory_skill_link_map(root: &Path) {
+    write(
+        &root.join("targets/codex/link-map.yaml"),
+        r#"schema_version: 1
+entries:
+  - id: reporting.sample
+    kind: symlinked-file
+    source: core/skills/sample
+    destination: skills/reporting/sample
+"#,
+    );
+}
+
 #[test]
 fn documented_plugin_manifest_divergence_reports_intentional_difference_exit_zero() {
     let tmp = copy_fixture();
@@ -205,6 +218,33 @@ fn unrelated_live_home_sibling_outside_owned_link_map_roots_is_ignored() {
     assert!(
         !out.stderr_text().contains("[extra/warn"),
         "unexpected extra finding for unrelated sibling; stderr=\n{}",
+        out.stderr_text(),
+    );
+}
+
+#[test]
+fn codex_domain_nested_directory_skill_symlink_is_not_extra_surface() {
+    let tmp = copy_fixture();
+    add_codex_directory_skill_link_map(tmp.path());
+
+    let codex_home = tmp.path().join("home/.codex");
+    let source = tmp.path().join("core/skills/sample");
+    let destination = codex_home.join("skills/reporting/sample");
+    fs::create_dir_all(destination.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&source, &destination).unwrap();
+
+    let codex_home_str = codex_home.to_str().unwrap();
+    let out = audit(tmp.path(), &[], &[("CODEX_HOME", codex_home_str)]);
+
+    assert_eq!(
+        out.code,
+        0,
+        "domain-nested directory skill symlink should not be reported as extra; stderr=\n{}",
+        out.stderr_text(),
+    );
+    assert!(
+        !out.stderr_text().contains("[extra/warn/codex]"),
+        "unexpected codex extra finding; stderr=\n{}",
         out.stderr_text(),
     );
 }

--- a/crates/agent-runtime-cli/tests/integration/doctor_skill_surface.rs
+++ b/crates/agent-runtime-cli/tests/integration/doctor_skill_surface.rs
@@ -1,0 +1,138 @@
+//! Integration coverage for `agent-runtime doctor --class skill-surface`.
+
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn run(args: &[&str]) -> CmdOutput {
+    cmd::run(&agent_runtime_bin(), args, &[], None)
+}
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn codex_fixture() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    write(
+        &tmp.path()
+            .join("build/codex/plugins/reporting/skills/daily-brief/SKILL.md"),
+        "# daily brief\n",
+    );
+    write(
+        &tmp.path()
+            .join("build/codex/plugins/reporting/skills/bad/SKILL.md"),
+        "# bad\n",
+    );
+    write(
+        &tmp.path().join("targets/codex/link-map.yaml"),
+        r#"schema_version: 1
+entries:
+  - id: reporting.daily-brief
+    kind: symlinked-file
+    source: build/codex/plugins/reporting/skills/daily-brief
+    destination: skills/reporting/daily-brief
+  - id: reporting.bad-file-leaf
+    kind: symlinked-file
+    source: build/codex/plugins/reporting/skills/bad/SKILL.md
+    destination: skills/reporting/bad/SKILL.md
+"#,
+    );
+    tmp
+}
+
+#[test]
+fn skill_surface_json_reports_directory_shape_and_file_leaf_warning() {
+    let tmp = codex_fixture();
+    let source_root = tmp.path().to_string_lossy().into_owned();
+
+    let output = run(&[
+        "doctor",
+        "--source-root",
+        &source_root,
+        "--product",
+        "codex",
+        "--class",
+        "skill-surface",
+        "--format",
+        "json",
+    ]);
+
+    assert_eq!(output.code, 1, "warning path should exit 1");
+    let json: Value = serde_json::from_str(&output.stdout_text()).unwrap();
+    assert_eq!(json["schema_version"], "agent-runtime-cli.doctor.v1");
+    assert_eq!(
+        json["acceptance_boundary"],
+        "shape validation only; live Codex Desktop discovery still requires `codex debug prompt-input` in a fresh session"
+    );
+    assert_eq!(
+        json["skill_surface"]["items"][0]["expected_codex_discoverable"],
+        true
+    );
+    assert_eq!(json["skill_surface"]["items"][0]["link_mode"], "directory");
+    assert_eq!(
+        json["skill_surface"]["items"][1]["warnings"][0]["code"],
+        "codex.active-skill.file-symlink"
+    );
+}
+
+#[test]
+fn skill_surface_human_output_ends_with_acceptance_boundary() {
+    let tmp = codex_fixture();
+    let source_root = tmp.path().to_string_lossy().into_owned();
+
+    let output = run(&[
+        "doctor",
+        "--source-root",
+        &source_root,
+        "--product",
+        "codex",
+        "--class",
+        "skill-surface",
+    ]);
+
+    assert_eq!(output.code, 1, "warning path should exit 1");
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.trim_end().ends_with(
+            "agent-runtime doctor: acceptance-boundary: shape validation only; live Codex Desktop discovery still requires `codex debug prompt-input` in a fresh session"
+        ),
+        "stderr should end with acceptance boundary: {stderr}"
+    );
+}
+
+#[test]
+fn skill_surface_empty_link_map_exits_zero_without_manifests() {
+    let tmp = TempDir::new().unwrap();
+    write(
+        &tmp.path().join("targets/codex/link-map.yaml"),
+        "schema_version: 1\nentries: []\n",
+    );
+    let source_root = tmp.path().to_string_lossy().into_owned();
+
+    let output = run(&[
+        "doctor",
+        "--source-root",
+        &source_root,
+        "--product",
+        "codex",
+        "--class",
+        "skill-surface",
+        "--format",
+        "json",
+    ]);
+
+    assert_eq!(output.code, 0, "empty link-map should exit 0");
+    let json: Value = serde_json::from_str(&output.stdout_text()).unwrap();
+    assert_eq!(json["skill_surface"]["items"], Value::Array(Vec::new()));
+}

--- a/docs/plans/codex-skill-surface-primitives/codex-skill-surface-primitives-execution-state.md
+++ b/docs/plans/codex-skill-surface-primitives/codex-skill-surface-primitives-execution-state.md
@@ -1,0 +1,91 @@
+<!-- execute-from-tracking-issue:state:v1 -->
+# Codex Skill Surface Primitives Execution State
+
+## Execution State
+
+- Status: in progress
+- Target scope: whole issue
+- Execution window: whole issue
+- Current task: final validation and delivery
+- Next task: open PR, complete review, merge, and close issue #446
+- Last updated: 2026-05-23 12:42 CST
+- Branch/commit/PR/release: `feat/issue-446-codex-skill-surface-primitives`,
+  pending commit and PR
+- Tracking issue: [#446](https://github.com/sympoies/nils-cli/issues/446)
+- Source document:
+  docs/plans/codex-skill-surface-primitives/codex-skill-surface-primitives-plan.md
+- Direct source-doc execution waiver: not applicable
+
+## Task Ledger
+
+| ID | Status | Task | Evidence | Notes |
+| --- | --- | --- | --- | --- |
+| Task 1.1 | done | Document directory-symlink contract | `cargo test -p agent-runtime-cli install` pass | Module docs and schema text now state file-or-directory acceptance. |
+| Task 1.2 | done | Pin non-recursive directory-source behavior | `cargo test -p agent-runtime-cli install` pass | Tests cover plan shape, apply idempotence, and real-directory refusal. |
+| Task 1.3 | done | Label dry-run link modes | `cargo test -p agent-runtime-cli` pass | Install output distinguishes file, directory, and recursive file symlinks. |
+| Task 2.1 | done | Add `doctor --class skill-surface` scaffold | `cargo test -p agent-runtime-cli doctor` pass | Class can run without runtime manifests when the link map is absent. |
+| Task 2.2 | done | Classify link-map entries | `cargo test -p agent-runtime-cli doctor::skill_surface` pass | JSON reports entry id, paths, link mode, discoverability, and warnings. |
+| Task 2.3 | done | Warn on Codex `SKILL.md` file symlinks | `cargo test -p agent-runtime-cli doctor` pass | Warning code is `codex.active-skill.file-symlink`. |
+| Task 3.1 | done | Pin audit-drift parent-scan behavior | `cargo test -p agent-runtime-cli audit_drift` pass | Domain-nested directory skill symlink is not treated as extra surface. |
+| Task 3.2 | done | Document live-acceptance boundary | `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` pass | `DEVELOPMENT.md` now names shape-only versus live Codex acceptance. |
+| Task 3.3 | done | Surface acceptance boundary in doctor output | `cargo test -p agent-runtime-cli doctor` pass | Human and JSON output include the boundary for Codex skill-surface checks. |
+
+## Validation
+
+| Command | Status | Summary | Artifact |
+| --- | --- | --- | --- |
+| `agent-docs resolve startup` | pass | Strict startup preflight passed. | terminal log |
+| `agent-docs resolve project-dev` | pass | Strict project-dev preflight passed. | terminal log |
+| `agent-docs resolve task-tools` | pass | Strict task-tools preflight passed before GitHub operations. | terminal log |
+| `plan-tooling validate --file ...codex-skill-surface-primitives-plan.md` | pass | Plan bundle validation passed after formatting. | terminal log |
+| `cargo test -p agent-runtime-cli doctor::skill_surface` | pass | Skill-surface classifier unit tests passed. | terminal log |
+| `cargo test -p agent-runtime-cli install` | pass | Install unit and filtered integration tests passed. | terminal log |
+| `cargo test -p agent-runtime-cli doctor` | pass | Doctor unit and filtered integration tests passed. | terminal log |
+| `cargo test -p agent-runtime-cli audit_drift` | pass | Audit-drift unit and filtered integration tests passed. | terminal log |
+| `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings` | pass | Agent-runtime CLI clippy passed. | terminal log |
+| `cargo test -p agent-runtime-cli` | pass | Agent-runtime CLI full crate tests passed. | terminal log |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` | pass | Docs gates, workspace clippy, nextest, and doc tests passed. | terminal log |
+| `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` | pass | Required checks, nextest, doctests, and coverage passed; line coverage was 85.30%. | `target/coverage/lcov.info` |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | pass | Docs placement, docs hygiene, markdownlint, plan bundle, CLI output contract, and fixture redaction checks passed after the final state update. | terminal log |
+| `agent-runtime doctor --class skill-surface --product codex --format json` | pass | Smoke against `graysurf/agent-runtime-kit`: 65 items, 0 findings, 0 warnings. | `agent-runtime-kit-skill-surface.json` |
+
+## Runtime Findings
+
+- `fix-now`: the original plan markdown exceeded the repository markdown line
+  length limit after edits; fixed by reflowing the plan without changing task
+  semantics.
+- `fix-now`: the full gate found stale third-party artifacts after the
+  `Cargo.lock` metadata hash changed; regenerated `THIRD_PARTY_LICENSES.md`
+  and `THIRD_PARTY_NOTICES.md`, then reran the full gate successfully.
+- `note`: `doctor --class skill-surface` is intentionally a shape diagnostic.
+  It reads the source-root link map and does not stat live `$CODEX_HOME`.
+
+## Blockers
+
+- none
+
+## Session Log
+
+### 2026-05-23 12:27 CST
+
+- Created tracking issue [#446](https://github.com/sympoies/nils-cli/issues/446)
+  with source, plan, and initial state snapshots.
+- Hardened install planning and executor tests around non-recursive directory
+  sources for `kind: symlinked-file`.
+- Added link-mode metadata through install planning, executor reporting, and
+  install command output.
+- Added `doctor --class skill-surface` with JSON and human output for Codex
+  active-skill shape checks.
+- Added audit-drift regression coverage for domain-nested directory skill
+  symlinks.
+- Updated `DEVELOPMENT.md` with the live Codex Desktop acceptance boundary.
+- Validated targeted tests and the `--local-fast` workspace gate.
+
+### 2026-05-23 12:41 CST
+
+- Ran the required non-doc delivery gate with coverage; the rerun passed after
+  regenerating third-party artifacts.
+- Captured a current `agent-runtime-kit` source-root skill-surface smoke under
+  the project output directory. It reported 65 items and no warnings.
+- Reran the docs-only gate after updating this execution-state file.
+- Next: commit, open PR, run specialist review, merge, and close issue #446.

--- a/docs/plans/codex-skill-surface-primitives/codex-skill-surface-primitives-plan.md
+++ b/docs/plans/codex-skill-surface-primitives/codex-skill-surface-primitives-plan.md
@@ -17,17 +17,24 @@ documentation and the live-acceptance boundary.
 - Primary source: `docs/plans/codex-skill-surface-primitives/codex-skill-surface-primitives-discussion-source.md`
 - Source type: `discussion-to-implementation-doc`
 - Open questions carried into execution:
-  - Schema alias such as `symlinked-path`: deferred per source Decision #4 — only revisit if Sprint 1 docs/tests cannot close the ambiguity.
-  - `audit-drift` `scan_scope: exact|parent` metadata field: deferred — Sprint 3 pins current parent-scan behaviour with a regression test; revisit only if a real conflict surfaces.
-  - Whether the Codex diagnostic also lives under `audit-drift`: this plan ships it under `doctor --class skill-surface` only; cross-listing in `audit-drift` is out of scope.
+  - Schema alias such as `symlinked-path`: deferred per source Decision #4. Only revisit if Sprint 1 docs/tests cannot close
+    the ambiguity.
+  - `audit-drift` `scan_scope: exact|parent` metadata field: deferred. Sprint 3 pins current parent-scan behaviour with a
+    regression test; revisit only if a real conflict surfaces.
+  - Whether the Codex diagnostic also lives under `audit-drift`: this plan ships it under `doctor --class skill-surface`
+    only; cross-listing in `audit-drift` is out of scope.
 
 ## Scope
 
 - In scope:
-  - Clarify the install-map contract for non-recursive `symlinked-file` entries whose source is a directory (module docs, schema help text, dry-run wording).
-  - Add tests that pin: non-recursive directory source → one `PlanAction::Symlink`; idempotent apply; refusal when destination is an existing directory.
-  - Add a new `doctor --class skill-surface` lane that classifies each link-map entry by link mode, reports Codex active-skill shape, and flags `SKILL.md` file symlinks under `$CODEX_HOME/skills/**`.
-  - Update operator-facing docs (`DEVELOPMENT.md` and/or runbooks) to state that `nils-cli` shape validation is not a substitute for live `codex debug prompt-input` acceptance.
+  - Clarify the install-map contract for non-recursive `symlinked-file` entries whose source is a directory.
+  - Cover module docs, schema help text, and dry-run wording.
+  - Add tests that pin non-recursive directory source to one `PlanAction::Symlink`, idempotent apply, and refusal when the
+    destination is an existing directory.
+  - Add a new `doctor --class skill-surface` lane that classifies each link-map entry by link mode, reports Codex
+    active-skill shape, and flags `SKILL.md` file symlinks under `$CODEX_HOME/skills/**`.
+  - Update operator-facing docs (`DEVELOPMENT.md` and/or runbooks) to state that `nils-cli` shape validation is not a
+    substitute for live `codex debug prompt-input` acceptance.
 - Out of scope:
   - Renaming `EntryKind::SymlinkedFile` / `kind: symlinked-file` or adding a schema alias.
   - Changing executor mutation rules, backup semantics, or overlay merge behaviour.
@@ -38,15 +45,20 @@ documentation and the live-acceptance boundary.
 
 ## Assumptions
 
-1. The source's confirmed facts hold: the current executor already produces the issue #43 passing shape (one directory symlink per non-recursive entry with a directory source). No core install primitive needs to change.
-2. The selected diagnostic host is `agent-runtime doctor` with a new `skill-surface` class, exposed through the existing class-based `DoctorFinding` printout plus structured (`--format json`) output already used by sibling classes.
-3. Domain-nested Codex active skill destinations (`$CODEX_HOME/skills/<domain>/<skill>`) are the supported shape; flat `$CODEX_HOME/skills/<skill>` is not introduced in this plan.
-4. Reading the link map at `<source_root>/targets/<product>/link-map.yaml` plus the existing `RuntimeRootsManifest` is enough input for the new diagnostic; no new manifest fields are required.
+1. The source's confirmed facts hold: the current executor already produces the issue #43 passing shape, one directory
+   symlink per non-recursive entry with a directory source. No core install primitive needs to change.
+2. The selected diagnostic host is `agent-runtime doctor` with a new `skill-surface` class, exposed through the existing
+   class-based `DoctorFinding` printout plus structured `--format json` output used by sibling classes.
+3. Domain-nested Codex active skill destinations (`$CODEX_HOME/skills/<domain>/<skill>`) are the supported shape. Flat
+   `$CODEX_HOME/skills/<skill>` is not introduced in this plan.
+4. Reading the link map at `<source_root>/targets/<product>/link-map.yaml` plus the existing `RuntimeRootsManifest` is
+   enough input for the new diagnostic; no new manifest fields are required.
 5. The crate-wide determinism contract (no `SystemTime::now`, no `HashMap`) still applies to the new code paths.
 
 ## Sprint 1: Contract Hardening, Tests, And Dry-Run Wording
 
-**Goal**: Make the existing directory-symlink primitive an explicit, tested, operator-visible contract without changing executor behaviour.
+**Goal**: Make the existing directory-symlink primitive an explicit, tested,
+operator-visible contract without changing executor behaviour.
 **Demo/Validation**:
 
 - Command(s):
@@ -54,9 +66,12 @@ documentation and the live-acceptance boundary.
   - `cargo nextest run -p agent-runtime-cli audit_drift`
   - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
 - Verify:
-  - New unit tests in `install/plan.rs` and `install/executor.rs` cover the directory-symlink path (plan shape, apply, idempotence, directory-destination refusal).
-  - `agent-runtime install --dry-run` printout distinguishes file symlink, directory symlink, and recursive expansion in `print_change` lines.
-  - `link-map.yaml` schema doc-comment in `install/link_map.rs` records that `kind=symlinked-file` + `recursive: false` accepts a directory source.
+  - New unit tests in `install/plan.rs` and `install/executor.rs` cover the directory-symlink path: plan shape, apply,
+    idempotence, and directory-destination refusal.
+  - `agent-runtime install --dry-run` printout distinguishes file symlink, directory symlink, and recursive expansion in
+    `print_change` lines.
+  - `link-map.yaml` schema doc-comment in `install/link_map.rs` records that `kind=symlinked-file` plus
+    `recursive: false` accepts a directory source.
 
 ### Task 1.1: Document the directory-symlink contract in install modules
 
@@ -64,7 +79,10 @@ documentation and the live-acceptance boundary.
   - `crates/agent-runtime-cli/src/install/plan.rs`
   - `crates/agent-runtime-cli/src/install/link_map.rs`
   - `crates/agent-runtime-cli/src/install.rs`
-- **Description**: Update module/`pub struct` doc comments to state that a non-recursive `symlinked-file` entry whose `source` resolves to a directory becomes one `PlanAction::Symlink` whose destination is a directory symlink. Tighten the validator error text for `kind=symlinked-file` so the schema message names the file-or-directory acceptance instead of implying file-only.
+- **Description**: Update module/`pub struct` doc comments to state that a non-recursive `symlinked-file` entry whose
+  `source` resolves to a directory becomes one `PlanAction::Symlink` whose destination is a directory symlink. Tighten the
+  validator error text for `kind=symlinked-file` so the schema message names file-or-directory acceptance instead of
+  implying file-only.
 - **Dependencies**:
   - none
 - **Complexity**: 2
@@ -80,7 +98,11 @@ documentation and the live-acceptance boundary.
 - **Location**:
   - `crates/agent-runtime-cli/src/install/plan.rs`
   - `crates/agent-runtime-cli/src/install/executor.rs`
-- **Description**: Add unit tests covering: (a) `InstallPlan::build` with `recursive: false` and a directory source emits exactly one `PlanAction::Symlink` whose destination is the link-map `destination` (not per-file expansion); (b) `executor::run` in `Mode::Apply` creates the directory symlink, treats `Mode::Apply` after `Mode::Apply` as a `NoOp`, and returns an `ApplyError::Io { kind: AlreadyExists }` (or equivalent refusal) when `dest` is an existing real directory.
+- **Description**: Add unit tests covering:
+  - `InstallPlan::build` with `recursive: false` and a directory source emits exactly one `PlanAction::Symlink` whose
+    destination is the link-map `destination`, not per-file expansion.
+  - `executor::run` in `Mode::Apply` creates the directory symlink, treats a second `Mode::Apply` as a `NoOp`, and returns
+    an `ApplyError::Io { kind: AlreadyExists }` or equivalent refusal when `dest` is an existing real directory.
 - **Dependencies**:
   - Task 1.1
 - **Complexity**: 3
@@ -95,20 +117,24 @@ documentation and the live-acceptance boundary.
 
 - **Location**:
   - `crates/agent-runtime-cli/src/commands/install.rs`
-- **Description**: Extend `print_change` (and any nearby `eprintln!` summary) so each `AppliedChange::SymlinkCreated|Replaced|FileBackedUpThenSymlinked` line names the link mode: `file symlink`, `directory symlink`, or `recursive file symlink` (when the entry was expanded). Derive the mode from `source` path metadata (existing `std::fs::symlink_metadata` is the canonical source). Keep summary counter wording.
+- **Description**: Extend `print_change` and nearby `eprintln!` summary output so each symlink change line names the link
+  mode: `file symlink`, `directory symlink`, or `recursive file symlink` when the entry was expanded. Derive the mode from
+  source path metadata where possible and keep summary counter wording.
 - **Dependencies**:
   - Task 1.1
 - **Complexity**: 3
 - **Acceptance criteria**:
   - Each printed change line includes one of the three link-mode tokens.
   - Operator-facing summary still prints `actions=` / `changes=` counts unchanged.
-  - At least one CLI smoke test or assertion covers the new wording for the directory-symlink path (snapshot or string-contains assertion).
+  - At least one CLI smoke test or assertion covers the new wording for the directory-symlink path.
 - **Validation**:
   - `cargo test -p agent-runtime-cli`
 
 ## Sprint 2: `doctor --class skill-surface` Diagnostic
 
-**Goal**: Add a machine-readable Codex skill-surface inspection lane to `doctor` that classifies link-map entries and emits Codex-specific shape warnings — without altering executor or audit-drift behaviour.
+**Goal**: Add a machine-readable Codex skill-surface inspection lane to
+`doctor` that classifies link-map entries and emits Codex-specific shape
+warnings without altering executor or audit-drift behaviour.
 **Demo/Validation**:
 
 - Command(s):
@@ -116,16 +142,23 @@ documentation and the live-acceptance boundary.
   - `cargo run -p agent-runtime-cli -- doctor --class skill-surface --product codex --format json --source-root <fixture>`
   - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
 - Verify:
-  - JSON output lists each link-map entry as a skill-surface item with `id`, `source`, `destination`, `link_mode`, `expected_codex_discoverable`, and optional `warnings`.
-  - A `kind=symlinked-file` entry whose destination matches `skills/**/SKILL.md` for `--product codex` emits a `codex.active-skill.file-symlink` warning.
-  - A domain-nested directory symlink (`skills/<domain>/<skill>` whose source is a directory) is reported as `expected_codex_discoverable=true` with no warnings.
+  - JSON output lists each link-map entry as a skill-surface item with `id`, `source`, `destination`, `link_mode`,
+    `expected_codex_discoverable`, and optional `warnings`.
+  - A `kind=symlinked-file` entry whose destination matches `skills/**/SKILL.md` for `--product codex` emits a
+    `codex.active-skill.file-symlink` warning.
+  - A domain-nested directory symlink (`skills/<domain>/<skill>` whose source is a directory) is reported as
+    `expected_codex_discoverable=true` with no warnings.
 
 ### Task 2.1: Add a `skill-surface` class scaffold to the doctor pipeline
 
 - **Location**:
   - `crates/agent-runtime-cli/src/doctor/`
   - `crates/agent-runtime-cli/src/commands/doctor.rs`
-- **Description**: Introduce a `skill_surface` module under `doctor/` with a `pub fn check(...) -> Vec<DoctorFinding>` signature mirroring sibling classes. Wire it behind the existing `--class` selector so `--class skill-surface` triggers it. Skip silently when the link map is missing (same pattern as `audit_drift::classes::extra`). No Codex-specific logic in this task — class wiring only. Sequential ordering note: although this task has no hard task-level dependency, it lands after Sprint 1 in the integration order so reviewers see contract-hardening changes before the new class.
+- **Description**: Introduce a `skill_surface` module under `doctor/` with a `pub fn check(...) -> Vec<DoctorFinding>`
+  signature mirroring sibling classes. Wire it behind the existing `--class` selector so `--class skill-surface` triggers
+  it. Skip silently when the link map is missing, matching `audit_drift::classes::extra`. No Codex-specific logic in this
+  task; class wiring only. Sequential ordering note: although this task has no hard task-level dependency, it lands after
+  Sprint 1 in the integration order so reviewers see contract-hardening changes before the new class.
 - **Dependencies**:
   - none
 - **Complexity**: 3
@@ -140,13 +173,20 @@ documentation and the live-acceptance boundary.
 
 - **Location**:
   - `crates/agent-runtime-cli/src/doctor/skill_surface.rs` (new)
-- **Description**: Implement classification: read `<source_root>/targets/<product>/link-map.yaml`, and for each entry produce `{ id, source, destination, link_mode: file|directory|recursive-file, expected_codex_discoverable }`. For `--product codex`, `expected_codex_discoverable` is `true` only when the entry is a `symlinked-file` non-recursive entry whose source is a directory and whose destination begins with `skills/<domain>/<skill>` (at least one path segment of domain plus one of skill). All other `--product codex` skills-prefixed entries are flagged as not Codex-discoverable. Other destinations are reported as `not-applicable`.
+- **Description**: Implement classification by reading `<source_root>/targets/<product>/link-map.yaml`. For each entry,
+  produce `{ id, source, destination, link_mode, expected_codex_discoverable }`, where `link_mode` is
+  `file|directory|recursive-file`. For `--product codex`, `expected_codex_discoverable` is `true` only when the entry is a
+  `symlinked-file` non-recursive entry whose source is a directory and whose destination begins with
+  `skills/<domain>/<skill>`. All other `--product codex` skills-prefixed entries are not Codex-discoverable. Other
+  destinations are reported as `not-applicable`.
 - **Dependencies**:
   - Task 2.1
 - **Complexity**: 5
 - **Acceptance criteria**:
-  - Pure-function classifier is unit-tested with: (a) directory-source non-recursive under `skills/<domain>/<skill>` → discoverable; (b) `SKILL.md` file leaf under `skills/<domain>/<skill>` → not discoverable; (c) recursive entry under `skills/...` → not discoverable; (d) non-skills destination → `not-applicable`.
-  - JSON output of `--format json` matches the documented field set with deterministic ordering (sorted by link-map declaration order, matching `InstallPlan`).
+  - Pure-function classifier is unit-tested with directory-source non-recursive under `skills/<domain>/<skill>`,
+    `SKILL.md` file leaf under `skills/<domain>/<skill>`, recursive entry under `skills/...`, and non-skills destination.
+  - JSON output of `--format json` matches the documented field set with deterministic ordering by link-map declaration
+    order, matching `InstallPlan`.
 - **Validation**:
   - `cargo nextest run -p agent-runtime-cli doctor::skill_surface`
 
@@ -155,7 +195,10 @@ documentation and the live-acceptance boundary.
 - **Location**:
   - `crates/agent-runtime-cli/src/doctor/skill_surface.rs`
   - `crates/agent-runtime-cli/src/commands/doctor.rs`
-- **Description**: For `--product codex`, any item whose destination matches `skills/**/SKILL.md` (any depth) emits a `DoctorFinding` with class `skill-surface`, severity `warn`, and a stable warning code `codex.active-skill.file-symlink`. Include the entry id, destination, and a one-line remediation pointing at "use a directory-symlink leaf at `skills/<domain>/<skill>`". Non-Codex products do not emit this warning.
+- **Description**: For `--product codex`, any item whose destination matches `skills/**/SKILL.md` at any depth emits a
+  `DoctorFinding` with class `skill-surface`, severity `warn`, and a stable warning code
+  `codex.active-skill.file-symlink`. Include the entry id, destination, and a one-line remediation pointing at
+  "use a directory-symlink leaf at `skills/<domain>/<skill>`". Non-Codex products do not emit this warning.
 - **Dependencies**:
   - Task 2.2
 - **Complexity**: 3
@@ -168,7 +211,10 @@ documentation and the live-acceptance boundary.
 
 ## Sprint 3: Audit-Drift Regression Pin, Operator Docs, And Live-Acceptance Boundary
 
-**Goal**: Lock in current `audit-drift` parent-scan behaviour against the domain-nested Codex shape, and make the live-acceptance boundary visible in operator docs and command output so a passing `doctor` is not mistaken for fresh Codex Desktop acceptance.
+**Goal**: Lock in current `audit-drift` parent-scan behaviour against the
+domain-nested Codex shape, and make the live-acceptance boundary visible in
+operator docs and command output so a passing `doctor` is not mistaken for
+fresh Codex Desktop acceptance.
 **Demo/Validation**:
 
 - Command(s):
@@ -176,21 +222,28 @@ documentation and the live-acceptance boundary.
   - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
   - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
 - Verify:
-  - New `audit_drift::classes::extra` test pins zero extra-surface findings against the issue #43 domain-nested directory-symlink fixture.
-  - `DEVELOPMENT.md` (or a targeted runbook) names `doctor --class skill-surface` as shape-only validation and points to `codex debug prompt-input` for live acceptance.
-  - `doctor --class skill-surface` operator-facing output (both human and JSON) includes a one-line acceptance-boundary footer/field.
+  - New `audit_drift::classes::extra` test pins zero extra-surface findings against the issue #43 domain-nested
+    directory-symlink fixture.
+  - `DEVELOPMENT.md` or a targeted runbook names `doctor --class skill-surface` as shape-only validation and points to
+    `codex debug prompt-input` for live acceptance.
+  - `doctor --class skill-surface` operator-facing output, both human and JSON, includes a one-line acceptance-boundary
+    footer or field.
 
 ### Task 3.1: Pin `audit-drift extra` behaviour for domain-nested directory symlinks
 
 - **Location**:
   - `crates/agent-runtime-cli/src/audit_drift/classes/extra.rs`
   - `crates/agent-runtime-cli/src/audit_drift/` (tests)
-- **Description**: Add a regression test that constructs a fixture link map containing a non-recursive `symlinked-file` entry whose destination is `skills/<domain>/<skill>` and whose source is a directory, materialises a matching live home, and asserts that `extra::check` produces zero `extra` findings. The test pins the current `scan_roots` parent-scan behaviour with the issue #43 passing shape. No code change to `extra.rs` itself. Sequential ordering note: although this task has no hard task-level dependency, it lands after Sprint 1/2 in the integration order to keep the diff stack reviewable.
+- **Description**: Add a regression test that constructs a fixture link map containing a non-recursive `symlinked-file`
+  entry whose destination is `skills/<domain>/<skill>` and whose source is a directory. Materialise a matching live home and
+  assert that `extra::check` produces zero `extra` findings. The test pins current `scan_roots` parent-scan behaviour with
+  the issue #43 passing shape. No code change to `extra.rs` itself.
 - **Dependencies**:
   - none
 - **Complexity**: 4
 - **Acceptance criteria**:
-  - Test fails if `scan_roots` is changed to widen extra detection beyond the entry's own parent for non-recursive entries in a way that would surface unrelated Codex-owned skills.
+  - Test fails if `scan_roots` widens extra detection beyond the entry's own parent for non-recursive entries in a way that
+    would surface unrelated Codex-owned skills.
   - Test passes today against unchanged `extra.rs`.
 - **Validation**:
   - `cargo nextest run -p agent-runtime-cli audit_drift`
@@ -199,8 +252,11 @@ documentation and the live-acceptance boundary.
 
 - **Location**:
   - `DEVELOPMENT.md`
-  - or a targeted runbook under `docs/runbooks/` if `DEVELOPMENT.md` is the wrong host (decide during execution; record decision in execution state)
-- **Description**: Add a short section (4–8 lines) stating that `agent-runtime doctor --class skill-surface` validates install-map shape only, that a passing run is not Codex Desktop acceptance, and that live acceptance requires `codex debug prompt-input` in a fresh Codex Desktop session with `$HOME/.agents` absent and legacy env vars unset. Link the discussion source as the rationale.
+  - or a targeted runbook under `docs/runbooks/` if `DEVELOPMENT.md` is the wrong host
+- **Description**: Add a short section stating that `agent-runtime doctor --class skill-surface` validates install-map shape
+  only, that a passing run is not Codex Desktop acceptance, and that live acceptance requires `codex debug prompt-input` in
+  a fresh Codex Desktop session with `$HOME/.agents` absent and legacy env vars unset. Link the discussion source as the
+  rationale.
 - **Dependencies**:
   - Task 2.3
 - **Complexity**: 2
@@ -215,7 +271,9 @@ documentation and the live-acceptance boundary.
 - **Location**:
   - `crates/agent-runtime-cli/src/doctor/skill_surface.rs`
   - `crates/agent-runtime-cli/src/commands/doctor.rs`
-- **Description**: When `doctor --class skill-surface --product codex` exits 0, append a one-line operator-facing footer (human format) and an `acceptance_boundary` string field (JSON format) stating that shape validation passed but live Codex Desktop discovery requires `codex debug prompt-input`. Apply to both warn and pass exits.
+- **Description**: When `doctor --class skill-surface --product codex` runs, append a one-line operator-facing footer in
+  human format and an `acceptance_boundary` string field in JSON format. The text states that shape validation passed but
+  live Codex Desktop discovery requires `codex debug prompt-input`. Apply to both warn and pass exits.
 - **Dependencies**:
   - Task 2.3
   - Task 3.2
@@ -233,25 +291,42 @@ documentation and the live-acceptance boundary.
   - `install::plan` tests for non-recursive directory source → one symlink action.
   - `install::executor` tests for apply + idempotence + directory-destination refusal using `tempfile::TempDir`.
   - `doctor::skill_surface` tests for link-mode classification and the Codex `SKILL.md`-leaf warning.
-  - `audit_drift::classes::extra` regression test pinning parent-scan behaviour against the domain-nested directory-symlink fixture.
+  - `audit_drift::classes::extra` regression test pinning parent-scan behaviour against the domain-nested directory-symlink
+    fixture.
 - Integration:
-  - `cargo run -p agent-runtime-cli -- install --dry-run` smoke against a fixture link map exercises the new printout wording.
-  - `cargo run -p agent-runtime-cli -- doctor --class skill-surface --product codex --format json` against fixtures exercises classification + warning + acceptance-boundary footer end-to-end.
+  - `cargo run -p agent-runtime-cli -- install --dry-run` smoke against a fixture link map exercises the new printout
+    wording.
+  - `cargo run -p agent-runtime-cli -- doctor --class skill-surface --product codex --format json` against fixtures
+    exercises classification, warning, and acceptance-boundary footer end-to-end.
 - E2E/manual:
-  - One-off manual run of `doctor --class skill-surface --product codex` against the real local install before Sprint 3 sign-off, captured under `${CLAUDE_KIT_STATE_HOME}/out/` per CLAUDE.md.
+  - One-off manual run of `doctor --class skill-surface --product codex` against the real local install before Sprint 3
+    sign-off, captured under `${CLAUDE_KIT_STATE_HOME}/out/` per CLAUDE.md.
 
 ## Risks & gotchas
 
-- The crate-wide `#![deny(clippy::disallowed_types, clippy::disallowed_methods)]` forbids `std::collections::HashMap` and `SystemTime::now`; the new diagnostic must use `BTreeMap`/`BTreeSet` for any aggregation and must not stamp wall-clock time into output. Lean on existing `render::time::source_commit_timestamp()` if a timestamp is needed (it is not, for this plan).
-- `print_change` wording is operator-facing; any change must keep current `actions=` / `changes=` counter format so downstream log parsers (if any) continue to work. Treat the new link-mode token as additive.
-- Sprint 2's classifier must not load or stat live `$CODEX_HOME` paths — it reads only the link map plus the source root. Stat-ing live paths would couple `doctor` to host state and break the current `--source-root` reproducibility contract.
-- `audit-drift::classes::extra::scan_roots` widens to `dest.parent()` for non-recursive entries. The regression test (Task 3.1) freezes this against the domain-nested Codex shape only. Introducing flat `skills/<skill>` destinations in a future plan is the migration path that would re-open this question; flag any such proposal in review.
-- Codex active-skill shape is a moving product target. The `codex.active-skill.file-symlink` warning encodes the *currently* known-bad shape (`skills/**/SKILL.md`). If Codex later accepts file leaves, the warning becomes a false positive — document the warning code in the operator runbook so it is searchable when the product changes.
-- Plan scope explicitly excludes a schema rename / alias and any `scan_scope` field. If Sprint 2/3 surfaces a real need (e.g. flat-skill-root conflict in the wild), escalate to a follow-up plan rather than widening this one.
+- The crate-wide `#![deny(clippy::disallowed_types, clippy::disallowed_methods)]` forbids `std::collections::HashMap` and
+  `SystemTime::now`. The new diagnostic must use deterministic aggregation and must not stamp wall-clock time into output.
+- `print_change` wording is operator-facing. Any change must keep current `actions=` / `changes=` counter format so
+  downstream log parsers continue to work. Treat the new link-mode token as additive.
+- Sprint 2's classifier must not load or stat live `$CODEX_HOME` paths. It reads only the link map plus the source root.
+  Stat-ing live paths would couple `doctor` to host state and break the current `--source-root` reproducibility contract.
+- `audit-drift::classes::extra::scan_roots` widens to `dest.parent()` for non-recursive entries. The regression test
+  freezes this against the domain-nested Codex shape only. Introducing flat `skills/<skill>` destinations in a future plan
+  is the migration path that would re-open this question; flag any such proposal in review.
+- Codex active-skill shape is a moving product target. The `codex.active-skill.file-symlink` warning encodes the currently
+  known-bad shape (`skills/**/SKILL.md`). If Codex later accepts file leaves, the warning becomes a false positive; document
+  the warning code in the operator runbook so it is searchable when the product changes.
+- Plan scope explicitly excludes a schema rename / alias and any `scan_scope` field. If Sprint 2/3 surfaces a real need,
+  such as flat-skill-root conflict in the wild, escalate to a follow-up plan rather than widening this one.
 
 ## Rollback plan
 
-- Sprint 1 changes are pure docs + tests + printout wording; revert the touched files to roll back. No data migration, no on-disk format change, no install behaviour change.
-- Sprint 2 introduces a new `doctor` class wired behind `--class skill-surface`. Roll back by deleting the new module and removing the class arm from `commands::doctor`. No state on disk, no schema change.
-- Sprint 3's `audit_drift` regression test is additive; delete the test file/section to revert. Doc changes in `DEVELOPMENT.md` (or runbook) revert by reverting the markdown patch. The `acceptance_boundary` footer/field is additive in `doctor` output — remove the print/serialize path to revert.
-- No external consumers should depend on the new printout tokens or the `acceptance_boundary` JSON field within this plan's lifecycle; if downstream tooling latches onto them later, treat that latching as the migration cost of a future rollback.
+- Sprint 1 changes are pure docs, tests, and printout wording; revert the touched files to roll back. No data migration, no
+  on-disk format change, no install behaviour change.
+- Sprint 2 introduces a new `doctor` class wired behind `--class skill-surface`. Roll back by deleting the new module and
+  removing the class arm from `commands::doctor`. No state on disk, no schema change.
+- Sprint 3's `audit_drift` regression test is additive; delete the test file or section to revert. Doc changes in
+  `DEVELOPMENT.md` revert by reverting the markdown patch. The `acceptance_boundary` footer/field is additive in `doctor`
+  output; remove the print/serialize path to revert.
+- No external consumers should depend on the new printout tokens or the `acceptance_boundary` JSON field within this plan's
+  lifecycle. If downstream tooling latches onto them later, treat that latching as the migration cost of a future rollback.


### PR DESCRIPTION
## Summary

- Add `agent-runtime doctor --class skill-surface` for source-root Codex active-skill shape diagnostics.
- Preserve symlink link-mode intent through install planning, executor dry-runs, and install output.
- Add audit-drift regression coverage so domain-nested directory skill symlinks are not treated as extra surface.

Refs #446.

## Test plan

- `cargo fmt --all -- --check`
- `cargo test -p agent-runtime-cli doctor::skill_surface`
- `cargo test -p agent-runtime-cli install`
- `cargo test -p agent-runtime-cli doctor`
- `cargo test -p agent-runtime-cli audit_drift`
- `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings`
- `cargo test -p agent-runtime-cli`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
- `agent-runtime doctor --class skill-surface --product codex --format json --source-root /Users/terry/Project/graysurf/agent-runtime-kit`

## Notes

- The new doctor class is a shape diagnostic over the source-root link map. Live Codex Desktop skill discovery still requires fresh-session acceptance with `codex debug prompt-input`.
