### PR TITLE
fix(plan-issue-cli): record close gates on required checks only (#502)

### DIFF
--- a/crates/plan-issue-cli/CHANGELOG.md
+++ b/crates/plan-issue-cli/CHANGELOG.md
@@ -6,6 +6,29 @@ versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- `plan-issue record close` no longer collapses non-required GitHub
+  `statusCheckRollup` failures into `linked-pr-not-merged`. The strict
+  closeout gate now consults a separate required-check rollup (via
+  `gh pr checks <pr> --required`), passes when required checks succeed
+  even if non-required workflows failed, and emits the distinct
+  `linked-pr-checks-failed` blocker code when required checks actually
+  fail. Provider adapters return `required_state`, `required_count`, and
+  the list of non-required failures alongside the existing aggregate
+  rollup. (sympoies/nils-cli#502)
+
+### Added
+
+- `plan-issue record close` accepts
+  `--allow-non-required-check-failure` plus
+  `--allow-non-required-check-failure-reason <text>` as an explicit,
+  evidence-emitting override for the degraded-provider case where
+  required-check state cannot be resolved. The override decision and
+  observed non-required failures are recorded under
+  `non_required_check_override` in the closeout-comment payload, and the
+  comment summary advertises that the override was used.
+
 ### BREAKING (Plan-Issue Lifecycle v3)
 
 - The `plan-issue record` surface is rewritten around the v3 issue-backed

--- a/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md
+++ b/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md
@@ -316,6 +316,16 @@ Failure modes that block close:
   (any finding with disposition `residual` and severity `blocker` /
   `major`).
 - `linked-pr-missing` / `linked-pr-not-merged` / `linked-pr-checks-failed`.
+  `linked-pr-not-merged` is reserved for refs whose provider lookup reports
+  a missing `merge_commit_sha`. `linked-pr-checks-failed` is emitted when
+  the provider's required-check rollup reports failure (or when the
+  provider cannot classify required vs. non-required checks and the
+  aggregate rollup reports failure without
+  `--allow-non-required-check-failure`). Non-required check failures alone
+  never block.
+- `record-close-override-reason-missing` (only when
+  `--allow-non-required-check-failure` is set without
+  `--allow-non-required-check-failure-reason`).
 - `approval-missing` / `approval-invalid`.
 - `dashboard-out-of-date` (recomputed dashboard differs from issue body).
 
@@ -327,11 +337,20 @@ unblock action.
 Linked PR evidence is verified against the provider, not text matching:
 
 - Each linked PR ref resolves to a provider PR.
-- Provider state must be `merged`.
-- Provider check rollup must be `success` or explicitly waived in the
-  closeout payload `notes` (with reviewer approval recorded).
+- Provider state must be `merged` (`merge_commit_sha` present).
+- Provider's **required**-check rollup must be `success`, `none` (zero
+  required checks), or unresolved-with-override. Non-required failures
+  are recorded under `linked_prs[].non_required_failures` for evidence
+  but do not block the gate.
 - The provider's `merge_commit_sha` is recorded back into the closeout
-  payload `linked_prs[].merge_sha`.
+  payload `linked_prs[].merge_sha`. Per-PR check breakdown is recorded
+  under `linked_prs[].{required_state, required_count, non_required_failures}`.
+- When the provider cannot resolve a required-check rollup (e.g. GitLab,
+  or a degraded `gh` call) and aggregate checks fail, the gate stays
+  conservative and emits `linked-pr-checks-failed` unless the operator
+  passes `--allow-non-required-check-failure --allow-non-required-check-failure-reason <text>`.
+  Override use is recorded in the closeout payload under
+  `non_required_check_override = {reason, observed_non_required_failures[]}`.
 
 ## Result JSON Envelope
 

--- a/crates/plan-issue-cli/src/commands/record.rs
+++ b/crates/plan-issue-cli/src/commands/record.rs
@@ -282,4 +282,22 @@ pub struct RecordCloseArgs {
     /// PR snapshots used in place of provider lookups.
     #[arg(long, value_name = "dir")]
     pub fixture: Option<PathBuf>,
+
+    /// Allow the linked-PR branch of the strict closeout gate to pass
+    /// even when the provider only reports a single aggregate check
+    /// state (no required/non-required breakdown) and that aggregate
+    /// state is `failure`. Use this when you have manually verified
+    /// that the failing checks are non-required. Requires
+    /// `--allow-non-required-check-failure-reason`. The override and
+    /// the observed non-required failures are recorded in the
+    /// closeout-comment evidence block.
+    #[arg(long = "allow-non-required-check-failure", default_value_t = false)]
+    pub allow_non_required_check_failure: bool,
+
+    /// Required when `--allow-non-required-check-failure` is set.
+    /// Non-empty free-form text describing why the operator verified
+    /// the failing checks are safe to ignore. Stored verbatim in the
+    /// closeout-comment evidence block.
+    #[arg(long = "allow-non-required-check-failure-reason", value_name = "text")]
+    pub allow_non_required_check_failure_reason: Option<String>,
 }

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -520,17 +520,50 @@ fn read_fixture_pr_snapshot(
         .and_then(|rollup| rollup.get("state"))
         .and_then(Value::as_str)
         .map(|s| s.to_ascii_lowercase());
-    let checks = match checks_str.as_deref() {
-        Some("success") => lifecycle_record::CheckStatus::Pass,
-        Some("failure" | "error") => lifecycle_record::CheckStatus::Fail,
-        _ => lifecycle_record::CheckStatus::None,
-    };
+    let checks = check_status_from_state(checks_str.as_deref());
+    let required_state = value
+        .get("requiredCheckRollup")
+        .and_then(|rollup| rollup.get("state"))
+        .and_then(Value::as_str)
+        .map(|s| s.to_ascii_lowercase());
+    let required_count = value
+        .get("requiredCheckRollup")
+        .and_then(|rollup| rollup.get("count"))
+        .and_then(Value::as_u64)
+        .and_then(|n| u32::try_from(n).ok());
+    let required_state_enum = required_state
+        .as_deref()
+        .map(|s| check_status_from_state(Some(s)));
+    let non_required_failures = value
+        .get("nonRequiredFailures")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
     Ok(lifecycle_record::LinkedPrEvidence {
         pr_ref: format!("{repo}#{pr}"),
         url: value.get("url").and_then(Value::as_str).map(str::to_string),
         merge_sha: if merged { merge_sha } else { None },
         checks,
+        required_state: required_state_enum,
+        required_count,
+        non_required_failures,
     })
+}
+
+fn check_status_from_state(state: Option<&str>) -> lifecycle_record::CheckStatus {
+    match state.map(str::to_ascii_lowercase).as_deref() {
+        Some("success" | "pass") => lifecycle_record::CheckStatus::Pass,
+        Some(
+            "failure" | "failed" | "error" | "cancelled" | "timed_out" | "action_required"
+            | "stale" | "startup_failure",
+        ) => lifecycle_record::CheckStatus::Fail,
+        _ => lifecycle_record::CheckStatus::None,
+    }
 }
 
 fn parse_issue_reference(value: &str) -> Result<u64, CommandError> {
@@ -1128,6 +1161,23 @@ fn run_record_close(
             )
         })?;
 
+    let override_reason = if args.allow_non_required_check_failure {
+        let reason = args
+            .allow_non_required_check_failure_reason
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                CommandError::usage(
+                    "record-close-override-reason-missing",
+                    "--allow-non-required-check-failure requires --allow-non-required-check-failure-reason <text>",
+                )
+            })?;
+        Some(reason.to_string())
+    } else {
+        None
+    };
+
     // Resolve evidence source.
     let (body, comments_json, repo_for_provider, issue_number) = if let Some(fixture_dir) =
         &args.fixture
@@ -1175,11 +1225,11 @@ fn run_record_close(
             let summary = adapter
                 .pr_merge_summary(&pr_repo, pr_number)
                 .map_err(|err| CommandError::runtime("record-close-pr-summary-failed", err))?;
-            let checks = match summary.checks.as_deref() {
-                Some("success") => lifecycle_record::CheckStatus::Pass,
-                Some("failure" | "error") => lifecycle_record::CheckStatus::Fail,
-                _ => lifecycle_record::CheckStatus::None,
-            };
+            let checks = check_status_from_state(summary.checks.as_deref());
+            let required_state = summary
+                .required_state
+                .as_deref()
+                .map(|s| check_status_from_state(Some(s)));
             linked_evidence.push(lifecycle_record::LinkedPrEvidence {
                 pr_ref: format!("{pr_repo}#{pr_number}"),
                 url: Some(pr_repo_info.pr_url(pr_number)),
@@ -1189,6 +1239,9 @@ fn run_record_close(
                     None
                 },
                 checks,
+                required_state,
+                required_count: summary.required_count,
+                non_required_failures: summary.non_required_failures,
             });
             let _ = provider_repo;
         } else {
@@ -1199,6 +1252,9 @@ fn run_record_close(
                 url: None,
                 merge_sha: None,
                 checks: lifecycle_record::CheckStatus::None,
+                required_state: None,
+                required_count: None,
+                non_required_failures: Vec::new(),
             });
         }
     }
