### PR TITLE
feat(forge-cli): accept --label as add-label shorthand on issue edit

### DIFF
--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -379,7 +379,7 @@ _arguments "${_arguments_options[@]}" : \
 '--title=[New title (re-validated against \`title_length\`)]:TITLE:_default' \
 '(--body-file)--body=[New body. Mutually exclusive with \`--body-file\`]:BODY:_default' \
 '--body-file=[Read body from a file. Use \`-\` for stdin]:BODY_FILE:_default' \
-'*--add-label=[Add a label. Repeat to add multiple]:NAME:_default' \
+'*--add-label=[Add a label. Repeat to add multiple. Accepts \`--label\` as a shorthand matching \`issue create --label\`]:NAME:_default' \
 '*--remove-label=[Remove a label. Repeat to remove multiple]:NAME:_default' \
 '*--add-assignee=[Add an assignee. Repeat to assign multiple]:LOGIN:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -827,8 +827,9 @@ pub struct IssueEditArgs {
     /// Read body from a file. Use `-` for stdin.
     #[arg(long = "body-file")]
     pub body_file: Option<String>,
-    /// Add a label. Repeat to add multiple.
-    #[arg(long = "add-label", value_name = "NAME")]
+    /// Add a label. Repeat to add multiple. Accepts `--label` as a shorthand
+    /// matching `issue create --label`.
+    #[arg(long = "add-label", alias = "label", value_name = "NAME")]
     pub add_label: Vec<String>,
     /// Remove a label. Repeat to remove multiple.
     #[arg(long = "remove-label", value_name = "NAME")]

--- a/crates/forge-cli/src/ops/issue_edit.rs
+++ b/crates/forge-cli/src/ops/issue_edit.rs
@@ -280,4 +280,23 @@ mod tests {
         assert_eq!(plan[al + 1], "bug");
         assert_eq!(plan[rl + 1], "stale");
     }
+
+    #[test]
+    fn cli_accepts_label_shorthand_for_add_label() {
+        use clap::Parser;
+
+        use crate::cli::{Cli, Command, IssueCommand};
+
+        let cli = Cli::try_parse_from(["forge-cli", "issue", "edit", "7", "--label", "type::test"])
+            .expect("cli should accept --label on issue edit");
+        let Some(Command::Issue(issue_args)) = cli.command else {
+            panic!("expected issue subcommand");
+        };
+        let Some(IssueCommand::Edit(args)) = issue_args.command else {
+            panic!("expected issue edit");
+        };
+        assert_eq!(args.id, 7);
+        assert_eq!(args.add_label, vec!["type::test".to_string()]);
+        assert!(args.remove_label.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

- Accept `--label` as a shorthand for `--add-label` on `forge-cli issue edit`, mirroring `issue create --label` ergonomics on both providers.
- Refresh the checked-in zsh completion asset so the `completion-asset-audit` gate stays green; the GitHub argv stays `--add-label`, the GitLab argv stays `--label`.

## Why

Downstream sandbox validation against `gitlab.gamania.com` recorded **F-8** when `forge-cli issue edit 4 --label 'type::test'` failed with `unknown-subcommand: unexpected argument '--label' found`. Operators kept reaching for `--label` because that is the spelling on `issue create`; this aliases it to the existing canonical flag so both spellings work.

## Test plan

- [x] `cargo test -p nils-forge-cli issue_edit` — six unit tests including the new `cli_accepts_label_shorthand_for_add_label` parse test
- [x] `scripts/ci/nils-cli-local-fast.sh` — full local fast gate (nextest + fmt/clippy + completion-asset-audit)
- [ ] Downstream sandbox re-run of the F-8 case once this lands

## Sandbox link

F-8 in `terrylin/agent-runtime-testing` source doc: <https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/blob/main/docs/plans/gitlab-skill-validation/gitlab-skill-validation-discussion-source.md?ref_type=heads>

Refs: #483 (forge-cli GitLab readiness companion).
