### PR TITLE
feat(forge-cli): add pr comments atom (G4)

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -127,6 +127,9 @@ _forge-cli() {
             forge__cli__help__pr,comment)
                 cmd="forge__cli__help__pr__comment"
                 ;;
+            forge__cli__help__pr,comments)
+                cmd="forge__cli__help__pr__comments"
+                ;;
             forge__cli__help__pr,create)
                 cmd="forge__cli__help__pr__create"
                 ;;
@@ -259,6 +262,9 @@ _forge-cli() {
             forge__cli__pr,comment)
                 cmd="forge__cli__pr__comment"
                 ;;
+            forge__cli__pr,comments)
+                cmd="forge__cli__pr__comments"
+                ;;
             forge__cli__pr,create)
                 cmd="forge__cli__pr__create"
                 ;;
@@ -294,6 +300,9 @@ _forge-cli() {
                 ;;
             forge__cli__pr__help,comment)
                 cmd="forge__cli__pr__help__comment"
+                ;;
+            forge__cli__pr__help,comments)
+                cmd="forge__cli__pr__help__comments"
                 ;;
             forge__cli__pr__help,create)
                 cmd="forge__cli__pr__help__create"
@@ -797,7 +806,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help__pr)
-            opts="create view list edit comment ready merge close checks wait-checks deliver"
+            opts="create view list edit comment comments ready merge close checks wait-checks deliver"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -839,6 +848,20 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help__pr__comment)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__pr__comments)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -1951,7 +1974,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr)
-            opts="-h --format --remote --provider --repo --dry-run --help create view list edit comment ready merge close checks wait-checks deliver help"
+            opts="-h --format --remote --provider --repo --dry-run --help create view list edit comment comments ready merge close checks wait-checks deliver help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2059,6 +2082,36 @@ _forge-cli() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab" -- "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__pr__comments)
+            opts="-h --format --remote --provider --repo --dry-run --help <ID>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
@@ -2281,7 +2334,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__help)
-            opts="create view list edit comment ready merge close checks wait-checks deliver help"
+            opts="create view list edit comment comments ready merge close checks wait-checks deliver help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2323,6 +2376,20 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__help__comment)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__pr__help__comments)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -141,6 +141,19 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ':id -- Numeric PR / MR id:_default' \
 && ret=0
 ;;
