### PR TITLE
feat(plan-issue-cli): execute.rs Markdown emitter migration

### DIFF
--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -5,8 +5,42 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use nils_common::git as common_git;
 use nils_common::markdown as common_markdown;
+use nils_markdown::Engine;
 use plan_tooling::parse::parse_plan_with_display;
+use serde::Serialize;
 use serde_json::{Value, json};
+
+const PLAN_STATUS_COMMENT_TEMPLATE: &str =
+    include_str!("../templates/execute/plan_status_comment.md.tera");
+const PLAN_STATUS_COMMENT_TEMPLATE_NAME: &str = "execute_plan_status_comment";
+
+const SUBAGENT_PROMPT_TEMPLATE: &str = include_str!("../templates/execute/subagent_prompt.md.tera");
+const SUBAGENT_PROMPT_TEMPLATE_NAME: &str = "execute_subagent_prompt";
+
+#[derive(Debug, Serialize)]
+struct PlanStatusCommentView {
+    total: usize,
+    planned: usize,
+    in_progress: usize,
+    blocked: usize,
+    done: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct SubagentPromptView<'a> {
+    issue: u64,
+    sprint: i32,
+    task: &'a str,
+    anchor_task: &'a str,
+    task_list: &'a str,
+    task_summary: &'a str,
+    owner: &'a str,
+    branch: &'a str,
+    worktree: &'a str,
+    execution_mode: &'a str,
+    notes: &'a str,
+    lane_tasks: &'a str,
+}
 
 use crate::cli::Cli;
 use crate::commands::build::{BuildPlanTaskSpecArgs, BuildTaskSpecArgs};
@@ -4644,6 +4678,16 @@ fn select_adapter_for_slug(
     Ok(crate::provider::select_adapter(&info, force))
 }
 
