### PR TITLE
refactor(nils-common): extract path normalization to shared module

### DIFF
--- a/crates/agent-scope-lock/src/lib.rs
+++ b/crates/agent-scope-lock/src/lib.rs
@@ -16,6 +16,7 @@ use serde_json::{Value, json};
 use cli::{ChangeMode, Cli, Command, CommonArgs, CreateArgs, OutputFormat, ValidateArgs};
 
 use nils_common::cli_contract::exit;
+use nils_common::fs::normalize_path as normalize_absolute_path;
 
 const EXIT_OK: i32 = exit::SUCCESS;
 const EXIT_RUNTIME_OR_SCOPE: i32 = exit::RUNTIME;
@@ -300,24 +301,6 @@ fn normalize_allowed_paths(repo_root: &Path, paths: &[PathBuf]) -> Result<Vec<St
     }
 
     Ok(normalized.into_iter().collect())
-}
-
-fn normalize_absolute_path(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-
-    for component in path.components() {
-        match component {
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-            Component::RootDir => normalized.push(component.as_os_str()),
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-        }
-    }
-
-    normalized
 }
 
 fn repo_relative_path(path: &Path) -> Result<String, CliError> {

--- a/crates/agent-workflow-primitives/src/test_first_evidence.rs
+++ b/crates/agent-workflow-primitives/src/test_first_evidence.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
 use clap::error::ErrorKind;
@@ -16,6 +16,7 @@ use cli::{
     RecordWaiverArgs,
 };
 use nils_common::cli_contract::exit;
+use nils_common::fs::normalize_path;
 use nils_common::redact::redact_text;
 
 const EXIT_OK: i32 = exit::SUCCESS;
@@ -372,22 +373,6 @@ fn absolute_path(path: &Path) -> Result<PathBuf, CliError> {
         )
     })?;
     Ok(normalize_path(&current_dir.join(path)))
