### PR TITLE
plan-issue-cli: v3 contract + record CLI scaffold (#448 S1)

### DIFF
--- a/crates/plan-issue-cli/docs/README.md
+++ b/crates/plan-issue-cli/docs/README.md
@@ -4,29 +4,40 @@
 
 Crate-local documentation for `nils-plan-issue-cli`.
 
-`Task Decomposition` is the crate's documented runtime-truth execution table for
-existing plan/sprint orchestration. Specs define `Owner` as a dispatch alias,
-document single-lane normalization to `per-sprint`, and treat
-task-spec/subagent prompts as derived artifacts (not a second issue-body
-dispatch table). `start-sprint` validates drift against plan-derived lanes and
-does not rewrite issue rows in runtime-truth mode.
+The default lifecycle for new issue-backed plan records is the
+**v3 issue-backed plan record lifecycle** owned by the
+`plan-issue record ...` surface. That surface opens provider issues,
+posts canonical lifecycle comments, audits and repairs dashboards, and
+performs strict provider-verified closeout. See
+[issue-backed plan record contract v2](specs/issue-backed-plan-record-contract-v2.md)
+and [plan-issue state machine v2](specs/plan-issue-state-machine-v2.md)
+for the normative spec.
 
-Issue-backed tracking and dispatch records that keep provider issue bodies as
-mutable dashboards use the newer `plan-issue record ...` surface. That surface
-renders/audits dashboards, append-only comments, dispatch ledgers, and closeout
-readiness locally; provider issue mutation remains outside this crate path.
+The prior `start-plan` / `start-sprint` Task Decomposition runtime is
+retained for existing dispatch flows that have not migrated yet. Its
+state machine, gate invariants, and runtime-truth row model live in the
+v1 specs and the
+[plan-issue CLI contract v2](specs/plan-issue-cli-contract-v2.md). New
+work should not target the Task Decomposition runtime.
 
 Current runtime ownership:
 
-- `plan-tooling split-prs` emits grouping primitives only.
-- `plan-issue-cli` materializes runtime `Owner/Branch/Worktree/Notes` metadata from plan content, grouping results, and prefixes.
-- `plan-issue record build-dispatch-ledger` consumes the same grouping
-  primitives without moving provider UI rendering into `plan-tooling`.
+- `plan-tooling` continues to own plan parsing, validation, split modeling,
+  and PR grouping primitives.
+- `plan-issue record` owns the v3 issue-backed plan record lifecycle:
+  open, post, audit, repair-dashboard, and close.
+- Prior `plan-issue start-plan` / `start-sprint` commands continue to
+  materialize Task Decomposition runtime metadata for in-flight dispatch
+  flows.
+- `forge-cli` and provider adapters own general provider operations that
+  are not part of the issue-backed plan record lifecycle.
 - markdown table cell canonicalization is provided by `nils-common::markdown`.
 
 ## Specs
 
-- [plan-issue CLI contract v2](specs/plan-issue-cli-contract-v2.md)
-- [issue-backed plan record contract v1](specs/issue-backed-plan-record-contract-v1.md)
-- [plan-issue state machine and gates v1](specs/plan-issue-state-machine-v1.md)
+- [issue-backed plan record contract v2 (current)](specs/issue-backed-plan-record-contract-v2.md)
+- [plan-issue state machine v2 (current)](specs/plan-issue-state-machine-v2.md)
+- [plan-issue CLI contract v2 (Task Decomposition runtime metadata)](specs/plan-issue-cli-contract-v2.md)
+- [plan-issue state machine v1 (Task Decomposition runtime)](specs/plan-issue-state-machine-v1.md)
 - [plan-issue gate matrix v1](specs/plan-issue-gate-matrix-v1.md)
+- [issue-backed plan record contract v1 (retired)](specs/issue-backed-plan-record-contract-v1.md)

--- a/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v1.md
+++ b/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v1.md
@@ -1,4 +1,13 @@
-# Issue-Backed Plan Record Contract v1
+# Issue-Backed Plan Record Contract v1 (Retired)
+
+> **Status:** Retired. This contract is superseded by
+> [issue-backed plan record contract v2](issue-backed-plan-record-contract-v2.md).
+> The v2 contract removes the dual marker families, the
+> caller-assembled closeout pipeline, and the local-only command boundary
+> in favor of one canonical marker family and provider-backed live
+> commands. Consumer skills must migrate to v2 in a coordinated
+> agent-runtime-kit release after the `plan-issue` v3 binary ships. This
+> document is kept only for migration reference.
 
 ## Scope
 

--- a/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md
+++ b/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md
@@ -1,0 +1,366 @@
+# Issue-Backed Plan Record Contract v2
+
+## Status
+
+- This spec defines the breaking v3 issue-backed plan record lifecycle owned by
+  the `plan-issue record ...` surface.
+- It replaces [issue-backed plan record contract v1](issue-backed-plan-record-contract-v1.md).
+- It supersedes the prior `start-plan` / `start-sprint` Task Decomposition
+  runtime for new agent-runtime-kit lifecycles; see
+  [plan-issue state machine v2](plan-issue-state-machine-v2.md).
+
+The spec is normative for v3 implementations across Sprints 1-5 of the
+`plan-issue-lifecycle-v3` plan.
+
+## Scope
+
+`plan-issue record` is now the high-level **owner** of issue-backed plan
+record lifecycle. It opens, posts to, audits, repairs, and closes provider
+issues that carry a plan execution timeline through append-only comments.
+
+In scope:
+
+- One canonical marker family for source, plan, state, session, validation,
+  review, and closeout comments.
+- Structured payload model embedded in lifecycle comments so audit and
+  closeout never parse prose Markdown for state.
+- High-level live commands `record open`, `record post`, `record audit`,
+  `record repair-dashboard`, and `record close` that perform provider issue
+  mutations (create, comment, edit, close) without composing `forge-cli` at
+  the skill level.
+- Strict closeout gate with provider-verified linked PR evidence.
+- Deterministic fixture mode for tests.
+
+Out of scope:
+
+- Plan parsing, validation, and PR-split modeling (owned by `plan-tooling`).
+- General provider lifecycle outside of plan-issue records (still owned by
+  `forge-cli` / provider adapters).
+- Migrating consumer skills until a `plan-issue` release containing this
+  contract is published.
+
+## Breaking Changes vs v1
+
+The following v1 surfaces are retired in v2:
+
+- `--marker-family` argument and the dual `compat` / `shared` marker
+  families.
+- `record render-comment` and `record render-dashboard` as primary
+  user-facing commands. Comment rendering becomes an implementation detail of
+  `record post`; dashboard rendering moves under `record repair-dashboard`.
+- `record closeout-gate` as a standalone command and its
+  `--require-complete`, `--require-session`, `--require-validation`,
+  `--require-review`, and `--require-closeout` flags. Closeout-gate
+  evaluation moves inside `record close` and is strict by default.
+- Implicit acceptance of v1 `plan-tracking-issue:*`,
+  `execute-from-tracking-issue:*`, `tracking-issue-closeout:*`, and
+  `deliver-dispatch-plan:*` markers as current lifecycle evidence. They are
+  ignored or reported as unsupported.
+- Prose-Markdown status parsing (`- Status: complete`) as the authoritative
+  signal for closeout state detection. The structured payload is the source
+  of truth.
+
+## Canonical Marker Family
+
+Every lifecycle comment opens with a single HTML-comment marker on its first
+non-empty line:
+
+```text
+<!-- plan-issue-record:v2 role=<role> profile=<profile> -->
+```
+
+Recognized roles:
+
+| Role         | Required (tracking) | Required (dispatch) | Purpose                                                  |
+| ------------ | ------------------- | ------------------- | -------------------------------------------------------- |
+| `source`     | yes                 | yes                 | Source snapshot (discussion / review document).          |
+| `plan`       | yes                 | yes                 | Plan document snapshot.                                  |
+| `state`      | yes                 | yes                 | Latest execution state (status, tasks, prs, updated_at). |
+| `session`    | optional            | yes                 | Implementation session log entry.                        |
+| `validation` | yes for closeout    | yes for closeout    | Validation command rows and overall status.              |
+| `review`     | yes for closeout    | yes for closeout    | Specialist review findings and decision.                 |
+| `closeout`   | yes for closeout    | yes for closeout    | Final closeout summary, PR merge evidence, approval.     |
+
+Recognized profiles: `tracking`, `dispatch`.
+
+Marker detection only accepts markers on the first non-empty line. Markers
+quoted inside snapshot bodies or fenced code blocks are ignored. v1 marker
+families are not recognized as current lifecycle markers.
+
+## Structured Payload Model
+
+Every lifecycle comment includes one fenced JSON block whose info-string is
+the literal token `plan-issue-record-payload`. The fence is the structured
+source of truth for audit, dashboard repair, and closeout gating. Visible
+Markdown around it is human commentary only. Implementations recognize the
+block by reading the opening fence line `<backticks>plan-issue-record-payload`
+(no language alias) and parsing the body as JSON.
+
+The envelope shape is:
+
+```json
+{
+  "schema": "plan-issue-record.payload.v2",
+  "role": "state",
+  "profile": "tracking",
+  "updated_at": "2026-05-23T08:42:11Z",
+  "data": { }
+}
+```
+
+Per-role `data` shapes:
+
+### `source` / `plan`
+
+```json
+{
+  "path": "docs/plans/<slug>/<file>.md",
+  "commit": "<full-sha>",
+  "title": "<optional>",
+  "summary": "<optional one-line summary>"
+}
+```
+
+### `state`
+
+```json
+{
+  "status": "in-progress|complete|blocked",
+  "target_scope": "<text>",
+  "current": "<text>",
+  "next_action": "<text>",
+  "tasks": [
+    {"id": "1.1", "status": "pending|in-progress|done|deferred", "title": "<text>"}
+  ],
+  "prs": [
+    {"ref": "owner/repo#123", "url": "<url>", "status": "open|merged|closed"}
+  ],
+  "blockers": ["<text>"],
+  "links": {
+    "source": "<url>",
+    "plan": "<url>",
+    "previous_state": "<url>"
+  }
+}
+```
+
+### `session`
+
+```json
+{
+  "summary": "<one-line>",
+  "highlights": ["<text>"],
+  "links": {"state": "<url>", "plan": "<url>"}
+}
+```
+
+### `validation`
+
+```json
+{
+  "overall": "pass|fail|partial",
+  "commands": [
+    {"command": "<exact-command>", "status": "pass|fail|skipped", "evidence": "<optional-url-or-path>"}
+  ],
+  "waivers": [{"command": "<text>", "reason": "<text>"}]
+}
+```
+
+### `review`
+
+```json
+{
+  "decision": "approve|request-changes|comments-only",
+  "lenses": ["testing", "maintainability", "..."],
+  "findings": [
+    {"id": "F1", "severity": "blocker|major|minor|nit", "disposition": "fixed|residual|follow-up|deferred|no-action", "summary": "<text>"}
+  ],
+  "outcome_comment_url": "<url>"
+}
+```
+
+### `closeout`
+
+```json
+{
+  "final_status": "complete",
+  "approval": {"comment_url": "<url>", "approver": "<login>"},
+  "linked_prs": [
+    {"ref": "owner/repo#123", "url": "<url>", "merge_sha": "<sha>", "checks": "pass|fail|none"}
+  ],
+  "final_validation_url": "<optional-url>",
+  "notes": "<optional>"
+}
+```
+
+The schema field name `plan-issue-record.payload.v2` is the on-wire schema
+identity. Audit logic must reject unknown schema names rather than guess.
+
+## Command Boundary
+
+- `plan-tooling`: plan parsing, validation, sprint and task split modeling.
+- `plan-issue record`: issue-backed plan record lifecycle, structured payload
+  rendering, audit, dashboard repair, closeout gating, and provider-backed
+  open / post / close.
+- `forge-cli`: general provider issue and PR operations that are not part of
+  the issue-backed plan record lifecycle (lane PRs, ad-hoc issues, comments
+  outside this lifecycle).
+- `review-evidence` / `code-review-specialists`: retained review records and
+  read-only specialist passes consumed by `record post --kind review`.
+
+## Provider-Backed Command Surface
+
+### `plan-issue record open`
+
+Bundle-first command that:
+
+1. Loads a plan bundle (source, plan, execution-state) from
+   `--bundle <dir>` or explicit `--source-file` / `--plan-file` /
+   `--execution-state-file` paths.
+2. Validates the plan bundle via `plan-tooling validate`.
+3. Verifies local source/plan files are committed and clean unless
+   `--allow-dirty` is passed (live mode only).
+4. Creates the provider issue with the dashboard rendered from the initial
+   execution state (issue body).
+5. Posts the source, plan, and initial state comments with canonical markers
+   and structured payloads.
+6. Repairs the dashboard with the freshly-created comment URLs.
+7. Returns issue URL and source/plan/state comment URLs.
+
+Modes:
+
+- `--dry-run`: render every provider mutation plan without writing.
+- `--fixture <dir>`: deterministic mode for tests; produces the same JSON
+  result shape using local files instead of provider calls.
+
+Required inputs in live mode: `--repo OWNER/REPO`, `--bundle <dir>` (or
+explicit file flags), and a title source (`--title` or plan-derived).
+
+### `plan-issue record post`
+
+High-level append-only comment command for `state`, `session`, `validation`,
+`review`, and `closeout` kinds.
+
+- Renders the canonical marker and structured payload from explicit fields
+  or a `--payload-file` JSON document.
+- Posts to the provider issue and returns the comment URL.
+- Supports `--dry-run` and `--fixture` modes.
+- `--kind closeout` is callable directly only when `record close` is not
+  used; `record close` posts the closeout comment internally and uses the
+  same renderer.
+
+### `plan-issue record audit`
+
+Returns typed evidence from the provider issue body and comments:
+
+- Live mode reads through the active provider.
+- `--body-file` and `--comments-json` continue to work for deterministic
+  tests.
+- Output JSON exposes the latest marker URL, created timestamp, profile,
+  role, status, and parsed payload per role.
+- Reports `missing_required` codes for each lifecycle role not satisfied.
+
+### `plan-issue record repair-dashboard`
+
+- Reads the latest audit evidence.
+- Computes the canonical dashboard from durable record links and the latest
+  state payload (no caller-supplied URL flags required).
+- Live mode edits the issue body. Local mode prints or writes the rendered
+  dashboard.
+- A complete record renders `## Final Dashboard`; otherwise `## Current
+  Dashboard`.
+
+### `plan-issue record close`
+
+Strict, single-command closeout:
+
+1. Fetches issue evidence through audit.
+2. Verifies presence of source, plan, state (`status=complete`), session,
+   validation (`overall=pass`), and review (decision among
+   `approve` / `comments-only`).
+3. Verifies linked PR evidence through provider state: every linked PR is
+   merged, with `merge_sha` and CI status recorded.
+4. Renders and posts the `closeout` comment with structured payload.
+5. Renders and edits the `## Final Dashboard` issue body.
+6. Closes the provider issue.
+
+`record close` removes all `--require-*` flags. The strict gate is
+non-optional. Inputs are limited to:
+
+- `--issue <number-or-url>` and `--repo OWNER/REPO` (live mode).
+- `--linked-pr <ref>` (repeatable; cross-checked against state payload).
+- `--approval <url-or-text>`.
+- `--bundle <dir>` (optional; used to validate that the closed plan still
+  matches local plan content).
+- `--fixture <dir>` + `--body-file` + `--comments-json` for tests.
+- `--dry-run` for non-mutating previews.
+
+## Strict Closeout Gate
+
+Failure modes that block close:
+
+- `state-missing` / `state-not-complete` / `state-stale` (state payload
+  `updated_at` older than the most recent session entry without a session
+  update).
+- `validation-missing` / `validation-failed` / `validation-stale`.
+- `review-missing` / `review-rejected` / `review-unresolved-findings`
+  (any finding with disposition `residual` and severity `blocker` /
+  `major`).
+- `linked-pr-missing` / `linked-pr-not-merged` / `linked-pr-checks-failed`.
+- `approval-missing` / `approval-invalid`.
+- `dashboard-out-of-date` (recomputed dashboard differs from issue body).
+
+Each failure returns a stable machine-readable code that maps to a single
+unblock action.
+
+## Provider Verification
+
+Linked PR evidence is verified against the provider, not text matching:
+
+- Each linked PR ref resolves to a provider PR.
+- Provider state must be `merged`.
+- Provider check rollup must be `success` or explicitly waived in the
+  closeout payload `notes` (with reviewer approval recorded).
+- The provider's `merge_commit_sha` is recorded back into the closeout
+  payload `linked_prs[].merge_sha`.
+
+## Result JSON Envelope
+
+Every `record` subcommand emits the shared CLI JSON envelope on `--format
+json`:
+
+```json
+{
+  "schema_version": "plan-issue-cli.record.<subcommand>.v2",
+  "command": "record.<subcommand>",
+  "status": "ok|error",
+  "payload": { ... }
+}
+```
+
+Examples of `payload`:
+
+- `record open` -> `{ "issue": {...}, "comments": {"source": "<url>", "plan": "<url>", "state": "<url>"} }`
+- `record close` -> `{ "issue": {...}, "closeout_url": "<url>", "final_dashboard": {...}, "linked_prs": [...] }`
+
+## Compatibility Layer
+
+There is none. Consumers must migrate from v1 markers and v1 command flags
+in a coordinated release of the consumer (agent-runtime-kit) after the
+`plan-issue` v3 release ships.
+
+## Test Fixtures
+
+Live commands accept a `--fixture <dir>` argument. The directory contains:
+
+- `issue-body.md`: provider issue body Markdown.
+- `comments.json`: provider comments JSON in `gh issue view --json comments`
+  shape.
+- `prs/<owner>__<repo>__<number>.json`: provider PR snapshots for
+  linked-PR verification.
+
+Fixture mode never reaches the network. It produces the same result-JSON
+shape as live mode so that consumer-side tests are deterministic.
+
+The Sprint 4 deliverable adds an agent-runtime-kit closeout fixture that
+exercises the strict close path end to end.

--- a/crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md
+++ b/crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md
@@ -1,4 +1,14 @@
-# plan-issue State Machine and Gate Invariants v1
+# plan-issue State Machine and Gate Invariants v1 (Task Decomposition Runtime)
+
+> **Status:** Prior surface. v1 describes the `start-plan` /
+> `start-sprint` Task Decomposition runtime. The default lifecycle for new
+> agent-runtime-kit issue-backed records is described in
+> [plan-issue state machine v2](plan-issue-state-machine-v2.md), which
+> pairs with [issue-backed plan record contract v2](issue-backed-plan-record-contract-v2.md).
+> v1 remains normative only for the Task Decomposition commands while
+> they continue to ship. `## Task Decomposition` is no longer the default
+> runtime-truth surface for agent-runtime-kit consumers; new lifecycles
+> live in append-only canonical marker comments.
 
 ## Purpose
 

--- a/crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v2.md
+++ b/crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v2.md
@@ -1,0 +1,125 @@
+# plan-issue State Machine v2 (Issue-Backed Lifecycle)
+
+## Status
+
+- This spec defines the v2 state machine that pairs with
+  [issue-backed plan record contract v2](issue-backed-plan-record-contract-v2.md).
+- It is the primary state machine for new agent-runtime-kit lifecycles.
+- It supersedes
+  [plan-issue state machine v1](plan-issue-state-machine-v1.md) for new
+  issue-backed plan records. The v1 Task Decomposition state machine is
+  retained only for the prior `start-plan` / `start-sprint` commands while
+  they remain available; it is no longer the default agent-runtime-kit
+  lifecycle truth.
+
+## Scope
+
+- In scope:
+  - Plan record states and transitions driven by `plan-issue record`.
+  - Required lifecycle evidence per state.
+  - Strict closeout gate inputs.
+- Out of scope:
+  - Task Decomposition `Owner` / `Branch` / `Worktree` runtime metadata
+    materialization. That contract continues to live in
+    [plan-issue CLI contract v2](plan-issue-cli-contract-v2.md) for the
+    `start-plan` / `start-sprint` commands.
+  - JSON envelope formatting (see contract spec).
+
+## Canonical State Objects
+
+- Plan record: one provider issue holding source, plan, state, session,
+  validation, review, and closeout comments under the canonical
+  `plan-issue-record:v2` marker family.
+- Lifecycle role evidence: parsed structured payloads, indexed by role with
+  the latest comment timestamp winning.
+
+## Plan Record States
+
+- `RECORD_UNOPENED`: no provider issue exists for this plan bundle.
+- `RECORD_OPEN_INITIAL`: issue exists with `source`, `plan`, and initial
+  `state` payloads; no session evidence yet.
+- `RECORD_OPEN_ACTIVE`: at least one `session` payload exists or `state`
+  payload has progressed beyond the initial snapshot.
+- `RECORD_VALIDATING`: latest `state` reports `status=complete` and at
+  least one `validation` payload exists with `overall=pass`.
+- `RECORD_REVIEWED`: latest `review` payload exists with decision in
+  `{approve, comments-only}` and no unresolved blocker / major findings.
+- `RECORD_READY_FOR_CLOSE`: every closeout gate (see below) passes.
+- `RECORD_CLOSED`: provider issue is closed and `closeout` payload was
+  posted with `final_status=complete`.
+
+## Transitions
+
+| Transition        | From                                         | To                                           | Command                                    |
+| ----------------- | -------------------------------------------- | -------------------------------------------- | ------------------------------------------ |
+| Open              | `RECORD_UNOPENED`                            | `RECORD_OPEN_INITIAL`                        | `plan-issue record open`                   |
+| Append session    | `RECORD_OPEN_INITIAL` / `RECORD_OPEN_ACTIVE` | `RECORD_OPEN_ACTIVE`                         | `plan-issue record post --kind session`    |
+| Update state      | `RECORD_OPEN_*`                              | unchanged or progression                     | `plan-issue record post --kind state`      |
+| Append validation | `RECORD_OPEN_ACTIVE`                         | `RECORD_VALIDATING` (when state is complete) | `plan-issue record post --kind validation` |
+| Append review     | `RECORD_VALIDATING`                          | `RECORD_REVIEWED`                            | `plan-issue record post --kind review`     |
+| Repair dashboard  | any                                          | unchanged                                    | `plan-issue record repair-dashboard`       |
+| Close             | `RECORD_REVIEWED` / `RECORD_READY_FOR_CLOSE` | `RECORD_CLOSED`                              | `plan-issue record close`                  |
+
+Each transition is realized through one provider-backed command. The state
+machine evaluates the latest payload per role; older payloads remain
+auditable but do not satisfy gate requirements once superseded.
+
+## Closeout Gate Invariants
+
+`plan-issue record close` evaluates the following before any mutation:
+
+1. `source` and `plan` markers exist with structured payloads. `commit`
+   matches a known commit in the local repo when `--bundle` is provided.
+2. Latest `state` payload has `status=complete`.
+3. Latest `state` payload `tasks` array has every entry in `done` or
+   `deferred` (with `deferred` entries explaining themselves via state
+   `notes`).
+4. Latest `validation` payload has `overall=pass`.
+5. Latest `review` payload `decision` is `approve` or `comments-only`,
+   with no `findings` entry whose disposition is `residual` and severity
+   `blocker` or `major`.
+6. Every entry in latest `state.prs` resolves through the provider to a
+   merged PR with a non-empty `merge_sha`.
+7. Approval evidence (`--approval`) is present and parses as a provider
+   comment URL or non-empty approval text.
+
+When any check fails, `record close` returns exit 1, posts no mutations,
+and emits a machine-readable failure code matching the spec
+[Strict Closeout Gate](issue-backed-plan-record-contract-v2.md#strict-closeout-gate).
+
+## Dashboard Invariants
+
+Dashboards are derived from the audit evidence:
+
+- `## Current Dashboard` while `RECORD_CLOSED` is not reached.
+- `## Final Dashboard` after `record close` succeeds.
+- Durable Record links are pulled from the latest marker per role; pending
+  roles show `pending`.
+- Dashboard repair is idempotent: running it twice yields the same body.
+
+## Worktree and Branch Invariants
+
+The v2 state machine does not touch worktrees or branches. Those concerns
+remain owned by `forge-cli` and dispatch-lane skills. `record post --kind
+state` may carry branch / worktree information inside its structured
+payload, but `plan-issue record` does not create, edit, or clean
+worktrees in v2.
+
+## Dry-Run Contract
+
+`--dry-run` is honored across `record open`, `record post`,
+`record repair-dashboard`, and `record close`:
+
+- No provider mutations are issued.
+- The rendered comment body, dashboard body, and intended provider actions
+  are printed.
+- The same JSON result shape as live mode is emitted, with mutation
+  fields marked `dry_run=true`.
+
+## Failure Contract
+
+- Closeout gate violations and provider verification failures exit 1.
+- Argument / usage errors exit 2.
+- Successful transitions exit 0.
+- All structured failures emit a stable machine-readable code in the JSON
+  envelope `error.code` field.

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -284,6 +284,10 @@ impl Command {
 impl RecordArgs {
     pub fn command_id(&self) -> &'static str {
         match &self.command {
+            record::RecordCommand::Open(_) => "record.open",
+            record::RecordCommand::Post(_) => "record.post",
+            record::RecordCommand::RepairDashboard(_) => "record.repair-dashboard",
+            record::RecordCommand::Close(_) => "record.close",
             record::RecordCommand::RenderDashboard(_) => "record.render-dashboard",
             record::RecordCommand::RenderComment(_) => "record.render-comment",
             record::RecordCommand::Audit(_) => "record.audit",

--- a/crates/plan-issue-cli/src/commands/record.rs
+++ b/crates/plan-issue-cli/src/commands/record.rs
@@ -13,6 +13,20 @@ pub struct RecordArgs {
 
 #[derive(Debug, Clone, Subcommand, Serialize)]
 pub enum RecordCommand {
+    /// Open a provider issue from a plan bundle and post initial lifecycle
+    /// comments (v3 issue-backed plan record contract).
+    Open(Box<RecordOpenArgs>),
+
+    /// Append a canonical lifecycle comment (state, session, validation,
+    /// review, or closeout) to an existing plan record issue.
+    Post(Box<RecordPostArgs>),
+
+    /// Recompute and edit the dashboard issue body from audit evidence.
+    RepairDashboard(Box<RecordRepairDashboardArgs>),
+
+    /// Close a plan record issue after the strict lifecycle gate passes.
+    Close(Box<RecordCloseArgs>),
+
     /// Render a mutable issue dashboard for an issue-backed plan record.
     RenderDashboard(Box<RenderDashboardArgs>),
 
@@ -269,6 +283,138 @@ pub struct RecordCloseoutGateArgs {
     /// comments, not for provider merge state.
     #[arg(long = "linked-pr", value_name = "ref")]
     pub linked_pr: Vec<String>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct RecordOpenArgs {
+    /// Lifecycle profile for the record.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Plan bundle directory. The bundle directory contains the source,
+    /// plan, and execution-state Markdown files using the
+    /// `<slug>-discussion-source.md` / `<slug>-review-source.md`,
+    /// `<slug>-plan.md`, and `<slug>-execution-state.md` naming
+    /// convention validated by `plan-tooling validate`.
+    #[arg(long, value_name = "dir")]
+    pub bundle: Option<PathBuf>,
+
+    /// Explicit source document path. Overrides bundle derivation.
+    #[arg(long = "source-file", value_name = "path")]
+    pub source_file: Option<PathBuf>,
+
+    /// Explicit plan document path. Overrides bundle derivation.
+    #[arg(long = "plan-file", value_name = "path")]
+    pub plan_file: Option<PathBuf>,
+
+    /// Explicit execution-state document path. Overrides bundle derivation.
+    #[arg(long = "execution-state-file", value_name = "path")]
+    pub execution_state_file: Option<PathBuf>,
+
+    /// Issue title. Defaults to the plan title.
+    #[arg(long, value_name = "text")]
+    pub title: Option<String>,
+
+    /// Allow opening the record even when local plan files are dirty.
+    #[arg(long = "allow-dirty")]
+    pub allow_dirty: bool,
+
+    /// Deterministic fixture mode. The directory is consumed instead of
+    /// live provider calls.
+    #[arg(long, value_name = "dir")]
+    pub fixture: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct RecordPostArgs {
+    /// Provider issue number or full URL.
+    #[arg(long, value_name = "issue")]
+    pub issue: String,
+
+    /// Lifecycle profile for the marker and payload.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Lifecycle comment kind. `source` and `plan` kinds are owned by
+    /// `record open` and rejected here.
+    #[arg(long, value_enum)]
+    pub kind: LifecycleCommentKind,
+
+    /// JSON file containing the structured payload `data` field.
+    #[arg(long = "payload-file", value_name = "path")]
+    pub payload_file: Option<PathBuf>,
+
+    /// Visible Markdown commentary appended after the structured payload.
+    #[arg(long = "summary-file", value_name = "path")]
+    pub summary_file: Option<PathBuf>,
+
+    /// Deterministic fixture mode.
+    #[arg(long, value_name = "dir")]
+    pub fixture: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct RecordRepairDashboardArgs {
+    /// Provider issue number or full URL.
+    #[arg(long, value_name = "issue")]
+    pub issue: Option<String>,
+
+    /// Provider issue body Markdown (deterministic mode).
+    #[arg(long = "body-file", value_name = "path")]
+    pub body_file: Option<PathBuf>,
+
+    /// JSON containing either `comments` from `gh issue view --json
+    /// comments` or a raw array of comment objects (deterministic mode).
+    #[arg(long = "comments-json", value_name = "path")]
+    pub comments_json: Option<PathBuf>,
+
+    /// Deterministic fixture mode.
+    #[arg(long, value_name = "dir")]
+    pub fixture: Option<PathBuf>,
+
+    /// Write rendered Markdown to this path instead of editing the issue.
+    #[arg(long, value_name = "path")]
+    pub out: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct RecordCloseArgs {
+    /// Provider issue number or full URL.
+    #[arg(long, value_name = "issue")]
+    pub issue: String,
+
+    /// Lifecycle profile of the record being closed.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Linked PR reference. Repeatable. Each ref is cross-checked against
+    /// the latest state payload and verified through the provider for
+    /// merge status.
+    #[arg(long = "linked-pr", value_name = "ref")]
+    pub linked_pr: Vec<String>,
+
+    /// Approval evidence. May be a provider comment URL or non-empty
+    /// approval text.
+    #[arg(long = "approval", value_name = "text")]
+    pub approval: Option<String>,
+
+    /// Plan bundle directory. Used for local source/plan commit
+    /// verification when provided.
+    #[arg(long, value_name = "dir")]
+    pub bundle: Option<PathBuf>,
+
+    /// Deterministic test mode: issue body Markdown.
+    #[arg(long = "body-file", value_name = "path")]
+    pub body_file: Option<PathBuf>,
+
+    /// Deterministic test mode: comments JSON.
+    #[arg(long = "comments-json", value_name = "path")]
+    pub comments_json: Option<PathBuf>,
+
+    /// Deterministic fixture mode. Contains issue body, comments JSON, and
+    /// PR snapshots used in place of provider lookups.
+    #[arg(long, value_name = "dir")]
+    pub fixture: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -15,8 +15,9 @@ use crate::commands::plan::{
     ResolveApprovalArgs, StartPlanArgs, StatusPlanArgs,
 };
 use crate::commands::record::{
-    BuildDispatchLedgerArgs, RecordArgs, RecordAuditArgs, RecordCloseoutGateArgs, RecordCommand,
-    RenderCommentArgs, RenderDashboardArgs,
+    BuildDispatchLedgerArgs, RecordArgs, RecordAuditArgs, RecordCloseArgs, RecordCloseoutGateArgs,
+    RecordCommand, RecordOpenArgs, RecordPostArgs, RecordRepairDashboardArgs, RenderCommentArgs,
+    RenderDashboardArgs,
 };
 use crate::commands::sprint::{
     AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs,
@@ -80,12 +81,52 @@ pub fn execute(binary: BinaryFlavor, cli: &Cli) -> Result<Value, CommandError> {
 
 fn run_record(args: &RecordArgs) -> Result<Value, CommandError> {
     match &args.command {
+        RecordCommand::Open(args) => run_record_open(args),
+        RecordCommand::Post(args) => run_record_post(args),
+        RecordCommand::RepairDashboard(args) => run_record_repair_dashboard(args),
+        RecordCommand::Close(args) => run_record_close(args),
         RecordCommand::RenderDashboard(args) => run_record_render_dashboard(args),
         RecordCommand::RenderComment(args) => run_record_render_comment(args),
         RecordCommand::Audit(args) => run_record_audit(args),
         RecordCommand::CloseoutGate(args) => run_record_closeout_gate(args),
         RecordCommand::BuildDispatchLedger(args) => run_record_build_dispatch_ledger(args),
     }
+}
+
+fn run_record_open(_args: &RecordOpenArgs) -> Result<Value, CommandError> {
+    Err(CommandError::usage(
+        "record-open-not-yet-implemented",
+        "`plan-issue record open` lifecycle wiring lands in plan-issue-lifecycle-v3 Sprint 3; \
+         the v2 spec contract is defined and the CLI surface is scaffolded so consumers can \
+         test against it",
+    ))
+}
+
+fn run_record_post(_args: &RecordPostArgs) -> Result<Value, CommandError> {
+    Err(CommandError::usage(
+        "record-post-not-yet-implemented",
+        "`plan-issue record post` lifecycle wiring lands in plan-issue-lifecycle-v3 Sprint 3; \
+         the v2 spec contract is defined and the CLI surface is scaffolded so consumers can \
+         test against it",
+    ))
+}
+
+fn run_record_repair_dashboard(_args: &RecordRepairDashboardArgs) -> Result<Value, CommandError> {
+    Err(CommandError::usage(
+        "record-repair-dashboard-not-yet-implemented",
+        "`plan-issue record repair-dashboard` lifecycle wiring lands in \
+         plan-issue-lifecycle-v3 Sprint 3; the v2 spec contract is defined and the CLI \
+         surface is scaffolded so consumers can test against it",
+    ))
+}
+
+fn run_record_close(_args: &RecordCloseArgs) -> Result<Value, CommandError> {
+    Err(CommandError::usage(
+        "record-close-not-yet-implemented",
+        "`plan-issue record close` lifecycle wiring lands in plan-issue-lifecycle-v3 Sprint 3; \
+         the v2 spec contract is defined and the CLI surface is scaffolded so consumers can \
+         test against it",
+    ))
 }
 
 fn run_record_render_dashboard(args: &RenderDashboardArgs) -> Result<Value, CommandError> {

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -735,3 +735,430 @@ fn finalize_markdown(lines: Vec<String>) -> String {
     }
     rendered
 }
+
+// -----------------------------------------------------------------------------
+// Structured lifecycle payload (issue-backed plan record contract v2)
+//
+// Each lifecycle comment carries one fenced JSON block whose info-string is the
+// literal token PAYLOAD_FENCE_INFO. Audit, dashboard repair, and closeout gate
+// evaluation consume the structured payload exclusively. Visible Markdown
+// around the fence is human commentary only.
+// -----------------------------------------------------------------------------
+
+/// On-wire schema identity for v2 lifecycle payloads.
+pub const PAYLOAD_SCHEMA_V2: &str = "plan-issue-record.payload.v2";
+
+/// Fenced-code-block info-string used to mark a lifecycle payload fence.
+pub const PAYLOAD_FENCE_INFO: &str = "plan-issue-record-payload";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PayloadRole {
+    Source,
+    Plan,
+    State,
+    Session,
+    Validation,
+    Review,
+    Closeout,
+}
+
+impl PayloadRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Source => "source",
+            Self::Plan => "plan",
+            Self::State => "state",
+            Self::Session => "session",
+            Self::Validation => "validation",
+            Self::Review => "review",
+            Self::Closeout => "closeout",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PayloadProfile {
+    Tracking,
+    Dispatch,
+}
+
+impl PayloadProfile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Tracking => "tracking",
+            Self::Dispatch => "dispatch",
+        }
+    }
+}
+
+/// Envelope for every lifecycle comment payload.
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct RecordPayload {
+    pub schema: String,
+    pub role: PayloadRole,
+    pub profile: PayloadProfile,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+    #[serde(default)]
+    pub data: Value,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct SnapshotData {
+    pub path: String,
+    pub commit: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StateStatus {
+    InProgress,
+    Complete,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TaskRowStatus {
+    Pending,
+    InProgress,
+    Done,
+    Deferred,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct TaskRowPayload {
+    pub id: String,
+    pub status: TaskRowStatus,
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PrLifecycleStatus {
+    Open,
+    Merged,
+    Closed,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct PrRefPayload {
+    #[serde(rename = "ref")]
+    pub pr_ref: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    pub status: PrLifecycleStatus,
+}
+
+#[derive(Debug, Clone, Default, Serialize, serde::Deserialize)]
+pub struct StateData {
+    pub status: Option<StateStatus>,
+    #[serde(default)]
+    pub target_scope: Option<String>,
+    #[serde(default)]
+    pub current: Option<String>,
+    #[serde(default)]
+    pub next_action: Option<String>,
+    #[serde(default)]
+    pub tasks: Vec<TaskRowPayload>,
+    #[serde(default)]
+    pub prs: Vec<PrRefPayload>,
+    #[serde(default)]
+    pub blockers: Vec<String>,
+    #[serde(default)]
+    pub links: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct SessionData {
+    pub summary: String,
+    #[serde(default)]
+    pub highlights: Vec<String>,
+    #[serde(default)]
+    pub links: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ValidationOverall {
+    Pass,
+    Fail,
+    Partial,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ValidationCommandStatus {
+    Pass,
+    Fail,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct ValidationCommand {
+    pub command: String,
+    pub status: ValidationCommandStatus,
+    #[serde(default)]
+    pub evidence: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct ValidationWaiver {
+    pub command: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct ValidationData {
+    pub overall: ValidationOverall,
+    #[serde(default)]
+    pub commands: Vec<ValidationCommand>,
+    #[serde(default)]
+    pub waivers: Vec<ValidationWaiver>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReviewDecision {
+    Approve,
+    RequestChanges,
+    CommentsOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FindingSeverity {
+    Blocker,
+    Major,
+    Minor,
+    Nit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FindingDisposition {
+    Fixed,
+    Residual,
+    FollowUp,
+    Deferred,
+    NoAction,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct ReviewFinding {
+    pub id: String,
+    pub severity: FindingSeverity,
+    pub disposition: FindingDisposition,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct ReviewData {
+    pub decision: ReviewDecision,
+    #[serde(default)]
+    pub lenses: Vec<String>,
+    #[serde(default)]
+    pub findings: Vec<ReviewFinding>,
+    #[serde(default)]
+    pub outcome_comment_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct ApprovalEvidence {
+    #[serde(default)]
+    pub comment_url: Option<String>,
+    #[serde(default)]
+    pub approver: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckStatus {
+    Pass,
+    Fail,
+    None,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct LinkedPrEvidence {
+    #[serde(rename = "ref")]
+    pub pr_ref: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub merge_sha: Option<String>,
+    pub checks: CheckStatus,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct CloseoutData {
+    pub final_status: String,
+    pub approval: ApprovalEvidence,
+    #[serde(default)]
+    pub linked_prs: Vec<LinkedPrEvidence>,
+    #[serde(default)]
+    pub final_validation_url: Option<String>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PayloadErrorKind {
+    NoFence,
+    MultipleFences,
+    SchemaMismatch,
+    InvalidJson,
+}
+
+#[derive(Debug, Clone)]
+pub struct PayloadError {
+    pub kind: PayloadErrorKind,
+    pub message: String,
+}
+
+impl PayloadError {
+    fn new(kind: PayloadErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for PayloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for PayloadError {}
+
+/// Extract the structured lifecycle payload fenced inside `comment_body`.
+///
+/// - Returns `Ok(payload)` on a single well-formed `plan-issue-record-payload`
+///   fence whose envelope `schema` matches [`PAYLOAD_SCHEMA_V2`].
+/// - Returns `Err(NoFence)` when the comment does not contain the fence.
+/// - Returns `Err(MultipleFences)` when multiple payload fences are present;
+///   each comment carries at most one payload.
+/// - Returns `Err(SchemaMismatch)` when the fence parses but its `schema`
+///   does not match the v2 wire identity.
+/// - Returns `Err(InvalidJson)` when the fence body is not valid JSON or
+///   does not deserialize into the envelope.
+pub fn extract_payload(comment_body: &str) -> Result<RecordPayload, PayloadError> {
+    let fences = collect_payload_fences(comment_body);
+    if fences.is_empty() {
+        return Err(PayloadError::new(
+            PayloadErrorKind::NoFence,
+            "no plan-issue-record-payload fence in comment body",
+        ));
+    }
+    if fences.len() > 1 {
+        return Err(PayloadError::new(
+            PayloadErrorKind::MultipleFences,
+            "multiple plan-issue-record-payload fences in comment body",
+        ));
+    }
+
+    let raw = &fences[0];
+    let payload: RecordPayload = serde_json::from_str(raw)
+        .map_err(|err| PayloadError::new(PayloadErrorKind::InvalidJson, err.to_string()))?;
+    if payload.schema != PAYLOAD_SCHEMA_V2 {
+        return Err(PayloadError::new(
+            PayloadErrorKind::SchemaMismatch,
+            format!(
+                "expected schema `{PAYLOAD_SCHEMA_V2}`, got `{}`",
+                payload.schema
+            ),
+        ));
+    }
+    Ok(payload)
+}
+
+fn collect_payload_fences(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current: Option<Vec<String>> = None;
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        if let Some(buf) = current.as_mut() {
+            if trimmed.starts_with("```") {
+                let mut block = String::new();
+                for chunk in buf.iter() {
+                    if !block.is_empty() {
+                        block.push('\n');
+                    }
+                    block.push_str(chunk);
+                }
+                out.push(block);
+                current = None;
+            } else {
+                buf.push(line.to_string());
+            }
+        } else if let Some(rest) = trimmed.strip_prefix("```")
+            && rest.trim() == PAYLOAD_FENCE_INFO
+        {
+            current = Some(Vec::new());
+        }
+    }
+    out
+}
+
+impl RecordPayload {
+    pub fn parse_state(&self) -> Result<StateData, PayloadError> {
+        self.decode_data(PayloadRole::State)
+    }
+
+    pub fn parse_session(&self) -> Result<SessionData, PayloadError> {
+        self.decode_data(PayloadRole::Session)
+    }
+
+    pub fn parse_validation(&self) -> Result<ValidationData, PayloadError> {
+        self.decode_data(PayloadRole::Validation)
+    }
+
+    pub fn parse_review(&self) -> Result<ReviewData, PayloadError> {
+        self.decode_data(PayloadRole::Review)
+    }
+
+    pub fn parse_closeout(&self) -> Result<CloseoutData, PayloadError> {
+        self.decode_data(PayloadRole::Closeout)
+    }
+
+    pub fn parse_snapshot(&self) -> Result<SnapshotData, PayloadError> {
+        if !matches!(self.role, PayloadRole::Source | PayloadRole::Plan) {
+            return Err(PayloadError::new(
+                PayloadErrorKind::SchemaMismatch,
+                format!(
+                    "expected source or plan payload, got `{}`",
+                    self.role.as_str()
+                ),
+            ));
+        }
+        serde_json::from_value::<SnapshotData>(self.data.clone())
+            .map_err(|err| PayloadError::new(PayloadErrorKind::InvalidJson, err.to_string()))
+    }
+
+    fn decode_data<T: serde::de::DeserializeOwned>(
+        &self,
+        expected: PayloadRole,
+    ) -> Result<T, PayloadError> {
+        if self.role != expected {
+            return Err(PayloadError::new(
+                PayloadErrorKind::SchemaMismatch,
+                format!(
+                    "expected role `{}`, got `{}`",
+                    expected.as_str(),
+                    self.role.as_str()
+                ),
+            ));
+        }
+        serde_json::from_value::<T>(self.data.clone())
+            .map_err(|err| PayloadError::new(PayloadErrorKind::InvalidJson, err.to_string()))
+    }
+}

--- a/crates/plan-issue-cli/tests/integration/cli_contract.rs
+++ b/crates/plan-issue-cli/tests/integration/cli_contract.rs
@@ -5,6 +5,7 @@ use pretty_assertions::assert_eq;
 
 use plan_issue_cli::cli::{Cli, OutputFormat};
 use plan_issue_cli::commands::plan::LinkPrStatus;
+use plan_issue_cli::commands::record::{LifecycleCommentKind, RecordCommand, RecordProfile};
 use plan_issue_cli::commands::{Command, PrGrouping, SplitStrategy};
 
 use crate::common;
@@ -351,6 +352,305 @@ fn cli_conflict_rules_reject_default_pr_grouping_with_deterministic() {
     let err = cli.validate().expect_err("semantic validation should fail");
     assert_eq!(err.code, "invalid-pr-grouping");
     assert!(err.message.contains("only valid when --strategy auto"));
+}
+
+// --- Sprint 1: plan-issue-lifecycle-v3 record surface ---
+
+#[test]
+fn cli_parse_contract_record_open_accepts_plan_bundle() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "open",
+        "--bundle",
+        "docs/plans/plan-issue-lifecycle-v3",
+        "--profile",
+        "tracking",
+    ])
+    .expect("parse record open");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::Record(args) => match &args.command {
+            RecordCommand::Open(open) => {
+                assert_eq!(open.profile, RecordProfile::Tracking);
+                assert_eq!(
+                    open.bundle.as_deref(),
+                    Some(PathBuf::from("docs/plans/plan-issue-lifecycle-v3").as_path()),
+                );
+                assert!(open.source_file.is_none());
+                assert!(open.plan_file.is_none());
+                assert!(open.execution_state_file.is_none());
+                assert!(!open.allow_dirty);
+                assert!(open.fixture.is_none());
+            }
+            other => panic!("unexpected record subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parse_contract_record_open_accepts_explicit_bundle_paths() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "open",
+        "--source-file",
+        "docs/plans/example/example-discussion-source.md",
+        "--plan-file",
+        "docs/plans/example/example-plan.md",
+        "--execution-state-file",
+        "docs/plans/example/example-execution-state.md",
+        "--title",
+        "Example Plan",
+        "--allow-dirty",
+    ])
+    .expect("parse record open with explicit files");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::Record(args) => match &args.command {
+            RecordCommand::Open(open) => {
+                assert_eq!(
+                    open.source_file,
+                    Some(PathBuf::from(
+                        "docs/plans/example/example-discussion-source.md"
+                    ))
+                );
+                assert_eq!(
+                    open.plan_file,
+                    Some(PathBuf::from("docs/plans/example/example-plan.md"))
+                );
+                assert_eq!(
+                    open.execution_state_file,
+                    Some(PathBuf::from(
+                        "docs/plans/example/example-execution-state.md"
+                    ))
+                );
+                assert_eq!(open.title.as_deref(), Some("Example Plan"));
+                assert!(open.allow_dirty);
+            }
+            other => panic!("unexpected record subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parse_contract_record_post_accepts_kind_and_payload_file() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--profile",
+        "tracking",
+        "--kind",
+        "state",
+        "--payload-file",
+        "state.json",
+    ])
+    .expect("parse record post");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::Record(args) => match &args.command {
+            RecordCommand::Post(post) => {
+                assert_eq!(post.issue, "448");
+                assert_eq!(post.profile, RecordProfile::Tracking);
+                assert_eq!(post.kind, LifecycleCommentKind::State);
+                assert_eq!(post.payload_file, Some(PathBuf::from("state.json")));
+                assert!(post.fixture.is_none());
+            }
+            other => panic!("unexpected record subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parse_contract_record_post_rejects_marker_family_flag() {
+    let err = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--kind",
+        "state",
+        "--marker-family",
+        "compat",
+    ])
+    .expect_err("clap should reject the v1-only --marker-family flag");
+
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("--marker-family"),
+        "expected rejection to mention --marker-family: {rendered}",
+    );
+}
+
+#[test]
+fn cli_parse_contract_record_repair_dashboard_accepts_fixture_inputs() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "repair-dashboard",
+        "--body-file",
+        "issue-body.md",
+        "--comments-json",
+        "comments.json",
+        "--out",
+        "dashboard.md",
+    ])
+    .expect("parse record repair-dashboard");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::Record(args) => match &args.command {
+            RecordCommand::RepairDashboard(repair) => {
+                assert_eq!(repair.body_file, Some(PathBuf::from("issue-body.md")));
+                assert_eq!(repair.comments_json, Some(PathBuf::from("comments.json")));
+                assert_eq!(repair.out, Some(PathBuf::from("dashboard.md")));
+                assert!(repair.fixture.is_none());
+                assert!(repair.issue.is_none());
+            }
+            other => panic!("unexpected record subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parse_contract_record_close_accepts_strict_inputs() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "close",
+        "--issue",
+        "448",
+        "--linked-pr",
+        "sympoies/nils-cli#500",
+        "--linked-pr",
+        "sympoies/nils-cli#501",
+        "--approval",
+        "https://github.com/sympoies/nils-cli/issues/448#issuecomment-1",
+        "--bundle",
+        "docs/plans/plan-issue-lifecycle-v3",
+    ])
+    .expect("parse record close");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::Record(args) => match &args.command {
+            RecordCommand::Close(close) => {
+                assert_eq!(close.issue, "448");
+                assert_eq!(
+                    close.linked_pr,
+                    vec![
+                        "sympoies/nils-cli#500".to_string(),
+                        "sympoies/nils-cli#501".to_string(),
+                    ]
+                );
+                assert_eq!(
+                    close.approval.as_deref(),
+                    Some("https://github.com/sympoies/nils-cli/issues/448#issuecomment-1"),
+                );
+                assert_eq!(
+                    close.bundle,
+                    Some(PathBuf::from("docs/plans/plan-issue-lifecycle-v3"))
+                );
+                assert!(close.body_file.is_none());
+                assert!(close.comments_json.is_none());
+                assert!(close.fixture.is_none());
+            }
+            other => panic!("unexpected record subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parse_contract_record_close_rejects_require_complete_flag() {
+    let err = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "close",
+        "--issue",
+        "448",
+        "--require-complete",
+    ])
+    .expect_err("clap should reject the v1 --require-complete flag on record close");
+
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("--require-complete"),
+        "expected rejection to mention --require-complete: {rendered}",
+    );
+}
+
+#[test]
+fn cli_parse_contract_record_close_rejects_other_require_flags() {
+    for flag in [
+        "--require-session",
+        "--require-validation",
+        "--require-review",
+        "--require-closeout",
+    ] {
+        let parsed = Cli::try_parse_from(["plan-issue", "record", "close", "--issue", "448", flag]);
+        let err = parsed.expect_err(&format!("clap should reject v1 require flag {flag}"));
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(flag),
+            "expected rejection to mention {flag}: {rendered}",
+        );
+    }
+}
+
+#[test]
+fn cli_parse_contract_record_close_accepts_fixture_mode() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "close",
+        "--issue",
+        "448",
+        "--linked-pr",
+        "sympoies/nils-cli#500",
+        "--approval",
+        "approved",
+        "--fixture",
+        "tests/fixtures/lifecycle/example",
+        "--body-file",
+        "issue-body.md",
+        "--comments-json",
+        "comments.json",
+    ])
+    .expect("parse record close with fixture");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::Record(args) => match &args.command {
+            RecordCommand::Close(close) => {
+                assert_eq!(
+                    close.fixture,
+                    Some(PathBuf::from("tests/fixtures/lifecycle/example"))
+                );
+                assert_eq!(close.body_file, Some(PathBuf::from("issue-body.md")));
+                assert_eq!(close.comments_json, Some(PathBuf::from("comments.json")));
+            }
+            other => panic!("unexpected record subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/plan-issue-cli/tests/integration/lifecycle_record.rs
+++ b/crates/plan-issue-cli/tests/integration/lifecycle_record.rs
@@ -4,6 +4,12 @@ use pretty_assertions::assert_eq;
 use serde_json::Value;
 use tempfile::TempDir;
 
+use plan_issue_cli::lifecycle_record::{
+    self, CheckStatus, FindingDisposition, FindingSeverity, PAYLOAD_SCHEMA_V2, PayloadErrorKind,
+    PayloadProfile, PayloadRole, PrLifecycleStatus, ReviewDecision, StateStatus, TaskRowStatus,
+    ValidationCommandStatus, ValidationOverall,
+};
+
 use crate::common;
 
 fn json_stdout(out: &common::CmdOut) -> Value {
@@ -257,4 +263,148 @@ fn issue_backed_lifecycle_build_dispatch_ledger_uses_plan_tooling_without_task_d
             .unwrap()
             > 0
     );
+}
+
+// --- Sprint 1 Task 1.3: lifecycle_record_structured_payloads ---
+
+fn payload_comment(body: &str) -> String {
+    format!(
+        "<!-- plan-issue-record:v2 role=state profile=tracking -->\n\n## State\n\n```plan-issue-record-payload\n{body}\n```\n",
+    )
+}
+
+#[test]
+fn lifecycle_record_structured_payloads_state_round_trip() {
+    let body = format!(
+        "{{\n  \"schema\": \"{PAYLOAD_SCHEMA_V2}\",\n  \"role\": \"state\",\n  \"profile\": \"tracking\",\n  \"updated_at\": \"2026-05-23T09:00:00Z\",\n  \"data\": {{\n    \"status\": \"in-progress\",\n    \"target_scope\": \"Plan-Issue v3 sprint 1\",\n    \"current\": \"Sprint 1 implementation\",\n    \"next_action\": \"Land spec PR\",\n    \"tasks\": [\n      {{\"id\": \"1.1\", \"status\": \"done\", \"title\": \"Spec\"}},\n      {{\"id\": \"1.2\", \"status\": \"in-progress\"}}\n    ],\n    \"prs\": [\n      {{\"ref\": \"sympoies/nils-cli#500\", \"url\": \"https://github.com/sympoies/nils-cli/pull/500\", \"status\": \"open\"}}\n    ],\n    \"blockers\": [],\n    \"links\": {{\"source\": \"https://github.com/sympoies/nils-cli/issues/448#issuecomment-100\"}}\n  }}\n}}"
+    );
+    let comment = payload_comment(&body);
+
+    let envelope = lifecycle_record::extract_payload(&comment).expect("extract state payload");
+    assert_eq!(envelope.role, PayloadRole::State);
+    assert_eq!(envelope.profile, PayloadProfile::Tracking);
+    assert_eq!(envelope.updated_at.as_deref(), Some("2026-05-23T09:00:00Z"));
+
+    let state = envelope.parse_state().expect("parse state data");
+    assert_eq!(state.status, Some(StateStatus::InProgress));
+    assert_eq!(
+        state.target_scope.as_deref(),
+        Some("Plan-Issue v3 sprint 1")
+    );
+    assert_eq!(state.tasks.len(), 2);
+    assert_eq!(state.tasks[0].id, "1.1");
+    assert_eq!(state.tasks[0].status, TaskRowStatus::Done);
+    assert_eq!(state.tasks[1].status, TaskRowStatus::InProgress);
+    assert_eq!(state.prs.len(), 1);
+    assert_eq!(state.prs[0].pr_ref, "sympoies/nils-cli#500");
+    assert_eq!(state.prs[0].status, PrLifecycleStatus::Open);
+    assert_eq!(
+        state.links.get("source").map(String::as_str),
+        Some("https://github.com/sympoies/nils-cli/issues/448#issuecomment-100"),
+    );
+}
+
+#[test]
+fn lifecycle_record_structured_payloads_validation_command_rows() {
+    let body = format!(
+        "{{\n  \"schema\": \"{PAYLOAD_SCHEMA_V2}\",\n  \"role\": \"validation\",\n  \"profile\": \"tracking\",\n  \"data\": {{\n    \"overall\": \"pass\",\n    \"commands\": [\n      {{\"command\": \"cargo test -p nils-plan-issue-cli\", \"status\": \"pass\"}},\n      {{\"command\": \"bash scripts/ci/nils-cli-checks-entrypoint.sh\", \"status\": \"pass\", \"evidence\": \"out/log.txt\"}}\n    ],\n    \"waivers\": []\n  }}\n}}"
+    );
+    let comment = payload_comment(&body);
+
+    let envelope = lifecycle_record::extract_payload(&comment).expect("extract validation payload");
+    let validation = envelope.parse_validation().expect("parse validation data");
+    assert_eq!(validation.overall, ValidationOverall::Pass);
+    assert_eq!(validation.commands.len(), 2);
+    for cmd in &validation.commands {
+        assert_eq!(cmd.status, ValidationCommandStatus::Pass);
+    }
+    assert_eq!(
+        validation.commands[1].evidence.as_deref(),
+        Some("out/log.txt")
+    );
+    assert!(validation.waivers.is_empty());
+}
+
+#[test]
+fn lifecycle_record_structured_payloads_review_findings_and_decision() {
+    let body = format!(
+        "{{\n  \"schema\": \"{PAYLOAD_SCHEMA_V2}\",\n  \"role\": \"review\",\n  \"profile\": \"tracking\",\n  \"data\": {{\n    \"decision\": \"approve\",\n    \"lenses\": [\"testing\", \"maintainability\"],\n    \"findings\": [\n      {{\"id\": \"F1\", \"severity\": \"minor\", \"disposition\": \"fixed\", \"summary\": \"Fence parser handles whitespace\"}},\n      {{\"id\": \"F2\", \"severity\": \"nit\", \"disposition\": \"no-action\", \"summary\": \"Comment wording\"}}\n    ],\n    \"outcome_comment_url\": \"https://github.com/sympoies/nils-cli/pull/500#issuecomment-200\"\n  }}\n}}"
+    );
+    let comment = payload_comment(&body);
+
+    let envelope = lifecycle_record::extract_payload(&comment).expect("extract review payload");
+    let review = envelope.parse_review().expect("parse review data");
+    assert_eq!(review.decision, ReviewDecision::Approve);
+    assert_eq!(review.lenses, vec!["testing", "maintainability"]);
+    assert_eq!(review.findings.len(), 2);
+    assert_eq!(review.findings[0].severity, FindingSeverity::Minor);
+    assert_eq!(review.findings[0].disposition, FindingDisposition::Fixed);
+    assert_eq!(review.findings[1].severity, FindingSeverity::Nit);
+    assert_eq!(review.findings[1].disposition, FindingDisposition::NoAction);
+    assert_eq!(
+        review.outcome_comment_url.as_deref(),
+        Some("https://github.com/sympoies/nils-cli/pull/500#issuecomment-200"),
+    );
+}
+
+#[test]
+fn lifecycle_record_structured_payloads_closeout_final_checks_and_merge_evidence() {
+    let body = format!(
+        "{{\n  \"schema\": \"{PAYLOAD_SCHEMA_V2}\",\n  \"role\": \"closeout\",\n  \"profile\": \"tracking\",\n  \"data\": {{\n    \"final_status\": \"complete\",\n    \"approval\": {{\"comment_url\": \"https://example/approve\", \"approver\": \"graysurf\"}},\n    \"linked_prs\": [\n      {{\"ref\": \"sympoies/nils-cli#500\", \"url\": \"https://github.com/sympoies/nils-cli/pull/500\", \"merge_sha\": \"abcd1234\", \"checks\": \"pass\"}},\n      {{\"ref\": \"sympoies/nils-cli#501\", \"merge_sha\": \"5678ef\", \"checks\": \"pass\"}}\n    ],\n    \"final_validation_url\": \"https://example/validation\"\n  }}\n}}"
+    );
+    let comment = payload_comment(&body);
+
+    let envelope = lifecycle_record::extract_payload(&comment).expect("extract closeout payload");
+    let closeout = envelope.parse_closeout().expect("parse closeout data");
+    assert_eq!(closeout.final_status, "complete");
+    assert_eq!(closeout.approval.approver.as_deref(), Some("graysurf"));
+    assert_eq!(closeout.linked_prs.len(), 2);
+    for pr in &closeout.linked_prs {
+        assert!(pr.merge_sha.is_some(), "merge_sha required: {pr:?}");
+        assert_eq!(pr.checks, CheckStatus::Pass);
+    }
+    assert_eq!(
+        closeout.final_validation_url.as_deref(),
+        Some("https://example/validation"),
+    );
+}
+
+#[test]
+fn lifecycle_record_structured_payloads_reject_schema_mismatch() {
+    let body = "{\n  \"schema\": \"plan-issue-record.payload.v1\",\n  \"role\": \"state\",\n  \"profile\": \"tracking\",\n  \"data\": {}\n}";
+    let comment = payload_comment(body);
+
+    let err = lifecycle_record::extract_payload(&comment).expect_err("schema mismatch");
+    assert_eq!(err.kind, PayloadErrorKind::SchemaMismatch);
+    assert!(
+        err.message.contains("plan-issue-record.payload.v2"),
+        "{}",
+        err.message,
+    );
+}
+
+#[test]
+fn lifecycle_record_structured_payloads_reject_missing_fence() {
+    let comment = "<!-- plan-issue-record:v2 role=state profile=tracking -->\n\nNo payload here.\n";
+    let err = lifecycle_record::extract_payload(comment).expect_err("no fence");
+    assert_eq!(err.kind, PayloadErrorKind::NoFence);
+}
+
+#[test]
+fn lifecycle_record_structured_payloads_reject_invalid_json() {
+    let comment = "```plan-issue-record-payload\n{ not json }\n```\n";
+    let err = lifecycle_record::extract_payload(comment).expect_err("invalid json");
+    assert_eq!(err.kind, PayloadErrorKind::InvalidJson);
+}
+
+#[test]
+fn lifecycle_record_structured_payloads_reject_role_decode_mismatch() {
+    let body = format!(
+        "{{\n  \"schema\": \"{PAYLOAD_SCHEMA_V2}\",\n  \"role\": \"session\",\n  \"profile\": \"tracking\",\n  \"data\": {{\"summary\": \"x\"}}\n}}"
+    );
+    let comment = payload_comment(&body);
+    let envelope = lifecycle_record::extract_payload(&comment).expect("extract session payload");
+    let err = envelope.parse_state().expect_err("state decode mismatch");
+    assert_eq!(err.kind, PayloadErrorKind::SchemaMismatch);
+    assert!(err.message.contains("state"), "{}", err.message);
 }


### PR DESCRIPTION
## Summary

Sprint 1 of the breaking `plan-issue` v3 issue-backed plan record rewrite
([#448](https://github.com/sympoies/nils-cli/issues/448)). Lands the v3
contract spec, the canonical `record open|post|repair-dashboard|close`
CLI surface (scaffolded), and structured payload types so Sprints 2-3 can
implement audit, dashboard repair, and live provider lifecycle on top
of one shared contract.

## Changes

- **Specs (Task 1.1)**
  - New `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md` — one canonical marker family, structured payloads, provider-backed open/post/audit/repair-dashboard/close, strict closeout gate, fixture mode.
  - New `crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v2.md` — v2 record states (`RECORD_UNOPENED → RECORD_CLOSED`), transitions, closeout invariants.
  - v1 contract + state machine docs marked retired / Task Decomposition runtime.
  - `crates/plan-issue-cli/docs/README.md` rewritten around the v2 lifecycle as the default.
- **CLI surface (Task 1.2)**
  - New `record open`, `record post`, `record repair-dashboard`, `record close` clap subcommands (`crates/plan-issue-cli/src/commands/record.rs`). Args satisfy the v2 contract: bundle-first inputs on `open`, kind-based `post`, fixture inputs on every command.
  - No `--marker-family` on the v2 surface. No `--require-*` flags on `record close`. Both rejected by clap; verified by new contract tests.
  - Dispatcher in `execute.rs` returns stable `*-not-yet-implemented` errors for the new commands so the binary compiles and the v2 contract is testable while Sprints 2-3 land lifecycle internals.
  - 9 new `cli_contract` tests cover open/post/repair-dashboard/close parse paths and reject the v1-only flags.
- **Structured payload (Task 1.3)**
  - `lifecycle_record.rs` gains `RecordPayload`, `StateData`, `SessionData`, `ValidationData`, `ReviewData`, `CloseoutData`, `SnapshotData` plus role / status / decision / severity / disposition / check-status enums.
  - `extract_payload()` parses a single `plan-issue-record-payload` fence per comment, validates the wire schema (`plan-issue-record.payload.v2`), and surfaces stable `PayloadErrorKind` codes for missing / duplicate / mismatched / invalid payloads.
  - 8 new `lifecycle_record_structured_payloads_*` tests cover state, validation, review, closeout payloads (acceptance criteria) plus schema / fence / role error paths.

## What this PR does **not** do

- No removal of v1 commands (`record render-comment`, `record render-dashboard`,
  `record closeout-gate`, `record build-dispatch-ledger`) — Sprint 4 retires those.
- No live provider mutations — Sprint 3 wires the lifecycle internals.
- No structured-payload-driven audit changes — Sprint 2 collapses the
  marker parsing and rebuilds audit on the new payloads.

## Test plan

- `cargo test -p nils-plan-issue-cli cli_contract` — 22 tests pass (13 prior + 9 new).
- `cargo test -p nils-plan-issue-cli lifecycle_record` — 13 tests pass (5 prior + 8 new).
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` — full local gate.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` — docs-only gate (rumdl, hygiene, placement, plan bundle).

Refs #448
