### PR TITLE
docs(plan-issue-cli): v3 CHANGELOG + consumer migration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,13 @@ Each crate is either a standalone CLI binary, a multi-binary crate, or a shared 
 - [crates/plan-tooling](crates/plan-tooling): Plan Format v1 tooling CLI (`to-json`, `validate`, `batches`, `artifact-audit`,
   `split-prs`, `scaffold`, `completion`), with bundle validation, advisory durable-artifact classification, deterministic/auto grouping
   primitives, and strict lane-metadata validation gates.
-- [crates/plan-issue-cli](crates/plan-issue-cli): Plan issue orchestration binaries (`plan-issue`, `plan-issue-local`) where
-  `Task Decomposition` is runtime truth, planning artifacts are derived outputs, and runtime lane metadata is materialized from
-  plan content + split-prs grouping results.
+- [crates/plan-issue-cli](crates/plan-issue-cli): Plan issue orchestration binaries (`plan-issue`, `plan-issue-local`).
+  The v3 issue-backed lifecycle is owned by `record open`, `record post`,
+  `record repair-dashboard`, `record audit`, and `record close` (see
+  [`docs/specs/issue-backed-plan-record-contract-v2.md`](crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md)).
+  `Task Decomposition` orchestration remains available through `start-plan`,
+  `start-sprint`, etc., with runtime lane metadata materialized from plan
+  content + split-prs grouping results.
 
 ## Shared helper policy (`nils-common`)
 

--- a/crates/plan-issue-cli/CHANGELOG.md
+++ b/crates/plan-issue-cli/CHANGELOG.md
@@ -6,6 +6,88 @@ versioning.
 
 ## [Unreleased]
 
