### PR TITLE
feat(release): use PR delivery as default for version bumps

### DIFF
--- a/.agents/skills/nils-cli-bump-version-tag-release/SKILL.md
+++ b/.agents/skills/nils-cli-bump-version-tag-release/SKILL.md
@@ -11,6 +11,8 @@ Prereqs:
 
 - Run inside the `nils-cli` git work tree (the script resolves the repo root via `git`).
 - `git`, `python3`, `cargo`, `semantic-commit`, and `git-scope` available on `PATH`.
+- `forge-cli` available on `PATH` for the default PR-based delivery (`forge-cli pr deliver`).
+  Falls back to legacy direct-push only when `--direct-push` or `--skip-push` is passed.
 - `gh` available on `PATH` to use the CI-gated fast path (required for strict `--ci-gate-main`)
   and to wait on `release.yml` runs during the tap stage.
 - `cargo-nextest` available on `PATH` when full release checks are required (`NILS_CLI_TEST_RUNNER=nextest`).
@@ -29,6 +31,11 @@ Inputs:
 - Required:
   - `--version X.Y.Z` (accepts `vX.Y.Z` and normalizes to `X.Y.Z`)
 - Optional (existing nils-cli stage):
+  - `--direct-push` (opt out of PR-based delivery: commit, tag, and push directly to the current
+    branch as the script used to. Fails on branches with required status checks; use PR mode there.)
+  - `--release-branch <name>` (override the PR-mode release branch name. Default is
+    `chore/release-X-Y-Z` with dots → dashes. Must start with `chore/` to satisfy the
+    `forge-cli pr deliver --kind chore` prefix rule.)
   - `--full-checks` (opt-in: run the full local audit stack via `nils-cli-verify-required-checks.sh`
     before commit; slow — only needed for paranoid releases such as toolchain or major dep bumps)
   - `--skip-checks` (deprecated alias of the new default; tolerated for backward-compat callers
@@ -36,15 +43,19 @@ Inputs:
   - `--ci-gate-main` (pre-bump strict gate: require the prior `origin/main` commit's `ci.yml` to be
     green; fail when gate conditions are not met)
   - `--skip-readme` (do not update README release tag example)
-  - `--skip-push` (do not push commit or tag to `origin`; **also disables the tap stage and the
-    bump-commit ci.yml wait**)
-  - `--skip-ci-wait` (do not wait for `ci.yml` on the bump commit before the tap stage; fire-and-forget)
+  - `--skip-push` (do not push commit or tag to `origin`; **implies `--direct-push` semantics
+    locally and disables the tap stage and the bump-commit ci.yml wait**)
+  - `--skip-ci-wait` (direct-push only: do not wait for `ci.yml` on the bump commit before the
+    tap stage. Ignored in PR mode because PR delivery already gates CI before merge.)
   - `--allow-dirty` (allow dirty release-managed files only: Cargo manifests, `Cargo.lock`,
     root `README.md`, and tracked third-party artifacts; fail on other dirty paths)
   - `--force-tag` (delete existing local/remote tag before re-tagging)
   - `NILS_CLI_TEST_RUNNER=cargo|nextest` (environment variable; default is `nextest` in this release script;
     only consulted when `--full-checks` is active)
-  - `NILS_CLI_CI_WAIT_SECONDS` (env var; max seconds to wait for the bump commit's `ci.yml`, default 1800)
+  - `NILS_CLI_CI_WAIT_SECONDS` (env var; direct-push only: max seconds to wait for the bump commit's
+    `ci.yml`, default 1800)
+  - `NILS_CLI_PR_WAIT` (env var; PR mode only: budget passed to `forge-cli pr deliver --timeout`,
+    default `30m`)
 - Optional (tap stage):
   - `--tap-dir <path>` (overrides env + convention resolution)
   - `--skip-tap` (skip the tap stage entirely)
@@ -59,14 +70,31 @@ Inputs:
   - `NILS_CLI_RELEASE_WAIT_SECONDS` (env var; max seconds to wait for source `release.yml`, default 1200)
   - `NILS_CLI_TAP_WAIT_SECONDS` (env var; max seconds to wait for tap `release.yml`, default 1200)
 
+Default delivery mode (PR-based):
+
+- Switches from `main` to a fresh `chore/release-X-Y-Z` branch before bumping any versions.
+  (If the user is already on that branch, it is reused; any other starting branch is rejected
+  so that `--direct-push` is an explicit opt-in.)
+- After commit, pushes the branch and invokes `forge-cli pr deliver --kind chore --method squash`,
+  which opens a draft PR, waits for required status checks to pass, promotes it to ready, and
+  squash-merges into `main` (deleting the source branch).
+- Fast-forwards local `main` to the merge commit, creates the annotated tag `vX.Y.Z` on that
+  commit, and pushes the tag to trigger `release.yml`.
+- The tap stage then runs as before.
+
+Use `--direct-push` to opt out and reuse the legacy "commit + tag directly on the current
+branch" path. Use `--skip-push` to keep everything local without opening a PR (also implies
+the legacy semantics locally).
+
 Default check selection (no `--full-checks` and no `--ci-gate-main`):
 
 - Refresh `Cargo.lock` via `cargo generate-lockfile`.
 - Regenerate tracked third-party artifacts so they match the new lockfile (CI's drift audit will
   reject mismatches on the bump commit).
 - Run `cargo check --workspace --locked` to catch lockfile/compile breaks locally.
-- No `ci.yml` query before bump — the safety net is the post-push `ci.yml` wait on the bump commit
-  itself (see Workflow below).
+- No `ci.yml` query before bump — in PR mode, `forge-cli pr deliver` waits for required checks
+  before merging; in direct-push mode, the post-push `ci.yml` wait on the bump commit is the
+  safety net (see Workflow below).
 
 Use `--full-checks` to additionally run the full audit stack locally
 (`nils-cli-verify-required-checks.sh`: clippy, nextest, zsh completion, all CI audit scripts).
@@ -93,8 +121,15 @@ Outputs (nils-cli stage):
 - Regenerates tracked third-party artifacts (`THIRD_PARTY_LICENSES.md`, `THIRD_PARTY_NOTICES.md`) so the bump commit matches CI's drift audit, then refreshes them again before commit.
 - Runs `nils-cli-verify-required-checks.sh` with `NILS_CLI_TEST_RUNNER=nextest` by default (only under `--full-checks`).
 - Creates a semantic commit for the version bump.
-- Creates an annotated tag `vX.Y.Z` and (unless `--skip-push`) pushes commit + tag to `origin`.
-- Unless `--skip-ci-wait`, waits for the source repo's `ci.yml` run on the bump commit to complete `success` before the tap stage (default 1800s; configurable via `NILS_CLI_CI_WAIT_SECONDS`). This is the primary safety gate that replaces the old local audit fallback.
+- PR mode (default): pushes the release branch and uses `forge-cli pr deliver --kind chore
+  --method squash` to open a draft PR, wait for required checks, promote, and squash-merge.
+  Then fast-forwards local `main` to the merge commit, deletes the local release branch,
+  creates the annotated tag `vX.Y.Z` on the merge commit, and pushes the tag to `origin`.
+- Direct-push mode (`--direct-push` or `--skip-push`): creates the annotated tag `vX.Y.Z` on
+  the current branch and (unless `--skip-push`) pushes commit + tag to `origin`. In this mode,
+  unless `--skip-ci-wait`, waits for the source repo's `ci.yml` run on the bump commit to
+  complete `success` before the tap stage (default 1800s; configurable via
+  `NILS_CLI_CI_WAIT_SECONDS`).
 - GitHub Release artifacts are built by `.github/workflows/release.yml` and include all workspace `bin` targets (auto-discovered via `scripts/workspace-bins.sh`).
 
 Outputs (tap stage):
@@ -123,11 +158,19 @@ Failure modes:
 - Dirty working tree without `--allow-dirty`, or dirty non-release-managed paths with
   `--allow-dirty`.
 - Tag already exists without `--force-tag`.
-- Required commands missing (`git`, `python3`, `cargo`, `semantic-commit`, `git-scope`).
+- Required commands missing (`git`, `python3`, `cargo`, `semantic-commit`, `git-scope`); in PR
+  mode also `forge-cli`.
 - `cargo-nextest` missing while `--full-checks` is active with the default `nextest` runner.
 - Strict `--ci-gate-main` requested but CI gate conditions are not met (`main`, `HEAD == origin/main`, green CI run, `gh` available).
 - `--full-checks` audit stack or `cargo check` fail.
-- Bump-commit `ci.yml` wait fails (non-success conclusion or exceeds `NILS_CLI_CI_WAIT_SECONDS`); use `--skip-ci-wait` only if you accept tap formula bump without that verification.
+- PR mode: starting branch is neither `main` nor the resolved release branch.
+- PR mode: `--release-branch <name>` does not start with `chore/`.
+- PR mode: the resolved release branch already exists locally (avoid silently reusing stale state).
+- PR mode: `forge-cli pr deliver` fails (CI check failure, merge rejection, timeout). The
+  pushed release branch is left in place for recovery.
+- Direct-push mode: bump-commit `ci.yml` wait fails (non-success conclusion or exceeds
+  `NILS_CLI_CI_WAIT_SECONDS`); use `--skip-ci-wait` only if you accept tap formula bump
+  without that verification.
 - Commit or tag creation fails.
 - Tap stage failures (only when the tap stage runs):
   - `--tap-dir` or `NILS_CLI_HOMEBREW_TAP_DIR` set but does not resolve to a git work tree.
@@ -149,15 +192,24 @@ Failure modes:
 
 - Validate inputs and environment.
 - Probe `RUSTC_WRAPPER` and disable it when it is incompatible with the active `rustc`.
+- Resolve delivery mode (PR by default; `--direct-push` or `--skip-push` switches to legacy).
 - `--from-tap` shortcut: skip nils-cli bump+tag and jump to the tap stage.
 - nils-cli stage:
   - Optional pre-bump strict gate: `--ci-gate-main` requires the prior `origin/main` commit's `ci.yml` to be green (otherwise dies).
+  - PR mode: switch from `main` to a freshly created `chore/release-X-Y-Z` branch
+    (or `--release-branch <name>` override) so the bump commit lands on a feature branch.
   - Bump workspace + crate versions and update README.
   - Refresh `Cargo.lock`, regenerate tracked third-party artifacts, then run `cargo check --workspace --locked`.
   - With `--full-checks`, additionally run the full local audit stack via `nils-cli-verify-required-checks.sh`.
   - Regenerate tracked third-party artifacts again before commit to keep release/CI artifacts in sync.
-  - Commit with `semantic-commit`, tag `vX.Y.Z`, and push to trigger the source `release.yml` and `ci.yml`.
-  - Unless `--skip-ci-wait`, wait for `ci.yml` on the bump commit to reach `completed success` before entering the tap stage; this is the canonical safety gate (use `NILS_CLI_CI_WAIT_SECONDS` to tune the timeout).
+  - Commit with `semantic-commit`.
+  - PR mode: push the release branch and run `forge-cli pr deliver --kind chore --method squash`
+    to open + wait + squash-merge. Fast-forward local `main` to the merge commit, then tag
+    `vX.Y.Z` on it and push the tag to trigger `release.yml`.
+  - Direct-push mode: tag `vX.Y.Z` on the current branch and push commit + tag to trigger
+    the source `release.yml` and `ci.yml`. Unless `--skip-ci-wait`, wait for `ci.yml` on the
+    bump commit to reach `completed success` before entering the tap stage (use
+    `NILS_CLI_CI_WAIT_SECONDS` to tune the timeout).
 - Tap stage (auto-skipped on `--skip-push` / `--skip-tap` / unresolved tap dir):
   - Verify tap is on clean `main`; fetch `--no-tags` and fast-forward.
   - Wait for source `release.yml` on `vX.Y.Z` to reach `completed success`.

--- a/.agents/skills/nils-cli-bump-version-tag-release/scripts/nils-cli-bump-version-tag-release.sh
+++ b/.agents/skills/nils-cli-bump-version-tag-release/scripts/nils-cli-bump-version-tag-release.sh
@@ -14,8 +14,16 @@ Options:
   --ci-gate-main          Require CI gate on main (pre-bump check): fail if the prior
                           origin/main commit's ci.yml run is not green.
   --skip-readme           Do not update README release tag examples.
-  --skip-push             Do not push commit or tag to origin (also disables tap stage).
-  --skip-ci-wait          Do not wait for ci.yml on the bump commit before the tap stage.
+  --direct-push           Opt out of the default PR-based flow and push the bump commit + tag
+                          directly to the current branch (legacy behavior). Fails when the
+                          branch is protected — use the default PR flow instead.
+  --release-branch <name> Override the release branch name used in PR mode
+                          (default: chore/release-X-Y-Z, where the version dots become dashes).
+                          Must start with 'chore/' so the forge-cli kind=chore prefix rule passes.
+  --skip-push             Do not push, do not open a PR, do not tag remote. Implies legacy
+                          direct-push semantics locally (commit + local tag) and disables the tap stage.
+  --skip-ci-wait          (direct-push mode only) Do not wait for ci.yml on the bump commit
+                          before the tap stage. Ignored in PR mode (PR delivery already gates CI).
   --allow-dirty           Allow dirty release-managed files only.
   --force-tag             Delete existing local/remote tag before re-tagging.
   --tap-dir <path>        Path to homebrew-tap work tree (overrides env + convention).
@@ -31,13 +39,20 @@ Options:
   -h, --help              Show help.
 
 Default behavior:
+  Bumping is delivered through a chore/release-X-Y-Z PR (`forge-cli pr deliver`), so the
+  bump commit lands on `main` only after the repo's required status checks (test,
+  test_macos, coverage, ...) pass. After the PR merges, the script tags `vX.Y.Z` on the
+  merge commit and pushes the tag to trigger `release.yml`. Use `--direct-push` to fall
+  back to the legacy "commit + tag directly on main" flow (only usable when the branch
+  is not protected); `--skip-push` keeps everything local without opening a PR.
+
   Local checks are minimal: refresh Cargo.lock, regenerate third-party artifacts,
   then run `cargo check --workspace --locked`. The full audit stack (clippy, nextest,
-  zsh completion, docs/audit scripts) runs on CI for every push — the bump commit
-  itself triggers ci.yml, and the tap stage waits for that run to be green before
-  bumping the homebrew formula. Use --full-checks to run the full audit locally
-  (slow); use --skip-ci-wait to fire-and-forget without gating on the bump commit's
-  ci.yml run.
+  zsh completion, docs/audit scripts) runs on CI for every PR — in PR mode the
+  delivery macro waits for it before merging; in direct-push mode the bump commit
+  triggers ci.yml and the tap stage waits for that run to be green. Use --full-checks
+  to run the full audit locally (slow); use --skip-ci-wait (direct-push only) to
+  fire-and-forget without gating on the bump commit's ci.yml run.
 
   After tagging the nils-cli release, the tap stage is run automatically when:
     - --skip-push is NOT set, AND