+fn render_subagent_prompt(view: &SubagentPromptView<'_>) -> String {
+    let mut engine = Engine::builder().build();
+    engine
+        .register_template(SUBAGENT_PROMPT_TEMPLATE_NAME, SUBAGENT_PROMPT_TEMPLATE)
+        .expect("subagent_prompt template registers");
+    engine
+        .render(SUBAGENT_PROMPT_TEMPLATE_NAME, view)
+        .expect("subagent_prompt template renders")
+}
+
 fn render_plan_status_comment(rows: &[TaskRow]) -> String {
     let mut counts: HashMap<String, usize> = HashMap::new();
     for row in rows {
@@ -4651,14 +4695,23 @@ fn render_plan_status_comment(rows: &[TaskRow]) -> String {
         *counts.entry(status).or_insert(0) += 1;
     }
 
-    format!(
-        "## Plan Status Snapshot\n\n- Total tasks: {}\n- planned: {}\n- in-progress: {}\n- blocked: {}\n- done: {}\n",
-        rows.len(),
-        counts.get("planned").copied().unwrap_or(0),
-        counts.get("in-progress").copied().unwrap_or(0),
-        counts.get("blocked").copied().unwrap_or(0),
-        counts.get("done").copied().unwrap_or(0),
-    )
+    let view = PlanStatusCommentView {
+        total: rows.len(),
+        planned: counts.get("planned").copied().unwrap_or(0),
+        in_progress: counts.get("in-progress").copied().unwrap_or(0),
+        blocked: counts.get("blocked").copied().unwrap_or(0),
+        done: counts.get("done").copied().unwrap_or(0),
+    };
+    let mut engine = Engine::builder().build();
+    engine
+        .register_template(
+            PLAN_STATUS_COMMENT_TEMPLATE_NAME,
+            PLAN_STATUS_COMMENT_TEMPLATE,
+        )
+        .expect("plan_status_comment template registers");
+    engine
+        .render(PLAN_STATUS_COMMENT_TEMPLATE_NAME, &view)
+        .expect("plan_status_comment template renders")
 }
 
 fn should_emit_comment(comment_mode: &crate::commands::CommentModeArgs) -> bool {
@@ -4782,15 +4835,20 @@ fn write_subagent_prompts(
                 row.summary.trim().to_string()
             };
             let path = out_dir.join(format!("{}.md", row.task_id));
-            let body = format!(
-                "# Subagent Task Prompt\n\n- Issue: #{issue}\n- Sprint: S{sprint}\n- Task: {}\n- Anchor: {anchor_task}\n- Tasks: {task_list}\n- Summary: {task_summary}\n- Owner: {}\n- Branch: {}\n- Worktree: {}\n- Execution Mode: {}\n- Notes: {}\n\n## Lane Tasks\n{lane_tasks}\n",
-                row.task_id,
-                lane.owner,
-                lane.branch,
-                lane.worktree,
-                lane.execution_mode,
-                lane.notes
-            );
+            let body = render_subagent_prompt(&SubagentPromptView {
+                issue,
+                sprint,
+                task: &row.task_id,
+                anchor_task: &anchor_task,
+                task_list: &task_list,
+                task_summary: &task_summary,
+                owner: &lane.owner,
+                branch: &lane.branch,
+                worktree: &lane.worktree,
+                execution_mode: &lane.execution_mode,
+                notes: &lane.notes,
+                lane_tasks: &lane_tasks,
+            });
             fs::write(&path, body).map_err(|err| {
                 format!("failed to write subagent prompt {}: {err}", path.display())
             })?;
@@ -6117,5 +6175,77 @@ mod tests {
             "issue/s1-t1"
         );
         assert_eq!(normalize_branch_name(" issue/s1-t2 "), "issue/s1-t2");
+    }
+
+    fn execute_golden_fixture(name: &str) -> String {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("golden")
+            .join("execute")
+            .join(name);
+        if std::env::var_os("BLESS_EXECUTE_GOLDEN").is_some() {
+            return path.to_string_lossy().into_owned();
+        }
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("read fixture {}: {err}", path.display()))
+    }
+
+    fn assert_or_bless_execute(name: &str, actual: &str) {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("golden")
+            .join("execute")
+            .join(name);
+        if std::env::var_os("BLESS_EXECUTE_GOLDEN").is_some() {
+            std::fs::create_dir_all(path.parent().unwrap()).expect("mkdir fixture dir");
+            std::fs::write(&path, actual).expect("write fixture");
+            return;
+        }
+        let expected = execute_golden_fixture(name);
+        assert_eq!(expected, actual, "golden mismatch for {name}");
+    }
+
+    #[test]
+    fn plan_status_comment_matches_golden_empty() {
+        let comment = render_plan_status_comment(&[]);
+        assert_or_bless_execute("plan_status_comment_empty.md", &comment);
+    }
+
+    #[test]
+    fn plan_status_comment_matches_golden_mixed() {
+        let rows = vec![
+            task_row("S1T1", "issue/s1-t1", "wt-1", "#1", "planned", "sprint=S1"),
+            task_row(
+                "S1T2",
+                "issue/s1-t2",
+                "wt-2",
+                "#2",
+                "in-progress",
+                "sprint=S1",
+            ),
+            task_row("S1T3", "issue/s1-t3", "wt-3", "#3", "done", "sprint=S1"),
+        ];
+        let comment = render_plan_status_comment(&rows);
+        assert_or_bless_execute("plan_status_comment_mixed.md", &comment);
+    }
+
+    #[test]
+    fn subagent_prompt_matches_golden() {
+        let view = SubagentPromptView {
+            issue: 541,
+            sprint: 2,
+            task: "2.6",
+            anchor_task: "2.6",
+            task_list: "2.6",
+            task_summary: "Migrate execute.rs Markdown emitters",
+            owner: "subagent-alpha",
+            branch: "issue/2-6",
+            worktree: "issue-2-6",
+            execution_mode: "pr-isolated",
+            notes: "depends on Task 2.5b",
+            lane_tasks: "- 2.6: Migrate execute.rs Markdown emitters",
+        };
+        let body = render_subagent_prompt(&view);
+        assert_or_bless_execute("subagent_prompt.md", &body);
     }
 }

