### PR TITLE
feat(forge-cli): add issue list subcommand

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -94,6 +94,9 @@ _forge-cli() {
             forge__cli__help__issue,edit)
                 cmd="forge__cli__help__issue__edit"
                 ;;
+            forge__cli__help__issue,list)
+                cmd="forge__cli__help__issue__list"
+                ;;
             forge__cli__help__issue,reopen)
                 cmd="forge__cli__help__issue__reopen"
                 ;;
@@ -175,6 +178,9 @@ _forge-cli() {
             forge__cli__issue,help)
                 cmd="forge__cli__issue__help"
                 ;;
+            forge__cli__issue,list)
+                cmd="forge__cli__issue__list"
+                ;;
             forge__cli__issue,reopen)
                 cmd="forge__cli__issue__reopen"
                 ;;
@@ -195,6 +201,9 @@ _forge-cli() {
                 ;;
             forge__cli__issue__help,help)
                 cmd="forge__cli__issue__help__help"
+                ;;
+            forge__cli__issue__help,list)
+                cmd="forge__cli__issue__help__list"
                 ;;
             forge__cli__issue__help,reopen)
                 cmd="forge__cli__issue__help__reopen"
@@ -581,7 +590,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help__issue)
-            opts="create view edit comment close reopen"
+            opts="create view list edit comment close reopen"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -637,6 +646,20 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help__issue__edit)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__issue__list)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1113,7 +1136,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__issue)
-            opts="-h --format --remote --provider --repo --dry-run --help create view edit comment close reopen help"
+            opts="-h --format --remote --provider --repo --dry-run --help create view list edit comment close reopen help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1315,7 +1338,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__issue__help)
-            opts="create view edit comment close reopen help"
+            opts="create view list edit comment close reopen help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1398,6 +1421,20 @@ _forge-cli() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        forge__cli__issue__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         forge__cli__issue__help__reopen)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
@@ -1419,6 +1456,56 @@ _forge-cli() {
                 return 0
             fi
             case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__issue__list)
+            opts="-h --state --label --author --assignee --limit --format --remote --provider --repo --dry-run --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --state)
+                    COMPREPLY=($(compgen -W "open closed all" -- "${cur}"))
+                    return 0
+                    ;;
+                --label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --author)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --assignee)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -352,6 +352,23 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ':id -- Numeric id:_default' \
 && ret=0
 ;;
+(list)
+_arguments "${_arguments_options[@]}" : \
+'--state=[Filter by state (default\: open)]:STATE:(open closed all)' \
+'*--label=[Filter by label. Repeatable. GitHub joins labels into a comma list (issue must have all labels); GitLab passes a repeated --label]:NAME:_default' \
+'--author=[Filter by author handle]:AUTHOR:_default' \
+'--assignee=[Filter by assignee handle]:ASSIGNEE:_default' \
+'--limit=[Cap the number of returned issues (default\: 30)]:LIMIT:_default' \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
 (edit)
 _arguments "${_arguments_options[@]}" : \
 '--title=[New title (re-validated against \`title_length\`)]:TITLE:_default' \
@@ -429,6 +446,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (view)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(list)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -795,6 +816,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (edit)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1013,6 +1038,7 @@ _forge-cli__subcmd__help__subcmd__issue_commands() {
     local commands; commands=(
 'create:Open a new issue' \
 'view:Fetch a single issue' \
+'list:List issues filtered by state / labels / author / assignee' \
 'edit:Mutate an issue' \
 'comment:Append a comment to an issue' \
 'close:Close an issue' \
@@ -1039,6 +1065,11 @@ _forge-cli__subcmd__help__subcmd__issue__subcmd__create_commands() {
 _forge-cli__subcmd__help__subcmd__issue__subcmd__edit_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli help issue edit commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__issue__subcmd__list_commands] )) ||
