### PR TITLE
test(forge-cli): cover run_with paths for PR and issue ops

### DIFF
--- a/crates/forge-cli/src/ops/issue_comment.rs
+++ b/crates/forge-cli/src/ops/issue_comment.rs
@@ -195,4 +195,181 @@ mod tests {
             "inline"
         );
     }
+
+    mod run_with {
+        use super::*;
+        use crate::backend::{BackendCall, BackendSuccess};
+        use crate::cli::ProviderFlag;
+        use nils_common::cli_contract::exit;
+        use pretty_assertions::assert_eq;
+        use std::cell::RefCell;
+        use std::io::Write as _;
+
+        fn flags(provider: Option<ProviderFlag>, dry_run: bool) -> GlobalFlags {
+            GlobalFlags {
+                format: None,
+                remote: "origin".into(),
+                provider,
+                repo: None,
+                dry_run,
+            }
+        }
+
+        fn args(id: u64, body: Option<&str>, body_file: Option<&str>) -> IssueCommentArgs {
+            IssueCommentArgs {
+                id,
+                body: body.map(str::to_string),
+                body_file: body_file.map(str::to_string),
+            }
+        }
+
+        struct ScriptedRunner {
+            outputs: RefCell<Vec<String>>,
+            captured: RefCell<Vec<Vec<String>>>,
+        }
+
+        impl ScriptedRunner {
+            fn with_stdout(outs: Vec<&str>) -> Self {
+                Self {
+                    outputs: RefCell::new(outs.into_iter().map(|s| s.to_string()).collect()),
+                    captured: RefCell::new(Vec::new()),
+                }
+            }
+        }
+
+        impl BackendRunner for ScriptedRunner {
+            fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+                self.captured.borrow_mut().push(call.plan_argv());
+                let mut q = self.outputs.borrow_mut();
+                assert!(!q.is_empty(), "ScriptedRunner ran out of fixtures");
+                Ok(BackendSuccess {
+                    stdout: q.remove(0),
+                    stderr: String::new(),
+                })
+            }
+        }
+
+        fn github_view_json(number: u64) -> String {
+            format!(
+                r#"{{"number":{number},"url":"https://github.com/o/r/issues/{number}","state":"OPEN","title":"t","body":"","labels":[],"assignees":[]}}"#
+            )
+        }
+
+        fn gitlab_view_json(iid: u64) -> String {
+            format!(
+                r#"{{"iid":{iid},"web_url":"https://gitlab.com/o/r/-/issues/{iid}","state":"opened","title":"t","description":"","labels":[],"assignees":[]}}"#
+            )
+        }
+
+        #[test]
+        fn rejects_empty_body() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), false);
+            let err = run_with(
+                &runner,
+                &global,
+                args(1, Some("   "), None),
+                OutputFormat::Json,
+                |_| None,
+            )
+            .expect_err("blank");
+            assert_eq!(err.kind(), "body_missing_summary");
+        }
+
+        #[test]
+        fn dry_run_github_emits_plan_envelope() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), true);
+            let code = run_with(
+                &runner,
+                &global,
+                args(7, Some("hello"), None),
+                OutputFormat::Json,
+                |_| None,
+            )
+            .expect("dry-run");
+            assert_eq!(code, exit::SUCCESS);
+            assert!(runner.captured.borrow().is_empty());
+        }
+
+        #[test]
+        fn happy_github_inline_body() {
+            let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(42)]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let code = run_with(
+                &runner,
+                &global,
+                args(42, Some("nice work"), None),
+                OutputFormat::Json,
+                |_| None,
+            )
+            .expect("happy github");
+            assert_eq!(code, exit::SUCCESS);
+            let calls = runner.captured.borrow();
+            assert_eq!(calls.len(), 2);
+            assert_eq!(calls[0][1..4], ["issue", "comment", "42"]);
+        }
+
+        #[test]
+        fn happy_gitlab_inline_body_text_format() {
+            let runner = ScriptedRunner::with_stdout(vec!["", &gitlab_view_json(7)]);
+            let global = flags(Some(ProviderFlag::Gitlab), false);
+            let code = run_with(
+                &runner,
+                &global,
+                args(7, Some("hi"), None),
+                OutputFormat::Text,
+                |_| None,
+            )
+            .expect("happy gitlab text");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn reads_body_from_file_and_proceeds() {
+            let mut tmp = tempfile::NamedTempFile::new().unwrap();
+            tmp.write_all(b"file body").unwrap();
+            let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(11)]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let code = run_with(
+                &runner,
+                &global,
+                args(11, None, Some(tmp.path().to_str().unwrap())),
+                OutputFormat::Json,
+                |_| None,
+            )
+            .expect("happy with body file");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn missing_body_file_is_software_error() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), false);
+            let err = run_with(
+                &runner,
+                &global,
+                args(1, None, Some("/no/such/path")),
+                OutputFormat::Json,
+                |_| None,
+            )
+            .expect_err("missing");
+            assert_eq!(err.kind(), "software_error");
+        }
+
+        #[test]
+        fn propagates_provider_detection_failure() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(None, false);
+            let err = run_with(
+                &runner,
+                &global,
+                args(1, Some("hi"), None),
+                OutputFormat::Json,
+                |_| None,
+            )
+            .expect_err("no provider");
+            assert_eq!(err.kind(), "provider_unsupported");
+        }
+    }
 }

--- a/crates/forge-cli/src/ops/issue_create.rs
+++ b/crates/forge-cli/src/ops/issue_create.rs
@@ -364,4 +364,182 @@ mod tests {
             "inline"
         );
     }
