### PR TITLE
feat(forge-cli): add label catalog operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,6 +2036,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "tempfile",
  "thiserror",
  "toml",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Completion obligations for those binaries are tracked in
 | ---- | -------- | -------- |
 | API testing | `api-rest`, `api-gql`, `api-grpc`, `api-websocket`, `api-test` | Run protocol-specific API checks or orchestrate a mixed API test suite. |
 | Git tooling | `git-scope`, `git-cli`, `git-summary`, `git-lock` | Inspect changes, run Git helper flows, summarize commits, or manage repo-local commit locks. |
-| Forge automation | `forge-cli` | Drive PR/MR + Issue lifecycle on GitHub (via `gh`) or GitLab (via `glab`) through a single provider-neutral surface; covers create / view / edit / comment / ready / merge / close, CI wait-checks, and the `pr deliver` macro. |
+| Forge automation | `forge-cli` | Drive PR/MR + Issue lifecycle and repository label catalog maintenance on GitHub (via `gh`) or GitLab (via `glab`) through a single provider-neutral surface; covers create / view / edit / comment / ready / merge / close, label list / audit / ensure, CI wait-checks, and the `pr deliver` macro. |
 | Agent policy and evidence | `agent-docs`, `agent-out`, `agent-scope-lock`, `test-first-evidence`, `web-evidence`, `browser-session`, `canary-check`, `docs-impact`, `heuristic-inbox`, `model-cross-check`, `repo-retro`, `review-evidence`, `skill-usage` | Resolve agent policy docs, allocate artifact paths, enforce edit scope, inspect repo retrospectives, or persist deterministic workflow evidence. |
 | Planning and delivery | `plan-tooling`, `plan-issue`, `plan-issue-local`, `semantic-commit` | Validate/split implementation plans, orchestrate issue delivery, rehearse local plan flows, or create semantic commits. |
 | Provider lanes | `codex-cli`, `gemini-cli` | Run provider-specific diagnostics, auth checks, and workflow adapters. |
@@ -59,7 +59,8 @@ Each crate is either a standalone CLI binary, a multi-binary crate, or a shared 
 - [crates/git-summary](crates/git-summary): Per-author contribution summaries over a date range (adds/dels/net/commits).
 - [crates/git-lock](crates/git-lock): Label-based commit locks per repo (lock/list/diff/unlock/tag).
 - [crates/forge-cli](crates/forge-cli): Provider-neutral forge CLI wrapping `gh` / `glab` for
-  PR/MR + Issue lifecycle, CI wait-checks, and the `pr deliver` macro
+  PR/MR + Issue lifecycle, repository label catalog maintenance, CI
+  wait-checks, and the `pr deliver` macro
   (open draft → CI green → ready → merge).
 
 ### Desktop, media, and local utility CLIs

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `95ab97c8b5a6161b7e28ab951e3a61ddec30dfa3df1c4d4834c7860fadc10e02`
+- Cargo.lock SHA256: `69e6633daad4e2af4d62a99ce161db10381a9bc2fd882f07047a9f5057e02313`
 - Third-party crates (`source != null`): 465
 - Workspace crates (`source == null`, excluded below): 31
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `95ab97c8b5a6161b7e28ab951e3a61ddec30dfa3df1c4d4834c7860fadc10e02`
+- Cargo.lock SHA256: `69e6633daad4e2af4d62a99ce161db10381a9bc2fd882f07047a9f5057e02313`
 - Third-party crates (`source != null`): 465
 
 ## Notice Extraction Policy

--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -31,6 +31,9 @@ _forge-cli() {
             forge__cli,issue)
                 cmd="forge__cli__issue"
                 ;;
+            forge__cli,label)
+                cmd="forge__cli__label"
+                ;;
             forge__cli,pr)
                 cmd="forge__cli__pr"
                 ;;
@@ -63,6 +66,9 @@ _forge-cli() {
                 ;;
             forge__cli__help,issue)
                 cmd="forge__cli__help__issue"
+                ;;
+            forge__cli__help,label)
+                cmd="forge__cli__help__label"
                 ;;
             forge__cli__help,pr)
                 cmd="forge__cli__help__pr"
@@ -102,6 +108,15 @@ _forge-cli() {
                 ;;
             forge__cli__help__issue,view)
                 cmd="forge__cli__help__issue__view"
+                ;;
+            forge__cli__help__label,audit)
+                cmd="forge__cli__help__label__audit"
+                ;;
+            forge__cli__help__label,ensure)
+                cmd="forge__cli__help__label__ensure"
+                ;;
+            forge__cli__help__label,list)
+                cmd="forge__cli__help__label__list"
                 ;;
             forge__cli__help__pr,checks)
                 cmd="forge__cli__help__pr__checks"
@@ -211,6 +226,30 @@ _forge-cli() {
             forge__cli__issue__help,view)
                 cmd="forge__cli__issue__help__view"
                 ;;
+            forge__cli__label,audit)
+                cmd="forge__cli__label__audit"
+                ;;
+            forge__cli__label,ensure)
+                cmd="forge__cli__label__ensure"
+                ;;
+            forge__cli__label,help)
+                cmd="forge__cli__label__help"
+                ;;
+            forge__cli__label,list)
+                cmd="forge__cli__label__list"
+                ;;
+            forge__cli__label__help,audit)
+                cmd="forge__cli__label__help__audit"
+                ;;
+            forge__cli__label__help,ensure)
+                cmd="forge__cli__label__help__ensure"
+                ;;
+            forge__cli__label__help,help)
+                cmd="forge__cli__label__help__help"
+                ;;
+            forge__cli__label__help,list)
+                cmd="forge__cli__label__help__list"
+                ;;
             forge__cli__pr,checks)
                 cmd="forge__cli__pr__checks"
                 ;;
@@ -302,7 +341,7 @@ _forge-cli() {
 
     case "${cmd}" in
         forge__cli)
-            opts="-h -V --format --remote --provider --repo --dry-run --help --version pr issue inbox repo auth completion help"
+            opts="-h -V --format --remote --provider --repo --dry-run --help --version pr issue label inbox repo auth completion help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -464,7 +503,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help)
-            opts="pr issue inbox repo auth completion help"
+            opts="pr issue label inbox repo auth completion help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -688,6 +727,62 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help__issue__view)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__label)
+            opts="list audit ensure"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__label__audit)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__label__ensure)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__label__list)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1645,6 +1740,216 @@ _forge-cli() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        forge__cli__label)
+            opts="-h --format --remote --provider --repo --dry-run --help list audit ensure help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__label__audit)
+            opts="-h --catalog --limit --format --remote --provider --repo --dry-run --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --catalog)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__label__ensure)
+            opts="-h --catalog --update-existing --limit --format --remote --provider --repo --dry-run --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --catalog)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__label__help)
+            opts="list audit ensure help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__label__help__audit)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__label__help__ensure)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__label__help__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__label__help__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__label__list)
+            opts="-h --limit --format --remote --provider --repo --dry-run --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         forge__cli__pr)
             opts="-h --format --remote --provider --repo --dry-run --help create view list edit comment ready merge close checks wait-checks deliver help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
@@ -1778,7 +2083,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__create)
-            opts="-h --head --base --title --body --body-file --kind --no-draft --reviewer --label --format --remote --provider --repo --dry-run --help"
+            opts="-h --head --base --title --body --body-file --kind --no-draft --reviewer --label --label-catalog --strict-labels --format --remote --provider --repo --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1816,6 +2121,10 @@ _forge-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --label-catalog)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
@@ -1840,7 +2149,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__deliver)
-            opts="-h --kind --title --body --body-file --head --base --method --reviewer --timeout --no-merge --allow-non-default-base --format --remote --provider --repo --dry-run --help"
+            opts="-h --kind --title --body --body-file --head --base --method --reviewer --label --label-catalog --strict-labels --timeout --no-merge --allow-non-default-base --format --remote --provider --repo --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1875,6 +2184,14 @@ _forge-cli() {
                     return 0
                     ;;
                 --reviewer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --label)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --label-catalog)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -64,12 +64,14 @@ _arguments "${_arguments_options[@]}" : \
 '--kind=[PR / MR kind (selects branch-prefix rule). Required]:KIND:(feature bug)' \
 '*--reviewer=[Add a reviewer (repeatable)]:USER:_default' \
 '*--label=[Add a label (repeatable)]:LABEL:_default' \
+'--label-catalog=[Validate labels against this catalog when \`--strict-labels\` is set]:PATH:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
 '--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
 '--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
 '--no-draft[Open as ready-for-review instead of draft (default\: open as draft)]' \
