### PR TITLE
Render plan issue lifecycle evidence visibly

### DIFF
--- a/crates/plan-issue-cli/src/commands/record.rs
+++ b/crates/plan-issue-cli/src/commands/record.rs
@@ -61,6 +61,13 @@ pub enum LifecycleCommentKind {
     Closeout,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
+pub enum TaskLedgerDisplay {
+    Auto,
+    Collapsed,
+    Expanded,
+}
+
 impl LifecycleCommentKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -192,9 +199,25 @@ pub struct RecordPostArgs {
     #[arg(long = "payload-file", value_name = "path")]
     pub payload_file: Option<PathBuf>,
 
+    /// Markdown execution-state document for state lifecycle comments.
+    #[arg(
+        long = "execution-state-file",
+        value_name = "path",
+        conflicts_with = "summary_file"
+    )]
+    pub execution_state_file: Option<PathBuf>,
+
     /// Visible Markdown commentary appended after the structured payload.
     #[arg(long = "summary-file", value_name = "path")]
     pub summary_file: Option<PathBuf>,
+
+    /// Task Ledger display mode for state lifecycle comments.
+    #[arg(
+        long = "task-ledger-display",
+        value_enum,
+        default_value_t = TaskLedgerDisplay::Auto
+    )]
+    pub task_ledger_display: TaskLedgerDisplay,
 
     /// Add a label alongside the lifecycle comment in live mode. Repeatable.
     #[arg(long = "add-label", value_name = "NAME")]

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -951,6 +951,22 @@ fn run_record_post(
         }
         _ => {}
     }
+    if args.execution_state_file.is_some()
+        && args.kind != crate::commands::record::LifecycleCommentKind::State
+    {
+        return Err(CommandError::usage(
+            "record-post-execution-state-file-kind-invalid",
+            "`record post --execution-state-file` is only valid with `--kind state`",
+        ));
+    }
+    if args.kind != crate::commands::record::LifecycleCommentKind::State
+        && args.task_ledger_display != crate::commands::record::TaskLedgerDisplay::Auto
+    {
+        return Err(CommandError::usage(
+            "record-post-task-ledger-display-kind-invalid",
+            "`record post --task-ledger-display` is only configurable with `--kind state`",
+        ));
+    }
 
     let payload_data = match &args.payload_file {
         Some(path) => read_payload_data(path)?,
@@ -966,16 +982,38 @@ fn run_record_post(
             ),
         )
     })?;
-    let summary = match &args.summary_file {
-        Some(path) => Some(read_text_file(path, "record-post-summary-read-failed")?),
-        None => None,
+    let summary = match (&args.execution_state_file, &args.summary_file) {
+        (Some(path), None) => {
+            let text = read_text_file(path, "record-post-execution-state-read-failed")?;
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                return Err(CommandError::usage(
+                    "record-post-execution-state-empty",
+                    format!("execution-state file {} is empty", path.display()),
+                ));
+            }
+            if !trimmed.contains("## Task Ledger") {
+                return Err(CommandError::usage(
+                    "record-post-execution-state-task-ledger-missing",
+                    format!(
+                        "execution-state file {} must contain `## Task Ledger`",
+                        path.display()
+                    ),
+                ));
+            }
+            Some(text)
+        }
+        (None, Some(path)) => Some(read_text_file(path, "record-post-summary-read-failed")?),
+        (None, None) => None,
+        (Some(_), Some(_)) => unreachable!("clap conflicts_with prevents both summary inputs"),
     };
-    let body = lifecycle_record::render_record_post_comment(
+    let body = lifecycle_record::render_record_post_comment_with_display(
         args.profile,
         args.kind,
         payload_data,
         summary.as_deref(),
         None,
+        args.task_ledger_display,
     )
     .map_err(|err| CommandError::runtime("record-post-render-failed", err))?;
 

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -1360,6 +1360,17 @@ fn run_record_close(
             "observed_non_required_failures": observed_failures,
         })
     });
