### PR TITLE
feat(plan-issue): pipe labels through record open/post/close

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-runtime-cli"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-docs"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-out"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-scope-lock"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-workflow-primitives"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-gql"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-grpc"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-rest"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-test"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-testing-core"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-websocket"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "nils-cli-template"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "nils-codex-cli"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "nils-common"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "base64",
  "clap",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "nils-forge-cli"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "nils-fzf-cli"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "nils-gemini-cli"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-cli"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-lock"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-scope"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-summary"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "nils-image-processing"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "nils-macos-agent"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "nils-memo-cli"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-issue-cli"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-tooling"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "nils-screen-record"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "block2",
  "chrono",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "nils-semantic-commit"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "nils-term"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "indicatif",
  "pretty_assertions",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "nils-test-support"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "nils-web-evidence"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ resolver = "2"
 # edition.
 edition = "2024"
 license = "MIT"
-version = "0.20.1"
+version = "0.21.0"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ This repo can publish prebuilt tarballs via GitHub Releases for both:
 - x86_64 (amd64)
 - aarch64 (arm64)
 
-To trigger a release build, push a tag like `v0.20.1`:
+To trigger a release build, push a tag like `v0.21.0`:
 
-- `git tag -a v0.20.1 -m "v0.20.1"`
-- `git push origin v0.20.1`
+- `git tag -a v0.21.0 -m "v0.21.0"`
+- `git push origin v0.21.0`
 
 Then download the matching `nils-cli-<tag>-<target>.tar.gz` asset, extract it, and add `<extract_dir>/bin` to your `PATH`.
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `4df212bd68ad17243f8bde6cca58fddbc5b2f03e2d684038640707f8a388bb06`
+- Cargo.lock SHA256: `b4c54ab5698fa41fef6ff7e1032d9404f2f5928df85fee0b060eb0f2c3cf72e5`
 - Third-party crates (`source != null`): 465
 - Workspace crates (`source == null`, excluded below): 31
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `4df212bd68ad17243f8bde6cca58fddbc5b2f03e2d684038640707f8a388bb06`
+- Cargo.lock SHA256: `b4c54ab5698fa41fef6ff7e1032d9404f2f5928df85fee0b060eb0f2c3cf72e5`
 - Third-party crates (`source != null`): 465
 
 ## Notice Extraction Policy

--- a/crates/agent-docs/Cargo.toml
+++ b/crates/agent-docs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-docs"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -19,12 +19,12 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 directories = { workspace = true }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 toml_edit = "0.25"
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/agent-out/Cargo.toml
+++ b/crates/agent-out/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-out"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -19,11 +19,11 @@ path = "src/main.rs"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-runtime-cli/Cargo.toml
+++ b/crates/agent-runtime-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-runtime-cli"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -28,5 +28,5 @@ tera = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/agent-scope-lock/Cargo.toml
+++ b/crates/agent-scope-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-scope-lock"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -14,11 +14,11 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-workflow-primitives/Cargo.toml
+++ b/crates/agent-workflow-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-workflow-primitives"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -58,15 +58,15 @@ path = "src/bin/test-first-evidence.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-agent-out = { version = "0.20.1", path = "../agent-out" }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
+nils-agent-out = { version = "0.21.0", path = "../agent-out" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-gql/Cargo.toml
+++ b/crates/api-gql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-gql"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,13 +12,13 @@ name = "api-gql"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.20.1", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.21.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-grpc/Cargo.toml
+++ b/crates/api-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-grpc"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-grpc"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.20.1", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.21.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.22"
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-rest/Cargo.toml
+++ b/crates/api-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-rest"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-rest"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.20.1", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.21.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.22"
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-test/Cargo.toml
+++ b/crates/api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-test"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -16,14 +16,14 @@ name = "api-test"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.20.1", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.21.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-testing-core/Cargo.toml
+++ b/crates/api-testing-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-testing-core"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -24,10 +24,10 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-websocket/Cargo.toml
+++ b/crates/api-websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-websocket"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-websocket"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.20.1", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.21.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }

--- a/crates/cli-template/Cargo.toml
+++ b/crates/cli-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-cli-template"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -13,13 +13,13 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/codex-cli/Cargo.toml
+++ b/crates/codex-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-codex-cli"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -23,10 +23,10 @@ reqwest = { version = "0.13", default-features = false, features = ["blocking", 
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.11"
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/forge-cli/Cargo.toml
+++ b/crates/forge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-forge-cli"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -20,7 +20,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 libc = "0.2"
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_yaml_ng = { workspace = true }
@@ -29,5 +29,5 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/fzf-cli/Cargo.toml
+++ b/crates/fzf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-fzf-cli"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -14,14 +14,14 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
 walkdir = "2"
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/gemini-cli/Cargo.toml
+++ b/crates/gemini-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-gemini-cli"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -21,9 +21,9 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/git-cli/Cargo.toml
+++ b/crates/git-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-cli"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -18,12 +18,12 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/git-lock/Cargo.toml
+++ b/crates/git-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-lock"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -15,10 +15,10 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 chrono = { version = "0.4", features = ["clock"] }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 tempfile = "3"
 pretty_assertions = { workspace = true }

--- a/crates/git-scope/Cargo.toml
+++ b/crates/git-scope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-scope"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -14,9 +14,9 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 tempfile = "3"
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }

