### PR TITLE
refactor(nils-common): extract display_path lossy helper

### DIFF
--- a/crates/agent-out/src/lib.rs
+++ b/crates/agent-out/src/lib.rs
@@ -17,6 +17,7 @@ use serde_json::{Value, json};
 use cli::{AuditArgs, AuditFormat, Cli, Command, ProjectArgs, ProjectFormat};
 
 use nils_common::cli_contract::exit;
+use nils_common::fs::display_path;
 
 const EXIT_OK: i32 = exit::SUCCESS;
 const EXIT_AUDIT_VIOLATIONS: i32 = exit::RUNTIME;
@@ -718,10 +719,6 @@ struct ErrorBody<'a> {
     message: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     details: Option<Value>,
-}
-
-fn display_path(path: &Path) -> String {
-    path.to_string_lossy().to_string()
 }
 
 #[cfg(test)]

--- a/crates/agent-scope-lock/src/lib.rs
+++ b/crates/agent-scope-lock/src/lib.rs
@@ -16,7 +16,7 @@ use serde_json::{Value, json};
 use cli::{ChangeMode, Cli, Command, CommonArgs, CreateArgs, OutputFormat, ValidateArgs};
 
 use nils_common::cli_contract::exit;
-use nils_common::fs::normalize_path as normalize_absolute_path;
+use nils_common::fs::{display_path, normalize_path as normalize_absolute_path};
 
 const EXIT_OK: i32 = exit::SUCCESS;
 const EXIT_RUNTIME_OR_SCOPE: i32 = exit::RUNTIME;
@@ -601,10 +601,6 @@ fn print_json_error(
 fn render_json_failure(err: serde_json::Error) -> i32 {
     eprintln!("agent-scope-lock: error: failed to render json: {err}");
     EXIT_RUNTIME_OR_SCOPE
-}
-
-fn display_path(path: &Path) -> String {
-    path.to_string_lossy().to_string()
 }
 
 #[derive(Debug)]

--- a/crates/agent-workflow-primitives/src/test_first_evidence.rs
+++ b/crates/agent-workflow-primitives/src/test_first_evidence.rs
@@ -16,7 +16,7 @@ use cli::{
     RecordWaiverArgs,
 };
 use nils_common::cli_contract::exit;
-use nils_common::fs::normalize_path;
+use nils_common::fs::{display_path, normalize_path};
 use nils_common::redact::redact_text;
 
 const EXIT_OK: i32 = exit::SUCCESS;
@@ -515,10 +515,6 @@ fn print_json_error(
 fn render_json_failure(err: serde_json::Error) -> i32 {
     eprintln!("test-first-evidence: error: failed to render json: {err}");
     EXIT_RUNTIME
-}
-
-fn display_path(path: &Path) -> String {
-    path.to_string_lossy().to_string()
 }
 
 #[derive(Debug)]

--- a/crates/nils-common/src/fs.rs
+++ b/crates/nils-common/src/fs.rs
@@ -6,6 +6,13 @@ use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
+/// Render `path` using `to_string_lossy` for use in CLI JSON envelopes and
+/// log messages. Lossy on purpose — non-UTF8 bytes are replaced with U+FFFD
+/// so the result is always serializable.
+pub fn display_path(path: &Path) -> String {
+    path.to_string_lossy().to_string()
+}
+
 /// Lexically normalize `path`: drop `.` components, collapse `..` components by
 /// popping the previous segment, and preserve any root or prefix (Windows
 /// drive / UNC). The result is purely syntactic — the filesystem is not
@@ -522,6 +529,12 @@ const ROUND_CONSTANTS: [u32; 64] = [
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn display_path_renders_unicode_paths_losslessly() {
+        assert_eq!(display_path(Path::new("/tmp/repo")), "/tmp/repo");
+        assert_eq!(display_path(Path::new("")), "");
+    }
 
     #[test]
     fn normalize_path_drops_curdir_components() {

--- a/crates/web-evidence/src/lib.rs
+++ b/crates/web-evidence/src/lib.rs
@@ -18,7 +18,7 @@ use serde_json::{Value, json};
 
 use cli::{CaptureArgs, Cli, Command, HttpMethod, OutputFormat};
 use nils_common::cli_contract::exit;
-use nils_common::fs::normalize_path as normalize_absolute_path;
+use nils_common::fs::{display_path, normalize_path as normalize_absolute_path};
 use nils_common::redact::{RedactedString, redact_text};
 
 const EXIT_OK: i32 = exit::SUCCESS;
@@ -735,10 +735,6 @@ fn unix_seconds_now() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
-}
-
-fn display_path(path: &Path) -> String {
-    path.to_string_lossy().to_string()
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

- Promote the trivial `path.to_string_lossy().to_string()` `display_path`
  wrappers that lived in four crates into a single
  `nils_common::fs::display_path` helper, so CLI JSON envelopes and log
  messages share one lossy path-rendering policy.
- Replace the private copies in `nils-agent-out`, `nils-agent-scope-lock`,
  `nils-web-evidence`, and
  `nils-agent-workflow-primitives::test_first_evidence` with imports of
  the shared helper.
- Cover the new helper with a unit test for ordinary and empty path
  inputs.

The richer normalize-and-stringify `display_path` in
`nils-agent-workflow-primitives::common` is intentionally untouched; it has
distinct semantics and is owned by that crate.

## Test plan

- [x] `cargo test -p nils-common -p nils-agent-out -p nils-agent-scope-lock -p nils-web-evidence -p nils-agent-workflow-primitives`
- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- [x] `bash scripts/generate-third-party-artifacts.sh --check`
