### PR TITLE
fix(plan-issue): hide record payload comments

### DIFF
--- a/crates/plan-issue-cli/CHANGELOG.md
+++ b/crates/plan-issue-cli/CHANGELOG.md
@@ -27,10 +27,11 @@ versioning.
     profile, role, status, and the parsed structured payload. Audit also
     surfaces a stable `missing_required` array (`source-missing`,
     `plan-missing`, `state-missing`).
-  - Every v2 lifecycle comment carries a fenced JSON block whose
-    info-string is the literal `plan-issue-record-payload`. The payload
-    is the structured source of truth for audit, dashboard repair, and
-    closeout gating. Prose-Markdown status parsing is no longer used.
+  - Every v2 lifecycle comment carries a hidden structured payload. Audit,
+    dashboard repair, and closeout gating consume that payload as the source
+    of truth; older visible `plan-issue-record-payload` fences remain
+    accepted for existing records. Prose-Markdown status parsing is no longer
+    used.
   - The `record closeout-gate` standalone command and its
     `--require-complete`, `--require-session`, `--require-validation`,
     `--require-review`, `--require-closeout` flags are retired.
@@ -69,8 +70,8 @@ versioning.
   and repairs the dashboard with the freshly-created comment URLs.
   Supports `--dry-run` and `--fixture <dir>` deterministic modes.
 - `plan-issue record post --issue <n> --kind <state|session|validation|review> --payload-file <p>`
-  appends one canonical lifecycle comment with the v2 marker + payload
-  fence. `--kind source|plan` is rejected (owned by `record open`);
+  appends one canonical lifecycle comment with the v2 marker + hidden payload
+  carrier. `--kind source|plan` is rejected (owned by `record open`);
   `--kind closeout` is rejected (owned by `record close`).
 - `plan-issue record repair-dashboard --issue <n>` (or `--body-file +
   --comments-json` for local mode) recomputes the canonical dashboard

--- a/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md
+++ b/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md
@@ -89,12 +89,16 @@ families are not recognized as current lifecycle markers.
 
 ## Structured Payload Model
 
-Every lifecycle comment includes one fenced JSON block whose info-string is
-the literal token `plan-issue-record-payload`. The fence is the structured
-source of truth for audit, dashboard repair, and closeout gating. Visible
-Markdown around it is human commentary only. Implementations recognize the
-block by reading the opening fence line `<backticks>plan-issue-record-payload`
-(no language alias) and parsing the body as JSON.
+Every lifecycle comment includes one hidden HTML-comment payload carrier. The
+payload is the structured source of truth for audit, dashboard repair, and
+closeout gating. Visible Markdown around it is human commentary only.
+
+Implementations recognize current payloads by reading a comment whose inner
+text starts with `plan-issue-record-payload:hex:` and hex-decoding the
+following JSON envelope. For backward compatibility, audit still accepts the
+older visible fenced JSON block whose info-string is the literal token
+`plan-issue-record-payload`, but new provider-backed comments must not render
+that visible fence by default.
 
 The envelope shape is:
 
@@ -241,8 +245,9 @@ explicit file flags), and a title source (`--title` or plan-derived).
 High-level append-only comment command for `state`, `session`, `validation`,
 `review`, and `closeout` kinds.
 
-- Renders the canonical marker and structured payload from explicit fields
-  or a `--payload-file` JSON document.
+- Renders the canonical marker, human summary Markdown when supplied, and a
+  hidden structured payload from explicit fields or a `--payload-file` JSON
+  document.
 - Posts to the provider issue and returns the comment URL.
 - Supports `--dry-run` and `--fixture` modes.
 - `--kind closeout` is callable directly only when `record close` is not

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -588,6 +588,18 @@ fn run_record_open(
             format!("failed to read {}: {err}", bundle.plan_file.display()),
         )
     })?;
