### PR TITLE
Release nils-cli 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-runtime-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-docs"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-out"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-scope-lock"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-workflow-primitives"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-gql"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-grpc"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-rest"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-test"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-testing-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-websocket"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "nils-cli-template"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "nils-codex-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "nils-common"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64",
  "clap",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "nils-forge-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "nils-fzf-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "nils-gemini-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-lock"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-scope"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-summary"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "nils-image-processing"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "nils-macos-agent"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "nils-memo-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-issue-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-tooling"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "nils-screen-record"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "block2",
  "chrono",
@@ -2251,7 +2251,7 @@ dependencies = [
 
 [[package]]
 name = "nils-semantic-commit"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "nils-term"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "indicatif",
  "pretty_assertions",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "nils-test-support"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "nils-web-evidence"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "2"
 # edition.
 edition = "2024"
 license = "MIT"
-version = "0.19.0"
+version = "0.20.0"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -176,10 +176,10 @@ This repo can publish prebuilt tarballs via GitHub Releases for both:
 - x86_64 (amd64)
 - aarch64 (arm64)
 
-To trigger a release build, push a tag like `v0.19.0`:
+To trigger a release build, push a tag like `v0.20.0`:
 
-- `git tag -a v0.19.0 -m "v0.19.0"`
-- `git push origin v0.19.0`
+- `git tag -a v0.20.0 -m "v0.20.0"`
+- `git push origin v0.20.0`
 
 Then download the matching `nils-cli-<tag>-<target>.tar.gz` asset, extract it, and add `<extract_dir>/bin` to your `PATH`.
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `45bdb60037fddece2d6db7ed8435b469c0bb0d250647416102d64fe8da7d966b`
+- Cargo.lock SHA256: `99e7683aacda55dbc1838bef647b7daed8b92e130d12c73e16426c5773089b15`
 - Third-party crates (`source != null`): 465
 - Workspace crates (`source == null`, excluded below): 31
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `45bdb60037fddece2d6db7ed8435b469c0bb0d250647416102d64fe8da7d966b`
+- Cargo.lock SHA256: `99e7683aacda55dbc1838bef647b7daed8b92e130d12c73e16426c5773089b15`
 - Third-party crates (`source != null`): 465
 
 ## Notice Extraction Policy

--- a/crates/agent-docs/Cargo.toml
+++ b/crates/agent-docs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-docs"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -19,12 +19,12 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 directories = { workspace = true }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 toml_edit = "0.25"
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/agent-out/Cargo.toml
+++ b/crates/agent-out/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-out"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -19,11 +19,11 @@ path = "src/main.rs"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-runtime-cli/Cargo.toml
+++ b/crates/agent-runtime-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-runtime-cli"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -28,5 +28,5 @@ tera = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/agent-scope-lock/Cargo.toml
+++ b/crates/agent-scope-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-scope-lock"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -14,11 +14,11 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-workflow-primitives/Cargo.toml
+++ b/crates/agent-workflow-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-workflow-primitives"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -58,15 +58,15 @@ path = "src/bin/test-first-evidence.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-agent-out = { version = "0.19.0", path = "../agent-out" }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
+nils-agent-out = { version = "0.20.0", path = "../agent-out" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-gql/Cargo.toml
+++ b/crates/api-gql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-gql"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,13 +12,13 @@ name = "api-gql"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.19.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.20.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-grpc/Cargo.toml
+++ b/crates/api-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-grpc"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-grpc"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.19.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.20.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.22"
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-rest/Cargo.toml
+++ b/crates/api-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-rest"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-rest"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.19.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.20.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.22"
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-test/Cargo.toml
+++ b/crates/api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-test"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -16,14 +16,14 @@ name = "api-test"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.19.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.20.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-testing-core/Cargo.toml
+++ b/crates/api-testing-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-testing-core"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -24,10 +24,10 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-websocket/Cargo.toml
+++ b/crates/api-websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-websocket"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-websocket"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.19.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.20.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }

--- a/crates/cli-template/Cargo.toml
+++ b/crates/cli-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-cli-template"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -13,13 +13,13 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/codex-cli/Cargo.toml
+++ b/crates/codex-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-codex-cli"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -23,10 +23,10 @@ reqwest = { version = "0.13", default-features = false, features = ["blocking", 
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.11"
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/forge-cli/Cargo.toml
+++ b/crates/forge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-forge-cli"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -19,7 +19,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 tempfile = "3"
@@ -27,5 +27,5 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/fzf-cli/Cargo.toml
+++ b/crates/fzf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-fzf-cli"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -14,14 +14,14 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
 walkdir = "2"
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/gemini-cli/Cargo.toml
+++ b/crates/gemini-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-gemini-cli"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -21,9 +21,9 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/git-cli/Cargo.toml
+++ b/crates/git-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-cli"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -18,12 +18,12 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/git-lock/Cargo.toml
+++ b/crates/git-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-lock"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -15,10 +15,10 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 chrono = { version = "0.4", features = ["clock"] }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 tempfile = "3"
 pretty_assertions = { workspace = true }

--- a/crates/git-scope/Cargo.toml
+++ b/crates/git-scope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-scope"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -14,9 +14,9 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 tempfile = "3"
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }

