### PR TITLE
fix(forge-cli): pr deliver tolerates gh exit-1 after merge

### DIFF
--- a/crates/forge-cli/src/ops/pr_merge.rs
+++ b/crates/forge-cli/src/ops/pr_merge.rs
@@ -176,7 +176,7 @@ fn run_lockdown_chain<R: BackendRunner>(
 
     // All gates clear — invoke the backend.
     let merge_call = build_merge_call(ctx, args.id, method, delete_branch);
-    runner.run(&merge_call)?;
+    invoke_merge_with_idempotency_check(runner, ctx, args.id, &merge_call)?;
 
     // Post-merge re-fetch for merge_sha.
     let merge_sha = fetch_merge_sha(runner, ctx, args.id)?;
@@ -287,6 +287,36 @@ fn fetch_repo_view<R: BackendRunner>(
     let call = repo_view::build_call_for_default_branch(ctx);
     let output = runner.run(&call)?;
     repo_view::parse_backend_output(ctx, &output)
+}
+
+/// Run the backend merge call, then verify the PR state if the backend
+/// exits non-zero. `gh` sometimes returns exit 1 after the actual merge
+/// API call succeeds — typically when a post-merge branch cleanup races
+/// the repo's `delete_branch_on_merge` setting, or when `gh` treats a
+/// non-fatal stderr warning as a failure. Treat the call as success only
+/// when GitHub / GitLab actually reports the PR as merged; otherwise
+/// propagate the original [`ForgeError::BackendError`] so a real merge
+/// failure stays loud.
+fn invoke_merge_with_idempotency_check<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    pr_id: u64,
+    merge_call: &BackendCall,
+) -> Result<(), ForgeError> {
+    match runner.run(merge_call) {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            if !matches!(err, ForgeError::BackendError { .. }) {
+                // Software / validation / unavailable errors short-circuit
+                // without consulting the live PR state.
+                return Err(err);
+            }
+            match fetch_pr_view(runner, ctx, pr_id) {
+                Ok(post) if post.state.eq_ignore_ascii_case("merged") => Ok(()),
+                _ => Err(err),
+            }
+        }
+    }
 }
 
 fn fetch_merge_sha<R: BackendRunner>(

--- a/crates/forge-cli/tests/integration/pr_deliver_chain.rs
+++ b/crates/forge-cli/tests/integration/pr_deliver_chain.rs
@@ -36,6 +36,22 @@ const FULL_PR_VIEW_JSON: &str = r#"{
   "labels": []
 }"#;
 
+/// Post-merge `pr view` payload — same as [`FULL_PR_VIEW_JSON`] except the
+/// state has flipped to `MERGED`. Used by stubs that need to surface a
+/// merged PR after the merge step ran (and possibly exited non-zero).
+const MERGED_PR_VIEW_JSON: &str = r#"{
+  "number": 123,
+  "url": "https://github.com/sympoies/nils-cli/pull/123",
+  "state": "MERGED",
+  "isDraft": false,
+  "title": "feat: sample feature",
+  "headRefName": "feat/sample",
+  "baseRefName": "main",
+  "mergeable": "MERGEABLE",
+  "mergedAt": "2026-05-23T12:00:00Z",
+  "labels": []
+}"#;
+
 /// Build the canonical Sprint 2 git tempdir: clean worktree on `feat/sample`
 /// tracking `origin/feat/sample` at the same SHA, with the remote URL set to
 /// `https://<host>/<repo_slug>.git` so provider detection lands on GitHub.
@@ -91,6 +107,42 @@ fn make_git_repo() -> TempDir {
 }
 
 fn write_full_chain_stub(stub: &StubEnv) -> PathBuf {
+    write_chain_stub(stub, FULL_PR_VIEW_JSON, MERGED_PR_VIEW_JSON, false)
+}
+
+/// Chain stub with a controllable `pr merge` failure mode used by the
+/// idempotency-on-non-zero-exit regression test. When `merge_exits_one` is
+/// true, the merge subcommand touches a sentinel file in `stub.tempdir`
+/// and exits 1 with a non-fatal stderr message. Subsequent `pr view`
+/// calls observe the sentinel and switch to the post-merge JSON so the
+/// macro can verify the PR actually landed.
+fn write_chain_stub_with_merge_exit(
+    stub: &StubEnv,
+    pre_view: &str,
+    post_view: &str,
+    merge_exits_one: bool,
+) -> PathBuf {
+    write_chain_stub(stub, pre_view, post_view, merge_exits_one)
+}
+
+fn write_chain_stub(
+    stub: &StubEnv,
+    pre_view: &str,
+    post_view: &str,
+    merge_exits_one: bool,
+) -> PathBuf {
+    let sentinel = stub.tempdir.path().join("merge-called");
+    let merge_branch = if merge_exits_one {
+        format!(
+            "    touch {sentinel}\n    echo 'X stderr warning after merge' >&2\n    exit 1\n",
+            sentinel = sentinel.display(),
+        )
+    } else {
+        format!(
+            "    touch {sentinel}\n    :\n",
+            sentinel = sentinel.display(),
+        )
+    };
     let body = format!(
         r#"#!/bin/sh
 set -e
@@ -125,11 +177,16 @@ EOF
 {checks}
 EOF
     ;;
-  "pr ready"|"pr merge")
+  "pr ready")
     :
     ;;
+  "pr merge")
+{merge_branch}
+    ;;
   "pr view")
-    # Distinguish the post-merge view (--json mergeCommit) from regular view.
+    # Distinguish the post-merge merge_sha view (--json mergeCommit) from
+    # regular view; for the latter, switch to the merged-state JSON once
+    # the merge step has been observed via the sentinel file.
     case "$*" in
       *"--json mergeCommit"*)
         cat <<'EOF'
