### PR TITLE
feat(plan-issue): vNext lifecycle controller surfaces

### DIFF
--- a/crates/plan-issue-cli/CHANGELOG.md
+++ b/crates/plan-issue-cli/CHANGELOG.md
@@ -6,6 +6,37 @@ versioning.
 
 ## [Unreleased]
 
+### Added (Plan-Issue vNext)
+
+- `plan-issue record template --kind <role> --shape markdown|json` —
+  non-mutating preview of every lifecycle role's visible body and JSON
+  payload skeleton, driven by the new vNext registry.
+- `plan-issue record audit --expect-visible` — opt-in visible
+  completeness lint over the latest comment body per role. Returns a
+  `visible` block with stable role-specific failure codes
+  (`state-missing-task-ledger`, `validation-missing-overall`, …) alongside
+  the existing hidden-payload audit result.
+- New `plan-issue tracking` surface covering:
+  - `tracking status` — reconcile provider issue evidence with optional
+    local run state and return the FSM state + recommended next action.
+  - `tracking run init` / `tracking run update` — typed local run-state
+    persistence (`plan-issue.execution-run.v1`) plus append-only
+    `events.jsonl` journal (`plan-issue.execution-event.v1`) under the
+    issue-scoped runtime root.
+  - `tracking checkpoint` — default dry-run rendering of role-allowed
+    lifecycle comments synthesized from the run state. `--live` opts in
+    to provider mutation; until the live adapter ships the controller
+    returns a `tracking-checkpoint-live-not-implemented` blocker.
+  - `tracking close-ready` — strict, non-mutating close-readiness probe
+    with role-specific blocked codes and visible-completeness gating.
+- `lifecycle_vnext` module tree (`registry`, `templates`, `visible_lint`,
+  `payloads`, `render`) plus `tracking` module tree (`run_state`,
+  `events`, `fsm`, `reconcile`, `checkpoint`, `close_ready`) so the
+  vNext controller has a clean boundary outside the catch-all executor.
+- `record_compat_baseline` integration tests locking the released
+  `record` subcommand surface, envelope, error shape, and tracking
+  schema constants before runtime-kit migrates.
+
 ### Fixed
 
 - `plan-issue record close` no longer collapses non-required GitHub

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -316,6 +316,12 @@ impl TrackingArgs {
     pub fn command_id(&self) -> &'static str {
         match &self.command {
             tracking::TrackingCommand::Status(_) => "tracking.status",
+            tracking::TrackingCommand::Run(run) => match &run.command {
+                tracking::TrackingRunCommand::Init(_) => "tracking.run.init",
+                tracking::TrackingRunCommand::Update(_) => "tracking.run.update",
+            },
+            tracking::TrackingCommand::Checkpoint(_) => "tracking.checkpoint",
+            tracking::TrackingCommand::CloseReady(_) => "tracking.close-ready",
         }
     }
 }

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod completion;
 pub mod plan;
 pub mod record;
 pub mod sprint;
+pub mod tracking;
 
 use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
@@ -18,6 +19,7 @@ use self::plan::{
 };
 use self::record::RecordArgs;
 use self::sprint::{AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs};
+use self::tracking::TrackingArgs;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
 pub enum PrGrouping {
@@ -185,6 +187,10 @@ pub enum Command {
     /// Render and audit issue-backed plan record dashboards and comments.
     Record(RecordArgs),
 
+    /// Run-state controller for the plan-tracking issue workflow
+    /// (`status`, `run init`, `run update`, `checkpoint`, `close-ready`).
+    Tracking(TrackingArgs),
+
     /// Export shell completion script.
     Completion(CompletionArgs),
 }
@@ -206,6 +212,7 @@ impl Command {
             Self::MultiSprintGuide(_) => "multi-sprint-guide",
             Self::ResolveApproval(_) => "resolve-approval",
             Self::Record(args) => args.command_id(),
+            Self::Tracking(args) => args.command_id(),
             Self::Completion(_) => "completion",
         }
     }
@@ -232,6 +239,7 @@ impl Command {
             // fields (`issue.url`, `comments.*`, `closeout_url`,
             // `final_dashboard`).
             Self::Record(_) => "v2",
+            Self::Tracking(_) => "v1",
             _ => "v1",
         };
         format!(
@@ -256,6 +264,7 @@ impl Command {
             Self::MultiSprintGuide(args) => serde_json::to_value(args),
             Self::ResolveApproval(args) => serde_json::to_value(args),
             Self::Record(args) => serde_json::to_value(args),
+            Self::Tracking(args) => serde_json::to_value(args),
             Self::Completion(args) => serde_json::to_value(args),
         };
 
@@ -279,6 +288,7 @@ impl Command {
             Self::LinkPr(args) => validate_link_pr_args(args),
             Self::MultiSprintGuide(args) => validate_multi_sprint_guide_args(args),
             Self::Record(_) => Ok(()),
+            Self::Tracking(_) => Ok(()),
             Self::Completion(_)
             | Self::StatusPlan(_)
             | Self::ReadyPlan(_)
@@ -298,6 +308,14 @@ impl RecordArgs {
             record::RecordCommand::Close(_) => "record.close",
             record::RecordCommand::Audit(_) => "record.audit",
             record::RecordCommand::Template(_) => "record.template",
+        }
+    }
+}
+
+impl TrackingArgs {
+    pub fn command_id(&self) -> &'static str {
+        match &self.command {
+            tracking::TrackingCommand::Status(_) => "tracking.status",
         }
     }
 }

--- a/crates/plan-issue-cli/src/commands/mod.rs
+++ b/crates/plan-issue-cli/src/commands/mod.rs
@@ -297,6 +297,7 @@ impl RecordArgs {
             record::RecordCommand::RepairDashboard(_) => "record.repair-dashboard",
             record::RecordCommand::Close(_) => "record.close",
             record::RecordCommand::Audit(_) => "record.audit",
+            record::RecordCommand::Template(_) => "record.template",
         }
     }
 }

--- a/crates/plan-issue-cli/src/commands/record.rs
+++ b/crates/plan-issue-cli/src/commands/record.rs
@@ -96,6 +96,13 @@ pub struct RecordAuditArgs {
     /// Expected profile. When omitted, all recognized markers are reported.
     #[arg(long, value_enum)]
     pub profile: Option<RecordProfile>,
+
+    /// Also run the visible-completeness lint against the latest comment body
+    /// per role. Produces stable role-specific failure codes
+    /// (`state-missing-task-ledger`, `validation-missing-overall`, …) in the
+    /// `visible` block of the audit result.
+    #[arg(long = "expect-visible", default_value_t = false)]
+    pub expect_visible: bool,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]

