### PR TITLE
fix(agent-docs): task-tools -> core/policies/cli-tools.md (#457)

### DIFF
--- a/crates/agent-docs/README.md
+++ b/crates/agent-docs/README.md
@@ -70,7 +70,7 @@ If neither is provided, the binary errors with
 | `startup`     | `home`    | Use `AGENTS.override.md` when present; else `AGENTS.md` | `true`   |
 | `startup`     | `project` | Use `AGENTS.override.md` when present; else `AGENTS.md` | `true`   |
 | `skill-dev`   | `home`    | `DEVELOPMENT.md`                                        | `true`   |
-| `task-tools`  | `home`    | `CLI_TOOLS.md`                                          | `true`   |
+| `task-tools`  | `home`    | `core/policies/cli-tools.md`                            | `true`   |
 | `project-dev` | `project` | `DEVELOPMENT.md`                                        | `true`   |
 
 `AGENTS.override.md` precedence is evaluated per scope independently.
@@ -392,14 +392,14 @@ $ echo $?
 ```text
 $ agent-docs baseline --check --target all
 BASELINE CHECK: all
-AGENT_DOCS_HOME: /Users/example/.agents
-PROJECT_PATH: /Users/example/work/nils-cli
+AGENT_DOCS_HOME: $HOME/.agents
+PROJECT_PATH: $HOME/work/nils-cli
 
-[home] startup policy /Users/example/.agents/AGENTS.md required present source=builtin-fallback why="startup home policy (AGENTS.override.md missing, fallback AGENTS.md)"
-[home] skill-dev /Users/example/.agents/DEVELOPMENT.md required missing source=builtin why="skill development guidance from AGENT_DOCS_HOME/DEVELOPMENT.md"
-[home] task-tools /Users/example/.agents/CLI_TOOLS.md required present source=builtin why="tool-selection guidance from AGENT_DOCS_HOME/CLI_TOOLS.md"
-[project] startup policy /Users/example/work/nils-cli/AGENTS.md required present source=builtin-fallback why="startup project policy (AGENTS.override.md missing, fallback AGENTS.md)"
-[project] project-dev /Users/example/work/nils-cli/DEVELOPMENT.md required present source=builtin why="project development guidance from PROJECT_PATH/DEVELOPMENT.md"
+[home] startup policy $HOME/.agents/AGENTS.md required present source=builtin-fallback why="startup home policy (AGENTS.override.md missing, fallback AGENTS.md)"
+[home] skill-dev $HOME/.agents/DEVELOPMENT.md required missing source=builtin why="skill development guidance from AGENT_DOCS_HOME/DEVELOPMENT.md"
+[home] task-tools $HOME/.agents/core/policies/cli-tools.md required present source=builtin why="tool-selection guidance from AGENT_DOCS_HOME/core/policies/cli-tools.md"
+[project] startup policy $HOME/work/nils-cli/AGENTS.md required present source=builtin-fallback why="startup project policy (AGENTS.override.md missing, fallback AGENTS.md)"
+[project] project-dev $HOME/work/nils-cli/DEVELOPMENT.md required present source=builtin why="project development guidance from PROJECT_PATH/DEVELOPMENT.md"
 
 missing_required: 1
 missing_optional: 0

--- a/crates/agent-docs/src/commands/add.rs
+++ b/crates/agent-docs/src/commands/add.rs
@@ -339,7 +339,7 @@ mod tests {
             target: Scope::Home,
             context: Context::TaskTools,
             scope: Scope::Home,
-            path: PathBuf::from("CLI_TOOLS.md"),
+            path: PathBuf::from("core/policies/cli-tools.md"),
             required: false,
             when: DocumentWhen::Always,
             notes: Some("initial".to_string()),
@@ -350,7 +350,7 @@ mod tests {
             target: Scope::Home,
             context: Context::TaskTools,
             scope: Scope::Home,
-            path: PathBuf::from("CLI_TOOLS.md"),
+            path: PathBuf::from("core/policies/cli-tools.md"),
             required: true,
             when: DocumentWhen::Always,
             notes: Some("updated".to_string()),
@@ -375,7 +375,7 @@ mod tests {
         let only = &loaded.documents[0];
         assert_eq!(only.context, Context::TaskTools);
         assert_eq!(only.scope, Scope::Home);
-        assert_eq!(only.path, Path::new("CLI_TOOLS.md"));
+        assert_eq!(only.path, Path::new("core/policies/cli-tools.md"));
         assert!(only.required);
         assert_eq!(only.when, DocumentWhen::Always);
         assert_eq!(only.notes.as_deref(), Some("updated"));
@@ -399,7 +399,7 @@ notes = "first"
 [[document]]
 context = "task-tools"
 scope = "home"
-path = "CLI_TOOLS.md"
+path = "core/policies/cli-tools.md"
 required = true
 when = "always"
 notes = "other"
@@ -482,7 +482,7 @@ notes = "second"
 [[document]]
 context = "task-tools"
 scope = "home"
-path = "CLI_TOOLS.md"
+path = "core/policies/cli-tools.md"
 required = false
 when = "always"
 notes = "before"
@@ -505,7 +505,7 @@ notes = "tail"
                 target: Scope::Home,
                 context: Context::TaskTools,
                 scope: Scope::Home,
-                path: PathBuf::from("CLI_TOOLS.md"),
+                path: PathBuf::from("core/policies/cli-tools.md"),
                 required: true,
                 when: DocumentWhen::Always,
                 notes: Some("after".to_string()),
@@ -536,7 +536,7 @@ notes = "tail"
 [[document]]
 context = "task-tools"
 scope = "home"
-path = "CLI_TOOLS.md"
+path = "core/policies/cli-tools.md"
 required = false
 when = "always"
 notes = "before"
@@ -551,7 +551,7 @@ notes = "before"
                 target: Scope::Home,
                 context: Context::TaskTools,
                 scope: Scope::Home,
-                path: PathBuf::from("CLI_TOOLS.md"),
+                path: PathBuf::from("core/policies/cli-tools.md"),
                 required: true,
                 when: DocumentWhen::Always,
                 notes: Some("after".to_string()),
@@ -575,7 +575,7 @@ notes = "before"
 [[document]]
 context = "task-tools" # keep context comment
 scope = "home" # keep scope comment
-path = "CLI_TOOLS.md" # keep path comment
+path = "core/policies/cli-tools.md" # keep path comment
 required = false # keep required comment
 when = "always" # keep when comment
 notes = "before" # keep notes comment
@@ -590,7 +590,7 @@ notes = "before" # keep notes comment
                 target: Scope::Home,
                 context: Context::TaskTools,
                 scope: Scope::Home,
-                path: PathBuf::from("CLI_TOOLS.md"),
+                path: PathBuf::from("core/policies/cli-tools.md"),
                 required: true,
                 when: DocumentWhen::Always,
                 notes: Some("after".to_string()),

--- a/crates/agent-docs/src/commands/baseline.rs
+++ b/crates/agent-docs/src/commands/baseline.rs
@@ -82,8 +82,8 @@ fn home_items(roots: &ResolvedRoots) -> Vec<BaselineCheckItem> {
             Context::TaskTools,
             "task-tools",
             &roots.docs_home,
-            "CLI_TOOLS.md",
-            "tool-selection guidance from AGENT_DOCS_HOME/CLI_TOOLS.md",
+            "core/policies/cli-tools.md",
+            "tool-selection guidance from AGENT_DOCS_HOME/core/policies/cli-tools.md",
             DocumentSource::Builtin,
         ),
     ]

--- a/crates/agent-docs/src/commands/scaffold_baseline.rs
+++ b/crates/agent-docs/src/commands/scaffold_baseline.rs
@@ -11,7 +11,7 @@ use crate::paths::normalize_path;
 
 const AGENTS_FILE_NAME: &str = "AGENTS.md";
 const DEVELOPMENT_FILE_NAME: &str = "DEVELOPMENT.md";
-const CLI_TOOLS_FILE_NAME: &str = "CLI_TOOLS.md";
+const CLI_TOOLS_FILE_NAME: &str = "core/policies/cli-tools.md";
 const DEVELOPMENT_TEMPLATE: &str = include_str!("../templates/development_default.md");
 const CLI_TOOLS_TEMPLATE: &str = include_str!("../templates/cli_tools_default.md");
 const SETUP_PLACEHOLDER: &str = "{{SETUP_COMMANDS}}";
@@ -652,7 +652,7 @@ mod tests {
             "# existing project dev\n"
         );
         assert!(!home.path().join("DEVELOPMENT.md").exists());
-        assert!(!home.path().join("CLI_TOOLS.md").exists());
+        assert!(!home.path().join("core/policies/cli-tools.md").exists());
         assert!(!project.path().join("AGENTS.md").exists());
     }
 

--- a/crates/agent-docs/src/resolver.rs
+++ b/crates/agent-docs/src/resolver.rs
@@ -83,8 +83,8 @@ pub fn resolve_builtin_only_with_mode(
             Context::TaskTools,
             Scope::Home,
             &roots.docs_home,
-            "CLI_TOOLS.md",
-            "tool-selection guidance from AGENT_DOCS_HOME/CLI_TOOLS.md",
+            "core/policies/cli-tools.md",
+            "tool-selection guidance from AGENT_DOCS_HOME/core/policies/cli-tools.md",
             DocumentSource::Builtin,
         )],
         Context::ProjectDev => vec![resolve_required_doc_with_project_fallback(

--- a/crates/agent-docs/src/templates/cli_tools_default.md
+++ b/crates/agent-docs/src/templates/cli_tools_default.md
@@ -1,4 +1,4 @@
-# CLI_TOOLS.md
+# CLI Tools
 
 ## Tool Selection
 

--- a/crates/agent-docs/tests/fixtures/add/preserve-key-order.expected.toml
+++ b/crates/agent-docs/tests/fixtures/add/preserve-key-order.expected.toml
@@ -1,7 +1,7 @@
 # key-order fixture
 
 [[document]]
-path = "CLI_TOOLS.md"
+path = "core/policies/cli-tools.md"
 # keep context block
 context = "task-tools"
 notes = "after"

--- a/crates/agent-docs/tests/fixtures/add/preserve-key-order.input.toml
+++ b/crates/agent-docs/tests/fixtures/add/preserve-key-order.input.toml
@@ -1,7 +1,7 @@
 # key-order fixture
 
 [[document]]
-path = "CLI_TOOLS.md"
+path = "core/policies/cli-tools.md"
 # keep context block
 context = "task-tools"
 notes = "before"

--- a/crates/agent-docs/tests/fixtures/add/preserve-multisection-comments.expected.toml
+++ b/crates/agent-docs/tests/fixtures/add/preserve-multisection-comments.expected.toml
@@ -10,7 +10,7 @@ context = "task-tools" # keep context inline
 scope = "home" # keep scope inline
 
 # section path
-path = "CLI_TOOLS.md" # keep path inline
+path = "core/policies/cli-tools.md" # keep path inline
 required = true # keep required inline
 
 # section when

--- a/crates/agent-docs/tests/fixtures/add/preserve-multisection-comments.input.toml
+++ b/crates/agent-docs/tests/fixtures/add/preserve-multisection-comments.input.toml
@@ -10,7 +10,7 @@ context = "task-tools" # keep context inline
 scope = "home" # keep scope inline
 
 # section path
-path = "CLI_TOOLS.md" # keep path inline
+path = "core/policies/cli-tools.md" # keep path inline
 required = false # keep required inline
 
 # section when

--- a/crates/agent-docs/tests/fixtures/config/AGENT_DOCS.invalid.toml
+++ b/crates/agent-docs/tests/fixtures/config/AGENT_DOCS.invalid.toml
@@ -31,7 +31,7 @@ notes = "required must be boolean"
 [[document]]
 context = "task-tools"
 scope = "home"
-path = "CLI_TOOLS.md"
+path = "core/policies/cli-tools.md"
 required = true
 when = "if-env:CI"
 notes = "unsupported when condition"

--- a/crates/agent-docs/tests/fixtures/config/AGENT_DOCS.valid.toml
+++ b/crates/agent-docs/tests/fixtures/config/AGENT_DOCS.valid.toml
@@ -40,7 +40,7 @@ notes = "skill-dev home baseline"
 [[document]]
 context = "task-tools"
 scope = "home"
-path = "CLI_TOOLS.md"
+path = "core/policies/cli-tools.md"
 required = true
 when = "always"
 notes = "task-tools home baseline"

--- a/crates/agent-docs/tests/fixtures/home/cli-tools.template.expected.md
+++ b/crates/agent-docs/tests/fixtures/home/cli-tools.template.expected.md
@@ -1,4 +1,4 @@
-# CLI_TOOLS.md
+# CLI Tools
 
 ## Tool Selection
 

--- a/crates/agent-docs/tests/fixtures/home/core/policies/cli-tools.md
+++ b/crates/agent-docs/tests/fixtures/home/core/policies/cli-tools.md
@@ -1,3 +1,3 @@
-# Fixture: home CLI_TOOLS
+# Fixture: home cli-tools
 
 id: fixture-home-cli-tools

--- a/crates/agent-docs/tests/integration/add.rs
+++ b/crates/agent-docs/tests/integration/add.rs
@@ -145,8 +145,9 @@ fn add_full_flow_for_home_and_project_scopes() {
     assert!(
         task_tools_required
             .iter()
-            .any(|line| line.contains("CLI_TOOLS.md") && line.contains("source=builtin")),
-        "task-tools output should include builtin CLI_TOOLS.md:\n{}",
+            .any(|line| line.contains("core/policies/cli-tools.md")
+                && line.contains("source=builtin")),
+        "task-tools output should include builtin core/policies/cli-tools.md:\n{}",
         task_tools_resolve.stdout
     );
     assert!(
@@ -206,7 +207,7 @@ fn run_home_task_tools_add_update(workspace: &common::FixtureWorkspace) -> commo
             "--scope",
             "home",
             "--path",
-            "CLI_TOOLS.md",
+            "core/policies/cli-tools.md",
             "--required",
             "--notes",
             "after",

--- a/crates/agent-docs/tests/integration/baseline.rs
+++ b/crates/agent-docs/tests/integration/baseline.rs
@@ -76,7 +76,7 @@ fn baseline_check_target_all_json_contains_required_fields_and_actions() {
     let project = TempDir::new().expect("failed to create project tempdir");
 
     write_markdown(&home.path().join("AGENTS.override.md"));
-    write_markdown(&home.path().join("CLI_TOOLS.md"));
+    write_markdown(&home.path().join("core/policies/cli-tools.md"));
     write_markdown(&project.path().join("AGENTS.md"));
 
     let report = check_builtin_baseline(BaselineTarget::All, &roots(&home, &project), false)

--- a/crates/agent-docs/tests/integration/config.rs
+++ b/crates/agent-docs/tests/integration/config.rs
@@ -101,7 +101,7 @@ fn load_scope_config_rejects_unsupported_when_with_actionable_error() {
 [[document]]
 context = "task-tools"
 scope = "home"
-path = "CLI_TOOLS.md"
+path = "core/policies/cli-tools.md"
 required = true
 when = "if-env:CI"
 "#,

--- a/crates/agent-docs/tests/integration/resolve_builtin.rs
+++ b/crates/agent-docs/tests/integration/resolve_builtin.rs
@@ -322,7 +322,7 @@ notes = "home-extra"
 [[document]]
 context = "task-tools"
 scope = "home"
-path = "CLI_TOOLS.md"
+path = "core/policies/cli-tools.md"
 required = true
 notes = "other-context-ignored"
 "#,
@@ -342,7 +342,7 @@ notes = "project-extra-overrides-home"
 [[document]]
 context = "project-dev"
 scope = "home"
-path = "CLI_TOOLS.md"
+path = "core/policies/cli-tools.md"
 required = false
 notes = "project-home-scope-entry"
 "#,
@@ -397,7 +397,7 @@ notes = "project-home-scope-entry"
     );
 
     let home_scoped = &documents[3];
-    assert!(home_scoped.path.ends_with("CLI_TOOLS.md"));
+    assert!(home_scoped.path.ends_with("core/policies/cli-tools.md"));
     assert_eq!(home_scoped.source, DocumentSource::ExtensionProject);
     assert!(!home_scoped.required);
     assert_eq!(home_scoped.status, DocumentStatus::Present);
@@ -440,7 +440,7 @@ fn expected_documents(context: Context) -> &'static [ExpectedDocument] {
         }],
         Context::TaskTools => &[ExpectedDocument {
             scope: "home",
-            file_name: "CLI_TOOLS.md",
+            file_name: "cli-tools.md",
             source: "builtin",
             status: "present",
         }],

--- a/crates/agent-docs/tests/integration/scaffold_baseline.rs
+++ b/crates/agent-docs/tests/integration/scaffold_baseline.rs
@@ -23,7 +23,7 @@ fn scaffold_baseline_missing_only_creates_only_missing_files() {
 
     let home_agents = workspace.docs_home.join("AGENTS.md");
     let home_development = workspace.docs_home.join("DEVELOPMENT.md");
-    let home_cli_tools = workspace.docs_home.join("CLI_TOOLS.md");
+    let home_cli_tools = workspace.docs_home.join("core/policies/cli-tools.md");
     let project_agents = workspace.project_path.join("AGENTS.md");
     let project_development = workspace.project_path.join("DEVELOPMENT.md");
 
@@ -35,7 +35,7 @@ fn scaffold_baseline_missing_only_creates_only_missing_files() {
     common::remove_file_if_exists(&project_development);
     assert!(
         !home_cli_tools.exists(),
-        "precondition: home CLI_TOOLS.md missing"
+        "precondition: home core/policies/cli-tools.md missing"
     );
     assert!(
         !project_development.exists(),
@@ -64,7 +64,7 @@ fn scaffold_baseline_missing_only_creates_only_missing_files() {
     assert_eq!(read_file(&home_development), home_development_before);
     assert_eq!(read_file(&project_agents), project_agents_before);
 
-    let expected_home_cli_tools = read_fixture("home/CLI_TOOLS.template.expected.md");
+    let expected_home_cli_tools = read_fixture("home/cli-tools.template.expected.md");
     let expected_project_development = read_fixture("project/DEVELOPMENT.template.expected.md");
     assert_eq!(read_file(&home_cli_tools), expected_home_cli_tools);
     assert_eq!(
@@ -79,7 +79,7 @@ fn scaffold_baseline_force_overwrite_updates_existing_baseline_files() {
     seed_cargo_workspace(&workspace.docs_home);
     seed_cargo_workspace(&workspace.project_path);
 
-    let home_cli_tools = workspace.docs_home.join("CLI_TOOLS.md");
+    let home_cli_tools = workspace.docs_home.join("core/policies/cli-tools.md");
     let project_development = workspace.project_path.join("DEVELOPMENT.md");
     common::write_text(&home_cli_tools, "# stale home cli tools\n");
     common::write_text(&project_development, "# stale project development\n");
@@ -102,7 +102,7 @@ fn scaffold_baseline_force_overwrite_updates_existing_baseline_files() {
         output.stdout
     );
 
-    let expected_home_cli_tools = read_fixture("home/CLI_TOOLS.template.expected.md");
+    let expected_home_cli_tools = read_fixture("home/cli-tools.template.expected.md");
     let expected_project_development = read_fixture("project/DEVELOPMENT.template.expected.md");
     let actual_home_cli_tools = read_file(&home_cli_tools);
     let actual_project_development = read_file(&project_development);
@@ -110,7 +110,7 @@ fn scaffold_baseline_force_overwrite_updates_existing_baseline_files() {
     assert_eq!(actual_project_development, expected_project_development);
     assert!(
         !actual_home_cli_tools.contains("stale"),
-        "force mode should overwrite stale CLI_TOOLS.md"
+        "force mode should overwrite stale core/policies/cli-tools.md"
     );
     assert!(
         !actual_project_development.contains("stale"),
@@ -161,9 +161,9 @@ fn scaffold_baseline_generated_templates_include_required_sections_and_actionabl
         development
     );
 
-    let cli_tools = read_file(&workspace.docs_home.join("CLI_TOOLS.md"));
+    let cli_tools = read_file(&workspace.docs_home.join("core/policies/cli-tools.md"));
     for required in [
-        "# CLI_TOOLS.md",
+        "# CLI Tools",
         "## Tool Selection",
         "## Setup Command",
         "## Build Command",
@@ -177,14 +177,14 @@ fn scaffold_baseline_generated_templates_include_required_sections_and_actionabl
     ] {
         assert!(
             cli_tools.contains(required),
-            "generated CLI_TOOLS.md missing `{required}`:\n{cli_tools}"
+            "generated core/policies/cli-tools.md missing `{required}`:\n{cli_tools}"
         );
     }
     assert!(
         !cli_tools.contains("{{SETUP_COMMANDS}}")
             && !cli_tools.contains("{{BUILD_COMMANDS}}")
             && !cli_tools.contains("{{TEST_COMMANDS}}"),
-        "generated CLI_TOOLS.md should resolve template placeholders:\n{}",
+        "generated core/policies/cli-tools.md should resolve template placeholders:\n{}",
         cli_tools
     );
 }

--- a/scripts/ci/agent-docs-snapshots.sh
+++ b/scripts/ci/agent-docs-snapshots.sh
@@ -14,7 +14,7 @@ fixture_dir="$repo_root/crates/agent-docs/tests/fixtures/add"
 manifest_path="$repo_root/crates/agent-docs/Cargo.toml"
 
 run_snapshot_tests() {
-  cargo test --manifest-path "$manifest_path" --test add --test baseline
+  cargo test --manifest-path "$manifest_path" --test integration -- add:: baseline::
 }
 
 bless_add_snapshots() {
@@ -46,7 +46,7 @@ bless_add_snapshots() {
       --target home \
       --context task-tools \
       --scope home \
-      --path CLI_TOOLS.md \
+      --path core/policies/cli-tools.md \
       --required \
       --notes after >/dev/null
 


### PR DESCRIPTION
## Summary

- Migrate the `agent-docs` `task-tools` builtin contract from `AGENT_DOCS_HOME/CLI_TOOLS.md` to `AGENT_DOCS_HOME/core/policies/cli-tools.md`, matching the runtime-kit layout where the catalog was migrated to `core/policies/`.
- No legacy fallback to root `CLI_TOOLS.md` — clean cutover per discussion on #457.
- Updates the resolver, baseline, scaffold-baseline (file + parent-dir creation works via existing `ensure_parent_dir`), README example block (also converted to `$HOME/...` form to satisfy portable-paths lint), fixtures, integration tests, and the snapshot CI script (also fixes the stale `--test add --test baseline` invocation to the actual `integration` test binary).
- README/fixtures no longer teach `AGENT_DOCS_HOME/CLI_TOOLS.md` as the runtime-kit task-tools source of truth.

## Test plan

- [x] `cargo test -p nils-agent-docs` → 62/62 passing (incl. `resolve_builtin`, `scaffold_baseline`, `add`, `baseline`).
- [x] `bash scripts/ci/agent-docs-snapshots.sh` → 14/14 snapshot tests pass with the corrected test binary target.
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` → passes (fmt, clippy, workspace test, docs-only lints).
- [x] With `AGENT_DOCS_HOME=/Users/terry/Project/graysurf/agent-runtime-kit`, `agent-docs resolve --context task-tools --strict --format checklist` → `cli-tools.md status=present path=.../core/policies/cli-tools.md`, exit 0.
- [x] `agent-docs baseline --check --target all --strict --format text` no longer reports missing `CLI_TOOLS.md`. Remaining `missing_required: 1` is an unrelated pre-existing extension-home miss for `docs/source/docs-placement-retention-policy-v1.md`, tracked separately.

## Out of scope

- The `forge-cli --repo` propagation bug surfaced in #457's follow-up comment will land as a separate PR on the same issue.
- The pre-existing project-dev gap on `docs/source/docs-placement-retention-policy-v1.md` is not addressed here.

Refs: #457
