### PR TITLE
feat(plan-issue-cli): hide retired record subs + closeout fixture

### DIFF
--- a/completions/bash/plan-issue
+++ b/completions/bash/plan-issue
@@ -67,14 +67,26 @@ _plan-issue() {
             plan__issue__record,build-dispatch-ledger)
                 cmd="plan__issue__record__build__dispatch__ledger"
                 ;;
+            plan__issue__record,close)
+                cmd="plan__issue__record__close"
+                ;;
             plan__issue__record,closeout-gate)
                 cmd="plan__issue__record__closeout__gate"
+                ;;
+            plan__issue__record,open)
+                cmd="plan__issue__record__open"
+                ;;
+            plan__issue__record,post)
+                cmd="plan__issue__record__post"
                 ;;
             plan__issue__record,render-comment)
                 cmd="plan__issue__record__render__comment"
                 ;;
             plan__issue__record,render-dashboard)
                 cmd="plan__issue__record__render__dashboard"
+                ;;
+            plan__issue__record,repair-dashboard)
+                cmd="plan__issue__record__repair__dashboard"
                 ;;
             *)
                 ;;
@@ -645,7 +657,7 @@ _plan-issue() {
             return 0
             ;;
         plan__issue__record)
-            opts="-f -h --repo --dry-run --force --json --format --state-dir --help render-dashboard render-comment audit closeout-gate build-dispatch-ledger"
+            opts="-f -h --repo --dry-run --force --json --format --state-dir --help open post repair-dashboard close render-dashboard render-comment audit closeout-gate build-dispatch-ledger"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -770,6 +782,64 @@ _plan-issue() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        plan__issue__record__close)
+            opts="-f -h --issue --profile --linked-pr --approval --bundle --body-file --comments-json --fixture --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --issue)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --linked-pr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --approval)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --bundle)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --comments-json)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --fixture)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         plan__issue__record__closeout__gate)
             opts="-f -h --body-file --comments-json --profile --require-complete --require-session --require-validation --require-review --require-closeout --approval --linked-pr --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
@@ -816,8 +886,8 @@ _plan-issue() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        plan__issue__record__render__comment)
-            opts="-f -h --profile --marker-family --kind --path --commit --content-file --title --details-summary --out --repo --dry-run --force --json --format --state-dir --help"
+        plan__issue__record__open)
+            opts="-f -h --profile --bundle --source-file --plan-file --execution-state-file --title --allow-dirty --fixture --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -827,8 +897,108 @@ _plan-issue() {
                     COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
                     return 0
                     ;;
-                --marker-family)
-                    COMPREPLY=($(compgen -W "shared compat" -- "${cur}"))
+                --bundle)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --source-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --plan-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --execution-state-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --title)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --fixture)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__record__post)
+            opts="-f -h --issue --profile --kind --payload-file --summary-file --fixture --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --issue)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --kind)
+                    COMPREPLY=($(compgen -W "source plan state session validation review closeout" -- "${cur}"))
+                    return 0
+                    ;;
+                --payload-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --summary-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --fixture)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__record__render__comment)
+            opts="-f -h --profile --kind --path --commit --content-file --title --details-summary --out --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
                     return 0
                     ;;
                 --kind)
@@ -954,6 +1124,52 @@ _plan-issue() {
                     return 0
                     ;;
                 --issue-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --out)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__record__repair__dashboard)
+            opts="-f -h --issue --body-file --comments-json --fixture --out --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --issue)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --comments-json)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --fixture)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/bash/plan-issue-local
+++ b/completions/bash/plan-issue-local
@@ -67,14 +67,26 @@ _plan-issue-local() {
             plan__issue__local__record,build-dispatch-ledger)
                 cmd="plan__issue__local__record__build__dispatch__ledger"
                 ;;
+            plan__issue__local__record,close)
+                cmd="plan__issue__local__record__close"
+                ;;
             plan__issue__local__record,closeout-gate)
                 cmd="plan__issue__local__record__closeout__gate"
+                ;;
+            plan__issue__local__record,open)
+                cmd="plan__issue__local__record__open"
+                ;;
+            plan__issue__local__record,post)
+                cmd="plan__issue__local__record__post"
                 ;;
             plan__issue__local__record,render-comment)
                 cmd="plan__issue__local__record__render__comment"
                 ;;
             plan__issue__local__record,render-dashboard)
                 cmd="plan__issue__local__record__render__dashboard"
+                ;;
+            plan__issue__local__record,repair-dashboard)
+                cmd="plan__issue__local__record__repair__dashboard"
                 ;;
             *)
                 ;;
@@ -645,7 +657,7 @@ _plan-issue-local() {
             return 0
             ;;
         plan__issue__local__record)
-            opts="-f -h --repo --dry-run --force --json --format --state-dir --help render-dashboard render-comment audit closeout-gate build-dispatch-ledger"
+            opts="-f -h --repo --dry-run --force --json --format --state-dir --help open post repair-dashboard close render-dashboard render-comment audit closeout-gate build-dispatch-ledger"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -770,6 +782,64 @@ _plan-issue-local() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        plan__issue__local__record__close)
+            opts="-f -h --issue --profile --linked-pr --approval --bundle --body-file --comments-json --fixture --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --issue)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --linked-pr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --approval)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --bundle)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --comments-json)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --fixture)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         plan__issue__local__record__closeout__gate)
             opts="-f -h --body-file --comments-json --profile --require-complete --require-session --require-validation --require-review --require-closeout --approval --linked-pr --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
