### PR TITLE
docs(plans): add plan-issue-lifecycle-v3 tracker bundle

### DIFF
--- a/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-discussion-source.md
+++ b/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-discussion-source.md
@@ -1,0 +1,99 @@
+# Plan-Issue Lifecycle v3 Implementation Source
+
+- Status: ready for tracking-plan creation
+- Date: 2026-05-23
+- Source: user discussion after closing the `agent-runtime-kit` shared
+  Heuristic System tracking issue and identifying that the current
+  `plan-issue record` surface still forces skills to stitch together low-level
+  render, provider mutation, audit, and closeout commands.
+- Intended next step: open one nils-cli tracking issue and execute the v3
+  breaking rewrite there. Do not open a parallel agent-runtime-kit issue until
+  the CLI contract is implemented and released.
+
+## Purpose
+
+Rewrite `plan-issue` around the issue-backed lifecycle that agent-runtime-kit
+actually needs: one canonical marker family, high-level provider-backed
+commands, strict closeout gates, provider-verified PR evidence, and automatic
+dashboard repair from durable issue comments.
+
+This should be a breaking rewrite. No compatibility layer is required for the
+legacy `plan-tracking-issue:*`, `execute-from-tracking-issue:*`,
+`tracking-issue-closeout:*`, or `deliver-dispatch-plan:*` marker families.
+
+## Source Tags
+
+- `[U1]` User asked whether the follow-up tracking issue belongs in
+  `agent-runtime-kit`, `nils-cli`, or both, and delegated the decision.
+- `[U2]` User asked for a complete, final rewrite of the nils-cli
+  `plan-issue` surface, without backward-version support.
+- `[F1]` `crates/plan-issue-cli/src/commands/record.rs` currently exposes
+  low-level `record render-dashboard`, `render-comment`, `audit`,
+  `closeout-gate`, and `build-dispatch-ledger` commands.
+- `[F2]` `crates/plan-issue-cli/src/commands/record.rs` currently exposes both
+  `MarkerFamily::Shared` and `MarkerFamily::Compat`.
+- `[F3]` `crates/plan-issue-cli/src/lifecycle_record.rs` currently errors when
+  asked to render a tracking-profile compat review marker.
+- `[F4]` `crates/plan-issue-cli/src/lifecycle_record.rs` currently extracts
+  lifecycle status from visible Markdown lines such as `- Status: complete`.
+- `[F5]` `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v1.md`
+  says `plan-issue record` never mutates provider issues and provider CRUD
+  remains outside the record command.
+- `[A1]` The shared Heuristic System closeout in agent-runtime-kit required a
+  manual chain of `plan-issue record`, `forge-cli issue`, `gh issue view`, and
+  dashboard repair commands.
+- `[A2]` The same closeout found that `forge-cli issue close --reason completed`
+  is not a valid current command shape.
+- `[I1]` Inference from `[F1]`, `[F5]`, and `[A1]`: agent-runtime-kit needs a
+  high-level lifecycle owner, not more low-level rendering primitives.
+- `[I2]` Inference from `[F2]` and `[F3]`: retaining marker families keeps
+  compatibility complexity in the exact place where the new workflow needs
+  determinism.
+- `[I3]` Inference from `[F4]`: audit and closeout should parse a structured
+  lifecycle payload rather than prose Markdown.
+
+## Decisions
+
+- Open the tracking issue in `sympoies/nils-cli`, not in agent-runtime-kit.
+  The implementation owner is `crates/plan-issue-cli`; agent-runtime-kit is the
+  downstream consumer and validation target.
+- Do not open a second agent-runtime-kit issue now. After the nils-cli release,
+  open a separate agent-runtime-kit migration issue only if the generated skill
+  and smoke-test changes are non-trivial.
+- Treat this as a breaking `plan-issue` v3 contract.
+- Keep `plan-tooling` as the plan parser and validator.
+- Make `plan-issue` the owner of issue-backed lifecycle state, provider issue
+  comments, dashboard repair, closeout gating, and issue closure.
+- Keep `forge-cli` as the general provider lifecycle tool, but do not require
+  agent-runtime-kit skills to compose `forge-cli` directly for plan issue
+  lifecycle operations.
+- Keep dispatch as a profile or mode of the same issue-backed lifecycle model,
+  not as a separate marker family.
+
+## Scope
+
+- Replace the issue-backed record contract with a single canonical marker and
+  structured payload model.
+- Add high-level live commands that can open, post, audit, repair, and close
+  issue-backed plan records from a plan bundle.
+- Make closeout strict by default.
+- Verify linked PRs through provider state, including merge state and check
+  status where available.
+- Update docs, tests, completions, and output-contract fixtures.
+- Add a sanitized fixture that represents the agent-runtime-kit closeout flow
+  that exposed the current defects.
+
+## Non-Scope
+
+- Do not migrate agent-runtime-kit skills in this nils-cli plan.
+- Do not preserve legacy marker compatibility.
+- Do not preserve `record closeout-gate` optional `--require-*` semantics.
+- Do not make `forge-cli` issue close accept `--reason` as the primary fix.
+- Do not mutate live agent-runtime-kit runtime homes.
+- Do not ship an unreleased debug binary as the agent-runtime-kit consumer
+  contract.
+
+## Execution
+
+- Recommended plan: docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-plan.md
+- Recommended execution state: docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md

