### PR TITLE
fix(forge-cli): propagate --repo into every backend argv (#457)

### DIFF
--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -768,6 +768,7 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
                 let ctx = match crate::provider::detect(
                     global.provider_hint(),
                     &global.remote,
+                    global.repo.as_deref(),
                     crate::provider::git_remote_url,
                 ) {
                     Ok(ctx) => ctx,

--- a/crates/forge-cli/src/macros/pr_deliver.rs
+++ b/crates/forge-cli/src/macros/pr_deliver.rs
@@ -99,7 +99,12 @@ pub fn run_with<R: BackendRunner, C: Clock>(
     format: OutputFormat,
     workdir: &Path,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, git_remote_url)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        git_remote_url,
+    )?;
 
     if global.dry_run {
         return Ok(emit_dry_run(&ctx, &args, format));
@@ -136,7 +141,7 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
     });
 
     // 2. repo.view
-    let repo_payload = match repo_view::compute(runner, ctx, global.repo.as_deref()) {
+    let repo_payload = match repo_view::compute(runner, ctx) {
         Ok(p) => p,
         Err(err) => {
             return Ok(emit_chain_failure(steps, args, ctx, None, &err, format));
@@ -439,7 +444,7 @@ fn pr_create_dry_plan(ctx: &ProviderContext, args: &PrDeliverArgs) -> Vec<String
 fn pr_wait_checks_dry_plan(ctx: &ProviderContext) -> Vec<String> {
     let prog = BackendProgram::for_provider(ctx.provider).default_executable();
     match ctx.provider {
-        Provider::GitHub => pr_checks::build_github_required_call("<pr-number>").plan_argv(),
+        Provider::GitHub => pr_checks::build_github_required_call(ctx, "<pr-number>").plan_argv(),
         Provider::GitLab => vec![
             prog.into(),
             "ci".into(),
@@ -602,6 +607,7 @@ mod tests {
             provider: Provider::GitHub,
             host: "github.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/auth_status.rs
+++ b/crates/forge-cli/src/ops/auth_status.rs
@@ -44,7 +44,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = crate::provider::detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = crate::provider::detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
 
     if global.dry_run {
         let call = build_call(&ctx);
@@ -73,7 +78,12 @@ pub fn compute<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     global: &GlobalFlags,
     remote_url_lookup: F,
 ) -> Result<AuthStatusPayload, ForgeError> {
-    let ctx = crate::provider::detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = crate::provider::detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     compute_with_ctx(runner, &ctx)
 }
 
@@ -208,6 +218,7 @@ mod tests {
             provider: Provider::GitHub,
             host: "github.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 
@@ -216,6 +227,7 @@ mod tests {
             provider: Provider::GitLab,
             host: "gitlab.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/issue_close.rs
+++ b/crates/forge-cli/src/ops/issue_close.rs
@@ -38,7 +38,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     let call = build_close_call(&ctx, id);
 
     if global.dry_run {
@@ -70,13 +75,14 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 
 fn build_close_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub | Provider::GitLab => vec![
             OsString::from("issue"),
             OsString::from("close"),
             OsString::from(id.to_string()),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -101,6 +107,7 @@ mod tests {
             provider: p,
             host: "x".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/issue_comment.rs
+++ b/crates/forge-cli/src/ops/issue_comment.rs
@@ -45,7 +45,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     let body = read_body(args.body.as_deref(), args.body_file.as_deref())?;
     if body.trim().is_empty() {
         return Err(ForgeError::validation(
@@ -84,7 +89,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 
 fn build_comment_call(ctx: &ProviderContext, id: u64, body: &str) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("issue"),
             OsString::from("comment"),
@@ -100,6 +105,7 @@ fn build_comment_call(ctx: &ProviderContext, id: u64, body: &str) -> BackendCall
             OsString::from(body),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -154,6 +160,7 @@ mod tests {
             provider: p,
             host: "x".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/issue_create.rs
+++ b/crates/forge-cli/src/ops/issue_create.rs
@@ -55,7 +55,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     title_length(&args.title)?;
     let body = read_body(args.body.as_deref(), args.body_file.as_deref())?;
     let body_tempfile = write_body_tempfile(&body)?;
@@ -150,6 +155,7 @@ fn build_create_call(
             }
         }
     }
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -270,6 +276,7 @@ mod tests {
             provider: p,
             host: "x".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 
@@ -295,6 +302,28 @@ mod tests {
         assert_eq!(label_count, 2);
         let asg_count = plan.iter().filter(|s| s.as_str() == "--assignee").count();
         assert_eq!(asg_count, 1);
+    }
+
+    #[test]
+    fn build_create_call_propagates_repo_override_to_argv() {
+        let mut ctx_gh = ctx(Provider::GitHub);
+        ctx_gh.repo = Some("owner/name".into());
+        let path = PathBuf::from("/tmp/body.md");
+        let plan_gh = build_create_call(&ctx_gh, "t", "b", &path, &[], &[]).plan_argv();
+        let gh_pos = plan_gh
+            .iter()
+            .position(|s| s == "--repo")
+            .expect("gh issue create dry-run plan must include --repo override");
+        assert_eq!(plan_gh[gh_pos + 1], "owner/name");
+
+        let mut ctx_glab = ctx(Provider::GitLab);
+        ctx_glab.repo = Some("owner/name".into());
+        let plan_glab = build_create_call(&ctx_glab, "t", "b", &path, &[], &[]).plan_argv();
+        let glab_pos = plan_glab
+            .iter()
+            .position(|s| s == "--repo")
+            .expect("glab issue create dry-run plan must include --repo override");
+        assert_eq!(plan_glab[glab_pos + 1], "owner/name");
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/issue_edit.rs
+++ b/crates/forge-cli/src/ops/issue_edit.rs
@@ -50,7 +50,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     if let Some(ref t) = args.title {
         title_length(t)?;
     }
@@ -140,6 +145,7 @@ fn build_edit_call(ctx: &ProviderContext, args: &IssueEditArgs, body: Option<&st
         argv.push(OsString::from(flag));
         argv.push(OsString::from(assignee));
     }
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -195,6 +201,7 @@ mod tests {
             provider: p,
             host: "x".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/issue_list.rs
+++ b/crates/forge-cli/src/ops/issue_list.rs
@@ -63,7 +63,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     let call = build_list_call(&ctx, &args);
 
     if global.dry_run {
@@ -135,6 +140,7 @@ fn build_list_call(ctx: &ProviderContext, args: &IssueListArgs) -> BackendCall {
             argv.push(OsString::from("json"));
         }
     }
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -327,6 +333,7 @@ mod tests {
             provider: p,
             host: "example.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/issue_reopen.rs
+++ b/crates/forge-cli/src/ops/issue_reopen.rs
@@ -38,7 +38,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     let call = build_reopen_call(&ctx, id);
 
     if global.dry_run {
@@ -69,13 +74,14 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 
 fn build_reopen_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub | Provider::GitLab => vec![
             OsString::from("issue"),
             OsString::from("reopen"),
             OsString::from(id.to_string()),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -100,6 +106,7 @@ mod tests {
             provider: p,
             host: "x".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/issue_view.rs
+++ b/crates/forge-cli/src/ops/issue_view.rs
@@ -50,7 +50,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     let call = build_view_call(&ctx, id);
 
     if global.dry_run {
@@ -75,7 +80,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 
 pub fn build_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("issue"),
             OsString::from("view"),
@@ -91,6 +96,7 @@ pub fn build_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
             OsString::from("json"),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -272,6 +278,7 @@ mod tests {
             provider: p,
             host: "example.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_checks.rs
+++ b/crates/forge-cli/src/ops/pr_checks.rs
@@ -148,7 +148,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     let payload = snapshot(runner, global, &ctx, args)?;
     Ok(emit_success(
         schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
@@ -190,10 +195,10 @@ fn snapshot_github<R: BackendRunner>(
     ctx: &ProviderContext,
     args: &PrChecksArgs,
 ) -> Result<PrChecksPayload, ForgeError> {
-    let call = build_github_call(&args.id);
+    let call = build_github_call(ctx, &args.id);
     let output = run_github_checks_call(runner, &call)?;
     if args.required_only {
-        let required_call = build_github_required_call(&args.id);
+        let required_call = build_github_required_call(ctx, &args.id);
         let required_output = run_github_checks_call(runner, &required_call)?;
         return parse_github_snapshot_with_required_output(ctx, &output, &required_output);
     }
@@ -202,43 +207,41 @@ fn snapshot_github<R: BackendRunner>(
 
 /// Build the `gh pr checks <id> --json …` call. Public so the dry-run helper
 /// can render the plan.
-pub fn build_github_call(id: &str) -> BackendCall {
-    BackendCall::new(
-        BackendProgram::Gh,
-        [
-            OsString::from("pr"),
-            OsString::from("checks"),
-            OsString::from(id),
-            OsString::from("--json"),
-            OsString::from(GH_JSON_FIELDS),
-        ],
-    )
+pub fn build_github_call(ctx: &ProviderContext, id: &str) -> BackendCall {
+    let mut argv: Vec<OsString> = vec![
+        OsString::from("pr"),
+        OsString::from("checks"),
+        OsString::from(id),
+        OsString::from("--json"),
+        OsString::from(GH_JSON_FIELDS),
+    ];
+    ctx.push_repo_override(&mut argv);
+    BackendCall::new(BackendProgram::Gh, argv)
 }
 
 /// Build the `gh pr checks <id> --required --json …` call used for GitHub
 /// required-check gating because `gh 2.92.0` no longer exposes `isRequired`
 /// through the JSON field set.
-pub fn build_github_required_call(id: &str) -> BackendCall {
-    BackendCall::new(
-        BackendProgram::Gh,
-        [
-            OsString::from("pr"),
-            OsString::from("checks"),
-            OsString::from(id),
-            OsString::from("--required"),
-            OsString::from("--json"),
-            OsString::from(GH_JSON_FIELDS),
-        ],
-    )
+pub fn build_github_required_call(ctx: &ProviderContext, id: &str) -> BackendCall {
+    let mut argv: Vec<OsString> = vec![
+        OsString::from("pr"),
+        OsString::from("checks"),
+        OsString::from(id),
+        OsString::from("--required"),
+        OsString::from("--json"),
+        OsString::from(GH_JSON_FIELDS),
+    ];
+    ctx.push_repo_override(&mut argv);
+    BackendCall::new(BackendProgram::Gh, argv)
 }
 
 /// Build the dry-run preview call for the current provider — public so
 /// downstream atoms (e.g. `pr wait-checks` dry-run) can reuse it.
 pub fn build_dry_run_call(ctx: &ProviderContext, args: &PrChecksArgs) -> BackendCall {
     match ctx.provider {
-        Provider::GitHub if args.required_only => build_github_required_call(&args.id),
-        Provider::GitHub => build_github_call(&args.id),
-        Provider::GitLab => pr_checks_gitlab::build_status_call(&args.id),
+        Provider::GitHub if args.required_only => build_github_required_call(ctx, &args.id),
+        Provider::GitHub => build_github_call(ctx, &args.id),
+        Provider::GitLab => pr_checks_gitlab::build_status_call(ctx, &args.id),
     }
 }
 
@@ -623,6 +626,7 @@ mod tests {
             provider: p,
             host: "example.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 
@@ -830,7 +834,7 @@ mod tests {
 
     #[test]
     fn build_github_call_carries_id_and_json_fields() {
-        let call = build_github_call("42");
+        let call = build_github_call(&ctx(Provider::GitHub), "42");
         let plan = call.plan_argv();
         assert_eq!(
             plan[1..4],
@@ -844,7 +848,7 @@ mod tests {
 
     #[test]
     fn build_github_required_call_uses_required_flag_and_supported_json_fields() {
-        let call = build_github_required_call("42");
+        let call = build_github_required_call(&ctx(Provider::GitHub), "42");
         let plan = call.plan_argv();
         assert!(plan.iter().any(|s| s == "--required"), "{plan:?}");
         let json_idx = plan.iter().position(|s| s == "--json").expect("--json arg");

--- a/crates/forge-cli/src/ops/pr_checks_gitlab.rs
+++ b/crates/forge-cli/src/ops/pr_checks_gitlab.rs
@@ -21,16 +21,15 @@ use crate::provider::ProviderContext;
 /// Build the `glab ci status -b <branch>` call. The id parameter is the
 /// branch name to query (the resolver upstream of this function converts a
 /// numeric MR id to its source branch).
-pub fn build_status_call(branch: &str) -> BackendCall {
-    BackendCall::new(
-        BackendProgram::Glab,
-        [
-            OsString::from("ci"),
-            OsString::from("status"),
-            OsString::from("-b"),
-            OsString::from(branch),
-        ],
-    )
+pub fn build_status_call(ctx: &ProviderContext, branch: &str) -> BackendCall {
+    let mut argv: Vec<OsString> = vec![
+        OsString::from("ci"),
+        OsString::from("status"),
+        OsString::from("-b"),
+        OsString::from(branch),
+    ];
+    ctx.push_repo_override(&mut argv);
+    BackendCall::new(BackendProgram::Glab, argv)
 }
 
 /// Build the `glab --version` probe call.
@@ -47,8 +46,8 @@ pub fn snapshot<R: BackendRunner>(
     args: &crate::cli::PrChecksArgs,
 ) -> Result<PrChecksPayload, ForgeError> {
     probe_version(runner)?;
-    let branch = resolve_branch(runner, &args.id)?;
-    let call = build_status_call(&branch);
+    let branch = resolve_branch(runner, ctx, &args.id)?;
+    let call = build_status_call(ctx, &branch);
     let output = runner.run(&call)?;
     parse_status_text(ctx, &output, args.required_only)
 }
@@ -80,20 +79,23 @@ pub fn probe_version<R: BackendRunner>(runner: &R) -> Result<(u32, u32, u32), Fo
 
 /// Resolve a PR id to a source branch. Numeric ids hit `glab mr view <id>`;
 /// branch-shaped ids pass through.
-fn resolve_branch<R: BackendRunner>(runner: &R, id: &str) -> Result<String, ForgeError> {
+fn resolve_branch<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    id: &str,
+) -> Result<String, ForgeError> {
     if !id.chars().all(|c| c.is_ascii_digit()) {
         return Ok(id.to_string());
     }
-    let call = BackendCall::new(
-        BackendProgram::Glab,
-        [
-            OsString::from("mr"),
-            OsString::from("view"),
-            OsString::from(id),
-            OsString::from("-F"),
-            OsString::from("json"),
-        ],
-    );
+    let mut argv: Vec<OsString> = vec![
+        OsString::from("mr"),
+        OsString::from("view"),
+        OsString::from(id),
+        OsString::from("-F"),
+        OsString::from("json"),
+    ];
+    ctx.push_repo_override(&mut argv);
+    let call = BackendCall::new(BackendProgram::Glab, argv);
     let out = runner.run(&call)?;
     let value: serde_json::Value = serde_json::from_str(out.stdout.trim()).map_err(|e| {
         ForgeError::software(
@@ -277,12 +279,13 @@ mod tests {
             provider: Provider::GitLab,
             host: "gitlab.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 
     #[test]
     fn build_status_call_uses_branch_flag() {
-        let call = build_status_call("feat/sample");
+        let call = build_status_call(&ctx(), "feat/sample");
         let plan = call.plan_argv();
         assert_eq!(
             plan[1..],
@@ -293,6 +296,18 @@ mod tests {
                 "feat/sample".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn build_status_call_includes_repo_override_when_set() {
+        let mut ctx = ctx();
+        ctx.repo = Some("owner/name".into());
+        let plan = build_status_call(&ctx, "feat/sample").plan_argv();
+        let pos = plan
+            .iter()
+            .position(|s| s == "--repo")
+            .expect("--repo present");
+        assert_eq!(plan[pos + 1], "owner/name");
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_close.rs
+++ b/crates/forge-cli/src/ops/pr_close.rs
@@ -42,7 +42,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     let call = build_close_call(&ctx, id);
 
     if global.dry_run {
@@ -76,7 +81,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 
 fn build_close_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("close"),
@@ -88,12 +93,13 @@ fn build_close_call(ctx: &ProviderContext, id: u64) -> BackendCall {
             OsString::from(id.to_string()),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
 fn build_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("view"),
@@ -111,6 +117,7 @@ fn build_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
             OsString::from("json"),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -135,6 +142,7 @@ mod tests {
             provider: p,
             host: "example.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_comment.rs
+++ b/crates/forge-cli/src/ops/pr_comment.rs
@@ -46,7 +46,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     let body = read_body(args.body.as_deref(), args.body_file.as_deref())?;
     if body.trim().is_empty() {
         return Err(ForgeError::validation(
@@ -89,7 +94,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 
 fn build_comment_call(ctx: &ProviderContext, id: u64, body: &str) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("comment"),
@@ -105,12 +110,13 @@ fn build_comment_call(ctx: &ProviderContext, id: u64, body: &str) -> BackendCall
             OsString::from(body),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
 fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("view"),
@@ -128,6 +134,7 @@ fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
             OsString::from("json"),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -182,6 +189,7 @@ mod tests {
             provider: p,
             host: "x".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_create.rs
+++ b/crates/forge-cli/src/ops/pr_create.rs
@@ -142,9 +142,12 @@ pub fn run_with<R: BackendRunner>(
     format: OutputFormat,
     env: &Environment<'_>,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, |r| {
-        (env.remote_url)(r)
-    })?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        |r| (env.remote_url)(r),
+    )?;
 
     // 1. Resolve head + base.
     let head = match args.head.clone() {
@@ -213,9 +216,12 @@ pub fn compute<R: BackendRunner>(
     args: &PrCreateArgs,
     env: &Environment<'_>,
 ) -> Result<PrCreatePayload, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, |r| {
-        (env.remote_url)(r)
-    })?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        |r| (env.remote_url)(r),
+    )?;
     let head = match args.head.clone() {
         Some(h) => h,
         None => (env.current_branch)()?,
@@ -391,12 +397,13 @@ fn build_create_call(
             }
         }
     }
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
 fn build_view_call(ctx: &ProviderContext, number: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("view"),
@@ -412,6 +419,7 @@ fn build_view_call(ctx: &ProviderContext, number: u64) -> BackendCall {
             OsString::from("json"),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -566,6 +574,7 @@ mod tests {
             provider: Provider::GitHub,
             host: "github.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 
@@ -574,6 +583,7 @@ mod tests {
             provider: Provider::GitLab,
             host: "gitlab.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_edit.rs
+++ b/crates/forge-cli/src/ops/pr_edit.rs
@@ -41,7 +41,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
 
     // Read the replacement body once; keep around so the temp file stays
     // alive through the backend call.
@@ -162,12 +167,13 @@ fn build_edit_call(
             }
         }
     }
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
 fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("view"),
@@ -185,6 +191,7 @@ fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
             OsString::from("json"),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -262,6 +269,7 @@ mod tests {
             provider: p,
             host: "x".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_list.rs
+++ b/crates/forge-cli/src/ops/pr_list.rs
@@ -58,7 +58,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     let call = build_list_call(&ctx, &args);
 
     if global.dry_run {
@@ -122,6 +127,7 @@ fn build_list_call(ctx: &ProviderContext, args: &PrListArgs) -> BackendCall {
             argv.push(OsString::from("json"));
         }
     }
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -243,6 +249,7 @@ mod tests {
             provider: p,
             host: "example.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_merge.rs
+++ b/crates/forge-cli/src/ops/pr_merge.rs
@@ -78,7 +78,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     workdir: &std::path::Path,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
 
     // Load .forge-cli.toml so the method default + delete_branch default flow
     // from the per-repo config when no explicit flag is set.
@@ -121,7 +126,12 @@ pub fn compute<R: BackendRunner>(
     args: &PrMergeArgs,
     workdir: &std::path::Path,
 ) -> Result<PrMergePayload, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, git_remote_url)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        git_remote_url,
+    )?;
     let cfg = ForgeConfig::load_from(workdir, find_git_toplevel(workdir).as_deref());
     let method = cfg.resolve_merge_method(args.method.map(|m| m.into_method()));
     let cfg_delete = cfg.resolve_delete_branch(None);
@@ -202,7 +212,7 @@ pub fn build_merge_call(
 ) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
     let id_str = id.to_string();
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => {
             let mut v = vec![
                 OsString::from("pr"),
@@ -235,6 +245,7 @@ pub fn build_merge_call(
             v
         }
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -259,7 +270,7 @@ fn fetch_pr_view<R: BackendRunner>(
 fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
     let id_str = id.to_string();
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("view"),
@@ -277,6 +288,7 @@ fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
             OsString::from("json"),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -332,7 +344,7 @@ fn fetch_merge_sha<R: BackendRunner>(
 fn merge_sha_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
     let id_str = id.to_string();
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("view"),
@@ -348,6 +360,7 @@ fn merge_sha_call(ctx: &ProviderContext, id: u64) -> BackendCall {
             OsString::from("json"),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -472,6 +485,7 @@ mod tests {
             provider,
             host: "github.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_ready.rs
+++ b/crates/forge-cli/src/ops/pr_ready.rs
@@ -53,7 +53,12 @@ where
     F: Fn(&str) -> Option<String>,
     G: FnOnce(&std::path::Path) -> Result<String, ForgeError>,
 {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     worktree_clean(workdir, git_status)?;
 
     let call = build_ready_call(&ctx, args.id);
@@ -105,7 +110,7 @@ fn run_backend_and_fetch<R: BackendRunner>(
 
 fn build_ready_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("ready"),
@@ -118,12 +123,13 @@ fn build_ready_call(ctx: &ProviderContext, id: u64) -> BackendCall {
             OsString::from("--ready"),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
 fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("view"),
@@ -141,6 +147,7 @@ fn pr_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
             OsString::from("json"),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -164,6 +171,7 @@ mod tests {
             provider: p,
             host: "x".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_view.rs
+++ b/crates/forge-cli/src/ops/pr_view.rs
@@ -56,7 +56,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
 
     // GitLab cannot resolve a branch name in a single view call; fan out to
     // `mr list --source-branch <branch>` first.
@@ -90,7 +95,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 
 fn build_view_call(ctx: &ProviderContext, id: &str) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
-    let argv: Vec<OsString> = match ctx.provider {
+    let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("pr"),
             OsString::from("view"),
@@ -106,6 +111,7 @@ fn build_view_call(ctx: &ProviderContext, id: &str) -> BackendCall {
             OsString::from("json"),
         ],
     };
+    ctx.push_repo_override(&mut argv);
     BackendCall::new(program, argv)
 }
 
@@ -117,7 +123,7 @@ fn resolve_branch_id<R: BackendRunner>(
     match ctx.provider {
         Provider::GitHub => Ok(branch.to_string()),
         Provider::GitLab => {
-            let argv: Vec<OsString> = vec![
+            let mut argv: Vec<OsString> = vec![
                 OsString::from("mr"),
                 OsString::from("list"),
                 OsString::from("--source-branch"),
@@ -125,6 +131,7 @@ fn resolve_branch_id<R: BackendRunner>(
                 OsString::from("-F"),
                 OsString::from("json"),
             ];
+            ctx.push_repo_override(&mut argv);
             let call = BackendCall::new(BackendProgram::Glab, argv);
             let output = runner.run(&call)?;
             extract_first_iid(&output.stdout).ok_or_else(|| {
@@ -309,6 +316,7 @@ mod tests {
             provider,
             host: "example.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_wait_checks.rs
+++ b/crates/forge-cli/src/ops/pr_wait_checks.rs
@@ -63,7 +63,12 @@ pub fn run_with<R: BackendRunner, C: Clock, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
     let snapshot_args = PrChecksArgs {
         id: args.id.clone(),
         required_only: args.required_only,
@@ -295,6 +300,7 @@ mod tests {
             provider: p,
             host: "example.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/repo_view.rs
+++ b/crates/forge-cli/src/ops/repo_view.rs
@@ -49,10 +49,15 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
-    let ctx = crate::provider::detect(global.provider_hint(), &global.remote, remote_url_lookup)?;
+    let ctx = crate::provider::detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
 
     if global.dry_run {
-        let call = build_call(&ctx, global.repo.as_deref());
+        let call = build_call(&ctx);
         let payload = DryRunPayload::new(ctx.provider, &call);
         return Ok(emit_success(
             schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
@@ -62,7 +67,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         ));
     }
 
-    let payload = compute(runner, &ctx, global.repo.as_deref())?;
+    let payload = compute(runner, &ctx)?;
     Ok(emit_success(
         schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
         payload,
@@ -73,25 +78,25 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 
 /// Macro-facing entry point: compute the payload without emitting. Used by
 /// `pr deliver` to capture the repo view step's typed output for the
-/// composite envelope.
+/// composite envelope. Repo override comes from `ctx.repo` (set by the
+/// global `--repo owner/name` flag in [`crate::provider::detect`]).
 pub fn compute<R: BackendRunner>(
     runner: &R,
     ctx: &ProviderContext,
-    repo_override: Option<&str>,
 ) -> Result<RepoViewPayload, ForgeError> {
-    let call = build_call(ctx, repo_override);
+    let call = build_call(ctx);
     let output = runner.run(&call)?;
     parse_backend_output(ctx, &output)
 }
 
-fn build_call(ctx: &ProviderContext, repo_override: Option<&str>) -> BackendCall {
+fn build_call(ctx: &ProviderContext) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
     let mut argv: Vec<OsString> = Vec::new();
     match ctx.provider {
         Provider::GitHub => {
             argv.push(OsString::from("repo"));
             argv.push(OsString::from("view"));
-            if let Some(slug) = repo_override {
+            if let Some(slug) = ctx.repo.as_deref() {
                 argv.push(OsString::from(slug));
             }
             argv.push(OsString::from("--json"));
@@ -100,7 +105,7 @@ fn build_call(ctx: &ProviderContext, repo_override: Option<&str>) -> BackendCall
         Provider::GitLab => {
             argv.push(OsString::from("repo"));
             argv.push(OsString::from("view"));
-            if let Some(slug) = repo_override {
+            if let Some(slug) = ctx.repo.as_deref() {
                 argv.push(OsString::from(slug));
             }
             argv.push(OsString::from("-F"));
@@ -112,8 +117,9 @@ fn build_call(ctx: &ProviderContext, repo_override: Option<&str>) -> BackendCall
 
 /// Re-export of the internal builder so `pr create` (and later atoms) can
 /// resolve the repo's default branch without duplicating the argv shape.
+/// Repo override (when set) flows through `ctx.repo`.
 pub fn build_call_for_default_branch(ctx: &ProviderContext) -> BackendCall {
-    build_call(ctx, None)
+    build_call(ctx)
 }
 
 /// Parse the backend stdout into the normalized payload.
@@ -283,6 +289,7 @@ mod tests {
             provider: Provider::GitHub,
             host: "github.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 
@@ -291,6 +298,7 @@ mod tests {
             provider: Provider::GitLab,
             host: "gitlab.com".into(),
             source: DetectionSource::Flag,
+            repo: None,
         }
     }
 
@@ -387,7 +395,7 @@ mod tests {
 
     #[test]
     fn build_call_github_argv() {
-        let call = build_call(&github_ctx(), None);
+        let call = build_call(&github_ctx());
         let argv = call.plan_argv();
         assert_eq!(argv[1..3], vec!["repo".to_string(), "view".to_string()]);
         assert!(argv.contains(&"--json".to_string()));
@@ -395,9 +403,18 @@ mod tests {
 
     #[test]
     fn build_call_gitlab_argv() {
-        let call = build_call(&gitlab_ctx(), None);
+        let call = build_call(&gitlab_ctx());
         let argv = call.plan_argv();
         assert_eq!(argv[1..3], vec!["repo".to_string(), "view".to_string()]);
         assert!(argv.contains(&"-F".to_string()));
+    }
+
+    #[test]
+    fn build_call_github_includes_repo_slug_when_ctx_has_repo() {
+        let mut ctx = github_ctx();
+        ctx.repo = Some("owner/name".into());
+        let argv = build_call(&ctx).plan_argv();
+        let pos = argv.iter().position(|s| s == "view").expect("view present");
+        assert_eq!(argv[pos + 1], "owner/name");
     }
 }

--- a/crates/forge-cli/src/provider.rs
+++ b/crates/forge-cli/src/provider.rs
@@ -6,6 +6,7 @@
 //! / `glab auth status` host match. Unknown host produces `USAGE 64` with
 //! `error.kind = "provider_unsupported"`.
 
+use std::ffi::OsString;
 use std::process::Command;
 
 use serde::Serialize;
@@ -45,6 +46,23 @@ pub struct ProviderContext {
     pub provider: Provider,
     pub host: String,
     pub source: DetectionSource,
+    /// Repo slug from `--repo owner/name`; ops push `--repo <slug>` into the
+    /// backend argv when set so dry-run plans and live calls hit the same repo.
+    pub repo: Option<String>,
+}
+
+impl ProviderContext {
+    /// Push `--repo <owner/name>` into `argv` when the caller passed
+    /// `--repo`. Both `gh` and `glab` accept the long form across all
+    /// non-`repo view` subcommands, so this helper centralizes the wiring.
+    /// `repo view` does not use this — it pushes the slug as a positional
+    /// argument instead.
+    pub fn push_repo_override(&self, argv: &mut Vec<OsString>) {
+        if let Some(slug) = self.repo.as_deref() {
+            argv.push(OsString::from("--repo"));
+            argv.push(OsString::from(slug));
+        }
+    }
 }
 
 /// Where the provider decision came from. Useful for diagnostics and tests.
@@ -65,13 +83,17 @@ pub enum DetectionSource {
 pub fn detect(
     hint: ProviderHint,
     remote: &str,
+    repo_override: Option<&str>,
     remote_url_lookup: impl Fn(&str) -> Option<String>,
 ) -> Result<ProviderContext, ForgeError> {
+    let repo = repo_override.map(str::to_string);
+
     if let ProviderHint::Forced(provider) = hint {
         return Ok(ProviderContext {
             provider,
             host: default_host_for(provider).to_string(),
             source: DetectionSource::Flag,
+            repo,
         });
     }
 
@@ -84,6 +106,7 @@ pub fn detect(
                 provider,
                 host,
                 source: DetectionSource::Remote,
+                repo,
             });
         }
         return Err(ForgeError::provider_unsupported(
@@ -251,8 +274,13 @@ mod tests {
             counter.set(counter.get() + 1);
             None
         };
-        let ctx = detect(ProviderHint::Forced(Provider::GitHub), "origin", lookup)
-            .expect("forced provider");
+        let ctx = detect(
+            ProviderHint::Forced(Provider::GitHub),
+            "origin",
+            None,
+            lookup,
+        )
+        .expect("forced provider");
         assert_eq!(ctx.provider, Provider::GitHub);
         assert_eq!(ctx.source, DetectionSource::Flag);
         assert_eq!(counter.get(), 0, "remote lookup must not run when forced");
@@ -260,7 +288,7 @@ mod tests {
 
     #[test]
     fn detect_from_remote_url() {
-        let ctx = detect(ProviderHint::Auto, "origin", |_| {
+        let ctx = detect(ProviderHint::Auto, "origin", None, |_| {
             Some("git@gitlab.com:owner/repo.git".to_string())
         })
         .expect("auto from remote");
@@ -271,7 +299,7 @@ mod tests {
 
     #[test]
     fn detect_unknown_host_errors() {
-        let err = detect(ProviderHint::Auto, "origin", |_| {
+        let err = detect(ProviderHint::Auto, "origin", None, |_| {
             Some("https://bitbucket.org/owner/repo.git".to_string())
         })
         .expect_err("unknown host");
@@ -280,7 +308,7 @@ mod tests {
 
     #[test]
     fn detect_no_remote_errors() {
-        let err = detect(ProviderHint::Auto, "origin", |_| None).expect_err("no remote");
+        let err = detect(ProviderHint::Auto, "origin", None, |_| None).expect_err("no remote");
         assert_eq!(err.kind(), "provider_unsupported");
     }
 }

--- a/crates/forge-cli/tests/integration/required_check_gate.rs
+++ b/crates/forge-cli/tests/integration/required_check_gate.rs
@@ -40,6 +40,7 @@ fn github_ctx() -> ProviderContext {
         provider: Provider::GitHub,
         host: "github.com".into(),
         source: DetectionSource::Flag,
+        repo: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Fix the `--repo owner/name` global flag so it actually reaches every backend invocation, not just `repo view`. Surfaced as a follow-up on #457 ([comment #4525727774](https://github.com/sympoies/nils-cli/issues/457#issuecomment-4525727774)): from one repo's checkout, `forge-cli issue create --repo other/repo --dry-run` returned a plan that omitted `--repo`, so the dry-run hid where the live call would actually target.

Root cause: `cli.rs` already accepts `--repo` and stores it on `GlobalFlags::repo`, but only `repo_view.rs` consumed it. Every other op silently dropped it — dry-run plan **and** live exec both used the auto-detected origin remote.

## Fix

- Carry the slug on `ProviderContext` (set inside `detect()`); add `ProviderContext::push_repo_override(&mut argv)` that pushes `--repo <slug>` for both `gh` and `glab`.
- Thread `global.repo.as_deref()` into every `detect(...)` call site.
- Append `ctx.push_repo_override(&mut argv)` inside every `build_*_call` (issue create/view/edit/close/reopen/comment/list, pr create/view/edit/close/comment/list/merge/ready/wait-checks/checks, `pr_checks_gitlab` status + branch resolver, and `pr_create`'s view re-fetch).
- Switch `repo_view` to read `ctx.repo` directly and drop its separate `repo_override` parameter, so `pr_create` / `pr_merge` default-branch lookups (and `pr_deliver`'s repo-view step) honor `--repo` automatically without extra plumbing.
- `auth_status` and `pr_checks_gitlab::build_version_call` are intentionally untouched (`gh auth status` / `glab --version` have no `--repo` semantics).
- New tests cover the override branch directly: `issue_create::build_create_call_propagates_repo_override_to_argv`, `pr_checks_gitlab::build_status_call_includes_repo_override_when_set`, `repo_view::build_call_github_includes_repo_slug_when_ctx_has_repo`.

## Test plan

- [x] `cargo test -p nils-forge-cli` → 248 lib + 114 integration + 0 doc, all green.
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` → 363/363 nextest passing, fmt + clippy + audits clean.
- [x] Repro the original comment scenario locally:
  ```text
  $ cargo run -q -p nils-forge-cli -- --repo sympoies/nils-cli --provider github --dry-run --format json \
        issue create --title "dry-run repo propagation probe" --body "probe" --label issue
  ```
  Now returns `"plan": ["gh","issue","create","--title",..."--label","issue","--repo","sympoies/nils-cli"]` — the `--repo` override appears in the plan (and the live call) instead of being silently dropped.

## Out of scope

- This PR does not change the `--repo` flag surface in `cli.rs` — only the wiring downstream.
- Layered on top of #458 (agent-docs task-tools path migration) — both PRs flow from #457 follow-ups; they touch disjoint crates.

Refs: #457
