### PR TITLE
feat(agent-runtime-cli): add list-skills subcommand

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -127,6 +127,9 @@ _forge-cli() {
             forge__cli__help__pr,comment)
                 cmd="forge__cli__help__pr__comment"
                 ;;
+            forge__cli__help__pr,comments)
+                cmd="forge__cli__help__pr__comments"
+                ;;
             forge__cli__help__pr,create)
                 cmd="forge__cli__help__pr__create"
                 ;;
@@ -259,6 +262,9 @@ _forge-cli() {
             forge__cli__pr,comment)
                 cmd="forge__cli__pr__comment"
                 ;;
+            forge__cli__pr,comments)
+                cmd="forge__cli__pr__comments"
+                ;;
             forge__cli__pr,create)
                 cmd="forge__cli__pr__create"
                 ;;
@@ -294,6 +300,9 @@ _forge-cli() {
                 ;;
             forge__cli__pr__help,comment)
                 cmd="forge__cli__pr__help__comment"
+                ;;
+            forge__cli__pr__help,comments)
+                cmd="forge__cli__pr__help__comments"
                 ;;
             forge__cli__pr__help,create)
                 cmd="forge__cli__pr__help__create"
@@ -797,7 +806,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help__pr)
-            opts="create view list edit comment ready merge close checks wait-checks deliver"
+            opts="create view list edit comment comments ready merge close checks wait-checks deliver"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -839,6 +848,20 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help__pr__comment)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__pr__comments)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1951,7 +1974,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr)
-            opts="-h --format --remote --provider --repo --dry-run --help create view list edit comment ready merge close checks wait-checks deliver help"
+            opts="-h --format --remote --provider --repo --dry-run --help create view list edit comment comments ready merge close checks wait-checks deliver help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2059,6 +2082,36 @@ _forge-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__pr__comments)
+            opts="-h --format --remote --provider --repo --dry-run --help <ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
@@ -2281,7 +2334,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__help)
-            opts="create view list edit comment ready merge close checks wait-checks deliver help"
+            opts="create view list edit comment comments ready merge close checks wait-checks deliver help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2323,6 +2376,20 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__help__comment)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__pr__help__comments)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -1711,7 +1711,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__issue__view)
-            opts="-h --format --remote --provider --repo --dry-run --help <ID>"
+            opts="-h --with-comments --format --remote --provider --repo --dry-run --help <ID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -351,10 +351,11 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
 '--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
 '--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--with-comments[Also fetch the issue'\''s comment stream and embed it under \`comments\` in the envelope payload. Adds one GitLab API call; for GitHub the comments are pulled in the same \`gh issue view --json\` invocation]' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':id -- Numeric id:_default' \
+':id -- Numeric issue id:_default' \
 && ret=0
 ;;
 (list)

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -141,6 +141,19 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ':id -- Numeric PR / MR id:_default' \
 && ret=0
 ;;
+(comments)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':id -- Numeric PR / MR id:_default' \
+&& ret=0
+;;
 (ready)
 _arguments "${_arguments_options[@]}" : \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
@@ -268,6 +281,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (comment)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(comments)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -905,6 +922,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(comments)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (ready)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1280,6 +1301,7 @@ _forge-cli__subcmd__help__subcmd__pr_commands() {
 'list:List PRs / MRs' \
 'edit:Mutate PR / MR title, body, base, labels, reviewers' \
 'comment:Append a comment to a PR / MR' \
+'comments:List the issue-style comment stream attached to a PR / MR' \
 'ready:Promote a draft PR / MR to ready-for-review' \
 'merge:Merge a ready PR / MR' \
 'close:Close a PR / MR without merging' \
@@ -1303,6 +1325,11 @@ _forge-cli__subcmd__help__subcmd__pr__subcmd__close_commands() {
 _forge-cli__subcmd__help__subcmd__pr__subcmd__comment_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli help pr comment commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__pr__subcmd__comments_commands] )) ||
+_forge-cli__subcmd__help__subcmd__pr__subcmd__comments_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli help pr comments commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__help__subcmd__pr__subcmd__create_commands] )) ||
 _forge-cli__subcmd__help__subcmd__pr__subcmd__create_commands() {
@@ -1577,6 +1604,7 @@ _forge-cli__subcmd__pr_commands() {
 'list:List PRs / MRs' \
 'edit:Mutate PR / MR title, body, base, labels, reviewers' \
 'comment:Append a comment to a PR / MR' \
+'comments:List the issue-style comment stream attached to a PR / MR' \
 'ready:Promote a draft PR / MR to ready-for-review' \
 'merge:Merge a ready PR / MR' \
 'close:Close a PR / MR without merging' \
@@ -1602,6 +1630,11 @@ _forge-cli__subcmd__pr__subcmd__comment_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli pr comment commands' commands "$@"
 }
+(( $+functions[_forge-cli__subcmd__pr__subcmd__comments_commands] )) ||
+_forge-cli__subcmd__pr__subcmd__comments_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli pr comments commands' commands "$@"
+}
 (( $+functions[_forge-cli__subcmd__pr__subcmd__create_commands] )) ||
 _forge-cli__subcmd__pr__subcmd__create_commands() {
     local commands; commands=()
@@ -1625,6 +1658,7 @@ _forge-cli__subcmd__pr__subcmd__help_commands() {
 'list:List PRs / MRs' \
 'edit:Mutate PR / MR title, body, base, labels, reviewers' \
 'comment:Append a comment to a PR / MR' \
+'comments:List the issue-style comment stream attached to a PR / MR' \
 'ready:Promote a draft PR / MR to ready-for-review' \
 'merge:Merge a ready PR / MR' \
 'close:Close a PR / MR without merging' \
@@ -1649,6 +1683,11 @@ _forge-cli__subcmd__pr__subcmd__help__subcmd__close_commands() {
 _forge-cli__subcmd__pr__subcmd__help__subcmd__comment_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli pr help comment commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__pr__subcmd__help__subcmd__comments_commands] )) ||
+_forge-cli__subcmd__pr__subcmd__help__subcmd__comments_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli pr help comments commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__pr__subcmd__help__subcmd__create_commands] )) ||
 _forge-cli__subcmd__pr__subcmd__help__subcmd__create_commands() {

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -379,7 +379,7 @@ _arguments "${_arguments_options[@]}" : \
 '--title=[New title (re-validated against \`title_length\`)]:TITLE:_default' \
 '(--body-file)--body=[New body. Mutually exclusive with \`--body-file\`]:BODY:_default' \
 '--body-file=[Read body from a file. Use \`-\` for stdin]:BODY_FILE:_default' \
-'*--add-label=[Add a label. Repeat to add multiple]:NAME:_default' \
+'*--add-label=[Add a label. Repeat to add multiple. Accepts \`--label\` as a shorthand matching \`issue create --label\`]:NAME:_default' \
 '*--remove-label=[Remove a label. Repeat to remove multiple]:NAME:_default' \
 '*--add-assignee=[Add an assignee. Repeat to assign multiple]:LOGIN:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -342,6 +342,13 @@ pub struct PrCommentArgs {
     pub body_file: Option<String>,
 }
 
+/// `pr comments` arguments.
+#[derive(Args, Debug, Clone)]
+pub struct PrCommentsArgs {
+    /// Numeric PR / MR id.
+    pub id: u64,
+}
+
 /// `pr ready` arguments.
 #[derive(Args, Debug, Clone)]
 pub struct PrReadyArgs {
@@ -528,6 +535,8 @@ pub enum PrCommand {
     Edit(PrEditArgs),
     /// Append a comment to a PR / MR.
     Comment(PrCommentArgs),
+    /// List the issue-style comment stream attached to a PR / MR.
+    Comments(PrCommentsArgs),
     /// Promote a draft PR / MR to ready-for-review.
     Ready(PrReadyArgs),
     /// Merge a ready PR / MR.
@@ -910,6 +919,9 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
         Some(Command::Pr(PrArgs {
             command: Some(PrCommand::Comment(args)),
         })) => ops::pr_comment::run(&global, args, format),
+        Some(Command::Pr(PrArgs {
+            command: Some(PrCommand::Comments(args)),
+        })) => ops::pr_comments::run(&global, args, format),
         Some(Command::Pr(PrArgs {
             command: Some(PrCommand::Ready(args)),
         })) => ops::pr_ready::run(&global, args, format),

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -827,8 +827,9 @@ pub struct IssueEditArgs {
     /// Read body from a file. Use `-` for stdin.
     #[arg(long = "body-file")]
     pub body_file: Option<String>,
-    /// Add a label. Repeat to add multiple.
-    #[arg(long = "add-label", value_name = "NAME")]
+    /// Add a label. Repeat to add multiple. Accepts `--label` as a shorthand
+    /// matching `issue create --label`.
+    #[arg(long = "add-label", alias = "label", value_name = "NAME")]
     pub add_label: Vec<String>,
     /// Remove a label. Repeat to remove multiple.
     #[arg(long = "remove-label", value_name = "NAME")]

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -640,10 +640,7 @@ pub enum IssueCommand {
     /// Open a new issue.
     Create(IssueCreateArgs),
     /// Fetch a single issue.
-    View {
-        /// Numeric id.
-        id: u64,
-    },
+    View(IssueViewArgs),
     /// List issues filtered by state / labels / author / assignee.
     List(IssueListArgs),
     /// Mutate an issue.
@@ -813,6 +810,18 @@ pub struct IssueCreateArgs {
     pub assignees: Vec<String>,
 }
 
+/// `issue view` arguments.
+#[derive(Args, Debug, Clone)]
+pub struct IssueViewArgs {
+    /// Numeric issue id.
+    pub id: u64,
+    /// Also fetch the issue's comment stream and embed it under `comments`
+    /// in the envelope payload. Adds one GitLab API call; for GitHub the
+    /// comments are pulled in the same `gh issue view --json` invocation.
+    #[arg(long = "with-comments", action = ArgAction::SetTrue)]
+    pub with_comments: bool,
+}
+
 /// `issue edit` arguments.
 #[derive(Args, Debug, Clone)]
 pub struct IssueEditArgs {
@@ -936,8 +945,8 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
             command: Some(IssueCommand::Create(args)),
         })) => ops::issue_create::run(&global, args, format),
         Some(Command::Issue(IssueArgs {
-            command: Some(IssueCommand::View { id }),
-        })) => ops::issue_view::run(&global, id, format),
+            command: Some(IssueCommand::View(args)),
+        })) => ops::issue_view::run(&global, args, format),
         Some(Command::Issue(IssueArgs {
             command: Some(IssueCommand::List(args)),
         })) => ops::issue_list::run(&global, args, format),

--- a/crates/forge-cli/src/ops/issue_edit.rs
+++ b/crates/forge-cli/src/ops/issue_edit.rs
@@ -280,4 +280,23 @@ mod tests {
         assert_eq!(plan[al + 1], "bug");
         assert_eq!(plan[rl + 1], "stale");
     }
+
+    #[test]
+    fn cli_accepts_label_shorthand_for_add_label() {
+        use clap::Parser;
+
+        use crate::cli::{Cli, Command, IssueCommand};
+
+        let cli = Cli::try_parse_from(["forge-cli", "issue", "edit", "7", "--label", "type::test"])
+            .expect("cli should accept --label on issue edit");
+        let Some(Command::Issue(issue_args)) = cli.command else {
+            panic!("expected issue subcommand");
+        };
+        let Some(IssueCommand::Edit(args)) = issue_args.command else {
+            panic!("expected issue edit");
+        };
+        assert_eq!(args.id, 7);
+        assert_eq!(args.add_label, vec!["type::test".to_string()]);
+        assert!(args.remove_label.is_empty());
+    }
 }

--- a/crates/forge-cli/src/ops/issue_view.rs
+++ b/crates/forge-cli/src/ops/issue_view.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use crate::backend::{
     BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
 };
-use crate::cli::{BINARY, GlobalFlags};
+use crate::cli::{BINARY, GlobalFlags, IssueViewArgs};
 use crate::envelope::emit_success;
 use crate::error::ForgeError;
 use crate::ops::pr_state::normalize_state;
@@ -24,6 +24,16 @@ pub const SCHEMA: &str = "issue.view";
 pub const SCHEMA_VERSION: u32 = 1;
 
 const GH_JSON_FIELDS: &str = "number,url,state,title,labels,assignees,body";
+const GH_JSON_FIELDS_WITH_COMMENTS: &str = "number,url,state,title,labels,assignees,body,comments";
+
+/// One issue comment, normalized across providers.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct IssueCommentSummary {
+    pub url: String,
+    pub author: String,
+    pub created_at: String,
+    pub body: String,
+}
 
 /// Envelope payload for `cli.forge-cli.issue.view.v1`.
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -36,17 +46,24 @@ pub struct IssueViewPayload {
     pub body: String,
     pub labels: Vec<String>,
     pub assignees: Vec<String>,
+    /// Populated only when the caller passed `--with-comments`; the empty
+    /// vector is always serialized so the schema shape is stable.
+    pub comments: Vec<IssueCommentSummary>,
 }
 
-pub fn run(global: &GlobalFlags, id: u64, format: OutputFormat) -> Result<i32, ForgeError> {
+pub fn run(
+    global: &GlobalFlags,
+    args: IssueViewArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
     let runner = ProcessRunner;
-    run_with(&runner, global, id, format, git_remote_url)
+    run_with(&runner, global, args, format, git_remote_url)
 }
 
 pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     runner: &R,
     global: &GlobalFlags,
-    id: u64,
+    args: IssueViewArgs,
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
@@ -56,7 +73,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         global.repo.as_deref(),
         remote_url_lookup,
     )?;
-    let call = build_view_call(&ctx, id);
+    let call = build_view_call_with(&ctx, args.id, args.with_comments);
 
     if global.dry_run {
         let payload = DryRunPayload::new(ctx.provider, &call);
@@ -69,7 +86,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     }
 
     let output = runner.run(&call)?;
-    let payload = parse_view_output(&ctx, &output)?;
+    let mut payload = parse_view_output_with(&ctx, &output, args.with_comments)?;
+    if args.with_comments && ctx.provider == Provider::GitLab {
+        let comments_call = build_gitlab_notes_call(&ctx, &payload)?;
+        let comments_output = runner.run(&comments_call)?;
+        payload.comments = parse_gitlab_notes(&comments_output, &payload.url)?;
+    }
     Ok(emit_success(
         schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
         payload,
@@ -78,15 +100,26 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     ))
 }
 
+/// View-only call for mutation ops that re-fetch after a write. Comments are
+/// never requested here so the post-action refresh stays a single backend hop.
 pub fn build_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    build_view_call_with(ctx, id, false)
+}
+
+fn build_view_call_with(ctx: &ProviderContext, id: u64, with_comments: bool) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
+    let gh_fields = if with_comments {
+        GH_JSON_FIELDS_WITH_COMMENTS
+    } else {
+        GH_JSON_FIELDS
+    };
     let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("issue"),
             OsString::from("view"),
             OsString::from(id.to_string()),
             OsString::from("--json"),
-            OsString::from(GH_JSON_FIELDS),
+            OsString::from(gh_fields),
         ],
         Provider::GitLab => vec![
             OsString::from("issue"),
@@ -100,9 +133,48 @@ pub fn build_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     BackendCall::new(program, argv)
 }
 
+/// Build the `glab api .../notes` call used by `--with-comments` on GitLab.
+/// The project path is derived from the issue's `web_url` so we do not need
+/// the user to pass `--repo`.
+fn build_gitlab_notes_call(
+    ctx: &ProviderContext,
+    view: &IssueViewPayload,
+) -> Result<BackendCall, ForgeError> {
+    let project_path = gitlab_project_path_from_url(&view.url).ok_or_else(|| {
+        ForgeError::software(
+            schema_err(),
+            "unable to derive GitLab project path from issue web_url",
+            Some(format!("url={}", view.url)),
+        )
+    })?;
+    let encoded = project_path.replace('/', "%2F");
+    let path = format!(
+        "projects/{encoded}/issues/{iid}/notes?per_page=100&order_by=created_at&sort=asc",
+        iid = view.number,
+    );
+    Ok(BackendCall::new(
+        BackendProgram::Glab,
+        [
+            OsString::from("api"),
+            OsString::from("--paginate"),
+            OsString::from("--hostname"),
+            OsString::from(ctx.host.as_str()),
+            OsString::from(path),
+        ],
+    ))
+}
+
 pub fn parse_view_output(
     ctx: &ProviderContext,
     output: &BackendSuccess,
+) -> Result<IssueViewPayload, ForgeError> {
+    parse_view_output_with(ctx, output, false)
+}
+
+fn parse_view_output_with(
+    ctx: &ProviderContext,
+    output: &BackendSuccess,
+    with_comments: bool,
 ) -> Result<IssueViewPayload, ForgeError> {
     let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
         ForgeError::software(
@@ -112,7 +184,7 @@ pub fn parse_view_output(
         )
     })?;
     match ctx.provider {
-        Provider::GitHub => parse_github(&value, ctx),
+        Provider::GitHub => parse_github(&value, ctx, with_comments),
         Provider::GitLab => parse_gitlab(&value, ctx),
     }
 }
@@ -120,11 +192,17 @@ pub fn parse_view_output(
 fn parse_github(
     value: &serde_json::Value,
     ctx: &ProviderContext,
+    with_comments: bool,
 ) -> Result<IssueViewPayload, ForgeError> {
     let state = normalize_state(
         value.get("state").and_then(|v| v.as_str()).unwrap_or(""),
         ctx.provider,
     )?;
+    let comments = if with_comments {
+        github_comments(value)
+    } else {
+        Vec::new()
+    };
     Ok(IssueViewPayload {
         provider: ctx.provider.as_str(),
         number: value
@@ -141,6 +219,7 @@ fn parse_github(
             .to_string(),
         labels: github_name_list(value, "labels"),
         assignees: github_assignees(value),
+        comments,
     })
 }
 
@@ -168,7 +247,155 @@ fn parse_gitlab(
             .to_string(),
         labels: gitlab_label_list(value),
         assignees: gitlab_assignees(value),
+        comments: Vec::new(),
     })
+}
+
+fn github_comments(value: &serde_json::Value) -> Vec<IssueCommentSummary> {
+    value
+        .get("comments")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|item| IssueCommentSummary {
+                    url: item
+                        .get("url")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    author: item
+                        .get("author")
+                        .and_then(|a| a.get("login"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    created_at: item
+                        .get("createdAt")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    body: item
+                        .get("body")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Parse the response from `glab api .../notes` (a JSON array of note
+/// objects). `issue_url` is the issue's `web_url`, used to construct each
+/// comment URL (`<issue_url>#note_<note_id>`) since notes don't carry their
+/// own HTML URL in the REST response.
+fn parse_gitlab_notes(
+    output: &BackendSuccess,
+    issue_url: &str,
+) -> Result<Vec<IssueCommentSummary>, ForgeError> {
+    let trimmed = output.stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    // `glab api --paginate` concatenates JSON arrays back-to-back when the
+    // result spans pages. Try one-shot parse first, then fall back to
+    // splitting on `][`.
+    let chunks = if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        vec![value]
+    } else {
+        let mut acc = Vec::new();
+        for raw in trimmed.split("][") {
+            let raw = raw.trim();
+            if raw.is_empty() {
+                continue;
+            }
+            let normalized = if raw.starts_with('[') {
+                raw.to_string()
+            } else {
+                format!("[{raw}")
+            };
+            let normalized = if normalized.ends_with(']') {
+                normalized
+            } else {
+                format!("{normalized}]")
+            };
+            let value: serde_json::Value = serde_json::from_str(&normalized).map_err(|e| {
+                ForgeError::software(
+                    schema_err(),
+                    "gitlab notes response is invalid JSON",
+                    Some(e.to_string()),
+                )
+            })?;
+            acc.push(value);
+        }
+        acc
+    };
+    let mut out = Vec::new();
+    for chunk in chunks {
+        let items = chunk
+            .as_array()
+            .map(|arr| arr.to_vec())
+            .unwrap_or_else(|| vec![chunk]);
+        for item in items {
+            // GitLab's REST `/notes` includes both user-authored comments and
+            // synthetic system notes (e.g. label changes). plan-issue and
+            // other audit consumers only want real comments.
+            if item
+                .get("system")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let id = item
+                .get("id")
+                .and_then(|v| v.as_u64())
+                .map(|n| n.to_string())
+                .unwrap_or_default();
+            let url = format!("{issue_url}#note_{id}");
+            out.push(IssueCommentSummary {
+                url,
+                author: item
+                    .get("author")
+                    .and_then(|a| a.get("username"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                created_at: item
+                    .get("created_at")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                body: item
+                    .get("body")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Extract the GitLab project path (group/project, possibly nested) from an
+/// issue's `web_url`. Returns `None` when the URL does not look like a GitLab
+/// issue URL. Accepts both `/-/issues/<iid>` and `/issues/<iid>` shapes.
+fn gitlab_project_path_from_url(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let path = after_scheme.split_once('/').map(|(_, rest)| rest)?;
+    let path = path.trim_end_matches('/');
+    let project_path = if let Some(idx) = path.find("/-/issues/") {
+        &path[..idx]
+    } else if let Some(idx) = path.find("/issues/") {
+        &path[..idx]
+    } else {
+        return None;
+    };
+    if project_path.is_empty() {
+        None
+    } else {
+        Some(project_path.to_string())
+    }
 }
 
 fn github_name_list(value: &serde_json::Value, key: &str) -> Vec<String> {
@@ -325,5 +552,154 @@ mod tests {
         };
         let p = parse_view_output(&ctx(Provider::GitLab), &output).unwrap();
         assert_eq!(p.state, "closed");
+    }
+
+    #[test]
+    fn build_view_call_github_includes_comments_field_when_requested() {
+        let plain = build_view_call_with(&ctx(Provider::GitHub), 5, false).plan_argv();
+        let json_plain = plain
+            .iter()
+            .position(|s| s == "--json")
+            .map(|i| plain[i + 1].as_str())
+            .unwrap();
+        assert!(
+            !json_plain.contains("comments"),
+            "default view should not request comments"
+        );
+
+        let with = build_view_call_with(&ctx(Provider::GitHub), 5, true).plan_argv();
+        let json_with = with
+            .iter()
+            .position(|s| s == "--json")
+            .map(|i| with[i + 1].as_str())
+            .unwrap();
+        assert!(
+            json_with.contains("comments"),
+            "--with-comments must extend --json"
+        );
+    }
+
+    #[test]
+    fn build_view_call_gitlab_does_not_change_for_with_comments() {
+        let plain = build_view_call_with(&ctx(Provider::GitLab), 5, false).plan_argv();
+        let with = build_view_call_with(&ctx(Provider::GitLab), 5, true).plan_argv();
+        assert_eq!(
+            plain, with,
+            "GitLab view call shape is identical; comments come from a follow-up api call"
+        );
+    }
+
+    #[test]
+    fn parse_github_with_comments_normalises_author_and_url() {
+        let output = BackendSuccess {
+            stdout: r#"{
+                "number":7,"url":"https://github.com/o/r/issues/7","state":"OPEN","title":"t","body":"b",
+                "labels":[],"assignees":[],
+                "comments":[
+                    {"author":{"login":"alice"},"body":"hi","url":"https://github.com/o/r/issues/7#issuecomment-1","createdAt":"2025-01-01T00:00:00Z"},
+                    {"author":{"login":"bob"},"body":"hello","url":"https://github.com/o/r/issues/7#issuecomment-2","createdAt":"2025-01-02T00:00:00Z"}
+                ]
+            }"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output_with(&ctx(Provider::GitHub), &output, true).unwrap();
+        assert_eq!(p.comments.len(), 2);
+        assert_eq!(p.comments[0].author, "alice");
+        assert_eq!(p.comments[0].body, "hi");
+        assert_eq!(
+            p.comments[0].url,
+            "https://github.com/o/r/issues/7#issuecomment-1"
+        );
+        assert_eq!(p.comments[0].created_at, "2025-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn parse_github_without_with_comments_keeps_comments_empty() {
+        let output = BackendSuccess {
+            stdout: r#"{"number":7,"url":"u","state":"OPEN","title":"t","body":"b","labels":[],"assignees":[],"comments":[{"author":{"login":"a"},"body":"x","url":"u","createdAt":"t"}]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitHub), &output).unwrap();
+        assert!(
+            p.comments.is_empty(),
+            "without --with-comments the field stays empty"
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_notes_filters_system_notes_and_constructs_url() {
+        let output = BackendSuccess {
+            stdout: r#"[
+                {"id":1,"body":"first","author":{"username":"alice"},"created_at":"2025-01-01T00:00:00Z","system":false},
+                {"id":2,"body":"added label","author":{"username":"alice"},"created_at":"2025-01-01T00:01:00Z","system":true},
+                {"id":3,"body":"second","author":{"username":"bob"},"created_at":"2025-01-02T00:00:00Z","system":false}
+            ]"#.into(),
+            stderr: String::new(),
+        };
+        let comments = parse_gitlab_notes(
+            &output,
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4",
+        )
+        .unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].author, "alice");
+        assert_eq!(comments[0].body, "first");
+        assert_eq!(
+            comments[0].url,
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4#note_1"
+        );
+        assert_eq!(comments[1].author, "bob");
+        assert_eq!(
+            comments[1].url,
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4#note_3"
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_notes_handles_empty_array() {
+        let output = BackendSuccess {
+            stdout: "[]".into(),
+            stderr: String::new(),
+        };
+        let comments =
+            parse_gitlab_notes(&output, "https://gitlab.example.com/g/p/-/issues/1").unwrap();
+        assert!(comments.is_empty());
+    }
+
+    #[test]
+    fn parse_gitlab_notes_handles_concatenated_pages() {
+        let output = BackendSuccess {
+            stdout: r#"[{"id":1,"body":"a","author":{"username":"u"},"created_at":"t","system":false}][{"id":2,"body":"b","author":{"username":"u"},"created_at":"t","system":false}]"#.into(),
+            stderr: String::new(),
+        };
+        let comments =
+            parse_gitlab_notes(&output, "https://gitlab.example.com/g/p/-/issues/1").unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].body, "a");
+        assert_eq!(comments[1].body, "b");
+    }
+
+    #[test]
+    fn gitlab_project_path_from_url_extracts_nested_groups() {
+        assert_eq!(
+            gitlab_project_path_from_url(
+                "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4"
+            )
+            .as_deref(),
+            Some("terrylin/agent-runtime-testing")
+        );
+        assert_eq!(
+            gitlab_project_path_from_url("https://gitlab.com/group/sub/project/-/issues/12")
+                .as_deref(),
+            Some("group/sub/project")
+        );
+        assert_eq!(
+            gitlab_project_path_from_url("https://gitlab.example.com/g/p/issues/1").as_deref(),
+            Some("g/p"),
+            "fallback for hosts that elide the `/-/` segment",
+        );
+        assert!(
+            gitlab_project_path_from_url("https://gitlab.example.com/not-an-issue-url").is_none()
+        );
     }
 }

--- a/crates/forge-cli/src/ops/mod.rs
+++ b/crates/forge-cli/src/ops/mod.rs
@@ -16,6 +16,7 @@ pub mod pr_checks;
 pub mod pr_checks_gitlab;
 pub mod pr_close;
 pub mod pr_comment;
+pub mod pr_comments;
 pub mod pr_create;
 pub mod pr_edit;
 pub mod pr_list;

--- a/crates/forge-cli/src/ops/pr_comments.rs
+++ b/crates/forge-cli/src/ops/pr_comments.rs
@@ -1,0 +1,602 @@
+//! `pr comments` atom — read-side companion to `pr comment`.
+//!
+//! Spec / ops: `cli.forge-cli.pr.comments.v1`. Returns the issue-style comment
+//! stream attached to a PR/MR (`/repos/<owner>/<repo>/issues/<n>/comments` on
+//! GitHub, `/projects/<encoded>/merge_requests/<iid>/notes` on GitLab). System
+//! notes (label/assignee changes) are filtered out so callers only see
+//! user-authored entries.
+
+use std::ffi::OsString;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{
+    BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
+};
+use crate::cli::{BINARY, GlobalFlags, PrCommentsArgs};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_view;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const SCHEMA: &str = "pr.comments";
+const SCHEMA_VERSION: u32 = 1;
+
+/// One PR / MR comment, normalized across providers.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrCommentSummary {
+    pub url: String,
+    pub author: String,
+    pub created_at: String,
+    pub body: String,
+}
+
+/// Envelope payload for `cli.forge-cli.pr.comments.v1`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrCommentsPayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub comments: Vec<PrCommentSummary>,
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    args: PrCommentsArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, args, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: PrCommentsArgs,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
+
+    // Resolve the canonical PR/MR URL first; both providers need the
+    // owner/repo (or group/project) segment for the comments API path, and
+    // re-using `pr view` keeps URL parsing in one place.
+    let view_output = runner.run(&pr_view::build_view_call(&ctx, &args.id.to_string()))?;
+    let view = pr_view::parse_view_output(&ctx, &view_output)?;
+
+    let comments_call = build_comments_call(&ctx, &view)?;
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &comments_call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let comments_output = runner.run(&comments_call)?;
+    let comments = match ctx.provider {
+        Provider::GitHub => parse_github_comments(&comments_output)?,
+        Provider::GitLab => parse_gitlab_notes(&comments_output, &view.url)?,
+    };
+
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        PrCommentsPayload {
+            provider: ctx.provider.as_str(),
+            number: view.number,
+            url: view.url,
+            comments,
+        },
+        format,
+        render_text,
+    ))
+}
+
+fn build_comments_call(
+    ctx: &ProviderContext,
+    view: &pr_view::PrViewPayload,
+) -> Result<BackendCall, ForgeError> {
+    match ctx.provider {
+        Provider::GitHub => {
+            let slug = github_repo_slug_from_url(&view.url).ok_or_else(|| {
+                ForgeError::software(
+                    schema_err(),
+                    "unable to derive GitHub owner/repo from PR url",
+                    Some(format!("url={}", view.url)),
+                )
+            })?;
+            let path = format!(
+                "repos/{slug}/issues/{n}/comments?per_page=100",
+                n = view.number,
+            );
+            Ok(BackendCall::new(
+                BackendProgram::Gh,
+                [
+                    OsString::from("api"),
+                    OsString::from("--paginate"),
+                    OsString::from(path),
+                ],
+            ))
+        }
+        Provider::GitLab => {
+            let project = gitlab_project_path_from_url(&view.url).ok_or_else(|| {
+                ForgeError::software(
+                    schema_err(),
+                    "unable to derive GitLab project path from MR web_url",
+                    Some(format!("url={}", view.url)),
+                )
+            })?;
+            let encoded = project.replace('/', "%2F");
+            let path = format!(
+                "projects/{encoded}/merge_requests/{iid}/notes?per_page=100&order_by=created_at&sort=asc",
+                iid = view.number,
+            );
+            Ok(BackendCall::new(
+                BackendProgram::Glab,
+                [
+                    OsString::from("api"),
+                    OsString::from("--paginate"),
+                    OsString::from("--hostname"),
+                    OsString::from(ctx.host.as_str()),
+                    OsString::from(path),
+                ],
+            ))
+        }
+    }
+}
+
+fn parse_github_comments(output: &BackendSuccess) -> Result<Vec<PrCommentSummary>, ForgeError> {
+    let chunks = split_concatenated_arrays(&output.stdout)?;
+    let mut out = Vec::new();
+    for chunk in chunks {
+        let items = chunk.as_array().cloned().unwrap_or_else(|| vec![chunk]);
+        for item in items {
+            out.push(PrCommentSummary {
+                url: item
+                    .get("html_url")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                author: item
+                    .get("user")
+                    .and_then(|u| u.get("login"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                created_at: item
+                    .get("created_at")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                body: item
+                    .get("body")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+fn parse_gitlab_notes(
+    output: &BackendSuccess,
+    mr_url: &str,
+) -> Result<Vec<PrCommentSummary>, ForgeError> {
+    let chunks = split_concatenated_arrays(&output.stdout)?;
+    let mut out = Vec::new();
+    for chunk in chunks {
+        let items = chunk.as_array().cloned().unwrap_or_else(|| vec![chunk]);
+        for item in items {
+            // Skip synthetic system notes (label changes, assignee changes,
+            // etc.) — only user-authored comments are useful to consumers.
+            if item
+                .get("system")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let id = item
+                .get("id")
+                .and_then(|v| v.as_u64())
+                .map(|n| n.to_string())
+                .unwrap_or_default();
+            out.push(PrCommentSummary {
+                url: format!("{mr_url}#note_{id}"),
+                author: item
+                    .get("author")
+                    .and_then(|a| a.get("username"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                created_at: item
+                    .get("created_at")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                body: item
+                    .get("body")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// `gh api --paginate` / `glab api --paginate` concatenate JSON arrays
+/// back-to-back when results span pages. Parse the trimmed stdout as one or
+/// more arrays.
+fn split_concatenated_arrays(stdout: &str) -> Result<Vec<serde_json::Value>, ForgeError> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        return Ok(vec![value]);
+    }
+    let mut acc = Vec::new();
+    for raw in trimmed.split("][") {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        let normalized = if raw.starts_with('[') {
+            raw.to_string()
+        } else {
+            format!("[{raw}")
+        };
+        let normalized = if normalized.ends_with(']') {
+            normalized
+        } else {
+            format!("{normalized}]")
+        };
+        let value: serde_json::Value = serde_json::from_str(&normalized).map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "comments response is invalid JSON",
+                Some(e.to_string()),
+            )
+        })?;
+        acc.push(value);
+    }
+    Ok(acc)
+}
+
+/// Extract `owner/repo` from a GitHub PR URL like
+/// `https://github.com/owner/repo/pull/<n>`.
+fn github_repo_slug_from_url(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let path = after_scheme.split_once('/').map(|(_, rest)| rest)?;
+    let pull_idx = path.find("/pull/").or_else(|| path.find("/issues/"))?;
+    let slug = &path[..pull_idx];
+    let mut parts = slug.splitn(3, '/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() || parts.next().is_some() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+/// Extract the GitLab project path (group[/subgroup]/project) from an MR's
+/// `web_url` like `https://gitlab.example.com/group/project/-/merge_requests/<iid>`.
+fn gitlab_project_path_from_url(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let path = after_scheme.split_once('/').map(|(_, rest)| rest)?;
+    let path = path.trim_end_matches('/');
+    let idx = path
+        .find("/-/merge_requests/")
+        .or_else(|| path.find("/merge_requests/"))?;
+    let project_path = &path[..idx];
+    if project_path.is_empty() {
+        None
+    } else {
+        Some(project_path.to_string())
+    }
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &PrCommentsPayload) {
+    println!(
+        "{provider} #{number} ({n} comments)\n  {url}",
+        provider = payload.provider,
+        number = payload.number,
+        n = payload.comments.len(),
+        url = payload.url,
+    );
+    for comment in &payload.comments {
+        let body_first_line = comment.body.lines().next().unwrap_or("");
+        println!(
+            "  - [{at}] {author}: {body}",
+            at = comment.created_at,
+            author = comment.author,
+            body = body_first_line,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use nils_common::cli_contract::OutputFormat;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::backend::BackendOutput;
+    use crate::cli::GlobalFlags;
+
+    struct ScriptedRunner {
+        outputs: RefCell<Vec<BackendSuccess>>,
+        calls: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl ScriptedRunner {
+        fn new(outputs: Vec<BackendSuccess>) -> Self {
+            Self {
+                outputs: RefCell::new(outputs),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl crate::backend::BackendRunner for ScriptedRunner {
+        fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+            self.calls.borrow_mut().push(call.plan_argv());
+            Ok(self.outputs.borrow_mut().remove(0))
+        }
+
+        fn run_raw(&self, call: &BackendCall) -> Result<BackendOutput, ForgeError> {
+            self.run(call).map(|s| BackendOutput {
+                exit_code: 0,
+                status_success: true,
+                stdout: s.stdout,
+                stderr: s.stderr,
+            })
+        }
+    }
+
+    fn json_global() -> GlobalFlags {
+        GlobalFlags {
+            format: Some(OutputFormat::Json),
+            remote: "origin".into(),
+            provider: Some(crate::cli::ProviderFlag::Github),
+            repo: Some("o/r".into()),
+            dry_run: false,
+        }
+    }
+
+    #[test]
+    fn github_repo_slug_from_pr_and_issue_urls() {
+        assert_eq!(
+            github_repo_slug_from_url("https://github.com/sympoies/nils-cli/pull/123").as_deref(),
+            Some("sympoies/nils-cli")
+        );
+        assert_eq!(
+            github_repo_slug_from_url("https://github.com/owner/repo/issues/9").as_deref(),
+            Some("owner/repo")
+        );
+        assert!(
+            github_repo_slug_from_url("https://github.com/just-owner").is_none(),
+            "missing /pull/ or /issues/ segment must yield None"
+        );
+    }
+
+    #[test]
+    fn gitlab_project_path_from_mr_url_handles_nested_groups() {
+        assert_eq!(
+            gitlab_project_path_from_url(
+                "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/12"
+            )
+            .as_deref(),
+            Some("terrylin/agent-runtime-testing")
+        );
+        assert_eq!(
+            gitlab_project_path_from_url("https://gitlab.com/group/sub/project/-/merge_requests/3")
+                .as_deref(),
+            Some("group/sub/project")
+        );
+        assert!(
+            gitlab_project_path_from_url("https://gitlab.example.com/g/p/-/issues/1").is_none()
+        );
+    }
+
+    #[test]
+    fn parse_github_comments_extracts_user_author_and_html_url() {
+        let output = BackendSuccess {
+            stdout: r#"[
+                {"user":{"login":"alice"},"body":"hi","html_url":"https://github.com/o/r/pull/1#issuecomment-100","created_at":"2025-01-01T00:00:00Z"},
+                {"user":{"login":"bob"},"body":"hello","html_url":"https://github.com/o/r/pull/1#issuecomment-101","created_at":"2025-01-02T00:00:00Z"}
+            ]"#.into(),
+            stderr: String::new(),
+        };
+        let comments = parse_github_comments(&output).unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].author, "alice");
+        assert_eq!(
+            comments[0].url,
+            "https://github.com/o/r/pull/1#issuecomment-100"
+        );
+        assert_eq!(comments[0].body, "hi");
+    }
+
+    #[test]
+    fn parse_github_comments_handles_concatenated_pages() {
+        let output = BackendSuccess {
+            stdout: r#"[{"user":{"login":"a"},"body":"x","html_url":"u","created_at":"t"}][{"user":{"login":"b"},"body":"y","html_url":"u","created_at":"t"}]"#.into(),
+            stderr: String::new(),
+        };
+        let comments = parse_github_comments(&output).unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].body, "x");
+        assert_eq!(comments[1].body, "y");
+    }
+
+    #[test]
+    fn parse_gitlab_notes_skips_system_notes_and_constructs_urls() {
+        let output = BackendSuccess {
+            stdout: r#"[
+                {"id":1,"body":"first","author":{"username":"alice"},"created_at":"2025-01-01T00:00:00Z","system":false},
+                {"id":2,"body":"added label","author":{"username":"alice"},"created_at":"2025-01-01T00:01:00Z","system":true},
+                {"id":3,"body":"second","author":{"username":"bob"},"created_at":"2025-01-02T00:00:00Z","system":false}
+            ]"#.into(),
+            stderr: String::new(),
+        };
+        let comments = parse_gitlab_notes(
+            &output,
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/12",
+        )
+        .unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].author, "alice");
+        assert_eq!(
+            comments[0].url,
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/12#note_1"
+        );
+        assert_eq!(comments[1].author, "bob");
+    }
+
+    #[test]
+    fn split_concatenated_arrays_returns_empty_for_empty_stdout() {
+        let chunks = split_concatenated_arrays("   \n").unwrap();
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn run_with_github_emits_envelope_and_invokes_two_backend_calls() {
+        // First call: `pr view 7 --json …`. Second call: `gh api --paginate
+        // repos/o/r/issues/7/comments?per_page=100`.
+        let runner = ScriptedRunner::new(vec![
+            BackendSuccess {
+                stdout: r#"{"number":7,"url":"https://github.com/o/r/pull/7","state":"OPEN","isDraft":false,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[]}"#.into(),
+                stderr: String::new(),
+            },
+            BackendSuccess {
+                stdout: r#"[{"user":{"login":"alice"},"body":"hi","html_url":"https://github.com/o/r/pull/7#issuecomment-1","created_at":"2025-01-01T00:00:00Z"}]"#.into(),
+                stderr: String::new(),
+            },
+        ]);
+        let global = json_global();
+        let code = run_with(
+            &runner,
+            &global,
+            PrCommentsArgs { id: 7 },
+            OutputFormat::Json,
+            |_| Some("git@github.com:o/r.git".into()),
+        )
+        .expect("github run_with");
+        assert_eq!(code, nils_common::cli_contract::exit::SUCCESS);
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 2, "expected pr view + comments api call");
+        assert_eq!(
+            calls[0][..3],
+            ["gh".to_string(), "pr".to_string(), "view".to_string()]
+        );
+        assert_eq!(
+            calls[1][..3],
+            [
+                "gh".to_string(),
+                "api".to_string(),
+                "--paginate".to_string()
+            ]
+        );
+        assert!(
+            calls[1]
+                .iter()
+                .any(|s| s.contains("repos/o/r/issues/7/comments")),
+            "comments path must reference owner/repo derived from view URL: {:?}",
+            calls[1]
+        );
+    }
+
+    #[test]
+    fn run_with_gitlab_builds_notes_path_from_mr_view_url() {
+        // GitLab path: `mr view -F json` then `glab api --paginate --hostname
+        // <h> /projects/<encoded>/merge_requests/12/notes…`.
+        let runner = ScriptedRunner::new(vec![
+            BackendSuccess {
+                stdout: r#"{"iid":12,"web_url":"https://gitlab.example.com/grp/proj/-/merge_requests/12","state":"opened","draft":false,"title":"t","source_branch":"feat/x","target_branch":"main","merge_status":"can_be_merged","labels":[]}"#.into(),
+                stderr: String::new(),
+            },
+            BackendSuccess {
+                stdout: r#"[{"id":9,"body":"hi","author":{"username":"alice"},"created_at":"t","system":false}]"#.into(),
+                stderr: String::new(),
+            },
+        ]);
+        let global = GlobalFlags {
+            format: Some(OutputFormat::Json),
+            remote: "origin".into(),
+            provider: Some(crate::cli::ProviderFlag::Gitlab),
+            repo: Some("grp/proj".into()),
+            dry_run: false,
+        };
+        let code = run_with(
+            &runner,
+            &global,
+            PrCommentsArgs { id: 12 },
+            OutputFormat::Json,
+            |_| Some("git@gitlab.example.com:grp/proj.git".into()),
+        )
+        .expect("gitlab run_with");
+        assert_eq!(code, nils_common::cli_contract::exit::SUCCESS);
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1][..2], ["glab".to_string(), "api".to_string()]);
+        assert!(
+            calls[1]
+                .iter()
+                .any(|s| s.contains("projects/grp%2Fproj/merge_requests/12/notes")),
+            "notes path must url-encode the project slug derived from MR web_url: {:?}",
+            calls[1]
+        );
+    }
+
+    #[test]
+    fn run_with_dry_run_emits_plan_envelope_without_running_comments_call() {
+        // Dry-run still runs the pr view call (used to derive the URL), then
+        // emits the comments call as a DryRunPayload without executing it.
+        let runner = ScriptedRunner::new(vec![BackendSuccess {
+            stdout: r#"{"number":7,"url":"https://github.com/o/r/pull/7","state":"OPEN","isDraft":false,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[]}"#.into(),
+            stderr: String::new(),
+        }]);
+        let global = GlobalFlags {
+            dry_run: true,
+            ..json_global()
+        };
+        let code = run_with(
+            &runner,
+            &global,
+            PrCommentsArgs { id: 7 },
+            OutputFormat::Json,
+            |_| Some("git@github.com:o/r.git".into()),
+        )
+        .expect("dry-run");
+        assert_eq!(code, nils_common::cli_contract::exit::SUCCESS);
+        assert_eq!(
+            runner.calls().len(),
+            1,
+            "dry-run must not invoke the comments call"
+        );
+    }
+}

--- a/crates/forge-cli/src/ops/pr_view.rs
+++ b/crates/forge-cli/src/ops/pr_view.rs
@@ -26,7 +26,7 @@ const SCHEMA: &str = "pr.view";
 const SCHEMA_VERSION: u32 = 1;
 
 const GH_JSON_FIELDS: &str =
-    "number,url,state,isDraft,title,headRefName,baseRefName,mergeable,mergedAt,labels";
+    "number,url,state,isDraft,title,headRefName,baseRefName,mergeable,mergedAt,mergeCommit,labels";
 
 /// Envelope payload for `cli.forge-cli.pr.view.v1`.
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -41,6 +41,11 @@ pub struct PrViewPayload {
     pub base: String,
     pub mergeable: &'static str,
     pub merged_at: Option<String>,
+    /// Commit SHA of the merge commit when the PR/MR is merged. Always
+    /// emitted (the field defaults to `null` for non-merged PRs); GitHub
+    /// derives it from `mergeCommit.oid`, GitLab reads the top-level
+    /// `merge_commit_sha`.
+    pub merge_commit_sha: Option<String>,
     pub labels: Vec<String>,
 }
 
@@ -183,6 +188,12 @@ fn parse_github(
     } else {
         normalize_state(raw_state, ctx.provider)?
     };
+    let merge_commit_sha = value
+        .get("mergeCommit")
+        .and_then(|mc| mc.get("oid"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.is_empty());
     let labels = github_label_names(value);
     Ok(PrViewPayload {
         provider: ctx.provider.as_str(),
@@ -201,6 +212,7 @@ fn parse_github(
         base: required_str(value, "baseRefName")?,
         mergeable: normalize_mergeable_github(value.get("mergeable").and_then(|v| v.as_str())),
         merged_at,
+        merge_commit_sha,
         labels,
     })
 }
@@ -221,6 +233,11 @@ fn parse_gitlab(
         .and_then(|v| v.as_bool())
         .or_else(|| value.get("work_in_progress").and_then(|v| v.as_bool()))
         .unwrap_or(false);
+    let merge_commit_sha = value
+        .get("merge_commit_sha")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.is_empty());
     let labels = gitlab_label_names(value);
     Ok(PrViewPayload {
         provider: ctx.provider.as_str(),
@@ -236,6 +253,7 @@ fn parse_gitlab(
         base: required_str(value, "target_branch")?,
         mergeable: normalize_mergeable_gitlab(value.get("merge_status").and_then(|v| v.as_str())),
         merged_at,
+        merge_commit_sha,
         labels,
     })
 }
@@ -404,5 +422,71 @@ mod tests {
         assert_eq!(extract_first_iid(s), Some("42".into()));
         assert_eq!(extract_first_iid("[]"), None);
         assert_eq!(extract_first_iid("not json"), None);
+    }
+
+    #[test]
+    fn build_view_call_github_requests_merge_commit_field() {
+        let plan = build_view_call(&ctx(Provider::GitHub), "5").plan_argv();
+        let json_idx = plan.iter().position(|s| s == "--json").unwrap();
+        assert!(
+            plan[json_idx + 1].contains("mergeCommit"),
+            "GitHub --json field list must request mergeCommit so merge_commit_sha is populated"
+        );
+    }
+
+    #[test]
+    fn parse_github_merged_pr_extracts_merge_commit_sha() {
+        let output = BackendSuccess {
+            stdout: r#"{
+                "number":5,"url":"u","state":"CLOSED","isDraft":false,"title":"t",
+                "headRefName":"feat/x","baseRefName":"main","mergeable":"UNKNOWN",
+                "mergedAt":"2026-05-19T10:00:00Z",
+                "mergeCommit":{"oid":"abcdef0123456789"},
+                "labels":[]
+            }"#
+            .into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitHub), &output).unwrap();
+        assert_eq!(p.state, "merged");
+        assert_eq!(p.merge_commit_sha.as_deref(), Some("abcdef0123456789"));
+    }
+
+    #[test]
+    fn parse_github_open_pr_has_no_merge_commit_sha() {
+        let output = BackendSuccess {
+            stdout: r#"{"number":5,"url":"u","state":"OPEN","isDraft":false,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"mergeCommit":null,"labels":[]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitHub), &output).unwrap();
+        assert_eq!(p.merge_commit_sha, None);
+    }
+
+    #[test]
+    fn parse_gitlab_merged_mr_extracts_merge_commit_sha() {
+        let output = BackendSuccess {
+            stdout: r#"{
+                "iid":7,"web_url":"u","state":"merged","draft":false,"title":"t",
+                "source_branch":"feat/x","target_branch":"main","merge_status":"can_be_merged",
+                "merged_at":"2026-05-19T10:00:00Z",
+                "merge_commit_sha":"1234567890abcdef",
+                "labels":[]
+            }"#
+            .into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitLab), &output).unwrap();
+        assert_eq!(p.state, "merged");
+        assert_eq!(p.merge_commit_sha.as_deref(), Some("1234567890abcdef"));
+    }
+
+    #[test]
+    fn parse_gitlab_open_mr_treats_empty_merge_commit_sha_as_none() {
+        let output = BackendSuccess {
+            stdout: r#"{"iid":7,"web_url":"u","state":"opened","draft":false,"title":"t","source_branch":"feat/x","target_branch":"main","merge_status":"can_be_merged","merge_commit_sha":"","labels":[]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitLab), &output).unwrap();
+        assert_eq!(p.merge_commit_sha, None);
     }
 }

--- a/crates/forge-cli/src/ops/pr_view.rs
+++ b/crates/forge-cli/src/ops/pr_view.rs
@@ -98,7 +98,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     ))
 }
 
-fn build_view_call(ctx: &ProviderContext, id: &str) -> BackendCall {
+pub(crate) fn build_view_call(ctx: &ProviderContext, id: &str) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
     let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![


### PR DESCRIPTION
## Summary

- Adds `agent-runtime list-skills`, a read-only subcommand that enumerates
  the skills `install` would activate for a given product + source-root.
  Reuses `LinkMap` and `InstallPlan::build`; deterministic `text` and
  `cli.agent-runtime.list-skills.v1` JSON output.
- Lets `agent-runtime-kit/scripts/ci/sandbox-install-rehearsal.sh` replace
  its codex/claude regex parsing of `install --dry-run` text with
  `jq -r '.skills[].id'`, closing the gap left by Resolved Decision #8 in
  the runtime-kit architecture doc (product CLIs never shipped
  `--home <dir> --list-skills`).

## Plan

- Tracking issue: #489 (`docs/plans/agent-runtime-list-skills/`)
- Cross-repo follow-up branch ready in
  `graysurf/agent-runtime-kit @ feat/sandbox-rehearsal-list-skills` and
  proven against this PR's binary; published as a separate PR once a
  nils-cli release ships `list-skills`.

## Changes

- `crates/agent-runtime-cli/src/commands/list_skills.rs`: new module with
  the clap surface, enumeration logic (codex `skills/<domain>/<skill>` /
  claude `plugins/<domain>/skills/<skill>/SKILL.md`), warning surfacing,
  and 9 unit tests covering identification, formatter inputs,
  warning-surface, and validation.
- `crates/agent-runtime-cli/src/lib.rs` and
  `crates/agent-runtime-cli/src/commands/mod.rs`: register
  `Command::ListSkills` and route stderr-prefixed errors like other
  subcommands.
- `crates/agent-runtime-cli/README.md`: document subcommand, JSON v1
  schema, and the rehearsal-replacement workflow.

## Test plan

- [x] `cargo test -p agent-runtime-cli list_skills` (9/9 pass).
- [x] `cargo test -p agent-runtime-cli` (full crate suite green).
- [x] `cargo clippy -p agent-runtime-cli --all-targets -- -D warnings`.
- [x] `cargo fmt --all -- --check`.
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
      (docs placement / hygiene / markdownlint / plan-bundle validate /
      CLI output contract / forge fixture redaction).
- [x] `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh`
      (full required-checks lane green).
- [x] End-to-end against a real agent-runtime-kit checkout:
      `agent-runtime list-skills --source-root <kit> --product codex
      --format json | jq -r '.skills[].id' | sort` matches the pinned
      `tests/sandbox/codex/expected-skills.txt` exactly (60 skills).
      Same for `--product claude` (60 skills).
- [x] Updated rehearsal script (`feat/sandbox-rehearsal-list-skills`
      branch in `graysurf/agent-runtime-kit`) runs green against this
      branch's binary.

## Risk

- JSON v1 schema becomes a consumer contract once merged; field
  additions are non-breaking, but removals or renames must bump the
  `schema` marker.
- Reuses `doctor::skill_surface` warning codes — downstream parsers must
  tolerate new codes appearing in the `warnings` array.
- Cross-repo rehearsal script keeps a regex fallback gated on
  `has_list_skills`, so the gate keeps working against pre-0.22.0
  binaries during release rollout.