--- a/crates/git-summary/Cargo.toml
+++ b/crates/git-summary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-summary"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -15,10 +15,10 @@ anyhow = { workspace = true }
 chrono = { version = "0.4", features = ["clock"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/image-processing/Cargo.toml
+++ b/crates/image-processing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-image-processing"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -20,8 +20,8 @@ serde_json = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 globset = "0.4"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
 resvg = "0.47"
 roxmltree = "0.21"
 usvg = "0.47"
@@ -29,6 +29,6 @@ uuid = { version = "1", features = ["v4"] }
 walkdir = "2"
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/macos-agent/Cargo.toml
+++ b/crates/macos-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-macos-agent"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -20,11 +20,11 @@ clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 regex = "1"
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
-screen-record = { version = "0.19.0", path = "../screen-record", package = "nils-screen-record" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
+screen-record = { version = "0.20.0", path = "../screen-record", package = "nils-screen-record" }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/memo-cli/Cargo.toml
+++ b/crates/memo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-memo-cli"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -24,10 +24,10 @@ chrono-tz = "0.10"
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-common/Cargo.toml
+++ b/crates/nils-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-common"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 description = "Library crate for nils-common in the nils-cli workspace."
@@ -14,6 +14,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-term/Cargo.toml
+++ b/crates/nils-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-term"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 description = "Library crate for nils-term in the nils-cli workspace."

--- a/crates/nils-test-support/Cargo.toml
+++ b/crates/nils-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-test-support"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/plan-issue-cli/Cargo.toml
+++ b/crates/plan-issue-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-issue-cli"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 default-run = "plan-issue"
@@ -25,10 +25,10 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
-plan-tooling = { version = "0.19.0", path = "../plan-tooling", package = "nils-plan-tooling" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
+plan-tooling = { version = "0.20.0", path = "../plan-tooling", package = "nils-plan-tooling" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/plan-tooling/Cargo.toml
+++ b/crates/plan-tooling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-tooling"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -16,14 +16,14 @@ name = "plan-tooling"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/screen-record/Cargo.toml
+++ b/crates/screen-record/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-screen-record"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 build = "build.rs"
@@ -20,7 +20,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 ctrlc = "3.5.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.13", features = ["randr"] }
@@ -41,7 +41,7 @@ block2 = "0.6.2"
 dispatch2 = "0.3.0"
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 tempfile = "3"
 
 [lints.rust]

--- a/crates/semantic-commit/Cargo.toml
+++ b/crates/semantic-commit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-semantic-commit"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -21,9 +21,9 @@ clap_complete = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
 time = { version = "0.3", features = ["formatting"] }
-nils-term = { version = "0.19.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.20.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/web-evidence/Cargo.toml
+++ b/crates/web-evidence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-web-evidence"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 license.workspace = true
 
@@ -18,13 +18,13 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.19.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 regex = "1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.19.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.20.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"


### PR DESCRIPTION
## Summary

Release nils-cli 0.20.0 from current `origin/main`, including the merged `agent-run` workflow primitive.

## Validation

- `cargo check --workspace --locked`
- regenerated `THIRD_PARTY_LICENSES.md` and `THIRD_PARTY_NOTICES.md`
- pre-bump `main` CI gate passed: https://github.com/sympoies/nils-cli/actions/runs/26361618165

## Test plan

- `cargo check --workspace --locked`
- `forge-cli pr deliver` provider checks before merge