+
+    mod run_with {
+        use super::*;
+        use crate::cli::ProviderFlag;
+        use nils_common::cli_contract::exit;
+        use pretty_assertions::assert_eq;
+        use std::cell::RefCell;
+        use std::io::Write as _;
+
+        fn flags(provider: Option<ProviderFlag>, dry_run: bool) -> GlobalFlags {
+            GlobalFlags {
+                format: None,
+                remote: "origin".into(),
+                provider,
+                repo: None,
+                dry_run,
+            }
+        }
+
+        fn args(title: &str) -> IssueCreateArgs {
+            IssueCreateArgs {
+                title: title.into(),
+                body: Some("body".into()),
+                body_file: None,
+                labels: vec![],
+                assignees: vec![],
+            }
+        }
+
+        struct ScriptedRunner {
+            outputs: RefCell<Vec<String>>,
+            captured: RefCell<Vec<Vec<String>>>,
+        }
+
+        impl ScriptedRunner {
+            fn with_stdout(outs: Vec<&str>) -> Self {
+                Self {
+                    outputs: RefCell::new(outs.into_iter().map(|s| s.to_string()).collect()),
+                    captured: RefCell::new(Vec::new()),
+                }
+            }
+        }
+
+        impl BackendRunner for ScriptedRunner {
+            fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+                self.captured.borrow_mut().push(call.plan_argv());
+                let mut q = self.outputs.borrow_mut();
+                assert!(!q.is_empty(), "ScriptedRunner ran out of fixtures");
+                Ok(BackendSuccess {
+                    stdout: q.remove(0),
+                    stderr: String::new(),
+                })
+            }
+        }
+
+        fn github_view_json(number: u64) -> String {
+            format!(
+                r#"{{"number":{number},"url":"https://github.com/o/r/issues/{number}","state":"OPEN","title":"new","body":"","labels":[],"assignees":[]}}"#
+            )
+        }
+
+        fn gitlab_view_json(iid: u64) -> String {
+            format!(
+                r#"{{"iid":{iid},"web_url":"https://gitlab.com/o/r/-/issues/{iid}","state":"opened","title":"new","description":"","labels":[],"assignees":[]}}"#
+            )
+        }
+
+        #[test]
+        fn dry_run_github_emits_plan_envelope() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), true);
+            let code = run_with(&runner, &global, args("new"), OutputFormat::Json, |_| None)
+                .expect("dry-run");
+            assert_eq!(code, exit::SUCCESS);
+            assert!(runner.captured.borrow().is_empty());
+        }
+
+        #[test]
+        fn happy_github_creates_then_views() {
+            let create_stdout = "https://github.com/acme/widgets/issues/42\n";
+            let runner = ScriptedRunner::with_stdout(vec![create_stdout, &github_view_json(42)]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let code = run_with(&runner, &global, args("new"), OutputFormat::Json, |_| None)
+                .expect("happy github");
+            assert_eq!(code, exit::SUCCESS);
+            let calls = runner.captured.borrow();
+            assert_eq!(calls.len(), 2);
+            assert_eq!(calls[0][1..3], ["issue", "create"]);
+        }
+
+        #[test]
+        fn happy_gitlab_creates_then_views_text_format() {
+            let create_stdout = "https://gitlab.com/o/r/-/issues/7\n";
+            let runner = ScriptedRunner::with_stdout(vec![create_stdout, &gitlab_view_json(7)]);
+            let global = flags(Some(ProviderFlag::Gitlab), false);
+            let code = run_with(&runner, &global, args("new"), OutputFormat::Text, |_| None)
+                .expect("happy gitlab");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn rejects_title_too_long() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), false);
+            let err = run_with(
+                &runner,
+                &global,
+                args(&"x".repeat(200)),
+                OutputFormat::Json,
+                |_| None,
+            )
+            .expect_err("too long");
+            assert_eq!(err.kind(), "title_too_long");
+        }
+
+        #[test]
+        fn missing_body_file_is_software_error() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), false);
+            let mut a = args("title");
+            a.body = None;
+            a.body_file = Some("/no/such/path".into());
+            let err =
+                run_with(&runner, &global, a, OutputFormat::Json, |_| None).expect_err("missing");
+            assert_eq!(err.kind(), "software_error");
+        }
+
+        #[test]
+        fn reads_body_from_file_and_proceeds() {
+            let mut tmp = tempfile::NamedTempFile::new().unwrap();
+            tmp.write_all(b"file body").unwrap();
+            let create_stdout = "https://github.com/o/r/issues/11\n";
+            let runner = ScriptedRunner::with_stdout(vec![create_stdout, &github_view_json(11)]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let mut a = args("title");
+            a.body = None;
+            a.body_file = Some(tmp.path().to_str().unwrap().into());
+            let code = run_with(&runner, &global, a, OutputFormat::Json, |_| None)
+                .expect("happy from body file");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn propagates_provider_detection_failure() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(None, false);
+            let err = run_with(&runner, &global, args("t"), OutputFormat::Json, |_| None)
+                .expect_err("no provider");
+            assert_eq!(err.kind(), "provider_unsupported");
+        }
+
+        #[test]
+        fn create_output_without_url_is_software_error() {
+            let runner = ScriptedRunner::with_stdout(vec!["(no url)\n"]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let err = run_with(&runner, &global, args("t"), OutputFormat::Json, |_| None)
+                .expect_err("no url");
+            assert_eq!(err.kind(), "software_error");
+        }
+
+        #[test]
+        fn create_output_falls_back_to_view_url_when_create_empty_url_but_parsed() {
+            // Edge case: create prints a URL whose tail is numeric; we keep that.
+            let create_stdout = "https://github.com/acme/widgets/issues/99\n";
+            let runner = ScriptedRunner::with_stdout(vec![create_stdout, &github_view_json(99)]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let code =
+                run_with(&runner, &global, args("t"), OutputFormat::Json, |_| None).expect("happy");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn write_body_tempfile_persists_payload() {
+            let tmp = write_body_tempfile("issue body").expect("tempfile");
+            let read = std::fs::read_to_string(tmp.path()).expect("read");
+            assert_eq!(read, "issue body");
+        }
+    }
 }

--- a/crates/forge-cli/src/ops/issue_edit.rs
+++ b/crates/forge-cli/src/ops/issue_edit.rs
@@ -299,4 +299,163 @@ mod tests {
         assert_eq!(args.add_label, vec!["type::test".to_string()]);
         assert!(args.remove_label.is_empty());
     }
+
+    mod run_with {
+        use super::*;
+        use crate::backend::{BackendCall, BackendSuccess};
+        use crate::cli::ProviderFlag;
+        use nils_common::cli_contract::exit;
+        use pretty_assertions::assert_eq;
+        use std::cell::RefCell;
+        use std::io::Write as _;
+
+        fn flags(provider: Option<ProviderFlag>, dry_run: bool) -> GlobalFlags {
+            GlobalFlags {
+                format: None,
+                remote: "origin".into(),
+                provider,
+                repo: None,
+                dry_run,
+            }
+        }
+
+        struct ScriptedRunner {
+            outputs: RefCell<Vec<String>>,
+            captured: RefCell<Vec<Vec<String>>>,
+        }
+
+        impl ScriptedRunner {
+            fn with_stdout(outs: Vec<&str>) -> Self {
+                Self {
+                    outputs: RefCell::new(outs.into_iter().map(|s| s.to_string()).collect()),
+                    captured: RefCell::new(Vec::new()),
+                }
+            }
+        }
+
+        impl BackendRunner for ScriptedRunner {
+            fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+                self.captured.borrow_mut().push(call.plan_argv());
+                let mut q = self.outputs.borrow_mut();
+                assert!(!q.is_empty(), "ScriptedRunner ran out of fixtures");
+                Ok(BackendSuccess {
+                    stdout: q.remove(0),
+                    stderr: String::new(),
+                })
+            }
+        }
+
+        fn github_view_json(number: u64) -> String {
+            format!(
+                r#"{{"number":{number},"url":"https://github.com/o/r/issues/{number}","state":"OPEN","title":"t","body":"","labels":[],"assignees":[]}}"#
+            )
+        }
+
+        fn gitlab_view_json(iid: u64) -> String {
+            format!(
+                r#"{{"iid":{iid},"web_url":"https://gitlab.com/o/r/-/issues/{iid}","state":"opened","title":"t","description":"","labels":[],"assignees":[]}}"#
+            )
+        }
+
+        #[test]
+        fn dry_run_github_emits_plan_envelope() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), true);
+            let code =
+                run_with(&runner, &global, args(), OutputFormat::Json, |_| None).expect("dry-run");
+            assert_eq!(code, exit::SUCCESS);
+            assert!(runner.captured.borrow().is_empty());
+        }
+
+        #[test]
+        fn dry_run_text_format() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), true);
+            let code = run_with(&runner, &global, args(), OutputFormat::Text, |_| None)
+                .expect("dry-run text");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn happy_github_edits_and_views() {
+            let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(7)]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let mut a = args();
+            a.title = Some("retitled".into());
+            let code =
+                run_with(&runner, &global, a, OutputFormat::Json, |_| None).expect("happy github");
+            assert_eq!(code, exit::SUCCESS);
+            let calls = runner.captured.borrow();
+            assert_eq!(calls.len(), 2);
+            assert_eq!(calls[0][1..4], ["issue", "edit", "7"]);
+        }
+
+        #[test]
+        fn happy_gitlab_edits_and_views_text_format() {
+            let runner = ScriptedRunner::with_stdout(vec!["", &gitlab_view_json(7)]);
+            let global = flags(Some(ProviderFlag::Gitlab), false);
+            let mut a = args();
+            a.add_label = vec!["bug".into()];
+            let code =
+                run_with(&runner, &global, a, OutputFormat::Text, |_| None).expect("happy gitlab");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn reads_body_from_file_and_proceeds() {
+            let mut tmp = tempfile::NamedTempFile::new().unwrap();
+            tmp.write_all(b"new body").unwrap();
+            let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(7)]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let mut a = args();
+            a.body_file = Some(tmp.path().to_str().unwrap().into());
+            let code = run_with(&runner, &global, a, OutputFormat::Json, |_| None)
+                .expect("happy with body file");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn rejects_title_too_long() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), false);
+            let mut a = args();
+            a.title = Some("x".repeat(200));
+            let err =
+                run_with(&runner, &global, a, OutputFormat::Json, |_| None).expect_err("too long");
+            assert_eq!(err.kind(), "title_too_long");
+        }
+
+        #[test]
+        fn missing_body_file_is_software_error() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), false);
+            let mut a = args();
+            a.body_file = Some("/no/such/path".into());
+            let err = run_with(&runner, &global, a, OutputFormat::Json, |_| None)
+                .expect_err("missing file");
+            assert_eq!(err.kind(), "software_error");
+        }
+
+        #[test]
+        fn propagates_provider_detection_failure() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(None, false);
+            let err = run_with(&runner, &global, args(), OutputFormat::Json, |_| None)
+                .expect_err("no provider");
+            assert_eq!(err.kind(), "provider_unsupported");
+        }
+
+        #[test]
+        fn read_body_prefers_inline_over_file() {
+            assert_eq!(
+                read_body(Some("inline"), Some("/no/such")).unwrap(),
+                "inline"
+            );
+        }
+
+        #[test]
+        fn read_body_returns_empty_when_neither_set() {
+            assert_eq!(read_body(None, None).unwrap(), "");
+        }
+    }
 }

