### PR TITLE
docs(plans): add plan-issue-record-audit-label-contract bundle

### DIFF
--- a/docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-discussion-source.md
+++ b/docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-discussion-source.md
@@ -1,0 +1,107 @@
+# `plan-issue record audit` Label Contract — Source
+
+| Field | Value |
+| --- | --- |
+| Status | Ready for implementation |
+| Date | 2026-05-26 |
+| Source issue | sympoies/nils-cli#535 (`plan-issue record audit rejects expected label flags`) |
+| Intended next step | Land Sprint 1 in this plan to close out #535 by documenting the contract instead of extending `record audit`. |
+
+## Purpose
+
+`plan-issue record audit` rejects `--label` and therefore cannot serve as a
+single typed check for both lifecycle-comment coverage and expected
+provider-issue labels. Issue #535 framed two contract options: extend
+`record audit` to accept expected labels, or formally keep label verification
+outside `record audit` and document the boundary. This plan commits to the
+second option (documentation-only contract clarification) because it matches
+current call-site usage in the repository and preserves the narrow scope of
+the audit command.
+
+## Confirmed facts
+
+- `nils-plan-issue-cli` 0.23.0's `RecordAuditArgs` exposes only `--body-file`,
+  `--comments-json`, `--profile`, and `--expect-visible`; the help output adds
+  the global `--repo`, `--dry-run`, `--force`, `--format`, and `--state-dir`
+  flags. `--label` is not accepted.
+  (`crates/plan-issue-cli/src/commands/record.rs:122-143`,
+  `plan-issue record audit --help`.) [F1]
+- `run_record_audit` reads body and comments JSON, then calls
+  `lifecycle_record::audit_record(body, comments, profile)`. The audit core
+  parses lifecycle markers and structured payloads from comments only; it
+  has no access to provider-issue labels.
+  (`crates/plan-issue-cli/src/execute.rs:1567-1587`,
+  `crates/plan-issue-cli/src/lifecycle_record.rs:396`.) [F2]
+- The v2 record contract spec describes `plan-issue record audit` in terms of
+  marker URL, timestamp, profile, role, status, and parsed payload per role.
+  It does not mention labels.
+  (`crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md:257-268`.)
+  [F3]
+- `RecordOpenArgs` accepts repeatable `--label`; `record post` and
+  `record close` accept `--add-label` / `--remove-label`. Label mutation is
+  consistently a write-path concern in plan-issue-cli, not a read-path
+  concern.
+  (`crates/plan-issue-cli/src/commands/record.rs:179-188`, `:266-273`,
+  `:341-346`.) [F4]
+- Repository sweep finds no remaining `record audit ... --label` invocations
+  in skills, scripts, runbooks, or fixtures. The downstream workflow friction
+  described in #535 has already been removed from active callers; only the
+  contract itself is undocumented.
+  (`grep -RIn "record audit.*--label" --include='*.md' --include='*.rs'
+  --include='*.sh'` returns no matches.) [F5]
+- `--expect-visible` (added in 0.22.4) extends `record audit` with the
+  visible-completeness lint, broadening the command beyond raw marker
+  parsing. That extension already moved the line on "what does audit cover";
+  this plan deliberately does not move it further to also cover label
+  validation. [F6]
+
+## Decisions
+
+1. **Keep labels out of `plan-issue record audit`.** The audit command stays
+   bounded to lifecycle markers, payloads, and the visible-completeness lint.
+   Label verification is a separate provider-state concern.
+2. **Document the boundary in v2 spec.** Add explicit language to the
+   `plan-issue record audit` section of
+   `issue-backed-plan-record-contract-v2.md` stating that label verification
+   is out of scope, and direct callers to perform label checks via the
+   provider (e.g. `gh issue view --json labels`, `forge-cli pr view`, or an
+   equivalent provider-native call).
+3. **Record the decision in the crate CHANGELOG.** Note that #535 is
+   closed by contract clarification rather than by adding a flag, so future
+   readers do not re-open the same proposal.
+4. **No CLI source changes.** No new flags, no new fixtures, no behavior
+   change. This is a docs-only fix landing on `main` once spec wording is
+   agreed.
+
+## Out of scope
+
+- Adding `--label` (or any new flag) to `record audit`.
+- Adding typed provider-label fetching to `lifecycle_record::audit_record`.
+- Changing how `record open` / `record post` / `record close` accept or
+  apply labels — those write paths are unaffected.
+- Building a separate `plan-issue` subcommand for label verification — if
+  one is needed in future, it should be opened as a separate proposal.
+
+## Validation strategy
+
+- `plan-tooling validate` on this bundle passes.
+- `cargo test -p nils-plan-issue-cli` continues to pass (no production code
+  changes; only docs and CHANGELOG).
+- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` passes for the
+  docs additions.
+- Issue #535 is closed with a comment linking to the tracking issue's
+  closeout, citing the v2 spec change as the contract decision.
+
+## Open questions carried into execution
+
+- none
+
+## Linked records
+
+- Source issue: <https://github.com/sympoies/nils-cli/issues/535>
+- Affected spec: `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`
+
+## Execution
+
+- Recommended plan: docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md
+- Recommended execution state: docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-execution-state.md

--- a/docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-execution-state.md
+++ b/docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-execution-state.md
@@ -1,0 +1,48 @@
+<!-- execute-from-tracking-issue:state:v1 -->
+# `plan-issue record audit` Label Contract Execution State
+
+## Execution State
+
+- Status: ready
+- Target scope: whole issue
+- Execution window: whole issue
+- Current task: Task 1.1
+- Next task: Inventory existing doc claims about `record audit`
+- Last updated: 2026-05-26 Asia/Taipei
+- Branch/commit/PR/release: `feat/plan-issue-record-audit-label-contract`; PR pending
+- Source document: docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md
+- Discussion source document: docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-discussion-source.md
+- Source issue: sympoies/nils-cli#535
+- Tracking issue: pending (this bundle drives `plan-issue record open`)
+- Source snapshot: pending
+- Plan snapshot: pending
+- Initial execution state snapshot: pending
+- Direct source-doc execution waiver: not applicable
+
+## Task Ledger
+
+| ID | Status | Task | Evidence | Notes |
+| --- | --- | --- | --- | --- |
+| Task 1.1 | pending | Inventory existing doc claims about `record audit` | — | — |
+| Task 1.2 | pending | Amend v2 spec audit section with explicit label boundary | — | — |
+| Task 1.3 | pending | Add CHANGELOG entry for the contract clarification | — | — |
+| Task 1.4 | pending | Open and merge the docs PR, then close #535 | — | — |
+
+## Validation
+
+| Command | Status | Summary | Artifact |
+| --- | --- | --- | --- |
+| `plan-tooling validate --file docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md --format text --explain` | pending | bundle gate | — |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | pending | docs hygiene + placement gates | — |
+
+## Blockers
+
+- none
+
+## Session Log
+
+- 2026-05-26: Bundle drafted to close out #535 with Option 2 (docs-only).
+  Slug chosen as `plan-issue-record-audit-label-contract`; primary area is
+  `area::cli`. Repository sweep confirmed no remaining
+  `record audit ... --label` callsites, so the change is contract-only and
+  the docs PR does not need a parallel code-callsite migration.

--- a/docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md
+++ b/docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md
@@ -1,0 +1,144 @@
+# Plan: `plan-issue record audit` Label Contract (Docs-Only)
+
+## Overview
+
+Close out sympoies/nils-cli#535 by documenting the contract that
+`plan-issue record audit` does not validate provider-issue labels, and that
+label verification must be performed via a separate provider-state call.
+This plan is docs-only: it amends the v2 record contract spec and the
+`plan-issue-cli` CHANGELOG; it adds no flags, no code, and no fixtures.
+Closing via docs is the cheaper of the two options enumerated in #535 and
+matches actual repository usage — no current caller passes `--label` to
+`record audit`.
+
+## Read First
+
+- Primary source:
+  docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-discussion-source.md
+- Source type: discussion-to-implementation-doc
+- Open questions carried into execution: none
+
+## Scope
+
+- In scope:
+  - Tightened wording for the `plan-issue record audit` section of
+    `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`
+    explicitly stating that label verification is out of scope.
+  - Brief CHANGELOG entry in `crates/plan-issue-cli/CHANGELOG.md` recording
+    the contract clarification and referencing #535.
+  - Final closing comment on #535 linking to the tracking issue closeout
+    and citing the spec change as the resolution.
+- Out of scope:
+  - Adding `--label` (or any new flag) to `record audit`.
+  - Changing `lifecycle_record::audit_record`, the audit JSON envelope, or
+    the visible-completeness lint.
+  - Changing `record open` / `record post` / `record close` label flags.
+  - Building a new label-verification subcommand.
+  - Touching any production Rust source under `crates/`.
+
+## Assumptions
+
+1. Workspace `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+   covers the docs hygiene gates this plan exercises.
+2. `plan-tooling validate` is sufficient as the plan-bundle gate; no
+   special acceptance fixtures are required for a docs-only change.
+3. The v2 spec is the canonical source for `record audit` behavior; no
+   other doc surface (runbooks, README, CHANGELOG) currently makes a
+   conflicting claim that would also need to be edited. Sprint 1 Task 1.1
+   re-confirms this before editing.
+
+## Sprint 1: Document the audit label contract
+
+**Goal**: Land a single docs PR that pins the contract: `record audit` does
+not validate labels, and callers must check labels through the provider.
+
+**Demo/Validation**:
+
+- Commands:
+  - `plan-tooling validate --file docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md --format text --explain`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+  - `grep -RIn "record audit" docs/ crates/plan-issue-cli/docs/ crates/plan-issue-cli/CHANGELOG.md`
+- Verify: Spec language explicitly names labels as out of scope for audit;
+  CHANGELOG references #535; no other doc surface still claims labels are
+  audit-covered.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 1.1: Inventory existing doc claims about `record audit`
+
+- **Location**:
+  - `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`
+  - `crates/plan-issue-cli/README.md`
+  - `crates/plan-issue-cli/CHANGELOG.md`
+  - `docs/` (top-level plan and runbook surfaces touching plan-issue audit)
+- **Description**: Run `grep -RIn "record audit" docs/ crates/plan-issue-cli/`
+  to enumerate every doc surface that describes `record audit`. Confirm the
+  v2 spec is the only surface that defines the audit contract and that no
+  other doc claims `record audit` covers labels.
+- **Dependencies**: none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Inventory captured in the execution-state Session Log.
+  - If any non-spec surface implies labels are audited, list it in the
+    Session Log so Task 1.2 / 1.3 can amend it too.
+- **Validation**:
+  - `grep -RIn "record audit" docs/ crates/plan-issue-cli/`
+
+### Task 1.2: Amend v2 spec audit section with explicit label boundary
+
+- **Location**:
+  - `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md:257-268`
+- **Description**: Append a short paragraph to the
+  `### plan-issue record audit` section stating that label verification is
+  out of scope. Direct callers to use the provider for label checks (e.g.
+  `gh issue view --json labels`, `forge-cli pr view`, or an equivalent
+  provider-native call), and note that label mutation remains the
+  responsibility of `record open` / `record post` / `record close`.
+- **Dependencies**: Task 1.1
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Spec section explicitly names labels as out of scope for audit.
+  - Spec wording does not imply a future intent to add `--label` to
+    `record audit`; if a separate label-verification command becomes
+    desirable, it is referenced as an open follow-up, not as a planned
+    flag on audit.
+- **Validation**:
+  - `plan-tooling validate --file docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md --format text`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+
+### Task 1.3: Add CHANGELOG entry for the contract clarification
+
+- **Location**:
+  - `crates/plan-issue-cli/CHANGELOG.md`
+- **Description**: Add an entry under the in-flight (Unreleased) section
+  recording that issue #535 is closed by docs clarification rather than by
+  adding a flag, with a one-line summary of the spec change and a link to
+  the v2 spec section.
+- **Dependencies**: Task 1.2
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - CHANGELOG entry references #535 and the v2 spec amendment.
+  - Entry sits under the correct unreleased / in-flight heading per the
+    crate's existing CHANGELOG conventions.
+- **Validation**:
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+
+### Task 1.4: Open and merge the docs PR, then close #535
+
+- **Location**:
+  - GitHub PR against `main`
+  - sympoies/nils-cli#535
+- **Description**: Use the active PR delivery skill to open a single docs
+  PR with the spec and CHANGELOG changes. After merge, post a closing
+  comment on #535 linking to the merged PR and the v2 spec section, then
+  close #535.
+- **Dependencies**: Task 1.3
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - PR is merged to `main` with `--docs-only` CI lane green.
+  - #535 is closed with a comment that cites the tracking issue closeout
+    and the merged spec section.
+- **Validation**:
+  - `forge-cli` (or the current PR delivery skill) reports the PR as
+    merged and #535 as closed.


