### PR TITLE
feat(forge-cli): add --with-comments to issue view (G1)

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -1711,7 +1711,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__issue__view)
-            opts="-h --format --remote --provider --repo --dry-run --help <ID>"
+            opts="-h --with-comments --format --remote --provider --repo --dry-run --help <ID>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -351,10 +351,11 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
 '--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
 '--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--with-comments[Also fetch the issue'\''s comment stream and embed it under \`comments\` in the envelope payload. Adds one GitLab API call; for GitHub the comments are pulled in the same \`gh issue view --json\` invocation]' \
 '--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':id -- Numeric id:_default' \
+':id -- Numeric issue id:_default' \
 && ret=0
 ;;
 (list)

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -640,10 +640,7 @@ pub enum IssueCommand {
     /// Open a new issue.
     Create(IssueCreateArgs),
     /// Fetch a single issue.
-    View {
-        /// Numeric id.
-        id: u64,
-    },
+    View(IssueViewArgs),
     /// List issues filtered by state / labels / author / assignee.
     List(IssueListArgs),
     /// Mutate an issue.
@@ -813,6 +810,18 @@ pub struct IssueCreateArgs {
     pub assignees: Vec<String>,
 }
 
+/// `issue view` arguments.
+#[derive(Args, Debug, Clone)]
+pub struct IssueViewArgs {
+    /// Numeric issue id.
+    pub id: u64,
+    /// Also fetch the issue's comment stream and embed it under `comments`
+    /// in the envelope payload. Adds one GitLab API call; for GitHub the
+    /// comments are pulled in the same `gh issue view --json` invocation.
+    #[arg(long = "with-comments", action = ArgAction::SetTrue)]
+    pub with_comments: bool,
+}
+
 /// `issue edit` arguments.
 #[derive(Args, Debug, Clone)]
 pub struct IssueEditArgs {
@@ -935,8 +944,8 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
             command: Some(IssueCommand::Create(args)),
         })) => ops::issue_create::run(&global, args, format),
         Some(Command::Issue(IssueArgs {
-            command: Some(IssueCommand::View { id }),
-        })) => ops::issue_view::run(&global, id, format),
+            command: Some(IssueCommand::View(args)),
+        })) => ops::issue_view::run(&global, args, format),
         Some(Command::Issue(IssueArgs {
             command: Some(IssueCommand::List(args)),
         })) => ops::issue_list::run(&global, args, format),

--- a/crates/forge-cli/src/ops/issue_view.rs
+++ b/crates/forge-cli/src/ops/issue_view.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use crate::backend::{
     BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
 };
-use crate::cli::{BINARY, GlobalFlags};
+use crate::cli::{BINARY, GlobalFlags, IssueViewArgs};
 use crate::envelope::emit_success;
 use crate::error::ForgeError;
 use crate::ops::pr_state::normalize_state;
@@ -24,6 +24,16 @@ pub const SCHEMA: &str = "issue.view";
 pub const SCHEMA_VERSION: u32 = 1;
 
 const GH_JSON_FIELDS: &str = "number,url,state,title,labels,assignees,body";
+const GH_JSON_FIELDS_WITH_COMMENTS: &str = "number,url,state,title,labels,assignees,body,comments";
+
+/// One issue comment, normalized across providers.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct IssueCommentSummary {
+    pub url: String,
+    pub author: String,
+    pub created_at: String,
+    pub body: String,
+}
 
 /// Envelope payload for `cli.forge-cli.issue.view.v1`.
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -36,17 +46,24 @@ pub struct IssueViewPayload {
     pub body: String,
     pub labels: Vec<String>,
     pub assignees: Vec<String>,
+    /// Populated only when the caller passed `--with-comments`; the empty
+    /// vector is always serialized so the schema shape is stable.
+    pub comments: Vec<IssueCommentSummary>,
 }
 
-pub fn run(global: &GlobalFlags, id: u64, format: OutputFormat) -> Result<i32, ForgeError> {
+pub fn run(
+    global: &GlobalFlags,
+    args: IssueViewArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
     let runner = ProcessRunner;
-    run_with(&runner, global, id, format, git_remote_url)
+    run_with(&runner, global, args, format, git_remote_url)
 }
 
 pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     runner: &R,
     global: &GlobalFlags,
-    id: u64,
+    args: IssueViewArgs,
     format: OutputFormat,
     remote_url_lookup: F,
 ) -> Result<i32, ForgeError> {
@@ -56,7 +73,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         global.repo.as_deref(),
         remote_url_lookup,
     )?;
-    let call = build_view_call(&ctx, id);
+    let call = build_view_call_with(&ctx, args.id, args.with_comments);
 
     if global.dry_run {
         let payload = DryRunPayload::new(ctx.provider, &call);
@@ -69,7 +86,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     }
 
     let output = runner.run(&call)?;
-    let payload = parse_view_output(&ctx, &output)?;
+    let mut payload = parse_view_output_with(&ctx, &output, args.with_comments)?;
+    if args.with_comments && ctx.provider == Provider::GitLab {
+        let comments_call = build_gitlab_notes_call(&ctx, &payload)?;
+        let comments_output = runner.run(&comments_call)?;
+        payload.comments = parse_gitlab_notes(&comments_output, &payload.url)?;
+    }
     Ok(emit_success(
         schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
         payload,
@@ -78,15 +100,26 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     ))
 }
 
+/// View-only call for mutation ops that re-fetch after a write. Comments are
+/// never requested here so the post-action refresh stays a single backend hop.
 pub fn build_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
+    build_view_call_with(ctx, id, false)
+}
+
+fn build_view_call_with(ctx: &ProviderContext, id: u64, with_comments: bool) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
+    let gh_fields = if with_comments {
+        GH_JSON_FIELDS_WITH_COMMENTS
+    } else {
+        GH_JSON_FIELDS
+    };
     let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![
             OsString::from("issue"),
             OsString::from("view"),
             OsString::from(id.to_string()),
             OsString::from("--json"),
-            OsString::from(GH_JSON_FIELDS),
+            OsString::from(gh_fields),
         ],
         Provider::GitLab => vec![
             OsString::from("issue"),
@@ -100,9 +133,48 @@ pub fn build_view_call(ctx: &ProviderContext, id: u64) -> BackendCall {
     BackendCall::new(program, argv)
 }
 
+/// Build the `glab api .../notes` call used by `--with-comments` on GitLab.
+/// The project path is derived from the issue's `web_url` so we do not need
+/// the user to pass `--repo`.
+fn build_gitlab_notes_call(
+    ctx: &ProviderContext,
+    view: &IssueViewPayload,
+) -> Result<BackendCall, ForgeError> {
+    let project_path = gitlab_project_path_from_url(&view.url).ok_or_else(|| {
+        ForgeError::software(
+            schema_err(),
+            "unable to derive GitLab project path from issue web_url",
+            Some(format!("url={}", view.url)),
+        )
+    })?;
+    let encoded = project_path.replace('/', "%2F");
+    let path = format!(
+        "projects/{encoded}/issues/{iid}/notes?per_page=100&order_by=created_at&sort=asc",
+        iid = view.number,
+    );
+    Ok(BackendCall::new(
+        BackendProgram::Glab,
+        [
+            OsString::from("api"),
+            OsString::from("--paginate"),
+            OsString::from("--hostname"),
+            OsString::from(ctx.host.as_str()),
+            OsString::from(path),
+        ],
+    ))
+}
+
 pub fn parse_view_output(
     ctx: &ProviderContext,
     output: &BackendSuccess,
+) -> Result<IssueViewPayload, ForgeError> {
+    parse_view_output_with(ctx, output, false)
+}
+
+fn parse_view_output_with(
+    ctx: &ProviderContext,
+    output: &BackendSuccess,
+    with_comments: bool,
 ) -> Result<IssueViewPayload, ForgeError> {
     let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
         ForgeError::software(
@@ -112,7 +184,7 @@ pub fn parse_view_output(
         )
     })?;
     match ctx.provider {
-        Provider::GitHub => parse_github(&value, ctx),
+        Provider::GitHub => parse_github(&value, ctx, with_comments),
         Provider::GitLab => parse_gitlab(&value, ctx),
     }
 }
@@ -120,11 +192,17 @@ pub fn parse_view_output(
 fn parse_github(
     value: &serde_json::Value,
     ctx: &ProviderContext,
+    with_comments: bool,
 ) -> Result<IssueViewPayload, ForgeError> {
     let state = normalize_state(
         value.get("state").and_then(|v| v.as_str()).unwrap_or(""),
         ctx.provider,
     )?;
+    let comments = if with_comments {
+        github_comments(value)
+    } else {
+        Vec::new()
+    };
     Ok(IssueViewPayload {
         provider: ctx.provider.as_str(),
         number: value
@@ -141,6 +219,7 @@ fn parse_github(
             .to_string(),
         labels: github_name_list(value, "labels"),
         assignees: github_assignees(value),
+        comments,
     })
 }
 
@@ -168,7 +247,155 @@ fn parse_gitlab(
             .to_string(),
         labels: gitlab_label_list(value),
         assignees: gitlab_assignees(value),
+        comments: Vec::new(),
     })
+}
+
+fn github_comments(value: &serde_json::Value) -> Vec<IssueCommentSummary> {
+    value
+        .get("comments")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|item| IssueCommentSummary {
+                    url: item
+                        .get("url")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    author: item
+                        .get("author")
+                        .and_then(|a| a.get("login"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    created_at: item
+                        .get("createdAt")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    body: item
+                        .get("body")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Parse the response from `glab api .../notes` (a JSON array of note
+/// objects). `issue_url` is the issue's `web_url`, used to construct each
+/// comment URL (`<issue_url>#note_<note_id>`) since notes don't carry their
+/// own HTML URL in the REST response.
+fn parse_gitlab_notes(
+    output: &BackendSuccess,
+    issue_url: &str,
+) -> Result<Vec<IssueCommentSummary>, ForgeError> {
+    let trimmed = output.stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    // `glab api --paginate` concatenates JSON arrays back-to-back when the
+    // result spans pages. Try one-shot parse first, then fall back to
+    // splitting on `][`.
+    let chunks = if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        vec![value]
+    } else {
+        let mut acc = Vec::new();
+        for raw in trimmed.split("][") {
+            let raw = raw.trim();
+            if raw.is_empty() {
+                continue;
+            }
+            let normalized = if raw.starts_with('[') {
+                raw.to_string()
+            } else {
+                format!("[{raw}")
+            };
+            let normalized = if normalized.ends_with(']') {
+                normalized
+            } else {
+                format!("{normalized}]")
+            };
+            let value: serde_json::Value = serde_json::from_str(&normalized).map_err(|e| {
+                ForgeError::software(
+                    schema_err(),
+                    "gitlab notes response is invalid JSON",
+                    Some(e.to_string()),
+                )
+            })?;
+            acc.push(value);
+        }
+        acc
+    };
+    let mut out = Vec::new();
+    for chunk in chunks {
+        let items = chunk
+            .as_array()
+            .map(|arr| arr.to_vec())
+            .unwrap_or_else(|| vec![chunk]);
+        for item in items {
+            // GitLab's REST `/notes` includes both user-authored comments and
+            // synthetic system notes (e.g. label changes). plan-issue and
+            // other audit consumers only want real comments.
+            if item
+                .get("system")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let id = item
+                .get("id")
+                .and_then(|v| v.as_u64())
+                .map(|n| n.to_string())
+                .unwrap_or_default();
+            let url = format!("{issue_url}#note_{id}");
+            out.push(IssueCommentSummary {
+                url,
+                author: item
+                    .get("author")
+                    .and_then(|a| a.get("username"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                created_at: item
+                    .get("created_at")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                body: item
+                    .get("body")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Extract the GitLab project path (group/project, possibly nested) from an
+/// issue's `web_url`. Returns `None` when the URL does not look like a GitLab
+/// issue URL. Accepts both `/-/issues/<iid>` and `/issues/<iid>` shapes.
+fn gitlab_project_path_from_url(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let path = after_scheme.split_once('/').map(|(_, rest)| rest)?;
+    let path = path.trim_end_matches('/');
+    let project_path = if let Some(idx) = path.find("/-/issues/") {
+        &path[..idx]
+    } else if let Some(idx) = path.find("/issues/") {
+        &path[..idx]
+    } else {
+        return None;
+    };
+    if project_path.is_empty() {
+        None
+    } else {
+        Some(project_path.to_string())
+    }
 }
 
 fn github_name_list(value: &serde_json::Value, key: &str) -> Vec<String> {
@@ -325,5 +552,154 @@ mod tests {
         };
         let p = parse_view_output(&ctx(Provider::GitLab), &output).unwrap();
         assert_eq!(p.state, "closed");
+    }
+
+    #[test]
+    fn build_view_call_github_includes_comments_field_when_requested() {
+        let plain = build_view_call_with(&ctx(Provider::GitHub), 5, false).plan_argv();
+        let json_plain = plain
+            .iter()
+            .position(|s| s == "--json")
+            .map(|i| plain[i + 1].as_str())
+            .unwrap();
+        assert!(
+            !json_plain.contains("comments"),
+            "default view should not request comments"
+        );
+
+        let with = build_view_call_with(&ctx(Provider::GitHub), 5, true).plan_argv();
+        let json_with = with
+            .iter()
+            .position(|s| s == "--json")
+            .map(|i| with[i + 1].as_str())
+            .unwrap();
+        assert!(
+            json_with.contains("comments"),
+            "--with-comments must extend --json"
+        );
+    }
+
+    #[test]
+    fn build_view_call_gitlab_does_not_change_for_with_comments() {
+        let plain = build_view_call_with(&ctx(Provider::GitLab), 5, false).plan_argv();
+        let with = build_view_call_with(&ctx(Provider::GitLab), 5, true).plan_argv();
+        assert_eq!(
+            plain, with,
+            "GitLab view call shape is identical; comments come from a follow-up api call"
+        );
+    }
+
+    #[test]
+    fn parse_github_with_comments_normalises_author_and_url() {
+        let output = BackendSuccess {
+            stdout: r#"{
+                "number":7,"url":"https://github.com/o/r/issues/7","state":"OPEN","title":"t","body":"b",
+                "labels":[],"assignees":[],
+                "comments":[
+                    {"author":{"login":"alice"},"body":"hi","url":"https://github.com/o/r/issues/7#issuecomment-1","createdAt":"2025-01-01T00:00:00Z"},
+                    {"author":{"login":"bob"},"body":"hello","url":"https://github.com/o/r/issues/7#issuecomment-2","createdAt":"2025-01-02T00:00:00Z"}
+                ]
+            }"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output_with(&ctx(Provider::GitHub), &output, true).unwrap();
+        assert_eq!(p.comments.len(), 2);
+        assert_eq!(p.comments[0].author, "alice");
+        assert_eq!(p.comments[0].body, "hi");
+        assert_eq!(
+            p.comments[0].url,
+            "https://github.com/o/r/issues/7#issuecomment-1"
+        );
+        assert_eq!(p.comments[0].created_at, "2025-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn parse_github_without_with_comments_keeps_comments_empty() {
+        let output = BackendSuccess {
+            stdout: r#"{"number":7,"url":"u","state":"OPEN","title":"t","body":"b","labels":[],"assignees":[],"comments":[{"author":{"login":"a"},"body":"x","url":"u","createdAt":"t"}]}"#.into(),
+            stderr: String::new(),
+        };
+        let p = parse_view_output(&ctx(Provider::GitHub), &output).unwrap();
+        assert!(
+            p.comments.is_empty(),
+            "without --with-comments the field stays empty"
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_notes_filters_system_notes_and_constructs_url() {
+        let output = BackendSuccess {
+            stdout: r#"[
+                {"id":1,"body":"first","author":{"username":"alice"},"created_at":"2025-01-01T00:00:00Z","system":false},
+                {"id":2,"body":"added label","author":{"username":"alice"},"created_at":"2025-01-01T00:01:00Z","system":true},
+                {"id":3,"body":"second","author":{"username":"bob"},"created_at":"2025-01-02T00:00:00Z","system":false}
+            ]"#.into(),
+            stderr: String::new(),
+        };
+        let comments = parse_gitlab_notes(
+            &output,
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4",
+        )
+        .unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].author, "alice");
+        assert_eq!(comments[0].body, "first");
+        assert_eq!(
+            comments[0].url,
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4#note_1"
+        );
+        assert_eq!(comments[1].author, "bob");
+        assert_eq!(
+            comments[1].url,
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4#note_3"
+        );
+    }
+
+    #[test]
+    fn parse_gitlab_notes_handles_empty_array() {
+        let output = BackendSuccess {
+            stdout: "[]".into(),
+            stderr: String::new(),
+        };
+        let comments =
+            parse_gitlab_notes(&output, "https://gitlab.example.com/g/p/-/issues/1").unwrap();
+        assert!(comments.is_empty());
+    }
+
+    #[test]
+    fn parse_gitlab_notes_handles_concatenated_pages() {
+        let output = BackendSuccess {
+            stdout: r#"[{"id":1,"body":"a","author":{"username":"u"},"created_at":"t","system":false}][{"id":2,"body":"b","author":{"username":"u"},"created_at":"t","system":false}]"#.into(),
+            stderr: String::new(),
+        };
+        let comments =
+            parse_gitlab_notes(&output, "https://gitlab.example.com/g/p/-/issues/1").unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].body, "a");
+        assert_eq!(comments[1].body, "b");
+    }
+
+    #[test]
+    fn gitlab_project_path_from_url_extracts_nested_groups() {
+        assert_eq!(
+            gitlab_project_path_from_url(
+                "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4"
+            )
+            .as_deref(),
+            Some("terrylin/agent-runtime-testing")
+        );
+        assert_eq!(
+            gitlab_project_path_from_url("https://gitlab.com/group/sub/project/-/issues/12")
+                .as_deref(),
+            Some("group/sub/project")
+        );
+        assert_eq!(
+            gitlab_project_path_from_url("https://gitlab.example.com/g/p/issues/1").as_deref(),
+            Some("g/p"),
+            "fallback for hosts that elide the `/-/` segment",
+        );
+        assert!(
+            gitlab_project_path_from_url("https://gitlab.example.com/not-an-issue-url").is_none()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Extend `forge-cli issue view` with `--with-comments` so the envelope payload carries a normalized `comments[]` stream. The field is always emitted (empty when the flag is absent) so the schema shape stays stable; GitHub pulls comments in the same `gh issue view --json` hop, GitLab adds one follow-up `glab api /projects/<encoded>/issues/<iid>/notes?--paginate` call and reconstructs each note URL from the issue web_url.
- Filter GitLab system notes (label/assignee change events surfaced by `/notes`) out of the comments array so plan-issue audit consumers only see user-authored entries. Keep `build_view_call(ctx, id)` returning the no-comments call for the mutation ops that re-fetch after a write.

## Why

This is **gap G1** identified in the Sprint 1 design note for the plan-issue-cli GitLab provider abstraction (#490). plan-issue's `issue_evidence` adapter method needs body + comments in one operation; without `--with-comments` it would have to do two subprocess hops per audit. GitHub one-hop performance is preserved; GitLab requires a second backend call but the contract stays consistent.

## Test plan

- [x] `cargo test -p nils-forge-cli issue_view` — 12 unit tests including 7 new ones covering both providers, system-note filtering, paginated GitLab responses, and the project-path URL parser
- [x] `scripts/ci/nils-cli-local-fast.sh` — full local fast gate (nextest + fmt + clippy + completion-asset-audit)
- [ ] Downstream sandbox revalidation through `plan-issue record audit` once the plan-issue routing layer (Sprint 2) lands

Refs: #490, #483.