-}
-
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-            Component::RootDir => normalized.push(component.as_os_str()),
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-        }
-    }
-    normalized
 }
 
 fn normalized_paths(paths: &[PathBuf]) -> Vec<String> {

--- a/crates/nils-common/src/fs.rs
+++ b/crates/nils-common/src/fs.rs
@@ -2,9 +2,33 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
+
+/// Lexically normalize `path`: drop `.` components, collapse `..` components by
+/// popping the previous segment, and preserve any root or prefix (Windows
+/// drive / UNC). The result is purely syntactic — the filesystem is not
+/// consulted.
+///
+/// Behavior matches the per-crate `normalize_absolute_path` / `normalize_path`
+/// helpers that previously lived in `agent-scope-lock`, `web-evidence`, and
+/// `agent-workflow-primitives::test_first_evidence`.
+pub fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
 
 pub const SECRET_FILE_MODE: u32 = 0o600;
 const MAX_TEMP_PATH_ATTEMPTS: u32 = 10;
@@ -498,6 +522,32 @@ const ROUND_CONSTANTS: [u32; 64] = [
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn normalize_path_drops_curdir_components() {
+        assert_eq!(
+            normalize_path(Path::new("/a/./b/./c")),
+            PathBuf::from("/a/b/c")
+        );
+    }
+
+    #[test]
+    fn normalize_path_collapses_parent_components() {
+        assert_eq!(
+            normalize_path(Path::new("/a/b/../c")),
+            PathBuf::from("/a/c")
+        );
+    }
+
+    #[test]
+    fn normalize_path_preserves_root_when_collapsing_past_start() {
+        assert_eq!(normalize_path(Path::new("/../a")), PathBuf::from("/a"));
+    }
+
+    #[test]
+    fn normalize_path_preserves_relative_paths() {
+        assert_eq!(normalize_path(Path::new("a/b/c")), PathBuf::from("a/b/c"));
+    }
 
     #[test]
     fn fs_replace_file_overwrites_existing_destination() {

--- a/crates/web-evidence/src/lib.rs
+++ b/crates/web-evidence/src/lib.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::ffi::OsString;
 use std::fs;
 use std::io::Read;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use clap::Parser;
@@ -18,6 +18,7 @@ use serde_json::{Value, json};
 
 use cli::{CaptureArgs, Cli, Command, HttpMethod, OutputFormat};
 use nils_common::cli_contract::exit;
+use nils_common::fs::normalize_path as normalize_absolute_path;
 use nils_common::redact::{RedactedString, redact_text};
 
 const EXIT_OK: i32 = exit::SUCCESS;
@@ -727,22 +728,6 @@ fn absolute_path(path: &Path) -> Result<PathBuf, CliError> {
         )
     })?;
     Ok(normalize_absolute_path(&current_dir.join(path)))
-}
-
-fn normalize_absolute_path(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-            Component::RootDir => normalized.push(component.as_os_str()),
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::Normal(part) => normalized.push(part),
-        }
-    }
-    normalized
 }
 
 fn unix_seconds_now() -> u64 {


### PR DESCRIPTION
## Summary

Fix the `--repo owner/name` global flag so it actually reaches every backend invocation, not just `repo view`. Surfaced as a follow-up on #457 ([comment #4525727774](https://github.com/sympoies/nils-cli/issues/457#issuecomment-4525727774)): from one repo's checkout, `forge-cli issue create --repo other/repo --dry-run` returned a plan that omitted `--repo`, so the dry-run hid where the live call would actually target.

Root cause: `cli.rs` already accepts `--repo` and stores it on `GlobalFlags::repo`, but only `repo_view.rs` consumed it. Every other op silently dropped it — dry-run plan **and** live exec both used the auto-detected origin remote.

## Fix

- Carry the slug on `ProviderContext` (set inside `detect()`); add `ProviderContext::push_repo_override(&mut argv)` that pushes `--repo <slug>` for both `gh` and `glab`.
- Thread `global.repo.as_deref()` into every `detect(...)` call site.
- Append `ctx.push_repo_override(&mut argv)` inside every `build_*_call` (issue create/view/edit/close/reopen/comment/list, pr create/view/edit/close/comment/list/merge/ready/wait-checks/checks, `pr_checks_gitlab` status + branch resolver, and `pr_create`'s view re-fetch).
- Switch `repo_view` to read `ctx.repo` directly and drop its separate `repo_override` parameter, so `pr_create` / `pr_merge` default-branch lookups (and `pr_deliver`'s repo-view step) honor `--repo` automatically without extra plumbing.
- `auth_status` and `pr_checks_gitlab::build_version_call` are intentionally untouched (`gh auth status` / `glab --version` have no `--repo` semantics).
- New tests cover the override branch directly: `issue_create::build_create_call_propagates_repo_override_to_argv`, `pr_checks_gitlab::build_status_call_includes_repo_override_when_set`, `repo_view::build_call_github_includes_repo_slug_when_ctx_has_repo`.

## Test plan

- [x] `cargo test -p nils-forge-cli` → 248 lib + 114 integration + 0 doc, all green.
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` → 363/363 nextest passing, fmt + clippy + audits clean.
- [x] Repro the original comment scenario locally:
  ```text
  $ cargo run -q -p nils-forge-cli -- --repo sympoies/nils-cli --provider github --dry-run --format json \
        issue create --title "dry-run repo propagation probe" --body "probe" --label issue
  ```
  Now returns `"plan": ["gh","issue","create","--title",..."--label","issue","--repo","sympoies/nils-cli"]` — the `--repo` override appears in the plan (and the live call) instead of being silently dropped.

## Out of scope

- This PR does not change the `--repo` flag surface in `cli.rs` — only the wiring downstream.
- Layered on top of #458 (agent-docs task-tools path migration) — both PRs flow from #457 follow-ups; they touch disjoint crates.

Refs: #457
