### PR TITLE
refactor(auth): share secret email resolution

### DIFF
--- a/crates/codex-cli/src/auth/use_secret.rs
+++ b/crates/codex-cli/src/auth/use_secret.rs
@@ -6,6 +6,7 @@ use crate::auth;
 use crate::auth::output::{self, AuthUseResult};
 use crate::paths;
 use nils_common::fs;
+use nils_common::provider_runtime::auth::{SecretFileResolution, resolve_secret_file_by_email};
 
 pub fn run(target: &str) -> Result<i32> {
     run_with_json(target, false)
@@ -84,8 +85,8 @@ pub fn run_with_json(target: &str, output_json: bool) -> Result<i32> {
         return Ok(code);
     }
 
-    match resolve_by_email(&secret_dir, target) {
-        ResolveResult::Exact(name) => {
+    match resolve_secret_file_by_email(&secret_dir, target) {
+        SecretFileResolution::Exact(name) => {
             let (code, auth_file) = apply_secret(&secret_dir, &name, output_json)?;
             if output_json && code == 0 {
                 output::emit_result(
@@ -100,7 +101,7 @@ pub fn run_with_json(target: &str, output_json: bool) -> Result<i32> {
             }
             Ok(code)
         }
-        ResolveResult::Ambiguous { candidates } => {
+        SecretFileResolution::Ambiguous { candidates } => {
             if output_json {
                 output::emit_error(
                     "auth use",
@@ -117,7 +118,7 @@ pub fn run_with_json(target: &str, output_json: bool) -> Result<i32> {
             }
             Ok(2)
         }
-        ResolveResult::NotFound => {
+        SecretFileResolution::NotFound => {
             if output_json {
                 output::emit_error(
                     "auth use",
@@ -176,123 +177,17 @@ fn apply_secret(
     Ok((0, Some(auth_file.display().to_string())))
 }
 
-fn resolve_by_email(secret_dir: &Path, target: &str) -> ResolveResult {
-    let query = target.to_lowercase();
-    let want_full = target.contains('@');
-
-    let mut matches = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(secret_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|s| s.to_str()) != Some("json") {
-                continue;
-            }
-            let email = match auth::email_from_auth_file(&path) {
-                Ok(Some(value)) => value,
-                _ => continue,
-            };
-            let email_lower = email.to_lowercase();
-            if want_full {
-                if email_lower == query {
-                    matches.push(file_name(&path));
-                }
-            } else if let Some(local_part) = email_lower.split('@').next()
-                && local_part == query
-            {
-                matches.push(file_name(&path));
-            }
-        }
-    }
-
-    if matches.len() == 1 {
-        ResolveResult::Exact(matches.remove(0))
-    } else if matches.is_empty() {
-        ResolveResult::NotFound
-    } else {
-        ResolveResult::Ambiguous {
-            candidates: matches,
-        }
-    }
-}
-
 fn secret_timestamp_path(target_file: &Path) -> Result<PathBuf> {
     paths::resolve_secret_timestamp_path(target_file)
         .ok_or_else(|| anyhow::anyhow!("CODEX_SECRET_CACHE_DIR not resolved"))
 }
 
-fn file_name(path: &Path) -> String {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default()
-        .to_string()
-}
-
-#[derive(Debug)]
-enum ResolveResult {
-    Exact(String),
-    Ambiguous { candidates: Vec<String> },
-    NotFound,
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{ResolveResult, file_name, resolve_by_email, secret_timestamp_path};
+    use super::secret_timestamp_path;
     use nils_test_support::{EnvGuard, GlobalStateLock};
     use pretty_assertions::assert_eq;
     use std::path::Path;
-
-    const HEADER: &str = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0";
-    const PAYLOAD_ALPHA: &str = "eyJzdWIiOiJ1c2VyXzEyMyIsImVtYWlsIjoiYWxwaGFAZXhhbXBsZS5jb20iLCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF91c2VyX2lkIjoidXNlcl8xMjMiLCJlbWFpbCI6ImFscGhhQGV4YW1wbGUuY29tIn19";
-    const PAYLOAD_BETA: &str = "eyJzdWIiOiJ1c2VyXzQ1NiIsImVtYWlsIjoiYmV0YUBleGFtcGxlLmNvbSIsImh0dHBzOi8vYXBpLm9wZW5haS5jb20vYXV0aCI6eyJjaGF0Z3B0X3VzZXJfaWQiOiJ1c2VyXzQ1NiIsImVtYWlsIjoiYmV0YUBleGFtcGxlLmNvbSJ9fQ";
-
-    fn token(payload: &str) -> String {
-        format!("{HEADER}.{payload}.sig")
-    }
-
-    fn auth_json(payload: &str) -> String {
-        format!(
-            r#"{{"tokens":{{"id_token":"{}","access_token":"{}"}}}}"#,
-            token(payload),
-            token(payload)
-        )
-    }
-
-    #[test]
-    fn resolve_by_email_supports_full_and_local_part_lookup() {
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        std::fs::write(dir.path().join("alpha.json"), auth_json(PAYLOAD_ALPHA)).expect("alpha");
-        std::fs::write(dir.path().join("beta.json"), auth_json(PAYLOAD_BETA)).expect("beta");
-
-        match resolve_by_email(dir.path(), "alpha@example.com") {
-            ResolveResult::Exact(name) => assert_eq!(name, "alpha.json"),
-            other => panic!("expected exact alpha match, got {other:?}"),
-        }
-        match resolve_by_email(dir.path(), "beta") {
-            ResolveResult::Exact(name) => assert_eq!(name, "beta.json"),
-            other => panic!("expected exact beta match, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn resolve_by_email_reports_ambiguous_and_not_found() {
-        let dir = tempfile::TempDir::new().expect("tempdir");
-        std::fs::write(dir.path().join("alpha-1.json"), auth_json(PAYLOAD_ALPHA)).expect("alpha-1");
-        std::fs::write(dir.path().join("alpha-2.json"), auth_json(PAYLOAD_ALPHA)).expect("alpha-2");
-
-        match resolve_by_email(dir.path(), "alpha@example.com") {
-            ResolveResult::Ambiguous { candidates } => {
-                assert_eq!(candidates.len(), 2);
-                assert!(candidates.contains(&"alpha-1.json".to_string()));
-                assert!(candidates.contains(&"alpha-2.json".to_string()));
-            }
-            other => panic!("expected ambiguous match, got {other:?}"),
-        }
-
-        match resolve_by_email(dir.path(), "missing@example.com") {
-            ResolveResult::NotFound => {}
-            other => panic!("expected not found, got {other:?}"),
-        }
-    }
 
     #[test]
     fn secret_timestamp_path_uses_cache_dir_and_default_file_name() {
@@ -309,11 +204,5 @@ mod tests {
 
         let without_name = secret_timestamp_path(Path::new("")).expect("timestamp path");
         assert_eq!(without_name, cache.join("auth.json.timestamp"));
-    }
-
-    #[test]
-    fn file_name_returns_empty_when_path_has_no_file_name() {
-        assert_eq!(file_name(Path::new("a/b/c.json")), "c.json");
-        assert_eq!(file_name(Path::new("")), "");
     }
 }

--- a/crates/gemini-cli/src/auth/use_secret.rs
+++ b/crates/gemini-cli/src/auth/use_secret.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use crate::auth;
 use crate::auth::output;
+use nils_common::provider_runtime::auth::{SecretFileResolution, resolve_secret_file_by_email};
 
 pub fn run(target: &str) -> i32 {
     run_with_json(target, false)
@@ -75,8 +76,8 @@ pub fn run_with_json(target: &str, output_json: bool) -> i32 {
         return code;
     }
 
-    match resolve_by_email(&secret_dir, target) {
-        ResolveResult::Exact(name) => {
+    match resolve_secret_file_by_email(&secret_dir, target) {
+        SecretFileResolution::Exact(name) => {
             let (code, auth_file) = apply_secret(&secret_dir, &name, output_json);
             if output_json && code == 0 {
                 let _ = output::emit_result(
@@ -91,7 +92,7 @@ pub fn run_with_json(target: &str, output_json: bool) -> i32 {
             }
             code
         }
-        ResolveResult::Ambiguous { candidates } => {
+        SecretFileResolution::Ambiguous { candidates } => {
             if output_json {
                 let _ = output::emit_error(
                     "auth use",
@@ -111,7 +112,7 @@ pub fn run_with_json(target: &str, output_json: bool) -> i32 {
             }
             2
         }
-        ResolveResult::NotFound => {
+        SecretFileResolution::NotFound => {
             if output_json {
                 let _ = output::emit_error(
                     "auth use",
@@ -171,105 +172,6 @@ fn apply_secret(secret_dir: &Path, secret_name: &str, output_json: bool) -> (i32
     (0, Some(auth_file.display().to_string()))
 }
 
-fn resolve_by_email(secret_dir: &Path, target: &str) -> ResolveResult {
-    let query = target.to_lowercase();
-    let want_full = target.contains('@');
-
-    let mut matches = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(secret_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|s| s.to_str()) != Some("json") {
-                continue;
-            }
-            let email = match auth::email_from_auth_file(&path) {
-                Ok(Some(value)) => value,
-                _ => continue,
-            };
-            let email_lower = email.to_lowercase();
-            if want_full {
-                if email_lower == query {
-                    matches.push(file_name(&path));
-                }
-            } else if let Some(local_part) = email_lower.split('@').next()
-                && local_part == query
-            {
-                matches.push(file_name(&path));
-            }
-        }
-    }
-
-    if matches.len() == 1 {
-        ResolveResult::Exact(matches.remove(0))
-    } else if matches.is_empty() {
-        ResolveResult::NotFound
-    } else {
-        ResolveResult::Ambiguous {
-            candidates: matches,
-        }
-    }
-}
-
 fn secret_timestamp_path(target_file: &Path) -> Option<PathBuf> {
     crate::paths::resolve_secret_timestamp_path(target_file)
-}
-
-fn file_name(path: &Path) -> String {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default()
-        .to_string()
-}
-
-#[derive(Debug)]
-enum ResolveResult {
-    Exact(String),
-    Ambiguous { candidates: Vec<String> },
-    NotFound,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{ResolveResult, resolve_by_email};
-
-    const HEADER: &str = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0";
-    const PAYLOAD_ALPHA: &str = "eyJzdWIiOiJ1c2VyXzEyMyIsImVtYWlsIjoiYWxwaGFAZXhhbXBsZS5jb20iLCJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF91c2VyX2lkIjoidXNlcl8xMjMiLCJlbWFpbCI6ImFscGhhQGV4YW1wbGUuY29tIn19";
-    const PAYLOAD_BETA: &str = "eyJzdWIiOiJ1c2VyXzQ1NiIsImVtYWlsIjoiYmV0YUBleGFtcGxlLmNvbSIsImh0dHBzOi8vYXBpLm9wZW5haS5jb20vYXV0aCI6eyJjaGF0Z3B0X3VzZXJfaWQiOiJ1c2VyXzQ1NiIsImVtYWlsIjoiYmV0YUBleGFtcGxlLmNvbSJ9fQ";
-
-    fn token(payload: &str) -> String {
-        format!("{HEADER}.{payload}.sig")
-    }
-
-    fn auth_json(payload: &str) -> String {
-        format!(
-            r#"{{"tokens":{{"id_token":"{}","access_token":"{}"}}}}"#,
-            token(payload),
-            token(payload)
-        )
-    }
-
-    #[test]
-    fn resolve_by_email_supports_full_and_local_part_lookup() {
-        let dir = std::env::temp_dir().join(format!(
-            "gemini-use-test-{}-{}",
-            std::process::id(),
-            super::super::now_epoch_seconds()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("dir");
-
-        std::fs::write(dir.join("alpha.json"), auth_json(PAYLOAD_ALPHA)).expect("alpha");
-        std::fs::write(dir.join("beta.json"), auth_json(PAYLOAD_BETA)).expect("beta");
-
-        match resolve_by_email(&dir, "alpha@example.com") {
-            ResolveResult::Exact(name) => assert_eq!(name, "alpha.json"),
-            other => panic!("expected exact alpha match, got {other:?}"),
-        }
-        match resolve_by_email(&dir, "beta") {
-            ResolveResult::Exact(name) => assert_eq!(name, "beta.json"),
-            other => panic!("expected exact beta match, got {other:?}"),
-        }
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
 }

--- a/crates/nils-common/src/provider_runtime/auth.rs
+++ b/crates/nils-common/src/provider_runtime/auth.rs
@@ -45,6 +45,47 @@ pub fn identity_key_from_auth_file(path: &Path) -> Result<Option<String>, CoreEr
     Ok(Some(key))
 }
 
+pub fn resolve_secret_file_by_email(secret_dir: &Path, target: &str) -> SecretFileResolution {
+    let query = target.to_lowercase();
+    let want_full = target.contains('@');
+
+    let mut matches = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(secret_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+
+            let email = match email_from_auth_file(&path) {
+                Ok(Some(value)) => value,
+                _ => continue,
+            };
+            let email_lower = email.to_lowercase();
+            if want_full {
+                if email_lower == query {
+                    matches.push(file_name(&path));
+                }
+            } else if let Some(local_part) = email_lower.split('@').next()
+                && local_part == query
+            {
+                matches.push(file_name(&path));
+            }
+        }
+    }
+    matches.sort();
+
+    if matches.len() == 1 {
+        SecretFileResolution::Exact(matches.remove(0))
+    } else if matches.is_empty() {
+        SecretFileResolution::NotFound
+    } else {
+        SecretFileResolution::Ambiguous {
+            candidates: matches,
+        }
+    }
+}
+
 pub fn token_from_auth_json(value: &serde_json::Value) -> Option<String> {
     json::string_at(value, &["tokens", "id_token"])
         .or_else(|| json::string_at(value, &["id_token"]))
@@ -74,6 +115,20 @@ fn account_id_from_auth_json(value: &Value, payload: Option<&Value>) -> Option<S
                 .and_then(|sub| sub.as_str())
                 .map(json::strip_newlines)
         })
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SecretFileResolution {
+    Exact(String),
+    Ambiguous { candidates: Vec<String> },
+    NotFound,
 }
 
 #[cfg(test)]
@@ -138,5 +193,61 @@ mod tests {
             identity_key_from_auth_file(&path).expect("identity key"),
             None
         );
+    }
+
+    #[test]
+    fn resolve_secret_file_by_email_supports_full_and_local_part_lookup() {
+        let dir = TempDir::new().expect("tempdir");
+        write_auth_json(
+            &dir.path().join("alpha.json"),
+            &auth_json_for_email("alpha@example.com"),
+        );
+        write_auth_json(
+            &dir.path().join("beta.json"),
+            &auth_json_for_email("beta@example.com"),
+        );
+        write_auth_json(&dir.path().join("notes.txt"), "not json");
+
+        assert_eq!(
+            resolve_secret_file_by_email(dir.path(), "alpha@example.com"),
+            SecretFileResolution::Exact("alpha.json".to_string())
+        );
+        assert_eq!(
+            resolve_secret_file_by_email(dir.path(), "beta"),
+            SecretFileResolution::Exact("beta.json".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_secret_file_by_email_reports_ambiguous_and_not_found() {
+        let dir = TempDir::new().expect("tempdir");
+        write_auth_json(
+            &dir.path().join("alpha-1.json"),
+            &auth_json_for_email("alpha@example.com"),
+        );
+        write_auth_json(
+            &dir.path().join("alpha-2.json"),
+            &auth_json_for_email("alpha@example.com"),
+        );
+
+        match resolve_secret_file_by_email(dir.path(), "alpha@example.com") {
+            SecretFileResolution::Ambiguous { candidates } => {
+                assert_eq!(
+                    candidates,
+                    vec!["alpha-1.json".to_string(), "alpha-2.json".to_string()]
+                );
+            }
+            other => panic!("expected ambiguous match, got {other:?}"),
+        }
+
+        assert_eq!(
+            resolve_secret_file_by_email(dir.path(), "missing@example.com"),
+            SecretFileResolution::NotFound
+        );
+    }
+
+    fn auth_json_for_email(email: &str) -> String {
+        let token = jwt(serde_json::json!({ "email": email }));
+        format!(r#"{{"tokens":{{"id_token":"{token}"}}}}"#)
     }
 }


### PR DESCRIPTION
## Summary

Extract the duplicated Codex/Gemini `auth use` email lookup into `nils-common::provider_runtime::auth`, keeping provider-specific output and apply behavior in each CLI while sharing the secret-file resolution contract.

## Changes

- Add `SecretFileResolution` and `resolve_secret_file_by_email` to `nils-common`.
- Replace the duplicated Codex and Gemini `auth use` resolvers with the shared helper.
- Sort ambiguous email matches for stable text and JSON error payloads.

## Test-First Evidence

Waiver: this is a narrow shared-foundation refactor of already-covered behavior, so I moved the existing resolver tests into `nils-common` before replacing the caller implementations and then validated the existing Codex/Gemini integration paths.

## Test plan

- `cargo test -p nils-common -p nils-codex-cli -p nils-gemini-cli resolve_secret_file_by_email`
- `cargo test -p nils-codex-cli secret_timestamp_path`
- `agent-run exec --cwd /Users/terry/.codex/worktrees/e1c9/nils-cli -- bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`

## Risk / Notes

- Low risk: behavior remains covered by existing Codex/Gemini `auth_use_email_resolution` integration tests, and only the shared resolver location changes.
