### PR TITLE
Require plan issue session evidence for closeout

### DIFF
--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -2163,6 +2163,21 @@ pub fn evaluate_strict_closeout_gate(
         ),
     }
 
+    match audit.evidence.get("session") {
+        Some(hit) => push_pass(
+            &mut checks,
+            "execution session",
+            hit.url.as_deref().unwrap_or("present").to_string(),
+        ),
+        None => push_fail(
+            &mut checks,
+            &mut blocked_codes,
+            "execution session",
+            "missing role=session lifecycle record".to_string(),
+            "session-missing",
+        ),
+    }
+
     match audit.evidence.get("validation") {
         Some(hit) => match hit.status.as_deref() {
             Some("pass") => push_pass(&mut checks, "validation", "pass".to_string()),
@@ -2459,10 +2474,12 @@ mod sprint3_tests {
         );
         let source = v2_body("source", json!({"path": "p", "commit": "c"}));
         let plan = v2_body("plan", json!({"path": "p", "commit": "c"}));
+        let session = v2_body("session", json!({"summary": "session complete"}));
         let audit = build_audit_with_evidence(vec![
             (source, "u-src"),
             (plan, "u-plan"),
             (state, "u-state"),
+            (session, "u-session"),
             (validation, "u-val"),
             (review, "u-rev"),
         ]);
@@ -2499,12 +2516,14 @@ mod sprint3_tests {
         );
         let source = v2_body("source", json!({"path": "p", "commit": "c"}));
         let plan = v2_body("plan", json!({"path": "p", "commit": "c"}));
+        let session = v2_body("session", json!({"summary": "session complete"}));
         let validation = v2_body("validation", json!({"overall": "pass"}));
         let review = v2_body("review", json!({"decision": "approve"}));
         let audit = build_audit_with_evidence(vec![
             (source, "a"),
             (plan, "b"),
             (state, "c"),
+            (session, "d"),
             (validation, "d"),
             (review, "e"),
         ]);
@@ -2538,12 +2557,14 @@ mod sprint3_tests {
             "state",
             json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
         );
+        let session = v2_body("session", json!({"summary": "session complete"}));
         let validation = v2_body("validation", json!({"overall": "pass"}));
         let review_rejected = v2_body("review", json!({"decision": "request-changes"}));
         let audit_rej = build_audit_with_evidence(vec![
             (source.clone(), "a"),
             (plan.clone(), "b"),
             (state.clone(), "c"),
+            (session.clone(), "d"),
             (validation.clone(), "d"),
             (review_rejected, "e"),
         ]);
@@ -2573,6 +2594,7 @@ mod sprint3_tests {
             (source, "a"),
             (plan, "b"),
             (state, "c"),
+            (session, "d"),
             (validation, "d"),
             (review_unresolved, "e"),
         ]);
@@ -2603,12 +2625,14 @@ mod sprint3_tests {
             "state",
             json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
         );
+        let session = v2_body("session", json!({"summary": "session complete"}));
         let validation = v2_body("validation", json!({"overall": "pass"}));
         let review = v2_body("review", json!({"decision": "approve"}));
         let audit = build_audit_with_evidence(vec![
             (source, "a"),
             (plan, "b"),
             (state, "c"),
+            (session, "d"),
             (validation, "d"),
             (review, "e"),
         ]);
@@ -2653,6 +2677,10 @@ mod sprint3_tests {
                 ),
                 "c",
             ),
+            (
+                v2_body("session", json!({"summary": "session complete"})),
+                "d",
+            ),
             (v2_body("validation", json!({"overall": "pass"})), "d"),
             (v2_body("review", json!({"decision": "approve"})), "e"),
         ]);
@@ -2691,6 +2719,10 @@ mod sprint3_tests {
                     json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
                 ),
                 "c",
+            ),
+            (
+                v2_body("session", json!({"summary": "session complete"})),
+                "d",
             ),
             (v2_body("validation", json!({"overall": "pass"})), "d"),
             (v2_body("review", json!({"decision": "approve"})), "e"),
@@ -2741,6 +2773,10 @@ mod sprint3_tests {
                     json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
                 ),
                 "c",
+            ),
+            (
+                v2_body("session", json!({"summary": "session complete"})),
+                "d",
             ),
             (v2_body("validation", json!({"overall": "pass"})), "d"),
             (v2_body("review", json!({"decision": "approve"})), "e"),
@@ -2797,12 +2833,14 @@ mod sprint3_tests {
             "state",
             json!({"status": "complete", "tasks": [], "prs": [], "blockers": [], "links": {}}),
         );
