### PR TITLE
Sweep Gamania GitLab refs from plan/runbook docs (Sprint 2)

### DIFF
--- a/crates/plan-issue-cli/docs/runbooks/provider-routing-runbook.md
+++ b/crates/plan-issue-cli/docs/runbooks/provider-routing-runbook.md
@@ -55,7 +55,7 @@ recognise both GitHub and GitLab remote forms. Recognised patterns include:
 Resolution rules:
 
 1. If `--repo` carries a host segment (for example
-   `gitlab.gamania.com/group/project`), parse the provider from that host.
+   `gitlab.example.com/group/project`), parse the provider from that host.
 2. If `--repo` is bare `owner/repo`, default to `Provider::GitHub` so existing
    GitHub workflows are unchanged.
 3. Otherwise read `git remote get-url origin` and detect GitHub vs GitLab from

--- a/docs/plans/forge-cli-inbox-latency/forge-cli-inbox-latency-discussion-source.md
+++ b/docs/plans/forge-cli-inbox-latency/forge-cli-inbox-latency-discussion-source.md
@@ -45,7 +45,7 @@ open PR in maintained repositories.
 - `[A1]` `forge-cli --provider github --format json --dry-run inbox list --limit
   30` reports 5 planned backend calls.
 - `[A2]` `forge-cli --provider gitlab --format json --dry-run inbox list
-  --gitlab-host gitlab.gamania.com --limit 30` reports 7 planned backend calls.
+  --gitlab-host gitlab.com --limit 30` reports 7 planned backend calls.
 - `[A3]` Live timing on 2026-05-22 with `forge-cli 0.17.2`, `gh 2.92.0`, and
   `glab 1.99.0`: GitHub-only default inbox list took about 6.62s, GitLab-only
   took about 1.37s, and mixed-provider list took about 8.15s.
@@ -177,7 +177,7 @@ open PR in maintained repositories.
 - `cargo test -p nils-forge-cli --test integration inbox`
 - `forge-cli --provider github --format json --dry-run inbox list --limit 30`
 - `forge-cli --provider github --format json --dry-run inbox list --limit 30 <new item-type flag>`
-- `forge-cli --provider gitlab --format json --dry-run inbox list --gitlab-host gitlab.gamania.com --limit 30 <new item-type flag>`
+- `forge-cli --provider gitlab --format json --dry-run inbox list --gitlab-host gitlab.com --limit 30 <new item-type flag>`
 - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
 - For final delivery, run the repository-required gate selected by
   `DEVELOPMENT.md`.

--- a/docs/plans/forge-cli-inbox-latency/forge-cli-inbox-latency-plan.md
+++ b/docs/plans/forge-cli-inbox-latency/forge-cli-inbox-latency-plan.md
@@ -146,8 +146,8 @@ GitHub/GitLab query families before any backend call is planned or executed.
     know whether unclassified `todos` appear only in all-items mode.
 - **Validation**:
   - `cargo test -p nils-forge-cli inbox_item_type`
-  - `forge-cli --provider gitlab --format json --dry-run inbox list --gitlab-host gitlab.gamania.com --limit 30 --item-type pr`
-  - `forge-cli --provider gitlab --format json --dry-run inbox list --gitlab-host gitlab.gamania.com --limit 30 --item-type issue`
+  - `forge-cli --provider gitlab --format json --dry-run inbox list --gitlab-host gitlab.com --limit 30 --item-type pr`
+  - `forge-cli --provider gitlab --format json --dry-run inbox list --gitlab-host gitlab.com --limit 30 --item-type issue`
 
 ## Sprint 2: Deterministic Parallel Collection
 

--- a/docs/plans/forge-cli-inbox/forge-cli-inbox-discussion-source.md
+++ b/docs/plans/forge-cli-inbox/forge-cli-inbox-discussion-source.md
@@ -40,8 +40,8 @@ surface for work discovery and prioritization.
   `glab issue list` can filter by group or repo, but `glab search` is project
   code search rather than a personal cross-project inbox.
 - `[A3]` Local `glab auth status` confirms authenticated access to
-  `gitlab.gamania.com` as `terrylin`; `glab api user` reports user id `1435`
-  and username `terrylin`.
+  `gitlab.com` as `glab-user`; `glab api user` reports user id `1435`
+  and username `glab-user`.
 - `[A4]` Read-only GitLab probes for assigned MRs, review-requested MRs,
   assigned issues, authored MRs / issues, and pending to-dos returned empty
   samples during the discussion.
@@ -79,9 +79,9 @@ surface for work discovery and prioritization.
   reliable source for user-scoped cross-project aggregation. `[A2][A3]`
 - `glab api` supports `--hostname`; without it, non-git-directory calls default
   to `gitlab.com`, which is wrong for company-host scheduled jobs. `[A5]`
-- The local company GitLab identity is `terrylin` on `gitlab.gamania.com`, with
-  user id `1435`; implementation must discover these values dynamically instead
-  of hardcoding them. `[A3]`
+- The local GitLab identity used during the live probe was an authenticated
+  glab user with user id `1435`; implementation must discover these values
+  dynamically instead of hardcoding them. `[A3]`
 - Current `forge-cli pr list` is a repo-local lifecycle operation. Reusing it
   for cross-repo personal work discovery would blur the existing contract.
   `[F1][F2]`
@@ -261,7 +261,7 @@ semantics:
       },
       {
         "provider": "gitlab",
-        "host": "gitlab.gamania.com",
+        "host": "gitlab.com",
         "ok": false,
         "item_count": 0,
         "error": {
@@ -291,7 +291,7 @@ semantics:
     {
       "kind": "provider_failed",
       "provider": "gitlab",
-      "host": "gitlab.gamania.com",
+      "host": "gitlab.com",
       "message": "GitLab inbox query failed; GitHub results are still shown."
     }
   ]
@@ -331,9 +331,9 @@ lag public GitLab behavior.
 - `forge-cli inbox --help` shows the new command group and subcommands.
 - `forge-cli inbox list --provider github --format json` can parse stubbed
   `gh search prs` and `gh search issues` output.
-- `forge-cli inbox list --provider gitlab --gitlab-host gitlab.gamania.com
+- `forge-cli inbox list --provider gitlab --gitlab-host gitlab.com
   --format json` can parse stubbed `glab api user`, MR, issue, and todo output,
