### PR TITLE
Align local validation policy

### DIFF
--- a/.agents/scripts/pre-pr.sh
+++ b/.agents/scripts/pre-pr.sh
@@ -1,25 +1,20 @@
 #!/usr/bin/env bash
 #
-# nils-cli's /pre-pr gate stack. The global dispatcher
-# (~/.claude/scripts/pre-pr.sh) execs this when cwd is nils-cli.
+# nils-cli's /pre-pr gate stack. The global dispatcher execs this when cwd is
+# nils-cli.
 #
-# Mirrors the canonical pre-delivery command from AGENTS.md §Required
-# Local Check Entrypoints:
-#   NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage
+# Mirrors the default local development command from AGENTS.md:
+#   bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast
 #
-# Note: this dispatcher runs a SUPERSET of the `nils-cli-verify-required-checks`
-# skill (it adds an llvm-cov coverage gate). Codex / opencode users who
-# discover through .agents/skills/ should invoke that skill directly for
-# the base check stack; see claude-kit's docs/dispatcher-commands.md for the
-# multi-CLI mirror rule.
-#
-# The entrypoint runs the required-checks verify script, optionally under
-# xvfb, and optionally with the llvm-cov coverage gate. Extra args forward
-# straight through (e.g. `--docs-only` for docs-only changes).
+# The full workspace and coverage gates are CI responsibilities for normal PRs.
+# Use --full or --with-coverage when a local CI-parity run is explicitly needed.
+# Extra args forward straight through.
 #
 # Examples:
-#   /pre-pr                  # full pre-delivery check (nextest + coverage gate)
-#   /pre-pr --docs-only      # skip heavy cargo checks for docs-only PRs
+#   /pre-pr                  # changed-scope local-fast check
+#   /pre-pr --docs-only      # docs-only check
+#   /pre-pr --full           # local full CI-parity check with nextest
+#   /pre-pr --with-coverage  # local full CI-parity + coverage check
 #
 set -euo pipefail
 
@@ -35,18 +30,37 @@ if [[ ! -x "$entrypoint" ]]; then
   exit 2
 fi
 
-# The entrypoint rejects `--with-coverage` alongside `--docs-only`, so only
-# auto-enable the coverage gate on full runs.
 has_docs_only=0
+force_full=0
+declare -a entry_args=()
 for arg in "$@"; do
-  if [[ "$arg" == "--docs-only" ]]; then
-    has_docs_only=1
-    break
-  fi
+  case "$arg" in
+    --docs-only)
+      has_docs_only=1
+      entry_args+=("$arg")
+      ;;
+    --full)
+      force_full=1
+      ;;
+    --with-coverage)
+      force_full=1
+      entry_args+=("$arg")
+      ;;
+    *)
+      entry_args+=("$arg")
+      ;;
+  esac
 done
 
-export NILS_CLI_TEST_RUNNER=nextest
 if [[ "$has_docs_only" -eq 1 ]]; then
-  exec bash "$entrypoint" "$@"
+  if [[ "$force_full" -eq 1 ]]; then
+    echo "pre-pr: --docs-only cannot be combined with --full or --with-coverage" >&2
+    exit 2
+  fi
+  exec bash "$entrypoint" "${entry_args[@]}"
 fi
-exec bash "$entrypoint" --with-coverage "$@"
+if [[ "$force_full" -eq 1 ]]; then
+  export NILS_CLI_TEST_RUNNER=nextest
+  exec bash "$entrypoint" "${entry_args[@]}"
+fi
+exec bash "$entrypoint" --local-fast "${entry_args[@]}"

--- a/.agents/skills/nils-cli-deliver-high-value-refactors/SKILL.md
+++ b/.agents/skills/nils-cli-deliver-high-value-refactors/SKILL.md
@@ -44,7 +44,8 @@ Failure modes:
 - No candidate passes the value gate (avoid refactor-for-refactor).
 - Candidate requires behavior changes that break parity expectations.
 - Shared extraction crosses crate boundaries with unclear ownership or high regression risk.
-- Unable to run required validation commands in the current environment.
+- Unable to run targeted or local-fast validation commands in the current
+  environment.
 
 ## Scripts (only entrypoints)
 
@@ -92,8 +93,11 @@ Failure modes:
 5. Validation
 
 - Run targeted tests for touched crates first.