@@ -137,9 +194,15 @@ EOF
 EOF
         ;;
       *)
-        cat <<'EOF'
-{view}
+        if [ -e {sentinel} ]; then
+          cat <<'EOF'
+{post_view}
 EOF
+        else
+          cat <<'EOF'
+{pre_view}
+EOF
+        fi
         ;;
     esac
     ;;
@@ -150,8 +213,11 @@ EOF
 esac
 "#,
         create = FIXTURE_CREATE_STDOUT,
-        view = FULL_PR_VIEW_JSON,
+        pre_view = pre_view,
+        post_view = post_view,
         checks = FIXTURE_CHECKS_JSON,
+        merge_branch = merge_branch,
+        sentinel = sentinel.display(),
     );
     let path = stub.tempdir.path().join("gh");
     fs::write(&path, body).expect("write gh stub");
@@ -347,4 +413,78 @@ fn pr_deliver_short_circuits_when_pr_create_validation_fails_with_data_65() {
         .map(|s| s["step"].as_str().unwrap_or(""))
         .collect();
     assert_eq!(steps, vec!["auth_status", "repo_view"]);
+}
+
+#[test]
+fn pr_deliver_treats_gh_exit_1_after_successful_merge_as_success() {
+    // Regression: `gh pr merge` can return exit 1 even after the API merge
+    // call succeeds (typically a branch-cleanup race or post-merge stderr
+    // warning treated as failure). The pr.merge atom should re-check the
+    // PR state and treat the chain as successful when GitHub reports the
+    // PR as merged, so `forge-cli pr deliver` does not surface a phantom
+    // `backend_error: gh exited with status 1` after the PR is actually on
+    // main.
+    let tempdir = make_git_repo();
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let gh_path = write_chain_stub_with_merge_exit(
+        &stub,
+        FULL_PR_VIEW_JSON,
+        MERGED_PR_VIEW_JSON,
+        /*merge_exits_one=*/ true,
+    );
+    let stub = stub.env("FORGE_CLI_GH_BIN", gh_path.to_string_lossy());
+
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "deliver",
+            "--kind",
+            "feature",
+            "--title",
+            "feat: sample feature",
+            "--body",
+            "## Summary\n\nLand the new feature.\n\n## Test plan\n\nVerified.\n",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--timeout",
+            "5s",
+        ],
+    );
+    assert_eq!(
+        out.code, 0,
+        "expected success when gh exits 1 but PR is merged; stdout={}\nstderr={}",
+        out.stdout, out.stderr
+    );
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["ok"], true);
+    let steps: Vec<&str> = envelope["data"]["steps"]
+        .as_array()
+        .expect("steps array")
+        .iter()
+        .map(|s| s["step"].as_str().unwrap_or(""))
+        .collect();
+    assert_eq!(
+        steps,
+        vec![
+            "auth_status",
+            "repo_view",
+            "create",
+            "wait_checks",
+            "ready",
+            "merge",
+        ],
+        "merge step must still be recorded as ok=true after recovery"
+    );
+    assert_eq!(envelope["data"]["pr"]["merged"], true);
+    assert_eq!(envelope["data"]["pr"]["merge_sha"], "abc123def456");
 }


### PR DESCRIPTION
## Summary

Fixes the recurring `backend_error: gh exited with status 1` tail noise
on `forge-cli pr deliver` runs where the GitHub merge API call actually
succeeds. The most common trigger is a branch-cleanup race when the
repo enables `delete_branch_on_merge` (gh tries `--delete-branch`
against an already-deleted ref) or when gh treats a non-fatal stderr
warning after the merge as a failure.

## What's in this PR

- `crates/forge-cli/src/ops/pr_merge.rs`: wraps the merge backend call
  in a new `invoke_merge_with_idempotency_check` helper. On
  `ForgeError::BackendError`, the helper re-fetches the PR view; if
  GitHub / GitLab reports `state=merged`, the chain proceeds and the
  post-merge `mergeCommit` fetch still surfaces the merge SHA. Other
  error variants (validation, software, unavailable) short-circuit
  without consulting live state.
- `crates/forge-cli/tests/integration/pr_deliver_chain.rs`: refactors
  the chain stub builder so the `pr merge` branch is parameterised
  (touch sentinel + exit 1 on demand) and the `pr view` branch flips
  to a `MERGED` state JSON once the sentinel exists. Adds a regression
  test `pr_deliver_treats_gh_exit_1_after_successful_merge_as_success`
  that pins the full six-step envelope (ok=true, merged=true,
  merge_sha=abc123def456) under the failure-then-merged scenario.

## Why this stays safe

- `ForgeError::BackendError` is the only variant that triggers the
  re-check. Lock-down policy errors (`Validation`, `RuntimeFailure`)
  and binary-missing errors still propagate unchanged.
- The re-check is read-only (one extra `gh pr view --json ...` call)
  and proceeds only when GitHub reports the PR as merged. A backend
  failure that left the PR open still propagates the original
  `BackendError` with the captured stderr.

## Validation

- `cargo test -p nils-forge-cli --test integration pr_deliver_chain`
  — 4 passed, including the new regression test.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — green
  (workspace Rust gate, 360 tests).

## Test plan

- [ ] GitHub CI green.
- [ ] Reviewer confirms the BackendError-only filter is the right
  scope (i.e. we are not accidentally swallowing
  `merge_method_unsupported` or `default_branch_protected`).
- [ ] Reviewer confirms the GitLab path is also covered — `glab mr
  merge` can hit the same race when the repo has
  `remove_source_branch_after_merge: true`.