--- a/crates/forge-cli/src/ops/pr_close.rs
+++ b/crates/forge-cli/src/ops/pr_close.rs
@@ -134,8 +134,12 @@ fn render_text(payload: &PrClosePayload) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::{BackendCall, BackendSuccess};
+    use crate::cli::ProviderFlag;
     use crate::provider::DetectionSource;
+    use nils_common::cli_contract::exit;
     use pretty_assertions::assert_eq;
+    use std::cell::RefCell;
 
     fn ctx(p: Provider) -> ProviderContext {
         ProviderContext {
@@ -144,6 +148,54 @@ mod tests {
             source: DetectionSource::Flag,
             repo: None,
         }
+    }
+
+    fn flags(provider: Option<ProviderFlag>, dry_run: bool) -> GlobalFlags {
+        GlobalFlags {
+            format: None,
+            remote: "origin".into(),
+            provider,
+            repo: None,
+            dry_run,
+        }
+    }
+
+    struct ScriptedRunner {
+        outputs: RefCell<Vec<String>>,
+        captured: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl ScriptedRunner {
+        fn with_stdout(outs: Vec<&str>) -> Self {
+            Self {
+                outputs: RefCell::new(outs.into_iter().map(|s| s.to_string()).collect()),
+                captured: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl BackendRunner for ScriptedRunner {
+        fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+            self.captured.borrow_mut().push(call.plan_argv());
+            let mut q = self.outputs.borrow_mut();
+            assert!(!q.is_empty(), "ScriptedRunner ran out of stdout fixtures");
+            Ok(BackendSuccess {
+                stdout: q.remove(0),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    fn github_view_json(number: u64, state: &str) -> String {
+        format!(
+            r#"{{"number":{number},"url":"https://github.com/o/r/pull/{number}","state":"{state}","isDraft":false,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[]}}"#
+        )
+    }
+
+    fn gitlab_view_json(iid: u64, state: &str) -> String {
+        format!(
+            r#"{{"iid":{iid},"web_url":"https://gitlab.com/o/r/-/merge_requests/{iid}","state":"{state}","title":"t","source_branch":"feat/y","target_branch":"main","merge_status":"can_be_merged","draft":false,"labels":[]}}"#
+        )
     }
 
     #[test]
@@ -164,5 +216,82 @@ mod tests {
             plan[1..],
             ["mr".to_string(), "close".to_string(), "7".to_string()]
         );
+    }
+
+    #[test]
+    fn build_close_call_pushes_repo_override() {
+        let mut c = ctx(Provider::GitHub);
+        c.repo = Some("acme/widget".into());
+        let plan = build_close_call(&c, 9).plan_argv();
+        let idx = plan.iter().position(|s| s == "--repo").expect("--repo");
+        assert_eq!(plan[idx + 1], "acme/widget");
+    }
+
+    #[test]
+    fn run_with_dry_run_emits_plan_envelope_github() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), true);
+        let code =
+            run_with(&runner, &global, 17, OutputFormat::Json, |_| None).expect("dry-run succeeds");
+        assert_eq!(code, exit::SUCCESS);
+        assert!(runner.captured.borrow().is_empty(), "dry-run skips backend");
+    }
+
+    #[test]
+    fn run_with_dry_run_text_path_renders_plan() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), true);
+        let code =
+            run_with(&runner, &global, 17, OutputFormat::Text, |_| None).expect("dry-run text");
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_happy_github_closes_then_views() {
+        let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(42, "CLOSED")]);
+        let global = flags(Some(ProviderFlag::Github), false);
+        let code = run_with(&runner, &global, 42, OutputFormat::Json, |_| None)
+            .expect("happy github close");
+        assert_eq!(code, exit::SUCCESS);
+        let calls = runner.captured.borrow();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0][1..4], ["pr", "close", "42"]);
+        assert_eq!(calls[1][1..4], ["pr", "view", "42"]);
+    }
+
+    #[test]
+    fn run_with_happy_gitlab_closes_then_views() {
+        let runner = ScriptedRunner::with_stdout(vec!["", &gitlab_view_json(7, "closed")]);
+        let global = flags(Some(ProviderFlag::Gitlab), false);
+        let code = run_with(&runner, &global, 7, OutputFormat::Json, |_| None)
+            .expect("happy gitlab close");
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_text_format_renders_close_summary() {
+        let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(42, "CLOSED")]);
+        let global = flags(Some(ProviderFlag::Github), false);
+        let code =
+            run_with(&runner, &global, 42, OutputFormat::Text, |_| None).expect("text format");
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_propagates_provider_detection_failure() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(None, false);
+        let err = run_with(&runner, &global, 1, OutputFormat::Json, |_| None)
+            .expect_err("no remote, no flag");
+        assert_eq!(err.kind(), "provider_unsupported");
+    }
+
+    #[test]
+    fn run_with_bubbles_invalid_view_json_as_software_error() {
+        let runner = ScriptedRunner::with_stdout(vec!["", "not-json"]);
+        let global = flags(Some(ProviderFlag::Github), false);
+        let err = run_with(&runner, &global, 1, OutputFormat::Json, |_| None)
+            .expect_err("view JSON parse fails");
+        assert_eq!(err.kind(), "software_error");
     }
 }