@@ -1226,6 +1282,7 @@ fn run_record_close(
             // `record audit --strict` surface).
             current_body: None,
             expected_dashboard: None,
+            allow_non_required_check_failure: args.allow_non_required_check_failure,
         },
     );
 
@@ -1246,6 +1303,25 @@ fn run_record_close(
     }
 
     // Render closeout comment using the same renderer as record post.
+    let check_status_to_str = |status: lifecycle_record::CheckStatus| match status {
+        lifecycle_record::CheckStatus::Pass => "pass",
+        lifecycle_record::CheckStatus::Fail => "fail",
+        lifecycle_record::CheckStatus::None => "none",
+    };
+    let override_block = override_reason.as_ref().map(|reason| {
+        let observed_failures: Vec<String> = linked_evidence
+            .iter()
+            .flat_map(|pr| {
+                pr.non_required_failures
+                    .iter()
+                    .map(move |name| format!("{}: {name}", pr.pr_ref))
+            })
+            .collect();
+        json!({
+            "reason": reason,
+            "observed_non_required_failures": observed_failures,
+        })
+    });
     let closeout_payload = json!({
         "final_status": "complete",
         "approval": {"comment_url": approval_text},
@@ -1256,21 +1332,26 @@ fn run_record_close(
                     "ref": pr.pr_ref,
                     "url": pr.url,
                     "merge_sha": pr.merge_sha,
-                    "checks": match pr.checks {
-                        lifecycle_record::CheckStatus::Pass => "pass",
-                        lifecycle_record::CheckStatus::Fail => "fail",
-                        lifecycle_record::CheckStatus::None => "none",
-                    },
+                    "checks": check_status_to_str(pr.checks),
+                    "required_state": pr.required_state.map(check_status_to_str),
+                    "required_count": pr.required_count,
+                    "non_required_failures": pr.non_required_failures,
                 })
             })
             .collect::<Vec<_>>(),
+        "non_required_check_override": override_block,
         "notes": null,
     });
+    let closeout_summary = if override_reason.is_some() {
+        "Strict closeout gate passed with non-required-check failure override; record closed by `plan-issue record close`."
+    } else {
+        "Strict closeout gate passed; record closed by `plan-issue record close`."
+    };
     let closeout_body = lifecycle_record::render_record_post_comment(
         args.profile,
         crate::commands::record::LifecycleCommentKind::Closeout,
         closeout_payload.clone(),
-        Some("Strict closeout gate passed; record closed by `plan-issue record close`."),
+        Some(closeout_summary),
         None,
     )
     .map_err(|err| CommandError::runtime("record-close-render-failed", err))?;

--- a/crates/plan-issue-cli/src/forge_cli_adapter.rs
+++ b/crates/plan-issue-cli/src/forge_cli_adapter.rs
@@ -340,11 +340,19 @@ impl ProviderAdapter for ForgeCliAdapter {
                 .filter(|s| !s.is_empty()),
             Err(_) => None,
         };
+        // GitLab has no first-class required-check concept: pipeline
+        // jobs are either reported by `glab` as a single rolled-up
+        // status, or not at all. We leave the required fields at
+        // `None`/empty so the close gate falls back to the aggregate
+        // `checks` value (matching pre-#502 GitLab behavior).
         Ok(PrMergeSummary {
             state,
             merged,
             merge_sha,
             checks,
+            required_state: None,
+            required_count: None,
+            non_required_failures: Vec::new(),
         })
     }
 

