### PR TITLE
feat(plan-issue-cli): render.rs Markdown engine migration

### DIFF
--- a/crates/plan-issue-cli/src/issue_body.rs
+++ b/crates/plan-issue-cli/src/issue_body.rs
@@ -4,28 +4,18 @@ use nils_common::markdown as common_markdown;
 use nils_markdown::{Engine, RenderError};
 use serde::Serialize;
 
-// Task 2.4 will switch `render::render_plan_issue_body` to call
-// `render_task_decomposition_block` instead of stitching the three
-// row helpers manually. Until then the template + view types live
-// here exercised only by the unit tests, so silence dead_code on
-// the new items in the lib target.
-
 /// Template body for the task-decomposition block. Bundled with
 /// `include_str!` per Decision 13 in the source document so the
 /// asset travels with the binary and no runtime filesystem lookup
 /// is required.
-#[allow(dead_code)]
 const TASK_DECOMPOSITION_TEMPLATE: &str = include_str!("../templates/issue_body.md.tera");
-#[allow(dead_code)]
 const TASK_DECOMPOSITION_TEMPLATE_NAME: &str = "issue_body";
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize)]
 struct TaskTableView<'a> {
     rows: Vec<TaskRowView<'a>>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize)]
 struct TaskRowView<'a> {
     task: &'a str,
@@ -61,11 +51,6 @@ impl<'a> From<&'a TaskRow> for TaskRowView<'a> {
 /// concatenation of [`task_decomposition_header_row`],
 /// [`task_decomposition_separator_row`], and
 /// [`format_task_decomposition_row`] for the same rows.
-///
-/// Sprint 2 Task 2.1 ships this function as the migration entry
-/// point; Task 2.4 will switch `render::render_plan_issue_body` to
-/// call it instead of stitching the three row helpers manually.
-#[allow(dead_code)]
 pub fn render_task_decomposition_block(rows: &[TaskRow]) -> Result<String, RenderError> {
     let mut engine = Engine::builder().build();
     engine.register_template(
@@ -225,10 +210,12 @@ pub fn parse_task_table(body: &str) -> Result<TaskTable, String> {
     })
 }
 
+#[cfg(test)]
 pub fn task_decomposition_header_row() -> String {
     format!("| {} |", TASK_DECOMPOSITION_COLUMNS.join(" | "))
 }
 
