### PR TITLE
fix(forge-cli): derive GitLab hostname from web_url not ctx.host

### DIFF
--- a/crates/forge-cli/src/ops/issue_view.rs
+++ b/crates/forge-cli/src/ops/issue_view.rs
@@ -134,16 +134,26 @@ fn build_view_call_with(ctx: &ProviderContext, id: u64, with_comments: bool) -> 
 }
 
 /// Build the `glab api .../notes` call used by `--with-comments` on GitLab.
-/// The project path is derived from the issue's `web_url` so we do not need
-/// the user to pass `--repo`.
+/// Both the project path AND the GitLab host are derived from the issue's
+/// `web_url` so we do not need the user to pass `--repo` or `--remote`. This
+/// also avoids the bug where forcing `--provider gitlab` makes
+/// `ProviderContext::host` default to `gitlab.com` even when the repo lives
+/// on a self-hosted instance like `gitlab.gamania.com`.
 fn build_gitlab_notes_call(
-    ctx: &ProviderContext,
+    _ctx: &ProviderContext,
     view: &IssueViewPayload,
 ) -> Result<BackendCall, ForgeError> {
     let project_path = gitlab_project_path_from_url(&view.url).ok_or_else(|| {
         ForgeError::software(
             schema_err(),
             "unable to derive GitLab project path from issue web_url",
+            Some(format!("url={}", view.url)),
+        )
+    })?;
+    let host = gitlab_host_from_url(&view.url).ok_or_else(|| {
+        ForgeError::software(
+            schema_err(),
+            "unable to derive GitLab host from issue web_url",
             Some(format!("url={}", view.url)),
         )
     })?;
@@ -158,10 +168,24 @@ fn build_gitlab_notes_call(
             OsString::from("api"),
             OsString::from("--paginate"),
             OsString::from("--hostname"),
-            OsString::from(ctx.host.as_str()),
+            OsString::from(host),
             OsString::from(path),
         ],
     ))
+}
+
+/// Extract the host (`<host>`) from an `https?://<host>/...` URL. Used
+/// alongside [`gitlab_project_path_from_url`] to wire `glab api --hostname`
+/// against the actual GitLab instance hosting the issue, not whatever
+/// `ProviderContext::host` defaulted to when `--provider gitlab` was forced.
+fn gitlab_host_from_url(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest)?;
+    let host = after_scheme.split_once('/').map(|(host, _)| host)?;
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_string())
+    }
 }
 
 pub fn parse_view_output(
@@ -682,6 +706,23 @@ mod tests {
         assert_eq!(comments.len(), 2);
         assert_eq!(comments[0].body, "a");
         assert_eq!(comments[1].body, "b");
+    }
+
+    #[test]
+    fn gitlab_host_from_url_extracts_host_segment() {
+        assert_eq!(
+            gitlab_host_from_url(
+                "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/work_items/6"
+            )
+            .as_deref(),
+            Some("gitlab.gamania.com"),
+        );
+        assert_eq!(
+            gitlab_host_from_url("https://gitlab.com/group/sub/project/-/issues/12").as_deref(),
+            Some("gitlab.com"),
+        );
+        assert!(gitlab_host_from_url("/no-scheme/path/-/issues/1").is_none());
+        assert!(gitlab_host_from_url("https://no-path-here").is_none());
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_comments.rs
+++ b/crates/forge-cli/src/ops/pr_comments.rs
@@ -135,22 +135,44 @@ fn build_comments_call(
                     Some(format!("url={}", view.url)),
                 )
             })?;
+            let host = gitlab_host_from_url(&view.url).ok_or_else(|| {
+                ForgeError::software(
+                    schema_err(),
+                    "unable to derive GitLab host from MR web_url",
+                    Some(format!("url={}", view.url)),
+                )
+            })?;
             let encoded = project.replace('/', "%2F");
             let path = format!(
                 "projects/{encoded}/merge_requests/{iid}/notes?per_page=100&order_by=created_at&sort=asc",
                 iid = view.number,
             );
+            let _ = ctx; // host derived from MR web_url, not ctx.host (see issue_view::build_gitlab_notes_call comment)
             Ok(BackendCall::new(
                 BackendProgram::Glab,
                 [
                     OsString::from("api"),
                     OsString::from("--paginate"),
                     OsString::from("--hostname"),
-                    OsString::from(ctx.host.as_str()),
+                    OsString::from(host),
                     OsString::from(path),
                 ],
             ))
         }
+    }
+}
+
+/// Extract the host (`<host>`) from an `https?://<host>/...` URL. Used to
+/// wire `glab api --hostname` against the actual GitLab instance the MR
+/// lives on rather than `ProviderContext::host` (which defaults to
+/// `gitlab.com` when `--provider gitlab` is forced).
+fn gitlab_host_from_url(url: &str) -> Option<String> {
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest)?;
+    let host = after_scheme.split_once('/').map(|(host, _)| host)?;
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_string())
     }
 }
 


### PR DESCRIPTION
## Summary

- Both `issue view --with-comments` and `pr comments` now derive the GitLab host from the issue/MR `web_url` they already fetched, instead of relying on `ProviderContext::host`, which falls back to the default `gitlab.com` when callers force `--provider gitlab` without an explicit `--remote`.
- Adds a regression test for the host extractor covering the live `gitlab.gamania.com` URL shape that surfaced this bug during plan-issue Sprint 2.2 sandbox smoke.

## Why

`forge-cli --format json --provider gitlab --repo terrylin/agent-runtime-testing issue view 7 --with-comments` from the sandbox returned `backend_error: glab exited with status 1: Unauthenticated` because the second-leg call expanded to `glab api --hostname gitlab.com ...` even though the repo lives on `gitlab.gamania.com`. The fix uses the host segment from `web_url` (which we already have after the initial view call) — no `--remote` or `--repo` shape change required.

## Test plan

- [x] `cargo test -p nils-forge-cli` — new `gitlab_host_from_url_extracts_host_segment` test plus existing `gitlab_project_path_from_url_extracts_nested_groups` continue to pass
- [x] `scripts/ci/nils-cli-local-fast.sh` — full local fast gate
- [ ] Re-run Sprint 2 Task 2.3 sandbox `record open` once this lands

Refs: #490, #494, #499, #500.
