### PR TITLE
Backfill gitlab-com-test-migration execution-state.md

### DIFF
--- a/docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-execution-state.md
+++ b/docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-execution-state.md
@@ -13,29 +13,29 @@
 - Discussion source document: docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-discussion-source.md
 - Tracking issue: sympoies/nils-cli#514 (closed)
 - Linked PRs: #515 (Sprint 1), #519 (Sprint 2), #521 (Sprint 3)
-- Source snapshot: https://github.com/sympoies/nils-cli/issues/514#issuecomment-4531553693
-- Plan snapshot: https://github.com/sympoies/nils-cli/issues/514#issuecomment-4531553879
-- Initial execution state snapshot: https://github.com/sympoies/nils-cli/issues/514#issuecomment-4531554068
+- Source snapshot: <https://github.com/sympoies/nils-cli/issues/514#issuecomment-4531553693>
+- Plan snapshot: <https://github.com/sympoies/nils-cli/issues/514#issuecomment-4531553879>
+- Initial execution state snapshot: <https://github.com/sympoies/nils-cli/issues/514#issuecomment-4531554068>
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger
 
-| ID | Status | Task | Evidence | Notes |
-| --- | --- | --- | --- | --- |
-| Task 1.1 | complete | `forge-cli/src/ops/issue_view.rs` fixture swap to gitlab.com / graysury sandbox slug | PR #515 | self-hosted doc comments at lines 141, 409 sanitized; 8 URL fixtures + host expectation updated |
-| Task 1.2 | complete | `forge-cli/src/ops/pr_comments.rs` fixture swap | PR #515 | 3 MR URL fixtures + `Some(...)` slug expectation updated |
-| Task 1.3 | complete | `plan-issue-cli/src/provider.rs` fixture swap | PR #515 | 5 fixture occurrences + line 57 comment; redundant `classify_host("gitlab.gamania.com")` case removed |
-| Task 1.4 | complete | `auth status` tests decoupled from a specific username | PR #515 | integration drops `data.user` asserts; unit asserts tightened in follow-up commit `8da0864` against `testuser-*` placeholders |
-| Task 1.5 | complete | `pr_deliver_chain.rs` + `exit_codes.rs` stub stderr aligned to placeholder username | PR #515 | |
-| Task 1.6 | complete | Sprint 1 audit + workspace test | PR #515 | `bash scripts/ci/nils-cli-local-fast.sh --base main` 225 tests passed; `rg` audit zero matches in `crates/` |
-| Task 2.1 | complete | `crates/plan-issue-cli/docs/runbooks/provider-routing-runbook.md` rewrite | PR #519 | self-hosted example softened to `gitlab.example.com` |
-| Task 2.2 | complete | `docs/plans/gitlab-mr-unblock/{plan,discussion-source}.md` rewrite | PR #519 | host + slug rehomed; narrative preserved |
-| Task 2.3 | complete | `docs/plans/plan-issue-cli-provider-abstraction/{plan,discussion-source,design-note}.md` rewrite | PR #519 | one in-prose example softened to `gitlab.example.com` |
-| Task 2.4 | complete | `docs/plans/forge-cli-inbox{,-latency}/*.md` rewrite | PR #519 | host swapped to `gitlab.com`; `terrylin` identity references rephrased; AC self-reference exception added |
-| Task 2.5 | complete | Sprint 2 audit + local-fast CI | PR #519 | docs-only gates green (markdownlint + plan-tooling validate + CLI output contract + forge-cli fixture audit) |
-| Task 3.1 | complete | Create `graysury/nils-cli-gitlab-sandbox` on gitlab.com | PR #521 | project id `82523245`, private, default branch `main`; initial README + disposable feature branch seeded via GitLab REST API |
-| Task 3.2 | complete | Live `forge-cli` GitLab-arm sweep | PR #521 | issue list / auth status / MR create+view+close all `ok=true`; envelopes retained under `evidence/sprint-3-sweep/` |
-| Task 3.3 | complete | Final consolidation + PR readiness | PR #521 | auth-status user redacted to `<authenticated-user>` to keep no-pinned-identity intent consistent with Sprint 1 |
+| ID       | Status   | Task                                                                                             | Evidence | Notes                                                                                                                         |
+| -------- | -------- | ------------------------------------------------------------------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Task 1.1 | complete | `forge-cli/src/ops/issue_view.rs` fixture swap to gitlab.com / graysury sandbox slug             | PR #515  | self-hosted doc comments at lines 141, 409 sanitized; 8 URL fixtures + host expectation updated                               |
+| Task 1.2 | complete | `forge-cli/src/ops/pr_comments.rs` fixture swap                                                  | PR #515  | 3 MR URL fixtures + `Some(...)` slug expectation updated                                                                      |
+| Task 1.3 | complete | `plan-issue-cli/src/provider.rs` fixture swap                                                    | PR #515  | 5 fixture occurrences + line 57 comment; redundant `classify_host("gitlab.gamania.com")` case removed                         |
+| Task 1.4 | complete | `auth status` tests decoupled from a specific username                                           | PR #515  | integration drops `data.user` asserts; unit asserts tightened in follow-up commit `8da0864` against `testuser-*` placeholders |
+| Task 1.5 | complete | `pr_deliver_chain.rs` + `exit_codes.rs` stub stderr aligned to placeholder username              | PR #515  |                                                                                                                               |
+| Task 1.6 | complete | Sprint 1 audit + workspace test                                                                  | PR #515  | `bash scripts/ci/nils-cli-local-fast.sh --base main` 225 tests passed; `rg` audit zero matches in `crates/`                   |
+| Task 2.1 | complete | `crates/plan-issue-cli/docs/runbooks/provider-routing-runbook.md` rewrite                        | PR #519  | self-hosted example softened to `gitlab.example.com`                                                                          |
+| Task 2.2 | complete | `docs/plans/gitlab-mr-unblock/{plan,discussion-source}.md` rewrite                               | PR #519  | host + slug rehomed; narrative preserved                                                                                      |
+| Task 2.3 | complete | `docs/plans/plan-issue-cli-provider-abstraction/{plan,discussion-source,design-note}.md` rewrite | PR #519  | one in-prose example softened to `gitlab.example.com`                                                                         |
+| Task 2.4 | complete | `docs/plans/forge-cli-inbox{,-latency}/*.md` rewrite                                             | PR #519  | host swapped to `gitlab.com`; `terrylin` identity references rephrased; AC self-reference exception added                     |
+| Task 2.5 | complete | Sprint 2 audit + local-fast CI                                                                   | PR #519  | docs-only gates green (markdownlint + plan-tooling validate + CLI output contract + forge-cli fixture audit)                  |
+| Task 3.1 | complete | Create `graysury/nils-cli-gitlab-sandbox` on gitlab.com                                          | PR #521  | project id `82523245`, private, default branch `main`; initial README + disposable feature branch seeded via GitLab REST API  |
+| Task 3.2 | complete | Live `forge-cli` GitLab-arm sweep                                                                | PR #521  | issue list / auth status / MR create+view+close all `ok=true`; envelopes retained under `evidence/sprint-3-sweep/`            |
+| Task 3.3 | complete | Final consolidation + PR readiness                                                               | PR #521  | auth-status user redacted to `<authenticated-user>` to keep no-pinned-identity intent consistent with Sprint 1                |
 
 ## Validation
 
