### PR TITLE
feat(plan-issue-cli): Sprint 2.2 wires record open on GitLab

### DIFF
--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -736,9 +736,13 @@ fn run_record_open(
         }));
     }
 
-    // Live mode.
-    let repo = resolve_repo_for_live(binary, repo_override)?;
-    let adapter = GhCliAdapter::new(force);
+    // Live mode. Sprint 2.2 routes `record open` through the provider-aware
+    // adapter selector so GitLab repos exercise `forge_cli_adapter::ForgeCliAdapter`
+    // (which shells out to `forge-cli`). GitHub repos keep using `GhCliAdapter`
+    // unchanged.
+    let repo_info = resolve_repo_info_for_live(binary, repo_override)?;
+    let adapter = crate::provider::select_adapter(&repo_info, force);
+    let repo = repo_info.slug;
 
     let body_path = write_temp_markdown("record-open-body", &initial_dashboard)
         .map_err(|err| CommandError::runtime("record-open-body-write-failed", err))?;
@@ -3332,23 +3336,26 @@ fn resolve_repo_for_live(
     binary: BinaryFlavor,
     repo_override: Option<&str>,
 ) -> Result<String, CommandError> {
+    // Sprint 2.2: stop early-rejecting GitLab. Dispatchers that still default
+    // to `GhCliAdapter` would now silently shell out to `gh` against a GitLab
+    // slug and fail with gh's error — that path is acceptable as a transitional
+    // failure mode because Sprint 3 / Sprint 4 will refactor those dispatchers
+    // to use [`crate::provider::select_adapter`]. The `record open` dispatcher
+    // already routes through `resolve_repo_info_for_live` + `select_adapter`,
+    // so it lands the GitLab path correctly.
+    Ok(resolve_repo_info_for_live(binary, repo_override)?.slug)
+}
+
+/// Provider-aware variant of `resolve_repo_for_live`. Used by dispatchers
+/// that route through [`crate::provider::select_adapter`] to pick the right
+/// `ProviderAdapter` implementation per provider.
+fn resolve_repo_info_for_live(
+    binary: BinaryFlavor,
+    repo_override: Option<&str>,
+) -> Result<crate::provider::Repo, CommandError> {
     ensure_live_binary(binary)?;
-    let info = crate::provider::resolve_repo(repo_override)
-        .map_err(|err| CommandError::usage("repo-resolution-failed", err))?;
-    if info.provider == crate::provider::Provider::GitLab {
-        // Sprint 2.1: routing layer is in place but the GitLab branch is a
-        // stub (see `forge_cli_adapter::ForgeCliAdapter`). Sprint 2.2 wires
-        // the actual `forge-cli` subprocess calls in.
-        return Err(CommandError::runtime(
-            "provider_not_implemented",
-            format!(
-                "plan-issue-cli GitLab support is wired to the routing layer but not yet active (Sprint 2.1 stub); track sympoies/nils-cli#490. Repo: {} at {}",
-                info.slug,
-                info.host.as_deref().unwrap_or("(unknown host)"),
-            ),
-        ));
-    }
-    Ok(info.slug)
+    crate::provider::resolve_repo(repo_override)
+        .map_err(|err| CommandError::usage("repo-resolution-failed", err))
 }
 
 fn render_plan_status_comment(rows: &[TaskRow]) -> String {

--- a/crates/plan-issue-cli/src/forge_cli_adapter.rs
+++ b/crates/plan-issue-cli/src/forge_cli_adapter.rs
@@ -1,80 +1,265 @@
 //! GitLab-backed `ProviderAdapter` that routes through `forge-cli`'s
-//! provider-neutral surface (Sprint 2 Task 2.1 stub; Task 2.2 fills in).
+//! provider-neutral surface.
 //!
-//! In Sprint 2.1 every method returns a typed `provider_not_implemented`
-//! error so the routing layer compiles, the GitHub path keeps working
-//! unchanged, and downstream callers learn that GitLab is wired up but
-//! not yet functional. Sprint 2.2 wires `create_issue`, `comment_issue`,
-//! `edit_issue_body`, and `edit_issue_labels` to actual `forge-cli`
-//! subprocess calls so `record open` works end-to-end on GitLab.
+//! Sprint 2 Task 2.2 wires the `record open` path (`create_issue`,
+//! `comment_issue`, `edit_issue_body`, `issue_evidence`, `edit_issue_labels`)
+//! through `forge-cli` subprocess calls. The remaining methods stay as
+//! `provider_not_implemented` stubs until Sprint 3 lands `record post / audit
+//! / close / link-pr` and Sprint 4 lands the dispatch family.
 //!
-//! The `#[allow(dead_code)]` on the impl is temporary: Task 2.1 ships only
-//! the early-rejection at `resolve_repo_for_live` boundary; Task 2.2 wires
-//! the constructor into the dispatcher call sites via
-//! `crate::provider::select_adapter`.
-#![allow(dead_code)]
+//! Subprocess details:
+//!
+//! - The adapter shells out to `forge-cli` (overridable via `FORGE_CLI_BIN`).
+//! - Every call passes `--format json --provider gitlab --repo <slug>` so the
+//!   target is unambiguous, even when the cwd's git remote points elsewhere.
+//! - The v1 envelope (`{ok, schema_version, data}` for success or
+//!   `{ok:false, error:{code,message}}`) is parsed into a typed error message
+//!   carrying both the forge-cli error code and the argv that failed.
+//!
+//! Comment-stream shape: `forge-cli issue view --with-comments` returns
+//! comments as `[{url, author, created_at, body}, ...]`. `issue_evidence`
+//! re-wraps them as `{"comments": [...]}` so the existing
+//! [`crate::lifecycle_record::audit_record`] parser (which reads `body`,
+//! `url`, `created_at`) accepts them unchanged.
 
 use std::path::Path;
 
+use nils_common::process as common_process;
 use serde_json::Value;
+use serde_json::json;
 
 use crate::commands::plan::CloseReason;
 use crate::github::{PrMergeSummary, ProviderAdapter};
 
-#[derive(Debug, Clone, Copy)]
+/// Runner abstraction so unit tests can inject scripted forge-cli responses.
+pub trait ForgeCliRunner {
+    fn run(&self, args: &[&str]) -> Result<String, String>;
+}
+
+/// Default runner: spawns `forge-cli` (or `FORGE_CLI_BIN`) and returns its
+/// stdout. Non-zero exits surface as `Err`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ProcessForgeCliRunner;
+
+impl ForgeCliRunner for ProcessForgeCliRunner {
+    fn run(&self, args: &[&str]) -> Result<String, String> {
+        let bin = std::env::var("FORGE_CLI_BIN").unwrap_or_else(|_| "forge-cli".to_string());
+
+        let output = common_process::run_output(&bin, args)
+            .map(|out| out.into_std_output())
+            .map_err(|err| format!("failed to execute {bin}: {err}"))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        if !output.status.success() {
+            let detail = if !stderr.trim().is_empty() {
+                stderr.trim().to_string()
+            } else {
+                stdout.trim().to_string()
+            };
+            return Err(format!("{bin} {} failed: {detail}", args.join(" ")));
+        }
+        Ok(stdout)
+    }
+}
+
+/// `ProviderAdapter` implementation for GitLab repos.
 pub struct ForgeCliAdapter {
-    #[allow(dead_code)]
-    // Sprint 2.2 will read this to forward `--force` to forge-cli mutation calls.
     force: bool,
+    runner: Box<dyn ForgeCliRunner + Send + Sync>,
 }
 
 impl ForgeCliAdapter {
-    pub const fn new(force: bool) -> Self {
-        Self { force }
+    pub fn new(force: bool) -> Self {
+        Self {
+            force,
+            runner: Box::new(ProcessForgeCliRunner),
+        }
+    }
+
+    /// Test-only constructor that swaps in a scripted runner.
+    #[cfg(test)]
+    pub fn with_runner(force: bool, runner: Box<dyn ForgeCliRunner + Send + Sync>) -> Self {
+        Self { force, runner }
+    }
+
+    /// Run forge-cli with the given args, parse the v1 envelope, and return
+    /// the `data` field. Surfaces forge-cli error envelopes verbatim.
+    fn run_envelope(&self, args: &[&str]) -> Result<Value, String> {
+        let stdout = self.runner.run(args)?;
+        let trimmed = stdout.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "forge-cli {} produced empty stdout",
+                args.join(" ")
+            ));
+        }
+        let value: Value = serde_json::from_str(trimmed)
+            .map_err(|err| format!("forge-cli {} output is not JSON: {err}", args.join(" ")))?;
+        if value.get("ok") == Some(&Value::Bool(false)) {
+            let code = value
+                .pointer("/error/code")
+                .and_then(Value::as_str)
+                .unwrap_or("?");
+            let message = value
+                .pointer("/error/message")
+                .and_then(Value::as_str)
+                .unwrap_or("?");
+            return Err(format!(
+                "forge-cli {} failed: {code}: {message}",
+                args.join(" ")
+            ));
+        }
+        value
+            .get("data")
+            .cloned()
+            .ok_or_else(|| format!("forge-cli {} envelope missing `data`", args.join(" ")))
+    }
+
+    /// Common argv prefix: `--format json --provider gitlab --repo <slug>`.
+    fn base_args<'a>(&self, repo: &'a str) -> Vec<&'a str> {
+        vec!["--format", "json", "--provider", "gitlab", "--repo", repo]
+    }
+
+    fn body_file_str(path: &Path) -> Result<&str, String> {
+        path.to_str()
+            .ok_or_else(|| format!("body file path is not valid UTF-8: {}", path.display()))
     }
 }
 
 fn not_implemented(op: &str) -> String {
     format!(
-        "provider_not_implemented: GitLab `{op}` is wired up to the routing layer but not yet implemented (Sprint 2.1 stub). Sprint 2.2 lands the GitLab path; track sympoies/nils-cli#490."
+        "provider_not_implemented: GitLab `{op}` is wired up to the routing layer but not yet implemented (Sprint 2.2 only ships `record open`). Track sympoies/nils-cli#490."
     )
 }
 
 impl ProviderAdapter for ForgeCliAdapter {
-    fn issue_body(&self, _repo: &str, _issue: u64) -> Result<String, String> {
-        Err(not_implemented("issue body"))
+    fn issue_body(&self, repo: &str, issue: u64) -> Result<String, String> {
+        let issue_str = issue.to_string();
+        let mut args = self.base_args(repo);
+        args.extend(["issue", "view", &issue_str]);
+        let data = self.run_envelope(&args)?;
+        data.get("body")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| "forge-cli issue view data missing `body`".to_string())
     }
 
-    fn issue_evidence(&self, _repo: &str, _issue: u64) -> Result<(String, String), String> {
-        Err(not_implemented("issue evidence (body + comments)"))
+    fn issue_evidence(&self, repo: &str, issue: u64) -> Result<(String, String), String> {
+        let issue_str = issue.to_string();
+        let mut args = self.base_args(repo);
+        args.extend(["issue", "view", &issue_str, "--with-comments"]);
+        let data = self.run_envelope(&args)?;
+        let body = data
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let comments = data
+            .get("comments")
+            .cloned()
+            .unwrap_or_else(|| Value::Array(Vec::new()));
+        // Re-shape into the `{"comments": [...]}` envelope expected by
+        // `lifecycle_record::audit_record`. The inner fields (`body`, `url`,
+        // `created_at`) already match what the audit parser reads.
+        let envelope = json!({ "comments": comments });
+        let comments_json = serde_json::to_string(&envelope)
+            .map_err(|err| format!("failed to serialize issue evidence comments: {err}"))?;
+        Ok((body, comments_json))
     }
 
     fn create_issue(
         &self,
-        _repo: &str,
-        _title: &str,
-        _body_file: &Path,
-        _labels: &[String],
+        repo: &str,
+        title: &str,
+        body_file: &Path,
+        labels: &[String],
     ) -> Result<(u64, String), String> {
-        Err(not_implemented("issue create"))
+        let body_file_str = Self::body_file_str(body_file)?;
+        let mut args = self.base_args(repo);
+        args.extend([
+            "issue",
+            "create",
+            "--title",
+            title,
+            "--body-file",
+            body_file_str,
+        ]);
+        let trimmed_labels: Vec<&str> = labels
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        for label in &trimmed_labels {
+            args.push("--label");
+            args.push(label);
+        }
+        let data = self.run_envelope(&args)?;
+        let number = data
+            .get("number")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| "forge-cli issue create data missing `number`".to_string())?;
+        let url = data
+            .get("url")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| "forge-cli issue create data missing `url`".to_string())?;
+        Ok((number, url))
     }
 
