### PR TITLE
Add agent-runtime prune-stale cleanup

### DIFF
--- a/crates/agent-runtime-cli/src/audit_drift/classes/extra.rs
+++ b/crates/agent-runtime-cli/src/audit_drift/classes/extra.rs
@@ -5,12 +5,12 @@
 //! user's unrelated runtime state does not become audit input.
 
 use crate::audit_drift::{DriftReport, Finding, Severity};
-use crate::install::link_map::{EntryKind, LinkMap, LinkMapError};
+use crate::install::link_map::{LinkMap, LinkMapError};
+use crate::live_surface;
 use crate::render::manifest::{ManifestSet, ProductRoot, RuntimeRootsManifest, SourceRoot};
 use anyhow::{Context, Result};
-use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
 
 pub const CLASS: &str = "extra";
 
@@ -36,15 +36,16 @@ pub fn check(
         Err(err) => return Err(err.into()),
     };
 
-    let expected = expected_live_paths(root.path(), &link_map);
-    let scan_roots = scan_roots(&link_map);
+    let expected = live_surface::expected_live_paths(root.path(), &link_map);
+    let scan_roots = live_surface::scan_roots(&link_map);
     if scan_roots.is_empty() {
         return Ok(());
     }
 
-    let live_files = live_files_under_roots(&live_home, &scan_roots)?;
+    let live_files = live_surface::live_files_under_roots(&live_home, &scan_roots)
+        .with_context(|| format!("scan live home {}", live_home.display()))?;
     for rel in live_files {
-        if expected.contains(&rel) || ignored_live_file(&rel) {
+        if expected.contains(&rel) || live_surface::ignored_live_file(&rel) {
             continue;
         }
         report.push(Finding {
@@ -76,135 +77,6 @@ fn product_root<'a>(
 fn resolve_live_home(root: &ProductRoot) -> PathBuf {
     let env: BTreeMap<String, String> = std::env::vars().collect();
     PathBuf::from(expand_env_vars(&root.live_home, &env))
-}
-
-fn expected_live_paths(source_root: &Path, link_map: &LinkMap) -> BTreeSet<PathBuf> {
-    let mut out = BTreeSet::new();
-    for entry in &link_map.entries {
-        let Some(dest) = clean_rel_path(&entry.destination) else {
-            continue;
-        };
-        match entry.kind {
-            EntryKind::SymlinkedFile if entry.recursive => {
-                let Some(source) = entry.source.as_deref().and_then(clean_rel_path) else {
-                    continue;
-                };
-                let source_abs = source_root.join(source);
-                if source_abs.is_dir() {
-                    for rel in source_files(&source_abs) {
-                        out.insert(dest.join(rel));
-                    }
-                } else if source_abs.exists() {
-                    out.insert(dest);
-                }
-            }
-            EntryKind::SymlinkedFile
-            | EntryKind::PluginManifestCopy
-            | EntryKind::BackedUpOnReplace
-            | EntryKind::ManagedBlock => {
-                out.insert(dest);
-            }
-        }
-    }
-    out
-}
-
-fn scan_roots(link_map: &LinkMap) -> BTreeSet<PathBuf> {
-    let mut out = BTreeSet::new();
-    for entry in &link_map.entries {
-        let Some(dest) = clean_rel_path(&entry.destination) else {
-            continue;
-        };
-        match entry.kind {
-            EntryKind::SymlinkedFile if entry.recursive => {
-                out.insert(dest);
-            }
-            EntryKind::SymlinkedFile
-            | EntryKind::PluginManifestCopy
-            | EntryKind::BackedUpOnReplace => {
-                if let Some(parent) = dest.parent()
-                    && !parent.as_os_str().is_empty()
-                {
-                    out.insert(parent.to_path_buf());
-                }
-            }
-            EntryKind::ManagedBlock => {}
-        }
-    }
-    out
-}
-
-fn source_files(root: &Path) -> BTreeSet<PathBuf> {
-    let mut out = BTreeSet::new();
-    collect_source_files(root, root, &mut out);
-    out
-}
-
-fn collect_source_files(root: &Path, dir: &Path, out: &mut BTreeSet<PathBuf>) {
-    let Ok(entries) = fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let Ok(kind) = entry.file_type() else {
-            continue;
-        };
-        if kind.is_dir() {
-            collect_source_files(root, &path, out);
-        } else if let Ok(rel) = path.strip_prefix(root) {
-            out.insert(rel.to_path_buf());
-        }
-    }
-}
-
-fn live_files_under_roots(
-    live_home: &Path,
-    roots: &BTreeSet<PathBuf>,
-) -> Result<BTreeSet<PathBuf>> {
-    let mut out = BTreeSet::new();
-    for rel_root in roots {
-        collect_live_files(live_home, rel_root, &mut out)?;
-    }
-    Ok(out)
-}
-
-fn collect_live_files(live_home: &Path, rel: &Path, out: &mut BTreeSet<PathBuf>) -> Result<()> {
-    let path = live_home.join(rel);
-    let Ok(meta) = fs::symlink_metadata(&path) else {
-        return Ok(());
-    };
-    if meta.file_type().is_symlink() || meta.is_file() {
-        out.insert(rel.to_path_buf());
-        return Ok(());
-    }
-    if !meta.is_dir() {
-        return Ok(());
-    }
-
-    let entries = fs::read_dir(&path).with_context(|| format!("read {}", path.display()))?;
-    for entry in entries {
-        let entry = entry.with_context(|| format!("read {}", path.display()))?;
-        collect_live_files(live_home, &rel.join(entry.file_name()), out)?;
-    }
-    Ok(())
-}
-
-fn clean_rel_path(path: impl AsRef<str>) -> Option<PathBuf> {
-    let path = Path::new(path.as_ref());
-    if path.as_os_str().is_empty() || path.is_absolute() {
-        return None;
-    }
-    if path
-        .components()
-        .any(|component| !matches!(component, Component::Normal(_)))
-    {
-        return None;
-    }
-    Some(path.to_path_buf())
-}
-
-fn ignored_live_file(path: &Path) -> bool {
-    path.file_name().and_then(|name| name.to_str()) == Some(".DS_Store")
 }
 
 fn expand_env_vars(raw: &str, env: &BTreeMap<String, String>) -> String {

--- a/crates/agent-runtime-cli/src/commands/mod.rs
+++ b/crates/agent-runtime-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod gc_backups;
 pub mod install;
 pub mod list_skills;
 pub mod pr_body;
+pub mod prune_stale;
 pub mod purge_state;
 pub mod render;
 pub mod restore_backups;

--- a/crates/agent-runtime-cli/src/commands/prune_stale.rs
+++ b/crates/agent-runtime-cli/src/commands/prune_stale.rs
@@ -1,0 +1,189 @@
+use crate::prune_stale::{self, Mode, PruneChange, PruneOptions};
+use crate::render::manifest::SourceRoot;
+use clap::{Args, ValueEnum};
+use serde::Serialize;
+use std::path::PathBuf;
+
+const SCHEMA_VERSION: &str = "cli.agent-runtime.prune-stale.v1";
+
+#[derive(Args, Debug)]
+pub struct PruneStaleArgs {
+    /// Source root containing `manifests/`, `core/`, `targets/`, `build/`.
+    /// Defaults to the current working directory.
+    #[arg(long)]
+    pub source_root: Option<PathBuf>,
+    /// Product to prune (`codex` or `claude`).
+    #[arg(long)]
+    pub product: String,
+    /// Absolute path of the runtime home to scan and optionally repair.
+    #[arg(long)]
+    pub live_home: PathBuf,
+    /// Skip the optional `.private/link-map.overrides.yaml` overlay merge.
+    #[arg(long, default_value_t = false)]
+    pub no_overlay: bool,
+    /// Override the overlay file location. When set, the conventional
+    /// `<source-root>/.private/link-map.overrides.yaml` is ignored.
+    #[arg(long, conflicts_with = "no_overlay")]
+    pub overlay_path: Option<PathBuf>,
+    /// Print stale candidates; do not mutate the filesystem.
+    #[arg(long, conflicts_with = "apply")]
+    pub dry_run: bool,
+    /// Remove provably owned stale symlinks and empty directories.
+    #[arg(long, conflicts_with = "dry_run")]
+    pub apply: bool,
+    /// Output format.
+    #[arg(long, value_enum, default_value = "text")]
+    pub format: OutputFormat,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Serialize)]
+struct JsonEnvelope<'a> {
+    schema_version: &'static str,
+    ok: bool,
+    data: JsonData<'a>,
+}
+
+#[derive(Serialize)]
+struct JsonData<'a> {
+    product: &'a str,
+    source_root: &'a std::path::Path,
+    live_home: &'a std::path::Path,
+    mode: Mode,
+    candidates: usize,
+    changes: usize,
+    skipped: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    overlay: Option<crate::install::OverlaySummary>,
+    records: &'a [PruneChange],
+}
+
+pub fn run(args: PruneStaleArgs) -> anyhow::Result<u8> {
+    if args.product != "claude" && args.product != "codex" {
+        anyhow::bail!(
+            "agent-runtime prune-stale: unknown --product `{}` (expected one of: claude, codex)",
+            args.product
+        );
+    }
+    if !args.live_home.is_absolute() {
+        anyhow::bail!(
+            "agent-runtime prune-stale: --live-home must be absolute (got: {})",
+            args.live_home.display()
+        );
+    }
+    if !args.dry_run && !args.apply {
+        anyhow::bail!("agent-runtime prune-stale: pass --dry-run or --apply");
+    }
+    let mode = if args.apply {
+        Mode::Apply
+    } else {
+        Mode::DryRun
+    };
+    let root = SourceRoot::from_arg_or_cwd(args.source_root.as_deref())?;
+    let options = PruneOptions {
+        overlay_enabled: !args.no_overlay,
+        overlay_path: args.overlay_path.clone(),
+    };
+    let outcome = prune_stale::run(&args.product, root.path(), &args.live_home, mode, &options)?;
+    match args.format {
+        OutputFormat::Text => print_text(&outcome),
+        OutputFormat::Json => print_json(&outcome)?,
+    }
+    Ok(0)
+}
+
+fn print_text(outcome: &prune_stale::PruneOutcome) {
+    if let Some(s) = outcome.overlay.as_ref() {
+        eprintln!(
+            "agent-runtime prune-stale: overlay merged (dropped={} replaced={} added={})",
+            s.dropped, s.replaced, s.added,
+        );
+    }
+    let changes = outcome.changes.iter().filter(|c| c.is_change()).count();
+    let skipped = outcome.changes.iter().filter(|c| c.is_skip()).count();
+    eprintln!(
+        "agent-runtime prune-stale: product={} mode={} candidates={} changes={} skipped={}",
+        outcome.product,
+        outcome.mode.label(),
+        outcome.changes.len(),
+        changes,
+        skipped,
+    );
+    for change in &outcome.changes {
+        eprintln!("{}", format_change(change));
+    }
+}
+
+fn print_json(outcome: &prune_stale::PruneOutcome) -> anyhow::Result<()> {
+    let envelope = JsonEnvelope {
+        schema_version: SCHEMA_VERSION,
+        ok: true,
+        data: JsonData {
+            product: &outcome.product,
+            source_root: &outcome.source_root,
+            live_home: &outcome.live_home,
+            mode: outcome.mode,
+            candidates: outcome.changes.len(),
+            changes: outcome.changes.iter().filter(|c| c.is_change()).count(),
+            skipped: outcome.changes.iter().filter(|c| c.is_skip()).count(),
+            overlay: outcome.overlay,
+            records: &outcome.changes,
+        },
+    };
+    println!("{}", serde_json::to_string_pretty(&envelope)?);
+    Ok(())
+}
+
+fn format_change(change: &PruneChange) -> String {
+    match change {
+        PruneChange::WouldRemoveSymlink {
+            rel_path, target, ..
+        } => format!(
+            "  - would remove symlink {} -> {}",
+            rel_path.display(),
+            target.display()
+        ),
+        PruneChange::RemovedSymlink {
+            rel_path, target, ..
+        } => format!(
+            "  - removed symlink {} -> {}",
+            rel_path.display(),
+            target.display()
+        ),
+        PruneChange::NoOpSymlink {
+            rel_path, target, ..
+        } => format!(
+            "  = no-op symlink {} -> {}",
+            rel_path.display(),
+            target.display()
+        ),
+        PruneChange::WouldRemoveEmptyDirectory { rel_path, .. } => {
+            format!("  - would remove empty directory {}", rel_path.display())
+        }
+        PruneChange::RemovedEmptyDirectory { rel_path, .. } => {
+            format!("  - removed empty directory {}", rel_path.display())
+        }
+        PruneChange::NoOpEmptyDirectory { rel_path, .. } => {
+            format!("  = no-op empty directory {}", rel_path.display())
+        }
+        PruneChange::SkippedForeignSymlink {
+            rel_path, target, ..
+        } => format!(
+            "  ? skip foreign symlink {} -> {}",
+            rel_path.display(),
+            target.display()
+        ),
+        PruneChange::SkippedRegularFile { rel_path, .. } => {
+            format!("  ? skip regular file {}", rel_path.display())
+        }
+        PruneChange::SkippedNonEmptyDirectory { rel_path, .. } => {
+            format!("  ? skip non-empty directory {}", rel_path.display())
+        }
+    }
+}

--- a/crates/agent-runtime-cli/src/install/overlay.rs
+++ b/crates/agent-runtime-cli/src/install/overlay.rs
@@ -17,7 +17,7 @@
 //! / forbidden fields).
 
 use super::link_map::{CommentStyle, EntryKind, LinkEntry, LinkMap, LinkMapError, SCHEMA_VERSION};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 /// Conventional location of the overlay file, relative to the agent-runtime-kit
@@ -112,7 +112,7 @@ impl LinkMapOverlay {
 /// this in dry-run / apply output so reviewers see at a glance that an
 /// overlay is in play (the architecture doc requires dry-run to expose
 /// the post-merge effective config).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 pub struct OverlaySummary {
     pub dropped: usize,
     pub replaced: usize,

--- a/crates/agent-runtime-cli/src/lib.rs
+++ b/crates/agent-runtime-cli/src/lib.rs
@@ -25,7 +25,9 @@ pub mod commands;
 pub mod doctor;
 pub mod gc_backups;
 pub mod install;
+pub mod live_surface;
 pub mod managed_block;
+pub mod prune_stale;
 pub mod purge_state;
 pub mod render;
 pub mod restore_backups;
@@ -60,6 +62,8 @@ pub enum Command {
     ListSkills(commands::list_skills::ListSkillsArgs),
     /// Render standardized PR / MR bodies for forge-cli create flows.
     PrBody(commands::pr_body::PrBodyArgs),
+    /// Remove stale managed runtime-home surfaces.
+    PruneStale(commands::prune_stale::PruneStaleArgs),
     /// Restore a runtime home from a recorded backup snapshot.
     RestoreBackups(commands::restore_backups::RestoreBackupsArgs),
     /// Purge runtime-managed state (use with caution).
@@ -77,6 +81,7 @@ impl Command {
             Command::GcBackups(_) => "gc-backups",
             Command::ListSkills(_) => "list-skills",
             Command::PrBody(_) => "pr-body",
+            Command::PruneStale(_) => "prune-stale",
             Command::RestoreBackups(_) => "restore-backups",
             Command::PurgeState(_) => "purge-state",
         }
@@ -147,6 +152,13 @@ pub fn run() -> ExitCode {
             Ok(code) => ExitCode::from(code),
             Err(err) => {
                 eprintln!("agent-runtime pr-body: {err:#}");
+                ExitCode::from(2)
+            }
+        },
+        Command::PruneStale(args) => match commands::prune_stale::run(args) {
+            Ok(code) => ExitCode::from(code),
+            Err(err) => {
+                eprintln!("agent-runtime prune-stale: {err:#}");
                 ExitCode::from(2)
             }
         },

--- a/crates/agent-runtime-cli/src/live_surface.rs
+++ b/crates/agent-runtime-cli/src/live_surface.rs
@@ -1,0 +1,142 @@
+//! Shared live runtime-home surface helpers.
+//!
+//! `audit-drift extra` and `prune-stale` must agree on which install-map
+//! destinations are expected and which runtime-home roots are safe to scan.
+
+use crate::install::link_map::{EntryKind, LinkMap};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+pub fn expected_live_paths(source_root: &Path, link_map: &LinkMap) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    for entry in &link_map.entries {
+        let Some(dest) = clean_rel_path(&entry.destination) else {
+            continue;
+        };
+        match entry.kind {
+            EntryKind::SymlinkedFile if entry.recursive => {
+                let Some(source) = entry.source.as_deref().and_then(clean_rel_path) else {
+                    continue;
+                };
+                let source_abs = source_root.join(source);
+                if source_abs.is_dir() {
+                    for rel in source_files(&source_abs) {
+                        out.insert(dest.join(rel));
+                    }
+                } else if source_abs.exists() {
+                    out.insert(dest);
+                }
+            }
+            EntryKind::SymlinkedFile
+            | EntryKind::PluginManifestCopy
+            | EntryKind::BackedUpOnReplace
+            | EntryKind::ManagedBlock => {
+                out.insert(dest);
+            }
+        }
+    }
+    out
+}
+
+pub fn scan_roots(link_map: &LinkMap) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    for entry in &link_map.entries {
+        let Some(dest) = clean_rel_path(&entry.destination) else {
+            continue;
+        };
+        match entry.kind {
+            EntryKind::SymlinkedFile if entry.recursive => {
+                out.insert(dest);
+            }
+            EntryKind::SymlinkedFile
+            | EntryKind::PluginManifestCopy
+            | EntryKind::BackedUpOnReplace => {
+                if let Some(parent) = dest.parent()
+                    && !parent.as_os_str().is_empty()
+                {
+                    out.insert(parent.to_path_buf());
+                }
+            }
+            EntryKind::ManagedBlock => {}
+        }
+    }
+    out
+}
+
+pub fn live_files_under_roots(
+    live_home: &Path,
+    roots: &BTreeSet<PathBuf>,
+) -> Result<BTreeSet<PathBuf>, std::io::Error> {
+    let mut out = BTreeSet::new();
+    for rel_root in roots {
+        collect_live_files(live_home, rel_root, &mut out)?;
+    }
+    Ok(out)
+}
+
+pub fn clean_rel_path(path: impl AsRef<str>) -> Option<PathBuf> {
+    let path = Path::new(path.as_ref());
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return None;
+    }
+    if path
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+    Some(path.to_path_buf())
+}
+
+pub fn ignored_live_file(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()) == Some(".DS_Store")
+}
+
+fn source_files(root: &Path) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    collect_source_files(root, root, &mut out);
+    out
+}
+
+fn collect_source_files(root: &Path, dir: &Path, out: &mut BTreeSet<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(kind) = entry.file_type() else {
+            continue;
+        };
+        if kind.is_dir() {
+            collect_source_files(root, &path, out);
+        } else if let Ok(rel) = path.strip_prefix(root) {
+            out.insert(rel.to_path_buf());
+        }
+    }
+}
+
+fn collect_live_files(
+    live_home: &Path,
+    rel: &Path,
+    out: &mut BTreeSet<PathBuf>,
+) -> Result<(), std::io::Error> {
+    let path = live_home.join(rel);
+    let Ok(meta) = fs::symlink_metadata(&path) else {
+        return Ok(());
+    };
+    if meta.file_type().is_symlink() || meta.is_file() {
+        out.insert(rel.to_path_buf());
+        return Ok(());
+    }
+    if !meta.is_dir() {
+        return Ok(());
+    }
+
+    let entries = fs::read_dir(&path)?;
+    for entry in entries {
+        let entry = entry?;
+        collect_live_files(live_home, &rel.join(entry.file_name()), out)?;
+    }
+    Ok(())
+}