@@ -816,8 +886,8 @@ _plan-issue-local() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        plan__issue__local__record__render__comment)
-            opts="-f -h --profile --marker-family --kind --path --commit --content-file --title --details-summary --out --repo --dry-run --force --json --format --state-dir --help"
+        plan__issue__local__record__open)
+            opts="-f -h --profile --bundle --source-file --plan-file --execution-state-file --title --allow-dirty --fixture --repo --dry-run --force --json --format --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -827,8 +897,108 @@ _plan-issue-local() {
                     COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
                     return 0
                     ;;
-                --marker-family)
-                    COMPREPLY=($(compgen -W "shared compat" -- "${cur}"))
+                --bundle)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --source-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --plan-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --execution-state-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --title)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --fixture)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__local__record__post)
+            opts="-f -h --issue --profile --kind --payload-file --summary-file --fixture --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --issue)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
+                    return 0
+                    ;;
+                --kind)
+                    COMPREPLY=($(compgen -W "source plan state session validation review closeout" -- "${cur}"))
+                    return 0
+                    ;;
+                --payload-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --summary-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --fixture)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__local__record__render__comment)
+            opts="-f -h --profile --kind --path --commit --content-file --title --details-summary --out --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -W "tracking dispatch" -- "${cur}"))
                     return 0
                     ;;
                 --kind)
@@ -954,6 +1124,52 @@ _plan-issue-local() {
                     return 0
                     ;;
                 --issue-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --out)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__issue__local__record__repair__dashboard)
+            opts="-f -h --issue --body-file --comments-json --fixture --out --repo --dry-run --force --json --format --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --issue)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --comments-json)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --fixture)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/zsh/_plan-issue
+++ b/completions/zsh/_plan-issue
@@ -333,7 +333,86 @@ _arguments "${_arguments_options[@]}" : \
         (( CURRENT += 1 ))
         curcontext="${curcontext%:*:*}:plan-issue-record-command-$line[1]:"
         case $line[1] in
-            (render-dashboard)
+            (open)
+_arguments "${_arguments_options[@]}" : \
+'--profile=[Lifecycle profile for the record]:PROFILE:(tracking dispatch)' \
+'--bundle=[Plan bundle directory. The bundle directory contains the source, plan, and execution-state Markdown files using the \`<slug>-discussion-source.md\` / \`<slug>-review-source.md\`, \`<slug>-plan.md\`, and \`<slug>-execution-state.md\` naming convention validated by \`plan-tooling validate\`]:dir:_files' \
+'--source-file=[Explicit source document path. Overrides bundle derivation]:path:_files' \
+'--plan-file=[Explicit plan document path. Overrides bundle derivation]:path:_files' \
+'--execution-state-file=[Explicit execution-state document path. Overrides bundle derivation]:path:_files' \
+'--title=[Issue title. Defaults to the plan title]:text:_default' \
+'--fixture=[Deterministic fixture mode. The directory is consumed instead of live provider calls]:dir:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--allow-dirty[Allow opening the record even when local plan files are dirty]' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(post)
+_arguments "${_arguments_options[@]}" : \
+'--issue=[Provider issue number or full URL]:issue:_default' \
+'--profile=[Lifecycle profile for the marker and payload]:PROFILE:(tracking dispatch)' \
+'--kind=[Lifecycle comment kind. \`source\` and \`plan\` kinds are owned by \`record open\` and rejected here]:KIND:(source plan state session validation review closeout)' \
+'--payload-file=[JSON file containing the structured payload \`data\` field]:path:_files' \
+'--summary-file=[Visible Markdown commentary appended after the structured payload]:path:_files' \
+'--fixture=[Deterministic fixture mode]:dir:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(repair-dashboard)
+_arguments "${_arguments_options[@]}" : \
+'--issue=[Provider issue number or full URL]:issue:_default' \
+'--body-file=[Provider issue body Markdown (deterministic mode)]:path:_files' \
+'--comments-json=[JSON containing either \`comments\` from \`gh issue view --json comments\` or a raw array of comment objects (deterministic mode)]:path:_files' \
+'--fixture=[Deterministic fixture mode]:dir:_files' \
+'--out=[Write rendered Markdown to this path instead of editing the issue]:path:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(close)
+_arguments "${_arguments_options[@]}" : \
+'--issue=[Provider issue number or full URL]:issue:_default' \
+'--profile=[Lifecycle profile of the record being closed]:PROFILE:(tracking dispatch)' \
+'*--linked-pr=[Linked PR reference. Repeatable. Each ref is cross-checked against the latest state payload and verified through the provider for merge status]:ref:_default' \
+'--approval=[Approval evidence. May be a provider comment URL or non-empty approval text]:text:_default' \
+'--bundle=[Plan bundle directory. Used for local source/plan commit verification when provided]:dir:_files' \
+'--body-file=[Deterministic test mode\: issue body Markdown]:path:_files' \
+'--comments-json=[Deterministic test mode\: comments JSON]:path:_files' \
+'--fixture=[Deterministic fixture mode. Contains issue body, comments JSON, and PR snapshots used in place of provider lookups]:dir:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(render-dashboard)
 _arguments "${_arguments_options[@]}" : \
 '--profile=[Lifecycle profile for the issue record]:PROFILE:(tracking dispatch)' \
 '--status=[Current lifecycle status shown in the dashboard]:text:_default' \
