### PR TITLE
feat(plan-issue-cli): Sprint 3 GitLab record post/audit/close/link-pr

### DIFF
--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -843,9 +843,10 @@ fn run_record_attach(
         }));
     }
 
-    let repo = resolve_repo_for_live(binary, repo_override)?;
+    let repo_info = resolve_repo_info_for_live(binary, repo_override)?;
+    let adapter = crate::provider::select_adapter(&repo_info, force);
+    let repo = repo_info.slug;
     let issue_url = format!("https://github.com/{repo}/issues/{issue_number}");
-    let adapter = GhCliAdapter::new(force);
 
     let source_path = write_temp_markdown("record-attach-source-comment", &seed.source_body)
         .map_err(|err| CommandError::runtime("record-attach-source-write-failed", err))?;
@@ -982,9 +983,10 @@ fn run_record_post(
         }));
     }
 
-    let repo = resolve_repo_for_live(binary, repo_override)?;
+    let repo_info = resolve_repo_info_for_live(binary, repo_override)?;
+    let adapter = crate::provider::select_adapter(&repo_info, force);
+    let repo = repo_info.slug;
     let issue_number = parse_issue_reference(&args.issue)?;
-    let adapter = GhCliAdapter::new(force);
     let comment_path = write_temp_markdown("record-post-comment", &body)
         .map_err(|err| CommandError::runtime("record-post-comment-write-failed", err))?;
     let url = adapter
@@ -1040,8 +1042,9 @@ fn run_record_repair_dashboard(
             ),
         )?;
         let issue_number = parse_issue_reference(issue_value)?;
-        let repo = resolve_repo_for_live(binary, repo_override)?;
-        let adapter = GhCliAdapter::new(force);
+        let repo_info = resolve_repo_info_for_live(binary, repo_override)?;
+        let adapter = crate::provider::select_adapter(&repo_info, force);
+        let repo = repo_info.slug;
         let (body, comments) = adapter
             .issue_evidence(&repo, issue_number)
             .map_err(|err| CommandError::runtime("record-repair-evidence-read-failed", err))?;
@@ -1085,7 +1088,11 @@ fn run_record_repair_dashboard(
 
     let issue_number = issue_number.expect("live mode has issue number");
     let repo = repo.expect("live mode has repo");
-    let adapter = GhCliAdapter::new(force);
+    // Re-resolve provider so this dispatcher works when the early branch
+    // populated `repo` from the `--repo` slug alone (no Repo struct kept).
+    let repo_info = crate::provider::resolve_repo(Some(&repo))
+        .map_err(|err| CommandError::usage("repo-resolution-failed", err))?;
+    let adapter = crate::provider::select_adapter(&repo_info, force);
     let dashboard_path = write_temp_markdown("record-repair-dashboard", &dashboard)
         .map_err(|err| CommandError::runtime("record-repair-dashboard-write-failed", err))?;
     adapter
@@ -1141,9 +1148,10 @@ fn run_record_close(
                 "plan-issue-local record close --issue <n> --body-file <path> --comments-json <path> --approval <evidence>",
             ),
         )?;
-        let repo = resolve_repo_for_live(binary, repo_override)?;
+        let repo_info = resolve_repo_info_for_live(binary, repo_override)?;
+        let adapter = crate::provider::select_adapter(&repo_info, force);
+        let repo = repo_info.slug;
         let issue_number = parse_issue_reference(&args.issue)?;
-        let adapter = GhCliAdapter::new(force);
         let (body, comments) = adapter
             .issue_evidence(&repo, issue_number)
             .map_err(|err| CommandError::runtime("record-close-evidence-read-failed", err))?;