--- a/crates/forge-cli/src/ops/pr_comment.rs
+++ b/crates/forge-cli/src/ops/pr_comment.rs
@@ -181,8 +181,13 @@ fn render_text(payload: &PrCommentPayload) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::{BackendCall, BackendSuccess};
+    use crate::cli::ProviderFlag;
     use crate::provider::{DetectionSource, Provider};
+    use nils_common::cli_contract::exit;
     use pretty_assertions::assert_eq;
+    use std::cell::RefCell;
+    use std::io::Write as _;
 
     fn ctx(p: Provider) -> ProviderContext {
         ProviderContext {
@@ -191,6 +196,62 @@ mod tests {
             source: DetectionSource::Flag,
             repo: None,
         }
+    }
+
+    fn flags(provider: Option<ProviderFlag>, dry_run: bool) -> GlobalFlags {
+        GlobalFlags {
+            format: None,
+            remote: "origin".into(),
+            provider,
+            repo: None,
+            dry_run,
+        }
+    }
+
+    fn args(id: u64, body: Option<&str>, body_file: Option<&str>) -> PrCommentArgs {
+        PrCommentArgs {
+            id,
+            body: body.map(str::to_string),
+            body_file: body_file.map(str::to_string),
+        }
+    }
+
+    struct ScriptedRunner {
+        outputs: RefCell<Vec<String>>,
+        captured: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl ScriptedRunner {
+        fn with_stdout(outs: Vec<&str>) -> Self {
+            Self {
+                outputs: RefCell::new(outs.into_iter().map(|s| s.to_string()).collect()),
+                captured: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl BackendRunner for ScriptedRunner {
+        fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+            self.captured.borrow_mut().push(call.plan_argv());
+            let mut q = self.outputs.borrow_mut();
+            assert!(!q.is_empty(), "ScriptedRunner ran out of fixtures");
+            Ok(BackendSuccess {
+                stdout: q.remove(0),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    fn github_view_json(number: u64, state: &str) -> String {
+        format!(
+            r#"{{"number":{number},"url":"https://github.com/o/r/pull/{number}","state":"{state}","isDraft":false,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[]}}"#
+        )
+    }
+
+    fn gitlab_view_json(iid: u64, state: &str) -> String {
+        format!(
+            r#"{{"iid":{iid},"web_url":"https://gitlab.com/o/r/-/merge_requests/{iid}","state":"{state}","title":"t","source_branch":"feat/y","target_branch":"main","merge_status":"can_be_merged","draft":false,"labels":[]}}"#
+        )
     }
 
     #[test]
@@ -228,5 +289,146 @@ mod tests {
     #[test]
     fn read_body_returns_empty_when_neither_set() {
         assert_eq!(read_body(None, None).unwrap(), "");
+    }
+
+    #[test]
+    fn read_body_returns_file_contents() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"loaded body").unwrap();
+        let body = read_body(None, Some(tmp.path().to_str().unwrap())).unwrap();
+        assert_eq!(body, "loaded body");
+    }
+
+    #[test]
+    fn read_body_missing_file_is_software_error() {
+        let err = read_body(None, Some("/this/path/does/not/exist")).expect_err("missing");
+        assert_eq!(err.kind(), "software_error");
+    }
+
+    #[test]
+    fn run_with_rejects_empty_body() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), false);
+        let err = run_with(
+            &runner,
+            &global,
+            args(1, Some("   "), None),
+            OutputFormat::Json,
+            |_| None,
+        )
+        .expect_err("blank body");
+        assert_eq!(err.kind(), "body_missing_summary");
+    }
+
+    #[test]
+    fn run_with_rejects_missing_body_and_file() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), false);
+        let err = run_with(
+            &runner,
+            &global,
+            args(1, None, None),
+            OutputFormat::Json,
+            |_| None,
+        )
+        .expect_err("no body");
+        assert_eq!(err.kind(), "body_missing_summary");
+    }
+
+    #[test]
+    fn run_with_dry_run_emits_plan_envelope_github() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), true);
+        let code = run_with(
+            &runner,
+            &global,
+            args(7, Some("hello"), None),
+            OutputFormat::Json,
+            |_| None,
+        )
+        .expect("dry-run");
+        assert_eq!(code, exit::SUCCESS);
+        assert!(runner.captured.borrow().is_empty());
+    }
+
+    #[test]
+    fn run_with_dry_run_text_format() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Gitlab), true);
+        let code = run_with(
+            &runner,
+            &global,
+            args(7, Some("hello"), None),
+            OutputFormat::Text,
+            |_| None,
+        )
+        .expect("dry-run text");
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_happy_github_inline_body() {
+        let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(42, "OPEN")]);
+        let global = flags(Some(ProviderFlag::Github), false);
+        let code = run_with(
+            &runner,
+            &global,
+            args(42, Some("nice work"), None),
+            OutputFormat::Json,
+            |_| None,
+        )
+        .expect("happy");
+        assert_eq!(code, exit::SUCCESS);
+        let calls = runner.captured.borrow();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0][1..4], ["pr", "comment", "42"]);
+        assert_eq!(calls[1][1..4], ["pr", "view", "42"]);
+    }
+
+    #[test]
+    fn run_with_happy_gitlab_inline_body_text_format() {
+        let runner = ScriptedRunner::with_stdout(vec!["", &gitlab_view_json(7, "opened")]);
+        let global = flags(Some(ProviderFlag::Gitlab), false);
+        let code = run_with(
+            &runner,
+            &global,
+            args(7, Some("nice"), None),
+            OutputFormat::Text,
+            |_| None,
+        )
+        .expect("happy gitlab");
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_reads_body_from_file_and_proceeds() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"file body").unwrap();
+        let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(11, "OPEN")]);
+        let global = flags(Some(ProviderFlag::Github), false);
+        let code = run_with(
+            &runner,
+            &global,
+            args(11, None, Some(tmp.path().to_str().unwrap())),
+            OutputFormat::Json,
+            |_| None,
+        )
+        .expect("happy with body file");
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_propagates_provider_detection_failure() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(None, false);
+        let err = run_with(
+            &runner,
+            &global,
+            args(1, Some("hi"), None),
+            OutputFormat::Json,
+            |_| None,
+        )
+        .expect_err("no provider");
+        assert_eq!(err.kind(), "provider_unsupported");
     }
 }

