### PR TITLE
plan-issue-cli: v2 marker collapse + audit/dashboard rewrite (#448 S2)

### DIFF
--- a/crates/plan-issue-cli/src/commands/record.rs
+++ b/crates/plan-issue-cli/src/commands/record.rs
@@ -59,23 +59,6 @@ impl RecordProfile {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
-pub enum MarkerFamily {
-    /// Emit the shared issue-backed-plan marker family.
-    Shared,
-    /// Emit compatibility markers used by the existing tracking lifecycle.
-    Compat,
-}
-
-impl MarkerFamily {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Shared => "shared",
-            Self::Compat => "compat",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
 pub enum LifecycleCommentKind {
     #[value(name = "source", alias = "source-snapshot")]
     Source,
@@ -190,10 +173,6 @@ pub struct RenderCommentArgs {
     /// Lifecycle profile for the comment marker and visible metadata.
     #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
     pub profile: RecordProfile,
-
-    /// Marker family to emit.
-    #[arg(long = "marker-family", value_enum, default_value_t = MarkerFamily::Compat)]
-    pub marker_family: MarkerFamily,
 
     /// Lifecycle comment kind.
     #[arg(long, value_enum)]

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -167,7 +167,6 @@ fn run_record_render_comment(args: &RenderCommentArgs) -> Result<Value, CommandE
     };
     let markdown = lifecycle_record::render_comment(CommentInput {
         profile: args.profile,
-        marker_family: args.marker_family,
         kind: args.kind,
         path: args.path.as_ref().map(|path| path_text(path)),
         commit: args.commit.clone(),
@@ -180,7 +179,6 @@ fn run_record_render_comment(args: &RenderCommentArgs) -> Result<Value, CommandE
 
     Ok(json!({
         "profile": args.profile.as_str(),
-        "marker_family": args.marker_family.as_str(),
         "kind": args.kind.as_str(),
         "operation": "render-comment",
         "out_path": out_path,

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::commands::record::{LifecycleCommentKind, MarkerFamily, RecordProfile};
+use crate::commands::record::{LifecycleCommentKind, RecordProfile};
 
 #[derive(Debug, Clone)]
 pub struct DashboardInput {
@@ -30,7 +30,6 @@ pub struct DashboardInput {
 #[derive(Debug, Clone)]
 pub struct CommentInput {
     pub profile: RecordProfile,
-    pub marker_family: MarkerFamily,
     pub kind: LifecycleCommentKind,
     pub path: Option<String>,
     pub commit: Option<String>,
@@ -40,21 +39,44 @@ pub struct CommentInput {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct MarkerHit {
-    pub role: String,
-    pub profile: String,
-    pub family: String,
+pub struct LifecycleEvidence {
+    pub role: PayloadRole,
+    pub profile: PayloadProfile,
     pub url: Option<String>,
     pub created_at: Option<String>,
+    /// Stable status string derived from the structured payload (e.g.
+    /// state `status`, validation `overall`, review `decision`). `None`
+    /// when the role does not declare a status or the payload could not
+    /// be parsed.
     pub status: Option<String>,
+    /// Parsed structured payload. `None` when the comment lacks a
+    /// `plan-issue-record-payload` fence; audit still records the marker
+    /// for visibility but downstream gates treat missing payloads as
+    /// unparseable evidence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<RecordPayload>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UnsupportedMarker {
+    pub marker_prefix: String,
+    pub url: Option<String>,
+    pub created_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RecordAudit {
     pub profile_filter: Option<String>,
     pub body_sections: BodySections,
-    pub markers: BTreeMap<String, MarkerHit>,
+    /// Latest v2 lifecycle evidence indexed by role name (`source`,
+    /// `plan`, `state`, `session`, `validation`, `review`, `closeout`).
+    pub evidence: BTreeMap<String, LifecycleEvidence>,
+    /// Stable machine-readable codes for missing required evidence
+    /// (e.g. `source-missing`, `plan-missing`, `state-missing`).
     pub missing_required: Vec<String>,
+    /// Pre-v2 markers seen during audit. Reported for visibility but not
+    /// counted as current lifecycle evidence.
+    pub unsupported_markers: Vec<UnsupportedMarker>,
     pub recognized_count: usize,
     #[serde(skip_serializing)]
     pub evidence_text: String,
@@ -194,7 +216,7 @@ pub fn render_dashboard(input: DashboardInput) -> String {
 }
 
 pub fn render_comment(input: CommentInput) -> Result<String, String> {
-    let marker = marker_for(input.marker_family, input.profile, input.kind)?;
+    let marker = marker_for(input.profile, input.kind);
     let heading = input
         .title
         .clone()
@@ -207,9 +229,7 @@ pub fn render_comment(input: CommentInput) -> Result<String, String> {
     out.push(format!("## {heading}"));
     out.push(String::new());
 
-    if input.marker_family == MarkerFamily::Shared || input.profile == RecordProfile::Dispatch {
-        out.push(format!("- Profile: {}", input.profile.as_str()));
-    }
+    out.push(format!("- Profile: {}", input.profile.as_str()));
     if let Some(path) = input
         .path
         .as_deref()
@@ -260,7 +280,8 @@ pub fn audit_record(
     profile_filter: Option<RecordProfile>,
 ) -> Result<RecordAudit, String> {
     let comments = parse_comments_json(comments_json)?;
-    let mut markers = BTreeMap::new();
+    let mut evidence: BTreeMap<String, LifecycleEvidence> = BTreeMap::new();
+    let mut unsupported_markers = Vec::new();
     let mut recognized_count = 0usize;
     let mut evidence_text = String::new();
     if let Some(body) = body {
@@ -269,51 +290,158 @@ pub fn audit_record(
     }
 
     for comment in comments {
-        let Some(body) = comment.body.as_deref() else {
+        let Some(comment_body) = comment.body.as_deref() else {
             continue;
         };
-        let Some(mut hit) = marker_hit(body) else {
+        let Some(first_marker) = first_comment_marker(comment_body) else {
             continue;
         };
-        if profile_filter.is_some_and(|profile| hit.profile != profile.as_str()) {
+        let Some(parsed) = parse_marker_line(first_marker) else {
             continue;
+        };
+        match parsed {
+            MarkerParse::V2 { role, profile } => {
+                if profile_filter.is_some_and(|expected| profile != PayloadProfile::from(expected))
+                {
+                    continue;
+                }
+                let url = comment.url.clone().or_else(|| comment.html_url.clone());
+                let created_at = comment.created_at.clone();
+                let payload = match extract_payload(comment_body) {
+                    Ok(payload) => Some(payload),
+                    Err(err) if err.kind == PayloadErrorKind::NoFence => None,
+                    Err(err) => {
+                        return Err(format!(
+                            "comment at {} has malformed payload: {}",
+                            url.as_deref().unwrap_or("(unknown url)"),
+                            err.message
+                        ));
+                    }
+                };
+                let status = payload.as_ref().and_then(derive_status_from_payload);
+                let candidate = LifecycleEvidence {
+                    role,
+                    profile,
+                    url,
+                    created_at: created_at.clone(),
+                    status,
+                    payload,
+                };
+                let key = role.as_str().to_string();
+                let supersedes = evidence
+                    .get(&key)
+                    .map(|existing| {
+                        compare_created_at(
+                            candidate.created_at.as_deref(),
+                            existing.created_at.as_deref(),
+                        ) != std::cmp::Ordering::Less
+                    })
+                    .unwrap_or(true);
+                if supersedes {
+                    evidence_text.push_str(comment_body);
+                    evidence_text.push('\n');
+                    recognized_count += 1;
+                    evidence.insert(key, candidate);
+                }
+            }
+            MarkerParse::Unsupported { prefix } => {
+                unsupported_markers.push(UnsupportedMarker {
+                    marker_prefix: prefix,
+                    url: comment.url.or(comment.html_url),
+                    created_at: comment.created_at,
+                });
+            }
         }
-        evidence_text.push_str(body);
-        evidence_text.push('\n');
-        hit.url = comment.url.or(comment.html_url);
-        hit.created_at = comment.created_at;
-        hit.status = extract_status(body);
-        recognized_count += 1;
-        markers.insert(hit.role.clone(), hit);
     }
 
     let mut missing_required = Vec::new();
-    for role in ["source_snapshot", "plan_snapshot", "state"] {
-        if !markers.contains_key(role) {
-            missing_required.push(role.to_string());
+    for code in ["source-missing", "plan-missing", "state-missing"] {
+        let role_key = code.trim_end_matches("-missing");
+        if !evidence.contains_key(role_key) {
+            missing_required.push(code.to_string());
         }
     }
 
     Ok(RecordAudit {
         profile_filter: profile_filter.map(|profile| profile.as_str().to_string()),
         body_sections: inspect_body_sections(body.unwrap_or_default()),
-        markers,
+        evidence,
         missing_required,
+        unsupported_markers,
         recognized_count,
         evidence_text,
     })
 }
 
+/// Compare two RFC3339 created-at strings. `None` is considered older than
+/// any `Some(_)`. This keeps latest-by-role selection deterministic even
+/// when GitHub returns comments out of order.
+fn compare_created_at(left: Option<&str>, right: Option<&str>) -> std::cmp::Ordering {
+    match (left, right) {
+        (Some(l), Some(r)) => l.cmp(r),
+        (Some(_), None) => std::cmp::Ordering::Greater,
+        (None, Some(_)) => std::cmp::Ordering::Less,
+        (None, None) => std::cmp::Ordering::Equal,
+    }
+}
+
+/// Derive a stable visible status string from a parsed payload, suitable
+/// for dashboard rendering and closeout gating. Returns `None` when the
+/// role does not declare a status or the payload's status field is
+/// unparseable.
+fn derive_status_from_payload(payload: &RecordPayload) -> Option<String> {
+    match payload.role {
+        PayloadRole::State => payload
+            .parse_state()
+            .ok()
+            .and_then(|data| data.status.map(|s| status_state_label(s).to_string())),
+        PayloadRole::Validation => payload
+            .parse_validation()
+            .ok()
+            .map(|data| validation_overall_label(data.overall).to_string()),
+        PayloadRole::Review => payload
+            .parse_review()
+            .ok()
+            .map(|data| review_decision_label(data.decision).to_string()),
+        PayloadRole::Closeout => payload.parse_closeout().ok().map(|data| data.final_status),
+        PayloadRole::Source | PayloadRole::Plan | PayloadRole::Session => None,
+    }
+}
+
+fn status_state_label(value: StateStatus) -> &'static str {
+    match value {
+        StateStatus::InProgress => "in-progress",
+        StateStatus::Complete => "complete",
+        StateStatus::Blocked => "blocked",
+    }
+}
+
+fn validation_overall_label(value: ValidationOverall) -> &'static str {
+    match value {
+        ValidationOverall::Pass => "pass",
+        ValidationOverall::Fail => "fail",
+        ValidationOverall::Partial => "partial",
+    }
+}
+
+fn review_decision_label(value: ReviewDecision) -> &'static str {
+    match value {
+        ReviewDecision::Approve => "approve",
+        ReviewDecision::RequestChanges => "request-changes",
+        ReviewDecision::CommentsOnly => "comments-only",
+    }
+}
+
 pub fn evaluate_closeout_gate(audit: &RecordAudit, input: CloseoutGateInput) -> CloseoutGateResult {
     let mut checks = Vec::new();
 
-    push_marker_check(&mut checks, audit, "source_snapshot", "source snapshot");
-    push_marker_check(&mut checks, audit, "plan_snapshot", "plan snapshot");
-    push_marker_check(&mut checks, audit, "state", "execution state");
+    push_evidence_check(&mut checks, audit, "source", "source snapshot");
+    push_evidence_check(&mut checks, audit, "plan", "plan snapshot");
+    push_evidence_check(&mut checks, audit, "state", "execution state");
 
     if input.require_complete {
         let (status, detail) = match audit
-            .markers
+            .evidence
             .get("state")
             .and_then(|hit| hit.status.as_deref())
         {
@@ -331,16 +459,16 @@ pub fn evaluate_closeout_gate(audit: &RecordAudit, input: CloseoutGateInput) -> 
     }
 
     if input.require_session {
-        push_marker_check(&mut checks, audit, "session", "completed session");
+        push_evidence_check(&mut checks, audit, "session", "completed session");
     }
     if input.require_validation {
-        push_marker_check(&mut checks, audit, "validation", "validation evidence");
+        push_evidence_check(&mut checks, audit, "validation", "validation evidence");
     }
     if input.require_review || input.profile == RecordProfile::Dispatch {
-        push_marker_check(&mut checks, audit, "review", "review evidence");
+        push_evidence_check(&mut checks, audit, "review", "review evidence");
     }
     if input.require_closeout {
-        push_marker_check(&mut checks, audit, "closeout", "closeout comment");
+        push_evidence_check(&mut checks, audit, "closeout", "closeout comment");
     }
 
     let approval = input.approval.as_deref().unwrap_or("").trim();
@@ -386,6 +514,177 @@ pub fn evaluate_closeout_gate(audit: &RecordAudit, input: CloseoutGateInput) -> 
 
     let ready = checks.iter().all(|check| check.status == "pass");
     CloseoutGateResult { ready, checks }
+}
+
+/// Render the canonical dashboard for an issue-backed plan record from
+/// audit evidence alone — callers no longer need to pass every per-role
+/// URL. Returns a `## Final Dashboard` when the latest state payload
+/// reports `status=complete`, otherwise `## Current Dashboard`. Pending
+/// roles render as `pending` so the dashboard remains idempotent across
+/// repeated calls with the same evidence.
+pub fn render_dashboard_from_audit(
+    audit: &RecordAudit,
+    title: Option<&str>,
+    issue_url: Option<&str>,
+) -> String {
+    let state_evidence = audit.evidence.get("state");
+    let state_data = state_evidence
+        .and_then(|hit| hit.payload.as_ref())
+        .and_then(|payload| payload.parse_state().ok());
+    let is_complete = state_evidence
+        .and_then(|hit| hit.status.as_deref())
+        .map(|status| status.eq_ignore_ascii_case("complete"))
+        .unwrap_or(false);
+
+    let dashboard_title = if is_complete {
+        "## Final Dashboard"
+    } else {
+        "## Current Dashboard"
+    };
+
+    let profile_str = state_evidence
+        .map(|hit| hit.profile.as_str().to_string())
+        .or_else(|| {
+            audit
+                .evidence
+                .values()
+                .next()
+                .map(|hit| hit.profile.as_str().to_string())
+        })
+        .unwrap_or_else(|| "tracking".to_string());
+
+    let status_value = state_evidence
+        .and_then(|hit| hit.status.clone())
+        .unwrap_or_else(|| "pending".to_string());
+
+    let target_scope = state_data
+        .as_ref()
+        .and_then(|data| data.target_scope.clone())
+        .unwrap_or_else(|| "pending".to_string());
+    let current = state_data
+        .as_ref()
+        .and_then(|data| data.current.clone())
+        .unwrap_or_else(|| "pending".to_string());
+    let next_action = state_data
+        .as_ref()
+        .and_then(|data| data.next_action.clone())
+        .unwrap_or_else(|| "pending".to_string());
+    let validation_status = audit
+        .evidence
+        .get("validation")
+        .and_then(|hit| hit.status.clone())
+        .unwrap_or_else(|| "pending".to_string());
+    let linked_prs = state_data
+        .as_ref()
+        .map(|data| {
+            data.prs
+                .iter()
+                .map(|pr| pr.url.clone().unwrap_or_else(|| pr.pr_ref.clone()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let blockers = state_data
+        .as_ref()
+        .map(|data| data.blockers.clone())
+        .unwrap_or_default();
+    let approval = audit
+        .evidence
+        .get("closeout")
+        .and_then(|hit| hit.payload.as_ref())
+        .and_then(|payload| payload.parse_closeout().ok())
+        .and_then(|data| data.approval.comment_url)
+        .unwrap_or_else(|| "pending".to_string());
+
+    let mut out = Vec::new();
+    out.push(dashboard_title.to_string());
+    out.push(String::new());
+    out.push("This issue is the durable tracking surface for an issue-backed plan execution. The full source, plan, and execution logs remain in".to_string());
+    out.push("append-only issue comments.".to_string());
+    out.push(String::new());
+    out.push(format!("- Status: {status_value}"));
+    out.push(format!("- Profile: {profile_str}"));
+    out.push(format!("- Target scope: {target_scope}"));
+    out.push(format!("- Current task: {current}"));
+    out.push(format!("- Next action: {next_action}"));
+    out.push(format!("- Validation: {validation_status}"));
+    out.push(format!(
+        "- Linked PRs: {}",
+        non_empty_join(&linked_prs, "none yet")
+    ));
+    out.push(format!("- Blockers: {}", non_empty_join(&blockers, "none")));
+    out.push(format!("- Review approval: {approval}"));
+    out.push(String::new());
+    out.push("## Durable Record".to_string());
+    out.push(String::new());
+    out.push(format!(
+        "- Source snapshot: {}",
+        dashboard_link(evidence_url(audit, "source").as_deref(), "source snapshot")
+    ));
+    out.push(format!(
+        "- Plan snapshot: {}",
+        dashboard_link(evidence_url(audit, "plan").as_deref(), "plan snapshot")
+    ));
+    out.push(format!(
+        "- Execution state: {}",
+        dashboard_link(evidence_url(audit, "state").as_deref(), "execution state")
+    ));
+    out.push(format!(
+        "- Latest session: {}",
+        dashboard_link(
+            evidence_url(audit, "session").as_deref(),
+            "Execution Session"
+        )
+    ));
+    out.push(format!(
+        "- Latest validation: {}",
+        dashboard_link(
+            evidence_url(audit, "validation").as_deref(),
+            "Validation Evidence"
+        )
+    ));
+    let is_dispatch_profile = profile_str == "dispatch";
+    if is_dispatch_profile || audit.evidence.contains_key("review") {
+        out.push(format!(
+            "- Latest review: {}",
+            dashboard_link(evidence_url(audit, "review").as_deref(), "Review Evidence")
+        ));
+    }
+    out.push(format!(
+        "- Closeout comment: {}",
+        dashboard_link(evidence_url(audit, "closeout").as_deref(), "closeout")
+    ));
+    out.push(String::new());
+    out.push("## Guardrails".to_string());
+    out.push(String::new());
+    out.push("- The issue body is a mutable dashboard only.".to_string());
+    out.push("- Append-only issue comments are the durable source of truth.".to_string());
+    out.push(
+        "- `plan-tooling` owns plan parsing, validation, batching, and PR split modeling only."
+            .to_string(),
+    );
+    out.push("- Provider create, comment, edit, and close operations remain owned by `forge-cli` or provider atoms.".to_string());
+
+    if title.is_some() || issue_url.is_some() {
+        out.push(String::new());
+        out.push("## Original Tracker".to_string());
+        out.push(String::new());
+        if let Some(title) = title.map(str::trim).filter(|value| !value.is_empty()) {
+            out.push(format!("- Title: {title}"));
+        }
+        if let Some(url) = issue_url.map(str::trim).filter(|value| !value.is_empty()) {
+            out.push(format!("- Issue: {url}"));
+        }
+    }
+
+    finalize_markdown(out)
+}
+
+fn evidence_url(audit: &RecordAudit, role: &str) -> Option<String> {
+    audit
+        .evidence
+        .get(role)
+        .and_then(|hit| hit.url.clone())
+        .filter(|value| !value.trim().is_empty())
 }
 
 pub fn render_closeout_checks(checks: &[CloseoutCheck]) -> String {
@@ -450,73 +749,13 @@ fn default_details_summary(kind: LifecycleCommentKind) -> &'static str {
     }
 }
 
-fn marker_for(
-    family: MarkerFamily,
-    profile: RecordProfile,
-    kind: LifecycleCommentKind,
-) -> Result<String, String> {
-    let marker = match family {
-        MarkerFamily::Shared => match kind {
-            LifecycleCommentKind::Source | LifecycleCommentKind::Plan => format!(
-                "<!-- issue-backed-plan:snapshot:v1 kind={} profile={} -->",
-                kind.as_str(),
-                profile.as_str()
-            ),
-            _ => format!(
-                "<!-- issue-backed-plan:{}:v1 profile={} -->",
-                kind.as_str(),
-                profile.as_str()
-            ),
-        },
-        MarkerFamily::Compat => compat_marker(profile, kind)?,
-    };
-    Ok(marker)
-}
-
-fn compat_marker(profile: RecordProfile, kind: LifecycleCommentKind) -> Result<String, String> {
-    let marker = match (profile, kind) {
-        (RecordProfile::Tracking, LifecycleCommentKind::Source)
-        | (RecordProfile::Tracking, LifecycleCommentKind::Plan) => format!(
-            "<!-- plan-tracking-issue:snapshot:v1 kind={} -->",
-            kind.as_str()
-        ),
-        (RecordProfile::Tracking, LifecycleCommentKind::State) => {
-            "<!-- execute-from-tracking-issue:state:v1 -->".to_string()
-        }
-        (RecordProfile::Tracking, LifecycleCommentKind::Session) => {
-            "<!-- execute-from-tracking-issue:session:v1 -->".to_string()
-        }
-        (RecordProfile::Tracking, LifecycleCommentKind::Validation) => {
-            "<!-- execute-from-tracking-issue:validation:v1 -->".to_string()
-        }
-        (RecordProfile::Tracking, LifecycleCommentKind::Closeout) => {
-            "<!-- tracking-issue-closeout:v1 -->".to_string()
-        }
-        (RecordProfile::Tracking, LifecycleCommentKind::Review) => {
-            return Err("tracking profile does not emit compat review markers".to_string());
-        }
-        (RecordProfile::Dispatch, LifecycleCommentKind::Source)
-        | (RecordProfile::Dispatch, LifecycleCommentKind::Plan) => format!(
-            "<!-- deliver-dispatch-plan:snapshot:v1 kind={} -->",
-            kind.as_str()
-        ),
-        (RecordProfile::Dispatch, LifecycleCommentKind::State) => {
-            "<!-- deliver-dispatch-plan:state:v1 -->".to_string()
-        }
-        (RecordProfile::Dispatch, LifecycleCommentKind::Session) => {
-            "<!-- deliver-dispatch-plan:session:v1 -->".to_string()
-        }
-        (RecordProfile::Dispatch, LifecycleCommentKind::Validation) => {
-            "<!-- deliver-dispatch-plan:validation:v1 -->".to_string()
-        }
-        (RecordProfile::Dispatch, LifecycleCommentKind::Review) => {
-            "<!-- deliver-dispatch-plan:review:v1 -->".to_string()
-        }
-        (RecordProfile::Dispatch, LifecycleCommentKind::Closeout) => {
-            "<!-- deliver-dispatch-plan:closeout:v1 -->".to_string()
-        }
-    };
-    Ok(marker)
+/// Render the canonical v2 marker for a lifecycle comment kind.
+fn marker_for(profile: RecordProfile, kind: LifecycleCommentKind) -> String {
+    format!(
+        "<!-- plan-issue-record:v2 role={} profile={} -->",
+        kind.as_str(),
+        profile.as_str()
+    )
 }
 
 fn parse_comments_json(raw: &str) -> Result<Vec<CommentJson>, String> {
@@ -560,11 +799,6 @@ fn string_field(object: &mut serde_json::Map<String, Value>, key: &str) -> Optio
         .and_then(|value| value.as_str().map(ToString::to_string))
 }
 
-fn marker_hit(body: &str) -> Option<MarkerHit> {
-    let marker = first_comment_marker(body)?;
-    parse_marker_line(marker)
-}
-
 fn first_comment_marker(body: &str) -> Option<&str> {
     for line in body.lines() {
         let trimmed = line.trim();
@@ -579,70 +813,75 @@ fn first_comment_marker(body: &str) -> Option<&str> {
     None
 }
 
-fn parse_marker_line(marker: &str) -> Option<MarkerHit> {
+/// Outcome of marker parsing on a comment's first non-empty line.
+#[derive(Debug, Clone)]
+enum MarkerParse {
+    /// Canonical v2 marker.
+    V2 {
+        role: PayloadRole,
+        profile: PayloadProfile,
+    },
+    /// Pre-v2 marker family the v3 lifecycle no longer recognizes as
+    /// current lifecycle evidence (but tracks for reporting).
+    Unsupported { prefix: String },
+}
+
+fn parse_marker_line(marker: &str) -> Option<MarkerParse> {
     let inner = marker.strip_prefix("<!--")?.strip_suffix("-->")?.trim();
     let attrs = parse_attrs(inner);
 
-    if inner.starts_with("issue-backed-plan:snapshot:v1") {
-        let kind = attrs.get("kind")?;
+    if let Some(rest) = inner.strip_prefix("plan-issue-record:v2") {
+        let _ = rest;
+        let role = attrs.get("role").and_then(|value| parse_role(value))?;
         let profile = attrs
             .get("profile")
-            .map(String::as_str)
-            .unwrap_or("tracking");
-        return Some(hit(format!("{kind}_snapshot"), profile, "shared"));
-    }
-    if let Some(rest) = inner.strip_prefix("issue-backed-plan:") {
-        let kind = rest.split(':').next()?;
-        let profile = attrs
-            .get("profile")
-            .map(String::as_str)
-            .unwrap_or("tracking");
-        return Some(hit(kind.to_string(), profile, "shared"));
+            .and_then(|value| parse_profile(value))
+            .unwrap_or(PayloadProfile::Tracking);
+        return Some(MarkerParse::V2 { role, profile });
     }
 
-    if inner.starts_with("plan-tracking-issue:snapshot:v") {
-        let kind = attrs.get("kind")?;
-        return Some(hit(format!("{kind}_snapshot"), "tracking", "compat"));
-    }
-    if let Some(rest) = inner.strip_prefix("execute-from-tracking-issue:") {
-        let kind = rest.split(':').next()?;
-        return Some(hit(kind.to_string(), "tracking", "compat"));
-    }
-    if let Some(rest) = inner.strip_prefix("execute-plan-tracking-issue:") {
-        let kind = rest.split(':').next()?;
-        return Some(hit(kind.to_string(), "tracking", "compat"));
-    }
-    if inner.starts_with("tracking-issue-closeout:v")
-        || inner.starts_with("plan-tracking-issue-closeout:v")
-    {
-        return Some(hit("closeout".to_string(), "tracking", "compat"));
-    }
-
-    if inner.starts_with("deliver-dispatch-plan:snapshot:v") {
-        let kind = attrs.get("kind")?;
-        return Some(hit(format!("{kind}_snapshot"), "dispatch", "compat"));
-    }
-    if let Some(rest) = inner.strip_prefix("deliver-dispatch-plan:") {
-        let kind = rest.split(':').next()?;
-        return Some(hit(kind.to_string(), "dispatch", "compat"));
-    }
-    if let Some(rest) = inner.strip_prefix("dispatch-plan:") {
-        let kind = rest.split(':').next()?;
-        return Some(hit(kind.to_string(), "dispatch", "compat"));
+    // Known pre-v2 marker families. They are no longer recognized as
+    // current lifecycle evidence but are reported by audit so callers
+    // can identify v1-marker comments that need migration to v2.
+    for prefix in [
+        "issue-backed-plan:",
+        "plan-tracking-issue:",
+        "execute-from-tracking-issue:",
+        "execute-plan-tracking-issue:",
+        "tracking-issue-closeout:",
+        "plan-tracking-issue-closeout:",
+        "deliver-dispatch-plan:",
+        "dispatch-plan:",
+    ] {
+        if inner.starts_with(prefix) {
+            return Some(MarkerParse::Unsupported {
+                prefix: prefix.trim_end_matches(':').to_string(),
+            });
+        }
     }
 
     None
 }
 
-fn hit(role: String, profile: &str, family: &str) -> MarkerHit {
-    MarkerHit {
-        role,
-        profile: profile.to_string(),
-        family: family.to_string(),
-        url: None,
-        created_at: None,
-        status: None,
-    }
+fn parse_role(value: &str) -> Option<PayloadRole> {
+    Some(match value {
+        "source" => PayloadRole::Source,
+        "plan" => PayloadRole::Plan,
+        "state" => PayloadRole::State,
+        "session" => PayloadRole::Session,
+        "validation" => PayloadRole::Validation,
+        "review" => PayloadRole::Review,
+        "closeout" => PayloadRole::Closeout,
+        _ => return None,
+    })
+}
+
+fn parse_profile(value: &str) -> Option<PayloadProfile> {
+    Some(match value {
+        "tracking" => PayloadProfile::Tracking,
+        "dispatch" => PayloadProfile::Dispatch,
+        _ => return None,
+    })
 }
 
 fn parse_attrs(marker: &str) -> BTreeMap<String, String> {
@@ -663,20 +902,6 @@ fn parse_attrs(marker: &str) -> BTreeMap<String, String> {
     attrs
 }
 
-fn extract_status(body: &str) -> Option<String> {
-    for line in body.lines() {
-        let trimmed = line.trim();
-        let Some(rest) = trimmed.strip_prefix("- Status:") else {
-            continue;
-        };
-        let status = rest.trim();
-        if !status.is_empty() {
-            return Some(status.to_string());
-        }
-    }
-    None
-}
-
 fn inspect_body_sections(body: &str) -> BodySections {
     BodySections {
         current_dashboard: body.contains("## Current Dashboard"),
@@ -687,13 +912,13 @@ fn inspect_body_sections(body: &str) -> BodySections {
     }
 }
 
-fn push_marker_check(
+fn push_evidence_check(
     checks: &mut Vec<CloseoutCheck>,
     audit: &RecordAudit,
     role: &str,
     label: &str,
 ) {
-    let (status, detail) = match audit.markers.get(role) {
+    let (status, detail) = match audit.evidence.get(role) {
         Some(hit) => (
             "pass",
             hit.url
@@ -716,7 +941,7 @@ fn audit_text_for_pr_search(audit: &RecordAudit) -> String {
     if !audit.evidence_text.trim().is_empty() {
         values.insert(audit.evidence_text.clone());
     }
-    for hit in audit.markers.values() {
+    for hit in audit.evidence.values() {
         if let Some(url) = hit.url.as_deref() {
             values.insert(url.to_string());
         }
@@ -789,6 +1014,15 @@ impl PayloadProfile {
         match self {
             Self::Tracking => "tracking",
             Self::Dispatch => "dispatch",
+        }
+    }
+}
+
+impl From<RecordProfile> for PayloadProfile {
+    fn from(value: RecordProfile) -> Self {
+        match value {
+            RecordProfile::Tracking => PayloadProfile::Tracking,
+            RecordProfile::Dispatch => PayloadProfile::Dispatch,
         }
     }
 }

--- a/crates/plan-issue-cli/tests/integration/lifecycle_record.rs
+++ b/crates/plan-issue-cli/tests/integration/lifecycle_record.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use pretty_assertions::assert_eq;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use plan_issue_cli::lifecycle_record::{
@@ -12,18 +12,35 @@ use plan_issue_cli::lifecycle_record::{
 
 use crate::common;
 
+/// Build a `plan-issue-record:v2` lifecycle comment body whose payload
+/// fence carries the given `data` value. Used by audit + closeout-gate
+/// tests in this file to produce comment JSON without re-deriving the
+/// fenced payload by hand.
+fn v2_comment_body(role: &str, profile: &str, data: Value) -> String {
+    let envelope = json!({
+        "schema": PAYLOAD_SCHEMA_V2,
+        "role": role,
+        "profile": profile,
+        "data": data,
+    });
+    let payload = serde_json::to_string(&envelope).expect("serialize payload");
+    format!(
+        "<!-- plan-issue-record:v2 role={role} profile={profile} -->\n\n```plan-issue-record-payload\n{payload}\n```\n",
+    )
+}
+
 fn json_stdout(out: &common::CmdOut) -> Value {
     serde_json::from_str(&out.stdout).expect("json stdout")
 }
 
 #[test]
-fn issue_backed_lifecycle_render_comment_emits_compat_tracking_snapshot() {
+fn issue_backed_lifecycle_render_comment_emits_v2_canonical_marker() {
     let tmp = TempDir::new().expect("tmp");
     let content = tmp.path().join("source.md");
     let rendered = tmp.path().join("comment.md");
     fs::write(
         &content,
-        "# Source\n\n<!-- execute-from-tracking-issue:validation:v1 -->\n",
+        "# Source\n\nQuoted markers inside details are ignored by the v2 parser:\n<!-- plan-issue-record:v2 role=state profile=tracking -->\n",
     )
     .expect("write content");
 
@@ -47,12 +64,19 @@ fn issue_backed_lifecycle_render_comment_emits_compat_tracking_snapshot() {
     assert_eq!(out.code, 0, "stderr: {}", out.stderr);
     let body = fs::read_to_string(&rendered).expect("read rendered");
     assert!(
-        body.starts_with("<!-- plan-tracking-issue:snapshot:v1 kind=source -->"),
+        body.starts_with("<!-- plan-issue-record:v2 role=source profile=tracking -->"),
         "{body}"
     );
     assert!(body.contains("## Source Snapshot"), "{body}");
     assert!(body.contains("<details>"), "{body}");
     assert!(!body.contains("## Task Decomposition"), "{body}");
+    // The v3 lifecycle no longer emits any pre-v2 marker family from
+    // `record render-comment`, even when the rendered content contains
+    // quoted v1 markers.
+    assert!(
+        !body.contains("plan-tracking-issue:snapshot:v1"),
+        "v2 render must not emit v1 outer marker: {body}"
+    );
 
     let payload = json_stdout(&out);
     assert_eq!(payload["command"], "record.render-comment");
@@ -60,7 +84,7 @@ fn issue_backed_lifecycle_render_comment_emits_compat_tracking_snapshot() {
 }
 
 #[test]
-fn issue_backed_lifecycle_audit_uses_only_top_level_comment_markers() {
+fn lifecycle_record_audit_returns_typed_v2_evidence_and_ignores_v1_markers() {
     let tmp = TempDir::new().expect("tmp");
     let body = tmp.path().join("body.md");
     let comments = tmp.path().join("comments.json");
@@ -69,26 +93,40 @@ fn issue_backed_lifecycle_audit_uses_only_top_level_comment_markers() {
         "## Current Dashboard\n\n## Durable Record\n\nNo task table here.\n",
     )
     .expect("write body");
-    fs::write(
-        &comments,
-        r##"{
-  "comments": [
-    {
-      "url": "https://github.com/owner/repo/issues/1#issuecomment-source",
-      "body": "<!-- plan-tracking-issue:snapshot:v1 kind=source -->\n\n## Source Snapshot\n\n<details>\n<summary>Source snapshot</summary>\n\n<!-- execute-from-tracking-issue:validation:v1 -->\n\n</details>\n"
-    },
-    {
-      "url": "https://github.com/owner/repo/issues/1#issuecomment-plan",
-      "body": "<!-- plan-tracking-issue:snapshot:v1 kind=plan -->\n\n## Plan Snapshot\n"
-    },
-    {
-      "url": "https://github.com/owner/repo/issues/1#issuecomment-state",
-      "body": "<!-- execute-from-tracking-issue:state:v1 -->\n\n## Execution State\n\n- Status: complete\n"
-    }
-  ]
-}"##,
-    )
-    .expect("write comments");
+
+    let payload = json!({
+        "comments": [
+            {
+                "url": "https://github.com/owner/repo/issues/1#issuecomment-source",
+                "body": v2_comment_body(
+                    "source",
+                    "tracking",
+                    json!({"path": "docs/plans/example/example-discussion-source.md", "commit": "abc1234"}),
+                ),
+            },
+            {
+                "url": "https://github.com/owner/repo/issues/1#issuecomment-plan",
+                "body": v2_comment_body(
+                    "plan",
+                    "tracking",
+                    json!({"path": "docs/plans/example/example-plan.md", "commit": "abc1234"}),
+                ),
+            },
+            {
+                "url": "https://github.com/owner/repo/issues/1#issuecomment-state",
+                "body": v2_comment_body(
+                    "state",
+                    "tracking",
+                    json!({"status": "complete", "target_scope": "v3", "tasks": [], "prs": []}),
+                ),
+            },
+            {
+                "url": "https://github.com/owner/repo/issues/1#issuecomment-v1-marker",
+                "body": "<!-- execute-from-tracking-issue:state:v1 -->\n\n## Execution State\n\n- Status: complete\n",
+            }
+        ]
+    });
+    fs::write(&comments, payload.to_string()).expect("write comments");
 
     let out = common::run_plan_issue_local(&[
         "--format",
@@ -108,16 +146,29 @@ fn issue_backed_lifecycle_audit_uses_only_top_level_comment_markers() {
     let audit = &payload["payload"]["result"]["audit"];
     assert_eq!(audit["recognized_count"], 3);
     assert_eq!(
-        audit["markers"]["source_snapshot"]["url"],
+        audit["evidence"]["source"]["url"],
         "https://github.com/owner/repo/issues/1#issuecomment-source"
     );
-    assert!(audit["markers"]["validation"].is_null());
+    assert_eq!(
+        audit["evidence"]["plan"]["url"],
+        "https://github.com/owner/repo/issues/1#issuecomment-plan"
+    );
+    assert_eq!(audit["evidence"]["state"]["status"], "complete");
+    assert_eq!(
+        audit["evidence"]["state"]["payload"]["schema"],
+        PAYLOAD_SCHEMA_V2
+    );
+    assert!(audit["evidence"]["validation"].is_null());
     assert_eq!(audit["missing_required"].as_array().unwrap().len(), 0);
+    assert_eq!(
+        audit["unsupported_markers"][0]["marker_prefix"],
+        "execute-from-tracking-issue"
+    );
     assert_eq!(audit["body_sections"]["task_decomposition"], false);
 }
 
 #[test]
-fn issue_backed_lifecycle_closeout_gate_reports_ready_when_required_markers_pass() {
+fn lifecycle_record_closeout_gate_passes_with_v2_payloads() {
     let tmp = TempDir::new().expect("tmp");
     let body = tmp.path().join("body.md");
     let comments = tmp.path().join("comments.json");
@@ -126,17 +177,42 @@ fn issue_backed_lifecycle_closeout_gate_reports_ready_when_required_markers_pass
         "## Final Dashboard\n\n## Durable Record\n\n## Closeout Checks\n",
     )
     .expect("write body");
-    fs::write(
-        &comments,
-        r##"[
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-source","body":"<!-- plan-tracking-issue:snapshot:v1 kind=source -->\n\n## Source Snapshot\n"},
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-plan","body":"<!-- plan-tracking-issue:snapshot:v1 kind=plan -->\n\n## Plan Snapshot\n"},
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-state","body":"<!-- execute-from-tracking-issue:state:v1 -->\n\n## Execution State\n\n- Status: complete\n"},
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-session","body":"<!-- execute-from-tracking-issue:session:v1 -->\n\n## Execution Session\n"},
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-validation","body":"<!-- execute-from-tracking-issue:validation:v1 -->\n\n## Validation Evidence\n"}
-]"##,
-    )
-    .expect("write comments");
+
+    let payload = json!([
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-source",
+            "body": v2_comment_body(
+                "source",
+                "tracking",
+                json!({"path": "docs/plans/example/example-discussion-source.md", "commit": "abc1234"}),
+            ),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-plan",
+            "body": v2_comment_body(
+                "plan",
+                "tracking",
+                json!({"path": "docs/plans/example/example-plan.md", "commit": "abc1234"}),
+            ),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-state",
+            "body": v2_comment_body(
+                "state",
+                "tracking",
+                json!({"status": "complete", "target_scope": "v3", "tasks": [], "prs": []}),
+            ),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-session",
+            "body": v2_comment_body("session", "tracking", json!({"summary": "Final session"})),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-validation",
+            "body": v2_comment_body("validation", "tracking", json!({"overall": "pass", "commands": []})),
+        }
+    ]);
+    fs::write(&comments, payload.to_string()).expect("write comments");
 
     let out = common::run_plan_issue_local(&[
         "--format",
@@ -171,7 +247,7 @@ fn issue_backed_lifecycle_closeout_gate_reports_ready_when_required_markers_pass
 }
 
 #[test]
-fn issue_backed_lifecycle_closeout_gate_filters_linked_prs_by_profile() {
+fn lifecycle_record_closeout_gate_filters_linked_prs_by_profile_v2() {
     let tmp = TempDir::new().expect("tmp");
     let body = tmp.path().join("body.md");
     let comments = tmp.path().join("comments.json");
@@ -180,19 +256,50 @@ fn issue_backed_lifecycle_closeout_gate_filters_linked_prs_by_profile() {
         "## Final Dashboard\n\n## Durable Record\n\n## Closeout Checks\n",
     )
     .expect("write body");
-    fs::write(
-        &comments,
-        r##"[
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-source","body":"<!-- issue-backed-plan:snapshot:v1 kind=source profile=dispatch -->\n\n## Source Snapshot\n"},
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-plan","body":"<!-- issue-backed-plan:snapshot:v1 kind=plan profile=dispatch -->\n\n## Plan Snapshot\n"},
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-state","body":"<!-- issue-backed-plan:state:v1 profile=dispatch -->\n\n## Execution State\n\n- Status: complete\n"},
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-session","body":"<!-- issue-backed-plan:session:v1 profile=dispatch -->\n\n## Execution Session\n"},
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-validation","body":"<!-- issue-backed-plan:validation:v1 profile=dispatch -->\n\n## Validation Evidence\n"},
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-review","body":"<!-- issue-backed-plan:review:v1 profile=dispatch -->\n\n## Review Evidence\n"},
-  {"url":"https://github.com/owner/repo/issues/1#issuecomment-tracking","body":"<!-- execute-from-tracking-issue:session:v1 -->\n\n## Execution Session\n\n- PR: #999\n"}
-]"##,
-    )
-    .expect("write comments");
+
+    let payload = json!([
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-source",
+            "body": v2_comment_body(
+                "source",
+                "dispatch",
+                json!({"path": "docs/plans/example/example-discussion-source.md", "commit": "abc1234"}),
+            ),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-plan",
+            "body": v2_comment_body(
+                "plan",
+                "dispatch",
+                json!({"path": "docs/plans/example/example-plan.md", "commit": "abc1234"}),
+            ),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-state",
+            "body": v2_comment_body(
+                "state",
+                "dispatch",
+                json!({"status": "complete", "target_scope": "v3", "tasks": [], "prs": []}),
+            ),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-session",
+            "body": v2_comment_body("session", "dispatch", json!({"summary": "Session"})),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-validation",
+            "body": v2_comment_body("validation", "dispatch", json!({"overall": "pass", "commands": []})),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-review",
+            "body": v2_comment_body("review", "dispatch", json!({"decision": "approve", "lenses": ["testing"], "findings": []})),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-tracking",
+            "body": v2_comment_body("session", "tracking", json!({"summary": "PR #999"})),
+        }
+    ]);
+    fs::write(&comments, payload.to_string()).expect("write comments");
 
     let out = common::run_plan_issue_local(&[
         "--format",
@@ -218,6 +325,9 @@ fn issue_backed_lifecycle_closeout_gate_filters_linked_prs_by_profile() {
     assert_eq!(out.code, 0, "stderr: {}", out.stderr);
     let payload = json_stdout(&out);
     let result = &payload["payload"]["result"];
+    // The dispatch-profile filter rejects the tracking-profile session
+    // payload, so `#999` (which appears only in the tracking session
+    // payload) is not present in any dispatch-profile evidence text.
     assert_eq!(result["ready"], false);
     assert!(
         result["checks_markdown"]
@@ -395,6 +505,215 @@ fn lifecycle_record_structured_payloads_reject_invalid_json() {
     let comment = "```plan-issue-record-payload\n{ not json }\n```\n";
     let err = lifecycle_record::extract_payload(comment).expect_err("invalid json");
     assert_eq!(err.kind, PayloadErrorKind::InvalidJson);
+}
+
+// --- Sprint 2 Tasks 2.1-2.3 acceptance tests ---
+
+#[test]
+fn lifecycle_record_audit_latest_marker_per_role_wins_by_timestamp() {
+    let earlier = v2_comment_body(
+        "state",
+        "tracking",
+        json!({"status": "in-progress", "target_scope": "v3"}),
+    );
+    let later = v2_comment_body(
+        "state",
+        "tracking",
+        json!({"status": "complete", "target_scope": "v3"}),
+    );
+    let comments = json!([
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-state-1",
+            "body": earlier,
+            "created_at": "2026-05-20T10:00:00Z",
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-state-2",
+            "body": later,
+            "created_at": "2026-05-23T10:00:00Z",
+        }
+    ]);
+
+    let tmp = TempDir::new().expect("tmp");
+    let comments_path = tmp.path().join("comments.json");
+    fs::write(&comments_path, comments.to_string()).expect("write comments");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "audit",
+        "--comments-json",
+        comments_path.to_str().expect("path"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = json_stdout(&out);
+    let audit = &payload["payload"]["result"]["audit"];
+    assert_eq!(audit["evidence"]["state"]["status"], "complete");
+    assert_eq!(
+        audit["evidence"]["state"]["url"],
+        "https://github.com/owner/repo/issues/1#issuecomment-state-2"
+    );
+}
+
+#[test]
+fn lifecycle_record_audit_reports_stable_missing_required_codes() {
+    let tmp = TempDir::new().expect("tmp");
+    let comments_path = tmp.path().join("comments.json");
+    let comments = json!({
+        "comments": [
+            {
+                "url": "https://github.com/owner/repo/issues/1#issuecomment-source",
+                "body": v2_comment_body(
+                    "source",
+                    "tracking",
+                    json!({"path": "docs/plans/example/example-discussion-source.md", "commit": "abc"}),
+                ),
+            }
+        ]
+    });
+    fs::write(&comments_path, comments.to_string()).expect("write comments");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "audit",
+        "--comments-json",
+        comments_path.to_str().expect("path"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let payload = json_stdout(&out);
+    let audit = &payload["payload"]["result"]["audit"];
+    let missing = audit["missing_required"]
+        .as_array()
+        .expect("missing_required array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(missing, vec!["plan-missing", "state-missing"]);
+}
+
+#[test]
+fn lifecycle_record_dashboard_renders_from_audit_without_explicit_urls() {
+    use lifecycle_record::render_dashboard_from_audit;
+
+    let comments = json!([
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-source",
+            "body": v2_comment_body(
+                "source",
+                "tracking",
+                json!({"path": "docs/plans/example/example-discussion-source.md", "commit": "abc"}),
+            ),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-plan",
+            "body": v2_comment_body(
+                "plan",
+                "tracking",
+                json!({"path": "docs/plans/example/example-plan.md", "commit": "abc"}),
+            ),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-state",
+            "body": v2_comment_body(
+                "state",
+                "tracking",
+                json!({
+                    "status": "in-progress",
+                    "target_scope": "v3 lifecycle rewrite",
+                    "current": "Sprint 2 PR",
+                    "next_action": "Land marker collapse",
+                    "tasks": [],
+                    "prs": [{"ref": "owner/repo#500", "url": "https://example/pull/500", "status": "open"}]
+                }),
+            ),
+        }
+    ]);
+    let audit =
+        lifecycle_record::audit_record(None, &comments.to_string(), None).expect("audit ok");
+
+    let rendered = render_dashboard_from_audit(
+        &audit,
+        Some("Plan-Issue Lifecycle v3"),
+        Some("https://github.com/owner/repo/issues/1"),
+    );
+
+    assert!(rendered.contains("## Current Dashboard"), "{rendered}");
+    assert!(
+        rendered.contains("- Target scope: v3 lifecycle rewrite"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("- Linked PRs: https://example/pull/500"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains(
+            "- Source snapshot: [source snapshot](https://github.com/owner/repo/issues/1#issuecomment-source)"
+        ),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("- Closeout comment: pending"),
+        "{rendered}"
+    );
+}
+
+#[test]
+fn lifecycle_record_dashboard_renders_final_when_state_complete() {
+    use lifecycle_record::render_dashboard_from_audit;
+
+    let comments = json!([
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-source",
+            "body": v2_comment_body("source", "tracking", json!({"path": "x", "commit": "abc"})),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-plan",
+            "body": v2_comment_body("plan", "tracking", json!({"path": "y", "commit": "abc"})),
+        },
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-state",
+            "body": v2_comment_body(
+                "state",
+                "tracking",
+                json!({"status": "complete", "target_scope": "v3", "tasks": [], "prs": []}),
+            ),
+        }
+    ]);
+    let audit =
+        lifecycle_record::audit_record(None, &comments.to_string(), None).expect("audit ok");
+
+    let rendered = render_dashboard_from_audit(&audit, None, None);
+    assert!(
+        rendered.contains("## Final Dashboard"),
+        "expected Final Dashboard heading: {rendered}"
+    );
+    assert!(!rendered.contains("## Current Dashboard"), "{rendered}");
+}
+
+#[test]
+fn lifecycle_record_dashboard_render_is_idempotent_for_same_audit() {
+    use lifecycle_record::render_dashboard_from_audit;
+
+    let comments = json!([
+        {
+            "url": "https://github.com/owner/repo/issues/1#issuecomment-state",
+            "body": v2_comment_body(
+                "state",
+                "tracking",
+                json!({"status": "in-progress", "target_scope": "v3", "current": "step", "next_action": "do", "tasks": [], "prs": []}),
+            ),
+        }
+    ]);
+    let audit =
+        lifecycle_record::audit_record(None, &comments.to_string(), None).expect("audit ok");
+
+    let first = render_dashboard_from_audit(&audit, None, None);
+    let second = render_dashboard_from_audit(&audit, None, None);
+    assert_eq!(first, second);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Sprint 2 of the breaking `plan-issue` v3 issue-backed plan record rewrite
([#448](https://github.com/sympoies/nils-cli/issues/448)). Collapses the
marker/parser/rendering internals to one canonical `plan-issue-record:v2`
marker family, rebuilds audit on top of the structured payloads landed
in Sprint 1, and adds a dashboard renderer that derives all durable-record
links from audit evidence alone.

## Changes

- **Task 2.1: Collapse marker parsing to canonical family.**
  - Removed `MarkerFamily` enum, `--marker-family` flag, and the dual
    `shared` / `compat` rendering paths (`commands/record.rs`,
    `src/lifecycle_record.rs`, `src/execute.rs`).
  - `parse_marker_line` now recognizes only the v2 marker
    `<!-- plan-issue-record:v2 role=<role> profile=<profile> -->`.
    Known pre-v2 prefixes (`plan-tracking-issue:`,
    `execute-from-tracking-issue:`, `tracking-issue-closeout:`,
    `deliver-dispatch-plan:`, `dispatch-plan:`,
    `issue-backed-plan:`, `execute-plan-tracking-issue:`,
    `plan-tracking-issue-closeout:`) are reported as
    `unsupported_markers` but no longer counted as current lifecycle
    evidence. The tracking-profile compat review-marker error path is
    gone because there is no compat branch.
  - `record render-comment` now always emits the canonical v2 marker
    with `- Profile:` metadata.

- **Task 2.2: Structured audit output.**
  - `RecordAudit` exposes `evidence: BTreeMap<String, LifecycleEvidence>`
    where every entry carries the role, profile, comment URL, created
    timestamp, parsed payload (`RecordPayload`), and a derived stable
    `status` string (state.status, validation.overall, review.decision,
    closeout.final_status).
  - Latest-by-timestamp wins per role; out-of-order GitHub comment
    arrays no longer cause non-deterministic audits.
  - `missing_required` now uses stable codes (`source-missing`,
    `plan-missing`, `state-missing`) instead of v1 role names.
  - Audit text searches and PR-presence lookups consume the new
    `evidence` map; closeout-gate `push_evidence_check` replaces the
    v1 `push_marker_check` against `audit.markers`.

- **Task 2.3: Render dashboards from audit evidence.**
  - New `render_dashboard_from_audit(audit, title, issue_url)` derives
    every durable-record link from `audit.evidence[<role>].url`. No
    caller-supplied URL flags are needed.
  - Renders `## Final Dashboard` when the latest state payload
    `status == "complete"`, else `## Current Dashboard`. Pending roles
    show `pending`. Output is idempotent across repeated calls on the
    same audit.

- **Tests.**
  - Rewrote four existing `issue_backed_lifecycle_*` tests to use v2
    markers + structured payloads (render-comment, audit,
    closeout-gate × 2). Helper `v2_comment_body()` makes the comment
    JSON deterministic.
  - Added 5 new Sprint 2 acceptance tests:
    `lifecycle_record_audit_latest_marker_per_role_wins_by_timestamp`,
    `lifecycle_record_audit_reports_stable_missing_required_codes`,
    `lifecycle_record_dashboard_renders_from_audit_without_explicit_urls`,
    `lifecycle_record_dashboard_renders_final_when_state_complete`,
    `lifecycle_record_dashboard_render_is_idempotent_for_same_audit`.

## What this PR does **not** do

- `record render-comment`, `record render-dashboard`, and
  `record closeout-gate` still exist on the CLI surface. Sprint 4
  retires them in favor of `record post|repair-dashboard|close`.
- `record open / post / repair-dashboard / close` still return
  `*-not-yet-implemented`. Sprint 3 wires the live provider lifecycle
  on top of the audit + dashboard primitives landed here.
- No agent-runtime-kit migration. The v1 marker families that consumer
  skills currently emit are no longer recognized as current lifecycle
  evidence; that breaking change is documented in the v2 contract spec
  (Sprint 1) and will be carried into the consumer rewrite by the
  Sprint 5 handoff notes.

## Test plan

- `cargo test -p nils-plan-issue-cli --test integration lifecycle_record` — 18 tests pass (was 13; 5 new acceptance tests added).
- `cargo test -p nils-plan-issue-cli --test integration` — 114 tests pass.
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` — full local gate.
- Manual smoke via `plan-issue-local record audit` on a v2-marker comment fixture (see retained review-evidence record).

Refs #448
