### PR TITLE
feat(skills): modernize project skill delivery

### DIFF
--- a/.agents/skills/nils-cli-deliver-high-value-refactors/SKILL.md
+++ b/.agents/skills/nils-cli-deliver-high-value-refactors/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nils-cli-deliver-high-value-refactors
-description: Find and implement high-value test/stability/shared-foundation refactors across crates, then deliver via deliver-feature-pr.
+description: Find and implement high-value test/stability/shared-foundation refactors across crates, then deliver through the current GitHub PR workflow.
 ---
 
 # Nils CLI Deliver High Value Refactors
@@ -11,10 +11,12 @@ Prereqs:
 
 - Run inside the `nils-cli` git work tree.
 - Rust toolchain available on `PATH` (`cargo`, `rustfmt`, `clippy`).
-- `git`, `gh`, `semantic-commit`, and `git-scope` available when delivering the PR end-to-end.
+- `git`, `gh`, `agent-runtime`, `forge-cli`, `semantic-commit`, and
+  `review-specialists` available when delivering the PR end-to-end.
 - Use this skill together with:
-  - `$deliver-feature-pr` as the canonical delivery policy.
-  - `$create-feature-pr` and `$close-feature-pr` through `$deliver-feature-pr`.
+  - `$deliver-github-pr` as the canonical delivery policy.
+  - `$create-github-pr` / `$close-github-pr` only when the delivery workflow
+    explicitly needs a narrower PR lifecycle surface.
 
 Inputs:
 
@@ -27,10 +29,13 @@ Inputs:
 Outputs:
 
 - One of two outcomes:
-  - `Implement`: at least one high-value refactor is implemented with tests and validation evidence, then delivered via `$deliver-feature-pr`.
+  - `Implement`: at least one high-value refactor is implemented with tests and
+    validation evidence, then delivered via `$deliver-github-pr`.
   - `No Action`: no high-value target found; return concrete recommendations and potential issue list.
 - Reporting split (strict):
-  - `Implement`: use `$deliver-feature-pr` delivery contract end-to-end (open PR, wait CI green, close PR).
+  - `Implement`: use `$deliver-github-pr` delivery contract end-to-end
+    (open PR, wait checks, run the required review gate, merge unless
+    explicitly stopped with `--no-merge`).
   - `No Action`: use `.agents/skills/nils-cli-deliver-high-value-refactors/references/NO_ACTION_RESPONSE_TEMPLATE.md`.
 
 Exit codes:
@@ -50,7 +55,8 @@ Failure modes:
 ## Scripts (only entrypoints)
 
 - `.agents/skills/nils-cli-deliver-high-value-refactors/scripts/render-refactor-response-template.sh` (`No Action` response only)
-- `$AGENT_HOME/skills/workflows/pr/feature/deliver-feature-pr/scripts/deliver-feature-pr.sh` (`Implement` delivery only)
+- Implement delivery uses the released CLIs directly through `$deliver-github-pr`;
+  do not call a skill-owned or runtime-home delivery script.
 
 ## Workflow
 
@@ -102,23 +108,42 @@ Failure modes:
 
 6. Delivery (required for implemented changes)
 