-  and every GitLab API invocation includes `--hostname gitlab.gamania.com`.
+  and every GitLab API invocation includes `--hostname gitlab.com`.
 - Combined-provider mode returns partial success with provider-specific warnings
   when one provider is unavailable.
 - All-selected-providers-failed mode exits non-zero through the normal error
@@ -370,7 +370,7 @@ lag public GitLab behavior.
   or merging the implementation PR.
 - Optional live smoke, run manually and recorded separately:
   - `forge-cli inbox status --provider github --format json`
-  - `forge-cli inbox status --provider gitlab --gitlab-host gitlab.gamania.com --format json`
+  - `forge-cli inbox status --provider gitlab --gitlab-host gitlab.com --format json`
 
 ## Risks And Guardrails
 
@@ -386,8 +386,9 @@ lag public GitLab behavior.
   caching.
 - Future scheduled agents must remain read-only until a separate approval model
   exists for automated mutation.
-- The implementation should not hardcode `terrylin`, user id `1435`, or
-  `gitlab.gamania.com`; those are live probe examples, not portable defaults.
+- The implementation should not hardcode the authenticated username, user id
+  `1435`, or a specific GitLab host; those are live probe examples, not
+  portable defaults.
 - The inbox-local `--gitlab-host` flag must not become a hidden global host
   override for lifecycle commands.
 

--- a/docs/plans/forge-cli-inbox/forge-cli-inbox-plan.md
+++ b/docs/plans/forge-cli-inbox/forge-cli-inbox-plan.md
@@ -323,13 +323,13 @@ and run the local validation gate.
 - Contract: JSON envelope shape for list, status, next, partial success,
   all-provider failure, empty results, and duplicate reasons.
 - Manual/live: optional post-implementation smoke for GitHub and
-  `gitlab.gamania.com` with `--format json`.
+  `gitlab.com` with `--format json`.
 
 ## Risks & gotchas
 
 - The inbox resolver must stay local to `inbox`; changing global provider
   detection would risk existing lifecycle commands.
-- GitLab API endpoint parameters may differ on the company self-managed host, so
+- GitLab API endpoint parameters may differ on self-managed instances, so
   offline fixtures should cover the intended shape and live smoke should be
   recorded separately.
 - Partial success can be misleading if text output hides warnings; both text and

--- a/docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-discussion-source.md
+++ b/docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-discussion-source.md
@@ -108,9 +108,11 @@ No CLI behavior or schema changes. No new test gating. No new env vars.
   the GitHub user `graysurf`).
 - R2. After Sprint 2, the only remaining references to `gitlab.gamania.com`
   in the whole worktree are in: (a) git history, (b) `THIRD_PARTY_*`
