### PR TITLE
fix(plan-tooling): retire review-to-improvement-doc source type

### DIFF
--- a/crates/plan-tooling/docs/specs/plan-source-bundle-contract-v1.md
+++ b/crates/plan-tooling/docs/specs/plan-source-bundle-contract-v1.md
@@ -50,11 +50,11 @@ The plan `Read First` section must use one accepted sibling source doc as `Prima
 - Open questions carried into execution: none
 ```
 
-Review-backed plans use:
+Review-backed source docs use the same source type — only the filename differs:
 
 ```md
 - Primary source: `docs/plans/<slug>/<slug>-review-source.md`
-- Source type: review-to-improvement-doc
+- Source type: discussion-to-implementation-doc
 ```
 
 `Source type: plan-only waiver` remains valid for plan-only documents, but it opts out of bundle

--- a/crates/plan-tooling/plan-template.md
+++ b/crates/plan-tooling/plan-template.md
@@ -5,7 +5,7 @@
 
 ## Read First
 - Primary source: <repo path, issue/ticket URL, or explicit plan-only waiver>
-- Source type: <discussion-to-implementation-doc | review-to-improvement-doc | existing issue/spec | plan-only waiver>
+- Source type: <discussion-to-implementation-doc | existing issue/spec | plan-only waiver>
 - Open questions carried into execution: none
 
 ## Scope

--- a/crates/plan-tooling/src/validate.rs
+++ b/crates/plan-tooling/src/validate.rs
@@ -497,7 +497,7 @@ fn validate_read_first(plan_path: &str, plan: &Plan, repo_root: &Path) -> Vec<St
         errs.push(format!("{plan_path}: Read First missing Source type"));
     } else if !is_allowed_source_type(&source_type) {
         errs.push(format!(
-            "{plan_path}: invalid Read First Source type (expected discussion-to-implementation-doc|review-to-improvement-doc|existing issue/spec|plan-only waiver): {}",
+            "{plan_path}: invalid Read First Source type (expected discussion-to-implementation-doc|existing issue/spec|plan-only waiver): {}",
             crate::repr::py_repr(&source_type)
         ));
     }