-- Run branch-intent preflight:
-  - `deliver-feature-pr.sh preflight --base main`
-- Use `$create-feature-pr` to create branch/commit/open PR from confirmed base branch.
-- Wait for GitHub required checks to become fully green:
-  - `deliver-feature-pr.sh wait-ci --pr <number>`
-- If checks fail, fix on the same feature branch, push, and re-run `wait-ci` until green.
-- Close after CI is green:
-  - `deliver-feature-pr.sh close --pr <number>`
-- The `Implement` branch is not complete until `$deliver-feature-pr` workflow finishes successfully.
+- Confirm the working tree contains only the intended refactor change set. If
+  the active checkout has unrelated dirty state, isolate the work in a clean
+  sibling worktree from `main`.
+- Create or reuse a feature branch from the confirmed `main` base. Use
+  lowercase, hyphenated names such as `feat/<slug>` unless the active project
+  rules require a more specific prefix.
+- Commit with `semantic-commit`; direct `git commit` is not the delivery path.
+- Render the PR body with `agent-runtime pr-body render`, including concrete
+  `## Summary` and `## Test plan` content grounded in the actual diff and
+  validation evidence.
+- Deliver through `$deliver-github-pr` / `forge-cli pr deliver`:
+  - open a PR against `main`;
+  - wait for required provider checks;
+  - run the mandatory `code-review-pre-merge-gate` scope with at least
+    `testing` and `maintainability`;
+  - repair concrete findings on the same branch and rerun affected validation;
+  - merge through `forge-cli pr merge` unless the user explicitly requested
+    `--no-merge`.
+- After delivery, restore branch/worktree state:
+  - in the primary checkout, switch back to `main`;
+  - in a linked or temporary worktree, do not leave `main` checked out; detach
+    the worktree at `HEAD` or remove the worktree after confirming no local
+    changes remain.
+- The `Implement` branch is not complete until the PR URL, check state, review
+  gate outcome, merge or `--no-merge` stop state, and final branch/worktree
+  state are known.
 
 7. Response contract (always required)
 
-- `Implement` path: report `$deliver-feature-pr` artifacts:
+- `Implement` path: report `$deliver-github-pr` artifacts:
   - PR URL
-  - CI status summary
-  - merge commit SHA
-  - final branch state
-- `No Action` path: use the no-action template with concrete recommendation list and potential issues.
+  - check status summary
+  - pre-merge review gate outcome
+  - merge commit SHA, or the explicit `--no-merge` stop state
+  - final branch/worktree state
+- `No Action` path: use the no-action template with concrete recommendation
+  list and potential issues; do not open a PR when no repo changes were made.
 - Render helpers:
   - `./.agents/skills/nils-cli-deliver-high-value-refactors/scripts/render-refactor-response-template.sh --mode no-action`

--- a/.agents/skills/nils-cli-deliver-high-value-refactors/references/IMPLEMENTATION_RESPONSE_TEMPLATE.md
+++ b/.agents/skills/nils-cli-deliver-high-value-refactors/references/IMPLEMENTATION_RESPONSE_TEMPLATE.md
@@ -28,3 +28,7 @@
 ## Delivery
 - Branch:
 - PR:
+- Checks:
+- Review gate:
+- Merge commit or stop state:
+- Final branch/worktree state:

--- a/.agents/skills/nils-cli-deliver-high-value-refactors/references/NO_ACTION_RESPONSE_TEMPLATE.md
+++ b/.agents/skills/nils-cli-deliver-high-value-refactors/references/NO_ACTION_RESPONSE_TEMPLATE.md
@@ -25,5 +25,5 @@
 - What could not be verified:
 
 ## Delivery
-- Branch:
-- PR:
+- PR: Not opened; no repo changes were made.
+- Final branch/worktree state:

--- a/.agents/skills/nils-cli-dispatch-crates-io-publish/SKILL.md
+++ b/.agents/skills/nils-cli-dispatch-crates-io-publish/SKILL.md
@@ -47,7 +47,10 @@ Outputs:
   - selected crate list and versions,
   - crates.io status snapshot metadata (json/text path + status).
 - Default report path:
-- `$AGENT_HOME/out/crates-io-publish-report-<timestamp>.md`
+  - a project run directory from
+    `agent-out project --topic crates-io-publish --mkdir`, when available;
+  - otherwise
+    `${CLAUDE_KIT_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit}/out/crates-io-publish/`.
 - Default status snapshot outputs:
   - `${report_file%.md}.status.json`
   - `${report_file%.md}.status.md`

--- a/.agents/skills/nils-cli-dispatch-crates-io-publish/scripts/publish-crates-io.sh
+++ b/.agents/skills/nils-cli-dispatch-crates-io-publish/scripts/publish-crates-io.sh
@@ -466,9 +466,17 @@ if errors:
 PY
 
 if [[ -z "$report_file" ]]; then