@@ -1158,7 +1166,12 @@ fn run_record_close(
             let pr_ev = read_fixture_pr_snapshot(fixture_dir, &pr_repo, pr_number)?;
             linked_evidence.push(pr_ev);
         } else if let Some(provider_repo) = &repo_for_provider {
-            let adapter = GhCliAdapter::new(force);
+            // Pick the adapter from the PR's repo, not the issue's repo —
+            // record-close supports cross-repo linked PRs (the PR lives in a
+            // different owner/repo from the tracking issue).
+            let pr_repo_info = crate::provider::resolve_repo(Some(&pr_repo))
+                .map_err(|err| CommandError::usage("repo-resolution-failed", err))?;
+            let adapter = crate::provider::select_adapter(&pr_repo_info, force);
             let summary = adapter
                 .pr_merge_summary(&pr_repo, pr_number)
                 .map_err(|err| CommandError::runtime("record-close-pr-summary-failed", err))?;
@@ -1292,7 +1305,9 @@ fn run_record_close(
     }
 
     let repo = repo_for_provider.expect("live mode has repo");
-    let adapter = GhCliAdapter::new(force);
+    let repo_info = crate::provider::resolve_repo(Some(&repo))
+        .map_err(|err| CommandError::usage("repo-resolution-failed", err))?;
+    let adapter = crate::provider::select_adapter(&repo_info, force);
     let closeout_path = write_temp_markdown("record-close-comment", &closeout_body)
         .map_err(|err| CommandError::runtime("record-close-comment-write-failed", err))?;
     let closeout_url = adapter
@@ -1656,7 +1671,10 @@ fn run_link_pr(
     repo_override: Option<&str>,
     args: &LinkPrArgs,
 ) -> Result<Value, CommandError> {
-    let adapter = GhCliAdapter::new(force);
+    // Adapter is constructed lazily once we know whether we're in body-file
+    // mode (no adapter needed) or live mode (adapter selected based on
+    // resolved repo provider).
+    let mut adapter: Option<Box<dyn crate::provider::ProviderAdapter>> = None;
 
     let (body, issue, repo, source, body_file_path) = if let Some(path) = &args.body_file {
         let body = fs::read_to_string(path).map_err(|err| {
@@ -1683,10 +1701,13 @@ fn run_link_pr(
                 "plan-issue-local link-pr --body-file <path> --task <task-id> --pr <ref> --dry-run",
             ),
         )?;
-        let repo = resolve_repo_for_live(binary, repo_override)?;
-        let body = adapter
+        let repo_info = resolve_repo_info_for_live(binary, repo_override)?;
+        let live_adapter = crate::provider::select_adapter(&repo_info, force);
+        let repo = repo_info.slug;
+        let body = live_adapter
             .issue_body(&repo, issue)
             .map_err(|err| CommandError::runtime("github-issue-read-failed", err))?;
+        adapter = Some(live_adapter);
         (
             body,
             Some(issue),
@@ -1743,7 +1764,13 @@ fn run_link_pr(
         })?;
         let body_path = write_temp_markdown("link-pr-issue-body", &updated_body)
             .map_err(|err| CommandError::runtime("issue-body-write-failed", err))?;
-        adapter
+        // In live mode the adapter was constructed in the issue branch
+        // above; this `expect` is unreachable because that branch is the
+        // only way `repo` becomes `Some` without `body_file_path`.
+        let live_adapter = adapter
+            .as_ref()
+            .expect("link-pr live mode constructed adapter alongside repo");
+        live_adapter
             .edit_issue_body(repo, issue, &body_path)
             .map_err(|err| CommandError::runtime("github-issue-update-failed", err))?;
         live_mutations = true;
@@ -3014,9 +3041,10 @@ fn collect_approval_candidates(
         "resolve-approval --pr <number>",
         Some("plan-issue resolve-approval --pr <number> --repo <owner/repo>"),
     )?;
-    let repo = resolve_repo_for_live(binary, repo_override)?;
+    let repo_info = resolve_repo_info_for_live(binary, repo_override)?;
+    let adapter = crate::provider::select_adapter(&repo_info, force);
+    let repo = repo_info.slug;
 
-    let adapter = GhCliAdapter::new(force);
     let comments = adapter
         .pr_comments(&repo, pr)
         .map_err(|err| CommandError::runtime("github-pr-comments-failed", err))?;

--- a/crates/plan-issue-cli/src/forge_cli_adapter.rs
+++ b/crates/plan-issue-cli/src/forge_cli_adapter.rs
@@ -66,6 +66,11 @@ impl ForgeCliRunner for ProcessForgeCliRunner {
 
 /// `ProviderAdapter` implementation for GitLab repos.
 pub struct ForgeCliAdapter {
+    /// Mirrors `GhCliAdapter::force`. Sprint 2/3 trait methods do not consult
+    /// it because forge-cli's own markdown-validation gates already enforce
+    /// the same policy; this field is retained so the adapter can grow a
+    /// `--force` pass-through later without an API change.
+    #[allow(dead_code)]
     force: bool,
     runner: Box<dyn ForgeCliRunner + Send + Sync>,
 }
@@ -126,12 +131,6 @@ impl ForgeCliAdapter {
         path.to_str()
             .ok_or_else(|| format!("body file path is not valid UTF-8: {}", path.display()))
     }
-}
-
-fn not_implemented(op: &str) -> String {
-    format!(
-        "provider_not_implemented: GitLab `{op}` is wired up to the routing layer but not yet implemented (Sprint 2.2 only ships `record open`). Track sympoies/nils-cli#490."
-    )
 }
 
 impl ProviderAdapter for ForgeCliAdapter {
@@ -264,27 +263,119 @@ impl ProviderAdapter for ForgeCliAdapter {
 
     fn close_issue(
         &self,
-        _repo: &str,
-        _issue: u64,
+        repo: &str,
+        issue: u64,
         _reason: CloseReason,
-        _close_comment: Option<&str>,
+        close_comment: Option<&str>,
     ) -> Result<(), String> {
-        // Sprint 3 lands `record close`; today close_issue stays a stub so
-        // any caller that hits it learns the gap with a typed message.
-        let _ = self.force;
-        Err(not_implemented("issue close"))
+        // GitLab `glab issue close` has no `--reason` or `--comment` flag,
+        // and `forge-cli issue close` mirrors that today. To preserve the
+        // "post a final comment + close" semantic that GitHub callers rely
+        // on, decompose into two atomic calls: `issue comment --body <c>`
+        // (only when a comment is supplied) then `issue close`. The
+        // `CloseReason` argument is intentionally dropped — GitLab has no
+        // native concept; both `Completed` and `NotPlanned` resolve to the
+        // same "closed" state.
+        let issue_str = issue.to_string();
+        if let Some(comment) = close_comment
+            && !comment.trim().is_empty()
+        {
+            let mut args = self.base_args(repo);
+            args.extend(["issue", "comment", &issue_str, "--body", comment]);
+            self.run_envelope(&args)?;
+        }
+        let mut args = self.base_args(repo);
+        args.extend(["issue", "close", &issue_str]);
+        self.run_envelope(&args).map(|_| ())
     }
 
-    fn pr_is_merged(&self, _repo: &str, _pr: u64) -> Result<bool, String> {
-        Err(not_implemented("pr is-merged"))
+    fn pr_is_merged(&self, repo: &str, pr: u64) -> Result<bool, String> {
+        let pr_str = pr.to_string();
+        let mut args = self.base_args(repo);
+        args.extend(["pr", "view", &pr_str]);
+        let data = self.run_envelope(&args)?;
+        let state = data
+            .get("state")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let merged_at_present = data.get("merged_at").map(|v| !v.is_null()).unwrap_or(false);
+        Ok(state.eq_ignore_ascii_case("merged") || merged_at_present)
     }
 
-    fn pr_merge_summary(&self, _repo: &str, _pr: u64) -> Result<PrMergeSummary, String> {
-        Err(not_implemented("pr merge-summary"))
+    fn pr_merge_summary(&self, repo: &str, pr: u64) -> Result<PrMergeSummary, String> {
+        // Compose `pr view` (state + merge_commit_sha) + `pr checks`
+        // (rolled-up status) — `pr view` payload exposes both fields after
+        // sympoies/nils-cli#495 (G3); `pr checks` was already there.
+        let pr_str = pr.to_string();
+
+        let mut view_args = self.base_args(repo);
+        view_args.extend(["pr", "view", &pr_str]);
+        let view = self.run_envelope(&view_args)?;
+        let state = view
+            .get("state")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let merged_at_present = view.get("merged_at").map(|v| !v.is_null()).unwrap_or(false);
+        let merged = state.eq_ignore_ascii_case("merged") || merged_at_present;
+        let merge_sha = view
+            .get("merge_commit_sha")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .filter(|s| !s.is_empty());
+
+        let mut checks_args = self.base_args(repo);
+        checks_args.extend(["pr", "checks", &pr_str]);
+        // `pr checks` exits non-zero when the rollup is `failure` / `pending`
+        // — that is information we want, not an error. The forge-cli error
+        // path here would surface those as `Err`; today's pr_checks_gitlab
+        // also already handles the "no pipeline" case (#485) returning
+        // empty success. For pr_merge_summary we just want the `state`
+        // field. If forge-cli errors, treat checks as `None`.
+        let checks = match self.run_envelope(&checks_args) {
+            Ok(checks_data) => checks_data
+                .get("state")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .filter(|s| !s.is_empty()),
+            Err(_) => None,
+        };
+        Ok(PrMergeSummary {
+            state,
+            merged,
+            merge_sha,
+            checks,
+        })
     }
 
-    fn pr_comments(&self, _repo: &str, _pr: u64) -> Result<Vec<Value>, String> {
-        Err(not_implemented("pr comments"))
+    fn pr_comments(&self, repo: &str, pr: u64) -> Result<Vec<Value>, String> {
+        // forge-cli `pr comments` returns `{provider, number, url, comments:[
+        // {url, author, created_at, body}, ...]}`. The plan-issue
+        // `resolve-approval` consumer reads `body`, `html_url`, `created_at`
+        // off each entry — rename `url` → `html_url` to keep that consumer
+        // unchanged (the GitHub adapter returns gh's raw payload which uses
+        // `html_url`).
+        let pr_str = pr.to_string();
+        let mut args = self.base_args(repo);
+        args.extend(["pr", "comments", &pr_str]);
+        let data = self.run_envelope(&args)?;
+        let arr = data
+            .get("comments")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let reshaped = arr
+            .into_iter()
+            .map(|mut item| {
+                if let Value::Object(ref mut obj) = item
+                    && let Some(url) = obj.remove("url")
+                {
+                    obj.insert("html_url".to_string(), url);
+                }
+                item
+            })
+            .collect();
+        Ok(reshaped)
     }
 }
 
@@ -554,31 +645,171 @@ mod tests {
     }
 
     #[test]
-    fn unimplemented_methods_still_return_provider_not_implemented() {
-        let (adapter, _) = adapter_with(vec![]);
+    fn close_issue_without_comment_invokes_only_issue_close() {
+        let (adapter, handle) = adapter_with(vec![
+            r#"{
+            "ok": true,
+            "schema_version": "cli.forge-cli.issue.close.v1",
+            "data": {"provider":"gitlab","number":7,"url":"u","state":"closed"}
+        }"#,
+        ]);
+        adapter
+            .close_issue("g/p", 7, CloseReason::Completed, None)
+            .expect("close without comment");
+        let calls = handle.calls();
+        assert_eq!(calls.len(), 1, "expected only the close call");
         assert!(
-            adapter
-                .close_issue("g/p", 1, CloseReason::Completed, None)
-                .unwrap_err()
-                .contains("provider_not_implemented")
+            calls[0]
+                .windows(2)
+                .any(|w| w[0] == "issue" && w[1] == "close")
+        );
+        // Reason is dropped — GitLab has no equivalent.
+        assert!(!calls[0].iter().any(|s| s.contains("--reason")));
+    }
+
+    #[test]
+    fn close_issue_with_comment_posts_then_closes() {
+        let (adapter, handle) = adapter_with(vec![
+            r#"{"ok":true,"schema_version":"cli.forge-cli.issue.comment.v1","data":{"provider":"gitlab","number":7,"url":"https://x.com/g/p/-/issues/7#note_42"}}"#,
+            r#"{"ok":true,"schema_version":"cli.forge-cli.issue.close.v1","data":{"provider":"gitlab","number":7,"url":"u","state":"closed"}}"#,
+        ]);
+        adapter
+            .close_issue(
+                "g/p",
+                7,
+                CloseReason::NotPlanned,
+                Some("closing because of X"),
+            )
+            .expect("close with comment");
+        let calls = handle.calls();
+        assert_eq!(calls.len(), 2, "expected comment then close");
+        assert!(
+            calls[0]
+                .windows(2)
+                .any(|w| w[0] == "issue" && w[1] == "comment")
+        );
+        let body_idx = calls[0].iter().position(|s| s == "--body").unwrap();
+        assert_eq!(calls[0][body_idx + 1], "closing because of X");
+        assert!(
+            calls[1]
+                .windows(2)
+                .any(|w| w[0] == "issue" && w[1] == "close")
+        );
+    }
+
+    #[test]
+    fn close_issue_blank_comment_skips_the_comment_call() {
+        let (adapter, handle) = adapter_with(vec![
+            r#"{
+            "ok": true,
+            "schema_version": "cli.forge-cli.issue.close.v1",
+            "data": {"provider":"gitlab","number":7,"url":"u","state":"closed"}
+        }"#,
+        ]);
+        adapter
+            .close_issue("g/p", 7, CloseReason::Completed, Some("   "))
+            .expect("close with blank comment");
+        assert_eq!(handle.calls().len(), 1, "blank comment must be skipped");
+    }
+
+    #[test]
+    fn pr_is_merged_returns_true_for_merged_state() {
+        let (adapter, _) = adapter_with(vec![
+            r#"{
+            "ok": true,
+            "schema_version": "cli.forge-cli.pr.view.v1",
+            "data": {"provider":"gitlab","number":7,"url":"u","state":"merged","draft":false,"title":"t","head":"x","base":"main","mergeable":"yes","merged_at":"2025-01-01T00:00:00Z","merge_commit_sha":"abc","labels":[]}
+        }"#,
+        ]);
+        assert!(adapter.pr_is_merged("g/p", 7).expect("merged state"));
+    }
+
+    #[test]
+    fn pr_is_merged_returns_false_for_open_state() {
+        let (adapter, _) = adapter_with(vec![
+            r#"{
+            "ok": true,
+            "schema_version": "cli.forge-cli.pr.view.v1",
+            "data": {"provider":"gitlab","number":7,"url":"u","state":"open","draft":false,"title":"t","head":"x","base":"main","mergeable":"yes","merged_at":null,"merge_commit_sha":null,"labels":[]}
+        }"#,
+        ]);
+        assert!(!adapter.pr_is_merged("g/p", 7).expect("open state"));
+    }
+
+    #[test]
+    fn pr_merge_summary_composes_view_and_checks() {
+        let (adapter, handle) = adapter_with(vec![
+            r#"{"ok":true,"schema_version":"cli.forge-cli.pr.view.v1","data":{"provider":"gitlab","number":7,"url":"u","state":"merged","draft":false,"title":"t","head":"x","base":"main","mergeable":"yes","merged_at":"2025-01-01T00:00:00Z","merge_commit_sha":"deadbeef","labels":[]}}"#,
+            r#"{"ok":true,"schema_version":"cli.forge-cli.pr.checks.v1","data":{"provider":"gitlab","state":"success","required_count":1,"success_count":1,"failed":[],"pending":[],"checks":[]}}"#,
+        ]);
+        let summary = adapter.pr_merge_summary("g/p", 7).expect("merge summary");
+        assert_eq!(summary.state, "merged");
+        assert!(summary.merged);
+        assert_eq!(summary.merge_sha.as_deref(), Some("deadbeef"));
+        assert_eq!(summary.checks.as_deref(), Some("success"));
+        let calls = handle.calls();
+        assert_eq!(calls.len(), 2);
+        assert!(calls[0].windows(2).any(|w| w[0] == "pr" && w[1] == "view"));
+        assert!(
+            calls[1]
+                .windows(2)
+                .any(|w| w[0] == "pr" && w[1] == "checks")
+        );
+    }
+
+    #[test]
+    fn pr_merge_summary_tolerates_checks_failure_by_returning_none() {
+        // `pr checks` exits non-zero when the rollup is failing — we want
+        // pr_merge_summary to keep going (returning checks=None) so callers
+        // can still see the view-side state + merge_sha.
+        let (adapter, _) = adapter_with(vec![
+            r#"{"ok":true,"schema_version":"cli.forge-cli.pr.view.v1","data":{"provider":"gitlab","number":7,"url":"u","state":"open","draft":false,"title":"t","head":"x","base":"main","mergeable":"yes","merged_at":null,"merge_commit_sha":null,"labels":[]}}"#,
+            r#"{"ok":false,"schema_version":"cli.forge-cli.error.v1","error":{"code":"backend_error","message":"checks rollup failure"}}"#,
+        ]);
+        let summary = adapter.pr_merge_summary("g/p", 7).expect("merge summary");
+        assert_eq!(summary.state, "open");
+        assert!(!summary.merged);
+        assert!(summary.merge_sha.is_none());
+        assert!(summary.checks.is_none(), "checks failure tolerated as None");
+    }
+
+    #[test]
+    fn pr_comments_reshapes_url_to_html_url_for_resolve_approval() {
+        let (adapter, _) = adapter_with(vec![
+            r#"{
+            "ok": true,
+            "schema_version": "cli.forge-cli.pr.comments.v1",
+            "data": {
+                "provider": "gitlab",
+                "number": 7,
+                "url": "https://x.com/g/p/-/merge_requests/7",
+                "comments": [
+                    {"url":"https://x.com/g/p/-/merge_requests/7#note_1","author":"alice","created_at":"2025-01-01T00:00:00Z","body":"- Decision: merge — approved"},
+                    {"url":"https://x.com/g/p/-/merge_requests/7#note_2","author":"bob","created_at":"2025-01-02T00:00:00Z","body":"some other note"}
+                ]
+            }
+        }"#,
+        ]);
+        let comments = adapter.pr_comments("g/p", 7).expect("comments");
+        assert_eq!(comments.len(), 2);
+        // resolve-approval reads `body`, `html_url`, `created_at`.
+        assert_eq!(
+            comments[0].get("html_url").and_then(Value::as_str),
+            Some("https://x.com/g/p/-/merge_requests/7#note_1")
         );
         assert!(
-            adapter
-                .pr_is_merged("g/p", 1)
-                .unwrap_err()
-                .contains("provider_not_implemented")
+            comments[0]
+                .get("body")
+                .and_then(Value::as_str)
+                .unwrap()
+                .contains("Decision: merge")
         );
-        assert!(
-            adapter
-                .pr_merge_summary("g/p", 1)
-                .unwrap_err()
-                .contains("provider_not_implemented")
+        assert_eq!(
+            comments[0].get("created_at").and_then(Value::as_str),
+            Some("2025-01-01T00:00:00Z")
         );
-        assert!(
-            adapter
-                .pr_comments("g/p", 1)
-                .unwrap_err()
-                .contains("provider_not_implemented")
-        );
+        // The forge-cli-native `url` key must be removed after the rename so
+        // consumers do not see two competing fields.
+        assert!(comments[0].get("url").is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Implement the remaining `ForgeCliAdapter` methods via `forge-cli` subprocess calls: `close_issue` decomposes into `issue comment` + `issue close` (GitLab has no `--reason` semantic, so the GitHub `Completed`/`NotPlanned` discriminator is dropped); `pr_is_merged` reads `pr view`'s `state` / `merged_at`; `pr_merge_summary` composes `pr view` (state + `merge_commit_sha` from #495 G3) with `pr checks` (rolled-up status, tolerated as `None` when the checks call fails); `pr_comments` reshapes `forge-cli pr comments` (#496 G4) to surface `html_url` for the existing `resolve-approval` consumer.
- Refactor the Sprint 3 lifecycle dispatchers — `record post / repair-dashboard / close / attach / link-pr` and `collect_approval_candidates` — to construct the adapter through `crate::provider::select_adapter(&Repo, force)`, so each path picks `GhCliAdapter` or the new `ForgeCliAdapter` based on the resolved provider; `link-pr` defers adapter construction so the body-file (no-network) mode stays unchanged.

## Why

This is **Sprint 3** of the plan-issue-cli GitLab provider abstraction (#490). Sprint 2 (#498, #499) landed the routing layer + `record open` GitLab path with sandbox verification; Sprint 3 flips the rest of the lifecycle that operates on an existing tracking issue onto GitLab. Sprint 4 will cover the dispatch family (`start-plan`, `start-sprint`, `ready-plan`, `accept-sprint`, `close-plan`, `cleanup-worktrees`).

## Test plan

- [x] `cargo test -p nils-plan-issue-cli` — 85 unit + 218 integration tests pass; 7 new `ForgeCliAdapter` scripted-runner tests cover `close_issue` (no-comment / with-comment / blank-comment / dropped reason), `pr_is_merged` (merged + open states), `pr_merge_summary` (view+checks composition + checks-failure tolerance), and `pr_comments` reshape
- [x] `scripts/ci/nils-cli-local-fast.sh` — full local fast gate (nextest + fmt + clippy `-D warnings` + completion-asset-audit + rumdl markdown lint)
- [ ] Sandbox revalidation: live `plan-issue record post / record close / link-pr / resolve-approval` against `gitlab.gamania.com`

Refs: #490, #498, #499, #500, #501.