@@ -59,4 +59,9 @@
 - 2026-05-25 — Sprint 2 PR #519 merged at `f0d3ca9` (plan / runbook docs sweep).
 - 2026-05-25 — Sprint 3 PR #521 merged at `55fadd4` (gitlab.com sandbox bootstrap + live forge-cli sweep).
 - 2026-05-25 — `plan-issue record close` accepted with all three PRs linked; issue #514 closed and labelled `state::closed`.
-- 2026-05-25 — Backfilled this execution-state file (operator-error recovery: it was referenced by the discussion source's `Recommended execution state:` pointer but never landed during the original delivery, which is why the initial `record open` state comment surfaced no visible task table — the structured task payload was still captured correctly in the hex-encoded marker so `record audit` and `record close` ran cleanly).
+- 2026-05-25 — Backfilled this execution-state file (operator-error recovery: it
+  was referenced by the discussion source's `Recommended execution state:`
+  pointer but never landed during the original delivery, which is why the
+  initial `record open` state comment surfaced no visible task table — the
+  structured task payload was still captured correctly in the hex-encoded
+  marker so `record audit` and `record close` ran cleanly).

--- a/docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-execution-state.md
+++ b/docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-execution-state.md
@@ -1,0 +1,62 @@
+# GitLab Test Migration Execution State
+
+## Current State
+
+- Status: complete
+- Target scope: whole plan (Sprints 1–3)
+- Execution window: 2026-05-25
+- Current task: complete
+- Next task: none
+- Last updated: 2026-05-25
+- Branch/commit: `main` after `55fadd4`
+- Source document: docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-plan.md
+- Discussion source document: docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-discussion-source.md
+- Tracking issue: sympoies/nils-cli#514 (closed)
+- Linked PRs: #515 (Sprint 1), #519 (Sprint 2), #521 (Sprint 3)
+- Source snapshot: https://github.com/sympoies/nils-cli/issues/514#issuecomment-4531553693
+- Plan snapshot: https://github.com/sympoies/nils-cli/issues/514#issuecomment-4531553879
+- Initial execution state snapshot: https://github.com/sympoies/nils-cli/issues/514#issuecomment-4531554068
+- Direct source-doc execution waiver: not applicable
+
+## Task Ledger
+
+| ID | Status | Task | Evidence | Notes |
+| --- | --- | --- | --- | --- |
+| Task 1.1 | complete | `forge-cli/src/ops/issue_view.rs` fixture swap to gitlab.com / graysury sandbox slug | PR #515 | self-hosted doc comments at lines 141, 409 sanitized; 8 URL fixtures + host expectation updated |
+| Task 1.2 | complete | `forge-cli/src/ops/pr_comments.rs` fixture swap | PR #515 | 3 MR URL fixtures + `Some(...)` slug expectation updated |
+| Task 1.3 | complete | `plan-issue-cli/src/provider.rs` fixture swap | PR #515 | 5 fixture occurrences + line 57 comment; redundant `classify_host("gitlab.gamania.com")` case removed |
+| Task 1.4 | complete | `auth status` tests decoupled from a specific username | PR #515 | integration drops `data.user` asserts; unit asserts tightened in follow-up commit `8da0864` against `testuser-*` placeholders |
+| Task 1.5 | complete | `pr_deliver_chain.rs` + `exit_codes.rs` stub stderr aligned to placeholder username | PR #515 | |
+| Task 1.6 | complete | Sprint 1 audit + workspace test | PR #515 | `bash scripts/ci/nils-cli-local-fast.sh --base main` 225 tests passed; `rg` audit zero matches in `crates/` |
+| Task 2.1 | complete | `crates/plan-issue-cli/docs/runbooks/provider-routing-runbook.md` rewrite | PR #519 | self-hosted example softened to `gitlab.example.com` |
+| Task 2.2 | complete | `docs/plans/gitlab-mr-unblock/{plan,discussion-source}.md` rewrite | PR #519 | host + slug rehomed; narrative preserved |
+| Task 2.3 | complete | `docs/plans/plan-issue-cli-provider-abstraction/{plan,discussion-source,design-note}.md` rewrite | PR #519 | one in-prose example softened to `gitlab.example.com` |
+| Task 2.4 | complete | `docs/plans/forge-cli-inbox{,-latency}/*.md` rewrite | PR #519 | host swapped to `gitlab.com`; `terrylin` identity references rephrased; AC self-reference exception added |
+| Task 2.5 | complete | Sprint 2 audit + local-fast CI | PR #519 | docs-only gates green (markdownlint + plan-tooling validate + CLI output contract + forge-cli fixture audit) |
+| Task 3.1 | complete | Create `graysury/nils-cli-gitlab-sandbox` on gitlab.com | PR #521 | project id `82523245`, private, default branch `main`; initial README + disposable feature branch seeded via GitLab REST API |
+| Task 3.2 | complete | Live `forge-cli` GitLab-arm sweep | PR #521 | issue list / auth status / MR create+view+close all `ok=true`; envelopes retained under `evidence/sprint-3-sweep/` |
+| Task 3.3 | complete | Final consolidation + PR readiness | PR #521 | auth-status user redacted to `<authenticated-user>` to keep no-pinned-identity intent consistent with Sprint 1 |
+
+## Validation
+
+| Command | Status | Summary | Artifact |
+| --- | --- | --- | --- |
+| `bash scripts/ci/nils-cli-local-fast.sh --base main` | pass | green on Sprint 1 (225 tests), Sprint 2 (docs-only gates), Sprint 3 (workspace rust gate) | n/a |
+| `cargo test -p nils-forge-cli` | pass | green in isolation; 234 tests on Sprint 1 head | n/a |
+| `cargo test -p nils-plan-issue-cli` | pass | green via local-fast nextest on Sprint 1 head | n/a |
+| `rg -n 'gitlab\.gamania\.com\|terrylin/agent-runtime-testing' --type rust` | pass | zero matches after Sprint 1 (plan AC-1) | n/a |
+| `rg -n 'gitlab\.gamania\.com\|terrylin/agent-runtime-testing' docs/ crates/*/docs/ \| grep -v docs/plans/gitlab-com-test-migration/` | pass | zero matches after Sprint 2; migration plan retains the names per the documented self-reference exception (plan AC-2) | n/a |
+| Live forge-cli sweep against `graysury/nils-cli-gitlab-sandbox` | pass | 5 envelopes `ok=true`; no `glab_version_unsupported` or `repo_not_found` (plan AC-4 + AC-5) | `evidence/sprint-3-sweep/` |
+| `cargo test --workspace` | waived | pre-existing parallel-test concurrency flake (`git command failed to spawn`); each failing test passes in isolation; canonical CI gate is `nils-cli-local-fast.sh`, which is unaffected | n/a |
+
+## Blockers
+
+- none
+
+## Session Log
+
+- 2026-05-25 — Sprint 1 PR #515 merged at `8cef514` (source fixture migration + auth-status decoupling).
+- 2026-05-25 — Sprint 2 PR #519 merged at `f0d3ca9` (plan / runbook docs sweep).
+- 2026-05-25 — Sprint 3 PR #521 merged at `55fadd4` (gitlab.com sandbox bootstrap + live forge-cli sweep).
+- 2026-05-25 — `plan-issue record close` accepted with all three PRs linked; issue #514 closed and labelled `state::closed`.
+- 2026-05-25 — Backfilled this execution-state file (operator-error recovery: it was referenced by the discussion source's `Recommended execution state:` pointer but never landed during the original delivery, which is why the initial `record open` state comment surfaced no visible task table — the structured task payload was still captured correctly in the hex-encoded marker so `record audit` and `record close` ran cleanly).


### PR DESCRIPTION
## Summary

Backfills the `gitlab-com-test-migration-execution-state.md` file that the plan bundle's discussion source has pointed at since plan tracker [#514](https://github.com/sympoies/nils-cli/issues/514) opened. The file was never landed during the original delivery, which is why the initial `record open` state comment ([#514 comment 4531554068](https://github.com/sympoies/nils-cli/issues/514#issuecomment-4531554068)) surfaced no visible task table — the structured task payload was still captured correctly in the hex-encoded marker, so `record audit` and `record close` ran cleanly.

This PR is a docs-only follow-up. No code, no behavior change. The tracker is already closed; this is just bringing the bundle to the canonical shape future contributors expect.

- New file: `docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-execution-state.md` with `## Current State` (status `complete`, linked PRs, snapshot URLs), a full task ledger (14 of 14 done with evidence + notes), a validation table, blockers section, and a session log.

## Acceptance

- ✅ `bash scripts/ci/nils-cli-local-fast.sh --base main` — docs-only gates green.
- ✅ `plan-tooling validate --file docs/plans/gitlab-com-test-migration/gitlab-com-test-migration-plan.md` — `ok=true`.
- ✅ Markdownlint: 20 issues auto-fixed by `rumdl fmt`; the remaining MD013 (long session-log line) wrapped manually.

## Test plan

- [x] `bash scripts/ci/nils-cli-local-fast.sh --base main`
- [x] `plan-tooling validate ... --format json`