+(comments)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab)' \
+'--repo=[Override the repo slug (\`owner/name\`). When absent it is derived from the remote URL]:owner/name:_default' \
+'--dry-run[Render the backend command that would run, without invoking it. The envelope'\''s \`data.plan\` carries the exact argv]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':id -- Numeric PR / MR id:_default' \
+&& ret=0
+;;
 (ready)
 _arguments "${_arguments_options[@]}" : \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
@@ -268,6 +281,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (comment)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(comments)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -904,6 +921,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(comments)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (ready)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -1279,6 +1300,7 @@ _forge-cli__subcmd__help__subcmd__pr_commands() {
 'list:List PRs / MRs' \
 'edit:Mutate PR / MR title, body, base, labels, reviewers' \
 'comment:Append a comment to a PR / MR' \
+'comments:List the issue-style comment stream attached to a PR / MR' \
 'ready:Promote a draft PR / MR to ready-for-review' \
 'merge:Merge a ready PR / MR' \
 'close:Close a PR / MR without merging' \
@@ -1302,6 +1324,11 @@ _forge-cli__subcmd__help__subcmd__pr__subcmd__close_commands() {
 _forge-cli__subcmd__help__subcmd__pr__subcmd__comment_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli help pr comment commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__pr__subcmd__comments_commands] )) ||
+_forge-cli__subcmd__help__subcmd__pr__subcmd__comments_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli help pr comments commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__help__subcmd__pr__subcmd__create_commands] )) ||
 _forge-cli__subcmd__help__subcmd__pr__subcmd__create_commands() {
@@ -1576,6 +1603,7 @@ _forge-cli__subcmd__pr_commands() {
 'list:List PRs / MRs' \
 'edit:Mutate PR / MR title, body, base, labels, reviewers' \
 'comment:Append a comment to a PR / MR' \
+'comments:List the issue-style comment stream attached to a PR / MR' \
 'ready:Promote a draft PR / MR to ready-for-review' \
 'merge:Merge a ready PR / MR' \
 'close:Close a PR / MR without merging' \
@@ -1601,6 +1629,11 @@ _forge-cli__subcmd__pr__subcmd__comment_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli pr comment commands' commands "$@"
 }
+(( $+functions[_forge-cli__subcmd__pr__subcmd__comments_commands] )) ||
+_forge-cli__subcmd__pr__subcmd__comments_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli pr comments commands' commands "$@"
+}
 (( $+functions[_forge-cli__subcmd__pr__subcmd__create_commands] )) ||
 _forge-cli__subcmd__pr__subcmd__create_commands() {
     local commands; commands=()
@@ -1624,6 +1657,7 @@ _forge-cli__subcmd__pr__subcmd__help_commands() {
 'list:List PRs / MRs' \
 'edit:Mutate PR / MR title, body, base, labels, reviewers' \
 'comment:Append a comment to a PR / MR' \
+'comments:List the issue-style comment stream attached to a PR / MR' \
 'ready:Promote a draft PR / MR to ready-for-review' \
 'merge:Merge a ready PR / MR' \
 'close:Close a PR / MR without merging' \
@@ -1648,6 +1682,11 @@ _forge-cli__subcmd__pr__subcmd__help__subcmd__close_commands() {
 _forge-cli__subcmd__pr__subcmd__help__subcmd__comment_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli pr help comment commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__pr__subcmd__help__subcmd__comments_commands] )) ||
+_forge-cli__subcmd__pr__subcmd__help__subcmd__comments_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli pr help comments commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__pr__subcmd__help__subcmd__create_commands] )) ||
 _forge-cli__subcmd__pr__subcmd__help__subcmd__create_commands() {

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -342,6 +342,13 @@ pub struct PrCommentArgs {
     pub body_file: Option<String>,
 }
 
+/// `pr comments` arguments.
+#[derive(Args, Debug, Clone)]
+pub struct PrCommentsArgs {
+    /// Numeric PR / MR id.
+    pub id: u64,
+}
+
 /// `pr ready` arguments.
 #[derive(Args, Debug, Clone)]
 pub struct PrReadyArgs {
@@ -528,6 +535,8 @@ pub enum PrCommand {
     Edit(PrEditArgs),
     /// Append a comment to a PR / MR.
     Comment(PrCommentArgs),
+    /// List the issue-style comment stream attached to a PR / MR.
+    Comments(PrCommentsArgs),
     /// Promote a draft PR / MR to ready-for-review.
     Ready(PrReadyArgs),
     /// Merge a ready PR / MR.
@@ -900,6 +909,9 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
         Some(Command::Pr(PrArgs {
             command: Some(PrCommand::Comment(args)),
         })) => ops::pr_comment::run(&global, args, format),
+        Some(Command::Pr(PrArgs {
+            command: Some(PrCommand::Comments(args)),
+        })) => ops::pr_comments::run(&global, args, format),
         Some(Command::Pr(PrArgs {
             command: Some(PrCommand::Ready(args)),
         })) => ops::pr_ready::run(&global, args, format),

--- a/crates/forge-cli/src/ops/mod.rs
+++ b/crates/forge-cli/src/ops/mod.rs
@@ -16,6 +16,7 @@ pub mod pr_checks;
 pub mod pr_checks_gitlab;
 pub mod pr_close;
 pub mod pr_comment;
+pub mod pr_comments;
 pub mod pr_create;
 pub mod pr_edit;
 pub mod pr_list;

--- a/crates/forge-cli/src/ops/pr_comments.rs
+++ b/crates/forge-cli/src/ops/pr_comments.rs
@@ -332,8 +332,58 @@ fn render_text(payload: &PrCommentsPayload) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::cell::RefCell;
+
+    use nils_common::cli_contract::OutputFormat;
     use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::backend::BackendOutput;
+    use crate::cli::GlobalFlags;
+
+    struct ScriptedRunner {
+        outputs: RefCell<Vec<BackendSuccess>>,
+        calls: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl ScriptedRunner {
+        fn new(outputs: Vec<BackendSuccess>) -> Self {
+            Self {
+                outputs: RefCell::new(outputs),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl crate::backend::BackendRunner for ScriptedRunner {
+        fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+            self.calls.borrow_mut().push(call.plan_argv());
+            Ok(self.outputs.borrow_mut().remove(0))
+        }
+
+        fn run_raw(&self, call: &BackendCall) -> Result<BackendOutput, ForgeError> {
+            self.run(call).map(|s| BackendOutput {
+                exit_code: 0,
+                status_success: true,
+                stdout: s.stdout,
+                stderr: s.stderr,
+            })
+        }
+    }
+
+    fn json_global() -> GlobalFlags {
+        GlobalFlags {
+            format: Some(OutputFormat::Json),
+            remote: "origin".into(),
+            provider: Some(crate::cli::ProviderFlag::Github),
+            repo: Some("o/r".into()),
+            dry_run: false,
+        }
+    }
 
     #[test]
     fn github_repo_slug_from_pr_and_issue_urls() {
@@ -429,5 +479,124 @@ mod tests {
     fn split_concatenated_arrays_returns_empty_for_empty_stdout() {
         let chunks = split_concatenated_arrays("   \n").unwrap();
         assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn run_with_github_emits_envelope_and_invokes_two_backend_calls() {
+        // First call: `pr view 7 --json …`. Second call: `gh api --paginate
+        // repos/o/r/issues/7/comments?per_page=100`.
+        let runner = ScriptedRunner::new(vec![
+            BackendSuccess {
+                stdout: r#"{"number":7,"url":"https://github.com/o/r/pull/7","state":"OPEN","isDraft":false,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[]}"#.into(),
+                stderr: String::new(),
+            },
+            BackendSuccess {
+                stdout: r#"[{"user":{"login":"alice"},"body":"hi","html_url":"https://github.com/o/r/pull/7#issuecomment-1","created_at":"2025-01-01T00:00:00Z"}]"#.into(),
+                stderr: String::new(),
+            },
+        ]);
+        let global = json_global();
+        let code = run_with(
+            &runner,
+            &global,
+            PrCommentsArgs { id: 7 },
+            OutputFormat::Json,
+            |_| Some("git@github.com:o/r.git".into()),
+        )
+        .expect("github run_with");
+        assert_eq!(code, nils_common::cli_contract::exit::SUCCESS);
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 2, "expected pr view + comments api call");
+        assert_eq!(
+            calls[0][..3],
+            ["gh".to_string(), "pr".to_string(), "view".to_string()]
+        );
+        assert_eq!(
+            calls[1][..3],
+            [
+                "gh".to_string(),
+                "api".to_string(),
+                "--paginate".to_string()
+            ]
+        );
+        assert!(
+            calls[1]
+                .iter()
+                .any(|s| s.contains("repos/o/r/issues/7/comments")),
+            "comments path must reference owner/repo derived from view URL: {:?}",
+            calls[1]
+        );
+    }
+
+    #[test]
+    fn run_with_gitlab_builds_notes_path_from_mr_view_url() {
+        // GitLab path: `mr view -F json` then `glab api --paginate --hostname
+        // <h> /projects/<encoded>/merge_requests/12/notes…`.
+        let runner = ScriptedRunner::new(vec![
+            BackendSuccess {
+                stdout: r#"{"iid":12,"web_url":"https://gitlab.example.com/grp/proj/-/merge_requests/12","state":"opened","draft":false,"title":"t","source_branch":"feat/x","target_branch":"main","merge_status":"can_be_merged","labels":[]}"#.into(),
+                stderr: String::new(),
+            },
+            BackendSuccess {
+                stdout: r#"[{"id":9,"body":"hi","author":{"username":"alice"},"created_at":"t","system":false}]"#.into(),
+                stderr: String::new(),
+            },
+        ]);
+        let global = GlobalFlags {
+            format: Some(OutputFormat::Json),
+            remote: "origin".into(),
+            provider: Some(crate::cli::ProviderFlag::Gitlab),
+            repo: Some("grp/proj".into()),
+            dry_run: false,
+        };
+        let code = run_with(
+            &runner,
+            &global,
+            PrCommentsArgs { id: 12 },
+            OutputFormat::Json,
+            |_| Some("git@gitlab.example.com:grp/proj.git".into()),
+        )
+        .expect("gitlab run_with");
+        assert_eq!(code, nils_common::cli_contract::exit::SUCCESS);
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1][..2], ["glab".to_string(), "api".to_string()]);
+        assert!(
+            calls[1]
+                .iter()
+                .any(|s| s.contains("projects/grp%2Fproj/merge_requests/12/notes")),
+            "notes path must url-encode the project slug derived from MR web_url: {:?}",
+            calls[1]
+        );
+    }
+
+    #[test]
+    fn run_with_dry_run_emits_plan_envelope_without_running_comments_call() {
+        // Dry-run still runs the pr view call (used to derive the URL), then
+        // emits the comments call as a DryRunPayload without executing it.
+        let runner = ScriptedRunner::new(vec![BackendSuccess {
+            stdout: r#"{"number":7,"url":"https://github.com/o/r/pull/7","state":"OPEN","isDraft":false,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[]}"#.into(),
+            stderr: String::new(),
+        }]);
+        let global = GlobalFlags {
+            dry_run: true,
+            ..json_global()
+        };
+        let code = run_with(
+            &runner,
+            &global,
+            PrCommentsArgs { id: 7 },
+            OutputFormat::Json,
+            |_| Some("git@github.com:o/r.git".into()),
+        )
+        .expect("dry-run");
+        assert_eq!(code, nils_common::cli_contract::exit::SUCCESS);
+        assert_eq!(
+            runner.calls().len(),
+            1,
+            "dry-run must not invoke the comments call"
+        );
     }
 }