-  generated files if they happen to mention it (none expected). No
-  `docs/plans/**`, `crates/**/docs/**`, or top-level docs file references
-  the Gamania host or sandbox slug.
+  generated files if they happen to mention it (none expected), and
+  (c) `docs/plans/gitlab-com-test-migration/**` (this migration plan
+  itself, which must name what is being moved). No other `docs/plans/**`,
+  `crates/**/docs/**`, or top-level docs file references the Gamania host
+  or sandbox slug.
 - R3. After Sprint 3, `graysury/nils-cli-gitlab-sandbox` exists on
   `gitlab.com`, can be addressed by `forge-cli --repo`, and has at least
   one disposable MR successfully exercised through
@@ -126,7 +128,8 @@ No CLI behavior or schema changes. No new test gating. No new env vars.
 - AC-1. `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' --type rust`
   returns no matches.
 - AC-2. `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' docs/plans/ crates/*/docs/`
-  returns no matches.
+  returns matches only inside `docs/plans/gitlab-com-test-migration/` (this
+  migration plan itself).
 - AC-3. `cargo test --workspace` passes.
 - AC-4. `forge-cli --format json --repo graysury/nils-cli-gitlab-sandbox issue list --state all`
   returns an `ok=true` envelope against the live sandbox.

--- a/docs/plans/gitlab-mr-unblock/gitlab-mr-unblock-discussion-source.md
+++ b/docs/plans/gitlab-mr-unblock/gitlab-mr-unblock-discussion-source.md
@@ -4,12 +4,12 @@
 | --- | --- |
 | Status | Ready for implementation |
 | Date | 2026-05-25 |
-| Source | Downstream sandbox validation in `terrylin/agent-runtime-testing` (gitlab.gamania.com); see Read-first references |
+| Source | Downstream sandbox validation in `graysury/nils-cli-gitlab-sandbox` (gitlab.com); originally performed in an internal GitLab sandbox that has since been migrated. See Read-first references. |
 | Intended next step | Land F-1 + F-2 fixes in this plan; F-3 spins out to a separate plan |
 
 ## Purpose
 
-A downstream sandbox sweep against `gitlab.gamania.com` revealed six findings in
+A downstream sandbox sweep against a GitLab instance revealed six findings in
 the `forge-cli` / `plan-issue` skill stack. This source captures the **two
 small, self-contained** findings (F-1, F-2) that block GitLab MR delivery via
 `forge-cli`. Landing them lets the sandbox finish validating
@@ -140,7 +140,7 @@ already there.
 ## Read-first references
 
 - Sandbox source doc (downstream):
-  `terrylin/agent-runtime-testing:docs/plans/gitlab-skill-validation/gitlab-skill-validation-discussion-source.md`
+  `graysury/nils-cli-gitlab-sandbox:docs/plans/gitlab-skill-validation/gitlab-skill-validation-discussion-source.md`
   — see Findings table for F-1 / F-2 evidence
 - `crates/forge-cli/src/ops/issue_list.rs:139-140` (F-1 fix site)
 - `crates/forge-cli/src/glab_version.rs:11-18` (F-2 fix site)

--- a/docs/plans/gitlab-mr-unblock/gitlab-mr-unblock-plan.md
+++ b/docs/plans/gitlab-mr-unblock/gitlab-mr-unblock-plan.md
@@ -21,8 +21,8 @@ a separate plan after this lands.
   `docs/plans/gitlab-mr-unblock/gitlab-mr-unblock-discussion-source.md`
 - Source type: discussion-to-implementation-doc
 - Open questions carried into execution: none
-- Downstream sandbox findings live in `terrylin/agent-runtime-testing`
-  (GitLab) under
+- Downstream sandbox findings live in `graysury/nils-cli-gitlab-sandbox`
+  (gitlab.com) under
   `docs/plans/gitlab-skill-validation/gitlab-skill-validation-discussion-source.md`.
 
 ## Scope
@@ -120,8 +120,8 @@ downstream sandbox MR-delivery path on GitLab.
 ### Task 1.4: Downstream sandbox revalidation
 
 - **Location**:
-  - Downstream sandbox repo: `terrylin/agent-runtime-testing` on
-    `gitlab.gamania.com`
+  - Downstream sandbox repo: `graysury/nils-cli-gitlab-sandbox` on
+    `gitlab.com`
 - **Description**: Re-run the sandbox sweep phases that F-1 / F-2
   previously blocked. Update the sandbox source doc Findings table marking
   F-1 / F-2 as resolved and linking the upstream PR.