+_forge-cli__subcmd__help__subcmd__issue__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli help issue list commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__help__subcmd__issue__subcmd__reopen_commands] )) ||
 _forge-cli__subcmd__help__subcmd__issue__subcmd__reopen_commands() {
@@ -1194,6 +1225,7 @@ _forge-cli__subcmd__issue_commands() {
     local commands; commands=(
 'create:Open a new issue' \
 'view:Fetch a single issue' \
+'list:List issues filtered by state / labels / author / assignee' \
 'edit:Mutate an issue' \
 'comment:Append a comment to an issue' \
 'close:Close an issue' \
@@ -1227,6 +1259,7 @@ _forge-cli__subcmd__issue__subcmd__help_commands() {
     local commands; commands=(
 'create:Open a new issue' \
 'view:Fetch a single issue' \
+'list:List issues filtered by state / labels / author / assignee' \
 'edit:Mutate an issue' \
 'comment:Append a comment to an issue' \
 'close:Close an issue' \
@@ -1260,6 +1293,11 @@ _forge-cli__subcmd__issue__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli issue help help commands' commands "$@"
 }
+(( $+functions[_forge-cli__subcmd__issue__subcmd__help__subcmd__list_commands] )) ||
+_forge-cli__subcmd__issue__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli issue help list commands' commands "$@"
+}
 (( $+functions[_forge-cli__subcmd__issue__subcmd__help__subcmd__reopen_commands] )) ||
 _forge-cli__subcmd__issue__subcmd__help__subcmd__reopen_commands() {
     local commands; commands=()
@@ -1269,6 +1307,11 @@ _forge-cli__subcmd__issue__subcmd__help__subcmd__reopen_commands() {
 _forge-cli__subcmd__issue__subcmd__help__subcmd__view_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli issue help view commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__issue__subcmd__list_commands] )) ||
+_forge-cli__subcmd__issue__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli issue list commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__issue__subcmd__reopen_commands] )) ||
 _forge-cli__subcmd__issue__subcmd__reopen_commands() {

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -315,6 +315,23 @@ operations:
       github: { program: gh,   argv: [issue, view, "{id}", --json, "number,url,state,title,labels,assignees,body"] }
       gitlab: { program: glab, argv: [issue, view, "{id}", -F, json] }
 
+  - id: issue.list
+    schema_version: cli.forge-cli.issue.list.v1
+    summary: List issues filtered by state / labels / author / assignee.
+    inputs:
+      - { name: --state,    type: enum<open|closed|all>, default: open }
+      - { name: --label,    type: list<string>,          default: [] }
+      - { name: --author,   type: string,                required: false }
+      - { name: --assignee, type: string,                required: false }
+      - { name: --limit,    type: integer,               default: 30 }
+    validations: []
+    backends:
+      github: { program: gh,   argv: [issue, list, --json, "number,url,state,title,labels,author,assignees"] }
+      gitlab: { program: glab, argv: [issue, list, -F, json] }
+    output:
+      data:
+        items: list<{ number, url, state, title, labels, author, assignees }>
+
   - id: issue.edit
     schema_version: cli.forge-cli.issue.edit.v1
     summary: Mutate issue title / body / labels / assignees.

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -188,6 +188,26 @@ pub enum PrStateFilter {
     All,
 }
 
+/// `--state` filter for `issue list`. Issues have no `merged` state, so
+/// this enum is intentionally narrower than [`PrStateFilter`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum IssueStateFilter {
+    Open,
+    Closed,
+    All,
+}
+
+impl IssueStateFilter {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IssueStateFilter::Open => "open",
+            IssueStateFilter::Closed => "closed",
+            IssueStateFilter::All => "all",
+        }
+    }
+}
+
 /// Inbox item-kind / reason filter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
 #[clap(rename_all = "lower")]
@@ -536,6 +556,8 @@ pub enum IssueCommand {
         /// Numeric id.
         id: u64,
     },
+    /// List issues filtered by state / labels / author / assignee.
+    List(IssueListArgs),
     /// Mutate an issue.
     Edit(IssueEditArgs),
     /// Append a comment to an issue.
@@ -604,6 +626,28 @@ pub struct InboxNextArgs {
     /// Number of ranked items to return (default: 5). Provider queries remain
     /// bounded at at least 30 candidates so ranking has enough input.
     #[arg(long, default_value_t = 5)]
+    pub limit: u32,
+}
+
+/// `issue list` arguments. Maps to
+/// `forge-cli-ops-v1.yaml::operations.issue.list` inputs.
+#[derive(Args, Debug, Clone)]
+pub struct IssueListArgs {
+    /// Filter by state (default: open).
+    #[arg(long, value_enum, default_value_t = IssueStateFilter::Open)]
+    pub state: IssueStateFilter,
+    /// Filter by label. Repeatable. GitHub joins labels into a comma list
+    /// (issue must have all labels); GitLab passes a repeated --label.
+    #[arg(long = "label", value_name = "NAME")]
+    pub labels: Vec<String>,
+    /// Filter by author handle.
+    #[arg(long)]
+    pub author: Option<String>,
+    /// Filter by assignee handle.
+    #[arg(long)]
+    pub assignee: Option<String>,
+    /// Cap the number of returned issues (default: 30).
+    #[arg(long, default_value_t = 30)]
     pub limit: u32,
 }
 