--- a/crates/plan-issue-cli/src/commands/record.rs
+++ b/crates/plan-issue-cli/src/commands/record.rs
@@ -31,6 +31,10 @@ pub enum RecordCommand {
 
     /// Audit issue body and comments for lifecycle markers.
     Audit(Box<RecordAuditArgs>),
+
+    /// Preview the visible Markdown or JSON payload skeleton for a lifecycle
+    /// role. Non-mutating; backed by the vNext lifecycle role registry.
+    Template(Box<RecordTemplateArgs>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
@@ -66,6 +70,39 @@ pub enum TaskLedgerDisplay {
     Auto,
     Collapsed,
     Expanded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ValueEnum)]
+pub enum TemplateFormatArg {
+    Markdown,
+    Json,
+}
+
+impl TemplateFormatArg {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Markdown => "markdown",
+            Self::Json => "json",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct RecordTemplateArgs {
+    /// Lifecycle profile for the template preview.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Lifecycle role to preview.
+    #[arg(long, value_enum)]
+    pub kind: LifecycleCommentKind,
+
+    /// Template output shape. `markdown` prints the visible body skeleton;
+    /// `json` prints the payload data skeleton. (Named `--shape` rather than
+    /// `--format` because the global `--format text|json` controls the
+    /// command envelope and would shadow a subcommand `--format` flag.)
+    #[arg(long, value_enum, default_value_t = TemplateFormatArg::Markdown)]
+    pub shape: TemplateFormatArg,
 }
 
 impl LifecycleCommentKind {

--- a/crates/plan-issue-cli/src/commands/tracking.rs
+++ b/crates/plan-issue-cli/src/commands/tracking.rs
@@ -22,6 +22,262 @@ pub enum TrackingCommand {
     /// Read issue lifecycle evidence + local run state and return the
     /// reconciled FSM state without provider mutation.
     Status(Box<TrackingStatusArgs>),
+
+    /// Manage a typed local run state (`run init`, `run update`).
+    Run(Box<TrackingRunArgs>),
+
+    /// Render or post checkpoint lifecycle comments derived from run state.
+    Checkpoint(Box<TrackingCheckpointArgs>),
+
+    /// Non-mutating close-readiness probe.
+    #[command(name = "close-ready")]
+    CloseReady(Box<TrackingCloseReadyArgs>),
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct TrackingRunArgs {
+    #[command(subcommand)]
+    pub command: TrackingRunCommand,
+}
+
+#[derive(Debug, Clone, Subcommand, Serialize)]
+pub enum TrackingRunCommand {
+    /// Create or refresh a run-state.json document under the issue runtime
+    /// root.
+    Init(Box<TrackingRunInitArgs>),
+
+    /// Update a previously-initialized run-state.json without provider
+    /// mutation.
+    Update(Box<TrackingRunUpdateArgs>),
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct TrackingRunInitArgs {
+    /// Repository slug in `owner/repo` form.
+    #[arg(long = "provider-repo", value_name = "owner/repo")]
+    pub provider_repo: String,
+
+    /// Issue number.
+    #[arg(long, value_name = "number")]
+    pub issue: u64,
+
+    /// Lifecycle profile for the new run.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Plan bundle directory.
+    #[arg(long, value_name = "dir")]
+    pub bundle: Option<PathBuf>,
+
+    /// Canonical execution-state Markdown.
+    #[arg(long = "execution-state-file", value_name = "path")]
+    pub execution_state_file: Option<PathBuf>,
+
+    /// Selected task id.
+    #[arg(long, value_name = "id")]
+    pub task: Option<String>,
+
+    /// Selected sprint number.
+    #[arg(long, value_name = "number")]
+    pub sprint: Option<i32>,
+
+    /// Branch backing the run.
+    #[arg(long, value_name = "name")]
+    pub branch: Option<String>,
+
+    /// Worktree path.
+    #[arg(long, value_name = "path")]
+    pub worktree: Option<PathBuf>,
+
+    /// Linked PR reference (`owner/repo#number`).
+    #[arg(long = "linked-pr", value_name = "ref")]
+    pub linked_pr: Option<String>,
+
+    /// Override the generated `run_id`. Useful for deterministic tests.
+    #[arg(long = "run-id", value_name = "id")]
+    pub run_id: Option<String>,
+
+    /// Override the recorded timestamp (`created_at` / `updated_at`).
+    #[arg(long = "now", value_name = "rfc3339")]
+    pub now: Option<String>,
+
+    /// Write to this run-state path instead of the issue runtime root.
+    #[arg(long = "out", value_name = "path")]
+    pub out: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct TrackingRunUpdateArgs {
+    /// Run-state path to mutate.
+    #[arg(long = "run-state", value_name = "path")]
+    pub run_state: PathBuf,
+
+    /// New phase. Optional.
+    #[arg(long, value_enum)]
+    pub phase: Option<RunPhaseArg>,
+
+    /// Update the selected task id.
+    #[arg(long = "selected-task", value_name = "id")]
+    pub selected_task: Option<String>,
+
+    /// Update the branch name.
+    #[arg(long, value_name = "name")]
+    pub branch: Option<String>,
+
+    /// Update the linked PR reference.
+    #[arg(long = "linked-pr", value_name = "ref")]
+    pub linked_pr: Option<String>,
+
+    /// Validation overall status update (`pass|partial|fail`).
+    #[arg(long = "validation-overall", value_name = "status")]
+    pub validation_overall: Option<String>,
+
+    /// Validation command row update.
+    #[arg(long = "validation-command", value_name = "command")]
+    pub validation_command: Option<String>,
+
+    /// Validation command status update.
+    #[arg(long = "validation-status", value_name = "status")]
+    pub validation_status: Option<String>,
+
+    /// Validation evidence path.
+    #[arg(long = "validation-evidence", value_name = "path")]
+    pub validation_evidence: Option<String>,
+
+    /// Review decision (`approve|request-changes|comments-only`).
+    #[arg(long = "review-decision", value_name = "decision")]
+    pub review_decision: Option<String>,
+
+    /// Free-form note appended to `notes`.
+    #[arg(long, value_name = "text")]
+    pub note: Option<String>,
+
+    /// Override the recorded `updated_at` timestamp.
+    #[arg(long = "now", value_name = "rfc3339")]
+    pub now: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, clap::ValueEnum)]
+pub enum RunPhaseArg {
+    Initial,
+    Implementing,
+    Validating,
+    Reviewing,
+    Blocked,
+    ReadyForClose,
+    Closed,
+}
+
+impl RunPhaseArg {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Initial => "initial",
+            Self::Implementing => "implementing",
+            Self::Validating => "validating",
+            Self::Reviewing => "reviewing",
+            Self::Blocked => "blocked",
+            Self::ReadyForClose => "ready_for_close",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct TrackingCheckpointArgs {
+    /// Repository slug for live mode.
+    #[arg(long = "provider-repo", value_name = "owner/repo")]
+    pub provider_repo: Option<String>,
+
+    /// Issue number for live mode.
+    #[arg(long, value_name = "number")]
+    pub issue: Option<u64>,
+
+    /// Lifecycle profile.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Run-state path.
+    #[arg(long = "run-state", value_name = "path")]
+    pub run_state: PathBuf,
+
+    /// Comma-separated lifecycle roles to render (`state,session,validation,review`).
+    #[arg(long, value_name = "roles", default_value = "state")]
+    pub post: String,
+
+    /// Always repair the dashboard after checkpoint posting.
+    #[arg(long = "repair-dashboard", default_value_t = false)]
+    pub repair_dashboard: bool,
+
+    /// Fixture directory for deterministic issue evidence.
+    #[arg(long, value_name = "dir")]
+    pub fixture: Option<PathBuf>,
+
+    /// Body file (deterministic mode).
+    #[arg(long = "body-file", value_name = "path")]
+    pub body_file: Option<PathBuf>,
+
+    /// Comments JSON file (deterministic mode).
+    #[arg(long = "comments-json", value_name = "path")]
+    pub comments_json: Option<PathBuf>,
+
+    /// Opt into live mutation. Without this flag, `tracking checkpoint`
+    /// renders the planned comments but never mutates the provider issue.
+    /// Live posting lands in Task 6.1; until then the controller returns a
+    /// `tracking-checkpoint-live-not-implemented` blocked code.
+    #[arg(long = "live", default_value_t = false)]
+    pub live: bool,
+
+    /// Run the visible-completeness lint against rendered bodies.
+    #[arg(long = "expect-visible", default_value_t = true)]
+    pub expect_visible: bool,
+
+    /// Write rendered comment bodies under this directory instead of the
+    /// run-state `rendered/` subtree.
+    #[arg(long = "rendered-out", value_name = "dir")]
+    pub rendered_out: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct TrackingCloseReadyArgs {
+    /// Repository slug.
+    #[arg(long = "provider-repo", value_name = "owner/repo")]
+    pub provider_repo: Option<String>,
+
+    /// Issue number.
+    #[arg(long, value_name = "number")]
+    pub issue: Option<u64>,
+
+    /// Lifecycle profile.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Run-state path.
+    #[arg(long = "run-state", value_name = "path")]
+    pub run_state: Option<PathBuf>,
+
+    /// Linked PR reference. Repeatable.
+    #[arg(long = "linked-pr", value_name = "ref")]
+    pub linked_pr: Vec<String>,
+
+    /// Approval evidence (URL or text).
+    #[arg(long, value_name = "text")]
+    pub approval: Option<String>,
+
+    /// Fixture directory.
+    #[arg(long, value_name = "dir")]
+    pub fixture: Option<PathBuf>,
+
+    /// Body file.
+    #[arg(long = "body-file", value_name = "path")]
+    pub body_file: Option<PathBuf>,
+
+    /// Comments JSON file.
+    #[arg(long = "comments-json", value_name = "path")]
+    pub comments_json: Option<PathBuf>,
+
+    /// Run the visible-completeness lint before reporting ready.
+    #[arg(long = "expect-visible", default_value_t = true)]
+    pub expect_visible: bool,
 }
 
 #[derive(Debug, Clone, Args, Serialize)]

--- a/crates/plan-issue-cli/src/commands/tracking.rs
+++ b/crates/plan-issue-cli/src/commands/tracking.rs
@@ -1,0 +1,65 @@
+//! `plan-issue tracking` subcommand surface.
+//!
+//! Owns the run-state controller commands (`status`, `run init`,
+//! `run update`, `checkpoint`, `close-ready`). The handlers live in
+//! [`crate::execute`] and the data shapes live in [`crate::tracking`].
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use crate::commands::record::RecordProfile;
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct TrackingArgs {
+    #[command(subcommand)]
+    pub command: TrackingCommand,
+}
+
+#[derive(Debug, Clone, Subcommand, Serialize)]
+pub enum TrackingCommand {
+    /// Read issue lifecycle evidence + local run state and return the
+    /// reconciled FSM state without provider mutation.
+    Status(Box<TrackingStatusArgs>),
+}
+
+#[derive(Debug, Clone, Args, Serialize)]
+pub struct TrackingStatusArgs {
+    /// Repository in `owner/repo` form. Required for live mode.
+    #[arg(long, value_name = "owner/repo")]
+    pub provider_repo: Option<String>,
+
+    /// Issue number. Required when reading live provider evidence.
+    #[arg(long, value_name = "number")]
+    pub issue: Option<u64>,
+
+    /// Lifecycle profile filter. Defaults to `tracking`.
+    #[arg(long, value_enum, default_value_t = RecordProfile::Tracking)]
+    pub profile: RecordProfile,
+
+    /// Provider issue body Markdown for deterministic mode.
+    #[arg(long = "body-file", value_name = "path")]
+    pub body_file: Option<PathBuf>,
+
+    /// JSON containing the issue comments (deterministic mode).
+    #[arg(long = "comments-json", value_name = "path")]
+    pub comments_json: Option<PathBuf>,
+
+    /// Fixture directory containing `body.md` and `comments.json`.
+    #[arg(long, value_name = "dir")]
+    pub fixture: Option<PathBuf>,
+
+    /// Local `run-state.json` path.
+    #[arg(long = "run-state", value_name = "path")]
+    pub run_state: Option<PathBuf>,
+
+    /// Plan bundle directory used to validate execution-state metadata.
+    #[arg(long, value_name = "dir")]
+    pub bundle: Option<PathBuf>,
+
+    /// Also run the visible-completeness lint against the latest comment
+    /// body per role.
+    #[arg(long = "expect-visible", default_value_t = false)]
+    pub expect_visible: bool,
+}

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -1499,10 +1499,120 @@ fn run_record_audit(args: &RecordAuditArgs) -> Result<Value, CommandError> {
     let audit = lifecycle_record::audit_record(body.as_deref(), &comments_json, args.profile)
         .map_err(|err| CommandError::runtime("record-audit-failed", err))?;
 
-    Ok(json!({
+    let mut payload = json!({
         "operation": "audit",
         "audit": audit,
+    });
+
+    if args.expect_visible {
+        let visible = run_record_audit_visible(&audit, &comments_json, args.profile)?;
+        payload["visible"] = visible;
+    }
+
+    Ok(payload)
+}
+
+fn run_record_audit_visible(
+    audit: &lifecycle_record::RecordAudit,
+    comments_json: &str,
+    profile_filter: Option<crate::commands::record::RecordProfile>,
+) -> Result<Value, CommandError> {
+    use crate::lifecycle_vnext::registry;
+    use crate::lifecycle_vnext::visible_lint;
+
+    let bodies = lifecycle_record::latest_role_bodies(comments_json, profile_filter)
+        .map_err(|err| CommandError::runtime("record-audit-visible-failed", err))?;
+
+    let mut role_reports: Vec<Value> = Vec::new();
+    let mut all_codes: Vec<&'static str> = Vec::new();
+    let mut overall_pass = true;
+
+    // Walk roles in canonical order so the output is deterministic regardless
+    // of HashMap iteration order.
+    for spec in registry::all_roles() {
+        let key = spec.marker_role.to_string();
+        let evidence = audit.evidence.get(&key);
+        let body = bodies.get(&spec.role);
+
+        let mut report_value = json!({
+            "role": spec.marker_role,
+            "present": evidence.is_some(),
+            "checked": body.is_some(),
+        });
+
+        if let Some(body) = body {
+            let hints = derive_lint_hints(spec.role, evidence);
+            let report = visible_lint::lint_visible(spec.role, body, hints);
+            let codes: Vec<&'static str> = report.codes();
+            if !report.is_pass() {
+                overall_pass = false;
+            }
+            all_codes.extend(report.codes());
+            let findings: Vec<Value> = report
+                .findings
+                .iter()
+                .map(|f| {
+                    json!({
+                        "code": f.code,
+                        "message": f.message,
+                    })
+                })
+                .collect();
+            report_value["pass"] = Value::Bool(report.is_pass());
+            report_value["codes"] = json!(codes);
+            report_value["findings"] = Value::Array(findings);
+        } else {
+            // No comment for this role; nothing to lint here. The
+            // `audit.missing_required` block already names whether the role
+            // is mandatory.
+            report_value["pass"] = Value::Bool(true);
+            report_value["codes"] = json!([] as [&str; 0]);
+            report_value["findings"] = Value::Array(Vec::new());
+        }
+
+        role_reports.push(report_value);
+    }
+
+    Ok(json!({
+        "expect_visible": true,
+        "overall_pass": overall_pass,
+        "codes": all_codes,
+        "roles": role_reports,
     }))
+}
+
+fn derive_lint_hints(
+    role: crate::lifecycle_record::PayloadRole,
+    evidence: Option<&crate::lifecycle_record::LifecycleEvidence>,
+) -> crate::lifecycle_vnext::visible_lint::LintHints {
+    use crate::lifecycle_record::PayloadRole;
+    use crate::lifecycle_vnext::visible_lint::LintHints;
+
+    let mut hints = LintHints::default();
+    let payload = evidence.and_then(|ev| ev.payload.as_ref());
+
+    match role {
+        PayloadRole::State => {
+            // Final state when the structured payload reports `complete`.
+            if let Some(payload) = payload {
+                if let Ok(state) = payload.parse_state() {
+                    hints.state_is_final = matches!(
+                        state.status,
+                        Some(crate::lifecycle_record::StateStatus::Complete)
+                    );
+                }
+            }
+        }
+        PayloadRole::Review => {
+            if let Some(payload) = payload {
+                if let Ok(review) = payload.parse_review() {
+                    hints.review_has_findings = !review.findings.is_empty();
+                }
+            }
+        }
+        _ => {}
+    }
+    hints
 }
 
 fn run_build_task_spec(args: &BuildTaskSpecArgs) -> Result<Value, CommandError> {

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -1656,13 +1656,763 @@ fn derive_lint_hints(
 }
 
 fn run_tracking(
-    _repo_override: Option<&str>,
+    repo_override: Option<&str>,
     args: &crate::commands::tracking::TrackingArgs,
 ) -> Result<Value, CommandError> {
-    use crate::commands::tracking::TrackingCommand;
+    use crate::commands::tracking::{TrackingCommand, TrackingRunCommand};
     match &args.command {
         TrackingCommand::Status(status) => run_tracking_status(status),
+        TrackingCommand::Run(run) => match &run.command {
+            TrackingRunCommand::Init(args) => run_tracking_run_init(repo_override, args),
+            TrackingRunCommand::Update(args) => run_tracking_run_update(args),
+        },
+        TrackingCommand::Checkpoint(args) => run_tracking_checkpoint(args),
+        TrackingCommand::CloseReady(args) => run_tracking_close_ready(args),
     }
+}
+
+fn run_tracking_run_init(
+    _repo_override: Option<&str>,
+    args: &crate::commands::tracking::TrackingRunInitArgs,
+) -> Result<Value, CommandError> {
+    use crate::runtime_layout;
+    use crate::tracking::events::{self, ExecutionEvent, ExecutionEventKind};
+    use crate::tracking::run_state::{
+        ExecutionRun, RunPhase, RunRoot, SelectedScope,
+    };
+
+    let run_id = args
+        .run_id
+        .clone()
+        .unwrap_or_else(|| default_run_id(args.issue, args.now.as_deref()));
+    let now = args
+        .now
+        .clone()
+        .unwrap_or_else(default_now);
+    let mut run = ExecutionRun::new(
+        run_id.clone(),
+        args.provider_repo.clone(),
+        args.issue,
+        args.profile.as_str().to_string(),
+        RunPhase::Initial,
+        now.clone(),
+    );
+    run.bundle = args.bundle.clone();
+    run.execution_state_file = args.execution_state_file.clone();
+    if args.task.is_some() || args.sprint.is_some() {
+        run.selected_scope = Some(SelectedScope {
+            sprint: args.sprint,
+            task: args.task.clone(),
+            title: None,
+        });
+    }
+    run.branch = args.branch.clone();
+    run.worktree = args.worktree.clone();
+    if let Some(linked) = &args.linked_pr {
+        run.pr = Some(crate::tracking::run_state::LinkedPr {
+            r#ref: linked.clone(),
+            url: None,
+            status: None,
+        });
+    }
+
+    let (run_state_path, events_path) = if let Some(out) = &args.out {
+        let events_path = out
+            .parent()
+            .map(|parent| parent.join("events.jsonl"))
+            .unwrap_or_else(|| PathBuf::from("events.jsonl"));
+        (out.clone(), events_path)
+    } else {
+        let repo_slug = runtime_layout::repo_slug(&args.provider_repo);
+        let root = RunRoot::new(&repo_slug, args.issue, run_id.clone())
+            .map_err(|err| CommandError::runtime("tracking-run-init-layout-failed", err.to_string()))?;
+        root.ensure_layout().map_err(|err| {
+            CommandError::runtime("tracking-run-init-mkdir-failed", err.to_string())
+        })?;
+        (root.run_state_path(), root.events_path())
+    };
+
+    crate::tracking::run_state::write_run_state(&run_state_path, &run)
+        .map_err(|err| CommandError::runtime("tracking-run-init-write-failed", err.to_string()))?;
+    let event = ExecutionEvent::new(run_id.clone(), ExecutionEventKind::RunStarted, now.clone())
+        .with_detail(serde_json::json!({
+            "repo": args.provider_repo,
+            "issue": args.issue,
+            "profile": args.profile.as_str(),
+        }));
+    events::append_event(&events_path, &event).map_err(|err| {
+        CommandError::runtime("tracking-run-init-event-append-failed", err.to_string())
+    })?;
+
+    Ok(json!({
+        "operation": "tracking.run.init",
+        "run_id": run_id,
+        "run_state_path": path_text(&run_state_path),
+        "events_path": path_text(&events_path),
+        "repo": args.provider_repo,
+        "issue": args.issue,
+        "profile": args.profile.as_str(),
+    }))
+}
+
+fn run_tracking_run_update(
+    args: &crate::commands::tracking::TrackingRunUpdateArgs,
+) -> Result<Value, CommandError> {
+    use crate::tracking::events::{self, ExecutionEvent, ExecutionEventKind};
+    use crate::tracking::run_state::{
+        self, LinkedPr, RunPhase, ValidationCommandRow, ValidationSummary,
+    };
+
+    let mut run = run_state::read_run_state(&args.run_state).map_err(|err| {
+        CommandError::runtime("tracking-run-update-read-failed", err.to_string())
+    })?;
+    let now = args
+        .now
+        .clone()
+        .unwrap_or_else(default_now);
+    let mut changes = Vec::new();
+    if let Some(phase) = args.phase {
+        let new_phase = match phase {
+            crate::commands::tracking::RunPhaseArg::Initial => RunPhase::Initial,
+            crate::commands::tracking::RunPhaseArg::Implementing => RunPhase::Implementing,
+            crate::commands::tracking::RunPhaseArg::Validating => RunPhase::Validating,
+            crate::commands::tracking::RunPhaseArg::Reviewing => RunPhase::Reviewing,
+            crate::commands::tracking::RunPhaseArg::Blocked => RunPhase::Blocked,
+            crate::commands::tracking::RunPhaseArg::ReadyForClose => RunPhase::ReadyForClose,
+            crate::commands::tracking::RunPhaseArg::Closed => RunPhase::Closed,
+        };
+        run.phase = new_phase;
+        changes.push("phase");
+    }
+    if let Some(task) = &args.selected_task {
+        let mut scope = run.selected_scope.clone().unwrap_or_default();
+        scope.task = Some(task.clone());
+        run.selected_scope = Some(scope);
+        changes.push("selected_task");
+    }
+    if let Some(branch) = &args.branch {
+        run.branch = Some(branch.clone());
+        changes.push("branch");
+    }
+    if let Some(pr) = &args.linked_pr {
+        run.pr = Some(LinkedPr {
+            r#ref: pr.clone(),
+            url: None,
+            status: None,
+        });
+        changes.push("linked_pr");
+    }
+    if args.validation_overall.is_some()
+        || args.validation_command.is_some()
+        || args.validation_status.is_some()
+        || args.validation_evidence.is_some()
+    {
+        let mut summary = run.validation.clone().unwrap_or_else(|| ValidationSummary {
+            overall: "pending".to_string(),
+            commands: Vec::new(),
+            waiver: None,
+            evidence_path: None,
+        });
+        if let Some(overall) = &args.validation_overall {
+            summary.overall = overall.clone();
+        }
+        if let (Some(command), Some(status)) =
+            (&args.validation_command, &args.validation_status)
+        {
+            summary.commands.push(ValidationCommandRow {
+                command: command.clone(),
+                status: status.clone(),
+                evidence: args.validation_evidence.clone(),
+            });
+        }
+        run.validation = Some(summary);
+        changes.push("validation");
+    }
+    if let Some(decision) = &args.review_decision {
+        let mut review = run.review.clone().unwrap_or_else(|| {
+            crate::tracking::run_state::ReviewSummary {
+                decision: decision.clone(),
+                findings_disposition: Vec::new(),
+                evidence: None,
+            }
+        });
+        review.decision = decision.clone();
+        run.review = Some(review);
+        changes.push("review");
+    }
+    if let Some(note) = &args.note {
+        run.notes.push(note.clone());
+        changes.push("note");
+    }
+    run.updated_at = now.clone();
+
+    run_state::write_run_state(&args.run_state, &run).map_err(|err| {
+        CommandError::runtime("tracking-run-update-write-failed", err.to_string())
+    })?;
+
+    // Append an event next to the run-state file.
+    if let Some(parent) = args.run_state.parent() {
+        let events_path = parent.join("events.jsonl");
+        let detail = serde_json::json!({"changed": changes});
+        let event = ExecutionEvent::new(run.run_id.clone(), ExecutionEventKind::RunUpdated, now.clone())
+            .with_detail(detail);
+        events::append_event(&events_path, &event).map_err(|err| {
+            CommandError::runtime("tracking-run-update-event-append-failed", err.to_string())
+        })?;
+    }
+
+    Ok(json!({
+        "operation": "tracking.run.update",
+        "run_id": run.run_id,
+        "phase": run.phase.as_str(),
+        "changed": changes,
+        "updated_at": run.updated_at,
+    }))
+}
+
+fn run_tracking_checkpoint(
+    args: &crate::commands::tracking::TrackingCheckpointArgs,
+) -> Result<Value, CommandError> {
+    use crate::lifecycle_record::{self, PayloadRole};
+    use crate::lifecycle_vnext::registry;
+    use crate::lifecycle_vnext::visible_lint;
+    use crate::tracking::reconcile;
+    use crate::tracking::run_state;
+
+    // Parse requested roles from the comma-separated `--post` flag.
+    let requested_roles: Vec<PayloadRole> = args
+        .post
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|name| match name {
+            "state" => Ok(PayloadRole::State),
+            "session" => Ok(PayloadRole::Session),
+            "validation" => Ok(PayloadRole::Validation),
+            "review" => Ok(PayloadRole::Review),
+            "source" | "plan" | "closeout" => Err(CommandError::usage(
+                "tracking-checkpoint-role-not-allowed",
+                format!(
+                    "role `{}` is not allowed from tracking checkpoint; use record open/close",
+                    name
+                ),
+            )),
+            other => Err(CommandError::usage(
+                "tracking-checkpoint-unknown-role",
+                format!("unknown lifecycle role `{}`", other),
+            )),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if requested_roles.is_empty() {
+        return Err(CommandError::usage(
+            "tracking-checkpoint-empty-roles",
+            "`--post` must name at least one lifecycle role",
+        ));
+    }
+
+    // Read provider evidence (fixture or explicit files).
+    let (body, comments_json) = resolve_checkpoint_inputs(args)?;
+    let audit = if let Some(comments) = comments_json.as_deref() {
+        Some(
+            lifecycle_record::audit_record(body.as_deref(), comments, Some(args.profile))
+                .map_err(|err| {
+                    CommandError::runtime("tracking-checkpoint-audit-failed", err)
+                })?,
+        )
+    } else {
+        None
+    };
+
+    // Read local run state.
+    let run = run_state::read_run_state(&args.run_state).map_err(|err| {
+        CommandError::runtime("tracking-checkpoint-run-state-read-failed", err.to_string())
+    })?;
+
+    // Reconcile.
+    let reconciled = reconcile::reconcile(audit.as_ref(), Some(&run));
+    let mut blocked: Vec<Value> = Vec::new();
+    if reconciled.is_stale() {
+        blocked.push(json!({
+            "code": "run-state-stale",
+            "message": "provider issue lifecycle evidence is newer than local run state; refuse live mutation",
+            "suggested_unblock": "run `plan-issue tracking status` and update run state before checkpoint",
+        }));
+    }
+    if reconciled
+        .recommended_action
+        .as_str()
+        == "open_record"
+    {
+        blocked.push(json!({
+            "code": "issue-evidence-missing",
+            "message": "record has not been opened yet",
+            "suggested_unblock": "run `plan-issue record open` first",
+        }));
+    }
+
+    // Build per-role payloads from run state and render bodies.
+    let mut rendered: Vec<Value> = Vec::new();
+    let mut visible_failures: Vec<Value> = Vec::new();
+    let mut roles_planned: Vec<&'static str> = Vec::new();
+    let mut roles_skipped: Vec<Value> = Vec::new();
+
+    for role in &requested_roles {
+        let spec = registry::role(*role);
+        let body_result = render_checkpoint_role(*role, &run, args)?;
+        match body_result {
+            CheckpointRoleResult::Empty(reason) => {
+                roles_skipped.push(json!({
+                    "role": spec.marker_role,
+                    "reason": reason,
+                }));
+            }
+            CheckpointRoleResult::Rendered(body) => {
+                let hints = checkpoint_lint_hints(*role, &run);
+                let report = visible_lint::lint_visible(*role, &body, hints);
+                if report.is_pass() {
+                    rendered.push(json!({
+                        "role": spec.marker_role,
+                        "body": body,
+                        "lint_pass": true,
+                    }));
+                    roles_planned.push(spec.marker_role);
+                } else {
+                    let codes: Vec<&'static str> = report.codes();
+                    visible_failures.push(json!({
+                        "role": spec.marker_role,
+                        "codes": codes,
+                    }));
+                    blocked.push(json!({
+                        "code": "visible-completeness-failed",
+                        "role": spec.marker_role,
+                        "message": format!(
+                            "rendered {} body fails visible-completeness lint",
+                            spec.marker_role
+                        ),
+                        "suggested_unblock": "fix run state / execution-state Markdown before posting",
+                    }));
+                }
+            }
+        }
+    }
+
+    let dry_run = !args.live;
+    // In dry-run mode, write rendered bodies for reproducibility.
+    let rendered_out = if dry_run {
+        let target_dir = args
+            .rendered_out
+            .clone()
+            .or_else(|| args.run_state.parent().map(|p| p.join("rendered")));
+        if let Some(dir) = target_dir.as_ref() {
+            let _ = crate::runtime_layout::ensure_dir(dir);
+            for entry in &rendered {
+                let role_name = entry["role"].as_str().unwrap_or("unknown");
+                let body = entry["body"].as_str().unwrap_or_default();
+                let path = dir.join(format!("{role_name}-comment.md"));
+                let _ = std::fs::write(&path, body);
+            }
+        }
+        target_dir
+    } else {
+        None
+    };
+
+    // Live checkpoint posting lands in Task 6.1; flag any live request as
+    // blocked until then.
+    let live_blocked = if args.live {
+        Some(json!({
+            "code": "tracking-checkpoint-live-not-implemented",
+            "message": "live tracking checkpoint posting will arrive in Task 6.1",
+            "suggested_unblock": "re-run with --dry-run or use `record post` directly",
+        }))
+    } else {
+        None
+    };
+    if let Some(extra) = live_blocked {
+        blocked.push(extra);
+    }
+
+    Ok(json!({
+        "operation": "tracking.checkpoint",
+        "mode": if !args.live { "dry-run" } else { "live" },
+        "fsm_state": reconciled.state.as_str(),
+        "roles_planned": roles_planned,
+        "roles_skipped": roles_skipped,
+        "rendered": rendered,
+        "visible_failures": visible_failures,
+        "blocked": blocked,
+        "rendered_out": rendered_out.map(|p| p.to_string_lossy().to_string()),
+        "repair_dashboard": args.repair_dashboard,
+    }))
+}
+
+enum CheckpointRoleResult {
+    Rendered(String),
+    Empty(String),
+}
+
+fn render_checkpoint_role(
+    role: crate::lifecycle_record::PayloadRole,
+    run: &crate::tracking::run_state::ExecutionRun,
+    _args: &crate::commands::tracking::TrackingCheckpointArgs,
+) -> Result<CheckpointRoleResult, CommandError> {
+    use crate::commands::record::{LifecycleCommentKind, RecordProfile, TaskLedgerDisplay};
+    use crate::lifecycle_record::{self, PayloadRole};
+    let kind = match role {
+        PayloadRole::State => LifecycleCommentKind::State,
+        PayloadRole::Session => LifecycleCommentKind::Session,
+        PayloadRole::Validation => LifecycleCommentKind::Validation,
+        PayloadRole::Review => LifecycleCommentKind::Review,
+        _ => unreachable!("filtered by caller"),
+    };
+
+    let payload = match role {
+        PayloadRole::State => synthesize_state_payload(run),
+        PayloadRole::Session => match synthesize_session_payload(run) {
+            Some(value) => value,
+            None => {
+                return Ok(CheckpointRoleResult::Empty(
+                    "no session content in run state; skip empty session checkpoint".to_string(),
+                ));
+            }
+        },
+        PayloadRole::Validation => match synthesize_validation_payload(run) {
+            Some(value) => value,
+            None => {
+                return Ok(CheckpointRoleResult::Empty(
+                    "no validation content in run state; skip empty validation checkpoint"
+                        .to_string(),
+                ));
+            }
+        },
+        PayloadRole::Review => match synthesize_review_payload(run) {
+            Some(value) => value,
+            None => {
+                return Ok(CheckpointRoleResult::Empty(
+                    "no review content in run state; skip empty review checkpoint".to_string(),
+                ));
+            }
+        },
+        _ => unreachable!(),
+    };
+
+    let body = lifecycle_record::render_record_post_comment_with_display(
+        RecordProfile::Tracking,
+        kind,
+        payload,
+        None,
+        Some(run.updated_at.as_str()),
+        TaskLedgerDisplay::Auto,
+    )
+    .map_err(|err| CommandError::runtime("tracking-checkpoint-render-failed", err))?;
+    Ok(CheckpointRoleResult::Rendered(body))
+}
+
+fn synthesize_state_payload(run: &crate::tracking::run_state::ExecutionRun) -> Value {
+    // Build a placeholder task row from the selected scope so the rendered
+    // body carries a `## Task Ledger` section. v1 controller leaves rich
+    // task ledger rendering to the canonical execution-state Markdown that
+    // skills supply via record post; this synthesizer is a deterministic
+    // baseline for `tracking checkpoint` previews.
+    let task_id = run
+        .selected_scope
+        .as_ref()
+        .and_then(|s| s.task.clone())
+        .unwrap_or_else(|| "1.1".to_string());
+    let task_title = run
+        .selected_scope
+        .as_ref()
+        .and_then(|s| s.title.clone())
+        .unwrap_or_else(|| "selected".to_string());
+    let task_status = match run.phase {
+        crate::tracking::run_state::RunPhase::Closed
+        | crate::tracking::run_state::RunPhase::ReadyForClose => "done",
+        crate::tracking::run_state::RunPhase::Blocked => "blocked",
+        _ => "in-progress",
+    };
+    json!({
+        "status": match run.phase {
+            crate::tracking::run_state::RunPhase::Closed
+            | crate::tracking::run_state::RunPhase::ReadyForClose => "complete",
+            crate::tracking::run_state::RunPhase::Blocked => "blocked",
+            _ => "in-progress",
+        },
+        "target_scope": run
+            .selected_scope
+            .as_ref()
+            .and_then(|s| s.title.clone())
+            .unwrap_or_else(|| "in-progress".to_string()),
+        "current": run.selected_scope.as_ref().and_then(|s| s.task.clone()).unwrap_or_default(),
+        "next_action": "",
+        "tasks": [
+            {"id": task_id, "status": task_status, "title": task_title}
+        ],
+        "prs": [],
+        "blockers": [],
+        "links": {},
+    })
+}
+
+fn synthesize_session_payload(run: &crate::tracking::run_state::ExecutionRun) -> Option<Value> {
+    let summary = run.notes.last()?;
+    if summary.trim().is_empty() {
+        return None;
+    }
+    Some(json!({
+        "summary": summary,
+        "highlights": run.notes.clone(),
+        "links": {},
+    }))
+}
+
+fn synthesize_validation_payload(run: &crate::tracking::run_state::ExecutionRun) -> Option<Value> {
+    let validation = run.validation.as_ref()?;
+    if validation.commands.is_empty() && validation.waiver.is_none() {
+        return None;
+    }
+    let commands: Vec<Value> = validation
+        .commands
+        .iter()
+        .map(|cmd| {
+            json!({
+                "command": cmd.command,
+                "status": cmd.status,
+                "evidence": cmd.evidence,
+            })
+        })
+        .collect();
+    Some(json!({
+        "overall": validation.overall,
+        "commands": commands,
+        "waivers": validation
+            .waiver
+            .as_ref()
+            .map(|w| vec![json!({"command": "validation", "reason": w})])
+            .unwrap_or_default(),
+    }))
+}
+
+fn synthesize_review_payload(run: &crate::tracking::run_state::ExecutionRun) -> Option<Value> {
+    let review = run.review.as_ref()?;
+    Some(json!({
+        "decision": review.decision,
+        "lenses": [],
+        "findings": [],
+        "outcome_comment_url": review.evidence,
+    }))
+}
+
+fn checkpoint_lint_hints(
+    role: crate::lifecycle_record::PayloadRole,
+    run: &crate::tracking::run_state::ExecutionRun,
+) -> crate::lifecycle_vnext::visible_lint::LintHints {
+    use crate::lifecycle_record::PayloadRole;
+    use crate::lifecycle_vnext::visible_lint::LintHints;
+    let mut hints = LintHints::default();
+    if matches!(role, PayloadRole::State) {
+        hints.state_is_final = matches!(
+            run.phase,
+            crate::tracking::run_state::RunPhase::ReadyForClose
+                | crate::tracking::run_state::RunPhase::Closed
+        );
+    }
+    hints
+}
+
+fn resolve_checkpoint_inputs(
+    args: &crate::commands::tracking::TrackingCheckpointArgs,
+) -> Result<(Option<String>, Option<String>), CommandError> {
+    if let Some(fixture) = &args.fixture {
+        let body_path = fixture.join("body.md");
+        let comments_path = fixture.join("comments.json");
+        let body = if body_path.exists() {
+            Some(read_text_file(
+                &body_path,
+                "tracking-checkpoint-body-read-failed",
+            )?)
+        } else {
+            None
+        };
+        let comments = if comments_path.exists() {
+            Some(read_text_file(
+                &comments_path,
+                "tracking-checkpoint-comments-read-failed",
+            )?)
+        } else {
+            None
+        };
+        return Ok((body, comments));
+    }
+    let body = match &args.body_file {
+        Some(path) => Some(read_text_file(path, "tracking-checkpoint-body-read-failed")?),
+        None => None,
+    };
+    let comments = match &args.comments_json {
+        Some(path) => Some(read_text_file(
+            path,
+            "tracking-checkpoint-comments-read-failed",
+        )?),
+        None => None,
+    };
+    Ok((body, comments))
+}
+
+fn run_tracking_close_ready(
+    args: &crate::commands::tracking::TrackingCloseReadyArgs,
+) -> Result<Value, CommandError> {
+    use crate::lifecycle_record::{self};
+    use crate::tracking::reconcile;
+    use crate::tracking::run_state;
+
+    let (body, comments_json) = resolve_close_ready_inputs(args)?;
+    let audit = if let Some(comments) = comments_json.as_deref() {
+        Some(
+            lifecycle_record::audit_record(body.as_deref(), comments, Some(args.profile))
+                .map_err(|err| {
+                    CommandError::runtime("tracking-close-ready-audit-failed", err)
+                })?,
+        )
+    } else {
+        None
+    };
+    let run = match &args.run_state {
+        Some(path) => Some(run_state::read_run_state(path).map_err(|err| {
+            CommandError::runtime("tracking-close-ready-run-state-read-failed", err.to_string())
+        })?),
+        None => None,
+    };
+
+    let reconciled = reconcile::reconcile(audit.as_ref(), run.as_ref());
+    let mut blockers: Vec<Value> = Vec::new();
+    let mut linked_prs: Vec<String> = args.linked_pr.clone();
+
+    if let Some(audit) = audit.as_ref() {
+        if let Some(state_evidence) = audit.evidence.get("state") {
+            if let Some(payload) = state_evidence.payload.as_ref() {
+                if let Ok(state) = payload.parse_state() {
+                    for pr in state.prs {
+                        linked_prs.push(pr.pr_ref);
+                    }
+                }
+            }
+        }
+    }
+    if let Some(run) = run.as_ref() {
+        if let Some(pr) = run.pr.as_ref() {
+            linked_prs.push(pr.r#ref.clone());
+        }
+    }
+    linked_prs.sort();
+    linked_prs.dedup();
+
+    // Missing roles for closeout block.
+    for code in &reconciled.missing_for_closeout {
+        blockers.push(json!({
+            "code": format!("{code}-missing"),
+            "message": format!("closeout requires `{code}` evidence"),
+            "suggested_unblock": "post the missing lifecycle evidence before close",
+        }));
+    }
+    if linked_prs.is_empty() && args.approval.is_none() {
+        blockers.push(json!({
+            "code": "closeout-missing-linked-pr",
+            "message": "no linked PR evidence and no `--approval` provided",
+            "suggested_unblock": "pass --linked-pr or --approval, or add the evidence to run state",
+        }));
+    }
+
+    // Visible completeness check (Task 6.2 deep gate).
+    let mut visible_summary = json!({"checked": false});
+    if args.expect_visible {
+        if let (Some(audit), Some(comments)) = (audit.as_ref(), comments_json.as_deref()) {
+            let visible = run_record_audit_visible(audit, comments, Some(args.profile))?;
+            let overall_pass = visible["overall_pass"].as_bool().unwrap_or(false);
+            visible_summary = json!({
+                "checked": true,
+                "pass": overall_pass,
+                "report": visible,
+            });
+            if !overall_pass {
+                blockers.push(json!({
+                    "code": "visible-completeness-failed",
+                    "message": "visible-completeness lint reported missing sections",
+                    "suggested_unblock": "fix the rendered lifecycle comments before close",
+                }));
+            }
+        }
+    }
+
+    let ready = blockers.is_empty()
+        && matches!(reconciled.state, crate::tracking::fsm::RecordState::RecordReadyForClose);
+
+    Ok(json!({
+        "operation": "tracking.close-ready",
+        "ready": ready,
+        "fsm_state": reconciled.state.as_str(),
+        "blockers": blockers,
+        "linked_prs": linked_prs,
+        "visible_completeness": visible_summary,
+    }))
+}
+
+fn resolve_close_ready_inputs(
+    args: &crate::commands::tracking::TrackingCloseReadyArgs,
+) -> Result<(Option<String>, Option<String>), CommandError> {
+    if let Some(fixture) = &args.fixture {
+        let body_path = fixture.join("body.md");
+        let comments_path = fixture.join("comments.json");
+        let body = if body_path.exists() {
+            Some(read_text_file(
+                &body_path,
+                "tracking-close-ready-body-read-failed",
+            )?)
+        } else {
+            None
+        };
+        let comments = if comments_path.exists() {
+            Some(read_text_file(
+                &comments_path,
+                "tracking-close-ready-comments-read-failed",
+            )?)
+        } else {
+            None
+        };
+        return Ok((body, comments));
+    }
+    let body = match &args.body_file {
+        Some(path) => Some(read_text_file(
+            path,
+            "tracking-close-ready-body-read-failed",
+        )?),
+        None => None,
+    };
+    let comments = match &args.comments_json {
+        Some(path) => Some(read_text_file(
+            path,
+            "tracking-close-ready-comments-read-failed",
+        )?),
+        None => None,
+    };
+    Ok((body, comments))
+}
+
+fn default_run_id(issue: u64, now: Option<&str>) -> String {
+    let mut id = String::new();
+    let timestamp = now.unwrap_or("00000000-000000");
+    let clean: String = timestamp
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect();
+    id.push_str(&clean);
+    id.push_str(&format!("-issue-{issue}"));
+    id
+}
+
+fn default_now() -> String {
+    // Deterministic placeholder when no `--now` is supplied. Tests can pass
+    // `--now` for stable values.
+    "1970-01-01T00:00:00Z".to_string()
 }
 
 fn run_tracking_status(

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -15,8 +15,9 @@ use crate::commands::plan::{
     ResolveApprovalArgs, StartPlanArgs, StatusPlanArgs,
 };
 use crate::commands::record::{
-    RecordArgs, RecordAttachArgs, RecordAuditArgs, RecordCloseArgs, RecordCommand, RecordOpenArgs,
-    RecordPostArgs, RecordRepairDashboardArgs,
+    LifecycleCommentKind, RecordArgs, RecordAttachArgs, RecordAuditArgs, RecordCloseArgs,
+    RecordCommand, RecordOpenArgs, RecordPostArgs, RecordRepairDashboardArgs, RecordTemplateArgs,
+    TemplateFormatArg,
 };
 use crate::commands::sprint::{
     AcceptSprintArgs, MultiSprintGuideArgs, ReadySprintArgs, StartSprintArgs,
@@ -96,6 +97,7 @@ fn run_record(
         }
         RecordCommand::Close(args) => run_record_close(binary, dry_run, force, repo_override, args),
         RecordCommand::Audit(args) => run_record_audit(args),
+        RecordCommand::Template(args) => run_record_template(args),
     }
 }
 
@@ -1487,6 +1489,43 @@ fn run_record_close(
         "linked_prs": linked_evidence,
         "final_dashboard": final_dashboard,
         "labels": labels_preview,
+    }))
+}
+
+fn run_record_template(args: &RecordTemplateArgs) -> Result<Value, CommandError> {
+    use crate::lifecycle_record::PayloadRole;
+    use crate::lifecycle_vnext::templates;
+
+    let role = match args.kind {
+        LifecycleCommentKind::Source => PayloadRole::Source,
+        LifecycleCommentKind::Plan => PayloadRole::Plan,
+        LifecycleCommentKind::State => PayloadRole::State,
+        LifecycleCommentKind::Session => PayloadRole::Session,
+        LifecycleCommentKind::Validation => PayloadRole::Validation,
+        LifecycleCommentKind::Review => PayloadRole::Review,
+        LifecycleCommentKind::Closeout => PayloadRole::Closeout,
+    };
+    let format = match args.shape {
+        TemplateFormatArg::Markdown => templates::TemplateFormat::Markdown,
+        TemplateFormatArg::Json => templates::TemplateFormat::Json,
+    };
+    let template = templates::render_template(args.profile, role, format)
+        .map_err(|err| CommandError::runtime(err.code(), err.to_string()))?;
+
+    Ok(json!({
+        "operation": "template",
+        "profile": args.profile.as_str(),
+        "role": match args.kind {
+            LifecycleCommentKind::Source => "source",
+            LifecycleCommentKind::Plan => "plan",
+            LifecycleCommentKind::State => "state",
+            LifecycleCommentKind::Session => "session",
+            LifecycleCommentKind::Validation => "validation",
+            LifecycleCommentKind::Review => "review",
+            LifecycleCommentKind::Closeout => "closeout",
+        },
+        "shape": args.shape.as_str(),
+        "template": template,
     }))
 }
 

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -72,6 +72,7 @@ pub fn execute(binary: BinaryFlavor, cli: &Cli) -> Result<Value, CommandError> {
         CliCommand::Record(args) => {
             run_record(binary, cli.dry_run, cli.force, cli.repo.as_deref(), args)
         }
+        CliCommand::Tracking(args) => run_tracking(cli.repo.as_deref(), args),
         CliCommand::Completion(_) => Err(CommandError::usage(
             "completion-direct-output-only",
             "completion output is emitted directly; run `<binary> completion <bash|zsh>`",
@@ -1652,6 +1653,142 @@ fn derive_lint_hints(
         _ => {}
     }
     hints
+}
+
+fn run_tracking(
+    _repo_override: Option<&str>,
+    args: &crate::commands::tracking::TrackingArgs,
+) -> Result<Value, CommandError> {
+    use crate::commands::tracking::TrackingCommand;
+    match &args.command {
+        TrackingCommand::Status(status) => run_tracking_status(status),
+    }
+}
+
+fn run_tracking_status(
+    args: &crate::commands::tracking::TrackingStatusArgs,
+) -> Result<Value, CommandError> {
+    use crate::lifecycle_record;
+    use crate::tracking::reconcile;
+    use crate::tracking::run_state;
+
+    let (body, comments_json) = resolve_tracking_status_inputs(args)?;
+    let audit = if let Some(comments) = comments_json.as_deref() {
+        Some(
+            lifecycle_record::audit_record(body.as_deref(), comments, Some(args.profile))
+                .map_err(|err| CommandError::runtime("tracking-status-audit-failed", err))?,
+        )
+    } else {
+        None
+    };
+
+    let run_state_value = match &args.run_state {
+        Some(path) => match run_state::read_run_state(path) {
+            Ok(value) => Some(value),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+            Err(err) => {
+                return Err(CommandError::runtime(
+                    "tracking-status-run-state-read-failed",
+                    err.to_string(),
+                ));
+            }
+        },
+        None => None,
+    };
+
+    let reconciled = reconcile::reconcile(audit.as_ref(), run_state_value.as_ref());
+
+    let mut payload = serde_json::json!({
+        "operation": "tracking.status",
+        "fsm_state": reconciled.state.as_str(),
+        "recommended_action": reconciled.recommended_action.as_str(),
+        "safe_transitions": reconciled.safe_transitions,
+        "missing_for_closeout": reconciled.missing_for_closeout,
+        "warnings": reconciled.warnings.iter().map(|w| serde_json::json!({
+            "code": w.code,
+            "message": w.message,
+        })).collect::<Vec<_>>(),
+        "blocked_reason": reconciled.blocked_reason,
+        "issue_truth": tracking_status_audit_summary(audit.as_ref()),
+        "run_state": tracking_status_run_state_summary(run_state_value.as_ref()),
+    });
+
+    if args.expect_visible {
+        if let (Some(audit), Some(comments)) = (audit.as_ref(), comments_json.as_deref()) {
+            let visible = run_record_audit_visible(audit, comments, Some(args.profile))?;
+            payload["visible"] = visible;
+        }
+    }
+
+    Ok(payload)
+}
+
+fn resolve_tracking_status_inputs(
+    args: &crate::commands::tracking::TrackingStatusArgs,
+) -> Result<(Option<String>, Option<String>), CommandError> {
+    if let Some(fixture) = &args.fixture {
+        let body_path = fixture.join("body.md");
+        let comments_path = fixture.join("comments.json");
+        let body = if body_path.exists() {
+            Some(read_text_file(&body_path, "tracking-status-body-read-failed")?)
+        } else {
+            None
+        };
+        let comments = if comments_path.exists() {
+            Some(read_text_file(
+                &comments_path,
+                "tracking-status-comments-read-failed",
+            )?)
+        } else {
+            None
+        };
+        return Ok((body, comments));
+    }
+    let body = match &args.body_file {
+        Some(path) => Some(read_text_file(path, "tracking-status-body-read-failed")?),
+        None => None,
+    };
+    let comments = match &args.comments_json {
+        Some(path) => Some(read_text_file(path, "tracking-status-comments-read-failed")?),
+        None => None,
+    };
+    if body.is_none() && comments.is_none() {
+        return Err(CommandError::usage(
+            "tracking-status-missing-input",
+            "tracking status requires --fixture <dir>, --comments-json <path>, or --body-file <path>",
+        ));
+    }
+    Ok((body, comments))
+}
+
+fn tracking_status_audit_summary(audit: Option<&crate::lifecycle_record::RecordAudit>) -> Value {
+    let Some(audit) = audit else {
+        return json!({"available": false});
+    };
+    let latest_roles: Vec<&String> = audit.evidence.keys().collect();
+    json!({
+        "available": true,
+        "recognized_count": audit.recognized_count,
+        "latest_roles": latest_roles,
+        "missing_required": audit.missing_required,
+    })
+}
+
+fn tracking_status_run_state_summary(
+    run: Option<&crate::tracking::run_state::ExecutionRun>,
+) -> Value {
+    let Some(run) = run else {
+        return json!({"available": false});
+    };
+    json!({
+        "available": true,
+        "run_id": run.run_id,
+        "phase": run.phase.as_str(),
+        "selected_task": run.selected_scope.as_ref().and_then(|s| s.task.clone()),
+        "branch": run.branch,
+        "pr": run.pr.as_ref().map(|p| p.r#ref.clone()),
+        "validation_overall": run.validation.as_ref().map(|v| v.overall.clone()),
+    })
 }
 
 fn run_build_task_spec(args: &BuildTaskSpecArgs) -> Result<Value, CommandError> {

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -7,12 +7,14 @@ mod forge_cli_adapter;
 mod github;
 mod issue_body;
 pub mod lifecycle_record;
+pub mod lifecycle_vnext;
 pub mod output;
 mod provider;
 mod render;
 pub mod runtime_layout;
 pub mod state;
 mod task_spec;
+pub mod tracking;
 
 use std::ffi::OsString;
 

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -360,6 +360,42 @@ pub fn audit_record(
     })
 }
 
+/// Return the latest visible comment body per lifecycle role, indexed by
+/// [`PayloadRole`]. Mirrors the latest-per-role selection inside
+/// [`audit_record`] and is the input the visible-completeness lint operates
+/// on (see [`crate::lifecycle_vnext::visible_lint`]).
+///
+/// `profile_filter` matches the same semantics as [`audit_record`] —
+/// comments whose marker carries a different profile are skipped.
+pub fn latest_role_bodies(
+    comments_json: &str,
+    profile_filter: Option<crate::commands::record::RecordProfile>,
+) -> Result<BTreeMap<PayloadRole, String>, String> {
+    let mut comments = parse_comments_json(comments_json)?;
+    comments.sort_by(|left, right| {
+        compare_created_at(right.created_at.as_deref(), left.created_at.as_deref())
+    });
+    let mut bodies: BTreeMap<PayloadRole, String> = BTreeMap::new();
+    for comment in comments {
+        let Some(body) = comment.body.as_deref() else {
+            continue;
+        };
+        let Some(first_marker) = first_comment_marker(body) else {
+            continue;
+        };
+        let Some(parsed) = parse_marker_line(first_marker) else {
+            continue;
+        };
+        if let MarkerParse::V2 { role, profile } = parsed {
+            if profile_filter.is_some_and(|expected| profile != PayloadProfile::from(expected)) {
+                continue;
+            }
+            bodies.entry(role).or_insert_with(|| body.to_string());
+        }
+    }
+    Ok(bodies)
+}
+
 /// Compare two RFC3339 created-at strings. `None` is considered older than
 /// any `Some(_)`. This keeps latest-by-role selection deterministic even
 /// when GitHub returns comments out of order.
@@ -825,7 +861,18 @@ pub const PAYLOAD_SCHEMA_V2: &str = "plan-issue-record.payload.v2";
 pub const PAYLOAD_FENCE_INFO: &str = "plan-issue-record-payload";
 const PAYLOAD_COMMENT_PREFIX: &str = "plan-issue-record-payload:hex:";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    serde::Deserialize,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum PayloadRole {
     Source,

--- a/crates/plan-issue-cli/src/lifecycle_vnext/mod.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/mod.rs
@@ -1,0 +1,38 @@
+//! vNext lifecycle implementation boundary for the plan-issue record
+//! workflow.
+//!
+//! Design references:
+//!
+//! - `docs/source/plan-issue-redesign/plan-tracking-issue-cli-redesign-v1.md`
+//!   (Workstreams 0–6 and the rewrite boundary)
+//! - `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`
+//!   (canonical lifecycle role list, visible templates, posting policies)
+//!
+//! Module map:
+//!
+//! - [`registry`] enumerates the seven lifecycle roles and the metadata each
+//!   role carries (heading, payload schema, direct-post permission, closeout
+//!   ownership).
+//! - [`templates`] renders the visible Markdown and JSON skeletons used by the
+//!   `record template` preview command.
+//! - [`visible_lint`] enforces visible-completeness rules for rendered
+//!   lifecycle comments (Task Ledger heading, validation status,
+//!   review decision, session summary, closeout approval, …).
+//! - [`payloads`] exposes typed payload helpers built on top of the legacy
+//!   [`crate::lifecycle_record`] data types until the catch-all
+//!   `lifecycle_record.rs` is fully migrated.
+//! - [`render`] is the registry-driven rendering surface used by `record post`
+//!   and the upcoming `tracking checkpoint` macro.
+//!
+//! The module deliberately keeps the public binary shell (`plan-issue` /
+//! `plan-issue-local`), the global output envelope, exit-code conventions,
+//! provider abstraction, and the existing `record` commands behaving the same
+//! way during the rewrite. Old internals continue to live in
+//! [`crate::lifecycle_record`] until Task 6.3 migrates them onto this
+//! registry.
+
+pub mod payloads;
+pub mod registry;
+pub mod render;
+pub mod templates;
+pub mod visible_lint;

--- a/crates/plan-issue-cli/src/lifecycle_vnext/mod.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/mod.rs
@@ -18,7 +18,7 @@
 //! - [`visible_lint`] enforces visible-completeness rules for rendered
 //!   lifecycle comments (Task Ledger heading, validation status,
 //!   review decision, session summary, closeout approval, …).
-//! - [`payloads`] exposes typed payload helpers built on top of the legacy
+//! - [`payloads`] exposes typed payload helpers built on top of the existing
 //!   [`crate::lifecycle_record`] data types until the catch-all
 //!   `lifecycle_record.rs` is fully migrated.
 //! - [`render`] is the registry-driven rendering surface used by `record post`

--- a/crates/plan-issue-cli/src/lifecycle_vnext/payloads.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/payloads.rs
@@ -1,0 +1,19 @@
+//! Typed payload helpers built on the existing [`crate::lifecycle_record`]
+//! data shapes.
+//!
+//! Task 1.1 keeps the legacy payload definitions (`RecordPayload`,
+//! `StateData`, `SessionData`, `ValidationData`, `ReviewData`,
+//! `CloseoutData`, `SnapshotData`) as the canonical structs. As the vNext
+//! registry, lint, and render modules mature, this module is the boundary
+//! that hides the legacy file from new consumers.
+//!
+//! Re-exports surface only the types that vNext code needs so we can move
+//! the underlying definitions during Task 6.3 (migrate record rendering
+//! internals to the vNext registry) without rewriting downstream imports.
+
+pub use crate::lifecycle_record::{
+    CloseoutData, PayloadProfile, PayloadRole, PrLifecycleStatus, PrRefPayload, RecordPayload,
+    ReviewData, ReviewDecision, SessionData, SnapshotData, StateData, StateStatus, TaskRowPayload,
+    TaskRowStatus, ValidationCommand, ValidationCommandStatus, ValidationData,
+    ValidationOverall, ValidationWaiver,
+};

--- a/crates/plan-issue-cli/src/lifecycle_vnext/payloads.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/payloads.rs
@@ -1,11 +1,11 @@
 //! Typed payload helpers built on the existing [`crate::lifecycle_record`]
 //! data shapes.
 //!
-//! Task 1.1 keeps the legacy payload definitions (`RecordPayload`,
+//! Task 1.1 keeps the existing payload definitions (`RecordPayload`,
 //! `StateData`, `SessionData`, `ValidationData`, `ReviewData`,
 //! `CloseoutData`, `SnapshotData`) as the canonical structs. As the vNext
 //! registry, lint, and render modules mature, this module is the boundary
-//! that hides the legacy file from new consumers.
+//! that hides the catch-all file from new consumers.
 //!
 //! Re-exports surface only the types that vNext code needs so we can move
 //! the underlying definitions during Task 6.3 (migrate record rendering

--- a/crates/plan-issue-cli/src/lifecycle_vnext/registry.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/registry.rs
@@ -1,0 +1,268 @@
+//! Lifecycle role registry.
+//!
+//! Single source of truth for the seven lifecycle comment roles defined in
+//! `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`:
+//!
+//! 1. `source` — durable plan source snapshot (open/attach only)
+//! 2. `plan` — durable plan snapshot (open/attach only)
+//! 3. `state` — execution-state checkpoint, requires visible Task Ledger
+//! 4. `session` — execution session summary, requires non-empty summary
+//! 5. `validation` — validation evidence, requires overall + commands/waiver
+//! 6. `review` — review evidence, requires decision and finding disposition
+//! 7. `closeout` — final closeout, owned by `record close`
+//!
+//! Each [`RoleSpec`] carries the metadata needed to drive
+//! [`super::templates`], [`super::visible_lint`], [`super::render`], and the
+//! `tracking::checkpoint` macro from one structured table.
+
+use crate::lifecycle_record::PayloadRole;
+
+/// Heading text used in the visible body for a lifecycle role.
+pub const HEADING_SOURCE: &str = "## Plan Source Snapshot";
+pub const HEADING_PLAN: &str = "## Plan Snapshot";
+pub const HEADING_STATE: &str = "## Execution State";
+pub const HEADING_SESSION: &str = "## Execution Session";
+pub const HEADING_VALIDATION: &str = "## Validation Evidence";
+pub const HEADING_REVIEW: &str = "## Review Evidence";
+pub const HEADING_CLOSEOUT: &str = "## Tracking Issue Closeout";
+
+/// Required visible sections expressed as canonical Markdown headings. The
+/// visible-completeness lint asserts that each heading appears verbatim in
+/// the rendered comment body.
+pub type VisibleSections = &'static [&'static str];
+
+/// Direct-post permission for a lifecycle role.
+///
+/// `record post --kind <role>` accepts roles where this is
+/// [`DirectPostPolicy::Allowed`]. Roles marked
+/// [`DirectPostPolicy::OpenAttachOnly`] are owned by `record open` /
+/// `record attach`. Roles marked [`DirectPostPolicy::RecordCloseOwned`] are
+/// owned by `record close`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectPostPolicy {
+    /// Skills may post directly via `record post --kind <role>`.
+    Allowed,
+    /// Posted only when `record open` or `record attach` snapshots the plan.
+    OpenAttachOnly,
+    /// Posted only when `record close` finishes the strict closeout gate.
+    RecordCloseOwned,
+}
+
+impl DirectPostPolicy {
+    pub fn allows_direct_post(self) -> bool {
+        matches!(self, Self::Allowed)
+    }
+}
+
+/// Dashboard repair expectation following a successful post for the role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DashboardRepair {
+    /// Caller should repair the dashboard body after the post.
+    Expected,
+    /// Dashboard repair is optional for this role.
+    Optional,
+    /// Dashboard repair is owned by `record close` only.
+    OwnedByCloseout,
+}
+
+/// Closeout ownership for a lifecycle role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseoutOwnership {
+    /// Role appears before closeout and is not the closeout post.
+    PreCloseout,
+    /// Role is the closeout post itself.
+    Closeout,
+}
+
+/// Structured payload schema declared for a lifecycle role. The strings are
+/// machine-stable identifiers used by `record template --format json` and
+/// the audit surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PayloadSchema {
+    Snapshot,
+    State,
+    Session,
+    Validation,
+    Review,
+    Closeout,
+}
+
+impl PayloadSchema {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Snapshot => "snapshot.v1",
+            Self::State => "state.v1",
+            Self::Session => "session.v1",
+            Self::Validation => "validation.v1",
+            Self::Review => "review.v1",
+            Self::Closeout => "closeout.v1",
+        }
+    }
+}
+
+/// Complete lifecycle role specification.
+#[derive(Debug, Clone, Copy)]
+pub struct RoleSpec {
+    pub role: PayloadRole,
+    pub marker_role: &'static str,
+    pub default_heading: &'static str,
+    pub required_visible_sections: VisibleSections,
+    pub payload_schema: PayloadSchema,
+    pub direct_post: DirectPostPolicy,
+    pub dashboard_repair: DashboardRepair,
+    pub closeout_ownership: CloseoutOwnership,
+}
+
+impl RoleSpec {
+    pub fn allows_direct_post(&self) -> bool {
+        self.direct_post.allows_direct_post()
+    }
+}
+
+const SOURCE_REQUIRED: VisibleSections = &[HEADING_SOURCE];
+const PLAN_REQUIRED: VisibleSections = &[HEADING_PLAN];
+const STATE_REQUIRED: VisibleSections = &[HEADING_STATE, "## Task Ledger"];
+const SESSION_REQUIRED: VisibleSections = &[HEADING_SESSION];
+const VALIDATION_REQUIRED: VisibleSections = &[HEADING_VALIDATION];
+const REVIEW_REQUIRED: VisibleSections = &[HEADING_REVIEW];
+const CLOSEOUT_REQUIRED: VisibleSections = &[HEADING_CLOSEOUT];
+
+const REGISTRY: &[RoleSpec] = &[
+    RoleSpec {
+        role: PayloadRole::Source,
+        marker_role: "source",
+        default_heading: HEADING_SOURCE,
+        required_visible_sections: SOURCE_REQUIRED,
+        payload_schema: PayloadSchema::Snapshot,
+        direct_post: DirectPostPolicy::OpenAttachOnly,
+        dashboard_repair: DashboardRepair::Optional,
+        closeout_ownership: CloseoutOwnership::PreCloseout,
+    },
+    RoleSpec {
+        role: PayloadRole::Plan,
+        marker_role: "plan",
+        default_heading: HEADING_PLAN,
+        required_visible_sections: PLAN_REQUIRED,
+        payload_schema: PayloadSchema::Snapshot,
+        direct_post: DirectPostPolicy::OpenAttachOnly,
+        dashboard_repair: DashboardRepair::Optional,
+        closeout_ownership: CloseoutOwnership::PreCloseout,
+    },
+    RoleSpec {
+        role: PayloadRole::State,
+        marker_role: "state",
+        default_heading: HEADING_STATE,
+        required_visible_sections: STATE_REQUIRED,
+        payload_schema: PayloadSchema::State,
+        direct_post: DirectPostPolicy::Allowed,
+        dashboard_repair: DashboardRepair::Expected,
+        closeout_ownership: CloseoutOwnership::PreCloseout,
+    },
+    RoleSpec {
+        role: PayloadRole::Session,
+        marker_role: "session",
+        default_heading: HEADING_SESSION,
+        required_visible_sections: SESSION_REQUIRED,
+        payload_schema: PayloadSchema::Session,
+        direct_post: DirectPostPolicy::Allowed,
+        dashboard_repair: DashboardRepair::Optional,
+        closeout_ownership: CloseoutOwnership::PreCloseout,
+    },
+    RoleSpec {
+        role: PayloadRole::Validation,
+        marker_role: "validation",
+        default_heading: HEADING_VALIDATION,
+        required_visible_sections: VALIDATION_REQUIRED,
+        payload_schema: PayloadSchema::Validation,
+        direct_post: DirectPostPolicy::Allowed,
+        dashboard_repair: DashboardRepair::Expected,
+        closeout_ownership: CloseoutOwnership::PreCloseout,
+    },
+    RoleSpec {
+        role: PayloadRole::Review,
+        marker_role: "review",
+        default_heading: HEADING_REVIEW,
+        required_visible_sections: REVIEW_REQUIRED,
+        payload_schema: PayloadSchema::Review,
+        direct_post: DirectPostPolicy::Allowed,
+        dashboard_repair: DashboardRepair::Expected,
+        closeout_ownership: CloseoutOwnership::PreCloseout,
+    },
+    RoleSpec {
+        role: PayloadRole::Closeout,
+        marker_role: "closeout",
+        default_heading: HEADING_CLOSEOUT,
+        required_visible_sections: CLOSEOUT_REQUIRED,
+        payload_schema: PayloadSchema::Closeout,
+        direct_post: DirectPostPolicy::RecordCloseOwned,
+        dashboard_repair: DashboardRepair::OwnedByCloseout,
+        closeout_ownership: CloseoutOwnership::Closeout,
+    },
+];
+
+/// All lifecycle role specifications in canonical order (source → closeout).
+pub fn all_roles() -> &'static [RoleSpec] {
+    REGISTRY
+}
+
+/// Look up the role specification for a [`PayloadRole`].
+pub fn role(role: PayloadRole) -> &'static RoleSpec {
+    for spec in REGISTRY {
+        if spec.role == role {
+            return spec;
+        }
+    }
+    // The registry covers every PayloadRole variant; unreachable in practice.
+    panic!("lifecycle_vnext::registry missing entry for {role:?}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_has_every_role() {
+        let roles: Vec<PayloadRole> = all_roles().iter().map(|spec| spec.role).collect();
+        assert_eq!(
+            roles,
+            vec![
+                PayloadRole::Source,
+                PayloadRole::Plan,
+                PayloadRole::State,
+                PayloadRole::Session,
+                PayloadRole::Validation,
+                PayloadRole::Review,
+                PayloadRole::Closeout,
+            ]
+        );
+    }
+
+    #[test]
+    fn source_and_plan_are_open_attach_only() {
+        assert_eq!(
+            role(PayloadRole::Source).direct_post,
+            DirectPostPolicy::OpenAttachOnly
+        );
+        assert_eq!(
+            role(PayloadRole::Plan).direct_post,
+            DirectPostPolicy::OpenAttachOnly
+        );
+    }
+
+    #[test]
+    fn closeout_is_record_close_owned() {
+        let closeout = role(PayloadRole::Closeout);
+        assert_eq!(closeout.direct_post, DirectPostPolicy::RecordCloseOwned);
+        assert_eq!(closeout.dashboard_repair, DashboardRepair::OwnedByCloseout);
+        assert_eq!(closeout.closeout_ownership, CloseoutOwnership::Closeout);
+    }
+
+    #[test]
+    fn state_requires_task_ledger_heading() {
+        let state = role(PayloadRole::State);
+        assert!(state
+            .required_visible_sections
+            .iter()
+            .any(|h| *h == "## Task Ledger"));
+    }
+}

--- a/crates/plan-issue-cli/src/lifecycle_vnext/registry.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/registry.rs
@@ -17,8 +17,9 @@
 
 use crate::lifecycle_record::PayloadRole;
 
-/// Heading text used in the visible body for a lifecycle role.
-pub const HEADING_SOURCE: &str = "## Plan Source Snapshot";
+/// Heading text used in the visible body for a lifecycle role. The headings
+/// match `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`.
+pub const HEADING_SOURCE: &str = "## Source Snapshot";
 pub const HEADING_PLAN: &str = "## Plan Snapshot";
 pub const HEADING_STATE: &str = "## Execution State";
 pub const HEADING_SESSION: &str = "## Execution Session";
@@ -264,5 +265,63 @@ mod tests {
             .required_visible_sections
             .iter()
             .any(|h| *h == "## Task Ledger"));
+    }
+
+    #[test]
+    fn registry_headings_match_taxonomy_doc() {
+        // Canonical headings come from
+        // docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md
+        // — keep in lockstep with the taxonomy table to prevent silent drift.
+        let expected: Vec<(PayloadRole, &'static str)> = vec![
+            (PayloadRole::Source, "## Source Snapshot"),
+            (PayloadRole::Plan, "## Plan Snapshot"),
+            (PayloadRole::State, "## Execution State"),
+            (PayloadRole::Session, "## Execution Session"),
+            (PayloadRole::Validation, "## Validation Evidence"),
+            (PayloadRole::Review, "## Review Evidence"),
+            (PayloadRole::Closeout, "## Tracking Issue Closeout"),
+        ];
+        for (role_id, heading) in expected {
+            assert_eq!(
+                role(role_id).default_heading,
+                heading,
+                "role {role_id:?} heading drift"
+            );
+        }
+    }
+
+    #[test]
+    fn every_role_has_visible_section_and_payload_schema() {
+        for spec in all_roles() {
+            assert!(
+                !spec.required_visible_sections.is_empty(),
+                "role {:?} has no required visible sections",
+                spec.role
+            );
+            // Every role advertises a payload schema identifier.
+            assert!(
+                !spec.payload_schema.as_str().is_empty(),
+                "role {:?} payload schema is empty",
+                spec.role
+            );
+        }
+    }
+
+    #[test]
+    fn direct_post_policy_matches_taxonomy() {
+        // source/plan are owned by record open|attach. closeout is owned by
+        // record close. All other roles allow direct record post.
+        for spec in all_roles() {
+            let expected = match spec.role {
+                PayloadRole::Source | PayloadRole::Plan => DirectPostPolicy::OpenAttachOnly,
+                PayloadRole::Closeout => DirectPostPolicy::RecordCloseOwned,
+                _ => DirectPostPolicy::Allowed,
+            };
+            assert_eq!(
+                spec.direct_post, expected,
+                "role {:?} direct-post policy drift",
+                spec.role
+            );
+        }
     }
 }

--- a/crates/plan-issue-cli/src/lifecycle_vnext/render.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/render.rs
@@ -1,0 +1,43 @@
+//! Registry-driven lifecycle comment renderer.
+//!
+//! Task 1.1 introduces the boundary; Tasks 3.2 and 6.3 migrate the real
+//! Markdown assembly from [`crate::lifecycle_record`] onto this surface so
+//! `record post`, `record open`, `record attach`, and `tracking checkpoint`
+//! all share one rendering engine per role.
+
+use crate::lifecycle_record::{self, CommentInput, PayloadRole};
+use crate::lifecycle_vnext::registry::{self, RoleSpec};
+
+/// Outcome of rendering one lifecycle comment.
+#[derive(Debug, Clone)]
+pub struct RenderedComment {
+    pub role: PayloadRole,
+    pub spec: &'static RoleSpec,
+    pub body: String,
+}
+
+/// Render a lifecycle comment for the given [`CommentInput`].
+///
+/// Until Task 6.3 migrates the renderer wholesale, this adapter delegates to
+/// the existing [`crate::lifecycle_record::render_comment`] implementation
+/// while exposing the vNext-shaped result. Errors are surfaced verbatim so
+/// upstream callers see the same stable strings.
+pub fn render(input: CommentInput) -> Result<RenderedComment, String> {
+    let role = derive_role(&input);
+    let spec = registry::role(role);
+    let body = lifecycle_record::render_comment(input)?;
+    Ok(RenderedComment { role, spec, body })
+}
+
+fn derive_role(input: &CommentInput) -> PayloadRole {
+    use crate::commands::record::LifecycleCommentKind;
+    match input.kind {
+        LifecycleCommentKind::Source => PayloadRole::Source,
+        LifecycleCommentKind::Plan => PayloadRole::Plan,
+        LifecycleCommentKind::State => PayloadRole::State,
+        LifecycleCommentKind::Session => PayloadRole::Session,
+        LifecycleCommentKind::Validation => PayloadRole::Validation,
+        LifecycleCommentKind::Review => PayloadRole::Review,
+        LifecycleCommentKind::Closeout => PayloadRole::Closeout,
+    }
+}

--- a/crates/plan-issue-cli/src/lifecycle_vnext/templates.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/templates.rs
@@ -1,0 +1,79 @@
+//! Deterministic template preview for lifecycle roles.
+//!
+//! Backs the upcoming `plan-issue record template` command. Skeleton lives in
+//! Task 1.1; the full Markdown + JSON skeleton output is implemented in
+//! Task 3.1 against
+//! `docs/source/plan-issue-redesign/plan-tracking-issue-cli-redesign-v1.md`
+//! Workstream 3 and
+//! `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`.
+//!
+//! The renderer must be a pure function over [`super::registry::RoleSpec`].
+//! It never emits a real hidden payload carrier — templates are previews of
+//! the comment shape, not lifecycle records.
+
+use crate::commands::record::RecordProfile;
+use crate::lifecycle_record::PayloadRole;
+use crate::lifecycle_vnext::registry;
+
+/// Output format requested by the template preview.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TemplateFormat {
+    /// Visible Markdown skeleton (headings + placeholder text).
+    Markdown,
+    /// Payload JSON data skeleton (no hidden carrier).
+    Json,
+}
+
+/// Error emitted by [`render_template`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TemplateError {
+    /// Asked for a role/profile combination that the registry forbids.
+    UnsupportedRoleProfile {
+        role: PayloadRole,
+        profile: RecordProfile,
+    },
+}
+
+impl std::fmt::Display for TemplateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedRoleProfile { role, profile } => {
+                write!(
+                    f,
+                    "lifecycle role `{}` is not supported for profile `{}`",
+                    role.as_str(),
+                    profile.as_str()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for TemplateError {}
+
+/// Render the template preview for the supplied role/profile in the requested
+/// format.
+///
+/// Implementation lands in Task 3.1; the Task 1.1 skeleton returns a stable
+/// "not yet implemented" payload so consumers can wire CLI plumbing without
+/// blocking on the visible/JSON skeletons.
+pub fn render_template(
+    profile: RecordProfile,
+    role: PayloadRole,
+    format: TemplateFormat,
+) -> Result<String, TemplateError> {
+    let _spec = registry::role(role);
+    // Task 3.1 fills in Markdown + JSON skeletons; this stub keeps the
+    // module path callable so the CLI surface can be added in parallel.
+    let payload = serde_json::json!({
+        "status": "not-implemented",
+        "task": "3.1",
+        "profile": profile.as_str(),
+        "role": role.as_str(),
+        "format": match format {
+            TemplateFormat::Markdown => "markdown",
+            TemplateFormat::Json => "json",
+        },
+    });
+    Ok(payload.to_string())
+}

--- a/crates/plan-issue-cli/src/lifecycle_vnext/templates.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/templates.rs
@@ -1,19 +1,19 @@
 //! Deterministic template preview for lifecycle roles.
 //!
-//! Backs the upcoming `plan-issue record template` command. Skeleton lives in
-//! Task 1.1; the full Markdown + JSON skeleton output is implemented in
-//! Task 3.1 against
-//! `docs/source/plan-issue-redesign/plan-tracking-issue-cli-redesign-v1.md`
-//! Workstream 3 and
-//! `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`.
+//! Backs the `plan-issue record template` command. Source of truth for the
+//! visible Markdown skeletons is
+//! `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`;
+//! payload JSON skeletons match the structured payload schemas declared in
+//! the same document.
 //!
-//! The renderer must be a pure function over [`super::registry::RoleSpec`].
-//! It never emits a real hidden payload carrier — templates are previews of
-//! the comment shape, not lifecycle records.
+//! Templates are previews of the comment shape. They never carry a real
+//! hidden `plan-issue-record-payload:hex:<>` payload carrier. The hidden
+//! line is rendered as a `<!-- ... -->` placeholder so agents see where the
+//! payload would land without producing a record-grade comment.
 
 use crate::commands::record::RecordProfile;
 use crate::lifecycle_record::PayloadRole;
-use crate::lifecycle_vnext::registry;
+use crate::lifecycle_vnext::registry::{self, RoleSpec};
 
 /// Output format requested by the template preview.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,6 +24,15 @@ pub enum TemplateFormat {
     Json,
 }
 
+impl TemplateFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Markdown => "markdown",
+            Self::Json => "json",
+        }
+    }
+}
+
 /// Error emitted by [`render_template`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TemplateError {