-  agent_home="${AGENT_HOME:-$HOME/.agents}"
   timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
-  report_file="${agent_home}/out/crates-io-publish-report-${timestamp}.md"
+  report_dir=""
+  if command -v agent-out >/dev/null 2>&1; then
+    report_dir="$(agent-out project --topic crates-io-publish --mkdir 2>/dev/null || true)"
+  fi
+  if [[ -z "$report_dir" ]]; then
+    state_home="${CLAUDE_KIT_STATE_HOME:-${XDG_STATE_HOME:-$HOME/.local/state}/agent-runtime-kit}"
+    report_dir="${state_home}/out/crates-io-publish"
+    mkdir -p "$report_dir"
+  fi
+  report_file="${report_dir}/crates-io-publish-report-${timestamp}.md"
 fi
 mkdir -p "$(dirname "$report_file")"
 

--- a/.agents/skills/nils-cli-dispatch-crates-io-publish/tests/test_publish_crates_io.sh
+++ b/.agents/skills/nils-cli-dispatch-crates-io-publish/tests/test_publish_crates_io.sh
@@ -135,6 +135,25 @@ MOCK
   chmod +x "${dir}/gh"
 }
 
+create_mock_agent_out() {
+  local dir="$1"
+  cat > "${dir}/agent-out" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "project" ]]; then
+  out_dir="${MOCK_AGENT_OUT_DIR:?MOCK_AGENT_OUT_DIR is required}"
+  mkdir -p "$out_dir"
+  printf '%s\n' "$out_dir"
+  exit 0
+fi
+
+echo "unexpected agent-out command: $*" >&2
+exit 1
+MOCK
+  chmod +x "${dir}/agent-out"
+}
+
 create_mock_status_script() {
   local dir="$1"
   cat > "${dir}/crates-io-status.sh" <<'MOCK'
@@ -263,6 +282,30 @@ test_dry_run_no_wait_dispatches_workflow() {
   assert_contains "$report" 'Status snapshot: `skipped`'
 }
 
+test_default_report_file_uses_agent_out_project_dir() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local repo="${tmp}/repo"
+  local bin_dir="${tmp}/bin"
+  local report_dir="${tmp}/agent-out-run"
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo"
+  create_mock_cargo "$bin_dir"
+  create_mock_gh "$bin_dir"
+  create_mock_agent_out "$bin_dir"
+
+  PATH="${bin_dir}:$PATH" \
+    MOCK_AGENT_OUT_DIR="$report_dir" \
+    "$entrypoint" --crate nils-a --dry-run-only --no-wait \
+    >"${tmp}/stdout.log" 2>"${tmp}/stderr.log"
+
+  local report
+  report="$(find "$report_dir" -type f -name 'crates-io-publish-report-*.md' -print -quit)"
+  [[ -n "$report" ]] || fail "expected default report under agent-out project dir"
+  assert_contains "$report" 'Mode: `dry-run`'
+  assert_contains "$report" 'Status snapshot: `skipped`'
+}
+
 if [[ ! -f "${skill_root}/SKILL.md" ]]; then
   echo "error: missing SKILL.md" >&2
   exit 1
@@ -279,5 +322,6 @@ fi
 test_publish_wait_success
 test_publish_wait_failure
 test_dry_run_no_wait_dispatches_workflow
+test_default_report_file_uses_agent_out_project_dir
 
 echo "ok: project skill smoke checks passed"

--- a/.agents/skills/nils-cli-maintain-test-coverage/SKILL.md
+++ b/.agents/skills/nils-cli-maintain-test-coverage/SKILL.md
@@ -33,6 +33,9 @@ Outputs:
   not only the percentage.
 - Focused validation for touched crates/tests, followed by fresh coverage
   evidence from CI or an explicit local coverage run when the change is ready.
+- When the workflow creates repository changes, a PR delivery path using
+  `semantic-commit`, `$deliver-github-pr`, and `forge-cli pr deliver` unless the
+  user explicitly requested local-only maintenance.
 - Follow-up issue evidence only when a clear bug or unresolved work is found
   outside the coverage-maintenance scope.
 