--- a/crates/plan-issue-cli/src/github.rs
+++ b/crates/plan-issue-cli/src/github.rs
@@ -69,6 +69,20 @@ pub struct PrMergeSummary {
     /// Rolled-up status check state when known
     /// (`success`, `failure`, `pending`, `error`, ...).
     pub checks: Option<String>,
+    /// Required-check rollup state when the adapter can resolve the
+    /// required/non-required distinction
+    /// (`success`, `failure`, `pending`, ...). `None` means the
+    /// adapter could not classify (e.g. GitLab today, or a degraded
+    /// `gh` call); the close gate falls back to `checks` in that case.
+    pub required_state: Option<String>,
+    /// Number of required checks reported by the provider. `None` when
+    /// classification is unavailable; `Some(0)` means zero required
+    /// checks were declared.
+    pub required_count: Option<u32>,
+    /// Names of non-required checks that ended in a failure-class
+    /// state. Used as informational evidence in the closeout comment;
+    /// the close gate never blocks on this alone.
+    pub non_required_failures: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -110,6 +124,105 @@ impl GhCliAdapter {
         markdown::validate_markdown_payload(payload).map_err(|err| {
             format!("{context}: {err}. Replace escaped controls or re-run with --force.")
         })
+    }
+
+    /// Resolve the required-check rollup for `repo#pr` via
+    /// `gh pr checks <pr> --required --json bucket,state,conclusion,name`.
+    ///
+    /// Returns `(required_state, required_count, non_required_failures)`.
+    /// All three are `None`/empty when `gh` rejects the call or the
+    /// JSON does not parse — the close gate then falls back to the
+    /// aggregate rollup carried in `checks`. The `rollup_value`
+    /// argument is the `statusCheckRollup` field harvested from
+    /// `gh pr view` and is used to compute the non-required failure
+    /// list (rollup names not in the required set).
+    fn pr_required_summary(
+        repo: &str,
+        pr: u64,
+        rollup_value: Option<&Value>,
+    ) -> (Option<String>, Option<u32>, Vec<String>) {
+        let args = vec![
+            "pr".to_string(),
+            "checks".to_string(),
+            pr.to_string(),
+            "--repo".to_string(),
+            repo.to_string(),
+            "--required".to_string(),
+            "--json".to_string(),
+            "bucket,state,conclusion,name".to_string(),
+        ];
+        let raw = match Self::run(&args) {
+            Ok(out) => out,
+            Err(_) => return (None, None, Vec::new()),
+        };
+        let required_array: Vec<Value> = match serde_json::from_str(raw.trim()) {
+            Ok(Value::Array(items)) => items,
+            Ok(_) => return (None, None, Vec::new()),
+            // `gh pr checks --required` prints nothing when the PR has
+            // no required checks; treat empty output as a zero-required
+            // success rollup so a non-required failure does not block
+            // the gate.
+            Err(_) if raw.trim().is_empty() => {
+                return (Some("success".to_string()), Some(0), Vec::new());
+            }
+            Err(_) => return (None, None, Vec::new()),
+        };
+        let required_count = u32::try_from(required_array.len()).unwrap_or(u32::MAX);
+        let required_state =
+            rollup_status(&Value::Array(required_array.clone())).unwrap_or_else(|| {
+                if required_array.is_empty() {
+                    "success".to_string()
+                } else {
+                    "unknown".to_string()
+                }
+            });
+
+        let required_names: std::collections::HashSet<String> = required_array
+            .iter()
+            .filter_map(|item| item.get("name").and_then(Value::as_str).map(str::to_string))
+            .collect();
+
+        let mut non_required_failures: Vec<String> = Vec::new();
+        if let Some(Value::Array(items)) = rollup_value {
+            for item in items {
+                let name = item
+                    .get("name")
+                    .or_else(|| item.get("context"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                let state_str = item
+                    .get("conclusion")
+                    .or_else(|| item.get("state"))
+                    .and_then(Value::as_str)
+                    .map(|s| s.to_ascii_lowercase());
+                let failed = matches!(
+                    state_str.as_deref(),
+                    Some(
+                        "failure"
+                            | "cancelled"
+                            | "timed_out"
+                            | "action_required"
+                            | "error"
+                            | "stale"
+                            | "startup_failure"
+                    )
+                );
+                if let Some(name) = name
+                    && failed
+                    && !required_names.contains(&name)
+                {
+                    non_required_failures.push(name);
+                }
+            }
+        }
+        non_required_failures.sort();
+        non_required_failures.dedup();
+
+        (
+            Some(required_state),
+            Some(required_count),
+            non_required_failures,
+        )
     }
 
     fn guard_markdown_file(&self, path: &Path, context: &str) -> Result<(), String> {
@@ -370,15 +483,20 @@ impl ProviderAdapter for GhCliAdapter {
             .and_then(Value::as_str)
             .map(str::to_string)
             .filter(|sha| !sha.is_empty());
-        let checks = json
-            .get("statusCheckRollup")
+        let rollup_value = json.get("statusCheckRollup");
+        let checks = rollup_value
             .and_then(rollup_status)
             .filter(|status| !status.is_empty());
+        let (required_state, required_count, non_required_failures) =
+            Self::pr_required_summary(repo, pr, rollup_value);
         Ok(PrMergeSummary {
             state,
             merged,
             merge_sha,
             checks,
+            required_state,
+            required_count,
+            non_required_failures,
         })
     }
 

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -2266,7 +2266,7 @@ mod sprint3_tests {
             checks: CheckStatus::Fail,
             required_state: None,
             required_count: None,
-            non_required_failures: vec!["legacy/lint".to_string()],
+            non_required_failures: vec!["opt-in/lint".to_string()],
         }];
 
         let blocked = evaluate_strict_closeout_gate(

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -1077,7 +1077,29 @@ pub struct LinkedPrEvidence {
     pub url: Option<String>,
     #[serde(default)]
     pub merge_sha: Option<String>,
+    /// Aggregate rollup over every PR check (required and non-required
+    /// combined). Kept for backward compatibility with the closeout
+    /// payload schema; the close gate now consults `required_state`
+    /// first and only falls back to `checks` when required-check state
+    /// is unknown.
     pub checks: CheckStatus,
+    /// Required-check rollup when the provider exposes the
+    /// required/non-required distinction. `None` means the adapter
+    /// could not resolve a required-only summary (e.g. GitLab today,
+    /// or a degraded `gh` call), in which case the gate falls back to
+    /// the aggregate `checks` value.
+    #[serde(default)]
+    pub required_state: Option<CheckStatus>,
+    /// Number of required checks reported by the provider. `None`
+    /// when required-check classification is unavailable; `Some(0)`
+    /// means the PR has zero required checks.
+    #[serde(default)]
+    pub required_count: Option<u32>,
+    /// Names of non-required checks that ended in a failure-class
+    /// state. Surfaced as informational evidence in the closeout
+    /// comment; never blocks the gate on its own.
+    #[serde(default)]
+    pub non_required_failures: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, serde::Deserialize)]
@@ -1546,6 +1568,12 @@ pub struct StrictCloseoutGateInput<'a> {
     /// not appear in the body.
     pub current_body: Option<&'a str>,
     pub expected_dashboard: Option<&'a str>,
+    /// When `true`, the linked-PR branch skips the conservative
+    /// "unknown required-check state with aggregate failure" check
+    /// and lets the gate pass on non-required failures alone. The
+    /// caller is responsible for surfacing the override decision in
+    /// closeout-comment evidence; the gate itself does not record it.
+    pub allow_non_required_check_failure: bool,
 }
 
 pub fn evaluate_strict_closeout_gate(
@@ -1755,28 +1783,62 @@ pub fn evaluate_strict_closeout_gate(
     if input.linked_prs.is_empty() {
         push_pass(&mut checks, "linked PRs", "none provided".to_string());
     } else {
-        let mut failing = Vec::new();
+        let mut unmerged: Vec<String> = Vec::new();
+        let mut required_failed: Vec<String> = Vec::new();
         for pr in input.linked_prs {
             let sha = pr.merge_sha.as_deref().map(str::trim).unwrap_or("");
             if sha.is_empty() {
-                failing.push(format!("{} (no merge_sha)", pr.pr_ref));
-            } else if !matches!(pr.checks, CheckStatus::Pass | CheckStatus::None) {
-                failing.push(format!("{} (checks={:?})", pr.pr_ref, pr.checks));
+                unmerged.push(format!("{} (no merge_sha)", pr.pr_ref));
+                continue;
+            }
+            match pr.required_state {
+                Some(CheckStatus::Fail) => {
+                    required_failed.push(format!("{} (required checks failed)", pr.pr_ref));
+                }
+                Some(CheckStatus::Pass | CheckStatus::None) => {
+                    // Required checks resolved cleanly (including the
+                    // `required_count == 0` case). Non-required failures
+                    // are informational only and never block.
+                }
+                None => {
+                    // Provider could not classify required-vs-non-required
+                    // (e.g. GitLab today, or a degraded `gh` call). Stay
+                    // conservative: aggregate failure blocks unless the
+                    // caller has set the explicit override flag.
+                    if matches!(pr.checks, CheckStatus::Fail)
+                        && !input.allow_non_required_check_failure
+                    {
+                        required_failed.push(format!(
+                            "{} (checks={:?}; required-state unknown)",
+                            pr.pr_ref, pr.checks
+                        ));
+                    }
+                }
             }
         }
-        if failing.is_empty() {
-            push_pass(
-                &mut checks,
-                "linked PRs",
-                format!("{} merged", input.linked_prs.len()),
-            );
-        } else {
+        if !unmerged.is_empty() {
             push_fail(
                 &mut checks,
                 &mut blocked_codes,
                 "linked PRs",
-                failing.join(", "),
+                unmerged.join(", "),
                 "linked-pr-not-merged",
+            );
+        }
+        if !required_failed.is_empty() {
+            push_fail(
+                &mut checks,
+                &mut blocked_codes,
+                "linked PRs required checks",
+                required_failed.join(", "),
+                "linked-pr-checks-failed",
+            );
+        }
+        if unmerged.is_empty() && required_failed.is_empty() {
+            push_pass(
+                &mut checks,
+                "linked PRs",
+                format!("{} merged", input.linked_prs.len()),
             );
         }
     }
@@ -1924,6 +1986,9 @@ mod sprint3_tests {
             url: Some("https://github.com/owner/repo/pull/1".to_string()),
             merge_sha: Some("abcdef1234567890".to_string()),
             checks: CheckStatus::Pass,
+            required_state: Some(CheckStatus::Pass),
+            required_count: Some(1),
+            non_required_failures: Vec::new(),
         }];
         let result = evaluate_strict_closeout_gate(
             &audit,
@@ -1933,6 +1998,7 @@ mod sprint3_tests {
                 linked_prs: &linked_prs,
                 current_body: None,
                 expected_dashboard: None,
+                allow_non_required_check_failure: false,
             },
         );
         assert!(result.ready, "gate should pass: {:?}", result.checks);
@@ -1964,6 +2030,7 @@ mod sprint3_tests {
                 linked_prs: &[],
                 current_body: None,
                 expected_dashboard: None,
+                allow_non_required_check_failure: false,
             },
         );
         assert!(!result.ready);
@@ -2002,6 +2069,7 @@ mod sprint3_tests {
                 linked_prs: &[],
                 current_body: None,
                 expected_dashboard: None,
+                allow_non_required_check_failure: false,
             },
         );
         assert!(res_rej.blocked_codes.iter().any(|c| c == "review-rejected"));
@@ -2030,6 +2098,7 @@ mod sprint3_tests {
                 linked_prs: &[],
                 current_body: None,
                 expected_dashboard: None,
+                allow_non_required_check_failure: false,
             },
         );
         assert!(
@@ -2062,6 +2131,9 @@ mod sprint3_tests {
             url: None,
             merge_sha: None,
             checks: CheckStatus::Pass,
+            required_state: Some(CheckStatus::Pass),
+            required_count: Some(0),
+            non_required_failures: Vec::new(),
         }];
         let res = evaluate_strict_closeout_gate(
             &audit,
@@ -2071,6 +2143,7 @@ mod sprint3_tests {
                 linked_prs: &linked,
                 current_body: None,
                 expected_dashboard: None,
+                allow_non_required_check_failure: false,
             },
         );
         assert!(
@@ -2078,6 +2151,156 @@ mod sprint3_tests {
                 .iter()
                 .any(|c| c == "linked-pr-not-merged")
         );
+    }
+
+    #[test]
+    fn strict_gate_passes_with_non_required_failure_when_required_pass() {
+        // Regression for sympoies/nils-cli#502: a non-required check
+        // failure with required-state success must not block the gate.
+        let audit = build_audit_with_evidence(vec![
+            (v2_body("source", json!({"path": "p", "commit": "c"})), "a"),
+            (v2_body("plan", json!({"path": "p", "commit": "c"})), "b"),
+            (
+                v2_body(
+                    "state",
+                    json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
+                ),
+                "c",
+            ),
+            (v2_body("validation", json!({"overall": "pass"})), "d"),
+            (v2_body("review", json!({"decision": "approve"})), "e"),
+        ]);
+        let linked = vec![LinkedPrEvidence {
+            pr_ref: "owner/repo#1".to_string(),
+            url: None,
+            merge_sha: Some("abc".to_string()),
+            checks: CheckStatus::Fail,
+            required_state: Some(CheckStatus::Pass),
+            required_count: Some(0),
+            non_required_failures: vec!["scripts/ci/all.sh".to_string()],
+        }];
+        let res = evaluate_strict_closeout_gate(
+            &audit,
+            StrictCloseoutGateInput {
+                profile: RecordProfile::Tracking,
+                approval: Some("ok"),
+                linked_prs: &linked,
+                current_body: None,
+                expected_dashboard: None,
+                allow_non_required_check_failure: false,
+            },
+        );
+        assert!(res.ready, "blocked: {:?}", res.blocked_codes);
+        assert!(res.blocked_codes.is_empty(), "{:?}", res.blocked_codes);
+    }
+
+    #[test]
+    fn strict_gate_emits_linked_pr_checks_failed_when_required_fail() {
+        let audit = build_audit_with_evidence(vec![
+            (v2_body("source", json!({"path": "p", "commit": "c"})), "a"),
+            (v2_body("plan", json!({"path": "p", "commit": "c"})), "b"),
+            (
+                v2_body(
+                    "state",
+                    json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
+                ),
+                "c",
+            ),
+            (v2_body("validation", json!({"overall": "pass"})), "d"),
+            (v2_body("review", json!({"decision": "approve"})), "e"),
+        ]);
+        let linked = vec![LinkedPrEvidence {
+            pr_ref: "owner/repo#1".to_string(),
+            url: None,
+            merge_sha: Some("abc".to_string()),
+            checks: CheckStatus::Fail,
+            required_state: Some(CheckStatus::Fail),
+            required_count: Some(2),
+            non_required_failures: Vec::new(),
+        }];
+        let res = evaluate_strict_closeout_gate(
+            &audit,
+            StrictCloseoutGateInput {
+                profile: RecordProfile::Tracking,
+                approval: Some("ok"),
+                linked_prs: &linked,
+                current_body: None,
+                expected_dashboard: None,
+                allow_non_required_check_failure: false,
+            },
+        );
+        assert!(
+            res.blocked_codes
+                .iter()
+                .any(|c| c == "linked-pr-checks-failed"),
+            "expected linked-pr-checks-failed, got {:?}",
+            res.blocked_codes
+        );
+        assert!(
+            !res.blocked_codes
+                .iter()
+                .any(|c| c == "linked-pr-not-merged"),
+            "must not collapse into linked-pr-not-merged"
+        );
+    }
+
+    #[test]
+    fn strict_gate_override_unblocks_unknown_required_state_aggregate_fail() {
+        let audit = build_audit_with_evidence(vec![
+            (v2_body("source", json!({"path": "p", "commit": "c"})), "a"),
+            (v2_body("plan", json!({"path": "p", "commit": "c"})), "b"),
+            (
+                v2_body(
+                    "state",
+                    json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
+                ),
+                "c",
+            ),
+            (v2_body("validation", json!({"overall": "pass"})), "d"),
+            (v2_body("review", json!({"decision": "approve"})), "e"),
+        ]);
+        let linked = vec![LinkedPrEvidence {
+            pr_ref: "owner/repo#1".to_string(),
+            url: None,
+            merge_sha: Some("abc".to_string()),
+            checks: CheckStatus::Fail,
+            required_state: None,
+            required_count: None,
+            non_required_failures: vec!["legacy/lint".to_string()],
+        }];
+
+        let blocked = evaluate_strict_closeout_gate(
+            &audit,
+            StrictCloseoutGateInput {
+                profile: RecordProfile::Tracking,
+                approval: Some("ok"),
+                linked_prs: &linked,
+                current_body: None,
+                expected_dashboard: None,
+                allow_non_required_check_failure: false,
+            },
+        );
+        assert!(
+            blocked
+                .blocked_codes
+                .iter()
+                .any(|c| c == "linked-pr-checks-failed"),
+            "conservative path blocks: {:?}",
+            blocked.blocked_codes
+        );
+
+        let unblocked = evaluate_strict_closeout_gate(
+            &audit,
+            StrictCloseoutGateInput {
+                profile: RecordProfile::Tracking,
+                approval: Some("ok"),
+                linked_prs: &linked,
+                current_body: None,
+                expected_dashboard: None,
+                allow_non_required_check_failure: true,
+            },
+        );
+        assert!(unblocked.ready, "{:?}", unblocked.blocked_codes);
     }
 
     #[test]
@@ -2105,6 +2328,7 @@ mod sprint3_tests {
                 linked_prs: &[],
                 current_body: None,
                 expected_dashboard: None,
+                allow_non_required_check_failure: false,
             },
         );
         assert!(res.blocked_codes.iter().any(|c| c == "approval-missing"));

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -979,7 +979,7 @@ fn record_close_fixture_override_passes_when_required_unknown_aggregate_fails() 
             "state": "MERGED",
             "mergeCommit": {"oid": "abc"},
             "statusCheckRollup": {"state": "failure"},