@@ -32,6 +41,14 @@ pub enum TemplateError {
         role: PayloadRole,
         profile: RecordProfile,
     },
+}
+
+impl TemplateError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::UnsupportedRoleProfile { .. } => "record-template-unsupported-role-profile",
+        }
+    }
 }
 
 impl std::fmt::Display for TemplateError {
@@ -51,29 +68,264 @@ impl std::fmt::Display for TemplateError {
 
 impl std::error::Error for TemplateError {}
 
-/// Render the template preview for the supplied role/profile in the requested
-/// format.
-///
-/// Implementation lands in Task 3.1; the Task 1.1 skeleton returns a stable
-/// "not yet implemented" payload so consumers can wire CLI plumbing without
-/// blocking on the visible/JSON skeletons.
+/// Render the template preview for the supplied role/profile in the
+/// requested format.
 pub fn render_template(
     profile: RecordProfile,
     role: PayloadRole,
     format: TemplateFormat,
 ) -> Result<String, TemplateError> {
-    let _spec = registry::role(role);
-    // Task 3.1 fills in Markdown + JSON skeletons; this stub keeps the
-    // module path callable so the CLI surface can be added in parallel.
-    let payload = serde_json::json!({
-        "status": "not-implemented",
-        "task": "3.1",
+    // Both lifecycle profiles share the same role inventory in v1; reject
+    // role/profile combos that have not been declared compatible. Today
+    // every role is allowed in both profiles, but the check is explicit so
+    // future profile-only roles surface here rather than silently rendering.
+    if !registry::all_roles().iter().any(|spec| spec.role == role) {
+        return Err(TemplateError::UnsupportedRoleProfile { role, profile });
+    }
+
+    let spec = registry::role(role);
+    let output = match format {
+        TemplateFormat::Markdown => render_markdown(spec, profile),
+        TemplateFormat::Json => render_json_skeleton(spec, profile),
+    };
+    Ok(output)
+}
+
+fn render_markdown(spec: &RoleSpec, profile: RecordProfile) -> String {
+    let marker = format!(
+        "<!-- plan-issue-record:v2 role={role} profile={profile} -->",
+        role = spec.marker_role,
+        profile = profile.as_str()
+    );
+    let payload_placeholder = format!(
+        "<!-- plan-issue-record-payload:hex:<{role}.v1 payload hex bytes> -->",
+        role = spec.marker_role
+    );
+    let body = role_visible_skeleton(spec.role);
+    format!(
+        "{marker}\n\n{heading}\n\n- Profile: {profile}\n{body}\n\n{payload_placeholder}\n",
+        heading = spec.default_heading,
+        profile = profile.as_str(),
+    )
+}
+
+fn role_visible_skeleton(role: PayloadRole) -> &'static str {
+    match role {
+        PayloadRole::Source => {
+            "- Path: `docs/plans/<slug>/<slug>-discussion-source.md`\n\
+             - Commit: `<full-sha>`\n\
+             - Summary: <one-line source summary>\n\
+             - Snapshot mode: local committed Markdown\n\n\
+             <details>\n<summary>Source snapshot</summary>\n\n\
+             <verbatim source document content>\n\n</details>"
+        }
+        PayloadRole::Plan => {
+            "- Path: `docs/plans/<slug>/<slug>-plan.md`\n\
+             - Commit: `<full-sha>`\n\
+             - Summary: <one-line plan summary>\n\
+             - Snapshot mode: local committed Markdown\n\n\
+             <details>\n<summary>Plan snapshot</summary>\n\n\
+             <verbatim plan content>\n\n</details>"
+        }
+        PayloadRole::State => {
+            "- Status: in-progress\n\
+             - Target scope: <issue-backed scope>\n\
+             - Current task: <task id or description>\n\
+             - Next task: <next action>\n\
+             - Last updated: YYYY-MM-DD\n\
+             - Branch: <branch>\n\
+             - PR: <owner/repo#number or pending>\n\
+             - Source document: docs/plans/<slug>/<source-file>\n\
+             - Plan document: docs/plans/<slug>/<slug>-plan.md\n\n\
+             ## Task Ledger\n\n\
+             <details>\n<summary>Show task ledger</summary>\n\n\
+             | ID | Status | Task | Notes |\n\
+             | --- | --- | --- | --- |\n\
+             | 1.1 | in-progress | <task title> | <short note> |\n\
+             | 1.2 | pending | <task title> |  |\n\n\
+             </details>\n\n\
+             ## Blockers\n\n\
+             - <blocker or `None`>\n\n\
+             ## Validation\n\n\
+             | Command | Status | Evidence |\n\
+             | --- | --- | --- |\n\
+             | `<command>` | pass|fail|skipped | <path or URL> |"
+        }
+        PayloadRole::Session => {
+            "- Summary: <one-line summary of work done in this session>\n\n\
+             ### Highlights\n\n\
+             - <meaningful implementation, investigation, or handoff note>\n\
+             - <branch, PR, or issue-visible decision>\n\n\
+             ### Links\n\n\
+             - State: <latest state comment URL>\n\
+             - PR: <PR URL or pending>\n\
+             - Artifacts: <validation or evidence path>\n\n\
+             ### Session Fields\n\n\
+             - branch: <branch>\n\
+             - pr: <owner/repo#number or pending>\n\
+             - selected_task: <task id>"
+        }
+        PayloadRole::Validation => {
+            "- Overall: pass|partial|fail\n\n\
+             | Command | Status | Evidence |\n\
+             | --- | --- | --- |\n\
+             | `<exact command>` | pass|fail|skipped | <artifact path, URL, or short reason> |\n\n\
+             ### Waivers\n\n\
+             - `<command>`: <why it was not run or why failure is accepted>"
+        }
+        PayloadRole::Review => {
+            "- Decision: approve|request-changes|comments-only\n\
+             - Lenses: testing, maintainability\n\
+             - Outcome comment: <provider comment URL or retained evidence path>\n\n\
+             | ID | Severity | Disposition | Summary |\n\
+             | --- | --- | --- | --- |\n\
+             | F1 | major | fixed|residual|follow-up|deferred|no-action | <finding summary> |"
+        }
+        PayloadRole::Closeout => {
+            "- Final status: complete\n\
+             - Approver: <login or source>\n\
+             - Approval: <comment URL or approval text>\n\
+             - Final validation: <validation evidence URL>\n\
+             - Notes: <optional closeout note>\n\n\
+             | PR | Merge SHA | Checks | Required | Non-required failures |\n\
+             | --- | --- | --- | --- | --- |\n\
+             | <PR URL or ref> | <sha> | pass|fail|none | pass|fail|none (<count>) | none |"
+        }
+    }
+}
+
+fn render_json_skeleton(spec: &RoleSpec, profile: RecordProfile) -> String {
+    let data = role_payload_skeleton(spec.role);
+    let envelope = serde_json::json!({
+        "schema": "plan-issue-record.payload.v2",
+        "role": spec.marker_role,
         "profile": profile.as_str(),
-        "role": role.as_str(),
-        "format": match format {
-            TemplateFormat::Markdown => "markdown",
-            TemplateFormat::Json => "json",
-        },
+        "data": data,
     });
-    Ok(payload.to_string())
+    serde_json::to_string_pretty(&envelope).unwrap_or_else(|_| envelope.to_string())
+}
+
+fn role_payload_skeleton(role: PayloadRole) -> serde_json::Value {
+    use serde_json::json;
+    match role {
+        PayloadRole::Source | PayloadRole::Plan => json!({
+            "path": "docs/plans/<slug>/<slug>-<source|plan>.md",
+            "commit": "<full-sha>",
+            "title": "<optional title>",
+            "summary": "<optional summary>"
+        }),
+        PayloadRole::State => json!({
+            "status": "in-progress|complete|blocked",
+            "target_scope": "<issue-backed scope>",
+            "current": "<current task or state>",
+            "next_action": "<next task or unblock action>",
+            "tasks": [
+                {"id": "1.1", "status": "pending|in-progress|done|deferred", "title": "<task title>"}
+            ],
+            "prs": [
+                {"ref": "owner/repo#123", "url": "<url>", "status": "open|merged|closed"}
+            ],
+            "blockers": ["<blocking fact>"],
+            "links": {
+                "source": "<url>",
+                "plan": "<url>",
+                "previous_state": "<url>"
+            }
+        }),
+        PayloadRole::Session => json!({
+            "summary": "<one-line summary>",
+            "highlights": ["<short bullet>"],
+            "links": {"state": "<url>", "pr": "<url>"}
+        }),
+        PayloadRole::Validation => json!({
+            "overall": "pass|partial|fail",
+            "commands": [
+                {"command": "<exact command>", "status": "pass|fail|skipped", "evidence": "<optional path or URL>"}
+            ],
+            "waivers": [
+                {"command": "<command>", "reason": "<reason>"}
+            ]
+        }),
+        PayloadRole::Review => json!({
+            "decision": "approve|request-changes|comments-only",
+            "lenses": ["testing", "maintainability"],
+            "findings": [
+                {
+                    "id": "F1",
+                    "severity": "blocker|major|minor|nit",
+                    "disposition": "fixed|residual|follow-up|deferred|no-action",
+                    "summary": "<finding summary>"
+                }
+            ],
+            "outcome_comment_url": "<optional URL>"
+        }),
+        PayloadRole::Closeout => json!({
+            "final_status": "complete",
+            "approval": {"comment_url": "<optional URL>", "approver": "<optional login>"},
+            "linked_prs": [
+                {
+                    "ref": "owner/repo#123",
+                    "url": "<optional URL>",
+                    "merge_sha": "<sha>",
+                    "checks": "pass|fail|none",
+                    "required_state": "pass|fail|none",
+                    "required_count": 0,
+                    "non_required_failures": []
+                }
+            ],
+            "non_required_check_override": {"reason": "<reason>", "observed_non_required_failures": []},
+            "final_validation_url": "<optional URL>",
+            "notes": "<optional note>"
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markdown_template_includes_role_heading_and_marker() {
+        for spec in registry::all_roles() {
+            let out =
+                render_template(RecordProfile::Tracking, spec.role, TemplateFormat::Markdown)
+                    .expect("render");
+            assert!(
+                out.contains("<!-- plan-issue-record:v2"),
+                "role {:?} missing marker: {out}",
+                spec.role
+            );
+            assert!(
+                out.contains(spec.default_heading),
+                "role {:?} missing heading {}: {out}",
+                spec.role,
+                spec.default_heading
+            );
+            // Payload placeholder must be a comment, not a fenced code block.
+            assert!(
+                !out.contains("```plan-issue-record-payload"),
+                "role {:?} must not render a real payload carrier: {out}",
+                spec.role
+            );
+            assert!(
+                out.contains("<!-- plan-issue-record-payload:hex:"),
+                "role {:?} missing payload placeholder: {out}",
+                spec.role
+            );
+        }
+    }
+
+    #[test]
+    fn json_template_includes_envelope_schema_and_role() {
+        for spec in registry::all_roles() {
+            let out =
+                render_template(RecordProfile::Tracking, spec.role, TemplateFormat::Json)
+                    .expect("render");
+            let value: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+            assert_eq!(value["schema"], "plan-issue-record.payload.v2");
+            assert_eq!(value["role"], spec.marker_role);
+            assert_eq!(value["profile"], "tracking");
+            assert!(value["data"].is_object());
+        }
+    }
 }

--- a/crates/plan-issue-cli/src/lifecycle_vnext/visible_lint.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/visible_lint.rs
@@ -1,0 +1,114 @@
+//! Visible-completeness lint for rendered lifecycle comments.
+//!
+//! The lint rejects Profile-only bodies and enforces role-specific visible
+//! sections from
+//! `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`.
+//! Full rules implemented in Task 2.2.
+//!
+//! Reusable surface:
+//!
+//! - [`lint_visible`] evaluates a rendered Markdown body against a role spec.
+//! - [`VisibleFinding`] carries a stable role-specific failure code.
+//! - [`VisibleReport`] aggregates findings into a pass/fail decision.
+
+use crate::lifecycle_record::PayloadRole;
+use crate::lifecycle_vnext::registry::{self, RoleSpec};
+
+/// Stable, role-specific failure code emitted by the lint.
+///
+/// Codes carry a structured prefix per role so runtime-kit and skill smoke
+/// can assert specific gaps (`state-missing-task-ledger`,
+/// `validation-missing-overall`, …). The full catalog is finalized in
+/// Task 2.2.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VisibleFinding {
+    pub role: PayloadRole,
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl VisibleFinding {
+    pub fn new(role: PayloadRole, code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            role,
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+/// Aggregated visible-completeness report.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VisibleReport {
+    pub findings: Vec<VisibleFinding>,
+}
+
+impl VisibleReport {
+    pub fn is_pass(&self) -> bool {
+        self.findings.is_empty()
+    }
+
+    pub fn push(&mut self, finding: VisibleFinding) {
+        self.findings.push(finding);
+    }
+}
+
+/// Hints that callers can pass to refine lint behavior. The full set is
+/// expanded in Task 2.2 (Task Ledger display mode, presence of findings,
+/// linked PRs, etc.).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LintHints {
+    /// `true` when the caller is rendering the final state checkpoint and the
+    /// Task Ledger must be expanded. Non-final state may collapse rows.
+    pub state_is_final: bool,
+    /// `true` when review findings are present and the review comment must
+    /// include a disposition row.
+    pub review_has_findings: bool,
+}
+
+/// Run the visible-completeness lint against a rendered Markdown body for the
+/// supplied lifecycle role.
+///
+/// The Task 1.1 skeleton only checks that the required headings from the
+/// registry appear verbatim. Task 2.2 expands the implementation to cover
+/// Task Ledger structure, validation status, review disposition, session
+/// summary, and closeout approval + linked PR evidence.
+pub fn lint_visible(role: PayloadRole, body: &str, hints: LintHints) -> VisibleReport {
+    let spec = registry::role(role);
+    let mut report = VisibleReport::default();
+    check_required_headings(spec, body, &mut report);
+    // Task 2.2 adds the role-specific rule blocks below this line.
+    let _ = hints;
+    report
+}
+
+fn check_required_headings(spec: &RoleSpec, body: &str, report: &mut VisibleReport) {
+    for heading in spec.required_visible_sections {
+        if !body_contains_heading(body, heading) {
+            report.push(VisibleFinding::new(
+                spec.role,
+                missing_heading_code(spec.role),
+                format!(
+                    "rendered {role} body is missing required heading `{heading}`",
+                    role = spec.marker_role
+                ),
+            ));
+        }
+    }
+}
+
+fn body_contains_heading(body: &str, heading: &str) -> bool {
+    body.lines().any(|line| line.trim_end() == heading)
+}
+
+fn missing_heading_code(role: PayloadRole) -> &'static str {
+    match role {
+        PayloadRole::Source => "source-missing-heading",
+        PayloadRole::Plan => "plan-missing-heading",
+        PayloadRole::State => "state-missing-heading",
+        PayloadRole::Session => "session-missing-heading",
+        PayloadRole::Validation => "validation-missing-heading",
+        PayloadRole::Review => "review-missing-heading",
+        PayloadRole::Closeout => "closeout-missing-heading",
+    }
+}

--- a/crates/plan-issue-cli/src/lifecycle_vnext/visible_lint.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/visible_lint.rs
@@ -337,21 +337,26 @@ fn body_contains_validation_command_row(body: &str) -> bool {
             saw_separator = false;
             continue;
         }
-        if trimmed.contains("| Command") {
+        if trimmed.contains("Command") && trimmed.contains("Status") {
             in_validation_table = true;
             saw_separator = false;
             continue;
         }
-        if in_validation_table && trimmed.starts_with("| ---") {
+        if in_validation_table && is_table_separator(trimmed) {
             saw_separator = true;
             continue;
         }
         if in_validation_table && saw_separator {
-            // Any data row inside the validation table counts.
             return true;
         }
     }
     false
+}
+
+fn is_table_separator(line: &str) -> bool {
+    line.chars()
+        .all(|c| matches!(c, '|' | '-' | ' ' | ':'))
+        && line.contains("---")
 }
 
 fn body_contains_review_disposition_row(body: &str) -> bool {

--- a/crates/plan-issue-cli/src/lifecycle_vnext/visible_lint.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/visible_lint.rs
@@ -3,7 +3,6 @@
 //! The lint rejects Profile-only bodies and enforces role-specific visible
 //! sections from
 //! `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`.
-//! Full rules implemented in Task 2.2.
 //!
 //! Reusable surface:
 //!
@@ -14,12 +13,45 @@
 use crate::lifecycle_record::PayloadRole;
 use crate::lifecycle_vnext::registry::{self, RoleSpec};
 
-/// Stable, role-specific failure code emitted by the lint.
-///
-/// Codes carry a structured prefix per role so runtime-kit and skill smoke
-/// can assert specific gaps (`state-missing-task-ledger`,
-/// `validation-missing-overall`, …). The full catalog is finalized in
-/// Task 2.2.
+/// Stable, role-specific failure codes emitted by the lint. Runtime-kit
+/// smoke and skill flows pattern-match on these strings, so each code is
+/// documented next to where it can be returned.
+pub mod codes {
+    // Generic.
+    pub const PROFILE_ONLY: &str = "profile-only";
+
+    // Heading presence (registry-driven).
+    pub const SOURCE_MISSING_HEADING: &str = "source-missing-heading";
+    pub const PLAN_MISSING_HEADING: &str = "plan-missing-heading";
+    pub const STATE_MISSING_HEADING: &str = "state-missing-heading";
+    pub const SESSION_MISSING_HEADING: &str = "session-missing-heading";
+    pub const VALIDATION_MISSING_HEADING: &str = "validation-missing-heading";
+    pub const REVIEW_MISSING_HEADING: &str = "review-missing-heading";
+    pub const CLOSEOUT_MISSING_HEADING: &str = "closeout-missing-heading";
+
+    // State.
+    pub const STATE_MISSING_TASK_LEDGER: &str = "state-missing-task-ledger";
+    pub const STATE_FINAL_TASK_LEDGER_NOT_EXPANDED: &str = "state-final-task-ledger-not-expanded";
+
+    // Session.
+    pub const SESSION_MISSING_SUMMARY: &str = "session-missing-summary";
+
+    // Validation.
+    pub const VALIDATION_MISSING_OVERALL: &str = "validation-missing-overall";
+    pub const VALIDATION_MISSING_COMMANDS_OR_WAIVER: &str =
+        "validation-missing-commands-or-waiver";
+
+    // Review.
+    pub const REVIEW_MISSING_DECISION: &str = "review-missing-decision";
+    pub const REVIEW_MISSING_DISPOSITION: &str = "review-missing-disposition";
+
+    // Closeout.
+    pub const CLOSEOUT_MISSING_FINAL_STATUS: &str = "closeout-missing-final-status";
+    pub const CLOSEOUT_MISSING_APPROVAL: &str = "closeout-missing-approval";
+    pub const CLOSEOUT_MISSING_LINKED_PR: &str = "closeout-missing-linked-pr";
+}
+
+/// Single lint finding.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VisibleFinding {
     pub role: PayloadRole,
@@ -51,34 +83,51 @@ impl VisibleReport {
     pub fn push(&mut self, finding: VisibleFinding) {
         self.findings.push(finding);
     }
+
+    pub fn codes(&self) -> Vec<&'static str> {
+        self.findings.iter().map(|f| f.code).collect()
+    }
 }
 
-/// Hints that callers can pass to refine lint behavior. The full set is
-/// expanded in Task 2.2 (Task Ledger display mode, presence of findings,
-/// linked PRs, etc.).
+/// Hints that callers pass to refine lint behavior beyond the registry
+/// defaults. `state_is_final` and `review_has_findings` mirror the taxonomy
+/// rules from the comment taxonomy doc.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct LintHints {
-    /// `true` when the caller is rendering the final state checkpoint and the
-    /// Task Ledger must be expanded. Non-final state may collapse rows.
+    /// `true` when the caller is rendering the final state checkpoint and
+    /// the Task Ledger must be expanded. Non-final state may collapse rows
+    /// but must keep the `## Task Ledger` heading visible.
     pub state_is_final: bool,
     /// `true` when review findings are present and the review comment must
     /// include a disposition row.
     pub review_has_findings: bool,
+    /// `true` when closeout intentionally has no linked PR (docs-only or
+    /// admin closeout). The closeout body must then carry an explicit
+    /// `Linked PRs: none` note instead of a PR row.
+    pub closeout_has_no_linked_pr_ok: bool,
 }
 
-/// Run the visible-completeness lint against a rendered Markdown body for the
-/// supplied lifecycle role.
-///
-/// The Task 1.1 skeleton only checks that the required headings from the
-/// registry appear verbatim. Task 2.2 expands the implementation to cover
-/// Task Ledger structure, validation status, review disposition, session
-/// summary, and closeout approval + linked PR evidence.
+/// Run the visible-completeness lint against a rendered Markdown body for
+/// the supplied lifecycle role.
 pub fn lint_visible(role: PayloadRole, body: &str, hints: LintHints) -> VisibleReport {
     let spec = registry::role(role);
     let mut report = VisibleReport::default();
+
+    check_profile_only(spec, body, &mut report);
     check_required_headings(spec, body, &mut report);
-    // Task 2.2 adds the role-specific rule blocks below this line.
-    let _ = hints;
+
+    match role {
+        PayloadRole::Source | PayloadRole::Plan => {
+            // Heading presence + non-Profile-only check is enough; snapshot
+            // bodies carry the `<details>` element from the taxonomy template.
+        }
+        PayloadRole::State => check_state(body, hints, &mut report),
+        PayloadRole::Session => check_session(body, &mut report),
+        PayloadRole::Validation => check_validation(body, &mut report),
+        PayloadRole::Review => check_review(body, hints, &mut report),
+        PayloadRole::Closeout => check_closeout(body, hints, &mut report),
+    }
+
     report
 }
 
@@ -97,18 +146,264 @@ fn check_required_headings(spec: &RoleSpec, body: &str, report: &mut VisibleRepo
     }
 }
 
+fn check_profile_only(spec: &RoleSpec, body: &str, report: &mut VisibleReport) {
+    if is_profile_only_body(body, spec.default_heading) {
+        report.push(VisibleFinding::new(
+            spec.role,
+            codes::PROFILE_ONLY,
+            format!(
+                "rendered {role} body has nothing beyond the role heading and `Profile:` line",
+                role = spec.marker_role
+            ),
+        ));
+    }
+}
+
+fn check_state(body: &str, hints: LintHints, report: &mut VisibleReport) {
+    if !body_contains_heading(body, "## Task Ledger") {
+        report.push(VisibleFinding::new(
+            PayloadRole::State,
+            codes::STATE_MISSING_TASK_LEDGER,
+            "state body must include a visible `## Task Ledger` heading",
+        ));
+    }
+    if hints.state_is_final && task_ledger_appears_collapsed(body) {
+        report.push(VisibleFinding::new(
+            PayloadRole::State,
+            codes::STATE_FINAL_TASK_LEDGER_NOT_EXPANDED,
+            "final state must expand the Task Ledger rows (no `<details>` wrapper)",
+        ));
+    }
+}
+
+fn check_session(body: &str, report: &mut VisibleReport) {
+    let summary_present = body.lines().any(|line| {
+        let trimmed = line.trim();
+        let prefix = "- Summary:";
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            !rest.trim().is_empty()
+        } else {
+            false
+        }
+    });
+    if !summary_present {
+        report.push(VisibleFinding::new(
+            PayloadRole::Session,
+            codes::SESSION_MISSING_SUMMARY,
+            "session body must contain a non-empty `- Summary:` line",
+        ));
+    }
+}
+
+fn check_validation(body: &str, report: &mut VisibleReport) {
+    let overall = body.lines().any(|line| {
+        let trimmed = line.trim();
+        let prefix = "- Overall:";
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            !rest.trim().is_empty()
+        } else {
+            false
+        }
+    });
+    if !overall {
+        report.push(VisibleFinding::new(
+            PayloadRole::Validation,
+            codes::VALIDATION_MISSING_OVERALL,
+            "validation body must contain a `- Overall: pass|partial|fail` line",
+        ));
+    }
+    // Commands table OR a Waivers section is required to back the overall.
+    let has_command_row = body_contains_validation_command_row(body);
+    let has_waiver = body_contains_heading(body, "### Waivers")
+        || body.lines().any(|line| line.trim_start().starts_with("- `"));
+    if !has_command_row && !has_waiver {
+        report.push(VisibleFinding::new(
+            PayloadRole::Validation,
+            codes::VALIDATION_MISSING_COMMANDS_OR_WAIVER,
+            "validation body must include at least one command row or an explicit waiver",
+        ));
+    }
+}
+
+fn check_review(body: &str, hints: LintHints, report: &mut VisibleReport) {
+    let decision_present = body.lines().any(|line| {
+        let trimmed = line.trim();
+        let prefix = "- Decision:";
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            !rest.trim().is_empty()
+        } else {
+            false
+        }
+    });
+    if !decision_present {
+        report.push(VisibleFinding::new(
+            PayloadRole::Review,
+            codes::REVIEW_MISSING_DECISION,
+            "review body must contain a `- Decision:` line with approve|request-changes|comments-only",
+        ));
+    }
+    if hints.review_has_findings && !body_contains_review_disposition_row(body) {
+        report.push(VisibleFinding::new(
+            PayloadRole::Review,
+            codes::REVIEW_MISSING_DISPOSITION,
+            "review body has findings but no disposition row in the findings table",
+        ));
+    }
+}
+
+fn check_closeout(body: &str, hints: LintHints, report: &mut VisibleReport) {
+    let final_status_present = body.lines().any(|line| {
+        let trimmed = line.trim();
+        let prefix = "- Final status:";
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            !rest.trim().is_empty()
+        } else {
+            false
+        }
+    });
+    if !final_status_present {
+        report.push(VisibleFinding::new(
+            PayloadRole::Closeout,
+            codes::CLOSEOUT_MISSING_FINAL_STATUS,
+            "closeout body must contain a `- Final status:` line",
+        ));
+    }
+    let approval_present = body.lines().any(|line| {
+        let trimmed = line.trim();
+        let prefix = "- Approval:";
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            !rest.trim().is_empty()
+        } else {
+            false
+        }
+    });
+    if !approval_present {
+        report.push(VisibleFinding::new(
+            PayloadRole::Closeout,
+            codes::CLOSEOUT_MISSING_APPROVAL,
+            "closeout body must contain a `- Approval:` line",
+        ));
+    }
+    if !hints.closeout_has_no_linked_pr_ok && !body_contains_closeout_linked_pr_evidence(body) {
+        report.push(VisibleFinding::new(
+            PayloadRole::Closeout,
+            codes::CLOSEOUT_MISSING_LINKED_PR,
+            "closeout body must include linked PR evidence or an explicit no-PR note",
+        ));
+    }
+}
+
 fn body_contains_heading(body: &str, heading: &str) -> bool {
     body.lines().any(|line| line.trim_end() == heading)
 }
 
