### PR TITLE
Migrate GitLab test fixtures to gitlab.com (Sprint 1)

### DIFF
--- a/crates/forge-cli/src/ops/auth_status.rs
+++ b/crates/forge-cli/src/ops/auth_status.rs
@@ -241,7 +241,7 @@ mod tests {
         let payload = parse_backend_output(&ctx, &output).expect("parse");
         assert_eq!(payload.provider, "github");
         assert_eq!(payload.host, "github.com");
-        assert!(payload.user.is_some());
+        assert_eq!(payload.user.as_deref(), Some("testuser-gh"));
         assert_eq!(
             payload.scopes,
             vec!["repo".to_string(), "read:org".to_string()]
@@ -258,7 +258,7 @@ mod tests {
         let payload = parse_backend_output(&ctx, &output).expect("parse");
         assert_eq!(payload.provider, "gitlab");
         assert_eq!(payload.host, "gitlab.com");
-        assert!(payload.user.is_some());
+        assert_eq!(payload.user.as_deref(), Some("testuser-glab"));
         assert!(payload.scopes.is_empty());
     }
 

--- a/crates/forge-cli/src/ops/auth_status.rs
+++ b/crates/forge-cli/src/ops/auth_status.rs
@@ -119,7 +119,7 @@ pub fn parse_backend_output(
 fn parse_github(text: &str, ctx: &ProviderContext) -> Result<AuthStatusPayload, ForgeError> {
     // gh prints:
     //   github.com
-    //     ✓ Logged in to github.com account graysurf (keyring)
+    //     ✓ Logged in to github.com account <user> (keyring)
     //     - Active account: true
     //     - Token scopes: 'repo', 'read:org'
     let host = find_first_match(text, "Logged in to", |after| {
@@ -146,7 +146,7 @@ fn parse_github(text: &str, ctx: &ProviderContext) -> Result<AuthStatusPayload, 
 fn parse_gitlab(text: &str, ctx: &ProviderContext) -> Result<AuthStatusPayload, ForgeError> {
     // glab prints:
     //   gitlab.com
-    //     ✓ Logged in to gitlab.com as graysurf (~/.config/glab-cli/config.yml)
+    //     ✓ Logged in to gitlab.com as <user> (~/.config/glab-cli/config.yml)
     //     ✓ Git operations for gitlab.com configured to use ssh protocol.
     //     ✓ API calls for gitlab.com are made over https protocol
     //     ✓ REST API Endpoint: https://gitlab.com/api/v4/
@@ -236,12 +236,12 @@ mod tests {
         let ctx = github_ctx();
         let output = BackendSuccess {
             stdout: String::new(),
-            stderr: "github.com\n  ✓ Logged in to github.com account graysurf (keyring)\n  - Active account: true\n  - Token scopes: 'repo', 'read:org'\n".into(),
+            stderr: "github.com\n  ✓ Logged in to github.com account testuser-gh (keyring)\n  - Active account: true\n  - Token scopes: 'repo', 'read:org'\n".into(),
         };
         let payload = parse_backend_output(&ctx, &output).expect("parse");
         assert_eq!(payload.provider, "github");
         assert_eq!(payload.host, "github.com");
-        assert_eq!(payload.user.as_deref(), Some("graysurf"));
+        assert!(payload.user.is_some());
         assert_eq!(
             payload.scopes,
             vec!["repo".to_string(), "read:org".to_string()]
@@ -253,12 +253,12 @@ mod tests {
         let ctx = gitlab_ctx();
         let output = BackendSuccess {
             stdout: String::new(),
-            stderr: "gitlab.com\n  ✓ Logged in to gitlab.com as graysurf (~/.config/glab-cli/config.yml)\n".into(),
+            stderr: "gitlab.com\n  ✓ Logged in to gitlab.com as testuser-glab (~/.config/glab-cli/config.yml)\n".into(),
         };
         let payload = parse_backend_output(&ctx, &output).expect("parse");
         assert_eq!(payload.provider, "gitlab");
         assert_eq!(payload.host, "gitlab.com");
-        assert_eq!(payload.user.as_deref(), Some("graysurf"));
+        assert!(payload.user.is_some());
         assert!(payload.scopes.is_empty());
     }
 

--- a/crates/forge-cli/src/ops/issue_view.rs
+++ b/crates/forge-cli/src/ops/issue_view.rs
@@ -138,7 +138,7 @@ fn build_view_call_with(ctx: &ProviderContext, id: u64, with_comments: bool) -> 
 /// `web_url` so we do not need the user to pass `--repo` or `--remote`. This
 /// also avoids the bug where forcing `--provider gitlab` makes
 /// `ProviderContext::host` default to `gitlab.com` even when the repo lives
-/// on a self-hosted instance like `gitlab.gamania.com`.
+/// on a different GitLab instance.
 fn build_gitlab_notes_call(
     _ctx: &ProviderContext,
     view: &IssueViewPayload,
@@ -405,8 +405,7 @@ fn parse_gitlab_notes(
 /// issue's `web_url`. Returns `None` when the URL does not look like a GitLab
 /// issue URL. Accepts `/-/issues/<iid>`, `/issues/<iid>`, and the newer
 /// `/-/work_items/<iid>` shape that GitLab returns for projects that have
-/// migrated issues to the unified Work Items API (live-observed on
-/// gitlab.gamania.com).
+/// migrated issues to the unified Work Items API.
 fn gitlab_project_path_from_url(url: &str) -> Option<String> {
     let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
     let path = after_scheme.split_once('/').map(|(_, rest)| rest)?;
@@ -667,7 +666,7 @@ mod tests {
         };
         let comments = parse_gitlab_notes(
             &output,
-            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4",
+            "https://gitlab.com/graysury/nils-cli-gitlab-sandbox/-/issues/4",
         )
         .unwrap();
         assert_eq!(comments.len(), 2);
@@ -675,12 +674,12 @@ mod tests {
         assert_eq!(comments[0].body, "first");
         assert_eq!(
             comments[0].url,
-            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4#note_1"
+            "https://gitlab.com/graysury/nils-cli-gitlab-sandbox/-/issues/4#note_1"
         );
         assert_eq!(comments[1].author, "bob");
         assert_eq!(
             comments[1].url,
-            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4#note_3"
+            "https://gitlab.com/graysury/nils-cli-gitlab-sandbox/-/issues/4#note_3"
         );
     }
 
@@ -712,10 +711,10 @@ mod tests {
     fn gitlab_host_from_url_extracts_host_segment() {
         assert_eq!(
             gitlab_host_from_url(
-                "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/work_items/6"
+                "https://gitlab.com/graysury/nils-cli-gitlab-sandbox/-/work_items/6"
             )
             .as_deref(),
-            Some("gitlab.gamania.com"),
+            Some("gitlab.com"),
         );
         assert_eq!(
             gitlab_host_from_url("https://gitlab.com/group/sub/project/-/issues/12").as_deref(),
@@ -729,17 +728,17 @@ mod tests {
     fn gitlab_project_path_from_url_extracts_nested_groups() {
         assert_eq!(
             gitlab_project_path_from_url(
-                "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/issues/4"
+                "https://gitlab.com/graysury/nils-cli-gitlab-sandbox/-/issues/4"
             )
             .as_deref(),
-            Some("terrylin/agent-runtime-testing")
+            Some("graysury/nils-cli-gitlab-sandbox")
         );
         assert_eq!(
             gitlab_project_path_from_url(
-                "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/work_items/6"
+                "https://gitlab.com/graysury/nils-cli-gitlab-sandbox/-/work_items/6"
             )
             .as_deref(),
-            Some("terrylin/agent-runtime-testing"),
+            Some("graysury/nils-cli-gitlab-sandbox"),
             "GitLab projects migrated to the Work Items API surface issues at /-/work_items/<iid>",
         );
         assert_eq!(

--- a/crates/forge-cli/src/ops/pr_comments.rs
+++ b/crates/forge-cli/src/ops/pr_comments.rs
@@ -440,10 +440,10 @@ mod tests {
     fn gitlab_project_path_from_mr_url_handles_nested_groups() {
         assert_eq!(
             gitlab_project_path_from_url(
-                "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/12"
+                "https://gitlab.com/graysury/nils-cli-gitlab-sandbox/-/merge_requests/12"
             )
             .as_deref(),
-            Some("terrylin/agent-runtime-testing")
+            Some("graysury/nils-cli-gitlab-sandbox")
         );
         assert_eq!(
             gitlab_project_path_from_url("https://gitlab.com/group/sub/project/-/merge_requests/3")
@@ -498,14 +498,14 @@ mod tests {
         };
         let comments = parse_gitlab_notes(
             &output,
-            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/12",
+            "https://gitlab.com/graysury/nils-cli-gitlab-sandbox/-/merge_requests/12",
         )
         .unwrap();
         assert_eq!(comments.len(), 2);
         assert_eq!(comments[0].author, "alice");
         assert_eq!(
             comments[0].url,
-            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/12#note_1"
+            "https://gitlab.com/graysury/nils-cli-gitlab-sandbox/-/merge_requests/12#note_1"
         );
         assert_eq!(comments[1].author, "bob");
     }

--- a/crates/forge-cli/tests/integration/auth_status.rs
+++ b/crates/forge-cli/tests/integration/auth_status.rs
@@ -7,14 +7,14 @@ use super::support::{StubEnv, parse_envelope, run_forge_cli};
 
 const GH_AUTH_STDERR: &str = "\
 github.com
-  ✓ Logged in to github.com account graysurf (keyring)
+  ✓ Logged in to github.com account testuser-gh (keyring)
   - Active account: true
   - Token scopes: 'repo', 'read:org'
 ";
 
 const GLAB_AUTH_STDERR: &str = "\
 gitlab.com
-  ✓ Logged in to gitlab.com as graysurf (~/.config/glab-cli/config.yml)
+  ✓ Logged in to gitlab.com as testuser-glab (~/.config/glab-cli/config.yml)
   ✓ Git operations for gitlab.com configured to use ssh protocol.
 ";
 
@@ -38,7 +38,7 @@ fn auth_status_github_returns_normalized_envelope() {
     assert_eq!(envelope["ok"], true);
     assert_eq!(envelope["data"]["provider"], "github");
     assert_eq!(envelope["data"]["host"], "github.com");
-    assert_eq!(envelope["data"]["user"], "graysurf");
+    assert!(envelope["data"]["user"].is_string());
     assert_eq!(envelope["data"]["scopes"].as_array().unwrap().len(), 2);
 }
 
@@ -54,16 +54,16 @@ fn auth_status_gitlab_returns_normalized_envelope() {
     assert_eq!(envelope["schema_version"], "cli.forge-cli.auth.status.v1");
     assert_eq!(envelope["data"]["provider"], "gitlab");
     assert_eq!(envelope["data"]["host"], "gitlab.com");
-    assert_eq!(envelope["data"]["user"], "graysurf");
+    assert!(envelope["data"]["user"].is_string());
     // glab auth status does not surface scopes.
     assert_eq!(envelope["data"]["scopes"].as_array().unwrap().len(), 0);
 }
 
 #[test]
 fn auth_status_envelope_is_parity_between_backends() {
-    // Identical user + host on both backends; envelope differs only in
-    // `data.provider` and `data.scopes` (which the spec admits since glab
-    // does not surface scopes).
+    // Envelope differs only in `data.provider` and `data.scopes` (which the
+    // spec admits since glab does not surface scopes). The username is not
+    // compared because each backend has its own identity surface.
     let gh = StubEnv::new().gh_stub(&gh_stub_script(GH_AUTH_STDERR));
     let glab = StubEnv::new().glab_stub(&gh_stub_script(GLAB_AUTH_STDERR));
     let gh_out = run_forge_cli(
@@ -78,5 +78,4 @@ fn auth_status_envelope_is_parity_between_backends() {
     let glab_env = parse_envelope(&glab_out.stdout);
     assert_eq!(gh_env["schema_version"], glab_env["schema_version"]);
     assert_eq!(gh_env["ok"], glab_env["ok"]);
-    assert_eq!(gh_env["data"]["user"], glab_env["data"]["user"]);
 }

--- a/crates/forge-cli/tests/integration/exit_codes.rs
+++ b/crates/forge-cli/tests/integration/exit_codes.rs
@@ -15,7 +15,7 @@ const GH_AUTH_OK: &str = "\
 #!/bin/sh
 cat <<'EOF' 1>&2
 github.com
-  ✓ Logged in to github.com account graysurf (keyring)
+  ✓ Logged in to github.com account testuser-gh (keyring)
 EOF
 ";
 

--- a/crates/forge-cli/tests/integration/pr_deliver_chain.rs
+++ b/crates/forge-cli/tests/integration/pr_deliver_chain.rs
@@ -150,7 +150,7 @@ case "$1 $2" in
   "auth status")
     cat <<'EOF' 1>&2
 github.com
-  ✓ Logged in to github.com account graysurf (keyring)
+  ✓ Logged in to github.com account testuser-gh (keyring)
   - Token scopes: 'repo', 'read:org'
 EOF
     ;;

--- a/crates/plan-issue-cli/src/provider.rs
+++ b/crates/plan-issue-cli/src/provider.rs
@@ -54,7 +54,7 @@ pub struct Repo {
     /// `owner/repo` (GitHub) or `group[/subgroup]/project` (GitLab).
     pub slug: String,
     /// Provider host as it appears in the remote URL (e.g. `github.com`,
-    /// `gitlab.gamania.com`). `None` when the provider was inferred without
+    /// `gitlab.com`). `None` when the provider was inferred without
     /// a host (e.g. bare `--repo owner/repo` default).
     pub host: Option<String>,
 }
@@ -314,7 +314,6 @@ mod tests {
     fn classify_host_recognises_github_and_gitlab() {
         assert_eq!(classify_host("github.com"), Some(Provider::GitHub));
         assert_eq!(classify_host("gitlab.com"), Some(Provider::GitLab));
-        assert_eq!(classify_host("gitlab.gamania.com"), Some(Provider::GitLab));
         assert_eq!(classify_host("bitbucket.org"), None);
     }
 
@@ -328,10 +327,10 @@ mod tests {
                 "github.com",
             ),
             (
-                "git@gitlab.gamania.com:terrylin/agent-runtime-testing.git",
+                "git@gitlab.com:graysury/nils-cli-gitlab-sandbox.git",
                 Provider::GitLab,
-                "terrylin/agent-runtime-testing",
-                "gitlab.gamania.com",
+                "graysury/nils-cli-gitlab-sandbox",
+                "gitlab.com",
             ),
             (
                 "https://gitlab.com/group/sub/project",
@@ -358,9 +357,9 @@ mod tests {
                 Provider::GitHub,
             ),
             (
-                "https://gitlab.gamania.com/terrylin/agent-runtime-testing.git",
-                "terrylin/agent-runtime-testing",
-                "gitlab.gamania.com",
+                "https://gitlab.com/graysury/nils-cli-gitlab-sandbox.git",
+                "graysury/nils-cli-gitlab-sandbox",
+                "gitlab.com",
                 Provider::GitLab,
             ),
             (

--- a/docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-discussion-source.md
+++ b/docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-discussion-source.md
@@ -1,0 +1,215 @@
+# GitLab Test Migration to gitlab.com Implementation Handoff
+
+| Field | Value |
+| --- | --- |
+| Status | Ready for implementation |
+| Date | 2026-05-25 |
+| Source | Conversation requirement: stop referencing the internal Gamania GitLab server in this public CLI repo; route GitLab-side tests / docs / live sandbox at `gitlab.com` instead |
+| Intended next step | Land Sprint 1 (fixture swap + auth-status decoupling), then Sprint 2 (docs sweep), then Sprint 3 (live sandbox on gitlab.com) |
+
+## Purpose
+
+`sympoies/nils-cli` currently mentions `gitlab.gamania.com` (Gamania internal
+GitLab instance) and `terrylin/agent-runtime-testing` (the Gamania-side
+sandbox project) in unit-test fixtures, plan/runbook docs, and a few
+auth-status stubs. The repo is published to GitHub and crates.io, so the
+internal-host references should be removed and the live GitLab sandbox should
+move to a `gitlab.com` project the maintainer can drive directly.
+
+This plan migrates the three reference surfaces in this order:
+
+1. **Source-level test fixtures** — flip the strings to `gitlab.com` and a
+   neutral sandbox slug; drop the username assertions that pin the maintainer
+   account.
+2. **Docs / runbook references** — rewrite the 7 plan + runbook files that
+   name the Gamania host or `terrylin/agent-runtime-testing`.
+3. **Live sandbox** — create `graysury/nils-cli-gitlab-sandbox` on
+   gitlab.com and validate the GitLab MR delivery skills against it.
+
+No CLI behavior or schema changes. No new test gating. No new env vars.
+
+## Confirmed facts
+
+- `glab auth status --hostname gitlab.com` reports `graysury` as the logged-in
+  user; the gitlab.com account has 0 projects today
+  (`projects?membership=true` returns `[]`). [A1]
+- Repo references to `gitlab.gamania.com` live in three source files (pure
+  `#[test]` fixtures, no network) and seven doc files (historical
+  plan/runbook handoffs). [F1]
+  - `crates/forge-cli/src/ops/issue_view.rs` — 8 URL hits + doc comments at
+    lines 141 / 409. The fixture purpose was to verify
+    `gitlab_host_from_url` extracts the host from `web_url` even on a
+    non-`gitlab.com` instance. [F2]
+  - `crates/forge-cli/src/ops/pr_comments.rs` — 3 URL hits in the MR-notes
+    fixture. [F3]
+  - `crates/plan-issue-cli/src/provider.rs` — 5 fixture hits (host
+    classification + ssh/https remote parsing) + doc comment at line 57. [F4]
+- `FORGE_CLI_E2E=1` is only mentioned in spec / plan docs; no test wiring
+  currently consumes it. All GitLab integration tests under
+  `crates/forge-cli/tests/integration/` use stub `glab` binaries. There is no
+  live-network test that depends on the Gamania server. [F5]
+- `crates/forge-cli/tests/integration/auth_status.rs` and
+  `crates/forge-cli/src/ops/auth_status.rs` pin the GitHub + GitLab user name
+  to `graysurf` (GitHub identity), even though the gitlab.com identity is
+  actually `graysury`. The integration test compares `user` across backends
+  for parity. [F6]
+- `crates/forge-cli/tests/integration/pr_deliver_chain.rs:153` and
+  `crates/forge-cli/tests/integration/exit_codes.rs:18` carry the same
+  `graysurf` stub stderr but do not assert on the value. [F7]
+
+## Decisions
+
+1. **Swap all `gitlab.gamania.com` strings to `gitlab.com`** in source fixtures
+   and the `terrylin/agent-runtime-testing` slug to `graysury/nils-cli-gitlab-sandbox`.
+   The fixtures still parse a `web_url` correctly (the parser code path is
+   exercised), but they no longer represent a self-hosted GitLab instance.
+   The narrow "non-`gitlab.com` host extraction" coverage is intentionally
+   dropped because it is not needed for this maintainer's workflow.
+2. **Decouple `auth status` tests from a specific username.** Integration
+   tests drop the `data.user == "graysurf"` assertions entirely. Unit-test
+   parser fixtures in `crates/forge-cli/src/ops/auth_status.rs` keep
+   structural coverage that the parser extracts a non-empty username, but
+   stop asserting the exact string. The integration parity test compares
+   schema/ok/host across backends — not the username.
+3. **Rewrite all 7 plan / runbook references**, not just the durable runbook.
+   Historical plan docs become inconsistent if half still name the Gamania
+   server. `gitlab.gamania.com` → `gitlab.com`; `terrylin/agent-runtime-testing`
+   → `graysury/nils-cli-gitlab-sandbox`.
+4. **Create `graysury/nils-cli-gitlab-sandbox` on gitlab.com**, visibility
+   `private`, default branch `main`, README only. This is the new home for
+   live `pr/create-gitlab-mr`, `pr/close-gitlab-mr`, and `pr/deliver-gitlab-mr`
+   validation sweeps.
+5. **No code-behavior changes.** This plan is a string + docs migration plus
+   a sandbox bootstrap; the provider abstraction, host classification, and
+   envelope contracts stay as they are.
+
+## Scope
+
+- In scope:
+  - String swap in 3 source files (13 fixture occurrences + 3 doc comments).
+  - Drop / soften username assertions across 2 auth-status test files.
+  - Rewrite 7 doc files (1 runbook + 6 plan docs) under
+    `crates/plan-issue-cli/docs/runbooks/` and `docs/plans/`.
+  - Create the gitlab.com sandbox project.
+  - Manual live sweep of `forge-cli` GitLab-arm commands against the new
+    sandbox; record evidence inside the worktree.
+- Out of scope:
+  - Adding gated live tests (`FORGE_CLI_E2E=1`).
+  - Reworking provider-detection or host-classification logic.
+  - Changing the published crates' behavior, CLI surface, or schemas.
+  - Importing or migrating data from `terrylin/agent-runtime-testing`.
+  - Touching the existing `gitlab.gamania.com` glab auth profile.
+
+## Requirements
+
+- R1. After Sprint 1, no source file (`crates/**/*.rs`) references
+  `gitlab.gamania.com`, `terrylin/agent-runtime-testing`, `graysurf`, or
+  `graysury` outside the agent-runtime-cli (which legitimately references
+  the GitHub user `graysurf`).
+- R2. After Sprint 2, the only remaining references to `gitlab.gamania.com`
+  in the whole worktree are in: (a) git history, (b) `THIRD_PARTY_*`
+  generated files if they happen to mention it (none expected). No
+  `docs/plans/**`, `crates/**/docs/**`, or top-level docs file references
+  the Gamania host or sandbox slug.
+- R3. After Sprint 3, `graysury/nils-cli-gitlab-sandbox` exists on
+  `gitlab.com`, can be addressed by `forge-cli --repo`, and has at least
+  one disposable MR successfully exercised through
+  `pr deliver --kind feature --no-merge`.
+- R4. `cargo test --workspace` is green throughout. No new failing tests
+  introduced.
+- R5. The local-fast CI gate from
+  `scripts/ci/nils-cli-local-fast.sh` (or its DEVELOPMENT.md equivalent)
+  passes on the migration branch before PR.
+
+## Acceptance criteria
+
+- AC-1. `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' --type rust`
+  returns no matches.
+- AC-2. `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' docs/plans/ crates/*/docs/`
+  returns no matches.
+- AC-3. `cargo test --workspace` passes.
+- AC-4. `forge-cli --format json --repo graysury/nils-cli-gitlab-sandbox issue list --state all`
+  returns an `ok=true` envelope against the live sandbox.
+- AC-5. A live `pr deliver --kind feature --no-merge` sweep on the sandbox
+  advances past the version probe and emits an `ok=true` envelope at the
+  create step (subsequent failures, if any, must not be host-related).
+
+## Validation plan
+
+1. `cargo test --workspace` after Sprint 1.
+2. `rg` audits per AC-1 / AC-2 after each sprint.
+3. Local-fast CI gate after Sprint 2 (`scripts/ci/nils-cli-local-fast.sh`).
+4. Sandbox bootstrap via `glab --hostname gitlab.com repo create
+   graysury/nils-cli-gitlab-sandbox --visibility private`.
+5. Live `forge-cli` sweep against the sandbox; capture the envelopes into
+   the worktree under `evidence/` (or the project-defined agent-out path)
+   for the PR description.
+
+## Findings table
+
+| ID | Source | Disposition |
+| --- | --- | --- |
+| F-1 | Source fixtures naming `gitlab.gamania.com` / `terrylin/agent-runtime-testing` | Sprint 1 |
+| F-2 | `auth status` tests pinning username `graysurf` | Sprint 1 |
+| F-3 | 7 plan/runbook docs referencing the Gamania host or sandbox slug | Sprint 2 |
+| F-4 | No gitlab.com sandbox project exists yet under `graysury` | Sprint 3 |
+| F-5 | gitlab.com identity is `graysury`, not `graysurf` (parity drift if not decoupled) | Sprint 1 (mitigated by F-2 decoupling) |
+
+## Risks and guardrails
+
+- **R-1**: Dropping the self-hosted-host fixture removes the regression
+  guardrail for the "host extracted from `web_url`" code path on non-`gitlab.com`
+  hosts. **Mitigation**: the parser is still exercised through the same
+  fixtures with `gitlab.com` URLs; if a non-`gitlab.com` regression matters
+  in the future, a dedicated test against `gitlab.example.com` (RFC reserved)
+  can be reintroduced without re-naming a real internal server.
+- **R-2**: Username-decoupling could weaken parser unit-test coverage if the
+  assertion is removed naively. **Mitigation**: keep a structural assertion
+  (e.g., `payload.user.is_some()` plus a substring containment check) and
+  use a neutral stub value such as `testuser-gh` / `testuser-glab` so the
+  parser still has to extract the right substring from stub stderr.
+- **R-3**: Live sandbox creation could collide with a future namespace
+  reservation on gitlab.com. **Mitigation**: project is private and named
+  `nils-cli-gitlab-sandbox` (no general-purpose name); rerunnable.
+- **R-4**: Doc rewrites in historical plan files may invalidate references
+  cited from other plans / runbooks. **Mitigation**: after the doc sweep,
+  `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing'` across the
+  whole worktree must return zero matches; any cross-file pointer that
+  breaks gets resolved in the same sprint.
+
+## Execution
+
+- Recommended plan: docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-plan.md
+- Recommended execution state: docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-execution-state.md
+- Status: ready
+- Next-task source: Sprint 1 in the plan
+
+## Retention intent
+
+Promote after merge. The "neutral hostname / decoupled username" pattern
+documented here is the canonical playbook for any future fixture that
+needs to look like GitLab without naming a real account or instance.
+
+## Read-first references
+
+- Source fixture sites:
+  - `crates/forge-cli/src/ops/issue_view.rs:670,678,683,715,718,732,739`
+    (plus comments at 141 and 409)
+  - `crates/forge-cli/src/ops/pr_comments.rs:443,501,508`
+  - `crates/plan-issue-cli/src/provider.rs:317,331,334,361,363` (plus comment
+    at 57)
+- Auth-status sites:
+  - `crates/forge-cli/tests/integration/auth_status.rs:10,17,41,57,81`
+  - `crates/forge-cli/src/ops/auth_status.rs:239,244,256,261`
+  - `crates/forge-cli/tests/integration/pr_deliver_chain.rs:153`
+  - `crates/forge-cli/tests/integration/exit_codes.rs:18`
+- Doc sites:
+  - `crates/plan-issue-cli/docs/runbooks/provider-routing-runbook.md`
+  - `docs/plans/gitlab-mr-unblock/gitlab-mr-unblock-{plan,discussion-source}.md`
+  - `docs/plans/plan-issue-cli-provider-abstraction/*.md`
+  - `docs/plans/forge-cli-inbox/*.md`
+  - `docs/plans/forge-cli-inbox-latency/*.md`
+
+## Source type
+
+`discussion-to-implementation-doc`

--- a/docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-plan.md
+++ b/docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-plan.md
@@ -1,0 +1,399 @@
+# Plan: GitLab Test Migration to gitlab.com
+
+## Overview
+
+Remove every reference to the internal Gamania GitLab server
+(`gitlab.gamania.com`) and the Gamania-side sandbox project
+(`terrylin/agent-runtime-testing`) from this repo, and bootstrap a
+gitlab.com sandbox the maintainer (`graysury`) can drive directly. Three
+ordered sprints:
+
+1. **Sprint 1 — Source fixture migration**: flip 13 `gitlab.gamania.com`
+   strings and 3 doc-comment mentions in `forge-cli` / `plan-issue-cli`
+   source files; decouple the `auth status` tests from a specific username.
+2. **Sprint 2 — Docs sweep**: rewrite 7 historical plan + runbook docs so
+   they point at `gitlab.com` and the new sandbox slug.
+3. **Sprint 3 — Live sandbox**: create
+   `graysury/nils-cli-gitlab-sandbox` on gitlab.com (private), then run a
+   live `forge-cli` GitLab-arm sweep to verify the migration end-to-end.
+
+No CLI behavior, schema, or env-var changes. No new test gating.
+
+## Read First
+
+- Primary source:
+  `docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-discussion-source.md`
+- Source type: discussion-to-implementation-doc
+- Open questions carried into execution: none
+- Worktree: `.claude/worktrees/gitlab-com-test-migration` on branch
+  `worktree-gitlab-com-test-migration`
+- gitlab.com auth: `glab auth status --hostname gitlab.com` →
+  logged in as `graysury` (verified 2026-05-25)
+
+## Scope
+
+- In scope:
+  - 3 source files: `crates/forge-cli/src/ops/issue_view.rs`,
+    `crates/forge-cli/src/ops/pr_comments.rs`,
+    `crates/plan-issue-cli/src/provider.rs`.
+  - 2 auth-status test files (integration + unit) + 2 incidental stub
+    stderr files (`pr_deliver_chain.rs`, `exit_codes.rs`) reviewed for
+    consistency.
+  - 7 doc files: runbook + 6 plan docs.
+  - Creating the live sandbox project on gitlab.com.
+  - Live `forge-cli` sweep against the new sandbox.
+- Out of scope:
+  - Provider-detection or host-classification code changes.
+  - Adding `FORGE_CLI_E2E=1` wiring.
+  - Adding any new automated tests that hit the network.
+  - Touching the existing `gitlab.gamania.com` auth profile in
+    `glab-cli/config.yml`.
+  - Migrating issues/MRs out of `terrylin/agent-runtime-testing`.
+
+## Sprint 1: Source fixture migration
+
+**Goal**: Every `crates/**/*.rs` file is free of `gitlab.gamania.com`,
+`terrylin/agent-runtime-testing`, `graysurf`, and `graysury`. Tests still
+pass. Auth-status tests no longer assert a specific username.
+
+**Demo / Validation**:
+
+- Commands:
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' crates/`
+    returns no matches.
+  - `rg -n 'graysurf|graysury' crates/forge-cli/` returns matches only in
+    files unrelated to `auth_status` / `pr_deliver_chain` / `exit_codes`
+    (the agent-runtime-cli crate legitimately references the GitHub
+    `graysurf/agent-runtime-kit` project).
+  - `cargo test -p forge-cli` and `cargo test -p plan-issue-cli` pass.
+- Verify: stub-binary integration tests still execute end-to-end; parser
+  unit tests still demonstrate the user / host fields get extracted.
+
+### Task 1.1: Swap `gitlab.gamania.com` in `forge-cli/src/ops/issue_view.rs`
+
+- **Location**:
+  - `crates/forge-cli/src/ops/issue_view.rs`
+- **Description**: Replace 8 `gitlab.gamania.com` URL occurrences and the
+  Gamania-flavored doc comments at lines 141 and 409 with `gitlab.com`.
+  Replace `terrylin/agent-runtime-testing` with `graysury/nils-cli-gitlab-sandbox`
+  in the same fixtures. The `Some("gitlab.gamania.com")` expected value at
+  line 718 becomes `Some("gitlab.com")`. The adjacent regression test for
+  the generic `gitlab.com/group/sub/project` case stays untouched.
+- **Dependencies**: none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - File contains zero `gitlab.gamania.com` / `terrylin/agent-runtime-testing`
+    occurrences.
+  - `cargo test -p forge-cli --lib ops::issue_view` is green.
+  - `gitlab_host_from_url` / `gitlab_project_path_from_url` still receive
+    real inputs (i.e., we did not collapse two URLs into one identical
+    string).
+- **Validation**:
+  - `cargo test -p forge-cli --lib ops::issue_view`
+
+### Task 1.2: Swap `gitlab.gamania.com` in `forge-cli/src/ops/pr_comments.rs`
+
+- **Location**:
+  - `crates/forge-cli/src/ops/pr_comments.rs`
+- **Description**: Replace the 3 `gitlab.gamania.com` MR URL occurrences
+  (lines 443 / 501 / 508) with `gitlab.com`, and the
+  `terrylin/agent-runtime-testing` slug with
+  `graysury/nils-cli-gitlab-sandbox`. The `Some("terrylin/agent-runtime-testing")`
+  expected value at line 446 becomes `Some("graysury/nils-cli-gitlab-sandbox")`.
+- **Dependencies**: none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - File contains zero `gitlab.gamania.com` / `terrylin/agent-runtime-testing`
+    occurrences.
+  - `cargo test -p forge-cli --lib ops::pr_comments` is green.
+- **Validation**:
+  - `cargo test -p forge-cli --lib ops::pr_comments`
+
+### Task 1.3: Swap `gitlab.gamania.com` in `plan-issue-cli/src/provider.rs`
+
+- **Location**:
+  - `crates/plan-issue-cli/src/provider.rs`
+- **Description**: Replace 5 fixture occurrences (lines 317 / 331 / 334 /
+  361 / 363) and the doc comment at line 57 with `gitlab.com` and
+  `graysury/nils-cli-gitlab-sandbox`. The `classify_host("gitlab.gamania.com")`
+  test asserts that a non-`gitlab.com` host classifies as `Provider::GitLab`;
+  rewrite as `classify_host("gitlab.com")` or keep a single
+  `classify_host("gitlab.example.com")` assertion if you want to preserve
+  the wildcard-host coverage (allowed but not required by this plan).
+- **Dependencies**: none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - File contains zero `gitlab.gamania.com` / `terrylin/agent-runtime-testing`
+    occurrences.
+  - `cargo test -p plan-issue-cli --lib provider` is green.
+  - `classify_host` still has at least one assertion that returns
+    `Some(Provider::GitLab)` for an input string starting with `gitlab.`.
+- **Validation**:
+  - `cargo test -p plan-issue-cli --lib provider`
+
+### Task 1.4: Decouple `auth status` tests from a specific username
+
+- **Location**:
+  - `crates/forge-cli/tests/integration/auth_status.rs`
+  - `crates/forge-cli/src/ops/auth_status.rs` (unit tests at lines 234–263)
+- **Description**: Two pieces:
+  1. **Integration tests** (`tests/integration/auth_status.rs`): remove the
+     `data.user == "graysurf"` assertions at lines 41 and 57, and remove
+     the cross-backend user comparison at line 81 (
+     `gh_env["data"]["user"] == glab_env["data"]["user"]`). The flow check
+     (status code, schema_version, ok, provider, host, scopes count) is
+     preserved. The stub stderr lines 10 / 17 keep a placeholder username
+     (e.g., `testuser-gh` / `testuser-glab`) so the parser still receives a
+     non-trivial input.
+  2. **Unit tests** (`src/ops/auth_status.rs`): keep the parser-extracts-user
+     coverage by replacing `Some("graysurf")` with a stable
+     `Some("testuser-gh")` / `Some("testuser-glab")` and updating the
+     corresponding stub stderr strings. The point is to keep proving that
+     "the user string in stderr ends up in `payload.user`" without pinning
+     a real account name.
+- **Dependencies**: none
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - No assertion in either file pins `graysurf` or `graysury`.
+  - `cargo test -p forge-cli --lib ops::auth_status` is green.
+  - `cargo test -p forge-cli --test '*' auth_status` is green.
+  - Stub stderr strings still produce a non-empty `payload.user` so the
+    parser branch coverage is preserved.
+- **Validation**:
+  - `cargo test -p forge-cli auth_status`
+
+### Task 1.5: Review incidental stub stderr in `pr_deliver_chain.rs` / `exit_codes.rs`
+
+- **Location**:
+  - `crates/forge-cli/tests/integration/pr_deliver_chain.rs:153`
+  - `crates/forge-cli/tests/integration/exit_codes.rs:18`
+- **Description**: Both files include a stub `gh auth status` stderr line
+  that names `graysurf`. Neither file asserts on that value. To stay
+  consistent with Task 1.4's decoupling, change the placeholder string to
+  `testuser-gh` (or whichever stable placeholder Task 1.4 chose). No
+  behavior change.
+- **Dependencies**:
+  - Task 1.4 (alignment on placeholder name)
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Stub stderr lines use the chosen placeholder name.
+  - `cargo test -p forge-cli` is green.
+- **Validation**:
+  - `cargo test -p forge-cli`
+
+### Task 1.6: Sprint 1 audit + workspace test
+
+- **Location**:
+  - Worktree root
+- **Description**: Run the rg audits and the full workspace test suite.
+- **Dependencies**:
+  - Task 1.1
+  - Task 1.2
+  - Task 1.3
+  - Task 1.4
+  - Task 1.5
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' crates/`
+    returns no matches.
+  - `cargo test --workspace` is green.
+- **Validation**:
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' crates/`
+  - `cargo test --workspace`
+
+## Sprint 2: Docs sweep
+
+**Goal**: Rewrite the 7 doc files so the only remaining mention of
+`gitlab.gamania.com` or `terrylin/agent-runtime-testing` anywhere in the
+worktree is in git history.
+
+**Demo / Validation**:
+
+- Commands:
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing'` against
+    the whole worktree returns no matches in tracked files.
+- Verify: cross-file pointers between plan docs still resolve.
+
+### Task 2.1: Rewrite `provider-routing-runbook.md`
+
+- **Location**:
+  - `crates/plan-issue-cli/docs/runbooks/provider-routing-runbook.md`
+- **Description**: This runbook is the durable post-promotion reference for
+  provider routing. Replace `gitlab.gamania.com` with `gitlab.com` and
+  `terrylin/agent-runtime-testing` with `graysury/nils-cli-gitlab-sandbox`
+  in body text and examples. Where the runbook discusses self-hosted GitLab
+  hosts conceptually, soften the example from "like `gitlab.gamania.com`"
+  to "like `gitlab.example.com`" so the public-doc tone stays neutral.
+- **Dependencies**: none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - File contains zero `gitlab.gamania.com` / `terrylin/agent-runtime-testing`.
+  - Cross-references inside the file still resolve to existing files /
+    sections.
+- **Validation**:
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing'
+    crates/plan-issue-cli/docs/runbooks/provider-routing-runbook.md`
+
+### Task 2.2: Rewrite `docs/plans/gitlab-mr-unblock/*.md`
+
+- **Location**:
+  - `docs/plans/gitlab-mr-unblock/gitlab-mr-unblock-discussion-source.md`
+  - `docs/plans/gitlab-mr-unblock/gitlab-mr-unblock-plan.md`
+- **Description**: Update the Source / Read-first / Sprint references that
+  point at the Gamania sandbox. Leave the historical narrative ("sandbox
+  sweep against …") intact, but rename the host and slug. Append a brief
+  note that the sandbox moved to `graysury/nils-cli-gitlab-sandbox` on
+  gitlab.com.
+- **Dependencies**: none
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - Both files contain zero `gitlab.gamania.com` / `terrylin/agent-runtime-testing`.
+  - Each file still reads as a coherent record of the original effort.
+- **Validation**:
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing'
+    docs/plans/gitlab-mr-unblock/`
+
+### Task 2.3: Rewrite `docs/plans/plan-issue-cli-provider-abstraction/*.md`
+
+- **Location**:
+  - `docs/plans/plan-issue-cli-provider-abstraction/plan-issue-cli-provider-abstraction-discussion-source.md`
+  - `docs/plans/plan-issue-cli-provider-abstraction/plan-issue-cli-provider-abstraction-plan.md`
+  - `docs/plans/plan-issue-cli-provider-abstraction/plan-issue-cli-provider-abstraction-design-note.md`
+- **Description**: Same approach as Task 2.2. Take care with example shell
+  commands that paste a full `plan-issue --repo …` invocation — replace
+  both host and slug so the example would actually run against the new
+  sandbox.
+- **Dependencies**: none
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - All three files contain zero `gitlab.gamania.com` / `terrylin/agent-runtime-testing`.
+  - Example commands stay runnable against the new sandbox.
+- **Validation**:
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing'
+    docs/plans/plan-issue-cli-provider-abstraction/`
+
+### Task 2.4: Rewrite `docs/plans/forge-cli-inbox*/*.md`
+
+- **Location**:
+  - `docs/plans/forge-cli-inbox/forge-cli-inbox-plan.md`
+  - `docs/plans/forge-cli-inbox/forge-cli-inbox-discussion-source.md`
+  - `docs/plans/forge-cli-inbox-latency/forge-cli-inbox-latency-plan.md`
+  - `docs/plans/forge-cli-inbox-latency/forge-cli-inbox-latency-discussion-source.md`
+- **Description**: Same as Task 2.2 / 2.3. The inbox docs mention the
+  Gamania host in passing (e.g., "live probe examples"). Update host and
+  slug, soften any "internal-only" framing to "GitLab instance".
+- **Dependencies**: none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - All four files contain zero `gitlab.gamania.com` / `terrylin/agent-runtime-testing`.
+- **Validation**:
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing'
+    docs/plans/forge-cli-inbox/ docs/plans/forge-cli-inbox-latency/`
+
+### Task 2.5: Sprint 2 audit + local-fast CI
+
+- **Location**:
+  - Worktree root
+- **Description**: Run a worktree-wide audit and the local-fast CI gate so
+  the docs sweep does not regress markdown / docs-hygiene checks.
+- **Dependencies**:
+  - Task 2.1
+  - Task 2.2
+  - Task 2.3
+  - Task 2.4
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing'` returns
+    no matches in tracked files.
+  - `scripts/ci/nils-cli-local-fast.sh` (or its DEVELOPMENT.md equivalent
+    sequence) passes.
+- **Validation**:
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing'`
+  - `scripts/ci/nils-cli-local-fast.sh`
+
+## Sprint 3: Live sandbox bootstrap + sweep
+
+**Goal**: Create the new gitlab.com sandbox and prove the GitLab arm of
+`forge-cli` works against it end-to-end, so the rewritten docs and tests
+reflect a real, reachable target.
+
+**Demo / Validation**:
+
+- Commands:
+  - `glab --hostname gitlab.com repo create graysury/nils-cli-gitlab-sandbox
+    --visibility private --description "Live sandbox for nils-cli forge-cli GitLab arm validation"`.
+  - `forge-cli --format json --repo graysury/nils-cli-gitlab-sandbox issue list
+    --state all` returns `ok=true`.
+  - Open a disposable MR via the `pr/deliver-gitlab-mr` skill (or the
+    underlying `forge-cli pr create … --no-merge`) and confirm
+    `ok=true` envelope at the create step.
+- Verify: live sweep evidence saved into the worktree and referenced in
+  the PR description.
+
+### Task 3.1: Create `graysury/nils-cli-gitlab-sandbox`
+
+- **Location**:
+  - gitlab.com (external resource)
+- **Description**: Use `glab --hostname gitlab.com repo create` to
+  bootstrap the project as private with a README. Default branch `main`.
+  No CI templates. Capture the project ID and HTTPS URL into Sprint 3
+  evidence.
+- **Dependencies**: none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Project visible at
+    `https://gitlab.com/graysury/nils-cli-gitlab-sandbox`.
+  - `glab --hostname gitlab.com repo view graysury/nils-cli-gitlab-sandbox`
+    succeeds.
+- **Validation**:
+  - `glab --hostname gitlab.com repo view graysury/nils-cli-gitlab-sandbox`
+
+### Task 3.2: Live `forge-cli` GitLab-arm sweep
+
+- **Location**:
+  - Worktree root + sandbox project
+- **Description**: With the rebuilt `forge-cli` binary, exercise:
+  - `forge-cli --repo graysury/nils-cli-gitlab-sandbox issue list --state all`
+  - `forge-cli --repo graysury/nils-cli-gitlab-sandbox auth status`
+  - One disposable MR through `pr create` (no merge), then `pr view`, then
+    `pr close`.
+  - Capture each envelope (`--format json`) into
+    `evidence/sprint-3-sweep/` inside the worktree (or use
+    `nils-cli agent-out project --topic gitlab-com-test-migration --mkdir`
+    if the project-specific output dir is preferred).
+- **Dependencies**:
+  - Task 3.1
+  - Task 1.6 (so source fixtures point at the new sandbox)
+  - Task 2.5 (so docs point at the new sandbox)
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - Every captured envelope has `ok=true` for the expected step.
+  - No envelope contains `error.kind = glab_version_unsupported` or
+    `error.kind = repo_not_found`.
+  - Evidence files committed (or attached to the PR description).
+- **Validation**:
+  - Manual review of captured envelopes.
+
+### Task 3.3: Final consolidation + PR readiness
+
+- **Location**:
+  - Worktree root
+- **Description**: Final audit, run the relevant DEVELOPMENT.md gates,
+  draft the PR title / body referencing the discussion source and
+  evidence. No code or docs change in this task — it is the close-out.
+- **Dependencies**:
+  - Task 3.1
+  - Task 3.2
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - `cargo test --workspace` is green on the final commit.
+  - `scripts/ci/nils-cli-local-fast.sh` (or DEVELOPMENT.md equivalent)
+    passes on the final commit.
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing'` returns
+    zero matches in tracked files.
+  - PR description links the discussion source, this plan, and the
+    Sprint 3 evidence.
+- **Validation**:
+  - `cargo test --workspace`
+  - `scripts/ci/nils-cli-local-fast.sh`
+  - `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing'`


### PR DESCRIPTION
## Summary

Sprint 1 of the [GitLab test migration plan](docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-plan.md) (issue #514). Removes `gitlab.gamania.com` (Gamania internal GitLab) and `terrylin/agent-runtime-testing` from `forge-cli` / `plan-issue-cli` source files, and decouples `auth status` tests from a specific maintainer username so the public test suite stops pinning a real identity.

- **Fixture swaps** (no behavior change): `gitlab.gamania.com` → `gitlab.com`, `terrylin/agent-runtime-testing` → `graysury/nils-cli-gitlab-sandbox` across `issue_view.rs`, `pr_comments.rs`, `provider.rs`.
- **`auth status` username decoupling**: integration tests drop `data.user` asserts and the parity user comparison; unit tests check `payload.user.is_some()` (parser still proves it extracted a value) instead of pinning `Some("graysurf")`. Stubs use neutral placeholders `testuser-gh` / `testuser-glab`.
- **Doc comments sanitized**: removed the "self-hosted instance like `gitlab.gamania.com`" / "live-observed on gitlab.gamania.com" lines from `issue_view.rs`.
- **`classify_host` wildcard case dropped**: `gitlab.gamania.com` assertion removed since the user explicitly asked for a flat `gitlab.com`-only test surface (`gitlab.com` is still covered).

Sandbox project `graysury/nils-cli-gitlab-sandbox` will be created in Sprint 3.

## Acceptance

- `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' --type rust` → no matches ✅
- `bash scripts/ci/nils-cli-local-fast.sh --base main` → 225 tests passed ✅
- `cargo test -p nils-forge-cli` and `cargo test -p nils-plan-issue-cli` → green in isolation ✅

Note: `cargo test --workspace` was flaky on this machine (a different test fails each run with `git command failed to spawn`), but each failing test passes when its package is run alone — pre-existing parallel-test concurrency issue unrelated to this diff. The canonical local-fast gate (per DEVELOPMENT.md) is green.

## Plan tracking

- Plan tracker: #514
- Sprint 2 (docs sweep) and Sprint 3 (live sandbox + sweep) follow as separate PRs against the same tracker.

## Test plan

- [x] `bash scripts/ci/nils-cli-local-fast.sh --base main`
- [x] `cargo test -p nils-forge-cli --lib ops::issue_view`
- [x] `cargo test -p nils-forge-cli --lib ops::pr_comments`
- [x] `cargo test -p nils-forge-cli --lib ops::auth_status`
- [x] `cargo test -p nils-plan-issue-cli --lib provider`
- [x] `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' crates/`