+'--strict-labels[Fail when selected labels are missing, not applicable, or conflict]' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -221,12 +223,15 @@ _arguments "${_arguments_options[@]}" : \
 '--base=[Target / base branch (defaults to the repo'\''s default branch)]:BASE:_default' \
 '--method=[Merge method (default\: squash)]:METHOD:(squash merge rebase)' \
 '*--reviewer=[Add a reviewer (repeatable)]:USER:_default' \
+'*--label=[Add a label to the created PR / MR (repeatable)]:LABEL:_default' \
+'--label-catalog=[Validate labels against this catalog when \`--strict-labels\` is set]:PATH:_default' \
 '--timeout=[CI-wait budget before declaring \`checks_timeout\` (default \`30m\`)]:TIMEOUT:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
 '--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
 '--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--strict-labels[Fail when selected labels are missing, not applicable, or conflict]' \
 '--no-merge[Stop after \`pr.wait-checks\` — do not promote to ready or merge]' \
 '--allow-non-default-base[Allow merges where the PR'\''s base is not the repo'\''s default branch]' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
@@ -466,6 +471,104 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (reopen)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+        esac
+    ;;
+esac
+;;
+(label)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+":: :_forge-cli__subcmd__label_commands" \
+"*::: :->label" \
+&& ret=0
+
+    case $state in
+    (label)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:forge-cli-label-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+'--limit=[Maximum labels to fetch from the provider]:LIMIT:_default' \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(audit)
+_arguments "${_arguments_options[@]}" : \
+'--catalog=[Path to the shared forge label catalog]:PATH:_default' \
+'--limit=[Maximum labels to fetch from the provider]:LIMIT:_default' \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(ensure)
+_arguments "${_arguments_options[@]}" : \
+'--catalog=[Path to the shared forge label catalog]:PATH:_default' \
+'--limit=[Maximum labels to fetch from the provider]:LIMIT:_default' \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--update-existing[Update color / description drift on existing labels]' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" : \
+":: :_forge-cli__subcmd__label__subcmd__help_commands" \
+"*::: :->help" \
+&& ret=0
+
+    case $state in
+    (help)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:forge-cli-label-help-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(audit)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(ensure)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -873,6 +976,34 @@ _arguments "${_arguments_options[@]}" : \
     ;;
 esac
 ;;
+(label)
+_arguments "${_arguments_options[@]}" : \
+":: :_forge-cli__subcmd__help__subcmd__label_commands" \
+"*::: :->label" \
+&& ret=0
+
+    case $state in
+    (label)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:forge-cli-help-label-command-$line[1]:"
+        case $line[1] in
+            (list)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(audit)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(ensure)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
 (inbox)
 _arguments "${_arguments_options[@]}" : \
 ":: :_forge-cli__subcmd__help__subcmd__inbox_commands" \
@@ -963,6 +1094,7 @@ _forge-cli_commands() {
     local commands; commands=(
 'pr:Pull / merge request lifecycle' \
 'issue:Issue lifecycle' \
+'label:Repository label catalog audit and ensure operations' \
 'inbox:Personal cross-repo work inbox' \
 'repo:Repository helpers' \
 'auth:Backend authentication helpers' \
@@ -1012,6 +1144,7 @@ _forge-cli__subcmd__help_commands() {
     local commands; commands=(
 'pr:Pull / merge request lifecycle' \
 'issue:Issue lifecycle' \
+'label:Repository label catalog audit and ensure operations' \
 'inbox:Personal cross-repo work inbox' \
 'repo:Repository helpers' \
 'auth:Backend authentication helpers' \
@@ -1113,6 +1246,30 @@ _forge-cli__subcmd__help__subcmd__issue__subcmd__reopen_commands() {
 _forge-cli__subcmd__help__subcmd__issue__subcmd__view_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli help issue view commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__label_commands] )) ||
+_forge-cli__subcmd__help__subcmd__label_commands() {
+    local commands; commands=(
+'list:List repository labels through the selected provider backend' \
+'audit:Compare repository labels against a machine-readable catalog' \
+'ensure:Create missing labels and optionally update color / description drift' \
+    )
+    _describe -t commands 'forge-cli help label commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__label__subcmd__audit_commands] )) ||
+_forge-cli__subcmd__help__subcmd__label__subcmd__audit_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli help label audit commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__label__subcmd__ensure_commands] )) ||
+_forge-cli__subcmd__help__subcmd__label__subcmd__ensure_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli help label ensure commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__label__subcmd__list_commands] )) ||
+_forge-cli__subcmd__help__subcmd__label__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli help label list commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__help__subcmd__pr_commands] )) ||
 _forge-cli__subcmd__help__subcmd__pr_commands() {
@@ -1355,6 +1512,61 @@ _forge-cli__subcmd__issue__subcmd__reopen_commands() {
 _forge-cli__subcmd__issue__subcmd__view_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli issue view commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__label_commands] )) ||
+_forge-cli__subcmd__label_commands() {
+    local commands; commands=(
+'list:List repository labels through the selected provider backend' \
+'audit:Compare repository labels against a machine-readable catalog' \
+'ensure:Create missing labels and optionally update color / description drift' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'forge-cli label commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__label__subcmd__audit_commands] )) ||
+_forge-cli__subcmd__label__subcmd__audit_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli label audit commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__label__subcmd__ensure_commands] )) ||
+_forge-cli__subcmd__label__subcmd__ensure_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli label ensure commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__label__subcmd__help_commands] )) ||
+_forge-cli__subcmd__label__subcmd__help_commands() {
+    local commands; commands=(
+'list:List repository labels through the selected provider backend' \
+'audit:Compare repository labels against a machine-readable catalog' \
+'ensure:Create missing labels and optionally update color / description drift' \
+'help:Print this message or the help of the given subcommand(s)' \
+    )
+    _describe -t commands 'forge-cli label help commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__label__subcmd__help__subcmd__audit_commands] )) ||
+_forge-cli__subcmd__label__subcmd__help__subcmd__audit_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli label help audit commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__label__subcmd__help__subcmd__ensure_commands] )) ||
+_forge-cli__subcmd__label__subcmd__help__subcmd__ensure_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli label help ensure commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__label__subcmd__help__subcmd__help_commands] )) ||
+_forge-cli__subcmd__label__subcmd__help__subcmd__help_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli label help help commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__label__subcmd__help__subcmd__list_commands] )) ||
+_forge-cli__subcmd__label__subcmd__help__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli label help list commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__label__subcmd__list_commands] )) ||
+_forge-cli__subcmd__label__subcmd__list_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli label list commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__pr_commands] )) ||
 _forge-cli__subcmd__pr_commands() {

--- a/crates/forge-cli/Cargo.toml
+++ b/crates/forge-cli/Cargo.toml
@@ -23,6 +23,7 @@ libc = "0.2"
 nils-common = { version = "0.20.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
+serde_yaml_ng = { workspace = true }
 tempfile = "3"
 thiserror = { workspace = true }
 toml = { workspace = true }

--- a/crates/forge-cli/README.md
+++ b/crates/forge-cli/README.md
@@ -1,9 +1,9 @@
 # forge-cli
 
 Provider-neutral CLI for remote forge operations (personal inbox discovery,
-PR/MR lifecycle, Issue lifecycle, CI wait). Two backends ship together: GitHub
-(wraps `gh`) and GitLab (wraps `glab`). Adopts `cli-output-contract-v1` from
-day one.
+PR/MR lifecycle, Issue lifecycle, CI wait, and repository label catalog
+maintenance). Two backends ship together: GitHub (wraps `gh`) and GitLab
+(wraps `glab`). Adopts `cli-output-contract-v1` from day one.
 
 ## Read first
 
@@ -19,6 +19,7 @@ day one.
 cargo run -p nils-forge-cli -- --help
 cargo run -p nils-forge-cli -- inbox status --format json
 cargo run -p nils-forge-cli -- auth status --format json
+cargo run -p nils-forge-cli -- label audit --catalog labels.yaml --format json
 cargo run -p nils-forge-cli -- pr deliver --kind feature --dry-run --format json
 ```
 
@@ -104,6 +105,28 @@ forge-cli --dry-run --format json inbox list --item-type pr
 
 GitLab `todos` are classified by `target_type` (or the target URL); todos whose
 target cannot be classified appear only in `--item-type all` mode.
+
+## Label catalog operations
+
+`forge-cli label` keeps provider labels aligned with a caller-owned YAML/JSON
+catalog. The catalog remains outside `nils-cli`; `forge-cli` only validates,
+audits, and applies the provider operations.
+
+```sh
+forge-cli label list --format json
+forge-cli label audit --catalog manifests/forge-labels.yaml --format json
+forge-cli --dry-run label ensure --catalog manifests/forge-labels.yaml --update-existing --format json
+```
+
+`label audit` reports missing catalog labels, color / description drift, and
+unknown shared labels. `label ensure` creates missing labels and updates
+existing color / description drift only with `--update-existing`; it never
+deletes labels or renames labels by default.
+
+`pr create` and `pr deliver` accept repeated `--label <name>` flags. Add
+`--label-catalog <path> --strict-labels` when the caller wants `forge-cli` to
+reject unknown, not-applicable, or mutually exclusive labels before a PR/MR is
+opened.
 
 ### Latency notes
 

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -67,6 +67,10 @@ validations_catalog:
     rule: "--keep-branch and --delete-branch are mutually exclusive"
     error_kind: keep_branch_conflict
     exit: DATA
+  label_catalog:
+    rule: "when --strict-labels is set, every selected label exists in --label-catalog, applies to the target, and exclusive groups do not conflict"
+    error_kind: label_unknown | label_not_applicable | label_group_conflict | label_catalog_missing
+    exit: DATA
 
 # ---------------------------------------------------------------------------
 # Global flags every subcommand inherits.
@@ -106,12 +110,15 @@ operations:
       - { name: --draft,       type: bool,           default: true }
       - { name: --reviewer,    type: list<string>,   default: [] }
       - { name: --label,       type: list<string>,   default: [] }
+      - { name: --label-catalog, type: path,          required: false }
+      - { name: --strict-labels, type: bool,          default: false }
     validations:
       - branch_name
       - branch_kind_matches
       - title_length
       - body_summary
       - body_test_plan
+      - label_catalog # only when --strict-labels is set
       - worktree_clean
       - head_pushed
     backends:
@@ -378,6 +385,62 @@ operations:
       github: { program: gh,   argv: [issue, reopen, "{id}"] }
       gitlab: { program: glab, argv: [issue, reopen, "{id}"] }
 
+  - id: label.list
+    schema_version: cli.forge-cli.label.list.v1
+    summary: List repository labels from the selected provider.
+    inputs:
+      - { name: --limit, type: integer, default: 200 }
+    validations: []
+    backends:
+      github: { program: gh,   argv: [label, list, --limit, "{limit}", --json, "id,name,color,description"] }
+      gitlab: { program: glab, argv: [label, list, --output, json, --per-page, "{limit}"] }
+    output:
+      data:
+        provider: enum<github|gitlab>
+        labels: list<{ id, name, color, description }>
+
+  - id: label.audit
+    schema_version: cli.forge-cli.label.audit.v1
+    summary: Compare repository labels against a caller-owned catalog.
+    inputs:
+      - { name: --catalog, type: path, required: true }
+      - { name: --limit,   type: integer, default: 200 }
+    validations: []
+    backends:
+      github: { derives_from: label.list }
+      gitlab: { derives_from: label.list }
+    output:
+      data:
+        provider: enum<github|gitlab>
+        status: enum<pass|fail>
+        missing: list<{ name, group, color, description, applies_to }>
+        drift: "list of { name, current, expected, fields }"
+        unknown_shared: list<{ id, name, color, description }>
+
+  - id: label.ensure
+    schema_version: cli.forge-cli.label.ensure.v1
+    summary: Create missing catalog labels and optionally update color / description drift.
+    inputs:
+      - { name: --catalog,         type: path, required: true }
+      - { name: --update-existing, type: bool, default: false }
+      - { name: --limit,           type: integer, default: 200 }
+    validations: []
+    backends:
+      github:
+        list: { derives_from: label.list }
+        create: { program: gh, argv: [label, create, "{name}", --color, "{color}", --description, "{description}"] }
+        update: { program: gh, argv: [label, edit, "{name}", --color, "{color}", --description, "{description}"] }
+      gitlab:
+        list: { derives_from: label.list }
+        create: { program: glab, argv: [label, create, --name, "{name}", --color, "#{color}", --description, "{description}"] }
+        update: { program: glab, argv: [label, edit, --label-id, "{id}", --color, "#{color}", --description, "{description}"] }
+    output:
+      data:
+        provider: enum<github|gitlab>
+        dry_run: bool
+        actions: "list of create/update action plans or applied actions"
+    notes: "Never deletes labels or renames labels by default. Existing color / description drift is updated only with --update-existing."
+
   - id: repo.view
     schema_version: cli.forge-cli.repo.view.v1
     summary: Resolve repo slug, default branch, default merge method.
@@ -495,6 +558,9 @@ macros:
       - { name: --base,                     type: string,                       default: repo-default-branch }
       - { name: --method,                   type: enum<squash|merge|rebase>,    default: squash }
       - { name: --reviewer,                 type: list<string>,                 default: [] }
+      - { name: --label,                    type: list<string>,                 default: [] }
+      - { name: --label-catalog,            type: path,                         required: false }
+      - { name: --strict-labels,            type: bool,                         default: false }
       - { name: --timeout,                  type: duration,                     default: 30m }
       - { name: --no-merge,                 type: bool,                         default: false }
       - { name: --allow-non-default-base,   type: bool,                         default: false }

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -16,6 +16,8 @@ Goals:
 - Replace ad-hoc `gh`/`glab` invocations scattered across agent-kit
   skills with one binary that enforces branch / body / state policy at
   the type level.
+- Manage provider labels from a caller-supplied machine-readable catalog
+  without making `forge-cli` the taxonomy source of truth.
 - Make the GitHub and GitLab lanes byte-identical from the caller's
   point of view (same flags, same envelope, same exit codes).
 - Codify defaults that were previously only described in skill
@@ -29,7 +31,6 @@ Goals:
 Non-goals (v1):
 
 - Release management (`gh release`, GitLab releases).
-- Label management.
 - Arbitrary `gh api` / GitLab REST passthrough — no escape hatch in v1
   on purpose; if a workflow needs it, the call belongs in a focused
   follow-up op, not a generic shim. **Deferred to v2** — see "Open
@@ -52,12 +53,15 @@ In scope (v1):
   (blocking poll until terminal).
 - Issue lifecycle: `issue create`, `view`, `edit`, `comment`, `close`,
   `reopen`.
+- Repository label lifecycle: `label list`, `label audit`, and
+  `label ensure`.
 - Read-only helpers used by the macros: `auth status`, `repo view`.
 - Macro ops: `pr deliver` (kind = `feature` | `bug`), composing the
   atoms above into the agent-kit standard "open draft → wait CI →
   ready → merge → cleanup" flow.
 
-Out of scope (v1): inbox mutations, release management, labels, raw REST
+Out of scope (v1): inbox mutations, release management, label deletion or
+rename-by-default, raw REST
 passthrough, issue macros, repo creation, branch protection management, code
 review state mutation beyond `pr ready`. Each of these would either widen the
 parity gap (GitLab has no equivalent today) or remove the "lock down behaviour"
@@ -110,6 +114,9 @@ Parity matrix (v1):
 | `issue comment <id>`  | `gh issue comment <id> --body …`                                | `glab issue note <id> --message …`                   | exact                                |
 | `issue close <id>`    | `gh issue close <id>`                                           | `glab issue close <id>`                              | exact                                |
 | `issue reopen <id>`   | `gh issue reopen <id>`                                          | `glab issue reopen <id>`                             | exact                                |
+| `label list`          | `gh label list --json …`                                        | `glab label list --output json`                      | exact                                |
+| `label audit`         | read labels, compare with caller catalog                        | same                                                 | exact                                |
+| `label ensure`        | `gh label create/edit`                                          | `glab label create/edit`                             | exact (no delete/rename by default)  |
 | `auth status`         | `gh auth status`                                                | `glab auth status`                                   | exact (text → typed)                 |
 | `repo view`           | `gh repo view --json …`                                         | `glab repo view -F json`                             | exact                                |
 | `inbox list`          | `gh search prs/issues --json …`                                 | `glab api --hostname <host> …`                       | normalized aggregation               |
@@ -152,6 +159,10 @@ forge-cli
 │   ├── comment
 │   ├── close
 │   └── reopen
+├── label
+│   ├── list
+│   ├── audit
+│   └── ensure
 ├── inbox
 │   ├── status
 │   ├── list
@@ -172,7 +183,8 @@ Global flags (every subcommand):
   backend's `--repo` / `-R` equivalent).
 - `--dry-run` — render the backend command that *would* run plus all
   validation checks, but do not invoke it. Output envelope carries the
-  exact argv under `data.plan`.
+  exact argv under `data.plan` for atomic commands or `data.actions[].plan`
+  for `label ensure`.
 
 `forge-cli` itself does not expose `--token`, `--host`, or any auth
 override. Those belong to `gh`/`glab` and are configured there.
@@ -223,6 +235,19 @@ Inbox-local flags:
   age-bounded by `--cache-max-age` (default `30m`), and disabled with
   `--no-cache`.
 
+Label-local flags:
+
+- `forge-cli label list --limit <n>` reads provider labels and emits
+  `cli.forge-cli.label.list.v1`.
+- `forge-cli label audit --catalog <path> --limit <n>` compares provider
+  labels to the caller-owned catalog and reports missing labels, color /
+  description drift, and unknown shared labels.
+- `forge-cli label ensure --catalog <path> [--update-existing]` creates
+  missing labels and updates existing color / description drift only when
+  explicitly requested. It never deletes or renames labels by default.
+- `pr create` and `pr deliver` accept `--label <name>` repeatedly. Catalog
+  validation is opt-in via `--label-catalog <path> --strict-labels`.
+
 ## Atomic op surface
 
 The full machine-readable list lives in
@@ -235,7 +260,8 @@ backend mapping, validation rules, and output schema versions.
 - Input: `--head <branch>` (default current branch), `--base <branch>`
   (default repo default branch), `--title <str>`, `--body-file <path>`
   or `--body <str>`, `--kind feature|bug`, `--draft` (default `true`),
-  `--reviewer <user>...`, `--label <name>...`.
+  `--reviewer <user>...`, `--label <name>...`,
+  `--label-catalog <path>`, `--strict-labels`.
 - Validation (see "Lock-down policy" for the full list):
   - branch name MUST match `^(feat|fix)/[a-z0-9][a-z0-9-]{1,63}$` and
     align with `--kind`;
@@ -285,6 +311,22 @@ backend mapping, validation rules, and output schema versions.
 - Output schema: `cli.forge-cli.pr.merge.v1`,
   `data = { number, url, merge_sha, method, deleted_branch }`.
 
+### `label audit` / `label ensure`
+
+- Input: `--catalog <path>` pointing at a caller-owned YAML/JSON catalog with
+  `groups[]` and `labels[]`. Labels declare `name`, `group`, `color`,
+  `description`, and `applies_to`.
+- `label audit` emits `cli.forge-cli.label.audit.v1` with
+  `data = { provider, status, missing, drift, unknown_shared }`.
+- `label ensure` emits `cli.forge-cli.label.ensure.v1` with
+  `data.actions[]` create/update plans. Missing labels are created; existing
+  label drift is updated only with `--update-existing`.
+- Provider behavior:
+  - GitHub: `gh label list/create/edit`.
+  - GitLab: `glab label list/create/edit`.
+- Non-goals: deletion, rename-by-default, and moving catalog ownership into
+  `nils-cli`.
+
 (See `forge-cli-ops-v1.yaml` for the remaining ops.)
 
 ## Macro: `pr deliver`
@@ -303,6 +345,8 @@ forge-cli pr deliver \
   [--base <branch>] [--head <branch>] \
   [--method squash|merge|rebase] \
   [--reviewer <user>...] \
+  [--label <name>...] \
+  [--label-catalog <path> --strict-labels] \
   [--timeout <duration>] \
   [--no-merge]        # stop after wait-checks; useful in CI
 ```
@@ -612,8 +656,6 @@ and `glab mr create …` invocations are removed.
 
 - Releases (`gh release create / view / edit`) — GitLab requires
   glab + tag flow; could fit a `forge-cli release …` tree later.
-- Labels (`gh label create`) — currently used once in agent-kit
-  (label bootstrap on a new repo). Either v2 op or one-off script.
 - `gh api` passthrough — explicitly out of v1 because it defeats the
   lock-down value. Re-evaluate if a real workflow needs a non-CRUD
   call (e.g. CODEOWNERS, branch protection) and only then.

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -108,6 +108,8 @@ pub enum Command {
     Pr(PrArgs),
     /// Issue lifecycle.
     Issue(IssueArgs),
+    /// Repository label catalog audit and ensure operations.
+    Label(LabelArgs),
     /// Personal cross-repo work inbox.
     Inbox(InboxArgs),
     /// Repository helpers.
@@ -128,6 +130,12 @@ pub struct PrArgs {
 pub struct IssueArgs {
     #[command(subcommand)]
     pub command: Option<IssueCommand>,
+}
+
+#[derive(Args, Debug)]
+pub struct LabelArgs {
+    #[command(subcommand)]
+    pub command: Option<LabelCommand>,
 }
 
 #[derive(Args, Debug)]
@@ -496,6 +504,12 @@ pub struct PrCreateArgs {
     /// Add a label (repeatable).
     #[arg(long = "label", value_name = "LABEL")]
     pub labels: Vec<String>,
+    /// Validate labels against this catalog when `--strict-labels` is set.
+    #[arg(long = "label-catalog", value_name = "PATH")]
+    pub label_catalog: Option<String>,
+    /// Fail when selected labels are missing, not applicable, or conflict.
+    #[arg(long = "strict-labels", action = ArgAction::SetTrue)]
+    pub strict_labels: bool,
 }
 
 /// `pr` subtree.
@@ -531,6 +545,47 @@ pub enum PrCommand {
     Deliver(PrDeliverArgs),
 }
 
+/// `label` subtree.
+#[derive(Subcommand, Debug)]
+pub enum LabelCommand {
+    /// List repository labels through the selected provider backend.
+    List(LabelListArgs),
+    /// Compare repository labels against a machine-readable catalog.
+    Audit(LabelAuditArgs),
+    /// Create missing labels and optionally update color / description drift.
+    Ensure(LabelEnsureArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct LabelListArgs {
+    /// Maximum labels to fetch from the provider.
+    #[arg(long, default_value_t = 200)]
+    pub limit: u32,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct LabelAuditArgs {
+    /// Path to the shared forge label catalog.
+    #[arg(long, value_name = "PATH")]
+    pub catalog: String,
+    /// Maximum labels to fetch from the provider.
+    #[arg(long, default_value_t = 200)]
+    pub limit: u32,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct LabelEnsureArgs {
+    /// Path to the shared forge label catalog.
+    #[arg(long, value_name = "PATH")]
+    pub catalog: String,
+    /// Update color / description drift on existing labels.
+    #[arg(long = "update-existing", action = ArgAction::SetTrue)]
+    pub update_existing: bool,
+    /// Maximum labels to fetch from the provider.
+    #[arg(long, default_value_t = 200)]
+    pub limit: u32,
+}
+
 /// `pr deliver` arguments. Maps to
 /// `forge-cli-ops-v1.yaml::operations.pr.deliver` inputs.
 #[derive(Args, Debug, Clone)]
@@ -559,6 +614,15 @@ pub struct PrDeliverArgs {
     /// Add a reviewer (repeatable).
     #[arg(long = "reviewer", value_name = "USER")]
     pub reviewers: Vec<String>,
+    /// Add a label to the created PR / MR (repeatable).
+    #[arg(long = "label", value_name = "LABEL")]
+    pub labels: Vec<String>,
+    /// Validate labels against this catalog when `--strict-labels` is set.
+    #[arg(long = "label-catalog", value_name = "PATH")]
+    pub label_catalog: Option<String>,
+    /// Fail when selected labels are missing, not applicable, or conflict.
+    #[arg(long = "strict-labels", action = ArgAction::SetTrue)]
+    pub strict_labels: bool,
     /// CI-wait budget before declaring `checks_timeout` (default `30m`).
     #[arg(long, value_parser = parse_duration, default_value = "30m")]
     pub timeout: Duration,
@@ -888,6 +952,9 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
         Some(Command::Issue(IssueArgs {
             command: Some(IssueCommand::Reopen { id }),
         })) => ops::issue_reopen::run(&global, id, format),
+        Some(Command::Label(LabelArgs {
+            command: Some(command),
+        })) => ops::label::run(&global, command, format),
         Some(Command::Inbox(InboxArgs {
             command: Some(command),
         })) => ops::inbox::run(&global, command, format),
@@ -897,6 +964,7 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
         | Some(Command::Repo(RepoArgs { command: None }))
         | Some(Command::Pr(PrArgs { command: None }))
         | Some(Command::Issue(IssueArgs { command: None }))
+        | Some(Command::Label(LabelArgs { command: None }))
         | Some(Command::Inbox(InboxArgs { command: None })) => {
             // No subcommand: print help and exit USAGE so callers don't
             // mistake the no-op for success.
@@ -1164,14 +1232,30 @@ mod tests {
 
     #[test]
     fn lists_every_issue_v1_subcommand() {
-        for sub in ["create", "view", "edit", "comment", "close", "reopen"] {
+        for sub in [
+            "create", "view", "list", "edit", "comment", "close", "reopen",
+        ] {
             let argv: Vec<&str> = match sub {
                 "create" => vec!["issue", "create", "--title", "demo"],
+                "list" => vec!["issue", "list"],
                 "comment" | "edit" => vec!["issue", sub, "1"],
                 _ => vec!["issue", sub, "1"],
             };
             let result = parse(&argv);
             assert!(result.is_ok(), "issue {sub} should parse, got {result:?}");
+        }
+    }
+
+    #[test]
+    fn lists_every_label_v1_subcommand() {
+        for sub in ["list", "audit", "ensure"] {
+            let argv: Vec<&str> = match sub {
+                "list" => vec!["label", "list"],
+                "audit" | "ensure" => vec!["label", sub, "--catalog", "labels.yaml"],
+                _ => unreachable!(),
+            };
+            let result = parse(&argv);
+            assert!(result.is_ok(), "label {sub} should parse, got {result:?}");
         }
     }
 

--- a/crates/forge-cli/src/macros/pr_deliver.rs
+++ b/crates/forge-cli/src/macros/pr_deliver.rs
@@ -321,7 +321,9 @@ fn build_create_args(args: &PrDeliverArgs, default_branch: &str) -> PrCreateArgs
         kind: args.kind,
         no_draft: false,
         reviewers: args.reviewers.clone(),
-        labels: Vec::new(),
+        labels: args.labels.clone(),
+        label_catalog: args.label_catalog.clone(),
+        strict_labels: args.strict_labels,
     }
 }
 
@@ -431,6 +433,19 @@ fn pr_create_dry_plan(ctx: &ProviderContext, args: &PrDeliverArgs) -> Vec<String
         argv.extend_from_slice(&["--body", "<inline>"]);
     } else if args.body_file.is_some() {
         argv.extend_from_slice(&["--body-file", "<path>"]);
+    }
+    let joined_labels = args.labels.join(",");
+    match ctx.provider {
+        Provider::GitHub => {
+            for label in &args.labels {
+                argv.extend_from_slice(&["--label", label]);
+            }
+        }
+        Provider::GitLab => {
+            if !args.labels.is_empty() {
+                argv.extend_from_slice(&["--label", &joined_labels]);
+            }
+        }
     }
     let mut out = vec![
         BackendProgram::for_provider(ctx.provider)
@@ -621,6 +636,9 @@ mod tests {
             base: Some("main".into()),
             method: MergeMethodFlag::Squash,
             reviewers: Vec::new(),
+            labels: Vec::new(),
+            label_catalog: None,
+            strict_labels: false,
             timeout: std::time::Duration::from_secs(30 * 60),
             no_merge,
             allow_non_default_base: false,

--- a/crates/forge-cli/src/ops/label.rs
+++ b/crates/forge-cli/src/ops/label.rs
@@ -880,7 +880,7 @@ mod tests {
                 id: None,
                 name: "status::unknown".into(),
                 color: "000000".into(),
-                description: "Legacy".into(),
+                description: "Unknown shared".into(),
             },
             ProviderLabel {
                 id: None,

--- a/crates/forge-cli/src/ops/label.rs
+++ b/crates/forge-cli/src/ops/label.rs
@@ -672,10 +672,262 @@ fn render_ensure_text(payload: &LabelEnsurePayload) {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn group(name: &str, prefix: &str, exclusive: bool, allow_extensions: bool) -> CatalogGroup {
+        CatalogGroup {
+            name: name.into(),
+            prefix: prefix.into(),
+            exclusive,
+            allow_extensions,
+        }
+    }
+
+    fn label(name: &str, group: &str, color: &str, description: &str) -> CatalogLabel {
+        CatalogLabel {
+            name: name.into(),
+            group: group.into(),
+            color: color.into(),
+            description: description.into(),
+            applies_to: Vec::new(),
+        }
+    }
+
+    fn ctx(provider: Provider, repo: Option<&str>) -> ProviderContext {
+        ProviderContext {
+            provider,
+            host: match provider {
+                Provider::GitHub => "github.com",
+                Provider::GitLab => "gitlab.com",
+            }
+            .into(),
+            source: crate::provider::DetectionSource::Flag,
+            repo: repo.map(str::to_string),
+        }
+    }
+
+    fn argv(call: &BackendCall) -> Vec<String> {
+        call.argv
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn write_catalog(dir: &Path, body: &str) -> String {
+        let path = dir.join("forge-labels.yaml");
+        std::fs::write(&path, body).expect("write label catalog");
+        path.to_string_lossy().into_owned()
+    }
 
     #[test]
     fn normalize_color_drops_hash_and_uppercases() {
         assert_eq!(normalize_color("#d73a4a"), "D73A4A");
+    }
+
+    #[test]
+    fn parse_list_output_accepts_provider_shapes() {
+        let output = BackendSuccess {
+            stdout: r##"[
+              {"id": 123, "name": "type::bug", "color": "#d73a4a", "description": "Bug"},
+              {"name": "area::runtime", "description": null}
+            ]"##
+            .into(),
+            stderr: String::new(),
+        };
+
+        let labels = parse_list_output(&ctx(Provider::GitHub, None), &output).expect("parse");
+
+        assert_eq!(
+            labels,
+            vec![
+                ProviderLabel {
+                    id: Some("123".into()),
+                    name: "type::bug".into(),
+                    color: "D73A4A".into(),
+                    description: "Bug".into(),
+                },
+                ProviderLabel {
+                    id: None,
+                    name: "area::runtime".into(),
+                    color: String::new(),
+                    description: String::new(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_list_output_rejects_invalid_json_shapes() {
+        let invalid = BackendSuccess {
+            stdout: "{not-json".into(),
+            stderr: String::new(),
+        };
+        assert_eq!(
+            parse_list_output(&ctx(Provider::GitHub, None), &invalid)
+                .expect_err("invalid json")
+                .kind(),
+            "software_error"
+        );
+
+        let object = BackendSuccess {
+            stdout: r#"{"labels":[]}"#.into(),
+            stderr: String::new(),
+        };
+        assert_eq!(
+            parse_list_output(&ctx(Provider::GitLab, None), &object)
+                .expect_err("array required")
+                .kind(),
+            "software_error"
+        );
+    }
+
+    #[test]
+    fn provider_calls_render_expected_backend_arguments() {
+        let expected = label("type::bug", "type", "D73A4A", "Bug");
+        let current = ProviderLabel {
+            id: Some("42".into()),
+            name: "type::bug".into(),
+            color: "FFFFFF".into(),
+            description: "Old".into(),
+        };
+
+        assert_eq!(
+            argv(&build_list_call(
+                &ctx(Provider::GitHub, Some("sympoies/nils-cli")),
+                25
+            )),
+            vec![
+                "label",
+                "list",
+                "--limit",
+                "25",
+                "--json",
+                "id,name,color,description",
+                "--repo",
+                "sympoies/nils-cli"
+            ]
+        );
+        assert_eq!(
+            argv(&build_create_call(&ctx(Provider::GitLab, None), &expected)),
+            vec![
+                "label",
+                "create",
+                "--name",
+                "type::bug",
+                "--color",
+                "#D73A4A",
+                "--description",
+                "Bug"
+            ]
+        );
+        assert_eq!(
+            argv(
+                &build_update_call(
+                    &ctx(Provider::GitLab, Some("group/project")),
+                    &expected,
+                    &current,
+                )
+                .expect("gitlab update")
+            ),
+            vec![
+                "label",
+                "edit",
+                "--label-id",
+                "42",
+                "--color",
+                "#D73A4A",
+                "--description",
+                "Bug",
+                "--repo",
+                "group/project"
+            ]
+        );
+        assert!(
+            build_update_call(
+                &ctx(Provider::GitLab, None),
+                &expected,
+                &ProviderLabel {
+                    id: None,
+                    ..current
+                },
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn audit_reports_missing_drift_and_unknown_shared_labels() {
+        let catalog = Catalog {
+            labels: vec![
+                label("type::bug", "type", "D73A4A", "Bug"),
+                label("status::blocked", "status", "B60205", "Blocked"),
+            ],
+            groups: vec![
+                group("type", "type::", true, false),
+                group("status", "status::", true, false),
+                group("area", "area::", false, true),
+            ],
+        };
+        let current = vec![
+            ProviderLabel {
+                id: None,
+                name: "type::bug".into(),
+                color: "FFFFFF".into(),
+                description: "Bug".into(),
+            },
+            ProviderLabel {
+                id: None,
+                name: "status::unknown".into(),
+                color: "000000".into(),
+                description: "Legacy".into(),
+            },
+            ProviderLabel {
+                id: None,
+                name: "area::repo-local".into(),
+                color: "000000".into(),
+                description: "Allowed extension".into(),
+            },
+        ];
+
+        let audit = audit_labels(&catalog, &current);
+
+        assert_eq!(audit.missing[0].name, "status::blocked");
+        assert_eq!(audit.drift[0].fields[0].field, "color");
+        assert_eq!(audit.unknown_shared[0].name, "status::unknown");
+    }
+
+    #[test]
+    fn catalog_loader_infers_groups_and_rejects_empty_catalogs() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let path = write_catalog(
+            tempdir.path(),
+            r##"
+groups:
+  - name: type
+    prefix: "type::"
+labels:
+  - name: "type::bug"
+    color: "#d73a4a"
+    description: Bug
+"##,
+        );
+
+        let catalog = load_catalog(&path).expect("catalog");
+        assert_eq!(catalog.labels[0].group, "type");
+        assert_eq!(catalog.labels[0].color, "D73A4A");
+
+        let empty = write_catalog(
+            tempdir.path(),
+            r##"
+groups: []
+labels: []
+"##,
+        );
+        assert_eq!(
+            load_catalog(&empty).expect_err("empty catalog").kind(),
+            "label_catalog_empty"
+        );
     }
 
     #[test]
@@ -718,5 +970,29 @@ mod tests {
             )
             .expect_err("exclusive conflict");
         assert_eq!(err.kind(), "label_group_conflict");
+    }
+
+    #[test]
+    fn validation_rejects_unknown_and_non_applicable_labels() {
+        let catalog = Catalog {
+            labels: vec![CatalogLabel {
+                name: "type::maintenance".into(),
+                group: "type".into(),
+                color: "0E8A16".into(),
+                description: String::new(),
+                applies_to: vec!["pr".into()],
+            }],
+            groups: vec![group("type", "type::", true, false)],
+        };
+
+        let unknown = catalog
+            .validate_selected_labels(&["area::local".into()], LabelTarget::Pr)
+            .expect_err("unknown label");
+        assert_eq!(unknown.kind(), "label_unknown");
+
+        let not_applicable = catalog
+            .validate_selected_labels(&["type::maintenance".into()], LabelTarget::Issue)
+            .expect_err("target mismatch");
+        assert_eq!(not_applicable.kind(), "label_not_applicable");
     }
 }

--- a/crates/forge-cli/src/ops/label.rs
+++ b/crates/forge-cli/src/ops/label.rs
@@ -1,0 +1,722 @@
+//! Provider-neutral repository label operations.
+//!
+//! The catalog lives outside `nils-cli`; this module intentionally accepts a
+//! small, explicit YAML/JSON shape and turns it into backend `gh label` /
+//! `glab label` calls without taking ownership of taxonomy policy.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsString;
+use std::fs;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::{Deserialize, Serialize};
+
+use crate::backend::{BackendCall, BackendProgram, BackendRunner, BackendSuccess, ProcessRunner};
+use crate::cli::{BINARY, GlobalFlags, LabelAuditArgs, LabelCommand, LabelEnsureArgs};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const LIST_SCHEMA: &str = "label.list";
+const AUDIT_SCHEMA: &str = "label.audit";
+const ENSURE_SCHEMA: &str = "label.ensure";
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ProviderLabel {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub name: String,
+    pub color: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LabelListPayload {
+    provider: &'static str,
+    labels: Vec<ProviderLabel>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LabelAuditPayload {
+    provider: &'static str,
+    status: &'static str,
+    missing: Vec<CatalogLabel>,
+    drift: Vec<LabelDrift>,
+    unknown_shared: Vec<ProviderLabel>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LabelEnsurePayload {
+    provider: &'static str,
+    dry_run: bool,
+    actions: Vec<EnsureAction>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EnsureAction {
+    kind: &'static str,
+    label: CatalogLabel,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    current: Option<ProviderLabel>,
+    fields: Vec<DriftField>,
+    plan: Vec<String>,
+    status: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LabelDrift {
+    name: String,
+    current: ProviderLabel,
+    expected: CatalogLabel,
+    fields: Vec<DriftField>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct DriftField {
+    field: &'static str,
+    expected: String,
+    actual: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CatalogRaw {
+    #[allow(dead_code)]
+    schema: Option<String>,
+    #[serde(default)]
+    groups: Vec<CatalogGroup>,
+    labels: Vec<CatalogLabelRaw>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CatalogGroup {
+    name: String,
+    prefix: String,
+    #[serde(default)]
+    exclusive: bool,
+    #[serde(default)]
+    allow_extensions: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CatalogLabelRaw {
+    name: String,
+    #[serde(default)]
+    group: Option<String>,
+    color: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    applies_to: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CatalogLabel {
+    pub name: String,
+    pub group: String,
+    pub color: String,
+    pub description: String,
+    pub applies_to: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct Catalog {
+    labels: Vec<CatalogLabel>,
+    groups: Vec<CatalogGroup>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabelTarget {
+    Issue,
+    Pr,
+    Mr,
+}
+
+impl LabelTarget {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Issue => "issue",
+            Self::Pr => "pr",
+            Self::Mr => "mr",
+        }
+    }
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    command: LabelCommand,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, command, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    command: LabelCommand,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
+
+    match command {
+        LabelCommand::List(args) => {
+            let labels = fetch_labels(runner, &ctx, args.limit)?;
+            Ok(emit_success(
+                schema_ok(LIST_SCHEMA),
+                LabelListPayload {
+                    provider: ctx.provider.as_str(),
+                    labels,
+                },
+                format,
+                render_list_text,
+            ))
+        }
+        LabelCommand::Audit(args) => run_audit(runner, &ctx, args, format),
+        LabelCommand::Ensure(args) => run_ensure(runner, global.dry_run, &ctx, args, format),
+    }
+}
+
+fn run_audit<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    args: LabelAuditArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let catalog = load_catalog(&args.catalog)?;
+    let current = fetch_labels(runner, ctx, args.limit)?;
+    let audit = audit_labels(&catalog, &current);
+    let status =
+        if audit.missing.is_empty() && audit.drift.is_empty() && audit.unknown_shared.is_empty() {
+            "pass"
+        } else {
+            "fail"
+        };
+    Ok(emit_success(
+        schema_ok(AUDIT_SCHEMA),
+        LabelAuditPayload {
+            provider: ctx.provider.as_str(),
+            status,
+            missing: audit.missing,
+            drift: audit.drift,
+            unknown_shared: audit.unknown_shared,
+        },
+        format,
+        render_audit_text,
+    ))
+}
+
+fn run_ensure<R: BackendRunner>(
+    runner: &R,
+    dry_run: bool,
+    ctx: &ProviderContext,
+    args: LabelEnsureArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let catalog = load_catalog(&args.catalog)?;
+    let current = fetch_labels(runner, ctx, args.limit)?;
+    let audit = audit_labels(&catalog, &current);
+    let mut actions = Vec::new();
+
+    for label in audit.missing {
+        let call = build_create_call(ctx, &label);
+        let plan = call.plan_argv();
+        if !dry_run {
+            let _ = runner.run(&call)?;
+        }
+        actions.push(EnsureAction {
+            kind: "create",
+            label,
+            current: None,
+            fields: Vec::new(),
+            plan,
+            status: if dry_run { "planned" } else { "applied" },
+        });
+    }
+
+    if args.update_existing {
+        for drift in audit.drift {
+            if let Some(call) = build_update_call(ctx, &drift.expected, &drift.current) {
+                let plan = call.plan_argv();
+                if !dry_run {
+                    let _ = runner.run(&call)?;
+                }
+                actions.push(EnsureAction {
+                    kind: "update",
+                    label: drift.expected,
+                    current: Some(drift.current),
+                    fields: drift.fields,
+                    plan,
+                    status: if dry_run { "planned" } else { "applied" },
+                });
+            }
+        }
+    }
+
+    Ok(emit_success(
+        schema_ok(ENSURE_SCHEMA),
+        LabelEnsurePayload {
+            provider: ctx.provider.as_str(),
+            dry_run,
+            actions,
+        },
+        format,
+        render_ensure_text,
+    ))
+}
+
+fn fetch_labels<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    limit: u32,
+) -> Result<Vec<ProviderLabel>, ForgeError> {
+    let call = build_list_call(ctx, limit);
+    let output = runner.run(&call)?;
+    parse_list_output(ctx, &output)
+}
+
+fn build_list_call(ctx: &ProviderContext, limit: u32) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let mut argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("label"),
+            OsString::from("list"),
+            OsString::from("--limit"),
+            OsString::from(limit.to_string()),
+            OsString::from("--json"),
+            OsString::from("id,name,color,description"),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("label"),
+            OsString::from("list"),
+            OsString::from("--output"),
+            OsString::from("json"),
+            OsString::from("--per-page"),
+            OsString::from(limit.to_string()),
+        ],
+    };
+    ctx.push_repo_override(&mut argv);
+    BackendCall::new(program, argv)
+}
+
+fn build_create_call(ctx: &ProviderContext, label: &CatalogLabel) -> BackendCall {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let mut argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("label"),
+            OsString::from("create"),
+            OsString::from(&label.name),
+            OsString::from("--color"),
+            OsString::from(&label.color),
+            OsString::from("--description"),
+            OsString::from(&label.description),
+        ],
+        Provider::GitLab => vec![
+            OsString::from("label"),
+            OsString::from("create"),
+            OsString::from("--name"),
+            OsString::from(&label.name),
+            OsString::from("--color"),
+            OsString::from(format!("#{}", label.color)),
+            OsString::from("--description"),
+            OsString::from(&label.description),
+        ],
+    };
+    ctx.push_repo_override(&mut argv);
+    BackendCall::new(program, argv)
+}
+
+fn build_update_call(
+    ctx: &ProviderContext,
+    expected: &CatalogLabel,
+    current: &ProviderLabel,
+) -> Option<BackendCall> {
+    let program = BackendProgram::for_provider(ctx.provider);
+    let mut argv: Vec<OsString> = match ctx.provider {
+        Provider::GitHub => vec![
+            OsString::from("label"),
+            OsString::from("edit"),
+            OsString::from(&expected.name),
+            OsString::from("--color"),
+            OsString::from(&expected.color),
+            OsString::from("--description"),
+            OsString::from(&expected.description),
+        ],
+        Provider::GitLab => {
+            let id = current.id.as_ref()?;
+            vec![
+                OsString::from("label"),
+                OsString::from("edit"),
+                OsString::from("--label-id"),
+                OsString::from(id),
+                OsString::from("--color"),
+                OsString::from(format!("#{}", expected.color)),
+                OsString::from("--description"),
+                OsString::from(&expected.description),
+            ]
+        }
+    };
+    ctx.push_repo_override(&mut argv);
+    Some(BackendCall::new(program, argv))
+}
+
+fn parse_list_output(
+    ctx: &ProviderContext,
+    output: &BackendSuccess,
+) -> Result<Vec<ProviderLabel>, ForgeError> {
+    let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            format!("{} label list JSON is invalid", ctx.provider.as_str()),
+            Some(e.to_string()),
+        )
+    })?;
+    let labels = value
+        .as_array()
+        .ok_or_else(|| {
+            ForgeError::software(
+                schema_err(),
+                "label list JSON must be an array",
+                Some(output.stdout.clone()),
+            )
+        })?
+        .iter()
+        .filter_map(parse_provider_label)
+        .collect();
+    Ok(labels)
+}
+
+fn parse_provider_label(value: &serde_json::Value) -> Option<ProviderLabel> {
+    let name = value.get("name")?.as_str()?.to_string();
+    let color = value
+        .get("color")
+        .and_then(|v| v.as_str())
+        .map(normalize_color)
+        .unwrap_or_default();
+    let description = value
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let id = value.get("id").and_then(|v| {
+        v.as_str()
+            .map(str::to_string)
+            .or_else(|| v.as_i64().map(|i| i.to_string()))
+            .or_else(|| v.as_u64().map(|i| i.to_string()))
+    });
+    Some(ProviderLabel {
+        id,
+        name,
+        color,
+        description,
+    })
+}
+
+struct AuditResult {
+    missing: Vec<CatalogLabel>,
+    drift: Vec<LabelDrift>,
+    unknown_shared: Vec<ProviderLabel>,
+}
+
+fn audit_labels(catalog: &Catalog, current: &[ProviderLabel]) -> AuditResult {
+    let current_by_name: BTreeMap<&str, &ProviderLabel> =
+        current.iter().map(|l| (l.name.as_str(), l)).collect();
+    let catalog_names: BTreeSet<&str> = catalog.labels.iter().map(|l| l.name.as_str()).collect();
+
+    let mut missing = Vec::new();
+    let mut drift = Vec::new();
+    for label in &catalog.labels {
+        let Some(current_label) = current_by_name.get(label.name.as_str()) else {
+            missing.push(label.clone());
+            continue;
+        };
+        let fields = drift_fields(label, current_label);
+        if !fields.is_empty() {
+            drift.push(LabelDrift {
+                name: label.name.clone(),
+                current: (*current_label).clone(),
+                expected: label.clone(),
+                fields,
+            });
+        }
+    }
+
+    let unknown_shared = current
+        .iter()
+        .filter(|label| {
+            !catalog_names.contains(label.name.as_str())
+                && catalog.is_known_shared_label(&label.name)
+        })
+        .cloned()
+        .collect();
+
+    AuditResult {
+        missing,
+        drift,
+        unknown_shared,
+    }
+}
+
+fn drift_fields(expected: &CatalogLabel, current: &ProviderLabel) -> Vec<DriftField> {
+    let mut fields = Vec::new();
+    if expected.color != current.color {
+        fields.push(DriftField {
+            field: "color",
+            expected: expected.color.clone(),
+            actual: current.color.clone(),
+        });
+    }
+    if expected.description != current.description {
+        fields.push(DriftField {
+            field: "description",
+            expected: expected.description.clone(),
+            actual: current.description.clone(),
+        });
+    }
+    fields
+}
+
+pub fn validate_label_inputs(
+    labels: &[String],
+    catalog_path: Option<&str>,
+    strict: bool,
+    target: LabelTarget,
+) -> Result<(), ForgeError> {
+    if !strict {
+        return Ok(());
+    }
+    let path = catalog_path.ok_or_else(|| {
+        ForgeError::validation(
+            schema_err(),
+            "label_catalog_missing",
+            "--strict-labels requires --label-catalog",
+            None,
+        )
+    })?;
+    let catalog = load_catalog(path)?;
+    catalog.validate_selected_labels(labels, target)
+}
+
+fn load_catalog(path: &str) -> Result<Catalog, ForgeError> {
+    let raw = fs::read_to_string(path).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            format!("failed to read label catalog '{path}'"),
+            Some(e.to_string()),
+        )
+    })?;
+    let parsed: CatalogRaw = serde_yaml_ng::from_str(&raw).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            format!("failed to parse label catalog '{path}'"),
+            Some(e.to_string()),
+        )
+    })?;
+    Catalog::from_raw(parsed)
+}
+
+impl Catalog {
+    fn from_raw(raw: CatalogRaw) -> Result<Self, ForgeError> {
+        if raw.labels.is_empty() {
+            return Err(ForgeError::validation(
+                schema_err(),
+                "label_catalog_empty",
+                "label catalog must contain at least one label",
+                None,
+            ));
+        }
+        let mut labels = Vec::with_capacity(raw.labels.len());
+        for label in raw.labels {
+            if label.name.trim().is_empty() {
+                return Err(ForgeError::validation(
+                    schema_err(),
+                    "label_catalog_invalid",
+                    "label catalog contains an empty label name",
+                    None,
+                ));
+            }
+            let group = label
+                .group
+                .clone()
+                .or_else(|| label.name.split_once("::").map(|(g, _)| g.to_string()))
+                .unwrap_or_default();
+            labels.push(CatalogLabel {
+                name: label.name,
+                group,
+                color: normalize_color(&label.color),
+                description: label.description,
+                applies_to: label.applies_to,
+            });
+        }
+        Ok(Self {
+            labels,
+            groups: raw.groups,
+        })
+    }
+
+    fn label_by_name(&self, name: &str) -> Option<&CatalogLabel> {
+        self.labels.iter().find(|label| label.name == name)
+    }
+
+    fn group_for_label(&self, name: &str) -> Option<&CatalogGroup> {
+        self.groups
+            .iter()
+            .find(|group| name.starts_with(&group.prefix))
+    }
+
+    fn is_extension_label(&self, name: &str) -> bool {
+        self.group_for_label(name)
+            .map(|group| group.allow_extensions)
+            .unwrap_or(false)
+    }
+
+    fn is_known_shared_label(&self, name: &str) -> bool {
+        self.group_for_label(name)
+            .map(|group| !group.allow_extensions)
+            .unwrap_or(false)
+    }
+
+    fn validate_selected_labels(
+        &self,
+        labels: &[String],
+        target: LabelTarget,
+    ) -> Result<(), ForgeError> {
+        let mut seen_exclusive: BTreeMap<String, String> = BTreeMap::new();
+        for name in labels {
+            let label = self.label_by_name(name);
+            if label.is_none() && !self.is_extension_label(name) {
+                return Err(ForgeError::validation(
+                    schema_err(),
+                    "label_unknown",
+                    format!("label '{name}' is not in the catalog"),
+                    None,
+                ));
+            }
+            if let Some(label) = label
+                && !label.applies_to.is_empty()
+                && !label.applies_to.iter().any(|v| v == target.as_str())
+            {
+                return Err(ForgeError::validation(
+                    schema_err(),
+                    "label_not_applicable",
+                    format!("label '{name}' does not apply to {}", target.as_str()),
+                    None,
+                ));
+            }
+            if let Some(group) = self.group_for_label(name)
+                && group.exclusive
+                && let Some(previous) = seen_exclusive.insert(group.name.clone(), name.to_string())
+            {
+                return Err(ForgeError::validation(
+                    schema_err(),
+                    "label_group_conflict",
+                    format!(
+                        "labels '{previous}' and '{name}' both belong to exclusive group '{}'",
+                        group.name
+                    ),
+                    None,
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn normalize_color(value: &str) -> String {
+    value.trim().trim_start_matches('#').to_ascii_uppercase()
+}
+
+fn schema_ok(op: &str) -> String {
+    schema_version_for(BINARY, op, SCHEMA_VERSION)
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_list_text(payload: &LabelListPayload) {
+    println!("{} labels: {}", payload.provider, payload.labels.len());
+}
+
+fn render_audit_text(payload: &LabelAuditPayload) {
+    println!(
+        "{} label audit: {} (missing={}, drift={}, unknown_shared={})",
+        payload.provider,
+        payload.status,
+        payload.missing.len(),
+        payload.drift.len(),
+        payload.unknown_shared.len()
+    );
+}
+
+fn render_ensure_text(payload: &LabelEnsurePayload) {
+    println!(
+        "{} label ensure: {} action(s){}",
+        payload.provider,
+        payload.actions.len(),
+        if payload.dry_run {
+            " planned"
+        } else {
+            " applied"
+        }
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn normalize_color_drops_hash_and_uppercases() {
+        assert_eq!(normalize_color("#d73a4a"), "D73A4A");
+    }
+
+    #[test]
+    fn extension_labels_are_valid_when_group_allows_extensions() {
+        let catalog = Catalog {
+            labels: vec![CatalogLabel {
+                name: "type::bug".into(),
+                group: "type".into(),
+                color: "D73A4A".into(),
+                description: String::new(),
+                applies_to: vec!["issue".into()],
+            }],
+            groups: vec![CatalogGroup {
+                name: "area".into(),
+                prefix: "area::".into(),
+                exclusive: true,
+                allow_extensions: true,
+            }],
+        };
+        catalog
+            .validate_selected_labels(&["area::local".into()], LabelTarget::Issue)
+            .expect("area extension should pass");
+    }
+
+    #[test]
+    fn exclusive_group_conflicts_are_rejected() {
+        let catalog = Catalog {
+            labels: Vec::new(),
+            groups: vec![CatalogGroup {
+                name: "type".into(),
+                prefix: "type::".into(),
+                exclusive: true,
+                allow_extensions: true,
+            }],
+        };
+        let err = catalog
+            .validate_selected_labels(
+                &["type::bug".into(), "type::feature".into()],
+                LabelTarget::Issue,
+            )
+            .expect_err("exclusive conflict");
+        assert_eq!(err.kind(), "label_group_conflict");
+    }
+}

--- a/crates/forge-cli/src/ops/mod.rs
+++ b/crates/forge-cli/src/ops/mod.rs
@@ -11,6 +11,7 @@ pub mod issue_edit;
 pub mod issue_list;
 pub mod issue_reopen;
 pub mod issue_view;
+pub mod label;
 pub mod pr_checks;
 pub mod pr_checks_gitlab;
 pub mod pr_close;

--- a/crates/forge-cli/src/ops/pr_create.rs
+++ b/crates/forge-cli/src/ops/pr_create.rs
@@ -32,6 +32,7 @@ use crate::backend::{
 use crate::cli::{BINARY, GlobalFlags, PrCreateArgs};
 use crate::envelope::emit_success;
 use crate::error::ForgeError;
+use crate::ops::label::{LabelTarget, validate_label_inputs};
 use crate::ops::repo_view;
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::validations::{
@@ -173,6 +174,16 @@ pub fn run_with<R: BackendRunner>(
     title_length(&args.title)?;
     body_summary(&body, &env.headings)?;
     body_test_plan(&body, &env.headings)?;
+    let label_target = match ctx.provider {
+        Provider::GitHub => LabelTarget::Pr,
+        Provider::GitLab => LabelTarget::Mr,
+    };
+    validate_label_inputs(
+        &args.labels,
+        args.label_catalog.as_deref(),
+        args.strict_labels,
+        label_target,
+    )?;
     worktree_clean(&env.workdir, |w| (env.git_status)(w))?;
     head_pushed(&env.workdir, |w| (env.head_state)(w))?;
 
@@ -237,6 +248,16 @@ pub fn compute<R: BackendRunner>(
     title_length(&args.title)?;
     body_summary(&body, &env.headings)?;
     body_test_plan(&body, &env.headings)?;
+    let label_target = match ctx.provider {
+        Provider::GitHub => LabelTarget::Pr,
+        Provider::GitLab => LabelTarget::Mr,
+    };
+    validate_label_inputs(
+        &args.labels,
+        args.label_catalog.as_deref(),
+        args.strict_labels,
+        label_target,
+    )?;
     worktree_clean(&env.workdir, |w| (env.git_status)(w))?;
     head_pushed(&env.workdir, |w| (env.head_state)(w))?;
 
@@ -757,6 +778,8 @@ mod tests {
             no_draft: false,
             reviewers: Vec::new(),
             labels: Vec::new(),
+            label_catalog: None,
+            strict_labels: false,
         }
     }
 

--- a/crates/forge-cli/tests/integration.rs
+++ b/crates/forge-cli/tests/integration.rs
@@ -10,6 +10,7 @@ mod integration {
     mod fixture_lint;
     mod inbox;
     mod issue_atoms;
+    mod label_ops;
     mod parity;
     mod pr_checks_github;
     mod pr_checks_gitlab;

--- a/crates/forge-cli/tests/integration/cli.rs
+++ b/crates/forge-cli/tests/integration/cli.rs
@@ -10,7 +10,15 @@ fn help_lists_every_top_level_subcommand() {
     let stub = StubEnv::new();
     let out = run_forge_cli(&stub, &["--help"]);
     assert_eq!(out.code, 0, "stderr={}", out.stderr);
-    for sub in ["pr", "issue", "inbox", "repo", "auth", "completion"] {
+    for sub in [
+        "pr",
+        "issue",
+        "label",
+        "inbox",
+        "repo",
+        "auth",
+        "completion",
+    ] {
         assert!(
             out.stdout.contains(sub),
             "--help missing {sub}: stdout={}",
@@ -32,6 +40,20 @@ fn inbox_cli_help_lists_every_v1_subcommand() {
         assert!(
             out.stdout.contains(sub),
             "inbox --help missing {sub}: stdout={}",
+            out.stdout
+        );
+    }
+}
+
+#[test]
+fn label_help_lists_every_v1_subcommand() {
+    let stub = StubEnv::new();
+    let out = run_forge_cli(&stub, &["label", "--help"]);
+    assert_eq!(out.code, 0);
+    for sub in ["list", "audit", "ensure"] {
+        assert!(
+            out.stdout.contains(sub),
+            "label --help missing {sub}: stdout={}",
             out.stdout
         );
     }

--- a/crates/forge-cli/tests/integration/label_ops.rs
+++ b/crates/forge-cli/tests/integration/label_ops.rs
@@ -1,0 +1,188 @@
+//! Integration tests for provider-neutral label catalog operations.
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+use super::support::{StubEnv, parse_envelope, run_forge_cli};
+
+fn write_catalog() -> (TempDir, String) {
+    let tempdir = TempDir::new().expect("tempdir");
+    let path = tempdir.path().join("forge-labels.yaml");
+    fs::write(
+        &path,
+        r#"schema: forge-label-catalog.v1
+groups:
+  - name: type
+    prefix: "type::"
+    exclusive: true
+  - name: area
+    prefix: "area::"
+    exclusive: true
+    allow_extensions: true
+labels:
+  - name: "type::bug"
+    group: type
+    color: d73a4a
+    description: Bug report or fix.
+    applies_to: [issue, pr, mr]
+  - name: "area::cli"
+    group: area
+    color: 1d76db
+    description: CLI surface.
+    applies_to: [issue, pr, mr]
+"#,
+    )
+    .expect("write catalog");
+    (tempdir, path.to_string_lossy().into_owned())
+}
+
+#[test]
+fn label_audit_github_reports_missing_and_drift() {
+    let (_tempdir, catalog) = write_catalog();
+    let stub = StubEnv::new().gh_stub(
+        r#"#!/bin/sh
+set -e
+case "$1 $2" in
+  "label list")
+    cat <<'EOF'
+[{"name":"type::bug","color":"ffffff","description":"old description"}]
+EOF
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 99
+    ;;
+esac
+"#,
+    );
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "label",
+            "audit",
+            "--catalog",
+            &catalog,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.label.audit.v1");
+    assert_eq!(env["data"]["provider"], "github");
+    assert_eq!(env["data"]["status"], "fail");
+    assert_eq!(env["data"]["missing"][0]["name"], "area::cli");
+    assert_eq!(env["data"]["drift"][0]["name"], "type::bug");
+    assert_eq!(env["data"]["drift"][0]["fields"][0]["field"], "color");
+}
+
+#[test]
+fn label_audit_gitlab_accepts_json_label_list() {
+    let (_tempdir, catalog) = write_catalog();
+    let stub = StubEnv::new().glab_stub(
+        r##"#!/bin/sh
+set -e
+case "$1 $2" in
+  "label list")
+    cat <<'EOF'
+[{"id":11,"name":"type::bug","color":"#D73A4A","description":"Bug report or fix."},{"id":12,"name":"area::cli","color":"#1D76DB","description":"CLI surface."}]
+EOF
+    ;;
+  *)
+    echo "unexpected glab args: $*" >&2
+    exit 99
+    ;;
+esac
+"##,
+    );
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "gitlab",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "label",
+            "audit",
+            "--catalog",
+            &catalog,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.label.audit.v1");
+    assert_eq!(env["data"]["provider"], "gitlab");
+    assert_eq!(env["data"]["status"], "pass");
+    assert_eq!(env["data"]["missing"].as_array().unwrap().len(), 0);
+    assert_eq!(env["data"]["drift"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn label_ensure_dry_run_emits_create_and_update_plans() {
+    let (_tempdir, catalog) = write_catalog();
+    let stub = StubEnv::new().gh_stub(
+        r#"#!/bin/sh
+set -e
+case "$1 $2" in
+  "label list")
+    cat <<'EOF'
+[{"name":"type::bug","color":"ffffff","description":"old description"}]
+EOF
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 99
+    ;;
+esac
+"#,
+    );
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--dry-run",
+            "--format",
+            "json",
+            "label",
+            "ensure",
+            "--catalog",
+            &catalog,
+            "--update-existing",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["schema_version"], "cli.forge-cli.label.ensure.v1");
+    assert_eq!(env["data"]["dry_run"], true);
+    let actions = env["data"]["actions"].as_array().expect("actions");
+    assert_eq!(actions.len(), 2, "actions={actions:?}");
+    assert_eq!(actions[0]["kind"], "create");
+    assert_eq!(actions[0]["label"]["name"], "area::cli");
+    assert_eq!(actions[1]["kind"], "update");
+    assert_eq!(actions[1]["label"]["name"], "type::bug");
+    let create_plan = actions[0]["plan"].as_array().unwrap();
+    assert!(create_plan.iter().any(|v| v == "label"), "{create_plan:?}");
+    assert!(create_plan.iter().any(|v| v == "create"), "{create_plan:?}");
+    assert!(
+        create_plan.iter().any(|v| v == "area::cli"),
+        "{create_plan:?}"
+    );
+    assert!(create_plan.iter().any(|v| v == "--repo"), "{create_plan:?}");
+}

--- a/crates/forge-cli/tests/integration/pr_create.rs
+++ b/crates/forge-cli/tests/integration/pr_create.rs
@@ -86,6 +86,28 @@ fn well_formed_body() -> &'static str {
     "## Summary\n\nLand the new feature.\n\n## Test plan\n\nVerified via cargo test.\n"
 }
 
+fn write_label_catalog() -> (TempDir, String) {
+    let tempdir = TempDir::new().expect("label catalog tempdir");
+    let path = tempdir.path().join("forge-labels.yaml");
+    fs::write(
+        &path,
+        r#"schema: forge-label-catalog.v1
+groups:
+  - name: type
+    prefix: "type::"
+    exclusive: true
+labels:
+  - name: "type::feature"
+    group: type
+    color: a2eeef
+    description: Feature work.
+    applies_to: [pr, mr]
+"#,
+    )
+    .expect("write catalog");
+    (tempdir, path.to_string_lossy().into_owned())
+}
+
 #[test]
 fn pr_create_dry_run_renders_plan_envelope() {
     let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
@@ -134,6 +156,45 @@ fn pr_create_dry_run_renders_plan_envelope() {
         plan_strings.contains(&"--draft".to_string()),
         "{plan_strings:?}"
     );
+}
+
+#[test]
+fn pr_create_strict_labels_rejects_unknown_catalog_label() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+    let (_catalog_tempdir, catalog) = write_label_catalog();
+
+    let stub = StubEnv::new();
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: strict labels",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+            "--label",
+            "priority::high",
+            "--label-catalog",
+            &catalog,
+            "--strict-labels",
+        ],
+        Some(&repo_path),
+    );
+    assert_eq!(out.code, 65, "expected DATA 65, stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["error"]["code"], "label_unknown");
 }
 
 #[test]

--- a/crates/forge-cli/tests/integration/pr_deliver.rs
+++ b/crates/forge-cli/tests/integration/pr_deliver.rs
@@ -174,6 +174,7 @@ fn pr_deliver_help_lists_every_documented_flag() {
         "--base",
         "--method",
         "--reviewer",
+        "--label",
         "--timeout",
         "--no-merge",
         "--allow-non-default-base",
@@ -184,4 +185,63 @@ fn pr_deliver_help_lists_every_documented_flag() {
             out.stdout
         );
     }
+}
+
+#[test]
+fn pr_deliver_dry_run_threads_labels_into_create_step() {
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+            "pr",
+            "deliver",
+            "--kind",
+            "feature",
+            "--title",
+            "demo",
+            "--body",
+            "## Summary\nx\n\n## Test plan\ny\n",
+            "--label",
+            "type::feature",
+            "--label",
+            "area::cli",
+            "--label",
+            "size::m",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    let create_plan = env["data"]["plan_steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["step"] == "create")
+        .expect("create step present")["plan"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect::<Vec<_>>();
+    let label_count = create_plan
+        .iter()
+        .filter(|s| s.as_str() == "--label")
+        .count();
+    assert_eq!(label_count, 3, "{create_plan:?}");
+    assert!(
+        create_plan.iter().any(|s| s == "type::feature"),
+        "{create_plan:?}"
+    );
+    assert!(
+        create_plan.iter().any(|s| s == "area::cli"),
+        "{create_plan:?}"
+    );
+    assert!(
+        create_plan.iter().any(|s| s == "size::m"),
+        "{create_plan:?}"
+    );
 }

--- a/crates/forge-cli/tests/integration/pr_wait_checks.rs
+++ b/crates/forge-cli/tests/integration/pr_wait_checks.rs
@@ -90,7 +90,7 @@ fn pr_wait_checks_succeeds_when_terminal_on_third_poll() {
             "--interval",
             "10ms",
             "--timeout",
-            "5s",
+            "20s",
         ],
     );
     assert_eq!(out.code, 0, "stderr={}", out.stderr);


### PR DESCRIPTION
## Summary

Add provider-neutral `forge-cli label list|audit|ensure` operations for caller-owned label catalogs, and thread strict catalog validation through `pr create` / `pr deliver` label inputs.

This supports graysurf/agent-runtime-kit#91 via sympoies/nils-cli#473 by making label audit, ensure, and PR/MR label validation available before runtime-kit skills consume the taxonomy.

## Test plan

- `agent-run exec --cwd /Users/terry/.codex/worktrees/574c/nils-cli-forge-label-taxonomy -- cargo test -p nils-forge-cli --test integration label_ -- --nocapture`
- `agent-run exec --cwd /Users/terry/.codex/worktrees/574c/nils-cli-forge-label-taxonomy -- cargo test -p nils-forge-cli --test integration pr_deliver_dry_run_threads_labels_into_create_step -- --nocapture`
- `agent-run exec --cwd /Users/terry/.codex/worktrees/574c/nils-cli-forge-label-taxonomy -- bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- `agent-run exec --cwd /Users/terry/.codex/worktrees/574c/nils-cli-forge-label-taxonomy -- cargo test -p nils-forge-cli --test integration -- --nocapture`
- `agent-run exec --cwd /Users/terry/.codex/worktrees/574c/nils-cli-forge-label-taxonomy -- cargo clippy -p nils-forge-cli --all-targets -- -D warnings`