+fn task_ledger_appears_collapsed(body: &str) -> bool {
+    // Heuristic: look at the section between `## Task Ledger` and the next
+    // h2 heading. If a `<details>` opens before any table row appears, the
+    // ledger is collapsed.
+    let mut in_section = false;
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed == "## Task Ledger" {
+            in_section = true;
+            continue;
+        }
+        if in_section && trimmed.starts_with("## ") {
+            return false;
+        }
+        if in_section {
+            if trimmed.starts_with("<details") {
+                return true;
+            }
+            if trimmed.starts_with("| ") {
+                return false;
+            }
+        }
+    }
+    false
+}
+
+fn body_contains_validation_command_row(body: &str) -> bool {
+    body.lines().any(|line| {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') {
+            return false;
+        }
+        // Reject header and separator rows.
+        if trimmed.contains("| Command") || trimmed.contains("---") {
+            return false;
+        }
+        // A real command row is fenced with backticks somewhere in the row.
+        trimmed.contains('`')
+    })
+}
+
+fn body_contains_review_disposition_row(body: &str) -> bool {
+    let dispositions = ["fixed", "residual", "follow-up", "deferred", "no-action"];
+    body.lines().any(|line| {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') {
+            return false;
+        }
+        if trimmed.contains("Disposition") || trimmed.contains("---") {
+            return false;
+        }
+        dispositions.iter().any(|d| trimmed.contains(d))
+    })
+}
+
+fn body_contains_closeout_linked_pr_evidence(body: &str) -> bool {
+    // Accept either a Markdown table row with a PR-looking cell or an
+    // explicit `- Linked PRs:` line.
+    let table_row = body.lines().any(|line| {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') || trimmed.contains("---") || trimmed.contains("| PR ") {
+            return false;
+        }
+        trimmed.contains('#') || trimmed.contains("http")
+    });
+    let linked_line = body.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("- Linked PR")
+            || trimmed.starts_with("- PR:")
+            || trimmed.starts_with("- Linked PRs:")
+    });
+    table_row || linked_line
+}
+
+fn is_profile_only_body(body: &str, default_heading: &str) -> bool {
+    let mut saw_heading = false;
+    let mut saw_profile = false;
+    let mut saw_other_content = false;
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.starts_with("<!--") || trimmed.ends_with("-->") {
+            continue;
+        }
+        if trimmed == default_heading {
+            saw_heading = true;
+            continue;
+        }
+        if trimmed.starts_with("- Profile:") {
+            saw_profile = true;
+            continue;
+        }
+        saw_other_content = true;
+    }
+    saw_heading && saw_profile && !saw_other_content
+}
+
 fn missing_heading_code(role: PayloadRole) -> &'static str {
     match role {
-        PayloadRole::Source => "source-missing-heading",
-        PayloadRole::Plan => "plan-missing-heading",
-        PayloadRole::State => "state-missing-heading",
-        PayloadRole::Session => "session-missing-heading",
-        PayloadRole::Validation => "validation-missing-heading",
-        PayloadRole::Review => "review-missing-heading",
-        PayloadRole::Closeout => "closeout-missing-heading",
+        PayloadRole::Source => codes::SOURCE_MISSING_HEADING,
+        PayloadRole::Plan => codes::PLAN_MISSING_HEADING,
+        PayloadRole::State => codes::STATE_MISSING_HEADING,
+        PayloadRole::Session => codes::SESSION_MISSING_HEADING,
+        PayloadRole::Validation => codes::VALIDATION_MISSING_HEADING,
+        PayloadRole::Review => codes::REVIEW_MISSING_HEADING,
+        PayloadRole::Closeout => codes::CLOSEOUT_MISSING_HEADING,
     }
 }

--- a/crates/plan-issue-cli/src/lifecycle_vnext/visible_lint.rs
+++ b/crates/plan-issue-cli/src/lifecycle_vnext/visible_lint.rs
@@ -324,18 +324,34 @@ fn task_ledger_appears_collapsed(body: &str) -> bool {
 }
 
 fn body_contains_validation_command_row(body: &str) -> bool {
-    body.lines().any(|line| {
+    // Walk lines and find table data rows under a validation-shaped header.
+    // The renderer in `lifecycle_record` does not necessarily wrap the
+    // command in backticks, so the lint accepts any non-empty data row
+    // beneath the `| Command | Status | Evidence |` header.
+    let mut in_validation_table = false;
+    let mut saw_separator = false;
+    for line in body.lines() {
         let trimmed = line.trim();
         if !trimmed.starts_with('|') {
-            return false;
+            in_validation_table = false;
+            saw_separator = false;
+            continue;
         }
-        // Reject header and separator rows.
-        if trimmed.contains("| Command") || trimmed.contains("---") {
-            return false;
+        if trimmed.contains("| Command") {
+            in_validation_table = true;
+            saw_separator = false;
+            continue;
         }
-        // A real command row is fenced with backticks somewhere in the row.
-        trimmed.contains('`')
-    })
+        if in_validation_table && trimmed.starts_with("| ---") {
+            saw_separator = true;
+            continue;
+        }
+        if in_validation_table && saw_separator {
+            // Any data row inside the validation table counts.
+            return true;
+        }
+    }
+    false
 }
 
 fn body_contains_review_disposition_row(body: &str) -> bool {

--- a/crates/plan-issue-cli/src/tracking/checkpoint.rs
+++ b/crates/plan-issue-cli/src/tracking/checkpoint.rs
@@ -1,0 +1,53 @@
+//! Tracking checkpoint behavior (dry-run and live).
+//!
+//! Task 1.1 declares the result shapes; Tasks 5.2, 5.3, and 6.1 implement
+//! the dry-run renderer, refusal cases, and live adapter over the existing
+//! lifecycle primitives.
+
+use serde::{Deserialize, Serialize};
+
+use crate::lifecycle_record::PayloadRole;
+
+/// Selected role with a fully rendered Markdown body ready to post.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckpointSlice {
+    pub role: PayloadRole,
+    pub body: String,
+    #[serde(default)]
+    pub planned_comment_url: Option<String>,
+}
+
+/// Outcome of one checkpoint pass (dry-run or live).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CheckpointPlan {
+    pub roles_planned: Vec<PayloadRole>,
+    pub roles_skipped: Vec<SkippedRole>,
+    pub rendered: Vec<CheckpointSlice>,
+    pub repair_dashboard: bool,
+    pub blocked: Vec<BlockedCheckpoint>,
+}
+
+impl CheckpointPlan {
+    pub fn is_blocked(&self) -> bool {
+        !self.blocked.is_empty()
+    }
+}
+
+/// Skipped role with the reason recorded for the JSON envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkippedRole {
+    pub role: PayloadRole,
+    pub reason: String,
+}
+
+/// Stable blocked code returned when a checkpoint is refused. Codes follow
+/// `<role>-<rule>` (`state-stale-run-state`, `validation-missing-overall`,
+/// `closeout-not-allowed-from-checkpoint`, …) — the full catalog is finalized
+/// in Task 5.3.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockedCheckpoint {
+    pub code: String,
+    pub role: Option<PayloadRole>,
+    pub message: String,
+    pub suggested_unblock: String,
+}

--- a/crates/plan-issue-cli/src/tracking/close_ready.rs
+++ b/crates/plan-issue-cli/src/tracking/close_ready.rs
@@ -1,0 +1,32 @@
+//! Non-mutating close-readiness probe.
+//!
+//! Task 1.1 declares the result shapes; Task 6.2 implements the probe
+//! against the same strict gates as `record close`.
+
+use serde::{Deserialize, Serialize};
+
+/// Stable blocked code emitted by the probe.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloseReadyBlocker {
+    pub code: String,
+    pub message: String,
+    pub suggested_unblock: String,
+}
+
+/// Outcome of the close-ready probe.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CloseReadyReport {
+    pub ready: bool,
+    pub blockers: Vec<CloseReadyBlocker>,
+    pub linked_prs: Vec<String>,
+    #[serde(default)]
+    pub visible_completeness: Option<VisibleSummary>,
+}
+
+/// Compact visible-completeness summary attached to the probe result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VisibleSummary {
+    pub checked: bool,
+    pub pass: bool,
+    pub findings: Vec<String>,
+}

--- a/crates/plan-issue-cli/src/tracking/events.rs
+++ b/crates/plan-issue-cli/src/tracking/events.rs
@@ -1,0 +1,60 @@
+//! Append-only event journal for tracking runs.
+//!
+//! Schema identifier: `plan-issue.execution-event.v1`. Records run start,
+//! task selection, run updates, validation/review evidence, checkpoint
+//! attempts (dry-run + live), reconciliation outcomes, and failures.
+//!
+//! Task 1.1 only introduces the data shapes; Task 4.1 wires the JSONL writer
+//! under the issue-scoped runtime root.
+
+use serde::{Deserialize, Serialize};
+
+pub const EVENT_SCHEMA: &str = "plan-issue.execution-event.v1";
+
+/// Discrete event kind written to `events.jsonl`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionEventKind {
+    RunStarted,
+    RunUpdated,
+    TaskSelected,
+    PhaseChanged,
+    ValidationRecorded,
+    ReviewRecorded,
+    Reconciled,
+    CheckpointPlanned,
+    CheckpointPosted,
+    CheckpointFailed,
+    BlockerAdded,
+    BlockerCleared,
+    RunCompleted,
+}
+
+/// One row in the append-only `events.jsonl` journal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionEvent {
+    pub schema: String,
+    pub run_id: String,
+    pub at: String,
+    pub kind: ExecutionEventKind,
+    #[serde(default)]
+    pub task: Option<String>,
+    #[serde(default)]
+    pub note: Option<String>,
+    #[serde(default)]
+    pub detail: serde_json::Value,
+}
+
+impl ExecutionEvent {
+    pub fn new(run_id: impl Into<String>, kind: ExecutionEventKind, at: impl Into<String>) -> Self {
+        Self {
+            schema: EVENT_SCHEMA.to_string(),
+            run_id: run_id.into(),
+            at: at.into(),
+            kind,
+            task: None,
+            note: None,
+            detail: serde_json::Value::Null,
+        }
+    }
+}

--- a/crates/plan-issue-cli/src/tracking/events.rs
+++ b/crates/plan-issue-cli/src/tracking/events.rs
@@ -3,15 +3,19 @@
 //! Schema identifier: `plan-issue.execution-event.v1`. Records run start,
 //! task selection, run updates, validation/review evidence, checkpoint
 //! attempts (dry-run + live), reconciliation outcomes, and failures.
-//!
-//! Task 1.1 only introduces the data shapes; Task 4.1 wires the JSONL writer
-//! under the issue-scoped runtime root.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::runtime_layout;
 
 pub const EVENT_SCHEMA: &str = "plan-issue.execution-event.v1";
 
-/// Discrete event kind written to `events.jsonl`.
+/// Discrete event type written to `events.jsonl`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecutionEventKind {
@@ -30,19 +34,46 @@ pub enum ExecutionEventKind {
     RunCompleted,
 }
 
+impl ExecutionEventKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::RunStarted => "run_started",
+            Self::RunUpdated => "run_updated",
+            Self::TaskSelected => "task_selected",
+            Self::PhaseChanged => "phase_changed",
+            Self::ValidationRecorded => "validation_recorded",
+            Self::ReviewRecorded => "review_recorded",
+            Self::Reconciled => "reconciled",
+            Self::CheckpointPlanned => "checkpoint_planned",
+            Self::CheckpointPosted => "checkpoint_posted",
+            Self::CheckpointFailed => "checkpoint_failed",
+            Self::BlockerAdded => "blocker_added",
+            Self::BlockerCleared => "blocker_cleared",
+            Self::RunCompleted => "run_completed",
+        }
+    }
+}
+
 /// One row in the append-only `events.jsonl` journal.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutionEvent {
     pub schema: String,
     pub run_id: String,
     pub at: String,
+    #[serde(rename = "type")]
     pub kind: ExecutionEventKind,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
-    #[serde(default)]
-    pub detail: serde_json::Value,
+    /// Free-form structured detail for the event. Stays a JSON object so the
+    /// schema can grow without rewriting prior events.
+    #[serde(default, skip_serializing_if = "is_null_value")]
+    pub detail: Value,
+}
+
+fn is_null_value(value: &Value) -> bool {
+    value.is_null()
 }
 
 impl ExecutionEvent {
@@ -54,7 +85,124 @@ impl ExecutionEvent {
             kind,
             task: None,
             note: None,
-            detail: serde_json::Value::Null,
+            detail: Value::Null,
         }
+    }
+
+    pub fn with_task(mut self, task: impl Into<String>) -> Self {
+        self.task = Some(task.into());
+        self
+    }
+
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
+        self.note = Some(note.into());
+        self
+    }
+
+    pub fn with_detail(mut self, detail: Value) -> Self {
+        self.detail = detail;
+        self
+    }
+}
+
+/// Append an event to `events.jsonl`. Creates parents and the file when
+/// missing; never rewrites prior lines.
+pub fn append_event(path: &Path, event: &ExecutionEvent) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        runtime_layout::ensure_dir(parent)?;
+    }
+    let serialized = serde_json::to_string(event)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    file.write_all(serialized.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+/// Parse every line of `events.jsonl` into an [`ExecutionEvent`]. Skips
+/// empty lines; reports malformed lines via the returned error.
+pub fn read_events(path: &Path) -> io::Result<Vec<ExecutionEvent>> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut events = Vec::new();
+    for (lineno, line) in reader.lines().enumerate() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let event: ExecutionEvent = serde_json::from_str(trimmed).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("events.jsonl line {lineno}: {err}"),
+            )
+        })?;
+        events.push(event);
+    }
+    Ok(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    #[test]
+    fn tracking_events_round_trip_single_event() {
+        let event = ExecutionEvent::new("run-1", ExecutionEventKind::RunStarted, "2026-05-26T00:00:00Z")
+            .with_note("session start");
+        let raw = serde_json::to_string(&event).expect("serialize");
+        let parsed: ExecutionEvent = serde_json::from_str(&raw).expect("parse");
+        assert_eq!(parsed.run_id, "run-1");
+        assert_eq!(parsed.kind, ExecutionEventKind::RunStarted);
+        assert_eq!(parsed.note.as_deref(), Some("session start"));
+    }
+
+    #[test]
+    fn tracking_events_appends_without_rewriting_prior_lines() {
+        let tmp = TempDir::new().expect("tmp");
+        let path = tmp.path().join("events.jsonl");
+        let e1 = ExecutionEvent::new("run-1", ExecutionEventKind::RunStarted, "t1");
+        let e2 = ExecutionEvent::new("run-1", ExecutionEventKind::Reconciled, "t2")
+            .with_detail(json!({"fsm_state": "RECORD_OPEN_ACTIVE"}));
+        let e3 = ExecutionEvent::new("run-1", ExecutionEventKind::CheckpointPosted, "t3")
+            .with_detail(json!({"roles": ["state", "validation"]}));
+        append_event(&path, &e1).expect("append 1");
+        append_event(&path, &e2).expect("append 2");
+        append_event(&path, &e3).expect("append 3");
+
+        let events = read_events(&path).expect("read");
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].kind, ExecutionEventKind::RunStarted);
+        assert_eq!(events[1].kind, ExecutionEventKind::Reconciled);
+        assert_eq!(events[2].kind, ExecutionEventKind::CheckpointPosted);
+        assert_eq!(events[2].detail["roles"][0], "state");
+    }
+
+    #[test]
+    fn tracking_events_skips_empty_lines_and_reports_malformed() {
+        let tmp = TempDir::new().expect("tmp");
+        let path = tmp.path().join("events.jsonl");
+        let good = ExecutionEvent::new("run-1", ExecutionEventKind::RunStarted, "t1");
+        append_event(&path, &good).expect("append good");
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open append")
+            .write_all(b"\n   \n")
+            .expect("blank lines");
+        let events = read_events(&path).expect("read");
+        assert_eq!(events.len(), 1);
+
+        // Malformed line should error.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("open append")
+            .write_all(b"not json\n")
+            .expect("bad line");
+        let err = read_events(&path).expect_err("malformed should error");
+        assert!(err.to_string().contains("line"));
     }
 }

--- a/crates/plan-issue-cli/src/tracking/fsm.rs
+++ b/crates/plan-issue-cli/src/tracking/fsm.rs
@@ -2,11 +2,11 @@
 //!
 //! States and transitions are defined in
 //! `docs/source/plan-issue-redesign/plan-tracking-issue-workflow-v1.md`.
-//!
-//! Task 1.1 declares the state set; Task 4.2 implements the transition
-//! function and reconciles provider evidence against local run state.
 
 use serde::{Deserialize, Serialize};
+
+use crate::lifecycle_record::{PayloadRole, RecordAudit};
+use crate::tracking::run_state::ExecutionRun;
 
 /// Canonical FSM state for the tracking record. Determined from provider
 /// issue evidence (the durable truth), reconciled against local run state.
@@ -66,5 +66,377 @@ impl RecommendedAction {
             Self::CallRecordClose => "call_record_close",
             Self::NoOp => "noop",
         }
+    }
+}
+
+/// FSM evaluation result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FsmEvaluation {
+    pub state: RecordState,
+    pub recommended: RecommendedAction,
+    pub missing_for_closeout: Vec<String>,
+    pub safe_transitions: Vec<String>,
+    pub blocked_reason: Option<String>,
+}
+
+/// Compute the FSM state from a record audit. `None` audit means no provider
+/// issue exists yet.
+pub fn evaluate_audit(audit: Option<&RecordAudit>) -> FsmEvaluation {
+    let Some(audit) = audit else {
+        return FsmEvaluation {
+            state: RecordState::RecordUnopened,
+            recommended: RecommendedAction::OpenRecord,
+            missing_for_closeout: vec![
+                "source".into(),
+                "plan".into(),
+                "state".into(),
+                "session".into(),
+                "validation".into(),
+                "review".into(),
+            ],
+            safe_transitions: vec!["open_record".into()],
+            blocked_reason: None,
+        };
+    };
+
+    let has_source = audit.evidence.contains_key("source");
+    let has_plan = audit.evidence.contains_key("plan");
+    let has_state = audit.evidence.contains_key("state");
+    let has_session = audit.evidence.contains_key("session");
+    let has_validation = audit.evidence.contains_key("validation");
+    let has_review = audit.evidence.contains_key("review");
+    let has_closeout = audit.evidence.contains_key("closeout");
+
+    if has_closeout {
+        return FsmEvaluation {
+            state: RecordState::RecordClosed,
+            recommended: RecommendedAction::NoOp,
+            missing_for_closeout: Vec::new(),
+            safe_transitions: Vec::new(),
+            blocked_reason: None,
+        };
+    }
+
+    // Required source/plan/state must exist before we can talk about progress.
+    if !(has_source && has_plan && has_state) {
+        let recommended = RecommendedAction::AttachInitialState;
+        let mut missing: Vec<String> = Vec::new();
+        if !has_source {
+            missing.push("source".into());
+        }
+        if !has_plan {
+            missing.push("plan".into());
+        }
+        if !has_state {
+            missing.push("state".into());
+        }
+        if !has_session {
+            missing.push("session".into());
+        }
+        if !has_validation {
+            missing.push("validation".into());
+        }
+        if !has_review {
+            missing.push("review".into());
+        }
+        return FsmEvaluation {
+            state: RecordState::RecordOpenInitial,
+            recommended,
+            missing_for_closeout: missing,
+            safe_transitions: vec!["attach_initial_state".into(), "checkpoint_progress".into()],
+            blocked_reason: None,
+        };
+    }
+
+    // Detect blocked status from the latest state payload.
+    let blocked = state_status_is_blocked(audit);
+    if blocked {
+        return FsmEvaluation {
+            state: RecordState::RecordBlocked,
+            recommended: RecommendedAction::ResolveBlocker,
+            missing_for_closeout: closeout_missing(audit),
+            safe_transitions: vec!["resolve_blocker".into(), "checkpoint_progress".into()],
+            blocked_reason: Some("latest state payload status=blocked".to_string()),
+        };
+    }
+
+    // Closeout readiness path: complete state + session + validation + review.
+    let state_complete = state_status_is(audit, "complete");
+    if state_complete && has_session && has_validation && has_review {
+        return FsmEvaluation {
+            state: RecordState::RecordReadyForClose,
+            recommended: RecommendedAction::RunCloseReady,
+            missing_for_closeout: Vec::new(),
+            safe_transitions: vec!["run_close_ready".into(), "call_record_close".into()],
+            blocked_reason: None,
+        };
+    }
+
+    if has_review {
+        let missing = closeout_missing(audit);
+        return FsmEvaluation {
+            state: RecordState::RecordReviewed,
+            recommended: if missing.is_empty() {
+                RecommendedAction::RunCloseReady
+            } else {
+                RecommendedAction::CheckpointProgress
+            },
+            missing_for_closeout: missing,
+            safe_transitions: vec!["checkpoint_progress".into(), "run_close_ready".into()],
+            blocked_reason: None,
+        };
+    }
+    if has_validation {
+        return FsmEvaluation {
+            state: RecordState::RecordValidating,
+            recommended: RecommendedAction::RecordReview,
+            missing_for_closeout: closeout_missing(audit),
+            safe_transitions: vec!["record_review".into(), "checkpoint_progress".into()],
+            blocked_reason: None,
+        };
+    }
+    if has_session {
+        return FsmEvaluation {
+            state: RecordState::RecordOpenActive,
+            recommended: RecommendedAction::RecordValidation,
+            missing_for_closeout: closeout_missing(audit),
+            safe_transitions: vec![
+                "record_validation".into(),
+                "checkpoint_progress".into(),
+                "record_review".into(),
+            ],
+            blocked_reason: None,
+        };
+    }
+    // Source/plan/state present but no session yet — initial open with no
+    // active work captured.
+    FsmEvaluation {
+        state: RecordState::RecordOpenInitial,
+        recommended: RecommendedAction::CheckpointProgress,
+        missing_for_closeout: closeout_missing(audit),
+        safe_transitions: vec!["checkpoint_progress".into(), "record_validation".into()],
+        blocked_reason: None,
+    }
+}
+
+fn closeout_missing(audit: &RecordAudit) -> Vec<String> {
+    let mut missing: Vec<String> = Vec::new();
+    if !audit.evidence.contains_key("session") {
+        missing.push("session".into());
+    }
+    if !audit.evidence.contains_key("validation") {
+        missing.push("validation".into());
+    }
+    if !audit.evidence.contains_key("review") {
+        missing.push("review".into());
+    }
+    // State must report `complete` for closeout. If we have state but it is
+    // not complete, surface the gap.
+    if let Some(state_evidence) = audit.evidence.get("state") {
+        let complete = state_evidence
+            .status
+            .as_deref()
+            .is_some_and(|status| status.eq_ignore_ascii_case("complete"));
+        if !complete {
+            missing.push("state_complete".into());
+        }
+    } else {
+        missing.push("state".into());
+    }
+    missing
+}
+
+fn state_status_is(audit: &RecordAudit, target: &str) -> bool {
+    audit
+        .evidence
+        .get("state")
+        .and_then(|ev| ev.status.as_deref())
+        .is_some_and(|status| status.eq_ignore_ascii_case(target))
+}
+
+fn state_status_is_blocked(audit: &RecordAudit) -> bool {
+    state_status_is(audit, "blocked")
+}
+
+/// Cross-check the FSM evaluation against local run state. Returns the
+/// staleness verdict the controller uses to refuse live mutation.
+pub fn run_state_is_stale(audit: Option<&RecordAudit>, run: &ExecutionRun) -> bool {
+    let Some(audit) = audit else {
+        return false;
+    };
+    // If the run state still says implementing but the issue already has a
+    // closeout comment, run state is stale.
+    if audit.evidence.contains_key("closeout") && !matches!(run.phase, crate::tracking::run_state::RunPhase::Closed) {
+        return true;
+    }
+    false
+}
+
+/// Helper used by the `tracking` command surface to project the FSM state
+/// onto the `PayloadRole`s missing for closeout.
+pub fn missing_payload_roles(audit: Option<&RecordAudit>) -> Vec<PayloadRole> {
+    let mut missing = Vec::new();
+    let Some(audit) = audit else {
+        return vec![
+            PayloadRole::Source,
+            PayloadRole::Plan,
+            PayloadRole::State,
+            PayloadRole::Session,
+            PayloadRole::Validation,
+            PayloadRole::Review,
+        ];
+    };
+    for role in [
+        PayloadRole::Source,
+        PayloadRole::Plan,
+        PayloadRole::State,
+        PayloadRole::Session,
+        PayloadRole::Validation,
+        PayloadRole::Review,
+    ] {
+        if !audit.evidence.contains_key(role.as_str()) {
+            missing.push(role);
+        }
+    }
+    missing
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lifecycle_record::{
+        BodySections, LifecycleEvidence, PayloadProfile, RecordAudit,
+    };
+    use std::collections::BTreeMap;
+
+    fn evidence_for(role: PayloadRole, status: Option<&str>) -> LifecycleEvidence {
+        LifecycleEvidence {
+            role,
+            profile: PayloadProfile::Tracking,
+            url: Some(format!("https://example.com/{}", role.as_str())),
+            created_at: Some("2026-05-26T00:00:00Z".to_string()),
+            status: status.map(|s| s.to_string()),
+            payload: None,
+        }
+    }
+
+    fn audit_with(roles: &[(PayloadRole, Option<&str>)]) -> RecordAudit {
+        let mut evidence: BTreeMap<String, LifecycleEvidence> = BTreeMap::new();
+        for (role, status) in roles {
+            evidence.insert(role.as_str().to_string(), evidence_for(*role, *status));
+        }
+        RecordAudit {
+            profile_filter: Some("tracking".to_string()),
+            body_sections: BodySections {
+                current_dashboard: false,
+                final_dashboard: false,
+                durable_record: false,
+                closeout_checks: false,
+                task_decomposition: false,
+            },
+            evidence,
+            missing_required: Vec::new(),
+            unsupported_markers: Vec::new(),
+            recognized_count: roles.len(),
+            evidence_text: String::new(),
+        }
+    }
+
+    #[test]
+    fn tracking_fsm_unopened_when_audit_missing() {
+        let result = evaluate_audit(None);
+        assert_eq!(result.state, RecordState::RecordUnopened);
+        assert_eq!(result.recommended, RecommendedAction::OpenRecord);
+    }
+
+    #[test]
+    fn tracking_fsm_open_initial_when_source_plan_state_present() {
+        let audit = audit_with(&[
+            (PayloadRole::Source, None),
+            (PayloadRole::Plan, None),
+            (PayloadRole::State, Some("in-progress")),
+        ]);
+        let result = evaluate_audit(Some(&audit));
+        assert_eq!(result.state, RecordState::RecordOpenInitial);
+        assert_eq!(result.recommended, RecommendedAction::CheckpointProgress);
+        assert!(result.missing_for_closeout.iter().any(|s| s == "session"));
+    }
+
+    #[test]
+    fn tracking_fsm_open_active_when_session_present() {
+        let audit = audit_with(&[
+            (PayloadRole::Source, None),
+            (PayloadRole::Plan, None),
+            (PayloadRole::State, Some("in-progress")),
+            (PayloadRole::Session, None),
+        ]);
+        let result = evaluate_audit(Some(&audit));
+        assert_eq!(result.state, RecordState::RecordOpenActive);
+        assert_eq!(result.recommended, RecommendedAction::RecordValidation);
+    }
+
+    #[test]
+    fn tracking_fsm_blocked_when_state_status_blocked() {
+        let audit = audit_with(&[
+            (PayloadRole::Source, None),
+            (PayloadRole::Plan, None),
+            (PayloadRole::State, Some("blocked")),
+        ]);
+        let result = evaluate_audit(Some(&audit));
+        assert_eq!(result.state, RecordState::RecordBlocked);
+        assert_eq!(result.recommended, RecommendedAction::ResolveBlocker);
+        assert!(result.blocked_reason.is_some());
+    }
+
+    #[test]
+    fn tracking_fsm_validating_when_validation_present() {
+        let audit = audit_with(&[
+            (PayloadRole::Source, None),
+            (PayloadRole::Plan, None),
+            (PayloadRole::State, Some("in-progress")),
+            (PayloadRole::Session, None),
+            (PayloadRole::Validation, Some("pass")),
+        ]);
+        let result = evaluate_audit(Some(&audit));
+        assert_eq!(result.state, RecordState::RecordValidating);
+        assert_eq!(result.recommended, RecommendedAction::RecordReview);
+    }
+
+    #[test]
+    fn tracking_fsm_reviewed_when_review_but_not_complete() {
+        let audit = audit_with(&[
+            (PayloadRole::Source, None),
+            (PayloadRole::Plan, None),
+            (PayloadRole::State, Some("in-progress")),
+            (PayloadRole::Session, None),
+            (PayloadRole::Validation, Some("pass")),
+            (PayloadRole::Review, Some("approve")),
+        ]);
+        let result = evaluate_audit(Some(&audit));
+        assert_eq!(result.state, RecordState::RecordReviewed);
+    }
+
+    #[test]
+    fn tracking_fsm_ready_for_close_when_all_present_and_complete() {
+        let audit = audit_with(&[
+            (PayloadRole::Source, None),
+            (PayloadRole::Plan, None),
+            (PayloadRole::State, Some("complete")),
+            (PayloadRole::Session, None),
+            (PayloadRole::Validation, Some("pass")),
+            (PayloadRole::Review, Some("approve")),
+        ]);
+        let result = evaluate_audit(Some(&audit));
+        assert_eq!(result.state, RecordState::RecordReadyForClose);
+        assert_eq!(result.recommended, RecommendedAction::RunCloseReady);
+        assert!(result.missing_for_closeout.is_empty());
+    }
+
+    #[test]
+    fn tracking_fsm_closed_when_closeout_present() {
+        let audit = audit_with(&[(PayloadRole::Closeout, Some("complete"))]);
+        let result = evaluate_audit(Some(&audit));
+        assert_eq!(result.state, RecordState::RecordClosed);
+        assert_eq!(result.recommended, RecommendedAction::NoOp);
     }
 }