-            "nonRequiredFailures": ["legacy/lint"],
+            "nonRequiredFailures": ["opt-in/lint"],
             "url": "https://github.com/owner/repo/pull/1"
         }),
     );
@@ -1019,7 +1019,7 @@ fn record_close_fixture_override_passes_when_required_unknown_aggregate_fails() 
         "ok",
         "--allow-non-required-check-failure",
         "--allow-non-required-check-failure-reason",
-        "operator verified legacy/lint is non-required",
+        "operator verified opt-in/lint is non-required",
         "--fixture",
         fixture.to_str().expect("fixture path"),
     ]);
@@ -1038,14 +1038,14 @@ fn record_close_fixture_override_passes_when_required_unknown_aggregate_fails() 
     let closeout = &audit["evidence"]["closeout"]["payload"]["data"];
     let override_block = &closeout["non_required_check_override"];
     assert_eq!(
-        override_block["reason"], "operator verified legacy/lint is non-required",
+        override_block["reason"], "operator verified opt-in/lint is non-required",
         "override block reason recorded"
     );
     assert!(
         override_block["observed_non_required_failures"]
             .as_array()
-            .is_some_and(|arr| arr.iter().any(|item| item == "owner/repo#1: legacy/lint")),
-        "expected observed failure list to include legacy/lint: {override_block}"
+            .is_some_and(|arr| arr.iter().any(|item| item == "owner/repo#1: opt-in/lint")),
+        "expected observed failure list to include opt-in/lint: {override_block}"
     );
 }
 

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -813,6 +813,243 @@ fn record_close_fixture_blocks_when_review_request_changes() {
 }
 
 #[test]