@@ -368,8 +447,6 @@ _arguments "${_arguments_options[@]}" : \
 (render-comment)
 _arguments "${_arguments_options[@]}" : \
 '--profile=[Lifecycle profile for the comment marker and visible metadata]:PROFILE:(tracking dispatch)' \
-'--marker-family=[Marker family to emit]:MARKER_FAMILY:((shared\:"Emit the shared issue-backed-plan marker family"
-compat\:"Emit compatibility markers used by the existing tracking lifecycle"))' \
 '--kind=[Lifecycle comment kind]:KIND:(source plan state session validation review closeout)' \
 '--path=[Source file path represented by this comment]:path:_files' \
 '--commit=[Commit hash for snapshot comments]:sha:_default' \
@@ -384,8 +461,8 @@ compat\:"Emit compatibility markers used by the existing tracking lifecycle"))' 
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
 '(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
-'-h[Print help (see more with '\''--help'\'')]' \
-'--help[Print help (see more with '\''--help'\'')]' \
+'-h[Print help]' \
+'--help[Print help]' \
 && ret=0
 ;;
 (audit)
@@ -546,11 +623,15 @@ _plan-issue__subcmd__ready-sprint_commands() {
 (( $+functions[_plan-issue__subcmd__record_commands] )) ||
 _plan-issue__subcmd__record_commands() {
     local commands; commands=(
-'render-dashboard:Render a mutable issue dashboard for an issue-backed plan record' \
-'render-comment:Render one append-only lifecycle comment' \
+'open:Open a provider issue from a plan bundle and post initial lifecycle comments (v3 issue-backed plan record contract)' \
+'post:Append a canonical lifecycle comment (state, session, validation, review, or closeout) to an existing plan record issue' \
+'repair-dashboard:Recompute and edit the dashboard issue body from audit evidence' \
+'close:Close a plan record issue after the strict lifecycle gate passes' \
+'render-dashboard:Render a mutable issue dashboard for an issue-backed plan record. Retired in v2 — dashboard rendering moved under \`record repair-dashboard\`. Kept callable as a transitional helper' \
+'render-comment:Render one append-only lifecycle comment. Retired in v2 — comment rendering is an implementation detail of \`record open\` / \`record post\`. Kept callable as a transitional helper' \
 'audit:Audit issue body and comments for lifecycle markers' \
-'closeout-gate:Evaluate closeout readiness from lifecycle audit evidence' \
-'build-dispatch-ledger:Build a dispatch ledger from plan metadata and split grouping rules' \
+'closeout-gate:Evaluate closeout readiness from lifecycle audit evidence. Retired in v2 — closeout gate evaluation moved inside \`record close\` (strict by default). Kept callable as a transitional helper' \
+'build-dispatch-ledger:Build a dispatch ledger from plan metadata and split grouping rules. Retired in v2 — dispatch consumers move to \`record open\` + state payload. Kept callable as a transitional helper' \
     )
     _describe -t commands 'plan-issue record commands' commands "$@"
 }
@@ -564,10 +645,25 @@ _plan-issue__subcmd__record__subcmd__build-dispatch-ledger_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue record build-dispatch-ledger commands' commands "$@"
 }
+(( $+functions[_plan-issue__subcmd__record__subcmd__close_commands] )) ||
+_plan-issue__subcmd__record__subcmd__close_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue record close commands' commands "$@"
+}
 (( $+functions[_plan-issue__subcmd__record__subcmd__closeout-gate_commands] )) ||
 _plan-issue__subcmd__record__subcmd__closeout-gate_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue record closeout-gate commands' commands "$@"
