### PR TITLE
Add agent-docs global scope inheritance

### DIFF
--- a/crates/agent-docs/README.md
+++ b/crates/agent-docs/README.md
@@ -7,7 +7,7 @@
 It resolves required Markdown documents by context and scope, with explicit precedence rules for:
 
 - startup policy files (`AGENTS.override.md` > `AGENTS.md`)
-- home vs project extension config (`AGENT_DOCS.toml`)
+- home, global, and project extension config (`AGENT_DOCS.toml`)
 - strict vs non-strict missing-doc behavior
 
 The CLI does not replace runtime `AGENTS.md` loading. It provides a testable resolution contract.
@@ -47,6 +47,8 @@ If neither is provided, the binary errors with
 
 - Paths are normalized lexically (`.` removed, duplicate separators collapsed).
 - Relative document paths in `AGENT_DOCS.toml` are resolved from their declared `scope` root.
+  `home` and `global` resolve from `AGENT_DOCS_HOME`; `project` resolves from
+  `PROJECT_PATH`.
 - Absolute document paths are kept absolute and ignore scope root joining.
 
 ## Scope and Context Model
@@ -55,6 +57,11 @@ If neither is provided, the binary errors with
 
 - `home`: rooted at effective `AGENT_DOCS_HOME`
 - `project`: rooted at effective `PROJECT_PATH`
+- `global`: rooted at effective `AGENT_DOCS_HOME` and inherited from the home catalog by every project repo
+
+Home-catalog `scope = "project"` entries apply only when `AGENT_DOCS_HOME` and
+`PROJECT_PATH` identify the same Git repository, including linked worktrees.
+Project-local `AGENT_DOCS.toml` files cannot declare `scope = "global"`.
 
 ### Built-in contexts
 
@@ -146,7 +153,7 @@ Flags:
 
 - `--target home|project` (required)
 - `--context startup|skill-dev|task-tools|project-dev` (required)
-- `--scope home|project` (required; target root for `path` resolution)
+- `--scope home|project|global` (required; target root for `path` resolution)
 - `--path <doc-path>` (required)
 - `--required` (set `required=true`; omitted means `required=false`)
 - `--when <condition>` (default: `always`)
@@ -176,6 +183,10 @@ agent-docs add \
 ```text
 add: target=project action=<inserted|updated> config=<PROJECT_PATH>/AGENT_DOCS.toml entries=<N>
 ```
+
+Use `--target home --scope global` for cross-repo home-catalog requirements.
+`--target project --scope global` is rejected because project-local catalogs
+cannot define global requirements.
 
 Verify both built-in and extension docs are present:
 
@@ -440,6 +451,8 @@ suggested_actions:
 1. Start with built-in baseline items for selected `--target`.
 2. Load extension configs in fixed order: `$AGENT_DOCS_HOME/AGENT_DOCS.toml` then `$PROJECT_PATH/AGENT_DOCS.toml`.
 3. Consider only extension entries with `required = true` and `scope` included by `--target`.
+   `--target home` includes `home` and `global`; `--target project` includes
+   `project`.
 4. Resolve each extension path, then de-dup by key: `(context, scope, normalized_path)`.
 5. Same-key override order:
    - within one config file, later `[[document]]` wins (last-write-wins)
@@ -471,14 +484,14 @@ notes = "Track required external CLIs for this project"
 
 ### Field contract
 
-| Field      | Type   | Required | Rules                                                       |
-| ---------- | ------ | -------- | ----------------------------------------------------------- |
-| `context`  | string | yes      | One of: `startup`, `skill-dev`, `task-tools`, `project-dev` |
-| `scope`    | string | yes      | One of: `home`, `project`                                   |
-| `path`     | string | yes      | Relative or absolute path to markdown doc                   |
-| `required` | bool   | no       | Default `false`                                             |
-| `when`     | string | no       | Default `always`; supported values: `always`                |
-| `notes`    | string | no       | Free text, default empty string                             |
+| Field      | Type   | Required | Rules                                                              |
+| ---------- | ------ | -------- | ------------------------------------------------------------------ |
+| `context`  | string | yes      | One of: `startup`, `skill-dev`, `task-tools`, `project-dev`        |
+| `scope`    | string | yes      | One of: `home`, `project`, `global`; `global` is home-catalog only |
+| `path`     | string | yes      | Relative or absolute path to markdown doc                          |
+| `required` | bool   | no       | Default `false`                                                    |
+| `when`     | string | no       | Default `always`; supported values: `always`                       |
+| `notes`    | string | no       | Free text, default empty string                                    |
 
 ### Deterministic merge contract
 
@@ -487,7 +500,10 @@ For `resolve --context <ctx>`:
 1. Start with built-in entries for `<ctx>`.
 2. Load entries from `$AGENT_DOCS_HOME/AGENT_DOCS.toml` (if file exists).
 3. Load entries from `$PROJECT_PATH/AGENT_DOCS.toml` (if file exists).
-4. Filter entries by exact `context == <ctx>`.
+4. Filter entries by exact `context == <ctx>` and catalog inheritance rules:
+   home-catalog `global` entries apply to every project; home-catalog
+   `project` entries apply only to the same Git repository; project-catalog
+   `global` entries are invalid.
 5. Normalize each entry path:
    - absolute path: keep as-is
    - relative path: join with root selected by entry `scope`

--- a/crates/agent-docs/src/cli.rs
+++ b/crates/agent-docs/src/cli.rs
@@ -11,7 +11,7 @@ use crate::model::{
     name = "agent-docs",
     version,
     about = "Deterministic required-doc discovery for agent workflows",
-    long_about = "Resolve, scaffold, and validate required agent documentation for home and project scopes.",
+    long_about = "Resolve, scaffold, and validate required agent documentation for home, global, and project scopes.",
     after_help = "EXAMPLES:\n  agent-docs resolve --context startup --strict --format checklist\n  agent-docs --docs-home ~/.agents resolve --context project-dev --strict\n  agent-docs baseline --check --target all --strict\n  agent-docs completion zsh\n\nENVIRONMENT:\n  AGENT_DOCS_HOME  Default docs home when --docs-home is omitted.\n  PROJECT_PATH     Default project root when --project-path is omitted.\n\nEXIT CODES:\n  0   success\n  1   runtime error\n  64  command-line usage error\n  65  invalid input data",
     disable_help_subcommand = true
 )]

--- a/crates/agent-docs/src/commands/add.rs
+++ b/crates/agent-docs/src/commands/add.rs
@@ -41,9 +41,18 @@ pub fn upsert_document(
     roots: &ResolvedRoots,
     request: AddDocumentRequest,
 ) -> Result<AddDocumentReport, ConfigLoadError> {
+    if request.target == Scope::Global {
+        return Err(ConfigLoadError::validation_root(
+            config_path_for_root(&roots.docs_home),
+            "target",
+            "--target global is not supported; use --target home for global-scope entries",
+        ));
+    }
+
     let target_root = match request.target {
         Scope::Home => roots.docs_home.as_path(),
         Scope::Project => roots.project_path.as_path(),
+        Scope::Global => unreachable!("global target rejected before root selection"),
     };
     upsert_document_at_root(target_root, request)
 }
@@ -54,6 +63,7 @@ pub fn upsert_document_at_root(
 ) -> Result<AddDocumentReport, ConfigLoadError> {
     let target = request.target;
     let config_path = config_path_for_root(target_root);
+    validate_request_scope(&request, &config_path)?;
     let entry = request.into_config_entry(&config_path)?;
 
     // Keep existing behavior: malformed existing config fails with a validation/parse error.
@@ -80,6 +90,29 @@ pub fn upsert_document_at_root(
         entry,
         document_count,
     })
