### PR TITLE
docs(plan-issue-cli): document record audit label boundary

### DIFF
--- a/crates/plan-issue-cli/CHANGELOG.md
+++ b/crates/plan-issue-cli/CHANGELOG.md
@@ -60,6 +60,17 @@ versioning.
   `non_required_check_override` in the closeout-comment payload, and the
   comment summary advertises that the override was used.
 
+### Documentation
+
+- `docs/specs/issue-backed-plan-record-contract-v2.md` now states
+  explicitly that `plan-issue record audit` does not validate
+  provider-issue labels and does not accept a `--label` flag. Callers
+  that need to verify expected labels must do so through the provider
+  (e.g. `gh issue view --json labels`, `forge-cli pr view`) as a separate
+  gate. Label mutation remains the responsibility of `record open`,
+  `record post`, and `record close` via `--label`, `--add-label`, and
+  `--remove-label`. (sympoies/nils-cli#535)
+
 ### BREAKING (Plan-Issue Lifecycle v3)
 
 - The `plan-issue record` surface is rewritten around the v3 issue-backed

--- a/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md
+++ b/crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md
@@ -267,6 +267,17 @@ Returns typed evidence from the provider issue body and comments:
 - Fails when a v2 lifecycle comment carries a malformed typed payload. A
   marker with an invalid payload is not counted as valid evidence.
 
+Label verification is out of scope for `record audit`. The command reads
+issue body and lifecycle comments only; it does not fetch or compare
+provider-issue labels and does not accept a `--label` flag. Callers that
+need to verify expected labels alongside the lifecycle audit must do so
+through the provider directly (for example `gh issue view --json labels`,
+`forge-cli pr view`, or an equivalent provider-native call) and treat that
+check as a separate gate in their workflow. Label mutation remains the
+responsibility of `record open`, `record post`, and `record close` via
+`--label`, `--add-label`, and `--remove-label`; those write paths are
+unaffected.
+
 ### `plan-issue record repair-dashboard`
 
 - Reads the latest audit evidence.

--- a/docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-execution-state.md
+++ b/docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-execution-state.md
@@ -3,37 +3,39 @@
 
 ## Execution State
 
-- Status: ready
+- Status: in-progress
 - Target scope: whole issue
 - Execution window: whole issue
-- Current task: Task 1.1
-- Next task: Inventory existing doc claims about `record audit`
+- Current task: Task 1.4
+- Next task: open the docs PR via `deliver-plan-tracking-issue`, then close sympoies/nils-cli#535
 - Last updated: 2026-05-26 Asia/Taipei
-- Branch/commit/PR/release: `feat/plan-issue-record-audit-label-contract`; PR pending
+- Branch/commit/PR/release:
+  `feat/plan-issue-audit-label-contract-sprint-1`; bundle PR
+  `sympoies/nils-cli#556` (merged → `f1aaa36`); Sprint 1 PR pending
 - Source document: docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md
 - Discussion source document: docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-discussion-source.md
 - Source issue: sympoies/nils-cli#535
-- Tracking issue: pending (this bundle drives `plan-issue record open`)
-- Source snapshot: pending
-- Plan snapshot: pending
-- Initial execution state snapshot: pending
+- Tracking issue: <https://github.com/sympoies/nils-cli/issues/555>
+- Source snapshot: <https://github.com/sympoies/nils-cli/issues/555#issuecomment-4543978961>
+- Plan snapshot: <https://github.com/sympoies/nils-cli/issues/555#issuecomment-4543979087>
+- Initial execution state snapshot: <https://github.com/sympoies/nils-cli/issues/555#issuecomment-4543979186>
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger
 
 | ID | Status | Task | Evidence | Notes |
 | --- | --- | --- | --- | --- |
-| Task 1.1 | pending | Inventory existing doc claims about `record audit` | — | — |
-| Task 1.2 | pending | Amend v2 spec audit section with explicit label boundary | — | — |
-| Task 1.3 | pending | Add CHANGELOG entry for the contract clarification | — | — |
-| Task 1.4 | pending | Open and merge the docs PR, then close #535 | — | — |
+| Task 1.1 | done | Inventory existing doc claims about `record audit` | session log 2026-05-26 (T1.1) | v2 spec is the only contract surface; README / CHANGELOG / runbook / tests / src have no label claim |
+| Task 1.2 | done | Amend v2 spec audit section with explicit label boundary | `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md` | added "Label verification is out of scope" paragraph below the audit bullets |
+| Task 1.3 | done | Add CHANGELOG entry for the contract clarification | `crates/plan-issue-cli/CHANGELOG.md` (Unreleased › Documentation) | references sympoies/nils-cli#535 |
+| Task 1.4 | pending | Open and merge the docs PR, then close #535 | — | handed off to `deliver-plan-tracking-issue` |
 
 ## Validation
 
 | Command | Status | Summary | Artifact |
 | --- | --- | --- | --- |
-| `plan-tooling validate --file docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md --format text --explain` | pending | bundle gate | — |
-| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | pending | docs hygiene + placement gates | — |
+| `plan-tooling validate --file docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-plan.md --format text --explain` | pass | bundle gate on bundle PR | sympoies/nils-cli#556 |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | pending | docs hygiene + placement gates over Sprint 1 changes | — |
 
 ## Blockers
 
@@ -46,3 +48,26 @@
   `area::cli`. Repository sweep confirmed no remaining
   `record audit ... --label` callsites, so the change is contract-only and
   the docs PR does not need a parallel code-callsite migration.
+- 2026-05-26 (bundle PR): Bundle landed on `main` via sympoies/nils-cli#556
+  (squash → `f1aaa36`). Sprint 1 execution branch
+  `feat/plan-issue-audit-label-contract-sprint-1` opened from new `main`
+  in a sibling worktree at
+  `nils-cli-worktrees/plan-issue-audit-label-contract-sprint-1` to keep
+  the user's parallel work on the primary worktree undisturbed.
+- 2026-05-26 (T1.1 inventory): `grep -RIn "record audit"` across `docs/`
+  and `crates/plan-issue-cli/` confirms only the v2 contract spec defines
+  the audit contract. README / CHANGELOG / `provider-routing-runbook.md`
+  / tests / `src/execute.rs` / `src/tracking/*` mention `record audit`
+  but make no claim about labels. No additional doc surface needs
+  amendment alongside the spec.
+- 2026-05-26 (T1.2 spec amendment): Appended a "Label verification is out
+  of scope" paragraph to the
+  `### plan-issue record audit` section of
+  `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`.
+  Wording directs callers to provider-native label checks
+  (`gh issue view --json labels`, `forge-cli pr view`) and re-affirms
+  `record open` / `record post` / `record close` as the write-side label
+  surface.
+- 2026-05-26 (T1.3 CHANGELOG): Added a `### Documentation` block under
+  the Unreleased section of `crates/plan-issue-cli/CHANGELOG.md`
+  recording the spec clarification and linking to sympoies/nils-cli#535.


### PR DESCRIPTION
## Summary

Document that `plan-issue record audit` does not validate provider-issue labels and does not accept `--label`. The v2 record contract spec now explicitly carves label verification out of audit scope and directs callers to provider-native label checks (e.g. `gh issue view --json labels`, `forge-cli pr view`). Label mutation remains on `record open`, `record post`, and `record close`. Refs sympoies/nils-cli#535. Tracking: sympoies/nils-cli#555.

## Changes

- `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`: append a "Label verification is out of scope" paragraph to the `### plan-issue record audit` section. Wording directs callers to provider-native label checks and reaffirms that label mutation stays on the write-path commands.
- `crates/plan-issue-cli/CHANGELOG.md`: add a `### Documentation` block under Unreleased recording the contract clarification and linking sympoies/nils-cli#535.
- `docs/plans/plan-issue-record-audit-label-contract/plan-issue-record-audit-label-contract-execution-state.md`: mark Sprint 1 Task 1.1-1.3 done, log inventory + amendment + CHANGELOG evidence in the Session Log.

## Test-First Evidence

- Waiver: docs-only contract clarification. No production code path changes, so no failing test was authored. Behaviour assertion is repository sweep: `grep -RIn "record audit.*--label" --include='*.md' --include='*.rs' --include='*.sh'` returns no matches, confirming no caller relies on the (rejected) flag today.

## Test plan

- `plan-tooling validate --file docs/plans/plan-issue-record-audit-label-contract/*-plan.md` — exit 0 (plan bundle gate green).
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` — PASS across docs placement, docs hygiene, markdown lint, plan-bundle validate, cli output contract, and forge-cli fixture redaction.
- `grep -RIn "record audit.*--label" --include='*.md' --include='*.rs' --include='*.sh'` — no callsites; confirms the contract clarification matches actual repo usage.

## Risk / Notes

- N/A — contract clarification only. No runtime behaviour, schema, or CLI surface change. The previously rejected `record audit --label` invocation continues to be rejected; this PR documents that as the explicit contract instead of an implementation gap.