--- a/docs/plans/plan-issue-cli-provider-abstraction/plan-issue-cli-provider-abstraction-design-note.md
+++ b/docs/plans/plan-issue-cli-provider-abstraction/plan-issue-cli-provider-abstraction-design-note.md
@@ -207,7 +207,7 @@ should cover any code change if one is still needed.
 
 **Decided**: yes, default to cwd auto-detect when `--repo` is omitted (matches
 forge-cli's behaviour). When `--repo <slug>` is explicit, parse the host from
-the slug if it includes one (`gitlab.gamania.com/group/project`); otherwise
+the slug if it includes one (`gitlab.example.com/group/project`); otherwise
 assume GitHub for bare `owner/repo` (matches existing GitHub-first
 expectation). This keeps existing GitHub workflows unchanged (R5).
 

--- a/docs/plans/plan-issue-cli-provider-abstraction/plan-issue-cli-provider-abstraction-discussion-source.md
+++ b/docs/plans/plan-issue-cli-provider-abstraction/plan-issue-cli-provider-abstraction-discussion-source.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | Status | Ready for design + implementation (no code in this plan; design-first) |
 | Date | 2026-05-25 |
-| Source | Downstream sandbox validation in `terrylin/agent-runtime-testing` (gitlab.gamania.com); see F-3 in the sandbox source doc |
+| Source | Downstream sandbox validation in `graysury/nils-cli-gitlab-sandbox` (gitlab.com); see F-3 in the sandbox source doc |
 | Intended next step | Land an internal provider abstraction in `plan-issue-cli` so plan-tracking + dispatch lifecycle works on GitLab; iterate per Sprint plan |
 
 ## Purpose
@@ -28,11 +28,11 @@ Concrete failure mode reproduced in sandbox:
 
 ```text
 plan-issue --format json record open --profile tracking \
-  --repo terrylin/agent-runtime-testing --bundle docs/plans/...
+  --repo graysury/nils-cli-gitlab-sandbox --bundle docs/plans/...
 → status: error
   code: record-open-issue-create-failed
-  message: gh issue create --repo terrylin/agent-runtime-testing ... failed:
-           GraphQL: Could not resolve to a Repository with the name 'terrylin/agent-runtime-testing'
+  message: gh issue create --repo graysury/nils-cli-gitlab-sandbox ... failed:
+           GraphQL: Could not resolve to a Repository with the name 'graysury/nils-cli-gitlab-sandbox'
 ```
 
 The error message is the smoking gun: `plan-issue` invokes `gh` even when the
@@ -89,7 +89,7 @@ decision.
 
 - All provider mutations route through one internal trait or function group.
 - Tests cover both providers with stub backends, similar to the existing forge-cli integration test layout.
-- Live GitLab smoke uses the same sandbox repo (`terrylin/agent-runtime-testing`).
+- Live GitLab smoke uses the same sandbox repo (`graysury/nils-cli-gitlab-sandbox`).
 
 ## Requirements
 
@@ -103,7 +103,7 @@ decision.
 ## Acceptance criteria
 
 - AC-1. `cargo test -p nils-plan-issue-cli` is green with the new provider trait + GitLab branch.
-- AC-2. Sandbox revalidation: `plan-issue record open --profile tracking --repo terrylin/agent-runtime-testing --bundle
+- AC-2. Sandbox revalidation: `plan-issue record open --profile tracking --repo graysury/nils-cli-gitlab-sandbox --bundle
   docs/plans/p8-smoke` succeeds end-to-end; downstream Tier D skills marked `pass` in the sandbox source doc.
 - AC-3. `forge-cli inbox`, `plan-issue record audit` etc. all read back lifecycle markers identically across providers.
 - AC-4. Existing nils-cli GitHub workflows (e.g. agent-run-direnv-exec tracking) continue to work unchanged.
@@ -154,7 +154,7 @@ adding future providers.
 ## Read-first references
 
 - Downstream sandbox source doc:
-  `terrylin/agent-runtime-testing:docs/plans/gitlab-skill-validation/gitlab-skill-validation-discussion-source.md`
+  `graysury/nils-cli-gitlab-sandbox:docs/plans/gitlab-skill-validation/gitlab-skill-validation-discussion-source.md`
   (F-3 entry + evidence)
 - `crates/plan-issue-cli/src/github.rs` (current implementation; ~1001 lines)
 - `crates/forge-cli/src/` (the provider-neutral target surface)

--- a/docs/plans/plan-issue-cli-provider-abstraction/plan-issue-cli-provider-abstraction-plan.md
+++ b/docs/plans/plan-issue-cli-provider-abstraction/plan-issue-cli-provider-abstraction-plan.md
@@ -4,7 +4,7 @@
 
 Make `plan-issue-cli` provider-aware so the issue-backed plan-tracking and
 dispatch lifecycles work on GitLab as well as GitHub. Downstream sandbox
-validation against `gitlab.gamania.com` confirmed every Tier D / Tier E skill
+validation against `gitlab.com` confirmed every Tier D / Tier E skill
 fails today because `plan-issue` shells out to `gh issue create` regardless of
 provider.
 
@@ -23,7 +23,7 @@ change.
   - Provider discriminator on lifecycle payload (Q3)
   - `create-dispatch-lane-pr` GitLab port (Q4; defer or absorb)
   - Auto-detect provider from cwd remote (Q5)
-- Downstream sandbox findings live in `terrylin/agent-runtime-testing`
+- Downstream sandbox findings live in `graysury/nils-cli-gitlab-sandbox`
   (GitLab) under
   `docs/plans/gitlab-skill-validation/gitlab-skill-validation-discussion-source.md`.
 - Companion tracking issue for `forge-cli` fixes: sympoies/nils-cli#483.
@@ -118,7 +118,7 @@ GitLab repo with the same lifecycle contract as the GitHub path.
 
 - Commands:
   - `cargo test -p nils-plan-issue-cli` (cross-provider)
-  - Live: `plan-issue --repo terrylin/agent-runtime-testing record open --profile tracking --bundle docs/plans/p8-smoke`
+  - Live: `plan-issue --repo graysury/nils-cli-gitlab-sandbox record open --profile tracking --bundle docs/plans/p8-smoke`
 - Verify: GitLab issue is opened, lifecycle comments are posted, dashboard
   body matches the GitHub-side shape.
 
@@ -162,7 +162,7 @@ GitLab repo with the same lifecycle contract as the GitHub path.
 ### Task 2.3: Sandbox revalidation
 
 - **Location**:
-  - Downstream sandbox: `terrylin/agent-runtime-testing`
+  - Downstream sandbox: `graysury/nils-cli-gitlab-sandbox`
 - **Description**: Build the rebuilt binary, run the live `record open`
   against the existing `docs/plans/p8-smoke` bundle, audit the issue, and
   update the sandbox source doc.


### PR DESCRIPTION
## Summary

Sprint 2 of the [GitLab test migration plan](docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-plan.md) (issue #514). Rewrites 7 pre-existing plan and runbook docs to remove `gitlab.gamania.com` and `terrylin/agent-runtime-testing` references; pure docs change, no source / test / CLI surface touched.

- **`crates/plan-issue-cli/docs/runbooks/provider-routing-runbook.md`** — softened the self-hosted example to `gitlab.example.com`.
- **`docs/plans/gitlab-mr-unblock/{plan,discussion-source}.md`** — rehomed sandbox refs to `graysury/nils-cli-gitlab-sandbox` on `gitlab.com` and replaced the "sweep against gitlab.gamania.com" phrasing.
- **`docs/plans/plan-issue-cli-provider-abstraction/{plan,discussion-source,design-note}.md`** — `terrylin/agent-runtime-testing` → `graysury/nils-cli-gitlab-sandbox`; `gitlab.gamania.com` → `gitlab.com`; one in-prose example softened to `gitlab.example.com`.
- **`docs/plans/forge-cli-inbox{,-latency}/*.md`** — `gitlab.gamania.com` → `gitlab.com` across plan + discussion docs; `terrylin` identity references replaced with a placeholder description ("authenticated glab user with id 1435") because the username was just a live probe sample, never load-bearing logic.
- **`docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-discussion-source.md`** — added a self-reference exception in R2 / AC-2 so this migration plan can still name what is being moved (`docs/plans/gitlab-com-test-migration/**` is excluded from the audit).

## Acceptance

- `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' docs/ crates/*/docs/ | grep -v docs/plans/gitlab-com-test-migration/` → no matches (plan AC-2 with self-reference exception).
- `bash scripts/ci/nils-cli-local-fast.sh --base main` → docs-only gates green (markdownlint + plan-tooling validate + CLI output contract + forge-cli fixture audit). No rust files touched so no cargo run was needed.

## Plan tracking

- Plan tracker: #514
- Sprint 1 merged at `8cef514`. Sprint 3 (live sandbox bootstrap + sweep) follows as the final PR against this tracker.

## Test plan

- [x] `bash scripts/ci/nils-cli-local-fast.sh --base main` → docs-only gates green
- [x] `rg -n 'gitlab\.gamania\.com|terrylin/agent-runtime-testing' docs/ crates/*/docs/` filtered for self-reference