+}
+
+fn validate_request_scope(
+    request: &AddDocumentRequest,
+    config_path: &Path,
+) -> Result<(), ConfigLoadError> {
+    if request.target == Scope::Global {
+        return Err(ConfigLoadError::validation_root(
+            config_path.to_path_buf(),
+            "target",
+            "--target global is not supported; use --target home for global-scope entries",
+        ));
+    }
+
+    if request.target == Scope::Project && request.scope == Scope::Global {
+        return Err(ConfigLoadError::validation_root(
+            config_path.to_path_buf(),
+            "scope",
+            "global scope is allowed only in the home catalog; use --target home --scope global or use scope = \"project\" for project-local requirements",
+        ));
+    }
+
+    Ok(())
 }
 
 fn load_document(config_path: &Path) -> Result<(DocumentMut, bool), ConfigLoadError> {

--- a/crates/agent-docs/src/commands/baseline.rs
+++ b/crates/agent-docs/src/commands/baseline.rs
@@ -8,6 +8,7 @@ use crate::model::{
     ConfigScopeFile, Context, DocumentSource, DocumentStatus, FallbackMode, Scope,
 };
 use crate::paths::normalize_path;
+use crate::scope_rules;
 
 pub fn check_builtin_baseline(
     target: BaselineTarget,
@@ -28,11 +29,13 @@ pub fn check_builtin_baseline_with_mode(
 
     let configs = load_configs_from_roots(roots)?;
     let configs_in_load_order = configs.in_load_order();
+    let home_project_scope_applies = scope_rules::home_catalog_project_scope_applies(roots);
     items.extend(required_extension_items(
         target,
         roots,
         fallback_mode,
         &configs_in_load_order,
+        home_project_scope_applies,
         &builtin_keys,
     ));
 
@@ -263,18 +266,23 @@ fn required_extension_items(
     roots: &ResolvedRoots,
     fallback_mode: FallbackMode,
     configs_in_load_order: &[&ConfigScopeFile],
+    home_project_scope_applies: bool,
     builtin_keys: &HashSet<BaselineKey>,
 ) -> Vec<BaselineCheckItem> {
     let mut extension_items = Vec::new();
     let mut extension_indices: HashMap<BaselineKey, usize> = HashMap::new();
 
     for config in configs_in_load_order {
-        merge_required_extension_items(
+        let merge_context = RequiredExtensionMergeContext {
             target,
             roots,
             fallback_mode,
             config,
+            home_project_scope_applies,
             builtin_keys,
+        };
+        merge_required_extension_items(
+            &merge_context,
             &mut extension_items,
             &mut extension_indices,
         );
@@ -283,23 +291,40 @@ fn required_extension_items(
     extension_items
 }
 
-fn merge_required_extension_items(
+struct RequiredExtensionMergeContext<'a> {
     target: BaselineTarget,
-    roots: &ResolvedRoots,
+    roots: &'a ResolvedRoots,
     fallback_mode: FallbackMode,
-    config: &ConfigScopeFile,
-    builtin_keys: &HashSet<BaselineKey>,
+    config: &'a ConfigScopeFile,
+    home_project_scope_applies: bool,
+    builtin_keys: &'a HashSet<BaselineKey>,
+}
+
+fn merge_required_extension_items(
+    merge_context: &RequiredExtensionMergeContext<'_>,
     extension_items: &mut Vec<BaselineCheckItem>,
     extension_indices: &mut HashMap<BaselineKey, usize>,
 ) {
+    let config = merge_context.config;
     for (index, entry) in config.documents.iter().enumerate() {
-        if !entry.required || !target_includes_scope(target, entry.scope) {
+        if !entry.required || !target_includes_scope(merge_context.target, entry.scope) {
+            continue;
+        }
+        if !scope_rules::should_include_extension_entry(
+            config.source_scope,
+            entry.scope,
+            merge_context.home_project_scope_applies,
+        ) {
             continue;
         }
 
-        let path = resolve_extension_path_with_project_fallback(entry, roots, fallback_mode);
+        let path = resolve_extension_path_with_project_fallback(
+            entry,
+            merge_context.roots,
+            merge_context.fallback_mode,
+        );
         let key = BaselineKey::new(entry.context, entry.scope, path.clone());
-        if builtin_keys.contains(&key) {
+        if merge_context.builtin_keys.contains(&key) {
             continue;
         }
 
@@ -330,7 +355,7 @@ fn merge_required_extension_items(
 
 fn target_includes_scope(target: BaselineTarget, scope: Scope) -> bool {
     match target {
-        BaselineTarget::Home => scope == Scope::Home,
+        BaselineTarget::Home => scope == Scope::Home || scope == Scope::Global,
         BaselineTarget::Project => scope == Scope::Project,
         BaselineTarget::All => true,
     }
@@ -338,16 +363,13 @@ fn target_includes_scope(target: BaselineTarget, scope: Scope) -> bool {
 
 fn extension_source(source_scope: Scope) -> DocumentSource {
     match source_scope {
-        Scope::Home => DocumentSource::ExtensionHome,
+        Scope::Home | Scope::Global => DocumentSource::ExtensionHome,
         Scope::Project => DocumentSource::ExtensionProject,
     }
 }
 
 fn resolve_extension_path(entry: &ConfigDocumentEntry, roots: &ResolvedRoots) -> PathBuf {
-    let root = match entry.scope {
-        Scope::Home => &roots.docs_home,
-        Scope::Project => &roots.project_path,
-    };
+    let root = scope_rules::root_for_entry_scope(entry.scope, roots);
     normalize_path(&root.join(&entry.path))
 }
 
@@ -416,7 +438,9 @@ impl BaselineKey {
 
 fn suggested_actions(items: &[BaselineCheckItem]) -> Vec<String> {
     let has_home_missing_required = items.iter().any(|item| {
-        item.scope == Scope::Home && item.required && matches!(item.status, DocumentStatus::Missing)
+        (item.scope == Scope::Home || item.scope == Scope::Global)
+            && item.required
+            && matches!(item.status, DocumentStatus::Missing)
     });
     let has_project_missing_required = items.iter().any(|item| {
         item.scope == Scope::Project

--- a/crates/agent-docs/src/commands/scaffold_agents.rs
+++ b/crates/agent-docs/src/commands/scaffold_agents.rs
@@ -46,6 +46,7 @@ pub struct ScaffoldAgentsReport {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScaffoldAgentsErrorKind {
     AlreadyExists,
+    UnsupportedTarget,
     Io,
 }
 
@@ -53,6 +54,7 @@ impl ScaffoldAgentsErrorKind {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::AlreadyExists => "already-exists",
+            Self::UnsupportedTarget => "unsupported-target",
             Self::Io => "io",
         }
     }
@@ -87,6 +89,14 @@ impl ScaffoldAgentsError {
             message: message.into(),
         }
     }
+
+    fn unsupported_target(output_path: PathBuf) -> Self {
+        Self {
+            kind: ScaffoldAgentsErrorKind::UnsupportedTarget,
+            output_path,
+            message: "scaffold-agents supports only --target home or --target project".to_string(),
+        }
+    }
 }
 
 impl fmt::Display for ScaffoldAgentsError {
@@ -107,6 +117,15 @@ pub fn scaffold_agents(
     request: &ScaffoldAgentsRequest,
     roots: &ResolvedRoots,
 ) -> Result<ScaffoldAgentsReport, ScaffoldAgentsError> {
+    if request.target == Scope::Global {
+        return Err(ScaffoldAgentsError::unsupported_target(
+            request
+                .output
+                .clone()
+                .unwrap_or_else(|| roots.docs_home.join(DEFAULT_AGENTS_FILE_NAME)),
+        ));
+    }
+
     let output_path = request
         .output
         .clone()
@@ -140,6 +159,7 @@ pub fn default_output_path(target: Scope, roots: &ResolvedRoots) -> PathBuf {
     let base = match target {
         Scope::Home => &roots.docs_home,
         Scope::Project => &roots.project_path,
+        Scope::Global => &roots.docs_home,
     };
     base.join(DEFAULT_AGENTS_FILE_NAME)
 }

--- a/crates/agent-docs/src/config.rs
+++ b/crates/agent-docs/src/config.rs
@@ -27,13 +27,40 @@ pub fn load_configs(
     project_path: &Path,
 ) -> Result<LoadedConfigs, ConfigLoadError> {
     let home = load_scope_config(Scope::Home, docs_home)?;
-    let project = load_scope_config(Scope::Project, project_path)?;
+    let project_global_handling = if same_config_file(docs_home, project_path) {
+        ProjectGlobalHandling::Skip
+    } else {
+        ProjectGlobalHandling::Reject
+    };
+    let project = load_scope_config_with_project_global_handling(
+        Scope::Project,
+        project_path,
+        project_global_handling,
+    )?;
     Ok(LoadedConfigs { home, project })
 }
 
 pub fn load_scope_config(
     source_scope: Scope,
     root: &Path,
+) -> Result<Option<ConfigScopeFile>, ConfigLoadError> {
+    load_scope_config_with_project_global_handling(
+        source_scope,
+        root,
+        ProjectGlobalHandling::Reject,
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectGlobalHandling {
+    Reject,
+    Skip,
+}
+
+fn load_scope_config_with_project_global_handling(
+    source_scope: Scope,
+    root: &Path,
+    project_global_handling: ProjectGlobalHandling,
 ) -> Result<Option<ConfigScopeFile>, ConfigLoadError> {
     let file_path = config_path_for_root(root);
     if !file_path.exists() {
@@ -47,7 +74,7 @@ pub fn load_scope_config(
         )
     })?;
     let parsed = parse_toml(&file_path, &raw)?;
-    let documents = parse_documents(source_scope, &file_path, &parsed)?;
+    let documents = parse_documents(source_scope, &file_path, &parsed, project_global_handling)?;
 
     Ok(Some(ConfigScopeFile {
         source_scope,
@@ -55,6 +82,14 @@ pub fn load_scope_config(
         file_path,
         documents,
     }))
+}
+
+fn same_config_file(docs_home: &Path, project_path: &Path) -> bool {
+    let home_config = config_path_for_root(docs_home);
+    let project_config = config_path_for_root(project_path);
+    let home = fs::canonicalize(&home_config).unwrap_or(home_config);
+    let project = fs::canonicalize(&project_config).unwrap_or(project_config);
+    home == project
 }
 
 fn parse_toml(file_path: &Path, raw: &str) -> Result<Value, ConfigLoadError> {
@@ -67,6 +102,7 @@ fn parse_documents(
     source_scope: Scope,
     file_path: &Path,
     parsed: &Value,
+    project_global_handling: ProjectGlobalHandling,
 ) -> Result<Vec<ConfigDocumentEntry>, ConfigLoadError> {
     let Some(root_table) = parsed.as_table() else {
         return Err(ConfigLoadError::validation_root(
@@ -101,6 +137,9 @@ fn parse_documents(
         validate_unknown_fields(file_path, index, table)?;
         let context = parse_context(file_path, index, table)?;
         let scope = parse_scope(file_path, index, table)?;
+        if should_skip_scope_for_source(source_scope, scope, project_global_handling) {
+            continue;
+        }
         validate_scope_for_source(source_scope, scope, file_path, index)?;
         let path = parse_path(file_path, index, table)?;
         let required = parse_required(file_path, index, table)?;
@@ -118,6 +157,16 @@ fn parse_documents(
     }
 
     Ok(documents)
+}
+
+fn should_skip_scope_for_source(
+    source_scope: Scope,
+    document_scope: Scope,
+    project_global_handling: ProjectGlobalHandling,
+) -> bool {
+    source_scope == Scope::Project
+        && document_scope == Scope::Global
+        && project_global_handling == ProjectGlobalHandling::Skip
 }
 
 fn validate_scope_for_source(

--- a/crates/agent-docs/src/config.rs
+++ b/crates/agent-docs/src/config.rs
@@ -47,7 +47,7 @@ pub fn load_scope_config(
         )
     })?;
     let parsed = parse_toml(&file_path, &raw)?;
-    let documents = parse_documents(&file_path, &parsed)?;
+    let documents = parse_documents(source_scope, &file_path, &parsed)?;
 
     Ok(Some(ConfigScopeFile {
         source_scope,
@@ -64,6 +64,7 @@ fn parse_toml(file_path: &Path, raw: &str) -> Result<Value, ConfigLoadError> {
 }
 
 fn parse_documents(
+    source_scope: Scope,
     file_path: &Path,
     parsed: &Value,
 ) -> Result<Vec<ConfigDocumentEntry>, ConfigLoadError> {
@@ -100,6 +101,7 @@ fn parse_documents(
         validate_unknown_fields(file_path, index, table)?;
         let context = parse_context(file_path, index, table)?;
         let scope = parse_scope(file_path, index, table)?;
+        validate_scope_for_source(source_scope, scope, file_path, index)?;
         let path = parse_path(file_path, index, table)?;
         let required = parse_required(file_path, index, table)?;
         let when = parse_when(file_path, index, table)?;
@@ -116,6 +118,24 @@ fn parse_documents(
     }
 
     Ok(documents)
+}
+
+fn validate_scope_for_source(
+    source_scope: Scope,
+    document_scope: Scope,
+    file_path: &Path,
+    index: usize,
+) -> Result<(), ConfigLoadError> {
+    if source_scope == Scope::Project && document_scope == Scope::Global {
+        return Err(ConfigLoadError::validation(
+            file_path.to_path_buf(),
+            index,
+            "scope",
+            "global scope is allowed only in the home catalog; use scope = \"project\" for project-local requirements",
+        ));
+    }
+
+    Ok(())
 }
 
 fn validate_unknown_fields(

--- a/crates/agent-docs/src/lib.rs
+++ b/crates/agent-docs/src/lib.rs
@@ -7,6 +7,7 @@ pub mod model;
 pub mod output;
 pub mod paths;
 pub mod resolver;
+mod scope_rules;
 
 use clap::Parser;
 
@@ -147,6 +148,9 @@ fn dispatch(cli: Cli) -> i32 {
                     match err.kind {
                         commands::scaffold_agents::ScaffoldAgentsErrorKind::AlreadyExists => {
                             EXIT_STRICT_MISSING_REQUIRED
+                        }
+                        commands::scaffold_agents::ScaffoldAgentsErrorKind::UnsupportedTarget => {
+                            EXIT_USAGE
                         }
                         commands::scaffold_agents::ScaffoldAgentsErrorKind::Io => EXIT_RUNTIME,
                     }

--- a/crates/agent-docs/src/model.rs
+++ b/crates/agent-docs/src/model.rs
@@ -56,6 +56,7 @@ pub const SUPPORTED_CONTEXTS: [Context; 4] = [
 pub enum Scope {
     Home,
     Project,
+    Global,
 }
 
 impl Scope {
@@ -63,17 +64,19 @@ impl Scope {
         match self {
             Self::Home => "home",
             Self::Project => "project",
+            Self::Global => "global",
         }
     }
 
     pub const fn supported_values() -> &'static [&'static str] {
-        &["home", "project"]
+        &["home", "project", "global"]
     }
 
     pub fn from_config_value(value: &str) -> Option<Self> {
         match value {
             "home" => Some(Self::Home),
             "project" => Some(Self::Project),
+            "global" => Some(Self::Global),
             _ => None,
         }
     }

--- a/crates/agent-docs/src/resolver.rs
+++ b/crates/agent-docs/src/resolver.rs
@@ -9,6 +9,7 @@ use crate::model::{
     SUPPORTED_CONTEXTS, Scope,
 };
 use crate::paths::normalize_path;
+use crate::scope_rules;
 
 pub fn supported_contexts() -> &'static [Context] {
     &SUPPORTED_CONTEXTS
@@ -137,13 +138,19 @@ pub fn resolve_with_configs_with_mode(
     let mut extension_documents: Vec<ResolvedDocument> = Vec::new();
     let mut extension_indices: HashMap<ResolveKey, usize> = HashMap::new();
 
+    let home_project_scope_applies = scope_rules::home_catalog_project_scope_applies(roots);
+
     for config in configs.in_load_order() {
-        merge_extension_documents(
+        let merge_context = ExtensionMergeContext {
             context,
             roots,
             fallback_mode,
             config,
-            &builtin_keys,
+            home_project_scope_applies,
+            builtin_keys: &builtin_keys,
+        };
+        merge_extension_documents(
+            &merge_context,
             &mut extension_documents,
             &mut extension_indices,
         );
@@ -165,29 +172,45 @@ pub fn resolve_with_configs_with_mode(
     }
 }
 
-fn merge_extension_documents(
+struct ExtensionMergeContext<'a> {
     context: Context,
-    roots: &ResolvedRoots,
+    roots: &'a ResolvedRoots,
     fallback_mode: FallbackMode,
-    config: &ConfigScopeFile,
-    builtin_keys: &HashSet<ResolveKey>,
+    config: &'a ConfigScopeFile,
+    home_project_scope_applies: bool,
+    builtin_keys: &'a HashSet<ResolveKey>,
+}
+
+fn merge_extension_documents(
+    merge_context: &ExtensionMergeContext<'_>,
     extension_documents: &mut Vec<ResolvedDocument>,
     extension_indices: &mut HashMap<ResolveKey, usize>,
 ) {
+    let config = merge_context.config;
     for (index, entry) in config.documents.iter().enumerate() {
-        if entry.context != context {
+        if entry.context != merge_context.context {
+            continue;
+        }
+        if !scope_rules::should_include_extension_entry(
+            config.source_scope,
+            entry.scope,
+            merge_context.home_project_scope_applies,
+        ) {
             continue;
         }
 
-        let resolved_path =
-            resolve_extension_path_with_project_fallback(entry, roots, fallback_mode);
-        let key = ResolveKey::new(context, entry.scope, resolved_path.clone());
-        if builtin_keys.contains(&key) {
+        let resolved_path = resolve_extension_path_with_project_fallback(
+            entry,
+            merge_context.roots,
+            merge_context.fallback_mode,
+        );
+        let key = ResolveKey::new(merge_context.context, entry.scope, resolved_path.clone());
+        if merge_context.builtin_keys.contains(&key) {
             continue;
         }
 
         let document = ResolvedDocument {
-            context,
+            context: merge_context.context,
             scope: entry.scope,
             path: resolved_path.clone(),
             required: entry.required,
@@ -212,16 +235,13 @@ fn merge_extension_documents(
 
 fn extension_source(source_scope: Scope) -> DocumentSource {
     match source_scope {
-        Scope::Home => DocumentSource::ExtensionHome,
+        Scope::Home | Scope::Global => DocumentSource::ExtensionHome,
         Scope::Project => DocumentSource::ExtensionProject,
     }
 }
 
 fn resolve_extension_path(entry: &ConfigDocumentEntry, roots: &ResolvedRoots) -> PathBuf {
-    let root = match entry.scope {
-        Scope::Home => &roots.docs_home,
-        Scope::Project => &roots.project_path,
-    };
+    let root = scope_rules::root_for_entry_scope(entry.scope, roots);
     normalize_path(&root.join(&entry.path))
 }
 

--- a/crates/agent-docs/src/scope_rules.rs
+++ b/crates/agent-docs/src/scope_rules.rs
@@ -1,0 +1,52 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use nils_common::git as shared_git;
+
+use crate::env::ResolvedRoots;
+use crate::model::Scope;
+use crate::paths::{normalize_path, normalize_root_path};
+
+pub fn should_include_extension_entry(
+    source_scope: Scope,
+    entry_scope: Scope,
+    home_project_scope_applies: bool,
+) -> bool {
+    match source_scope {
+        Scope::Home => match entry_scope {
+            Scope::Project => home_project_scope_applies,
+            Scope::Home | Scope::Global => true,
+        },
+        Scope::Project => true,
+        Scope::Global => false,
+    }
+}
+
+pub fn home_catalog_project_scope_applies(roots: &ResolvedRoots) -> bool {
+    if let (Some(docs_home_repo), Some(project_repo)) = (
+        git_common_dir(&roots.docs_home),
+        git_common_dir(&roots.project_path),
+    ) {
+        return docs_home_repo == project_repo;
+    }
+
+    canonical_root(&roots.docs_home) == canonical_root(&roots.project_path)
+}
+
+pub fn root_for_entry_scope(scope: Scope, roots: &ResolvedRoots) -> &Path {
+    match scope {
+        Scope::Home | Scope::Global => &roots.docs_home,
+        Scope::Project => &roots.project_path,
+    }
+}
+
+fn git_common_dir(root: &Path) -> Option<PathBuf> {
+    let raw = shared_git::rev_parse_in(root, &["--git-common-dir"])
+        .ok()
+        .flatten()?;
+    Some(canonical_root(&normalize_root_path(Path::new(&raw), root)))
+}
+
+fn canonical_root(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| normalize_path(path))
+}

--- a/crates/agent-docs/tests/integration/add.rs
+++ b/crates/agent-docs/tests/integration/add.rs
@@ -195,6 +195,93 @@ fn add_full_flow_for_home_and_project_scopes() {
     );
 }
 
+#[test]
+fn add_supports_global_scope_in_home_catalog() {
+    let workspace = common::FixtureWorkspace::from_fixtures();
+    common::write_text(
+        &workspace.docs_home.join("GLOBAL_POLICY.md"),
+        "# Fixture: global policy\n",
+    );
+
+    let output = common::run_agent_docs_command(
+        &workspace,
+        &[
+            "add",
+            "--target",
+            "home",
+            "--context",
+            "project-dev",
+            "--scope",
+            "global",
+            "--path",
+            "GLOBAL_POLICY.md",
+            "--required",
+            "--notes",
+            "global project-dev extension",
+        ],
+    );
+    assert!(
+        output.success(),
+        "add(home global) should succeed, got code={} stderr={}",
+        output.exit_code,
+        output.stderr
+    );
+
+    let loaded = load_scope_config(Scope::Home, &workspace.docs_home)
+        .expect("load home config")
+        .expect("home config should exist");
+    let global_entry = loaded
+        .documents
+        .iter()
+        .find(|entry| entry.path == Path::new("GLOBAL_POLICY.md"))
+        .expect("global extension entry should exist");
+    assert_eq!(global_entry.context, Context::ProjectDev);
+    assert_eq!(global_entry.scope, Scope::Global);
+    assert!(global_entry.required);
+    assert_eq!(
+        global_entry.notes.as_deref(),
+        Some("global project-dev extension")
+    );
+}
+
+#[test]
+fn add_rejects_global_scope_in_project_catalog() {
+    let workspace = common::FixtureWorkspace::from_fixtures();
+
+    let output = common::run_agent_docs_command(
+        &workspace,
+        &[
+            "add",
+            "--target",
+            "project",
+            "--context",
+            "project-dev",
+            "--scope",
+            "global",
+            "--path",
+            "GLOBAL_POLICY.md",
+            "--required",
+        ],
+    );
+
+    assert_eq!(
+        output.exit_code, 3,
+        "add(project global) should fail with config error, stdout=\n{}\nstderr=\n{}",
+        output.stdout, output.stderr
+    );
+    assert!(
+        output
+            .stderr
+            .contains("global scope is allowed only in the home catalog"),
+        "stderr should explain the global-scope boundary:\n{}",
+        output.stderr
+    );
+    assert!(
+        !workspace.project_path.join(CONFIG_FILE_NAME).exists(),
+        "rejected add should not create a project AGENT_DOCS.toml"
+    );
+}
+
 fn run_home_task_tools_add_update(workspace: &common::FixtureWorkspace) -> common::CliOutput {
     common::run_agent_docs_command(
         workspace,

--- a/crates/agent-docs/tests/integration/baseline.rs
+++ b/crates/agent-docs/tests/integration/baseline.rs
@@ -44,6 +44,38 @@ fn baseline_check_target_home_reports_three_home_items() {
 }
 
 #[test]
+fn baseline_check_target_home_includes_required_global_extension_docs() {
+    let home = TempDir::new().expect("failed to create home tempdir");
+    let project = TempDir::new().expect("failed to create project tempdir");
+    write_markdown(&home.path().join("AGENTS.md"));
+    write_markdown(&home.path().join("GLOBAL_POLICY.md"));
+    write_text(
+        &home.path().join(CONFIG_FILE_NAME),
+        r#"
+[[document]]
+context = "project-dev"
+scope = "global"
+path = "GLOBAL_POLICY.md"
+required = true
+when = "always"
+notes = "cross-repo global project-dev policy"
+"#,
+    );
+
+    let report = check_builtin_baseline(BaselineTarget::Home, &roots(&home, &project), false)
+        .expect("baseline check should succeed");
+    let global_item = report
+        .items
+        .iter()
+        .find(|item| item.scope == Scope::Global && item.path.ends_with("GLOBAL_POLICY.md"))
+        .expect("baseline --target home should include global extension docs");
+
+    assert_eq!(global_item.source, DocumentSource::ExtensionHome);
+    assert_eq!(global_item.status, DocumentStatus::Present);
+    assert_eq!(global_item.path, home.path().join("GLOBAL_POLICY.md"));
+}
+
+#[test]
 fn baseline_check_target_project_reports_present_and_missing_in_text_output() {
     let home = TempDir::new().expect("failed to create home tempdir");
     let project = TempDir::new().expect("failed to create project tempdir");
@@ -298,7 +330,7 @@ when = "always"
 }
 
 #[test]
-fn baseline_check_same_key_project_override_keeps_first_seen_extension_position() {
+fn baseline_check_skips_unrelated_home_project_entries_before_project_extensions() {
     let home = TempDir::new().expect("failed to create home tempdir");
     let project = TempDir::new().expect("failed to create project tempdir");
     write_markdown(&project.path().join("AGENTS.md"));
@@ -352,18 +384,12 @@ notes = "project-alpha"
         })
         .collect();
 
-    assert_eq!(extension_items.len(), 2);
+    assert_eq!(extension_items.len(), 1);
     assert_eq!(
         extension_items[0].path,
         project.path().join("EXTRA_ALPHA.md"),
-        "first-seen extension key position should remain stable after override"
+        "project config should supply the project-scope extension for unrelated repos"
     );
     assert_eq!(extension_items[0].source, DocumentSource::ExtensionProject);
     assert!(extension_items[0].why.contains("project-alpha"));
-    assert_eq!(
-        extension_items[1].path,
-        project.path().join("EXTRA_BETA.md")
-    );
-    assert_eq!(extension_items[1].source, DocumentSource::ExtensionHome);
-    assert!(extension_items[1].why.contains("home-beta"));
 }

--- a/crates/agent-docs/tests/integration/config.rs
+++ b/crates/agent-docs/tests/integration/config.rs
@@ -276,6 +276,39 @@ path = "GLOBAL_POLICY.md"
 }
 
 #[test]
+fn load_configs_allows_global_scope_when_home_and_project_share_catalog() {
+    let repo = TempDir::new().expect("create shared repo dir");
+    write_config(
+        repo.path(),
+        r#"
+[[document]]
+context = "project-dev"
+scope = "global"
+path = "GLOBAL_POLICY.md"
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "PROJECT_POLICY.md"
+"#,
+    );
+
+    let loaded = load_configs(repo.path(), repo.path()).expect("shared catalog should load");
+    let home_config = loaded.home.as_ref().expect("home config should load");
+    let project_config = loaded.project.as_ref().expect("project config should load");
+
+    assert_eq!(home_config.documents.len(), 2);
+    assert!(
+        home_config
+            .documents
+            .iter()
+            .any(|entry| entry.scope == Scope::Global)
+    );
+    assert_eq!(project_config.documents.len(), 1);
+    assert_eq!(project_config.documents[0].scope, Scope::Project);
+}
+
+#[test]
 fn load_scope_config_rejects_path_that_is_only_whitespace() {
     let home = TempDir::new().expect("create home dir");
     write_config(

--- a/crates/agent-docs/tests/integration/config.rs
+++ b/crates/agent-docs/tests/integration/config.rs
@@ -250,6 +250,32 @@ path = "AGENTS.md"
 }
 
 #[test]
+fn load_scope_config_rejects_global_scope_from_project_catalog() {
+    let project = TempDir::new().expect("create project dir");
+    write_config(
+        project.path(),
+        r#"
+[[document]]
+context = "project-dev"
+scope = "global"
+path = "GLOBAL_POLICY.md"
+"#,
+    );
+
+    let err = load_scope_config(Scope::Project, project.path())
+        .expect_err("project catalog should reject global scope");
+    assert_eq!(err.kind, ConfigErrorKind::Validation);
+    assert_eq!(err.document_index, Some(0));
+    assert_eq!(err.field.as_deref(), Some("scope"));
+    assert!(
+        err.message
+            .contains("global scope is allowed only in the home catalog"),
+        "unexpected error message: {}",
+        err.message
+    );
+}
+
+#[test]
 fn load_scope_config_rejects_path_that_is_only_whitespace() {
     let home = TempDir::new().expect("create home dir");
     write_config(

--- a/crates/agent-docs/tests/integration/resolve_builtin.rs
+++ b/crates/agent-docs/tests/integration/resolve_builtin.rs
@@ -2,9 +2,12 @@ use crate::common;
 use std::fs;
 
 use agent_docs::config::CONFIG_FILE_NAME;
+use agent_docs::env::ResolvedRoots;
 use agent_docs::model::{Context, DocumentSource, DocumentStatus, OutputFormat, ResolveFormat};
 use agent_docs::{output, resolver};
+use nils_test_support::git as test_git;
 use serde::Deserialize;
+use tempfile::TempDir;
 
 #[derive(Debug, Clone, Copy)]
 struct ExpectedDocument {
@@ -361,7 +364,7 @@ notes = "project-home-scope-entry"
     );
 
     let documents = &first.documents;
-    assert_eq!(documents.len(), 4);
+    assert_eq!(documents.len(), 3);
     assert_eq!(
         documents
             .iter()
@@ -376,17 +379,14 @@ notes = "project-home-scope-entry"
     assert_eq!(builtin.source, DocumentSource::Builtin);
     assert!(builtin.required);
 
-    let binary = &documents[1];
-    assert!(binary.path.ends_with("BINARY_DEPENDENCIES.md"));
-    assert_eq!(binary.source, DocumentSource::ExtensionHome);
-    assert!(binary.required);
-    assert_eq!(binary.status, DocumentStatus::Present);
     assert!(
-        binary.why.contains("home-binary-second"),
-        "later entries in one config should win"
+        documents
+            .iter()
+            .all(|doc| !doc.path.ends_with("BINARY_DEPENDENCIES.md")),
+        "home-catalog project-scope docs should be skipped for unrelated repos"
     );
 
-    let extra = &documents[2];
+    let extra = &documents[1];
     assert!(extra.path.ends_with("docs/EXTRA_POLICY.md"));
     assert_eq!(extra.source, DocumentSource::ExtensionProject);
     assert!(extra.required);
@@ -396,15 +396,140 @@ notes = "project-home-scope-entry"
         "project config should override home config duplicates"
     );
 
-    let home_scoped = &documents[3];
+    let home_scoped = &documents[2];
     assert!(home_scoped.path.ends_with("core/policies/cli-tools.md"));
     assert_eq!(home_scoped.source, DocumentSource::ExtensionProject);
     assert!(!home_scoped.required);
     assert_eq!(home_scoped.status, DocumentStatus::Present);
 
-    assert_eq!(first.summary.required_total, 3);
-    assert_eq!(first.summary.present_required, 3);
+    assert_eq!(first.summary.required_total, 2);
+    assert_eq!(first.summary.present_required, 2);
     assert_eq!(first.summary.missing_required, 0);
+}
+
+#[test]
+fn resolve_home_global_entry_is_inherited_cross_repo_and_resolves_from_docs_home() {
+    let workspace = common::FixtureWorkspace::from_fixtures();
+    common::write_text(
+        &workspace.docs_home.join("GLOBAL_POLICY.md"),
+        "# Fixture: global policy\n",
+    );
+    fs::write(
+        workspace.docs_home.join(CONFIG_FILE_NAME),
+        r#"
+[[document]]
+context = "project-dev"
+scope = "global"
+path = "GLOBAL_POLICY.md"
+required = true
+when = "always"
+notes = "cross-repo global project-dev policy"
+"#,
+    )
+    .expect("write home config");
+
+    let report = resolver::resolve_builtin(Context::ProjectDev, &workspace.roots(), false);
+    let global_doc = report
+        .documents
+        .iter()
+        .find(|doc| doc.scope.as_str() == "global")
+        .expect("project-dev should include inherited global home-catalog docs");
+
+    assert_eq!(global_doc.source, DocumentSource::ExtensionHome);
+    assert_eq!(global_doc.status, DocumentStatus::Present);
+    assert_eq!(
+        global_doc.path,
+        workspace.docs_home.join("GLOBAL_POLICY.md")
+    );
+    assert_eq!(report.summary.required_total, 2);
+    assert_eq!(report.summary.present_required, 2);
+}
+
+#[test]
+fn resolve_home_project_entry_is_skipped_for_unrelated_project_repo() {
+    let workspace = common::FixtureWorkspace::from_fixtures();
+    common::write_text(
+        &workspace.project_path.join("HOME_PROJECT_ONLY.md"),
+        "# Fixture: unrelated project copy\n",
+    );
+    fs::write(
+        workspace.docs_home.join(CONFIG_FILE_NAME),
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "HOME_PROJECT_ONLY.md"
+required = true
+when = "always"
+notes = "runtime-kit-only policy"
+"#,
+    )
+    .expect("write home config");
+
+    let report = resolver::resolve_builtin(Context::ProjectDev, &workspace.roots(), false);
+
+    assert!(
+        report
+            .documents
+            .iter()
+            .all(|doc| !doc.path.ends_with("HOME_PROJECT_ONLY.md")),
+        "home-catalog project-scope docs must not leak into unrelated repos: {:#?}",
+        report.documents
+    );
+    assert_eq!(report.summary.required_total, 1);
+}
+
+#[test]
+fn resolve_home_project_entry_applies_for_linked_worktree_identity() {
+    let repo = test_git::init_repo_with(test_git::InitRepoOptions::new().with_initial_commit());
+    fs::write(repo.path().join("DEVELOPMENT.md"), "# Development\n").expect("write development");
+    fs::write(
+        repo.path().join("RUNTIME_ONLY.md"),
+        "# Runtime-only policy\n",
+    )
+    .expect("write runtime-only policy");
+    fs::write(
+        repo.path().join(CONFIG_FILE_NAME),
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "RUNTIME_ONLY.md"
+required = true
+when = "always"
+notes = "same-repo runtime-kit policy"
+"#,
+    )
+    .expect("write home config");
+    test_git::git(
+        repo.path(),
+        &["add", "DEVELOPMENT.md", "RUNTIME_ONLY.md", CONFIG_FILE_NAME],
+    );
+    test_git::git(repo.path(), &["commit", "-m", "add agent docs fixtures"]);
+
+    let workspace = TempDir::new().expect("create workspace");
+    let linked_worktree = workspace.path().join("linked");
+    test_git::worktree_add_branch(repo.path(), &linked_worktree, "linked-agent-docs");
+    fs::remove_file(linked_worktree.join(CONFIG_FILE_NAME))
+        .expect("remove linked worktree project-local config");
+    let roots = ResolvedRoots {
+        docs_home: repo.path().to_path_buf(),
+        project_path: linked_worktree.clone(),
+        is_linked_worktree: true,
+        git_common_dir: None,
+        primary_worktree_path: Some(repo.path().to_path_buf()),
+    };
+
+    let report = resolver::resolve_builtin(Context::ProjectDev, &roots, false);
+    let same_repo_doc = report
+        .documents
+        .iter()
+        .find(|doc| doc.path.ends_with("RUNTIME_ONLY.md"))
+        .expect("home-catalog project-scope doc should apply for linked worktrees");
+
+    assert_eq!(same_repo_doc.source, DocumentSource::ExtensionHome);
+    assert_eq!(same_repo_doc.status, DocumentStatus::Present);
+    assert_eq!(same_repo_doc.path, linked_worktree.join("RUNTIME_ONLY.md"));
 }
 
 fn all_contexts() -> [Context; 4] {

--- a/crates/plan-issue-cli/tests/fixtures/shell_parity/README.md
+++ b/crates/plan-issue-cli/tests/fixtures/shell_parity/README.md
@@ -12,7 +12,6 @@ bash crates/plan-issue-cli/tests/fixtures/shell_parity/regenerate.sh
 
 Normalization rules applied by `regenerate.sh`:
 - Replace `${PLAN_ISSUE_HOME}` absolute path with `$PLAN_ISSUE_HOME`.
-- Replace `${HOME}/.config/agent-kit` absolute path with `$AGENT_KIT_HOME`.
 
 Fixtures:
 - `multi_sprint_guide_dry_run.txt`: `multi-sprint-guide --dry-run` baseline.

--- a/crates/plan-issue-cli/tests/fixtures/shell_parity/regenerate.sh
+++ b/crates/plan-issue-cli/tests/fixtures/shell_parity/regenerate.sh
@@ -14,8 +14,7 @@ cd "$repo_root"
 
 normalize_paths() {
   sed \
-    -e "s|${PLAN_ISSUE_HOME%/}|\$PLAN_ISSUE_HOME|g" \
-    -e "s|$HOME/.config/agent-kit|\$AGENT_KIT_HOME|g"
+    -e "s|${PLAN_ISSUE_HOME%/}|\$PLAN_ISSUE_HOME|g"
 }
 
 run_plan_issue_local() {

--- a/docs/plans/agent-docs-global-scope-inheritance/agent-docs-global-scope-inheritance-discussion-source.md
+++ b/docs/plans/agent-docs-global-scope-inheritance/agent-docs-global-scope-inheritance-discussion-source.md
@@ -1,0 +1,270 @@
+# Agent Docs Global Scope Inheritance Implementation Handoff
+
+- Status: ready for plan generation
+- Date: 2026-05-24
+- Source: local discussion about `agent-docs` inheritance semantics, current
+  `agent-docs` resolver behavior, current `agent-runtime-kit` home catalog,
+  and the legacy shell-parity fixture normalization rule.
+- Intended next step: create a focused implementation plan for `agent-docs`
+  global-scope inheritance and the related legacy fixture cleanup. This source
+  document is not itself the implementation plan.
+
+## Purpose
+
+`AGENT_DOCS_HOME` should be able to stay pointed at the active
+`agent-runtime-kit` checkout while preventing `agent-runtime-kit` project-only
+documentation requirements from leaking into unrelated repositories.
+
+The desired model is:
+
+- `scope = "global"` entries in the home catalog are inherited by every
+  project repo.
+- `scope = "project"` entries in the home catalog apply only when the active
+  project is `agent-runtime-kit` itself, including its linked worktrees.
+- Project-local `AGENT_DOCS.toml` files continue to define project-specific
+  requirements for their own repo.
+
+This work should also remove the legacy `$HOME/.config/agent-kit` normalization
+rule from the `plan-issue-cli` shell parity fixtures, because that runtime root
+is retired.
+
+## Source Tags
+
+- `[U1]` The user wants to keep `AGENT_DOCS_HOME` set to the
+  `agent-runtime-kit` checkout, but only inherit entries from
+  `/Users/terry/Project/graysurf/agent-runtime-kit/AGENT_DOCS.toml` when those
+  entries use `scope = "global"`.
+- `[U2]` The user wants
+  `crates/plan-issue-cli/tests/fixtures/shell_parity/regenerate.sh` to stop
+  normalizing `$HOME/.config/agent-kit` to `$AGENT_KIT_HOME`, because that is
+  legacy state.
+- `[F1]` `crates/agent-docs/src/model.rs` currently supports only
+  `Scope::Home` and `Scope::Project`; `scope = "global"` is not accepted.
+- `[F2]` `crates/agent-docs/src/config.rs` loads one home config from
+  `docs_home` and one project config from `project_path`.
+- `[F3]` `crates/agent-docs/src/resolver.rs` currently merges all extension
+  documents whose context matches, and resolves `scope = "project"` paths
+  against the active project path.
+- `[F4]` `crates/agent-docs/tests/integration/resolve_builtin.rs` currently
+  asserts that home-catalog `scope = "project"` entries apply to the active
+  project and can be overridden by the project catalog.
+- `[F5]` `crates/agent-docs/tests/integration/config.rs` currently verifies
+  unsupported scope values are rejected, so adding `global` changes the schema
+  contract.
+- `[F6]`
+  `/Users/terry/Project/graysurf/agent-runtime-kit/AGENT_DOCS.toml` currently
+  contains a `scope = "project"` docs-placement requirement intended for the
+  runtime-kit source repo, but today it leaks into nils-cli when used as the
+  home catalog.
+- `[F7]`
+  `crates/plan-issue-cli/tests/fixtures/shell_parity/regenerate.sh` and its
+  README still mention `$HOME/.config/agent-kit` / `$AGENT_KIT_HOME`.
+- `[F8]` `DEVELOPMENT.md` defines the docs-only validation lane as
+  `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`, and the general
+  check set includes docs placement, docs hygiene, markdown lint, plan bundle
+  validation, CLI output contract lint, and fixture lint.
+
+## Confirmed Facts
+
+- The current `agent-docs` schema has no `global` scope. Adding this behavior
+  requires code and tests in `crates/agent-docs`, not only a TOML change.
+  `[F1][F5]`
+- `agent-docs` currently treats home-catalog project entries as requirements
+  for the active `project_path`. This is why a runtime-kit document path was
+  checked under the nils-cli repo. `[F2][F3][F4][F6]`
+- Pointing both `--docs-home` and `--project-path` at nils-cli avoids the leak,
+  but that does not preserve the desired architecture where `AGENT_DOCS_HOME`
+  remains the runtime-kit checkout. `[U1][F2]`
+- The shell-parity fixture normalizer still contains the retired
+  `$HOME/.config/agent-kit` path, and the README documents the same legacy
+  normalization rule. `[U2][F7]`
+
+## Decisions
+
+1. Add a first-class `global` document scope to `agent-docs`.
+2. Treat `scope = "global"` as the only home-catalog scope that applies to
+   unrelated project repos.
+3. Resolve home-catalog `scope = "global"` document paths relative to
+   `AGENT_DOCS_HOME` / `--docs-home`, not relative to the active project.
+4. Keep home-catalog `scope = "project"` entries local to the docs-home repo:
+   they apply when the active project is the same repo as `docs_home`, including
+   linked worktree cases.
+5. Reject `scope = "global"` in project-local `AGENT_DOCS.toml` files. Global
+   requirements must come from the home catalog only.
+6. Remove the legacy `$HOME/.config/agent-kit` normalization from the
+   `plan-issue-cli` shell parity fixture workflow instead of replacing it with
+   another generic runtime-root placeholder.
+
+## Scope
+
+In scope:
+
+- Extend `crates/agent-docs` schema and resolver behavior for `scope =
+  "global"`.
+- Update `agent-docs` tests to cover cross-repo home-catalog inheritance,
+  same-repo runtime-kit project entries, project-local rejection of global
+  entries, and output determinism.
+- Update baseline/add command behavior if their use of `Scope` would expose
+  invalid `global` combinations.
+- Update the runtime-kit home catalog after the CLI supports `global`, changing
+  intentionally cross-repo entries to `scope = "global"` and leaving
+  runtime-kit-only entries as `scope = "project"`.
+- Remove `$HOME/.config/agent-kit` / `$AGENT_KIT_HOME` normalization from
+  `crates/plan-issue-cli/tests/fixtures/shell_parity/regenerate.sh` and update
+  the fixture README.
+
+Out of scope:
+
+- Changing startup built-in policy resolution for `AGENTS.md`. This source
+  document only covers `AGENT_DOCS.toml` extension documents.
+- Reintroducing `$HOME/.agents`, `$HOME/.config/agent-kit`, or `$AGENT_HOME` as
+  docs-home indirection.
+- Redesigning project-local `scope = "home"` behavior unless tests show it is
+  directly entangled with the new `global` validation.
+- Changing unrelated historical docs that merely record old
+  `$HOME/.config/agent-kit` commands as past execution evidence.
+
+## Implementation Boundaries
+
+- `crates/agent-docs/src/model.rs` owns accepted scope names and serialized
+  scope values.
+- `crates/agent-docs/src/config.rs` owns TOML parsing and should produce an
+  actionable error when a project-local catalog declares `scope = "global"`.
+- `crates/agent-docs/src/resolver.rs` owns inheritance filtering, path root
+  selection, deduplication, and deterministic output order.
+- `crates/agent-docs/src/commands/baseline.rs` and
+  `crates/agent-docs/src/commands/add.rs` should be audited because they map
+  scopes to roots/sources and may expose `global` through CLI flags.
+- Integration tests under `crates/agent-docs/tests/integration/` should be the
+  primary acceptance harness.
+- `crates/plan-issue-cli/tests/fixtures/shell_parity/` owns the fixture
+  normalization rule and shell parity README.
+- `/Users/terry/Project/graysurf/agent-runtime-kit/AGENT_DOCS.toml` is a
+  coordinated downstream config update. It must not use `scope = "global"` in
+  a runtime environment that still runs an older released `agent-docs` binary.
+
+## Requirements
+
+- `scope = "global"` is accepted in the home catalog and appears in JSON/text
+  output as a distinct scope.
+- A home-catalog `scope = "global"` entry resolves its path from `docs_home`.
+- A home-catalog `scope = "project"` entry does not apply when `project_path`
+  points at an unrelated repo.
+- A home-catalog `scope = "project"` entry still applies when `project_path`
+  is the same repo as `docs_home`; linked worktrees of the same repository
+  should be treated as same-repo if the resolver already has enough git root
+  evidence to do that safely.
+- Project-local `scope = "global"` entries fail with a clear validation error
+  that says global scope is allowed only in the home catalog.
+- Project-local `scope = "project"` entries continue to resolve from
+  `project_path` and override duplicate inherited entries where applicable.
+- Existing built-in docs remain immutable and deduplicated.
+- The `plan-issue-cli` shell parity fixture workflow no longer mentions or
+  normalizes `$HOME/.config/agent-kit` / `$AGENT_KIT_HOME`.
+
+## Acceptance Criteria
+
+- With `docs_home=/Users/terry/Project/graysurf/agent-runtime-kit` and
+  `project_path=/Users/terry/Project/sympoies/nils-cli`, `agent-docs resolve
+  --context project-dev --format json` includes home-catalog `global` entries
+  from runtime-kit and nils-cli project entries, but does not include
+  runtime-kit home-catalog `project` entries.
+- In that cross-repo case, inherited global document paths point at
+  `/Users/terry/Project/graysurf/agent-runtime-kit/...`, not
+  `/Users/terry/Project/sympoies/nils-cli/...`.
+- With both `docs_home` and `project_path` pointing at runtime-kit, runtime-kit
+  home-catalog `project` entries are included.
+- A fixture where a project `AGENT_DOCS.toml` declares `scope = "global"` fails
+  before resolution with an actionable config validation error.
+- Existing `agent-docs` output remains deterministic across repeated resolves.
+- `cargo test -p agent-docs` passes.
+- `bash -n crates/plan-issue-cli/tests/fixtures/shell_parity/regenerate.sh`
+  passes after removing the legacy normalizer.
+- `rg "\.config/agent-kit|AGENT_KIT_HOME"
+  crates/plan-issue-cli/tests/fixtures/shell_parity` returns no matches after
+  the fixture cleanup.
+- Full non-doc validation passes before delivery:
+  `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh
+  --with-coverage`.
+
+## Validation Plan
+
+For the source document PR:
+
+- `agent-docs resolve --docs-home /Users/terry/Project/sympoies/nils-cli
+  --project-path /Users/terry/Project/sympoies/nils-cli --context startup
+  --strict --format checklist`
+- `agent-docs resolve --docs-home /Users/terry/Project/sympoies/nils-cli
+  --project-path /Users/terry/Project/sympoies/nils-cli --context project-dev
+  --strict --format checklist`
+- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+
+For the implementation:
+
+- Add failing integration tests for the cross-repo inheritance contract before
+  changing resolver behavior.
+- Run `cargo test -p agent-docs`.
+- Run `bash -n
+  crates/plan-issue-cli/tests/fixtures/shell_parity/regenerate.sh`.
+- Run the fixture search acceptance check for retired path placeholders.
+- Run
+  `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh
+  --with-coverage` before delivery.
+
+## Risks And Guardrails
+
+- Backward compatibility risk: changing `agent-runtime-kit/AGENT_DOCS.toml` to
+  `scope = "global"` before releasing or installing a compatible `agent-docs`
+  binary will make older binaries reject the catalog.
+- Resolver ambiguity risk: `scope` currently controls path root selection,
+  output labeling, and deduplication. The implementation must keep these
+  responsibilities explicit for `global` rather than treating it as a cosmetic
+  alias.
+- Worktree risk: exact path equality is too narrow if runtime-kit work happens
+  in linked worktrees. Prefer an existing git-root/common-dir comparison if it
+  is already available and deterministic.
+- Overreach risk: do not use this change to redesign all home/project startup
+  policy. Keep the change scoped to `AGENT_DOCS.toml` extension documents.
+- Fixture cleanup risk: remove the legacy path normalization only from the
+  shell parity fixture workflow and README. Do not rewrite historical plan
+  evidence unless a separate docs-retention decision asks for it.
+
+## Execution
+
+Recommended plan:
+docs/plans/agent-docs-global-scope-inheritance/agent-docs-global-scope-inheritance-plan.md
+
+Recommended execution state:
+docs/plans/agent-docs-global-scope-inheritance/agent-docs-global-scope-inheritance-execution-state.md
+
+- Status: not started
+- Next-task source: this discussion-source document.
+
+## Retention Intent
+
+Keep this document as the read-first source for the implementation plan and
+execution state. After delivery, retain it as plan provenance unless the final
+plan promotes the stable `agent-docs` global-scope contract into a crate docs
+spec or runbook.
+
+## Resolved Decisions
+
+- `agent-docs add --target home --scope global ...` should be supported as a
+  first-class authoring path. `agent-docs add --target project --scope global`
+  must fail with an actionable error because project-local catalogs cannot
+  declare global requirements.
+- Same-repo detection for home-catalog `scope = "project"` should use Git
+  repository identity when both roots are Git repositories. Compare canonical
+  Git common-dir or equivalent repository identity so linked worktrees of the
+  same repository count as same-repo. Fall back to canonical path equality only
+  when Git identity is unavailable.
+- Global documents should participate in `baseline --target home` for the first
+  implementation. Do not add a separate `baseline --target global` target yet.
+  If home baseline output becomes confusing, add an explicit filter later, such
+  as `agent-docs baseline --target home --scope global`.
+
+## Recommended Next Artifact
+
+Create
+`docs/plans/agent-docs-global-scope-inheritance/agent-docs-global-scope-inheritance-plan.md`
+and link this source document under the plan's `Read First` section.


### PR DESCRIPTION
## Summary

- Add first-class `scope = "global"` support to `agent-docs` home catalogs, including resolver inheritance, add/baseline behavior, validation errors, and integration coverage.
- Remove the retired `$HOME/.config/agent-kit` / `$AGENT_KIT_HOME` normalizer from `plan-issue-cli` shell parity fixtures and include the implementation-readiness source document.

## Test plan

- `cargo test -p nils-agent-docs`
- `bash -n crates/plan-issue-cli/tests/fixtures/shell_parity/regenerate.sh`
- `rg "\.config/agent-kit|AGENT_KIT_HOME" crates/plan-issue-cli/tests/fixtures/shell_parity`
- `PATH="/Users/terry/Project/sympoies/nils-cli/target/debug:$PATH" agent-docs resolve --docs-home /Users/terry/Project/graysurf/agent-runtime-kit --project-path /Users/terry/Project/sympoies/nils-cli --context project-dev --strict --format json`
- `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage`