@@ -555,10 +555,7 @@ fn clean_source_value(value: &str) -> String {
 fn is_allowed_source_type(value: &str) -> bool {
     matches!(
         value,
-        "discussion-to-implementation-doc"
-            | "review-to-improvement-doc"
-            | "existing issue/spec"
-            | "plan-only waiver"
+        "discussion-to-implementation-doc" | "existing issue/spec" | "plan-only waiver"
     )
 }
 
@@ -856,7 +853,7 @@ pub(crate) const EXPLAIN_CATALOG: &[ExplainCatalogEntry] = &[
         explain: ExplainEntry {
             class: "read-first-missing",
             rule: "Plans must start with a Read First section that names the primary source artifact.",
-            example: "## Read First\n\n- Primary source: docs/runbooks/example-source.md\n- Source type: review-to-improvement-doc\n- Open questions carried into execution: none",
+            example: "## Read First\n\n- Primary source: docs/runbooks/example-source.md\n- Source type: discussion-to-implementation-doc\n- Open questions carried into execution: none",
         },
     },
     ExplainCatalogEntry {
@@ -872,7 +869,7 @@ pub(crate) const EXPLAIN_CATALOG: &[ExplainCatalogEntry] = &[
         explain: ExplainEntry {
             class: "read-first-source-type-missing",
             rule: "Read First must declare a `Source type` value.",
-            example: "- Source type: review-to-improvement-doc",
+            example: "- Source type: discussion-to-implementation-doc",
         },
     },
     ExplainCatalogEntry {
@@ -1578,9 +1575,9 @@ mod tests {
     #[test]
     fn allowed_source_types_are_exact() {
         assert!(is_allowed_source_type("discussion-to-implementation-doc"));
-        assert!(is_allowed_source_type("review-to-improvement-doc"));
         assert!(is_allowed_source_type("existing issue/spec"));
         assert!(is_allowed_source_type("plan-only waiver"));
+        assert!(!is_allowed_source_type("review-to-improvement-doc"));
         assert!(!is_allowed_source_type("review"));
     }
 

--- a/crates/plan-tooling/tests/integration/validate.rs
+++ b/crates/plan-tooling/tests/integration/validate.rs
@@ -1353,7 +1353,7 @@ const MISSING_SOURCE_PATH_PLAN: &str = r#"# Plan: Missing source path
 ## Read First
 
 - Primary source: docs/source/missing.md
-- Source type: review-to-improvement-doc
+- Source type: discussion-to-implementation-doc
 - Open questions carried into execution: none
 
 ## Sprint 1: First sprint

--- a/docs/plans/cli-destructive-operation-safety/cli-destructive-operation-safety-plan.md
+++ b/docs/plans/cli-destructive-operation-safety/cli-destructive-operation-safety-plan.md
@@ -12,7 +12,7 @@ appears, not before.
 ## Read First
 
 - Primary source: docs/plans/cli-destructive-operation-safety/cli-destructive-operation-safety-review-source.md
-- Source type: review-to-improvement-doc
+- Source type: discussion-to-implementation-doc
 - Open questions carried into execution:
   - For `memo-cli delete`: redefine `--hard` as a real mode (soft vs. hard) or remove? Default: redefine.
   - For `git-lock unlock --dry-run`: summary table vs. raw `git diff`? Default: summary table, `--verbose` for full diff.

--- a/docs/plans/cli-dispatch-modernization/cli-dispatch-modernization-plan.md
+++ b/docs/plans/cli-dispatch-modernization/cli-dispatch-modernization-plan.md
@@ -14,7 +14,7 @@ migration. Sprint 1 lands the smallest migrations (`semantic-commit`,
 
 - Primary source:
   docs/plans/cli-dispatch-modernization/cli-dispatch-modernization-review-source.md
-- Source type: review-to-improvement-doc
+- Source type: discussion-to-implementation-doc
 - Open questions carried into execution:
   - Keep `git-cli` Groups as nested clap subcommands? Default: yes.
   - Keep `fzf-cli` interactive loops inside the handler with clap parsing only the entry args? Default: yes.

--- a/docs/plans/cli-help-and-env-discoverability/cli-help-and-env-discoverability-plan.md
+++ b/docs/plans/cli-help-and-env-discoverability/cli-help-and-env-discoverability-plan.md
@@ -12,7 +12,7 @@ binary and resolves the `api-gql` implicit-default UX decision.
 
 - Primary source:
   docs/plans/cli-help-and-env-discoverability/cli-help-and-env-discoverability-review-source.md
-- Source type: review-to-improvement-doc
+- Source type: discussion-to-implementation-doc
 - Open questions carried into execution:
   - Are `EXIT CODES` blocks mandatory on every binary? Default: yes, consistency outweighs the small extra cost.
   - For `api-gql`: document the implicit `call` default, or remove the fallback entirely? Default: document the default (no breaking change).

--- a/docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
+++ b/docs/plans/cli-output-contract-unification/cli-output-contract-unification-plan.md
@@ -13,7 +13,7 @@ remaining binaries in three batches grouped by ownership.
 
 - Primary source:
   docs/plans/cli-output-contract-unification/cli-output-contract-unification-review-source.md
-- Source type: review-to-improvement-doc
+- Source type: discussion-to-implementation-doc
 - Open questions carried into execution:
   - Whether `cli-template` migrates before or after `memo-cli` (default: `cli-template` first as a contract reference implementation).
   - Whether the parse-error envelope ships as a `nils-common` helper or a per-binary copy (default: shared helper to ensure shape parity).
@@ -387,7 +387,6 @@ binaries with shared crates can be reviewed together.
   - crates/agent-docs/src/
   - crates/agent-scope-lock/src/
   - crates/web-evidence/src/
-  - crates/test-first-evidence/src/
   - crates/image-processing/src/
   - crates/codex-cli/src/
   - crates/gemini-cli/src/

--- a/docs/plans/cli-ux-progress-and-defaults/cli-ux-progress-and-defaults-plan.md
+++ b/docs/plans/cli-ux-progress-and-defaults/cli-ux-progress-and-defaults-plan.md
@@ -12,7 +12,7 @@ helper. Sprint 2 covers the two user-visible default knobs: a
 ## Read First
 
 - Primary source: docs/plans/cli-ux-progress-and-defaults/cli-ux-progress-and-defaults-review-source.md
-- Source type: review-to-improvement-doc
+- Source type: discussion-to-implementation-doc
 - Open questions carried into execution:
   - Add `truncated: true` to JSON output? Default: yes.
   - Should env be a default, flag override? Default: yes.

--- a/docs/plans/plan-bundle-validation-guardrails/plan-bundle-validation-guardrails-plan.md
+++ b/docs/plans/plan-bundle-validation-guardrails/plan-bundle-validation-guardrails-plan.md
@@ -13,7 +13,7 @@ rewrite same-line sprint metadata into the canonical two-line shape.
 
 - Primary source:
   docs/plans/plan-bundle-validation-guardrails/plan-bundle-validation-guardrails-review-source.md
-- Source type: review-to-improvement-doc
+- Source type: discussion-to-implementation-doc
 - Open questions carried into execution:
   - Should the plan-bundle gate scan only changed files in CI, or all
     `docs/plans/**/*-plan.md` locally? Default to changed files in CI and all

--- a/docs/plans/plan-tooling-validate-ergonomics/plan-tooling-validate-ergonomics-plan.md
+++ b/docs/plans/plan-tooling-validate-ergonomics/plan-tooling-validate-ergonomics-plan.md
@@ -13,7 +13,7 @@ grouping intent. Within-sprint tasks may run in parallel where they touch indepe
 
 - Primary source:
   docs/plans/plan-tooling-validate-ergonomics/plan-tooling-validate-ergonomics-review-source.md
-- Source type: review-to-improvement-doc
+- Source type: discussion-to-implementation-doc
 - Open questions carried into execution:
   - Should `plan-tooling spec` (F6) ship as JSON schema or flat catalog? Default to flat catalog
     this round; schema is follow-up.

--- a/docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-plan.md
+++ b/docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-plan.md
@@ -13,7 +13,7 @@ changes are allowed only when the new tests reveal a contract mismatch.
 ## Read First
 
 - Primary source: docs/plans/testing-audits-cli-contracts/testing-audits-cli-contracts-review-source.md
-- Source type: review-to-improvement-doc
+- Source type: discussion-to-implementation-doc
 - Open questions carried into execution: none
 
 ## Scope


### PR DESCRIPTION
## Summary

Drop `review-to-improvement-doc` from the accepted plan-tooling source-type set now that the runtime-kit has consolidated review and improvement source documents into `discussion-to-implementation-doc`, and refresh the `--explain` examples, template, spec, and the eight existing `docs/plans/**` plans that still declared the retired source type so `plan-tooling validate` stays green.

## Problem

- Expected: `plan-tooling validate --format text --explain` should advertise the current accepted source-type set.
- Actual: it still printed `Source type: review-to-improvement-doc` examples even though the runtime-kit no longer ships that skill, and the validator still accepted that retired value.
- Impact: plan authors were steered toward a retired source-type label; new plans that copied the example diverged from the live runtime-kit contract.

## Reproduction

1. `cargo run -p nils-plan-tooling --bin plan-tooling -- validate --format text --explain`
2. Observe `- Source type: review-to-improvement-doc` in the `read-first-source-type-missing` and `read-first-missing` examples.
3. Confirm `is_allowed_source_type("review-to-improvement-doc")` returned `true`.

## Issues Found

- Closes #478

## Fix Approach

- Remove `review-to-improvement-doc` from `is_allowed_source_type`; update the invalid-source-type error message and the two `--explain` catalog examples to advertise `discussion-to-implementation-doc`.
- Flip the corresponding unit test from `assert!(is_allowed_source_type(...))` to `assert!(!is_allowed_source_type(...))` so the regression stays pinned.
- Refresh the plan template, plan-source bundle contract (review-backed source docs keep the `*-review-source.md` filename but use `discussion-to-implementation-doc`), and the integration fixture string.
- Rewrite the eight existing `docs/plans/**` plans that still declared the retired source type; drop a stale `crates/test-first-evidence/src/` location entry uncovered while revalidating one of them so the touched-plan gate stays green.

## Test-First Evidence

- Behavioral pin: flipped `allowed_source_types_are_exact` (`crates/plan-tooling/src/validate.rs:1578-1585`) so `is_allowed_source_type("review-to-improvement-doc")` now asserts `false`.
- Fixture coverage: `MISSING_SOURCE_PATH_PLAN` in `crates/plan-tooling/tests/integration/validate.rs:1351-1357` now exercises `discussion-to-implementation-doc`, keeping the existing missing-path error path intact while ensuring the rejected source-type is no longer covered as a happy path.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — local-fast changed-scope gate (docs hygiene/placement, markdownlint, plan-bundle validate, cli-output contract lint, `nils-plan-tooling` fmt/clippy/tests/doctests). Result: PASS (197/197 tests).
- `cargo run -p nils-plan-tooling --bin plan-tooling -- validate --format text --explain` — confirmed `--explain` examples now read `Source type: discussion-to-implementation-doc`; remaining stderr is two unrelated pre-existing plan-bundle errors on `main`.

## Risk / Notes

- Plans authored before this change that still wrote `Source type: review-to-improvement-doc` will now fail `plan-tooling validate`; the eight in-repo plans have been migrated and the spec/template advertise only the live set.