-- If scope is broad or cross-crate, run:
-  - `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
+- Run the default changed-scope gate:
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
+- If debugging CI parity or release-quality risk locally, run the full stack
+  explicitly:
+  - `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`
 - Report exact commands and pass/fail status.
 
 6. Delivery (required for implemented changes)
@@ -101,7 +105,7 @@ Failure modes:
 - Run branch-intent preflight:
   - `deliver-feature-pr.sh preflight --base main`
 - Use `$create-feature-pr` to create branch/commit/open PR from confirmed base branch.
-- Wait for checks to become fully green:
+- Wait for GitHub required checks to become fully green:
   - `deliver-feature-pr.sh wait-ci --pr <number>`
 - If checks fail, fix on the same feature branch, push, and re-run `wait-ci` until green.
 - Close after CI is green:

--- a/.agents/skills/nils-cli-deliver-new-cli-crate/SKILL.md
+++ b/.agents/skills/nils-cli-deliver-new-cli-crate/SKILL.md
@@ -43,7 +43,7 @@ Failure modes:
 - Required policy documents are missing.
 - `agent-docs resolve --context project-dev --strict` fails.
 - JSON contract or parity requirements are underspecified and cannot be inferred.
-- Required repository checks fail.
+- Local changed-scope checks or CI-required checks fail.
 
 ## Scripts (only entrypoints)
 
@@ -67,8 +67,10 @@ Failure modes:
    - publishable crates follow workspace metadata conventions and release order checks,
    - internal-only crates explicitly set/document `publish = false`.
 6. Validate before delivery:
-   - `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
+   - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
    - if publishable: `scripts/publish-crates.sh --dry-run --crate <crate-package-name>`
+   - rely on the GitHub required checks for the full workspace and coverage
+     gates before merge.
 7. In the final response, include:
    - what was changed,
    - policy gates satisfied,

--- a/.agents/skills/nils-cli-deliver-new-cli-crate/scripts/create-cli-crate.sh
+++ b/.agents/skills/nils-cli-deliver-new-cli-crate/scripts/create-cli-crate.sh
@@ -104,8 +104,9 @@ else
 1) Ensure command contract covers human-readable mode and JSON mode.
 2) Add JSON contract tests (schema envelope, error envelope, no secret leakage).
 3) Align Cargo metadata and publishability rules.
-4) Run ./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh.
+4) Run bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast.
 5) If publishable, run scripts/publish-crates.sh --dry-run --crate <crate-package-name>.
+6) Use GitHub required checks for full workspace and coverage gates before merge.
 IMPLEMENT
 fi
 

--- a/.agents/skills/nils-cli-maintain-test-coverage/SKILL.md
+++ b/.agents/skills/nils-cli-maintain-test-coverage/SKILL.md
@@ -31,8 +31,8 @@ Outputs:
   and selected hotspot files/modules/functions.
 - A small test-maintenance change set that improves behavioral confidence,
   not only the percentage.
-- Focused validation for touched crates/tests, followed by the repo coverage
-  gate when the change is ready.
+- Focused validation for touched crates/tests, followed by fresh coverage
+  evidence from CI or an explicit local coverage run when the change is ready.
 - Follow-up issue evidence only when a clear bug or unresolved work is found
   outside the coverage-maintenance scope.
 
@@ -69,7 +69,7 @@ repository files.
 - If a relevant `target/coverage/lcov.info` already exists, summarize it:
   `bash scripts/ci/coverage-summary.sh target/coverage/lcov.info`.
 - If the artifact is missing or stale and the environment has the required
-  tooling, generate coverage with:
+  tooling, generate explicit local coverage with:
 
 ```bash
 NILS_CLI_TEST_RUNNER=nextest \
@@ -121,8 +121,10 @@ cargo nextest run -p <crate> <test-filter>
 cargo test -p <crate> <test-filter>
 ```
 