--- a/crates/agent-runtime-cli/src/prune_stale.rs
+++ b/crates/agent-runtime-cli/src/prune_stale.rs
@@ -1,0 +1,547 @@
+//! `agent-runtime prune-stale` body.
+//!
+//! The command scans only install-map-owned runtime-home roots, then removes
+//! stale symlinks whose targets are lexically under the selected source root.
+//! Ambiguous user-owned files, non-empty directories, and foreign symlinks are
+//! reported but never deleted.
+
+use crate::install::link_map::{LinkMap, LinkMapError};
+use crate::install::overlay::{self, LinkMapOverlay, OverlaySummary};
+use crate::install::plan::{InstallPlan, PlanAction, PlanError};
+use crate::live_surface;
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Mode {
+    DryRun,
+    Apply,
+}
+
+impl Mode {
+    pub fn label(self) -> &'static str {
+        match self {
+            Mode::DryRun => "dry-run",
+            Mode::Apply => "apply",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PruneOptions {
+    pub overlay_enabled: bool,
+    pub overlay_path: Option<PathBuf>,
+}
+
+impl Default for PruneOptions {
+    fn default() -> Self {
+        Self {
+            overlay_enabled: true,
+            overlay_path: None,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum PruneError {
+    #[error("link-map: {0}")]
+    LinkMap(#[from] LinkMapError),
+    #[error("plan: {0}")]
+    Plan(#[from] PlanError),
+    #[error("io error at `{path}`: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+#[derive(Debug, Serialize)]
+pub struct PruneOutcome {
+    pub product: String,
+    pub source_root: PathBuf,
+    pub live_home: PathBuf,
+    pub mode: Mode,
+    pub changes: Vec<PruneChange>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub overlay: Option<OverlaySummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum PruneChange {
+    WouldRemoveSymlink {
+        rel_path: PathBuf,
+        path: PathBuf,
+        target: PathBuf,
+    },
+    RemovedSymlink {
+        rel_path: PathBuf,
+        path: PathBuf,
+        target: PathBuf,
+    },
+    NoOpSymlink {
+        rel_path: PathBuf,
+        path: PathBuf,
+        target: PathBuf,
+    },
+    WouldRemoveEmptyDirectory {
+        rel_path: PathBuf,
+        path: PathBuf,
+    },
+    RemovedEmptyDirectory {
+        rel_path: PathBuf,
+        path: PathBuf,
+    },
+    NoOpEmptyDirectory {
+        rel_path: PathBuf,
+        path: PathBuf,
+    },
+    SkippedForeignSymlink {
+        rel_path: PathBuf,
+        path: PathBuf,
+        target: PathBuf,
+    },
+    SkippedRegularFile {
+        rel_path: PathBuf,
+        path: PathBuf,
+    },
+    SkippedNonEmptyDirectory {
+        rel_path: PathBuf,
+        path: PathBuf,
+    },
+}
+
+impl PruneChange {
+    pub fn is_change(&self) -> bool {
+        matches!(
+            self,
+            PruneChange::WouldRemoveSymlink { .. }
+                | PruneChange::RemovedSymlink { .. }
+                | PruneChange::WouldRemoveEmptyDirectory { .. }
+                | PruneChange::RemovedEmptyDirectory { .. }
+        )
+    }
+
+    pub fn is_skip(&self) -> bool {
+        matches!(
+            self,
+            PruneChange::SkippedForeignSymlink { .. }
+                | PruneChange::SkippedRegularFile { .. }
+                | PruneChange::SkippedNonEmptyDirectory { .. }
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Candidate {
+    Symlink {
+        rel_path: PathBuf,
+        path: PathBuf,
+        target: PathBuf,
+    },
+    EmptyDirectory {
+        rel_path: PathBuf,
+        path: PathBuf,
+    },
+    SkippedForeignSymlink {
+        rel_path: PathBuf,
+        path: PathBuf,
+        target: PathBuf,
+    },
+    SkippedRegularFile {
+        rel_path: PathBuf,
+        path: PathBuf,
+    },
+    SkippedNonEmptyDirectory {
+        rel_path: PathBuf,
+        path: PathBuf,
+    },
+}
+
+pub fn run(
+    product: &str,
+    source_root: &Path,
+    live_home: &Path,
+    mode: Mode,
+    options: &PruneOptions,
+) -> Result<PruneOutcome, PruneError> {
+    let mut link_map = LinkMap::load(source_root, product)?;
+    let overlay = merge_overlay(&mut link_map, source_root, options)?;
+    let plan = InstallPlan::build(product, source_root, live_home, Path::new(""), &link_map)?;
+    let expected = expected_paths_from_plan(live_home, &plan);
+    let scan_roots = live_surface::scan_roots(&link_map);
+    let candidates = collect_candidates(live_home, source_root, &expected, &scan_roots)?;
+    let changes = match mode {
+        Mode::DryRun => candidates.into_iter().map(dry_run_change).collect(),
+        Mode::Apply => apply_candidates(candidates)?,
+    };
+
+    Ok(PruneOutcome {
+        product: product.to_string(),
+        source_root: source_root.to_path_buf(),
+        live_home: live_home.to_path_buf(),
+        mode,
+        changes,
+        overlay,
+    })
+}
+
+fn merge_overlay(
+    link_map: &mut LinkMap,
+    source_root: &Path,
+    options: &PruneOptions,
+) -> Result<Option<OverlaySummary>, PruneError> {
+    if !options.overlay_enabled {
+        return Ok(None);
+    }
+    let overlay_opt = match options.overlay_path.as_deref() {
+        Some(path) => LinkMapOverlay::load_from(path)?,
+        None => LinkMapOverlay::load_optional(source_root)?,
+    };
+    match overlay_opt {
+        Some(overlay) => {
+            let summary = overlay::apply(link_map, &overlay)?;
+            Ok(Some(summary))
+        }
+        None => Ok(None),
+    }
+}
+
+fn expected_paths_from_plan(live_home: &Path, plan: &InstallPlan) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    for action in &plan.actions {
+        let PlanAction::Symlink { dest, .. } = action else {
+            continue;
+        };
+        if let Ok(rel) = dest.strip_prefix(live_home) {
+            out.insert(rel.to_path_buf());
+        }
+    }
+    out
+}
+
+fn collect_candidates(
+    live_home: &Path,
+    source_root: &Path,
+    expected: &BTreeSet<PathBuf>,
+    scan_roots: &BTreeSet<PathBuf>,
+) -> Result<Vec<Candidate>, PruneError> {
+    let mut candidates = Vec::new();
+    for rel_root in scan_roots {
+        collect_dir(
+            live_home,
+            source_root,
+            expected,
+            rel_root,
+            rel_root,
+            true,
+            &mut candidates,
+        )?;
+    }
+    candidates.sort_by(candidate_order);
+    candidates.dedup();
+    Ok(candidates)
+}
+
+fn collect_dir(
+    live_home: &Path,
+    source_root: &Path,
+    expected: &BTreeSet<PathBuf>,
+    scan_root: &Path,
+    rel_dir: &Path,
+    is_scan_root: bool,
+    candidates: &mut Vec<Candidate>,
+) -> Result<bool, PruneError> {
+    let dir = live_home.join(rel_dir);
+    let Ok(meta) = fs::symlink_metadata(&dir) else {
+        return Ok(false);
+    };
+    if !meta.is_dir() || meta.file_type().is_symlink() {
+        return Ok(false);
+    }
+
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(&dir).map_err(|source| PruneError::Io {
+        path: dir.clone(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| PruneError::Io {
+            path: dir.clone(),
+            source,
+        })?;
+        entries.push(entry.file_name());
+    }
+    entries.sort();
+
+    let mut all_children_removable = true;
+    let mut saw_removable_child = false;
+    for name in entries {
+        let child_rel = rel_dir.join(&name);
+        let child_abs = live_home.join(&child_rel);
+        if expected.contains(&child_rel) || live_surface::ignored_live_file(&child_rel) {
+            all_children_removable = false;
+            continue;
+        }
+        let Ok(child_meta) = fs::symlink_metadata(&child_abs) else {
+            continue;
+        };
+        if child_meta.file_type().is_symlink() {
+            let target = fs::read_link(&child_abs).map_err(|source| PruneError::Io {
+                path: child_abs.clone(),
+                source,
+            })?;
+            if symlink_target_is_owned(source_root, &target) {
+                candidates.push(Candidate::Symlink {
+                    rel_path: child_rel,
+                    path: child_abs,
+                    target,
+                });
+                saw_removable_child = true;
+            } else {
+                candidates.push(Candidate::SkippedForeignSymlink {
+                    rel_path: child_rel,
+                    path: child_abs,
+                    target,
+                });
+                all_children_removable = false;
+            }
+        } else if child_meta.is_file() {
+            candidates.push(Candidate::SkippedRegularFile {
+                rel_path: child_rel,
+                path: child_abs,
+            });
+            all_children_removable = false;
+        } else if child_meta.is_dir() {
+            let child_removable = collect_dir(
+                live_home,
+                source_root,
+                expected,
+                scan_root,
+                &child_rel,
+                false,
+                candidates,
+            )?;
+            if !child_removable {
+                all_children_removable = false;
+            } else {
+                saw_removable_child = true;
+            }
+        } else {
+            all_children_removable = false;
+        }
+    }
+
+    if is_scan_root {
+        return Ok(false);
+    }
+
+    if all_children_removable && saw_removable_child {
+        candidates.push(Candidate::EmptyDirectory {
+            rel_path: rel_dir.to_path_buf(),
+            path: dir,
+        });
+        return Ok(true);
+    }
+
+    if !has_expected_descendant(expected, rel_dir) && rel_dir.starts_with(scan_root) {
+        candidates.push(Candidate::SkippedNonEmptyDirectory {
+            rel_path: rel_dir.to_path_buf(),
+            path: dir,
+        });
+    }
+    Ok(false)
+}
+
+fn has_expected_descendant(expected: &BTreeSet<PathBuf>, rel_dir: &Path) -> bool {
+    expected.iter().any(|path| path.starts_with(rel_dir))
+}
+
+fn dry_run_change(candidate: Candidate) -> PruneChange {
+    match candidate {
+        Candidate::Symlink {
+            rel_path,
+            path,
+            target,
+        } => PruneChange::WouldRemoveSymlink {
+            rel_path,
+            path,
+            target,
+        },
+        Candidate::EmptyDirectory { rel_path, path } => {
+            PruneChange::WouldRemoveEmptyDirectory { rel_path, path }
+        }
+        Candidate::SkippedForeignSymlink {
+            rel_path,
+            path,
+            target,
+        } => PruneChange::SkippedForeignSymlink {
+            rel_path,
+            path,
+            target,
+        },
+        Candidate::SkippedRegularFile { rel_path, path } => {
+            PruneChange::SkippedRegularFile { rel_path, path }
+        }
+        Candidate::SkippedNonEmptyDirectory { rel_path, path } => {
+            PruneChange::SkippedNonEmptyDirectory { rel_path, path }
+        }
+    }
+}
+
+fn apply_candidates(candidates: Vec<Candidate>) -> Result<Vec<PruneChange>, PruneError> {
+    let mut symlinks = Vec::new();
+    let mut dirs = Vec::new();
+    let mut skips = Vec::new();
+    for candidate in candidates {
+        match candidate {
+            Candidate::Symlink { .. } => symlinks.push(candidate),
+            Candidate::EmptyDirectory { .. } => dirs.push(candidate),
+            Candidate::SkippedForeignSymlink { .. }
+            | Candidate::SkippedRegularFile { .. }
+            | Candidate::SkippedNonEmptyDirectory { .. } => skips.push(dry_run_change(candidate)),
+        }
+    }
+    dirs.sort_by(|a, b| {
+        candidate_depth(b)
+            .cmp(&candidate_depth(a))
+            .then_with(|| candidate_order(a, b))
+    });
+
+    let mut changes = Vec::new();
+    for candidate in symlinks {
+        let Candidate::Symlink {
+            rel_path,
+            path,
+            target,
+        } = candidate
+        else {
+            unreachable!();
+        };
+        match fs::remove_file(&path) {
+            Ok(()) => changes.push(PruneChange::RemovedSymlink {
+                rel_path,
+                path,
+                target,
+            }),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                changes.push(PruneChange::NoOpSymlink {
+                    rel_path,
+                    path,
+                    target,
+                });
+            }
+            Err(source) => return Err(PruneError::Io { path, source }),
+        }
+    }
+    for candidate in dirs {
+        let Candidate::EmptyDirectory { rel_path, path } = candidate else {
+            unreachable!();
+        };
+        match fs::remove_dir(&path) {
+            Ok(()) => changes.push(PruneChange::RemovedEmptyDirectory { rel_path, path }),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                changes.push(PruneChange::NoOpEmptyDirectory { rel_path, path });
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::DirectoryNotEmpty => {
+                changes.push(PruneChange::SkippedNonEmptyDirectory { rel_path, path });
+            }
+            Err(source) => return Err(PruneError::Io { path, source }),
+        }
+    }
+    changes.extend(skips);
+    changes.sort_by(change_order);
+    Ok(changes)
+}
+
+fn candidate_depth(candidate: &Candidate) -> usize {
+    candidate_rel_path(candidate).components().count()
+}
+
+fn candidate_order(a: &Candidate, b: &Candidate) -> std::cmp::Ordering {
+    candidate_rel_path(a)
+        .cmp(candidate_rel_path(b))
+        .then_with(|| candidate_rank(a).cmp(&candidate_rank(b)))
+}
+
+fn candidate_rank(candidate: &Candidate) -> u8 {
+    match candidate {
+        Candidate::Symlink { .. } => 0,
+        Candidate::EmptyDirectory { .. } => 1,
+        Candidate::SkippedForeignSymlink { .. } => 2,
+        Candidate::SkippedRegularFile { .. } => 3,
+        Candidate::SkippedNonEmptyDirectory { .. } => 4,
+    }
+}
+
+fn candidate_rel_path(candidate: &Candidate) -> &Path {
+    match candidate {
+        Candidate::Symlink { rel_path, .. }
+        | Candidate::EmptyDirectory { rel_path, .. }
+        | Candidate::SkippedForeignSymlink { rel_path, .. }
+        | Candidate::SkippedRegularFile { rel_path, .. }
+        | Candidate::SkippedNonEmptyDirectory { rel_path, .. } => rel_path,
+    }
+}
+
+fn change_order(a: &PruneChange, b: &PruneChange) -> std::cmp::Ordering {
+    change_rel_path(a)
+        .cmp(change_rel_path(b))
+        .then_with(|| change_rank(a).cmp(&change_rank(b)))
+}
+
+fn change_rank(change: &PruneChange) -> u8 {
+    match change {
+        PruneChange::WouldRemoveSymlink { .. } | PruneChange::RemovedSymlink { .. } => 0,
+        PruneChange::NoOpSymlink { .. } => 1,
+        PruneChange::WouldRemoveEmptyDirectory { .. }
+        | PruneChange::RemovedEmptyDirectory { .. } => 2,
+        PruneChange::NoOpEmptyDirectory { .. } => 3,
+        PruneChange::SkippedForeignSymlink { .. } => 4,
+        PruneChange::SkippedRegularFile { .. } => 5,
+        PruneChange::SkippedNonEmptyDirectory { .. } => 6,
+    }
+}
+
+fn change_rel_path(change: &PruneChange) -> &Path {
+    match change {
+        PruneChange::WouldRemoveSymlink { rel_path, .. }
+        | PruneChange::RemovedSymlink { rel_path, .. }
+        | PruneChange::NoOpSymlink { rel_path, .. }
+        | PruneChange::WouldRemoveEmptyDirectory { rel_path, .. }
+        | PruneChange::RemovedEmptyDirectory { rel_path, .. }
+        | PruneChange::NoOpEmptyDirectory { rel_path, .. }
+        | PruneChange::SkippedForeignSymlink { rel_path, .. }
+        | PruneChange::SkippedRegularFile { rel_path, .. }
+        | PruneChange::SkippedNonEmptyDirectory { rel_path, .. } => rel_path,
+    }
+}
+
+fn symlink_target_is_owned(source_root: &Path, target: &Path) -> bool {
+    if !target.is_absolute() {
+        return false;
+    }
+    let source_root = normalize_absolute_path(source_root);
+    let target = normalize_absolute_path(target);
+    target.starts_with(source_root)
+}
+
+fn normalize_absolute_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => out.push(prefix.as_os_str()),
+            Component::RootDir => out.push(Path::new("/")),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::Normal(part) => out.push(part),
+        }
+    }
+    out
+}

--- a/crates/agent-runtime-cli/tests/integration.rs
+++ b/crates/agent-runtime-cli/tests/integration.rs
@@ -35,6 +35,8 @@ mod list_skills;
 mod managed_block;
 #[path = "integration/pr_body.rs"]
 mod pr_body;
+#[path = "integration/prune_stale.rs"]
+mod prune_stale;
 #[path = "integration/purge_state.rs"]
 mod purge_state;
 #[path = "integration/render.rs"]

--- a/crates/agent-runtime-cli/tests/integration/cli.rs
+++ b/crates/agent-runtime-cli/tests/integration/cli.rs
@@ -20,6 +20,7 @@ const ALL_SUBCOMMANDS: &[&str] = &[
     "gc-backups",
     "list-skills",
     "pr-body",
+    "prune-stale",
     "restore-backups",
     "purge-state",
 ];

--- a/crates/agent-runtime-cli/tests/integration/prune_stale.rs
+++ b/crates/agent-runtime-cli/tests/integration/prune_stale.rs
@@ -1,0 +1,286 @@
+//! `agent-runtime prune-stale` integration coverage.
+//!
+//! The command removes only stale live surfaces that are provably owned by
+//! the active agent-runtime-kit source root. It must leave ambiguous user
+//! runtime-home content untouched.
+
+use nils_test_support::bin;
+use nils_test_support::cmd::{self, CmdOutput};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn agent_runtime_bin() -> PathBuf {
+    bin::resolve("agent-runtime")
+}
+
+fn run_cli(args: &[&str]) -> CmdOutput {
+    cmd::run(&agent_runtime_bin(), args, &[], None)
+}
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn symlink(source: &Path, dest: &Path) {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    std::os::unix::fs::symlink(source, dest).unwrap();
+}
+
+fn build_codex_source_root(tmp: &Path) -> PathBuf {
+    let root = tmp.join("src");
+    write(
+        &root.join("build/codex/plugins/reporting/skills/current/SKILL.md"),
+        "# current\n",
+    );
+    write(
+        &root.join("targets/codex/link-map.yaml"),
+        r#"schema_version: 1
+entries:
+  - id: reporting.current
+    kind: symlinked-file
+    source: build/codex/plugins/reporting/skills/current
+    destination: skills/reporting/current
+"#,
+    );
+    fs::canonicalize(&root).unwrap()
+}
+
+fn build_claude_source_root(tmp: &Path) -> PathBuf {
+    let root = tmp.join("src");
+    write(
+        &root.join("build/claude/plugins/reporting/skills/current/SKILL.md"),
+        "# current\n",
+    );
+    write(
+        &root.join("targets/claude/link-map.yaml"),
+        r#"schema_version: 1
+entries:
+  - id: reporting.skills-tree
+    kind: symlinked-file
+    source: build/claude/plugins/reporting/skills
+    destination: plugins/reporting/skills
+    recursive: true
+"#,
+    );
+    fs::canonicalize(&root).unwrap()
+}
+
+#[test]
+fn dry_run_reports_owned_stale_codex_skill_without_mutating_home() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_codex_source_root(tmp.path());
+    let live_home = tmp.path().join("codex-home");
+    let stale_dest = live_home.join("skills/reporting/old");
+    symlink(
+        &source_root.join("build/codex/plugins/reporting/skills/old"),
+        &stale_dest,
+    );
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let live_arg = live_home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "prune-stale",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "codex",
+        "--live-home",
+        &live_arg,
+        "--dry-run",
+    ]);
+
+    assert_eq!(
+        output.code,
+        0,
+        "dry-run should succeed; stderr=\n{}",
+        output.stderr_text()
+    );
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.contains("would remove symlink"),
+        "dry-run should report stale symlink removal; stderr=\n{stderr}"
+    );
+    assert!(
+        stderr.contains("skills/reporting/old"),
+        "dry-run should name the stale skill; stderr=\n{stderr}"
+    );
+    assert!(
+        fs::symlink_metadata(&stale_dest)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "dry-run must not remove stale symlink"
+    );
+}
+
+#[test]
+fn apply_removes_owned_stale_codex_skill_and_second_apply_is_clean_noop() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_codex_source_root(tmp.path());
+    let live_home = tmp.path().join("codex-home");
+    let stale_dest = live_home.join("skills/reporting/old");
+    symlink(
+        &source_root.join("build/codex/plugins/reporting/skills/old"),
+        &stale_dest,
+    );
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let live_arg = live_home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "prune-stale",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "codex",
+        "--live-home",
+        &live_arg,
+        "--apply",
+    ]);
+
+    assert_eq!(
+        output.code,
+        0,
+        "apply should succeed; stderr=\n{}",
+        output.stderr_text()
+    );
+    assert!(
+        fs::symlink_metadata(&stale_dest).is_err(),
+        "apply should remove stale symlink"
+    );
+
+    let second = run_cli(&[
+        "prune-stale",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "codex",
+        "--live-home",
+        &live_arg,
+        "--apply",
+    ]);
+    assert_eq!(
+        second.code,
+        0,
+        "second apply should succeed; stderr=\n{}",
+        second.stderr_text()
+    );
+    assert!(
+        second.stderr_text().contains("changes=0"),
+        "second apply should report no changes; stderr=\n{}",
+        second.stderr_text()
+    );
+}
+
+#[test]
+fn apply_prunes_recursive_claude_stale_skill_files_and_empty_directories() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_claude_source_root(tmp.path());
+    let live_home = tmp.path().join("claude-home");
+    let stale_skill = live_home.join("plugins/reporting/skills/old");
+    symlink(
+        &source_root.join("build/claude/plugins/reporting/skills/old/SKILL.md"),
+        &stale_skill.join("SKILL.md"),
+    );
+    symlink(
+        &source_root.join("build/claude/plugins/reporting/skills/old/scripts/tool.sh"),
+        &stale_skill.join("scripts/tool.sh"),
+    );
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let live_arg = live_home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "prune-stale",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "claude",
+        "--live-home",
+        &live_arg,
+        "--apply",
+    ]);
+
+    assert_eq!(
+        output.code,
+        0,
+        "apply should succeed; stderr=\n{}",
+        output.stderr_text()
+    );
+    assert!(
+        !stale_skill.exists(),
+        "empty stale skill directory should be removed after stale symlinks"
+    );
+}
+
+#[test]
+fn apply_skips_foreign_symlink_regular_file_and_non_empty_directory() {
+    let tmp = TempDir::new().unwrap();
+    let source_root = build_claude_source_root(tmp.path());
+    let live_home = tmp.path().join("claude-home");
+    let scan_root = live_home.join("plugins/reporting/skills");
+    let foreign = scan_root.join("foreign/SKILL.md");
+    let regular = scan_root.join("regular/SKILL.md");
+    let non_empty = scan_root.join("non-empty");
+    let empty_user_dir = scan_root.join("empty-user");
+
+    symlink(Path::new("/var/empty/foreign-skill"), &foreign);
+    write(&regular, "# user-owned regular file\n");
+    write(&non_empty.join("note.txt"), "user-owned note\n");
+    fs::create_dir_all(&empty_user_dir).unwrap();
+
+    let source_arg = source_root.to_string_lossy().into_owned();
+    let live_arg = live_home.to_string_lossy().into_owned();
+    let output = run_cli(&[
+        "prune-stale",
+        "--source-root",
+        &source_arg,
+        "--product",
+        "claude",
+        "--live-home",
+        &live_arg,
+        "--apply",
+    ]);
+
+    assert_eq!(
+        output.code,
+        0,
+        "apply should succeed with skipped candidates; stderr=\n{}",
+        output.stderr_text()
+    );
+    let stderr = output.stderr_text();
+    assert!(
+        stderr.contains("foreign symlink"),
+        "foreign symlink should be reported as skipped; stderr=\n{stderr}"
+    );
+    assert!(
+        stderr.contains("regular file"),
+        "regular file should be reported as skipped; stderr=\n{stderr}"
+    );
+    assert!(
+        stderr.contains("non-empty directory"),
+        "non-empty directory should be reported as skipped; stderr=\n{stderr}"
+    );
+    assert!(
+        fs::symlink_metadata(&foreign)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(
+        fs::read_to_string(&regular).unwrap(),
+        "# user-owned regular file\n"
+    );
+    assert_eq!(
+        fs::read_to_string(non_empty.join("note.txt")).unwrap(),
+        "user-owned note\n"
+    );
+    assert!(
+        empty_user_dir.is_dir(),
+        "pre-existing empty user directory should not be removed"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `agent-runtime prune-stale` as a dry-run/apply cleanup primitive for managed runtime skill surfaces. The command removes only owned stale symlinks that point back into the selected source root, prunes directories that become empty as a result, and reports foreign symlinks or user-owned files without deleting them.

This supports graysurf/agent-runtime-kit#119 by giving the runtime-kit sync wrapper a released CLI primitive for stale Codex/Claude skill removal.

## Test plan

- `cargo test -p agent-runtime-cli --test integration prune_stale`
- `cargo test -p agent-runtime-cli --test integration install_pipeline`
- `cargo test -p agent-runtime-cli --test integration uninstall`
- `cargo test -p agent-runtime-cli --test integration audit_drift_extra_intentional`
- `cargo test -p agent-runtime-cli --test integration cli`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