--- a/crates/git-summary/Cargo.toml
+++ b/crates/git-summary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-summary"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -15,10 +15,10 @@ anyhow = { workspace = true }
 chrono = { version = "0.4", features = ["clock"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/image-processing/Cargo.toml
+++ b/crates/image-processing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-image-processing"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -20,8 +20,8 @@ serde_json = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 globset = "0.4"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
 resvg = "0.47"
 roxmltree = "0.21"
 usvg = "0.47"
@@ -29,6 +29,6 @@ uuid = { version = "1", features = ["v4"] }
 walkdir = "2"
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/macos-agent/Cargo.toml
+++ b/crates/macos-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-macos-agent"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -20,11 +20,11 @@ clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 regex = "1"
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
-screen-record = { version = "0.20.1", path = "../screen-record", package = "nils-screen-record" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
+screen-record = { version = "0.21.0", path = "../screen-record", package = "nils-screen-record" }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/memo-cli/Cargo.toml
+++ b/crates/memo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-memo-cli"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -24,10 +24,10 @@ chrono-tz = "0.10"
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-common/Cargo.toml
+++ b/crates/nils-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-common"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 description = "Library crate for nils-common in the nils-cli workspace."
@@ -14,6 +14,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-term/Cargo.toml
+++ b/crates/nils-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-term"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 description = "Library crate for nils-term in the nils-cli workspace."

--- a/crates/nils-test-support/Cargo.toml
+++ b/crates/nils-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-test-support"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/plan-issue-cli/Cargo.toml
+++ b/crates/plan-issue-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-issue-cli"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 default-run = "plan-issue"
@@ -25,10 +25,10 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
-plan-tooling = { version = "0.20.1", path = "../plan-tooling", package = "nils-plan-tooling" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
+plan-tooling = { version = "0.21.0", path = "../plan-tooling", package = "nils-plan-tooling" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/plan-issue-cli/src/commands/record.rs
+++ b/crates/plan-issue-cli/src/commands/record.rs
@@ -121,6 +121,11 @@ pub struct RecordOpenArgs {
     #[arg(long = "allow-dirty")]
     pub allow_dirty: bool,
 
+    /// Label to apply at issue creation. Repeatable. Empty values are
+    /// dropped. Names are passed through to `gh issue create --label`.
+    #[arg(long = "label", value_name = "NAME")]
+    pub labels: Vec<String>,
+
     /// Deterministic fixture mode. The directory is consumed instead of
     /// live provider calls.
     #[arg(long, value_name = "dir")]
@@ -149,6 +154,15 @@ pub struct RecordPostArgs {
     /// Visible Markdown commentary appended after the structured payload.
     #[arg(long = "summary-file", value_name = "path")]
     pub summary_file: Option<PathBuf>,
+
+    /// Add a label alongside the lifecycle comment in live mode. Repeatable.
+    #[arg(long = "add-label", value_name = "NAME")]
+    pub add_labels: Vec<String>,
+
+    /// Remove a label alongside the lifecycle comment in live mode.
+    /// Repeatable.
+    #[arg(long = "remove-label", value_name = "NAME")]
+    pub remove_labels: Vec<String>,
 
     /// Deterministic fixture mode.
     #[arg(long, value_name = "dir")]
@@ -212,6 +226,16 @@ pub struct RecordCloseArgs {
     /// Deterministic test mode: comments JSON.
     #[arg(long = "comments-json", value_name = "path")]
     pub comments_json: Option<PathBuf>,
+
+    /// Add a label as part of the closeout transition in live mode (e.g.
+    /// `state::closed`). Repeatable.
+    #[arg(long = "add-label", value_name = "NAME")]
+    pub add_labels: Vec<String>,
+
+    /// Remove a label as part of the closeout transition in live mode
+    /// (e.g. earlier `state::*` markers). Repeatable.
+    #[arg(long = "remove-label", value_name = "NAME")]
+    pub remove_labels: Vec<String>,
 
     /// Deterministic fixture mode. Contains issue body, comments JSON, and
     /// PR snapshots used in place of provider lookups.

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -508,6 +508,39 @@ fn read_payload_data(path: &Path) -> Result<Value, CommandError> {
     })
 }
 
+/// Trim, drop empty values, and reject names that appear in both
+/// `--add-label` and `--remove-label`. Used by `record post` and
+/// `record close` to keep the live `edit_issue_labels` call coherent.
+fn normalize_label_mutations(
+    add: &[String],
+    remove: &[String],
+    command_code: &'static str,
+) -> Result<(Vec<String>, Vec<String>), CommandError> {
+    let normalize = |raw: &[String]| -> Vec<String> {
+        raw.iter()
+            .map(|label| label.trim().to_string())
+            .filter(|label| !label.is_empty())
+            .collect()
+    };
+    let add_clean = normalize(add);
+    let remove_clean = normalize(remove);
+    let conflicts: Vec<&str> = add_clean
+        .iter()
+        .filter(|label| remove_clean.iter().any(|other| other == *label))
+        .map(String::as_str)
+        .collect();
+    if !conflicts.is_empty() {
+        return Err(CommandError::usage(
+            "record-label-mutation-conflict",
+            format!(
+                "{command_code}: label(s) appear in both --add-label and --remove-label: {}",
+                conflicts.join(", ")
+            ),
+        ));
+    }
+    Ok((add_clean, remove_clean))
+}
+
 fn run_record_open(
     binary: BinaryFlavor,
     dry_run: bool,
@@ -628,6 +661,13 @@ fn run_record_open(
 
     let initial_dashboard = record_initial_dashboard(args.profile, &plan_title, None);
 
+    let normalized_labels: Vec<String> = args
+        .labels
+        .iter()
+        .map(|label| label.trim().to_string())
+        .filter(|label| !label.is_empty())
+        .collect();
+
     let preview = json!({
         "issue_body_markdown": initial_dashboard,
         "comments": {
@@ -640,6 +680,7 @@ fn run_record_open(
         "plan_path": path_text(&bundle.plan_file),
         "source_commit": source_snapshot.commit,
         "plan_commit": plan_snapshot.commit,
+        "labels": normalized_labels.clone(),
     });
 
     if binary != BinaryFlavor::PlanIssue || dry_run {
@@ -659,7 +700,7 @@ fn run_record_open(
     let body_path = write_temp_markdown("record-open-body", &initial_dashboard)
         .map_err(|err| CommandError::runtime("record-open-body-write-failed", err))?;
     let (issue_number, issue_url) = adapter
-        .create_issue(&repo, &plan_title, &body_path, &[])
+        .create_issue(&repo, &plan_title, &body_path, &normalized_labels)
         .map_err(|err| CommandError::runtime("record-open-issue-create-failed", err))?;
 
     let source_path = write_temp_markdown("record-open-source-comment", &source_body)
@@ -700,6 +741,7 @@ fn run_record_open(
         "mode": "live",
         "issue": {"number": issue_number, "url": issue_url},
         "comments": {"source": source_url, "plan": plan_url, "state": state_url},
+        "labels": normalized_labels,
         "dashboard_markdown": repaired,
     }))
 }
@@ -758,6 +800,14 @@ fn run_record_post(
     )
     .map_err(|err| CommandError::runtime("record-post-render-failed", err))?;
 
+    let (add_labels, remove_labels) =
+        normalize_label_mutations(&args.add_labels, &args.remove_labels, "record-post")?;
+    let label_mutation_planned = !add_labels.is_empty() || !remove_labels.is_empty();
+    let labels_preview = json!({
+        "add": add_labels.clone(),
+        "remove": remove_labels.clone(),
+    });
+
     // Fixture mode: just return the rendered body + simulated URL.
     if let Some(fixture_dir) = &args.fixture {
         let _ = fixture_dir;
@@ -770,6 +820,7 @@ fn run_record_post(
             "kind": args.kind.as_str(),
             "comment_body": body,
             "comment_url": null,
+            "labels": labels_preview,
         }));
     }
 
@@ -782,6 +833,7 @@ fn run_record_post(
             "issue": args.issue,
             "kind": args.kind.as_str(),
             "comment_body": body,
+            "labels": labels_preview,
         }));
     }
 
@@ -794,6 +846,12 @@ fn run_record_post(
         .comment_issue(&repo, issue_number, &comment_path)
         .map_err(|err| CommandError::runtime("record-post-comment-post-failed", err))?;
 
+    if label_mutation_planned {
+        adapter
+            .edit_issue_labels(&repo, issue_number, &add_labels, &remove_labels)
+            .map_err(|err| CommandError::runtime("record-post-label-edit-failed", err))?;
+    }
+
     Ok(json!({
         "operation": "record.post",
         "execution_mode": binary.execution_mode(),
@@ -802,6 +860,7 @@ fn run_record_post(
         "issue": args.issue,
         "kind": args.kind.as_str(),
         "comment_url": url,
+        "labels": labels_preview,
     }))
 }
 
@@ -1058,12 +1117,21 @@ fn run_record_close(
     )
     .map_err(|err| CommandError::runtime("record-close-render-failed", err))?;
 
+    let (add_labels, remove_labels) =
+        normalize_label_mutations(&args.add_labels, &args.remove_labels, "record-close")?;
+    let label_mutation_planned = !add_labels.is_empty() || !remove_labels.is_empty();
+    let labels_preview = json!({
+        "add": add_labels.clone(),
+        "remove": remove_labels.clone(),
+    });
+
     // Bundle preview for dry-run and fixture modes.
     let preview = json!({
         "closeout_comment_body": closeout_body,
         "final_dashboard": canonical_dashboard,
         "blocked_codes": gate.blocked_codes,
         "checks": gate.checks,
+        "labels": labels_preview.clone(),
     });
 
     if args.fixture.is_some() || dry_run || binary != BinaryFlavor::PlanIssue {
@@ -1112,6 +1180,12 @@ fn run_record_close(
         )
         .map_err(|err| CommandError::runtime("record-close-issue-close-failed", err))?;
 
+    if label_mutation_planned {
+        adapter
+            .edit_issue_labels(&repo, issue_number, &add_labels, &remove_labels)
+            .map_err(|err| CommandError::runtime("record-close-label-edit-failed", err))?;
+    }
+
     Ok(json!({
         "operation": "record.close",
         "execution_mode": binary.execution_mode(),
@@ -1124,6 +1198,7 @@ fn run_record_close(
         "closeout_url": closeout_url,
         "linked_prs": linked_evidence,
         "final_dashboard": final_dashboard,
+        "labels": labels_preview,
     }))
 }
 

--- a/crates/plan-issue-cli/tests/integration/cli_contract.rs
+++ b/crates/plan-issue-cli/tests/integration/cli_contract.rs
@@ -691,3 +691,95 @@ fn cli_conflict_rules_reject_summary_and_summary_file_together() {
         "{rendered}"
     );
 }
+
+#[test]
+fn cli_parse_contract_record_open_accepts_repeatable_label() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "open",
+        "--bundle",
+        "docs/plans/example",
+        "--label",
+        "workflow::plan",
+        "--label",
+        "state::needs-triage",
+    ])
+    .expect("parse record open with labels");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::Record(args) => match &args.command {
+            RecordCommand::Open(open) => {
+                assert_eq!(open.labels, vec!["workflow::plan", "state::needs-triage"]);
+            }
+            other => panic!("unexpected record subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parse_contract_record_post_accepts_add_remove_label() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--kind",
+        "state",
+        "--add-label",
+        "state::blocked",
+        "--remove-label",
+        "state::in-progress",
+    ])
+    .expect("parse record post with label mutations");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::Record(args) => match &args.command {
+            RecordCommand::Post(post) => {
+                assert_eq!(post.add_labels, vec!["state::blocked"]);
+                assert_eq!(post.remove_labels, vec!["state::in-progress"]);
+            }
+            other => panic!("unexpected record subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parse_contract_record_close_accepts_add_remove_label() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "close",
+        "--issue",
+        "448",
+        "--linked-pr",
+        "sympoies/nils-cli#500",
+        "--approval",
+        "https://github.com/sympoies/nils-cli/issues/448#issuecomment-1",
+        "--add-label",
+        "state::closed",
+        "--remove-label",
+        "state::in-progress",
+    ])
+    .expect("parse record close with label mutations");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::Record(args) => match &args.command {
+            RecordCommand::Close(close) => {
+                assert_eq!(close.add_labels, vec!["state::closed"]);
+                assert_eq!(close.remove_labels, vec!["state::in-progress"]);
+            }
+            other => panic!("unexpected record subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -1215,6 +1215,223 @@ fn agent_runtime_kit_lifecycle_fixture_passes_strict_v2_closeout_end_to_end() {
     );
 }
 
+/// Issue sympoies/nils-cli#479: `record open --label` exposes labels in the
+/// dry-run preview so downstream consumers can audit creation-time labels
+/// without hitting the provider.
+#[test]
+fn record_open_dry_run_includes_labels_in_preview() {
+    use nils_test_support::git::{InitRepoOptions, git, init_repo_with};
+
+    let stub = StubBinDir::new();
+    stub.write_exe("gh", record_open_dry_run_gh_stub());
+
+    let repo = init_repo_with(InitRepoOptions::new().with_branch("main"));
+    let bundle = repo.path().join("docs/plans/sample");
+    fs::create_dir_all(&bundle).expect("create bundle dir");
+    let source = bundle.join("sample-discussion-source.md");
+    let plan = bundle.join("sample-plan.md");
+    let execution_state = bundle.join("sample-execution-state.md");
+    fs::write(&source, "# Source\n\n- Decision: implement v2 lifecycle.\n").expect("write source");
+    fs::write(
+        &plan,
+        "# Plan: Sample Plan\n\n## Overview\n\n- Sample plan body.\n\n## Read First\n\n- Primary source: docs/plans/sample/sample-discussion-source.md\n- Source type: discussion-to-implementation-doc\n- Open questions carried into execution: none\n\n## Scope\n\n- In scope:\n  - Demo plan.\n- Out of scope:\n  - none.\n\n## Assumptions\n\n1. Demo only.\n\n## Sprint 1: Demo\n\n**Goal**: Demo the surface.\n\n**PR grouping intent**: group\n**Execution Profile**: serial\n\n### Task 1.1: Demo task\n\n- **Location**:\n  - `docs/plans/sample/sample-plan.md`\n- **Description**: Demo task description.\n- **Dependencies**:\n  - none\n- **Complexity**: 1\n- **Acceptance criteria**:\n  - The demo task is complete.\n- **Validation**:\n  - `true`\n",
+    )
+    .expect("write plan");
+    fs::write(
+        &execution_state,
+        "# Sample Execution State\n\n<!-- plan-issue-record:v2 role=state profile=tracking -->\n\n## Execution State\n\n- Status: pending\n- Target scope: Sample Plan\n",
+    )
+    .expect("write execution state");
+    git(repo.path(), &["add", "."]);
+    git(
+        repo.path(),
+        &[
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test",
+            "commit",
+            "-m",
+            "seed bundle",
+            "--no-gpg-sign",
+        ],
+    );
+
+    let opts = dry_run_cmd_options(stub.path()).with_cwd(repo.path());
+    let bundle_arg = bundle.to_string_lossy().to_string();
+    let out = nils_test_support::cmd::run_resolved(
+        "plan-issue-local",
+        &[
+            "--format",
+            "json",
+            "record",
+            "open",
+            "--bundle",
+            &bundle_arg,
+            "--label",
+            "workflow::plan",
+            "--label",
+            " state::needs-triage ",
+            "--label",
+            "",
+        ],
+        &opts,
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+    let parsed: Value = serde_json::from_str(&out.stdout_text()).expect("json");
+    let result = &parsed["payload"]["result"];
+    assert_eq!(result["mode"], "dry-run");
+    let labels = result["preview"]["labels"]
+        .as_array()
+        .expect("preview.labels array");
+    let labels: Vec<&str> = labels.iter().filter_map(Value::as_str).collect();
+    assert_eq!(
+        labels,
+        vec!["workflow::plan", "state::needs-triage"],
+        "empty/whitespace labels must be dropped and non-empty values trimmed"
+    );
+}
+
+/// `record post --add-label / --remove-label` exposes the planned label
+/// mutation in dry-run output and in fixture mode without touching gh.
+#[test]
+fn record_post_dry_run_includes_label_mutations() {
+    let tmp = TempDir::new().expect("tempdir");
+    let payload = tmp.path().join("state.json");
+    fs::write(
+        &payload,
+        json!({"status": "blocked", "tasks": [], "prs": [], "blockers": [], "links": {}})
+            .to_string(),
+    )
+    .expect("write payload");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "--dry-run",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--kind",
+        "state",
+        "--payload-file",
+        payload.to_str().expect("payload path"),
+        "--add-label",
+        "state::blocked",
+        "--remove-label",
+        "state::in-progress",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let result = &parsed["payload"]["result"];
+    assert_eq!(result["mode"], "dry-run");
+    assert_eq!(result["labels"]["add"][0], "state::blocked");
+    assert_eq!(result["labels"]["remove"][0], "state::in-progress");
+}
+
+/// `record close --add-label / --remove-label` shows the planned closeout
+/// label transition in fixture preview output.
+#[test]
+fn record_close_fixture_includes_label_mutations() {
+    let fixture = Path::new("tests/fixtures/lifecycle/agent-runtime-kit-closeout").to_path_buf();
+    assert!(fixture.exists(), "fixture missing: {}", fixture.display());
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "42",
+        "--linked-pr",
+        "sympoies/agent-runtime-kit#1",
+        "--approval",
+        "https://github.com/sympoies/agent-runtime-kit/issues/42#issuecomment-approval",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+        "--add-label",
+        "state::closed",
+        "--remove-label",
+        "state::in-progress",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let labels = &parsed["payload"]["result"]["preview"]["labels"];
+    assert_eq!(labels["add"][0], "state::closed");
+    assert_eq!(labels["remove"][0], "state::in-progress");
+}
+
+/// Same label name in `--add-label` and `--remove-label` is incoherent — the
+/// helper rejects it with a usage error so the live `gh issue edit` call is
+/// never built.
+#[test]
+fn record_post_rejects_conflicting_label_mutations() {
+    let tmp = TempDir::new().expect("tempdir");
+    let payload = tmp.path().join("state.json");
+    fs::write(
+        &payload,
+        json!({"status": "in-progress", "tasks": [], "prs": [], "blockers": [], "links": {}})
+            .to_string(),
+    )
+    .expect("write payload");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "--dry-run",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--kind",
+        "state",
+        "--payload-file",
+        payload.to_str().expect("payload path"),
+        "--add-label",
+        "state::needs-triage",
+        "--remove-label",
+        "state::needs-triage",
+    ]);
+    assert_ne!(out.code, 0, "conflicting label mutation should fail");
+    let joined = format!("{}\n{}", out.stderr, out.stdout);
+    assert!(
+        joined.contains("record-label-mutation-conflict"),
+        "expected record-label-mutation-conflict code, got: {joined}"
+    );
+}
+
+#[test]
+fn record_close_rejects_conflicting_label_mutations() {
+    let fixture = Path::new("tests/fixtures/lifecycle/agent-runtime-kit-closeout").to_path_buf();
+    assert!(fixture.exists(), "fixture missing: {}", fixture.display());
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "42",
+        "--linked-pr",
+        "sympoies/agent-runtime-kit#1",
+        "--approval",
+        "ok",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+        "--add-label",
+        "state::closed",
+        "--remove-label",
+        "state::closed",
+    ]);
+    assert_ne!(out.code, 0, "conflicting label mutation should fail");
+    let joined = format!("{}\n{}", out.stderr, out.stdout);
+    assert!(
+        joined.contains("record-label-mutation-conflict"),
+        "expected record-label-mutation-conflict code, got: {joined}"
+    );
+}
+
 /// Sprint 4 Task 4.3: same fixture, but force the strict gate to fail by
 /// flipping the PR snapshot to unmerged. Verifies the gate code surfaces.
 #[test]