+}
+(( $+functions[_plan-issue__subcmd__record__subcmd__open_commands] )) ||
+_plan-issue__subcmd__record__subcmd__open_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue record open commands' commands "$@"
+}
+(( $+functions[_plan-issue__subcmd__record__subcmd__post_commands] )) ||
+_plan-issue__subcmd__record__subcmd__post_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue record post commands' commands "$@"
 }
 (( $+functions[_plan-issue__subcmd__record__subcmd__render-comment_commands] )) ||
 _plan-issue__subcmd__record__subcmd__render-comment_commands() {
@@ -578,6 +674,11 @@ _plan-issue__subcmd__record__subcmd__render-comment_commands() {
 _plan-issue__subcmd__record__subcmd__render-dashboard_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue record render-dashboard commands' commands "$@"
+}
+(( $+functions[_plan-issue__subcmd__record__subcmd__repair-dashboard_commands] )) ||
+_plan-issue__subcmd__record__subcmd__repair-dashboard_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue record repair-dashboard commands' commands "$@"
 }
 (( $+functions[_plan-issue__subcmd__resolve-approval_commands] )) ||
 _plan-issue__subcmd__resolve-approval_commands() {

--- a/completions/zsh/_plan-issue-local
+++ b/completions/zsh/_plan-issue-local
@@ -333,7 +333,86 @@ _arguments "${_arguments_options[@]}" : \
         (( CURRENT += 1 ))
         curcontext="${curcontext%:*:*}:plan-issue-local-record-command-$line[1]:"
         case $line[1] in
-            (render-dashboard)
+            (open)
+_arguments "${_arguments_options[@]}" : \
+'--profile=[Lifecycle profile for the record]:PROFILE:(tracking dispatch)' \
+'--bundle=[Plan bundle directory. The bundle directory contains the source, plan, and execution-state Markdown files using the \`<slug>-discussion-source.md\` / \`<slug>-review-source.md\`, \`<slug>-plan.md\`, and \`<slug>-execution-state.md\` naming convention validated by \`plan-tooling validate\`]:dir:_files' \
+'--source-file=[Explicit source document path. Overrides bundle derivation]:path:_files' \
+'--plan-file=[Explicit plan document path. Overrides bundle derivation]:path:_files' \
+'--execution-state-file=[Explicit execution-state document path. Overrides bundle derivation]:path:_files' \
+'--title=[Issue title. Defaults to the plan title]:text:_default' \
+'--fixture=[Deterministic fixture mode. The directory is consumed instead of live provider calls]:dir:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--allow-dirty[Allow opening the record even when local plan files are dirty]' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(post)
+_arguments "${_arguments_options[@]}" : \
+'--issue=[Provider issue number or full URL]:issue:_default' \
+'--profile=[Lifecycle profile for the marker and payload]:PROFILE:(tracking dispatch)' \
+'--kind=[Lifecycle comment kind. \`source\` and \`plan\` kinds are owned by \`record open\` and rejected here]:KIND:(source plan state session validation review closeout)' \
+'--payload-file=[JSON file containing the structured payload \`data\` field]:path:_files' \
+'--summary-file=[Visible Markdown commentary appended after the structured payload]:path:_files' \
+'--fixture=[Deterministic fixture mode]:dir:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(repair-dashboard)
+_arguments "${_arguments_options[@]}" : \
+'--issue=[Provider issue number or full URL]:issue:_default' \
+'--body-file=[Provider issue body Markdown (deterministic mode)]:path:_files' \
+'--comments-json=[JSON containing either \`comments\` from \`gh issue view --json comments\` or a raw array of comment objects (deterministic mode)]:path:_files' \
+'--fixture=[Deterministic fixture mode]:dir:_files' \
+'--out=[Write rendered Markdown to this path instead of editing the issue]:path:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(close)
+_arguments "${_arguments_options[@]}" : \
+'--issue=[Provider issue number or full URL]:issue:_default' \
+'--profile=[Lifecycle profile of the record being closed]:PROFILE:(tracking dispatch)' \
+'*--linked-pr=[Linked PR reference. Repeatable. Each ref is cross-checked against the latest state payload and verified through the provider for merge status]:ref:_default' \
+'--approval=[Approval evidence. May be a provider comment URL or non-empty approval text]:text:_default' \
+'--bundle=[Plan bundle directory. Used for local source/plan commit verification when provided]:dir:_files' \
+'--body-file=[Deterministic test mode\: issue body Markdown]:path:_files' \
+'--comments-json=[Deterministic test mode\: comments JSON]:path:_files' \
+'--fixture=[Deterministic fixture mode. Contains issue body, comments JSON, and PR snapshots used in place of provider lookups]:dir:_files' \
+'--repo=[Pass-through repository target for GitHub operations]:owner/repo:_default' \
+'--format=[Output format]:FORMAT:(text json)' \
+'--state-dir=[Runtime workspace root. Overrides \$PLAN_ISSUE_HOME and the \$XDG_STATE_HOME/plan-issue default. Artefacts land under \`<state-dir>/out/plan-issue-delivery/...\`]:PATH:_files' \
+'--dry-run[Print write actions without mutating GitHub state]' \
+'-f[Bypass markdown payload guard for GitHub body/comment writes]' \
+'--force[Bypass markdown payload guard for GitHub body/comment writes]' \
+'(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(render-dashboard)
 _arguments "${_arguments_options[@]}" : \
 '--profile=[Lifecycle profile for the issue record]:PROFILE:(tracking dispatch)' \
 '--status=[Current lifecycle status shown in the dashboard]:text:_default' \
@@ -368,8 +447,6 @@ _arguments "${_arguments_options[@]}" : \
 (render-comment)
 _arguments "${_arguments_options[@]}" : \
 '--profile=[Lifecycle profile for the comment marker and visible metadata]:PROFILE:(tracking dispatch)' \
-'--marker-family=[Marker family to emit]:MARKER_FAMILY:((shared\:"Emit the shared issue-backed-plan marker family"
-compat\:"Emit compatibility markers used by the existing tracking lifecycle"))' \
 '--kind=[Lifecycle comment kind]:KIND:(source plan state session validation review closeout)' \
 '--path=[Source file path represented by this comment]:path:_files' \
 '--commit=[Commit hash for snapshot comments]:sha:_default' \
@@ -384,8 +461,8 @@ compat\:"Emit compatibility markers used by the existing tracking lifecycle"))' 
 '-f[Bypass markdown payload guard for GitHub body/comment writes]' \
 '--force[Bypass markdown payload guard for GitHub body/comment writes]' \
 '(--format)--json[Hidden alias for \`--format json\` (kept for backwards compatibility)]' \