+fn record_close_fixture_passes_with_non_required_failure_when_zero_required() {
+    // Regression for sympoies/nils-cli#502:
+    // PR merged, zero required checks, one non-required check failed.
+    // Strict closeout gate must not block on non-required failures.
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let body = "## Current Dashboard\n\n- Status: in-progress\n";
+    write_fixture_files(&fixture, body, &build_closeout_evidence("owner/repo#1"));
+    write_pr_fixture(
+        &fixture,
+        "owner/repo",
+        1,
+        json!({
+            "state": "MERGED",
+            "mergeCommit": {"oid": "deadbeefcafebabe"},
+            "statusCheckRollup": {"state": "failure"},
+            "requiredCheckRollup": {"state": "success", "count": 0},
+            "nonRequiredFailures": ["scripts/ci/all.sh"],
+            "url": "https://github.com/owner/repo/pull/1"
+        }),
+    );
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "9",
+        "--linked-pr",
+        "owner/repo#1",
+        "--approval",
+        "https://github.com/owner/repo/issues/9#issuecomment-approval",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let result = &parsed["payload"]["result"];
+    assert_eq!(result["operation"], "record.close");
+    let preview = &result["preview"];
+    assert!(
+        preview["blocked_codes"]
+            .as_array()
+            .expect("array")
+            .is_empty(),
+        "blocked_codes should be empty: {}",
+        preview["blocked_codes"]
+    );
+    let linked = &result["linked_prs"][0];
+    assert_eq!(linked["required_count"], 0);
+    assert_eq!(linked["required_state"], "pass");
+    assert_eq!(linked["non_required_failures"][0], "scripts/ci/all.sh");
+}
+
+#[test]
+fn record_close_fixture_passes_with_non_required_failure_when_required_pass() {
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let body = "## Current Dashboard\n";
+    write_fixture_files(&fixture, body, &build_closeout_evidence("owner/repo#1"));
+    write_pr_fixture(
+        &fixture,
+        "owner/repo",
+        1,
+        json!({
+            "state": "MERGED",
+            "mergeCommit": {"oid": "abc"},
+            "statusCheckRollup": {"state": "failure"},
+            "requiredCheckRollup": {"state": "success", "count": 3},
+            "nonRequiredFailures": ["lint-experimental"],
+            "url": "https://github.com/owner/repo/pull/1"
+        }),
+    );
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "9",
+        "--linked-pr",
+        "owner/repo#1",
+        "--approval",
+        "ok",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+}
+
+#[test]
+fn record_close_fixture_blocks_with_linked_pr_checks_failed_when_required_fail() {
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let body = "## Current Dashboard\n";
+    write_fixture_files(&fixture, body, &build_closeout_evidence("owner/repo#1"));
+    write_pr_fixture(
+        &fixture,
+        "owner/repo",
+        1,
+        json!({
+            "state": "MERGED",
+            "mergeCommit": {"oid": "abc"},
+            "statusCheckRollup": {"state": "failure"},
+            "requiredCheckRollup": {"state": "failure", "count": 2},
+            "nonRequiredFailures": [],
+            "url": "https://github.com/owner/repo/pull/1"
+        }),
+    );
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "9",
+        "--linked-pr",
+        "owner/repo#1",
+        "--approval",
+        "ok",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+
+    assert_ne!(out.code, 0, "required-check failure must block");
+    let joined = format!("{}\n{}", out.stderr, out.stdout);
+    assert!(
+        joined.contains("linked-pr-checks-failed"),
+        "expected linked-pr-checks-failed: {joined}"
+    );
+    assert!(
+        !joined.contains("linked-pr-not-merged"),
+        "must not collapse into linked-pr-not-merged: {joined}"
+    );
+}
+
+#[test]
+fn record_close_fixture_override_passes_when_required_unknown_aggregate_fails() {
+    // When the adapter cannot resolve required-check state (`requiredCheckRollup`
+    // absent), the gate stays conservative and blocks on aggregate failure.
+    // The override flag unblocks it and records evidence in the closeout body.
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let body = "## Current Dashboard\n";
+    write_fixture_files(&fixture, body, &build_closeout_evidence("owner/repo#1"));
+    write_pr_fixture(
+        &fixture,
+        "owner/repo",
+        1,
+        json!({
+            "state": "MERGED",
+            "mergeCommit": {"oid": "abc"},
+            "statusCheckRollup": {"state": "failure"},
+            "nonRequiredFailures": ["legacy/lint"],
+            "url": "https://github.com/owner/repo/pull/1"
+        }),
+    );
+
+    // Without the override → blocked.
+    let blocked = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "9",
+        "--linked-pr",
+        "owner/repo#1",
+        "--approval",
+        "ok",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+    assert_ne!(blocked.code, 0, "conservative block expected");
+    assert!(
+        format!("{}\n{}", blocked.stderr, blocked.stdout).contains("linked-pr-checks-failed"),
+        "expected linked-pr-checks-failed under unknown required state"
+    );
+
+    // With the override + reason → passes and records evidence.
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "9",
+        "--linked-pr",
+        "owner/repo#1",
+        "--approval",
+        "ok",
+        "--allow-non-required-check-failure",
+        "--allow-non-required-check-failure-reason",
+        "operator verified legacy/lint is non-required",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+
+    assert_eq!(out.code, 0, "override should unblock: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let body = parsed["payload"]["result"]["preview"]["closeout_comment_body"]
+        .as_str()
+        .expect("closeout body")
+        .to_string();
+    assert!(
+        body.contains("non-required-check failure override"),
+        "expected override summary in body: {body}"
+    );
+    let audit = audit_single_comment_body(&body);
+    let closeout = &audit["evidence"]["closeout"]["payload"]["data"];
+    let override_block = &closeout["non_required_check_override"];
+    assert_eq!(
+        override_block["reason"], "operator verified legacy/lint is non-required",
+        "override block reason recorded"
+    );
+    assert!(
+        override_block["observed_non_required_failures"]
+            .as_array()
+            .is_some_and(|arr| arr.iter().any(|item| item == "owner/repo#1: legacy/lint")),
+        "expected observed failure list to include legacy/lint: {override_block}"
+    );
+}
+
+#[test]
 fn record_close_fixture_blocks_when_state_not_complete() {
     let tmp = TempDir::new().expect("tempdir");
     let fixture = tmp.path().join("fixture");

--- a/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-discussion-source.md
+++ b/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-discussion-source.md
@@ -13,7 +13,7 @@
 GitHub's `statusCheckRollup` as a hard close blocker, even when the linked PR
 is already merged and the PR's required-check rollup is `success` (or has
 `required_count = 0`). This contradicts the contract documented in
-[issue-backed-plan-record-contract-v2](../../crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md):
+[issue-backed-plan-record-contract-v2](../../../crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md):
 `linked-pr-not-merged` should only fire when the PR is genuinely unmerged or
 required checks fail, not when a non-required workflow happens to be red.
 

--- a/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-discussion-source.md
+++ b/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-discussion-source.md
@@ -1,0 +1,234 @@
+# plan-issue `record close` Non-Required Check Gate Fix — Source
+
+| Field | Value |
+| --- | --- |
+| Status | Ready for implementation |
+| Date | 2026-05-25 |
+| Source | sympoies/nils-cli#502 (`plan-issue close treats non-required checks as failed`) |
+| Intended next step | Implement Sprint 1 in this plan and land alongside the issue's closing PR |
+
+## Purpose
+
+`plan-issue record close --linked-pr ...` currently treats any failed item in
+GitHub's `statusCheckRollup` as a hard close blocker, even when the linked PR
+is already merged and the PR's required-check rollup is `success` (or has
+`required_count = 0`). This contradicts the contract documented in
+[issue-backed-plan-record-contract-v2](../../crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md):
+`linked-pr-not-merged` should only fire when the PR is genuinely unmerged or
+required checks fail, not when a non-required workflow happens to be red.
+
+The downstream symptom observed in `graysurf/agent-runtime-kit#69` closeout:
+
+- `record-close-gate-failed`
+- `linked-pr-not-merged`
+- `linked PRs: graysurf/agent-runtime-kit#103 (checks=Fail)`
+
+…even though `forge-cli pr checks 103` reported `state=success`,
+`required_count=0` and the only red item was an unrelated `scripts/ci/all.sh`
+workflow.
+
+## Confirmed facts
+
+- The close-gate blocker string `linked PRs: <ref> (checks=Fail)` and the code
+  `linked-pr-not-merged` come from
+  `crates/plan-issue-cli/src/lifecycle_record.rs:1763-1780`. The gate currently
+  rejects any `CheckStatus` that is neither `Pass` nor `None`. [F1]
+- `CheckStatus` and `LinkedPrEvidence` are defined in
+  `crates/plan-issue-cli/src/lifecycle_record.rs:1066-1080` and carry only a
+  single tri-state field; they do not preserve required-vs-non-required
+  classification. [F2]
+- `record close` resolves linked-PR evidence in
+  `crates/plan-issue-cli/src/execute.rs:1162-1204`. It calls
+  `adapter.pr_merge_summary(...)` and then flattens `summary.checks` (a single
+  string state) into `CheckStatus` at lines 1178-1182. [F3]
+- The GitHub adapter (`crates/plan-issue-cli/src/github.rs:64,348-383,477-518`)
+  fetches `state,mergeCommit,statusCheckRollup` and runs `rollup_status` to
+  compute a single aggregate state; it does not surface required-only status
+  or any breakdown. [F4]
+- The GitLab adapter (`crates/plan-issue-cli/src/forge_cli_adapter.rs:305-349`)
+  has the same shape: it forwards `forge-cli pr view`'s rolled-up `state` and
+  drops per-check detail with a TODO comment acknowledging the gap. [F5]
+- `forge-cli` already exposes the required-vs-non-required distinction:
+  `crates/forge-cli/src/ops/pr_checks.rs` returns
+  `PrChecksPayload { required_count, failed, checks: Vec<CheckItem { required, .. }> }`
+  (`required_count` at line 126, `required: bool` at line 95), and
+  `crates/forge-cli/src/ops/required_check_gate.rs:46-98` implements the
+  correct "only block on required failures" pattern via
+  `ensure_required_checks_green` + `classify`. plan-issue does not call this
+  path today. [F6]
+- Fixture closeout tests live at
+  `crates/plan-issue-cli/tests/integration/live_record_ops.rs:648,718` and
+  read PR snapshots through `read_fixture_pr_snapshot`
+  (`crates/plan-issue-cli/src/execute.rs:488-534`), which also only reads
+  `statusCheckRollup.state` — so any fix has to update fixtures and that
+  parsing path too. [F7]
+- The contract spec already names the relevant failure codes:
+  `linked-pr-missing`, `linked-pr-not-merged`, and `linked-pr-checks-failed`
+  (`crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md:318`).
+  Today, non-required failures collapse into `linked-pr-not-merged` instead
+  of being either ignored or surfaced as a distinct code. [F8]
+
+## Decisions
+
+1. **Gate on required-check status, not aggregate status.** When the provider
+   exposes required-check data, `record close` only blocks on a required-check
+   failure or on an unmerged PR. Non-required failures are recorded as
+   informational evidence in the closeout comment but do not fail the gate.
+2. **Distinguish `linked-pr-not-merged` from `linked-pr-checks-failed`.** The
+   contract spec already lists `linked-pr-checks-failed` as a distinct failure
+   code. Wire it up so an unmerged PR and a required-check failure no longer
+   share a blocker code.
+3. **Reuse forge-cli's required-only path; do not re-implement.** plan-issue
+   consumes `forge-cli pr checks --required-only` (or the equivalent library
+   call) when available, instead of re-parsing GitHub's `statusCheckRollup`.
+   The existing parser in `crates/forge-cli/src/ops/pr_checks.rs` and the
+   `required_check_gate` classification stay the source of truth.
+4. **Add explicit override only as a defense-in-depth knob.**
+   `--allow-non-required-check-failure` is added to `RecordCloseArgs` for the
+   case where the provider cannot resolve required-check state (e.g. a
+   degraded `gh`/`glab` call). When set, the closeout comment records the
+   override decision and the observed non-required failures.
+5. **Provider-agnostic shape.** Both GitHub (`src/github.rs`) and GitLab
+   (`src/forge_cli_adapter.rs`) adapters return a richer linked-PR summary
+   that carries `required_count`, `required_failed`, and `required_state`.
+   The lifecycle record consumes this without provider-specific branching.
+6. **Out of scope.** No changes to `forge-cli` itself; it already does the
+   right thing. No changes to `pr_merge_summary`'s other callers; we add a
+   parallel call rather than mutate the existing signature.
+
+## Scope
+
+- Edit `crates/plan-issue-cli/src/lifecycle_record.rs` (`CheckStatus` /
+  `LinkedPrEvidence` shape; `evaluate_strict_closeout_gate` logic) so the
+  close gate distinguishes required-vs-non-required failures.
+- Edit `crates/plan-issue-cli/src/github.rs` and
+  `crates/plan-issue-cli/src/forge_cli_adapter.rs` so adapters report
+  required-check details (count, state, failed list) in addition to the
+  aggregate rollup.
+- Edit `crates/plan-issue-cli/src/execute.rs` (`record close` live + fixture
+  paths) so linked-PR evidence carries the new required-check fields and the
+  override flag is honored.
+- Add `--allow-non-required-check-failure` to `RecordCloseArgs` in
+  `crates/plan-issue-cli/src/commands/record.rs`.
+- Add fixtures and integration tests in
+  `crates/plan-issue-cli/tests/fixtures/lifecycle/` and
+  `crates/plan-issue-cli/tests/integration/live_record_ops.rs` covering:
+  PR merged + zero required + non-required fail; PR merged + required pass +
+  non-required fail; PR merged + required fail (must still block).
+
+## Non-scope
+
+- No changes to `forge-cli` `pr_checks` / `required_check_gate` semantics.
+- No new `provider-cli` abstraction beyond the new adapter return fields.
+- No changes to `pr_merge_summary` semantics for other callers.
+- No backfill of historical closeout comments.
+- No changes to the v2 contract spec's failure-code names; we just wire
+  `linked-pr-checks-failed` through.
+
+## Requirements
+
+- R1. `record close --linked-pr <merged PR with required success + non-required fail>`
+  succeeds on both fixture and live paths.
+- R2. `record close --linked-pr <merged PR with required failure>` still fails
+  with the new `linked-pr-checks-failed` code (not `linked-pr-not-merged`).
+- R3. `record close --linked-pr <unmerged PR>` still fails with
+  `linked-pr-not-merged` regardless of check state.
+- R4. `--allow-non-required-check-failure` documented in `--help`, and when
+  used in the override scenario writes `record-close-allow-non-required:` plus
+  the observed failures into the closeout comment evidence block.
+- R5. Existing `live_record_ops.rs` integration tests continue to pass without
+  modification beyond fixture additions and any new assertions explicitly
+  exercising the new behavior.
+
+## Acceptance criteria
+
+- AC-1. `cargo test -p plan-issue-cli` is green.
+- AC-2. New integration test covering the three fixture scenarios above is
+  added and green.
+- AC-3. `plan-issue --help record close` documents the new flag; release notes
+  reference issue #502.
+- AC-4. Re-running the original `graysurf/agent-runtime-kit#69` closeout
+  scenario against a freshly built binary no longer reports
+  `record-close-gate-failed` for a non-required workflow failure.
+
+## Validation plan
+
+1. `cargo test -p plan-issue-cli` (worktree).
+2. `cargo build --release -p plan-issue-cli` and copy binary into
+   `~/.local/nils-cli/plan-issue`.
+3. Re-run the original closeout shape against a disposable issue using the
+   fixture path (`--fixture` directory built from #103 snapshot data) and
+   verify the gate passes without overriding.
+4. Run `plan-issue record close --dry-run` against a live merged PR with a
+   non-required failed workflow (any nils-cli PR with a deliberately-failing
+   non-required job) and confirm `ok=true`.
+
+## Findings table
+
+| ID | Source | Disposition |
+| --- | --- | --- |
+| F-1 | sympoies/nils-cli#502 + lifecycle_record.rs:1763 | In scope — gate-logic rewrite |
+| F-2 | execute.rs:1178-1182 | In scope — `CheckStatus` shape change |
+| F-3 | github.rs + forge_cli_adapter.rs | In scope — adapter returns required-check detail |
+| F-4 | commands/record.rs:238-286 | In scope — `--allow-non-required-check-failure` flag |
+| F-5 | tests/fixtures/lifecycle/ | In scope — new fixtures + tests |
+| F-6 | forge-cli pr_checks / required_check_gate | Reused as-is — out of scope |
+
+## Risks and guardrails
+
+- **R-1**: Adapter shape change ripples into other callers of
+  `pr_merge_summary`. Mitigation: add a parallel method or return the
+  required-check fields as `Option<_>` so existing callers ignore them.
+- **R-2**: GitLab `forge-cli pr checks` may not surface a true `required_count`
+  on every project (GitLab has no first-class required-check concept; it maps
+  to pipeline jobs). Mitigation: when the adapter cannot resolve a meaningful
+  `required_count`, fall back to the existing aggregate `state` semantics and
+  document the limitation; this matches existing GitLab gating behavior.
+- **R-3**: Override flag risks erosion of the close gate's intent. Mitigation:
+  always emit a discoverable trace in the closeout comment when the override
+  is exercised and require an explicit non-empty reason string (rejected with
+  `record-close-override-reason-missing` otherwise).
+
+## Execution
+
+- Recommended plan:
+  `docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-plan.md`
+- Recommended execution state:
+  `docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-execution-state.md`
+- Status: ready
+- Next-task source: this plan's Sprint 1
+
+## Retention intent
+
+Promote after merge. The required-vs-non-required distinction is the canonical
+contract for any future plan-issue lifecycle gate that consumes provider check
+state, so the structured evidence shape introduced here should outlive this
+PR.
+
+## Read-first references
+
+- `crates/plan-issue-cli/src/lifecycle_record.rs:1066-1080` (`CheckStatus`,
+  `LinkedPrEvidence`)
+- `crates/plan-issue-cli/src/lifecycle_record.rs:1755-1782` (close gate's
+  linked-PR branch)
+- `crates/plan-issue-cli/src/execute.rs:1160-1204` (live linked-PR resolution)
+- `crates/plan-issue-cli/src/execute.rs:488-534` (fixture linked-PR snapshot
+  parser)
+- `crates/plan-issue-cli/src/github.rs:64,348-383,477-518`
+  (`PrMergeSummary`, `pr_merge_summary`, `rollup_status`)
+- `crates/plan-issue-cli/src/forge_cli_adapter.rs:305-349` (GitLab adapter
+  `pr_merge_summary`)
+- `crates/plan-issue-cli/src/commands/record.rs:238-286` (`RecordCloseArgs`)
+- `crates/plan-issue-cli/tests/integration/live_record_ops.rs:648,718` (close
+  gate fixture tests)
+- `crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout/prs/sympoies__agent-runtime-kit__1.json`
+  (existing PR fixture shape)
+- `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md:318`
+  (failure-code contract)
+- `crates/forge-cli/src/ops/pr_checks.rs:95,123-126`,
+  `crates/forge-cli/src/ops/required_check_gate.rs:46-98` (source of truth
+  for required-only classification)
+
+## Source type
+
+`discussion-to-implementation-doc`

--- a/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-execution-state.md
+++ b/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-execution-state.md
@@ -13,10 +13,10 @@
 - Source document: docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-plan.md
 - Discussion source document: `docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-discussion-source.md`
 - Source issue: sympoies/nils-cli#502
-- Tracking issue: pending
-- Source snapshot: pending
-- Plan snapshot: pending
-- Initial execution state snapshot: pending
+- Tracking issue: https://github.com/sympoies/nils-cli/issues/509
+- Source snapshot: https://github.com/sympoies/nils-cli/issues/509#issuecomment-4531384206
+- Plan snapshot: https://github.com/sympoies/nils-cli/issues/509#issuecomment-4531384284
+- Initial execution state snapshot: https://github.com/sympoies/nils-cli/issues/509#issuecomment-4531384371
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger

--- a/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-execution-state.md
+++ b/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-execution-state.md
@@ -1,0 +1,33 @@
+<!-- execute-from-tracking-issue:state:v1 -->
+# plan-issue `record close` Non-Required Check Gate Execution State
+
+## Execution State
+
+- Status: ready
+- Target scope: whole issue
+- Execution window: whole issue
+- Current task: Task 1.1
+- Next task: widen `CheckStatus` / `LinkedPrEvidence` to carry required-check detail
+- Last updated: 2026-05-25 Asia/Taipei
+- Branch/commit/PR/release: `fix/plan-issue-close-non-required-checks`; PR pending
+- Source document: docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-plan.md
+- Discussion source document: `docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-discussion-source.md`
+- Source issue: sympoies/nils-cli#502
+- Tracking issue: pending
+- Source snapshot: pending
+- Plan snapshot: pending
+- Initial execution state snapshot: pending
+- Direct source-doc execution waiver: not applicable
+
+## Task Ledger
+
+| ID | Status | Task | Evidence | Notes |
+| --- | --- | --- | --- | --- |
+| Task 1.1 | pending | Widen `CheckStatus` / `LinkedPrEvidence` | — | — |
+| Task 1.2 | pending | Rewrite close-gate linked-PR branch | — | — |
+| Task 1.3 | pending | Expand provider adapters with required-check detail | — | — |
+| Task 1.4 | pending | Wire `record close` live + fixture paths | — | — |
+| Task 1.5 | pending | Add `--allow-non-required-check-failure` flag + evidence | — | — |
+| Task 1.6 | pending | Fixtures and integration coverage | — | — |
+| Task 1.7 | pending | CHANGELOG / spec / `--help` wiring | — | — |
+| Task 1.8 | pending | Build, install, re-run original closeout scenario | — | — |

--- a/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-execution-state.md
+++ b/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-execution-state.md
@@ -13,10 +13,10 @@
 - Source document: docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-plan.md
 - Discussion source document: `docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-discussion-source.md`
 - Source issue: sympoies/nils-cli#502
-- Tracking issue: https://github.com/sympoies/nils-cli/issues/509
-- Source snapshot: https://github.com/sympoies/nils-cli/issues/509#issuecomment-4531384206
-- Plan snapshot: https://github.com/sympoies/nils-cli/issues/509#issuecomment-4531384284
-- Initial execution state snapshot: https://github.com/sympoies/nils-cli/issues/509#issuecomment-4531384371
+- Tracking issue: <https://github.com/sympoies/nils-cli/issues/509>
+- Source snapshot: <https://github.com/sympoies/nils-cli/issues/509#issuecomment-4531384206>
+- Plan snapshot: <https://github.com/sympoies/nils-cli/issues/509#issuecomment-4531384284>
+- Initial execution state snapshot: <https://github.com/sympoies/nils-cli/issues/509#issuecomment-4531384371>
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger

--- a/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-plan.md
+++ b/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-plan.md
@@ -230,4 +230,4 @@ override flag with explicit evidence emission.
   - Fixture-mode close runs with `ok=true` and an empty
     `blocked_codes` list for the original PR shape.
 - **Validation**:
-  - `plan-issue --format json record close --dry-run --fixture crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout --repo graysurf/agent-runtime-kit record-close 69 --linked-pr graysurf/agent-runtime-kit#103`
+  - `cargo test -p nils-plan-issue-cli record_close_fixture_passes_with_non_required_failure_when_zero_required`

--- a/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-plan.md
+++ b/docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-plan.md
@@ -1,0 +1,233 @@
+# Plan: plan-issue `record close` Non-Required Check Gate Fix
+
+## Overview
+
+Land a focused fix in `plan-issue-cli` so that `record close --linked-pr ...`
+no longer treats non-required GitHub `statusCheckRollup` failures as hard
+close blockers. The gate must:
+
+- Only fail with `linked-pr-not-merged` when the PR is truly unmerged.
+- Fail with the contract-listed `linked-pr-checks-failed` code when required
+  checks fail (or required-check state is unknown).
+- Treat non-required failures as informational evidence in the closeout
+  comment, never as a blocker.
+- Expose an explicit, evidence-emitting override
+  (`--allow-non-required-check-failure`) for the degraded-provider edge case.
+
+Issue: sympoies/nils-cli#502.
+
+## Read First
+
+- Primary source:
+  `docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-discussion-source.md`
+- Source type: discussion-to-implementation-doc
+- Open questions carried into execution: none
+- Upstream contract:
+  `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md:318`
+  (`linked-pr-missing` / `linked-pr-not-merged` / `linked-pr-checks-failed`)
+- Existing required-only classifier reused as-is:
+  `crates/forge-cli/src/ops/required_check_gate.rs:46-98`
+
+## Scope
+
+- In scope:
+  - `CheckStatus` / `LinkedPrEvidence` shape updates in
+    `crates/plan-issue-cli/src/lifecycle_record.rs`.
+  - Strict-closeout-gate logic update in the same file.
+  - `record close` linked-PR resolution in
+    `crates/plan-issue-cli/src/execute.rs` (live + fixture paths).
+  - GitHub and GitLab adapter return-shape changes
+    (`crates/plan-issue-cli/src/github.rs`,
+    `crates/plan-issue-cli/src/forge_cli_adapter.rs`).
+  - New `--allow-non-required-check-failure` and
+    `--allow-non-required-check-failure-reason` flags on `RecordCloseArgs`
+    in `crates/plan-issue-cli/src/commands/record.rs`.
+  - Fixture additions under
+    `crates/plan-issue-cli/tests/fixtures/lifecycle/` and integration
+    coverage in
+    `crates/plan-issue-cli/tests/integration/live_record_ops.rs`.
+  - Closeout-comment evidence block addition when the override is used.
+  - CHANGELOG and `--help` updates.
+- Out of scope:
+  - Any change to `forge-cli pr_checks` or `required_check_gate`.
+  - Any change to `pr_merge_summary` callers other than `record close`.
+  - Reworking the GitLab pipeline-vs-required mapping (GitLab has no
+    first-class required concept; we fall back to aggregate state when
+    `required_count` is unresolvable and document it).
+  - Backfilling historical closeout comments.
+
+## Sprint 1: Required-check-aware close gate
+
+**Goal**: Make `record close` gate on required-check status, distinguish
+`linked-pr-checks-failed` from `linked-pr-not-merged`, and ship the
+override flag with explicit evidence emission.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p plan-issue-cli`
+  - `cargo build --release -p plan-issue-cli`
+  - Fixture-mode rerun of `record close` against a
+    "merged + required pass + non-required fail" PR snapshot.
+- Verify: All three fixture scenarios (PR merged + zero required +
+  non-required fail; PR merged + required pass + non-required fail;
+  PR merged + required fail) gate as documented.
+
+### Task 1.1: Widen `CheckStatus` / `LinkedPrEvidence` to carry required-check detail
+
+- **Location**:
+  - `crates/plan-issue-cli/src/lifecycle_record.rs:1066-1080`
+- **Description**: Replace the single-state `CheckStatus` with a struct (or
+  expand `LinkedPrEvidence`) that records: aggregate state, required-check
+  state, required count, and the list of failing non-required check names.
+  Keep `Default` semantics equivalent to today's `CheckStatus::None`.
+- **Dependencies**: none
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - Existing call sites compile (callers that only know aggregate state
+    pass `None` for required fields).
+  - Unit tests cover serde + display for the new shape.
+- **Validation**:
+  - `cargo test -p plan-issue-cli lifecycle_record`
+
+### Task 1.2: Rewrite the linked-PR branch of `evaluate_strict_closeout_gate`
+
+- **Location**:
+  - `crates/plan-issue-cli/src/lifecycle_record.rs:1755-1782`
+- **Description**: Replace the single
+  `!matches!(pr.checks, CheckStatus::Pass | CheckStatus::None)` test with the
+  required-only rule: block when `merge_sha` is missing
+  (`linked-pr-not-merged`); block when required-check state is `Fail` or
+  unknown-with-required-count>0 (`linked-pr-checks-failed`); pass otherwise.
+  Honor the override flag by skipping the required-state check when set,
+  while still recording the observed failures.
+- **Dependencies**: Task 1.1
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - Gate emits `linked-pr-not-merged` only for unmerged PRs.
+  - Gate emits `linked-pr-checks-failed` for required failures.
+  - Non-required failures alone never block.
+  - Override path emits a `record-close-allow-non-required` evidence entry.
+- **Validation**:
+  - `cargo test -p plan-issue-cli lifecycle_record`
+
+### Task 1.3: Expand provider adapters to return required-check detail
+
+- **Location**:
+  - `crates/plan-issue-cli/src/github.rs:64,348-383,477-518`
+  - `crates/plan-issue-cli/src/forge_cli_adapter.rs:305-349`
+- **Description**: Extend `PrMergeSummary` (or add a sibling type) with
+  `required_state: Option<String>`, `required_count: Option<u32>`, and
+  `non_required_failures: Vec<String>`. The GitHub adapter calls
+  `forge-cli`'s required-only path (or replicates the `required: bool`
+  filter against GitHub's GraphQL output) to populate these. The GitLab
+  adapter populates what it can from `forge-cli pr checks` and leaves the
+  required fields `None` when unavailable.
+- **Dependencies**: Task 1.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - GitHub adapter returns populated required fields when checks exist.
+  - GitLab adapter leaves required fields `None` and is documented as such
+    in the spec comment.
+  - Unit tests cover the parse paths for: zero required + one non-required
+    fail; one required pass + one non-required fail; one required fail.
+- **Validation**:
+  - `cargo test -p plan-issue-cli github`
+  - `cargo test -p plan-issue-cli forge_cli_adapter`
+
+### Task 1.4: Wire `record close` and fixture snapshot to the new shape
+
+- **Location**:
+  - `crates/plan-issue-cli/src/execute.rs:488-534,1160-1204`
+- **Description**: Update `read_fixture_pr_snapshot` to read the new
+  required-check fields from PR fixtures and update the live linked-PR
+  loop to consume the adapter's extended return type. Pass the override
+  flag plus reason string into the `StrictCloseoutGateInput`.
+- **Dependencies**: Task 1.2, Task 1.3
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - Live and fixture paths produce equivalent `LinkedPrEvidence` shapes.
+  - `record close` JSON envelope includes the new fields under linked-PR
+    evidence.
+- **Validation**:
+  - `cargo test -p plan-issue-cli execute`
+
+### Task 1.5: Add CLI flag and closeout-comment evidence emission
+
+- **Location**:
+  - `crates/plan-issue-cli/src/commands/record.rs:238-286`
+  - Closeout-comment renderer in `crates/plan-issue-cli/src/lifecycle_record.rs`
+- **Description**: Add
+  `--allow-non-required-check-failure` (bool) and
+  `--allow-non-required-check-failure-reason` (string, required when the
+  bool is set) to `RecordCloseArgs`. Wire the values into the gate input
+  (Task 1.4). On override, the rendered closeout comment includes a
+  dedicated `Override:` block listing the reason and the observed
+  non-required failures. Missing reason fails with
+  `record-close-override-reason-missing`.
+- **Dependencies**: Task 1.2, Task 1.4
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - `plan-issue --help record close` documents both flags.
+  - Override exercise emits the dedicated evidence block in the comment.
+- **Validation**:
+  - `cargo test -p plan-issue-cli commands::record`
+
+### Task 1.6: Fixtures and integration coverage
+
+- **Location**:
+  - `crates/plan-issue-cli/tests/fixtures/lifecycle/...` (add new fixtures)
+  - `crates/plan-issue-cli/tests/integration/live_record_ops.rs:648,718`
+- **Description**: Add three PR fixtures covering: (a) merged +
+  `required_count = 0` + one non-required fail; (b) merged + one required
+  pass + one non-required fail; (c) merged + one required fail. Add three
+  integration tests:
+  - `record_close_passes_with_non_required_failure_when_zero_required`
+  - `record_close_passes_with_non_required_failure_when_required_pass`
+  - `record_close_blocks_with_linked_pr_checks_failed_when_required_fail`
+  - `record_close_override_emits_allow_non_required_evidence`
+- **Dependencies**: Task 1.4, Task 1.5
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - All four new integration tests pass.
+  - Existing close-gate tests remain unmodified except for any required
+    field additions to their fixtures.
+- **Validation**:
+  - `cargo test -p plan-issue-cli --test integration`
+
+### Task 1.7: CHANGELOG, help text, and spec wiring
+
+- **Location**:
+  - `crates/plan-issue-cli/CHANGELOG.md`
+  - `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md:318`
+- **Description**: Add a CHANGELOG entry referencing issue #502 and the new
+  `linked-pr-checks-failed` wiring. Tighten the spec line to explicitly state
+  that `linked-pr-not-merged` is reserved for `merge_sha`-missing PRs and
+  that `linked-pr-checks-failed` covers required-check failures (or
+  unknown required state with `required_count > 0`). Mention the override
+  flag and the override evidence block.
+- **Dependencies**: Task 1.6
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - CHANGELOG and spec lines reflect the new behavior.
+  - `plan-issue record close --help` matches the spec wording.
+- **Validation**:
+  - `cargo test -p plan-issue-cli` (covers contract-spec consistency tests
+    if any).
+
+### Task 1.8: Build, install, and re-run the original closeout scenario
+
+- **Location**:
+  - `~/.local/nils-cli/plan-issue` (install target)
+  - `target/release/plan-issue` (build artifact)
+- **Description**: Rebuild `plan-issue-cli` with the new gate, install
+  locally, and re-run the `graysurf/agent-runtime-kit#69` closeout shape in
+  fixture mode using a snapshot built from #103. The original failure must
+  no longer surface, without using the override flag.
+- **Dependencies**: Task 1.7
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Fixture-mode close runs with `ok=true` and an empty
+    `blocked_codes` list for the original PR shape.
+- **Validation**:
+  - `plan-issue --format json record close --dry-run --fixture crates/plan-issue-cli/tests/fixtures/lifecycle/agent-runtime-kit-closeout --repo graysurf/agent-runtime-kit record-close 69 --linked-pr graysurf/agent-runtime-kit#103`


### PR DESCRIPTION
## Summary

Fixes #502. `plan-issue record close --linked-pr ...` previously treated any failed item in GitHub's `statusCheckRollup` as a hard close blocker, collapsing every failure (required or not) into `linked-pr-not-merged`. The original closeout for graysurf/agent-runtime-kit#69 hit this against #103 even though the linked PR was merged with `required_count = 0` and only one non-required workflow had failed.

The fix gates on the required-check rollup, not the aggregate one.

### What changes

- **`LinkedPrEvidence` / `PrMergeSummary`** carry three new fields: `required_state`, `required_count`, `non_required_failures`. GitHub adapter populates them via `gh pr checks <pr> --required`. GitLab adapter leaves them at `None` (no first-class required concept), so behavior on GitLab stays the same.
- **`evaluate_strict_closeout_gate`** linked-PR branch:
  - Missing `merge_sha` → `linked-pr-not-merged`.
  - `required_state == Fail` → `linked-pr-checks-failed` (newly wired; was previously collapsed into `linked-pr-not-merged`).
  - `required_state == Pass` (or zero required) → pass, even if non-required checks failed.
  - `required_state == None` with aggregate `Fail` → conservative `linked-pr-checks-failed` unless `--allow-non-required-check-failure` is set.
- **`--allow-non-required-check-failure --allow-non-required-check-failure-reason <text>`** flags added to `RecordCloseArgs` for the degraded-provider case. Reason is required when the flag is set (`record-close-override-reason-missing` otherwise); override + observed non-required failures are recorded under `non_required_check_override` in the closeout payload and the comment summary advertises the override.
- **CHANGELOG** and the v2 contract spec are tightened to make the `linked-pr-not-merged` vs. `linked-pr-checks-failed` distinction explicit, and to document the override.

### What stays the same

- `pr_merge_summary` signature only grows fields; no caller outside `record close` changes.
- `CheckStatus` enum is unchanged.
- No changes to `forge-cli`; the existing `pr_checks` / `required_check_gate` surfaces remain the source of truth for required-check classification.

### Tracking issue

- sympoies/nils-cli#509 (plan bundle + lifecycle comments)
- Bundle: `docs/plans/plan-issue-close-non-required-checks/`

## Test plan

- [x] `cargo test -p nils-plan-issue-cli` (88 lib + 144 integration, all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --locked --workspace` clean
- [x] `bash scripts/ci/third-party-artifacts-audit.sh` PASS
- [x] `bash scripts/ci/completion-asset-audit.sh` PASS
- [x] `rumdl check docs/plans/plan-issue-close-non-required-checks/` clean
- [x] `plan-tooling validate --file ...-plan.md` green
- [x] New integration tests cover: zero-required + non-required fail (pass), required pass + non-required fail (pass), required fail (block with `linked-pr-checks-failed`), override path (pass + override evidence emitted)
- [x] New lifecycle_record unit tests cover the same three gate scenarios at the gate-input level

🤖 Generated with [Claude Code](https://claude.com/claude-code)