+### BREAKING (Plan-Issue Lifecycle v3)
+
+- The `plan-issue record` surface is rewritten around the v3 issue-backed
+  plan record contract (see
+  [`docs/specs/issue-backed-plan-record-contract-v2.md`](docs/specs/issue-backed-plan-record-contract-v2.md)
+  and [`docs/specs/plan-issue-state-machine-v2.md`](docs/specs/plan-issue-state-machine-v2.md)).
+  Consumers (notably `agent-runtime-kit`) must migrate after upgrading to
+  the next plan-issue-cli release. There is no compat shim.
+  - The `--marker-family compat|shared` argument is removed. There is now
+    one canonical marker family
+    `<!-- plan-issue-record:v2 role=<role> profile=<profile> -->`. Pre-v2
+    markers (`plan-tracking-issue:`, `execute-from-tracking-issue:`,
+    `tracking-issue-closeout:`, `deliver-dispatch-plan:`, ...) are
+    reported by audit as `unsupported_markers` and ignored as current
+    lifecycle evidence.
+  - Audit JSON renames `audit.markers` to `audit.evidence` and indexes by
+    role (`source`, `plan`, `state`, `session`, `validation`, `review`,
+    `closeout`). Each entry exposes the latest URL, created timestamp,
+    profile, role, status, and the parsed structured payload. Audit also
+    surfaces a stable `missing_required` array (`source-missing`,
+    `plan-missing`, `state-missing`).
+  - Every v2 lifecycle comment carries a fenced JSON block whose
+    info-string is the literal `plan-issue-record-payload`. The payload
+    is the structured source of truth for audit, dashboard repair, and
+    closeout gating. Prose-Markdown status parsing is no longer used.
+  - The `record closeout-gate` standalone command and its
+    `--require-complete`, `--require-session`, `--require-validation`,
+    `--require-review`, `--require-closeout` flags are retired.
+    Closeout-gate evaluation now runs inside `record close` and is
+    strict by default. Failure modes return stable codes
+    (`source-missing`, `plan-missing`, `state-missing`,
+    `state-not-complete`, `state-tasks-incomplete`, `validation-missing`,
+    `validation-failed`, `review-missing`, `review-rejected`,
+    `review-unresolved-findings`, `linked-pr-not-merged`,
+    `approval-missing`).
+  - `record render-comment`, `record render-dashboard`,
+    `record closeout-gate`, and `record build-dispatch-ledger` are
+    retired from the primary `record --help` surface via
+    `#[command(hide = true)]`. They remain callable as transitional
+    helpers until the next major release, but consumers should migrate
+    to `record open`, `record post`, `record repair-dashboard`, and
+    `record close` immediately.
+  - `record close` now requires a non-empty `--approval` URL or text. The
+    strict gate verifies linked PR evidence through provider state
+    (`gh pr view --json state,mergeCommit,statusCheckRollup`) and
+    records the resolved `merge_sha` + `checks` rollup back into the
+    closeout payload.
+  - The JSON envelope `schema_version` for every `record` subcommand
+    bumps to `plan-issue-cli.record.<sub>.v2`. v1 readers that only read
+    the older fields are still compatible because new fields are
+    additive at the result top level, but consumers should pin v2 before
+    reading new fields (`issue.url`, `comments.{source,plan,state}`,
+    `closeout_url`, `final_dashboard`).
+
+### Added (Plan-Issue Lifecycle v3)
+
+- `plan-issue record open --bundle <dir>` opens a provider issue from a
+  plan bundle, validates the plan via `plan-tooling`, verifies source +
+  plan files are committed (`--allow-dirty` opts out), posts canonical
+  v2 source / plan / initial-state comments with structured payloads,
+  and repairs the dashboard with the freshly-created comment URLs.
+  Supports `--dry-run` and `--fixture <dir>` deterministic modes.
+- `plan-issue record post --issue <n> --kind <state|session|validation|review> --payload-file <p>`
+  appends one canonical lifecycle comment with the v2 marker + payload
+  fence. `--kind source|plan` is rejected (owned by `record open`);
+  `--kind closeout` is rejected (owned by `record close`).
+- `plan-issue record repair-dashboard --issue <n>` (or `--body-file +
+  --comments-json` for local mode) recomputes the canonical dashboard
+  from audit evidence and edits the issue body without requiring
+  caller-supplied per-role URLs.
+- `plan-issue record close --issue <n> --linked-pr <ref>... --approval <url-or-text>`
+  performs strict closeout: audit → strict gate → closeout comment →
+  final dashboard → issue close, with provider-verified PR merge
+  evidence.
+- Adapter additions: `GitHubAdapter::issue_evidence`,
+  `GitHubAdapter::pr_merge_summary`, and `comment_issue` now returns the
+  posted comment URL.
+- Agent-runtime-kit consumer handoff: see
+  [`docs/specs/issue-backed-plan-record-contract-v2.md`](docs/specs/issue-backed-plan-record-contract-v2.md)
+  section "Consumer Migration" for example commands for replacing the
+  current `--marker-family compat` invocations.
+
 ### BREAKING
 
 - `start-plan` and `start-sprint` retire the previous flat artifact

--- a/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md
+++ b/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md
@@ -349,6 +349,74 @@ There is none. Consumers must migrate from v1 markers and v1 command flags
 in a coordinated release of the consumer (agent-runtime-kit) after the
 `plan-issue` v3 release ships.
 
