### PR TITLE
feat(plan-issue-cli): templated task table (#541 Sprint 2 Task 2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,6 +2220,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "nils-common",
+ "nils-markdown",
  "nils-plan-tooling",
  "nils-test-support",
  "pretty_assertions",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `948bd2a04842bf2f9571b526a27e561414b543a1cdae07eb3d22438a08fe7eef`
+- Cargo.lock SHA256: `f710c744a38c0ce663fdf6c9e7ec42e81278f8bc61cd104401f45075c297eb5f`
 - Third-party crates (`source != null`): 465
 - Workspace crates (`source == null`, excluded below): 32
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `948bd2a04842bf2f9571b526a27e561414b543a1cdae07eb3d22438a08fe7eef`
+- Cargo.lock SHA256: `f710c744a38c0ce663fdf6c9e7ec42e81278f8bc61cd104401f45075c297eb5f`
 - Third-party crates (`source != null`): 465
 
 ## Notice Extraction Policy

--- a/crates/plan-issue-cli/Cargo.toml
+++ b/crates/plan-issue-cli/Cargo.toml
@@ -26,9 +26,11 @@ clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-markdown = { version = "0.23.0", path = "../nils-markdown", package = "nils-markdown" }
 plan-tooling = { version = "0.23.0", path = "../plan-tooling", package = "nils-plan-tooling" }
 
 [dev-dependencies]
+nils-markdown = { version = "0.23.0", path = "../nils-markdown", package = "nils-markdown", features = ["test-support"] }
 nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/plan-issue-cli/src/issue_body.rs
+++ b/crates/plan-issue-cli/src/issue_body.rs
@@ -1,6 +1,90 @@
 use std::collections::HashMap;
 
 use nils_common::markdown as common_markdown;
+use nils_markdown::{Engine, RenderError};
+use serde::Serialize;
+
+// Task 2.4 will switch `render::render_plan_issue_body` to call
+// `render_task_decomposition_block` instead of stitching the three
+// row helpers manually. Until then the template + view types live
+// here exercised only by the unit tests, so silence dead_code on
+// the new items in the lib target.
+
+/// Template body for the task-decomposition block. Bundled with
+/// `include_str!` per Decision 13 in the source document so the
+/// asset travels with the binary and no runtime filesystem lookup
+/// is required.
+#[allow(dead_code)]
+const TASK_DECOMPOSITION_TEMPLATE: &str = include_str!("../templates/issue_body.md.tera");
+#[allow(dead_code)]
+const TASK_DECOMPOSITION_TEMPLATE_NAME: &str = "issue_body";
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+struct TaskTableView<'a> {
+    rows: Vec<TaskRowView<'a>>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+struct TaskRowView<'a> {
+    task: &'a str,
+    summary: &'a str,
+    owner: &'a str,
+    branch: &'a str,
+    worktree: &'a str,
+    execution_mode: &'a str,
+    pr: &'a str,
+    status: &'a str,
+    notes: &'a str,
+}
+
+impl<'a> From<&'a TaskRow> for TaskRowView<'a> {
+    fn from(row: &'a TaskRow) -> Self {
+        Self {
+            task: &row.task,
+            summary: &row.summary,
+            owner: &row.owner,
+            branch: &row.branch,
+            worktree: &row.worktree,
+            execution_mode: &row.execution_mode,
+            pr: &row.pr,
+            status: &row.status,
+            notes: &row.notes,
+        }
+    }
+}
+
+/// Render the task-decomposition table block (header row, separator
+/// row, and one row per `rows` entry) through the
+/// [`nils_markdown::Engine`]. Output is byte-equal to the previous
+/// concatenation of [`task_decomposition_header_row`],
+/// [`task_decomposition_separator_row`], and
+/// [`format_task_decomposition_row`] for the same rows.
+///
+/// Sprint 2 Task 2.1 ships this function as the migration entry
+/// point; Task 2.4 will switch `render::render_plan_issue_body` to
+/// call it instead of stitching the three row helpers manually.
+#[allow(dead_code)]
+pub fn render_task_decomposition_block(rows: &[TaskRow]) -> Result<String, RenderError> {
+    let mut engine = Engine::builder().build();
+    engine.register_template(
+        TASK_DECOMPOSITION_TEMPLATE_NAME,
+        TASK_DECOMPOSITION_TEMPLATE,
+    )?;
+    let view = TaskTableView {
+        rows: rows.iter().map(TaskRowView::from).collect(),
+    };
+    let rendered = engine.render(TASK_DECOMPOSITION_TEMPLATE_NAME, &view)?;
+    // Match the `out.join("\n")` contract used by
+    // `render::render_plan_issue_body`: the table block lives as
+    // elements in a `Vec<String>` and is joined with `\n` later, so
+    // it must not carry a trailing newline of its own. The template
+    // file ends with the standard EOF newline per workspace
+    // convention; strip exactly one trailing `\n` to keep the
+    // template human-friendly and the output byte-stable.
+    Ok(rendered.strip_suffix('\n').unwrap_or(&rendered).to_string())
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskRow {
@@ -479,9 +563,98 @@ fn format_markdown_row(row: &TaskRow) -> String {
 mod tests {
     use super::{
         TaskRow, format_task_decomposition_row, is_placeholder, normalize_pr_display,
-        parse_pr_number, parse_task_table, row_sprint, task_decomposition_header_row,
-        task_decomposition_separator_row, validate_rows,
+        parse_pr_number, parse_task_table, render_task_decomposition_block, row_sprint,
+        task_decomposition_header_row, task_decomposition_separator_row, validate_rows,
     };
+
+    fn sample_task_rows() -> Vec<TaskRow> {
+        vec![
+            TaskRow {
+                task: "S1T1".to_string(),
+                summary: "Add foo".to_string(),
+                owner: "subagent".to_string(),
+                branch: "issue/s1t1".to_string(),
+                worktree: "issue-s1t1".to_string(),
+                execution_mode: "pr-isolated".to_string(),
+                pr: "#101".to_string(),
+                status: "done".to_string(),
+                notes: "-".to_string(),
+                line_index: 0,
+            },
+            TaskRow {
+                task: "S1T2".to_string(),
+                summary: "Pipe|in|summary".to_string(),
+                owner: "main".to_string(),
+                branch: "issue/s1t2".to_string(),
+                worktree: "issue-s1t2".to_string(),
+                execution_mode: "per-sprint".to_string(),
+                pr: "TBD".to_string(),
+                status: "planned".to_string(),
+                notes: "sprint=S1; group=A".to_string(),
+                line_index: 1,
+            },
+            TaskRow {
+                task: "S2T1".to_string(),
+                summary: "Multi\nline\nnotes".to_string(),
+                owner: "subagent".to_string(),
+                branch: "issue/s2t1".to_string(),
+                worktree: "issue-s2t1".to_string(),
+                execution_mode: "pr-shared".to_string(),
+                pr: "#202".to_string(),
+                status: "in-progress".to_string(),
+                notes: "Pipe|here".to_string(),
+                line_index: 2,
+            },
+        ]
+    }
+
+    fn baseline_via_helpers(rows: &[TaskRow]) -> String {
+        let mut out: Vec<String> = vec![
+            task_decomposition_header_row(),
+            task_decomposition_separator_row(),
+        ];
+        for row in rows {
+            out.push(format_task_decomposition_row([
+                &row.task,
+                &row.summary,
+                &row.owner,
+                &row.branch,
+                &row.worktree,
+                &row.execution_mode,
+                &row.pr,
+                &row.status,
+                &row.notes,
+            ]));
+        }
+        out.join("\n")
+    }
+
+    #[test]
+    fn render_task_decomposition_block_matches_helper_composition_for_sample_rows() {
+        let rows = sample_task_rows();
+        let baseline = baseline_via_helpers(&rows);
+        let rendered = render_task_decomposition_block(&rows).expect("render block");
+        pretty_assertions::assert_eq!(baseline, rendered);
+    }
+
+    #[test]
+    fn render_task_decomposition_block_matches_helper_composition_for_empty_rows() {
+        let baseline = baseline_via_helpers(&[]);
+        let rendered = render_task_decomposition_block(&[]).expect("render block");
+        pretty_assertions::assert_eq!(baseline, rendered);
+    }
+
+    #[test]
+    fn render_task_decomposition_block_matches_committed_golden() {
+        let rows = sample_task_rows();
+        let fixture = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/golden/issue_body/task_table.golden.md"
+        ))
+        .expect("read golden fixture");
+        let rendered = render_task_decomposition_block(&rows).expect("render block");
+        pretty_assertions::assert_eq!(fixture, rendered);
+    }
 
     #[test]
     fn parse_task_table_extracts_rows() {

--- a/crates/plan-issue-cli/templates/issue_body.md.tera
+++ b/crates/plan-issue-cli/templates/issue_body.md.tera
@@ -1,0 +1,5 @@
+| Task | Summary | Owner | Branch | Worktree | Execution Mode | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+{%- for row in rows %}
+| {{ row.task | md_cell }} | {{ row.summary | md_cell }} | {{ row.owner | md_cell }} | {{ row.branch | md_cell }} | {{ row.worktree | md_cell }} | {{ row.execution_mode | md_cell }} | {{ row.pr | md_cell }} | {{ row.status | md_cell }} | {{ row.notes | md_cell }} |
+{%- endfor %}

--- a/crates/plan-issue-cli/tests/golden/issue_body/task_table.golden.md
+++ b/crates/plan-issue-cli/tests/golden/issue_body/task_table.golden.md
@@ -1,0 +1,5 @@
+| Task | Summary | Owner | Branch | Worktree | Execution Mode | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| S1T1 | Add foo | subagent | issue/s1t1 | issue-s1t1 | pr-isolated | #101 | done | - |
+| S1T2 | Pipe/in/summary | main | issue/s1t2 | issue-s1t2 | per-sprint | TBD | planned | sprint=S1; group=A |
+| S2T1 | Multi line notes | subagent | issue/s2t1 | issue-s2t1 | pr-shared | #202 | in-progress | Pipe/here |


### PR DESCRIPTION
## Summary

- Sprint 2 Task 2.1 of tracking issue #541. Migrates the
  `plan-issue-cli` task-decomposition table block to a
  `nils-markdown` template + flat view struct without changing any
  caller. The three existing row helpers (`task_decomposition_header_row`,
  `task_decomposition_separator_row`, `format_task_decomposition_row`)
  stay in place for Task 2.4 to switch `render::render_plan_issue_body`
  onto the new entry point.
- New `render_task_decomposition_block(rows)` constructs an
  `Engine::builder()`, registers the `include_str!`'d
  `issue_body.md.tera`, and renders a `TaskTableView` with
  `TaskRowView` rows. Cell escaping moves from
  `sanitize_table_value`'s call to `nils_common::markdown::canonicalize_table_cell`
  into the template's `| md_cell` filter, so the migrated path no
  longer calls `canonicalize_table_cell` directly.

## What changed

- `crates/plan-issue-cli/Cargo.toml`: add path dep on `nils-markdown`
  (lib) and dev-dep on `nils-markdown` with `test-support` feature.
- `crates/plan-issue-cli/templates/issue_body.md.tera`: new template
  rendering the full table (header + separator + one row per entry).
- `crates/plan-issue-cli/src/issue_body.rs`: new view structs,
  template constants, and `render_task_decomposition_block`
  function. Items are `#[allow(dead_code)]` until Task 2.4 wires
  them; comment block in the file points there.
- `crates/plan-issue-cli/tests/golden/issue_body/task_table.golden.md`:
  representative committed capture of the table block.
- Three new unit tests in `issue_body.rs`: empty-row parity,
  sample-row parity (covers pipe + newline canonicalization), and
  committed golden parity.

## Validation

- [x] `cargo test -p nils-plan-issue-cli` (232 lib, 117 integration — 349 passed)
- [x] `cargo nextest run -p nils-plan-issue-cli` (349 passed)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
- [x] `bash scripts/ci/third-party-artifacts-audit.sh --strict` (regenerated)
- [x] `cargo build --workspace --locked`

## Tracking issue

- Issue #541
- Plan: `docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md`
- Source doc: `docs/plans/markdown-render-template-layer/markdown-render-template-layer-discussion-source.md`

## Test plan

- [x] `cargo test -p nils-plan-issue-cli`
- [x] `cargo nextest run -p nils-plan-issue-cli`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
- [x] `cargo build --workspace --locked`
- [ ] Required GitHub checks green on this PR