-'-h[Print help (see more with '\''--help'\'')]' \
-'--help[Print help (see more with '\''--help'\'')]' \
+'-h[Print help]' \
+'--help[Print help]' \
 && ret=0
 ;;
 (audit)
@@ -546,11 +623,15 @@ _plan-issue-local__subcmd__ready-sprint_commands() {
 (( $+functions[_plan-issue-local__subcmd__record_commands] )) ||
 _plan-issue-local__subcmd__record_commands() {
     local commands; commands=(
-'render-dashboard:Render a mutable issue dashboard for an issue-backed plan record' \
-'render-comment:Render one append-only lifecycle comment' \
+'open:Open a provider issue from a plan bundle and post initial lifecycle comments (v3 issue-backed plan record contract)' \
+'post:Append a canonical lifecycle comment (state, session, validation, review, or closeout) to an existing plan record issue' \
+'repair-dashboard:Recompute and edit the dashboard issue body from audit evidence' \
+'close:Close a plan record issue after the strict lifecycle gate passes' \
+'render-dashboard:Render a mutable issue dashboard for an issue-backed plan record. Retired in v2 — dashboard rendering moved under \`record repair-dashboard\`. Kept callable as a transitional helper' \
+'render-comment:Render one append-only lifecycle comment. Retired in v2 — comment rendering is an implementation detail of \`record open\` / \`record post\`. Kept callable as a transitional helper' \
 'audit:Audit issue body and comments for lifecycle markers' \
-'closeout-gate:Evaluate closeout readiness from lifecycle audit evidence' \
-'build-dispatch-ledger:Build a dispatch ledger from plan metadata and split grouping rules' \
+'closeout-gate:Evaluate closeout readiness from lifecycle audit evidence. Retired in v2 — closeout gate evaluation moved inside \`record close\` (strict by default). Kept callable as a transitional helper' \
+'build-dispatch-ledger:Build a dispatch ledger from plan metadata and split grouping rules. Retired in v2 — dispatch consumers move to \`record open\` + state payload. Kept callable as a transitional helper' \
     )
     _describe -t commands 'plan-issue-local record commands' commands "$@"
 }
@@ -564,10 +645,25 @@ _plan-issue-local__subcmd__record__subcmd__build-dispatch-ledger_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local record build-dispatch-ledger commands' commands "$@"
 }
+(( $+functions[_plan-issue-local__subcmd__record__subcmd__close_commands] )) ||
+_plan-issue-local__subcmd__record__subcmd__close_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue-local record close commands' commands "$@"
+}
 (( $+functions[_plan-issue-local__subcmd__record__subcmd__closeout-gate_commands] )) ||
 _plan-issue-local__subcmd__record__subcmd__closeout-gate_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local record closeout-gate commands' commands "$@"
