### PR TITLE
fix(forge-cli): accept GitLab Work Items url in issue view parser

### DIFF
--- a/crates/forge-cli/src/ops/issue_view.rs
+++ b/crates/forge-cli/src/ops/issue_view.rs
@@ -379,12 +379,17 @@ fn parse_gitlab_notes(
 
 /// Extract the GitLab project path (group/project, possibly nested) from an
 /// issue's `web_url`. Returns `None` when the URL does not look like a GitLab
-/// issue URL. Accepts both `/-/issues/<iid>` and `/issues/<iid>` shapes.
+/// issue URL. Accepts `/-/issues/<iid>`, `/issues/<iid>`, and the newer
+/// `/-/work_items/<iid>` shape that GitLab returns for projects that have
+/// migrated issues to the unified Work Items API (live-observed on
+/// gitlab.gamania.com).
 fn gitlab_project_path_from_url(url: &str) -> Option<String> {
     let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
     let path = after_scheme.split_once('/').map(|(_, rest)| rest)?;
     let path = path.trim_end_matches('/');
     let project_path = if let Some(idx) = path.find("/-/issues/") {
+        &path[..idx]
+    } else if let Some(idx) = path.find("/-/work_items/") {
         &path[..idx]
     } else if let Some(idx) = path.find("/issues/") {
         &path[..idx]
@@ -687,6 +692,14 @@ mod tests {
             )
             .as_deref(),
             Some("terrylin/agent-runtime-testing")
+        );
+        assert_eq!(
+            gitlab_project_path_from_url(
+                "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/work_items/6"
+            )
+            .as_deref(),
+            Some("terrylin/agent-runtime-testing"),
+            "GitLab projects migrated to the Work Items API surface issues at /-/work_items/<iid>",
         );
         assert_eq!(
             gitlab_project_path_from_url("https://gitlab.com/group/sub/project/-/issues/12")


### PR DESCRIPTION
## Summary

- Surfaced live during plan-issue Sprint 2.2 record-open smoke against `gitlab.gamania.com`: that project has been migrated to GitLab's unified Work Items API, so `glab issue view --json` returns `web_url=https://.../-/work_items/<iid>` rather than `/-/issues/<iid>`, which made `gitlab_project_path_from_url` return `None` and the follow-up `glab api projects/<encoded>/issues/<iid>/notes` call never ran.
- Add `/-/work_items/` as a third accepted URL prefix alongside `/-/issues/` and `/issues/`. Regression test uses the actual gitlab.gamania.com URL shape observed during the smoke.

## Why

This unblocks Sprint 2 Task 2.3 (sandbox revalidation). Without this fix, `plan-issue record open` fails on any GitLab project that's been moved to Work Items even though the v1 envelope contract is otherwise honoured. The fix is a one-line allowlist extension; no schema or behaviour change for projects that still use the legacy `/-/issues/` URL.

## Test plan

- [x] `cargo test -p nils-forge-cli issue_view` — 13 unit tests including new `gitlab_project_path_from_url_extracts_nested_groups` assertion using the literal gitlab.gamania.com sandbox URL
- [x] `scripts/ci/nils-cli-local-fast.sh` — full local fast gate
- [ ] Re-run Sprint 2 Task 2.3 sandbox `record open` once this lands

Refs: #490, #494 (G1), #499 (Sprint 2.2).