-    fn edit_issue_body(&self, _repo: &str, _issue: u64, _body_file: &Path) -> Result<(), String> {
-        Err(not_implemented("issue edit body"))
+    fn edit_issue_body(&self, repo: &str, issue: u64, body_file: &Path) -> Result<(), String> {
+        let issue_str = issue.to_string();
+        let body_file_str = Self::body_file_str(body_file)?;
+        let mut args = self.base_args(repo);
+        args.extend(["issue", "edit", &issue_str, "--body-file", body_file_str]);
+        self.run_envelope(&args).map(|_| ())
     }
 
-    fn comment_issue(&self, _repo: &str, _issue: u64, _body_file: &Path) -> Result<String, String> {
-        Err(not_implemented("issue comment"))
+    fn comment_issue(&self, repo: &str, issue: u64, body_file: &Path) -> Result<String, String> {
+        let issue_str = issue.to_string();
+        let body_file_str = Self::body_file_str(body_file)?;
+        let mut args = self.base_args(repo);
+        args.extend(["issue", "comment", &issue_str, "--body-file", body_file_str]);
+        let data = self.run_envelope(&args)?;
+        data.get("url")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| "forge-cli issue comment data missing `url`".to_string())
     }
 
     fn edit_issue_labels(
         &self,
-        _repo: &str,
-        _issue: u64,
-        _add: &[String],
-        _remove: &[String],
+        repo: &str,
+        issue: u64,
+        add: &[String],
+        remove: &[String],
     ) -> Result<(), String> {
-        Err(not_implemented("issue edit labels"))
+        let issue_str = issue.to_string();
+        let trimmed_add: Vec<&str> = add
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        let trimmed_remove: Vec<&str> = remove
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if trimmed_add.is_empty() && trimmed_remove.is_empty() {
+            return Ok(());
+        }
+        let mut args = self.base_args(repo);
+        args.extend(["issue", "edit", &issue_str]);
+        for label in &trimmed_add {
+            args.push("--add-label");
+            args.push(label);
+        }
+        for label in &trimmed_remove {
+            args.push("--remove-label");
+            args.push(label);
+        }
+        self.run_envelope(&args).map(|_| ())
     }
 
     fn close_issue(
@@ -84,6 +269,9 @@ impl ProviderAdapter for ForgeCliAdapter {
         _reason: CloseReason,
         _close_comment: Option<&str>,
     ) -> Result<(), String> {
+        // Sprint 3 lands `record close`; today close_issue stays a stub so
+        // any caller that hits it learns the gap with a typed message.
+        let _ = self.force;
         Err(not_implemented("issue close"))
     }
 
@@ -102,71 +290,293 @@ impl ProviderAdapter for ForgeCliAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::cell::RefCell;
     use std::path::PathBuf;
 
-    #[test]
-    fn every_method_returns_provider_not_implemented() {
-        let adapter = ForgeCliAdapter::new(false);
-        let body_file = PathBuf::from("/dev/null");
+    use super::*;
 
+    /// One scripted forge-cli response. The runner panics if the next call
+    /// doesn't match the expected argv prefix; that makes regressions in the
+    /// argv shape obvious.
+    struct ScriptedRunner {
+        responses: RefCell<Vec<String>>,
+        calls: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl ScriptedRunner {
+        fn new(responses: Vec<&str>) -> Self {
+            Self {
+                responses: RefCell::new(responses.into_iter().map(String::from).collect()),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl ForgeCliRunner for ScriptedRunner {
+        fn run(&self, args: &[&str]) -> Result<String, String> {
+            self.calls
+                .borrow_mut()
+                .push(args.iter().map(|s| s.to_string()).collect());
+            let mut pending = self.responses.borrow_mut();
+            if pending.is_empty() {
+                return Err(format!(
+                    "ScriptedRunner exhausted: no canned response for argv {:?}",
+                    args
+                ));
+            }
+            Ok(pending.remove(0))
+        }
+    }
+
+    fn adapter_with(responses: Vec<&str>) -> (ForgeCliAdapter, std::sync::Arc<RunnerHandle>) {
+        let runner = std::sync::Arc::new(RunnerHandle::new(responses));
+        let proxy = RunnerProxy {
+            inner: runner.clone(),
+        };
+        (ForgeCliAdapter::with_runner(false, Box::new(proxy)), runner)
+    }
+
+    /// Thread-safe wrapper around `ScriptedRunner` so the adapter trait
+    /// bound (`Send + Sync`) is satisfied while keeping the test API tiny.
+    struct RunnerHandle {
+        inner: std::sync::Mutex<ScriptedRunner>,
+    }
+
+    impl RunnerHandle {
+        fn new(responses: Vec<&str>) -> Self {
+            Self {
+                inner: std::sync::Mutex::new(ScriptedRunner::new(responses)),
+            }
+        }
+
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.inner.lock().unwrap().calls()
+        }
+    }
+
+    struct RunnerProxy {
+        inner: std::sync::Arc<RunnerHandle>,
+    }
+
+    impl ForgeCliRunner for RunnerProxy {
+        fn run(&self, args: &[&str]) -> Result<String, String> {
+            self.inner.inner.lock().unwrap().run(args)
+        }
+    }
+
+    #[test]
+    fn create_issue_passes_provider_and_repo_and_parses_envelope() {
+        let (adapter, handle) = adapter_with(vec![
+            r#"{
+            "schema_version": "cli.forge-cli.issue.create.v1",
+            "ok": true,
+            "data": {
+                "provider": "gitlab",
+                "number": 7,
+                "url": "https://gitlab.example.com/grp/proj/-/issues/7"
+            }
+        }"#,
+        ]);
+        let body = PathBuf::from("/tmp/body.md");
+        let (n, url) = adapter
+            .create_issue(
+                "grp/proj",
+                "title",
+                &body,
+                &["type::feature".into(), "  ".into(), "area::cli".into()],
+            )
+            .expect("create");
+        assert_eq!(n, 7);
+        assert_eq!(url, "https://gitlab.example.com/grp/proj/-/issues/7");
+
+        let calls = handle.calls();
+        assert_eq!(calls.len(), 1);
+        let argv = &calls[0];
+        assert!(argv.iter().any(|s| s == "--provider"), "{argv:?}");
+        assert_eq!(
+            argv[argv.iter().position(|s| s == "--provider").unwrap() + 1],
+            "gitlab"
+        );
+        assert_eq!(
+            argv[argv.iter().position(|s| s == "--repo").unwrap() + 1],
+            "grp/proj"
+        );
+        assert!(argv.windows(2).any(|w| w[0] == "issue" && w[1] == "create"));
+        // Blank labels are skipped.
+        let label_idxs: Vec<usize> = argv
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.as_str() == "--label")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(label_idxs.len(), 2);
+        assert_eq!(argv[label_idxs[0] + 1], "type::feature");
+        assert_eq!(argv[label_idxs[1] + 1], "area::cli");
+    }
+
+    #[test]
+    fn comment_issue_returns_data_url_from_envelope() {
+        let (adapter, _) = adapter_with(vec![
+            r#"{
+            "ok": true,
+            "schema_version": "cli.forge-cli.issue.comment.v1",
+            "data": {"provider":"gitlab","number":7,"url":"https://x.com/g/p/-/issues/7#note_42"}
+        }"#,
+        ]);
+        let url = adapter
+            .comment_issue("g/p", 7, Path::new("/tmp/body.md"))
+            .expect("comment");
+        assert_eq!(url, "https://x.com/g/p/-/issues/7#note_42");
+    }
+
+    #[test]
+    fn edit_issue_body_passes_body_file_flag() {
+        let (adapter, handle) = adapter_with(vec![
+            r#"{
+            "ok": true,
+            "schema_version": "cli.forge-cli.issue.edit.v1",
+            "data": {"provider":"gitlab","number":7,"url":"u","state":"open","title":"t","labels":[],"assignees":[]}
+        }"#,
+        ]);
+        adapter
+            .edit_issue_body("g/p", 7, Path::new("/tmp/new-body.md"))
+            .expect("edit");
+        let argv = &handle.calls()[0];
+        let body_file_idx = argv.iter().position(|s| s == "--body-file").unwrap();
+        assert_eq!(argv[body_file_idx + 1], "/tmp/new-body.md");
+        assert!(argv.windows(2).any(|w| w[0] == "issue" && w[1] == "edit"));
+    }
+
+    #[test]
+    fn issue_evidence_reshapes_comments_into_gh_compatible_envelope() {
+        let (adapter, _) = adapter_with(vec![
+            r#"{
+            "ok": true,
+            "schema_version": "cli.forge-cli.issue.view.v1",
+            "data": {
+                "provider": "gitlab",
+                "number": 7,
+                "url": "https://x.com/g/p/-/issues/7",
+                "state": "open",
+                "title": "t",
+                "body": "issue body here",
+                "labels": [],
+                "assignees": [],
+                "comments": [
+                    {"url":"https://x.com/g/p/-/issues/7#note_1","author":"alice","created_at":"2025-01-01T00:00:00Z","body":"first"},
+                    {"url":"https://x.com/g/p/-/issues/7#note_2","author":"bob","created_at":"2025-01-02T00:00:00Z","body":"second"}
+                ]
+            }
+        }"#,
+        ]);
+        let (body, comments_json) = adapter.issue_evidence("g/p", 7).expect("evidence");
+        assert_eq!(body, "issue body here");
+        let reparsed: Value = serde_json::from_str(&comments_json).unwrap();
+        let arr = reparsed.get("comments").and_then(Value::as_array).unwrap();
+        assert_eq!(arr.len(), 2);
+        // The audit parser reads `body`, `url`, and `created_at` (already
+        // present in the forge-cli normalized shape) — no further reshape.
+        assert_eq!(arr[0].get("body").and_then(Value::as_str), Some("first"));
+        assert_eq!(
+            arr[0].get("url").and_then(Value::as_str),
+            Some("https://x.com/g/p/-/issues/7#note_1")
+        );
+        assert_eq!(
+            arr[0].get("created_at").and_then(Value::as_str),
+            Some("2025-01-01T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn edit_issue_labels_skips_blank_entries_and_omits_call_when_both_empty() {
+        let (adapter, handle) = adapter_with(vec![
+            r#"{
+            "ok": true,
+            "schema_version": "cli.forge-cli.issue.edit.v1",
+            "data": {"provider":"gitlab","number":7,"url":"u","state":"open","title":"t","labels":[],"assignees":[]}
+        }"#,
+        ]);
+        // No labels — no subprocess call.
+        adapter
+            .edit_issue_labels("g/p", 7, &[], &[])
+            .expect("noop labels");
+        assert!(
+            handle.calls().is_empty(),
+            "edit_issue_labels with no labels must not shell out"
+        );
+
+        // One label each, plus blank entries that should be skipped.
+        adapter
+            .edit_issue_labels(
+                "g/p",
+                7,
+                &["type::test".into(), "  ".into()],
+                &["state::stale".into()],
+            )
+            .expect("labels");
+        let argv = &handle.calls()[0];
+        let adds: Vec<usize> = argv
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.as_str() == "--add-label")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(adds.len(), 1);
+        assert_eq!(argv[adds[0] + 1], "type::test");
+        let rms: Vec<usize> = argv
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.as_str() == "--remove-label")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(rms.len(), 1);
+        assert_eq!(argv[rms[0] + 1], "state::stale");
+    }
+
+    #[test]
+    fn forge_cli_error_envelope_is_propagated() {
+        let (adapter, _) = adapter_with(vec![
+            r#"{
+            "ok": false,
+            "schema_version": "cli.forge-cli.error.v1",
+            "error": {"code":"some-code","message":"some message"}
+        }"#,
+        ]);
+        let err = adapter
+            .create_issue("g/p", "t", Path::new("/tmp/b.md"), &[])
+            .expect_err("envelope error");
+        assert!(err.contains("some-code"), "{err}");
+        assert!(err.contains("some message"), "{err}");
+    }
+
+    #[test]
+    fn unimplemented_methods_still_return_provider_not_implemented() {
+        let (adapter, _) = adapter_with(vec![]);
         assert!(
             adapter
-                .issue_body("r", 1)
+                .close_issue("g/p", 1, CloseReason::Completed, None)
                 .unwrap_err()
                 .contains("provider_not_implemented")
         );
         assert!(
             adapter
-                .issue_evidence("r", 1)
+                .pr_is_merged("g/p", 1)
                 .unwrap_err()
                 .contains("provider_not_implemented")
         );
         assert!(
             adapter
-                .create_issue("r", "t", &body_file, &[])
+                .pr_merge_summary("g/p", 1)
                 .unwrap_err()
                 .contains("provider_not_implemented")
         );
         assert!(
             adapter
-                .edit_issue_body("r", 1, &body_file)
-                .unwrap_err()
-                .contains("provider_not_implemented")
-        );
-        assert!(
-            adapter
-                .comment_issue("r", 1, &body_file)
-                .unwrap_err()
-                .contains("provider_not_implemented")
-        );
-        assert!(
-            adapter
-                .edit_issue_labels("r", 1, &[], &[])
-                .unwrap_err()
-                .contains("provider_not_implemented")
-        );
-        assert!(
-            adapter
-                .close_issue("r", 1, CloseReason::Completed, None)
-                .unwrap_err()
-                .contains("provider_not_implemented")
-        );
-        assert!(
-            adapter
-                .pr_is_merged("r", 1)
-                .unwrap_err()
-                .contains("provider_not_implemented")
-        );
-        assert!(
-            adapter
-                .pr_merge_summary("r", 1)
-                .unwrap_err()
-                .contains("provider_not_implemented")
-        );
-        assert!(
-            adapter
-                .pr_comments("r", 1)
+                .pr_comments("g/p", 1)
                 .unwrap_err()
                 .contains("provider_not_implemented")
         );


### PR DESCRIPTION
## Summary

- Implement `ForgeCliAdapter::create_issue / comment_issue / edit_issue_body / issue_evidence / edit_issue_labels` via `forge-cli` subprocess calls (overridable through `FORGE_CLI_BIN`); each invocation passes `--format json --provider gitlab --repo <slug>` so the target is unambiguous regardless of cwd. The v1 envelope is parsed into typed errors with `error.code:message` carried verbatim.
- Refactor the `record open` dispatcher to resolve provider via new `resolve_repo_info_for_live` + `provider::select_adapter`. Drop the Sprint 2.1 early-rejection in `resolve_repo_for_live` (other dispatchers still default to `GhCliAdapter` until Sprint 3, where they'll get the same refactor). Re-shape `issue_evidence` comments into `{"comments":[...]}` so the existing `lifecycle_record::audit_record` parser accepts the forge-cli normalized shape unchanged.

## Why

This is **Sprint 2 Task 2.2** of the plan-issue-cli GitLab provider abstraction (#490). Sprint 2.1 (#498) landed the routing layer with stub GitLab methods; this PR makes `record open` actually work on GitLab repos by routing the 5 methods through `forge-cli` subprocess calls. The remaining methods (`close_issue`, `pr_is_merged`, `pr_merge_summary`, `pr_comments`) stay as `provider_not_implemented` stubs — Sprint 3 lands `record post / audit / close / link-pr` and Sprint 4 lands the dispatch family.

## Test plan

- [x] `cargo test -p nils-plan-issue-cli` — 78 unit + 218 integration tests pass; 6 new `ForgeCliAdapter` scripted-runner tests cover argv shape, label normalisation, comment reshaping, error envelope propagation, and the unimplemented-methods stub
- [x] `scripts/ci/nils-cli-local-fast.sh` — full local fast gate (nextest + fmt + clippy `-D warnings` + completion-asset-audit + rumdl markdown lint)
- [ ] Sprint 2 Task 2.3 sandbox revalidation: live `plan-issue record open --profile tracking --repo terrylin/agent-runtime-testing --bundle docs/plans/p8-smoke` against `gitlab.gamania.com`

Refs: #490, #498. Sandbox F-3 entry: <https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/blob/main/docs/plans/gitlab-skill-validation/gitlab-skill-validation-discussion-source.md>