@@ -750,6 +794,9 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
         Some(Command::Issue(IssueArgs {
             command: Some(IssueCommand::View { id }),
         })) => ops::issue_view::run(&global, id, format),
+        Some(Command::Issue(IssueArgs {
+            command: Some(IssueCommand::List(args)),
+        })) => ops::issue_list::run(&global, args, format),
         Some(Command::Issue(IssueArgs {
             command: Some(IssueCommand::Edit(args)),
         })) => ops::issue_edit::run(&global, args, format),

--- a/crates/forge-cli/src/ops/issue_list.rs
+++ b/crates/forge-cli/src/ops/issue_list.rs
@@ -1,0 +1,482 @@
+//! `issue list` atom.
+//!
+//! Spec / ops: `cli.forge-cli.issue.list.v1`. Returns a flat array of
+//! issue summaries filtered by `--state`, `--label`, `--author`,
+//! `--assignee`, `--limit`. Mirrors the shape of `pr list` so callers can
+//! treat both subtrees uniformly. Labels are repeatable; the GitHub
+//! backend joins them into a comma list per `gh issue list --label`'s
+//! contract.
+
+use std::ffi::OsString;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{
+    BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
+};
+use crate::cli::{BINARY, GlobalFlags, IssueListArgs, IssueStateFilter};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_state::normalize_state;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const SCHEMA: &str = "issue.list";
+const SCHEMA_VERSION: u32 = 1;
+
+const GH_JSON_FIELDS: &str = "number,url,state,title,labels,author,assignees";
+
+/// Envelope payload for `cli.forge-cli.issue.list.v1`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct IssueListPayload {
+    pub provider: &'static str,
+    pub items: Vec<IssueListItem>,
+}
+
+/// One row in the issue list envelope. Mirrors `IssueViewPayload`
+/// minus the body field — list endpoints do not return issue bodies
+/// on either backend.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct IssueListItem {
+    pub number: u64,
+    pub url: String,
+    pub state: &'static str,
+    pub title: String,
+    pub labels: Vec<String>,
+    pub author: Option<String>,
+    pub assignees: Vec<String>,
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    args: IssueListArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, args, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: IssueListArgs,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let call = build_list_call(&ctx, &args);
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let output = runner.run(&call)?;
+    let payload = parse_list_output(&ctx, &output)?;
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        payload,
+        format,
+        render_text,
+    ))
+}
+
+fn build_list_call(ctx: &ProviderContext, args: &IssueListArgs) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let limit = args.limit.max(1);
+    let mut argv: Vec<OsString> = Vec::new();
+    match ctx.provider {
+        Provider::GitHub => {
+            argv.push(OsString::from("issue"));
+            argv.push(OsString::from("list"));
+            argv.push(OsString::from("--state"));
+            argv.push(OsString::from(args.state.as_str()));
+            argv.push(OsString::from("--limit"));
+            argv.push(OsString::from(limit.to_string()));
+            if !args.labels.is_empty() {
+                argv.push(OsString::from("--label"));
+                argv.push(OsString::from(args.labels.join(",")));
+            }
+            if let Some(a) = &args.author {
+                argv.push(OsString::from("--author"));
+                argv.push(OsString::from(a));
+            }
+            if let Some(a) = &args.assignee {
+                argv.push(OsString::from("--assignee"));
+                argv.push(OsString::from(a));
+            }
+            argv.push(OsString::from("--json"));
+            argv.push(OsString::from(GH_JSON_FIELDS));
+        }
+        Provider::GitLab => {
+            argv.push(OsString::from("issue"));
+            argv.push(OsString::from("list"));
+            argv.push(OsString::from(gitlab_state_flag(args.state)));
+            argv.push(OsString::from("--per-page"));
+            argv.push(OsString::from(limit.to_string()));
+            for label in &args.labels {
+                argv.push(OsString::from("--label"));
+                argv.push(OsString::from(label));
+            }
+            if let Some(a) = &args.author {
+                argv.push(OsString::from("--author"));
+                argv.push(OsString::from(a));
+            }
+            if let Some(a) = &args.assignee {
+                argv.push(OsString::from("--assignee"));
+                argv.push(OsString::from(a));
+            }
+            argv.push(OsString::from("-F"));
+            argv.push(OsString::from("json"));
+        }
+    }
+    BackendCall::new(program, argv)
+}
+
+fn gitlab_state_flag(state: IssueStateFilter) -> &'static str {
+    match state {
+        IssueStateFilter::Open => "--opened",
+        IssueStateFilter::Closed => "--closed",
+        IssueStateFilter::All => "--all",
+    }
+}
+
+pub fn parse_list_output(
+    ctx: &ProviderContext,
+    output: &BackendSuccess,
+) -> Result<IssueListPayload, ForgeError> {
+    let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            "issue list JSON is invalid",
+            Some(e.to_string()),
+        )
+    })?;
+    let arr = value.as_array().ok_or_else(|| {
+        ForgeError::software(
+            schema_err(),
+            "issue list JSON is not an array",
+            Some(format!("got: {value}")),
+        )
+    })?;
+    let items = arr
+        .iter()
+        .map(|raw| parse_item(raw, ctx))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(IssueListPayload {
+        provider: ctx.provider.as_str(),
+        items,
+    })
+}
+
+fn parse_item(raw: &serde_json::Value, ctx: &ProviderContext) -> Result<IssueListItem, ForgeError> {
+    match ctx.provider {
+        Provider::GitHub => Ok(IssueListItem {
+            number: raw
+                .get("number")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| missing("number"))?,
+            url: required_str(raw, "url")?,
+            state: normalize_state(
+                raw.get("state").and_then(|v| v.as_str()).unwrap_or(""),
+                ctx.provider,
+            )?,
+            title: required_str(raw, "title")?,
+            labels: github_name_list(raw, "labels"),
+            author: raw
+                .get("author")
+                .and_then(|v| v.get("login").and_then(|n| n.as_str()))
+                .map(str::to_string),
+            assignees: github_login_list(raw, "assignees"),
+        }),
+        Provider::GitLab => Ok(IssueListItem {
+            number: raw
+                .get("iid")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| missing("iid"))?,
+            url: required_str(raw, "web_url")?,
+            state: normalize_state(
+                raw.get("state").and_then(|v| v.as_str()).unwrap_or(""),
+                ctx.provider,
+            )?,
+            title: required_str(raw, "title")?,
+            labels: gitlab_label_list(raw),
+            author: raw
+                .get("author")
+                .and_then(|v| v.get("username").and_then(|n| n.as_str()))
+                .map(str::to_string),
+            assignees: gitlab_username_list(raw, "assignees"),
+        }),
+    }
+}
+
+fn github_name_list(raw: &serde_json::Value, key: &str) -> Vec<String> {
+    raw.get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    item.get("name")
+                        .and_then(|n| n.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn github_login_list(raw: &serde_json::Value, key: &str) -> Vec<String> {
+    raw.get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    item.get("login")
+                        .and_then(|n| n.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn gitlab_label_list(raw: &serde_json::Value) -> Vec<String> {
+    raw.get("labels")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    item.as_str().map(str::to_string).or_else(|| {
+                        item.get("name")
+                            .and_then(|n| n.as_str())
+                            .map(str::to_string)
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn gitlab_username_list(raw: &serde_json::Value, key: &str) -> Vec<String> {
+    raw.get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    item.get("username")
+                        .and_then(|n| n.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn required_str(raw: &serde_json::Value, key: &str) -> Result<String, ForgeError> {
+    raw.get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| missing(key))
+}
+
+fn missing(key: &str) -> ForgeError {
+    ForgeError::software(
+        schema_err(),
+        format!("missing required field '{key}' in issue list item"),
+        None,
+    )
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &IssueListPayload) {
+    for item in &payload.items {
+        let author = item.author.as_deref().unwrap_or("<unknown>");
+        let labels = if item.labels.is_empty() {
+            String::new()
+        } else {
+            format!(" {{{}}}", item.labels.join(","))
+        };
+        println!(
+            "#{n} [{s}]{l} {t} ({a}) — {u}",
+            n = item.number,
+            s = item.state,
+            l = labels,
+            t = item.title,
+            a = author,
+            u = item.url,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::DetectionSource;
+    use pretty_assertions::assert_eq;
+
+    fn ctx(p: Provider) -> ProviderContext {
+        ProviderContext {
+            provider: p,
+            host: "example.com".into(),
+            source: DetectionSource::Flag,
+        }
+    }
+
+    fn default_args() -> IssueListArgs {
+        IssueListArgs {
+            state: IssueStateFilter::Open,
+            labels: Vec::new(),
+            author: None,
+            assignee: None,
+            limit: 30,
+        }
+    }
+
+    #[test]
+    fn build_list_call_github_passes_state_and_limit() {
+        let call = build_list_call(&ctx(Provider::GitHub), &default_args());
+        let plan = call.plan_argv();
+        assert_eq!(plan[1..3], ["issue".to_string(), "list".to_string()]);
+        let s_idx = plan.iter().position(|s| s == "--state").unwrap();
+        assert_eq!(plan[s_idx + 1], "open");
+        let l_idx = plan.iter().position(|s| s == "--limit").unwrap();
+        assert_eq!(plan[l_idx + 1], "30");
+        // No --label flag when labels list is empty.
+        assert!(!plan.iter().any(|s| s == "--label"));
+    }
+
+    #[test]
+    fn build_list_call_github_joins_labels_into_csv() {
+        let mut args = default_args();
+        args.labels = vec!["plan".into(), "support-matrix".into()];
+        let call = build_list_call(&ctx(Provider::GitHub), &args);
+        let plan = call.plan_argv();
+        let l_idx = plan.iter().position(|s| s == "--label").unwrap();
+        assert_eq!(plan[l_idx + 1], "plan,support-matrix");
+    }
+
+    #[test]
+    fn build_list_call_github_includes_optional_filters() {
+        let mut args = default_args();
+        args.labels = vec!["bug".into()];
+        args.author = Some("alice".into());
+        args.assignee = Some("bob".into());
+        args.limit = 5;
+        args.state = IssueStateFilter::Closed;
+        let call = build_list_call(&ctx(Provider::GitHub), &args);
+        let plan = call.plan_argv();
+        let s_idx = plan.iter().position(|s| s == "--state").unwrap();
+        assert_eq!(plan[s_idx + 1], "closed");
+        let a_idx = plan.iter().position(|s| s == "--author").unwrap();
+        assert_eq!(plan[a_idx + 1], "alice");
+        let asn_idx = plan.iter().position(|s| s == "--assignee").unwrap();
+        assert_eq!(plan[asn_idx + 1], "bob");
+        let l_idx = plan.iter().position(|s| s == "--limit").unwrap();
+        assert_eq!(plan[l_idx + 1], "5");
+    }
+
+    #[test]
+    fn build_list_call_gitlab_maps_state_to_flag_and_repeats_labels() {
+        let mut args = default_args();
+        args.state = IssueStateFilter::Closed;
+        args.labels = vec!["plan".into(), "support-matrix".into()];
+        let call = build_list_call(&ctx(Provider::GitLab), &args);
+        let plan = call.plan_argv();
+        assert!(plan.contains(&"--closed".to_string()));
+        assert!(plan.contains(&"--per-page".to_string()));
+        assert!(plan.contains(&"-F".to_string()));
+        let label_count = plan.iter().filter(|s| *s == "--label").count();
+        assert_eq!(
+            label_count, 2,
+            "GitLab labels are passed via repeated --label"
+        );
+    }
+
+    #[test]
+    fn build_list_call_clamps_zero_limit_to_one() {
+        let mut args = default_args();
+        args.limit = 0;
+        let call = build_list_call(&ctx(Provider::GitHub), &args);
+        let plan = call.plan_argv();
+        let l_idx = plan.iter().position(|s| s == "--limit").unwrap();
+        assert_eq!(plan[l_idx + 1], "1");
+    }
+
+    #[test]
+    fn parse_list_output_github_normalises_state_and_collects_labels() {
+        let stdout = r#"[
+          {"number":1,"url":"u1","state":"OPEN","title":"a",
+           "labels":[{"name":"plan"},{"name":"support-matrix"}],
+           "author":{"login":"alice"},"assignees":[{"login":"bob"}]},
+          {"number":2,"url":"u2","state":"CLOSED","title":"b",
+           "labels":[],"author":{"login":"carol"},"assignees":[]}
+        ]"#;
+        let payload = parse_list_output(
+            &ctx(Provider::GitHub),
+            &BackendSuccess {
+                stdout: stdout.into(),
+                stderr: String::new(),
+            },
+        )
+        .unwrap();
+        assert_eq!(payload.items.len(), 2);
+        assert_eq!(payload.items[0].state, "open");
+        assert_eq!(
+            payload.items[0].labels,
+            vec!["plan".to_string(), "support-matrix".to_string()]
+        );
+        assert_eq!(payload.items[0].author.as_deref(), Some("alice"));
+        assert_eq!(payload.items[0].assignees, vec!["bob".to_string()]);
+        assert_eq!(payload.items[1].state, "closed");
+        assert!(payload.items[1].labels.is_empty());
+    }
+
+    #[test]
+    fn parse_list_output_gitlab_accepts_string_or_object_labels() {
+        let stdout = r#"[
+          {"iid":7,"web_url":"u","state":"opened","title":"x",
+           "labels":["plan", {"name":"support-matrix"}],
+           "author":{"username":"alice"},"assignees":[{"username":"bob"}]}
+        ]"#;
+        let payload = parse_list_output(
+            &ctx(Provider::GitLab),
+            &BackendSuccess {
+                stdout: stdout.into(),
+                stderr: String::new(),
+            },
+        )
+        .unwrap();
+        assert_eq!(payload.items[0].number, 7);
+        assert_eq!(payload.items[0].state, "open");
+        assert_eq!(
+            payload.items[0].labels,
+            vec!["plan".to_string(), "support-matrix".to_string()]
+        );
+        assert_eq!(payload.items[0].author.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn parse_list_output_rejects_non_array() {
+        let err = parse_list_output(
+            &ctx(Provider::GitHub),
+            &BackendSuccess {
+                stdout: r#"{"number":1}"#.into(),
+                stderr: String::new(),
+            },
+        )
+        .unwrap_err();
+        let rendered = format!("{err:?}");
+        assert!(
+            rendered.contains("not an array"),
+            "expected 'not an array' in error, got {rendered}"
+        );
+    }
+}

--- a/crates/forge-cli/src/ops/mod.rs
+++ b/crates/forge-cli/src/ops/mod.rs
@@ -8,6 +8,7 @@ pub mod issue_close;
 pub mod issue_comment;
 pub mod issue_create;
 pub mod issue_edit;
+pub mod issue_list;
 pub mod issue_reopen;
 pub mod issue_view;
 pub mod pr_checks;


### PR DESCRIPTION
## Summary

Adds `forge-cli issue list` as the natural counterpart to `forge-cli pr
list`, so callers can preflight tracking-issue duplicates (e.g.
`agent-runtime-kit/docs/plans/support-matrix/` Sprint 3.2) without
falling back to raw `gh issue list`.

## What's in this PR

- New ops module `crates/forge-cli/src/ops/issue_list.rs` mirroring
  the `pr_list.rs` shape: GitHub joins repeated `--label` into a CSV,
  GitLab repeats the flag per upstream backend semantics. The
  envelope payload follows `IssueViewPayload` minus `body`.
- New `IssueStateFilter` enum (`open|closed|all` — no `merged`) and
  `IssueListArgs` clap struct in `src/cli.rs`, with the matching
  `IssueCommand::List` variant and dispatch case.
- `issue.list` operation added to
  `crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml`.
- Bash + zsh completion assets regenerated from the new clap surface.
- 8 unit tests covering argv shape (state, label CSV vs repeat,
  optional filters, zero-limit clamp) and payload normalisation
  (GitHub state map, GitLab label string-or-object shape, non-array
  reject path).

## Validation

- `cargo test -p nils-forge-cli` — 113 passed / 0 failed.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — green
  (docs-only + workspace Rust gate).

## Test plan

- [ ] GitHub CI green.
- [ ] Reviewer confirms the label semantics divergence between GH
  (CSV → AND) and GitLab (repeat → OR per glab default) is
  intentional and documented in the help text.
- [ ] Reviewer confirms the dropped `merged` state is correct for
  issues vs PRs.
