### PR TITLE
fix(plan-issue-cli): accept GitLab note URLs in approval validator

### DIFF
--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -2183,7 +2183,7 @@ fn run_close_plan(
     if !approval_comment_url_looks_valid(&args.approved_comment_url) {
         return Err(CommandError::usage(
             "invalid-approval-comment-url",
-            "--approved-comment-url must be a GitHub issue/pull comment URL",
+            "--approved-comment-url must be a GitHub issue/pull or GitLab issue/MR note comment URL",
         ));
     }
 
@@ -2872,7 +2872,7 @@ fn run_accept_sprint(
     if !approval_comment_url_looks_valid(&args.approved_comment_url) {
         return Err(CommandError::usage(
             "invalid-approval-comment-url",
-            "--approved-comment-url must be a GitHub issue/pull comment URL",
+            "--approved-comment-url must be a GitHub issue/pull or GitLab issue/MR note comment URL",
         ));
     }
 
@@ -3451,16 +3451,33 @@ fn load_close_comment(
 
 fn approval_comment_url_looks_valid(url: &str) -> bool {
     let trimmed = url.trim();
-    if !trimmed.starts_with("https://github.com/") {
-        return false;
+    if let Some(rest) = trimmed.strip_prefix("https://github.com/") {
+        let Some((base, suffix)) = rest.split_once("#issuecomment-") else {
+            return false;
+        };
+        if !suffix.chars().all(|ch| ch.is_ascii_digit()) {
+            return false;
+        }
+        return base.contains("/issues/") || base.contains("/pull/");
     }
-    let Some((base, suffix)) = trimmed.split_once("#issuecomment-") else {
-        return false;
-    };
-    if !suffix.chars().all(|ch| ch.is_ascii_digit()) {
-        return false;
+    if let Some(rest) = trimmed.strip_prefix("https://") {
+        let Some((host, path)) = rest.split_once('/') else {
+            return false;
+        };
+        if !(host == "gitlab.com" || host.starts_with("gitlab.") || host.contains(".gitlab.")) {
+            return false;
+        }
+        let Some((base, suffix)) = path.split_once("#note_") else {
+            return false;
+        };
+        if !suffix.chars().all(|ch| ch.is_ascii_digit()) {
+            return false;
+        }
+        return base.contains("/-/issues/")
+            || base.contains("/-/merge_requests/")
+            || base.contains("/-/work_items/");
     }
-    base.contains("/issues/") || base.contains("/pull/")
+    false
 }
 
 fn path_text(path: &Path) -> String {
@@ -4397,11 +4414,26 @@ mod tests {
         assert!(approval_comment_url_looks_valid(
             "https://github.com/sympoies/nils-cli/pull/221#issuecomment-456"
         ));
+        assert!(approval_comment_url_looks_valid(
+            "https://gitlab.com/group/project/-/issues/12#note_789"
+        ));
+        assert!(approval_comment_url_looks_valid(
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/7#note_321"
+        ));
+        assert!(approval_comment_url_looks_valid(
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/work_items/13#note_654"
+        ));
         assert!(!approval_comment_url_looks_valid(
             "https://example.com/issues/217#issuecomment-123"
         ));
         assert!(!approval_comment_url_looks_valid(
             "https://github.com/sympoies/nils-cli/issues/217#comment-123"
+        ));
+        assert!(!approval_comment_url_looks_valid(
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/7#note_abc"
+        ));
+        assert!(!approval_comment_url_looks_valid(
+            "https://gitlab.gamania.com/terrylin/agent-runtime-testing/-/merge_requests/7"
         ));
 
         assert!(should_emit_comment(&CommentModeArgs {

--- a/crates/plan-issue-cli/tests/integration/parity_guardrails.rs
+++ b/crates/plan-issue-cli/tests/integration/parity_guardrails.rs
@@ -275,7 +275,7 @@ fn command_guardrails_close_plan_requires_github_comment_url_format() {
     assert_eq!(payload["error"]["code"], "invalid-approval-comment-url");
     assert_eq!(
         payload["error"]["message"],
-        "--approved-comment-url must be a GitHub issue/pull comment URL"
+        "--approved-comment-url must be a GitHub issue/pull or GitLab issue/MR note comment URL"
     );
 }
 


### PR DESCRIPTION
## Summary
- Extend `approval_comment_url_looks_valid` to recognise GitLab `https://gitlab.<host>/.../-/{issues,merge_requests,work_items}/<n>#note_<digits>` URLs in addition to GitHub `#issuecomment-<digits>`.
- Refresh the usage error string from "must be a GitHub issue/pull comment URL" to "must be a GitHub issue/pull or GitLab issue/MR note comment URL".
- Update the parity guardrail to match the broadened message.

## Why
`accept-sprint` and `close-plan` route through the strict validator. On GitLab, `resolve-approval` emits `#note_<id>` URLs, which the prior GitHub-only check rejected — this blocked dispatch lifecycle completion on `gitlab.gamania.com` (issue #510 F-14, surfaced during the live P3-1 smoke against `terrylin/agent-runtime-testing`).

## Test plan
- [x] `cargo test -p nils-plan-issue-cli` (144 tests, including the extended `helper_url_validation_and_comment_mode_are_stable` covering GitHub + GitLab issue / MR / work_items URLs and rejection cases).
- [x] `cargo fmt --check -p nils-plan-issue-cli` clean.
- [x] `cargo clippy -p nils-plan-issue-cli --no-deps -- -D warnings` clean.
- [ ] Live re-run against a GitLab sandbox (will retest after release ships).

Refs #510