### PR TITLE
docs(plans): fix wrong-depth crates link in plan-issue-lifecycle-v3

### DIFF
--- a/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md
+++ b/docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md
@@ -115,6 +115,6 @@ Tracked here so the next major-release cycle can act on them:
 - This plan intentionally does not preserve backwards compatibility.
 - This plan does not mutate agent-runtime-kit source files.
 - The agent-runtime-kit consumer migration is documented in
-  [`crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`](../../crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md)
+  [`crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`](../../../crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md)
   ("Consumer Migration" section). It happens after the next
   plan-issue-cli release cuts.


### PR DESCRIPTION
## Summary

Restore green main for the `markdownlint-audit.sh --strict` lint, which is currently failing on every PR that branches off `daca432` (the #459 merge commit) and onwards.

`docs/plans/plan-issue-lifecycle-v3/plan-issue-lifecycle-v3-execution-state.md:118` has:

```
[`crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`](../../crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md)
```

From `docs/plans/plan-issue-lifecycle-v3/`, `../../` only ascends to `docs/`, so the target resolves to `docs/crates/...` (which doesn't exist) and `rumdl` flags `[MD057]`. The fix is to ascend one more level to repo root: `../../../crates/...`.

This regression made it into main even though #459's own `test` job was `FAILURE` at merge time (mergedAt 2026-05-23T15:25:40Z).

## Test plan

- [x] `bash scripts/ci/markdownlint-audit.sh --strict` → `Success: No issues found in 156 files` locally (pre-fix the same script reported 2 issues in 1/156 files).
- [x] One-character diff; no other docs touched.

## Out of scope

- Doesn't address why #459 was merged with a failing `test` job — that's a process / branch-protection concern separate from this lint fix.
- Doesn't audit other `docs/plans/**` directories for similar wrong-depth links (a quick sweep showed only this single match for `../../crates` in `docs/plans/plan-issue-lifecycle-v3/`).

Refs: #457 follow-ups (#458, #460 unblock)