+}
+(( $+functions[_plan-issue-local__subcmd__record__subcmd__open_commands] )) ||
+_plan-issue-local__subcmd__record__subcmd__open_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue-local record open commands' commands "$@"
+}
+(( $+functions[_plan-issue-local__subcmd__record__subcmd__post_commands] )) ||
+_plan-issue-local__subcmd__record__subcmd__post_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue-local record post commands' commands "$@"
 }
 (( $+functions[_plan-issue-local__subcmd__record__subcmd__render-comment_commands] )) ||
 _plan-issue-local__subcmd__record__subcmd__render-comment_commands() {
@@ -578,6 +674,11 @@ _plan-issue-local__subcmd__record__subcmd__render-comment_commands() {
 _plan-issue-local__subcmd__record__subcmd__render-dashboard_commands() {
     local commands; commands=()
     _describe -t commands 'plan-issue-local record render-dashboard commands' commands "$@"
+}
+(( $+functions[_plan-issue-local__subcmd__record__subcmd__repair-dashboard_commands] )) ||
+_plan-issue-local__subcmd__record__subcmd__repair-dashboard_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-issue-local record repair-dashboard commands' commands "$@"
 }
 (( $+functions[_plan-issue-local__subcmd__resolve-approval_commands] )) ||
 _plan-issue-local__subcmd__resolve-approval_commands() {

--- a/crates/plan-issue-cli/src/commands/record.rs
+++ b/crates/plan-issue-cli/src/commands/record.rs
@@ -28,18 +28,30 @@ pub enum RecordCommand {
     Close(Box<RecordCloseArgs>),
 
     /// Render a mutable issue dashboard for an issue-backed plan record.
+    /// Retired in v2 — dashboard rendering moved under `record repair-dashboard`.
+    /// Kept callable as a transitional helper.
+    #[command(hide = true)]
     RenderDashboard(Box<RenderDashboardArgs>),
 
     /// Render one append-only lifecycle comment.
+    /// Retired in v2 — comment rendering is an implementation detail of
+    /// `record open` / `record post`. Kept callable as a transitional helper.
+    #[command(hide = true)]
     RenderComment(Box<RenderCommentArgs>),
 
     /// Audit issue body and comments for lifecycle markers.
     Audit(Box<RecordAuditArgs>),
 
     /// Evaluate closeout readiness from lifecycle audit evidence.
+    /// Retired in v2 — closeout gate evaluation moved inside `record close`
+    /// (strict by default). Kept callable as a transitional helper.
+    #[command(hide = true)]
     CloseoutGate(Box<RecordCloseoutGateArgs>),
 
     /// Build a dispatch ledger from plan metadata and split grouping rules.
+    /// Retired in v2 — dispatch consumers move to `record open` + state
+    /// payload. Kept callable as a transitional helper.
+    #[command(hide = true)]
     BuildDispatchLedger(Box<BuildDispatchLedgerArgs>),
 }
 

--- a/crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout/comments.json
+++ b/crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout/comments.json
@@ -1,0 +1,34 @@
+{
+  "comments": [
+    {
+      "url": "https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-source",
+      "created_at": "2026-05-20T08:00:00Z",
+      "body": "<!-- plan-issue-record:v2 role=source profile=tracking -->\n\n## Source Snapshot\n\n- Profile: tracking\n- Path: `docs/plans/agent-runtime-kit-closeout/agent-runtime-kit-closeout-discussion-source.md`\n- Commit: `src111111`\n\n```plan-issue-record-payload\n{\n  \"schema\": \"plan-issue-record.payload.v2\",\n  \"role\": \"source\",\n  \"profile\": \"tracking\",\n  \"data\": {\"path\": \"docs/plans/agent-runtime-kit-closeout/agent-runtime-kit-closeout-discussion-source.md\", \"commit\": \"src1111111111111111111111111111111111111\"}\n}\n```\n"
+    },
+    {
+      "url": "https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-plan",
+      "created_at": "2026-05-20T08:01:00Z",
+      "body": "<!-- plan-issue-record:v2 role=plan profile=tracking -->\n\n## Plan Snapshot\n\n- Profile: tracking\n- Path: `docs/plans/agent-runtime-kit-closeout/agent-runtime-kit-closeout-plan.md`\n- Commit: `pln111111`\n\n```plan-issue-record-payload\n{\n  \"schema\": \"plan-issue-record.payload.v2\",\n  \"role\": \"plan\",\n  \"profile\": \"tracking\",\n  \"data\": {\"path\": \"docs/plans/agent-runtime-kit-closeout/agent-runtime-kit-closeout-plan.md\", \"commit\": \"pln1111111111111111111111111111111111111\"}\n}\n```\n"
+    },
+    {
+      "url": "https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-state",
+      "created_at": "2026-05-22T18:00:00Z",
+      "body": "<!-- plan-issue-record:v2 role=state profile=tracking -->\n\n## Execution State\n\n- Profile: tracking\n\n```plan-issue-record-payload\n{\n  \"schema\": \"plan-issue-record.payload.v2\",\n  \"role\": \"state\",\n  \"profile\": \"tracking\",\n  \"updated_at\": \"2026-05-22T18:00:00Z\",\n  \"data\": {\n    \"status\": \"complete\",\n    \"target_scope\": \"agent-runtime-kit closeout fixture\",\n    \"current\": \"complete\",\n    \"next_action\": \"closeout\",\n    \"tasks\": [\n      {\"id\": \"1.1\", \"status\": \"done\", \"title\": \"Implement skill consumers\"},\n      {\"id\": \"1.2\", \"status\": \"done\", \"title\": \"Wire dispatch lanes\"},\n      {\"id\": \"1.3\", \"status\": \"deferred\", \"title\": \"Tooling polish\"}\n    ],\n    \"prs\": [\n      {\"ref\": \"sympoies/agent-runtime-kit#1\", \"url\": \"https://github.com/sympoies/agent-runtime-kit/pull/1\", \"status\": \"merged\"}\n    ],\n    \"blockers\": [],\n    \"links\": {\n      \"source\": \"https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-source\",\n      \"plan\": \"https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-plan\"\n    }\n  }\n}\n```\n"
+    },
+    {
+      "url": "https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-session",
+      "created_at": "2026-05-22T18:10:00Z",
+      "body": "<!-- plan-issue-record:v2 role=session profile=tracking -->\n\n## Execution Session\n\n- Profile: tracking\n\n```plan-issue-record-payload\n{\n  \"schema\": \"plan-issue-record.payload.v2\",\n  \"role\": \"session\",\n  \"profile\": \"tracking\",\n  \"data\": {\n    \"summary\": \"Implementation complete; ready for closeout.\",\n    \"highlights\": [\"All tasks done or explicitly deferred\", \"Provider-side PR merged\"],\n    \"links\": {\"state\": \"https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-state\"}\n  }\n}\n```\n"
+    },
+    {
+      "url": "https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-validation",
+      "created_at": "2026-05-22T18:15:00Z",
+      "body": "<!-- plan-issue-record:v2 role=validation profile=tracking -->\n\n## Validation Evidence\n\n- Profile: tracking\n\n```plan-issue-record-payload\n{\n  \"schema\": \"plan-issue-record.payload.v2\",\n  \"role\": \"validation\",\n  \"profile\": \"tracking\",\n  \"data\": {\n    \"overall\": \"pass\",\n    \"commands\": [\n      {\"command\": \"cargo test\", \"status\": \"pass\"},\n      {\"command\": \"npm test\", \"status\": \"pass\"}\n    ],\n    \"waivers\": []\n  }\n}\n```\n"
+    },
+    {
+      "url": "https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-review",
+      "created_at": "2026-05-22T18:30:00Z",
+      "body": "<!-- plan-issue-record:v2 role=review profile=tracking -->\n\n## Review Evidence\n\n- Profile: tracking\n\n```plan-issue-record-payload\n{\n  \"schema\": \"plan-issue-record.payload.v2\",\n  \"role\": \"review\",\n  \"profile\": \"tracking\",\n  \"data\": {\n    \"decision\": \"approve\",\n    \"lenses\": [\"testing\", \"maintainability\", \"api-contract\"],\n    \"findings\": [\n      {\"id\": \"F1\", \"severity\": \"minor\", \"disposition\": \"fixed\", \"summary\": \"Edge case test added\"}\n    ],\n    \"outcome_comment_url\": \"https://github.com/sympoies/agent-runtime-kit/pull/1#issuecomment-outcome\"\n  }\n}\n```\n"
+    }
+  ]
+}

--- a/crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout/issue-body.md
+++ b/crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout/issue-body.md
@@ -1,0 +1,33 @@
+## Current Dashboard
+
+This issue is the durable tracking surface for an issue-backed plan execution. The full source, plan, and execution logs remain in
+append-only issue comments.
+
+- Status: in-progress
+- Profile: tracking
+- Target scope: agent-runtime-kit closeout fixture
+- Current task: closeout pending
+- Next action: run `plan-issue record close`
+- Validation: pending
+- Linked PRs: https://github.com/sympoies/agent-runtime-kit/pull/1
+- Blockers: none
+- Review approval: pending
+
+## Durable Record
+
+- Source snapshot: pending
+- Plan snapshot: pending
+- Execution state: pending
+- Latest session: pending
+- Latest validation: pending
+- Closeout comment: pending
+
+## Guardrails
+
+- The issue body is a mutable dashboard only.
+- Append-only issue comments are the durable source of truth.
+
+## Original Tracker
+
+- Title: agent-runtime-kit closeout fixture
+- Issue: https://github.com/sympoies/agent-runtime-kit/issues/42

--- a/crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout/prs/sympoies__agent-runtime-kit__1.json
+++ b/crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout/prs/sympoies__agent-runtime-kit__1.json
@@ -1,0 +1,6 @@
+{
+  "state": "MERGED",
+  "mergeCommit": {"oid": "merge1111111111111111111111111111111111"},
+  "statusCheckRollup": {"state": "success"},
+  "url": "https://github.com/sympoies/agent-runtime-kit/pull/1"
+}

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -683,3 +683,126 @@ fn record_open_dry_run_returns_preview_without_gh_calls() {
         "{source_comment}"
     );
 }
+
+/// Sprint 4 Task 4.3: exercise the v3 closeout end-to-end against a sanitized
+/// agent-runtime-kit fixture. Asserts that one `record close` invocation can
+/// audit the issue, verify provider PR merge evidence, render the closeout
+/// comment + final dashboard, and that no v1 markers leak into the result.
+#[test]
+fn agent_runtime_kit_lifecycle_fixture_passes_strict_v2_closeout_end_to_end() {
+    let fixture = Path::new("tests/fixtures/lifecycle/agent-runtime-kit-closeout").to_path_buf();
+    assert!(fixture.exists(), "fixture missing: {}", fixture.display());
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "42",
+        "--linked-pr",
+        "sympoies/agent-runtime-kit#1",
+        "--approval",
+        "https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-approval",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let result = &parsed["payload"]["result"];
+    assert_eq!(result["operation"], "record.close");
+    assert_eq!(result["mode"], "fixture");
+    assert_eq!(result["dry_run"], true);
+
+    let preview = &result["preview"];
+    let closeout_body = preview["closeout_comment_body"]
+        .as_str()
+        .expect("closeout body present");
+    // Closeout comment uses the v2 marker and carries provider-verified
+    // merge_sha from the fixture PR snapshot.
+    assert!(
+        closeout_body.starts_with("<!-- plan-issue-record:v2 role=closeout profile=tracking -->"),
+        "{closeout_body}"
+    );
+    assert!(
+        closeout_body.contains("\"merge_sha\": \"merge1111111111111111111111111111111111\""),
+        "merge_sha must come from PR fixture, not state payload: {closeout_body}"
+    );
+    assert!(
+        closeout_body.contains("\"final_status\": \"complete\""),
+        "{closeout_body}"
+    );
+    // Sanity: no v1 marker bleed-through.
+    assert!(
+        !closeout_body.contains("execute-from-tracking-issue:")
+            && !closeout_body.contains("plan-tracking-issue:"),
+        "v1 markers must not appear in v2 closeout body: {closeout_body}"
+    );
+
+    let final_dashboard = preview["final_dashboard"]
+        .as_str()
+        .expect("final dashboard present");
+    assert!(
+        final_dashboard.starts_with("## Final Dashboard"),
+        "complete state must render Final Dashboard: {final_dashboard}"
+    );
+    // Durable record links derive from audit, not caller-supplied URLs.
+    assert!(
+        final_dashboard.contains(
+            "https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-source"
+        ),
+        "dashboard must include source URL from audit: {final_dashboard}"
+    );
+    assert!(
+        final_dashboard
+            .contains("https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-state"),
+        "dashboard must include state URL from audit: {final_dashboard}"
+    );
+}
+
+/// Sprint 4 Task 4.3: same fixture, but force the strict gate to fail by
+/// flipping the PR snapshot to unmerged. Verifies the gate code surfaces.
+#[test]
+fn agent_runtime_kit_lifecycle_fixture_blocks_when_pr_unmerged() {
+    let src = Path::new("tests/fixtures/lifecycle/agent-runtime-kit-closeout");
+    let tmp = TempDir::new().expect("tmp");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(fixture.join("prs")).expect("create fixture dirs");
+    fs::copy(src.join("issue-body.md"), fixture.join("issue-body.md")).expect("copy body");
+    fs::copy(src.join("comments.json"), fixture.join("comments.json")).expect("copy comments");
+    // Replace the PR snapshot with an open PR so the strict gate fails.
+    fs::write(
+        fixture.join("prs/sympoies__agent-runtime-kit__1.json"),
+        serde_json::to_string(&json!({
+            "state": "OPEN",
+            "mergeCommit": null,
+            "statusCheckRollup": {"state": "pending"},
+            "url": "https://github.com/sympoies/agent-runtime-kit/pull/1"
+        }))
+        .expect("pr json"),
+    )
+    .expect("write open pr fixture");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "42",
+        "--linked-pr",
+        "sympoies/agent-runtime-kit#1",
+        "--approval",
+        "ok",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+
+    assert_ne!(out.code, 0, "unmerged PR should block strict closeout");
+    let joined = format!("{}\n{}", out.stderr, out.stdout);
+    assert!(
+        joined.contains("linked-pr-not-merged"),
+        "expected linked-pr-not-merged code, got: {joined}"
+    );
+}


### PR DESCRIPTION
## Summary

Sprint 4 of the plan-issue-lifecycle-v3 plan ([tracking issue #448](https://github.com/sympoies/nils-cli/issues/448)) trims the `plan-issue record` surface and adds the agent-runtime-kit closeout fixture:

- Hide `record render-dashboard | render-comment | closeout-gate | build-dispatch-ledger` from the primary help via `#[command(hide = true)]`. The retired subcommands stay callable as transitional helpers until consumers migrate; only `record --help` and downstream docs narrow to the v3 lifecycle (`open | post | repair-dashboard | close | audit`).
- Regenerate bash + zsh completions for both `plan-issue` and `plan-issue-local` so the new Sprint 3 subcommands (`open`, `post`, `repair-dashboard`, `close`) tab-complete alongside the still-callable retired entries.
- Add the agent-runtime-kit closeout fixture under `crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout/` with full v2 evidence (source / plan / state=complete / session / validation=pass / review=approve) plus a provider PR snapshot. Two new integration tests prove the strict v3 closeout end-to-end against the fixture and assert it fails with `linked-pr-not-merged` when the PR snapshot is flipped to OPEN.

## What stays out of scope

- Task Decomposition CLI (`start-plan`, `start-sprint`, etc.) is **not** retired in this PR — those handlers + tests are a larger refactor that the v3 spec's Compatibility Layer explicitly says happens "in a coordinated release of the consumer after `plan-issue` v3 ships." Sprint 5 handoff notes will flag this for the next release.
- Result envelope normalization (`mode`-keyed shape inconsistency flagged by the Sprint 3 specialist review) — deferred to a follow-up.

## Test plan

- [x] `cargo test -p nils-plan-issue-cli` pass (66 lib + 127 integration; new `agent_runtime_kit_lifecycle_fixture_passes_strict_v2_closeout_end_to_end` + `agent_runtime_kit_lifecycle_fixture_blocks_when_pr_unmerged`).
- [x] `cargo fmt --all -- --check` pass.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` pass.
- [x] `bash scripts/ci/{docs-hygiene,markdownlint,third-party-artifacts,completion-asset,completion-flag-parity,cli-output-contract-lint}.sh --strict` all pass.
- [x] `./target/debug/plan-issue-local record --help` lists only `open`, `post`, `repair-dashboard`, `close`, `audit` (retired subcommands callable but hidden).

Tracking issue: <https://github.com/sympoies/nils-cli/issues/448>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