+    let final_validation_url = audit
+        .evidence
+        .get("validation")
+        .and_then(|hit| hit.url.clone());
+    let closeout_notes = if linked_evidence.is_empty() {
+        Some(
+            "No linked PRs were provided; closeout relied on issue-visible state, validation, review, and approval evidence.",
+        )
+    } else {
+        None
+    };
     let closeout_payload = json!({
         "final_status": "complete",
         "approval": {"comment_url": approval_text},
@@ -1378,7 +1389,8 @@ fn run_record_close(
             })
             .collect::<Vec<_>>(),
         "non_required_check_override": override_block,
-        "notes": null,
+        "final_validation_url": final_validation_url,
+        "notes": closeout_notes,
     });
     let closeout_summary = if override_reason.is_some() {
         "Strict closeout gate passed with non-required-check failure override; record closed by `plan-issue record close`."

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -1557,7 +1557,6 @@ pub fn render_record_post_comment_with_display(
     out.push(format!("## {heading}"));
     out.push(String::new());
     out.push(format!("- Profile: {}", profile.as_str()));
-    out.push(String::new());
     out.push(visible_content);
     out.push(String::new());
     out.push(envelope_carrier);
@@ -1637,6 +1636,7 @@ fn render_state_markdown_with_task_ledger_display(
     display: TaskLedgerDisplay,
     state: &StateData,
 ) -> Result<String, String> {
+    let markdown = normalize_state_markdown_for_comment(markdown)?;
     let effective = match display {
         TaskLedgerDisplay::Expanded => TaskLedgerDisplay::Expanded,
         TaskLedgerDisplay::Collapsed => TaskLedgerDisplay::Collapsed,
@@ -1649,10 +1649,10 @@ fn render_state_markdown_with_task_ledger_display(
         }
     };
     if effective == TaskLedgerDisplay::Expanded {
-        return Ok(markdown.trim().to_string());
+        return Ok(markdown);
     }
 
-    let lines: Vec<&str> = markdown.trim().lines().collect();
+    let lines: Vec<&str> = markdown.lines().collect();
     let Some(start) = lines
         .iter()
         .position(|line| line.trim() == "## Task Ledger")
@@ -1692,6 +1692,39 @@ fn render_state_markdown_with_task_ledger_display(
     Ok(finalize_markdown(out).trim().to_string())
 }
 
+fn normalize_state_markdown_for_comment(markdown: &str) -> Result<String, String> {
+    let stripped = markdown
+        .trim()
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.starts_with("<!-- plan-issue-record:")
+                && !trimmed.starts_with("<!-- execute-from-tracking-issue:")
+        })
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let Some(execution_heading) = stripped
+        .iter()
+        .position(|line| line.trim() == "## Execution State")
+    else {
+        return Err("execution-state markdown is missing `## Execution State`".to_string());
+    };
+
+    let mut out = stripped
+        .into_iter()
+        .skip(execution_heading + 1)
+        .filter(|line| !line.trim().starts_with("- Profile:"))
+        .collect::<Vec<_>>();
+    while out.first().is_some_and(|line| line.trim().is_empty()) {
+        out.remove(0);
+    }
+    let normalized = finalize_markdown(out).trim().to_string();
+    if normalized.is_empty() {
+        return Err("execution-state markdown has no visible state content".to_string());
+    }
+    Ok(normalized)
+}
+
 fn is_terminal_state(state: &StateData) -> bool {
     state.status == Some(StateStatus::Complete)
         && state
@@ -1713,14 +1746,14 @@ fn render_state_payload_visible(state: &StateData) -> String {
         out.push(format!("- Target scope: {value}"));
     }
     if let Some(value) = state.current.as_deref().filter(|value| !value.is_empty()) {
-        out.push(format!("- Current: {value}"));
+        out.push(format!("- Current task: {value}"));
     }
     if let Some(value) = state
         .next_action
         .as_deref()
         .filter(|value| !value.is_empty())
     {
-        out.push(format!("- Next action: {value}"));
+        out.push(format!("- Next task: {value}"));
     }
     if !state.tasks.is_empty() {
         out.push(String::new());

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -1938,8 +1938,10 @@ fn render_closeout_payload_visible(closeout: &CloseoutData) -> String {
             ));
         }
     }