+## Consumer Migration
+
+The agent-runtime-kit dispatch skills are the primary downstream consumer
+of this contract. They currently call `plan-issue` 0.17.x with
+`--marker-family compat` and assemble closeout from `record render-comment`,
+`record render-dashboard`, and `record closeout-gate` by hand. The
+migration is a one-time replacement of those invocations with the new
+provider-backed surface.
+
+### Before (v1, retired)
+
+```bash
+# Open a tracking issue and seed snapshots manually.
+plan-issue record render-comment \
+  --marker-family compat --kind source --content-file source.md --commit "$SOURCE_SHA" \
+  --out source.md
+forge-cli --provider github issue create --repo "$REPO" --title "$TITLE" --body-file source.md
+
+# Post lifecycle comments manually.
+plan-issue record render-comment --marker-family compat --kind state \
+  --content-file state.md --out state.md
+forge-cli --provider github issue comment "$ISSUE" --repo "$REPO" --body-file state.md
+
+# Evaluate closeout gate explicitly.
+plan-issue record closeout-gate \
+  --body-file issue-body.md --comments-json comments.json \
+  --require-complete --require-validation --require-review --require-closeout \
+  --approval "$APPROVAL_URL"
+
+# Close issue manually.
+forge-cli --provider github issue close "$ISSUE" --repo "$REPO" --reason completed
+```
+
+### After (v2, current)
+
+```bash
+# Open the tracking issue from a plan bundle.
+plan-issue --repo "$REPO" record open --bundle docs/plans/<slug>
+
+# Post one lifecycle comment.
+plan-issue --repo "$REPO" record post \
+  --issue "$ISSUE" --kind state --payload-file state.json
+
+# Refresh the dashboard from audit (no caller-supplied URLs).
+plan-issue --repo "$REPO" record repair-dashboard --issue "$ISSUE"
+
+# Strict closeout: audit, gate, comment, repair, close in one call.
+plan-issue --repo "$REPO" record close \
+  --issue "$ISSUE" \
+  --linked-pr "$REPO#$PR_NUMBER" \
+  --approval "$APPROVAL_URL"
+```
+
+### Migration checklist
+
+- [ ] Replace any `--marker-family compat` callsites with v2 invocations.
+- [ ] Replace `record render-comment | render-dashboard | closeout-gate`
+      composition with `record open | post | repair-dashboard | close`.
+- [ ] Switch JSON consumers from `audit.markers` (v1) to `audit.evidence`
+      keyed by role (v2).
+- [ ] Re-pin the JSON envelope on `plan-issue-cli.record.<sub>.v2` before
+      reading the new top-level fields (`issue.url`, `comments.*`,
+      `closeout_url`, `final_dashboard`).
+- [ ] After upgrading, re-post v2-marker `source`, `plan`, and `state`
+      comments on any in-flight tracking issue so audit can find them
+      (Sprint 1 + 2 lifecycle comments on existing issues remain v1 and
+      audit treats them as `unsupported_markers`).
+
 ## Test Fixtures
 
 Live commands accept a `--fixture <dir>` argument. The directory contains:


### PR DESCRIPTION
## Summary

Sprint 5 of the plan-issue-lifecycle-v3 plan ([tracking issue #448](https://github.com/sympoies/nils-cli/issues/448)) lands the release readiness gate, breaking-change documentation, and the agent-runtime-kit consumer handoff:

- **CHANGELOG**: add a `BREAKING (Plan-Issue Lifecycle v3)` section covering the marker collapse, `audit.markers → audit.evidence` rename, retired Record subcommands, strict closeout gate, non-empty `--approval` requirement, and `schema_version` bump to `plan-issue-cli.record.<sub>.v2`. Add an `Added (Plan-Issue Lifecycle v3)` block summarizing the new `record open | post | repair-dashboard | close` surface plus the GitHubAdapter additions.
- **v2 spec**: add a `Consumer Migration` section with before/after example commands so agent-runtime-kit (and any other consumer) can replace `--marker-family compat` invocations after the next plan-issue-cli release ships.
- **README**: update the plan-issue-cli pointer to highlight the v3 issue-backed lifecycle alongside the still-available Task Decomposition orchestration.

Full local validation gate passes (`NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` → `ok: all nils-cli checks passed`).

The execution-state ledger update happens on the plan branch (`plan/plan-issue-lifecycle-v3`) in [`007bbd0`](https://github.com/sympoies/nils-cli/commit/007bbd0c87c8d518c8aee89921dacf3d47567518) and marks all 14 tasks done with the matching PR + commit SHA evidence plus a Deferred Follow-ups block for the next major-release cycle.

## Test plan

- [x] `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh` (full local gate; 3590 tests + 6 audits + fmt + clippy + doc tests all pass).
- [x] `cargo test -p nils-plan-issue-cli` pass (66 lib + 127 integration tests).
- [x] `cargo fmt --all -- --check` pass.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` pass.

Tracking issue: <https://github.com/sympoies/nils-cli/issues/448>.

After this merges + user approval, the closeout step re-posts v2 source/plan/state lifecycle comments on #448 so audit can find them, then runs `plan-issue record close` against the strict v3 gate to close the issue with a `## Final Dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
