### PR TITLE
feat(forge-cli): broaden branch prefix to CC type set

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -2163,7 +2163,7 @@ _forge-cli() {
                     return 0
                     ;;
                 --kind)
-                    COMPREPLY=($(compgen -W "feature bug" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "feature bug chore docs ci refactor" -- "${cur}"))
                     return 0
                     ;;
                 --reviewer)
@@ -2209,7 +2209,7 @@ _forge-cli() {
             fi
             case "${prev}" in
                 --kind)
-                    COMPREPLY=($(compgen -W "feature bug" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "feature bug chore docs ci refactor" -- "${cur}"))
                     return 0
                     ;;
                 --title)

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -61,7 +61,7 @@ _arguments "${_arguments_options[@]}" : \
 '--title=[PR / MR title (required)]:TITLE:_default' \
 '(--body-file)--body=[PR / MR body / description text. Mutually exclusive with \`--body-file\`]:BODY:_default' \
 '--body-file=[Read PR / MR body from a file. Use \`-\` to read from stdin]:PATH:_default' \
-'--kind=[PR / MR kind (selects branch-prefix rule). Required]:KIND:(feature bug)' \
+'--kind=[PR / MR kind (selects branch-prefix rule). Required]:KIND:(feature bug chore docs ci refactor)' \
 '*--reviewer=[Add a reviewer (repeatable)]:USER:_default' \
 '*--label=[Add a label (repeatable)]:LABEL:_default' \
 '--label-catalog=[Validate labels against this catalog when \`--strict-labels\` is set]:PATH:_default' \
@@ -228,7 +228,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (deliver)
 _arguments "${_arguments_options[@]}" : \
-'--kind=[PR / MR kind (selects branch-prefix rule). Required]:KIND:(feature bug)' \
+'--kind=[PR / MR kind (selects branch-prefix rule). Required]:KIND:(feature bug chore docs ci refactor)' \
 '--title=[PR / MR title (required)]:TITLE:_default' \
 '(--body-file)--body=[PR / MR body / description text. Mutually exclusive with \`--body-file\`]:BODY:_default' \
 '--body-file=[Read PR / MR body from a file. Use \`-\` to read from stdin]:PATH:_default' \

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -169,6 +169,10 @@ pub struct CompletionArgs {
 pub enum PrKindFlag {
     Feature,
     Bug,
+    Chore,
+    Docs,
+    Ci,
+    Refactor,
 }
 
 impl PrKindFlag {
@@ -176,6 +180,10 @@ impl PrKindFlag {
         match self {
             PrKindFlag::Feature => crate::validations::PrKind::Feature,
             PrKindFlag::Bug => crate::validations::PrKind::Bug,
+            PrKindFlag::Chore => crate::validations::PrKind::Chore,
+            PrKindFlag::Docs => crate::validations::PrKind::Docs,
+            PrKindFlag::Ci => crate::validations::PrKind::Ci,
+            PrKindFlag::Refactor => crate::validations::PrKind::Refactor,
         }
     }
 
@@ -183,6 +191,10 @@ impl PrKindFlag {
         match self {
             PrKindFlag::Feature => "feature",
             PrKindFlag::Bug => "bug",
+            PrKindFlag::Chore => "chore",
+            PrKindFlag::Docs => "docs",
+            PrKindFlag::Ci => "ci",
+            PrKindFlag::Refactor => "refactor",
         }
     }
 }

--- a/crates/forge-cli/src/validations.rs
+++ b/crates/forge-cli/src/validations.rs
@@ -23,20 +23,30 @@ use crate::cli::BINARY;
 use crate::error::ForgeError;
 
 /// PR/MR kind declared by the caller via `--kind`. Drives the
-/// `branch_kind_matches` rule plus the macro in Sprint 6.
+/// `branch_kind_matches` rule plus the macro in Sprint 6. The set tracks
+/// the Conventional Commits type whitelist (`feature`, `bug`, `chore`,
+/// `docs`, `ci`, `refactor`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrKind {
     Feature,
     Bug,
+    Chore,
+    Docs,
+    Ci,
+    Refactor,
 }
 
 impl PrKind {
     /// Render the kind to the lower-case enum literal used in envelopes and
-    /// argv (`feature`, `bug`).
+    /// argv.
     pub fn as_str(self) -> &'static str {
         match self {
             PrKind::Feature => "feature",
             PrKind::Bug => "bug",
+            PrKind::Chore => "chore",
+            PrKind::Docs => "docs",
+            PrKind::Ci => "ci",
+            PrKind::Refactor => "refactor",
         }
     }
 
