### PR TITLE
Move local release install helper

### DIFF
--- a/.agents/skills/nils-cli-install-local-release-binaries/SKILL.md
+++ b/.agents/skills/nils-cli-install-local-release-binaries/SKILL.md
@@ -34,4 +34,4 @@ Exit codes:
 
 ## Scripts (only entrypoints)
 
-- `.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh`
+- `scripts/install-local-release-binaries.sh`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,4 +49,4 @@
 
 - Recommended tooling bootstrap: `scripts/setup-rust-tooling.sh`
 - Local release install helper:
-  `./.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh`
+  `./scripts/install-local-release-binaries.sh`

--- a/BINARY_DEPENDENCIES.md
+++ b/BINARY_DEPENDENCIES.md
@@ -84,7 +84,7 @@ in `crates/*/src`.
 These are repository scripts (not third-party packages):
 
 - Install workspace binaries:
-  - `./.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh`
+  - `./scripts/install-local-release-binaries.sh`
 - Run default local changed-scope checks:
   - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
 - Run full CI parity checks when needed locally:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -242,5 +242,5 @@ Canonical completion policy and validation workflow:
 Build and install workspace binaries into `~/.local/nils-cli/`:
 
 ```bash
-./.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh
+./scripts/install-local-release-binaries.sh
 ```

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ Use [DEVELOPMENT.md](DEVELOPMENT.md) as the canonical checklist.
 ## Local install (release)
 
 - Build + install all workspace binaries into `~/.local/nils-cli/`:
-  - `./.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh`
+  - `./scripts/install-local-release-binaries.sh`
 - Install only a specific binary:
-  - `./.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh --bin git-scope`
+  - `./scripts/install-local-release-binaries.sh --bin git-scope`
 - Add the install dir to `PATH` (example):
   - `export PATH="$HOME/.local/nils-cli:$PATH"`
 

--- a/scripts/install-local-release-binaries.sh
+++ b/scripts/install-local-release-binaries.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  nils-cli-install-local-release-binaries.sh [--help] [--prefix PATH] [--bin NAME]... [--skip-build]
+  install-local-release-binaries.sh [--help] [--prefix PATH] [--bin NAME]... [--skip-build]
 
 Builds the Rust workspace in release mode and installs the binaries into a local
 directory (default: ~/.local/nils-cli).
@@ -20,9 +20,9 @@ Default binaries:
   - Use --bin NAME (repeatable) to install a subset
 
 Example:
-  ./.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh
-  ./.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh --bin git-scope
-  ./.agents/skills/nils-cli-install-local-release-binaries/scripts/nils-cli-install-local-release-binaries.sh --prefix ~/.local/nils-cli
+  ./scripts/install-local-release-binaries.sh
+  ./scripts/install-local-release-binaries.sh --bin git-scope
+  ./scripts/install-local-release-binaries.sh --prefix ~/.local/nils-cli
 USAGE
 }
 


### PR DESCRIPTION
## Summary

Moves the local release binary install helper from the project-local skill tree into the root `scripts/` directory and updates the repo docs and skill reference to use the canonical helper path.

## Changes

- Relocates `nils-cli-install-local-release-binaries.sh` to `scripts/install-local-release-binaries.sh`.
- Updates `AGENTS.md`, `BINARY_DEPENDENCIES.md`, `DEVELOPMENT.md`, `README.md`, and the project-local skill to reference the root script.

## Test-First Evidence

- Waiver: this is a committed script relocation and documentation/reference update, so a failing behavioral test before the move was not practical.

## Test plan

- PASS: `AGENT_DOCS_HOME=/Users/terry/Project/graysurf/agent-runtime-kit agent-docs resolve --context startup --strict --format checklist`
- PASS: `AGENT_DOCS_HOME=/Users/terry/Project/graysurf/agent-runtime-kit agent-docs resolve --context project-dev --strict --format checklist`
- PASS: `agent-run exec --cwd /Users/terry/.codex/worktrees/2b25/nils-cli -- bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`

## Risk / Notes

- Low risk: the script content is preserved and references now point at the root helper path.