--- a/crates/plan-issue-cli/src/tracking/fsm.rs
+++ b/crates/plan-issue-cli/src/tracking/fsm.rs
@@ -1,0 +1,70 @@
+//! Deterministic finite state machine for the plan-tracking record.
+//!
+//! States and transitions are defined in
+//! `docs/source/plan-issue-redesign/plan-tracking-issue-workflow-v1.md`.
+//!
+//! Task 1.1 declares the state set; Task 4.2 implements the transition
+//! function and reconciles provider evidence against local run state.
+
+use serde::{Deserialize, Serialize};
+
+/// Canonical FSM state for the tracking record. Determined from provider
+/// issue evidence (the durable truth), reconciled against local run state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RecordState {
+    RecordUnopened,
+    RecordOpenInitial,
+    RecordOpenActive,
+    RecordBlocked,
+    RecordValidating,
+    RecordReviewed,
+    RecordReadyForClose,
+    RecordClosed,
+}
+
+impl RecordState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RecordUnopened => "RECORD_UNOPENED",
+            Self::RecordOpenInitial => "RECORD_OPEN_INITIAL",
+            Self::RecordOpenActive => "RECORD_OPEN_ACTIVE",
+            Self::RecordBlocked => "RECORD_BLOCKED",
+            Self::RecordValidating => "RECORD_VALIDATING",
+            Self::RecordReviewed => "RECORD_REVIEWED",
+            Self::RecordReadyForClose => "RECORD_READY_FOR_CLOSE",
+            Self::RecordClosed => "RECORD_CLOSED",
+        }
+    }
+}
+
+/// Recommended next action emitted alongside the FSM evaluation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecommendedAction {
+    OpenRecord,
+    AttachInitialState,
+    CheckpointProgress,
+    RecordValidation,
+    RecordReview,
+    ResolveBlocker,
+    RunCloseReady,
+    CallRecordClose,
+    NoOp,
+}
+
+impl RecommendedAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::OpenRecord => "open_record",
+            Self::AttachInitialState => "attach_initial_state",
+            Self::CheckpointProgress => "checkpoint_progress",
+            Self::RecordValidation => "record_validation",
+            Self::RecordReview => "record_review",
+            Self::ResolveBlocker => "resolve_blocker",
+            Self::RunCloseReady => "run_close_ready",
+            Self::CallRecordClose => "call_record_close",
+            Self::NoOp => "noop",
+        }
+    }
+}

--- a/crates/plan-issue-cli/src/tracking/mod.rs
+++ b/crates/plan-issue-cli/src/tracking/mod.rs
@@ -1,0 +1,34 @@
+//! vNext tracking controller boundary.
+//!
+//! Design references:
+//!
+//! - `docs/source/plan-issue-redesign/plan-tracking-issue-run-state-controller-v1.md`
+//!   (run-state schema, event journal, FSM, reconciliation, command surface)
+//! - `docs/source/plan-issue-redesign/plan-tracking-issue-workflow-v1.md`
+//!   (workflow states and timing rules)
+//!
+//! Module map:
+//!
+//! - [`run_state`] — typed `plan-issue.execution-run.v1` schema and on-disk
+//!   helpers (`run-state.json`).
+//! - [`events`] — append-only `plan-issue.execution-event.v1` journal
+//!   (`events.jsonl`).
+//! - [`fsm`] — deterministic state machine over the lifecycle evidence.
+//! - [`reconcile`] — combines provider evidence, plan bundle, run state, and
+//!   events into a reconciled view that the FSM evaluates.
+//! - [`checkpoint`] — dry-run and live checkpoint behavior built on top of
+//!   the lifecycle renderer + visible-lint surfaces.
+//! - [`close_ready`] — non-mutating close-readiness probe that mirrors the
+//!   `record close` strict gate.
+//!
+//! The boundary is intentionally narrow: low-level provider IO and
+//! Markdown rendering are reused from [`crate::lifecycle_record`] and
+//! [`crate::lifecycle_vnext`]; this module owns local execution state,
+//! reconciliation, and the high-level commands.
+
+pub mod checkpoint;
+pub mod close_ready;
+pub mod events;
+pub mod fsm;
+pub mod reconcile;
+pub mod run_state;

--- a/crates/plan-issue-cli/src/tracking/reconcile.rs
+++ b/crates/plan-issue-cli/src/tracking/reconcile.rs
@@ -1,20 +1,24 @@
 //! Provider-evidence reconciliation for tracking runs.
 //!
-//! Task 1.1 declares the inputs/outputs; Task 4.2 wires the actual
-//! reconciliation logic (provider issue comments + dashboard + plan bundle +
-//! run state + event journal → FSM input).
+//! Combines record audit + plan bundle + run state + events into a
+//! [`Reconciled`] view that the [`super::fsm`] evaluation builds on.
 
 use serde::{Deserialize, Serialize};
 
-use crate::tracking::fsm::{RecommendedAction, RecordState};
+use crate::lifecycle_record::RecordAudit;
+use crate::tracking::fsm::{self, FsmEvaluation, RecommendedAction, RecordState};
+use crate::tracking::run_state::ExecutionRun;
 
-/// Reconciled view used by [`super::fsm`] and the `tracking status` command.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+/// Reconciled view used by the `tracking status` command and downstream
+/// checkpoint/close-ready logic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Reconciled {
-    pub state: Option<RecordState>,
-    pub recommended_action: Option<RecommendedAction>,
+    pub state: RecordState,
+    pub recommended_action: RecommendedAction,
     pub warnings: Vec<ReconciliationWarning>,
-    pub safe_transitions: Vec<RecordState>,
+    pub safe_transitions: Vec<String>,
+    pub missing_for_closeout: Vec<String>,
+    pub blocked_reason: Option<String>,
 }
 
 impl Reconciled {
@@ -25,10 +29,10 @@ impl Reconciled {
     }
 }
 
-/// Specific reconciliation warning emitted to the caller.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReconciliationWarning {
     pub kind: ReconciliationWarningKind,
+    pub code: String,
     pub message: String,
 }
 
@@ -45,4 +49,178 @@ pub enum ReconciliationWarningKind {
     LifecycleRoleMissing,
     /// Run state cannot be parsed; controller falls back to provider truth.
     RunStateUnparseable,
+    /// Run state names artifacts the provider has not seen yet.
+    RunStateAheadOfIssue,
+}
+
+/// Reconcile provider audit, optional run state, and optional plan-bundle
+/// status into a [`Reconciled`] view.
+pub fn reconcile(audit: Option<&RecordAudit>, run: Option<&ExecutionRun>) -> Reconciled {
+    let evaluation: FsmEvaluation = fsm::evaluate_audit(audit);
+
+    let mut warnings = Vec::new();
+    if let (Some(audit), Some(run)) = (audit, run) {
+        if fsm::run_state_is_stale(Some(audit), run) {
+            warnings.push(ReconciliationWarning {
+                kind: ReconciliationWarningKind::LocalRunStateStale,
+                code: "run-state-stale".to_string(),
+                message:
+                    "provider issue lifecycle evidence is newer than local run state; refuse live mutation until reconciled".to_string(),
+            });
+        }
+        if run.validation.as_ref().is_some_and(|v| v.overall.eq_ignore_ascii_case("pass"))
+            && !audit.evidence.contains_key("validation")
+        {
+            warnings.push(ReconciliationWarning {
+                kind: ReconciliationWarningKind::RunStateAheadOfIssue,
+                code: "run-state-validation-not-posted".to_string(),
+                message:
+                    "run state has passing validation but issue has no validation lifecycle comment"
+                        .to_string(),
+            });
+        }
+    }
+
+    // Surface missing lifecycle roles as warnings so callers can act on each.
+    for role in fsm::missing_payload_roles(audit) {
+        warnings.push(ReconciliationWarning {
+            kind: ReconciliationWarningKind::LifecycleRoleMissing,
+            code: format!("{}-missing", role.as_str()),
+            message: format!("lifecycle role `{}` has no current evidence", role.as_str()),
+        });
+    }
+
+    Reconciled {
+        state: evaluation.state,
+        recommended_action: evaluation.recommended,
+        warnings,
+        safe_transitions: evaluation.safe_transitions.clone(),
+        missing_for_closeout: evaluation.missing_for_closeout.clone(),
+        blocked_reason: evaluation.blocked_reason,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lifecycle_record::{
+        BodySections, LifecycleEvidence, PayloadProfile, PayloadRole, RecordAudit,
+    };
+    use crate::tracking::run_state::{ExecutionRun, RunPhase, ValidationSummary};
+    use std::collections::BTreeMap;
+
+    fn evidence_for(role: PayloadRole, status: Option<&str>) -> LifecycleEvidence {
+        LifecycleEvidence {
+            role,
+            profile: PayloadProfile::Tracking,
+            url: Some("https://example.com".to_string()),
+            created_at: Some("2026-05-26T00:00:00Z".to_string()),
+            status: status.map(|s| s.to_string()),
+            payload: None,
+        }
+    }
+
+    fn audit_with(roles: &[(PayloadRole, Option<&str>)]) -> RecordAudit {
+        let mut evidence: BTreeMap<String, LifecycleEvidence> = BTreeMap::new();
+        for (role, status) in roles {
+            evidence.insert(role.as_str().to_string(), evidence_for(*role, *status));
+        }
+        RecordAudit {
+            profile_filter: Some("tracking".to_string()),
+            body_sections: BodySections {
+                current_dashboard: false,
+                final_dashboard: false,
+                durable_record: false,
+                closeout_checks: false,
+                task_decomposition: false,
+            },
+            evidence,
+            missing_required: Vec::new(),
+            unsupported_markers: Vec::new(),
+            recognized_count: roles.len(),
+            evidence_text: String::new(),
+        }
+    }
+
+    fn fixture_run(phase: RunPhase) -> ExecutionRun {
+        ExecutionRun::new(
+            "run-1",
+            "owner/repo",
+            123,
+            "tracking",
+            phase,
+            "2026-05-26T00:00:00Z",
+        )
+    }
+
+    #[test]
+    fn tracking_reconcile_emits_state_and_recommended_action() {
+        let audit = audit_with(&[
+            (PayloadRole::Source, None),
+            (PayloadRole::Plan, None),
+            (PayloadRole::State, Some("in-progress")),
+            (PayloadRole::Session, None),
+        ]);
+        let result = reconcile(Some(&audit), None);
+        assert_eq!(result.state, RecordState::RecordOpenActive);
+        assert_eq!(result.recommended_action, RecommendedAction::RecordValidation);
+    }
+
+    #[test]
+    fn tracking_reconcile_reports_stale_when_issue_closed_but_run_active() {
+        let audit = audit_with(&[(PayloadRole::Closeout, Some("complete"))]);
+        let run = fixture_run(RunPhase::Implementing);
+        let result = reconcile(Some(&audit), Some(&run));
+        assert!(result.is_stale(), "expected stale warning: {result:?}");
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.code == "run-state-stale")
+        );
+    }
+
+    #[test]
+    fn tracking_reconcile_flags_run_state_ahead_when_validation_passed_but_not_posted() {
+        let audit = audit_with(&[
+            (PayloadRole::Source, None),
+            (PayloadRole::Plan, None),
+            (PayloadRole::State, Some("in-progress")),
+        ]);
+        let mut run = fixture_run(RunPhase::Validating);
+        run.validation = Some(ValidationSummary {
+            overall: "pass".to_string(),
+            commands: Vec::new(),
+            waiver: None,
+            evidence_path: None,
+        });
+        let result = reconcile(Some(&audit), Some(&run));
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.code == "run-state-validation-not-posted"),
+            "warnings: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn tracking_reconcile_surfaces_missing_role_warnings() {
+        let audit = audit_with(&[
+            (PayloadRole::Source, None),
+            (PayloadRole::Plan, None),
+            (PayloadRole::State, Some("in-progress")),
+        ]);
+        let result = reconcile(Some(&audit), None);
+        let missing_codes: Vec<_> = result
+            .warnings
+            .iter()
+            .filter(|w| matches!(w.kind, ReconciliationWarningKind::LifecycleRoleMissing))
+            .map(|w| w.code.clone())
+            .collect();
+        assert!(missing_codes.contains(&"session-missing".to_string()));
+        assert!(missing_codes.contains(&"validation-missing".to_string()));
+        assert!(missing_codes.contains(&"review-missing".to_string()));
+    }
 }

--- a/crates/plan-issue-cli/src/tracking/reconcile.rs
+++ b/crates/plan-issue-cli/src/tracking/reconcile.rs
@@ -1,0 +1,48 @@
+//! Provider-evidence reconciliation for tracking runs.
+//!
+//! Task 1.1 declares the inputs/outputs; Task 4.2 wires the actual
+//! reconciliation logic (provider issue comments + dashboard + plan bundle +
+//! run state + event journal → FSM input).
+
+use serde::{Deserialize, Serialize};
+
+use crate::tracking::fsm::{RecommendedAction, RecordState};
+
+/// Reconciled view used by [`super::fsm`] and the `tracking status` command.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Reconciled {
+    pub state: Option<RecordState>,
+    pub recommended_action: Option<RecommendedAction>,
+    pub warnings: Vec<ReconciliationWarning>,
+    pub safe_transitions: Vec<RecordState>,
+}
+
+impl Reconciled {
+    pub fn is_stale(&self) -> bool {
+        self.warnings
+            .iter()
+            .any(|w| matches!(w.kind, ReconciliationWarningKind::LocalRunStateStale))
+    }
+}
+
+/// Specific reconciliation warning emitted to the caller.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReconciliationWarning {
+    pub kind: ReconciliationWarningKind,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconciliationWarningKind {
+    /// Provider issue evidence is ahead of local run state.
+    LocalRunStateStale,
+    /// Plan bundle on disk is dirty relative to the snapshot.
+    PlanBundleDirty,
+    /// Dashboard body is out of sync with current lifecycle evidence.
+    DashboardOutOfSync,
+    /// Lifecycle role expected by the FSM is missing.
+    LifecycleRoleMissing,
+    /// Run state cannot be parsed; controller falls back to provider truth.
+    RunStateUnparseable,
+}

--- a/crates/plan-issue-cli/src/tracking/run_state.rs
+++ b/crates/plan-issue-cli/src/tracking/run_state.rs
@@ -3,27 +3,36 @@
 //! Schema identifier: `plan-issue.execution-run.v1`. File layout under the
 //! existing state-dir contract is documented in
 //! `docs/source/plan-issue-redesign/plan-tracking-issue-run-state-controller-v1.md`.
-//!
-//! Task 1.1 only introduces the data shapes; Task 4.1 wires the actual JSON
-//! reader/writer, schema validation, and disk layout.
 
-use std::path::PathBuf;
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::runtime_layout::{self, IssueRoot};
 
 /// Stable schema identifier embedded in every `run-state.json` document.
 pub const RUN_STATE_SCHEMA: &str = "plan-issue.execution-run.v1";
 
-/// High-level execution phase. Mirrors the FSM states without dragging in
-/// reconciliation details.
+const RUNS_DIR: &str = "runs";
+const RUN_STATE_FILE: &str = "run-state.json";
+const EVENTS_FILE: &str = "events.jsonl";
+const INPUTS_DIR: &str = "inputs";
+const RENDERED_DIR: &str = "rendered";
+const ARTIFACTS_DIR: &str = "artifacts";
+
+/// High-level execution phase. Maps onto FSM states but stays human-friendly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RunPhase {
     Initial,
-    Active,
-    Blocked,
+    Implementing,
     Validating,
-    Reviewed,
+    Reviewing,
+    Blocked,
     ReadyForClose,
     Closed,
 }
@@ -32,89 +41,430 @@ impl RunPhase {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Initial => "initial",
-            Self::Active => "active",
-            Self::Blocked => "blocked",
+            Self::Implementing => "implementing",
             Self::Validating => "validating",
-            Self::Reviewed => "reviewed",
+            Self::Reviewing => "reviewing",
+            Self::Blocked => "blocked",
             Self::ReadyForClose => "ready_for_close",
             Self::Closed => "closed",
         }
     }
 }
 
-/// Typed run state document persisted as `run-state.json` under the
-/// issue-scoped runtime root.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExecutionRun {
-    pub schema: String,
-    pub run_id: String,
-    pub repo: String,
-    pub issue: u64,
-    pub plan_bundle: PathBuf,
-    #[serde(default)]
-    pub selected_task: Option<String>,
-    #[serde(default)]
-    pub selected_sprint: Option<String>,
-    #[serde(default)]
-    pub branch: Option<String>,
-    #[serde(default)]
-    pub worktree: Option<PathBuf>,
-    #[serde(default)]
-    pub linked_pr: Option<String>,
-    pub phase: RunPhase,
-    #[serde(default)]
-    pub notes: Vec<String>,
-    #[serde(default)]
-    pub validation: Option<ValidationSummary>,
-    #[serde(default)]
-    pub review: Option<ReviewSummary>,
-    #[serde(default)]
-    pub artifacts: Vec<ArtifactRef>,
-    #[serde(default)]
-    pub blockers: Vec<BlockerRef>,
-    pub started_at: String,
-    pub updated_at: String,
+/// Selected scope (sprint, task, title) recorded in the run.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SelectedScope {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sprint: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
-/// Compact validation summary captured in run state. Detailed evidence lives
-/// in lifecycle comments and validation artifacts.
+/// Linked PR reference captured in the run state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinkedPr {
+    #[serde(rename = "ref")]
+    pub r#ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+/// Compact validation summary captured in run state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidationSummary {
     pub overall: String,
-    #[serde(default)]
-    pub commands: Vec<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub commands: Vec<ValidationCommandRow>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub waiver: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub evidence_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationCommandRow {
+    pub command: String,
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<String>,
 }
 
 /// Compact review summary captured in run state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReviewSummary {
     pub decision: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub findings_disposition: Vec<String>,
-    #[serde(default)]
-    pub evidence_path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<String>,
 }
 
-/// Reference to a large retained artifact (validation log, review report, …).
-/// Large blobs live on disk; the run state only carries a path or redacted
-/// preview.
+/// Captured reconciliation snapshot from a prior FSM evaluation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LastReconciled {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fsm_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dashboard_status: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub latest_comments: BTreeMap<String, String>,
+}
+
+/// Pending transition the controller will perform next.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ArtifactRef {
+pub struct PendingTransition {
     pub kind: String,
-    pub path: PathBuf,
-    #[serde(default)]
-    pub preview: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
-/// Reference to a current execution blocker.
+/// Typed run state document persisted as `run-state.json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockerRef {
-    pub code: String,
-    pub message: String,
-    #[serde(default)]
-    pub owner: Option<String>,
+pub struct ExecutionRun {
+    pub schema: String,
+    pub run_id: String,
+    pub repo: String,
+    pub issue: u64,
+    pub profile: String,
+    pub phase: RunPhase,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bundle: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_state_file: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_scope: Option<SelectedScope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr: Option<LinkedPr>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reconciled: Option<LastReconciled>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_transition: Option<PendingTransition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation: Option<ValidationSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review: Option<ReviewSummary>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub artifacts: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<String>,
+    /// Free-form extra fields kept around so future schema additions do not
+    /// silently drop on read/write round-trip.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra: Option<Value>,
+}
+
+impl ExecutionRun {
+    pub fn new(
+        run_id: impl Into<String>,
+        repo: impl Into<String>,
+        issue: u64,
+        profile: impl Into<String>,
+        phase: RunPhase,
+        at: impl Into<String>,
+    ) -> Self {
+        let at = at.into();
+        Self {
+            schema: RUN_STATE_SCHEMA.to_string(),
+            run_id: run_id.into(),
+            repo: repo.into(),
+            issue,
+            profile: profile.into(),
+            phase,
+            created_at: at.clone(),
+            updated_at: at,
+            bundle: None,
+            execution_state_file: None,
+            selected_scope: None,
+            branch: None,
+            worktree: None,
+            pr: None,
+            last_reconciled: None,
+            pending_transition: None,
+            validation: None,
+            review: None,
+            artifacts: BTreeMap::new(),
+            notes: Vec::new(),
+            extra: None,
+        }
+    }
+}
+
+/// Validation errors emitted by [`parse_run_state`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunStateError {
+    SchemaMismatch { actual: String },
+    MissingField(&'static str),
+    Malformed(String),
+}
+
+impl std::fmt::Display for RunStateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SchemaMismatch { actual } => write!(
+                f,
+                "run-state.json schema mismatch: expected {RUN_STATE_SCHEMA}, got {actual}"
+            ),
+            Self::MissingField(name) => write!(f, "run-state.json missing required field `{name}`"),
+            Self::Malformed(msg) => write!(f, "run-state.json malformed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for RunStateError {}
+
+/// Parse a `run-state.json` body and validate the schema id and required
+/// fields.
+pub fn parse_run_state(raw: &str) -> Result<ExecutionRun, RunStateError> {
+    let value: Value = serde_json::from_str(raw).map_err(|err| {
+        RunStateError::Malformed(format!("failed to parse JSON: {err}"))
+    })?;
+    let schema = value
+        .get("schema")
+        .and_then(Value::as_str)
+        .ok_or(RunStateError::MissingField("schema"))?;
+    if schema != RUN_STATE_SCHEMA {
+        return Err(RunStateError::SchemaMismatch {
+            actual: schema.to_string(),
+        });
+    }
+    for required in ["run_id", "repo", "issue", "profile", "phase", "created_at", "updated_at"] {
+        if value.get(required).is_none() {
+            return Err(RunStateError::MissingField(name_for(required)));
+        }
+    }
+    serde_json::from_value::<ExecutionRun>(value)
+        .map_err(|err| RunStateError::Malformed(err.to_string()))
+}
+
+fn name_for(field: &str) -> &'static str {
+    match field {
+        "run_id" => "run_id",
+        "repo" => "repo",
+        "issue" => "issue",
+        "profile" => "profile",
+        "phase" => "phase",
+        "created_at" => "created_at",
+        "updated_at" => "updated_at",
+        _ => "unknown",
+    }
+}
+
+/// Serialize an [`ExecutionRun`] to canonical JSON.
+pub fn render_run_state(run: &ExecutionRun) -> Result<String, RunStateError> {
+    serde_json::to_string_pretty(run).map_err(|err| RunStateError::Malformed(err.to_string()))
+}
+
+/// Read `run-state.json` from disk.
+pub fn read_run_state(path: &Path) -> io::Result<ExecutionRun> {
+    let raw = fs::read_to_string(path)?;
+    parse_run_state(&raw).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+}
+
+/// Write `run-state.json` to disk. Creates parent directories as needed.
+pub fn write_run_state(path: &Path, run: &ExecutionRun) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        runtime_layout::ensure_dir(parent)?;
+    }
+    let rendered = render_run_state(run)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    fs::write(path, rendered)
+}
+
+/// Issue-scoped run root rooted under the existing
+/// [`crate::runtime_layout::IssueRoot`] contract.
+#[derive(Debug, Clone)]
+pub struct RunRoot {
+    issue_root: IssueRoot,
+    run_id: String,
+}
+
+impl RunRoot {
+    /// Build the run root under `<issue-root>/runs/<run-id>/`.
+    pub fn new(
+        repo_slug: &str,
+        issue_number: u64,
+        run_id: impl Into<String>,
+    ) -> Result<Self, runtime_layout::RuntimeLayoutError> {
+        let issue_root = IssueRoot::new(repo_slug, issue_number)?;
+        Ok(Self {
+            issue_root,
+            run_id: run_id.into(),
+        })
+    }
+
+    pub fn issue_root(&self) -> &IssueRoot {
+        &self.issue_root
+    }
+
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    pub fn root(&self) -> PathBuf {
+        self.issue_root.root().join(RUNS_DIR).join(&self.run_id)
+    }
+
+    pub fn run_state_path(&self) -> PathBuf {
+        self.root().join(RUN_STATE_FILE)
+    }
+
+    pub fn events_path(&self) -> PathBuf {
+        self.root().join(EVENTS_FILE)
+    }
+
+    pub fn inputs_dir(&self) -> PathBuf {
+        self.root().join(INPUTS_DIR)
+    }
+
+    pub fn rendered_dir(&self) -> PathBuf {
+        self.root().join(RENDERED_DIR)
+    }
+
+    pub fn artifacts_dir(&self) -> PathBuf {
+        self.root().join(ARTIFACTS_DIR)
+    }
+
+    /// Ensure the full directory tree exists.
+    pub fn ensure_layout(&self) -> io::Result<()> {
+        runtime_layout::ensure_dir(&self.root())?;
+        runtime_layout::ensure_dir(&self.inputs_dir())?;
+        runtime_layout::ensure_dir(&self.rendered_dir())?;
+        runtime_layout::ensure_dir(&self.artifacts_dir())?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn tracking_run_state_round_trips_required_and_recommended_fields() {
+        let mut run = ExecutionRun::new(
+            "20260526-150405-issue-123",
+            "owner/repo",
+            123,
+            "tracking",
+            RunPhase::Implementing,
+            "2026-05-26T15:04:05Z",
+        );
+        run.bundle = Some(PathBuf::from("docs/plans/example"));
+        run.execution_state_file = Some(PathBuf::from(
+            "docs/plans/example/example-execution-state.md",
+        ));
+        run.selected_scope = Some(SelectedScope {
+            sprint: Some(1),
+            task: Some("1.2".to_string()),
+            title: Some("visible lint".to_string()),
+        });
+        run.branch = Some("feat/x".to_string());
+        run.pr = Some(LinkedPr {
+            r#ref: "owner/repo#456".to_string(),
+            url: Some("https://example.com/pr/456".to_string()),
+            status: Some("open".to_string()),
+        });
+        run.validation = Some(ValidationSummary {
+            overall: "pass".to_string(),
+            commands: vec![ValidationCommandRow {
+                command: "cargo test".to_string(),
+                status: "pass".to_string(),
+                evidence: Some("log.txt".to_string()),
+            }],
+            waiver: None,
+            evidence_path: None,
+        });
+        let rendered = render_run_state(&run).expect("render");
+        let parsed = parse_run_state(&rendered).expect("parse");
+        assert_eq!(parsed.run_id, run.run_id);
+        assert_eq!(parsed.repo, run.repo);
+        assert_eq!(parsed.issue, run.issue);
+        assert_eq!(parsed.phase, run.phase);
+        assert_eq!(
+            parsed
+                .selected_scope
+                .as_ref()
+                .and_then(|s| s.task.clone()),
+            Some("1.2".to_string())
+        );
+        assert_eq!(
+            parsed.validation.as_ref().map(|v| v.overall.clone()),
+            Some("pass".to_string())
+        );
+    }
+
+    #[test]
+    fn tracking_run_state_rejects_wrong_schema() {
+        let raw = json!({
+            "schema": "wrong.schema.v1",
+            "run_id": "x",
+            "repo": "o/r",
+            "issue": 1,
+            "profile": "tracking",
+            "phase": "initial",
+            "created_at": "x",
+            "updated_at": "x"
+        })
+        .to_string();
+        match parse_run_state(&raw) {
+            Err(RunStateError::SchemaMismatch { actual }) => assert_eq!(actual, "wrong.schema.v1"),
+            other => panic!("expected SchemaMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tracking_run_state_rejects_missing_required_field() {
+        let raw = json!({
+            "schema": RUN_STATE_SCHEMA,
+            "run_id": "x",
+            "issue": 1,
+            "profile": "tracking",
+            "phase": "initial",
+            "created_at": "x",
+            "updated_at": "x"
+        })
+        .to_string();
+        match parse_run_state(&raw) {
+            Err(RunStateError::MissingField("repo")) => {}
+            other => panic!("expected MissingField(repo), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tracking_run_state_runroot_layout_under_state_dir() {
+        let runroot = RunRoot::new("owner__repo", 123, "20260526-run-1").expect("runroot");
+        let expected_root_suffix = "owner__repo/issue-123/runs/20260526-run-1";
+        assert!(
+            runroot
+                .root()
+                .to_string_lossy()
+                .ends_with(expected_root_suffix),
+            "runroot suffix drift: {}",
+            runroot.root().display()
+        );
+        assert!(
+            runroot
+                .run_state_path()
+                .to_string_lossy()
+                .ends_with("runs/20260526-run-1/run-state.json")
+        );
+        assert!(
+            runroot
+                .events_path()
+                .to_string_lossy()
+                .ends_with("runs/20260526-run-1/events.jsonl")
+        );
+    }
 }

--- a/crates/plan-issue-cli/src/tracking/run_state.rs
+++ b/crates/plan-issue-cli/src/tracking/run_state.rs
@@ -1,0 +1,120 @@
+//! Typed local run-state for `plan-issue tracking`.
+//!
+//! Schema identifier: `plan-issue.execution-run.v1`. File layout under the
+//! existing state-dir contract is documented in
+//! `docs/source/plan-issue-redesign/plan-tracking-issue-run-state-controller-v1.md`.
+//!
+//! Task 1.1 only introduces the data shapes; Task 4.1 wires the actual JSON
+//! reader/writer, schema validation, and disk layout.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Stable schema identifier embedded in every `run-state.json` document.
+pub const RUN_STATE_SCHEMA: &str = "plan-issue.execution-run.v1";
+
+/// High-level execution phase. Mirrors the FSM states without dragging in
+/// reconciliation details.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunPhase {
+    Initial,
+    Active,
+    Blocked,
+    Validating,
+    Reviewed,
+    ReadyForClose,
+    Closed,
+}
+
+impl RunPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Initial => "initial",
+            Self::Active => "active",
+            Self::Blocked => "blocked",
+            Self::Validating => "validating",
+            Self::Reviewed => "reviewed",
+            Self::ReadyForClose => "ready_for_close",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+/// Typed run state document persisted as `run-state.json` under the
+/// issue-scoped runtime root.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionRun {
+    pub schema: String,
+    pub run_id: String,
+    pub repo: String,
+    pub issue: u64,
+    pub plan_bundle: PathBuf,
+    #[serde(default)]
+    pub selected_task: Option<String>,
+    #[serde(default)]
+    pub selected_sprint: Option<String>,
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default)]
+    pub worktree: Option<PathBuf>,
+    #[serde(default)]
+    pub linked_pr: Option<String>,
+    pub phase: RunPhase,
+    #[serde(default)]
+    pub notes: Vec<String>,
+    #[serde(default)]
+    pub validation: Option<ValidationSummary>,
+    #[serde(default)]
+    pub review: Option<ReviewSummary>,
+    #[serde(default)]
+    pub artifacts: Vec<ArtifactRef>,
+    #[serde(default)]
+    pub blockers: Vec<BlockerRef>,
+    pub started_at: String,
+    pub updated_at: String,
+}
+
+/// Compact validation summary captured in run state. Detailed evidence lives
+/// in lifecycle comments and validation artifacts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationSummary {
+    pub overall: String,
+    #[serde(default)]
+    pub commands: Vec<String>,
+    #[serde(default)]
+    pub waiver: Option<String>,
+    #[serde(default)]
+    pub evidence_path: Option<PathBuf>,
+}
+
+/// Compact review summary captured in run state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewSummary {
+    pub decision: String,
+    #[serde(default)]
+    pub findings_disposition: Vec<String>,
+    #[serde(default)]
+    pub evidence_path: Option<PathBuf>,
+}
+
+/// Reference to a large retained artifact (validation log, review report, …).
+/// Large blobs live on disk; the run state only carries a path or redacted
+/// preview.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactRef {
+    pub kind: String,
+    pub path: PathBuf,
+    #[serde(default)]
+    pub preview: Option<String>,
+}
+
+/// Reference to a current execution blocker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockerRef {
+    pub code: String,
+    pub message: String,
+    #[serde(default)]
+    pub owner: Option<String>,
+}

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -17,6 +17,10 @@ mod grouping_default;
 mod help_snapshot;
 #[path = "integration/lifecycle_record.rs"]
 mod lifecycle_record;
+#[path = "integration/lifecycle_vnext_registry.rs"]
+mod lifecycle_vnext_registry;
+#[path = "integration/visible_lint.rs"]
+mod visible_lint;
 #[path = "integration/link_pr_flow.rs"]
 mod link_pr_flow;
 #[path = "integration/live_issue_ops.rs"]
@@ -29,6 +33,8 @@ mod live_start_sprint_runtime_truth;
 mod output_contract;
 #[path = "integration/parity_guardrails.rs"]
 mod parity_guardrails;
+#[path = "integration/record_audit.rs"]
+mod record_audit;
 #[path = "integration/record_compat_baseline.rs"]
 mod record_compat_baseline;
 #[path = "integration/resolve_approval.rs"]

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -53,8 +53,14 @@ mod tracking_events;
 mod tracking_fsm;
 #[path = "integration/tracking_reconcile.rs"]
 mod tracking_reconcile;
+#[path = "integration/tracking_checkpoint_dry_run.rs"]
+mod tracking_checkpoint_dry_run;
+#[path = "integration/tracking_checkpoint_refusals.rs"]
+mod tracking_checkpoint_refusals;
 #[path = "integration/tracking_run_state.rs"]
 mod tracking_run_state;
+#[path = "integration/tracking_run_update.rs"]
+mod tracking_run_update;
 #[path = "integration/tracking_status.rs"]
 mod tracking_status;
 #[path = "integration/start_plan_canonical.rs"]

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -29,6 +29,8 @@ mod live_start_sprint_runtime_truth;
 mod output_contract;
 #[path = "integration/parity_guardrails.rs"]
 mod parity_guardrails;
+#[path = "integration/record_compat_baseline.rs"]
+mod record_compat_baseline;
 #[path = "integration/resolve_approval.rs"]
 mod resolve_approval;
 #[path = "integration/runtime_layout_parity.rs"]

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -19,6 +19,8 @@ mod help_snapshot;
 mod lifecycle_record;
 #[path = "integration/lifecycle_vnext_registry.rs"]
 mod lifecycle_vnext_registry;
+#[path = "integration/lifecycle_vnext_render.rs"]
+mod lifecycle_vnext_render;
 #[path = "integration/visible_lint.rs"]
 mod visible_lint;
 #[path = "integration/link_pr_flow.rs"]
@@ -37,6 +39,8 @@ mod parity_guardrails;
 mod record_audit;
 #[path = "integration/record_compat_baseline.rs"]
 mod record_compat_baseline;
+#[path = "integration/record_template.rs"]
+mod record_template;
 #[path = "integration/resolve_approval.rs"]
 mod resolve_approval;
 #[path = "integration/runtime_layout_parity.rs"]

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -47,6 +47,16 @@ mod resolve_approval;
 mod runtime_layout_parity;
 #[path = "integration/runtime_truth_plan_and_sprint_flow.rs"]
 mod runtime_truth_plan_and_sprint_flow;
+#[path = "integration/tracking_events.rs"]
+mod tracking_events;
+#[path = "integration/tracking_fsm.rs"]
+mod tracking_fsm;
+#[path = "integration/tracking_reconcile.rs"]
+mod tracking_reconcile;
+#[path = "integration/tracking_run_state.rs"]
+mod tracking_run_state;
+#[path = "integration/tracking_status.rs"]
+mod tracking_status;
 #[path = "integration/start_plan_canonical.rs"]
 mod start_plan_canonical;
 #[path = "integration/start_sprint_canonical.rs"]

--- a/crates/plan-issue-cli/tests/integration.rs
+++ b/crates/plan-issue-cli/tests/integration.rs
@@ -57,6 +57,8 @@ mod tracking_reconcile;
 mod tracking_checkpoint_dry_run;
 #[path = "integration/tracking_checkpoint_refusals.rs"]
 mod tracking_checkpoint_refusals;
+#[path = "integration/tracking_close_ready.rs"]
+mod tracking_close_ready;
 #[path = "integration/tracking_run_state.rs"]
 mod tracking_run_state;
 #[path = "integration/tracking_run_update.rs"]