### PR DESCRIPTION
## Summary

Add the `plan-issue-record-audit-label-contract` plan bundle (discussion source, plan, execution state) under `docs/plans/`. This bundle scaffolds the tracking issue (#555) that will close sympoies/nils-cli#535 with Option 2 — a docs-only contract clarification that keeps label verification outside `plan-issue record audit` and pins the boundary in the v2 record contract spec. No CLI or production source changes ship in this PR.

## Changes

- Add `docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-discussion-source.md` capturing the audit-label contract facts and the Option 2 decision.
- Add `docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md` (Sprint 1: doc inventory, v2 spec amendment, CHANGELOG entry, PR + close #535).
- Add `docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-execution-state.md` with the initial task ledger.

## Test-First Evidence

- Waiver: docs-only plan bundle scaffolding. No production behavior change, so no failing test was authored. Validation rests on `plan-tooling validate` plus the docs CI lane.

## Test plan

- `plan-tooling validate --file docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md --format text` — exit 0 locally.
- `plan-issue --repo sympoies/nils-cli --format json --dry-run record open --profile tracking --bundle docs/plans/plan-issue-record-audit-label-contract ...` — clean preview locally.
- Docs lane in `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` — expected to pass through CI.

## Risk / Notes

- N/A — bundle is docs-only and additive under `docs/plans/`; no CLI / spec / production source touched in this PR. Sprint 1's spec + CHANGELOG edits ship in a follow-up PR driven from a worktree by `execute-plan-tracking-issue`.