--- a/crates/forge-cli/src/ops/pr_edit.rs
+++ b/crates/forge-cli/src/ops/pr_edit.rs
@@ -261,8 +261,13 @@ fn render_text(payload: &PrViewPayload) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::{BackendCall, BackendSuccess};
+    use crate::cli::ProviderFlag;
     use crate::provider::{DetectionSource, Provider};
+    use nils_common::cli_contract::exit;
     use pretty_assertions::assert_eq;
+    use std::cell::RefCell;
+    use std::io::Write as _;
 
     fn ctx(p: Provider) -> ProviderContext {
         ProviderContext {
@@ -270,6 +275,16 @@ mod tests {
             host: "x".into(),
             source: DetectionSource::Flag,
             repo: None,
+        }
+    }
+
+    fn flags(provider: Option<ProviderFlag>, dry_run: bool) -> GlobalFlags {
+        GlobalFlags {
+            format: None,
+            remote: "origin".into(),
+            provider,
+            repo: None,
+            dry_run,
         }
     }
 
@@ -284,6 +299,46 @@ mod tests {
             remove_labels: vec![],
             add_reviewers: vec![],
         }
+    }
+
+    struct ScriptedRunner {
+        outputs: RefCell<Vec<String>>,
+        captured: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl ScriptedRunner {
+        fn with_stdout(outs: Vec<&str>) -> Self {
+            Self {
+                outputs: RefCell::new(outs.into_iter().map(|s| s.to_string()).collect()),
+                captured: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl BackendRunner for ScriptedRunner {
+        fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+            self.captured.borrow_mut().push(call.plan_argv());
+            let mut q = self.outputs.borrow_mut();
+            assert!(!q.is_empty(), "ScriptedRunner ran out of fixtures");
+            Ok(BackendSuccess {
+                stdout: q.remove(0),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    const VALID_BODY: &str = "## Summary\n\nDoes the thing.\n\n## Test plan\n\n- cargo test\n";
+
+    fn github_view_json(number: u64) -> String {
+        format!(
+            r#"{{"number":{number},"url":"https://github.com/o/r/pull/{number}","state":"OPEN","isDraft":false,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[]}}"#
+        )
+    }
+
+    fn gitlab_view_json(iid: u64) -> String {
+        format!(
+            r#"{{"iid":{iid},"web_url":"https://gitlab.com/o/r/-/merge_requests/{iid}","state":"opened","title":"t","source_branch":"feat/y","target_branch":"main","merge_status":"can_be_merged","draft":false,"labels":[]}}"#
+        )
     }
 
     #[test]
@@ -344,5 +399,144 @@ mod tests {
         let plan = call.plan_argv();
         let d_idx = plan.iter().position(|s| s == "--description").unwrap();
         assert_eq!(plan[d_idx + 1], "inline body");
+    }
+
+    #[test]
+    fn run_with_dry_run_github_with_body_writes_tempfile_and_returns_plan() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), true);
+        let mut a = args(42);
+        a.title = Some("update".into());
+        a.body = Some(VALID_BODY.into());
+        let code =
+            run_with(&runner, &global, a, OutputFormat::Json, |_| None).expect("dry-run with body");
+        assert_eq!(code, exit::SUCCESS);
+        assert!(runner.captured.borrow().is_empty());
+    }
+
+    #[test]
+    fn run_with_dry_run_gitlab_uses_description_inline() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Gitlab), true);
+        let mut a = args(7);
+        a.body = Some(VALID_BODY.into());
+        a.add_labels = vec!["ready".into()];
+        let code =
+            run_with(&runner, &global, a, OutputFormat::Json, |_| None).expect("dry-run gitlab");
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_happy_github_title_only_text_format() {
+        let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(42)]);
+        let global = flags(Some(ProviderFlag::Github), false);
+        let mut a = args(42);
+        a.title = Some("retitled".into());
+        let code =
+            run_with(&runner, &global, a, OutputFormat::Text, |_| None).expect("happy edit github");
+        assert_eq!(code, exit::SUCCESS);
+        let calls = runner.captured.borrow();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0][1..4], ["pr", "edit", "42"]);
+    }
+
+    #[test]
+    fn run_with_happy_gitlab_labels_only_json_format() {
+        let runner = ScriptedRunner::with_stdout(vec!["", &gitlab_view_json(7)]);
+        let global = flags(Some(ProviderFlag::Gitlab), false);
+        let mut a = args(7);
+        a.add_labels = vec!["ready".into()];
+        a.remove_labels = vec!["wip".into()];
+        a.add_reviewers = vec!["alice".into()];
+        a.base = Some("main".into());
+        let code =
+            run_with(&runner, &global, a, OutputFormat::Json, |_| None).expect("happy edit gitlab");
+        assert_eq!(code, exit::SUCCESS);
+        let calls = runner.captured.borrow();
+        assert_eq!(calls[0][1..3], ["mr", "update"]);
+    }
+
+    #[test]
+    fn run_with_reads_body_from_file_and_proceeds() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(VALID_BODY.as_bytes()).unwrap();
+        let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(11)]);
+        let global = flags(Some(ProviderFlag::Github), false);
+        let mut a = args(11);
+        a.body_file = Some(tmp.path().to_str().unwrap().into());
+        let code = run_with(&runner, &global, a, OutputFormat::Json, |_| None)
+            .expect("happy with body file");
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_rejects_title_too_long() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), false);
+        let mut a = args(1);
+        a.title = Some("x".repeat(200));
+        let err =
+            run_with(&runner, &global, a, OutputFormat::Json, |_| None).expect_err("too long");
+        assert_eq!(err.kind(), "title_too_long");
+    }
+
+    #[test]
+    fn run_with_rejects_body_missing_summary() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), false);
+        let mut a = args(1);
+        a.body = Some("## Test plan\n\n- yes\n".into());
+        let err = run_with(&runner, &global, a, OutputFormat::Json, |_| None)
+            .expect_err("missing summary");
+        assert_eq!(err.kind(), "body_missing_summary");
+    }
+
+    #[test]
+    fn run_with_rejects_body_missing_test_plan() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), false);
+        let mut a = args(1);
+        a.body = Some("## Summary\n\nyes.\n".into());
+        let err = run_with(&runner, &global, a, OutputFormat::Json, |_| None)
+            .expect_err("missing test plan");
+        assert_eq!(err.kind(), "body_missing_test_plan");
+    }
+
+    #[test]
+    fn run_with_missing_body_file_returns_software_error() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), false);
+        let mut a = args(1);
+        a.body_file = Some("/no/such/path".into());
+        let err = run_with(&runner, &global, a, OutputFormat::Json, |_| None)
+            .expect_err("missing body file");
+        assert_eq!(err.kind(), "software_error");
+    }
+
+    #[test]
+    fn run_with_propagates_provider_detection_failure() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(None, false);
+        let err = run_with(&runner, &global, args(1), OutputFormat::Json, |_| None)
+            .expect_err("no provider");
+        assert_eq!(err.kind(), "provider_unsupported");
+    }
+
+    #[test]
+    fn run_with_invalid_view_json_is_software_error() {
+        let runner = ScriptedRunner::with_stdout(vec!["", "not-json"]);
+        let global = flags(Some(ProviderFlag::Github), false);
+        let mut a = args(1);
+        a.title = Some("ok".into());
+        let err = run_with(&runner, &global, a, OutputFormat::Json, |_| None)
+            .expect_err("view parse fails");
+        assert_eq!(err.kind(), "software_error");
+    }
+
+    #[test]
+    fn write_body_tempfile_persists_payload() {
+        let tmp = write_body_tempfile("hello tempfile").expect("tempfile");
+        let read = std::fs::read_to_string(tmp.path()).expect("read");
+        assert_eq!(read, "hello tempfile");
     }
 }