--- a/crates/forge-cli/src/ops/pr_comments.rs
+++ b/crates/forge-cli/src/ops/pr_comments.rs
@@ -1,0 +1,433 @@
+//! `pr comments` atom — read-side companion to `pr comment`.
+//!
+//! Spec / ops: `cli.forge-cli.pr.comments.v1`. Returns the issue-style comment
+//! stream attached to a PR/MR (`/repos/<owner>/<repo>/issues/<n>/comments` on
+//! GitHub, `/projects/<encoded>/merge_requests/<iid>/notes` on GitLab). System
+//! notes (label/assignee changes) are filtered out so callers only see
+//! user-authored entries.
+
+use std::ffi::OsString;
+
+use nils_common::cli_contract::{OutputFormat, schema_version_for};
+use serde::Serialize;
+
+use crate::backend::{
+    BackendCall, BackendProgram, BackendRunner, BackendSuccess, DryRunPayload, ProcessRunner,
+};
+use crate::cli::{BINARY, GlobalFlags, PrCommentsArgs};
+use crate::envelope::emit_success;
+use crate::error::ForgeError;
+use crate::ops::pr_view;
+use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
+
+const SCHEMA: &str = "pr.comments";
+const SCHEMA_VERSION: u32 = 1;
+
+/// One PR / MR comment, normalized across providers.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrCommentSummary {
+    pub url: String,
+    pub author: String,
+    pub created_at: String,
+    pub body: String,
+}
+
+/// Envelope payload for `cli.forge-cli.pr.comments.v1`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct PrCommentsPayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub comments: Vec<PrCommentSummary>,
+}
+
+pub fn run(
+    global: &GlobalFlags,
+    args: PrCommentsArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let runner = ProcessRunner;
+    run_with(&runner, global, args, format, git_remote_url)
+}
+
+pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
+    runner: &R,
+    global: &GlobalFlags,
+    args: PrCommentsArgs,
+    format: OutputFormat,
+    remote_url_lookup: F,
+) -> Result<i32, ForgeError> {
+    let ctx = detect(
+        global.provider_hint(),
+        &global.remote,
+        global.repo.as_deref(),
+        remote_url_lookup,
+    )?;
+
+    // Resolve the canonical PR/MR URL first; both providers need the
+    // owner/repo (or group/project) segment for the comments API path, and
+    // re-using `pr view` keeps URL parsing in one place.
+    let view_output = runner.run(&pr_view::build_view_call(&ctx, &args.id.to_string()))?;
+    let view = pr_view::parse_view_output(&ctx, &view_output)?;
+
+    let comments_call = build_comments_call(&ctx, &view)?;
+
+    if global.dry_run {
+        let payload = DryRunPayload::new(ctx.provider, &comments_call);
+        return Ok(emit_success(
+            schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+            payload,
+            format,
+            |p| println!("would run: {plan}", plan = p.plan.join(" ")),
+        ));
+    }
+
+    let comments_output = runner.run(&comments_call)?;
+    let comments = match ctx.provider {
+        Provider::GitHub => parse_github_comments(&comments_output)?,
+        Provider::GitLab => parse_gitlab_notes(&comments_output, &view.url)?,
+    };
+
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION),
+        PrCommentsPayload {
+            provider: ctx.provider.as_str(),
+            number: view.number,
+            url: view.url,
+            comments,
+        },
+        format,
+        render_text,
+    ))
+}
+
+fn build_comments_call(
+    ctx: &ProviderContext,
+    view: &pr_view::PrViewPayload,
+) -> Result<BackendCall, ForgeError> {
+    match ctx.provider {
+        Provider::GitHub => {
+            let slug = github_repo_slug_from_url(&view.url).ok_or_else(|| {
+                ForgeError::software(
+                    schema_err(),
+                    "unable to derive GitHub owner/repo from PR url",
+                    Some(format!("url={}", view.url)),
+                )
+            })?;
+            let path = format!(
+                "repos/{slug}/issues/{n}/comments?per_page=100",
+                n = view.number,
+            );
+            Ok(BackendCall::new(
+                BackendProgram::Gh,
+                [
+                    OsString::from("api"),
+                    OsString::from("--paginate"),
+                    OsString::from(path),
+                ],
+            ))
+        }
+        Provider::GitLab => {
+            let project = gitlab_project_path_from_url(&view.url).ok_or_else(|| {
+                ForgeError::software(
+                    schema_err(),
+                    "unable to derive GitLab project path from MR web_url",
+                    Some(format!("url={}", view.url)),
+                )
+            })?;
+            let encoded = project.replace('/', "%2F");
+            let path = format!(
+                "projects/{encoded}/merge_requests/{iid}/notes?per_page=100&order_by=created_at&sort=asc",
+                iid = view.number,
+            );
+            Ok(BackendCall::new(
+                BackendProgram::Glab,
+                [
+                    OsString::from("api"),
+                    OsString::from("--paginate"),
+                    OsString::from("--hostname"),
+                    OsString::from(ctx.host.as_str()),
+                    OsString::from(path),
+                ],
+            ))
+        }
+    }
+}
+
+fn parse_github_comments(output: &BackendSuccess) -> Result<Vec<PrCommentSummary>, ForgeError> {
+    let chunks = split_concatenated_arrays(&output.stdout)?;
+    let mut out = Vec::new();
+    for chunk in chunks {
+        let items = chunk.as_array().cloned().unwrap_or_else(|| vec![chunk]);
+        for item in items {
+            out.push(PrCommentSummary {
+                url: item
+                    .get("html_url")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                author: item
+                    .get("user")
+                    .and_then(|u| u.get("login"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                created_at: item
+                    .get("created_at")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                body: item
+                    .get("body")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+fn parse_gitlab_notes(
+    output: &BackendSuccess,
+    mr_url: &str,
+) -> Result<Vec<PrCommentSummary>, ForgeError> {
+    let chunks = split_concatenated_arrays(&output.stdout)?;
+    let mut out = Vec::new();
+    for chunk in chunks {
+        let items = chunk.as_array().cloned().unwrap_or_else(|| vec![chunk]);
+        for item in items {
+            // Skip synthetic system notes (label changes, assignee changes,
+            // etc.) — only user-authored comments are useful to consumers.
+            if item
+                .get("system")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let id = item
+                .get("id")
+                .and_then(|v| v.as_u64())
+                .map(|n| n.to_string())
+                .unwrap_or_default();
+            out.push(PrCommentSummary {
+                url: format!("{mr_url}#note_{id}"),
+                author: item
+                    .get("author")
+                    .and_then(|a| a.get("username"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                created_at: item
+                    .get("created_at")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                body: item
+                    .get("body")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// `gh api --paginate` / `glab api --paginate` concatenate JSON arrays
+/// back-to-back when results span pages. Parse the trimmed stdout as one or
+/// more arrays.
+fn split_concatenated_arrays(stdout: &str) -> Result<Vec<serde_json::Value>, ForgeError> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        return Ok(vec![value]);
+    }
+    let mut acc = Vec::new();
+    for raw in trimmed.split("][") {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        let normalized = if raw.starts_with('[') {
+            raw.to_string()
+        } else {
+            format!("[{raw}")
+        };
+        let normalized = if normalized.ends_with(']') {
+            normalized
+        } else {
+            format!("{normalized}]")
+        };
+        let value: serde_json::Value = serde_json::from_str(&normalized).map_err(|e| {
+            ForgeError::software(
+                schema_err(),
+                "comments response is invalid JSON",
+                Some(e.to_string()),
+            )
+        })?;
+        acc.push(value);
+    }
+    Ok(acc)
+}
+
+/// Extract `owner/repo` from a GitHub PR URL like
+/// `https://github.com/owner/repo/pull/<n>`.
+fn github_repo_slug_from_url(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let path = after_scheme.split_once('/').map(|(_, rest)| rest)?;
+    let pull_idx = path.find("/pull/").or_else(|| path.find("/issues/"))?;
+    let slug = &path[..pull_idx];
+    let mut parts = slug.splitn(3, '/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() || parts.next().is_some() {
+        return None;
+    }
+    Some(format!("{owner}/{repo}"))
+}
+
+/// Extract the GitLab project path (group[/subgroup]/project) from an MR's
+/// `web_url` like `https://gitlab.example.com/group/project/-/merge_requests/<iid>`.
+fn gitlab_project_path_from_url(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let path = after_scheme.split_once('/').map(|(_, rest)| rest)?;
+    let path = path.trim_end_matches('/');
+    let idx = path
+        .find("/-/merge_requests/")
+        .or_else(|| path.find("/merge_requests/"))?;
+    let project_path = &path[..idx];
+    if project_path.is_empty() {
+        None
+    } else {
+        Some(project_path.to_string())
+    }
+}
+
+fn schema_err() -> String {
+    schema_version_for(BINARY, "error", 1)
+}
+
+fn render_text(payload: &PrCommentsPayload) {
+    println!(
+        "{provider} #{number} ({n} comments)\n  {url}",
+        provider = payload.provider,
+        number = payload.number,
+        n = payload.comments.len(),
+        url = payload.url,
+    );
+    for comment in &payload.comments {
+        let body_first_line = comment.body.lines().next().unwrap_or("");
+        println!(
+            "  - [{at}] {author}: {body}",
+            at = comment.created_at,
+            author = comment.author,
+            body = body_first_line,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn github_repo_slug_from_pr_and_issue_urls() {
+        assert_eq!(
+            github_repo_slug_from_url("https://github.com/sympoies/nils-cli/pull/123").as_deref(),
+            Some("sympoies/nils-cli")
+        );
+        assert_eq!(
+            github_repo_slug_from_url("https://github.com/owner/repo/issues/9").as_deref(),
+            Some("owner/repo")
+        );
+        assert!(
+            github_repo_slug_from_url("https://github.com/just-owner").is_none(),
+            "missing /pull/ or /issues/ segment must yield None"
+        );
+    }
+
+    #[test]
+    fn gitlab_project_path_from_mr_url_handles_nested_groups() {
+        assert_eq!(
+            gitlab_project_path_from_url(
+                "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/12"
+            )
+            .as_deref(),
+            Some("terrylin/agent-runtime-testing")
+        );
+        assert_eq!(
+            gitlab_project_path_from_url("https://gitlab.com/group/sub/project/-/merge_requests/3")
+                .as_deref(),
+            Some("group/sub/project")
+        );
+        assert!(
+            gitlab_project_path_from_url("https://gitlab.example.com/g/p/-/issues/1").is_none()
+        );
+    }
+
+    #[test]
+    fn parse_github_comments_extracts_user_author_and_html_url() {
+        let output = BackendSuccess {
+            stdout: r#"[
+                {"user":{"login":"alice"},"body":"hi","html_url":"https://github.com/o/r/pull/1#issuecomment-100","created_at":"2025-01-01T00:00:00Z"},
+                {"user":{"login":"bob"},"body":"hello","html_url":"https://github.com/o/r/pull/1#issuecomment-101","created_at":"2025-01-02T00:00:00Z"}
+            ]"#.into(),
+            stderr: String::new(),
+        };
+        let comments = parse_github_comments(&output).unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].author, "alice");
+        assert_eq!(
+            comments[0].url,
+            "https://github.com/o/r/pull/1#issuecomment-100"
+        );
+        assert_eq!(comments[0].body, "hi");
+    }
+
+    #[test]
+    fn parse_github_comments_handles_concatenated_pages() {
+        let output = BackendSuccess {
+            stdout: r#"[{"user":{"login":"a"},"body":"x","html_url":"u","created_at":"t"}][{"user":{"login":"b"},"body":"y","html_url":"u","created_at":"t"}]"#.into(),
+            stderr: String::new(),
+        };
+        let comments = parse_github_comments(&output).unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].body, "x");
+        assert_eq!(comments[1].body, "y");
+    }
+
+    #[test]
+    fn parse_gitlab_notes_skips_system_notes_and_constructs_urls() {
+        let output = BackendSuccess {
+            stdout: r#"[
+                {"id":1,"body":"first","author":{"username":"alice"},"created_at":"2025-01-01T00:00:00Z","system":false},
+                {"id":2,"body":"added label","author":{"username":"alice"},"created_at":"2025-01-01T00:01:00Z","system":true},
+                {"id":3,"body":"second","author":{"username":"bob"},"created_at":"2025-01-02T00:00:00Z","system":false}
+            ]"#.into(),
+            stderr: String::new(),
+        };
+        let comments = parse_gitlab_notes(
+            &output,
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/12",
+        )
+        .unwrap();
+        assert_eq!(comments.len(), 2);
+        assert_eq!(comments[0].author, "alice");
+        assert_eq!(
+            comments[0].url,
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/12#note_1"
+        );
+        assert_eq!(comments[1].author, "bob");
+    }
+
+    #[test]
+    fn split_concatenated_arrays_returns_empty_for_empty_stdout() {
+        let chunks = split_concatenated_arrays("   \n").unwrap();
+        assert!(chunks.is_empty());
+    }
+}

--- a/crates/forge-cli/src/ops/pr_view.rs
+++ b/crates/forge-cli/src/ops/pr_view.rs
@@ -93,7 +93,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     ))
 }
 
-fn build_view_call(ctx: &ProviderContext, id: &str) -> BackendCall {
+pub(crate) fn build_view_call(ctx: &ProviderContext, id: &str) -> BackendCall {
     let program = BackendProgram::for_provider(ctx.provider);
     let mut argv: Vec<OsString> = match ctx.provider {
         Provider::GitHub => vec![


### PR DESCRIPTION
## Summary

- Add a new `forge-cli pr comments <id>` op (schema `cli.forge-cli.pr.comments.v1`) that returns the issue-style comment stream attached to a PR/MR as a normalized array of `{url, author, created_at, body}` records. GitHub backs the call with `gh api --paginate /repos/<owner>/<repo>/issues/<n>/comments`, GitLab with `glab api --paginate --hostname <h> /projects/<encoded>/merge_requests/<iid>/notes?order_by=created_at&sort=asc`.
- Both providers run an initial `pr view` so URL parsing (owner/repo for GitHub, group/project for GitLab) stays in one place; GitLab system notes (label/assignee changes) are filtered out so consumers only see user-authored entries. Re-uses the same concatenated-array splitter pattern introduced by the issue notes path in #494.

## Why

This is **gap G4** from the Sprint 1 design note for the plan-issue-cli GitLab provider abstraction (#490). plan-issue's `resolve-approval` flow scans a PR's issue-comment stream for an approval phrase; today the GitHub-only adapter shells out to `gh api` directly. Exposing this through a provider-neutral forge-cli atom lets the new `ForgeCliAdapter` use one call on both providers.

## Test plan

- [x] `cargo test -p nils-forge-cli pr_comments` — 6 unit tests covering both providers, URL parsing (PR + issue URLs, nested groups), paginated GitHub responses, GitLab system-note filtering, and the empty-stdout edge
- [x] `scripts/ci/nils-cli-local-fast.sh` — full local fast gate (nextest + fmt + clippy + completion-asset-audit)
- [ ] Downstream sandbox revalidation through plan-issue `resolve-approval` once the routing layer (Sprint 3) lands

Refs: #490, #483. Mirrors #494's `issue view --with-comments` pattern.