+    let execution_state_content = bundle
+        .execution_state_file
+        .as_deref()
+        .map(|path| {
+            fs::read_to_string(path).map_err(|err| {
+                CommandError::runtime(
+                    "record-open-execution-state-read-failed",
+                    format!("failed to read {}: {err}", path.display()),
+                )
+            })
+        })
+        .transpose()?;
 
     let source_body = lifecycle_record::render_record_snapshot_comment(
         args.profile,
@@ -607,11 +619,16 @@ fn run_record_open(
     .map_err(|err| CommandError::runtime("record-open-plan-render-failed", err))?;
 
     let initial_state = build_initial_state_payload(&plan);
+    let state_summary = execution_state_content
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("Initial execution state seeded by `plan-issue record open`.");
     let state_body = lifecycle_record::render_record_post_comment(
         args.profile,
         crate::commands::record::LifecycleCommentKind::State,
         initial_state.clone(),
-        Some("Initial execution state seeded by `plan-issue record open`."),
+        Some(state_summary),
         None,
     )
     .map_err(|err| CommandError::runtime("record-open-state-render-failed", err))?;

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -49,10 +49,10 @@ pub struct LifecycleEvidence {
     /// when the role does not declare a status or the payload could not
     /// be parsed.
     pub status: Option<String>,
-    /// Parsed structured payload. `None` when the comment lacks a
-    /// `plan-issue-record-payload` fence; audit still records the marker
-    /// for visibility but downstream gates treat missing payloads as
-    /// unparseable evidence.
+    /// Parsed structured payload. `None` when the comment lacks a hidden
+    /// payload carrier or older `plan-issue-record-payload` fence; audit
+    /// still records the marker for visibility but downstream gates treat
+    /// missing payloads as unparseable evidence.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<RecordPayload>,
 }
@@ -964,17 +964,19 @@ fn finalize_markdown(lines: Vec<String>) -> String {
 // -----------------------------------------------------------------------------
 // Structured lifecycle payload (issue-backed plan record contract v2)
 //
-// Each lifecycle comment carries one fenced JSON block whose info-string is the
-// literal token PAYLOAD_FENCE_INFO. Audit, dashboard repair, and closeout gate
-// evaluation consume the structured payload exclusively. Visible Markdown
-// around the fence is human commentary only.
+// Each lifecycle comment carries one hidden payload carrier. Audit, dashboard
+// repair, and closeout gate evaluation consume the structured payload
+// exclusively. Visible Markdown around the carrier is human commentary only.
+// The older PAYLOAD_FENCE_INFO fenced block remains accepted for existing
+// records created before the hidden carrier renderer.
 // -----------------------------------------------------------------------------
 
 /// On-wire schema identity for v2 lifecycle payloads.
 pub const PAYLOAD_SCHEMA_V2: &str = "plan-issue-record.payload.v2";
 
-/// Fenced-code-block info-string used to mark a lifecycle payload fence.
+/// Older fenced-code-block info-string used to mark a lifecycle payload.
 pub const PAYLOAD_FENCE_INFO: &str = "plan-issue-record-payload";
+const PAYLOAD_COMMENT_PREFIX: &str = "plan-issue-record-payload:hex:";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -1274,33 +1276,42 @@ impl std::fmt::Display for PayloadError {
 
 impl std::error::Error for PayloadError {}
 
-/// Extract the structured lifecycle payload fenced inside `comment_body`.
+/// Extract the structured lifecycle payload carried inside `comment_body`.
 ///
-/// - Returns `Ok(payload)` on a single well-formed `plan-issue-record-payload`
-///   fence whose envelope `schema` matches [`PAYLOAD_SCHEMA_V2`].
-/// - Returns `Err(NoFence)` when the comment does not contain the fence.
-/// - Returns `Err(MultipleFences)` when multiple payload fences are present;
+/// - Returns `Ok(payload)` on a single well-formed hidden carrier or older
+///   `plan-issue-record-payload` fence whose envelope `schema` matches
+///   [`PAYLOAD_SCHEMA_V2`].
+/// - Returns `Err(NoFence)` when the comment does not contain either payload
+///   carrier.
+/// - Returns `Err(MultipleFences)` when multiple payload carriers are present;
 ///   each comment carries at most one payload.
-/// - Returns `Err(SchemaMismatch)` when the fence parses but its `schema`
+/// - Returns `Err(SchemaMismatch)` when the payload parses but its `schema`
 ///   does not match the v2 wire identity.
-/// - Returns `Err(InvalidJson)` when the fence body is not valid JSON or
+/// - Returns `Err(InvalidJson)` when the payload body is not valid JSON or
 ///   does not deserialize into the envelope.
 pub fn extract_payload(comment_body: &str) -> Result<RecordPayload, PayloadError> {
+    let carriers = collect_payload_comment_carriers(comment_body)?;
     let fences = collect_payload_fences(comment_body);
-    if fences.is_empty() {
+    let payload_count = carriers.len() + fences.len();
+    if payload_count == 0 {
         return Err(PayloadError::new(
             PayloadErrorKind::NoFence,
-            "no plan-issue-record-payload fence in comment body",
+            "no plan-issue-record-payload carrier or fence in comment body",
         ));
     }
-    if fences.len() > 1 {
+    if payload_count > 1 {
         return Err(PayloadError::new(
             PayloadErrorKind::MultipleFences,
-            "multiple plan-issue-record-payload fences in comment body",
+            "multiple plan-issue-record-payload carriers or fences in comment body",
         ));
     }
 
-    let raw = &fences[0];
+    let raw = carriers.first().or_else(|| fences.first()).ok_or_else(|| {
+        PayloadError::new(
+            PayloadErrorKind::NoFence,
+            "no plan-issue-record-payload carrier or fence in comment body",
+        )
+    })?;
     let payload: RecordPayload = serde_json::from_str(raw)
         .map_err(|err| PayloadError::new(PayloadErrorKind::InvalidJson, err.to_string()))?;
     if payload.schema != PAYLOAD_SCHEMA_V2 {
@@ -1313,6 +1324,37 @@ pub fn extract_payload(comment_body: &str) -> Result<RecordPayload, PayloadError
         ));
     }
     Ok(payload)
+}
+
+fn collect_payload_comment_carriers(body: &str) -> Result<Vec<String>, PayloadError> {
+    let mut out = Vec::new();
+    for line in body.lines() {
+        let trimmed = line.trim();
+        let Some(inner) = trimmed
+            .strip_prefix("<!--")
+            .and_then(|value| value.strip_suffix("-->"))
+        else {
+            continue;
+        };
+        let inner = inner.trim();
+        let Some(encoded) = inner.strip_prefix(PAYLOAD_COMMENT_PREFIX) else {
+            continue;
+        };
+        let payload = decode_hex(encoded.trim()).map_err(|err| {
+            PayloadError::new(
+                PayloadErrorKind::InvalidJson,
+                format!("invalid hidden payload carrier: {err}"),
+            )
+        })?;
+        let payload = String::from_utf8(payload).map_err(|err| {
+            PayloadError::new(
+                PayloadErrorKind::InvalidJson,
+                format!("hidden payload carrier is not UTF-8: {err}"),
+            )
+        })?;
+        out.push(payload);
+    }
+    Ok(out)
 }
 
 fn collect_payload_fences(body: &str) -> Vec<String> {
@@ -1341,6 +1383,41 @@ fn collect_payload_fences(body: &str) -> Vec<String> {
         }
     }
     out
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn decode_hex(input: &str) -> Result<Vec<u8>, String> {
+    if !input.len().is_multiple_of(2) {
+        return Err("hex payload has odd length".to_string());
+    }
+    let mut out = Vec::with_capacity(input.len() / 2);
+    let bytes = input.as_bytes();
+    for pair in bytes.chunks_exact(2) {
+        let hi = hex_value(pair[0])
+            .ok_or_else(|| format!("invalid hex digit `{}`", char::from(pair[0])))?;
+        let lo = hex_value(pair[1])
+            .ok_or_else(|| format!("invalid hex digit `{}`", char::from(pair[1])))?;
+        out.push((hi << 4) | lo);
+    }
+    Ok(out)
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
 }
 
 impl RecordPayload {
@@ -1402,8 +1479,9 @@ impl RecordPayload {
 //
 // `render_record_snapshot_comment` and `render_record_post_comment` produce the
 // canonical Markdown body for `record open` and `record post`: every comment
-// carries the v2 marker on its first line plus a single
-// `plan-issue-record-payload` JSON fence as the structured source of truth.
+// carries the v2 marker on its first line plus a hidden payload carrier as the
+// structured source of truth. Audit still accepts the older visible payload
+// fence for records created before this renderer was fixed.
 // -----------------------------------------------------------------------------
 
 fn payload_role_for_kind(kind: LifecycleCommentKind) -> PayloadRole {
@@ -1418,13 +1496,17 @@ fn payload_role_for_kind(kind: LifecycleCommentKind) -> PayloadRole {
     }
 }
 
-fn render_payload_fence(envelope: &RecordPayload) -> Result<String, String> {
-    serde_json::to_string_pretty(envelope).map_err(|err| err.to_string())
+fn render_payload_carrier(envelope: &RecordPayload) -> Result<String, String> {
+    let envelope_json = serde_json::to_string(envelope).map_err(|err| err.to_string())?;
+    Ok(format!(
+        "<!-- {PAYLOAD_COMMENT_PREFIX}{} -->",
+        encode_hex(envelope_json.as_bytes())
+    ))
 }
 
 /// Render the canonical v2 source/plan snapshot comment used by
 /// `record open`. The body carries the v2 marker, visible details, and a
-/// `plan-issue-record-payload` JSON fence carrying [`SnapshotData`].
+/// hidden structured payload carrying [`SnapshotData`].
 pub fn render_record_snapshot_comment(
     profile: RecordProfile,
     kind: LifecycleCommentKind,
@@ -1449,7 +1531,7 @@ pub fn render_record_snapshot_comment(
         updated_at: updated_at.map(str::to_string),
         data: serde_json::to_value(snapshot).map_err(|err| err.to_string())?,
     };
-    let envelope_json = render_payload_fence(&envelope)?;
+    let envelope_carrier = render_payload_carrier(&envelope)?;
 
     let marker = marker_for(profile, kind);
     let heading = default_heading(profile, kind);
@@ -1484,9 +1566,7 @@ pub fn render_record_snapshot_comment(
     out.push(String::new());
     out.push("</details>".to_string());
     out.push(String::new());
-    out.push(format!("```{PAYLOAD_FENCE_INFO}"));
-    out.push(envelope_json);
-    out.push("```".to_string());
+    out.push(envelope_carrier);
     Ok(finalize_markdown(out))
 }
 
@@ -1517,7 +1597,7 @@ pub fn render_record_post_comment(
         updated_at: updated_at.map(str::to_string),
         data: payload_data,
     };
-    let envelope_json = render_payload_fence(&envelope)?;
+    let envelope_carrier = render_payload_carrier(&envelope)?;
 
     let marker = marker_for(profile, kind);
     let heading = default_heading(profile, kind);
@@ -1533,9 +1613,7 @@ pub fn render_record_post_comment(
         out.push(text.to_string());
     }
     out.push(String::new());
-    out.push(format!("```{PAYLOAD_FENCE_INFO}"));
-    out.push(envelope_json);
-    out.push("```".to_string());
+    out.push(envelope_carrier);
     Ok(finalize_markdown(out))
 }
 
@@ -2133,7 +2211,7 @@ mod sprint3_tests {
     }
 
     #[test]
-    fn render_record_post_comment_emits_marker_and_payload_fence() {
+    fn render_record_post_comment_emits_marker_and_hidden_payload_carrier() {
         let body = render_record_post_comment(
             RecordProfile::Tracking,
             LifecycleCommentKind::State,
@@ -2146,11 +2224,14 @@ mod sprint3_tests {
             body.starts_with("<!-- plan-issue-record:v2 role=state profile=tracking -->"),
             "{body}"
         );
-        assert!(body.contains(&format!("```{PAYLOAD_FENCE_INFO}")), "{body}");
         assert!(
-            body.contains("\"schema\": \"plan-issue-record.payload.v2\""),
+            !body.contains(&format!("```{PAYLOAD_FENCE_INFO}")),
             "{body}"
         );
+        assert!(body.contains(PAYLOAD_COMMENT_PREFIX), "{body}");
+        let payload = extract_payload(&body).expect("payload");
+        assert_eq!(payload.schema, PAYLOAD_SCHEMA_V2);
+        assert_eq!(payload.role, PayloadRole::State);
         assert!(body.contains("session summary"), "{body}");
     }
 
@@ -2168,7 +2249,7 @@ mod sprint3_tests {
     }
 
     #[test]
-    fn render_record_snapshot_comment_includes_details_and_payload() {
+    fn render_record_snapshot_comment_includes_details_and_hidden_payload() {
         let snapshot = SnapshotData {
             path: "docs/plans/sample/sample-plan.md".to_string(),
             commit: "abc1234".to_string(),
@@ -2190,10 +2271,13 @@ mod sprint3_tests {
         assert!(body.contains("- Commit: `abc1234`"), "{body}");
         assert!(body.contains("- Summary: One-liner"), "{body}");
         assert!(body.contains("<details>"), "{body}");
-        assert!(body.contains(&format!("```{PAYLOAD_FENCE_INFO}")), "{body}");
         assert!(
-            body.contains("\"schema\": \"plan-issue-record.payload.v2\""),
+            !body.contains(&format!("```{PAYLOAD_FENCE_INFO}")),
             "{body}"
         );
+        assert!(body.contains(PAYLOAD_COMMENT_PREFIX), "{body}");
+        let payload = extract_payload(&body).expect("payload");
+        assert_eq!(payload.schema, PAYLOAD_SCHEMA_V2);
+        assert_eq!(payload.role, PayloadRole::Plan);
     }
 }

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -1328,7 +1328,14 @@ pub fn extract_payload(comment_body: &str) -> Result<RecordPayload, PayloadError
 
 fn collect_payload_comment_carriers(body: &str) -> Result<Vec<String>, PayloadError> {
     let mut out = Vec::new();
+    let mut details_depth = 0usize;
     for line in body.lines() {
+        if update_details_depth(line, &mut details_depth) {
+            continue;
+        }
+        if details_depth > 0 {
+            continue;
+        }
         let trimmed = line.trim();
         let Some(inner) = trimmed
             .strip_prefix("<!--")
@@ -1360,6 +1367,7 @@ fn collect_payload_comment_carriers(body: &str) -> Result<Vec<String>, PayloadEr
 fn collect_payload_fences(body: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut current: Option<Vec<String>> = None;
+    let mut details_depth = 0usize;
     for line in body.lines() {
         let trimmed = line.trim_start();
         if let Some(buf) = current.as_mut() {
@@ -1376,13 +1384,34 @@ fn collect_payload_fences(body: &str) -> Vec<String> {
             } else {
                 buf.push(line.to_string());
             }
-        } else if let Some(rest) = trimmed.strip_prefix("```")
-            && rest.trim() == PAYLOAD_FENCE_INFO
-        {
-            current = Some(Vec::new());
+        } else {
+            if update_details_depth(line, &mut details_depth) {
+                continue;
+            }
+            if details_depth > 0 {
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("```")
+                && rest.trim() == PAYLOAD_FENCE_INFO
+            {
+                current = Some(Vec::new());
+            }
         }
     }
     out
+}
+
+fn update_details_depth(line: &str, depth: &mut usize) -> bool {
+    let trimmed = line.trim();
+    if trimmed.starts_with("<details") {
+        *depth += 1;
+        return true;
+    }
+    if trimmed.starts_with("</details>") {
+        *depth = depth.saturating_sub(1);
+        return true;
+    }
+    false
 }
 
 fn encode_hex(bytes: &[u8]) -> String {
@@ -2279,5 +2308,36 @@ mod sprint3_tests {
         let payload = extract_payload(&body).expect("payload");
         assert_eq!(payload.schema, PAYLOAD_SCHEMA_V2);
         assert_eq!(payload.role, PayloadRole::Plan);
+    }
+
+    #[test]
+    fn extract_payload_ignores_payload_markers_inside_snapshot_details() {
+        let nested_payload = RecordPayload {
+            schema: PAYLOAD_SCHEMA_V2.to_string(),
+            role: PayloadRole::State,
+            profile: PayloadProfile::Tracking,
+            updated_at: None,
+            data: json!({"status": "complete"}),
+        };
+        let nested_carrier = render_payload_carrier(&nested_payload).expect("nested carrier");
+        let snapshot = SnapshotData {
+            path: "docs/plans/sample/sample-discussion-source.md".to_string(),
+            commit: "abc1234".to_string(),
+            title: None,
+            summary: None,
+        };
+        let body = render_record_snapshot_comment(
+            RecordProfile::Tracking,
+            LifecycleCommentKind::Source,
+            &snapshot,
+            &format!(
+                "# Source\n\n{nested_carrier}\n\n```{PAYLOAD_FENCE_INFO}\n{{not valid json}}\n```\n"
+            ),
+            None,
+        )
+        .expect("render");
+
+        let payload = extract_payload(&body).expect("payload");
+        assert_eq!(payload.role, PayloadRole::Source);
     }
 }

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -13,8 +13,8 @@ use crate::common;
 const PAYLOAD_SCHEMA_V2: &str = "plan-issue-record.payload.v2";
 const PAYLOAD_FENCE_INFO: &str = "plan-issue-record-payload";
 
-/// Build a `plan-issue-record:v2` comment body with the payload fence
-/// carrying `data` for the given role/profile.
+/// Build an older `plan-issue-record:v2` comment body with a visible payload
+/// fence carrying `data` for the given role/profile.
 fn v2_comment_body(role: &str, profile: &str, data: Value) -> String {
     let envelope = json!({
         "schema": PAYLOAD_SCHEMA_V2,
@@ -50,6 +50,34 @@ fn write_pr_fixture(dir: &Path, repo: &str, pr: u64, value: Value) {
         serde_json::to_string(&value).expect("pr json"),
     )
     .expect("write pr fixture");
+}
+
+fn audit_single_comment_body(body: &str) -> Value {
+    let tmp = TempDir::new().expect("tempdir");
+    let comments_json = tmp.path().join("comments.json");
+    fs::write(
+        &comments_json,
+        json!({
+            "comments": [
+                {"body": body, "url": "https://github.com/owner/repo/issues/1#issuecomment-record"}
+            ]
+        })
+        .to_string(),
+    )
+    .expect("write comments json");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "audit",
+        "--comments-json",
+        comments_json.to_str().expect("comments path"),
+        "--profile",
+        "tracking",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    parse_json(&out.stdout)["payload"]["result"]["audit"].clone()
 }
 
 #[test]
@@ -95,8 +123,14 @@ fn record_post_state_with_payload_file_renders_v2_marker_in_dry_run() {
         body.starts_with("<!-- plan-issue-record:v2 role=state profile=tracking -->"),
         "{body}"
     );
-    assert!(body.contains(&format!("```{PAYLOAD_FENCE_INFO}")), "{body}");
-    assert!(body.contains("\"target_scope\": \"scope\""), "{body}");
+    assert!(
+        !body.contains(&format!("```{PAYLOAD_FENCE_INFO}")),
+        "{body}"
+    );
+    assert!(
+        body.contains("<!-- plan-issue-record-payload:hex:"),
+        "{body}"
+    );
 }
 
 #[test]
@@ -323,11 +357,18 @@ fn record_close_fixture_passes_strict_gate_with_complete_v2_evidence() {
         body.starts_with("<!-- plan-issue-record:v2 role=closeout profile=tracking -->"),
         "{body}"
     );
-    assert!(body.contains("\"final_status\": \"complete\""), "{body}");
     assert!(
-        body.contains("\"merge_sha\": \"deadbeefcafebabe\""),
+        !body.contains(&format!("```{PAYLOAD_FENCE_INFO}")),
         "{body}"
     );
+    assert!(
+        body.contains("<!-- plan-issue-record-payload:hex:"),
+        "{body}"
+    );
+    let audit = audit_single_comment_body(body);
+    let closeout = &audit["evidence"]["closeout"]["payload"]["data"];
+    assert_eq!(closeout["final_status"], "complete");
+    assert_eq!(closeout["linked_prs"][0]["merge_sha"], "deadbeefcafebabe");
     let final_dashboard = preview["final_dashboard"]
         .as_str()
         .expect("final dashboard");
@@ -632,12 +673,18 @@ fn record_open_dry_run_returns_preview_without_gh_calls() {
     fs::create_dir_all(&bundle).expect("create bundle dir");
     let source = bundle.join("sample-discussion-source.md");
     let plan = bundle.join("sample-plan.md");
+    let execution_state = bundle.join("sample-execution-state.md");
     fs::write(&source, "# Source\n\n- Decision: implement v2 lifecycle.\n").expect("write source");
     fs::write(
         &plan,
         "# Plan: Sample Plan\n\n## Overview\n\n- Sample plan body.\n\n## Read First\n\n- Primary source: docs/plans/sample/sample-discussion-source.md\n- Source type: discussion-to-implementation-doc\n- Open questions carried into execution: none\n\n## Scope\n\n- In scope:\n  - Demo plan.\n- Out of scope:\n  - none.\n\n## Assumptions\n\n1. Demo only.\n\n## Sprint 1: Demo\n\n**Goal**: Demo the surface.\n\n**PR grouping intent**: group\n**Execution Profile**: serial\n\n### Task 1.1: Demo task\n\n- **Location**:\n  - `docs/plans/sample/sample-plan.md`\n- **Description**: Demo task description.\n- **Dependencies**:\n  - none\n- **Complexity**: 1\n- **Acceptance criteria**:\n  - The demo task is complete.\n- **Validation**:\n  - `true`\n",
     )
     .expect("write plan");
+    fs::write(
+        &execution_state,
+        "# Sample Execution State\n\n<!-- plan-issue-record:v2 role=state profile=tracking -->\n\n## Execution State\n\n- Status: pending\n- Target scope: Sample Plan\n",
+    )
+    .expect("write execution state");
     git(repo.path(), &["add", "."]);
     git(
         repo.path(),
@@ -682,6 +729,70 @@ fn record_open_dry_run_returns_preview_without_gh_calls() {
         source_comment.starts_with("<!-- plan-issue-record:v2 role=source profile=tracking -->"),
         "{source_comment}"
     );
+    let plan_comment = preview["comments"]["plan"].as_str().expect("plan comment");
+    let state_comment = preview["comments"]["state"]
+        .as_str()
+        .expect("state comment");
+    for (label, comment) in [
+        ("source", source_comment),
+        ("plan", plan_comment),
+        ("state", state_comment),
+    ] {
+        assert!(
+            !comment.contains(&format!("```{PAYLOAD_FENCE_INFO}")),
+            "{label} comment should not visibly leak payload JSON:\n{comment}"
+        );
+    }
+    assert!(
+        state_comment.contains("# Sample Execution State"),
+        "{state_comment}"
+    );
+    assert!(
+        state_comment.contains("- Status: pending"),
+        "{state_comment}"
+    );
+    assert!(
+        !state_comment.contains("Initial execution state seeded"),
+        "{state_comment}"
+    );
+
+    let comments_json = repo.path().join("comments.json");
+    fs::write(
+        &comments_json,
+        json!({
+            "comments": [
+                {"body": source_comment, "url": "https://github.com/owner/repo/issues/1#issuecomment-source"},
+                {"body": plan_comment, "url": "https://github.com/owner/repo/issues/1#issuecomment-plan"},
+                {"body": state_comment, "url": "https://github.com/owner/repo/issues/1#issuecomment-state"}
+            ]
+        })
+        .to_string(),
+    )
+    .expect("write comments json");
+
+    let audit = nils_test_support::cmd::run_resolved(
+        "plan-issue-local",
+        &[
+            "--format",
+            "json",
+            "record",
+            "audit",
+            "--comments-json",
+            comments_json.to_str().expect("comments path"),
+            "--profile",
+            "tracking",
+        ],
+        &opts,
+    );
+    assert_eq!(audit.code, 0, "stderr: {}", audit.stderr_text());
+    let parsed_audit: Value = serde_json::from_str(&audit.stdout_text()).expect("audit json");
+    let audit_result = &parsed_audit["payload"]["result"]["audit"];
+    assert_eq!(audit_result["recognized_count"], 3);
+    assert_eq!(
+        audit_result["missing_required"],
+        json!([]),
+        "{audit_result}"
+    );
 }
 
 /// Sprint 4 Task 4.3: exercise the v3 closeout end-to-end against a sanitized
@@ -720,18 +831,25 @@ fn agent_runtime_kit_lifecycle_fixture_passes_strict_v2_closeout_end_to_end() {
         .as_str()
         .expect("closeout body present");
     // Closeout comment uses the v2 marker and carries provider-verified
-    // merge_sha from the fixture PR snapshot.
+    // merge_sha from the fixture PR snapshot in the hidden payload.
     assert!(
         closeout_body.starts_with("<!-- plan-issue-record:v2 role=closeout profile=tracking -->"),
         "{closeout_body}"
     );
     assert!(
-        closeout_body.contains("\"merge_sha\": \"merge1111111111111111111111111111111111\""),
-        "merge_sha must come from PR fixture, not state payload: {closeout_body}"
+        !closeout_body.contains(&format!("```{PAYLOAD_FENCE_INFO}")),
+        "{closeout_body}"
     );
     assert!(
-        closeout_body.contains("\"final_status\": \"complete\""),
+        closeout_body.contains("<!-- plan-issue-record-payload:hex:"),
         "{closeout_body}"
+    );
+    let audit = audit_single_comment_body(closeout_body);
+    let closeout = &audit["evidence"]["closeout"]["payload"]["data"];
+    assert_eq!(closeout["final_status"], "complete");
+    assert_eq!(
+        closeout["linked_prs"][0]["merge_sha"], "merge1111111111111111111111111111111111",
+        "merge_sha must come from PR fixture, not state payload: {closeout_body}"
     );
     // Sanity: no v1 marker bleed-through.
     assert!(


### PR DESCRIPTION
## Summary

- Hide `plan-issue` v2 structured payloads in hidden HTML-comment carriers while preserving audit support for older visible payload fences.
- Restore `record open` state comments to inline the bundle execution-state Markdown while keeping the structured state payload available for audit and closeout.

Fixes #463

## Test plan

- `cargo test -p nils-plan-issue-cli --test integration`
- `cargo test -p nils-plan-issue-cli --lib`
- `cargo run --manifest-path /Users/terry/.codex/worktrees/8dba/nils-cli/Cargo.toml -p nils-plan-issue-cli --bin plan-issue-local -- --format json record open --dry-run --profile tracking --repo graysurf/agent-runtime-kit --bundle docs/plans/nils-cli-version-alignment | jq '{has_visible_payload_fence:{source:(.payload.result.preview.comments.source|contains("```plan-issue-record-payload")),plan:(.payload.result.preview.comments.plan|contains("```plan-issue-record-payload")),state:(.payload.result.preview.comments.state|contains("```plan-issue-record-payload"))}, has_hidden_payload:{source:(.payload.result.preview.comments.source|contains("<!-- plan-issue-record-payload:hex:")),plan:(.payload.result.preview.comments.plan|contains("<!-- plan-issue-record-payload:hex:")),state:(.payload.result.preview.comments.state|contains("<!-- plan-issue-record-payload:hex:"))}, state_has_execution_state_markdown:(.payload.result.preview.comments.state|contains("# nils-cli Version Alignment Execution State")), state_has_seeded_summary:(.payload.result.preview.comments.state|contains("Initial execution state seeded"))}'`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