-    if !closeout.linked_prs.is_empty() {
-        out.push(String::new());
+    out.push(String::new());
+    if closeout.linked_prs.is_empty() {
+        out.push("- Linked PRs: none".to_string());
+    } else {
         out.push("| PR | Merge SHA | Checks | Required | Non-required failures |".to_string());
         out.push("| --- | --- | --- | --- | --- |".to_string());
         for pr in &closeout.linked_prs {
@@ -2930,6 +2932,24 @@ mod sprint3_tests {
         assert!(
             closeout.contains("- Observed failures: owner/repo#1: opt-in/lint"),
             "{closeout}"
+        );
+
+        let no_pr_closeout = render_record_post_comment(
+            RecordProfile::Tracking,
+            LifecycleCommentKind::Closeout,
+            json!({
+                "final_status": "complete",
+                "approval": {"comment_url": "https://example.test/approval"},
+                "linked_prs": [],
+                "notes": "closed without linked PR"
+            }),
+            Some("Closeout summary."),
+            None,
+        )
+        .expect("closeout render");
+        assert!(
+            no_pr_closeout.contains("- Linked PRs: none"),
+            "{no_pr_closeout}"
         );
     }
 

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::commands::record::{LifecycleCommentKind, RecordProfile};
+use crate::commands::record::{LifecycleCommentKind, RecordProfile, TaskLedgerDisplay};
 
 #[derive(Debug, Clone)]
 pub struct DashboardInput {
@@ -1109,6 +1109,8 @@ pub struct CloseoutData {
     #[serde(default)]
     pub linked_prs: Vec<LinkedPrEvidence>,
     #[serde(default)]
+    pub non_required_check_override: Option<Value>,
+    #[serde(default)]
     pub final_validation_url: Option<String>,
     #[serde(default)]
     pub notes: Option<String>,
@@ -1507,6 +1509,24 @@ pub fn render_record_post_comment(
     summary: Option<&str>,
     updated_at: Option<&str>,
 ) -> Result<String, String> {
+    render_record_post_comment_with_display(
+        profile,
+        kind,
+        payload_data,
+        summary,
+        updated_at,
+        TaskLedgerDisplay::Auto,
+    )
+}
+
+pub fn render_record_post_comment_with_display(
+    profile: RecordProfile,
+    kind: LifecycleCommentKind,
+    payload_data: Value,
+    summary: Option<&str>,
+    updated_at: Option<&str>,
+    task_ledger_display: TaskLedgerDisplay,
+) -> Result<String, String> {
     if matches!(
         kind,
         LifecycleCommentKind::Source | LifecycleCommentKind::Plan
@@ -1517,6 +1537,8 @@ pub fn render_record_post_comment(
         ));
     }
 
+    let visible_content =
+        render_visible_post_content(kind, &payload_data, summary, task_ledger_display)?;
     let envelope = RecordPayload {
         schema: PAYLOAD_SCHEMA_V2.to_string(),
         role: payload_role_for_kind(kind),
@@ -1535,13 +1557,442 @@ pub fn render_record_post_comment(
     out.push(format!("## {heading}"));
     out.push(String::new());
     out.push(format!("- Profile: {}", profile.as_str()));
-    if let Some(text) = summary.map(str::trim).filter(|value| !value.is_empty()) {
-        out.push(String::new());
-        out.push(text.to_string());
-    }
+    out.push(String::new());
+    out.push(visible_content);
     out.push(String::new());
     out.push(envelope_carrier);
     Ok(finalize_markdown(out))
+}
+
+fn render_visible_post_content(
+    kind: LifecycleCommentKind,
+    payload_data: &Value,
+    summary: Option<&str>,
+    task_ledger_display: TaskLedgerDisplay,
+) -> Result<String, String> {
+    let summary = summary.map(str::trim).filter(|value| !value.is_empty());
+    let generated = match kind {
+        LifecycleCommentKind::State => {
+            let state = serde_json::from_value::<StateData>(payload_data.clone())
+                .map_err(|err| format!("state payload invalid for visible rendering: {err}"))?;
+            match summary {
+                Some(text) if text.contains("## Task Ledger") => {
+                    render_state_markdown_with_task_ledger_display(
+                        text,
+                        task_ledger_display,
+                        &state,
+                    )?
+                }
+                Some(text) => text.to_string(),
+                None => render_state_payload_visible(&state),
+            }
+        }
+        LifecycleCommentKind::Session => {
+            let session = serde_json::from_value::<SessionData>(payload_data.clone())
+                .map_err(|err| format!("session payload invalid for visible rendering: {err}"))?;
+            combine_summary_and_generated(
+                summary,
+                render_session_payload_visible(&session, payload_data),
+            )
+        }
+        LifecycleCommentKind::Validation => {
+            let validation = serde_json::from_value::<ValidationData>(payload_data.clone())
+                .map_err(|err| {
+                    format!("validation payload invalid for visible rendering: {err}")
+                })?;
+            combine_summary_and_generated(summary, render_validation_payload_visible(&validation))
+        }
+        LifecycleCommentKind::Review => {
+            let review = serde_json::from_value::<ReviewData>(payload_data.clone())
+                .map_err(|err| format!("review payload invalid for visible rendering: {err}"))?;
+            combine_summary_and_generated(summary, render_review_payload_visible(&review))
+        }
+        LifecycleCommentKind::Closeout => {
+            let closeout = serde_json::from_value::<CloseoutData>(payload_data.clone())
+                .map_err(|err| format!("closeout payload invalid for visible rendering: {err}"))?;
+            combine_summary_and_generated(summary, render_closeout_payload_visible(&closeout))
+        }
+        LifecycleCommentKind::Source | LifecycleCommentKind::Plan => unreachable!(),
+    };
+
+    if generated.trim().is_empty() {
+        return Err(format!(
+            "`record post --kind {}` would render no visible lifecycle content",
+            kind.as_str()
+        ));
+    }
+    Ok(generated)
+}
+
+fn combine_summary_and_generated(summary: Option<&str>, generated: String) -> String {
+    match (summary, generated.trim().is_empty()) {
+        (Some(text), false) => format!("{}\n\n{}", text.trim(), generated.trim()),
+        (Some(text), true) => text.trim().to_string(),
+        (None, _) => generated,
+    }
+}
+
+fn render_state_markdown_with_task_ledger_display(
+    markdown: &str,
+    display: TaskLedgerDisplay,
+    state: &StateData,
+) -> Result<String, String> {
+    let effective = match display {
+        TaskLedgerDisplay::Expanded => TaskLedgerDisplay::Expanded,
+        TaskLedgerDisplay::Collapsed => TaskLedgerDisplay::Collapsed,
+        TaskLedgerDisplay::Auto => {
+            if is_terminal_state(state) {
+                TaskLedgerDisplay::Expanded
+            } else {
+                TaskLedgerDisplay::Collapsed
+            }
+        }
+    };
+    if effective == TaskLedgerDisplay::Expanded {
+        return Ok(markdown.trim().to_string());
+    }
+
+    let lines: Vec<&str> = markdown.trim().lines().collect();
+    let Some(start) = lines
+        .iter()
+        .position(|line| line.trim() == "## Task Ledger")
+    else {
+        return Err("execution-state markdown is missing `## Task Ledger`".to_string());
+    };
+    let end = lines
+        .iter()
+        .enumerate()
+        .skip(start + 1)
+        .find_map(|(idx, line)| {
+            if line.starts_with("## ") {
+                Some(idx)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(lines.len());
+    let body = lines[start + 1..end].join("\n").trim().to_string();
+    if body.is_empty() {
+        return Err("execution-state Task Ledger section is empty".to_string());
+    }
+
+    let mut out = Vec::new();
+    out.extend(lines[..=start].iter().map(|line| (*line).to_string()));
+    out.push(String::new());
+    out.push("<details>".to_string());
+    out.push("<summary>Show task ledger</summary>".to_string());
+    out.push(String::new());
+    out.push(body);
+    out.push(String::new());
+    out.push("</details>".to_string());
+    if end < lines.len() {
+        out.push(String::new());
+        out.extend(lines[end..].iter().map(|line| (*line).to_string()));
+    }
+    Ok(finalize_markdown(out).trim().to_string())
+}
+
+fn is_terminal_state(state: &StateData) -> bool {
+    state.status == Some(StateStatus::Complete)
+        && state
+            .tasks
+            .iter()
+            .all(|task| matches!(task.status, TaskRowStatus::Done | TaskRowStatus::Deferred))
+}
+
+fn render_state_payload_visible(state: &StateData) -> String {
+    let mut out = Vec::new();
+    if let Some(status) = state.status {
+        out.push(format!("- Status: {}", status_state_label(status)));
+    }
+    if let Some(value) = state
+        .target_scope
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        out.push(format!("- Target scope: {value}"));
+    }
+    if let Some(value) = state.current.as_deref().filter(|value| !value.is_empty()) {
+        out.push(format!("- Current: {value}"));
+    }
+    if let Some(value) = state
+        .next_action
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        out.push(format!("- Next action: {value}"));
+    }
+    if !state.tasks.is_empty() {
+        out.push(String::new());
+        out.push("## Task Ledger".to_string());
+        out.push(String::new());
+        out.push("| ID | Status | Task |".to_string());
+        out.push("| --- | --- | --- |".to_string());
+        for task in &state.tasks {
+            out.push(format!(
+                "| {} | {} | {} |",
+                table_cell(&task.id),
+                table_cell(task_row_status_label(task.status)),
+                table_cell(task.title.as_deref().unwrap_or(""))
+            ));
+        }
+    }
+    finalize_markdown(out).trim().to_string()
+}
+
+fn render_session_payload_visible(session: &SessionData, raw: &Value) -> String {
+    let mut out = vec![format!("- Summary: {}", session.summary.trim())];
+    if !session.highlights.is_empty() {
+        out.push(String::new());
+        out.push("### Highlights".to_string());
+        out.push(String::new());
+        for item in &session.highlights {
+            out.push(format!("- {}", item.trim()));
+        }
+    }
+    if !session.links.is_empty() {
+        out.push(String::new());
+        out.push("### Links".to_string());
+        out.push(String::new());
+        for (key, value) in &session.links {
+            out.push(format!("- {}: {}", key.trim(), value.trim()));
+        }
+    }
+    if let Some(object) = raw.as_object() {
+        let extras = object
+            .iter()
+            .filter(|(key, value)| {
+                !matches!(key.as_str(), "summary" | "highlights" | "links") && !value.is_null()
+            })
+            .collect::<Vec<_>>();
+        if !extras.is_empty() {
+            out.push(String::new());
+            out.push("### Session Fields".to_string());
+            out.push(String::new());
+            for (key, value) in extras {
+                out.push(format!("- {}: {}", key.trim(), visible_value(value)));
+            }
+        }
+    }
+    finalize_markdown(out).trim().to_string()
+}
+
+fn render_validation_payload_visible(validation: &ValidationData) -> String {
+    let mut out = vec![format!(
+        "- Overall: {}",
+        validation_overall_label(validation.overall)
+    )];
+    if !validation.commands.is_empty() {
+        out.push(String::new());
+        out.push("| Command | Status | Evidence |".to_string());
+        out.push("| --- | --- | --- |".to_string());
+        for command in &validation.commands {
+            out.push(format!(
+                "| {} | {} | {} |",
+                table_cell(&command.command),
+                table_cell(validation_command_status_label(command.status)),
+                table_cell(command.evidence.as_deref().unwrap_or(""))
+            ));
+        }
+    }
+    if !validation.waivers.is_empty() {
+        out.push(String::new());
+        out.push("### Waivers".to_string());
+        out.push(String::new());
+        for waiver in &validation.waivers {
+            out.push(format!(
+                "- `{}`: {}",
+                waiver.command.trim(),
+                waiver.reason.trim()
+            ));
+        }
+    }
+    finalize_markdown(out).trim().to_string()
+}
+
+fn render_review_payload_visible(review: &ReviewData) -> String {
+    let mut out = vec![format!(
+        "- Decision: {}",
+        review_decision_label(review.decision)
+    )];
+    if !review.lenses.is_empty() {
+        out.push(format!("- Lenses: {}", review.lenses.join(", ")));
+    }
+    if let Some(url) = review
+        .outcome_comment_url
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        out.push(format!("- Outcome comment: {}", url.trim()));
+    }
+    if !review.findings.is_empty() {
+        out.push(String::new());
+        out.push("| ID | Severity | Disposition | Summary |".to_string());
+        out.push("| --- | --- | --- | --- |".to_string());
+        for finding in &review.findings {
+            out.push(format!(
+                "| {} | {} | {} | {} |",
+                table_cell(&finding.id),
+                table_cell(finding_severity_label(finding.severity)),
+                table_cell(finding_disposition_label(finding.disposition)),
+                table_cell(&finding.summary)
+            ));
+        }
+    }
+    finalize_markdown(out).trim().to_string()
+}
+
+fn render_closeout_payload_visible(closeout: &CloseoutData) -> String {
+    let mut out = vec![format!("- Final status: {}", closeout.final_status.trim())];
+    if let Some(approver) = closeout
+        .approval
+        .approver
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        out.push(format!("- Approver: {}", approver.trim()));
+    }
+    if let Some(url) = closeout
+        .approval
+        .comment_url
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        out.push(format!("- Approval: {}", url.trim()));
+    }
+    if let Some(url) = closeout
+        .final_validation_url
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        out.push(format!("- Final validation: {}", url.trim()));
+    }
+    if let Some(notes) = closeout
+        .notes
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        out.push(format!("- Notes: {}", notes.trim()));
+    }
+    if let Some(override_block) = closeout
+        .non_required_check_override
+        .as_ref()
+        .filter(|value| !value.is_null())
+    {
+        out.push(String::new());
+        out.push("### Non-required Check Override".to_string());
+        out.push(String::new());
+        if let Some(reason) = override_block
+            .get("reason")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+        {
+            out.push(format!("- Reason: {}", reason.trim()));
+        }
+        if let Some(failures) = override_block
+            .get("observed_non_required_failures")
+            .and_then(Value::as_array)
+            .filter(|items| !items.is_empty())
+        {
+            out.push(format!(
+                "- Observed failures: {}",
+                failures
+                    .iter()
+                    .map(visible_value)
+                    .filter(|value| !value.trim().is_empty())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
+    if !closeout.linked_prs.is_empty() {
+        out.push(String::new());
+        out.push("| PR | Merge SHA | Checks | Required | Non-required failures |".to_string());
+        out.push("| --- | --- | --- | --- | --- |".to_string());
+        for pr in &closeout.linked_prs {
+            let pr_label = pr.url.as_deref().unwrap_or(&pr.pr_ref);
+            let required = pr
+                .required_state
+                .map(check_status_label)
+                .unwrap_or("unknown");
+            let required_count = pr
+                .required_count
+                .map(|count| format!(" ({count})"))
+                .unwrap_or_default();
+            out.push(format!(
+                "| {} | {} | {} | {}{} | {} |",
+                table_cell(pr_label),
+                table_cell(pr.merge_sha.as_deref().unwrap_or("")),
+                table_cell(check_status_label(pr.checks)),
+                table_cell(required),
+                required_count,
+                table_cell(&non_empty_join(&pr.non_required_failures, "none"))
+            ));
+        }
+    }
+    finalize_markdown(out).trim().to_string()
+}
+
+fn task_row_status_label(status: TaskRowStatus) -> &'static str {
+    match status {
+        TaskRowStatus::Pending => "pending",
+        TaskRowStatus::InProgress => "in-progress",
+        TaskRowStatus::Done => "done",
+        TaskRowStatus::Deferred => "deferred",
+    }
+}
+
+fn validation_command_status_label(status: ValidationCommandStatus) -> &'static str {
+    match status {
+        ValidationCommandStatus::Pass => "pass",
+        ValidationCommandStatus::Fail => "fail",
+        ValidationCommandStatus::Skipped => "skipped",
+    }
+}
+
+fn finding_severity_label(severity: FindingSeverity) -> &'static str {
+    match severity {
+        FindingSeverity::Blocker => "blocker",
+        FindingSeverity::Major => "major",
+        FindingSeverity::Minor => "minor",
+        FindingSeverity::Nit => "nit",
+    }
+}
+
+fn finding_disposition_label(disposition: FindingDisposition) -> &'static str {
+    match disposition {
+        FindingDisposition::Fixed => "fixed",
+        FindingDisposition::Residual => "residual",
+        FindingDisposition::FollowUp => "follow-up",
+        FindingDisposition::Deferred => "deferred",
+        FindingDisposition::NoAction => "no-action",
+    }
+}
+
+fn check_status_label(status: CheckStatus) -> &'static str {
+    match status {
+        CheckStatus::Pass => "pass",
+        CheckStatus::Fail => "fail",
+        CheckStatus::None => "none",
+    }
+}
+
+fn table_cell(value: &str) -> String {
+    value.trim().replace('|', "\\|").replace('\n', "<br>")
+}
+
+fn visible_value(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.trim().to_string(),
+        Value::Array(items) => items
+            .iter()
+            .map(visible_value)
+            .collect::<Vec<_>>()
+            .join(", "),
+        Value::Object(_) => value.to_string(),
+        Value::Null => String::new(),
+        _ => value.to_string(),
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -2357,6 +2808,96 @@ mod sprint3_tests {
         assert_eq!(payload.schema, PAYLOAD_SCHEMA_V2);
         assert_eq!(payload.role, PayloadRole::State);
         assert!(body.contains("session summary"), "{body}");
+    }
+
+    #[test]
+    fn render_record_post_comment_synthesizes_validation_review_and_closeout() {
+        let validation = render_record_post_comment(
+            RecordProfile::Tracking,
+            LifecycleCommentKind::Validation,
+            json!({
+                "overall": "pass",
+                "commands": [{"command": "cargo test", "status": "pass", "evidence": "ok"}],
+                "waivers": []
+            }),
+            None,
+            None,
+        )
+        .expect("validation render");
+        assert!(validation.contains("- Overall: pass"), "{validation}");
+        assert!(
+            validation.contains("| cargo test | pass | ok |"),
+            "{validation}"
+        );
+        assert!(validation.contains(PAYLOAD_COMMENT_PREFIX), "{validation}");
+
+        let review = render_record_post_comment(
+            RecordProfile::Tracking,
+            LifecycleCommentKind::Review,
+            json!({
+                "decision": "approve",
+                "lenses": ["testing", "maintainability"],
+                "findings": [{
+                    "id": "F1",
+                    "severity": "minor",
+                    "disposition": "fixed",
+                    "summary": "covered"
+                }],
+                "outcome_comment_url": "https://example.test/review"
+            }),
+            None,
+            None,
+        )
+        .expect("review render");
+        assert!(review.contains("- Decision: approve"), "{review}");
+        assert!(
+            review.contains("- Lenses: testing, maintainability"),
+            "{review}"
+        );
+        assert!(
+            review.contains("| F1 | minor | fixed | covered |"),
+            "{review}"
+        );
+
+        let closeout = render_record_post_comment(
+            RecordProfile::Tracking,
+            LifecycleCommentKind::Closeout,
+            json!({
+                "final_status": "complete",
+                "approval": {"comment_url": "https://example.test/approval"},
+                "linked_prs": [{
+                    "ref": "owner/repo#1",
+                    "url": "https://example.test/pr/1",
+                    "merge_sha": "abc123",
+                    "checks": "pass",
+                    "required_state": "pass",
+                    "required_count": 2,
+                    "non_required_failures": []
+                }],
+                "non_required_check_override": {
+                    "reason": "operator accepted non-required lint",
+                    "observed_non_required_failures": ["owner/repo#1: opt-in/lint"]
+                },
+                "notes": "closed"
+            }),
+            Some("Closeout summary."),
+            None,
+        )
+        .expect("closeout render");
+        assert!(closeout.contains("Closeout summary."), "{closeout}");
+        assert!(closeout.contains("- Final status: complete"), "{closeout}");
+        assert!(
+            closeout.contains("| https://example.test/pr/1 | abc123 | pass | pass (2) | none |"),
+            "{closeout}"
+        );
+        assert!(
+            closeout.contains("- Reason: operator accepted non-required lint"),
+            "{closeout}"
+        );
+        assert!(
+            closeout.contains("- Observed failures: owner/repo#1: opt-in/lint"),
+            "{closeout}"
+        );
     }
 
     #[test]

--- a/crates/plan-issue-cli/tests/integration/cli_contract.rs
+++ b/crates/plan-issue-cli/tests/integration/cli_contract.rs
@@ -5,7 +5,9 @@ use pretty_assertions::assert_eq;
 
 use plan_issue_cli::cli::{Cli, OutputFormat};
 use plan_issue_cli::commands::plan::LinkPrStatus;
-use plan_issue_cli::commands::record::{LifecycleCommentKind, RecordCommand, RecordProfile};
+use plan_issue_cli::commands::record::{
+    LifecycleCommentKind, RecordCommand, RecordProfile, TaskLedgerDisplay,
+};
 use plan_issue_cli::commands::{Command, PrGrouping, SplitStrategy};
 
 use crate::common;
@@ -782,6 +784,42 @@ fn cli_parse_contract_record_post_accepts_add_remove_label() {
             RecordCommand::Post(post) => {
                 assert_eq!(post.add_labels, vec!["state::blocked"]);
                 assert_eq!(post.remove_labels, vec!["state::in-progress"]);
+            }
+            other => panic!("unexpected record subcommand: {other:?}"),
+        },
+        other => panic!("unexpected command parsed: {other:?}"),
+    }
+}
+
+#[test]
+fn cli_parse_contract_record_post_accepts_execution_state_file_and_display() {
+    let cli = Cli::try_parse_from([
+        "plan-issue",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--kind",
+        "state",
+        "--execution-state-file",
+        "docs/plans/example/example-execution-state.md",
+        "--task-ledger-display",
+        "collapsed",
+    ])
+    .expect("parse record post with execution state file");
+
+    cli.validate().expect("validation");
+
+    match &cli.command {
+        Command::Record(args) => match &args.command {
+            RecordCommand::Post(post) => {
+                assert_eq!(
+                    post.execution_state_file,
+                    Some(PathBuf::from(
+                        "docs/plans/example/example-execution-state.md"
+                    ))
+                );
+                assert_eq!(post.task_ledger_display, TaskLedgerDisplay::Collapsed);
             }
             other => panic!("unexpected record subcommand: {other:?}"),
         },

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -233,6 +233,8 @@ fn record_post_state_execution_state_file_collapses_non_final_in_dry_run() {
     let body = parsed["payload"]["result"]["comment_body"]
         .as_str()
         .expect("comment body");
+    assert_eq!(body.matches("## Execution State").count(), 1, "{body}");
+    assert!(body.contains("- Profile: tracking"), "{body}");
     assert!(body.contains("## Task Ledger"), "{body}");
     assert!(body.contains("<details>"), "{body}");
     assert!(
@@ -300,9 +302,72 @@ fn record_post_state_execution_state_file_expands_final_in_dry_run() {
     let body = parsed["payload"]["result"]["comment_body"]
         .as_str()
         .expect("comment body");
+    assert_eq!(body.matches("## Execution State").count(), 1, "{body}");
+    assert!(body.contains("- Profile: tracking"), "{body}");
     assert!(body.contains("## Task Ledger"), "{body}");
     assert!(body.contains("| 1.1 | done | Demo task |"), "{body}");
     assert!(!body.contains("<details>"), "{body}");
+}
+
+#[test]
+fn record_post_state_execution_state_file_keeps_legacy_visible_fields() {
+    let tmp = TempDir::new().expect("tempdir");
+    let payload = tmp.path().join("state.json");
+    let execution_state = tmp.path().join("state.md");
+    fs::write(
+        &payload,
+        json!({
+            "status": "in-progress",
+            "target_scope": "plan issue lifecycle comment visibility",
+            "current": "implement Sprint 1 in sympoies/nils-cli",
+            "next_action": "add lifecycle visible rendering support",
+            "tasks": [{"id": "1.1", "status": "pending", "title": "Renderer"}],
+            "prs": [],
+            "blockers": [],
+            "links": {}
+        })
+        .to_string(),
+    )
+    .expect("write payload");
+    fs::write(
+        &execution_state,
+        "# Execution State: Plan Issue Lifecycle Comment Visibility\n\n<!-- execute-from-tracking-issue:state:v1 -->\n## Execution State\n\n- Status: tracking issue opened\n- Profile: tracking\n- Target scope: make plan-issue lifecycle comments visibly include detailed state, validation, review, session, and closeout evidence\n- Current task: implement Sprint 1 in sympoies/nils-cli.\n- Next task: add lifecycle visible rendering support to plan-issue record post and record close.\n- Last updated: 2026-05-25\n- Branch: feat/plan-issue-state-visibility\n- Source document: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-plan.md\n- Plan document: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-plan.md\n- Review source: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-review-source.md\n\n## Task Ledger\n\n| ID | Status | Task |\n| --- | --- | --- |\n| 1.1 | pending | Renderer |\n",
+    )
+    .expect("write execution state");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "post",
+        "--issue",
+        "115",
+        "--kind",
+        "state",
+        "--payload-file",
+        payload.to_str().expect("payload str"),
+        "--execution-state-file",
+        execution_state.to_str().expect("execution state str"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let body = parsed["payload"]["result"]["comment_body"]
+        .as_str()
+        .expect("comment body");
+    assert_eq!(body.matches("## Execution State").count(), 1, "{body}");
+    assert_eq!(body.matches("- Profile: tracking").count(), 1, "{body}");
+    assert!(!body.contains("# Execution State:"), "{body}");
+    assert!(body.contains("- Status: tracking issue opened"), "{body}");
+    assert!(body.contains("- Last updated: 2026-05-25"), "{body}");
+    assert!(
+        body.contains("- Branch: feat/plan-issue-state-visibility"),
+        "{body}"
+    );
+    assert!(body.contains("- Source document: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-plan.md"), "{body}");
+    assert!(body.contains("- Plan document: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-plan.md"), "{body}");
+    assert!(body.contains("- Review source: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-review-source.md"), "{body}");
+    assert!(body.contains("<details>"), "{body}");
 }
 
 #[test]

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use pretty_assertions::assert_eq;
+use pretty_assertions::{assert_eq, assert_ne};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -184,6 +184,196 @@ fn record_post_state_summary_file_is_rendered_in_dry_run() {
     assert!(
         body.starts_with("<!-- plan-issue-record:v2 role=state profile=tracking -->"),
         "{body}"
+    );
+}
+
+#[test]
+fn record_post_state_execution_state_file_collapses_non_final_in_dry_run() {
+    let tmp = TempDir::new().expect("tempdir");
+    let payload = tmp.path().join("state.json");
+    let execution_state = tmp.path().join("state.md");
+    fs::write(
+        &payload,
+        json!({
+            "status": "in-progress",
+            "target_scope": "ledger surface",
+            "current": "working",
+            "next_action": "continue",
+            "tasks": [{"id": "1.1", "status": "pending", "title": "Demo task"}],
+            "prs": [],
+            "blockers": [],
+            "links": {}
+        })
+        .to_string(),
+    )
+    .expect("write payload");
+    fs::write(
+        &execution_state,
+        "# Sample Execution State\n\n## Execution State\n\n- Status: in-progress\n\n## Task Ledger\n\n| ID | Status | Task |\n| --- | --- | --- |\n| 1.1 | pending | Demo task |\n\n## Validation\n\n| Command | Status |\n| --- | --- |\n| `true` | pass |\n",
+    )
+    .expect("write execution state");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--kind",
+        "state",
+        "--payload-file",
+        payload.to_str().expect("payload str"),
+        "--execution-state-file",
+        execution_state.to_str().expect("execution state str"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let body = parsed["payload"]["result"]["comment_body"]
+        .as_str()
+        .expect("comment body");
+    assert!(body.contains("## Task Ledger"), "{body}");
+    assert!(body.contains("<details>"), "{body}");
+    assert!(
+        body.contains("<summary>Show task ledger</summary>"),
+        "{body}"
+    );
+    assert!(body.contains("| 1.1 | pending | Demo task |"), "{body}");
+    assert!(body.contains("## Validation"), "{body}");
+    assert!(
+        body.contains("<!-- plan-issue-record-payload:hex:"),
+        "{body}"
+    );
+    let details_start = body.find("<details>").expect("details start");
+    let validation_start = body.find("## Validation").expect("validation heading");
+    let payload_start = body
+        .find("<!-- plan-issue-record-payload:hex:")
+        .expect("payload marker");
+    assert!(details_start < validation_start, "{body}");
+    assert!(validation_start < payload_start, "{body}");
+}
+
+#[test]
+fn record_post_state_execution_state_file_expands_final_in_dry_run() {
+    let tmp = TempDir::new().expect("tempdir");
+    let payload = tmp.path().join("state.json");
+    let execution_state = tmp.path().join("state.md");
+    fs::write(
+        &payload,
+        json!({
+            "status": "complete",
+            "target_scope": "ledger surface",
+            "current": "done",
+            "next_action": "closeout",
+            "tasks": [{"id": "1.1", "status": "done", "title": "Demo task"}],
+            "prs": [],
+            "blockers": [],
+            "links": {}
+        })
+        .to_string(),
+    )
+    .expect("write payload");
+    fs::write(
+        &execution_state,
+        "# Sample Execution State\n\n## Execution State\n\n- Status: complete\n\n## Task Ledger\n\n| ID | Status | Task |\n| --- | --- | --- |\n| 1.1 | done | Demo task |\n",
+    )
+    .expect("write execution state");
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--kind",
+        "state",
+        "--payload-file",
+        payload.to_str().expect("payload str"),
+        "--execution-state-file",
+        execution_state.to_str().expect("execution state str"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let parsed = parse_json(&out.stdout);
+    let body = parsed["payload"]["result"]["comment_body"]
+        .as_str()
+        .expect("comment body");
+    assert!(body.contains("## Task Ledger"), "{body}");
+    assert!(body.contains("| 1.1 | done | Demo task |"), "{body}");
+    assert!(!body.contains("<details>"), "{body}");
+}
+
+#[test]
+fn record_post_execution_state_file_requires_state_kind_and_task_ledger() {
+    let tmp = TempDir::new().expect("tempdir");
+    let payload = tmp.path().join("validation.json");
+    let execution_state = tmp.path().join("state.md");
+    fs::write(
+        &payload,
+        json!({"overall": "pass", "commands": [], "waivers": []}).to_string(),
+    )
+    .expect("write payload");
+    fs::write(&execution_state, "# State\n").expect("write execution state");
+
+    let wrong_kind = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--kind",
+        "validation",
+        "--payload-file",
+        payload.to_str().expect("payload str"),
+        "--execution-state-file",
+        execution_state.to_str().expect("execution state str"),
+    ]);
+    assert_ne!(wrong_kind.code, 0);
+    assert!(
+        wrong_kind
+            .stdout
+            .contains("record-post-execution-state-file-kind-invalid"),
+        "{}",
+        wrong_kind.stdout
+    );
+
+    let state_payload = tmp.path().join("state.json");
+    fs::write(
+        &state_payload,
+        json!({
+            "status": "in-progress",
+            "tasks": [],
+            "prs": [],
+            "blockers": [],
+            "links": {}
+        })
+        .to_string(),
+    )
+    .expect("write state payload");
+    let missing_ledger = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "post",
+        "--issue",
+        "448",
+        "--kind",
+        "state",
+        "--payload-file",
+        state_payload.to_str().expect("payload str"),
+        "--execution-state-file",
+        execution_state.to_str().expect("execution state str"),
+    ]);
+    assert_ne!(missing_ledger.code, 0);
+    assert!(
+        missing_ledger
+            .stdout
+            .contains("record-post-execution-state-task-ledger-missing"),
+        "{}",
+        missing_ledger.stdout
     );
 }
 

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -32,6 +32,21 @@ fn parse_json(stdout: &str) -> Value {
     serde_json::from_str(stdout).expect("stdout is valid JSON")
 }
 
+fn assert_comment_visible_prefix(body: &str, expected: &str) {
+    let payload_start = body
+        .find("<!-- plan-issue-record-payload:hex:")
+        .expect("hidden payload carrier");
+    assert_eq!(&body[..payload_start], expected, "{body}");
+    assert!(
+        body[payload_start..].ends_with(" -->\n"),
+        "payload carrier should terminate the comment body:\n{body}"
+    );
+    assert!(
+        !body.contains(&format!("```{PAYLOAD_FENCE_INFO}")),
+        "payload must remain hidden:\n{body}"
+    );
+}
+
 fn write_fixture_files(dir: &Path, body: &str, comments: &Value) {
     fs::write(dir.join("issue-body.md"), body).expect("write fixture body");
     fs::write(
@@ -233,19 +248,25 @@ fn record_post_state_execution_state_file_collapses_non_final_in_dry_run() {
     let body = parsed["payload"]["result"]["comment_body"]
         .as_str()
         .expect("comment body");
-    assert_eq!(body.matches("## Execution State").count(), 1, "{body}");
-    assert!(body.contains("- Profile: tracking"), "{body}");
-    assert!(body.contains("## Task Ledger"), "{body}");
-    assert!(body.contains("<details>"), "{body}");
-    assert!(
-        body.contains("<summary>Show task ledger</summary>"),
-        "{body}"
-    );
-    assert!(body.contains("| 1.1 | pending | Demo task |"), "{body}");
-    assert!(body.contains("## Validation"), "{body}");
-    assert!(
-        body.contains("<!-- plan-issue-record-payload:hex:"),
-        "{body}"
+    assert_comment_visible_prefix(
+        body,
+        concat!(
+            "<!-- plan-issue-record:v2 role=state profile=tracking -->\n\n",
+            "## Execution State\n\n",
+            "- Profile: tracking\n",
+            "- Status: in-progress\n\n",
+            "## Task Ledger\n\n",
+            "<details>\n",
+            "<summary>Show task ledger</summary>\n\n",
+            "| ID | Status | Task |\n",
+            "| --- | --- | --- |\n",
+            "| 1.1 | pending | Demo task |\n\n",
+            "</details>\n\n",
+            "## Validation\n\n",
+            "| Command | Status |\n",
+            "| --- | --- |\n",
+            "| `true` | pass |\n\n",
+        ),
     );
     let details_start = body.find("<details>").expect("details start");
     let validation_start = body.find("## Validation").expect("validation heading");
@@ -302,15 +323,23 @@ fn record_post_state_execution_state_file_expands_final_in_dry_run() {
     let body = parsed["payload"]["result"]["comment_body"]
         .as_str()
         .expect("comment body");
-    assert_eq!(body.matches("## Execution State").count(), 1, "{body}");
-    assert!(body.contains("- Profile: tracking"), "{body}");
-    assert!(body.contains("## Task Ledger"), "{body}");
-    assert!(body.contains("| 1.1 | done | Demo task |"), "{body}");
-    assert!(!body.contains("<details>"), "{body}");
+    assert_comment_visible_prefix(
+        body,
+        concat!(
+            "<!-- plan-issue-record:v2 role=state profile=tracking -->\n\n",
+            "## Execution State\n\n",
+            "- Profile: tracking\n",
+            "- Status: complete\n\n",
+            "## Task Ledger\n\n",
+            "| ID | Status | Task |\n",
+            "| --- | --- | --- |\n",
+            "| 1.1 | done | Demo task |\n\n",
+        ),
+    );
 }
 
 #[test]
-fn record_post_state_execution_state_file_keeps_legacy_visible_fields() {
+fn record_post_state_execution_state_file_preserves_execution_metadata_fields() {
     let tmp = TempDir::new().expect("tempdir");
     let payload = tmp.path().join("state.json");
     let execution_state = tmp.path().join("state.md");
@@ -355,19 +384,30 @@ fn record_post_state_execution_state_file_keeps_legacy_visible_fields() {
     let body = parsed["payload"]["result"]["comment_body"]
         .as_str()
         .expect("comment body");
-    assert_eq!(body.matches("## Execution State").count(), 1, "{body}");
-    assert_eq!(body.matches("- Profile: tracking").count(), 1, "{body}");
-    assert!(!body.contains("# Execution State:"), "{body}");
-    assert!(body.contains("- Status: tracking issue opened"), "{body}");
-    assert!(body.contains("- Last updated: 2026-05-25"), "{body}");
-    assert!(
-        body.contains("- Branch: feat/plan-issue-state-visibility"),
-        "{body}"
+    assert_comment_visible_prefix(
+        body,
+        concat!(
+            "<!-- plan-issue-record:v2 role=state profile=tracking -->\n\n",
+            "## Execution State\n\n",
+            "- Profile: tracking\n",
+            "- Status: tracking issue opened\n",
+            "- Target scope: make plan-issue lifecycle comments visibly include detailed state, validation, review, session, and closeout evidence\n",
+            "- Current task: implement Sprint 1 in sympoies/nils-cli.\n",
+            "- Next task: add lifecycle visible rendering support to plan-issue record post and record close.\n",
+            "- Last updated: 2026-05-25\n",
+            "- Branch: feat/plan-issue-state-visibility\n",
+            "- Source document: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-plan.md\n",
+            "- Plan document: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-plan.md\n",
+            "- Review source: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-review-source.md\n\n",
+            "## Task Ledger\n\n",
+            "<details>\n",
+            "<summary>Show task ledger</summary>\n\n",
+            "| ID | Status | Task |\n",
+            "| --- | --- | --- |\n",
+            "| 1.1 | pending | Renderer |\n\n",
+            "</details>\n\n",
+        ),
     );
-    assert!(body.contains("- Source document: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-plan.md"), "{body}");
-    assert!(body.contains("- Plan document: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-plan.md"), "{body}");
-    assert!(body.contains("- Review source: docs/plans/plan-issue-lifecycle-comment-visibility/plan-issue-lifecycle-comment-visibility-review-source.md"), "{body}");
-    assert!(body.contains("<details>"), "{body}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add visible lifecycle evidence rendering to `plan-issue record post` and `record close` so issue timelines no longer show Profile-only tracking comments.

## Changes

- Add `--execution-state-file` and Task Ledger display modes for state lifecycle posts.
- Synthesize visible session, validation, review, and closeout evidence from structured payloads.
- Cover CLI parsing, dry-run rendering, error handling, and closeout override visibility.

## Test-First Evidence

- Added focused failing-path coverage for missing Task Ledger and invalid `--execution-state-file` kind before relying on implementation.

## Test plan

- `cargo test -p nils-plan-issue-cli`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- `./scripts/install-local-release-binaries.sh --bin plan-issue --bin plan-issue-local`
- Runtime-kit dispatch smoke with the local `plan-issue` binary placed before Homebrew on `PATH`.

## Risk / Notes

- Low runtime risk: existing `--summary-file` behavior remains accepted for compatibility; new strictness applies to the explicit execution-state path and visible rendering gates.