--- a/crates/plan-issue-cli/templates/execute/plan_status_comment.md.tera
+++ b/crates/plan-issue-cli/templates/execute/plan_status_comment.md.tera
@@ -1,0 +1,7 @@
+## Plan Status Snapshot
+
+- Total tasks: {{ total }}
+- planned: {{ planned }}
+- in-progress: {{ in_progress }}
+- blocked: {{ blocked }}
+- done: {{ done }}

--- a/crates/plan-issue-cli/templates/execute/subagent_prompt.md.tera
+++ b/crates/plan-issue-cli/templates/execute/subagent_prompt.md.tera
@@ -1,0 +1,16 @@
+# Subagent Task Prompt
+
+- Issue: #{{ issue }}
+- Sprint: S{{ sprint }}
+- Task: {{ task }}
+- Anchor: {{ anchor_task }}
+- Tasks: {{ task_list }}
+- Summary: {{ task_summary }}
+- Owner: {{ owner }}
+- Branch: {{ branch }}
+- Worktree: {{ worktree }}
+- Execution Mode: {{ execution_mode }}
+- Notes: {{ notes }}
+
+## Lane Tasks
+{{ lane_tasks }}

--- a/crates/plan-issue-cli/tests/golden/execute/plan_status_comment_empty.md
+++ b/crates/plan-issue-cli/tests/golden/execute/plan_status_comment_empty.md
@@ -1,0 +1,7 @@
+## Plan Status Snapshot
+
+- Total tasks: 0
+- planned: 0
+- in-progress: 0
+- blocked: 0
+- done: 0

--- a/crates/plan-issue-cli/tests/golden/execute/plan_status_comment_mixed.md
+++ b/crates/plan-issue-cli/tests/golden/execute/plan_status_comment_mixed.md
@@ -1,0 +1,7 @@
+## Plan Status Snapshot
+
+- Total tasks: 3
+- planned: 1
+- in-progress: 1
+- blocked: 0
+- done: 1

--- a/crates/plan-issue-cli/tests/golden/execute/subagent_prompt.md
+++ b/crates/plan-issue-cli/tests/golden/execute/subagent_prompt.md
@@ -1,0 +1,16 @@
+# Subagent Task Prompt
+
+- Issue: #541
+- Sprint: S2
+- Task: 2.6
+- Anchor: 2.6
+- Tasks: 2.6
+- Summary: Migrate execute.rs Markdown emitters
+- Owner: subagent-alpha
+- Branch: issue/2-6
+- Worktree: issue-2-6
+- Execution Mode: pr-isolated
+- Notes: depends on Task 2.5b
+
+## Lane Tasks
+- 2.6: Migrate execute.rs Markdown emitters

--- a/docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md
+++ b/docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md
@@ -510,23 +510,39 @@ pre-migration output.
 
 - **Location**:
   - crates/plan-issue-cli/src/execute.rs
-  - crates/plan-issue-cli/templates/execute/state_update.md.tera (new)
-  - crates/plan-issue-cli/templates/execute/follow_up.md.tera (new)
+  - crates/plan-issue-cli/templates/execute/plan_status_comment.md.tera (new)
+  - crates/plan-issue-cli/templates/execute/subagent_prompt.md.tera (new)
   - crates/plan-issue-cli/tests/golden/execute/ (new fixture dir)