@@ -47,17 +57,26 @@ impl PrKind {
         match value {
             "feature" => Some(PrKind::Feature),
             "bug" => Some(PrKind::Bug),
+            "chore" => Some(PrKind::Chore),
+            "docs" => Some(PrKind::Docs),
+            "ci" => Some(PrKind::Ci),
+            "refactor" => Some(PrKind::Refactor),
             _ => None,
         }
     }
 }
 
 /// Branch prefix recovered from a branch name that matches the
-/// `branch_name` rule.
+/// `branch_name` rule. The set tracks the Conventional Commits type
+/// whitelist (`feat`, `fix`, `chore`, `docs`, `ci`, `refactor`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BranchPrefix {
     Feat,
     Fix,
+    Chore,
+    Docs,
+    Ci,
+    Refactor,
 }
 
 impl BranchPrefix {
@@ -65,6 +84,10 @@ impl BranchPrefix {
         match self {
             BranchPrefix::Feat => "feat",
             BranchPrefix::Fix => "fix",
+            BranchPrefix::Chore => "chore",
+            BranchPrefix::Docs => "docs",
+            BranchPrefix::Ci => "ci",
+            BranchPrefix::Refactor => "refactor",
         }
     }
 }
@@ -93,23 +116,37 @@ fn schema() -> String {
     schema_version_for(BINARY, "error", 1)
 }
 
-/// Rule 1a — branch name matches `^(feat|fix)/[a-z0-9][a-z0-9-]{1,63}$`.
+/// Rule 1a — branch name matches
+/// `^(feat|fix|chore|docs|ci|refactor)/[a-z0-9][a-z0-9.-]{1,63}$`.
 ///
-/// Returns the matched prefix so callers can chain into
+/// The slug character class permits `.` so release-style branches such as
+/// `chore/release-0.22.1` validate without forcing kebab-case versions on
+/// callers. Returns the matched prefix so callers can chain into
 /// [`branch_kind_matches`] without re-parsing.
 pub fn branch_name(branch: &str) -> Result<BranchPrefix, ForgeError> {
     let (prefix, rest) = match branch.split_once('/') {
         Some((p, r)) => (p, r),
-        None => return Err(branch_name_err(branch, "missing 'feat/' or 'fix/' prefix")),
+        None => {
+            return Err(branch_name_err(
+                branch,
+                "missing one of feat|fix|chore|docs|ci|refactor prefix",
+            ));
+        }
     };
 
     let prefix = match prefix {
         "feat" => BranchPrefix::Feat,
         "fix" => BranchPrefix::Fix,
+        "chore" => BranchPrefix::Chore,
+        "docs" => BranchPrefix::Docs,
+        "ci" => BranchPrefix::Ci,
+        "refactor" => BranchPrefix::Refactor,
         other => {
             return Err(branch_name_err(
                 branch,
-                &format!("unknown prefix '{other}' (expected 'feat' or 'fix')"),
+                &format!(
+                    "unknown prefix '{other}' (expected one of feat|fix|chore|docs|ci|refactor)"
+                ),
             ));
         }
     };
@@ -132,10 +169,10 @@ pub fn branch_name(branch: &str) -> Result<BranchPrefix, ForgeError> {
         ));
     }
     for &b in &bytes[1..] {
-        if !(b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-') {
+        if !(b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'.') {
             return Err(branch_name_err(
                 branch,
-                "slug must be lowercase [a-z0-9-] only",
+                "slug must be lowercase [a-z0-9.-] only",
             ));
         }
     }
@@ -147,16 +184,22 @@ fn branch_name_err(branch: &str, why: &str) -> ForgeError {
         schema(),
         "branch_name_invalid",
         format!("branch '{branch}' is invalid: {why}"),
-        Some("rule=^(feat|fix)/[a-z0-9][a-z0-9-]{1,63}$".to_string()),
+        Some("rule=^(feat|fix|chore|docs|ci|refactor)/[a-z0-9][a-z0-9.-]{1,63}$".to_string()),
     )
 }
 
