### PR TITLE
fix(plan-issue-cli): provider-aware issue/PR url hints

### DIFF
--- a/crates/forge-cli/tests/integration/pr_checks_gitlab.rs
+++ b/crates/forge-cli/tests/integration/pr_checks_gitlab.rs
@@ -180,7 +180,13 @@ exit 99
 fn pr_checks_glab_no_pipeline_is_success_zero_count() {
     let stub = StubEnv::new().glab_stub(&glab_stub_no_pipeline(VERSION_OK));
     let argv = vec![
-        "--provider", "gitlab", "--format", "json", "pr", "checks", "feat/sample",
+        "--provider",
+        "gitlab",
+        "--format",
+        "json",
+        "pr",
+        "checks",
+        "feat/sample",
     ];
     let out = run_forge_cli(&stub, &argv);
     let env = parse_envelope(&out.stdout);

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -845,8 +845,8 @@ fn run_record_attach(
 
     let repo_info = resolve_repo_info_for_live(binary, repo_override)?;
     let adapter = crate::provider::select_adapter(&repo_info, force);
+    let issue_url = repo_info.issue_url(issue_number);
     let repo = repo_info.slug;
-    let issue_url = format!("https://github.com/{repo}/issues/{issue_number}");
 
     let source_path = write_temp_markdown("record-attach-source-comment", &seed.source_body)
         .map_err(|err| CommandError::runtime("record-attach-source-write-failed", err))?;
@@ -1044,11 +1044,11 @@ fn run_record_repair_dashboard(
         let issue_number = parse_issue_reference(issue_value)?;
         let repo_info = resolve_repo_info_for_live(binary, repo_override)?;
         let adapter = crate::provider::select_adapter(&repo_info, force);
+        let issue_url = repo_info.issue_url(issue_number);
         let repo = repo_info.slug;
         let (body, comments) = adapter
             .issue_evidence(&repo, issue_number)
             .map_err(|err| CommandError::runtime("record-repair-evidence-read-failed", err))?;
-        let issue_url = format!("https://github.com/{repo}/issues/{issue_number}");
         (
             body,
             comments,
@@ -1134,7 +1134,7 @@ fn run_record_close(
     {
         let (body, comments) = read_fixture_evidence(fixture_dir)?;
         let issue_number = parse_issue_reference(&args.issue)?;
-        (body, comments, None, issue_number)
+        (body, comments, None::<crate::provider::Repo>, issue_number)
     } else if let (Some(body_file), Some(comments_path)) = (&args.body_file, &args.comments_json) {
         let body = read_text_file(body_file, "record-close-body-read-failed")?;
         let comments = read_text_file(comments_path, "record-close-comments-read-failed")?;
@@ -1150,12 +1150,11 @@ fn run_record_close(
         )?;
         let repo_info = resolve_repo_info_for_live(binary, repo_override)?;
         let adapter = crate::provider::select_adapter(&repo_info, force);
-        let repo = repo_info.slug;
         let issue_number = parse_issue_reference(&args.issue)?;
         let (body, comments) = adapter
-            .issue_evidence(&repo, issue_number)
+            .issue_evidence(&repo_info.slug, issue_number)
             .map_err(|err| CommandError::runtime("record-close-evidence-read-failed", err))?;
-        (body, comments, Some(repo), issue_number)
+        (body, comments, Some(repo_info), issue_number)
     };
 
     // Resolve linked PRs through provider/fixture for merge_sha + checks.
@@ -1169,6 +1168,7 @@ fn run_record_close(
             // Pick the adapter from the PR's repo, not the issue's repo —
             // record-close supports cross-repo linked PRs (the PR lives in a
             // different owner/repo from the tracking issue).
+            let _ = provider_repo;
             let pr_repo_info = crate::provider::resolve_repo(Some(&pr_repo))
                 .map_err(|err| CommandError::usage("repo-resolution-failed", err))?;
             let adapter = crate::provider::select_adapter(&pr_repo_info, force);
@@ -1182,7 +1182,7 @@ fn run_record_close(
             };
             linked_evidence.push(lifecycle_record::LinkedPrEvidence {
                 pr_ref: format!("{pr_repo}#{pr_number}"),
-                url: Some(format!("https://github.com/{pr_repo}/pull/{pr_number}")),
+                url: Some(pr_repo_info.pr_url(pr_number)),
                 merge_sha: if summary.merged {
                     summary.merge_sha
                 } else {
@@ -1209,7 +1209,7 @@ fn run_record_close(
     // Compute canonical final dashboard from audit.
     let issue_url_hint = repo_for_provider
         .as_ref()
-        .map(|repo| format!("https://github.com/{repo}/issues/{issue_number}"));
+        .map(|repo| repo.issue_url(issue_number));
     let canonical_dashboard =
         lifecycle_record::render_dashboard_from_audit(&audit, None, issue_url_hint.as_deref());
 
@@ -1304,10 +1304,10 @@ fn run_record_close(
         }));
     }
 
-    let repo = repo_for_provider.expect("live mode has repo");
-    let repo_info = crate::provider::resolve_repo(Some(&repo))
-        .map_err(|err| CommandError::usage("repo-resolution-failed", err))?;
+    let repo_info = repo_for_provider.expect("live mode has repo");
     let adapter = crate::provider::select_adapter(&repo_info, force);
+    let repo = repo_info.slug.clone();
+    let issue_url = repo_info.issue_url(issue_number);
     let closeout_path = write_temp_markdown("record-close-comment", &closeout_body)
         .map_err(|err| CommandError::runtime("record-close-comment-write-failed", err))?;
     let closeout_url = adapter
@@ -1321,11 +1321,8 @@ fn run_record_close(
     let audit_after =
         lifecycle_record::audit_record(Some(&body_after), &comments_after, Some(args.profile))
             .map_err(|err| CommandError::runtime("record-close-audit-reread-failed", err))?;
-    let final_dashboard = lifecycle_record::render_dashboard_from_audit(
-        &audit_after,
-        None,
-        Some(&format!("https://github.com/{repo}/issues/{issue_number}")),
-    );
+    let final_dashboard =
+        lifecycle_record::render_dashboard_from_audit(&audit_after, None, Some(&issue_url));
     let dashboard_path = write_temp_markdown("record-close-dashboard", &final_dashboard)
         .map_err(|err| CommandError::runtime("record-close-dashboard-write-failed", err))?;
     adapter
@@ -1353,7 +1350,7 @@ fn run_record_close(
         "mode": "live",
         "issue": {
             "number": issue_number,
-            "url": format!("https://github.com/{repo}/issues/{issue_number}"),
+            "url": issue_url,
         },
         "closeout_url": closeout_url,
         "linked_prs": linked_evidence,

--- a/crates/plan-issue-cli/src/provider.rs
+++ b/crates/plan-issue-cli/src/provider.rs
@@ -59,6 +59,51 @@ pub struct Repo {
     pub host: Option<String>,
 }
 
+impl Repo {
+    fn default_host(&self) -> &str {
+        self.host.as_deref().unwrap_or(match self.provider {
+            Provider::GitHub => "github.com",
+            Provider::GitLab => "gitlab.com",
+        })
+    }
+
+    /// Canonical issue URL hint used by lifecycle dashboards. GitHub uses
+    /// `https://github.com/<slug>/issues/<n>`; GitLab uses
+    /// `https://<host>/<slug>/-/issues/<n>` (GitLab redirects this to the
+    /// Work Items surface when needed).
+    pub fn issue_url(&self, issue_number: u64) -> String {
+        match self.provider {
+            Provider::GitHub => format!(
+                "https://{host}/{slug}/issues/{issue_number}",
+                host = self.default_host(),
+                slug = self.slug,
+            ),
+            Provider::GitLab => format!(
+                "https://{host}/{slug}/-/issues/{issue_number}",
+                host = self.default_host(),
+                slug = self.slug,
+            ),
+        }
+    }
+
+    /// Canonical PR / MR URL. GitHub uses `<host>/<slug>/pull/<n>`; GitLab
+    /// uses `<host>/<slug>/-/merge_requests/<n>`.
+    pub fn pr_url(&self, pr_number: u64) -> String {
+        match self.provider {
+            Provider::GitHub => format!(
+                "https://{host}/{slug}/pull/{pr_number}",
+                host = self.default_host(),
+                slug = self.slug,
+            ),
+            Provider::GitLab => format!(
+                "https://{host}/{slug}/-/merge_requests/{pr_number}",
+                host = self.default_host(),
+                slug = self.slug,
+            ),
+        }
+    }
+}
+
 /// Resolve a [`Repo`] from `--repo` and/or the cwd's git remote, mirroring
 /// `forge-cli`'s detection ladder but kept local so plan-issue does not need
 /// to subprocess-shell-out to `forge-cli repo view` just to learn its own


### PR DESCRIPTION
## Summary

- Add `Repo::issue_url(n)` / `Repo::pr_url(n)` helpers that emit `https://<host>/<slug>/issues/<n>` (GitHub) or `https://<host>/<slug>/-/issues/<n>` / `/-/merge_requests/<n>` (GitLab), and replace the five `format!("https://github.com/{repo}/...")` hardcodes in `record attach / repair-dashboard / close`.
- Thread the resolved `Repo` (host + provider) through the live record-close pipeline so the dashboard hint matches the provider.

## Why

Surfaced live during Sprint 3 sandbox smoke (gitlab.gamania.com issue #10): the GitLab dashboard rendered \`https://github.com/...\` URLs because the hint format string was hardcoded. plan-issue otherwise worked, but the rendered dashboard contained dead/wrong links — usability hit for the user goal of running issue/MR skills on GitLab.

## Test plan

- [x] \`cargo test -p nils-plan-issue-cli\` — 85 unit + 218 integration pass
- [x] \`scripts/ci/nils-cli-local-fast.sh\` — full local gate
- [ ] Re-run Sprint 3 sandbox \`record repair-dashboard\` once this lands

Refs: #490, #503.