-- Run related crate or workspace checks after the focused loop is green.
-- Finish non-doc coverage-maintenance changes with:
+- Run related crate checks and the default local-fast gate after the focused
+  loop is green.
+- Finish non-doc coverage-maintenance changes with CI coverage evidence, or run
+  explicit local coverage when the feedback is needed before pushing:
 
 ```bash
 NILS_CLI_TEST_RUNNER=nextest \

--- a/.agents/skills/nils-cli-verify-required-checks/SKILL.md
+++ b/.agents/skills/nils-cli-verify-required-checks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nils-cli-verify-required-checks
-description: Run the required nils-cli checks from DEVELOPMENT.md.
+description: Run the full nils-cli CI/parity checks from DEVELOPMENT.md.
 ---
 
 # Nils CLI Verify Required Checks
@@ -18,7 +18,7 @@ Inputs:
 
 Outputs:
 
-- Runs the required checks defined in `DEVELOPMENT.md`.
+- Runs the full CI/parity checks defined in `DEVELOPMENT.md`.
 - In `--docs-only` mode, runs only the documentation checks defined there.
 - Prints the failing command (if any) and exits non-zero on failure.
 
@@ -32,7 +32,7 @@ Failure modes:
 
 - Not in a git work tree (cannot resolve repo root).
 - Missing a required tool on `PATH`.
-- Any of the required lint/tests fail.
+- Any of the full-stack lint/tests fail.
 
 ## Scripts (only entrypoints)
 
@@ -40,20 +40,21 @@ Failure modes:
 
 ## Workflow
 
-- Run before you claim a task is done.
+- For day-to-day implementation, prefer the changed-scope local gate:
+  `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`.
+- Run this full stack locally only when you need CI parity, release-quality
+  verification, or CI debugging evidence.
 - For docs-only changes (`README.md` / `docs/**` / `*.md` only), prefer:
-  - `.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh --docs-only`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
 - If it fails, fix the reported issue and re-run until it exits `0`.
 
 ## Alternate entry points
 
-Claude Code's `/pre-pr` slash command covers the same intent via
-`<repo>/.agents/scripts/pre-pr.sh`, which runs a **superset** of these
-checks: `scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` adds
-an llvm-cov coverage gate on top of the base audit stack. Invoke this
-skill's script directly when you want the base stack without the coverage
-gate, or when you are driving from a CLI that discovers through
-`.agents/skills/` (codex / opencode).
+Claude Code's `/pre-pr` slash command covers the default local intent via
+`<repo>/.agents/scripts/pre-pr.sh`, which runs
+`scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` by default. Use
+`/pre-pr --full` or this skill's script directly only for local CI parity; use
+`/pre-pr --with-coverage` when local coverage evidence is explicitly needed.
 
 See claude-kit's `docs/dispatcher-commands.md` for the multi-CLI mirror
 rule behind this pairing.

--- a/.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
+++ b/.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
@@ -6,7 +6,7 @@ usage() {
 Usage:
   nils-cli-verify-required-checks.sh [--docs-only] [--help]
 
-Runs the required pre-delivery checks from DEVELOPMENT.md:
+Runs the full CI/parity checks from DEVELOPMENT.md:
   - bash scripts/ci/docs-placement-audit.sh --strict
   - bash scripts/ci/docs-hygiene-audit.sh --strict
   - bash scripts/ci/markdownlint-audit.sh --strict
@@ -26,7 +26,7 @@ Runs the required pre-delivery checks from DEVELOPMENT.md:
 
 Modes:
   (default)
-    Run full required checks.
+    Run full CI/parity checks.
   --docs-only
     Run documentation-only checks:
       - bash scripts/ci/docs-placement-audit.sh --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Scope
+
+- This file contains `nils-cli`-specific agent instructions only.
+- Global agent behavior, response style, dispatch flow, clarification policy,
+  commit policy, and shared tool rules are inherited from the fallback
+  `AGENTS.md`.
+- Do not duplicate global guidance here; add only local overrides or local
+  document pointers.
+
+## Local Source Of Truth
+
+- Development contract: `DEVELOPMENT.md`
+- Runtime dependency and degradation reference: `BINARY_DEPENDENCIES.md`
+- CLI completion policy: `docs/runbooks/cli-completion-development-standard.md`
+- New CLI crate standard: `docs/runbooks/new-cli-crate-development-standard.md`
+- Crate docs placement policy: `docs/specs/crate-docs-placement-policy.md`
+
+## Required Local Check Entrypoints
+
+- Exact check contents and tool prerequisites are defined in `DEVELOPMENT.md`.
+- Default local development and pre-PR check:
+  `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
+- Docs-only changes:
+  `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+- Full CI parity checks are not the default local loop. Run them locally only
+  when debugging CI, preparing release-quality verification, or explicitly
+  asked:
+  `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`
+- Full coverage is owned by CI for normal PRs. Run it locally only for
+  coverage maintenance, release-quality verification, or CI debugging:
+  `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage`
+- GitHub required checks for `main` must include `test`, `test_macos`, and
+  `coverage`; those checks are the full-suite merge gate.
+- When completion assets change, also run:
+  - `zsh -n completions/zsh/_<cli>`
+  - `bash -n completions/bash/<cli>`
+
+## Repo Conventions
+
+- In Rust tests, prefer `pretty_assertions::{assert_eq, assert_ne}` for clearer
+  diffs.
+- Every user-facing CLI must expose root `-V, --version`.
+- For clap-based CLIs, set `#[command(version)]` on the root `Parser`.
+- `--help` output should show `-V, --version`.
+
+## Local Helpers
+
+- Recommended tooling bootstrap: `scripts/setup-rust-tooling.sh`
+- Local release install helper:
+  `./.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh`

--- a/BINARY_DEPENDENCIES.md
+++ b/BINARY_DEPENDENCIES.md
@@ -82,8 +82,10 @@ These are repository scripts (not third-party packages):
 
 - Install workspace binaries:
   - `./.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh`
-- Run required repository checks:
-  - `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
+- Run default local changed-scope checks:
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
+- Run full CI parity checks when needed locally:
+  - `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`
 - Supporting utilities:
   - `scripts/generate-third-party-artifacts.sh`
   - `scripts/workspace-bins.sh`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This document is the local development contract for:
 
 - environment setup
 - local test/check execution
-- mandatory pre-commit and pre-delivery gates
+- local development validation and CI delivery gates
 
 For runtime dependency details and degradation behavior, see `BINARY_DEPENDENCIES.md`.
 
@@ -40,7 +40,7 @@ Local fast changed-scope checks also require:
 - `python3`
 - `cargo` for non-document changes
 
-Full required checks also require:
+CI/full parity checks also require:
 
 - `cargo`
 - `python3`
@@ -71,7 +71,12 @@ Desktop session with `$HOME/.agents` absent and legacy skill environment
 variables unset. Rationale:
 `docs/plans/codex-skill-surface-primitives/codex-skill-surface-primitives-discussion-source.md`.
 
-## 3. Canonical local test flows
+## 3. Canonical validation flows
+
+Local development defaults to changed-scope validation. The full workspace test
+stack and coverage gate are CI responsibilities for normal PRs; run them
+locally only when you need CI parity, release-quality verification, coverage
+maintenance, or explicit debugging evidence.
 
 Primary local entrypoint for day-to-day implementation work:
 
@@ -104,6 +109,8 @@ bash scripts/ci/nils-cli-checks-entrypoint.sh
 ```
 
 This delegates to `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`.
+It is what CI uses for the full `test` and `test_macos` jobs; it is not the
+default local development loop.
 
 ### 3.1 Docs-only changes fast path
 
@@ -148,7 +155,7 @@ The local fast gate is conservative. Changes to `nils-common`, `nils-term`,
 `.github/`, or other workspace-level paths use a workspace Rust gate because
 package-scoped checks can miss reverse-dependency breakage.
 
-### 3.3 CI-like required checks (optional local parity / CI gate)
+### 3.3 Full checks (CI gate / optional local parity)
 
 ```bash
 NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh
@@ -160,17 +167,18 @@ Notes:
 - Because doctests are not included in nextest, the entrypoint also runs
   `cargo test --workspace --doc` when `NILS_CLI_TEST_RUNNER=nextest`.
 
-### 3.4 Full coverage flow (CI/release gate)
+### 3.4 Full coverage flow (CI gate / explicit local parity)
 
-Coverage gate is mandatory in CI and release-quality verification for non-doc
-changes (total line coverage must stay `>= 85.00%`):
+Coverage gate is mandatory in CI for non-doc changes and in explicit
+release-quality verification (total line coverage must stay `>= 85.00%`).
+Normal local development does not need to run coverage before opening a PR:
 
 ```bash
 NILS_CLI_TEST_RUNNER=nextest \
   bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage
 ```
 
-`--with-coverage` runs, after required checks:
+`--with-coverage` runs, after the full check stack:
 
 ```bash
 mkdir -p target/coverage
@@ -179,13 +187,14 @@ bash scripts/ci/coverage-summary.sh target/coverage/lcov.info
 cargo test --workspace --doc
 ```
 
-Use the default threshold for delivery. To run a stricter local check, override the threshold:
+Use the default threshold for CI parity. To run a stricter local check, override
+the threshold:
 
 ```bash
 NILS_CLI_COVERAGE_FAIL_UNDER_LINES=90 bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage
 ```
 
-## 4. Required checks included by the entrypoint
+## 4. Full checks included by the CI entrypoint
 
 `bash scripts/ci/nils-cli-checks-entrypoint.sh` includes:
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,13 @@ Local shell setup:
 
 Use [DEVELOPMENT.md](DEVELOPMENT.md) as the canonical checklist.
 
-- Full required checks: `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
-- Docs-only fast path: `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh --docs-only`
+- Default local check: `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
+- Docs-only fast path: `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+- Full CI parity check, when needed locally:
+  `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`
+- Full coverage is enforced by CI for PRs; run
+  `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage`
+  only for coverage/release/CI-debugging work.
 - Regenerate third-party license/notice artifacts after dependency or metadata changes:
   - `bash scripts/generate-third-party-artifacts.sh --write`
 - Verify third-party artifacts are current (fails on drift):

--- a/crates/agent-docs/src/commands/scaffold_baseline.rs
+++ b/crates/agent-docs/src/commands/scaffold_baseline.rs
@@ -17,6 +17,7 @@ const CLI_TOOLS_TEMPLATE: &str = include_str!("../templates/cli_tools_default.md
 const SETUP_PLACEHOLDER: &str = "{{SETUP_COMMANDS}}";
 const BUILD_PLACEHOLDER: &str = "{{BUILD_COMMANDS}}";
 const TEST_PLACEHOLDER: &str = "{{TEST_COMMANDS}}";
+const CHECKS_ENTRYPOINT_PATH: &str = "scripts/ci/nils-cli-checks-entrypoint.sh";
 const CHECKS_SCRIPT_PATH: &str =
     ".agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh";
 
@@ -419,12 +420,16 @@ struct WorkflowCommands {
 fn detect_workflow_commands(root: &Path) -> WorkflowCommands {
     if root.join("Cargo.toml").exists() {
         let mut test = Vec::new();
-        if root.join(CHECKS_SCRIPT_PATH).exists() {
+        if root.join(CHECKS_ENTRYPOINT_PATH).exists() {
+            test.push(format!("bash {CHECKS_ENTRYPOINT_PATH} --local-fast"));
+        } else if root.join(CHECKS_SCRIPT_PATH).exists() {
             test.push(format!("./{CHECKS_SCRIPT_PATH}"));
         }
-        test.push("cargo fmt --all -- --check".to_string());
-        test.push("cargo clippy --all-targets --all-features -- -D warnings".to_string());
-        test.push("cargo test --workspace".to_string());
+        if test.is_empty() {
+            test.push("cargo fmt --all -- --check".to_string());
+            test.push("cargo clippy --all-targets --all-features -- -D warnings".to_string());
+            test.push("cargo test --workspace".to_string());
+        }
 
         return WorkflowCommands {
             setup: vec!["cargo fetch".to_string()],
@@ -657,7 +662,7 @@ mod tests {
     }
 
     #[test]
-    fn scaffold_baseline_uses_checks_script_when_present_for_cargo_projects() {
+    fn scaffold_baseline_uses_local_fast_entrypoint_when_present_for_cargo_projects() {
         let home = TempDir::new().expect("create home tempdir");
         let project = TempDir::new().expect("create project tempdir");
         fs::write(
@@ -665,7 +670,7 @@ mod tests {
             "[package]\nname = \"demo\"\n",
         )
         .expect("seed cargo file");
-        let checks_script = project.path().join(CHECKS_SCRIPT_PATH);
+        let checks_script = project.path().join(CHECKS_ENTRYPOINT_PATH);
         fs::create_dir_all(
             checks_script
                 .parent()
@@ -686,8 +691,8 @@ mod tests {
             fs::read_to_string(project.path().join("DEVELOPMENT.md")).expect("read development");
         assert!(
             development_written
-                .contains("./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh")
+                .contains("bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast")
         );
-        assert!(development_written.contains("cargo test --workspace"));
+        assert!(!development_written.contains("cargo test --workspace"));
     }
 }

--- a/crates/agent-docs/src/templates/development_default.md
+++ b/crates/agent-docs/src/templates/development_default.md
@@ -18,7 +18,7 @@ Run build commands before sharing changes:
 
 ## Test
 
-Run checks before delivery:
+Run project-defined local checks before delivery:
 
 ```bash
 {{TEST_COMMANDS}}

--- a/crates/agent-docs/tests/fixtures/project/DEVELOPMENT.template.expected.md
+++ b/crates/agent-docs/tests/fixtures/project/DEVELOPMENT.template.expected.md
@@ -18,7 +18,7 @@ cargo build --workspace
 
 ## Test
 
-Run checks before delivery:
+Run project-defined local checks before delivery:
 
 ```bash
 cargo fmt --all -- --check

--- a/docs/runbooks/cli-completion-development-standard.md
+++ b/docs/runbooks/cli-completion-development-standard.md
@@ -9,9 +9,9 @@ gates.
 
 - Global completion obligations and alias families:
   - `AGENTS.md`
-- Required checks and coverage policy:
+- Local validation and CI coverage policy:
   - `DEVELOPMENT.md`
-  - `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
 - Workspace completion assets and tests:
   - `completions/zsh/`
   - `completions/bash/`
@@ -181,9 +181,10 @@ Validation expectation:
 - migration contracts must include explicit evidence for completion metadata checks
 - validation must include completion-mode toggle and alternate-dispatch grep checks for touched completion paths
 
-## Testing Requirements and Required Checks Linkage
+## Testing Requirements and Validation Linkage
 
-Completion work must satisfy completion-specific checks and repository gates.
+Completion work must satisfy completion-specific checks, local changed-scope
+validation, and GitHub required checks before merge.
 
 Mandatory completion-focused validation when completion code changes:
 
@@ -193,15 +194,17 @@ Mandatory completion-focused validation when completion code changes:
 4. export smoke check from CLI (example pattern):
    - `<cli> completion zsh | rg -- "--help|--version|--"`
 
-Mandatory repository checks:
+Mandatory local repository validation:
 
 - preferred single entrypoint:
-  - `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
 - docs-only fast path (when all changed files are docs):
-  - `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh --docs-only`
-- for non-doc changes, coverage must remain `>= 85.00%` per `DEVELOPMENT.md`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+- for non-doc changes, GitHub required checks enforce full workspace tests and
+  coverage `>= 85.00%` per `DEVELOPMENT.md`
 
-Completion changes are not deliverable until required checks pass.
+Completion changes are not merge-ready until local validation and GitHub
+required checks are green.
 
 ## Rollout Checklist: Migrating an Existing CLI
 
@@ -222,6 +225,6 @@ is captured, and acceptance criteria are checked.
 8. if dynamic values are needed, add `CompleteEnv` (or crate-local `__complete` only where justified)
 9. enforce single-path completion policy and metadata values (no runtime completion-mode gates or alternate completion functions)
 10. sync aliases in both alias files when alias-bearing CLIs are touched and update the contract `alias map` with any rewrite semantics
-11. run contract validation commands and required repository checks; record output in the contract, including completion metadata
+11. run contract validation commands and local repository validation; record output in the contract, including completion metadata and CI status
     verification evidence
 12. mark contract acceptance criteria complete and link the contract path in PR notes

--- a/docs/runbooks/new-cli-crate-development-standard.md
+++ b/docs/runbooks/new-cli-crate-development-standard.md
@@ -16,9 +16,9 @@ Use these as the source of truth to avoid policy drift:
 
 - Global CLI priorities and completion expectations:
   - `AGENTS.md`
-- Required checks and coverage policy:
+- Local validation and CI coverage policy:
   - `DEVELOPMENT.md`
-  - `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
 - Workspace completion architecture and migration rules:
   - `docs/runbooks/cli-completion-development-standard.md`
 - Publishing workflow and order:
@@ -44,7 +44,8 @@ If a crate is intentionally internal-only, keep this standard for UX/testing qua
 3. Implement behavior with parity/consistency to workspace conventions.
 4. Add tests for both human-readable and JSON contracts.
 5. Verify publish-readiness metadata and release order.
-6. Run required repository checks before delivery.
+6. Run local changed-scope validation before delivery; rely on GitHub required
+   checks for full workspace and coverage gates before merge.
 
 ## Crate Scaffold Rules
 
@@ -151,10 +152,10 @@ Minimum testing for new CLI crates:
 5. Completion architecture conformance to `docs/runbooks/cli-completion-development-standard.md` when completion assets are introduced or
    modified.
 
-Preferred single entrypoint:
+Preferred local validation entrypoint:
 
 ```bash
-./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
+bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast
 ```
 
 Pre-commit docs placement audit (required):
@@ -163,7 +164,8 @@ Pre-commit docs placement audit (required):
 bash scripts/ci/docs-placement-audit.sh --strict
 ```
 
-For exact command set and coverage threshold, follow `DEVELOPMENT.md`.
+For exact command sets, optional full local parity, and the CI coverage
+threshold, follow `DEVELOPMENT.md`.
 
 ## Publish Readiness Checklist
 
@@ -212,4 +214,4 @@ agent-docs resolve --context project-dev --strict --format checklist
 - [ ] Error envelope is machine-consumable in JSON mode.
 - [ ] No sensitive fields leak in JSON output.
 - [ ] Publish-readiness items are complete (or crate is explicitly internal-only).
-- [ ] Required repository checks pass.
+- [ ] Local validation passes and GitHub required checks are green.

--- a/docs/runbooks/test-cleanup-governance.md
+++ b/docs/runbooks/test-cleanup-governance.md
@@ -48,7 +48,8 @@ Before marking a candidate `remove`, include all of the following:
 - Candidate path and symbol evidence from stale-test inventory output.
 - Confirmation that `contract-allowlist.tsv` does not protect the candidate path.
 - Replacement test evidence when user-visible behavior could change.
-- Explicit validation command outputs in the PR (`test-stale-audit`, required checks, and coverage gate).
+- Explicit validation command outputs in the PR (`test-stale-audit`, focused or
+  local-fast checks, and CI coverage gate).
 
 For `rewrite`, document:
 
@@ -70,9 +71,13 @@ For `rewrite`, document:
   - Fails on new orphaned helper regressions relative to `scripts/ci/test-stale-audit-baseline.tsv`.
   - Fails when baseline contains entries outside the frozen S3T1 allowlist.
   - Fails on deprecated-path leftovers (`deprecated_path_marker`) in the current inventory.
-- `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
-  - Must pass before delivery.
-- Coverage gate (non-docs changes):
+- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
+  - Default local validation before delivery.
+- GitHub required checks (non-doc changes):
+  - `test`
+  - `test_macos`
+  - `coverage`
+- Coverage gate command used by CI:
   - `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85`
   - `scripts/ci/coverage-summary.sh target/coverage/lcov.info`
 
@@ -81,6 +86,6 @@ For `rewrite`, document:
 - Decision mode selected: `remove`, `keep`, `rewrite`, or `defer`.
 - Evidence links include crate/file/symbol and replacement assertions when required.
 - `bash scripts/ci/test-stale-audit.sh --strict` output is clean.
-- Required checks entrypoint passes.
-- Coverage gate result is attached for non-doc changes.
+- Local validation passes.
+- GitHub required checks are green, including coverage for non-doc changes.
 - Baseline updates are justified and limited to reviewed stale-helper removals.

--- a/docs/specs/completion-contract-template.md
+++ b/docs/specs/completion-contract-template.md
@@ -124,8 +124,9 @@ Record command-level and repository-level checks for this migration.
      crates/<crate>/docs/reports/<cli>-completion-migration-contract.md
    ```
 
-1. `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh`
+1. `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
    - use `--docs-only` only when all changed files are docs.
+   - record GitHub required-check status before merge.
 
 ### test coverage mapping
 

--- a/docs/specs/crate-docs-placement-policy.md
+++ b/docs/specs/crate-docs-placement-policy.md
@@ -29,7 +29,7 @@ types before choosing a path.
 Only the following root-level documentation categories are allowed as canonical sources:
 
 - `/README.md` (workspace overview)
-- `/DEVELOPMENT.md` (workspace required checks and developer workflow)
+- `/DEVELOPMENT.md` (workspace validation and developer workflow)
 - `/AGENTS.md` (agent behavior policy)
 - `/BINARY_DEPENDENCIES.md` (workspace shared binary prerequisites)
 - `/docs/plans/*.md` (workspace planning documents)
@@ -117,8 +117,8 @@ Contributors SHOULD:
 
 ## Enforcement Reference
 
-`DEVELOPMENT.md` required checks reference this policy. Future automation and CI checks MUST enforce
-the same placement rules.
+`DEVELOPMENT.md` validation flows reference this policy. Future automation and
+CI checks MUST enforce the same placement rules.
 
 Recommended CI companions:
 

--- a/docs/specs/workspace-ci-entrypoint-inventory-v1.md
+++ b/docs/specs/workspace-ci-entrypoint-inventory-v1.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 
-This inventory records the canonical owner for each active CI/release workflow check and defines keep/delete criteria for helper scripts.
+This inventory records the canonical owner for each active CI/release workflow
+check, the default local validation path, and keep/delete criteria for helper
+scripts.
 It is the source of truth for Sprint 1 CI entrypoint consolidation.
 
 ## Keep/Delete Criteria
@@ -24,7 +26,7 @@ out of scope for this governance inventory; flag it as a follow-up.
 | Job | Step | Canonical owner | Decision | Notes |
 | --- | --- | --- | --- | --- |
 | `test`, `test_macos` | `Checkout`, `Set up Rust`, `Cache cargo`, `Set up Node.js`, tool bootstrap | Upstream GitHub Actions + runner bootstrap shell | keep | Platform bootstrap stays in workflow. |
-| `test`, `test_macos` | `Nils CLI checks (includes third-party-artifacts-audit, Completion asset audit, docs-hygiene-audit, test-stale-audit)` | `scripts/ci/nils-cli-checks-entrypoint.sh` -> `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` | keep | Canonical verification contract after setup. |
+| `test`, `test_macos` | `Nils CLI checks (includes third-party-artifacts-audit, Completion asset audit, docs-hygiene-audit, test-stale-audit)` | `scripts/ci/nils-cli-checks-entrypoint.sh` -> `./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` | keep | Full CI verification contract after setup. |
 | `test`, `test_macos` | `Third-party artifact audit` (removed) | replaced by required-checks script ordering | delete | Duplicate workflow fragment removed. |
 | `test`, `test_macos` | `Completion asset audit` (removed) | replaced by required-checks script ordering | delete | Duplicate workflow fragment removed. |
 | `test`, `test_macos` | `Publish JUnit report`, `Upload JUnit XML` | upstream Actions artifacts/reporting | keep | Post-check reporting only. |
@@ -49,13 +51,17 @@ out of scope for this governance inventory; flag it as a follow-up.
 
 ## Required-Checks Script Ownership
 
-`./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` is canonical for verification ordering:
+`./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh` is canonical for full CI verification ordering:
 
 1. docs/stale/third-party/completion audits (`scripts/ci/*`)
 2. completion registration/parity checks
 3. compile/test gates (`cargo fmt`, `cargo clippy`, workspace tests)
 
-No workflow may duplicate these audit commands as independent pre-steps unless the required-checks entrypoint is updated first.
+No workflow may duplicate these audit commands as independent pre-steps unless
+the required-checks entrypoint is updated first. Day-to-day local development
+uses `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`, which
+escalates to the workspace Rust gate when changed files can affect reverse
+dependencies.
 
 ## Helper Surface Decisions (Sprint 1 Scope)
 
@@ -65,17 +71,17 @@ records the keep/delete decision plus the active caller evidence.
 | Path | Decision | Active caller evidence |
 | --- | --- | --- |
 | `scripts/ci/agent-docs-snapshots.sh` | keep | `crates/agent-docs/README.md` snapshot workflow (`scripts/ci/agent-docs-snapshots.sh [--bless]`) |
-| `scripts/ci/completion-asset-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` step |
-| `scripts/ci/completion-flag-parity-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` step |
+| `scripts/ci/completion-asset-audit.sh` | keep | `DEVELOPMENT.md` full checks list + `nils-cli-verify-required-checks.sh` step |
+| `scripts/ci/completion-flag-parity-audit.sh` | keep | `DEVELOPMENT.md` full checks list + `nils-cli-verify-required-checks.sh` step |
 | `scripts/ci/coverage-badge.sh` | keep | `.github/workflows/ci.yml` `coverage_badge` job |
 | `scripts/ci/coverage-summary.sh` | keep | `.github/workflows/ci.yml` `coverage` job + `DEVELOPMENT.md` coverage flow |
-| `scripts/ci/docs-hygiene-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` docs-only and full passes |
-| `scripts/ci/docs-placement-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` docs-only and full passes |
-| `scripts/ci/markdownlint-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` docs-only and full passes |
-| `scripts/ci/nils-cli-checks-entrypoint.sh` | keep | `.github/workflows/ci.yml` `test` and `test_macos` jobs + `DEVELOPMENT.md` contributor commands |
+| `scripts/ci/docs-hygiene-audit.sh` | keep | `DEVELOPMENT.md` full checks list + `nils-cli-verify-required-checks.sh` docs-only and full passes |
+| `scripts/ci/docs-placement-audit.sh` | keep | `DEVELOPMENT.md` full checks list + `nils-cli-verify-required-checks.sh` docs-only and full passes |
+| `scripts/ci/markdownlint-audit.sh` | keep | `DEVELOPMENT.md` full checks list + `nils-cli-verify-required-checks.sh` docs-only and full passes |
+| `scripts/ci/nils-cli-checks-entrypoint.sh` | keep | `.github/workflows/ci.yml` `test` and `test_macos` jobs + `DEVELOPMENT.md` local-fast and CI/full commands |
 | `scripts/ci/release-tarball-third-party-audit.sh` | keep | `.github/workflows/release.yml` `build` job |
-| `scripts/ci/test-stale-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` step |
-| `scripts/ci/third-party-artifacts-audit.sh` | keep | `DEVELOPMENT.md` required checks list + `nils-cli-verify-required-checks.sh` step + dependabot bump skill |
+| `scripts/ci/test-stale-audit.sh` | keep | `DEVELOPMENT.md` full checks list + `nils-cli-verify-required-checks.sh` step |
+| `scripts/ci/third-party-artifacts-audit.sh` | keep | `DEVELOPMENT.md` full checks list + `nils-cli-verify-required-checks.sh` step + dependabot bump skill |
 
 ## Auxiliary Wrapper / Tooling Decisions
 

--- a/scripts/ci/nils-cli-checks-entrypoint.sh
+++ b/scripts/ci/nils-cli-checks-entrypoint.sh
@@ -7,20 +7,22 @@ Usage:
   scripts/ci/nils-cli-checks-entrypoint.sh [--xvfb] [--local-fast] [--with-coverage] [verify-script args...]
 
 Description:
-  Canonical cross-platform entrypoint for CI verification jobs.
-  - Runs ./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
+  Canonical cross-platform entrypoint for local-fast and CI verification jobs.
+  - By default, runs the full CI parity stack through
+    ./.agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh
   - Reuses the current Bash interpreter so nested audit scripts run with the same shell version.
   - Optionally wraps execution with xvfb-run for Linux runners.
-  - Optionally runs the local fast changed-scope gate.
-  - Optionally runs the local coverage gate and summary after required checks.
+  - Runs the local fast changed-scope gate with --local-fast; this is the
+    default day-to-day development and pre-PR path.
+  - Optionally runs the coverage gate and summary after the full CI stack.
 
 Options:
   --xvfb             Run checks under `xvfb-run -a`
   --local-fast       Run fast local changed-scope validation instead of the
-                     full required-checks script. Pass --base <ref>,
+                     full CI/parity script. Pass --base <ref>,
                      --plan-only, or --changed-file <path> through to
                      scripts/ci/nils-cli-local-fast.sh.
-  --with-coverage    Run coverage gate after required checks:
+  --with-coverage    Run coverage gate after the full CI stack:
                      cargo llvm-cov nextest --profile ci --workspace --lcov \
                        --output-path target/coverage/lcov.info --fail-under-lines <N>
                      bash scripts/ci/coverage-summary.sh target/coverage/lcov.info
@@ -178,4 +180,4 @@ run cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/
 run bash scripts/ci/coverage-summary.sh target/coverage/lcov.info
 run cargo test --workspace --doc
 
-echo "ok: required checks + coverage gate passed"
+echo "ok: full CI/parity checks + coverage gate passed"

--- a/scripts/dev/workspace-shared-crate-audit.sh
+++ b/scripts/dev/workspace-shared-crate-audit.sh
@@ -504,8 +504,8 @@ This rubric classifies findings into `migrate`, `extend-shared`, `keep-local`, o
 ## Test and Delivery Gates
 
 1. Characterization-first for high-risk work before helper extraction or behavior rewiring.
-2. Required checks from `DEVELOPMENT.md` must pass before delivery.
-3. Workspace coverage gate remains at or above the documented threshold.
+2. Local changed-scope checks from `DEVELOPMENT.md` must pass before delivery.
+3. GitHub required checks own full workspace and coverage gates before merge.
 4. Any parity-sensitive exception must include explicit tests and rationale in the PR.
 
 ## Classification Rules


### PR DESCRIPTION
## Summary

- Default local development and pre-PR guidance to `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`, with full workspace and coverage checks kept as explicit CI/parity paths.
- Add tracked `AGENTS.md`, update agent skills/runbooks/script help for the new wording, and make `agent-docs scaffold-baseline` emit the local-fast command for nils-style repos.
- Configure GitHub `main` branch protection so `test`, `test_macos`, and `coverage` are strict required checks before merge.

## Test plan

- `bash -n .agents/scripts/pre-pr.sh scripts/ci/nils-cli-checks-entrypoint.sh .agents/skills/nils-cli-verify-required-checks/scripts/nils-cli-verify-required-checks.sh .agents/skills/nils-cli-deliver-new-cli-crate/scripts/create-cli-crate.sh scripts/dev/workspace-shared-crate-audit.sh`
- `cargo fmt --all -- --check`
- `cargo test -p nils-agent-docs scaffold_baseline`
- `bash .agents/scripts/pre-pr.sh --docs-only --with-coverage; test $? -eq 2`
- `bash .agents/scripts/pre-pr.sh --plan-only`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