-/// Rule 1b — declared `--kind` matches the branch prefix
-/// (`feature` ↔ `feat/*`, `bug` ↔ `fix/*`).
+/// Rule 1b — declared `--kind` matches the branch prefix one-for-one
+/// (`feature` ↔ `feat/*`, `bug` ↔ `fix/*`, `chore` ↔ `chore/*`,
+/// `docs` ↔ `docs/*`, `ci` ↔ `ci/*`, `refactor` ↔ `refactor/*`).
 pub fn branch_kind_matches(prefix: BranchPrefix, kind: PrKind) -> Result<(), ForgeError> {
     let ok = matches!(
         (prefix, kind),
-        (BranchPrefix::Feat, PrKind::Feature) | (BranchPrefix::Fix, PrKind::Bug)
+        (BranchPrefix::Feat, PrKind::Feature)
+            | (BranchPrefix::Fix, PrKind::Bug)
+            | (BranchPrefix::Chore, PrKind::Chore)
+            | (BranchPrefix::Docs, PrKind::Docs)
+            | (BranchPrefix::Ci, PrKind::Ci)
+            | (BranchPrefix::Refactor, PrKind::Refactor)
     );
     if ok {
         Ok(())
@@ -170,7 +213,7 @@ pub fn branch_kind_matches(prefix: BranchPrefix, kind: PrKind) -> Result<(), For
                 kind = kind.as_str(),
             ),
             Some(format!(
-                "feature -> feat/*, bug -> fix/* (branch_prefix={p}, kind={k})",
+                "feature -> feat/*, bug -> fix/*, chore -> chore/*, docs -> docs/*, ci -> ci/*, refactor -> refactor/* (branch_prefix={p}, kind={k})",
                 p = prefix.as_str(),
                 k = kind.as_str(),
             )),
@@ -423,10 +466,25 @@ mod tests {
     }
 
     #[test]
-    fn branch_name_accepts_feat_and_fix() {
+    fn branch_name_accepts_full_conventional_commits_set() {
         assert_eq!(ok_branch("feat/forge-cli-v1"), BranchPrefix::Feat);
         assert_eq!(ok_branch("fix/abc-123-mr-body"), BranchPrefix::Fix);
         assert_eq!(ok_branch("feat/a"), BranchPrefix::Feat);
+        assert_eq!(ok_branch("chore/release-0.22.1"), BranchPrefix::Chore);
+        assert_eq!(ok_branch("docs/release-notes"), BranchPrefix::Docs);
+        assert_eq!(ok_branch("ci/upgrade-runners"), BranchPrefix::Ci);
+        assert_eq!(
+            ok_branch("refactor/forge-cli-validations"),
+            BranchPrefix::Refactor,
+        );
+    }
+
+    #[test]
+    fn branch_name_accepts_dot_in_slug() {
+        // SemVer-shaped release branches must validate without forcing the
+        // bump skill to kebab-case the version segment.
+        assert_eq!(ok_branch("chore/release-1.2.3"), BranchPrefix::Chore);
+        assert_eq!(ok_branch("fix/2.0.0-hotfix"), BranchPrefix::Fix);
     }
 
     #[test]
@@ -443,7 +501,9 @@ mod tests {
 
     #[test]
     fn branch_name_rejects_unknown_prefix() {
-        let err = branch_name("docs/release-notes").expect_err("docs/");
+        let err = branch_name("hotfix/something").expect_err("hotfix/");
+        assert_eq!(err_kind(err), "branch_name_invalid");
+        let err = branch_name("issue/s1-t1-foo").expect_err("issue/");
         assert_eq!(err_kind(err), "branch_name_invalid");
     }
 
@@ -470,6 +530,10 @@ mod tests {
     fn branch_kind_matches_happy_paths() {
         branch_kind_matches(BranchPrefix::Feat, PrKind::Feature).expect("feat+feature");
         branch_kind_matches(BranchPrefix::Fix, PrKind::Bug).expect("fix+bug");
+        branch_kind_matches(BranchPrefix::Chore, PrKind::Chore).expect("chore+chore");
+        branch_kind_matches(BranchPrefix::Docs, PrKind::Docs).expect("docs+docs");
+        branch_kind_matches(BranchPrefix::Ci, PrKind::Ci).expect("ci+ci");
+        branch_kind_matches(BranchPrefix::Refactor, PrKind::Refactor).expect("refactor+refactor");
     }
 
     #[test]
@@ -477,6 +541,12 @@ mod tests {
         let err = branch_kind_matches(BranchPrefix::Feat, PrKind::Bug).expect_err("feat+bug");
         assert_eq!(err_kind(err), "branch_kind_mismatch");
         let err = branch_kind_matches(BranchPrefix::Fix, PrKind::Feature).expect_err("fix+feat");
+        assert_eq!(err_kind(err), "branch_kind_mismatch");
+        let err =
+            branch_kind_matches(BranchPrefix::Chore, PrKind::Feature).expect_err("chore+feat");
+        assert_eq!(err_kind(err), "branch_kind_mismatch");
+        let err =
+            branch_kind_matches(BranchPrefix::Docs, PrKind::Refactor).expect_err("docs+refactor");
         assert_eq!(err_kind(err), "branch_kind_mismatch");
     }
 
@@ -624,8 +694,16 @@ mod tests {
     fn pr_kind_round_trips_strings() {
         assert_eq!(PrKind::parse("feature"), Some(PrKind::Feature));
         assert_eq!(PrKind::parse("bug"), Some(PrKind::Bug));
+        assert_eq!(PrKind::parse("chore"), Some(PrKind::Chore));
+        assert_eq!(PrKind::parse("docs"), Some(PrKind::Docs));
+        assert_eq!(PrKind::parse("ci"), Some(PrKind::Ci));
+        assert_eq!(PrKind::parse("refactor"), Some(PrKind::Refactor));
         assert_eq!(PrKind::parse("nope"), None);
         assert_eq!(PrKind::Feature.as_str(), "feature");
         assert_eq!(PrKind::Bug.as_str(), "bug");
+        assert_eq!(PrKind::Chore.as_str(), "chore");
+        assert_eq!(PrKind::Docs.as_str(), "docs");
+        assert_eq!(PrKind::Ci.as_str(), "ci");
+        assert_eq!(PrKind::Refactor.as_str(), "refactor");
     }
 }

--- a/crates/forge-cli/tests/integration/validations.rs
+++ b/crates/forge-cli/tests/integration/validations.rs
@@ -29,7 +29,7 @@ fn validation_kinds_match_spec_catalog() {
     ];
 
     let errs: Vec<&'static str> = vec![
-        branch_name("docs/release").unwrap_err().kind(),
+        branch_name("hotfix/release").unwrap_err().kind(),
         branch_kind_matches(BranchPrefix::Feat, PrKind::Bug)
             .unwrap_err()
             .kind(),

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -68,12 +68,14 @@ pub struct PrefixArgs {
     #[arg(long, default_value = "subagent", value_name = "text")]
     pub owner_prefix: String,
 
-    /// Branch prefix.
-    #[arg(long, default_value = "issue", value_name = "text")]
+    /// Branch prefix. Defaults to `feat` so dispatch lane branches pass the
+    /// `forge-cli` Conventional Commits prefix rule
+    /// (`feat|fix|chore|docs|ci|refactor`).
+    #[arg(long, default_value = "feat", value_name = "text")]
     pub branch_prefix: String,
 
     /// Worktree prefix.
-    #[arg(long, default_value = "issue__", value_name = "text")]
+    #[arg(long, default_value = "feat__", value_name = "text")]
     pub worktree_prefix: String,
 }
 

--- a/crates/plan-issue-cli/src/task_spec.rs
+++ b/crates/plan-issue-cli/src/task_spec.rs
@@ -309,7 +309,7 @@ fn pr_grouping_label(grouping: PrGrouping) -> &'static str {
 fn normalize_branch_prefix(value: &str) -> String {
     let trimmed = value.trim().trim_end_matches('/');
     if trimmed.is_empty() {
-        "issue".to_string()
+        "feat".to_string()
     } else {
         trimmed.to_string()
     }
@@ -318,7 +318,7 @@ fn normalize_branch_prefix(value: &str) -> String {
 fn normalize_worktree_prefix(value: &str) -> String {
     let trimmed = value.trim().trim_end_matches(['-', '_']);
     if trimmed.is_empty() {
-        "issue".to_string()
+        "feat".to_string()
     } else {
         trimmed.to_string()
     }

--- a/crates/plan-issue-cli/tests/integration/live_issue_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_issue_ops.rs
@@ -130,33 +130,33 @@ fn issue_body_with_preface(task_rows: &str) -> String {
 
 fn issue_body_sprint4_planned() -> String {
     issue_body_with_preface(
-        r#"| S3T1 | Implement task-spec generation core using `plan-tooling` | subagent-s3-t1 | issue/s3-t1-implement-task-spec-generation-core-using-plan-t | issue-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.1 |
-| S3T2 | Implement issue-body and sprint-comment rendering engine | subagent-s3-t1 | issue/s3-t1-implement-task-spec-generation-core-using-plan-t | issue-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.2 |
-| S3T3 | Implement independent local dry-run workflow | subagent-s3-t1 | issue/s3-t1-implement-task-spec-generation-core-using-plan-t | issue-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.3 |
-| S4T1 | Implement GitHub adapter abstraction and `gh` backend | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | TBD | planned | sprint=S4; plan-task:Task 4.1; deps=Task 3.3; validate=cargo test -p nils-plan-issue-cli github_adapter; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
-| S4T2 | Implement live plan-level commands | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | TBD | planned | sprint=S4; plan-task:Task 4.2; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_plan_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
-| S4T3 | Implement live sprint-level commands and guide output | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | TBD | planned | sprint=S4; plan-task:Task 4.3; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_sprint_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
+        r#"| S3T1 | Implement task-spec generation core using `plan-tooling` | subagent-s3-t1 | feat/s3-t1-implement-task-spec-generation-core-using-plan-t | feat-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.1 |
+| S3T2 | Implement issue-body and sprint-comment rendering engine | subagent-s3-t1 | feat/s3-t1-implement-task-spec-generation-core-using-plan-t | feat-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.2 |
+| S3T3 | Implement independent local dry-run workflow | subagent-s3-t1 | feat/s3-t1-implement-task-spec-generation-core-using-plan-t | feat-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.3 |
+| S4T1 | Implement GitHub adapter abstraction and `gh` backend | subagent-s4-t1 | feat/s4-t1-implement-github-adapter-abstraction-and-gh-back | feat-s4-t1 | per-sprint | TBD | planned | sprint=S4; plan-task:Task 4.1; deps=Task 3.3; validate=cargo test -p nils-plan-issue-cli github_adapter; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
+| S4T2 | Implement live plan-level commands | subagent-s4-t1 | feat/s4-t1-implement-github-adapter-abstraction-and-gh-back | feat-s4-t1 | per-sprint | TBD | planned | sprint=S4; plan-task:Task 4.2; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_plan_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
+| S4T3 | Implement live sprint-level commands and guide output | subagent-s4-t1 | feat/s4-t1-implement-github-adapter-abstraction-and-gh-back | feat-s4-t1 | per-sprint | TBD | planned | sprint=S4; plan-task:Task 4.3; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_sprint_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
 "#,
     )
 }
 
 fn issue_body_sprint4_in_progress() -> String {
     issue_body_with_preface(
-        r#"| S3T1 | Implement task-spec generation core using `plan-tooling` | subagent-s3-t1 | issue/s3-t1-implement-task-spec-generation-core-using-plan-t | issue-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.1 |
-| S3T2 | Implement issue-body and sprint-comment rendering engine | subagent-s3-t1 | issue/s3-t1-implement-task-spec-generation-core-using-plan-t | issue-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.2 |
-| S3T3 | Implement independent local dry-run workflow | subagent-s3-t1 | issue/s3-t1-implement-task-spec-generation-core-using-plan-t | issue-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.3 |
-| S4T1 | Implement GitHub adapter abstraction and `gh` backend | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | #222 | in-progress | sprint=S4; plan-task:Task 4.1; deps=Task 3.3; validate=cargo test -p nils-plan-issue-cli github_adapter; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
-| S4T2 | Implement live plan-level commands | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | #222 | in-progress | sprint=S4; plan-task:Task 4.2; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_plan_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
-| S4T3 | Implement live sprint-level commands and guide output | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | #222 | in-progress | sprint=S4; plan-task:Task 4.3; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_sprint_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
+        r#"| S3T1 | Implement task-spec generation core using `plan-tooling` | subagent-s3-t1 | feat/s3-t1-implement-task-spec-generation-core-using-plan-t | feat-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.1 |
+| S3T2 | Implement issue-body and sprint-comment rendering engine | subagent-s3-t1 | feat/s3-t1-implement-task-spec-generation-core-using-plan-t | feat-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.2 |
+| S3T3 | Implement independent local dry-run workflow | subagent-s3-t1 | feat/s3-t1-implement-task-spec-generation-core-using-plan-t | feat-s3-t1 | per-sprint | #221 | done | sprint=S3; plan-task:Task 3.3 |
+| S4T1 | Implement GitHub adapter abstraction and `gh` backend | subagent-s4-t1 | feat/s4-t1-implement-github-adapter-abstraction-and-gh-back | feat-s4-t1 | per-sprint | #222 | in-progress | sprint=S4; plan-task:Task 4.1; deps=Task 3.3; validate=cargo test -p nils-plan-issue-cli github_adapter; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
+| S4T2 | Implement live plan-level commands | subagent-s4-t1 | feat/s4-t1-implement-github-adapter-abstraction-and-gh-back | feat-s4-t1 | per-sprint | #222 | in-progress | sprint=S4; plan-task:Task 4.2; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_plan_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
+| S4T3 | Implement live sprint-level commands and guide output | subagent-s4-t1 | feat/s4-t1-implement-github-adapter-abstraction-and-gh-back | feat-s4-t1 | per-sprint | #222 | in-progress | sprint=S4; plan-task:Task 4.3; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_sprint_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
 "#,
     )
 }
 
 fn issue_body_plan_done() -> String {
     issue_body_with_preface(
-        r#"| S4T1 | Implement GitHub adapter abstraction and `gh` backend | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | #222 | done | sprint=S4; plan-task:Task 4.1; deps=Task 3.3; validate=cargo test -p nils-plan-issue-cli github_adapter; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
-| S4T2 | Implement live plan-level commands | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | #222 | done | sprint=S4; plan-task:Task 4.2; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_plan_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
-| S4T3 | Implement live sprint-level commands and guide output | subagent-s4-t1 | issue/s4-t1-implement-github-adapter-abstraction-and-gh-back | issue-s4-t1 | per-sprint | #222 | done | sprint=S4; plan-task:Task 4.3; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_sprint_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
+        r#"| S4T1 | Implement GitHub adapter abstraction and `gh` backend | subagent-s4-t1 | feat/s4-t1-implement-github-adapter-abstraction-and-gh-back | feat-s4-t1 | per-sprint | #222 | done | sprint=S4; plan-task:Task 4.1; deps=Task 3.3; validate=cargo test -p nils-plan-issue-cli github_adapter; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
+| S4T2 | Implement live plan-level commands | subagent-s4-t1 | feat/s4-t1-implement-github-adapter-abstraction-and-gh-back | feat-s4-t1 | per-sprint | #222 | done | sprint=S4; plan-task:Task 4.2; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_plan_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
+| S4T3 | Implement live sprint-level commands and guide output | subagent-s4-t1 | feat/s4-t1-implement-github-adapter-abstraction-and-gh-back | feat-s4-t1 | per-sprint | #222 | done | sprint=S4; plan-task:Task 4.3; deps=Task 4.1; validate=cargo test -p nils-plan-issue-cli live_sprint_commands; pr-grouping=per-sprint; pr-group=s4; shared-pr-anchor=S4T1 |
 "#,
     )
 }
@@ -420,7 +420,7 @@ fn live_sprint_commands_start_ready_accept_and_guide_are_deterministic() {
     let start_spec = fs::read_to_string(start_spec_path).expect("read start task-spec");
     assert!(start_spec.contains("subagent-s4-t1"), "{start_spec}");
     assert!(
-        start_spec.contains("issue/s4-t1-implement-github-adapter-abstraction-and-gh-back"),
+        start_spec.contains("feat/s4-t1-implement-github-adapter-abstraction-and-gh-back"),
         "{start_spec}"
     );
     assert!(


### PR DESCRIPTION
## Summary
- Extend `BranchPrefix`, `PrKind`, and `PrKindFlag` with `chore`, `docs`, `ci`, and `refactor` alongside `feat`/`fix`; `branch_kind_matches` mirrors the six 1:1 pairings.
- Loosen the slug character class to `[a-z0-9.-]` so SemVer release branches such as `chore/release-0.22.1` validate without forcing the bump skill to kebab-case the version.
- Update the rule string, mismatch detail, completion goldens (bash + zsh), `validation_kinds_match_spec_catalog` integration test, and `validations` unit tests for the new whitelist.
- Switch `plan-issue-cli` `--branch-prefix` / `--worktree-prefix` defaults from `issue` / `issue__` to `feat` / `feat__` so dispatch lane branches pass the broadened forge-cli rule out of the box; refresh `live_issue_ops` fixture strings.

## Why
Per #510 F-12: the prior `^(feat|fix)/[a-z0-9][a-z0-9-]{1,63}$` rule rejected (a) `chore/release-X.Y.Z` from the release skill, (b) `.` in the slug (forcing the 0.22.1 release branch to `feat/release-0-22-1`), and (c) the `issue/` lane prefix that `plan-issue start-plan` defaults to. Aligning the prefix whitelist with the Conventional Commits type set + allowing `.` clears all three; switching the plan-issue default to `feat/` removes the surviving lane-branch friction without weakening the forge-cli contract further.

## Test plan
- [x] `cargo test -p nils-forge-cli` (294 lib + 128 integration; new cases for chore/docs/ci/refactor accept paths, dotted slugs, crossed kind/prefix pairs, and extended `PrKind::parse` round-trips).
- [x] `cargo test -p nils-plan-issue-cli` (88 lib + 144 integration; fixture markdown tables and `task_spec` fallbacks track the new defaults).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --no-deps -- -D warnings` clean.
- [x] `cargo check --workspace --locked` clean.
- [ ] Live re-run via the next release verifies the release skill clears branch-name validation without the kebab-case workaround.

Refs #510