+        let session = v2_body("session", json!({"summary": "session complete"}));
         let validation = v2_body("validation", json!({"overall": "pass"}));
         let review = v2_body("review", json!({"decision": "approve"}));
         let audit = build_audit_with_evidence(vec![
             (source, "a"),
             (plan, "b"),
             (state, "c"),
+            (session, "d"),
             (validation, "d"),
             (review, "e"),
         ]);

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -873,6 +873,18 @@ fn build_closeout_evidence(linked_pr_ref: &str) -> Value {
                 "created_at": "2026-05-23T10:00:00Z"
             },
             {
+                "url": "https://github.com/owner/repo/issues/9#issuecomment-session",
+                "body": v2_comment_body(
+                    "session",
+                    "tracking",
+                    json!({
+                        "summary": "implementation session completed",
+                        "highlights": ["state, validation, and review evidence recorded"]
+                    }),
+                ),
+                "created_at": "2026-05-23T10:30:00Z"
+            },
+            {
                 "url": "https://github.com/owner/repo/issues/9#issuecomment-validation",
                 "body": v2_comment_body(
                     "validation",
@@ -900,6 +912,18 @@ fn build_closeout_evidence(linked_pr_ref: &str) -> Value {
             }
         ]
     })
+}
+
+fn remove_session_comment(comments: &mut Value) {
+    comments["comments"]
+        .as_array_mut()
+        .expect("comments array")
+        .retain(|comment| {
+            !comment["body"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("role=session")
+        });
 }
 
 #[test]
@@ -1006,6 +1030,51 @@ fn record_close_fixture_passes_strict_gate_with_complete_v2_evidence() {
     assert!(
         final_dashboard.starts_with("## Final Dashboard"),
         "{final_dashboard}"
+    );
+}
+
+#[test]
+fn record_close_fixture_blocks_when_session_comment_missing() {
+    let tmp = TempDir::new().expect("tempdir");
+    let fixture = tmp.path().join("fixture");
+    fs::create_dir_all(&fixture).expect("create fixture");
+
+    let mut comments = build_closeout_evidence("owner/repo#1");
+    remove_session_comment(&mut comments);
+    let body = "## Current Dashboard\n\n- Status: complete\n- Latest session: pending\n\n## Session Log\n\n- Notes embedded in state only.\n";
+    write_fixture_files(&fixture, body, &comments);
+    write_pr_fixture(
+        &fixture,
+        "owner/repo",
+        1,
+        json!({
+            "state": "MERGED",
+            "mergeCommit": {"oid": "deadbeefcafebabe"},
+            "statusCheckRollup": {"state": "success"},
+            "url": "https://github.com/owner/repo/pull/1"
+        }),
+    );
+
+    let out = common::run_plan_issue_local(&[
+        "--format",
+        "json",
+        "record",
+        "close",
+        "--issue",
+        "9",
+        "--linked-pr",
+        "owner/repo#1",
+        "--approval",
+        "https://github.com/owner/repo/issues/9#issuecomment-approval",
+        "--fixture",
+        fixture.to_str().expect("fixture path"),
+    ]);
+
+    assert_ne!(out.code, 0, "missing session must block closeout");
+    let joined = format!("{}\n{}", out.stderr, out.stdout);
+    assert!(
+        joined.contains("session-missing"),
+        "expected session-missing, got: {joined}"
     );
 }
 


### PR DESCRIPTION
## Summary

Require `plan-issue record close` to reject tracking or dispatch records that lack a real `role=session` lifecycle comment. This closes the gap where a state comment could contain a `## Session Log` section while the issue dashboard still reported `Latest session: pending`.

## Problem

- Expected: closeout readiness requires a latest session lifecycle record.
- Actual: strict closeout accepted source, plan, complete state, validation, review, approval, and merged PR evidence even when no `role=session` comment existed.
- Impact: downstream plan issues could close with `Latest session: pending`.

## Reproduction

1. Build a plan issue record fixture with source, plan, complete state, validation, review, approval, and merged PR evidence.
2. Remove the `role=session` lifecycle comment while leaving a visible `## Session Log` in the issue body.
3. Run `plan-issue record close --fixture <fixture>`.

## Issues Found

- graysurf/agent-runtime-kit#120

## Fix Approach

Add `session-missing` to the strict closeout gate and update complete closeout fixtures so passing cases include a real session lifecycle comment. The missing-session regression fixture proves state-embedded session notes are not enough.

## Test-First Evidence

- Added a failing regression fixture first in `live_record_ops::record_close_fixture_blocks_when_session_comment_missing`, then implemented the closeout gate.

## Test plan

- `cargo fmt --all --check` (pass)
- `cargo test -p nils-plan-issue-cli lifecycle_record -- --nocapture` (pass)
- `cargo test -p nils-plan-issue-cli live_record_ops::record_close -- --nocapture` (pass)
- `cargo build -p nils-plan-issue-cli --bins` (pass)

## Risk / Notes

- Older active v2 records without session comments will now need an explicit session backfill before closeout.