+#[cfg(test)]
 pub fn task_decomposition_separator_row() -> String {
     let separators = std::iter::repeat_n("---", TASK_DECOMPOSITION_COLUMNS.len())
         .collect::<Vec<_>>()

--- a/crates/plan-issue-cli/src/lib.rs
+++ b/crates/plan-issue-cli/src/lib.rs
@@ -5,15 +5,15 @@ pub mod dispatch_record;
 mod execute;
 mod forge_cli_adapter;
 mod github;
-mod issue_body;
+pub mod issue_body;
 pub mod lifecycle_record;
 pub mod lifecycle_vnext;
 pub mod output;
 mod provider;
-mod render;
+pub mod render;
 pub mod runtime_layout;
 pub mod state;
-mod task_spec;
+pub mod task_spec;
 pub mod tracking;
 
 use std::ffi::OsString;

--- a/crates/plan-issue-cli/src/render.rs
+++ b/crates/plan-issue-cli/src/render.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use nils_markdown::Engine;
+use serde::Serialize;
+
 use crate::commands::SplitStrategy;
 use crate::issue_body;
 use crate::task_spec::{
@@ -10,6 +13,40 @@ use crate::task_spec::{
 use nils_common::fs as common_fs;
 use nils_common::git as common_git;
 use nils_common::markdown as common_markdown;
+
+const PLAN_ISSUE_BODY_TEMPLATE: &str = include_str!("../templates/render/plan_issue_body.md.tera");
+const PLAN_ISSUE_BODY_TEMPLATE_NAME: &str = "render_plan_issue_body";
+
+const SPRINT_COMMENT_TEMPLATE: &str = include_str!("../templates/render/sprint_comment.md.tera");
+const SPRINT_COMMENT_TEMPLATE_NAME: &str = "render_sprint_comment";
+
+#[derive(Debug, Serialize)]
+struct PlanIssueBodyView<'a> {
+    pre_table: String,
+    task_table_block: String,
+    plan_file_display: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct SprintCommentView<'a> {
+    heading: String,
+    sprint: i32,
+    sprint_name: &'a str,
+    task_count: usize,
+    lead: &'static str,
+    mode: &'static str,
+    approval_comment_url: Option<&'a str>,
+    sprint_section: Option<String>,
+    note_text: Option<String>,
+    task_rows: Vec<SprintTaskRowView<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct SprintTaskRowView<'a> {
+    task: &'a str,
+    summary: String,
+    third_col: String,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SprintCommentMode {
@@ -84,82 +121,75 @@ pub fn render_plan_issue_body(
         plan_title.trim().to_string()
     };
 
-    let mut out: Vec<String> = load_pre_sprint_plan_lines(plan_file)
+    let mut header_lines = load_pre_sprint_plan_lines(plan_file)
         .filter(|lines| !lines.is_empty())
         .unwrap_or_else(|| vec![format!("# {fallback_title}")]);
-
-    if out.last().is_some_and(|line| !line.trim().is_empty()) {
-        out.push(String::new());
+    while header_lines
+        .last()
+        .map(|line| line.trim().is_empty())
+        .unwrap_or(false)
+    {
+        header_lines.pop();
     }
-
-    out.extend([
-        "## Task Decomposition".to_string(),
-        String::new(),
-        issue_body::task_decomposition_header_row(),
-        issue_body::task_decomposition_separator_row(),
-    ]);
+    let pre_table = header_lines.join("\n");
 
     let runtime_lane_metadata = runtime_lane_metadata_by_task(rows, strategy);
+    let task_rows: Vec<issue_body::TaskRow> = rows
+        .iter()
+        .map(|row| {
+            let lane = runtime_lane_metadata.get(&row.task_id);
+            let owner = lane
+                .map(|metadata| metadata.owner.clone())
+                .unwrap_or_else(|| row.owner.clone());
+            let branch = lane
+                .map(|metadata| metadata.branch.clone())
+                .unwrap_or_else(|| row.branch.clone());
+            let worktree = lane
+                .map(|metadata| metadata.worktree.clone())
+                .unwrap_or_else(|| row.worktree.clone());
+            let execution_mode = lane
+                .map(|metadata| metadata.execution_mode.clone())
+                .unwrap_or_else(|| "pr-isolated".to_string());
+            let notes = lane
+                .map(|metadata| metadata.notes.trim().to_string())
+                .unwrap_or_else(|| row.notes.trim().to_string());
+            let notes = common_markdown::canonicalize_table_cell(&notes);
+            let notes = if notes.trim().is_empty() {
+                "-".to_string()
+            } else {
+                notes
+            };
+            issue_body::TaskRow {
+                task: row.task_id.clone(),
+                summary: row.summary.clone(),
+                owner,
+                branch,
+                worktree,
+                execution_mode,
+                pr: "TBD".to_string(),
+                status: "planned".to_string(),
+                notes,
+                line_index: 0,
+            }
+        })
+        .collect();
 
-    for row in rows {
-        let lane = runtime_lane_metadata.get(&row.task_id);
-        let owner = lane
-            .map(|metadata| metadata.owner.clone())
-            .unwrap_or_else(|| row.owner.clone());
-        let branch = lane
-            .map(|metadata| metadata.branch.clone())
-            .unwrap_or_else(|| row.branch.clone());
-        let worktree = lane
-            .map(|metadata| metadata.worktree.clone())
-            .unwrap_or_else(|| row.worktree.clone());
-        let execution_mode = lane
-            .map(|metadata| metadata.execution_mode.clone())
-            .unwrap_or_else(|| "pr-isolated".to_string());
-        let notes = lane
-            .map(|metadata| metadata.notes.trim().to_string())
-            .unwrap_or_else(|| row.notes.trim().to_string());
-        let notes = common_markdown::canonicalize_table_cell(&notes);
-        let notes = if notes.trim().is_empty() {
-            "-".to_string()
-        } else {
-            notes
-        };
-        out.push(issue_body::format_task_decomposition_row([
-            &row.task_id,
-            &row.summary,
-            &owner,
-            &branch,
-            &worktree,
-            &execution_mode,
-            "TBD",
-            "planned",
-            &notes,
-        ]));
-    }
+    let task_table_block = issue_body::render_task_decomposition_block(&task_rows)
+        .expect("task-decomposition block renders");
 
-    out.extend([
-        String::new(),
-        "## Consistency Rules".to_string(),
-        String::new(),
-        "- `Status` must be one of: `planned`, `in-progress`, `blocked`, `done`.".to_string(),
-        "- `Status` = `in-progress` or `done` requires non-`TBD` execution metadata (`Owner`, `Branch`, `Worktree`, `Execution Mode`, `PR`).".to_string(),
-        "- `Owner` must be a subagent identifier (contains `subagent`) once the task is assigned; `main-agent` ownership is invalid for implementation tasks.".to_string(),
-        "- `Execution Mode` should be one of: `per-sprint`, `pr-isolated`, `pr-shared` (or `TBD` before assignment).".to_string(),
-        "- `Branch` and `Worktree` uniqueness is enforced only for rows using `Execution Mode = pr-isolated`.".to_string(),
-        String::new(),
-        "## Risks / Uncertainties".to_string(),
-        String::new(),
-        "- Sprint approvals may be recorded before final close; issue stays open until final plan acceptance.".to_string(),
-        "- Close gate fails if task statuses or PR merge states in the issue body are incomplete.".to_string(),
-        String::new(),
-        "## Evidence".to_string(),
-        String::new(),
-        format!("- Plan source: `{plan_file_display}`"),
-        "- Sprint approvals: issue comments (one comment per accepted sprint)".to_string(),
-        "- Final approval: issue/pull comment URL passed to `close-plan`".to_string(),
-    ]);
+    let view = PlanIssueBodyView {
+        pre_table,
+        task_table_block,
+        plan_file_display,
+    };
 
-    format!("{}\n", out.join("\n"))
+    let mut engine = Engine::builder().build();
+    engine
+        .register_template(PLAN_ISSUE_BODY_TEMPLATE_NAME, PLAN_ISSUE_BODY_TEMPLATE)
+        .expect("plan_issue_body template registers");
+    engine
+        .render(PLAN_ISSUE_BODY_TEMPLATE_NAME, &view)
+        .expect("plan_issue_body template renders")
 }
 
 fn load_pre_sprint_plan_lines(plan_file: &Path) -> Option<Vec<String>> {
@@ -237,118 +267,104 @@ pub fn render_sprint_comment(input: SprintCommentInput<'_>) -> Result<String, St
         .map(parse_issue_pr_values)
         .unwrap_or_default();
 
-    let mut out: Vec<String> = Vec::new();
-    let (heading, lead) = match mode {
+    let (heading, lead, mode_token) = match mode {
         SprintCommentMode::Start => (
             format!("## Sprint {sprint} Start"),
             "Main-agent starts this sprint on the plan issue and dispatches implementation to subagents.",
+            "start",
         ),
         SprintCommentMode::Ready => (
             format!("## Sprint {sprint} Ready for Review"),
             "Main-agent requests sprint-level review before merge/acceptance on the plan issue (the issue remains open).",
+            "ready",
         ),
         SprintCommentMode::Accepted => (
             format!("## Sprint {sprint} Accepted"),
             "Main-agent records sprint acceptance after merge gate passes and sprint rows are synced to done (issue remains open for remaining sprints).",
+            "accepted",
         ),
     };
 
-    out.push(heading);
-    out.push(String::new());
-    out.push(format!("- Sprint: {sprint} ({sprint_name})"));
-    out.push(format!("- Tasks in sprint: {}", rows.len()));
-    out.push(format!("- Note: {lead}"));
-    if mode == SprintCommentMode::Start {
-        out.push(
-            "- Execution Mode comes from current Task Decomposition for each sprint task."
-                .to_string(),
-        );
-    } else {
-        out.push(
-            "- PR values come from current Task Decomposition; unresolved tasks remain `TBD` until PRs are linked."
-                .to_string(),
-        );
-    }
+    let approval_url = approval_comment_url
+        .map(str::trim)
+        .filter(|trimmed| !trimmed.is_empty());
 
-    if let Some(url) = approval_comment_url {
-        let trimmed = url.trim();
-        if !trimmed.is_empty() {
-            out.push(format!("- Approval comment URL: {trimmed}"));
-        }
-    }
-
-    out.push(String::new());
-    match mode {
-        SprintCommentMode::Start => {
-            out.push("| Task | Summary | Execution Mode |".to_string());
-            out.push("| --- | --- | --- |".to_string());
-            for row in rows {
-                let execution_mode = execution_modes
+    let task_rows: Vec<SprintTaskRowView<'_>> = rows
+        .iter()
+        .map(|row| {
+            let summary = if row.summary.is_empty() {
+                "-".to_string()
+            } else {
+                row.summary.clone()
+            };
+            let third_col = match mode {
+                SprintCommentMode::Start => execution_modes
                     .get(&row.task_id)
-                    .map(String::as_str)
-                    .unwrap_or("pr-isolated");
-                out.push(format!(
-                    "| {} | {} | {} |",
-                    row.task_id,
-                    if row.summary.is_empty() {
-                        "-"
-                    } else {
-                        &row.summary
-                    },
-                    execution_mode
-                ));
-            }
-
-            let sprint_section = extract_sprint_section(plan_file, sprint)?;
-            if !sprint_section.is_empty() {
-                out.push(String::new());
-                out.push(sprint_section);
-            }
-        }
-        SprintCommentMode::Ready | SprintCommentMode::Accepted => {
-            out.push("| Task | Summary | PR |".to_string());
-            out.push("| --- | --- | --- |".to_string());
-            for row in rows {
-                let mut pr_value = issue_pr_values
-                    .get(&row.task_id)
-                    .map(|v| normalize_pr_display(v))
-                    .unwrap_or_default();
-                if pr_value.is_empty() {
-                    let execution_mode = execution_modes
+                    .cloned()
+                    .unwrap_or_else(|| "pr-isolated".to_string()),
+                SprintCommentMode::Ready | SprintCommentMode::Accepted => {
+                    let mut pr_value = issue_pr_values
                         .get(&row.task_id)
-                        .map(String::as_str)
-                        .unwrap_or("pr-isolated");
-                    pr_value = if execution_mode == "per-sprint" {
-                        "TBD (per-sprint)".to_string()
-                    } else {
-                        format!("TBD (group:{})", row.pr_group)
-                    };
-                }
-                out.push(format!(
-                    "| {} | {} | {} |",
-                    row.task_id,
-                    if row.summary.is_empty() {
-                        "-"
-                    } else {
-                        &row.summary
-                    },
+                        .map(|v| normalize_pr_display(v))
+                        .unwrap_or_default();
+                    if pr_value.is_empty() {
+                        let execution_mode = execution_modes
+                            .get(&row.task_id)
+                            .map(String::as_str)
+                            .unwrap_or("pr-isolated");
+                        pr_value = if execution_mode == "per-sprint" {
+                            "TBD (per-sprint)".to_string()
+                        } else {
+                            format!("TBD (group:{})", row.pr_group)
+                        };
+                    }
                     pr_value
-                ));
+                }
+            };
+            SprintTaskRowView {
+                task: &row.task_id,
+                summary,
+                third_col,
             }
-        }
-    }
+        })
+        .collect();
 
-    if let Some(note) = note_text {
-        let trimmed = note.trim();
-        if !trimmed.is_empty() {
-            out.push(String::new());
-            out.push("## Main-Agent Notes".to_string());
-            out.push(String::new());
-            out.push(trimmed.to_string());
+    let sprint_section = if mode == SprintCommentMode::Start {
+        let section = extract_sprint_section(plan_file, sprint)?;
+        if section.is_empty() {
+            None
+        } else {
+            Some(section)
         }
-    }
+    } else {
+        None
+    };
 
-    Ok(format!("{}\n", out.join("\n")))
+    let note_text_owned = note_text
+        .map(str::trim)
+        .filter(|trimmed| !trimmed.is_empty())
+        .map(str::to_string);
+
+    let view = SprintCommentView {
+        heading,
+        sprint,
+        sprint_name,
+        task_count: rows.len(),
+        lead,
+        mode: mode_token,
+        approval_comment_url: approval_url,
+        sprint_section,
+        note_text: note_text_owned,
+        task_rows,
+    };
+
+    let mut engine = Engine::builder().build();
+    engine
+        .register_template(SPRINT_COMMENT_TEMPLATE_NAME, SPRINT_COMMENT_TEMPLATE)
+        .map_err(|err| format!("sprint_comment template register failed: {err}"))?;
+    engine
+        .render(SPRINT_COMMENT_TEMPLATE_NAME, &view)
+        .map_err(|err| format!("sprint_comment template render failed: {err}"))
 }
 
 pub fn write_rendered(path: &Path, content: &str) -> Result<(), String> {

--- a/crates/plan-issue-cli/templates/render/plan_issue_body.md.tera
+++ b/crates/plan-issue-cli/templates/render/plan_issue_body.md.tera
@@ -1,0 +1,24 @@
+{{ pre_table }}
+
+## Task Decomposition
+
+{{ task_table_block }}
+
+## Consistency Rules
+
+- `Status` must be one of: `planned`, `in-progress`, `blocked`, `done`.
+- `Status` = `in-progress` or `done` requires non-`TBD` execution metadata (`Owner`, `Branch`, `Worktree`, `Execution Mode`, `PR`).
+- `Owner` must be a subagent identifier (contains `subagent`) once the task is assigned; `main-agent` ownership is invalid for implementation tasks.
+- `Execution Mode` should be one of: `per-sprint`, `pr-isolated`, `pr-shared` (or `TBD` before assignment).
+- `Branch` and `Worktree` uniqueness is enforced only for rows using `Execution Mode = pr-isolated`.
+
+## Risks / Uncertainties
+
+- Sprint approvals may be recorded before final close; issue stays open until final plan acceptance.
+- Close gate fails if task statuses or PR merge states in the issue body are incomplete.
+
+## Evidence
+
+- Plan source: `{{ plan_file_display }}`
+- Sprint approvals: issue comments (one comment per accepted sprint)
+- Final approval: issue/pull comment URL passed to `close-plan`

--- a/crates/plan-issue-cli/templates/render/sprint_comment.md.tera
+++ b/crates/plan-issue-cli/templates/render/sprint_comment.md.tera
@@ -1,0 +1,37 @@
+{{ heading }}
+
+- Sprint: {{ sprint }} ({{ sprint_name }})
+- Tasks in sprint: {{ task_count }}
+- Note: {{ lead }}
+{%- if mode == "start" %}
+- Execution Mode comes from current Task Decomposition for each sprint task.
+{%- else %}
+- PR values come from current Task Decomposition; unresolved tasks remain `TBD` until PRs are linked.
+{%- endif %}
+{%- if approval_comment_url %}
+- Approval comment URL: {{ approval_comment_url }}
+{%- endif %}
+
+{% if mode == "start" -%}
+| Task | Summary | Execution Mode |
+| --- | --- | --- |
+{%- for row in task_rows %}
+| {{ row.task }} | {{ row.summary }} | {{ row.third_col }} |
+{%- endfor %}
+{%- if sprint_section %}
+
+{{ sprint_section }}
+{%- endif %}
+{%- else -%}
+| Task | Summary | PR |
+| --- | --- | --- |
+{%- for row in task_rows %}
+| {{ row.task }} | {{ row.summary }} | {{ row.third_col }} |
+{%- endfor %}
+{%- endif %}
+{%- if note_text %}
+
+## Main-Agent Notes
+
+{{ note_text }}
+{%- endif %}

--- a/crates/plan-issue-cli/tests/golden/render/plan_issue_body_multi_rows.md
+++ b/crates/plan-issue-cli/tests/golden/render/plan_issue_body_multi_rows.md
@@ -1,0 +1,30 @@
+# Multi Sprint Plan
+
+Overview line.
+
+## Task Decomposition
+
+| Task | Summary | Owner | Branch | Worktree | Execution Mode | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1.1 | Bootstrap repo | subagent-alpha | issue/1-1 | issue-1-1 | per-sprint | TBD | planned | - |
+| 1.2 | Add ci | subagent-alpha | issue/1-1 | issue-1-1 | per-sprint | TBD | planned | depends on 1.1 |
+| 2.1 | Pipe/in/summary | subagent-charlie | issue/2-1 | issue-2-1 | per-sprint | TBD | planned | Multi line note |
+
+## Consistency Rules
+
+- `Status` must be one of: `planned`, `in-progress`, `blocked`, `done`.
+- `Status` = `in-progress` or `done` requires non-`TBD` execution metadata (`Owner`, `Branch`, `Worktree`, `Execution Mode`, `PR`).
+- `Owner` must be a subagent identifier (contains `subagent`) once the task is assigned; `main-agent` ownership is invalid for implementation tasks.
+- `Execution Mode` should be one of: `per-sprint`, `pr-isolated`, `pr-shared` (or `TBD` before assignment).
+- `Branch` and `Worktree` uniqueness is enforced only for rows using `Execution Mode = pr-isolated`.
+
+## Risks / Uncertainties
+
+- Sprint approvals may be recorded before final close; issue stays open until final plan acceptance.
+- Close gate fails if task statuses or PR merge states in the issue body are incomplete.
+
+## Evidence
+
+- Plan source: `docs/plans/multi/multi-plan.md`
+- Sprint approvals: issue comments (one comment per accepted sprint)
+- Final approval: issue/pull comment URL passed to `close-plan`

--- a/crates/plan-issue-cli/tests/golden/render/plan_issue_body_no_rows.md
+++ b/crates/plan-issue-cli/tests/golden/render/plan_issue_body_no_rows.md
@@ -1,0 +1,25 @@
+# example-plan
+
+## Task Decomposition
+
+| Task | Summary | Owner | Branch | Worktree | Execution Mode | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+
+## Consistency Rules
+
+- `Status` must be one of: `planned`, `in-progress`, `blocked`, `done`.
+- `Status` = `in-progress` or `done` requires non-`TBD` execution metadata (`Owner`, `Branch`, `Worktree`, `Execution Mode`, `PR`).
+- `Owner` must be a subagent identifier (contains `subagent`) once the task is assigned; `main-agent` ownership is invalid for implementation tasks.
+- `Execution Mode` should be one of: `per-sprint`, `pr-isolated`, `pr-shared` (or `TBD` before assignment).
+- `Branch` and `Worktree` uniqueness is enforced only for rows using `Execution Mode = pr-isolated`.
+
+## Risks / Uncertainties
+
+- Sprint approvals may be recorded before final close; issue stays open until final plan acceptance.
+- Close gate fails if task statuses or PR merge states in the issue body are incomplete.
+
+## Evidence
+
+- Plan source: `docs/plans/example/example-plan.md`
+- Sprint approvals: issue comments (one comment per accepted sprint)
+- Final approval: issue/pull comment URL passed to `close-plan`

--- a/crates/plan-issue-cli/tests/golden/render/plan_issue_body_single_row.md
+++ b/crates/plan-issue-cli/tests/golden/render/plan_issue_body_single_row.md
@@ -1,0 +1,28 @@
+# Example Plan
+
+Intro paragraph.
+
+## Task Decomposition
+
+| Task | Summary | Owner | Branch | Worktree | Execution Mode | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1.1 | Add feature foo | subagent-alpha | issue/1-1 | issue-1-1 | pr-isolated | TBD | planned | Initial note |
+
+## Consistency Rules
+
+- `Status` must be one of: `planned`, `in-progress`, `blocked`, `done`.
+- `Status` = `in-progress` or `done` requires non-`TBD` execution metadata (`Owner`, `Branch`, `Worktree`, `Execution Mode`, `PR`).
+- `Owner` must be a subagent identifier (contains `subagent`) once the task is assigned; `main-agent` ownership is invalid for implementation tasks.
+- `Execution Mode` should be one of: `per-sprint`, `pr-isolated`, `pr-shared` (or `TBD` before assignment).
+- `Branch` and `Worktree` uniqueness is enforced only for rows using `Execution Mode = pr-isolated`.
+
+## Risks / Uncertainties
+
+- Sprint approvals may be recorded before final close; issue stays open until final plan acceptance.
+- Close gate fails if task statuses or PR merge states in the issue body are incomplete.
+
+## Evidence
+
+- Plan source: `docs/plans/example/example-plan.md`
+- Sprint approvals: issue comments (one comment per accepted sprint)
+- Final approval: issue/pull comment URL passed to `close-plan`

--- a/crates/plan-issue-cli/tests/golden/render/sprint_comment_accepted.md
+++ b/crates/plan-issue-cli/tests/golden/render/sprint_comment_accepted.md
@@ -1,0 +1,16 @@
+## Sprint 1 Accepted
+
+- Sprint: 1 (First sprint)
+- Tasks in sprint: 2
+- Note: Main-agent records sprint acceptance after merge gate passes and sprint rows are synced to done (issue remains open for remaining sprints).
+- PR values come from current Task Decomposition; unresolved tasks remain `TBD` until PRs are linked.
+- Approval comment URL: https://example.test/approval/1
+
+| Task | Summary | PR |
+| --- | --- | --- |
+| 1.1 | Bootstrap repo | #101 |
+| 1.2 | Add ci | #102 |
+
+## Main-Agent Notes
+
+All sprint 1 tasks done.

--- a/crates/plan-issue-cli/tests/golden/render/sprint_comment_ready.md
+++ b/crates/plan-issue-cli/tests/golden/render/sprint_comment_ready.md
@@ -1,0 +1,12 @@
+## Sprint 1 Ready for Review
+
+- Sprint: 1 (First sprint)
+- Tasks in sprint: 2
+- Note: Main-agent requests sprint-level review before merge/acceptance on the plan issue (the issue remains open).
+- PR values come from current Task Decomposition; unresolved tasks remain `TBD` until PRs are linked.
+- Approval comment URL: https://example.test/approval/1
+
+| Task | Summary | PR |
+| --- | --- | --- |
+| 1.1 | Bootstrap repo | TBD (per-sprint) |
+| 1.2 | Add ci | TBD (per-sprint) |

--- a/crates/plan-issue-cli/tests/golden/render/sprint_comment_start.md
+++ b/crates/plan-issue-cli/tests/golden/render/sprint_comment_start.md
@@ -1,0 +1,19 @@
+## Sprint 1 Start
+
+- Sprint: 1 (First sprint)
+- Tasks in sprint: 2
+- Note: Main-agent starts this sprint on the plan issue and dispatches implementation to subagents.
+- Execution Mode comes from current Task Decomposition for each sprint task.
+
+| Task | Summary | Execution Mode |
+| --- | --- | --- |
+| 1.1 | Bootstrap repo | per-sprint |
+| 1.2 | Add ci | per-sprint |
+
+## Sprint 1: First sprint
+
+Goals: do the thing.
+
+### Task 1.1: Bootstrap repo
+
+- Bootstrap.

--- a/crates/plan-issue-cli/tests/golden_render.rs
+++ b/crates/plan-issue-cli/tests/golden_render.rs
@@ -1,0 +1,267 @@
+//! Byte-equality golden tests for render.rs Markdown emitters.
+//!
+//! Covers `render::render_plan_issue_body` (3 representative inputs)
+//! and `render::render_sprint_comment` (Start / Ready / Accepted
+//! modes). Each scenario builds inputs from in-test data + a
+//! tempfile-backed plan stub and asserts byte equality against a
+//! committed fixture under `tests/golden/render/`.
+//!
+//! Set `BLESS_RENDER_GOLDEN=1` to overwrite the fixtures from the
+//! current renderer output instead of asserting.
+
+use std::path::{Path, PathBuf};
+
+use plan_issue_cli::commands::{PrGrouping, SplitStrategy};
+use plan_issue_cli::render::{
+    SprintCommentInput, SprintCommentMode, render_plan_issue_body, render_sprint_comment,
+};
+use plan_issue_cli::task_spec::TaskSpecRow;
+use tempfile::TempDir;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("golden")
+        .join("render")
+        .join(name)
+}
+
+fn assert_or_bless(name: &str, actual: &str) {
+    let path = fixture_path(name);
+    if std::env::var_os("BLESS_RENDER_GOLDEN").is_some() {
+        std::fs::create_dir_all(path.parent().unwrap()).expect("mkdir fixture dir");
+        std::fs::write(&path, actual).expect("write fixture");
+        return;
+    }
+    let expected = std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("read fixture {}: {err}", path.display()));
+    pretty_assertions::assert_eq!(expected, actual, "golden mismatch for {name}");
+}
+
+fn write_plan_file(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, content).expect("write plan file");
+    path
+}
+
+#[allow(clippy::too_many_arguments)]
+fn row(
+    task_id: &str,
+    summary: &str,
+    branch: &str,
+    worktree: &str,
+    owner: &str,
+    notes: &str,
+    pr_group: &str,
+    sprint: i32,
+    grouping: PrGrouping,
+) -> TaskSpecRow {
+    TaskSpecRow {
+        task_id: task_id.into(),
+        summary: summary.into(),
+        branch: branch.into(),
+        worktree: worktree.into(),
+        owner: owner.into(),
+        notes: notes.into(),
+        pr_group: pr_group.into(),
+        sprint,
+        grouping,
+    }
+}
+
+// --- render_plan_issue_body scenarios ----------------------------------
+
+#[test]
+fn plan_issue_body_no_rows_matches_golden() {
+    let tmp = TempDir::new().expect("tempdir");
+    // Empty plan file -> fallback title.
+    let plan_path = write_plan_file(tmp.path(), "empty-plan.md", "");
+    let out = render_plan_issue_body(
+        &plan_path,
+        "docs/plans/example/example-plan.md",
+        "",
+        &[],
+        SplitStrategy::Deterministic,
+    );
+    assert_or_bless("plan_issue_body_no_rows.md", &out);
+}
+
+#[test]
+fn plan_issue_body_single_row_matches_golden() {
+    let tmp = TempDir::new().expect("tempdir");
+    let plan_path = write_plan_file(
+        tmp.path(),
+        "single-plan.md",
+        "# Example Plan\n\nIntro paragraph.\n\n## Sprint 1: First sprint\n\nbody\n",
+    );
+    let rows = vec![row(
+        "1.1",
+        "Add feature foo",
+        "issue/1-1",
+        "issue-1-1",
+        "subagent-alpha",
+        "Initial note",
+        "1",
+        1,
+        PrGrouping::Group,
+    )];
+    let out = render_plan_issue_body(
+        &plan_path,
+        "docs/plans/example/example-plan.md",
+        "Example Plan",
+        &rows,
+        SplitStrategy::Deterministic,
+    );
+    assert_or_bless("plan_issue_body_single_row.md", &out);
+}
+
+#[test]
+fn plan_issue_body_multi_rows_matches_golden() {
+    let tmp = TempDir::new().expect("tempdir");
+    let plan_path = write_plan_file(
+        tmp.path(),
+        "multi-plan.md",
+        "# Multi Sprint Plan\n\nOverview line.\n\n## Sprint 1: Setup\n\nfoo\n\n## Sprint 2: Build\n\nbar\n",
+    );
+    let rows = vec![
+        row(
+            "1.1",
+            "Bootstrap repo",
+            "issue/1-1",
+            "issue-1-1",
+            "subagent-alpha",
+            "-",
+            "1",
+            1,
+            PrGrouping::Group,
+        ),
+        row(
+            "1.2",
+            "Add ci",
+            "issue/1-2",
+            "issue-1-2",
+            "subagent-bravo",
+            "depends on 1.1",
+            "1",
+            1,
+            PrGrouping::Group,
+        ),
+        row(
+            "2.1",
+            "Pipe|in|summary",
+            "issue/2-1",
+            "issue-2-1",
+            "subagent-charlie",
+            "Multi line\nnote",
+            "2",
+            2,
+            PrGrouping::PerSprint,
+        ),
+    ];
+    let out = render_plan_issue_body(
+        &plan_path,
+        "docs/plans/multi/multi-plan.md",
+        "Multi Sprint Plan",
+        &rows,
+        SplitStrategy::Deterministic,
+    );
+    assert_or_bless("plan_issue_body_multi_rows.md", &out);
+}
+
+// --- render_sprint_comment scenarios -----------------------------------
+
+fn sprint_comment_rows() -> Vec<TaskSpecRow> {
+    vec![
+        row(
+            "1.1",
+            "Bootstrap repo",
+            "issue/1-1",
+            "issue-1-1",
+            "subagent-alpha",
+            "-",
+            "1",
+            1,
+            PrGrouping::Group,
+        ),
+        row(
+            "1.2",
+            "Add ci",
+            "issue/1-2",
+            "issue-1-2",
+            "subagent-bravo",
+            "-",
+            "1",
+            1,
+            PrGrouping::Group,
+        ),
+    ]
+}
+
+fn sprint_comment_plan_file(dir: &Path) -> PathBuf {
+    write_plan_file(
+        dir,
+        "sprint-plan.md",
+        "# Sprint Plan\n\nIntro.\n\n## Sprint 1: First sprint\n\nGoals: do the thing.\n\n### Task 1.1: Bootstrap repo\n\n- Bootstrap.\n\n## Sprint 2: Second sprint\n\nMore.\n",
+    )
+}
+
+#[test]
+fn sprint_comment_start_matches_golden() {
+    let tmp = TempDir::new().expect("tempdir");
+    let plan_path = sprint_comment_plan_file(tmp.path());
+    let rows = sprint_comment_rows();
+    let out = render_sprint_comment(SprintCommentInput {
+        mode: SprintCommentMode::Start,
+        plan_file: &plan_path,
+        sprint: 1,
+        sprint_name: "First sprint",
+        rows: &rows,
+        strategy: SplitStrategy::Deterministic,
+        note_text: None,
+        approval_comment_url: None,
+        issue_body_text: None,
+    })
+    .expect("render");
+    assert_or_bless("sprint_comment_start.md", &out);
+}
+
+#[test]
+fn sprint_comment_ready_matches_golden() {
+    let tmp = TempDir::new().expect("tempdir");
+    let plan_path = sprint_comment_plan_file(tmp.path());
+    let rows = sprint_comment_rows();
+    let out = render_sprint_comment(SprintCommentInput {
+        mode: SprintCommentMode::Ready,
+        plan_file: &plan_path,
+        sprint: 1,
+        sprint_name: "First sprint",
+        rows: &rows,
+        strategy: SplitStrategy::Deterministic,
+        note_text: None,
+        approval_comment_url: Some("https://example.test/approval/1"),
+        issue_body_text: None,
+    })
+    .expect("render");
+    assert_or_bless("sprint_comment_ready.md", &out);
+}
+
+#[test]
+fn sprint_comment_accepted_matches_golden() {
+    let tmp = TempDir::new().expect("tempdir");
+    let plan_path = sprint_comment_plan_file(tmp.path());
+    let rows = sprint_comment_rows();
+    let issue_body = "## Task Decomposition\n\n| Task | PR |\n| --- | --- |\n| 1.1 | #101 |\n| 1.2 | https://github.com/foo/bar/pull/102 |\n";
+    let out = render_sprint_comment(SprintCommentInput {
+        mode: SprintCommentMode::Accepted,
+        plan_file: &plan_path,
+        sprint: 1,
+        sprint_name: "First sprint",
+        rows: &rows,
+        strategy: SplitStrategy::Deterministic,
+        note_text: Some("All sprint 1 tasks done."),
+        approval_comment_url: Some("https://example.test/approval/1"),
+        issue_body_text: Some(issue_body),
+    })
+    .expect("render");
+    assert_or_bless("sprint_comment_accepted.md", &out);
+}

--- a/docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md
+++ b/docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md
@@ -405,22 +405,33 @@ pre-migration output.
 
 - **Location**:
   - crates/plan-issue-cli/src/render.rs
-  - crates/plan-issue-cli/templates/dashboard.md.tera (new)
-  - crates/plan-issue-cli/templates/lifecycle_record.md.tera (preview only; full migration in Task 2.5)
-  - crates/plan-issue-cli/tests/golden/dashboard/ (new fixture dir)
-- **Description**: Dashboard rendering (549 lines source, 24 sites).
-  Provider-visible byte stability matters most here. Migrate
-  dashboard composition; leave `lifecycle_record` for Task 2.5.
+  - crates/plan-issue-cli/templates/render/plan_issue_body.md.tera (new)
+  - crates/plan-issue-cli/templates/render/sprint_comment.md.tera (new)
+  - crates/plan-issue-cli/tests/golden/render/ (new fixture dir)
+- **Description**: Provider-visible Markdown emitters in render.rs
+  (549 lines, ~21 `format!`/`out.push` sites): `render_plan_issue_body`
+  (initial plan-issue body, including the Task 2.1 task-decomposition
+  table) and `render_sprint_comment` (sprint Start / Ready / Accepted
+  comments). The discussion source calls these "dashboards"; the file
+  itself names them `render_plan_issue_body` and
+  `render_sprint_comment`. The actual dashboard (`render_dashboard`,
+  `render_dashboard_from_audit`) lives in `lifecycle_record.rs` and is
+  Task 2.5's scope. This task also wires `render_plan_issue_body` to
+  reuse the `render_task_decomposition_block` helper introduced in
+  Task 2.1 (closes the dead-code allowance there).
 - **Dependencies**:
   - Task 2.3
 - **Complexity**:
   - 6
 - **Acceptance criteria**:
-  - Dashboard output byte-identical to capture for at least three
-    representative inputs (no tasks, mixed-status tasks, all done).
+  - `render_plan_issue_body` output byte-identical to capture for at
+    least three representative inputs (no rows, mixed-status rows,
+    all-done rows).
+  - `render_sprint_comment` output byte-identical to capture for
+    Sprint Start / Ready / Accepted modes.
 - **Validation**:
-  - `cargo test -p plan-issue-cli render::dashboard`
-  - `cargo test -p plan-issue-cli --test golden_dashboard`
+  - `cargo test -p plan-issue-cli render`
+  - `cargo test -p plan-issue-cli --test golden_render`
 
 ### Task 2.5: Migrate `plan-issue-cli/src/lifecycle_record.rs`
 


### PR DESCRIPTION
## Summary

- Sprint 2 Task 2.4 of issue #541. Migrate `render.rs`'s two provider-visible Markdown emitters (`render_plan_issue_body` and `render_sprint_comment`) from inline `format!`/`out.push` chains into `nils_markdown::Engine`-rendered Tera templates under `crates/plan-issue-cli/templates/render/`.
- Wires `render_plan_issue_body` to reuse the `render_task_decomposition_block` helper introduced in Task 2.1 (closes the `#[allow(dead_code)]` allowance there). Now-unused row helpers (`task_decomposition_header_row`, `task_decomposition_separator_row`) become `#[cfg(test)]`-only.
- Adds `tests/golden_render.rs` with 3 `render_plan_issue_body` fixtures (no rows / single row / multi rows) and 3 `render_sprint_comment` fixtures (Start / Ready / Accepted). `BLESS_RENDER_GOLDEN=1` re-captures fixtures from the live engine output.
- Plan amendment: Task 2.4 scope was renamed from "dashboard rendering" to accurately describe `render.rs`'s two emitters. The actual dashboard (`render_dashboard`, `render_dashboard_from_audit`) lives in `lifecycle_record.rs` and remains Task 2.5's scope.
- Makes `render`, `task_spec`, and `issue_body` modules `pub` so the integration test under `tests/` can build view inputs.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo nextest run -p nils-plan-issue-cli` — 362/362 pass (was 356 + 6 new golden tests)
- [x] `cargo test -p nils-plan-issue-cli --test golden_render` — 6/6 pass
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
- [x] `bash scripts/ci/completion-asset-audit.sh --strict`
- [x] `bash scripts/generate-third-party-artifacts.sh --check`
- [x] `plan-tooling validate --file docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md`
- [x] Pre-migration vs post-migration render output diff (all 6 scenarios, captured via `git stash` of the migration) is empty

## Notes

- Workspace clippy / publish-crates dry-run pre-existing failures on `main` are not exercised here; this PR is plan-issue-cli scoped.
- Templates + golden fixtures live outside the rumdl audit scope (audit covers README/docs/crates-docs only), matching the precedent set by `issue_body.md.tera` (PR #543) and `lifecycle_vnext.md.tera` (PR #545).

🤖 Generated with [Claude Code](https://claude.com/claude-code)