-- **Description**: Longest plan-issue surface (151 inline sites).
-  Migrated last in this crate so earlier patterns are proven. Should
-  start only after Task 2.5b (the rest of the lifecycle_record
-  migration) lands; the formal dependency stays "Task 2.5" because
-  plan-tooling validation only accepts `Task N.M` references.
+- **Description**: execute.rs has 151 `format!`/`push` sites across
+  6121 lines, but most are JSON value construction, file paths,
+  error/log strings, and `KEY=value` dry-run guides — not
+  provider-visible Markdown. Only two sites emit Markdown to
+  providers or to-disk consumers and need template migration:
+  `render_plan_status_comment` (5-line plan-status snapshot used by
+  the local previews) and the inline subagent task-prompt body
+  inside `write_subagent_prompts` (header + metadata bullets +
+  Lane Tasks section, written to disk per subagent lane). The
+  placeholder templates from the original plan
+  (`state_update.md.tera`, `follow_up.md.tera`) referred to
+  emitters that do not exist in this file; the actual checkpoint
+  state/session/validation/review comments are produced by
+  `lifecycle_record::render_record_post_comment_with_display`
+  (already templated in Tasks 2.5 / 2.5b) and are not re-emitted in
+  `execute.rs`. Start only after Task 2.5b lands; the formal
+  dependency stays "Task 2.5" because plan-tooling validation only
+  accepts `Task N.M` references.
 - **Dependencies**:
   - Task 2.5
 - **Complexity**:
-  - 7
+  - 3
 - **Acceptance criteria**:
-  - Execution-state and follow-up comment output is byte-identical
-    to capture for representative inputs.
+  - `render_plan_status_comment` output byte-identical to capture
+    for representative inputs (empty rows, mixed-status rows).
+  - Subagent prompt body output byte-identical to capture for at
+    least one task row.
 - **Validation**:
   - `cargo test -p plan-issue-cli execute`
+  - `cargo test -p plan-issue-cli --test golden_execute`
 
 ### Task 2.7: Migrate `agent-workflow-primitives/src/review_specialists.rs`
 


### PR DESCRIPTION
## Summary

- Sprint 2 Task 2.6 of issue #541. Migrate the two Markdown emitters in `crates/plan-issue-cli/src/execute.rs` to `nils_markdown::Engine`-rendered Tera templates: `render_plan_status_comment` (5-line plan-status snapshot) → `templates/execute/plan_status_comment.md.tera`; the inline subagent task-prompt body inside `write_subagent_prompts` → `templates/execute/subagent_prompt.md.tera` (extracted as `render_subagent_prompt()` for unit-testability).
- Plan amendment: Task 2.6 was rescoped after analysis showed the "151 inline sites" referenced in the plan was the TOTAL `format!`/`push` count across 6121 lines. Only two of those sites emit provider-visible Markdown; the other 149 generate JSON values, file paths, key=value dry-run guides, and error/log strings, and stay in Rust. The placeholder template names from the original plan (`state_update.md.tera`, `follow_up.md.tera`) referred to emitters that don't exist in this file — checkpoint state/session/validation/review comments come from `lifecycle_record::render_record_post_comment_with_display` (already templated in #547 / #548).
- Adds 3 byte-equality golden fixtures (`plan_status_comment_empty.md`, `plan_status_comment_mixed.md`, `subagent_prompt.md`). Pre/post diff against the prior `format!()` renderer is byte-identical, verified by manual comparison of the original format-string layouts against the rendered output.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo nextest run -p nils-plan-issue-cli` — 376/376 pass (was 373 + 3 new golden tests)
- [x] `cargo nextest run --workspace` — full workspace passes (4017+ tests)
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
- [x] `bash scripts/ci/completion-asset-audit.sh --strict`
- [x] `bash scripts/generate-third-party-artifacts.sh --check`
- [x] `plan-tooling validate --file docs/plans/markdown-render-template-layer/markdown-render-template-layer-plan.md`

## Notes

- This closes out the plan-issue-cli portion of Sprint 2 Tier-A migration. Next: Task 2.7 (`agent-workflow-primitives/src/review_specialists.rs`).
- Templates + golden fixtures live outside the rumdl audit scope, matching prior Tier-A precedent (PRs #543, #545–#548).

🤖 Generated with [Claude Code](https://claude.com/claude-code)