### PR TITLE
fix(forge-cli): stop racing on FORGE_CLI_GH_BIN in pr_comments tests

### DIFF
--- a/crates/forge-cli/src/backend.rs
+++ b/crates/forge-cli/src/backend.rs
@@ -28,7 +28,7 @@ pub const ENV_GLAB_BIN: &str = "FORGE_CLI_GLAB_BIN";
 pub const STDERR_TAIL_BYTES: usize = 2 * 1024;
 
 /// Backend program selector. Each variant maps to one external binary.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackendProgram {
     Gh,
     Glab,

--- a/crates/forge-cli/src/ops/pr_comments.rs
+++ b/crates/forge-cli/src/ops/pr_comments.rs
@@ -341,9 +341,17 @@ mod tests {
     use crate::backend::BackendOutput;
     use crate::cli::GlobalFlags;
 
+    /// One recorded backend call. We capture `(program, argv)` rather than
+    /// `call.plan_argv()` so the test does not race against any other test
+    /// that mutates `FORGE_CLI_GH_BIN` / `FORGE_CLI_GLAB_BIN` while running
+    /// in parallel — `plan_argv()` resolves the binary name through those
+    /// env vars, but the abstract `program` enum is set at construction time
+    /// inside `build_*_call` and is race-free.
+    type RecordedCall = (BackendProgram, Vec<String>);
+
     struct ScriptedRunner {
         outputs: RefCell<Vec<BackendSuccess>>,
-        calls: RefCell<Vec<Vec<String>>>,
+        calls: RefCell<Vec<RecordedCall>>,
     }
 
     impl ScriptedRunner {
@@ -354,14 +362,19 @@ mod tests {
             }
         }
 
-        fn calls(&self) -> Vec<Vec<String>> {
+        fn calls(&self) -> Vec<RecordedCall> {
             self.calls.borrow().clone()
         }
     }
 
     impl crate::backend::BackendRunner for ScriptedRunner {
         fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
-            self.calls.borrow_mut().push(call.plan_argv());
+            let argv = call
+                .argv
+                .iter()
+                .map(|os| os.to_string_lossy().into_owned())
+                .collect();
+            self.calls.borrow_mut().push((call.program, argv));
             Ok(self.outputs.borrow_mut().remove(0))
         }
 
@@ -508,20 +521,16 @@ mod tests {
 
         let calls = runner.calls();
         assert_eq!(calls.len(), 2, "expected pr view + comments api call");
+        assert_eq!(calls[0].0, BackendProgram::Gh);
+        assert_eq!(calls[0].1[..2], ["pr".to_string(), "view".to_string()]);
+        assert_eq!(calls[1].0, BackendProgram::Gh);
         assert_eq!(
-            calls[0][..3],
-            ["gh".to_string(), "pr".to_string(), "view".to_string()]
-        );
-        assert_eq!(
-            calls[1][..3],
-            [
-                "gh".to_string(),
-                "api".to_string(),
-                "--paginate".to_string()
-            ]
+            calls[1].1[..2],
+            ["api".to_string(), "--paginate".to_string()]
         );
         assert!(
             calls[1]
+                .1
                 .iter()
                 .any(|s| s.contains("repos/o/r/issues/7/comments")),
             "comments path must reference owner/repo derived from view URL: {:?}",
@@ -562,9 +571,11 @@ mod tests {
 
         let calls = runner.calls();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[1][..2], ["glab".to_string(), "api".to_string()]);
+        assert_eq!(calls[1].0, BackendProgram::Glab);
+        assert_eq!(calls[1].1[..1], ["api".to_string()]);
         assert!(
             calls[1]
+                .1
                 .iter()
                 .any(|s| s.contains("projects/grp%2Fproj/merge_requests/12/notes")),
             "notes path must url-encode the project slug derived from MR web_url: {:?}",


### PR DESCRIPTION
## Summary

- Stop the `ops::pr_comments::tests::run_with_*` tests added in #496 from racing against other tests that mutate `FORGE_CLI_GH_BIN` / `FORGE_CLI_GLAB_BIN` while running in parallel — `ScriptedRunner` now captures `(BackendProgram, Vec<String>)` from each call instead of going through `BackendCall::plan_argv()`, which resolves the binary name via those env vars.
- Derive `PartialEq + Eq` on `BackendProgram` so the new assertions can compare the abstract enum directly.

## Why

`cargo test -p nils-forge-cli` flaked roughly 1-in-3 runs on `main` after #496 landed: the assertion `calls[0][..3] == ["gh", "pr", "view"]` would occasionally see a stub path instead of `"gh"` because a concurrent test was mid-mutation of `FORGE_CLI_GH_BIN`. Skipping the env-var-resolved binary name fixes the race without sacrificing test coverage.

The pre-existing `ops::inbox::tests::inbox_tcp_vpn_probe_connects_and_reports_refused_ports` flake on TCP/VPN probe is unrelated and outside this PR's scope.

## Test plan

- [x] `cargo test -p nils-forge-cli` — green on 4 consecutive runs after the fix (1 in 8 runs still flakes on the unrelated VPN probe test)
- [x] `scripts/ci/nils-cli-local-fast.sh` not relevant here (only test-only changes outside changed-scope; full cargo test exercises the assertions)

Refs: #496.