--- a/crates/plan-issue-cli/tests/integration/lifecycle_vnext_registry.rs
+++ b/crates/plan-issue-cli/tests/integration/lifecycle_vnext_registry.rs
@@ -1,0 +1,122 @@
+//! Integration coverage for the lifecycle role registry (Task 2.1).
+//!
+//! Mirrors the unit tests in `lifecycle_vnext::registry::tests` so the plan
+//! validation command
+//! `cargo test -p nils-plan-issue-cli lifecycle_vnext_registry --no-fail-fast`
+//! finds at least one matching test name regardless of how cargo filters
+//! the inner module paths.
+//!
+//! Sources:
+//!
+//! - `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`
+//! - `docs/source/plan-issue-redesign/plan-tracking-issue-cli-redesign-v1.md`
+
+use plan_issue_cli::lifecycle_record::PayloadRole;
+use plan_issue_cli::lifecycle_vnext::registry::{
+    self, DashboardRepair, DirectPostPolicy, PayloadSchema,
+};
+
+#[test]
+fn lifecycle_vnext_registry_covers_every_payload_role() {
+    let roles: Vec<PayloadRole> = registry::all_roles().iter().map(|spec| spec.role).collect();
+    assert_eq!(
+        roles,
+        vec![
+            PayloadRole::Source,
+            PayloadRole::Plan,
+            PayloadRole::State,
+            PayloadRole::Session,
+            PayloadRole::Validation,
+            PayloadRole::Review,
+            PayloadRole::Closeout,
+        ]
+    );
+}
+
+#[test]
+fn lifecycle_vnext_registry_headings_match_taxonomy() {
+    let expected: Vec<(PayloadRole, &str)> = vec![
+        (PayloadRole::Source, "## Source Snapshot"),
+        (PayloadRole::Plan, "## Plan Snapshot"),
+        (PayloadRole::State, "## Execution State"),
+        (PayloadRole::Session, "## Execution Session"),
+        (PayloadRole::Validation, "## Validation Evidence"),
+        (PayloadRole::Review, "## Review Evidence"),
+        (PayloadRole::Closeout, "## Tracking Issue Closeout"),
+    ];
+    for (role_id, heading) in expected {
+        assert_eq!(
+            registry::role(role_id).default_heading,
+            heading,
+            "role {role_id:?} heading drift vs taxonomy doc"
+        );
+    }
+}
+
+#[test]
+fn lifecycle_vnext_registry_state_requires_task_ledger() {
+    let state = registry::role(PayloadRole::State);
+    assert!(
+        state
+            .required_visible_sections
+            .iter()
+            .any(|h| *h == "## Task Ledger"),
+        "state visible sections missing ## Task Ledger: {:?}",
+        state.required_visible_sections
+    );
+}
+
+#[test]
+fn lifecycle_vnext_registry_source_and_plan_open_attach_only() {
+    assert_eq!(
+        registry::role(PayloadRole::Source).direct_post,
+        DirectPostPolicy::OpenAttachOnly
+    );
+    assert_eq!(
+        registry::role(PayloadRole::Plan).direct_post,
+        DirectPostPolicy::OpenAttachOnly
+    );
+}
+
+#[test]
+fn lifecycle_vnext_registry_closeout_is_record_close_owned() {
+    let closeout = registry::role(PayloadRole::Closeout);
+    assert_eq!(closeout.direct_post, DirectPostPolicy::RecordCloseOwned);
+    assert_eq!(closeout.dashboard_repair, DashboardRepair::OwnedByCloseout);
+}
+
+#[test]
+fn lifecycle_vnext_registry_payload_schemas_declared_for_every_role() {
+    let expected: Vec<(PayloadRole, PayloadSchema)> = vec![
+        (PayloadRole::Source, PayloadSchema::Snapshot),
+        (PayloadRole::Plan, PayloadSchema::Snapshot),
+        (PayloadRole::State, PayloadSchema::State),
+        (PayloadRole::Session, PayloadSchema::Session),
+        (PayloadRole::Validation, PayloadSchema::Validation),
+        (PayloadRole::Review, PayloadSchema::Review),
+        (PayloadRole::Closeout, PayloadSchema::Closeout),
+    ];
+    for (role_id, schema) in expected {
+        assert_eq!(
+            registry::role(role_id).payload_schema,
+            schema,
+            "role {role_id:?} payload schema drift"
+        );
+    }
+}
+
+#[test]
+fn lifecycle_vnext_registry_iteration_proves_visible_template_and_schema() {
+    for spec in registry::all_roles() {
+        assert!(
+            !spec.required_visible_sections.is_empty(),
+            "role {:?} missing visible template",
+            spec.role
+        );
+        assert!(
+            !spec.payload_schema.as_str().is_empty(),
+            "role {:?} missing payload schema id",
+            spec.role
+        );
+    }
+}

--- a/crates/plan-issue-cli/tests/integration/lifecycle_vnext_render.rs
+++ b/crates/plan-issue-cli/tests/integration/lifecycle_vnext_render.rs
@@ -4,7 +4,7 @@
 //! existing CLI dry-run path and assert:
 //!
 //! - first-line v2 marker shape
-//! - hidden payload carrier shape (HTML comment, not the legacy fenced
+//! - hidden payload carrier shape (HTML comment, not the pre-v2 fenced
 //!   `plan-issue-record-payload` code block)
 //! - canonical visible heading from the registry
 //! - visible completeness via `lifecycle_vnext::visible_lint`
@@ -57,7 +57,7 @@ fn assert_marker_and_carrier_shape(body: &str, role: PayloadRole) {
     );
     assert!(
         !body.contains("```plan-issue-record-payload"),
-        "role {role:?} contains legacy visible fenced payload: {body}"
+        "role {role:?} contains pre-v2 visible fenced payload: {body}"
     );
     assert!(
         body.contains(spec.default_heading),

--- a/crates/plan-issue-cli/tests/integration/lifecycle_vnext_render.rs
+++ b/crates/plan-issue-cli/tests/integration/lifecycle_vnext_render.rs
@@ -1,0 +1,338 @@
+//! Renderer fixture coverage for the vNext lifecycle roles (Task 3.2).
+//!
+//! For every role we render a real lifecycle comment body through the
+//! existing CLI dry-run path and assert:
+//!
+//! - first-line v2 marker shape
+//! - hidden payload carrier shape (HTML comment, not the legacy fenced
+//!   `plan-issue-record-payload` code block)
+//! - canonical visible heading from the registry
+//! - visible completeness via `lifecycle_vnext::visible_lint`
+//!
+//! Source: `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`.
+
+use std::fs;
+use std::path::Path;
+
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use nils_test_support::cmd::{CmdOptions, run_resolved};
+
+use plan_issue_cli::lifecycle_record::PayloadRole;
+use plan_issue_cli::lifecycle_vnext::registry;
+use plan_issue_cli::lifecycle_vnext::visible_lint::{LintHints, lint_visible};
+
+use crate::common;
+
+fn json_stdout(stdout: &str) -> Value {
+    serde_json::from_str(stdout).expect("json stdout")
+}
+
+fn write_payload(dir: &Path, name: &str, data: Value) -> std::path::PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, data.to_string()).expect("write payload");
+    path
+}
+
+fn assert_marker_and_carrier_shape(body: &str, role: PayloadRole) {
+    let spec = registry::role(role);
+    let expected_first = format!(
+        "<!-- plan-issue-record:v2 role={} profile=tracking -->",
+        spec.marker_role
+    );
+    let first_non_empty = body
+        .lines()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or_default();
+    assert_eq!(
+        first_non_empty.trim(),
+        expected_first,
+        "role {role:?} first-line marker drift: {body}"
+    );
+    assert!(
+        body.contains("<!-- plan-issue-record-payload:hex:"),
+        "role {role:?} missing hidden payload carrier: {body}"
+    );
+    assert!(
+        !body.contains("```plan-issue-record-payload"),
+        "role {role:?} contains legacy visible fenced payload: {body}"
+    );
+    assert!(
+        body.contains(spec.default_heading),
+        "role {role:?} missing default heading `{}`: {body}",
+        spec.default_heading
+    );
+}
+
+fn post_dry_run(kind: &str, payload_path: &Path, extra: &[&str]) -> Value {
+    let mut args: Vec<&str> = vec![
+        "--format",
+        "json",
+        "record",
+        "post",
+        "--issue",
+        "42",
+        "--kind",
+        kind,
+        "--payload-file",
+        payload_path.to_str().expect("payload str"),
+    ];
+    args.extend_from_slice(extra);
+    let out = common::run_plan_issue_local(&args);
+    assert_eq!(out.code, 0, "kind {kind} stderr: {}", out.stderr);
+    json_stdout(&out.stdout)
+}
+
+#[test]
+fn lifecycle_vnext_render_state_non_final_collapses_task_ledger() {
+    let tmp = TempDir::new().expect("tmp");
+    let payload = write_payload(
+        tmp.path(),
+        "state.json",
+        json!({
+            "status": "in-progress",
+            "target_scope": "vnext-render",
+            "current": "task 3.2",
+            "next_action": "task 4.1",
+            "tasks": [
+                {"id": "1.1", "status": "done", "title": "registry"},
+                {"id": "1.2", "status": "in-progress", "title": "visible-lint"}
+            ],
+            "prs": [],
+            "blockers": [],
+            "links": {}
+        }),
+    );
+    let result = post_dry_run("state", &payload, &["--task-ledger-display", "collapsed"]);
+    let body = result["payload"]["result"]["comment_body"]
+        .as_str()
+        .expect("body")
+        .to_string();
+    assert_marker_and_carrier_shape(&body, PayloadRole::State);
+    let report = lint_visible(PayloadRole::State, &body, LintHints::default());
+    assert!(report.is_pass(), "lint findings={:?}", report.findings);
+    // Non-final state must still expose the `## Task Ledger` heading even
+    // when rows are collapsed.
+    assert!(
+        body.contains("## Task Ledger"),
+        "non-final state missing Task Ledger heading: {body}"
+    );
+}
+
+#[test]
+fn lifecycle_vnext_render_state_final_expands_task_ledger() {
+    let tmp = TempDir::new().expect("tmp");
+    let payload = write_payload(
+        tmp.path(),
+        "state.json",
+        json!({
+            "status": "complete",
+            "target_scope": "vnext-render",
+            "current": "complete",
+            "next_action": "closeout",
+            "tasks": [
+                {"id": "1.1", "status": "done", "title": "registry"},
+                {"id": "1.2", "status": "done", "title": "visible-lint"}
+            ],
+            "prs": [
+                {"ref": "owner/repo#1", "url": "https://example.com/pr/1", "status": "merged"}
+            ],
+            "blockers": [],
+            "links": {}
+        }),
+    );
+    let result = post_dry_run("state", &payload, &["--task-ledger-display", "expanded"]);
+    let body = result["payload"]["result"]["comment_body"]
+        .as_str()
+        .expect("body")
+        .to_string();
+    assert_marker_and_carrier_shape(&body, PayloadRole::State);
+    let hints = LintHints {
+        state_is_final: true,
+        ..LintHints::default()
+    };
+    let report = lint_visible(PayloadRole::State, &body, hints);
+    assert!(report.is_pass(), "lint findings={:?}", report.findings);
+}
+
+#[test]
+fn lifecycle_vnext_render_session_visible_body_passes_lint() {
+    let tmp = TempDir::new().expect("tmp");
+    let payload = write_payload(
+        tmp.path(),
+        "session.json",
+        json!({
+            "summary": "completed registry and visible-lint",
+            "highlights": ["passed cargo test", "wrote fixtures"],
+            "links": {"state": "https://example.com/state", "pr": "https://example.com/pr"}
+        }),
+    );
+    let result = post_dry_run("session", &payload, &[]);
+    let body = result["payload"]["result"]["comment_body"]
+        .as_str()
+        .expect("body")
+        .to_string();
+    assert_marker_and_carrier_shape(&body, PayloadRole::Session);
+    let report = lint_visible(PayloadRole::Session, &body, LintHints::default());
+    assert!(report.is_pass(), "lint findings={:?}", report.findings);
+}
+
+#[test]
+fn lifecycle_vnext_render_validation_visible_body_passes_lint() {
+    let tmp = TempDir::new().expect("tmp");
+    let payload = write_payload(
+        tmp.path(),
+        "validation.json",
+        json!({
+            "overall": "pass",
+            "commands": [
+                {"command": "cargo test -p nils-plan-issue-cli lifecycle_vnext_render", "status": "pass", "evidence": "ci.log"}
+            ],
+            "waivers": []
+        }),
+    );
+    let result = post_dry_run("validation", &payload, &[]);
+    let body = result["payload"]["result"]["comment_body"]
+        .as_str()
+        .expect("body")
+        .to_string();
+    assert_marker_and_carrier_shape(&body, PayloadRole::Validation);
+    let report = lint_visible(PayloadRole::Validation, &body, LintHints::default());
+    assert!(
+        report.is_pass(),
+        "lint findings={:?}\nbody:\n{body}",
+        report.findings
+    );
+}
+
+#[test]
+fn lifecycle_vnext_render_review_visible_body_passes_lint() {
+    let tmp = TempDir::new().expect("tmp");
+    let payload = write_payload(
+        tmp.path(),
+        "review.json",
+        json!({
+            "decision": "approve",
+            "lenses": ["testing", "maintainability"],
+            "findings": [
+                {"id": "F1", "severity": "minor", "disposition": "fixed", "summary": "tiny nit"}
+            ],
+            "outcome_comment_url": "https://example.com/review"
+        }),
+    );
+    let result = post_dry_run("review", &payload, &[]);
+    let body = result["payload"]["result"]["comment_body"]
+        .as_str()
+        .expect("body")
+        .to_string();
+    assert_marker_and_carrier_shape(&body, PayloadRole::Review);
+    let hints = LintHints {
+        review_has_findings: true,
+        ..LintHints::default()
+    };
+    let report = lint_visible(PayloadRole::Review, &body, hints);
+    assert!(report.is_pass(), "lint findings={:?}", report.findings);
+}
+
+#[test]
+fn lifecycle_vnext_render_source_and_plan_via_record_attach() {
+    use nils_test_support::git::{InitRepoOptions, git, init_repo_with};
+
+    let repo = init_repo_with(InitRepoOptions::new().with_branch("main"));
+    let bundle = repo.path().join("docs/plans/sample");
+    fs::create_dir_all(&bundle).expect("create bundle dir");
+    let source = bundle.join("sample-discussion-source.md");
+    let plan = bundle.join("sample-plan.md");
+    let execution_state = bundle.join("sample-execution-state.md");
+    fs::write(&source, "# Source\n\n- Decision: render source fixture.\n")
+        .expect("write source");
+    fs::write(
+        &plan,
+        "# Plan: Render Fixture\n\n## Overview\n\n- Demo plan.\n\n## Read First\n\n- Primary source: docs/plans/sample/sample-discussion-source.md\n- Source type: discussion-to-implementation-doc\n- Open questions carried into execution: none\n\n## Scope\n\n- In scope:\n  - Demo.\n- Out of scope:\n  - none.\n\n## Assumptions\n\n1. Demo only.\n\n## Sprint 1: Demo\n\n**Goal**: Demo.\n\n**PR grouping intent**: group\n**Execution Profile**: serial\n\n### Task 1.1: Demo\n\n- **Location**:\n  - `docs/plans/sample/sample-plan.md`\n- **Description**: Demo.\n- **Dependencies**:\n  - none\n- **Complexity**: 1\n- **Acceptance criteria**:\n  - Demo.\n- **Validation**:\n  - `true`\n",
+    )
+    .expect("write plan");
+    fs::write(
+        &execution_state,
+        "# Sample Execution State\n\n<!-- plan-issue-record:v2 role=state profile=tracking -->\n\n## Execution State\n\n- Profile: tracking\n- Status: pending\n- Target scope: render\n\n## Task Ledger\n\n| ID | Status |\n| --- | --- |\n| 1.1 | pending |\n",
+    )
+    .expect("write execution state");
+    git(repo.path(), &["add", "."]);
+    git(
+        repo.path(),
+        &[
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test",
+            "commit",
+            "-m",
+            "seed render fixture",
+            "--no-gpg-sign",
+        ],
+    );
+
+    let bundle_arg = bundle.to_string_lossy().to_string();
+    let out = run_resolved(
+        "plan-issue-local",
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "record",
+            "attach",
+            "--issue",
+            "69",
+            "--bundle",
+            &bundle_arg,
+        ],
+        &CmdOptions::new().with_cwd(repo.path()),
+    );
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr_text());
+    let parsed = json_stdout(&out.stdout_text());
+    let comments = &parsed["payload"]["result"]["preview"]["comments"];
+
+    for (role_name, role_id) in [
+        ("source", PayloadRole::Source),
+        ("plan", PayloadRole::Plan),
+    ] {
+        let body = comments[role_name].as_str().unwrap_or_default().to_string();
+        assert_marker_and_carrier_shape(&body, role_id);
+        let report = lint_visible(role_id, &body, LintHints::default());
+        assert!(
+            report.is_pass(),
+            "role {role_id:?} lint findings={:?}",
+            report.findings
+        );
+    }
+}
+
+#[test]
+fn lifecycle_vnext_render_closeout_passes_lint_via_template_then_lint() {
+    // Closeout is owned by `record close`; the existing
+    // `record_close_fixture_passes_strict_gate_with_complete_v2_evidence` test
+    // proves end-to-end rendering. For focused renderer coverage we exercise
+    // the canonical visible shape through the `record template` preview and
+    // then synthesize the equivalent payload-backed body using the registry's
+    // heading. This proves the visible body is lint-clean for the closeout
+    // role using only deterministic inputs.
+    let body = "<!-- plan-issue-record:v2 role=closeout profile=tracking -->\n\n\
+        ## Tracking Issue Closeout\n\n\
+        - Profile: tracking\n\
+        - Final status: complete\n\
+        - Approver: someone\n\
+        - Approval: https://example.com/approval\n\
+        - Final validation: https://example.com/validation\n\n\
+        | PR | Merge SHA | Checks | Required | Non-required failures |\n\
+        | --- | --- | --- | --- | --- |\n\
+        | owner/repo#123 | deadbeef | pass | pass | none |\n\n\
+        <!-- plan-issue-record-payload:hex:abcd -->\n";
+    let report = lint_visible(PayloadRole::Closeout, body, LintHints::default());
+    assert!(
+        report.is_pass(),
+        "closeout fixture should lint clean; findings={:?}",
+        report.findings
+    );
+    assert_marker_and_carrier_shape(body, PayloadRole::Closeout);
+}

--- a/crates/plan-issue-cli/tests/integration/record_audit.rs
+++ b/crates/plan-issue-cli/tests/integration/record_audit.rs
@@ -1,0 +1,218 @@
+//! `plan-issue record audit --expect-visible` integration coverage (Task 2.3).
+//!
+//! Source: `docs/source/plan-issue-redesign/plan-tracking-issue-cli-redesign-v1.md`
+//! Workstream 2 ("Visible Completeness Lint").
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use plan_issue_cli::lifecycle_record::PAYLOAD_SCHEMA_V2;
+
+use crate::common;
+
+fn json_stdout(out: &common::CmdOut) -> Value {
+    serde_json::from_str(&out.stdout).expect("json stdout")
+}
+
+fn v2_comment(role: &str, profile: &str, data: Value, visible: &str) -> String {
+    let envelope = json!({
+        "schema": PAYLOAD_SCHEMA_V2,
+        "role": role,
+        "profile": profile,
+        "data": data,
+    });
+    let payload = serde_json::to_string(&envelope).expect("serialize payload");
+    format!(
+        "<!-- plan-issue-record:v2 role={role} profile={profile} -->\n\n{visible}\n\n```plan-issue-record-payload\n{payload}\n```\n",
+    )
+}
+
+fn write_fixture(role_bodies: &[(&str, Value, &str)]) -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let tmp = TempDir::new().expect("tmp");
+    let body = tmp.path().join("body.md");
+    fs::write(&body, "## Current Dashboard\n").expect("body");
+
+    let comments: Vec<Value> = role_bodies
+        .iter()
+        .enumerate()
+        .map(|(idx, (role, data, visible))| {
+            json!({
+                "url": format!("https://example.com/c{idx}"),
+                "created_at": format!("2026-05-26T08:00:0{idx}Z"),
+                "body": v2_comment(role, "tracking", data.clone(), visible),
+            })
+        })
+        .collect();
+    let comments_path = tmp.path().join("comments.json");
+    fs::write(
+        &comments_path,
+        json!({"comments": comments}).to_string(),
+    )
+    .expect("comments");
+    (tmp, body, comments_path)
+}
+
+#[test]
+fn record_audit_default_does_not_emit_visible_block() {
+    let (_tmp, body, comments) = write_fixture(&[(
+        "state",
+        json!({"status": "in-progress", "target_scope": "x", "tasks": [], "prs": []}),
+        "## Execution State\n\n- Profile: tracking\n- Status: in-progress\n\n## Task Ledger\n\n<details></details>",
+    )]);
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "record",
+        "audit",
+        "--profile",
+        "tracking",
+        "--body-file",
+        body.to_str().expect("body"),
+        "--comments-json",
+        comments.to_str().expect("comments"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let envelope = json_stdout(&out);
+    assert!(
+        envelope["payload"]["result"]["visible"].is_null(),
+        "default audit must not emit visible block: {envelope}"
+    );
+}
+
+#[test]
+fn record_audit_expect_visible_passes_for_complete_evidence() {
+    let (_tmp, body, comments) = write_fixture(&[
+        (
+            "source",
+            json!({"path": "docs/plans/foo/foo.md", "commit": "abc"}),
+            "## Source Snapshot\n\n- Profile: tracking\n- Path: `docs/plans/foo/foo.md`\n- Commit: `abc`",
+        ),
+        (
+            "plan",
+            json!({"path": "docs/plans/foo/foo-plan.md", "commit": "abc"}),
+            "## Plan Snapshot\n\n- Profile: tracking\n- Path: `docs/plans/foo/foo-plan.md`\n- Commit: `abc`",
+        ),
+        (
+            "state",
+            json!({"status": "in-progress", "target_scope": "x", "tasks": [], "prs": []}),
+            "## Execution State\n\n- Profile: tracking\n- Status: in-progress\n\n## Task Ledger\n\n<details>\n\n| ID | Status |\n| --- | --- |\n| 1.1 | done |\n\n</details>",
+        ),
+    ]);
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "record",
+        "audit",
+        "--profile",
+        "tracking",
+        "--body-file",
+        body.to_str().expect("body"),
+        "--comments-json",
+        comments.to_str().expect("comments"),
+        "--expect-visible",
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let envelope = json_stdout(&out);
+    let visible = &envelope["payload"]["result"]["visible"];
+    assert_eq!(visible["expect_visible"], true, "{envelope}");
+    assert_eq!(visible["overall_pass"], true, "{envelope}");
+    assert!(
+        visible["codes"].as_array().unwrap().is_empty(),
+        "visible codes should be empty: {envelope}"
+    );
+    let roles = visible["roles"].as_array().expect("roles array");
+    let role_names: Vec<&str> = roles.iter().map(|r| r["role"].as_str().unwrap()).collect();
+    assert_eq!(
+        role_names,
+        vec!["source", "plan", "state", "session", "validation", "review", "closeout"]
+    );
+}
+
+#[test]
+fn record_audit_expect_visible_blocks_missing_task_ledger() {
+    let (_tmp, body, comments) = write_fixture(&[(
+        "state",
+        json!({"status": "in-progress", "target_scope": "x", "tasks": [], "prs": []}),
+        "## Execution State\n\n- Profile: tracking\n- Status: in-progress\n",
+    )]);
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "record",
+        "audit",
+        "--profile",
+        "tracking",
+        "--body-file",
+        body.to_str().expect("body"),
+        "--comments-json",
+        comments.to_str().expect("comments"),
+        "--expect-visible",
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let envelope = json_stdout(&out);
+    let visible = &envelope["payload"]["result"]["visible"];
+    assert_eq!(visible["overall_pass"], false, "{envelope}");
+    let codes: Vec<&str> = visible["codes"]
+        .as_array()
+        .expect("codes array")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        codes.contains(&"state-missing-task-ledger"),
+        "codes={codes:?}"
+    );
+}
+
+#[test]
+fn record_audit_expect_visible_blocks_profile_only_session() {
+    let (_tmp, body, comments) = write_fixture(&[(
+        "session",
+        json!({"summary": "internal note"}),
+        "## Execution Session\n\n- Profile: tracking\n",
+    )]);
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "record",
+        "audit",
+        "--body-file",
+        body.to_str().expect("body"),
+        "--comments-json",
+        comments.to_str().expect("comments"),
+        "--expect-visible",
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let envelope = json_stdout(&out);
+    let visible = &envelope["payload"]["result"]["visible"];
+    let codes: Vec<&str> = visible["codes"]
+        .as_array()
+        .expect("codes")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        codes.iter().any(|c| *c == "session-missing-summary" || *c == "profile-only"),
+        "expected session-missing-summary or profile-only; got {codes:?}"
+    );
+}
+
+#[test]
+fn record_audit_expect_visible_help_mentions_flag() {
+    let out = common::run_plan_issue(&["record", "audit", "--help"]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    assert!(
+        out.stdout.contains("--expect-visible"),
+        "help missing --expect-visible flag: {}",
+        out.stdout
+    );
+}

--- a/crates/plan-issue-cli/tests/integration/record_compat_baseline.rs
+++ b/crates/plan-issue-cli/tests/integration/record_compat_baseline.rs
@@ -1,0 +1,251 @@
+//! Plan Issue vNext compatibility baseline (Task 1.2).
+//!
+//! Locks the released `record` command surface, envelope, and error shape
+//! before the vNext rewrite begins so an accidental regression during
+//! Sprint 2–6 fails CI here instead of breaking runtime-kit downstream.
+//!
+//! Source: `docs/plans/plan-issue-vnext-implementation/plan-issue-vnext-implementation-plan.md`
+//! Task 1.2; design constraints from
+//! `docs/source/plan-issue-redesign/plan-tracking-issue-cli-redesign-v1.md`
+//! ("Preserve" table).
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use plan_issue_cli::commands::record::{LifecycleCommentKind, RecordProfile};
+use plan_issue_cli::lifecycle_record::PAYLOAD_SCHEMA_V2;
+use plan_issue_cli::lifecycle_vnext::registry;
+use plan_issue_cli::tracking;
+
+use crate::common;
+
+fn json_stdout(out: &common::CmdOut) -> Value {
+    serde_json::from_str(&out.stdout).expect("json stdout")
+}
+
+fn v2_comment_body(role: &str, profile: &str, data: Value) -> String {
+    let envelope = json!({
+        "schema": PAYLOAD_SCHEMA_V2,
+        "role": role,
+        "profile": profile,
+        "data": data,
+    });
+    let payload = serde_json::to_string(&envelope).expect("serialize payload");
+    format!(
+        "<!-- plan-issue-record:v2 role={role} profile={profile} -->\n\n```plan-issue-record-payload\n{payload}\n```\n",
+    )
+}
+
+/// Lock the released `record` subcommand names so vNext rewrites cannot
+/// accidentally rename, merge, or drop a subcommand without surfacing here.
+#[test]
+fn record_subcommand_help_keeps_released_command_surface() {
+    for sub in [
+        "open",
+        "attach",
+        "post",
+        "repair-dashboard",
+        "close",
+        "audit",
+    ] {
+        let out = common::run_plan_issue(&["record", sub, "--help"]);
+        assert_eq!(
+            out.code, 0,
+            "record {sub} --help should exit success; stderr: {}",
+            out.stderr
+        );
+        assert!(
+            out.stdout.contains(sub),
+            "record {sub} --help stdout missing subcommand name: {}",
+            out.stdout
+        );
+    }
+}
+
+/// Lock the LifecycleCommentKind value-enum so downstream runtime-kit
+/// usage of `--kind <role>` keeps the same set of accepted roles during
+/// the rewrite.
+#[test]
+fn lifecycle_comment_kind_value_enum_keeps_seven_roles() {
+    use LifecycleCommentKind::*;
+    let roles = [Source, Plan, State, Session, Validation, Review, Closeout];
+    let strs: Vec<&'static str> = roles.iter().map(|k| k.as_str()).collect();
+    assert_eq!(
+        strs,
+        vec![
+            "source",
+            "plan",
+            "state",
+            "session",
+            "validation",
+            "review",
+            "closeout"
+        ]
+    );
+
+    // Profile surface must stay binary tracking|dispatch.
+    assert_eq!(RecordProfile::Tracking.as_str(), "tracking");
+    assert_eq!(RecordProfile::Dispatch.as_str(), "dispatch");
+}
+
+/// Representative success envelope: `record audit` returns the v2 schema
+/// envelope, `status=ok`, and a typed `audit` payload. Runtime-kit and
+/// runtime smoke both depend on this envelope shape.
+#[test]
+fn record_audit_success_envelope_shape_is_stable() {
+    let tmp = TempDir::new().expect("tmp");
+    let body = tmp.path().join("body.md");
+    let comments = tmp.path().join("comments.json");
+    fs::write(&body, "## Current Dashboard\n\n## Durable Record\n").expect("write body");
+    let payload = json!({
+        "comments": [
+            {
+                "url": "https://github.com/owner/repo/issues/1#issuecomment-state",
+                "body": v2_comment_body(
+                    "state",
+                    "tracking",
+                    json!({
+                        "status": "in-progress",
+                        "target_scope": "compat baseline",
+                        "tasks": [],
+                        "prs": []
+                    }),
+                ),
+            }
+        ]
+    });
+    fs::write(&comments, payload.to_string()).expect("write comments");
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "record",
+        "audit",
+        "--profile",
+        "tracking",
+        "--body-file",
+        body.to_str().expect("body"),
+        "--comments-json",
+        comments.to_str().expect("comments"),
+    ]);
+
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let envelope = json_stdout(&out);
+    assert_eq!(
+        envelope["schema_version"], "plan-issue-cli.record.audit.v2",
+        "schema_version drift; full envelope: {envelope}"
+    );
+    assert_eq!(envelope["command"], "record.audit");
+    assert_eq!(envelope["status"], "ok");
+    assert_eq!(envelope["payload"]["execution_mode"], "live");
+    assert!(
+        envelope["payload"]["result"]["audit"].is_object(),
+        "audit payload missing: {envelope}"
+    );
+}
+
+/// Representative failure envelope: missing required `--comments-json`
+/// returns the usage exit code (64) — locks parse-time error behavior.
+#[test]
+fn record_audit_failure_returns_usage_exit_for_missing_arg() {
+    let out = common::run_plan_issue(&["--format", "json", "record", "audit"]);
+    assert_eq!(
+        out.code, 64,
+        "record audit without args should exit USAGE (64); stderr: {}",
+        out.stderr
+    );
+}
+
+/// Representative runtime failure: `record audit` against a path that does
+/// not exist returns the v2 error envelope with `status=error` and a stable
+/// machine-readable code (not a panic, not an unbounded message).
+#[test]
+fn record_audit_runtime_failure_envelope_is_stable() {
+    let tmp = TempDir::new().expect("tmp");
+    let body = tmp.path().join("missing-body.md");
+    let comments = tmp.path().join("missing-comments.json");
+    // Intentionally do not create the files.
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "record",
+        "audit",
+        "--body-file",
+        body.to_str().expect("body"),
+        "--comments-json",
+        comments.to_str().expect("comments"),
+    ]);
+
+    assert_ne!(out.code, 0, "missing fixture must not silently succeed");
+    let envelope = json_stdout(&out);
+    assert_eq!(envelope["schema_version"], "plan-issue-cli.record.audit.v2");
+    assert_eq!(envelope["command"], "record.audit");
+    assert_eq!(envelope["status"], "error");
+    let code = envelope["error"]["code"]
+        .as_str()
+        .expect("error.code is a string");
+    assert!(!code.is_empty(), "error code should be a non-empty string");
+}
+
+/// vNext registry must cover every released `LifecycleCommentKind`. This
+/// guards against accidental drift where the rewrite drops or renames a
+/// role compared to the released `record post --kind` surface.
+#[test]
+fn lifecycle_vnext_registry_matches_released_role_set() {
+    let registered: Vec<&'static str> = registry::all_roles()
+        .iter()
+        .map(|spec| spec.marker_role)
+        .collect();
+    assert_eq!(
+        registered,
+        vec![
+            "source",
+            "plan",
+            "state",
+            "session",
+            "validation",
+            "review",
+            "closeout"
+        ]
+    );
+}
+
+/// Runtime layout resolution must remain shared infrastructure. Tracking
+/// modules read schema identifiers but rely on the canonical
+/// `runtime_layout::runtime_root()` for the on-disk path math (Task 4.1
+/// implementation; this baseline asserts the shapes line up at
+/// compile/link time).
+#[test]
+fn tracking_run_state_schema_constants_are_stable() {
+    assert_eq!(
+        tracking::run_state::RUN_STATE_SCHEMA,
+        "plan-issue.execution-run.v1"
+    );
+    assert_eq!(
+        tracking::events::EVENT_SCHEMA,
+        "plan-issue.execution-event.v1"
+    );
+}
+
+/// Plan-issue-local must still expose the released `record` surface so
+/// fixture-driven runtime smoke continues to work during the vNext rewrite.
+#[test]
+fn plan_issue_local_keeps_record_subcommand_help() {
+    let out = common::run_plan_issue_local(&["record", "--help"]);
+    assert_eq!(
+        out.code, 0,
+        "plan-issue-local record --help should exit success; stderr: {}",
+        out.stderr
+    );
+    for sub in ["open", "attach", "post", "repair-dashboard", "close", "audit"] {
+        assert!(
+            out.stdout.contains(sub),
+            "plan-issue-local record --help missing `{sub}`: {}",
+            out.stdout
+        );
+    }
+}

--- a/crates/plan-issue-cli/tests/integration/record_template.rs
+++ b/crates/plan-issue-cli/tests/integration/record_template.rs
@@ -56,10 +56,10 @@ fn record_template_markdown_renders_every_role() {
             template.contains("<!-- plan-issue-record-payload:hex:"),
             "role {role} markdown missing payload placeholder: {template}"
         );
-        // Templates must not render the legacy visible fenced payload.
+        // Templates must not render the pre-v2 visible fenced payload.
         assert!(
             !template.contains("```plan-issue-record-payload"),
-            "role {role} markdown contains legacy fenced payload: {template}"
+            "role {role} markdown contains pre-v2 fenced payload: {template}"
         );
     }
 }