--- a/crates/plan-tooling/Cargo.toml
+++ b/crates/plan-tooling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-tooling"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -16,14 +16,14 @@ name = "plan-tooling"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/screen-record/Cargo.toml
+++ b/crates/screen-record/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-screen-record"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 build = "build.rs"
@@ -20,7 +20,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 ctrlc = "3.5.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.13", features = ["randr"] }
@@ -41,7 +41,7 @@ block2 = "0.6.2"
 dispatch2 = "0.3.0"
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 tempfile = "3"
 
 [lints.rust]

--- a/crates/semantic-commit/Cargo.toml
+++ b/crates/semantic-commit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-semantic-commit"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -21,9 +21,9 @@ clap_complete = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
 time = { version = "0.3", features = ["formatting"] }
-nils-term = { version = "0.20.1", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.21.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/web-evidence/Cargo.toml
+++ b/crates/web-evidence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-web-evidence"
-version = "0.20.1"
+version = "0.21.0"
 edition.workspace = true
 license.workspace = true
 
@@ -18,13 +18,13 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.20.1", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.21.0", path = "../nils-common", package = "nils-common" }
 regex = "1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.20.1", path = "../nils-test-support" }
+nils-test-support = { version = "0.21.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"


### PR DESCRIPTION
## Summary

Implements sympoies/nils-cli#479 by exposing label flags on the v3
`plan-issue record` surface and bumping the workspace to `0.21.0` for the
new CLI surface.

Refs sympoies/nils-cli#479. Unblocks
graysurf/agent-runtime-kit#93 / agent-runtime-kit#94.

## Changes

- `record open` accepts repeatable `--label <NAME>`; labels are trimmed,
  empty values are dropped, and the resulting list flows through the
  existing `GhCliAdapter::create_issue` path so creation-time labels reach
  `gh issue create --label`.
- `record post` accepts repeatable `--add-label / --remove-label`; in live
  mode the lifecycle comment posts as before and then a single
  `edit_issue_labels` call applies the mutation. The same name in both add
  and remove is rejected as `record-label-mutation-conflict`.
- `record close` accepts the same `--add-label / --remove-label` mutation
  pair (intended for `state::closed` transitions); applied via
  `edit_issue_labels` after `close_issue` so the labels reflect the
  closed state.
- Dry-run, fixture, and live output JSON now surface the planned labels
  under `result.labels` (`record.open` → `[…]`; `record.post`/`record.close`
  → `{add, remove}`), giving downstream skills a deterministic audit shape.
- Workspace + crate versions bumped to `0.21.0` and `THIRD_PARTY_*.md`
  regenerated to match the refreshed `Cargo.lock`.

## Test-First Evidence

Test-first evidence: added integration coverage before relying on the
flags downstream.

- `cli_parse_contract_record_open_accepts_repeatable_label`
- `cli_parse_contract_record_post_accepts_add_remove_label`
- `cli_parse_contract_record_close_accepts_add_remove_label`
- `record_open_dry_run_includes_labels_in_preview` — empty/whitespace
  labels are dropped, non-empty values are trimmed.
- `record_post_dry_run_includes_label_mutations`
- `record_close_fixture_includes_label_mutations`
- `record_post_rejects_conflicting_label_mutations`
- `record_close_rejects_conflicting_label_mutations`

## Test plan

- `cargo test -p nils-plan-issue-cli` — 135 integration tests pass
  (127 pre-existing + 8 new).
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — green.
- `bash scripts/generate-third-party-artifacts.sh --check` — clean.
- `bash scripts/ci/completion-asset-audit.sh` — green.
- `cargo build --workspace --locked` — green.
- `rumdl check` — no new findings on this branch.

## Risk / Notes

- Minor version bump because the new flags are an additive but
  user-visible CLI surface change. No breaking changes; existing callers
  that pass no label flags keep the previous behavior bit-for-bit.
- `record open --label` exits the binary at the existing `create_issue`
  call site; that adapter already accepted a `labels: &[String]`
  parameter and was previously passed an empty slice.
- `record post` / `record close` label mutation runs after the lifecycle
  comment / close action succeeds; if `edit_issue_labels` fails the
  surrounding command is still considered failed (returns the
  `*-label-edit-failed` error code).
- Catalog-validated `--label-catalog` is intentionally out of scope here
  to keep this change minimal; it can be added later as a follow-up if
  the downstream label taxonomy needs strict gating on the v3 record
  surface.
