### PR TITLE
feat(plan-issue-cli): live record open/post/close + strict v2 gate

### DIFF
--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -224,7 +224,12 @@ impl Command {
             // (Task 1.3); dispatch records gain `worktree_abs_path`
             // (Task 1.4).
             Self::StartSprint(_) => "v2",
-            Self::Record(_) => "v1",
+            // v2 lifecycle record subcommand surface (Sprint 3): live
+            // open/post/repair-dashboard/close, structured payloads, and
+            // strict closeout gate. The result envelope grew live operation
+            // fields (`issue.url`, `comments.*`, `closeout_url`,
+            // `final_dashboard`).
+            Self::Record(_) => "v2",
             _ => "v1",
         };
         format!(

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -71,7 +71,9 @@ pub fn execute(binary: BinaryFlavor, cli: &Cli) -> Result<Value, CommandError> {
         CliCommand::ResolveApproval(args) => {
             run_resolve_approval_json(binary, cli.force, cli.repo.as_deref(), args)
         }
-        CliCommand::Record(args) => run_record(args),
+        CliCommand::Record(args) => {
+            run_record(binary, cli.dry_run, cli.force, cli.repo.as_deref(), args)
+        }
         CliCommand::Completion(_) => Err(CommandError::usage(
             "completion-direct-output-only",
             "completion output is emitted directly; run `<binary> completion <bash|zsh>`",
@@ -79,12 +81,20 @@ pub fn execute(binary: BinaryFlavor, cli: &Cli) -> Result<Value, CommandError> {
     }
 }
 
-fn run_record(args: &RecordArgs) -> Result<Value, CommandError> {
+fn run_record(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    force: bool,
+    repo_override: Option<&str>,
+    args: &RecordArgs,
+) -> Result<Value, CommandError> {
     match &args.command {
-        RecordCommand::Open(args) => run_record_open(args),
-        RecordCommand::Post(args) => run_record_post(args),
-        RecordCommand::RepairDashboard(args) => run_record_repair_dashboard(args),
-        RecordCommand::Close(args) => run_record_close(args),
+        RecordCommand::Open(args) => run_record_open(binary, dry_run, force, repo_override, args),
+        RecordCommand::Post(args) => run_record_post(binary, dry_run, force, repo_override, args),
+        RecordCommand::RepairDashboard(args) => {
+            run_record_repair_dashboard(binary, dry_run, force, repo_override, args)
+        }
+        RecordCommand::Close(args) => run_record_close(binary, dry_run, force, repo_override, args),
         RecordCommand::RenderDashboard(args) => run_record_render_dashboard(args),
         RecordCommand::RenderComment(args) => run_record_render_comment(args),
         RecordCommand::Audit(args) => run_record_audit(args),
@@ -93,40 +103,1008 @@ fn run_record(args: &RecordArgs) -> Result<Value, CommandError> {
     }
 }
 
-fn run_record_open(_args: &RecordOpenArgs) -> Result<Value, CommandError> {
+#[derive(Debug, Clone)]
+struct RecordBundle {
+    source_file: PathBuf,
+    plan_file: PathBuf,
+    /// Resolved when present; `None` only when the caller explicitly opted out.
+    #[allow(dead_code)]
+    execution_state_file: Option<PathBuf>,
+}
+
+fn resolve_record_bundle(
+    bundle: Option<&Path>,
+    explicit_source: Option<&Path>,
+    explicit_plan: Option<&Path>,
+    explicit_execution_state: Option<&Path>,
+) -> Result<RecordBundle, CommandError> {
+    if let (Some(source), Some(plan)) = (explicit_source, explicit_plan) {
+        return Ok(RecordBundle {
+            source_file: source.to_path_buf(),
+            plan_file: plan.to_path_buf(),
+            execution_state_file: explicit_execution_state.map(Path::to_path_buf),
+        });
+    }
+
+    let bundle_dir = bundle.ok_or_else(|| {
+        CommandError::usage(
+            "record-open-missing-bundle",
+            "either --bundle <dir> or both --source-file and --plan-file are required",
+        )
+    })?;
+    if !bundle_dir.is_dir() {
+        return Err(CommandError::usage(
+            "record-open-bundle-not-dir",
+            format!("--bundle path is not a directory: {}", bundle_dir.display()),
+        ));
+    }
+
+    let mut plan_file: Option<PathBuf> = None;
+    let mut source_file: Option<PathBuf> = None;
+    let mut execution_state_file: Option<PathBuf> = None;
+    let entries = fs::read_dir(bundle_dir).map_err(|err| {
+        CommandError::runtime(
+            "record-open-bundle-read-failed",
+            format!("failed to read bundle dir {}: {err}", bundle_dir.display()),
+        )
+    })?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.ends_with("-plan.md") {
+            plan_file = Some(path.clone());
+        } else if name.ends_with("-discussion-source.md") || name.ends_with("-review-source.md") {
+            source_file = Some(path.clone());
+        } else if name.ends_with("-execution-state.md") {
+            execution_state_file = Some(path.clone());
+        }
+    }
+
+    let plan_file = explicit_plan
+        .map(Path::to_path_buf)
+        .or(plan_file)
+        .ok_or_else(|| {
+            CommandError::usage(
+                "record-open-missing-plan",
+                format!(
+                    "no <slug>-plan.md found in bundle {} and no --plan-file provided",
+                    bundle_dir.display()
+                ),
+            )
+        })?;
+    let source_file = explicit_source
+        .map(Path::to_path_buf)
+        .or(source_file)
+        .ok_or_else(|| {
+            CommandError::usage(
+                "record-open-missing-source",
+                format!(
+                    "no <slug>-discussion-source.md or <slug>-review-source.md found in bundle {} and no --source-file provided",
+                    bundle_dir.display()
+                ),
+            )
+        })?;
+    let execution_state_file = explicit_execution_state
+        .map(Path::to_path_buf)
+        .or(execution_state_file);
+
+    Ok(RecordBundle {
+        source_file,
+        plan_file,
+        execution_state_file,
+    })
+}
+
+fn last_commit_for_path(path: &Path) -> Result<String, CommandError> {
+    let arg_path = path.to_string_lossy().to_string();
+    let output =
+        common_git::run_output(&["log", "-n", "1", "--format=%H", "--", arg_path.as_str()])
+            .map_err(|err| {
+                CommandError::runtime(
+                    "record-open-git-log-failed",
+                    format!("git log {arg_path} failed: {err}"),
+                )
+            })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(CommandError::runtime(
+            "record-open-git-log-failed",
+            format!("git log {arg_path}: {stderr}"),
+        ));
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() {
+        return Err(CommandError::runtime(
+            "record-open-uncommitted",
+            format!(
+                "path {} has no commit in git history; commit it first or pass --allow-dirty",
+                path.display()
+            ),
+        ));
+    }
+    Ok(sha)
+}
+
+fn path_is_dirty(path: &Path) -> Result<bool, CommandError> {
+    let arg_path = path.to_string_lossy().to_string();
+    let output = common_git::run_output(&["status", "--porcelain", "--", arg_path.as_str()])
+        .map_err(|err| {
+            CommandError::runtime(
+                "record-open-git-status-failed",
+                format!("git status {arg_path} failed: {err}"),
+            )
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(CommandError::runtime(
+            "record-open-git-status-failed",
+            format!("git status {arg_path}: {stderr}"),
+        ));
+    }
+    Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+fn resolve_bundle_snapshots(
+    bundle: &RecordBundle,
+    allow_dirty: bool,
+) -> Result<
+    (
+        lifecycle_record::SnapshotData,
+        lifecycle_record::SnapshotData,
+    ),
+    CommandError,
+> {
+    for (label, path) in [("source", &bundle.source_file), ("plan", &bundle.plan_file)] {
+        if !path.exists() {
+            return Err(CommandError::usage(
+                "record-open-bundle-file-missing",
+                format!("{label} file not found: {}", path.display()),
+            ));
+        }
+        if !allow_dirty && path_is_dirty(path)? {
+            return Err(CommandError::usage(
+                "record-open-bundle-dirty",
+                format!(
+                    "{label} file {} has uncommitted changes; commit them or pass --allow-dirty",
+                    path.display()
+                ),
+            ));
+        }
+    }
+
+    let source_commit = last_commit_for_path(&bundle.source_file)?;
+    let plan_commit = last_commit_for_path(&bundle.plan_file)?;
+
+    let source_snapshot = lifecycle_record::SnapshotData {
+        path: relative_repo_path(&bundle.source_file),
+        commit: source_commit,
+        title: None,
+        summary: None,
+    };
+    let plan_snapshot = lifecycle_record::SnapshotData {
+        path: relative_repo_path(&bundle.plan_file),
+        commit: plan_commit,
+        title: None,
+        summary: None,
+    };
+    Ok((source_snapshot, plan_snapshot))
+}
+
+fn relative_repo_path(path: &Path) -> String {
+    // Try to express the path relative to the repo root for stable
+    // payload identity; otherwise fall back to the display path.
+    let cwd = std::env::current_dir().ok();
+    if let Some(cwd) = cwd
+        && let Ok(stripped) = path.strip_prefix(&cwd)
+    {
+        return stripped.to_string_lossy().to_string();
+    }
+    path.to_string_lossy().to_string()
+}
+
+fn build_initial_state_payload(plan: &plan_tooling::parse::Plan) -> Value {
+    let tasks = plan
+        .sprints
+        .iter()
+        .flat_map(|sprint| {
+            sprint.tasks.iter().map(|task| {
+                json!({
+                    "id": task.id,
+                    "status": "pending",
+                    "title": task.name,
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "status": "in-progress",
+        "target_scope": plan.title,
+        "current": "Sprint 1 ready",
+        "next_action": "execute Sprint 1 tasks",
+        "tasks": tasks,
+        "prs": [],
+        "blockers": [],
+        "links": {},
+    })
+}
+
+fn parse_plan_for_record(plan_file: &Path) -> Result<plan_tooling::parse::Plan, CommandError> {
+    let resolved = task_spec::resolve_plan_file(plan_file);
+    let display = plan_file.to_string_lossy().to_string();
+    let (plan, errors) = parse_plan_with_display(&resolved, &display).map_err(|err| {
+        CommandError::runtime(
+            "record-open-plan-parse-failed",
+            format!("failed to read {}: {err}", plan_file.display()),
+        )
+    })?;
+    if !errors.is_empty() {
+        return Err(CommandError::runtime(
+            "record-open-plan-invalid",
+            errors.join(" | "),
+        ));
+    }
+    Ok(plan)
+}
+
+fn record_initial_dashboard(
+    profile: crate::commands::record::RecordProfile,
+    plan_title: &str,
+    issue_url: Option<&str>,
+) -> String {
+    lifecycle_record::render_dashboard(DashboardInput {
+        profile,
+        status: "in-progress".to_string(),
+        target_scope: plan_title.to_string(),
+        current: "Sprint 1 ready".to_string(),
+        next_action: "execute Sprint 1 tasks".to_string(),
+        validation: "pending".to_string(),
+        linked_prs: Vec::new(),
+        blockers: Vec::new(),
+        approval: "pending".to_string(),
+        source_url: None,
+        plan_url: None,
+        state_url: None,
+        session_url: None,
+        validation_url: None,
+        review_url: None,
+        closeout_url: None,
+        title: Some(plan_title.to_string()),
+        issue_url: issue_url.map(str::to_string),
+    })
+}
+
+fn read_fixture_evidence(fixture_dir: &Path) -> Result<(String, String), CommandError> {
+    let body_path = fixture_dir.join("issue-body.md");
+    let comments_path = fixture_dir.join("comments.json");
+    let body = fs::read_to_string(&body_path).map_err(|err| {
+        CommandError::runtime(
+            "record-fixture-body-read-failed",
+            format!("failed to read fixture body {}: {err}", body_path.display()),
+        )
+    })?;
+    let comments = fs::read_to_string(&comments_path).map_err(|err| {
+        CommandError::runtime(
+            "record-fixture-comments-read-failed",
+            format!(
+                "failed to read fixture comments {}: {err}",
+                comments_path.display()
+            ),
+        )
+    })?;
+    Ok((body, comments))
+}
+
+fn read_fixture_pr_snapshot(
+    fixture_dir: &Path,
+    repo: &str,
+    pr: u64,
+) -> Result<lifecycle_record::LinkedPrEvidence, CommandError> {
+    let slug = repo.replace('/', "__");
+    let file = fixture_dir.join("prs").join(format!("{slug}__{pr}.json"));
+    let raw = fs::read_to_string(&file).map_err(|err| {
+        CommandError::runtime(
+            "record-fixture-pr-missing",
+            format!("failed to read PR fixture {}: {err}", file.display()),
+        )
+    })?;
+    let value: Value = serde_json::from_str(&raw).map_err(|err| {
+        CommandError::runtime(
+            "record-fixture-pr-invalid",
+            format!("failed to parse PR fixture {}: {err}", file.display()),
+        )
+    })?;
+    let state = value
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let merged = state.eq_ignore_ascii_case("merged");
+    let merge_sha = value
+        .get("mergeCommit")
+        .and_then(|v| v.get("oid"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let checks_str = value
+        .get("statusCheckRollup")
+        .and_then(|rollup| rollup.get("state"))
+        .and_then(Value::as_str)
+        .map(|s| s.to_ascii_lowercase());
+    let checks = match checks_str.as_deref() {
+        Some("success") => lifecycle_record::CheckStatus::Pass,
+        Some("failure" | "error") => lifecycle_record::CheckStatus::Fail,
+        _ => lifecycle_record::CheckStatus::None,
+    };
+    Ok(lifecycle_record::LinkedPrEvidence {
+        pr_ref: format!("{repo}#{pr}"),
+        url: value.get("url").and_then(Value::as_str).map(str::to_string),
+        merge_sha: if merged { merge_sha } else { None },
+        checks,
+    })
+}
+
+fn parse_issue_reference(value: &str) -> Result<u64, CommandError> {
+    let trimmed = value.trim();
+    if let Ok(num) = trimmed.parse::<u64>() {
+        return Ok(num);
+    }
+    if let Some(tail) = trimmed.rsplit('/').next()
+        && let Ok(num) = tail.parse::<u64>()
+    {
+        return Ok(num);
+    }
     Err(CommandError::usage(
-        "record-open-not-yet-implemented",
-        "`plan-issue record open` lifecycle wiring lands in plan-issue-lifecycle-v3 Sprint 3; \
-         the v2 spec contract is defined and the CLI surface is scaffolded so consumers can \
-         test against it",
+        "record-invalid-issue",
+        format!("--issue must be a number or full URL, got `{value}`"),
     ))
 }
 
-fn run_record_post(_args: &RecordPostArgs) -> Result<Value, CommandError> {
+fn parse_linked_pr_reference(value: &str) -> Result<(String, u64), CommandError> {
+    let trimmed = value.trim();
+    if let Some((repo, number_raw)) = trimmed.rsplit_once('#') {
+        if !repo.contains('/') {
+            return Err(CommandError::usage(
+                "record-invalid-linked-pr",
+                format!("--linked-pr must be `owner/repo#NN` or a PR URL, got `{value}`"),
+            ));
+        }
+        let number = number_raw.parse::<u64>().map_err(|err| {
+            CommandError::usage(
+                "record-invalid-linked-pr",
+                format!("--linked-pr number is not numeric in `{value}`: {err}"),
+            )
+        })?;
+        return Ok((repo.to_string(), number));
+    }
+    if trimmed.starts_with("https://github.com/") {
+        let tail = trimmed.trim_end_matches('/');
+        if let Some(rest) = tail.strip_prefix("https://github.com/") {
+            let mut parts = rest.splitn(4, '/');
+            let owner = parts.next().unwrap_or("");
+            let repo = parts.next().unwrap_or("");
+            let kind = parts.next().unwrap_or("");
+            let number = parts.next().unwrap_or("");
+            if !owner.is_empty()
+                && !repo.is_empty()
+                && (kind == "pull" || kind == "issues")
+                && let Ok(num) = number.parse::<u64>()
+            {
+                return Ok((format!("{owner}/{repo}"), num));
+            }
+        }
+    }
     Err(CommandError::usage(
-        "record-post-not-yet-implemented",
-        "`plan-issue record post` lifecycle wiring lands in plan-issue-lifecycle-v3 Sprint 3; \
-         the v2 spec contract is defined and the CLI surface is scaffolded so consumers can \
-         test against it",
+        "record-invalid-linked-pr",
+        format!("--linked-pr must be `owner/repo#NN` or a PR URL, got `{value}`"),
     ))
 }
 
-fn run_record_repair_dashboard(_args: &RecordRepairDashboardArgs) -> Result<Value, CommandError> {
-    Err(CommandError::usage(
-        "record-repair-dashboard-not-yet-implemented",
-        "`plan-issue record repair-dashboard` lifecycle wiring lands in \
-         plan-issue-lifecycle-v3 Sprint 3; the v2 spec contract is defined and the CLI \
-         surface is scaffolded so consumers can test against it",
-    ))
+fn read_payload_data(path: &Path) -> Result<Value, CommandError> {
+    let raw = fs::read_to_string(path).map_err(|err| {
+        CommandError::runtime(
+            "record-post-payload-read-failed",
+            format!("failed to read --payload-file {}: {err}", path.display()),
+        )
+    })?;
+    serde_json::from_str(&raw).map_err(|err| {
+        CommandError::runtime(
+            "record-post-payload-invalid",
+            format!("invalid JSON in --payload-file {}: {err}", path.display()),
+        )
+    })
 }
 
-fn run_record_close(_args: &RecordCloseArgs) -> Result<Value, CommandError> {
-    Err(CommandError::usage(
-        "record-close-not-yet-implemented",
-        "`plan-issue record close` lifecycle wiring lands in plan-issue-lifecycle-v3 Sprint 3; \
-         the v2 spec contract is defined and the CLI surface is scaffolded so consumers can \
-         test against it",
-    ))
+fn run_record_open(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    force: bool,
+    repo_override: Option<&str>,
+    args: &RecordOpenArgs,
+) -> Result<Value, CommandError> {
+    // Fixture mode is deterministic and never reaches the network.
+    if let Some(fixture_dir) = &args.fixture {
+        let (body, comments_json) = read_fixture_evidence(fixture_dir)?;
+        let audit = lifecycle_record::audit_record(Some(&body), &comments_json, Some(args.profile))
+            .map_err(|err| CommandError::runtime("record-open-fixture-audit-failed", err))?;
+        let source_url = audit
+            .evidence
+            .get("source")
+            .and_then(|hit| hit.url.clone())
+            .unwrap_or_default();
+        let plan_url = audit
+            .evidence
+            .get("plan")
+            .and_then(|hit| hit.url.clone())
+            .unwrap_or_default();
+        let state_url = audit
+            .evidence
+            .get("state")
+            .and_then(|hit| hit.url.clone())
+            .unwrap_or_default();
+        let plan_title = args
+            .title
+            .clone()
+            .unwrap_or_else(|| "fixture-plan".to_string());
+        let dashboard = lifecycle_record::render_dashboard_from_audit(
+            &audit,
+            Some(&plan_title),
+            audit
+                .evidence
+                .values()
+                .next()
+                .and_then(|hit| hit.url.as_deref().and_then(|url| url.split('#').next())),
+        );
+        return Ok(json!({
+            "operation": "record.open",
+            "execution_mode": binary.execution_mode(),
+            "dry_run": true,
+            "mode": "fixture",
+            "issue": {"number": null, "url": null},
+            "comments": {"source": source_url, "plan": plan_url, "state": state_url},
+            "dashboard_markdown": dashboard,
+        }));
+    }
+
+    let bundle = resolve_record_bundle(
+        args.bundle.as_deref(),
+        args.source_file.as_deref(),
+        args.plan_file.as_deref(),
+        args.execution_state_file.as_deref(),
+    )?;
+    let plan = parse_plan_for_record(&bundle.plan_file)?;
+    let plan_title = args.title.clone().unwrap_or_else(|| plan.title.clone());
+
+    let (source_snapshot, plan_snapshot) = resolve_bundle_snapshots(&bundle, args.allow_dirty)?;
+    let source_content = fs::read_to_string(&bundle.source_file).map_err(|err| {
+        CommandError::runtime(
+            "record-open-source-read-failed",
+            format!("failed to read {}: {err}", bundle.source_file.display()),
+        )
+    })?;
+    let plan_content = fs::read_to_string(&bundle.plan_file).map_err(|err| {
+        CommandError::runtime(
+            "record-open-plan-read-failed",
+            format!("failed to read {}: {err}", bundle.plan_file.display()),
+        )
+    })?;
+
+    let source_body = lifecycle_record::render_record_snapshot_comment(
+        args.profile,
+        crate::commands::record::LifecycleCommentKind::Source,
+        &source_snapshot,
+        &source_content,
+        None,
+    )
+    .map_err(|err| CommandError::runtime("record-open-source-render-failed", err))?;
+    let plan_body = lifecycle_record::render_record_snapshot_comment(
+        args.profile,
+        crate::commands::record::LifecycleCommentKind::Plan,
+        &plan_snapshot,
+        &plan_content,
+        None,
+    )
+    .map_err(|err| CommandError::runtime("record-open-plan-render-failed", err))?;
+
+    let initial_state = build_initial_state_payload(&plan);
+    let state_body = lifecycle_record::render_record_post_comment(
+        args.profile,
+        crate::commands::record::LifecycleCommentKind::State,
+        initial_state.clone(),
+        Some("Initial execution state seeded by `plan-issue record open`."),
+        None,
+    )
+    .map_err(|err| CommandError::runtime("record-open-state-render-failed", err))?;
+
+    let initial_dashboard = record_initial_dashboard(args.profile, &plan_title, None);
+
+    let preview = json!({
+        "issue_body_markdown": initial_dashboard,
+        "comments": {
+            "source": source_body,
+            "plan": plan_body,
+            "state": state_body,
+        },
+        "plan_title": plan_title,
+        "source_path": path_text(&bundle.source_file),
+        "plan_path": path_text(&bundle.plan_file),
+        "source_commit": source_snapshot.commit,
+        "plan_commit": plan_snapshot.commit,
+    });
+
+    if binary != BinaryFlavor::PlanIssue || dry_run {
+        return Ok(json!({
+            "operation": "record.open",
+            "execution_mode": binary.execution_mode(),
+            "dry_run": true,
+            "mode": "dry-run",
+            "preview": preview,
+        }));
+    }
+
+    // Live mode.
+    let repo = resolve_repo_for_live(binary, repo_override)?;
+    let adapter = GhCliAdapter::new(force);
+
+    let body_path = write_temp_markdown("record-open-body", &initial_dashboard)
+        .map_err(|err| CommandError::runtime("record-open-body-write-failed", err))?;
+    let (issue_number, issue_url) = adapter
+        .create_issue(&repo, &plan_title, &body_path, &[])
+        .map_err(|err| CommandError::runtime("record-open-issue-create-failed", err))?;
+
+    let source_path = write_temp_markdown("record-open-source-comment", &source_body)
+        .map_err(|err| CommandError::runtime("record-open-source-write-failed", err))?;
+    let source_url = adapter
+        .comment_issue(&repo, issue_number, &source_path)
+        .map_err(|err| CommandError::runtime("record-open-source-post-failed", err))?;
+    let plan_path = write_temp_markdown("record-open-plan-comment", &plan_body)
+        .map_err(|err| CommandError::runtime("record-open-plan-write-failed", err))?;
+    let plan_url = adapter
+        .comment_issue(&repo, issue_number, &plan_path)
+        .map_err(|err| CommandError::runtime("record-open-plan-post-failed", err))?;
+    let state_path = write_temp_markdown("record-open-state-comment", &state_body)
+        .map_err(|err| CommandError::runtime("record-open-state-write-failed", err))?;
+    let state_url = adapter
+        .comment_issue(&repo, issue_number, &state_path)
+        .map_err(|err| CommandError::runtime("record-open-state-post-failed", err))?;
+
+    // Repair dashboard with freshly-created comment URLs through audit.
+    let (body_after, comments_json) = adapter
+        .issue_evidence(&repo, issue_number)
+        .map_err(|err| CommandError::runtime("record-open-evidence-read-failed", err))?;
+    let audit =
+        lifecycle_record::audit_record(Some(&body_after), &comments_json, Some(args.profile))
+            .map_err(|err| CommandError::runtime("record-open-audit-failed", err))?;
+    let repaired =
+        lifecycle_record::render_dashboard_from_audit(&audit, Some(&plan_title), Some(&issue_url));
+    let repaired_path = write_temp_markdown("record-open-dashboard", &repaired)
+        .map_err(|err| CommandError::runtime("record-open-dashboard-write-failed", err))?;
+    adapter
+        .edit_issue_body(&repo, issue_number, &repaired_path)
+        .map_err(|err| CommandError::runtime("record-open-dashboard-edit-failed", err))?;
+
+    Ok(json!({
+        "operation": "record.open",
+        "execution_mode": binary.execution_mode(),
+        "dry_run": false,
+        "mode": "live",
+        "issue": {"number": issue_number, "url": issue_url},
+        "comments": {"source": source_url, "plan": plan_url, "state": state_url},
+        "dashboard_markdown": repaired,
+    }))
+}
+
+fn run_record_post(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    force: bool,
+    repo_override: Option<&str>,
+    args: &RecordPostArgs,
+) -> Result<Value, CommandError> {
+    match args.kind {
+        crate::commands::record::LifecycleCommentKind::Source
+        | crate::commands::record::LifecycleCommentKind::Plan => {
+            return Err(CommandError::usage(
+                "record-post-kind-not-allowed",
+                format!(
+                    "`record post --kind {}` is rejected; source/plan are owned by `record open`",
+                    args.kind.as_str()
+                ),
+            ));
+        }
+        crate::commands::record::LifecycleCommentKind::Closeout => {
+            return Err(CommandError::usage(
+                "record-post-closeout-not-allowed",
+                "`record post --kind closeout` is rejected; use `plan-issue record close` which posts the closeout comment after the strict gate passes",
+            ));
+        }
+        _ => {}
+    }
+
+    let payload_data = match &args.payload_file {
+        Some(path) => read_payload_data(path)?,
+        None => Value::Null,
+    };
+    let summary = match &args.summary_file {
+        Some(path) => Some(read_text_file(path, "record-post-summary-read-failed")?),
+        None => None,
+    };
+    let body = lifecycle_record::render_record_post_comment(
+        args.profile,
+        args.kind,
+        payload_data,
+        summary.as_deref(),
+        None,
+    )
+    .map_err(|err| CommandError::runtime("record-post-render-failed", err))?;
+
+    // Fixture mode: just return the rendered body + simulated URL.
+    if let Some(fixture_dir) = &args.fixture {
+        let _ = fixture_dir;
+        return Ok(json!({
+            "operation": "record.post",
+            "execution_mode": binary.execution_mode(),
+            "dry_run": true,
+            "mode": "fixture",
+            "issue": args.issue,
+            "kind": args.kind.as_str(),
+            "comment_body": body,
+            "comment_url": null,
+        }));
+    }
+
+    if binary != BinaryFlavor::PlanIssue || dry_run {
+        return Ok(json!({
+            "operation": "record.post",
+            "execution_mode": binary.execution_mode(),
+            "dry_run": true,
+            "mode": "dry-run",
+            "issue": args.issue,
+            "kind": args.kind.as_str(),
+            "comment_body": body,
+        }));
+    }
+
+    let repo = resolve_repo_for_live(binary, repo_override)?;
+    let issue_number = parse_issue_reference(&args.issue)?;
+    let adapter = GhCliAdapter::new(force);
+    let comment_path = write_temp_markdown("record-post-comment", &body)
+        .map_err(|err| CommandError::runtime("record-post-comment-write-failed", err))?;
+    let url = adapter
+        .comment_issue(&repo, issue_number, &comment_path)
+        .map_err(|err| CommandError::runtime("record-post-comment-post-failed", err))?;
+
+    Ok(json!({
+        "operation": "record.post",
+        "execution_mode": binary.execution_mode(),
+        "dry_run": false,
+        "mode": "live",
+        "issue": args.issue,
+        "kind": args.kind.as_str(),
+        "comment_url": url,
+    }))
+}
+
+fn run_record_repair_dashboard(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    force: bool,
+    repo_override: Option<&str>,
+    args: &RecordRepairDashboardArgs,
+) -> Result<Value, CommandError> {
+    let (body, comments_json, issue_number, repo, issue_url) = if let Some(fixture_dir) =
+        &args.fixture
+    {
+        let (body, comments) = read_fixture_evidence(fixture_dir)?;
+        (body, comments, None, None, None)
+    } else if let (Some(body_file), Some(comments_path)) = (&args.body_file, &args.comments_json) {
+        let body = read_text_file(body_file, "record-repair-body-read-failed")?;
+        let comments = read_text_file(comments_path, "record-repair-comments-read-failed")?;
+        (body, comments, None, None, None)
+    } else {
+        let issue_value = args.issue.as_deref().ok_or_else(|| {
+                CommandError::usage(
+                    "record-repair-missing-issue",
+                    "--issue is required for live record repair-dashboard (or pass --body-file + --comments-json / --fixture)",
+                )
+            })?;
+        ensure_live_binary_for_command(
+            binary,
+            "record repair-dashboard --issue <number>",
+            Some(
+                "plan-issue-local record repair-dashboard --body-file <path> --comments-json <path>",
+            ),
+        )?;
+        let issue_number = parse_issue_reference(issue_value)?;
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        let adapter = GhCliAdapter::new(force);
+        let (body, comments) = adapter
+            .issue_evidence(&repo, issue_number)
+            .map_err(|err| CommandError::runtime("record-repair-evidence-read-failed", err))?;
+        let issue_url = format!("https://github.com/{repo}/issues/{issue_number}");
+        (
+            body,
+            comments,
+            Some(issue_number),
+            Some(repo),
+            Some(issue_url),
+        )
+    };
+
+    let audit = lifecycle_record::audit_record(Some(&body), &comments_json, None)
+        .map_err(|err| CommandError::runtime("record-repair-audit-failed", err))?;
+    let dashboard =
+        lifecycle_record::render_dashboard_from_audit(&audit, None, issue_url.as_deref());
+
+    if let Some(out) = &args.out {
+        render::write_rendered(out, &dashboard)
+            .map_err(|err| CommandError::runtime("record-repair-out-write-failed", err))?;
+        return Ok(json!({
+            "operation": "record.repair-dashboard",
+            "execution_mode": binary.execution_mode(),
+            "dry_run": true,
+            "mode": "local",
+            "out_path": path_text(out),
+            "dashboard_markdown": dashboard,
+        }));
+    }
+
+    if dry_run || issue_number.is_none() {
+        return Ok(json!({
+            "operation": "record.repair-dashboard",
+            "execution_mode": binary.execution_mode(),
+            "dry_run": true,
+            "mode": "dry-run",
+            "dashboard_markdown": dashboard,
+        }));
+    }
+
+    let issue_number = issue_number.expect("live mode has issue number");
+    let repo = repo.expect("live mode has repo");
+    let adapter = GhCliAdapter::new(force);
+    let dashboard_path = write_temp_markdown("record-repair-dashboard", &dashboard)
+        .map_err(|err| CommandError::runtime("record-repair-dashboard-write-failed", err))?;
+    adapter
+        .edit_issue_body(&repo, issue_number, &dashboard_path)
+        .map_err(|err| CommandError::runtime("record-repair-edit-failed", err))?;
+
+    Ok(json!({
+        "operation": "record.repair-dashboard",
+        "execution_mode": binary.execution_mode(),
+        "dry_run": false,
+        "mode": "live",
+        "issue": {"number": issue_number, "url": issue_url},
+        "dashboard_markdown": dashboard,
+    }))
+}
+
+fn run_record_close(
+    binary: BinaryFlavor,
+    dry_run: bool,
+    force: bool,
+    repo_override: Option<&str>,
+    args: &RecordCloseArgs,
+) -> Result<Value, CommandError> {
+    let approval_text = args
+        .approval
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            CommandError::usage(
+                "record-close-missing-approval",
+                "--approval is required and must be a non-empty URL or text",
+            )
+        })?;
+
+    // Resolve evidence source.
+    let (body, comments_json, repo_for_provider, issue_number) = if let Some(fixture_dir) =
+        &args.fixture
+    {
+        let (body, comments) = read_fixture_evidence(fixture_dir)?;
+        let issue_number = parse_issue_reference(&args.issue)?;
+        (body, comments, None, issue_number)
+    } else if let (Some(body_file), Some(comments_path)) = (&args.body_file, &args.comments_json) {
+        let body = read_text_file(body_file, "record-close-body-read-failed")?;
+        let comments = read_text_file(comments_path, "record-close-comments-read-failed")?;
+        let issue_number = parse_issue_reference(&args.issue)?;
+        (body, comments, None, issue_number)
+    } else {
+        ensure_live_binary_for_command(
+            binary,
+            "record close --issue <number> --linked-pr <ref> --approval <evidence>",
+            Some(
+                "plan-issue-local record close --issue <n> --body-file <path> --comments-json <path> --approval <evidence>",
+            ),
+        )?;
+        let repo = resolve_repo_for_live(binary, repo_override)?;
+        let issue_number = parse_issue_reference(&args.issue)?;
+        let adapter = GhCliAdapter::new(force);
+        let (body, comments) = adapter
+            .issue_evidence(&repo, issue_number)
+            .map_err(|err| CommandError::runtime("record-close-evidence-read-failed", err))?;
+        (body, comments, Some(repo), issue_number)
+    };
+
+    // Resolve linked PRs through provider/fixture for merge_sha + checks.
+    let mut linked_evidence: Vec<lifecycle_record::LinkedPrEvidence> = Vec::new();
+    for raw in &args.linked_pr {
+        let (pr_repo, pr_number) = parse_linked_pr_reference(raw)?;
+        if let Some(fixture_dir) = &args.fixture {
+            let pr_ev = read_fixture_pr_snapshot(fixture_dir, &pr_repo, pr_number)?;
+            linked_evidence.push(pr_ev);
+        } else if let Some(provider_repo) = &repo_for_provider {
+            let adapter = GhCliAdapter::new(force);
+            let summary = adapter
+                .pr_merge_summary(&pr_repo, pr_number)
+                .map_err(|err| CommandError::runtime("record-close-pr-summary-failed", err))?;
+            let checks = match summary.checks.as_deref() {
+                Some("success") => lifecycle_record::CheckStatus::Pass,
+                Some("failure" | "error") => lifecycle_record::CheckStatus::Fail,
+                _ => lifecycle_record::CheckStatus::None,
+            };
+            linked_evidence.push(lifecycle_record::LinkedPrEvidence {
+                pr_ref: format!("{pr_repo}#{pr_number}"),
+                url: Some(format!("https://github.com/{pr_repo}/pull/{pr_number}")),
+                merge_sha: if summary.merged {
+                    summary.merge_sha
+                } else {
+                    None
+                },
+                checks,
+            });
+            let _ = provider_repo;
+        } else {
+            // body-file/comments-json mode without fixture: cannot resolve PR
+            // state without the provider. Treat as missing merge_sha.
+            linked_evidence.push(lifecycle_record::LinkedPrEvidence {
+                pr_ref: format!("{pr_repo}#{pr_number}"),
+                url: None,
+                merge_sha: None,
+                checks: lifecycle_record::CheckStatus::None,
+            });
+        }
+    }
+
+    let audit = lifecycle_record::audit_record(Some(&body), &comments_json, Some(args.profile))
+        .map_err(|err| CommandError::runtime("record-close-audit-failed", err))?;
+
+    // Compute canonical final dashboard from audit.
+    let issue_url_hint = repo_for_provider
+        .as_ref()
+        .map(|repo| format!("https://github.com/{repo}/issues/{issue_number}"));
+    let canonical_dashboard =
+        lifecycle_record::render_dashboard_from_audit(&audit, None, issue_url_hint.as_deref());
+
+    let gate = lifecycle_record::evaluate_strict_closeout_gate(
+        &audit,
+        lifecycle_record::StrictCloseoutGateInput {
+            profile: args.profile,
+            approval: Some(approval_text),
+            linked_prs: &linked_evidence,
+            // record close repairs the dashboard as part of its own flow
+            // (after posting the closeout comment), so the body-vs-canonical
+            // diff is not a useful pre-flight signal here. The dashboard
+            // failure mode remains available to other callers (e.g. a future
+            // `record audit --strict` surface).
+            current_body: None,
+            expected_dashboard: None,
+        },
+    );
+
+    if !gate.ready {
+        return Err(CommandError::runtime(
+            "record-close-gate-failed",
+            format!(
+                "strict closeout gate blocked: {} ({})",
+                gate.blocked_codes.join(", "),
+                gate.checks
+                    .iter()
+                    .filter(|check| check.status == "fail")
+                    .map(|check| format!("{}: {}", check.check, check.detail))
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            ),
+        ));
+    }
+
+    // Render closeout comment using the same renderer as record post.
+    let closeout_payload = json!({
+        "final_status": "complete",
+        "approval": {"comment_url": approval_text},
+        "linked_prs": linked_evidence
+            .iter()
+            .map(|pr| {
+                json!({
+                    "ref": pr.pr_ref,
+                    "url": pr.url,
+                    "merge_sha": pr.merge_sha,
+                    "checks": match pr.checks {
+                        lifecycle_record::CheckStatus::Pass => "pass",
+                        lifecycle_record::CheckStatus::Fail => "fail",
+                        lifecycle_record::CheckStatus::None => "none",
+                    },
+                })
+            })
+            .collect::<Vec<_>>(),
+        "notes": null,
+    });
+    let closeout_body = lifecycle_record::render_record_post_comment(
+        args.profile,
+        crate::commands::record::LifecycleCommentKind::Closeout,
+        closeout_payload.clone(),
+        Some("Strict closeout gate passed; record closed by `plan-issue record close`."),
+        None,
+    )
+    .map_err(|err| CommandError::runtime("record-close-render-failed", err))?;
+
+    // Bundle preview for dry-run and fixture modes.
+    let preview = json!({
+        "closeout_comment_body": closeout_body,
+        "final_dashboard": canonical_dashboard,
+        "blocked_codes": gate.blocked_codes,
+        "checks": gate.checks,
+    });
+
+    if args.fixture.is_some() || dry_run || binary != BinaryFlavor::PlanIssue {
+        return Ok(json!({
+            "operation": "record.close",
+            "execution_mode": binary.execution_mode(),
+            "dry_run": true,
+            "mode": if args.fixture.is_some() { "fixture" } else { "dry-run" },
+            "issue": {"number": issue_number, "url": issue_url_hint},
+            "linked_prs": linked_evidence,
+            "preview": preview,
+        }));
+    }
+
+    let repo = repo_for_provider.expect("live mode has repo");
+    let adapter = GhCliAdapter::new(force);
+    let closeout_path = write_temp_markdown("record-close-comment", &closeout_body)
+        .map_err(|err| CommandError::runtime("record-close-comment-write-failed", err))?;
+    let closeout_url = adapter
+        .comment_issue(&repo, issue_number, &closeout_path)
+        .map_err(|err| CommandError::runtime("record-close-comment-post-failed", err))?;
+
+    // Re-audit so the final dashboard includes the closeout URL.
+    let (body_after, comments_after) = adapter
+        .issue_evidence(&repo, issue_number)
+        .map_err(|err| CommandError::runtime("record-close-evidence-reread-failed", err))?;
+    let audit_after =
+        lifecycle_record::audit_record(Some(&body_after), &comments_after, Some(args.profile))
+            .map_err(|err| CommandError::runtime("record-close-audit-reread-failed", err))?;
+    let final_dashboard = lifecycle_record::render_dashboard_from_audit(
+        &audit_after,
+        None,
+        Some(&format!("https://github.com/{repo}/issues/{issue_number}")),
+    );
+    let dashboard_path = write_temp_markdown("record-close-dashboard", &final_dashboard)
+        .map_err(|err| CommandError::runtime("record-close-dashboard-write-failed", err))?;
+    adapter
+        .edit_issue_body(&repo, issue_number, &dashboard_path)
+        .map_err(|err| CommandError::runtime("record-close-dashboard-edit-failed", err))?;
+    adapter
+        .close_issue(
+            &repo,
+            issue_number,
+            crate::commands::plan::CloseReason::Completed,
+            None,
+        )
+        .map_err(|err| CommandError::runtime("record-close-issue-close-failed", err))?;
+
+    Ok(json!({
+        "operation": "record.close",
+        "execution_mode": binary.execution_mode(),
+        "dry_run": false,
+        "mode": "live",
+        "issue": {
+            "number": issue_number,
+            "url": format!("https://github.com/{repo}/issues/{issue_number}"),
+        },
+        "closeout_url": closeout_url,
+        "linked_prs": linked_evidence,
+        "final_dashboard": final_dashboard,
+    }))
 }
 
 fn run_record_render_dashboard(args: &RenderDashboardArgs) -> Result<Value, CommandError> {
@@ -3090,8 +4068,25 @@ mod tests {
             unreachable!("edit_issue_body is not needed in this test")
         }
 
-        fn comment_issue(&self, _repo: &str, _issue: u64, _body_file: &Path) -> Result<(), String> {
+        fn comment_issue(
+            &self,
+            _repo: &str,
+            _issue: u64,
+            _body_file: &Path,
+        ) -> Result<String, String> {
             unreachable!("comment_issue is not needed in this test")
+        }
+
+        fn issue_evidence(&self, _repo: &str, _issue: u64) -> Result<(String, String), String> {
+            unreachable!("issue_evidence is not needed in this test")
+        }
+
+        fn pr_merge_summary(
+            &self,
+            _repo: &str,
+            _pr: u64,
+        ) -> Result<crate::github::PrMergeSummary, String> {
+            unreachable!("pr_merge_summary is not needed in this test")
         }
 
         fn edit_issue_labels(

--- a/crates/plan-issue-cli/src/github.rs
+++ b/crates/plan-issue-cli/src/github.rs
@@ -11,6 +11,12 @@ use crate::commands::plan::CloseReason;
 pub trait GitHubAdapter {
     fn issue_body(&self, repo: &str, issue: u64) -> Result<String, String>;
 
+    /// Fetch the issue body plus comments JSON, suitable for `audit_record`
+    /// fixture parsing. Returns `(body, comments_json)` where
+    /// `comments_json` is the raw JSON string from
+    /// `gh issue view --json comments`.
+    fn issue_evidence(&self, repo: &str, issue: u64) -> Result<(String, String), String>;
+
     fn create_issue(
         &self,
         repo: &str,
@@ -21,7 +27,9 @@ pub trait GitHubAdapter {
 
     fn edit_issue_body(&self, repo: &str, issue: u64, body_file: &Path) -> Result<(), String>;
 
-    fn comment_issue(&self, repo: &str, issue: u64, body_file: &Path) -> Result<(), String>;
+    /// Post an issue comment. Returns the URL of the created comment as
+    /// printed by `gh issue comment` on stdout.
+    fn comment_issue(&self, repo: &str, issue: u64, body_file: &Path) -> Result<String, String>;
 
     fn edit_issue_labels(
         &self,
@@ -41,10 +49,26 @@ pub trait GitHubAdapter {
 
     fn pr_is_merged(&self, repo: &str, pr: u64) -> Result<bool, String>;
 
+    /// Provider-verified PR summary used by `record close` strict gating.
+    /// Returns merge state, optional merge commit SHA, and rolled-up check
+    /// status when available.
+    fn pr_merge_summary(&self, repo: &str, pr: u64) -> Result<PrMergeSummary, String>;
+
     /// List the PR's issue-style comments via `gh api`. Returns an array of
     /// objects with at least `body` and `html_url` keys (passed through
     /// from the GitHub REST response). Used by `resolve-approval`.
     fn pr_comments(&self, repo: &str, pr: u64) -> Result<Vec<Value>, String>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrMergeSummary {
+    /// Raw `state` field from the GitHub PR view (`MERGED`, `OPEN`, `CLOSED`).
+    pub state: String,
+    pub merged: bool,
+    pub merge_sha: Option<String>,
+    /// Rolled-up status check state when known
+    /// (`success`, `failure`, `pending`, `error`, ...).
+    pub checks: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -124,6 +148,33 @@ impl GitHubAdapter for GhCliAdapter {
         Ok(body.to_string())
     }
 
+    fn issue_evidence(&self, repo: &str, issue: u64) -> Result<(String, String), String> {
+        let args = vec![
+            "issue".to_string(),
+            "view".to_string(),
+            issue.to_string(),
+            "--repo".to_string(),
+            repo.to_string(),
+            "--json".to_string(),
+            "body,comments".to_string(),
+        ];
+        let stdout = Self::run(&args)?;
+        let json = Self::parse_json(&stdout, "issue view (body+comments)")?;
+        let body = json
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let comments = json
+            .get("comments")
+            .cloned()
+            .unwrap_or(Value::Array(Vec::new()));
+        let envelope = serde_json::json!({ "comments": comments });
+        let comments_json = serde_json::to_string(&envelope)
+            .map_err(|err| format!("failed to serialize issue evidence comments: {err}"))?;
+        Ok((body, comments_json))
+    }
+
     fn create_issue(
         &self,
         repo: &str,
@@ -174,7 +225,7 @@ impl GitHubAdapter for GhCliAdapter {
         Self::run(&args).map(|_| ())
     }
 
-    fn comment_issue(&self, repo: &str, issue: u64, body_file: &Path) -> Result<(), String> {
+    fn comment_issue(&self, repo: &str, issue: u64, body_file: &Path) -> Result<String, String> {
         self.guard_markdown_file(body_file, "github issue comment write rejected")?;
 
         let args = vec![
@@ -186,7 +237,9 @@ impl GitHubAdapter for GhCliAdapter {
             "--body-file".to_string(),
             body_file.to_string_lossy().to_string(),
         ];
-        Self::run(&args).map(|_| ())
+        let stdout = Self::run(&args)?;
+        let url = stdout.lines().last().unwrap_or("").trim().to_string();
+        Ok(url)
     }
 
     fn edit_issue_labels(
@@ -288,6 +341,43 @@ impl GitHubAdapter for GhCliAdapter {
         Ok(merged_at_present || merged_state)
     }
 
+    fn pr_merge_summary(&self, repo: &str, pr: u64) -> Result<PrMergeSummary, String> {
+        let args = vec![
+            "pr".to_string(),
+            "view".to_string(),
+            pr.to_string(),
+            "--repo".to_string(),
+            repo.to_string(),
+            "--json".to_string(),
+            "state,mergeCommit,statusCheckRollup".to_string(),
+        ];
+        let stdout = Self::run(&args)?;
+        let json = Self::parse_json(&stdout, "pr view (merge summary)")?;
+
+        let state = json
+            .get("state")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let merged = state.eq_ignore_ascii_case("merged");
+        let merge_sha = json
+            .get("mergeCommit")
+            .and_then(|value| value.get("oid"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .filter(|sha| !sha.is_empty());
+        let checks = json
+            .get("statusCheckRollup")
+            .and_then(rollup_status)
+            .filter(|status| !status.is_empty());
+        Ok(PrMergeSummary {
+            state,
+            merged,
+            merge_sha,
+            checks,
+        })
+    }
+
     fn pr_comments(&self, repo: &str, pr: u64) -> Result<Vec<Value>, String> {
         // Use `--paginate` so PRs with > 100 comments still return the full
         // list. Endpoint mirrors REST `/repos/{owner}/{repo}/issues/{n}/comments`
@@ -337,6 +427,49 @@ impl GitHubAdapter for GhCliAdapter {
             }
         }
         Ok(combined)
+    }
+}
+
+fn rollup_status(rollup: &Value) -> Option<String> {
+    let extract_state = |item: &Value| -> Option<String> {
+        item.get("state")
+            .and_then(Value::as_str)
+            .map(|status| status.to_ascii_lowercase())
+            .or_else(|| {
+                item.get("conclusion")
+                    .and_then(Value::as_str)
+                    .map(|status| status.to_ascii_lowercase())
+            })
+    };
+
+    match rollup {
+        Value::Array(items) if items.is_empty() => Some("none".to_string()),
+        Value::Array(items) => {
+            let mut has_failure = false;
+            let mut has_pending = false;
+            let mut has_success = false;
+            for item in items {
+                match extract_state(item).as_deref() {
+                    Some("success" | "neutral" | "skipped") => has_success = true,
+                    Some("failure" | "cancelled" | "timed_out" | "action_required" | "error") => {
+                        has_failure = true
+                    }
+                    Some("pending" | "in_progress" | "queued" | "expected") => has_pending = true,
+                    _ => {}
+                }
+            }
+            if has_failure {
+                Some("failure".to_string())
+            } else if has_pending {
+                Some("pending".to_string())
+            } else if has_success {
+                Some("success".to_string())
+            } else {
+                Some("unknown".to_string())
+            }
+        }
+        Value::Object(_) => extract_state(rollup),
+        _ => None,
     }
 }
 

--- a/crates/plan-issue-cli/src/github.rs
+++ b/crates/plan-issue-cli/src/github.rs
@@ -238,8 +238,12 @@ impl GitHubAdapter for GhCliAdapter {
             body_file.to_string_lossy().to_string(),
         ];
         let stdout = Self::run(&args)?;
-        let url = stdout.lines().last().unwrap_or("").trim().to_string();
-        Ok(url)
+        extract_issue_comment_url(&stdout).ok_or_else(|| {
+            format!(
+                "gh issue comment did not print a recognisable comment URL; got: {:?}",
+                stdout.trim()
+            )
+        })
     }
 
     fn edit_issue_labels(
@@ -430,6 +434,46 @@ impl GitHubAdapter for GhCliAdapter {
     }
 }
 
+/// Pick the first line in `stdout` that looks like a GitHub issue/PR
+/// comment URL (`https://github.com/<owner>/<repo>/(issues|pull)/<n>#issuecomment-<m>`).
+/// Returns the trimmed URL or `None` if no line matches.
+///
+/// Used by `GhCliAdapter::comment_issue` so banner / warning lines from `gh`
+/// do not corrupt the returned URL. Address PR-454 specialist review finding
+/// (security/0.80) — `stdout.lines().last()` returned an empty string when
+/// `gh` emitted a trailing newline.
+fn extract_issue_comment_url(stdout: &str) -> Option<String> {
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if is_issue_comment_url(trimmed) {
+            return Some(trimmed.to_string());
+        }
+    }
+    None
+}
+
+fn is_issue_comment_url(value: &str) -> bool {
+    let Some(rest) = value.strip_prefix("https://github.com/") else {
+        return false;
+    };
+    let Some((base, suffix)) = rest.split_once("#issuecomment-") else {
+        return false;
+    };
+    if !suffix.chars().all(|ch| ch.is_ascii_digit()) || suffix.is_empty() {
+        return false;
+    }
+    let mut parts = base.splitn(4, '/');
+    let owner = parts.next().unwrap_or("");
+    let repo = parts.next().unwrap_or("");
+    let kind = parts.next().unwrap_or("");
+    let number = parts.next().unwrap_or("");
+    !owner.is_empty()
+        && !repo.is_empty()
+        && (kind == "issues" || kind == "pull")
+        && number.chars().all(|ch| ch.is_ascii_digit())
+        && !number.is_empty()
+}
+
 fn rollup_status(rollup: &Value) -> Option<String> {
     let extract_state = |item: &Value| -> Option<String> {
         item.get("state")
@@ -548,7 +592,10 @@ fn issue_number_from_url(url: &str) -> Option<u64> {
 mod tests {
     use std::fs;
 
-    use super::{issue_number_from_url, normalize_repo_slug};
+    use super::{
+        extract_issue_comment_url, is_issue_comment_url, issue_number_from_url,
+        normalize_repo_slug, rollup_status,
+    };
     use crate::commands::plan::CloseReason;
     use crate::github::{GhCliAdapter, GitHubAdapter, resolve_repo};
     use nils_test_support::git::{InitRepoOptions, git, init_repo_with};
@@ -588,6 +635,11 @@ case "$cmd $sub" in
   "issue edit")
     ;;
   "issue comment")
+    if [[ -n "${GH_STUB_ISSUE_COMMENT_URL:-}" ]]; then
+      printf '%s\n' "$GH_STUB_ISSUE_COMMENT_URL"
+    else
+      printf '%s\n' 'https://github.com/sympoies/nils-cli/issues/217#issuecomment-1'
+    fi
     ;;
   "issue close")
     ;;
@@ -826,5 +878,124 @@ esac
             err_unparseable.contains("unable to derive owner/repo"),
             "{err_unparseable}"
         );
+    }
+
+    // Sprint 3 PR-454 specialist review follow-ups (testing + security).
+
+    #[test]
+    fn extract_issue_comment_url_picks_recognisable_line_and_rejects_noise() {
+        let url = "https://github.com/sympoies/nils-cli/issues/448#issuecomment-12345";
+        assert_eq!(extract_issue_comment_url(url).as_deref(), Some(url));
+        let with_banner = format!("warning: deprecated\n{url}\n");
+        assert_eq!(
+            extract_issue_comment_url(&with_banner).as_deref(),
+            Some(url)
+        );
+        let pr_url = "https://github.com/sympoies/nils-cli/pull/454#issuecomment-99";
+        assert_eq!(extract_issue_comment_url(pr_url).as_deref(), Some(pr_url));
+
+        assert_eq!(extract_issue_comment_url(""), None);
+        assert_eq!(extract_issue_comment_url("\n\n"), None);
+        assert_eq!(
+            extract_issue_comment_url("https://example.com/owner/repo/issues/1#issuecomment-1"),
+            None
+        );
+        assert_eq!(
+            extract_issue_comment_url("https://github.com/owner/repo/issues/1#comment-1"),
+            None
+        );
+        assert!(!is_issue_comment_url("not a url"));
+    }
+
+    #[test]
+    fn rollup_status_normalizes_array_and_object_shapes() {
+        use serde_json::json;
+        assert_eq!(rollup_status(&json!([])), Some("none".to_string()));
+        assert_eq!(
+            rollup_status(&json!([{"state": "SUCCESS"}, {"state": "success"}])),
+            Some("success".to_string())
+        );
+        assert_eq!(
+            rollup_status(&json!([{"state": "success"}, {"state": "failure"}])),
+            Some("failure".to_string())
+        );
+        assert_eq!(
+            rollup_status(&json!([{"state": "success"}, {"state": "pending"}])),
+            Some("pending".to_string())
+        );
+        assert_eq!(
+            rollup_status(&json!({"state": "success"})),
+            Some("success".to_string())
+        );
+        assert_eq!(
+            rollup_status(&json!({"conclusion": "failure"})),
+            Some("failure".to_string())
+        );
+        assert_eq!(rollup_status(&json!(null)), None);
+    }
+
+    fn gh_pr_merge_summary_stub_script() -> &'static str {
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-}"; sub="${2:-}"
+case "$cmd $sub" in
+  "pr view")
+    if [[ -n "${GH_STUB_PR_VIEW_FULL_JSON:-}" ]]; then
+      printf '%s\n' "$GH_STUB_PR_VIEW_FULL_JSON"
+    else
+      printf '%s\n' '{"state":"MERGED","mergeCommit":{"oid":"abcd"},"statusCheckRollup":{"state":"success"}}'
+    fi
+    ;;
+  *)
+    echo "unsupported gh call: $*" >&2
+    exit 1
+    ;;
+esac
+"#
+    }
+
+    #[test]
+    fn gh_adapter_pr_merge_summary_parses_state_merge_sha_and_checks() {
+        let lock = GlobalStateLock::new();
+        let stubs = StubBinDir::new();
+        stubs.write_exe("gh", gh_pr_merge_summary_stub_script());
+        let _path = prepend_path(&lock, stubs.path());
+
+        let adapter = GhCliAdapter::new(false);
+        let summary = adapter
+            .pr_merge_summary("sympoies/nils-cli", 454)
+            .expect("merge summary");
+        assert_eq!(summary.state, "MERGED");
+        assert!(summary.merged);
+        assert_eq!(summary.merge_sha.as_deref(), Some("abcd"));
+        assert_eq!(summary.checks.as_deref(), Some("success"));
+
+        let _open = EnvGuard::set(
+            &lock,
+            "GH_STUB_PR_VIEW_FULL_JSON",
+            r#"{"state":"OPEN","mergeCommit":null,"statusCheckRollup":{"state":"pending"}}"#,
+        );
+        let summary_open = adapter
+            .pr_merge_summary("sympoies/nils-cli", 454)
+            .expect("open pr summary");
+        assert!(!summary_open.merged);
+        assert!(summary_open.merge_sha.is_none());
+        assert_eq!(summary_open.checks.as_deref(), Some("pending"));
+        drop(_open);
+
+        let _empty = EnvGuard::set(
+            &lock,
+            "GH_STUB_PR_VIEW_FULL_JSON",
+            r#"{"state":"MERGED","mergeCommit":{"oid":""},"statusCheckRollup":[]}"#,
+        );
+        let summary_empty = adapter
+            .pr_merge_summary("sympoies/nils-cli", 454)
+            .expect("empty rollup summary");
+        assert!(summary_empty.merged);
+        assert!(
+            summary_empty.merge_sha.is_none(),
+            "empty oid should be filtered out"
+        );
+        assert_eq!(summary_empty.checks.as_deref(), Some("none"));
     }
 }

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -1543,8 +1543,9 @@ pub fn render_record_post_comment(
 // Strict closeout gate (Sprint 3)
 //
 // Sprint 3 introduces `evaluate_strict_closeout_gate` for `record close`. It
-// supersedes the v1 `evaluate_closeout_gate` which is retained for the legacy
-// `record closeout-gate` subcommand until Sprint 4 retires that surface.
+// supersedes the v1 `evaluate_closeout_gate`, which is retained as a
+// transitional helper for the `record closeout-gate` subcommand until
+// Sprint 4 retires that surface.
 // -----------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -1396,3 +1396,803 @@ impl RecordPayload {
             .map_err(|err| PayloadError::new(PayloadErrorKind::InvalidJson, err.to_string()))
     }
 }
+
+// -----------------------------------------------------------------------------
+// v2 provider-backed renderers (Sprint 3)
+//
+// `render_record_snapshot_comment` and `render_record_post_comment` produce the
+// canonical Markdown body for `record open` and `record post`: every comment
+// carries the v2 marker on its first line plus a single
+// `plan-issue-record-payload` JSON fence as the structured source of truth.
+// -----------------------------------------------------------------------------
+
+fn payload_role_for_kind(kind: LifecycleCommentKind) -> PayloadRole {
+    match kind {
+        LifecycleCommentKind::Source => PayloadRole::Source,
+        LifecycleCommentKind::Plan => PayloadRole::Plan,
+        LifecycleCommentKind::State => PayloadRole::State,
+        LifecycleCommentKind::Session => PayloadRole::Session,
+        LifecycleCommentKind::Validation => PayloadRole::Validation,
+        LifecycleCommentKind::Review => PayloadRole::Review,
+        LifecycleCommentKind::Closeout => PayloadRole::Closeout,
+    }
+}
+
+fn render_payload_fence(envelope: &RecordPayload) -> Result<String, String> {
+    serde_json::to_string_pretty(envelope).map_err(|err| err.to_string())
+}
+
+/// Render the canonical v2 source/plan snapshot comment used by
+/// `record open`. The body carries the v2 marker, visible details, and a
+/// `plan-issue-record-payload` JSON fence carrying [`SnapshotData`].
+pub fn render_record_snapshot_comment(
+    profile: RecordProfile,
+    kind: LifecycleCommentKind,
+    snapshot: &SnapshotData,
+    content: &str,
+    updated_at: Option<&str>,
+) -> Result<String, String> {
+    if !matches!(
+        kind,
+        LifecycleCommentKind::Source | LifecycleCommentKind::Plan
+    ) {
+        return Err(format!(
+            "render_record_snapshot_comment: expected source or plan kind, got `{}`",
+            kind.as_str()
+        ));
+    }
+
+    let envelope = RecordPayload {
+        schema: PAYLOAD_SCHEMA_V2.to_string(),
+        role: payload_role_for_kind(kind),
+        profile: PayloadProfile::from(profile),
+        updated_at: updated_at.map(str::to_string),
+        data: serde_json::to_value(snapshot).map_err(|err| err.to_string())?,
+    };
+    let envelope_json = render_payload_fence(&envelope)?;
+
+    let marker = marker_for(profile, kind);
+    let heading = default_heading(profile, kind);
+    let details_summary = default_details_summary(kind);
+
+    let mut out = Vec::new();
+    out.push(marker);
+    out.push(String::new());
+    out.push(format!("## {heading}"));
+    out.push(String::new());
+    out.push(format!("- Profile: {}", profile.as_str()));
+    if !snapshot.path.trim().is_empty() {
+        out.push(format!("- Path: `{}`", snapshot.path.trim()));
+    }
+    if !snapshot.commit.trim().is_empty() {
+        out.push(format!("- Commit: `{}`", snapshot.commit.trim()));
+    }
+    if let Some(summary) = snapshot
+        .summary
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        out.push(format!("- Summary: {summary}"));
+    }
+    out.push("- Snapshot mode: local committed Markdown".to_string());
+    out.push(String::new());
+    out.push("<details>".to_string());
+    out.push(format!("<summary>{details_summary}</summary>"));
+    out.push(String::new());
+    out.push(content.to_string());
+    out.push(String::new());
+    out.push("</details>".to_string());
+    out.push(String::new());
+    out.push(format!("```{PAYLOAD_FENCE_INFO}"));
+    out.push(envelope_json);
+    out.push("```".to_string());
+    Ok(finalize_markdown(out))
+}
+
+/// Render the canonical v2 lifecycle comment used by `record post` for
+/// state, session, validation, review, and closeout kinds. Source/plan
+/// kinds are rejected because `record open` owns them.
+pub fn render_record_post_comment(
+    profile: RecordProfile,
+    kind: LifecycleCommentKind,
+    payload_data: Value,
+    summary: Option<&str>,
+    updated_at: Option<&str>,
+) -> Result<String, String> {
+    if matches!(
+        kind,
+        LifecycleCommentKind::Source | LifecycleCommentKind::Plan
+    ) {
+        return Err(format!(
+            "render_record_post_comment: source/plan kinds are owned by `record open`, got `{}`",
+            kind.as_str()
+        ));
+    }
+
+    let envelope = RecordPayload {
+        schema: PAYLOAD_SCHEMA_V2.to_string(),
+        role: payload_role_for_kind(kind),
+        profile: PayloadProfile::from(profile),
+        updated_at: updated_at.map(str::to_string),
+        data: payload_data,
+    };
+    let envelope_json = render_payload_fence(&envelope)?;
+
+    let marker = marker_for(profile, kind);
+    let heading = default_heading(profile, kind);
+
+    let mut out = Vec::new();
+    out.push(marker);
+    out.push(String::new());
+    out.push(format!("## {heading}"));
+    out.push(String::new());
+    out.push(format!("- Profile: {}", profile.as_str()));
+    if let Some(text) = summary.map(str::trim).filter(|value| !value.is_empty()) {
+        out.push(String::new());
+        out.push(text.to_string());
+    }
+    out.push(String::new());
+    out.push(format!("```{PAYLOAD_FENCE_INFO}"));
+    out.push(envelope_json);
+    out.push("```".to_string());
+    Ok(finalize_markdown(out))
+}
+
+// -----------------------------------------------------------------------------
+// Strict closeout gate (Sprint 3)
+//
+// Sprint 3 introduces `evaluate_strict_closeout_gate` for `record close`. It
+// supersedes the v1 `evaluate_closeout_gate` which is retained for the legacy
+// `record closeout-gate` subcommand until Sprint 4 retires that surface.
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StrictCloseoutGateResult {
+    pub ready: bool,
+    pub checks: Vec<CloseoutCheck>,
+    /// Stable machine-readable codes for blocked items, one per failure.
+    pub blocked_codes: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StrictCloseoutGateInput<'a> {
+    pub profile: RecordProfile,
+    pub approval: Option<&'a str>,
+    /// Provider-verified linked PR evidence. Each entry must carry a
+    /// `merge_sha`; missing merge_sha is treated as `linked-pr-not-merged`.
+    pub linked_prs: &'a [LinkedPrEvidence],
+    /// Current issue body. When paired with `expected_dashboard`, the gate
+    /// fails with `dashboard-out-of-date` if the recomputed dashboard does
+    /// not appear in the body.
+    pub current_body: Option<&'a str>,
+    pub expected_dashboard: Option<&'a str>,
+}
+
+pub fn evaluate_strict_closeout_gate(
+    audit: &RecordAudit,
+    input: StrictCloseoutGateInput<'_>,
+) -> StrictCloseoutGateResult {
+    let mut checks = Vec::new();
+    let mut blocked_codes: Vec<String> = Vec::new();
+
+    let push_pass = |checks: &mut Vec<CloseoutCheck>, check: &str, detail: String| {
+        checks.push(CloseoutCheck {
+            check: check.to_string(),
+            status: "pass".to_string(),
+            detail,
+        });
+    };
+    let push_fail = |checks: &mut Vec<CloseoutCheck>,
+                     blocked: &mut Vec<String>,
+                     check: &str,
+                     detail: String,
+                     code: &str| {
+        checks.push(CloseoutCheck {
+            check: check.to_string(),
+            status: "fail".to_string(),
+            detail,
+        });
+        blocked.push(code.to_string());
+    };
+
+    for (role, label, code) in [
+        ("source", "source snapshot", "source-missing"),
+        ("plan", "plan snapshot", "plan-missing"),
+    ] {
+        if audit.evidence.contains_key(role) {
+            push_pass(&mut checks, label, "present".to_string());
+        } else {
+            push_fail(
+                &mut checks,
+                &mut blocked_codes,
+                label,
+                "missing".to_string(),
+                code,
+            );
+        }
+    }
+
+    match audit.evidence.get("state") {
+        Some(hit) => {
+            let status = hit.status.as_deref();
+            let parsed = hit
+                .payload
+                .as_ref()
+                .and_then(|payload| payload.parse_state().ok());
+            match status {
+                Some(value) if value.eq_ignore_ascii_case("complete") => {
+                    let tasks_incomplete = parsed
+                        .as_ref()
+                        .map(|data| {
+                            data.tasks.iter().any(|task| {
+                                !matches!(
+                                    task.status,
+                                    TaskRowStatus::Done | TaskRowStatus::Deferred
+                                )
+                            })
+                        })
+                        .unwrap_or(false);
+                    if tasks_incomplete {
+                        push_fail(
+                            &mut checks,
+                            &mut blocked_codes,
+                            "execution state",
+                            "complete but tasks are not all done/deferred".to_string(),
+                            "state-tasks-incomplete",
+                        );
+                    } else {
+                        push_pass(&mut checks, "execution state", "complete".to_string());
+                    }
+                }
+                Some(value) => push_fail(
+                    &mut checks,
+                    &mut blocked_codes,
+                    "execution state",
+                    format!("latest state status is `{value}`"),
+                    "state-not-complete",
+                ),
+                None => push_fail(
+                    &mut checks,
+                    &mut blocked_codes,
+                    "execution state",
+                    "missing payload status".to_string(),
+                    "state-not-complete",
+                ),
+            }
+        }
+        None => push_fail(
+            &mut checks,
+            &mut blocked_codes,
+            "execution state",
+            "missing".to_string(),
+            "state-missing",
+        ),
+    }
+
+    match audit.evidence.get("validation") {
+        Some(hit) => match hit.status.as_deref() {
+            Some("pass") => push_pass(&mut checks, "validation", "pass".to_string()),
+            Some(value) => push_fail(
+                &mut checks,
+                &mut blocked_codes,
+                "validation",
+                format!("latest validation overall = `{value}`"),
+                "validation-failed",
+            ),
+            None => push_fail(
+                &mut checks,
+                &mut blocked_codes,
+                "validation",
+                "missing payload status".to_string(),
+                "validation-failed",
+            ),
+        },
+        None => push_fail(
+            &mut checks,
+            &mut blocked_codes,
+            "validation",
+            "missing".to_string(),
+            "validation-missing",
+        ),
+    }
+
+    match audit.evidence.get("review") {
+        Some(hit) => {
+            let parsed = hit.payload.as_ref().map(|payload| payload.parse_review());
+            match parsed {
+                Some(Ok(data)) => match data.decision {
+                    ReviewDecision::RequestChanges => push_fail(
+                        &mut checks,
+                        &mut blocked_codes,
+                        "review",
+                        "decision = request-changes".to_string(),
+                        "review-rejected",
+                    ),
+                    decision => {
+                        let unresolved = data.findings.iter().any(|finding| {
+                            matches!(finding.disposition, FindingDisposition::Residual)
+                                && matches!(
+                                    finding.severity,
+                                    FindingSeverity::Blocker | FindingSeverity::Major
+                                )
+                        });
+                        if unresolved {
+                            push_fail(
+                                &mut checks,
+                                &mut blocked_codes,
+                                "review",
+                                "unresolved blocker/major findings".to_string(),
+                                "review-unresolved-findings",
+                            );
+                        } else {
+                            let label = match decision {
+                                ReviewDecision::Approve => "approve",
+                                ReviewDecision::CommentsOnly => "comments-only",
+                                ReviewDecision::RequestChanges => unreachable!(),
+                            };
+                            push_pass(&mut checks, "review", format!("decision = {label}"));
+                        }
+                    }
+                },
+                Some(Err(err)) => push_fail(
+                    &mut checks,
+                    &mut blocked_codes,
+                    "review",
+                    format!("malformed review payload: {}", err.message),
+                    "review-rejected",
+                ),
+                None => push_fail(
+                    &mut checks,
+                    &mut blocked_codes,
+                    "review",
+                    "missing payload".to_string(),
+                    "review-missing",
+                ),
+            }
+        }
+        None => push_fail(
+            &mut checks,
+            &mut blocked_codes,
+            "review",
+            "missing".to_string(),
+            "review-missing",
+        ),
+    }
+
+    let approval_text = input.approval.unwrap_or("").trim();
+    if approval_text.is_empty() {
+        push_fail(
+            &mut checks,
+            &mut blocked_codes,
+            "close approval",
+            "missing explicit approval".to_string(),
+            "approval-missing",
+        );
+    } else {
+        push_pass(&mut checks, "close approval", approval_text.to_string());
+    }
+
+    if input.linked_prs.is_empty() {
+        push_pass(&mut checks, "linked PRs", "none provided".to_string());
+    } else {
+        let mut failing = Vec::new();
+        for pr in input.linked_prs {
+            let sha = pr.merge_sha.as_deref().map(str::trim).unwrap_or("");
+            if sha.is_empty() {
+                failing.push(format!("{} (no merge_sha)", pr.pr_ref));
+            } else if !matches!(pr.checks, CheckStatus::Pass | CheckStatus::None) {
+                failing.push(format!("{} (checks={:?})", pr.pr_ref, pr.checks));
+            }
+        }
+        if failing.is_empty() {
+            push_pass(
+                &mut checks,
+                "linked PRs",
+                format!("{} merged", input.linked_prs.len()),
+            );
+        } else {
+            push_fail(
+                &mut checks,
+                &mut blocked_codes,
+                "linked PRs",
+                failing.join(", "),
+                "linked-pr-not-merged",
+            );
+        }
+    }
+
+    if let (Some(current), Some(expected)) = (input.current_body, input.expected_dashboard) {
+        let current_norm = normalize_for_dashboard_compare(current);
+        let expected_norm = normalize_for_dashboard_compare(expected);
+        if current_norm.contains(&expected_norm) {
+            push_pass(&mut checks, "dashboard", "matches canonical".to_string());
+        } else {
+            push_fail(
+                &mut checks,
+                &mut blocked_codes,
+                "dashboard",
+                "dashboard differs from recomputed canonical".to_string(),
+                "dashboard-out-of-date",
+            );
+        }
+    }
+
+    let ready = checks.iter().all(|check| check.status == "pass");
+    StrictCloseoutGateResult {
+        ready,
+        checks,
+        blocked_codes,
+    }
+}
+
+fn normalize_for_dashboard_compare(text: &str) -> String {
+    text.lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod sprint3_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn build_audit_with_evidence(comments: Vec<(serde_json::Value, &str)>) -> RecordAudit {
+        let payload = json!({
+            "comments": comments
+                .into_iter()
+                .map(|(body, url)| json!({"body": body, "url": url, "created_at": "2026-05-23T08:00:00Z"}))
+                .collect::<Vec<_>>()
+        });
+        audit_record(None, &payload.to_string(), None).expect("audit ok")
+    }
+
+    fn v2_body(role: &str, data: Value) -> Value {
+        let envelope = json!({
+            "schema": PAYLOAD_SCHEMA_V2,
+            "role": role,
+            "profile": "tracking",
+            "data": data,
+        });
+        let payload_json = serde_json::to_string(&envelope).expect("serialize");
+        json!(format!(
+            "<!-- plan-issue-record:v2 role={role} profile=tracking -->\n\n```{PAYLOAD_FENCE_INFO}\n{payload_json}\n```\n",
+        ))
+    }
+
+    #[test]
+    fn audit_treats_v2_marker_without_payload_fence_as_payload_none() {
+        // Reproduces [F11] deferred follow-up: v2 marker with no payload
+        // fence should leave evidence.payload = None instead of erroring.
+        let body_only_marker = json!(
+            "<!-- plan-issue-record:v2 role=session profile=tracking -->\n\n## Execution Session\n\nfreeform notes, no payload\n"
+        );
+        let audit = build_audit_with_evidence(vec![(
+            body_only_marker,
+            "https://github.com/owner/repo/issues/1#issuecomment-session",
+        )]);
+        let session = audit
+            .evidence
+            .get("session")
+            .expect("session evidence registered");
+        assert!(session.payload.is_none(), "payload should be None");
+        assert_eq!(audit.recognized_count, 1);
+    }
+
+    #[test]
+    fn audit_strict_fails_on_malformed_payload() {
+        // [F11] deferred: malformed payload fence must error rather than
+        // silently degrade to payload=None.
+        let body = json!(
+            "<!-- plan-issue-record:v2 role=state profile=tracking -->\n\n```plan-issue-record-payload\n{not valid json\n```\n"
+        );
+        let payload = json!({
+            "comments": [{
+                "body": body,
+                "url": "https://github.com/owner/repo/issues/1#issuecomment-bad",
+                "created_at": "2026-05-23T08:00:00Z",
+            }]
+        });
+        let err = audit_record(None, &payload.to_string(), None)
+            .expect_err("malformed payload should fail audit");
+        assert!(
+            err.contains("malformed payload"),
+            "error should mention malformed payload: {err}"
+        );
+    }
+
+    #[test]
+    fn strict_gate_passes_when_all_v2_evidence_complete_and_merged() {
+        let state = v2_body(
+            "state",
+            json!({
+                "status": "complete",
+                "target_scope": "scope",
+                "tasks": [
+                    {"id": "1.1", "status": "done", "title": "x"},
+                    {"id": "1.2", "status": "deferred", "title": "y"},
+                ],
+                "prs": [{"ref": "owner/repo#1", "url": "u", "status": "merged"}],
+                "blockers": [],
+                "links": {},
+            }),
+        );
+        let validation = v2_body(
+            "validation",
+            json!({"overall": "pass", "commands": [], "waivers": []}),
+        );
+        let review = v2_body(
+            "review",
+            json!({
+                "decision": "approve",
+                "lenses": ["testing"],
+                "findings": [],
+            }),
+        );
+        let source = v2_body("source", json!({"path": "p", "commit": "c"}));
+        let plan = v2_body("plan", json!({"path": "p", "commit": "c"}));
+        let audit = build_audit_with_evidence(vec![
+            (source, "u-src"),
+            (plan, "u-plan"),
+            (state, "u-state"),
+            (validation, "u-val"),
+            (review, "u-rev"),
+        ]);
+
+        let linked_prs = vec![LinkedPrEvidence {
+            pr_ref: "owner/repo#1".to_string(),
+            url: Some("https://github.com/owner/repo/pull/1".to_string()),
+            merge_sha: Some("abcdef1234567890".to_string()),
+            checks: CheckStatus::Pass,
+        }];
+        let result = evaluate_strict_closeout_gate(
+            &audit,
+            StrictCloseoutGateInput {
+                profile: RecordProfile::Tracking,
+                approval: Some("https://github.com/owner/repo/issues/1#issuecomment-9"),
+                linked_prs: &linked_prs,
+                current_body: None,
+                expected_dashboard: None,
+            },
+        );
+        assert!(result.ready, "gate should pass: {:?}", result.checks);
+        assert!(result.blocked_codes.is_empty());
+    }
+
+    #[test]
+    fn strict_gate_blocks_when_state_not_complete() {
+        let state = v2_body(
+            "state",
+            json!({"status": "in-progress", "target_scope": "s", "tasks": [], "prs": [], "blockers": [], "links": {}}),
+        );
+        let source = v2_body("source", json!({"path": "p", "commit": "c"}));
+        let plan = v2_body("plan", json!({"path": "p", "commit": "c"}));
+        let validation = v2_body("validation", json!({"overall": "pass"}));
+        let review = v2_body("review", json!({"decision": "approve"}));
+        let audit = build_audit_with_evidence(vec![
+            (source, "a"),
+            (plan, "b"),
+            (state, "c"),
+            (validation, "d"),
+            (review, "e"),
+        ]);
+        let result = evaluate_strict_closeout_gate(
+            &audit,
+            StrictCloseoutGateInput {
+                profile: RecordProfile::Tracking,
+                approval: Some("ok"),
+                linked_prs: &[],
+                current_body: None,
+                expected_dashboard: None,
+            },
+        );
+        assert!(!result.ready);
+        assert!(
+            result
+                .blocked_codes
+                .iter()
+                .any(|c| c == "state-not-complete"),
+            "{:?}",
+            result.blocked_codes
+        );
+    }
+
+    #[test]
+    fn strict_gate_blocks_when_review_rejected_or_unresolved() {
+        let source = v2_body("source", json!({"path": "p", "commit": "c"}));
+        let plan = v2_body("plan", json!({"path": "p", "commit": "c"}));
+        let state = v2_body(
+            "state",
+            json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
+        );
+        let validation = v2_body("validation", json!({"overall": "pass"}));
+        let review_rejected = v2_body("review", json!({"decision": "request-changes"}));
+        let audit_rej = build_audit_with_evidence(vec![
+            (source.clone(), "a"),
+            (plan.clone(), "b"),
+            (state.clone(), "c"),
+            (validation.clone(), "d"),
+            (review_rejected, "e"),
+        ]);
+        let res_rej = evaluate_strict_closeout_gate(
+            &audit_rej,
+            StrictCloseoutGateInput {
+                profile: RecordProfile::Tracking,
+                approval: Some("ok"),
+                linked_prs: &[],
+                current_body: None,
+                expected_dashboard: None,
+            },
+        );
+        assert!(res_rej.blocked_codes.iter().any(|c| c == "review-rejected"));
+
+        let review_unresolved = v2_body(
+            "review",
+            json!({
+                "decision": "approve",
+                "findings": [
+                    {"id": "F1", "severity": "blocker", "disposition": "residual", "summary": "x"}
+                ]
+            }),
+        );
+        let audit_un = build_audit_with_evidence(vec![
+            (source, "a"),
+            (plan, "b"),
+            (state, "c"),
+            (validation, "d"),
+            (review_unresolved, "e"),
+        ]);
+        let res_un = evaluate_strict_closeout_gate(
+            &audit_un,
+            StrictCloseoutGateInput {
+                profile: RecordProfile::Tracking,
+                approval: Some("ok"),
+                linked_prs: &[],
+                current_body: None,
+                expected_dashboard: None,
+            },
+        );
+        assert!(
+            res_un
+                .blocked_codes
+                .iter()
+                .any(|c| c == "review-unresolved-findings")
+        );
+    }
+
+    #[test]
+    fn strict_gate_blocks_when_linked_pr_missing_merge_sha() {
+        let source = v2_body("source", json!({"path": "p", "commit": "c"}));
+        let plan = v2_body("plan", json!({"path": "p", "commit": "c"}));
+        let state = v2_body(
+            "state",
+            json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
+        );
+        let validation = v2_body("validation", json!({"overall": "pass"}));
+        let review = v2_body("review", json!({"decision": "approve"}));
+        let audit = build_audit_with_evidence(vec![
+            (source, "a"),
+            (plan, "b"),
+            (state, "c"),
+            (validation, "d"),
+            (review, "e"),
+        ]);
+        let linked = vec![LinkedPrEvidence {
+            pr_ref: "owner/repo#1".to_string(),
+            url: None,
+            merge_sha: None,
+            checks: CheckStatus::Pass,
+        }];
+        let res = evaluate_strict_closeout_gate(
+            &audit,
+            StrictCloseoutGateInput {
+                profile: RecordProfile::Tracking,
+                approval: Some("ok"),
+                linked_prs: &linked,
+                current_body: None,
+                expected_dashboard: None,
+            },
+        );
+        assert!(
+            res.blocked_codes
+                .iter()
+                .any(|c| c == "linked-pr-not-merged")
+        );
+    }
+
+    #[test]
+    fn strict_gate_blocks_when_approval_empty() {
+        let source = v2_body("source", json!({"path": "p", "commit": "c"}));
+        let plan = v2_body("plan", json!({"path": "p", "commit": "c"}));
+        let state = v2_body(
+            "state",
+            json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
+        );
+        let validation = v2_body("validation", json!({"overall": "pass"}));
+        let review = v2_body("review", json!({"decision": "approve"}));
+        let audit = build_audit_with_evidence(vec![
+            (source, "a"),
+            (plan, "b"),
+            (state, "c"),
+            (validation, "d"),
+            (review, "e"),
+        ]);
+        let res = evaluate_strict_closeout_gate(
+            &audit,
+            StrictCloseoutGateInput {
+                profile: RecordProfile::Tracking,
+                approval: Some("   "),
+                linked_prs: &[],
+                current_body: None,
+                expected_dashboard: None,
+            },
+        );
+        assert!(res.blocked_codes.iter().any(|c| c == "approval-missing"));
+    }
+
+    #[test]
+    fn render_record_post_comment_emits_marker_and_payload_fence() {
+        let body = render_record_post_comment(
+            RecordProfile::Tracking,
+            LifecycleCommentKind::State,
+            json!({"status": "complete", "tasks": [], "prs": []}),
+            Some("session summary"),
+            Some("2026-05-23T08:42:11Z"),
+        )
+        .expect("render");
+        assert!(
+            body.starts_with("<!-- plan-issue-record:v2 role=state profile=tracking -->"),
+            "{body}"
+        );
+        assert!(body.contains(&format!("```{PAYLOAD_FENCE_INFO}")), "{body}");
+        assert!(
+            body.contains("\"schema\": \"plan-issue-record.payload.v2\""),
+            "{body}"
+        );
+        assert!(body.contains("session summary"), "{body}");
+    }
+
+    #[test]
+    fn render_record_post_comment_rejects_source_or_plan() {
+        let err = render_record_post_comment(
+            RecordProfile::Tracking,
+            LifecycleCommentKind::Source,
+            json!({}),
+            None,
+            None,
+        )
+        .expect_err("must reject source");
+        assert!(err.contains("source"), "{err}");
+    }
+
+    #[test]
+    fn render_record_snapshot_comment_includes_details_and_payload() {
+        let snapshot = SnapshotData {
+            path: "docs/plans/sample/sample-plan.md".to_string(),
+            commit: "abc1234".to_string(),
+            title: Some("Sample Plan".to_string()),
+            summary: Some("One-liner".to_string()),
+        };
+        let body = render_record_snapshot_comment(
+            RecordProfile::Tracking,
+            LifecycleCommentKind::Plan,
+            &snapshot,
+            "# Sample Plan\n\nbody...\n",
+            Some("2026-05-23T08:42:11Z"),
+        )
+        .expect("render");
+        assert!(
+            body.contains("- Path: `docs/plans/sample/sample-plan.md`"),
+            "{body}"
+        );
+        assert!(body.contains("- Commit: `abc1234`"), "{body}");
+        assert!(body.contains("- Summary: One-liner"), "{body}");
+        assert!(body.contains("<details>"), "{body}");
+        assert!(body.contains(&format!("```{PAYLOAD_FENCE_INFO}")), "{body}");
+        assert!(
+            body.contains("\"schema\": \"plan-issue-record.payload.v2\""),
+            "{body}"
+        );
+    }
+}

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -21,6 +21,8 @@ mod lifecycle_record;
 mod link_pr_flow;
 #[path = "integration/live_issue_ops.rs"]
 mod live_issue_ops;
+#[path = "integration/live_record_ops.rs"]
+mod live_record_ops;
 #[path = "integration/live_start_sprint_runtime_truth.rs"]
 mod live_start_sprint_runtime_truth;
 #[path = "integration/output_contract.rs"]

--- a/crates/plan-issue-cli/tests/integration/live_issue_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_issue_ops.rs
@@ -75,6 +75,8 @@ case "$cmd $sub" in
     ;;
   "issue comment")
     capture_comment_file "$@"
+    issue_num="${3:-1}"
+    printf '%s\n' "${PLAN_ISSUE_GH_COMMENT_URL:-https://github.com/sympoies/nils-cli/issues/${issue_num}#issuecomment-1}"
     ;;
   "issue close")
     ;;

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -1,0 +1,685 @@
+use std::fs;
+use std::path::Path;
+
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use nils_test_support::StubBinDir;
+use nils_test_support::cmd::CmdOptions;
+
+use crate::common;
+
+const PAYLOAD_SCHEMA_V2: &str = "plan-issue-record.payload.v2";
+const PAYLOAD_FENCE_INFO: &str = "plan-issue-record-payload";
+
+/// Build a `plan-issue-record:v2` comment body with the payload fence
+/// carrying `data` for the given role/profile.
+fn v2_comment_body(role: &str, profile: &str, data: Value) -> String {
+    let envelope = json!({
+        "schema": PAYLOAD_SCHEMA_V2,
+        "role": role,
+        "profile": profile,
+        "data": data,
+    });
+    let payload = serde_json::to_string(&envelope).expect("payload json");
+    format!(
+        "<!-- plan-issue-record:v2 role={role} profile={profile} -->\n\n```{PAYLOAD_FENCE_INFO}\n{payload}\n```\n",
+    )
+}
+
+fn parse_json(stdout: &str) -> Value {
+    serde_json::from_str(stdout).expect("stdout is valid JSON")
+}
+
+fn write_fixture_files(dir: &Path, body: &str, comments: &Value) {
+    fs::write(dir.join("issue-body.md"), body).expect("write fixture body");
+    fs::write(
+        dir.join("comments.json"),
+        serde_json::to_string(comments).expect("comments json"),
+    )
+    .expect("write fixture comments");
+}
+
+fn write_pr_fixture(dir: &Path, repo: &str, pr: u64, value: Value) {
+    let prs = dir.join("prs");
+    fs::create_dir_all(&prs).expect("create prs dir");
+    let slug = repo.replace('/', "__");
+    fs::write(
+        prs.join(format!("{slug}__{pr}.json")),
+        serde_json::to_string(&value).expect("pr json"),
+    )
+    .expect("write pr fixture");
+}
+
+#[test]
+fn record_post_state_with_payload_file_renders_v2_marker_in_dry_run() {
+    let tmp = TempDir::new().expect("tempdir");
+    let payload = tmp.path().join("state.json");
+    fs::write(
+        &payload,
+        json!({
+            "status": "in-progress",
+            "target_scope": "scope",
+            "tasks": [{"id": "1.1", "status": "done", "title": "x"}],
+            "prs": [],
+            "blockers": [],
+            "links": {}
+        })
+        .to_string(),
+    )
+    .expect("write payload");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--kind",
+        "state",
+        "--payload-file",
+        payload.to_str().expect("payload str"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let result = &parsed["payload"]["result"];
+    assert_eq!(result["operation"], "record.post");
+    assert_eq!(result["kind"], "state");
+    let body = result["comment_body"]
+        .as_str()
+        .expect("comment_body in dry-run");
+    assert!(
+        body.starts_with("<!-- plan-issue-record:v2 role=state profile=tracking -->"),
+        "{body}"
+    );
+    assert!(body.contains(&format!("```{PAYLOAD_FENCE_INFO}")), "{body}");
+    assert!(body.contains("\"target_scope\": \"scope\""), "{body}");
+}
+
+#[test]
+fn record_post_rejects_source_plan_and_closeout_kinds() {
+    for kind in ["source", "plan", "closeout"] {
+        let out = common::run_plan_issue_local(&[
+            "--format", "json", "record", "post", "--issue", "1", "--kind", kind,
+        ]);
+        assert_ne!(out.code, 0, "kind {kind} should be rejected");
+        assert!(
+            out.stderr.contains("record-post-") || out.stdout.contains("record-post-"),
+            "expected record-post error for kind {kind}: stdout={} stderr={}",
+            out.stdout,
+            out.stderr
+        );
+    }
+}
+
+#[test]
+fn record_repair_dashboard_renders_canonical_dashboard_from_body_and_comments() {
+    let tmp = TempDir::new().expect("tempdir");
+    let body_path = tmp.path().join("body.md");
+    let comments_path = tmp.path().join("comments.json");
+    fs::write(
+        &body_path,
+        "## Current Dashboard\n\n- Status: in-progress\n",
+    )
+    .expect("write body");
+
+    let comments = json!({
+        "comments": [
+            {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-state-1",
+                "body": v2_comment_body(
+                    "state",
+                    "tracking",
+                    json!({
+                        "status": "in-progress",
+                        "target_scope": "sample plan",
+                        "current": "Sprint 2 in progress",
+                        "next_action": "land Sprint 2",
+                        "tasks": [{"id": "1.1", "status": "done", "title": "x"}],
+                        "prs": [{"ref": "owner/repo#1", "url": "https://github.com/owner/repo/pull/1", "status": "merged"}],
+                        "blockers": [],
+                        "links": {}
+                    }),
+                ),
+                "created_at": "2026-05-23T10:00:00Z"
+            },
+            {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-source",
+                "body": v2_comment_body(
+                    "source",
+                    "tracking",
+                    json!({"path": "docs/plans/sample/sample-discussion-source.md", "commit": "abc"}),
+                ),
+                "created_at": "2026-05-23T09:00:00Z"
+            }
+        ]
+    });
+    fs::write(
+        &comments_path,
+        serde_json::to_string(&comments).expect("json"),
+    )
+    .expect("write comments");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "repair-dashboard",
+        "--body-file",
+        body_path.to_str().expect("body path"),
+        "--comments-json",
+        comments_path.to_str().expect("comments path"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let dashboard = parsed["payload"]["result"]["dashboard_markdown"]
+        .as_str()
+        .expect("dashboard markdown");
+    assert!(dashboard.starts_with("## Current Dashboard"), "{dashboard}");
+    assert!(dashboard.contains("- Status: in-progress"), "{dashboard}");
+    // Source URL from latest audit evidence should appear in Durable Record.
+    assert!(
+        dashboard.contains("https://github.com/owner/repo/issues/9#issuecomment-source"),
+        "{dashboard}"
+    );
+}
+
+#[test]
+fn record_close_requires_non_empty_approval() {
+    let out =
+        common::run_plan_issue_local(&["--format", "json", "record", "close", "--issue", "9"]);
+    assert_ne!(out.code, 0, "missing --approval should fail");
+    assert!(
+        out.stderr.contains("record-close-missing-approval")
+            || out.stdout.contains("record-close-missing-approval"),
+        "stderr: {} stdout: {}",
+        out.stderr,
+        out.stdout
+    );
+}
+
+fn build_closeout_evidence(linked_pr_ref: &str) -> Value {
+    json!({
+        "comments": [
+            {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-source",
+                "body": v2_comment_body(
+                    "source",
+                    "tracking",
+                    json!({"path": "docs/plans/sample/sample-discussion-source.md", "commit": "src1234"}),
+                ),
+                "created_at": "2026-05-23T09:00:00Z"
+            },
+            {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-plan",
+                "body": v2_comment_body(
+                    "plan",
+                    "tracking",
+                    json!({"path": "docs/plans/sample/sample-plan.md", "commit": "pln1234"}),
+                ),
+                "created_at": "2026-05-23T09:01:00Z"
+            },
+            {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-state",
+                "body": v2_comment_body(
+                    "state",
+                    "tracking",
+                    json!({
+                        "status": "complete",
+                        "target_scope": "sample plan",
+                        "current": "complete",
+                        "next_action": "closeout",
+                        "tasks": [
+                            {"id": "1.1", "status": "done", "title": "x"},
+                            {"id": "1.2", "status": "deferred", "title": "y"},
+                        ],
+                        "prs": [{"ref": linked_pr_ref, "url": "https://github.com/owner/repo/pull/1", "status": "merged"}],
+                        "blockers": [],
+                        "links": {}
+                    }),
+                ),
+                "created_at": "2026-05-23T10:00:00Z"
+            },
+            {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-validation",
+                "body": v2_comment_body(
+                    "validation",
+                    "tracking",
+                    json!({
+                        "overall": "pass",
+                        "commands": [{"command": "cargo test", "status": "pass"}],
+                        "waivers": []
+                    }),
+                ),
+                "created_at": "2026-05-23T11:00:00Z"
+            },
+            {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-review",
+                "body": v2_comment_body(
+                    "review",
+                    "tracking",
+                    json!({
+                        "decision": "approve",
+                        "lenses": ["testing", "maintainability"],
+                        "findings": [],
+                    }),
+                ),
+                "created_at": "2026-05-23T12:00:00Z"
+            }
+        ]
+    })
+}
+
+#[test]
+fn record_close_fixture_passes_strict_gate_with_complete_v2_evidence() {
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let body = "## Current Dashboard\n\n- Status: in-progress\n";
+    write_fixture_files(&fixture, body, &build_closeout_evidence("owner/repo#1"));
+    write_pr_fixture(
+        &fixture,
+        "owner/repo",
+        1,
+        json!({
+            "state": "MERGED",
+            "mergeCommit": {"oid": "deadbeefcafebabe"},
+            "statusCheckRollup": {"state": "success"},
+            "url": "https://github.com/owner/repo/pull/1"
+        }),
+    );
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "9",
+        "--linked-pr",
+        "owner/repo#1",
+        "--approval",
+        "https://github.com/owner/repo/issues/9#issuecomment-approval",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let result = &parsed["payload"]["result"];
+    assert_eq!(result["operation"], "record.close");
+    assert_eq!(result["mode"], "fixture");
+    assert_eq!(result["dry_run"], true);
+    let preview = &result["preview"];
+    let body = preview["closeout_comment_body"]
+        .as_str()
+        .expect("closeout body");
+    assert!(
+        body.starts_with("<!-- plan-issue-record:v2 role=closeout profile=tracking -->"),
+        "{body}"
+    );
+    assert!(body.contains("\"final_status\": \"complete\""), "{body}");
+    assert!(
+        body.contains("\"merge_sha\": \"deadbeefcafebabe\""),
+        "{body}"
+    );
+    let final_dashboard = preview["final_dashboard"]
+        .as_str()
+        .expect("final dashboard");
+    assert!(
+        final_dashboard.starts_with("## Final Dashboard"),
+        "{final_dashboard}"
+    );
+}
+
+#[test]
+fn record_close_fixture_blocks_when_linked_pr_not_merged() {
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let body = "## Current Dashboard\n";
+    write_fixture_files(&fixture, body, &build_closeout_evidence("owner/repo#1"));
+    write_pr_fixture(
+        &fixture,
+        "owner/repo",
+        1,
+        json!({
+            "state": "OPEN",
+            "mergeCommit": null,
+            "statusCheckRollup": {"state": "pending"},
+            "url": "https://github.com/owner/repo/pull/1"
+        }),
+    );
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "9",
+        "--linked-pr",
+        "owner/repo#1",
+        "--approval",
+        "ok",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+
+    assert_ne!(out.code, 0, "unmerged PR should block strict gate");
+    let joined = format!("{}\n{}", out.stderr, out.stdout);
+    assert!(
+        joined.contains("linked-pr-not-merged"),
+        "expected linked-pr-not-merged code, got: {joined}"
+    );
+}
+
+#[test]
+fn record_close_fixture_blocks_when_review_request_changes() {
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    // Replace the review entry in the evidence stack with a
+    // request-changes decision.
+    let mut comments = build_closeout_evidence("owner/repo#1");
+    let comments_list = comments["comments"].as_array_mut().expect("comments array");
+    let last_index = comments_list.len() - 1;
+    comments_list[last_index] = json!({
+        "url": "https://github.com/owner/repo/issues/9#issuecomment-review-rej",
+        "body": v2_comment_body(
+            "review",
+            "tracking",
+            json!({"decision": "request-changes", "findings": []}),
+        ),
+        "created_at": "2026-05-23T12:00:00Z"
+    });
+    write_fixture_files(&fixture, "## Current Dashboard\n", &comments);
+    write_pr_fixture(
+        &fixture,
+        "owner/repo",
+        1,
+        json!({
+            "state": "MERGED",
+            "mergeCommit": {"oid": "abc"},
+            "statusCheckRollup": {"state": "success"},
+            "url": "https://github.com/owner/repo/pull/1"
+        }),
+    );
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "9",
+        "--linked-pr",
+        "owner/repo#1",
+        "--approval",
+        "ok",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+    assert_ne!(out.code, 0);
+    let joined = format!("{}\n{}", out.stderr, out.stdout);
+    assert!(
+        joined.contains("review-rejected"),
+        "expected review-rejected: {joined}"
+    );
+}
+
+#[test]
+fn record_close_fixture_blocks_when_state_not_complete() {
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let mut comments = build_closeout_evidence("owner/repo#1");
+    let comments_list = comments["comments"].as_array_mut().expect("comments array");
+    // Replace the state entry (index 2) with status=in-progress.
+    comments_list[2] = json!({
+        "url": "https://github.com/owner/repo/issues/9#issuecomment-state",
+        "body": v2_comment_body(
+            "state",
+            "tracking",
+            json!({
+                "status": "in-progress",
+                "target_scope": "x",
+                "tasks": [],
+                "prs": [],
+                "blockers": [],
+                "links": {}
+            }),
+        ),
+        "created_at": "2026-05-23T10:00:00Z"
+    });
+    write_fixture_files(&fixture, "## Current Dashboard\n", &comments);
+    write_pr_fixture(
+        &fixture,
+        "owner/repo",
+        1,
+        json!({
+            "state": "MERGED",
+            "mergeCommit": {"oid": "abc"},
+            "statusCheckRollup": {"state": "success"},
+            "url": "https://github.com/owner/repo/pull/1"
+        }),
+    );
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "9",
+        "--linked-pr",
+        "owner/repo#1",
+        "--approval",
+        "ok",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+    assert_ne!(out.code, 0);
+    let joined = format!("{}\n{}", out.stderr, out.stdout);
+    assert!(
+        joined.contains("state-not-complete"),
+        "expected state-not-complete: {joined}"
+    );
+}
+
+#[test]
+fn record_open_fixture_mode_returns_v2_evidence_urls() {
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let body = "## Current Dashboard\n";
+    let comments = json!({
+        "comments": [
+            {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-source",
+                "body": v2_comment_body(
+                    "source",
+                    "tracking",
+                    json!({"path": "docs/plans/sample/sample-discussion-source.md", "commit": "src1"}),
+                ),
+                "created_at": "2026-05-23T09:00:00Z"
+            },
+            {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-plan",
+                "body": v2_comment_body(
+                    "plan",
+                    "tracking",
+                    json!({"path": "docs/plans/sample/sample-plan.md", "commit": "pln1"}),
+                ),
+                "created_at": "2026-05-23T09:01:00Z"
+            },
+            {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-state",
+                "body": v2_comment_body(
+                    "state",
+                    "tracking",
+                    json!({"status": "in-progress", "tasks": [], "prs": [], "blockers": [], "links": {}}),
+                ),
+                "created_at": "2026-05-23T09:02:00Z"
+            }
+        ]
+    });
+    write_fixture_files(&fixture, body, &comments);
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "open",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+        "--title",
+        "Sample Plan",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let result = &parsed["payload"]["result"];
+    assert_eq!(result["operation"], "record.open");
+    assert_eq!(result["mode"], "fixture");
+    let comments_result = &result["comments"];
+    assert_eq!(
+        comments_result["source"],
+        "https://github.com/owner/repo/issues/9#issuecomment-source"
+    );
+    assert_eq!(
+        comments_result["plan"],
+        "https://github.com/owner/repo/issues/9#issuecomment-plan"
+    );
+    assert_eq!(
+        comments_result["state"],
+        "https://github.com/owner/repo/issues/9#issuecomment-state"
+    );
+}
+
+#[test]
+fn record_post_state_fixture_returns_rendered_body_without_provider_call() {
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+    write_fixture_files(&fixture, "## Current Dashboard\n", &json!({"comments": []}));
+    let payload = tmp.path().join("payload.json");
+    fs::write(
+        &payload,
+        json!({"status": "in-progress", "tasks": [], "prs": [], "blockers": [], "links": {}})
+            .to_string(),
+    )
+    .expect("write payload");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "post",
+        "--issue",
+        "9",
+        "--kind",
+        "state",
+        "--payload-file",
+        payload.to_str().expect("payload str"),
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let result = &parsed["payload"]["result"];
+    assert_eq!(result["mode"], "fixture");
+    assert_eq!(result["kind"], "state");
+    let body = result["comment_body"]
+        .as_str()
+        .expect("comment body in fixture mode");
+    assert!(
+        body.contains("<!-- plan-issue-record:v2 role=state profile=tracking -->"),
+        "{body}"
+    );
+}
+
+fn record_open_dry_run_gh_stub() -> &'static str {
+    r#"#!/usr/bin/env bash
+echo "record_open_dry_run_gh_stub should not be called" >&2
+exit 1
+"#
+}
+
+fn dry_run_cmd_options(stub_dir: &Path) -> CmdOptions {
+    common::plan_issue_cmd_options()
+        .with_env_remove_prefix("PLAN_ISSUE_GH_")
+        .with_path_prepend(stub_dir)
+}
+
+#[test]
+fn record_open_dry_run_returns_preview_without_gh_calls() {
+    use nils_test_support::git::{InitRepoOptions, git, init_repo_with};
+
+    let stub = StubBinDir::new();
+    stub.write_exe("gh", record_open_dry_run_gh_stub());
+
+    let repo = init_repo_with(InitRepoOptions::new().with_branch("main"));
+    let bundle = repo.path().join("docs/plans/sample");
+    fs::create_dir_all(&bundle).expect("create bundle dir");
+    let source = bundle.join("sample-discussion-source.md");
+    let plan = bundle.join("sample-plan.md");
+    fs::write(&source, "# Source\n\n- Decision: implement v2 lifecycle.\n").expect("write source");
+    fs::write(
+        &plan,
+        "# Plan: Sample Plan\n\n## Overview\n\n- Sample plan body.\n\n## Read First\n\n- Primary source: docs/plans/sample/sample-discussion-source.md\n- Source type: discussion-to-implementation-doc\n- Open questions carried into execution: none\n\n## Scope\n\n- In scope:\n  - Demo plan.\n- Out of scope:\n  - none.\n\n## Assumptions\n\n1. Demo only.\n\n## Sprint 1: Demo\n\n**Goal**: Demo the surface.\n\n**PR grouping intent**: group\n**Execution Profile**: serial\n\n### Task 1.1: Demo task\n\n- **Location**:\n  - `docs/plans/sample/sample-plan.md`\n- **Description**: Demo task description.\n- **Dependencies**:\n  - none\n- **Complexity**: 1\n- **Acceptance criteria**:\n  - The demo task is complete.\n- **Validation**:\n  - `true`\n",
+    )
+    .expect("write plan");
+    git(repo.path(), &["add", "."]);
+    git(
+        repo.path(),
+        &[
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test",
+            "commit",
+            "-m",
+            "seed bundle",
+            "--no-gpg-sign",
+        ],
+    );
+
+    let opts = dry_run_cmd_options(stub.path()).with_cwd(repo.path());
+    let bundle_arg = bundle.to_string_lossy().to_string();
+    let out = nils_test_support::cmd::run_resolved(
+        "plan-issue-local",
+        &[
+            "--format",
+            "json",
+            "record",
+            "open",
+            "--bundle",
+            &bundle_arg,
+        ],
+        &opts,
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+    let parsed: Value = serde_json::from_str(&out.stdout_text()).expect("json");
+    let result = &parsed["payload"]["result"];
+    assert_eq!(result["operation"], "record.open");
+    assert_eq!(result["mode"], "dry-run");
+    assert_eq!(result["dry_run"], true);
+    let preview = &result["preview"];
+    assert_eq!(preview["plan_title"], "Plan: Sample Plan");
+    let source_comment = preview["comments"]["source"]
+        .as_str()
+        .expect("source comment");
+    assert!(
+        source_comment.starts_with("<!-- plan-issue-record:v2 role=source profile=tracking -->"),
+        "{source_comment}"
+    );
+}


### PR DESCRIPTION
## Summary

Sprint 3 of the plan-issue-lifecycle-v3 plan ([tracking issue #448](https://github.com/sympoies/nils-cli/issues/448)) wires the live `plan-issue record open|post|repair-dashboard|close` surface scaffolded in Sprint 1 + 2:

- `record open` accepts a `--bundle <dir>` (or explicit `--source-file` / `--plan-file` / `--execution-state-file`), parses the plan via `plan-tooling`, verifies the source/plan files are committed (unless `--allow-dirty`), creates the provider issue with an initial dashboard, posts canonical v2 source/plan/state lifecycle comments with structured payloads, and repairs the dashboard from the freshly-created comment URLs.
- `record post` is an append-only command for `state | session | validation | review` kinds with `--payload-file` JSON; it rejects `source`, `plan`, and `closeout` kinds (the first two are owned by `record open`; closeout is owned by `record close`).
- `record close` audits the issue, runs the strict v2 closeout gate (`state.status=complete`, all tasks `done|deferred`, `validation.overall=pass`, review not request-changes and no unresolved blocker/major findings, every linked PR resolves to provider state `MERGED` with a `merge_sha`, non-empty `--approval`), posts the closeout comment, repairs the final dashboard, and closes the issue. Failure modes surface stable machine-readable codes (`state-not-complete`, `validation-failed`, `review-rejected`, `review-unresolved-findings`, `linked-pr-not-merged`, `approval-missing`).
- `record repair-dashboard` now routes through `render_dashboard_from_audit` for both fixture/local mode (`--body-file --comments-json`) and live mode (`--issue` via the GitHub adapter).
- Every record subcommand supports the matching `--fixture <dir>` deterministic mode (issue body + comments JSON + `prs/<owner>__<repo>__N.json` snapshots for linked-PR verification), so consumer tests stay network-free.

## What changed under the hood

- `GitHubAdapter::comment_issue` now returns the posted comment URL (parsed from `gh issue comment` stdout); existing live callers are unchanged because they discard the success value.
- New adapter methods `issue_evidence` (body + comments JSON, used by audit/repair/close) and `pr_merge_summary` (provider-verified merge state + `merge_sha` + checks rollup, used by the strict gate).
- New `lifecycle_record::{render_record_snapshot_comment, render_record_post_comment, evaluate_strict_closeout_gate}` plus `StrictCloseoutGateResult { ready, checks, blocked_codes }`.
- `commands/mod.rs:schema_version()` bumps the Record arm to `plan-issue-cli.record.<sub>.v2` so consumers can pin the v2 result envelope (`issue.url`, `comments.*`, `closeout_url`, `final_dashboard`).
- `record close --approval` is now validated as non-empty.

## Deferred follow-ups from Sprint 1 / 2 addressed here

- Payload-fence-missing audit test (v2 marker → `evidence.payload = None` rather than error).
- Malformed payload strict-fail audit test.
- `schema_version()` bump to v2 for Record subcommands.
- Non-empty `--approval` validation on `record close`.
- `render_dashboard_from_audit` wired through `record repair-dashboard` and the closeout final-dashboard step.

## Deferred to Sprint 4 / 5

- Sprint 4: retire `record render-comment` / `record render-dashboard` / `record closeout-gate` from the primary surface, regenerate bash + zsh completions, refresh the CLI output contract fixtures, add the `agent-runtime-kit-closeout.json` fixture.
- Sprint 5: full local gate, CHANGELOG breaking-change entries (audit role rename, retired subcommands), agent-runtime-kit consumer migration handoff notes.

## Test plan

- [x] `cargo test -p nils-plan-issue-cli` (63 lib + 125 integration tests pass; 10 new sprint3 helper tests + 11 new live_record_ops integration tests added).
- [x] `cargo nextest run --profile ci --workspace` (3590 tests, all pass).
- [x] `cargo fmt --all -- --check`.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
- [x] `bash scripts/ci/markdownlint-audit.sh --strict`.
- [x] `bash scripts/ci/third-party-artifacts-audit.sh --strict`.
- [x] `bash scripts/ci/completion-asset-audit.sh --strict`.
- [x] `bash scripts/ci/completion-flag-parity-audit.sh --strict`.
- [x] `bash scripts/ci/cli-output-contract-lint.sh --strict`.

Tracking issue: <https://github.com/sympoies/nils-cli/issues/448>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