--- a/crates/plan-issue-cli/tests/integration/record_template.rs
+++ b/crates/plan-issue-cli/tests/integration/record_template.rs
@@ -1,0 +1,167 @@
+//! `plan-issue record template` integration coverage (Task 3.1).
+//!
+//! The non-mutating preview command must render the visible Markdown
+//! skeleton and JSON payload skeleton for every lifecycle role using the
+//! same vNext registry that drives the renderer.
+//!
+//! Source: `docs/source/plan-issue-redesign/plan-tracking-issue-cli-redesign-v1.md`
+//! Workstream 3.
+
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+
+use crate::common;
+
+fn json_stdout(out: &common::CmdOut) -> Value {
+    serde_json::from_str(&out.stdout).expect("json stdout")
+}
+
+#[test]
+fn record_template_help_lists_template_under_record() {
+    let out = common::run_plan_issue(&["record", "--help"]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    assert!(
+        out.stdout.contains("template"),
+        "record --help missing template subcommand: {}",
+        out.stdout
+    );
+}
+
+#[test]
+fn record_template_markdown_renders_every_role() {
+    for role in ["source", "plan", "state", "session", "validation", "review", "closeout"] {
+        let out = common::run_plan_issue(&[
+            "--format",
+            "json",
+            "record",
+            "template",
+            "--profile",
+            "tracking",
+            "--kind",
+            role,
+            "--shape",
+            "markdown",
+        ]);
+        assert_eq!(out.code, 0, "role {role} stderr: {}", out.stderr);
+        let envelope = json_stdout(&out);
+        let template = envelope["payload"]["result"]["template"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            template.contains("<!-- plan-issue-record:v2"),
+            "role {role} markdown missing marker: {template}"
+        );
+        assert!(
+            template.contains("<!-- plan-issue-record-payload:hex:"),
+            "role {role} markdown missing payload placeholder: {template}"
+        );
+        // Templates must not render the legacy visible fenced payload.
+        assert!(
+            !template.contains("```plan-issue-record-payload"),
+            "role {role} markdown contains legacy fenced payload: {template}"
+        );
+    }
+}
+
+#[test]
+fn record_template_json_renders_every_role() {
+    for role in ["source", "plan", "state", "session", "validation", "review", "closeout"] {
+        let out = common::run_plan_issue(&[
+            "--format",
+            "json",
+            "record",
+            "template",
+            "--profile",
+            "tracking",
+            "--kind",
+            role,
+            "--shape",
+            "json",
+        ]);
+        assert_eq!(out.code, 0, "role {role} stderr: {}", out.stderr);
+        let envelope = json_stdout(&out);
+        let template = envelope["payload"]["result"]["template"]
+            .as_str()
+            .unwrap_or_default();
+        let parsed: Value = serde_json::from_str(template).expect("template is valid JSON");
+        assert_eq!(parsed["schema"], "plan-issue-record.payload.v2");
+        assert_eq!(parsed["role"], role);
+        assert_eq!(parsed["profile"], "tracking");
+        assert!(parsed["data"].is_object(), "role {role} data missing");
+    }
+}
+
+#[test]
+fn record_template_state_markdown_includes_task_ledger() {
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "record",
+        "template",
+        "--kind",
+        "state",
+        "--shape",
+        "markdown",
+    ]);
+    assert_eq!(out.code, 0);
+    let envelope = json_stdout(&out);
+    let template = envelope["payload"]["result"]["template"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        template.contains("## Task Ledger"),
+        "state template missing ## Task Ledger heading: {template}"
+    );
+}
+
+#[test]
+fn record_template_envelope_shape_is_stable() {
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "record",
+        "template",
+        "--kind",
+        "validation",
+        "--shape",
+        "markdown",
+    ]);
+    assert_eq!(out.code, 0);
+    let envelope = json_stdout(&out);
+    assert_eq!(envelope["schema_version"], "plan-issue-cli.record.template.v2");
+    assert_eq!(envelope["command"], "record.template");
+    assert_eq!(envelope["status"], "ok");
+    let result = &envelope["payload"]["result"];
+    assert_eq!(result["operation"], "template");
+    assert_eq!(result["profile"], "tracking");
+    assert_eq!(result["role"], "validation");
+    assert_eq!(result["shape"], "markdown");
+}
+
+#[test]
+fn record_template_dispatch_profile_renders_for_every_role() {
+    for role in ["source", "plan", "state", "session", "validation", "review", "closeout"] {
+        let out = common::run_plan_issue(&[
+            "--format",
+            "json",
+            "record",
+            "template",
+            "--profile",
+            "dispatch",
+            "--kind",
+            role,
+            "--shape",
+            "markdown",
+        ]);
+        assert_eq!(out.code, 0, "dispatch role {role} stderr: {}", out.stderr);
+        let envelope = json_stdout(&out);
+        let template = envelope["payload"]["result"]["template"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            template.contains("profile=dispatch"),
+            "dispatch role {role} marker profile drift: {template}"
+        );
+    }
+}

--- a/crates/plan-issue-cli/tests/integration/tracking_checkpoint_dry_run.rs
+++ b/crates/plan-issue-cli/tests/integration/tracking_checkpoint_dry_run.rs
@@ -1,0 +1,229 @@
+//! `plan-issue tracking checkpoint --dry-run` integration coverage (Task 5.2).
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use plan_issue_cli::lifecycle_record::PAYLOAD_SCHEMA_V2;
+
+use crate::common;
+
+fn json_stdout(out: &common::CmdOut) -> Value {
+    serde_json::from_str(&out.stdout).expect("json stdout")
+}
+
+fn v2_comment(role: &str, profile: &str, data: Value, visible: &str) -> String {
+    let envelope = json!({
+        "schema": PAYLOAD_SCHEMA_V2,
+        "role": role,
+        "profile": profile,
+        "data": data,
+    });
+    let payload = serde_json::to_string(&envelope).expect("serialize");
+    format!(
+        "<!-- plan-issue-record:v2 role={role} profile={profile} -->\n\n{visible}\n\n```plan-issue-record-payload\n{payload}\n```\n",
+    )
+}
+
+fn write_fixture(roles: &[(&str, Value, &str, &str)]) -> TempDir {
+    let tmp = TempDir::new().expect("tmp");
+    fs::write(tmp.path().join("body.md"), "## Current Dashboard\n").expect("body");
+    let comments: Vec<Value> = roles
+        .iter()
+        .enumerate()
+        .map(|(idx, (role, data, visible, at))| {
+            json!({
+                "url": format!("https://example.com/c{idx}"),
+                "created_at": at,
+                "body": v2_comment(role, "tracking", data.clone(), visible),
+            })
+        })
+        .collect();
+    fs::write(
+        tmp.path().join("comments.json"),
+        json!({"comments": comments}).to_string(),
+    )
+    .expect("comments");
+    tmp
+}
+
+fn write_run_state(path: &std::path::Path, phase: &str, notes: &[&str]) {
+    let body = json!({
+        "schema": "plan-issue.execution-run.v1",
+        "run_id": "run-1",
+        "repo": "owner/repo",
+        "issue": 123,
+        "profile": "tracking",
+        "phase": phase,
+        "created_at": "2026-05-26T00:00:00Z",
+        "updated_at": "2026-05-26T01:00:00Z",
+        "selected_scope": {
+            "task": "1.2",
+            "title": "demo"
+        },
+        "branch": "feat/x",
+        "notes": notes,
+    });
+    fs::write(path, body.to_string()).expect("run-state");
+}
+
+#[test]
+fn tracking_checkpoint_dry_run_renders_state_role_from_run_state() {
+    let fixture = write_fixture(&[
+        (
+            "source",
+            json!({"path": "p", "commit": "c"}),
+            "## Source Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:00Z",
+        ),
+        (
+            "plan",
+            json!({"path": "p", "commit": "c"}),
+            "## Plan Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:01Z",
+        ),
+        (
+            "state",
+            json!({"status": "in-progress", "target_scope": "x", "tasks": [], "prs": []}),
+            "## Execution State\n\n- Profile: tracking\n- Status: in-progress\n\n## Task Ledger\n\n| ID | Status |\n| --- | --- |\n| 1.1 | done |",
+            "2026-05-26T00:00:02Z",
+        ),
+    ]);
+    let tmp = TempDir::new().expect("tmp");
+    let rs_path = tmp.path().join("run-state.json");
+    write_run_state(&rs_path, "implementing", &["latest progress"]);
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "checkpoint",
+        "--profile",
+        "tracking",
+        "--run-state",
+        rs_path.to_str().expect("rs"),
+        "--post",
+        "state",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    assert_eq!(result["mode"], "dry-run");
+    let planned: Vec<&str> = result["roles_planned"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(planned.contains(&"state"), "planned={planned:?} full={result}");
+    let rendered = &result["rendered"];
+    assert!(rendered.is_array() && !rendered.as_array().unwrap().is_empty());
+    let body = rendered[0]["body"]
+        .as_str()
+        .expect("body")
+        .to_string();
+    assert!(body.starts_with("<!-- plan-issue-record:v2 role=state"));
+    assert!(body.contains("## Task Ledger"));
+}
+
+#[test]
+fn tracking_checkpoint_dry_run_skips_empty_session_and_validation_roles() {
+    let fixture = write_fixture(&[
+        (
+            "source",
+            json!({"path": "p", "commit": "c"}),
+            "## Source Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:00Z",
+        ),
+        (
+            "plan",
+            json!({"path": "p", "commit": "c"}),
+            "## Plan Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:01Z",
+        ),
+    ]);
+    let tmp = TempDir::new().expect("tmp");
+    let rs_path = tmp.path().join("run-state.json");
+    write_run_state(&rs_path, "implementing", &[]); // no notes, no validation
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "checkpoint",
+        "--run-state",
+        rs_path.to_str().expect("rs"),
+        "--post",
+        "session,validation",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    let planned: Vec<&str> = result["roles_planned"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(planned.is_empty(), "planned should be empty: {planned:?}");
+    let skipped: Vec<&str> = result["roles_skipped"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["role"].as_str().unwrap())
+        .collect();
+    assert!(skipped.contains(&"session"));
+    assert!(skipped.contains(&"validation"));
+}
+
+#[test]
+fn tracking_checkpoint_dry_run_writes_rendered_bodies_under_run_dir() {
+    let fixture = write_fixture(&[
+        (
+            "source",
+            json!({"path": "p", "commit": "c"}),
+            "## Source Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:00Z",
+        ),
+        (
+            "plan",
+            json!({"path": "p", "commit": "c"}),
+            "## Plan Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:01Z",
+        ),
+        (
+            "state",
+            json!({"status": "in-progress", "target_scope": "x", "tasks": [], "prs": []}),
+            "## Execution State\n\n- Profile: tracking\n- Status: in-progress\n\n## Task Ledger\n\n| ID | Status |\n| --- | --- |\n| 1.1 | done |",
+            "2026-05-26T00:00:02Z",
+        ),
+    ]);
+    let tmp = TempDir::new().expect("tmp");
+    let rs_path = tmp.path().join("run-state.json");
+    write_run_state(&rs_path, "implementing", &["latest"]);
+    let rendered_dir = tmp.path().join("rendered-out");
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "checkpoint",
+        "--run-state",
+        rs_path.to_str().expect("rs"),
+        "--post",
+        "state",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+        "--rendered-out",
+        rendered_dir.to_str().expect("rendered out"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    assert_eq!(result["mode"], "dry-run");
+    let written = rendered_dir.join("state-comment.md");
+    assert!(written.exists(), "rendered file not written: {}", written.display());
+}

--- a/crates/plan-issue-cli/tests/integration/tracking_checkpoint_refusals.rs
+++ b/crates/plan-issue-cli/tests/integration/tracking_checkpoint_refusals.rs
@@ -1,0 +1,208 @@
+//! `plan-issue tracking checkpoint` refusal coverage (Task 5.3).
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use plan_issue_cli::lifecycle_record::PAYLOAD_SCHEMA_V2;
+
+use crate::common;
+
+fn json_stdout(out: &common::CmdOut) -> Value {
+    serde_json::from_str(&out.stdout).expect("json stdout")
+}
+
+fn v2_comment(role: &str, profile: &str, data: Value, visible: &str) -> String {
+    let envelope = json!({
+        "schema": PAYLOAD_SCHEMA_V2,
+        "role": role,
+        "profile": profile,
+        "data": data,
+    });
+    let payload = serde_json::to_string(&envelope).expect("serialize");
+    format!(
+        "<!-- plan-issue-record:v2 role={role} profile={profile} -->\n\n{visible}\n\n```plan-issue-record-payload\n{payload}\n```\n",
+    )
+}
+
+fn write_fixture(roles: &[(&str, Value, &str, &str)]) -> TempDir {
+    let tmp = TempDir::new().expect("tmp");
+    fs::write(tmp.path().join("body.md"), "## Current Dashboard\n").expect("body");
+    let comments: Vec<Value> = roles
+        .iter()
+        .enumerate()
+        .map(|(idx, (role, data, visible, at))| {
+            json!({
+                "url": format!("https://example.com/c{idx}"),
+                "created_at": at,
+                "body": v2_comment(role, "tracking", data.clone(), visible),
+            })
+        })
+        .collect();
+    fs::write(
+        tmp.path().join("comments.json"),
+        json!({"comments": comments}).to_string(),
+    )
+    .expect("comments");
+    tmp
+}
+
+fn write_run_state(path: &std::path::Path, phase: &str) {
+    let body = json!({
+        "schema": "plan-issue.execution-run.v1",
+        "run_id": "run-1",
+        "repo": "owner/repo",
+        "issue": 123,
+        "profile": "tracking",
+        "phase": phase,
+        "created_at": "2026-05-26T00:00:00Z",
+        "updated_at": "2026-05-26T01:00:00Z"
+    });
+    fs::write(path, body.to_string()).expect("run-state");
+}
+
+#[test]
+fn tracking_checkpoint_refusals_reject_source_plan_closeout_post_kinds() {
+    let tmp = TempDir::new().expect("tmp");
+    let rs_path = tmp.path().join("run-state.json");
+    write_run_state(&rs_path, "implementing");
+
+    for kind in ["source", "plan", "closeout"] {
+        let out = common::run_plan_issue(&[
+            "--format",
+            "json",
+            "tracking",
+            "checkpoint",
+            "--run-state",
+            rs_path.to_str().expect("rs"),
+            "--post",
+            kind,
+        ]);
+        assert_ne!(out.code, 0, "post {kind} should fail");
+        let envelope = json_stdout(&out);
+        assert_eq!(
+            envelope["error"]["code"],
+            "tracking-checkpoint-role-not-allowed"
+        );
+    }
+}
+
+#[test]
+fn tracking_checkpoint_refusals_block_when_run_state_stale_vs_issue_closed() {
+    let fixture = write_fixture(&[(
+        "closeout",
+        json!({
+            "final_status": "complete",
+            "approval": {"approver": "x"},
+            "linked_prs": [],
+            "final_validation_url": null,
+        }),
+        "## Tracking Issue Closeout\n\n- Profile: tracking\n- Final status: complete\n- Approval: x",
+        "2026-05-26T00:00:00Z",
+    )]);
+    let tmp = TempDir::new().expect("tmp");
+    let rs_path = tmp.path().join("run-state.json");
+    write_run_state(&rs_path, "implementing");
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "checkpoint",
+        "--run-state",
+        rs_path.to_str().expect("rs"),
+        "--post",
+        "state",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    let codes: Vec<&str> = result["blocked"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|b| b["code"].as_str().unwrap())
+        .collect();
+    assert!(
+        codes.contains(&"run-state-stale"),
+        "blocked codes: {codes:?}"
+    );
+    assert!(result["roles_planned"].as_array().unwrap().is_empty() == false || result["blocked"].as_array().unwrap().is_empty() == false);
+}
+
+#[test]
+fn tracking_checkpoint_refusals_live_mode_blocks_until_task_6_1_lands() {
+    let fixture = write_fixture(&[
+        (
+            "source",
+            json!({"path": "p", "commit": "c"}),
+            "## Source Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:00Z",
+        ),
+        (
+            "plan",
+            json!({"path": "p", "commit": "c"}),
+            "## Plan Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:01Z",
+        ),
+        (
+            "state",
+            json!({"status": "in-progress", "target_scope": "x", "tasks": [], "prs": []}),
+            "## Execution State\n\n- Profile: tracking\n- Status: in-progress\n\n## Task Ledger\n\n| ID | Status |\n| --- | --- |\n| 1.1 | done |",
+            "2026-05-26T00:00:02Z",
+        ),
+    ]);
+    let tmp = TempDir::new().expect("tmp");
+    let rs_path = tmp.path().join("run-state.json");
+    write_run_state(&rs_path, "implementing");
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "checkpoint",
+        "--run-state",
+        rs_path.to_str().expect("rs"),
+        "--post",
+        "state",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+        "--live",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    let codes: Vec<&str> = result["blocked"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|b| b["code"].as_str().unwrap())
+        .collect();
+    assert!(
+        codes.contains(&"tracking-checkpoint-live-not-implemented"),
+        "blocked codes: {codes:?}"
+    );
+}
+
+#[test]
+fn tracking_checkpoint_refusals_block_unknown_role() {
+    let tmp = TempDir::new().expect("tmp");
+    let rs_path = tmp.path().join("run-state.json");
+    write_run_state(&rs_path, "implementing");
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "checkpoint",
+        "--run-state",
+        rs_path.to_str().expect("rs"),
+        "--post",
+        "bogus",
+    ]);
+    assert_ne!(out.code, 0);
+    let envelope = json_stdout(&out);
+    assert_eq!(envelope["error"]["code"], "tracking-checkpoint-unknown-role");
+}

--- a/crates/plan-issue-cli/tests/integration/tracking_close_ready.rs
+++ b/crates/plan-issue-cli/tests/integration/tracking_close_ready.rs
@@ -1,0 +1,231 @@
+//! `plan-issue tracking close-ready` integration coverage (Task 6.2).
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use plan_issue_cli::lifecycle_record::PAYLOAD_SCHEMA_V2;
+
+use crate::common;
+
+fn json_stdout(out: &common::CmdOut) -> Value {
+    serde_json::from_str(&out.stdout).expect("json stdout")
+}
+
+fn v2_comment(role: &str, profile: &str, data: Value, visible: &str) -> String {
+    let envelope = json!({
+        "schema": PAYLOAD_SCHEMA_V2,
+        "role": role,
+        "profile": profile,
+        "data": data,
+    });
+    let payload = serde_json::to_string(&envelope).expect("serialize");
+    format!(
+        "<!-- plan-issue-record:v2 role={role} profile={profile} -->\n\n{visible}\n\n```plan-issue-record-payload\n{payload}\n```\n",
+    )
+}
+
+fn write_fixture(roles: &[(&str, Value, &str, &str)]) -> TempDir {
+    let tmp = TempDir::new().expect("tmp");
+    fs::write(tmp.path().join("body.md"), "## Final Dashboard\n").expect("body");
+    let comments: Vec<Value> = roles
+        .iter()
+        .enumerate()
+        .map(|(idx, (role, data, visible, at))| {
+            json!({
+                "url": format!("https://example.com/c{idx}"),
+                "created_at": at,
+                "body": v2_comment(role, "tracking", data.clone(), visible),
+            })
+        })
+        .collect();
+    fs::write(
+        tmp.path().join("comments.json"),
+        json!({"comments": comments}).to_string(),
+    )
+    .expect("comments");
+    tmp
+}
+
+fn complete_fixture() -> TempDir {
+    write_fixture(&[
+        (
+            "source",
+            json!({"path": "p", "commit": "c"}),
+            "## Source Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:00Z",
+        ),
+        (
+            "plan",
+            json!({"path": "p", "commit": "c"}),
+            "## Plan Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:01Z",
+        ),
+        (
+            "state",
+            json!({
+                "status": "complete",
+                "target_scope": "x",
+                "tasks": [{"id": "1.1", "status": "done", "title": "x"}],
+                "prs": [{"ref": "owner/repo#1", "url": "https://example.com/pr/1", "status": "merged"}]
+            }),
+            "## Execution State\n\n- Profile: tracking\n- Status: complete\n\n## Task Ledger\n\n| ID | Status |\n| --- | --- |\n| 1.1 | done |",
+            "2026-05-26T00:00:02Z",
+        ),
+        (
+            "session",
+            json!({"summary": "completed"}),
+            "## Execution Session\n\n- Profile: tracking\n- Summary: completed",
+            "2026-05-26T00:00:03Z",
+        ),
+        (
+            "validation",
+            json!({"overall": "pass", "commands": [{"command": "cargo test", "status": "pass"}], "waivers": []}),
+            "## Validation Evidence\n\n- Profile: tracking\n- Overall: pass\n\n| Command | Status | Evidence |\n|---|---|---|\n| cargo test | pass | log |",
+            "2026-05-26T00:00:04Z",
+        ),
+        (
+            "review",
+            json!({"decision": "approve", "findings": [], "lenses": ["testing"]}),
+            "## Review Evidence\n\n- Profile: tracking\n- Decision: approve",
+            "2026-05-26T00:00:05Z",
+        ),
+    ])
+}
+
+#[test]
+fn tracking_close_ready_reports_ready_for_complete_fixture() {
+    let fixture = complete_fixture();
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "close-ready",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+        "--approval",
+        "https://example.com/approval",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    assert_eq!(result["fsm_state"], "RECORD_READY_FOR_CLOSE");
+    let blockers: Vec<&str> = result["blockers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|b| b["code"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        result["ready"], true,
+        "expected ready=true; blockers={blockers:?} result={result}"
+    );
+}
+
+#[test]
+fn tracking_close_ready_blocks_when_missing_validation() {
+    let fixture = write_fixture(&[
+        (
+            "source",
+            json!({"path": "p", "commit": "c"}),
+            "## Source Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:00Z",
+        ),
+        (
+            "plan",
+            json!({"path": "p", "commit": "c"}),
+            "## Plan Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:01Z",
+        ),
+        (
+            "state",
+            json!({"status": "complete", "target_scope": "x", "tasks": [], "prs": []}),
+            "## Execution State\n\n- Profile: tracking\n- Status: complete\n\n## Task Ledger\n\n| ID | Status |\n| --- | --- |\n| 1.1 | done |",
+            "2026-05-26T00:00:02Z",
+        ),
+        (
+            "session",
+            json!({"summary": "done"}),
+            "## Execution Session\n\n- Profile: tracking\n- Summary: done",
+            "2026-05-26T00:00:03Z",
+        ),
+    ]);
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "close-ready",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+        "--approval",
+        "approver",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    assert_eq!(result["ready"], false);
+    let codes: Vec<&str> = result["blockers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|b| b["code"].as_str().unwrap())
+        .collect();
+    assert!(codes.iter().any(|c| *c == "validation-missing"));
+}
+
+#[test]
+fn tracking_close_ready_collects_linked_prs_from_state_and_flag() {
+    let fixture = complete_fixture();
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "close-ready",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+        "--approval",
+        "approver",
+        "--linked-pr",
+        "owner/repo#999",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    let linked: Vec<&str> = result["linked_prs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(linked.contains(&"owner/repo#1"));
+    assert!(linked.contains(&"owner/repo#999"));
+}
+
+#[test]
+fn tracking_close_ready_is_non_mutating() {
+    // The command must not post comments or repair dashboards; the JSON
+    // envelope therefore never names a `posted` field.
+    let fixture = complete_fixture();
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "close-ready",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+        "--approval",
+        "approver",
+    ]);
+    assert_eq!(out.code, 0);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    assert!(result.get("posted").is_none());
+    assert!(result.get("dashboard_repaired").is_none());
+}
+
+#[test]
+fn tracking_close_ready_help_lists_required_args() {
+    let out = common::run_plan_issue(&["tracking", "close-ready", "--help"]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    assert!(out.stdout.contains("--linked-pr"));
+    assert!(out.stdout.contains("--approval"));
+    assert!(out.stdout.contains("--expect-visible"));
+}

--- a/crates/plan-issue-cli/tests/integration/tracking_events.rs
+++ b/crates/plan-issue-cli/tests/integration/tracking_events.rs
@@ -1,0 +1,105 @@
+//! Append-only event journal integration coverage (Task 4.1).
+//!
+//! Source: `docs/source/plan-issue-redesign/plan-tracking-issue-run-state-controller-v1.md`.
+
+use std::io::Write;
+
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use tempfile::TempDir;
+
+use plan_issue_cli::tracking::events::{
+    self, EVENT_SCHEMA, ExecutionEvent, ExecutionEventKind,
+};
+
+#[test]
+fn tracking_events_schema_identifier_is_stable() {
+    assert_eq!(EVENT_SCHEMA, "plan-issue.execution-event.v1");
+}
+
+#[test]
+fn tracking_events_appends_run_start_through_checkpoint_in_order() {
+    let tmp = TempDir::new().expect("tmp");
+    let path = tmp.path().join("nested/events.jsonl");
+    let sequence: Vec<ExecutionEvent> = vec![
+        ExecutionEvent::new("run-1", ExecutionEventKind::RunStarted, "t1"),
+        ExecutionEvent::new("run-1", ExecutionEventKind::TaskSelected, "t2")
+            .with_task("1.2"),
+        ExecutionEvent::new("run-1", ExecutionEventKind::ValidationRecorded, "t3")
+            .with_detail(json!({"status": "pass"})),
+        ExecutionEvent::new("run-1", ExecutionEventKind::Reconciled, "t4")
+            .with_detail(json!({"fsm_state": "RECORD_OPEN_ACTIVE"})),
+        ExecutionEvent::new("run-1", ExecutionEventKind::CheckpointPosted, "t5")
+            .with_detail(json!({"roles": ["state", "validation"]})),
+        ExecutionEvent::new("run-1", ExecutionEventKind::CheckpointFailed, "t6")
+            .with_detail(json!({"code": "transition-not-allowed"})),
+    ];
+    for event in &sequence {
+        events::append_event(&path, event).expect("append");
+    }
+    let read = events::read_events(&path).expect("read");
+    let kinds: Vec<_> = read.iter().map(|e| e.kind.clone()).collect();
+    assert_eq!(
+        kinds,
+        vec![
+            ExecutionEventKind::RunStarted,
+            ExecutionEventKind::TaskSelected,
+            ExecutionEventKind::ValidationRecorded,
+            ExecutionEventKind::Reconciled,
+            ExecutionEventKind::CheckpointPosted,
+            ExecutionEventKind::CheckpointFailed,
+        ]
+    );
+    assert_eq!(read[1].task.as_deref(), Some("1.2"));
+    assert_eq!(read[4].detail["roles"][0], "state");
+    assert_eq!(read[5].detail["code"], "transition-not-allowed");
+}
+
+#[test]
+fn tracking_events_jsonl_does_not_rewrite_prior_lines() {
+    let tmp = TempDir::new().expect("tmp");
+    let path = tmp.path().join("events.jsonl");
+    events::append_event(
+        &path,
+        &ExecutionEvent::new("run-1", ExecutionEventKind::RunStarted, "t1"),
+    )
+    .expect("append 1");
+
+    // Capture the raw file contents and confirm appending another event
+    // simply adds bytes at the tail.
+    let raw_before = std::fs::read_to_string(&path).expect("read");
+    events::append_event(
+        &path,
+        &ExecutionEvent::new("run-1", ExecutionEventKind::RunCompleted, "t2"),
+    )
+    .expect("append 2");
+    let raw_after = std::fs::read_to_string(&path).expect("read");
+    assert!(
+        raw_after.starts_with(&raw_before),
+        "second append rewrote prior lines: before={raw_before:?} after={raw_after:?}"
+    );
+}
+
+#[test]
+fn tracking_events_large_detail_can_be_stored_as_path_pointer() {
+    // The journal must store path/preview pointers, not inline blobs. This
+    // test demonstrates the supported pattern: callers store paths (or
+    // redacted previews) in `detail`, then read the artifact lazily.
+    let tmp = TempDir::new().expect("tmp");
+    let log = tmp.path().join("artifacts/validation/log.txt");
+    std::fs::create_dir_all(log.parent().unwrap()).expect("mkdir");
+    let mut f = std::fs::File::create(&log).expect("create");
+    f.write_all(b"large evidence body").expect("write");
+    let path = tmp.path().join("events.jsonl");
+    let event = ExecutionEvent::new("run-1", ExecutionEventKind::ValidationRecorded, "t1")
+        .with_detail(json!({
+            "evidence_path": log.to_string_lossy(),
+            "preview": "large evidence...",
+        }));
+    events::append_event(&path, &event).expect("append");
+    let read = events::read_events(&path).expect("read");
+    assert!(read[0].detail["evidence_path"]
+        .as_str()
+        .unwrap_or_default()
+        .ends_with("artifacts/validation/log.txt"));
+}

--- a/crates/plan-issue-cli/tests/integration/tracking_fsm.rs
+++ b/crates/plan-issue-cli/tests/integration/tracking_fsm.rs
@@ -1,0 +1,153 @@
+//! FSM evaluation integration coverage (Task 4.2).
+
+use std::collections::BTreeMap;
+
+use pretty_assertions::assert_eq;
+
+use plan_issue_cli::lifecycle_record::{
+    BodySections, LifecycleEvidence, PayloadProfile, PayloadRole, RecordAudit,
+};
+use plan_issue_cli::tracking::fsm::{
+    self, RecommendedAction, RecordState,
+};
+
+fn evidence_for(role: PayloadRole, status: Option<&str>) -> LifecycleEvidence {
+    LifecycleEvidence {
+        role,
+        profile: PayloadProfile::Tracking,
+        url: Some("https://example.com".to_string()),
+        created_at: Some("2026-05-26T00:00:00Z".to_string()),
+        status: status.map(|s| s.to_string()),
+        payload: None,
+    }
+}
+
+fn audit_with(roles: &[(PayloadRole, Option<&str>)]) -> RecordAudit {
+    let mut evidence: BTreeMap<String, LifecycleEvidence> = BTreeMap::new();
+    for (role, status) in roles {
+        evidence.insert(role.as_str().to_string(), evidence_for(*role, *status));
+    }
+    RecordAudit {
+        profile_filter: Some("tracking".to_string()),
+        body_sections: BodySections {
+            current_dashboard: false,
+            final_dashboard: false,
+            durable_record: false,
+            closeout_checks: false,
+            task_decomposition: false,
+        },
+        evidence,
+        missing_required: Vec::new(),
+        unsupported_markers: Vec::new(),
+        recognized_count: roles.len(),
+        evidence_text: String::new(),
+    }
+}
+
+#[test]
+fn tracking_fsm_handles_full_lifecycle_progression() {
+    // RECORD_UNOPENED → open
+    let unopened = fsm::evaluate_audit(None);
+    assert_eq!(unopened.state, RecordState::RecordUnopened);
+    assert_eq!(unopened.recommended, RecommendedAction::OpenRecord);
+
+    // RECORD_OPEN_INITIAL → checkpoint
+    let initial = fsm::evaluate_audit(Some(&audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+        (PayloadRole::State, Some("in-progress")),
+    ])));
+    assert_eq!(initial.state, RecordState::RecordOpenInitial);
+
+    // RECORD_OPEN_ACTIVE → record_validation
+    let active = fsm::evaluate_audit(Some(&audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+        (PayloadRole::State, Some("in-progress")),
+        (PayloadRole::Session, None),
+    ])));
+    assert_eq!(active.state, RecordState::RecordOpenActive);
+    assert_eq!(active.recommended, RecommendedAction::RecordValidation);
+
+    // RECORD_VALIDATING → record_review
+    let validating = fsm::evaluate_audit(Some(&audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+        (PayloadRole::State, Some("in-progress")),
+        (PayloadRole::Session, None),
+        (PayloadRole::Validation, Some("pass")),
+    ])));
+    assert_eq!(validating.state, RecordState::RecordValidating);
+    assert_eq!(validating.recommended, RecommendedAction::RecordReview);
+
+    // RECORD_REVIEWED (state still in-progress) → checkpoint_progress
+    let reviewed = fsm::evaluate_audit(Some(&audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+        (PayloadRole::State, Some("in-progress")),
+        (PayloadRole::Session, None),
+        (PayloadRole::Validation, Some("pass")),
+        (PayloadRole::Review, Some("approve")),
+    ])));
+    assert_eq!(reviewed.state, RecordState::RecordReviewed);
+
+    // RECORD_READY_FOR_CLOSE → run_close_ready
+    let ready = fsm::evaluate_audit(Some(&audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+        (PayloadRole::State, Some("complete")),
+        (PayloadRole::Session, None),
+        (PayloadRole::Validation, Some("pass")),
+        (PayloadRole::Review, Some("approve")),
+    ])));
+    assert_eq!(ready.state, RecordState::RecordReadyForClose);
+    assert_eq!(ready.recommended, RecommendedAction::RunCloseReady);
+
+    // RECORD_CLOSED → no_op
+    let closed = fsm::evaluate_audit(Some(&audit_with(&[(
+        PayloadRole::Closeout,
+        Some("complete"),
+    )])));
+    assert_eq!(closed.state, RecordState::RecordClosed);
+    assert_eq!(closed.recommended, RecommendedAction::NoOp);
+}
+
+#[test]
+fn tracking_fsm_blocked_state_maps_to_state_payload_status() {
+    let audit = audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+        (PayloadRole::State, Some("blocked")),
+    ]);
+    let result = fsm::evaluate_audit(Some(&audit));
+    assert_eq!(result.state, RecordState::RecordBlocked);
+    assert_eq!(result.recommended, RecommendedAction::ResolveBlocker);
+    assert!(result.blocked_reason.is_some());
+}
+
+#[test]
+fn tracking_fsm_missing_roles_produce_precise_next_actions() {
+    // Only source/plan → recommend attach_initial_state
+    let no_state = fsm::evaluate_audit(Some(&audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+    ])));
+    assert_eq!(no_state.recommended, RecommendedAction::AttachInitialState);
+    assert!(no_state.missing_for_closeout.iter().any(|s| s == "state"));
+
+    // No issue → recommend open_record
+    let unopened = fsm::evaluate_audit(None);
+    assert_eq!(unopened.recommended, RecommendedAction::OpenRecord);
+}
+
+#[test]
+fn tracking_fsm_safe_transitions_are_stable_per_state() {
+    let active = fsm::evaluate_audit(Some(&audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+        (PayloadRole::State, Some("in-progress")),
+        (PayloadRole::Session, None),
+    ])));
+    assert!(active.safe_transitions.iter().any(|s| s == "record_validation"));
+    assert!(active.safe_transitions.iter().any(|s| s == "checkpoint_progress"));
+}