@@ -688,6 +703,8 @@ full_checks=0
 skip_checks=0  # backward-compat alias of new default; tracked for usage notes only
 ci_gate_main=0
 skip_readme=0
+direct_push=0
+release_branch_arg=""
 skip_push=0
 skip_ci_wait=0
 allow_dirty=0
@@ -725,6 +742,17 @@ while [[ $# -gt 0 ]]; do
     --skip-readme)
       skip_readme=1
       shift
+      ;;
+    --direct-push)
+      direct_push=1
+      shift
+      ;;
+    --release-branch)
+      if [[ $# -lt 2 ]]; then
+        die "--release-branch requires a value"
+      fi
+      release_branch_arg="${2:-}"
+      shift 2
       ;;
     --skip-push)
       skip_push=1
@@ -883,6 +911,44 @@ fi
 
 if [[ "$skip_checks" -eq 1 && "$full_checks" -eq 0 ]]; then
   note "--skip-checks is a deprecated alias of the new default (locked cargo check only); ignoring"
+fi
+
+# === Delivery mode resolution ================================================
+# PR mode (default) opens a chore/release-X-Y-Z PR via `forge-cli pr deliver`
+# so the bump commit lands on `main` only after required status checks pass.
+# `--direct-push` and `--skip-push` both fall back to legacy commit-on-current-branch.
+
+pr_mode=1
+if [[ "$direct_push" -eq 1 || "$skip_push" -eq 1 ]]; then
+  pr_mode=0
+fi
+
+release_branch=""
+if [[ "$pr_mode" -eq 1 ]]; then
+  command -v forge-cli >/dev/null 2>&1 \
+    || die "forge-cli is required for PR-based delivery (use --direct-push to opt out)"
+
+  if [[ -n "$release_branch_arg" ]]; then
+    release_branch="$release_branch_arg"
+  else
+    release_branch="chore/release-$(echo "$version" | tr . -)"
+  fi
+  if ! [[ "$release_branch" == chore/* ]]; then
+    die "--release-branch must start with 'chore/' to match forge-cli kind=chore (got: ${release_branch})"
+  fi
+
+  if [[ "$current_branch" == "$release_branch" ]]; then
+    note "already on release branch ${release_branch}; reusing"
+  elif [[ "$current_branch" == "main" ]]; then
+    if git rev-parse --verify "refs/heads/${release_branch}" >/dev/null 2>&1; then
+      die "release branch already exists locally: ${release_branch} (delete it or pass --release-branch to override)"
+    fi
+    note "creating release branch ${release_branch} from main"
+    git checkout -b "$release_branch"
+    current_branch="$release_branch"
+  else
+    die "PR mode requires starting from 'main' or '${release_branch}' (current=${current_branch:-detached}); use --direct-push to opt out"
+  fi
 fi
 
 python3 - "$version" <<'PY'
@@ -1085,40 +1151,94 @@ fi
   done
 } | semantic-commit commit
 
-if [[ "$skip_push" -eq 0 ]]; then
-  git push origin HEAD
-fi
+if [[ "$pr_mode" -eq 1 ]]; then
+  # === PR-based delivery ====================================================
+  note "pushing release branch ${release_branch} to origin"
+  git push -u origin HEAD
 
-if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
-  if [[ "$force_tag" -eq 1 ]]; then
-    git tag -d "$tag"
-    if [[ "$skip_push" -eq 0 ]]; then
-      git push origin ":refs/tags/${tag}"
-    fi
-  else
-    die "tag already exists: ${tag} (use --force-tag to replace)"
+  pr_body_file="$(mktemp)"
+  {
+    printf '## Summary\n\n'
+    for line in "${body_lines[@]}"; do
+      printf '%s\n' "$line"
+    done
+    printf '\n## Test plan\n\n'
+    printf -- '- [ ] CI: required status checks green\n'
+    printf -- '- [ ] After merge: tag %s and confirm release.yml publishes artifacts\n' "$tag"
+    printf -- '- [ ] Tap stage updates homebrew formula\n'
+  } >"$pr_body_file"
+
+  note "opening + waiting + merging release PR via forge-cli pr deliver"
+  forge-cli pr deliver \
+    --kind chore \
+    --title "chore(release): bump cli versions to ${version}" \
+    --body-file "$pr_body_file" \
+    --method squash \
+    --timeout "${NILS_CLI_PR_WAIT:-30m}" \
+    || { rm -f "$pr_body_file"; die "forge-cli pr deliver failed; release branch ${release_branch} left in place for recovery"; }
+  rm -f "$pr_body_file"
+
+  note "switching back to main and fast-forwarding"
+  git checkout main
+  git fetch origin --quiet
+  git reset --hard origin/main
+  if git rev-parse --verify "refs/heads/${release_branch}" >/dev/null 2>&1; then
+    git branch -D "$release_branch" >/dev/null 2>&1 || true
   fi
-fi
 
-git tag -a "$tag" -m "$tag"
+  bump_sha="$(git rev-parse --verify HEAD)"
 
-if [[ "$skip_push" -eq 0 ]]; then
+  if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+    if [[ "$force_tag" -eq 1 ]]; then
+      git tag -d "$tag"
+      git push origin ":refs/tags/${tag}" || true
+    else
+      die "tag already exists: ${tag} (use --force-tag to replace)"
+    fi
+  fi
+
+  git tag -a "$tag" -m "$tag" "$bump_sha"
   git push origin "$tag"
-fi
+  note "release tag ${tag} created on ${bump_sha}"
+  if [[ "$skip_ci_wait" -eq 1 ]]; then
+    note "--skip-ci-wait set; ignored in PR mode (PR delivery already gated CI)"
+  fi
+else
+  # === Legacy direct-push delivery ==========================================
+  if [[ "$skip_push" -eq 0 ]]; then
+    git push origin HEAD
+  fi
 
-note "release tag ${tag} created"
+  if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+    if [[ "$force_tag" -eq 1 ]]; then
+      git tag -d "$tag"
+      if [[ "$skip_push" -eq 0 ]]; then
+        git push origin ":refs/tags/${tag}"
+      fi
+    else
+      die "tag already exists: ${tag} (use --force-tag to replace)"
+    fi
+  fi
 
-# === Wait for ci.yml on the bump commit (default safety gate) ===============
+  git tag -a "$tag" -m "$tag"
 
-if [[ "$skip_push" -eq 0 && "$skip_ci_wait" -eq 0 ]]; then
-  if ! command -v gh >/dev/null 2>&1; then
-    warn "gh not on PATH; skipping ci.yml wait on bump commit"
-  elif [[ -z "$source_repo_slug" || "$source_repo_slug" == *"/"*"/"* ]]; then
-    warn "could not determine source repo slug; skipping ci.yml wait"
-  else
-    bump_sha="$(git rev-parse --verify HEAD)"
-    note "waiting for ${source_repo_slug} ci.yml on bump commit ${bump_sha}"
-    wait_for_release_run "$source_repo_slug" "ci.yml" "$bump_sha" "${NILS_CLI_CI_WAIT_SECONDS:-1800}"
+  if [[ "$skip_push" -eq 0 ]]; then
+    git push origin "$tag"
+  fi
+
+  note "release tag ${tag} created"
+
+  # Wait for ci.yml on the bump commit (default direct-push safety gate)
+  if [[ "$skip_push" -eq 0 && "$skip_ci_wait" -eq 0 ]]; then
+    if ! command -v gh >/dev/null 2>&1; then
+      warn "gh not on PATH; skipping ci.yml wait on bump commit"
+    elif [[ -z "$source_repo_slug" || "$source_repo_slug" == *"/"*"/"* ]]; then
+      warn "could not determine source repo slug; skipping ci.yml wait"
+    else
+      bump_sha="$(git rev-parse --verify HEAD)"
+      note "waiting for ${source_repo_slug} ci.yml on bump commit ${bump_sha}"
+      wait_for_release_run "$source_repo_slug" "ci.yml" "$bump_sha" "${NILS_CLI_CI_WAIT_SECONDS:-1800}"
+    fi
   fi
 fi
 

--- a/.agents/skills/nils-cli-bump-version-tag-release/tests/test_bump_version_tag_release.sh
+++ b/.agents/skills/nils-cli-bump-version-tag-release/tests/test_bump_version_tag_release.sh
@@ -734,6 +734,145 @@ PY
   assert_not_contains "$formula_path" 'v0.6.4/nils-cli-v0.6.4'
 }
 
+create_mock_forge_cli_deliver() {
+  # The mock simulates a successful PR deliver by fast-forwarding the bare
+  # remote's main to the freshly pushed release branch, then printing a final
+  # status line the way `forge-cli pr deliver` does.
+  local bin_dir="$1"
+  local bare_remote="$2"
+  cat > "${bin_dir}/forge-cli" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="\${MOCK_LOG:?}"
+echo "forge-cli:\$*" >> "\$log_file"
+
+if [[ "\${1:-}" != "pr" || "\${2:-}" != "deliver" ]]; then
+  echo "unexpected forge-cli command: \$*" >&2
+  exit 1
+fi
+
+# Determine the branch that was just pushed by inspecting the bare remote.
+release_branch="\$(git -C "${bare_remote}" symbolic-ref --short HEAD 2>/dev/null || true)"
+# Find which branch ref was most recently advanced ahead of main.
+for ref in \$(git -C "${bare_remote}" for-each-ref --format='%(refname:short)' refs/heads); do
+  if [[ "\$ref" == "main" ]]; then
+    continue
+  fi
+  release_branch="\$ref"
+  break
+done
+
+if [[ -z "\$release_branch" ]]; then
+  echo "mock forge-cli: could not detect release branch on remote" >&2
+  exit 1
+fi
+
+# Fast-forward main to the release branch on the bare remote (simulates squash-merge).
+release_sha="\$(git -C "${bare_remote}" rev-parse "refs/heads/\$release_branch")"
+git -C "${bare_remote}" update-ref refs/heads/main "\$release_sha"
+git -C "${bare_remote}" update-ref -d "refs/heads/\$release_branch"
+
+echo "merged #999 via squash → \$release_sha (branch deleted)"
+EOF
+  chmod +x "${bin_dir}/forge-cli"
+}
+
+test_pr_mode_default_opens_pr_and_tags_merge_commit() {
+  local tmp repo remote bin_dir log_file stderr_file
+  tmp="$(mktemp -d)"
+  repo="${tmp}/repo"
+  remote="${tmp}/repo.git"
+  bin_dir="${tmp}/bin"
+  log_file="${tmp}/mock.log"
+  stderr_file="${tmp}/stderr.log"
+
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo" "v0.6.4"
+  create_mock_cargo "$bin_dir"
+  create_mock_semantic_commit "$bin_dir"
+  create_mock_git_scope "$bin_dir"
+
+  git init --bare "$remote" >/dev/null
+  git -C "$repo" remote add origin "$remote"
+  git -C "$repo" push -u origin main >/dev/null
+
+  create_mock_forge_cli_deliver "$bin_dir" "$remote"
+
+  (
+    cd "$repo"
+    env -u RUSTC_WRAPPER -u NILS_CLI_HOMEBREW_TAP_DIR \
+      PATH="${bin_dir}:$PATH" \
+      MOCK_LOG="$log_file" \
+      "$entrypoint" --version v0.6.5
+  ) >"${tmp}/stdout.log" 2>"${stderr_file}"
+
+  # forge-cli was invoked with the expected shape.
+  assert_contains "$log_file" 'forge-cli:pr deliver --kind chore'
+  assert_contains "$log_file" 'bump cli versions to 0.6.5'
+  assert_contains "$log_file" '--method squash'
+  # The release branch existed on the remote before merge and is gone now.
+  if git -C "$remote" rev-parse --verify "refs/heads/chore/release-0-6-5" >/dev/null 2>&1; then
+    fail "mock forge-cli left release branch behind on remote"
+  fi
+  # main on the remote contains the bump commit.
+  remote_main_msg="$(git -C "$remote" log -1 --pretty=%s main)"
+  if [[ "$remote_main_msg" != "chore(release): bump cli versions to 0.6.5" ]]; then
+    fail "remote main does not point at the bump commit (got: ${remote_main_msg})"
+  fi
+  # Local repo back on main with tag v0.6.5 pointing at the merge commit.
+  local current_branch
+  current_branch="$(git -C "$repo" branch --show-current)"
+  if [[ "$current_branch" != "main" ]]; then
+    fail "expected to be back on main after PR delivery (got: ${current_branch})"
+  fi
+  local tagged_sha local_main_sha
+  # ^{} dereferences annotated-tag objects down to the commit they tag.
+  tagged_sha="$(git -C "$repo" rev-parse --verify "refs/tags/v0.6.5^{}")"
+  local_main_sha="$(git -C "$repo" rev-parse --verify HEAD)"
+  if [[ "$tagged_sha" != "$local_main_sha" ]]; then
+    fail "tag v0.6.5 (${tagged_sha}) does not point at local main (${local_main_sha})"
+  fi
+}
+
+test_pr_mode_rejects_non_chore_release_branch() {
+  local tmp repo bin_dir stderr_file
+  tmp="$(mktemp -d)"
+  repo="${tmp}/repo"
+  bin_dir="${tmp}/bin"
+  stderr_file="${tmp}/stderr.log"
+
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo" "v0.6.4"
+  create_mock_cargo "$bin_dir"
+  create_mock_semantic_commit "$bin_dir"
+  create_mock_git_scope "$bin_dir"
+
+  # Provide a forge-cli stub so the up-front PATH check passes; the script
+  # should die on the prefix validation before invoking it.
+  cat > "${bin_dir}/forge-cli" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "${bin_dir}/forge-cli"
+
+  set +e
+  (
+    cd "$repo"
+    env -u RUSTC_WRAPPER -u NILS_CLI_HOMEBREW_TAP_DIR \
+      PATH="${bin_dir}:$PATH" \
+      "$entrypoint" --version 0.6.5 --release-branch feat/release-0-6-5 \
+      >"${tmp}/stdout.log" 2>"${stderr_file}"
+  )
+  local rc=$?
+  set -e
+
+  if [[ "$rc" -eq 0 ]]; then
+    fail "expected --release-branch without chore/ prefix to exit non-zero"
+  fi
+  assert_contains "$stderr_file" "must start with 'chore/'"
+}
+
 if [[ ! -f "${skill_root}/SKILL.md" ]]; then
   fail "missing SKILL.md"
 fi
@@ -751,5 +890,7 @@ test_from_tap_without_tag_fails
 test_from_tap_with_skip_tap_is_mutually_exclusive
 test_from_tap_upgrades_installed_local_brew_formula
 test_formula_inplace_editor_idempotent
+test_pr_mode_default_opens_pr_and_tags_merge_commit
+test_pr_mode_rejects_non_chore_release_branch
 
 echo "ok: project skill smoke checks passed"


### PR DESCRIPTION
## Summary

Switch the `nils-cli-bump-version-tag-release` skill to deliver version bumps through a `chore/release-X-Y-Z` PR by default, so the bump commit only reaches `main` after the repo's required status checks pass. The legacy commit-directly-to-current-branch path is preserved behind `--direct-push` (and is still implied by `--skip-push` for local-only runs). Scope is limited to the one skill: `SKILL.md`, its release script, and its smoke tests.

## Changes

- Add a PR-mode delivery path: switch from `main` to a fresh `chore/release-X-Y-Z` branch (override via `--release-branch <name>`, must start with `chore/`), push it, and call `forge-cli pr deliver --kind chore --method squash` to open + wait-for-checks + squash-merge.
- After merge, fast-forward local `main` to the merge commit, create the annotated `vX.Y.Z` tag on it, push the tag to trigger `release.yml`, and let the tap stage run as before.
- Add `--direct-push` to opt out of PR mode (legacy commit-on-current-branch path). `--skip-push` continues to keep everything local and now implies direct-push semantics. `--skip-ci-wait` is documented as direct-push-only (PR delivery already gates CI).
- New env var `NILS_CLI_PR_WAIT` (default `30m`) feeds `forge-cli pr deliver --timeout`. `forge-cli` is added to the required-commands list for PR mode.
- Refuse to enter PR mode from any branch other than `main` or the resolved release branch, refuse a non-`chore/` `--release-branch`, and refuse to silently reuse an existing local release branch.
- `SKILL.md`: rewrite the prereqs, inputs, outputs, failure-modes, and workflow sections so PR-mode is described as the default and direct-push is the explicit fallback.

## Test-First Evidence

Two new smoke tests were added in `tests/test_bump_version_tag_release.sh` alongside the script change:

- `test_pr_mode_default_opens_pr_and_tags_merge_commit` — drives the default (PR) path against a bare-remote mock of `forge-cli pr deliver`, then asserts the release branch was pushed, the mock was invoked with `pr deliver --kind chore … --method squash`, the release branch is removed from the remote, remote `main` advances to the bump commit, the working tree returns to local `main`, and the annotated tag `vX.Y.Z` resolves to the same commit as local `main`.
- `test_pr_mode_rejects_non_chore_release_branch` — runs the script with `--release-branch feat/release-0-6-5`, expects a non-zero exit, and asserts the error message mentions `must start with 'chore/'`.

These cover the happy path and the most load-bearing input-validation guard. The remaining branch-state guards (refuse-from-feature-branch, refuse-existing-local-branch) are simple `die` calls in the same code block; they share a single resolution function with the validated guard and are exercised manually rather than via dedicated mocks.

## Test plan

- `bash .agents/skills/nils-cli-bump-version-tag-release/tests/test_bump_version_tag_release.sh` — green locally; ends with `ok: project skill smoke checks passed` and exercises both new PR-mode tests on top of the existing suite.
- Required GitHub status checks on this PR (test, test_macos, coverage, third-party-artifacts, completion-asset-audit, Cargo.lock locked-build, rumdl format) — gated via `forge-cli pr deliver` / `pr wait-checks`.
- Production validation: the next real `vX.Y.Z` bump will exercise the PR path end-to-end. If anything blocks merge, `--direct-push` is the documented fallback and is covered by the unchanged legacy tests already in the suite.

## Risk / Notes

- Behavior change for the next release run: invoking the skill without `--direct-push` now creates a `chore/release-X-Y-Z` branch and opens a PR instead of pushing the bump commit directly. Operators who expected the legacy direct-push behavior need to pass `--direct-push` explicitly. Mitigated by documenting the change in `SKILL.md` (Default delivery mode section) and by leaving the legacy path intact and tested.
- PR delivery introduces a hard dependency on `forge-cli` in PATH for the default flow. Mitigated by an up-front `command -v` check that fails fast with a clear message pointing at `--direct-push`.
- If `forge-cli pr deliver` fails partway (e.g. required check failure, timeout), the pushed release branch is intentionally left on the remote for recovery — documented in the Failure modes section. No tag is created in that case, so re-running after a fix is safe.
- Skill-local scope only; no changes to runtime or other skills, no migration burden.