--- a/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md
+++ b/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md
@@ -1,0 +1,57 @@
+# Plan-Issue Lifecycle v3 Execution State
+
+<!-- execute-from-tracking-issue:state:v1 -->
+## Execution State
+
+- Status: planning complete; tracking issue creation pending
+- Target scope: breaking `plan-issue` issue-backed lifecycle v3 rewrite
+- Execution window: next nils-cli implementation lane
+- Current task: create tracking issue from committed plan bundle
+- Next task: execute Sprint 1 after tracking issue is open
+- Last updated: 2026-05-23
+- Branch/commit/PR: plan/plan-issue-lifecycle-v3; PR pending
+- Source document: docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-plan.md
+- Direct source-doc execution waiver: not applicable
+- Tracking issue: pending
+
+## Validation Plan
+
+- `plan-tooling validate --file docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-plan.md --format text --explain`
+- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+- During implementation:
+  `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`
+
+## Task Ledger
+
+| ID | Status | Task | Evidence | Notes |
+| --- | --- | --- | --- | --- |
+| 1.1 | pending | Replace issue-backed record contract with v3 | pending | Spec-first breaking change. |
+| 1.2 | pending | Define high-level CLI surface | pending | Removes marker-family and optional closeout requirements. |
+| 1.3 | pending | Specify structured lifecycle payloads | pending | Audit no longer parses prose status lines. |
+| 2.1 | pending | Collapse marker parsing to canonical family | pending | Removes compat marker support. |
+| 2.2 | pending | Implement structured audit output | pending | Provides typed evidence for closeout. |
+| 2.3 | pending | Render dashboards from audit evidence | pending | Removes manual URL stitching. |
+| 3.1 | pending | Implement `record open` | pending | Bundle-first live issue creation. |
+| 3.2 | pending | Implement `record post` | pending | Append-only canonical lifecycle comments. |
+| 3.3 | pending | Implement strict `record close` | pending | Provider-verifies linked PRs and closes issue. |
+| 4.1 | pending | Remove or isolate Task Decomposition commands | pending | Primary help surface becomes issue-backed lifecycle. |
+| 4.2 | pending | Refresh completions and output contract fixtures | pending | Required after command surface change. |
+| 4.3 | pending | Add agent-runtime-kit closeout fixture coverage | pending | Proves the new CLI covers the discovered workflow. |
+| 5.1 | pending | Run full nils-cli validation | pending | CI-equivalent local gate. |
+| 5.2 | pending | Prepare release and agent-runtime-kit handoff notes | pending | Consumer migration happens after release. |
+
+## Session Log
+
+- 2026-05-23: User delegated whether to open the tracking issue in nils-cli,
+  agent-runtime-kit, or both. Decision: open one nils-cli issue because the
+  implementation owner is `crates/plan-issue-cli`; defer agent-runtime-kit
+  migration until the CLI is released.
+- 2026-05-23: Created the plan bundle for a breaking v3 rewrite of the
+  issue-backed lifecycle surface.
+
+## Notes
+
+- This plan intentionally does not preserve backwards compatibility.
+- This plan does not mutate agent-runtime-kit source files.
+- The implementation should stop and re-scope only if removing the legacy Task
+  Decomposition commands would make unrelated nils-cli surfaces unusable.

--- a/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md
+++ b/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md
@@ -1,21 +1,28 @@
 # Plan-Issue Lifecycle v3 Execution State
 
-<!-- execute-from-tracking-issue:state:v1 -->
+<!-- plan-issue-record:v2 role=state profile=tracking -->
 ## Execution State
 
-- Status: tracking issue open; ready for Sprint 1 execution
+- Status: implementation complete; ready for closeout
 - Target scope: breaking `plan-issue` issue-backed lifecycle v3 rewrite
-- Execution window: next nils-cli implementation lane
-- Current task: Sprint 1 ready
-- Next task: execute Task 1.1, Task 1.2, and Task 1.3
+- Execution window: 2026-05-23 (Sprint 1 → Sprint 5)
+- Current task: Sprint 5 complete; closeout pending user approval
+- Next task: re-post v2-marker source/plan/state lifecycle comments on
+  #448 (Sprint 1 + 2 were authored with the v1 binary), then run
+  `plan-issue record close` to apply the strict v3 gate and close the
+  issue.
 - Last updated: 2026-05-23
