### PR TITLE
docs(plans): rescope task_spec.rs audit (#541 Sprint 2 Task 2.2)

### DIFF
--- a/crates/plan-issue-cli/src/task_spec.rs
+++ b/crates/plan-issue-cli/src/task_spec.rs
@@ -1,3 +1,28 @@
+//! Task-spec builder and TSV writer for the plan-issue-cli runtime.
+//!
+//! This module is intentionally **not** a Markdown emitter: the only
+//! string output below is [`render_tsv`], which produces a
+//! tab-separated `.tsv` file consumed by downstream subagent
+//! lanes. The two
+//! [`nils_common::markdown::canonicalize_table_cell`] calls inside
+//! `build_task_spec` (notes joined for newly-built rows and notes
+//! copied from already-parsed `TaskSpecRow` values) keep
+//! `TaskSpecRow.notes` safe for a single-line TSV cell by collapsing
+//! embedded newlines and replacing `|` with `/`. They are kept here
+//! at struct-construction time, not at TSV emission time, so any
+//! consumer that reads `TaskSpecRow.notes` directly sees the same
+//! pre-canonicalized value.
+//!
+//! The Markdown emitters live in [`crate::render`] and
+//! [`crate::issue_body::render_task_decomposition_block`]; both rely
+//! on the [`nils_common::markdown` v1 contract] idempotency of
+//! `canonicalize_table_cell` so a notes value that has already been
+//! canonicalized here can pass through the template-side `| md_cell`
+//! filter (registered by `nils-markdown`) without double-escaping.
+//! This is the Sprint 2 plan's Task 2.2 audit deliverable: no
+//! Markdown migration is required for this file because no Markdown
+//! is rendered here.
+
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 

--- a/docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md
+++ b/docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md
@@ -347,24 +347,38 @@ pre-migration output.
   - `cargo test -p plan-issue-cli issue_body`
   - `cargo test -p plan-issue-cli --test golden`
 
-### Task 2.2: Migrate `plan-issue-cli/src/task_spec.rs`
+### Task 2.2: Confirm `plan-issue-cli/src/task_spec.rs` TSV / Markdown boundary
 
 - **Location**:
   - crates/plan-issue-cli/src/task_spec.rs
-  - crates/plan-issue-cli/templates/task_spec.md.tera (new)
-  - crates/plan-issue-cli/tests/golden/task_spec/ (new fixture dir)
-- **Description**: 28 inline Markdown sites. Exercises the `md_cell`
-  filter on task tables.
+- **Description**: Pre-execution scoping for Sprint 2 found that
+  `task_spec.rs` is a TSV emitter, not a Markdown emitter: its only
+  string output is `render_tsv`, and the two
+  `nils_common::markdown::canonicalize_table_cell` calls inside
+  (lines around `notes.join("; ")` and `notes: ...row.notes`) make
+  the resulting `TaskSpecRow.notes` field TSV-cell-safe (newline
+  collapse, pipe escape). The original plan's "28 inline Markdown
+  sites" count does not match the file. Task 2.2 is now an audit and
+  documentation step: confirm no Markdown emission lives here, add
+  a module-level doc note so future readers do not confuse the
+  pre-canonicalization with Markdown escaping, and rely on
+  `canonicalize_table_cell` idempotency
+  ([`nils-common` markdown helpers contract v1]) so Task 2.4's
+  template-side `| md_cell` filter does not double-escape the same
+  notes downstream in `render::render_plan_issue_body`.
 - **Dependencies**:
   - Task 2.1
 - **Complexity**:
-  - 5
+  - 1
 - **Acceptance criteria**:
-  - Task-spec rendering is byte-identical to pre-migration capture.
-  - Golden coverage includes at least one row whose source contains a
-    literal pipe character to prove `md_cell` is wired correctly.
+  - `task_spec.rs` carries a module-level doc note that calls out
+    the TSV-only contract and the
+    `canonicalize_table_cell` idempotency with `md_cell`.
+  - No production behavior change: `render_tsv` output stays
+    byte-stable for all inputs.
+  - `cargo test -p nils-plan-issue-cli` stays green.
 - **Validation**:
-  - `cargo test -p plan-issue-cli task_spec`
+  - `cargo test -p nils-plan-issue-cli`
 
 ### Task 2.3: Migrate `plan-issue-cli/src/lifecycle_vnext/templates.rs`
 


### PR DESCRIPTION
## Summary

- Sprint 2 Task 2.2 of tracking issue #541, re-scoped from "migrate
  to template" to "audit and document". Pre-execution scoping found
  `plan-issue-cli/src/task_spec.rs` is a TSV emitter, not a Markdown
  emitter: `render_tsv` is the only string output, and the two
  `nils_common::markdown::canonicalize_table_cell` calls inside
  `build_task_spec` keep `TaskSpecRow.notes` safe for a single TSV
  cell (newline collapse + `|` → `/`).
- Plan amendment in `markdown-render-template-layer-plan.md`
  replaces the original Task 2.2 acceptance with an audit step.
  `task_spec.rs` gains a module-level doc note that spells out the
  TSV / Markdown boundary and the idempotency contract that lets
  Task 2.4's `| md_cell` filter avoid double-escaping the same
  notes downstream in `render::render_plan_issue_body`.

## What changed

- `docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md`:
  rewrite Task 2.2 description / acceptance / validation.
- `crates/plan-issue-cli/src/task_spec.rs`: new module-level doc
  note. No code logic change.

## Why this is not a no-op

The original "Migrate task_spec.rs (28 inline Markdown sites)"
acceptance does not match the file — there are zero Markdown
emission sites in `task_spec.rs`. Folding the "migration" into Task
2.4 (`render.rs`) without recording the audit would leave the plan
inconsistent with the code. The doc note also makes the
`canonicalize_table_cell` ↔ `md_cell` idempotency contract obvious
to future readers, so the eventual Task 2.4 template-side escaping
is reviewable on its own.

## Validation

- [x] `cargo test -p nils-plan-issue-cli` (no test surface changed)
- [x] `cargo nextest run -p nils-plan-issue-cli` (349 passed)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
- [x] `plan-tooling validate` (exit 0 after the Task 2.2 rewrite)

## Tracking issue

- Issue #541
- Plan: `docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md`

## Test plan

- [x] `cargo nextest run -p nils-plan-issue-cli` (349 passed)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
- [x] `plan-tooling validate`
- [ ] Required GitHub checks green on this PR