--- a/crates/plan-issue-cli/tests/integration/tracking_reconcile.rs
+++ b/crates/plan-issue-cli/tests/integration/tracking_reconcile.rs
@@ -1,0 +1,127 @@
+//! Reconciliation integration coverage (Task 4.2).
+
+use std::collections::BTreeMap;
+
+use pretty_assertions::assert_eq;
+
+use plan_issue_cli::lifecycle_record::{
+    BodySections, LifecycleEvidence, PayloadProfile, PayloadRole, RecordAudit,
+};
+use plan_issue_cli::tracking::fsm::{RecommendedAction, RecordState};
+use plan_issue_cli::tracking::reconcile::{self, ReconciliationWarningKind};
+use plan_issue_cli::tracking::run_state::{ExecutionRun, RunPhase, ValidationSummary};
+
+fn evidence_for(role: PayloadRole, status: Option<&str>) -> LifecycleEvidence {
+    LifecycleEvidence {
+        role,
+        profile: PayloadProfile::Tracking,
+        url: Some("https://example.com".to_string()),
+        created_at: Some("2026-05-26T00:00:00Z".to_string()),
+        status: status.map(|s| s.to_string()),
+        payload: None,
+    }
+}
+
+fn audit_with(roles: &[(PayloadRole, Option<&str>)]) -> RecordAudit {
+    let mut evidence: BTreeMap<String, LifecycleEvidence> = BTreeMap::new();
+    for (role, status) in roles {
+        evidence.insert(role.as_str().to_string(), evidence_for(*role, *status));
+    }
+    RecordAudit {
+        profile_filter: Some("tracking".to_string()),
+        body_sections: BodySections {
+            current_dashboard: false,
+            final_dashboard: false,
+            durable_record: false,
+            closeout_checks: false,
+            task_decomposition: false,
+        },
+        evidence,
+        missing_required: Vec::new(),
+        unsupported_markers: Vec::new(),
+        recognized_count: roles.len(),
+        evidence_text: String::new(),
+    }
+}
+
+fn fixture_run(phase: RunPhase) -> ExecutionRun {
+    ExecutionRun::new(
+        "run-1",
+        "owner/repo",
+        123,
+        "tracking",
+        phase,
+        "2026-05-26T00:00:00Z",
+    )
+}
+
+#[test]
+fn tracking_reconcile_provider_evidence_wins_when_issue_closed() {
+    let audit = audit_with(&[(PayloadRole::Closeout, Some("complete"))]);
+    // Local run state still thinks we are implementing.
+    let run = fixture_run(RunPhase::Implementing);
+    let report = reconcile::reconcile(Some(&audit), Some(&run));
+    assert_eq!(report.state, RecordState::RecordClosed);
+    assert!(report.is_stale(), "expected stale warning: {report:?}");
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|w| w.kind == ReconciliationWarningKind::LocalRunStateStale),
+        "warnings: {:?}",
+        report.warnings
+    );
+}
+
+#[test]
+fn tracking_reconcile_emits_run_state_ahead_for_unposted_validation() {
+    let audit = audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+        (PayloadRole::State, Some("in-progress")),
+    ]);
+    let mut run = fixture_run(RunPhase::Validating);
+    run.validation = Some(ValidationSummary {
+        overall: "pass".to_string(),
+        commands: Vec::new(),
+        waiver: None,
+        evidence_path: None,
+    });
+    let report = reconcile::reconcile(Some(&audit), Some(&run));
+    assert!(report
+        .warnings
+        .iter()
+        .any(|w| w.code == "run-state-validation-not-posted"));
+}
+
+#[test]
+fn tracking_reconcile_missing_role_warnings_are_role_specific() {
+    let audit = audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+        (PayloadRole::State, Some("in-progress")),
+    ]);
+    let report = reconcile::reconcile(Some(&audit), None);
+    let missing_codes: Vec<String> = report
+        .warnings
+        .iter()
+        .filter(|w| matches!(w.kind, ReconciliationWarningKind::LifecycleRoleMissing))
+        .map(|w| w.code.clone())
+        .collect();
+    assert!(missing_codes.iter().any(|c| c == "session-missing"));
+    assert!(missing_codes.iter().any(|c| c == "validation-missing"));
+    assert!(missing_codes.iter().any(|c| c == "review-missing"));
+}
+
+#[test]
+fn tracking_reconcile_safe_transitions_match_fsm() {
+    let audit = audit_with(&[
+        (PayloadRole::Source, None),
+        (PayloadRole::Plan, None),
+        (PayloadRole::State, Some("in-progress")),
+        (PayloadRole::Session, None),
+    ]);
+    let report = reconcile::reconcile(Some(&audit), None);
+    assert!(report.safe_transitions.iter().any(|s| s == "record_validation"));
+    assert_eq!(report.recommended_action, RecommendedAction::RecordValidation);
+}

--- a/crates/plan-issue-cli/tests/integration/tracking_run_state.rs
+++ b/crates/plan-issue-cli/tests/integration/tracking_run_state.rs
@@ -1,0 +1,105 @@
+//! Run-state schema integration coverage (Task 4.1).
+//!
+//! Source: `docs/source/plan-issue-redesign/plan-tracking-issue-run-state-controller-v1.md`.
+
+use std::path::PathBuf;
+
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+use plan_issue_cli::tracking::run_state::{
+    self, ExecutionRun, LinkedPr, RUN_STATE_SCHEMA, RunPhase, RunStateError, ValidationCommandRow,
+    ValidationSummary,
+};
+
+fn fixture_run() -> ExecutionRun {
+    let mut run = ExecutionRun::new(
+        "20260526-150405-issue-123",
+        "owner/repo",
+        123,
+        "tracking",
+        RunPhase::Implementing,
+        "2026-05-26T15:04:05Z",
+    );
+    run.bundle = Some(PathBuf::from("docs/plans/example"));
+    run.execution_state_file = Some(PathBuf::from(
+        "docs/plans/example/example-execution-state.md",
+    ));
+    run.branch = Some("feat/example".to_string());
+    run.pr = Some(LinkedPr {
+        r#ref: "owner/repo#456".to_string(),
+        url: Some("https://example.com/pr/456".to_string()),
+        status: Some("open".to_string()),
+    });
+    run.validation = Some(ValidationSummary {
+        overall: "pass".to_string(),
+        commands: vec![ValidationCommandRow {
+            command: "cargo test".to_string(),
+            status: "pass".to_string(),
+            evidence: Some("log.txt".to_string()),
+        }],
+        waiver: None,
+        evidence_path: None,
+    });
+    run
+}
+
+#[test]
+fn tracking_run_state_round_trips_disk_io() {
+    let tmp = TempDir::new().expect("tmp");
+    let path = tmp.path().join("run-state.json");
+    let run = fixture_run();
+    run_state::write_run_state(&path, &run).expect("write");
+    let loaded = run_state::read_run_state(&path).expect("read");
+    assert_eq!(loaded.run_id, run.run_id);
+    assert_eq!(loaded.repo, run.repo);
+    assert_eq!(loaded.issue, run.issue);
+    assert_eq!(loaded.phase, run.phase);
+    assert_eq!(loaded.bundle, run.bundle);
+    assert_eq!(loaded.execution_state_file, run.execution_state_file);
+    assert_eq!(loaded.branch, run.branch);
+    assert_eq!(loaded.pr.as_ref().map(|p| p.r#ref.clone()), Some("owner/repo#456".to_string()));
+    assert_eq!(
+        loaded.validation.as_ref().map(|v| v.overall.clone()),
+        Some("pass".to_string())
+    );
+}
+
+#[test]
+fn tracking_run_state_runroot_uses_existing_layout_contract() {
+    let runroot = run_state::RunRoot::new("owner__repo", 123, "20260526-run-1").expect("runroot");
+    let suffix = "owner__repo/issue-123/runs/20260526-run-1";
+    assert!(
+        runroot.root().to_string_lossy().ends_with(suffix),
+        "runroot drift: {}",
+        runroot.root().display()
+    );
+    assert!(runroot.run_state_path().ends_with("run-state.json"));
+    assert!(runroot.events_path().ends_with("events.jsonl"));
+}
+
+#[test]
+fn tracking_run_state_rejects_wrong_schema_id() {
+    let body = serde_json::json!({
+        "schema": "plan-issue.unknown.v1",
+        "run_id": "x",
+        "repo": "o/r",
+        "issue": 1,
+        "profile": "tracking",
+        "phase": "initial",
+        "created_at": "x",
+        "updated_at": "x"
+    })
+    .to_string();
+    match run_state::parse_run_state(&body) {
+        Err(RunStateError::SchemaMismatch { actual }) => {
+            assert_eq!(actual, "plan-issue.unknown.v1");
+        }
+        other => panic!("expected SchemaMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn tracking_run_state_schema_identifier_is_stable() {
+    assert_eq!(RUN_STATE_SCHEMA, "plan-issue.execution-run.v1");
+}

--- a/crates/plan-issue-cli/tests/integration/tracking_run_update.rs
+++ b/crates/plan-issue-cli/tests/integration/tracking_run_update.rs
@@ -1,0 +1,164 @@
+//! `plan-issue tracking run init` + `tracking run update` integration
+//! coverage (Task 5.1).
+//!
+//! Source: `docs/source/plan-issue-redesign/plan-tracking-issue-run-state-controller-v1.md`.
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use plan_issue_cli::tracking::run_state::{self, RUN_STATE_SCHEMA};
+
+use crate::common;
+
+fn json_stdout(out: &common::CmdOut) -> Value {
+    serde_json::from_str(&out.stdout).expect("json stdout")
+}
+
+#[test]
+fn tracking_run_update_init_writes_run_state_and_events() {
+    let tmp = TempDir::new().expect("tmp");
+    let run_state_path = tmp.path().join("run-state.json");
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "run",
+        "init",
+        "--provider-repo",
+        "owner/repo",
+        "--issue",
+        "123",
+        "--task",
+        "1.2",
+        "--branch",
+        "feat/x",
+        "--now",
+        "2026-05-26T00:00:00Z",
+        "--run-id",
+        "run-test",
+        "--out",
+        run_state_path.to_str().expect("path"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let envelope = json_stdout(&out);
+    assert_eq!(envelope["command"], "tracking.run.init");
+    let result = &envelope["payload"]["result"];
+    assert_eq!(result["run_id"], "run-test");
+    assert!(run_state_path.exists());
+    let events_path = run_state_path
+        .parent()
+        .map(|p| p.join("events.jsonl"))
+        .expect("events");
+    assert!(events_path.exists(), "events.jsonl should exist");
+
+    // Verify schema id stayed stable.
+    let raw = fs::read_to_string(&run_state_path).expect("read");
+    assert!(raw.contains(RUN_STATE_SCHEMA));
+}
+
+#[test]
+fn tracking_run_update_changes_phase_and_appends_event() {
+    let tmp = TempDir::new().expect("tmp");
+    let run_state_path = tmp.path().join("run-state.json");
+
+    // Initialize.
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "run",
+        "init",
+        "--provider-repo",
+        "owner/repo",
+        "--issue",
+        "123",
+        "--now",
+        "2026-05-26T00:00:00Z",
+        "--run-id",
+        "run-update",
+        "--out",
+        run_state_path.to_str().expect("path"),
+    ]);
+    assert_eq!(out.code, 0, "init stderr: {}", out.stderr);
+
+    // Update phase + validation.
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "run",
+        "update",
+        "--run-state",
+        run_state_path.to_str().expect("path"),
+        "--phase",
+        "validating",
+        "--validation-overall",
+        "pass",
+        "--validation-command",
+        "cargo test",
+        "--validation-status",
+        "pass",
+        "--note",
+        "validated locally",
+        "--now",
+        "2026-05-26T00:01:00Z",
+    ]);
+    assert_eq!(out.code, 0, "update stderr: {}", out.stderr);
+    let envelope = json_stdout(&out);
+    let result = &envelope["payload"]["result"];
+    assert_eq!(result["phase"], "validating");
+    let changed: Vec<&str> = result["changed"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(changed.contains(&"phase"));
+    assert!(changed.contains(&"validation"));
+    assert!(changed.contains(&"note"));
+
+    let run = run_state::read_run_state(&run_state_path).expect("read");
+    assert_eq!(run.phase.as_str(), "validating");
+    assert_eq!(
+        run.validation.as_ref().map(|v| v.overall.clone()),
+        Some("pass".to_string())
+    );
+    assert!(!run.notes.is_empty());
+    let events = std::fs::read_to_string(run_state_path.parent().unwrap().join("events.jsonl"))
+        .expect("events");
+    assert!(events.contains("run_updated"));
+}
+
+#[test]
+fn tracking_run_update_rejects_invalid_run_state() {
+    let tmp = TempDir::new().expect("tmp");
+    let run_state_path = tmp.path().join("run-state.json");
+    fs::write(&run_state_path, "not json").expect("write");
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "run",
+        "update",
+        "--run-state",
+        run_state_path.to_str().expect("path"),
+        "--phase",
+        "validating",
+    ]);
+    assert_ne!(out.code, 0, "should fail");
+    let envelope = json_stdout(&out);
+    assert_eq!(envelope["error"]["code"], "tracking-run-update-read-failed");
+}
+
+#[test]
+fn tracking_run_update_help_lists_run_init_and_update() {
+    let out = common::run_plan_issue(&["tracking", "run", "--help"]);
+    assert_eq!(out.code, 0);
+    assert!(out.stdout.contains("init"));
+    assert!(out.stdout.contains("update"));
+}

--- a/crates/plan-issue-cli/tests/integration/tracking_status.rs
+++ b/crates/plan-issue-cli/tests/integration/tracking_status.rs
@@ -1,0 +1,295 @@
+//! `plan-issue tracking status` integration coverage (Task 4.3).
+//!
+//! Source: `docs/source/plan-issue-redesign/plan-tracking-issue-run-state-controller-v1.md`.
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use plan_issue_cli::lifecycle_record::PAYLOAD_SCHEMA_V2;
+
+use crate::common;
+
+fn v2_comment(role: &str, profile: &str, data: Value, visible: &str) -> String {
+    let envelope = json!({
+        "schema": PAYLOAD_SCHEMA_V2,
+        "role": role,
+        "profile": profile,
+        "data": data,
+    });
+    let payload = serde_json::to_string(&envelope).expect("serialize");
+    format!(
+        "<!-- plan-issue-record:v2 role={role} profile={profile} -->\n\n{visible}\n\n```plan-issue-record-payload\n{payload}\n```\n",
+    )
+}
+
+fn write_fixture(
+    roles: &[(&str, Value, &str, &str)], // role, payload, visible body, created_at
+) -> TempDir {
+    let tmp = TempDir::new().expect("tmp");
+    fs::write(tmp.path().join("body.md"), "## Current Dashboard\n").expect("body");
+    let comments: Vec<Value> = roles
+        .iter()
+        .enumerate()
+        .map(|(idx, (role, data, visible, at))| {
+            json!({
+                "url": format!("https://example.com/c{idx}"),
+                "created_at": at,
+                "body": v2_comment(role, "tracking", data.clone(), visible),
+            })
+        })
+        .collect();
+    fs::write(
+        tmp.path().join("comments.json"),
+        json!({"comments": comments}).to_string(),
+    )
+    .expect("comments");
+    tmp
+}
+
+fn json_stdout(out: &common::CmdOut) -> Value {
+    serde_json::from_str(&out.stdout).expect("json stdout")
+}
+
+#[test]
+fn tracking_status_emits_stable_envelope_for_fixture_input() {
+    let fixture = write_fixture(&[
+        (
+            "source",
+            json!({"path": "p", "commit": "c"}),
+            "## Source Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:00Z",
+        ),
+        (
+            "plan",
+            json!({"path": "p", "commit": "c"}),
+            "## Plan Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:01Z",
+        ),
+        (
+            "state",
+            json!({"status": "in-progress", "target_scope": "x", "tasks": [], "prs": []}),
+            "## Execution State\n\n- Profile: tracking\n- Status: in-progress\n\n## Task Ledger\n\n| ID | Status |\n| --- | --- |\n| 1.1 | done |",
+            "2026-05-26T00:00:02Z",
+        ),
+    ]);
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "status",
+        "--profile",
+        "tracking",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let envelope = json_stdout(&out);
+    assert_eq!(envelope["schema_version"], "plan-issue-cli.tracking.status.v1");
+    assert_eq!(envelope["command"], "tracking.status");
+    assert_eq!(envelope["status"], "ok");
+    let result = &envelope["payload"]["result"];
+    assert_eq!(result["operation"], "tracking.status");
+    assert_eq!(result["fsm_state"], "RECORD_OPEN_INITIAL");
+    let truth = &result["issue_truth"];
+    assert_eq!(truth["available"], true);
+    let roles: Vec<&str> = truth["latest_roles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(roles.contains(&"source"));
+    assert!(roles.contains(&"plan"));
+    assert!(roles.contains(&"state"));
+}
+
+#[test]
+fn tracking_status_blocked_state_recommends_resolve_blocker() {
+    let fixture = write_fixture(&[
+        (
+            "source",
+            json!({"path": "p", "commit": "c"}),
+            "## Source Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:00Z",
+        ),
+        (
+            "plan",
+            json!({"path": "p", "commit": "c"}),
+            "## Plan Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:01Z",
+        ),
+        (
+            "state",
+            json!({"status": "blocked", "target_scope": "x", "tasks": [], "prs": [], "blockers": ["waiting on review"]}),
+            "## Execution State\n\n- Profile: tracking\n- Status: blocked\n\n## Task Ledger\n\n| ID | Status |\n| --- | --- |\n| 1.1 | pending |",
+            "2026-05-26T00:00:02Z",
+        ),
+    ]);
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "status",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    assert_eq!(result["fsm_state"], "RECORD_BLOCKED");
+    assert_eq!(result["recommended_action"], "resolve_blocker");
+    assert!(result["blocked_reason"].is_string());
+}
+
+#[test]
+fn tracking_status_reports_stale_run_state_when_issue_closed() {
+    let fixture = write_fixture(&[
+        (
+            "closeout",
+            json!({
+                "final_status": "complete",
+                "approval": {"approver": "x"},
+                "linked_prs": [],
+                "final_validation_url": null,
+            }),
+            "## Tracking Issue Closeout\n\n- Profile: tracking\n- Final status: complete\n- Approval: x",
+            "2026-05-26T00:00:00Z",
+        ),
+    ]);
+    let tmp = TempDir::new().expect("tmp");
+    let run_state_path = tmp.path().join("run-state.json");
+    fs::write(
+        &run_state_path,
+        json!({
+            "schema": "plan-issue.execution-run.v1",
+            "run_id": "run-1",
+            "repo": "owner/repo",
+            "issue": 123,
+            "profile": "tracking",
+            "phase": "implementing",
+            "created_at": "2026-05-26T00:00:00Z",
+            "updated_at": "2026-05-26T00:00:00Z"
+        })
+        .to_string(),
+    )
+    .expect("run-state");
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "status",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+        "--run-state",
+        run_state_path.to_str().expect("run-state"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    assert_eq!(result["fsm_state"], "RECORD_CLOSED");
+    let warnings: Vec<&str> = result["warnings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|w| w["code"].as_str().unwrap())
+        .collect();
+    assert!(
+        warnings.iter().any(|c| *c == "run-state-stale"),
+        "warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn tracking_status_ready_for_close_emits_run_close_ready() {
+    let fixture = write_fixture(&[
+        (
+            "source",
+            json!({"path": "p", "commit": "c"}),
+            "## Source Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:00Z",
+        ),
+        (
+            "plan",
+            json!({"path": "p", "commit": "c"}),
+            "## Plan Snapshot\n\n- Profile: tracking\n- Path: `p`",
+            "2026-05-26T00:00:01Z",
+        ),
+        (
+            "state",
+            json!({"status": "complete", "target_scope": "x", "tasks": [], "prs": [{"ref": "o/r#1", "url": "u", "status": "merged"}]}),
+            "## Execution State\n\n- Profile: tracking\n- Status: complete\n\n## Task Ledger\n\n| ID | Status |\n| --- | --- |\n| 1.1 | done |",
+            "2026-05-26T00:00:02Z",
+        ),
+        (
+            "session",
+            json!({"summary": "done"}),
+            "## Execution Session\n\n- Profile: tracking\n- Summary: done",
+            "2026-05-26T00:00:03Z",
+        ),
+        (
+            "validation",
+            json!({"overall": "pass", "commands": [{"command": "cargo test", "status": "pass"}], "waivers": []}),
+            "## Validation Evidence\n\n- Profile: tracking\n- Overall: pass\n\n| Command | Status | Evidence |\n|---|---|---|\n| cargo test | pass | log |",
+            "2026-05-26T00:00:04Z",
+        ),
+        (
+            "review",
+            json!({"decision": "approve", "findings": [], "lenses": ["testing"]}),
+            "## Review Evidence\n\n- Profile: tracking\n- Decision: approve",
+            "2026-05-26T00:00:05Z",
+        ),
+    ]);
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "status",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    assert_eq!(result["fsm_state"], "RECORD_READY_FOR_CLOSE");
+    assert_eq!(result["recommended_action"], "run_close_ready");
+    assert!(result["missing_for_closeout"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn tracking_status_expect_visible_flows_through_to_visible_lint() {
+    let fixture = write_fixture(&[(
+        "state",
+        json!({"status": "in-progress", "target_scope": "x", "tasks": [], "prs": []}),
+        "## Execution State\n\n- Profile: tracking\n- Status: in-progress\n",
+        "2026-05-26T00:00:00Z",
+    )]);
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "status",
+        "--fixture",
+        fixture.path().to_str().expect("fixture"),
+        "--expect-visible",
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    let result = json_stdout(&out)["payload"]["result"].clone();
+    assert!(result["visible"].is_object(), "visible missing: {result}");
+    assert_eq!(result["visible"]["overall_pass"], false);
+    let codes: Vec<&str> = result["visible"]["codes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(codes.contains(&"state-missing-task-ledger"), "codes={codes:?}");
+}
+
+#[test]
+fn tracking_status_help_lists_status_subcommand() {
+    let out = common::run_plan_issue(&["tracking", "--help"]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+    assert!(out.stdout.contains("status"), "missing status: {}", out.stdout);
+}

--- a/crates/plan-issue-cli/tests/integration/visible_lint.rs
+++ b/crates/plan-issue-cli/tests/integration/visible_lint.rs
@@ -1,0 +1,344 @@
+//! Visible-completeness lint coverage (Task 2.2).
+//!
+//! For every lifecycle role, exercise one passing fixture and one or more
+//! failing fixtures so failure codes stay stable and Hidden-payload success
+//! alone cannot satisfy visible completeness.
+//!
+//! Source: `docs/source/plan-issue-redesign/plan-tracking-issue-comment-taxonomy-v1.md`.
+
+use plan_issue_cli::lifecycle_record::PayloadRole;
+use plan_issue_cli::lifecycle_vnext::visible_lint::{LintHints, codes, lint_visible};
+
+fn body_pass_state_non_final() -> String {
+    "<!-- plan-issue-record:v2 role=state profile=tracking -->\n\n\
+     ## Execution State\n\n\
+     - Profile: tracking\n\
+     - Status: in-progress\n\
+     - Target scope: vNext sprint 2\n\
+     - Current task: 2.2\n\n\
+     ## Task Ledger\n\n\
+     <details><summary>Show task ledger</summary>\n\n\
+     | ID | Status | Task |\n\
+     | --- | --- | --- |\n\
+     | 2.1 | done | registry |\n\
+     | 2.2 | in-progress | visible-lint |\n\n\
+     </details>\n"
+        .to_string()
+}
+
+fn body_pass_state_final_expanded() -> String {
+    "## Execution State\n\n\
+     - Profile: tracking\n\
+     - Status: complete\n\
+     - Target scope: vNext sprint 2\n\n\
+     ## Task Ledger\n\n\
+     | ID | Status | Task |\n\
+     | --- | --- | --- |\n\
+     | 2.1 | done | registry |\n\
+     | 2.2 | done | visible-lint |\n"
+        .to_string()
+}
+
+#[test]
+fn visible_lint_state_passing_non_final() {
+    let report = lint_visible(
+        PayloadRole::State,
+        &body_pass_state_non_final(),
+        LintHints::default(),
+    );
+    assert!(
+        report.is_pass(),
+        "non-final state should lint clean; findings={:?}",
+        report.findings
+    );
+}
+
+#[test]
+fn visible_lint_state_final_must_expand_task_ledger() {
+    let hints = LintHints {
+        state_is_final: true,
+        ..LintHints::default()
+    };
+    let collapsed = body_pass_state_non_final();
+    let report = lint_visible(PayloadRole::State, &collapsed, hints);
+    assert!(
+        report
+            .codes()
+            .contains(&codes::STATE_FINAL_TASK_LEDGER_NOT_EXPANDED),
+        "final state with collapsed ledger should fail; codes={:?}",
+        report.codes()
+    );
+}
+
+#[test]
+fn visible_lint_state_final_expanded_passes() {
+    let hints = LintHints {
+        state_is_final: true,
+        ..LintHints::default()
+    };
+    let report = lint_visible(PayloadRole::State, &body_pass_state_final_expanded(), hints);
+    assert!(
+        report.is_pass(),
+        "expanded final state should lint clean; findings={:?}",
+        report.findings
+    );
+}
+
+#[test]
+fn visible_lint_state_missing_task_ledger_is_blocked() {
+    let body = "## Execution State\n\n- Profile: tracking\n- Status: in-progress\n";
+    let report = lint_visible(PayloadRole::State, body, LintHints::default());
+    assert!(
+        report.codes().contains(&codes::STATE_MISSING_TASK_LEDGER),
+        "codes={:?}",
+        report.codes()
+    );
+}
+
+#[test]
+fn visible_lint_session_requires_non_empty_summary() {
+    let pass = "## Execution Session\n\n- Profile: tracking\n- Summary: implemented vNext registry\n";
+    let fail = "## Execution Session\n\n- Profile: tracking\n- Summary: \n";
+
+    let ok = lint_visible(PayloadRole::Session, pass, LintHints::default());
+    assert!(ok.is_pass(), "{:?}", ok.findings);
+
+    let bad = lint_visible(PayloadRole::Session, fail, LintHints::default());
+    assert!(
+        bad.codes().contains(&codes::SESSION_MISSING_SUMMARY),
+        "codes={:?}",
+        bad.codes()
+    );
+}
+
+#[test]
+fn visible_lint_validation_requires_overall_and_evidence() {
+    let pass = "## Validation Evidence\n\n\
+                - Profile: tracking\n\
+                - Overall: pass\n\n\
+                | Command | Status | Evidence |\n\
+                | --- | --- | --- |\n\
+                | `cargo test` | pass | log.txt |\n";
+    let no_overall = "## Validation Evidence\n\n- Profile: tracking\n\n| Command |\n|---|\n| `cargo test` |\n";
+    let no_evidence = "## Validation Evidence\n\n- Profile: tracking\n- Overall: pass\n";
+
+    let ok = lint_visible(PayloadRole::Validation, pass, LintHints::default());
+    assert!(ok.is_pass(), "{:?}", ok.findings);
+
+    let bad1 = lint_visible(PayloadRole::Validation, no_overall, LintHints::default());
+    assert!(
+        bad1.codes().contains(&codes::VALIDATION_MISSING_OVERALL),
+        "codes={:?}",
+        bad1.codes()
+    );
+
+    let bad2 = lint_visible(PayloadRole::Validation, no_evidence, LintHints::default());
+    assert!(
+        bad2.codes()
+            .contains(&codes::VALIDATION_MISSING_COMMANDS_OR_WAIVER),
+        "codes={:?}",
+        bad2.codes()
+    );
+}
+
+#[test]
+fn visible_lint_review_decision_and_disposition() {
+    let pass_with_findings = "## Review Evidence\n\n\
+        - Profile: tracking\n\
+        - Decision: approve\n\n\
+        | ID | Severity | Disposition | Summary |\n\
+        | --- | --- | --- | --- |\n\
+        | F1 | minor | fixed | tiny nit |\n";
+    let pass_no_findings = "## Review Evidence\n\n- Profile: tracking\n- Decision: comments-only\n";
+    let no_decision = "## Review Evidence\n\n- Profile: tracking\n";
+    let with_findings_no_disposition = "## Review Evidence\n\n\
+        - Profile: tracking\n\
+        - Decision: approve\n\n\
+        | ID | Severity | Disposition | Summary |\n\
+        | --- | --- | --- | --- |\n\
+        | F1 | minor | TBD | tiny nit |\n";
+
+    let hints_findings = LintHints {
+        review_has_findings: true,
+        ..LintHints::default()
+    };
+
+    let ok = lint_visible(PayloadRole::Review, pass_with_findings, hints_findings);
+    assert!(ok.is_pass(), "{:?}", ok.findings);
+
+    let ok_empty = lint_visible(
+        PayloadRole::Review,
+        pass_no_findings,
+        LintHints::default(),
+    );
+    assert!(ok_empty.is_pass(), "{:?}", ok_empty.findings);
+
+    let bad_no_decision = lint_visible(PayloadRole::Review, no_decision, LintHints::default());
+    assert!(
+        bad_no_decision
+            .codes()
+            .contains(&codes::REVIEW_MISSING_DECISION),
+        "codes={:?}",
+        bad_no_decision.codes()
+    );
+
+    let bad_missing_disposition = lint_visible(
+        PayloadRole::Review,
+        with_findings_no_disposition,
+        hints_findings,
+    );
+    assert!(
+        bad_missing_disposition
+            .codes()
+            .contains(&codes::REVIEW_MISSING_DISPOSITION),
+        "codes={:?}",
+        bad_missing_disposition.codes()
+    );
+}
+
+#[test]
+fn visible_lint_closeout_requires_approval_and_linked_pr() {
+    let pass = "## Tracking Issue Closeout\n\n\
+        - Profile: tracking\n\
+        - Final status: complete\n\
+        - Approval: https://example.com/approval\n\n\
+        | PR | Merge SHA | Checks |\n\
+        | --- | --- | --- |\n\
+        | owner/repo#123 | abc123 | pass |\n";
+    let no_approval = "## Tracking Issue Closeout\n\n\
+        - Profile: tracking\n\
+        - Final status: complete\n\n\
+        | PR | Merge SHA |\n\
+        | --- | --- |\n\
+        | owner/repo#1 | x |\n";
+    let no_pr = "## Tracking Issue Closeout\n\n\
+        - Profile: tracking\n\
+        - Final status: complete\n\
+        - Approval: approver text\n";
+    let no_pr_with_note = "## Tracking Issue Closeout\n\n\
+        - Profile: tracking\n\
+        - Final status: complete\n\
+        - Approval: approver text\n\
+        - Linked PRs: none (docs-only)\n";
+
+    let ok = lint_visible(PayloadRole::Closeout, pass, LintHints::default());
+    assert!(ok.is_pass(), "{:?}", ok.findings);
+
+    let bad1 = lint_visible(PayloadRole::Closeout, no_approval, LintHints::default());
+    assert!(
+        bad1.codes().contains(&codes::CLOSEOUT_MISSING_APPROVAL),
+        "codes={:?}",
+        bad1.codes()
+    );
+
+    let bad2 = lint_visible(PayloadRole::Closeout, no_pr, LintHints::default());
+    assert!(
+        bad2.codes().contains(&codes::CLOSEOUT_MISSING_LINKED_PR),
+        "codes={:?}",
+        bad2.codes()
+    );
+
+    let allow_no_pr = LintHints {
+        closeout_has_no_linked_pr_ok: true,
+        ..LintHints::default()
+    };
+    let bad_should_pass = lint_visible(PayloadRole::Closeout, no_pr_with_note, allow_no_pr);
+    assert!(
+        bad_should_pass.is_pass(),
+        "explicit no-PR note should satisfy linked-PR rule: {:?}",
+        bad_should_pass.findings
+    );
+}
+
+#[test]
+fn visible_lint_source_and_plan_reject_profile_only() {
+    let source_pass = "## Source Snapshot\n\n\
+        - Profile: tracking\n\
+        - Path: `docs/plans/foo/foo.md`\n\
+        - Commit: `abc1234`\n";
+    let source_profile_only = "## Source Snapshot\n\n- Profile: tracking\n";
+
+    let ok = lint_visible(PayloadRole::Source, source_pass, LintHints::default());
+    assert!(ok.is_pass(), "{:?}", ok.findings);
+
+    let bad = lint_visible(PayloadRole::Source, source_profile_only, LintHints::default());
+    assert!(
+        bad.codes().contains(&codes::PROFILE_ONLY),
+        "codes={:?}",
+        bad.codes()
+    );
+
+    let plan_pass = "## Plan Snapshot\n\n\
+        - Profile: tracking\n\
+        - Path: `docs/plans/foo/foo-plan.md`\n";
+    let plan_profile_only = "## Plan Snapshot\n\n- Profile: tracking\n";
+
+    let ok_plan = lint_visible(PayloadRole::Plan, plan_pass, LintHints::default());
+    assert!(ok_plan.is_pass(), "{:?}", ok_plan.findings);
+
+    let bad_plan = lint_visible(PayloadRole::Plan, plan_profile_only, LintHints::default());
+    assert!(
+        bad_plan.codes().contains(&codes::PROFILE_ONLY),
+        "codes={:?}",
+        bad_plan.codes()
+    );
+}
+
+#[test]
+fn visible_lint_rejects_profile_only_state_body() {
+    let body = "## Execution State\n\n- Profile: tracking\n";
+    let report = lint_visible(PayloadRole::State, body, LintHints::default());
+    // Profile-only state also missing Task Ledger; both codes should be
+    // reported so callers can act on either path.
+    assert!(report.codes().contains(&codes::PROFILE_ONLY));
+    assert!(report.codes().contains(&codes::STATE_MISSING_TASK_LEDGER));
+}
+
+#[test]
+fn visible_lint_missing_heading_returns_role_specific_code() {
+    let bodies: Vec<(PayloadRole, &str, &str)> = vec![
+        (
+            PayloadRole::Source,
+            "- Profile: tracking\n",
+            codes::SOURCE_MISSING_HEADING,
+        ),
+        (
+            PayloadRole::Plan,
+            "- Profile: tracking\n",
+            codes::PLAN_MISSING_HEADING,
+        ),
+        (
+            PayloadRole::State,
+            "- Profile: tracking\n",
+            codes::STATE_MISSING_HEADING,
+        ),
+        (
+            PayloadRole::Session,
+            "- Profile: tracking\n",
+            codes::SESSION_MISSING_HEADING,
+        ),
+        (
+            PayloadRole::Validation,
+            "- Profile: tracking\n",
+            codes::VALIDATION_MISSING_HEADING,
+        ),
+        (
+            PayloadRole::Review,
+            "- Profile: tracking\n",
+            codes::REVIEW_MISSING_HEADING,
+        ),
+        (
+            PayloadRole::Closeout,
+            "- Profile: tracking\n",
+            codes::CLOSEOUT_MISSING_HEADING,
+        ),
+    ];
+    for (role_id, body, expected) in bodies {
+        let report = lint_visible(role_id, body, LintHints::default());
+        assert!(
+            report.codes().contains(&expected),
+            "role {role_id:?} missing-heading code drift: {:?}",
+            report.codes()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the vNext plan-issue lifecycle controller surfaces — registry-driven
  templates, deterministic FSM, typed local run state, and tracking
  commands — without disturbing the released v3 `record` surface.
- Brings the strict close-readiness probe, opt-in visible-completeness
  lint, and non-mutating dry-run rendering needed to migrate
  `agent-runtime-kit` dispatch and tracking skills onto the controller.

## Scope

- `lifecycle_vnext` module tree: `registry`, `templates`, `visible_lint`,
  `payloads`, `render` — 7 `RoleSpec` entries with default heading,
  payload schema, `DirectPostPolicy`, `DashboardRepair`, and
  `CloseoutOwnership`.
- `tracking` module tree: `run_state` (`plan-issue.execution-run.v1`),
  `events` (`plan-issue.execution-event.v1`), `fsm`, `reconcile`,
  `checkpoint`, `close_ready` — issue-scoped local layout under the
  runtime root.
- New subcommands:
  - `plan-issue record template --kind <role> --shape markdown|json`
  - `plan-issue record audit --expect-visible` (visible-completeness lint
    with stable role-specific failure codes)
  - `plan-issue tracking status`
  - `plan-issue tracking run init` / `run update`
  - `plan-issue tracking checkpoint` (dry-run default; `--live` returns
    `tracking-checkpoint-live-not-implemented` until the live adapter
    ships)
  - `plan-issue tracking close-ready` (strict, non-mutating probe)

## Test plan

- [x] `cargo test -p plan-issue-cli` — 114 unit + 232 integration tests
  pass on the branch.
- [x] `record_compat_baseline` integration tests lock the released
  `record` subcommand surface, envelope, error shape, and tracking schema
  constants before runtime-kit migrates.
- [x] Manual exercise of `record template`, `record audit
  --expect-visible`, `tracking status`, `tracking run init/update`,
  `tracking checkpoint` (dry-run), and `tracking close-ready` against a
  local fixture.

## Deferred / known follow-ups

- Live `tracking checkpoint` provider mutation adapter — gated behind
  `--live`; controller returns
  `tracking-checkpoint-live-not-implemented` until that lands.
- Migrating `record open/post/repair-dashboard/close/audit` rendering
  internals onto the vNext registry — internal refactor; observable
  behavior is already covered by the new registry/lint/template surface.

## Notes for downstream consumers

- `agent-runtime-kit` dispatch and tracking skill bodies have been
  rewritten on the companion `feat/plan-issue-vnext` branch and require
  this release floor before they can be activated against released
  binaries.