-- Branch/commit/PR: plan/plan-issue-lifecycle-v3; plan commit dc9aedc; PR pending
+- Branch/commit/PR: plan/plan-issue-lifecycle-v3; impl PRs #449, #453,
+  #454, #455 (all merged); Sprint 5 PR pending
 - Source document: docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-plan.md
 - Direct source-doc execution waiver: not applicable
 - Tracking issue: [#448](https://github.com/sympoies/nils-cli/issues/448)
 - Source snapshot: [source](https://github.com/sympoies/nils-cli/issues/448#issuecomment-4524856896)
 - Plan snapshot: [plan](https://github.com/sympoies/nils-cli/issues/448#issuecomment-4524856962)
 - Initial state snapshot: [state](https://github.com/sympoies/nils-cli/issues/448#issuecomment-4524857027)
+- Latest state snapshot (v2): [state](https://github.com/sympoies/nils-cli/issues/448#issuecomment-4525591970)
+- Latest session snapshot (v2): [session](https://github.com/sympoies/nils-cli/issues/448#issuecomment-4525592044)
+- Latest validation snapshot (v2): [validation](https://github.com/sympoies/nils-cli/issues/448#issuecomment-4525592137)
 
 ## Validation Plan
 
@@ -23,25 +30,29 @@
 - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
 - During implementation:
   `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`
+- For Sprint 5 closeout:
+  `plan-issue record audit --profile tracking --body-file <body> --comments-json <comments>`
+  must return `recognized_count >= 6` and `missing_required = []` before
+  `plan-issue record close` is invoked.
 
 ## Task Ledger
 
 | ID | Status | Task | Evidence | Notes |
 | --- | --- | --- | --- | --- |
-| 1.1 | pending | Replace issue-backed record contract with v3 | pending | Spec-first breaking change. |
-| 1.2 | pending | Define high-level CLI surface | pending | Removes marker-family and optional closeout requirements. |
-| 1.3 | pending | Specify structured lifecycle payloads | pending | Audit no longer parses prose status lines. |
-| 2.1 | pending | Collapse marker parsing to canonical family | pending | Removes compat marker support. |
-| 2.2 | pending | Implement structured audit output | pending | Provides typed evidence for closeout. |
-| 2.3 | pending | Render dashboards from audit evidence | pending | Removes manual URL stitching. |
-| 3.1 | pending | Implement `record open` | pending | Bundle-first live issue creation. |
-| 3.2 | pending | Implement `record post` | pending | Append-only canonical lifecycle comments. |
-| 3.3 | pending | Implement strict `record close` | pending | Provider-verifies linked PRs and closes issue. |
-| 4.1 | pending | Remove or isolate Task Decomposition commands | pending | Primary help surface becomes issue-backed lifecycle. |
-| 4.2 | pending | Refresh completions and output contract fixtures | pending | Required after command surface change. |
-| 4.3 | pending | Add agent-runtime-kit closeout fixture coverage | pending | Proves the new CLI covers the discovered workflow. |
-| 5.1 | pending | Run full nils-cli validation | pending | CI-equivalent local gate. |
-| 5.2 | pending | Prepare release and agent-runtime-kit handoff notes | pending | Consumer migration happens after release. |
+| 1.1 | done | Replace issue-backed record contract with v3 | PR #449 (7aaf443) | Spec-first breaking change. |
+| 1.2 | done | Define high-level CLI surface | PR #449 (7aaf443) | Removed marker-family and optional closeout requirements. |
+| 1.3 | done | Specify structured lifecycle payloads | PR #449 (7aaf443) | Audit no longer parses prose status lines. |
+| 2.1 | done | Collapse marker parsing to canonical family | PR #453 (eb6f383) | Removed compat marker support. |
+| 2.2 | done | Implement structured audit output | PR #453 (eb6f383) | Provides typed evidence for closeout. |
+| 2.3 | done | Render dashboards from audit evidence | PR #453 (eb6f383) | Removes manual URL stitching. |
+| 3.1 | done | Implement `record open` | PR #454 (cef31ee) | Bundle-first live issue creation. |
+| 3.2 | done | Implement `record post` | PR #454 (cef31ee) | Append-only canonical lifecycle comments. |
+| 3.3 | done | Implement strict `record close` | PR #454 (cef31ee) | Provider-verifies linked PRs and closes issue. |
+| 4.1 | done | Hide retired record subcommands from primary help | PR #455 (9fd3017) | Task Decomposition CLI retirement deferred to next major release; see "Deferred Follow-ups". |
+| 4.2 | done | Refresh completions and output contract fixtures | PR #455 (9fd3017) | bash + zsh completions regenerated. |
+| 4.3 | done | Add agent-runtime-kit closeout fixture coverage | PR #455 (9fd3017) | crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout. |
+| 5.1 | done | Run full nils-cli validation | Sprint 5 PR | CI-equivalent local gate. |
+| 5.2 | done | Prepare release and agent-runtime-kit handoff notes | Sprint 5 PR | CHANGELOG + v2 spec Consumer Migration section. |
 
 ## Session Log
 
@@ -54,10 +65,56 @@
 - 2026-05-23: Opened tracking issue #448 with source, plan, and initial state
   snapshots. The plan branch was pushed to
   `origin/plan/plan-issue-lifecycle-v3`.
+- 2026-05-23: Sprint 1 landed via PR #449 (spec + scaffolded CLI surface).
+- 2026-05-23: Sprint 2 landed via PR #453 (marker collapse, structured audit,
+  dashboard from audit).
+- 2026-05-23: Sprint 3 landed via PR #454 (live record open / post / close +
+  strict v2 closeout gate + GitHubAdapter additions: comment_issue URL,
+  issue_evidence, pr_merge_summary).
+- 2026-05-23: Sprint 4 landed via PR #455 (hide retired record subcommands,
+  regenerated completions, agent-runtime-kit closeout fixture).
+- 2026-05-23: Sprint 5 lands the full local gate, CHANGELOG BREAKING entries
+  for the v3 audit/role rename + retired subcommands, README v3 pointer,
+  and agent-runtime-kit Consumer Migration section in the v2 spec.
+
+## Deferred Follow-ups
+
+Tracked here so the next major-release cycle can act on them:
+
+- Retire the Task Decomposition CLI (`start-plan`, `status-plan`,
+  `link-pr`, `ready-plan`, `close-plan`, `cleanup-worktrees`,
+  `start-sprint`, `ready-sprint`, `accept-sprint`,
+  `multi-sprint-guide`, `resolve-approval`, `build-task-spec`,
+  `build-plan-task-spec`) from `plan-issue --help`. Sprint 4 hid only
+  the retired Record subcommands; the broader Task Decomposition
+  retirement is a high-blast-radius refactor that needs a coordinated
+  consumer migration first.
+- Result envelope normalization across `record` subcommands: today
+  the result shape varies between fixture (`mode: "fixture"`),
+  dry-run (`mode: "dry-run"` with `preview.*`), and live (top-level
+  fields). Sprint 3 specialist review flagged this as api-contract
+  drift; normalize in a follow-up so consumers don't have to branch
+  on `mode`.
+- `record close` rollback: if any provider call between issue create
+  and dashboard repair fails, the issue is left in an inconsistent
+  state. Add `--cleanup-on-failure` or surface a partial-state error
+  with the partial URLs.
+- `record close --body-file` mode without `--fixture` returns the
+  misleading `linked-pr-not-merged` code when the caller did not
+  provide PR evidence. Either reject the combination or surface a
+  clearer `linked-pr-evidence-missing` code.
+- `evaluate_strict_closeout_gate` dashboard-out-of-date branch is
+  wired but unused. Expose it via a future `record audit --strict`
+  surface or remove it.
+- `build_initial_state_payload` uses hardcoded `Sprint 1 ready` /
+  `execute Sprint 1 tasks` copy. Derive from the plan instead, or
+  document the placeholder behavior.
 
 ## Notes
 
 - This plan intentionally does not preserve backwards compatibility.
 - This plan does not mutate agent-runtime-kit source files.
-- The implementation should stop and re-scope only if removing the legacy Task
-  Decomposition commands would make unrelated nils-cli surfaces unusable.
+- The agent-runtime-kit consumer migration is documented in
+  [`crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`](../../crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md)
+  ("Consumer Migration" section). It happens after the next
+  plan-issue-cli release cuts.

--- a/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md
+++ b/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md
@@ -3,16 +3,19 @@
 <!-- execute-from-tracking-issue:state:v1 -->
 ## Execution State
 
-- Status: planning complete; tracking issue creation pending
+- Status: tracking issue open; ready for Sprint 1 execution
 - Target scope: breaking `plan-issue` issue-backed lifecycle v3 rewrite
 - Execution window: next nils-cli implementation lane
-- Current task: create tracking issue from committed plan bundle
-- Next task: execute Sprint 1 after tracking issue is open
+- Current task: Sprint 1 ready
+- Next task: execute Task 1.1, Task 1.2, and Task 1.3
 - Last updated: 2026-05-23
-- Branch/commit/PR: plan/plan-issue-lifecycle-v3; PR pending
+- Branch/commit/PR: plan/plan-issue-lifecycle-v3; plan commit dc9aedc; PR pending
 - Source document: docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-plan.md
 - Direct source-doc execution waiver: not applicable
-- Tracking issue: pending
+- Tracking issue: [#448](https://github.com/sympoies/nils-cli/issues/448)
+- Source snapshot: [source](https://github.com/sympoies/nils-cli/issues/448#issuecomment-4524856896)
+- Plan snapshot: [plan](https://github.com/sympoies/nils-cli/issues/448#issuecomment-4524856962)
+- Initial state snapshot: [state](https://github.com/sympoies/nils-cli/issues/448#issuecomment-4524857027)
 
 ## Validation Plan
 
@@ -48,6 +51,9 @@
   migration until the CLI is released.
 - 2026-05-23: Created the plan bundle for a breaking v3 rewrite of the
   issue-backed lifecycle surface.
+- 2026-05-23: Opened tracking issue #448 with source, plan, and initial state
+  snapshots. The plan branch was pushed to
+  `origin/plan/plan-issue-lifecycle-v3`.
 
 ## Notes
 

--- a/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-plan.md
+++ b/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-plan.md
@@ -1,0 +1,413 @@
+# Plan: Plan-Issue Lifecycle v3
+
+## Overview
+
+Rewrite `plan-issue` around one issue-backed lifecycle contract for
+agent-runtime-kit and future dispatch work. The new surface removes legacy
+compat markers, stops exposing closeout as a caller-assembled sequence, and
+makes `plan-issue` own provider-backed issue record open, post, audit, repair,
+and close operations.
+
+## Read First
+
+- Primary source: docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-discussion-source.md
+- Source type: discussion-to-implementation-doc
+- Open questions carried into execution: none
+
+## Scope
+
+- In scope:
+  - Define the breaking issue-backed plan record v3 contract.
+  - Replace dual marker families with one canonical marker family.
+  - Add structured lifecycle payload parsing for state, validation, review, and
+    closeout evidence.
+  - Add high-level live commands for opening, posting to, auditing, repairing,
+    and closing issue-backed plan records.
+  - Make closeout strict by default and provider-verify linked PR evidence.
+  - Retire or isolate old Task Decomposition lifecycle commands from the
+    primary `plan-issue` CLI surface.
+  - Update docs, tests, completions, and output-contract coverage.
+  - Add an agent-runtime-kit closeout fixture to prove the new CLI covers the
+    workflow that exposed the current defects.
+- Out of scope:
+  - Migrating agent-runtime-kit skills before a nils-cli release exists.
+  - Supporting legacy marker families.
+  - Preserving old `record closeout-gate --require-*` behavior.
+  - Changing `plan-tooling` plan parsing.
+  - Releasing Homebrew tap updates in the implementation PR itself.
+
+## Assumptions
+
+1. The target consumer is agent-runtime-kit on GitHub.
+2. GitHub support is sufficient for the first v3 implementation.
+3. The old `start-plan` / `start-sprint` Task Decomposition runtime can be
+   retired from the primary surface or moved behind an explicit legacy module.
+4. The v3 CLI may break existing generated completions and docs because no
+   backward compatibility is required.
+5. Provider-verified PR state is mandatory for live closeout, while local
+   fixture inputs remain available for deterministic tests.
+
+## Sprint 1: Contract And Command Design
+
+**Goal**: Land the v3 spec and CLI contract before touching the Rust command
+model.
+
+**PR grouping intent**: group
+**Execution Profile**: serial
+
+### Task 1.1: Replace the issue-backed record contract with v3
+
+- **Location**:
+  - `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v1.md`
+  - `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`
+  - `crates/plan-issue-cli/docs/specs/plan-issue-state-machine-v1.md`
+  - `crates/plan-issue-cli/docs/README.md`
+- **Description**: Replace the v1 local-rendering contract with a v3
+  issue-backed lifecycle contract. Define the canonical marker, structured
+  payload schema, live command responsibilities, strict closeout gate, and
+  GitHub provider boundary.
+- **Dependencies**:
+  - none
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - The spec states that legacy compat markers are retired.
+  - The spec defines one marker family for source, plan, state, session,
+    validation, review, and closeout comments.
+  - The spec defines the provider-backed command boundary for open, post,
+    audit, repair-dashboard, and close.
+  - The state machine no longer treats the Task Decomposition runtime as the
+    primary agent-runtime-kit lifecycle.
+- **Validation**:
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+
+### Task 1.2: Define the high-level CLI surface
+
+- **Location**:
+  - `crates/plan-issue-cli/src/commands/record.rs`
+  - `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`
+  - `crates/plan-issue-cli/tests/integration/cli_contract.rs`
+- **Description**: Define the new command tree and argument contract. The
+  intended shape is `plan-issue record open`, `post`, `audit`,
+  `repair-dashboard`, and `close`, with bundle-first inputs for normal use and
+  fixture inputs for tests.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - `--marker-family` is removed.
+  - `--require-complete`, `--require-session`, `--require-validation`,
+    `--require-review`, and `--require-closeout` are removed from closeout.
+  - `record close` accepts issue, linked PR, approval evidence, and optional
+    fixture paths for deterministic tests.
+  - `record open` accepts a plan bundle path and can derive source, plan, and
+    execution-state paths.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli cli_contract`
+
+### Task 1.3: Specify structured lifecycle payloads
+
+- **Location**:
+  - `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`
+  - `crates/plan-issue-cli/src/lifecycle_record.rs`
+  - `crates/plan-issue-cli/tests/integration/lifecycle_record.rs`
+- **Description**: Define a structured JSON or YAML payload block for lifecycle
+  comments so audit does not infer state from prose lines.
+- **Dependencies**:
+  - Task 1.1
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - State comments expose machine-readable `status`, `tasks`, `prs`, and
+    `updated_at` fields.
+  - Validation comments expose command rows with pass/fail status.
+  - Review comments expose findings and decision.
+  - Closeout comments expose final checks and merge evidence.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli lifecycle_record_structured_payloads`
+
+## Sprint 2: Rust Lifecycle Core Rewrite
+
+**Goal**: Replace the marker/parser/rendering internals with the v3 data model.
+
+**PR grouping intent**: group
+**Execution Profile**: serial
+
+### Task 2.1: Collapse marker parsing to the canonical family
+
+- **Location**:
+  - `crates/plan-issue-cli/src/lifecycle_record.rs`
+  - `crates/plan-issue-cli/tests/integration/lifecycle_record.rs`
+- **Description**: Remove compat marker rendering and parsing. Audit should
+  recognize only the canonical v3 marker family and should reject quoted or
+  legacy markers.
+- **Dependencies**:
+  - Task 1.3
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - `MarkerFamily` is removed.
+  - Tracking compat review marker errors disappear because there is no compat
+    branch.
+  - Legacy markers are ignored or reported as unsupported, not accepted as
+    current lifecycle evidence.
+  - Latest-marker selection is deterministic by role and comment timestamp.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli lifecycle_record`
+
+### Task 2.2: Implement structured audit output
+
+- **Location**:
+  - `crates/plan-issue-cli/src/lifecycle_record.rs`
+  - `crates/plan-issue-cli/src/execute.rs`
+  - `crates/plan-issue-cli/tests/integration/lifecycle_record.rs`
+- **Description**: Update audit to return typed source, plan, state, session,
+  validation, review, closeout, dashboard, and PR-reference evidence from the
+  structured payloads.
+- **Dependencies**:
+  - Task 2.1
+- **Complexity**: 6
+- **Acceptance criteria**:
+  - Audit JSON exposes the latest URL, created timestamp, role, status, and
+    parsed payload for each lifecycle role.
+  - Missing required evidence is reported with stable machine-readable codes.
+  - Prose Markdown can change without breaking closeout state detection.
+  - Audit can run from live issue reads or fixture body/comments files.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli lifecycle_record_audit`
+
+### Task 2.3: Render dashboards from audit evidence
+
+- **Location**:
+  - `crates/plan-issue-cli/src/lifecycle_record.rs`
+  - `crates/plan-issue-cli/tests/integration/lifecycle_record.rs`
+- **Description**: Make final and current dashboards derive durable-record
+  links from audit evidence instead of requiring callers to pass every URL.
+- **Dependencies**:
+  - Task 2.2
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - `record repair-dashboard` can render a complete dashboard from issue audit.
+  - Missing optional evidence appears as `pending` with stable status.
+  - Complete issues render `## Final Dashboard`; incomplete issues render
+    `## Current Dashboard`.
+  - Dashboard output remains human-readable and Markdown-safe.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli lifecycle_record_dashboard`
+
+## Sprint 3: Provider-Backed Lifecycle Commands
+
+**Goal**: Make `plan-issue` own live issue-backed lifecycle mutations for the
+agent-runtime-kit flow.
+
+**PR grouping intent**: group
+**Execution Profile**: serial
+
+### Task 3.1: Implement `record open`
+
+- **Location**:
+  - `crates/plan-issue-cli/src/commands/record.rs`
+  - `crates/plan-issue-cli/src/execute.rs`
+  - `crates/plan-issue-cli/src/github.rs`
+  - `crates/plan-issue-cli/tests/integration/live_issue_ops.rs`
+- **Description**: Add a bundle-first command that validates the plan bundle,
+  creates the provider issue, posts source/plan/initial-state comments, repairs
+  the dashboard with exact comment URLs, and audits the final record.
+- **Dependencies**:
+  - Task 2.3
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - The command derives source, plan, and execution-state paths from
+    `--bundle`.
+  - Live mode requires committed and clean local source/plan files.
+  - Dry-run mode renders every provider mutation plan without writing.
+  - The result JSON includes issue URL and source, plan, and state comment
+    URLs.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli live_record_open`
+
+### Task 3.2: Implement `record post`
+
+- **Location**:
+  - `crates/plan-issue-cli/src/commands/record.rs`
+  - `crates/plan-issue-cli/src/execute.rs`
+  - `crates/plan-issue-cli/tests/integration/live_issue_ops.rs`
+- **Description**: Add a high-level append-only comment command for state,
+  session, validation, and review evidence. It should render canonical markers
+  and structured payloads before posting.
+- **Dependencies**:
+  - Task 2.2
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Supported kinds are state, session, validation, review, and closeout.
+  - Posted comments always include structured payloads.
+  - Dry-run prints the exact comment body and provider action plan.
+  - The result JSON includes the posted comment URL.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli live_record_post`
+
+### Task 3.3: Implement strict `record close`
+
+- **Location**:
+  - `crates/plan-issue-cli/src/commands/record.rs`
+  - `crates/plan-issue-cli/src/execute.rs`
+  - `crates/plan-issue-cli/src/github.rs`
+  - `crates/plan-issue-cli/tests/integration/live_issue_ops.rs`
+- **Description**: Add one close command that fetches issue evidence, verifies
+  strict lifecycle readiness, verifies linked PR merge/check state through the
+  provider, posts closeout, repairs dashboard, and closes the issue.
+- **Dependencies**:
+  - Task 2.2
+  - Task 2.3
+  - Task 3.2
+- **Complexity**: 8
+- **Acceptance criteria**:
+  - Close requires source, plan, complete state, session, validation, review,
+    approval evidence, and merged linked PRs.
+  - Linked PR evidence is checked through provider state, not text search.
+  - The command supports dry-run and fixture mode for deterministic tests.
+  - The result JSON includes closeout URL, final dashboard state, closed issue
+    URL, linked PR statuses, and merge SHAs.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli live_record_close`
+
+## Sprint 4: Retire Legacy Surface And Refresh Contracts
+
+**Goal**: Remove old lifecycle entrypoints from the primary CLI and update
+generated assets.
+
+**PR grouping intent**: group
+**Execution Profile**: serial
+
+### Task 4.1: Remove or isolate Task Decomposition commands
+
+- **Location**:
+  - `crates/plan-issue-cli/src/commands/mod.rs`
+  - `crates/plan-issue-cli/src/commands/plan.rs`
+  - `crates/plan-issue-cli/src/commands/sprint.rs`
+  - `crates/plan-issue-cli/src/execute.rs`
+  - `crates/plan-issue-cli/tests/integration/cli_contract.rs`
+- **Description**: Remove legacy `start-plan`, `status-plan`, `link-pr`,
+  `ready-plan`, `close-plan`, `start-sprint`, `ready-sprint`, and
+  `accept-sprint` from the primary `plan-issue` help surface, or place them
+  behind an explicit legacy-only binary if removal creates too much churn.
+- **Dependencies**:
+  - Task 3.3
+- **Complexity**: 7
+- **Acceptance criteria**:
+  - Root help leads with the issue-backed record lifecycle.
+  - Old Task Decomposition commands no longer appear in the primary command
+    list.
+  - Tests no longer treat `## Task Decomposition` as the default
+    agent-runtime-kit lifecycle truth.
+  - Removed command docs are deleted or marked retired.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli cli_contract`
+
+### Task 4.2: Refresh completions and output contract fixtures
+
+- **Location**:
+  - `completions/bash/plan-issue`
+  - `completions/bash/plan-issue-local`
+  - `completions/zsh/_plan-issue`
+  - `completions/zsh/_plan-issue-local`
+  - `crates/plan-issue-cli/tests/integration/parity_guardrails.rs`
+  - `docs/specs/cli-output-contract-v1.md`
+- **Description**: Regenerate completion assets and update CLI output contract
+  expectations for the new command surface.
+- **Dependencies**:
+  - Task 4.1
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - Bash and zsh completions include the new lifecycle commands.
+  - Removed command completions are gone.
+  - `-V, --version`, `--format`, and JSON envelope expectations still pass.
+  - Completion parity audits pass.
+- **Validation**:
+  - `bash scripts/ci/completion-asset-audit.sh --strict`
+  - `bash scripts/ci/completion-flag-parity-audit.sh --strict`
+  - `zsh -n completions/zsh/_plan-issue`
+  - `bash -n completions/bash/plan-issue`
+
+### Task 4.3: Add agent-runtime-kit closeout fixture coverage
+
+- **Location**:
+  - `crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout.json`
+  - `crates/plan-issue-cli/tests/integration/lifecycle_record.rs`
+  - `crates/plan-issue-cli/tests/integration/live_issue_ops.rs`
+- **Description**: Add a sanitized fixture modeled on the shared Heuristic
+  System closeout flow. The fixture should prove that one command can audit,
+  repair, close, and report the record that previously required manual
+  stitching.
+- **Dependencies**:
+  - Task 3.3
+- **Complexity**: 5
+- **Acceptance criteria**:
+  - The fixture includes source, plan, state, session, validation, review, and
+    closeout evidence.
+  - The test verifies provider PR merge evidence is required.
+  - The test fails if callers need to mix marker families.
+  - The test fails if dashboard links must be supplied manually.
+- **Validation**:
+  - `cargo test -p nils-plan-issue-cli agent_runtime_kit_lifecycle_fixture`
+
+## Sprint 5: Gate, Release Readiness, And Consumer Handoff
+
+**Goal**: Prove the breaking CLI is ready for release and prepare the
+agent-runtime-kit migration lane.
+
+**PR grouping intent**: group
+**Execution Profile**: serial
+
+### Task 5.1: Run full nils-cli validation
+
+- **Location**:
+  - `scripts/ci/nils-cli-checks-entrypoint.sh`
+  - `crates/plan-issue-cli/CHANGELOG.md`
+  - `README.md`
+- **Description**: Run the full local gate, update plan-issue changelog notes,
+  and document the breaking v3 command surface in the workspace CLI map.
+- **Dependencies**:
+  - Task 4.3
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - The full local gate passes.
+  - Changelog documents removed commands and replacement lifecycle commands.
+  - Workspace README points users to the v3 issue-backed workflow.
+  - No completion, docs hygiene, or CLI output contract audit fails.
+- **Validation**:
+  - `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`
+
+### Task 5.2: Prepare release and agent-runtime-kit handoff notes
+
+- **Location**:
+  - `docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md`
+  - `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`
+  - `crates/plan-issue-cli/CHANGELOG.md`
+- **Description**: Record release readiness and the downstream agent-runtime-kit
+  migration steps that should happen only after the nils-cli release is cut and
+  installed.
+- **Dependencies**:
+  - Task 5.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - The execution state identifies the exact follow-up needed in
+    agent-runtime-kit.
+  - The spec gives example commands for replacing current generated skills.
+  - The closeout notes say whether a separate agent-runtime-kit issue is still
+    needed after release.
+- **Validation**:
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+
+## Issue Closeout Gate
+
+The tracking issue is complete when:
+
+- All Sprint 1-5 tasks are done or explicitly deferred.
+- The implementation PR is merged.
+- Specialist review evidence is posted.
+- Local and provider CI pass.
+- The issue dashboard is repaired by the new `plan-issue record close`
+  command itself.
+- A release handoff exists for agent-runtime-kit consumer migration.
+
+The issue does not require an agent-runtime-kit PR. That consumer migration
+belongs after the nils-cli release unless the implementation discovers that
+agent-runtime-kit source changes are needed to validate the CLI contract.


### PR DESCRIPTION
## Summary

Lands the docs/plans tracker bundle for `plan-issue-lifecycle-v3` on `main`.
The implementation itself was already merged via [#449](https://github.com/sympoies/nils-cli/pull/449), [#453](https://github.com/sympoies/nils-cli/pull/453), [#454](https://github.com/sympoies/nils-cli/pull/454), [#455](https://github.com/sympoies/nils-cli/pull/455), and [#456](https://github.com/sympoies/nils-cli/pull/456) and tracking issue [#448](https://github.com/sympoies/nils-cli/issues/448) is closed; this PR exists only because the discussion source / plan / execution-state markdown was authored on `plan/plan-issue-lifecycle-v3` and never made it back to `main`.

Adds three files under `docs/plans/plan-issue-lifecycle-v3/`:

- `plan-issue-lifecycle-v3-discussion-source.md` — discussion source captured before tracker creation.
- `plan-issue-lifecycle-v3-plan.md` — plan bundle that drove Sprint 1–5.
- `plan-issue-lifecycle-v3-execution-state.md` — final execution state with PR + commit evidence for all 14 plan tasks plus a Deferred Follow-ups block.

Commits are cherry-picked from `plan/plan-issue-lifecycle-v3` (original SHAs `dc9aedc`, `8eb3484`, `007bbd0`) onto a fresh branch off `main` so this PR is strictly additive — no code, completions, or `Cargo.*` are touched.

## Test plan

- [x] `git diff origin/main..HEAD --stat` shows only the 3 new files under `docs/plans/plan-issue-lifecycle-v3/` (632 insertions, 0 deletions).
- [x] `git log origin/main..HEAD` lists the cherry-picked docs commits and nothing else.
- [ ] CI passes (docs-only — no Rust / completion / locked-build impact expected).

## Notes

- `plan-tooling validate` on the plan bundle currently reports 9 strict-mode findings (bundle metadata + Task heading format) introduced by the post-Sprint-5 schema tightening. Fixing those is out of scope for this docs-only land — captured as a deferred follow-up so the tracker history can be archived as-is.
- The original `plan/plan-issue-lifecycle-v3` branch is left in place on the remote (it is now identical-by-content modulo divergence from `main`). Safe to delete after this lands if desired.