@@ -131,11 +134,33 @@ NILS_CLI_TEST_RUNNER=nextest \
   bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage
 ```
 
+6. Deliver changed repo state through PR.
+
+- If the workflow produced test or product-code changes, confirm the working
+  tree contains only the intended coverage-maintenance change set. Use a clean
+  sibling worktree from `main` when the active checkout has unrelated dirty
+  state.
+- Commit with `semantic-commit`; direct `git commit` is not the delivery path.
+- Render the PR body with `agent-runtime pr-body render`. Put the coverage
+  artifact path, hotspot summary, focused test commands, local-fast result, and
+  any explicit coverage run in `## Test plan`.
+- Deliver through `$deliver-github-pr` / `forge-cli pr deliver` against `main`.
+  Wait for required checks and the required pre-merge review gate unless the
+  user explicitly requested `--no-merge`.
+- After delivery, restore branch/worktree state:
+  - in the primary checkout, switch back to `main`;
+  - in a linked or temporary worktree, do not leave `main` checked out; detach
+    the worktree at `HEAD` or remove the worktree after confirming no local
+    changes remain.
+- If no repo changes were made, do not open a PR; report the coverage evidence
+  and rejected candidates instead.
+
 ## Boundary
 
 This skill guides coverage-maintenance work only. It does not lower the 85%
 coverage gate, edit CI thresholds, broaden snapshots for percentage-only gains,
-or require follow-up issues when no clear bug or unresolved work exists. If
-hotspot extraction needs to become a stable repository command, first extract
-that deterministic behavior into released `nils-cli` tooling and keep this
-skill as the orchestration layer.
+or require follow-up issues when no clear bug or unresolved work exists. PR
+delivery is limited to the coverage-maintenance changes this workflow created.
+If hotspot extraction needs to become a stable repository command, first
+extract that deterministic behavior into released `nils-cli` tooling and keep
+this skill as the orchestration layer.


### PR DESCRIPTION
## Summary

Modernizes the project-local skill guidance so implementation-oriented nils-cli skills deliver through the current `deliver-github-pr` / `forge-cli pr deliver` path instead of the retired runtime-home helper assumptions. It also moves the crates.io publish report default away from `AGENT_HOME` and covers the new `agent-out` default path with a smoke test.

## Changes

- Replaced the high-value refactor skill's retired `$deliver-feature-pr` contract with `deliver-github-pr`, `semantic-commit`, rendered PR bodies, pre-merge review gates, and branch/worktree cleanup rules.
- Added PR delivery expectations to the coverage-maintenance skill when it creates repository changes.
- Updated crates.io publish reporting to prefer `agent-out project --topic crates-io-publish --mkdir`, with a state-home fallback, and added a regression test for the default report path.

## Test-First Evidence

Test-first waiver: this is a workflow documentation and shell helper cleanup. I first inspected the affected skills and existing smoke tests, then added the crates.io publish regression coverage alongside the helper change before running focused and repo-local validation.

## Test plan

- PASS: `bash .agents/skills/nils-cli-deliver-high-value-refactors/tests/test_render_refactor_response_template.sh`
- PASS: `bash .agents/skills/nils-cli-dispatch-crates-io-publish/tests/test_publish_crates_io.sh`
- PASS: `bash .agents/skills/nils-cli-maintain-test-coverage/tests/test_coverage_hotspots.sh`
- PASS: `bash -n .agents/skills/nils-cli-dispatch-crates-io-publish/scripts/publish-crates-io.sh .agents/skills/nils-cli-dispatch-crates-io-publish/tests/test_publish_crates_io.sh`
- PASS: `git diff --check`
- PASS: `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (docs checks, shell syntax, `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run --profile ci --workspace` with 3746 passed, and doctests)

## Risk / Notes

- Low risk: changes are limited to project-local skill guidance and one skill-owned publish helper default path.
- Dependabot delivery still uses raw `gh pr` lifecycle calls and was intentionally left for a separate follow-up instead of being mixed into this PR.