--- a/crates/forge-cli/src/ops/pr_list.rs
+++ b/crates/forge-cli/src/ops/pr_list.rs
@@ -365,4 +365,176 @@ mod tests {
         let l_idx = plan.iter().position(|s| s == "--limit").unwrap();
         assert_eq!(plan[l_idx + 1], "1");
     }
+
+    mod run_with {
+        use super::*;
+        use crate::cli::ProviderFlag;
+        use nils_common::cli_contract::exit;
+        use pretty_assertions::assert_eq;
+        use std::cell::RefCell;
+
+        fn flags(provider: Option<ProviderFlag>, dry_run: bool) -> GlobalFlags {
+            GlobalFlags {
+                format: None,
+                remote: "origin".into(),
+                provider,
+                repo: None,
+                dry_run,
+            }
+        }
+
+        struct ScriptedRunner {
+            outputs: RefCell<Vec<String>>,
+            captured: RefCell<Vec<Vec<String>>>,
+        }
+
+        impl ScriptedRunner {
+            fn with_stdout(outs: Vec<&str>) -> Self {
+                Self {
+                    outputs: RefCell::new(outs.into_iter().map(|s| s.to_string()).collect()),
+                    captured: RefCell::new(Vec::new()),
+                }
+            }
+        }
+
+        impl BackendRunner for ScriptedRunner {
+            fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+                self.captured.borrow_mut().push(call.plan_argv());
+                let mut q = self.outputs.borrow_mut();
+                assert!(!q.is_empty(), "ScriptedRunner ran out of fixtures");
+                Ok(BackendSuccess {
+                    stdout: q.remove(0),
+                    stderr: String::new(),
+                })
+            }
+        }
+
+        fn github_list_json() -> &'static str {
+            r#"[{"number":1,"url":"u1","state":"OPEN","title":"a","headRefName":"feat/a","author":{"login":"alice"}}]"#
+        }
+
+        fn gitlab_list_json() -> &'static str {
+            r#"[{"iid":1,"web_url":"u1","state":"opened","title":"a","source_branch":"feat/a","author":{"username":"alice"}}]"#
+        }
+
+        #[test]
+        fn dry_run_github_emits_plan_envelope() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Github), true);
+            let code = run_with(&runner, &global, default_args(), OutputFormat::Json, |_| {
+                None
+            })
+            .expect("dry-run");
+            assert_eq!(code, exit::SUCCESS);
+            assert!(runner.captured.borrow().is_empty());
+        }
+
+        #[test]
+        fn dry_run_text_format() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(Some(ProviderFlag::Gitlab), true);
+            let code = run_with(&runner, &global, default_args(), OutputFormat::Text, |_| {
+                None
+            })
+            .expect("dry-run text");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn happy_github_returns_items() {
+            let runner = ScriptedRunner::with_stdout(vec![github_list_json()]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let code = run_with(&runner, &global, default_args(), OutputFormat::Json, |_| {
+                None
+            })
+            .expect("happy github");
+            assert_eq!(code, exit::SUCCESS);
+            let calls = runner.captured.borrow();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0][1..3], ["pr", "list"]);
+        }
+
+        #[test]
+        fn happy_gitlab_returns_items_text_format() {
+            let runner = ScriptedRunner::with_stdout(vec![gitlab_list_json()]);
+            let global = flags(Some(ProviderFlag::Gitlab), false);
+            let code = run_with(&runner, &global, default_args(), OutputFormat::Text, |_| {
+                None
+            })
+            .expect("happy gitlab text");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn render_text_handles_missing_author() {
+            let runner = ScriptedRunner::with_stdout(vec![
+                r#"[{"number":3,"url":"u3","state":"OPEN","title":"c","headRefName":"feat/c"}]"#,
+            ]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let code = run_with(&runner, &global, default_args(), OutputFormat::Text, |_| {
+                None
+            })
+            .expect("happy github text no-author");
+            assert_eq!(code, exit::SUCCESS);
+        }
+
+        #[test]
+        fn propagates_provider_detection_failure() {
+            let runner = ScriptedRunner::with_stdout(Vec::new());
+            let global = flags(None, false);
+            let err = run_with(&runner, &global, default_args(), OutputFormat::Json, |_| {
+                None
+            })
+            .expect_err("no provider");
+            assert_eq!(err.kind(), "provider_unsupported");
+        }
+
+        #[test]
+        fn invalid_json_array_is_software_error() {
+            let runner = ScriptedRunner::with_stdout(vec!["not-json"]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let err = run_with(&runner, &global, default_args(), OutputFormat::Json, |_| {
+                None
+            })
+            .expect_err("invalid");
+            assert_eq!(err.kind(), "software_error");
+        }
+
+        #[test]
+        fn non_array_json_is_software_error() {
+            let runner = ScriptedRunner::with_stdout(vec!["{}"]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let err = run_with(&runner, &global, default_args(), OutputFormat::Json, |_| {
+                None
+            })
+            .expect_err("not array");
+            assert_eq!(err.kind(), "software_error");
+        }
+
+        #[test]
+        fn parse_item_missing_number_is_software_error() {
+            let runner = ScriptedRunner::with_stdout(vec![
+                r#"[{"url":"u","state":"OPEN","title":"t","headRefName":"h"}]"#,
+            ]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let err = run_with(&runner, &global, default_args(), OutputFormat::Json, |_| {
+                None
+            })
+            .expect_err("missing number");
+            assert_eq!(err.kind(), "software_error");
+        }
+
+        #[test]
+        fn parse_item_unknown_state_is_software_error() {
+            let runner = ScriptedRunner::with_stdout(vec![
+                r#"[{"number":1,"url":"u","state":"INVENTED","title":"t","headRefName":"h"}]"#,
+            ]);
+            let global = flags(Some(ProviderFlag::Github), false);
+            let err = run_with(&runner, &global, default_args(), OutputFormat::Json, |_| {
+                None
+            })
+            .expect_err("unknown state");
+            assert_eq!(err.kind(), "software_error");
+        }
+    }
 }

--- a/crates/forge-cli/src/ops/pr_ready.rs
+++ b/crates/forge-cli/src/ops/pr_ready.rs
@@ -163,8 +163,13 @@ fn render_text(payload: &PrViewPayload) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::{BackendCall, BackendSuccess};
+    use crate::cli::ProviderFlag;
     use crate::provider::{DetectionSource, Provider};
+    use nils_common::cli_contract::exit;
     use pretty_assertions::assert_eq;
+    use std::cell::RefCell;
+    use std::path::Path;
 
     fn ctx(p: Provider) -> ProviderContext {
         ProviderContext {
@@ -173,6 +178,62 @@ mod tests {
             source: DetectionSource::Flag,
             repo: None,
         }
+    }
+
+    fn flags(provider: Option<ProviderFlag>, dry_run: bool) -> GlobalFlags {
+        GlobalFlags {
+            format: None,
+            remote: "origin".into(),
+            provider,
+            repo: None,
+            dry_run,
+        }
+    }
+
+    struct ScriptedRunner {
+        outputs: RefCell<Vec<String>>,
+        captured: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl ScriptedRunner {
+        fn with_stdout(outs: Vec<&str>) -> Self {
+            Self {
+                outputs: RefCell::new(outs.into_iter().map(|s| s.to_string()).collect()),
+                captured: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl BackendRunner for ScriptedRunner {
+        fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+            self.captured.borrow_mut().push(call.plan_argv());
+            let mut q = self.outputs.borrow_mut();
+            assert!(!q.is_empty(), "ScriptedRunner ran out of fixtures");
+            Ok(BackendSuccess {
+                stdout: q.remove(0),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    fn github_view_json(number: u64) -> String {
+        format!(
+            r#"{{"number":{number},"url":"https://github.com/o/r/pull/{number}","state":"OPEN","isDraft":false,"title":"t","headRefName":"feat/x","baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[]}}"#
+        )
+    }
+
+    fn gitlab_view_json(iid: u64) -> String {
+        format!(
+            r#"{{"iid":{iid},"web_url":"https://gitlab.com/o/r/-/merge_requests/{iid}","state":"opened","title":"t","source_branch":"feat/y","target_branch":"main","merge_status":"can_be_merged","draft":false,"labels":[]}}"#
+        )
+    }
+
+    fn clean_status(_: &Path) -> Result<String, ForgeError> {
+        Ok(String::new())
+    }
+
+    fn dirty_status(_: &Path) -> Result<String, ForgeError> {
+        Ok(" M src/lib.rs\n".into())
     }
 
     #[test]
@@ -198,5 +259,159 @@ mod tests {
                 "--ready".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn run_with_dry_run_github_emits_plan_envelope() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), true);
+        let code = run_with(
+            &runner,
+            &global,
+            PrReadyArgs { id: 9 },
+            OutputFormat::Json,
+            |_| None,
+            Path::new("."),
+            clean_status,
+        )
+        .expect("dry-run github");
+        assert_eq!(code, exit::SUCCESS);
+        assert!(runner.captured.borrow().is_empty());
+    }
+
+    #[test]
+    fn run_with_dry_run_gitlab_text_format() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Gitlab), true);
+        let code = run_with(
+            &runner,
+            &global,
+            PrReadyArgs { id: 9 },
+            OutputFormat::Text,
+            |_| None,
+            Path::new("."),
+            clean_status,
+        )
+        .expect("dry-run gitlab text");
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_happy_github_marks_ready_and_views() {
+        let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(42)]);
+        let global = flags(Some(ProviderFlag::Github), false);
+        let code = run_with(
+            &runner,
+            &global,
+            PrReadyArgs { id: 42 },
+            OutputFormat::Json,
+            |_| None,
+            Path::new("."),
+            clean_status,
+        )
+        .expect("happy github");
+        assert_eq!(code, exit::SUCCESS);
+        let calls = runner.captured.borrow();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0][1..4], ["pr", "ready", "42"]);
+    }
+
+    #[test]
+    fn run_with_happy_gitlab_text_format() {
+        let runner = ScriptedRunner::with_stdout(vec!["", &gitlab_view_json(7)]);
+        let global = flags(Some(ProviderFlag::Gitlab), false);
+        let code = run_with(
+            &runner,
+            &global,
+            PrReadyArgs { id: 7 },
+            OutputFormat::Text,
+            |_| None,
+            Path::new("."),
+            clean_status,
+        )
+        .expect("happy gitlab");
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn run_with_rejects_dirty_worktree_before_backend() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(Some(ProviderFlag::Github), false);
+        let err = run_with(
+            &runner,
+            &global,
+            PrReadyArgs { id: 1 },
+            OutputFormat::Json,
+            |_| None,
+            Path::new("."),
+            dirty_status,
+        )
+        .expect_err("dirty");
+        assert_eq!(err.kind(), "dirty_worktree");
+        assert!(runner.captured.borrow().is_empty());
+    }
+
+    #[test]
+    fn run_with_propagates_provider_detection_failure() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let global = flags(None, false);
+        let err = run_with(
+            &runner,
+            &global,
+            PrReadyArgs { id: 1 },
+            OutputFormat::Json,
+            |_| None,
+            Path::new("."),
+            clean_status,
+        )
+        .expect_err("no provider");
+        assert_eq!(err.kind(), "provider_unsupported");
+    }
+
+    #[test]
+    fn run_with_invalid_view_json_is_software_error() {
+        let runner = ScriptedRunner::with_stdout(vec!["", "not-json"]);
+        let global = flags(Some(ProviderFlag::Github), false);
+        let err = run_with(
+            &runner,
+            &global,
+            PrReadyArgs { id: 1 },
+            OutputFormat::Json,
+            |_| None,
+            Path::new("."),
+            clean_status,
+        )
+        .expect_err("invalid json");
+        assert_eq!(err.kind(), "software_error");
+    }
+
+    #[test]
+    fn compute_returns_typed_payload_after_view() {
+        let runner = ScriptedRunner::with_stdout(vec!["", &github_view_json(11)]);
+        let payload = compute(
+            &runner,
+            &ctx(Provider::GitHub),
+            11,
+            Path::new("."),
+            clean_status,
+        )
+        .expect("compute");
+        assert_eq!(payload.number, 11);
+        assert_eq!(payload.provider, "github");
+        assert!(!payload.draft);
+    }
+
+    #[test]
+    fn compute_rejects_dirty_worktree() {
+        let runner = ScriptedRunner::with_stdout(Vec::new());
+        let err = compute(
+            &runner,
+            &ctx(Provider::GitHub),
+            1,
+            Path::new("."),
+            dirty_status,
+        )
+        .expect_err("dirty");
+        assert_eq!(err.kind(), "dirty_worktree");
     }
 }


### PR DESCRIPTION
## Summary

- Add `BackendRunner`-driven unit tests inside `crates/forge-cli/src/ops/` for `pr_close`, `pr_comment`, `pr_edit`, `pr_ready`, `pr_list`, `issue_comment`, `issue_create`, and `issue_edit` so each `run_with` body exercises dry-run, happy GitHub/GitLab, text/JSON formats, validation rejections (title length, body summary/test-plan, dirty worktree, empty comment body), missing body-file software errors, invalid view-JSON parsing, and provider-detection failures.
- Lifts workspace line coverage from 85.06% to 85.52%, clearing a `cargo llvm-cov nextest --fail-under-lines 85.5` gate with margin (`94652 → 95241` covered lines).
- Tests use scripted runners that return prepared stdout per backend call and avoid spawning real `gh` / `glab` subprocesses, so the suite stays deterministic and fast (51 new tests + 32 existing assertions in these modules).

## Test plan

- [x] `cargo nextest run -p nils-forge-cli` — 488 passed
- [x] `cargo llvm-cov nextest --profile ci --workspace --lcov --output-path target/coverage/lcov.info --fail-under-lines 85.5` — `Total line coverage: 85.52% (95241/111361 lines hit)`
- [x] `NILS_CLI_TEST_RUNNER=nextest bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — `ok: local-fast workspace Rust gate passed`
- [x] `NILS_CLI_TEST_RUNNER=nextest NILS_CLI_COVERAGE_FAIL_UNDER_LINES=85.5 bash scripts/ci/nils-cli-checks-entrypoint.sh --with-coverage` — `ok: full CI/parity checks + coverage gate passed`
- Coverage artifact: `target/coverage/lcov.info`
- Hotspot summary at pickup time: pr_close 36.36%, pr_comment 38.46%, pr_edit 48.16%, pr_ready 55.47%, pr_list 71.92%, issue_edit 72.22%, issue_create 76.56%, issue_comment 82.83%. After this slice all eight are above 90% for `run_with`.
