### PR TITLE
feat(plan-issue-cli): repair closeout Required column rendering

### DIFF
--- a/crates/plan-issue-cli/CHANGELOG.md
+++ b/crates/plan-issue-cli/CHANGELOG.md
@@ -39,6 +39,21 @@ versioning.
 
 ### Fixed
 
+- `plan-issue record close` closeout-comment table renders the
+  `Required` column as `none required` (zero required checks defined),
+  `pass (N)`, `fail (N)`, `none`, or `unknown` instead of collapsing
+  every `required_state == None` cause into the single misleading
+  `unknown` label. Two underlying repairs feed the new rendering: the
+  GitHub adapter's `pr_required_summary` now drops the unsupported
+  `conclusion` field from the `gh pr checks --required --json …` call
+  list (the call was exiting 5 with `Unknown JSON field: "conclusion"`
+  on current `gh`) and recognises `gh`'s `no required checks reported
+  on the '<branch>' branch` stderr message as the canonical
+  zero-required success rollup, mapping it to
+  `(Some("success"), Some(0), [])` so the renderer can pick the new
+  `none required` label. The `closeout.v1` payload wire format is
+  unchanged; historical closeout records remain immutable.
+  (sympoies/nils-cli#561, observation source #541)
 - `plan-issue record close` no longer collapses non-required GitHub
   `statusCheckRollup` failures into `linked-pr-not-merged`. The strict
   closeout gate now consults a separate required-check rollup (via

--- a/crates/plan-issue-cli/src/github.rs
+++ b/crates/plan-issue-cli/src/github.rs
@@ -84,30 +84,95 @@ pub struct PrMergeSummary {
     pub non_required_failures: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+/// Output captured from a single `gh` invocation. Exposes stdout, stderr,
+/// and exit status so callers that need to branch on stderr text (e.g.
+/// `pr_required_summary`'s "no required checks reported" recognition) can
+/// inspect every channel without re-shelling out.
+#[derive(Debug, Clone)]
+pub struct GhRunOutput {
+    pub success: bool,
+    /// Raw exit code surfaced from the runner. Production paths only
+    /// branch on `success`; the field is kept for tests that need to
+    /// assert a specific non-zero code, and for future probes.
+    #[allow(dead_code)]
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Test-friendly indirection over the `gh` shellout. Production code uses
+/// [`default_gh_runner`]; tests inject a fake that returns canned outputs
+/// via [`GhCliAdapter::with_runner`].
+pub type GhRunner = fn(&[&str]) -> Result<GhRunOutput, String>;
+
+/// Default runner backing [`GhCliAdapter`]. Spawns the real `gh` binary
+/// and forwards stdout / stderr / exit status into [`GhRunOutput`].
+pub fn default_gh_runner(args: &[&str]) -> Result<GhRunOutput, String> {
+    let output = common_process::run_output("gh", args)
+        .map(|output| output.into_std_output())
+        .map_err(|err| format!("failed to execute gh: {err}"))?;
+    Ok(GhRunOutput {
+        success: output.status.success(),
+        exit_code: output.status.code(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
 pub struct GhCliAdapter {
     force: bool,
+    runner: GhRunner,
+}
+
+impl Default for GhCliAdapter {
+    fn default() -> Self {
+        Self {
+            force: false,
+            runner: default_gh_runner,
+        }
+    }
 }
 
 impl GhCliAdapter {
     pub const fn new(force: bool) -> Self {
-        Self { force }
+        Self {
+            force,
+            runner: default_gh_runner,
+        }
     }
 
-    fn run(args: &[String]) -> Result<String, String> {
-        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
-        let output = common_process::run_output("gh", &arg_refs)
-            .map(|output| output.into_std_output())
-            .map_err(|err| format!("failed to execute gh: {err}"))?;
+    /// Build an adapter with a custom runner. Used by unit tests to drive
+    /// `gh` call sites deterministically; production callers should keep
+    /// using [`GhCliAdapter::new`].
+    #[cfg(test)]
+    pub const fn with_runner(force: bool, runner: GhRunner) -> Self {
+        Self { force, runner }
+    }
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            let detail = if stderr.is_empty() { stdout } else { stderr };
+    fn run(&self, args: &[String]) -> Result<String, String> {
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+        let output = (self.runner)(&arg_refs)?;
+        if !output.success {
+            let stderr_trim = output.stderr.trim();
+            let stdout_trim = output.stdout.trim();
+            let detail = if stderr_trim.is_empty() {
+                stdout_trim
+            } else {
+                stderr_trim
+            };
             return Err(format!("gh {} failed: {detail}", args.join(" ")));
         }
+        Ok(output.stdout)
+    }
 
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    /// Like [`Self::run`] but surfaces the full [`GhRunOutput`] regardless
+    /// of exit status. Used by `pr_required_summary` so the "no required
+    /// checks reported" stderr branch can be recognised without losing
+    /// other failure paths.
+    fn run_full(&self, args: &[String]) -> Result<GhRunOutput, String> {
+        let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+        (self.runner)(&arg_refs)
     }
 
     fn parse_json(stdout: &str, context: &str) -> Result<Value, String> {
@@ -136,6 +201,7 @@ impl GhCliAdapter {
     /// `gh pr view` and is used to compute the non-required failure
     /// list (rollup names not in the required set).
     fn pr_required_summary(
+        &self,
         repo: &str,
         pr: u64,
         rollup_value: Option<&Value>,
@@ -148,33 +214,60 @@ impl GhCliAdapter {
             repo.to_string(),
             "--required".to_string(),
             "--json".to_string(),
-            "bucket,state,conclusion,name".to_string(),
+            // Only fields this function actually reads. `conclusion` was
+            // listed historically but the function never indexes
+            // `required_array[].conclusion`; current `gh` (cli >=2.x)
+            // also rejects `conclusion` outright with
+            // `Unknown JSON field: "conclusion"` (exit 5), which would
+            // otherwise force every callsite into the catch-all `unknown`
+            // render branch.
+            "name,state".to_string(),
         ];
-        let raw = match Self::run(&args) {
+        let output = match self.run_full(&args) {
             Ok(out) => out,
+            // Spawn failures (network / `gh` not installed) — fall back
+            // to the catch-all `unknown` render branch.
             Err(_) => return (None, None, Vec::new()),
         };
+        if !output.success {
+            // upstream contract: `gh pr checks --required` exits non-zero
+            // and writes `no required checks reported on the '<branch>'
+            // branch` to stderr when the target branch has no
+            // branch-protection rule. Treat that case as the canonical
+            // zero-required success rollup so non-required failures do
+            // not block the close gate and the renderer can show
+            // `none required` rather than `unknown`. Other non-zero
+            // exits remain failures and propagate as `(None, None, [])`.
+            if output.stderr.contains("no required checks reported") {
+                return (Some("success".to_string()), Some(0), Vec::new());
+            }
+            return (None, None, Vec::new());
+        }
+        let raw = output.stdout;
         let required_array: Vec<Value> = match serde_json::from_str(raw.trim()) {
             Ok(Value::Array(items)) => items,
             Ok(_) => return (None, None, Vec::new()),
-            // `gh pr checks --required` prints nothing when the PR has
-            // no required checks; treat empty output as a zero-required
-            // success rollup so a non-required failure does not block
-            // the gate.
+            // Defensive secondary: if a future `gh` version starts
+            // exiting 0 with empty stdout for the same condition (e.g.
+            // `--json` mode flips to "empty array"), still treat it as
+            // zero-required success.
             Err(_) if raw.trim().is_empty() => {
                 return (Some("success".to_string()), Some(0), Vec::new());
             }
             Err(_) => return (None, None, Vec::new()),
         };
         let required_count = u32::try_from(required_array.len()).unwrap_or(u32::MAX);
-        let required_state =
-            rollup_status(&Value::Array(required_array.clone())).unwrap_or_else(|| {
-                if required_array.is_empty() {
-                    "success".to_string()
-                } else {
-                    "unknown".to_string()
-                }
-            });
+        // Empty array means "no required checks defined" — same logical
+        // state as the stderr-recognition branch above and the
+        // defensive empty-stdout branch. Map directly to "success" so
+        // the renderer can pick the `none required` label rather than
+        // bouncing through `rollup_status`, which would return "none"
+        // for an empty array and downgrade to `CheckStatus::None`.
+        if required_array.is_empty() {
+            return (Some("success".to_string()), Some(0), Vec::new());
+        }
+        let required_state = rollup_status(&Value::Array(required_array.clone()))
+            .unwrap_or_else(|| "unknown".to_string());
 
         let required_names: std::collections::HashSet<String> = required_array
             .iter()
@@ -251,7 +344,7 @@ impl ProviderAdapter for GhCliAdapter {
             "--json".to_string(),
             "body".to_string(),
         ];
-        let stdout = Self::run(&args)?;
+        let stdout = self.run(&args)?;
         let json = Self::parse_json(&stdout, "issue view")?;
         let body = json
             .get("body")
@@ -270,7 +363,7 @@ impl ProviderAdapter for GhCliAdapter {
             "--json".to_string(),
             "body,comments".to_string(),
         ];
-        let stdout = Self::run(&args)?;
+        let stdout = self.run(&args)?;
         let json = Self::parse_json(&stdout, "issue view (body+comments)")?;
         let body = json
             .get("body")
@@ -315,7 +408,7 @@ impl ProviderAdapter for GhCliAdapter {
             }
         }
 
-        let stdout = Self::run(&args)?;
+        let stdout = self.run(&args)?;
         let url = stdout.trim().to_string();
         let issue_number = issue_number_from_url(&url)
             .ok_or_else(|| format!("unable to parse issue number from gh output: {url}"))?;
@@ -334,7 +427,7 @@ impl ProviderAdapter for GhCliAdapter {
             "--body-file".to_string(),
             body_file.to_string_lossy().to_string(),
         ];
-        Self::run(&args).map(|_| ())
+        self.run(&args).map(|_| ())
     }
 
     fn comment_issue(&self, repo: &str, issue: u64, body_file: &Path) -> Result<String, String> {
@@ -349,7 +442,7 @@ impl ProviderAdapter for GhCliAdapter {
             "--body-file".to_string(),
             body_file.to_string_lossy().to_string(),
         ];
-        let stdout = Self::run(&args)?;
+        let stdout = self.run(&args)?;
         extract_issue_comment_url(&stdout).ok_or_else(|| {
             format!(
                 "gh issue comment did not print a recognisable comment URL; got: {:?}",
@@ -399,7 +492,7 @@ impl ProviderAdapter for GhCliAdapter {
             return Ok(());
         }
 
-        Self::run(&args).map(|_| ())
+        self.run(&args).map(|_| ())
     }
 
     fn close_issue(
@@ -432,7 +525,7 @@ impl ProviderAdapter for GhCliAdapter {
             }
         }
 
-        Self::run(&args).map(|_| ())
+        self.run(&args).map(|_| ())
     }
 
     fn pr_is_merged(&self, repo: &str, pr: u64) -> Result<bool, String> {
@@ -445,7 +538,7 @@ impl ProviderAdapter for GhCliAdapter {
             "--json".to_string(),
             "state,mergedAt".to_string(),
         ];
-        let stdout = Self::run(&args)?;
+        let stdout = self.run(&args)?;
         let json = Self::parse_json(&stdout, "pr view")?;
 
         let merged_at_present = !json.get("mergedAt").is_some_and(Value::is_null);
@@ -467,7 +560,7 @@ impl ProviderAdapter for GhCliAdapter {
             "--json".to_string(),
             "state,mergeCommit,statusCheckRollup".to_string(),
         ];
-        let stdout = Self::run(&args)?;
+        let stdout = self.run(&args)?;
         let json = Self::parse_json(&stdout, "pr view (merge summary)")?;
 
         let state = json
@@ -487,7 +580,7 @@ impl ProviderAdapter for GhCliAdapter {
             .and_then(rollup_status)
             .filter(|status| !status.is_empty());
         let (required_state, required_count, non_required_failures) =
-            Self::pr_required_summary(repo, pr, rollup_value);
+            self.pr_required_summary(repo, pr, rollup_value);
         Ok(PrMergeSummary {
             state,
             merged,
@@ -505,7 +598,7 @@ impl ProviderAdapter for GhCliAdapter {
         // which is the issue-style stream used for review-evidence comments.
         let endpoint = format!("repos/{repo}/issues/{pr}/comments");
         let args = vec!["api".to_string(), "--paginate".to_string(), endpoint];
-        let stdout = Self::run(&args)?;
+        let stdout = self.run(&args)?;
 
         // `gh api --paginate` concatenates JSON arrays back-to-back without
         // a wrapping comma, so we parse each top-level array on its own
@@ -975,5 +1068,134 @@ esac
             "empty oid should be filtered out"
         );
         assert_eq!(summary_empty.checks.as_deref(), Some("none"));
+    }
+
+    // Sprint 1 of the closeout required-check rendering plan
+    // (sympoies/nils-cli#561): exercise pr_required_summary's
+    // "no required checks reported" stderr recognition deterministically
+    // through an injected `GhRunner`, plus the success + failure paths.
+
+    use super::{GhRunOutput, default_gh_runner};
+
+    fn ok_runner(stdout: &str) -> super::GhRunner {
+        // Each branch returns a fresh static fn so we can use them as
+        // `GhRunner` (fn pointer) values without capturing locals.
+        // The injected runner is keyed by the `--required` flag; a smarter
+        // dispatcher per-test would be overkill for unit coverage.
+        match stdout {
+            "empty_array" => |_| {
+                Ok(GhRunOutput {
+                    success: true,
+                    exit_code: Some(0),
+                    stdout: "[]".to_string(),
+                    stderr: String::new(),
+                })
+            },
+            "one_required_pass" => |_| {
+                Ok(GhRunOutput {
+                    success: true,
+                    exit_code: Some(0),
+                    stdout: r#"[{"name":"ci","state":"SUCCESS"}]"#.to_string(),
+                    stderr: String::new(),
+                })
+            },
+            _ => |_| {
+                Ok(GhRunOutput {
+                    success: true,
+                    exit_code: Some(0),
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            },
+        }
+    }
+
+    fn stderr_runner(message: &'static str) -> super::GhRunner {
+        // Map the canonical stderr strings to static-only branches the
+        // `GhRunner` (fn pointer) type permits.
+        match message {
+            "no_required" => |_| {
+                Ok(GhRunOutput {
+                    success: false,
+                    exit_code: Some(1),
+                    stdout: String::new(),
+                    stderr: "no required checks reported on the 'feature/x' branch\n"
+                        .to_string(),
+                })
+            },
+            "auth" => |_| {
+                Ok(GhRunOutput {
+                    success: false,
+                    exit_code: Some(4),
+                    stdout: String::new(),
+                    stderr: "gh: GraphQL error: Could not resolve to a PR\n".to_string(),
+                })
+            },
+            _ => |_| Err("simulated spawn failure".to_string()),
+        }
+    }
+
+    #[test]
+    fn pr_required_summary_recognises_no_required_checks_reported_stderr() {
+        // The canonical exit-1 + "no required checks reported on the
+        // '<branch>' branch" stderr message must be classified as the
+        // zero-required success case, not as the catch-all `(None, None, [])`.
+        let adapter = GhCliAdapter::with_runner(false, stderr_runner("no_required"));
+        let (state, count, non_required) =
+            adapter.pr_required_summary("sympoies/nils-cli", 553, None);
+        assert_eq!(state.as_deref(), Some("success"));
+        assert_eq!(count, Some(0));
+        assert!(non_required.is_empty());
+    }
+
+    #[test]
+    fn pr_required_summary_returns_zero_required_on_empty_array_stdout() {
+        let adapter = GhCliAdapter::with_runner(false, ok_runner("empty_array"));
+        let (state, count, non_required) =
+            adapter.pr_required_summary("sympoies/nils-cli", 553, None);
+        assert_eq!(state.as_deref(), Some("success"));
+        assert_eq!(count, Some(0));
+        assert!(non_required.is_empty());
+    }
+
+    #[test]
+    fn pr_required_summary_returns_pass_with_count_for_one_required_check() {
+        let adapter = GhCliAdapter::with_runner(false, ok_runner("one_required_pass"));
+        let (state, count, non_required) =
+            adapter.pr_required_summary("sympoies/nils-cli", 553, None);
+        assert_eq!(state.as_deref(), Some("success"));
+        assert_eq!(count, Some(1));
+        assert!(non_required.is_empty());
+    }
+
+    #[test]
+    fn pr_required_summary_returns_none_on_unrecognised_failure_stderr() {
+        // Any non-zero exit whose stderr does NOT include
+        // "no required checks reported" stays in the catch-all
+        // `(None, None, [])` branch so the renderer can emit `unknown`
+        // and a future regression remains visible.
+        let adapter = GhCliAdapter::with_runner(false, stderr_runner("auth"));
+        let (state, count, non_required) =
+            adapter.pr_required_summary("sympoies/nils-cli", 553, None);
+        assert!(state.is_none());
+        assert!(count.is_none());
+        assert!(non_required.is_empty());
+    }
+
+    #[test]
+    fn pr_required_summary_returns_none_on_runner_spawn_failure() {
+        let adapter = GhCliAdapter::with_runner(false, stderr_runner("spawn"));
+        let (state, count, non_required) =
+            adapter.pr_required_summary("sympoies/nils-cli", 553, None);
+        assert!(state.is_none());
+        assert!(count.is_none());
+        assert!(non_required.is_empty());
+    }
+
+    #[test]
+    fn default_gh_runner_is_callable_via_function_pointer() {
+        // Smoke that the production runner satisfies the `GhRunner` type
+        // (fn pointer) bound without indirection at the call site.
+        let _: super::GhRunner = default_gh_runner;
     }
 }

--- a/crates/plan-issue-cli/src/github.rs
+++ b/crates/plan-issue-cli/src/github.rs
@@ -1119,8 +1119,7 @@ esac
                     success: false,
                     exit_code: Some(1),
                     stdout: String::new(),
-                    stderr: "no required checks reported on the 'feature/x' branch\n"
-                        .to_string(),
+                    stderr: "no required checks reported on the 'feature/x' branch\n".to_string(),
                 })
             },
             "auth" => |_| {

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -2059,8 +2059,7 @@ fn render_closeout_payload_visible(closeout: &CloseoutData) -> String {
             .iter()
             .map(|pr| {
                 let pr_label = pr.url.as_deref().unwrap_or(&pr.pr_ref);
-                let required_label =
-                    required_check_label(pr.required_state, pr.required_count);
+                let required_label = required_check_label(pr.required_state, pr.required_count);
                 CloseoutPrRow {
                     label: table_cell(pr_label),
                     merge_sha: table_cell(pr.merge_sha.as_deref().unwrap_or("")),

--- a/crates/plan-issue-cli/src/lifecycle_record.rs
+++ b/crates/plan-issue-cli/src/lifecycle_record.rs
@@ -2059,19 +2059,13 @@ fn render_closeout_payload_visible(closeout: &CloseoutData) -> String {
             .iter()
             .map(|pr| {
                 let pr_label = pr.url.as_deref().unwrap_or(&pr.pr_ref);
-                let required = pr
-                    .required_state
-                    .map(check_status_label)
-                    .unwrap_or("unknown");
-                let required_count = pr
-                    .required_count
-                    .map(|count| format!(" ({count})"))
-                    .unwrap_or_default();
+                let required_label =
+                    required_check_label(pr.required_state, pr.required_count);
                 CloseoutPrRow {
                     label: table_cell(pr_label),
                     merge_sha: table_cell(pr.merge_sha.as_deref().unwrap_or("")),
                     checks: check_status_label(pr.checks),
-                    required: format!("{}{}", table_cell(required), required_count),
+                    required: table_cell(&required_label),
                     non_required_failures: table_cell(&non_empty_join(
                         &pr.non_required_failures,
                         "none",
@@ -2131,6 +2125,42 @@ fn check_status_label(status: CheckStatus) -> &'static str {
         CheckStatus::Pass => "pass",
         CheckStatus::Fail => "fail",
         CheckStatus::None => "none",
+    }
+}
+
+/// Render the closeout-comment `Required` column from the
+/// `(required_state, required_count)` pair on a [`LinkedPrEvidence`].
+///
+/// Five label branches:
+///
+/// - `Some(Pass) + Some(0)` → `"none required"` — no required-check
+///   rule exists for the branch (or rule explicitly declares zero
+///   required checks). The earlier rendering collapsed this into
+///   `"unknown"` even on healthy PRs (sympoies/nils-cli#541 closeout).
+/// - `Some(Pass) + Some(N>=1)` → `"pass (N)"` — required checks
+///   enforced and green.
+/// - `Some(Pass) + None` → `"pass"` — required-state known but count
+///   not surfaced by the provider; defensive case kept for future
+///   adapters.
+/// - `Some(Fail) + …` → `"fail (N)"` or `"fail"` — required checks
+///   enforced and at least one is red. Non-required failures are
+///   carried in the adjacent column.
+/// - `Some(None) + …` → `"none"` — provider reported no aggregate
+///   rollup at all (e.g. PR #554 on #541's closeout, where GHA never
+///   registered any check suite).
+/// - `None + …` → `"unknown"` — adapter probe failed (e.g. `gh` spawn
+///   error, `gh pr checks --required` non-zero with unrecognised
+///   stderr, fixture omits the field). Kept as the catch-all so a
+///   future probe regression remains visible.
+fn required_check_label(state: Option<CheckStatus>, count: Option<u32>) -> String {
+    match (state, count) {
+        (Some(CheckStatus::Pass), Some(0)) => "none required".to_string(),
+        (Some(CheckStatus::Pass), Some(n)) => format!("pass ({n})"),
+        (Some(CheckStatus::Pass), None) => "pass".to_string(),
+        (Some(CheckStatus::Fail), Some(n)) => format!("fail ({n})"),
+        (Some(CheckStatus::Fail), None) => "fail".to_string(),
+        (Some(CheckStatus::None), _) => "none".to_string(),
+        (None, _) => "unknown".to_string(),
     }
 }
 
@@ -3188,5 +3218,45 @@ mod sprint3_tests {
 
         let payload = extract_payload(&body).expect("payload");
         assert_eq!(payload.role, PayloadRole::Source);
+    }
+
+    #[test]
+    fn required_check_label_emits_five_distinct_branches() {
+        // `Some(Pass) + Some(0)` is the "no required-check rule" case
+        // observed on sympoies/nils-cli#541's closeout — was previously
+        // collapsed into "unknown".
+        assert_eq!(
+            required_check_label(Some(CheckStatus::Pass), Some(0)),
+            "none required"
+        );
+
+        // `Some(Pass) + Some(N>=1)` keeps the existing "pass (N)" shape.
+        assert_eq!(
+            required_check_label(Some(CheckStatus::Pass), Some(3)),
+            "pass (3)"
+        );
+
+        // `Some(Pass) + None` is the defensive case for adapters that
+        // know the state but not the count.
+        assert_eq!(required_check_label(Some(CheckStatus::Pass), None), "pass");
+
+        // `Some(Fail) + Some(N)` keeps the existing "fail (N)" shape.
+        assert_eq!(
+            required_check_label(Some(CheckStatus::Fail), Some(2)),
+            "fail (2)"
+        );
+        assert_eq!(required_check_label(Some(CheckStatus::Fail), None), "fail");
+
+        // `Some(None)` is the aggregate-rollup-absent case (PR #554 on
+        // #541's closeout — GHA never registered any check suite).
+        assert_eq!(
+            required_check_label(Some(CheckStatus::None), Some(0)),
+            "none"
+        );
+        assert_eq!(required_check_label(Some(CheckStatus::None), None), "none");
+
+        // `None` is the catch-all for probe failures / fixture omissions.
+        assert_eq!(required_check_label(None, None), "unknown");
+        assert_eq!(required_check_label(None, Some(0)), "unknown");
     }
 }

--- a/crates/plan-issue-cli/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue-cli/tests/integration/live_record_ops.rs
@@ -1233,6 +1233,21 @@ fn record_close_fixture_passes_with_non_required_failure_when_zero_required() {
     assert_eq!(linked["required_count"], 0);
     assert_eq!(linked["required_state"], "pass");
     assert_eq!(linked["non_required_failures"][0], "scripts/ci/all.sh");
+
+    // sympoies/nils-cli#561 follow-up: rendered closeout-comment table
+    // must label the zero-required case `none required`, not `unknown`
+    // and not `pass (0)`.
+    let body = preview["closeout_comment_body"]
+        .as_str()
+        .expect("closeout body");
+    assert!(
+        body.contains("| none required |"),
+        "expected `none required` in closeout body, got: {body}"
+    );
+    assert!(
+        !body.contains("| unknown |"),
+        "expected no `unknown` cell in closeout body, got: {body}"
+    );
 }
 
 #[test]

--- a/docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-execution-state.md
+++ b/docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-execution-state.md
@@ -1,0 +1,55 @@
+<!-- execute-from-tracking-issue:state:v1 -->
+# plan-issue closeout `Required` column rendering fix — Execution State
+
+## Execution State
+
+- Status: ready
+- Target scope: whole plan
+- Execution window: whole plan (single sprint)
+- Current task: Task 1.1
+- Next task: Introduce `GhRunner` abstraction and migrate all `Self::run` call sites
+- Last updated: 2026-05-26 Asia/Taipei
+- Branch/commit/PR/release: `feat/plan-issue-closeout-required-check-rendering-bundle`; PR pending
+- Source document: docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-plan.md
+- Discussion source document: docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-discussion-source.md
+- Source issue: sympoies/nils-cli#541 (post-merge closeout-comment observation; bug surfaces visible at <https://github.com/sympoies/nils-cli/issues/541#issuecomment-4543937296>)
+- Tracking issue: pending (this bundle drives `plan-issue record open`)
+- Source snapshot: pending
+- Plan snapshot: pending
+- Initial execution state snapshot: pending
+- Direct source-doc execution waiver: not applicable
+
+## Task Ledger
+
+| ID       | Status  | Task                                                                    | Evidence | Notes                                                              |
+| -------- | ------- | ----------------------------------------------------------------------- | -------- | ------------------------------------------------------------------ |
+| Task 1.1 | pending | Introduce `GhRunner` abstraction and migrate all `Self::run` call sites | —        | scope expansion past `pr_required_summary` per Decision 5          |
+| Task 1.2 | pending | Repair `pr_required_summary` live probe                                 | —        | drops `conclusion` from `--json`; adds `no required checks` branch |
+| Task 1.3 | pending | Widen renderer to five-label `Required` column                          | —        | `none required` / `pass (N)` / `fail (N)` / `none` / `unknown`     |
+| Task 1.4 | pending | Probe and renderer integration coverage                                 | —        | injected-runner unit test + closeout-render integration assertions |
+| Task 1.5 | pending | CHANGELOG, manual live verification, and PR                             | —        | embeds before/after rendering of `Required` column                 |
+
+## Validation
+
+| Command                                                                                                                                                             | Status  | Summary                                                                              | Artifact |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------ | -------- |
+| `plan-tooling validate --file docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-plan.md --format text --explain` | pending | bundle gate                                                                          | —        |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`                                                                                                         | pending | docs hygiene, placement, rumdl, plan-bundle, cli-output-contract, forge-cli fixture  | —        |
+| `cargo test -p plan-issue-cli`                                                                                                                                      | pending | per-crate gate (must pass without workspace `serde_json/preserve_order` unification) | —        |
+| `cargo nextest run --workspace`                                                                                                                                     | pending | workspace gate                                                                       | —        |
+| `cargo clippy -p plan-issue-cli --all-targets --all-features -- -D warnings`                                                                                        | pending | crate-scope clippy                                                                   | —        |
+
+## Blockers
+
+- none
+
+## Session Log
+
+- 2026-05-26: Bundle drafted. Source doc previously merged at PR #558
+  (commit `8741a79` on `main`). Decisions locked at source-doc fold-in
+  `0d09ccd`: label string `none required`; `GhRunner` covers every
+  `github.rs` `Self::run` caller; GitLab fallback at
+  `forge_cli_adapter.rs:353-354` explicitly out of scope (tracked at
+  sympoies/nils-cli#557). Repository sweep confirms no other consumer
+  of the closeout-table `Required` cell strings (free-form Markdown
+  only).

--- a/docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-plan.md
+++ b/docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-plan.md
@@ -1,0 +1,250 @@
+# Plan: plan-issue closeout `Required` column rendering fix
+
+## Overview
+
+Land a focused fix in `plan-issue-cli` so that the `record close`
+closeout-comment's `Required` column stops collapsing every healthy and
+unhealthy code path into the single label `unknown`. The fix has three
+layers:
+
+- Repair the live probe in
+  `crates/plan-issue-cli/src/github.rs:138-225` (`pr_required_summary`)
+  so it can actually return `(Some("success"), Some(0), [])` on the
+  canonical "no required-check rule" path: drop the `conclusion`
+  field from the `gh pr checks --required --json …` invocation and
+  add a stderr branch recognising the "no required checks reported"
+  message.
+- Make every existing `Self::run` call site in `github.rs` go through
+  a single module-scope `GhRunner` abstraction so the live probe can
+  be exercised in unit tests without a real `gh` binary on PATH.
+- Widen the closeout-comment renderer in
+  `crates/plan-issue-cli/src/lifecycle_record.rs:2062-2074` to five
+  labels (`none required` / `pass (N)` / `fail (N)` / `none` /
+  `unknown`) so the three present-day `required_state == None` causes
+  are distinguishable, and a future regression remains visible.
+
+The `closeout.v1` payload wire format is intentionally unchanged.
+Historical closeout comments (e.g. sympoies/nils-cli#541's #4543937296)
+remain immutable; only records produced after the fix lands carry the
+new labels.
+
+Source: this bundle's discussion source doc (Read First, below).
+
+## Read First
+
+- Primary source:
+  `docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-discussion-source.md`
+- Source type: discussion-to-implementation-doc
+- Open questions carried into execution: none (three resolved at
+  source-doc fold-in commit `0d09ccd`: label string locked to
+  `none required`; `GhRunner` covers all `Self::run` callers; GitLab
+  fallback explicitly out of scope and tracked under
+  sympoies/nils-cli#557)
+- Upstream contract:
+  `crates/plan-issue-cli/docs/specs/issue-backed-plan-record-contract-v2.md`
+  — `closeout.v1` payload `linked_prs[].required_state` stays nullable
+  string over the wire.
+- Sibling follow-up (out of scope here, tracked separately):
+  sympoies/nils-cli#557 (GitLab adapter renders `Required: unknown`
+  for healthy PRs).
+- Earlier related plan whose Risk R-2 deferred the GitLab parity:
+  `docs/plans/plan-issue-close-non-required-checks/plan-issue-close-non-required-checks-discussion-source.md`
+
+## Scope
+
+- In scope:
+  - Module-scope `GhRunner` abstraction in
+    `crates/plan-issue-cli/src/github.rs` and migration of every
+    existing `Self::run(&args)` call site onto it.
+  - `pr_required_summary` `--json` field list fix (drop `conclusion`).
+  - `pr_required_summary` stderr branch recognising `no required
+    checks reported`.
+  - Renderer change in `crates/plan-issue-cli/src/lifecycle_record.rs`
+    `linked_prs[]` row construction (`required` column only).
+  - Renderer-layer unit tests covering all five label branches.
+  - Probe-layer unit test exercising the no-required-checks success
+    path of `pr_required_summary` through an injected runner.
+  - Optional `#[ignore]`-by-default contract test that hits the real
+    `gh` binary to guard against future `gh` regressions on the
+    `no required checks reported` stderr.
+  - CHANGELOG entry referencing this fix and the parent
+    sympoies/nils-cli#541 closeout observation.
+- Out of scope:
+  - Any change to the `closeout.v1` payload shape or the
+    `LinkedPrEvidence` field shape.
+  - Any change to the close-gate semantics fixed under
+    `docs/plans/plan-issue-close-non-required-checks/` /
+    sympoies/nils-cli#502.
+  - GitLab adapter parity (`forge_cli_adapter.rs:353-354` stays
+    `(None, None)`; tracked at sympoies/nils-cli#557).
+  - Adding branch protection on `sympoies/nils-cli main`.
+  - Backfilling historical closeout comments.
+  - Any change to the `Checks` (aggregate) column rendering. PR #554's
+    `Checks: none` row on #541's closeout reflects a separate GHA
+    workflow-trigger glitch and is not addressed here.
+
+## Assumptions
+
+- Current `gh` (Homebrew `gh` on the maintainer's machine) is the
+  representative client. Reproduced 2026-05-26 against PRs #542 and
+  #553 on sympoies/nils-cli: `gh pr checks <pr> --required --json
+  bucket,state,conclusion,name` exits 5 with `Unknown JSON field:
+  "conclusion"`; `gh pr checks <pr> --required --json name,state`
+  exits 1 with stderr `no required checks reported on the '<branch>'
+  branch` when the target branch has no branch protection.
+- The `none required` label string is acceptable to closeout-comment
+  consumers; no automation is known to parse the `Required` column
+  today.
+
+## Sprint 1: Live probe and renderer fix
+
+**Goal**: Make `plan-issue record close --dry-run` render PRs under a
+branch without a required-check rule as `Required: none required` (not
+`unknown`) on a live `gh` install, with deterministic unit-test
+coverage for every render branch and the probe's happy path.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p plan-issue-cli`
+  - `cargo build --release -p plan-issue-cli`
+  - `plan-issue record close --issue 541 --repo sympoies/nils-cli
+    --linked-pr sympoies/nils-cli#542 --linked-pr sympoies/nils-cli#553
+    --approval "post-fix verification" --dry-run`
+- Verify: the rendered closeout-comment table renders `Required: none
+  required` for every PR row (matching the current absence of
+  required-check rules on `main`).
+
+### Task 1.1: Introduce `GhRunner` abstraction and migrate all `Self::run` call sites
+
+- **Location**:
+  - `crates/plan-issue-cli/src/github.rs:97-111` (current `Self::run`)
+  - All other `Self::run` call sites in the same file
+- **Description**: Introduce a small module-scope abstraction — either
+  a function pointer type alias (`type GhRunner = fn(&[&str]) ->
+  Result<RunOutput, String>`) or a tiny `trait GhRunner` — that wraps
+  the existing `gh` shellout behaviour. Migrate every existing
+  `Self::run(&args)` call site in `github.rs` onto the new runner.
+  Production code passes the real runner; tests can inject a fake.
+  No behaviour change for production callers.
+- **Dependencies**: none
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - Every existing `Self::run(&args)` call site in
+    `crates/plan-issue-cli/src/github.rs` is routed through the new
+    abstraction.
+  - Production behaviour unchanged: `cargo test -p plan-issue-cli`
+    passes without modifications to existing fixture data.
+  - A new module-level test exercises an injected fake runner and
+    asserts the abstraction handles success, non-zero exit, and
+    stderr capture correctly.
+- **Validation**:
+  - `cargo test -p plan-issue-cli github`
+
+### Task 1.2: Repair `pr_required_summary` live probe
+
+- **Location**:
+  - `crates/plan-issue-cli/src/github.rs:138-225`
+- **Description**: Drop the unsupported `conclusion` field from the
+  `gh pr checks --required --json …` invocation (the function never
+  reads `conclusion` from the resulting array; the rollup-side
+  `.get("conclusion").or_else(|| item.get("state"))` is on a different
+  Value entirely). Add a stderr branch: when `gh` exits non-zero and
+  stderr contains the substring `no required checks reported`, treat
+  it as the zero-required-checks success case and return
+  `(Some("success"), Some(0), Vec::new())`. Keep the existing
+  empty-stdout fallback as a defensive secondary path. Add a
+  `// upstream contract:` comment near the matcher pinning the
+  canonical `gh` message so the next reader knows what to update if
+  `gh` regresses.
+- **Dependencies**: Task 1.1
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - The function returns `(Some("success"), Some(0), Vec::new())`
+    when the injected runner reports exit 1 + stderr containing
+    `no required checks reported`.
+  - Other non-zero exits still propagate as `(None, None, Vec::new())`.
+  - The `--json` argument list contains only fields the function
+    actually reads.
+- **Validation**:
+  - `cargo test -p plan-issue-cli github pr_required_summary`
+
+### Task 1.3: Widen renderer to five-label `Required` column
+
+- **Location**:
+  - `crates/plan-issue-cli/src/lifecycle_record.rs:2062-2074`
+- **Description**: Replace the current
+  `required_state.map(check_status_label).unwrap_or("unknown")` with a
+  closed-form match over `(required_state, required_count)` that emits
+  one of five labels: `none required` for
+  `Some(CheckStatus::Pass) + Some(0)`; `pass (N)` for
+  `Some(CheckStatus::Pass) + Some(N>=1)`; `fail (N)` for
+  `Some(CheckStatus::Fail) + Some(N)` (count omitted when
+  `required_count` is `None`); `none` for `Some(CheckStatus::None)`;
+  `unknown` for `None`. The renderer can land before or after Task
+  1.2 because it operates on the payload-side fields, not on `gh`.
+- **Dependencies**: none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - All five branches are exercised by unit tests asserting the exact
+    rendered cell text.
+  - No change to the `closeout.v1` payload shape; only the rendered
+    Markdown cell changes.
+  - Existing renderer test fixtures continue to pass with their
+    expected labels adjusted to the new strings.
+- **Validation**:
+  - `cargo test -p plan-issue-cli lifecycle_record render`
+
+### Task 1.4: Probe and renderer integration coverage
+
+- **Location**:
+  - `crates/plan-issue-cli/src/github.rs` (probe-side test, using the
+    injected runner from Task 1.1)
+  - `crates/plan-issue-cli/tests/integration/` (closeout-render
+    integration; reuses existing fixture infrastructure)
+- **Description**: Add a probe-side unit test asserting the "no
+  required checks reported" stderr path produces
+  `(Some("success"), Some(0), Vec::new())` through an injected
+  runner. Add an integration test asserting that `record close
+  --dry-run` against a fixture PR seeded with `required_state=Pass,
+  required_count=0` renders `Required: none required` in the closeout
+  table, and that a fixture omitting `requiredCheckRollup` renders
+  `Required: unknown` without crashing.
+- **Dependencies**: Task 1.1, Task 1.2, Task 1.3
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - Probe unit test passes deterministically without `gh` on PATH.
+  - Integration tests cover the two new render outcomes.
+  - Optional `#[ignore]`-by-default integration test wires the real
+    `gh` shellout and asserts the no-required-checks path end-to-end
+    against `sympoies/nils-cli#553` (or equivalent), so a future `gh`
+    regression on the stderr message can be caught manually with
+    `cargo test --ignored`.
+- **Validation**:
+  - `cargo test -p plan-issue-cli`
+  - `cargo nextest run --workspace`
+
+### Task 1.5: CHANGELOG, manual live verification, and PR
+
+- **Location**:
+  - `crates/plan-issue-cli/CHANGELOG.md`
+  - `target/release/plan-issue` (build artifact)
+- **Description**: Add a CHANGELOG entry under the next
+  `plan-issue-cli` version referencing this fix and the parent
+  observation on sympoies/nils-cli#541. Build the binary locally,
+  re-run `plan-issue record close --dry-run --issue 541 --repo
+  sympoies/nils-cli --linked-pr sympoies/nils-cli#542 …` against the
+  live provider, and screenshot the rendered closeout-table snippet
+  in the PR description so reviewers can see the before/after
+  rendering without rebuilding locally. Open the implementation PR.
+- **Dependencies**: Task 1.4
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - CHANGELOG entry lands in the same PR as the implementation.
+  - The PR description embeds (or links) a manual verification
+    transcript showing the new `none required` rendering.
+  - PR title fits the project's 70-char title cap.
+- **Validation**:
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+    (CHANGELOG hygiene)
+  - `cargo nextest run --workspace` (full gate)


### PR DESCRIPTION
## Summary

- Repair `plan-issue-cli`'s closeout-comment `Required` column so it
  stops collapsing every healthy and unhealthy code path into the
  single label `unknown`. Surfaces and decisions in
  `docs/plans/plan-issue-closeout-required-check-rendering/` (bundled
  in the first commit; tracking issue #561).
- Two underlying bugs fixed in `crates/plan-issue-cli/src/github.rs`'s
  `pr_required_summary`: (a) drop the unsupported `conclusion` field
  from the `gh pr checks --required --json …` invocation — current
  `gh` exits 5 with `Unknown JSON field: "conclusion"`, forcing every
  call into the catch-all `(None, None, [])` branch; (b) recognise
  `gh`'s exit-non-zero + `no required checks reported on the
  '<branch>' branch` stderr as the canonical zero-required success
  rollup, returning `(Some("success"), Some(0), Vec::new())` instead
  of the catch-all. Also short-circuit the `Value::Array(empty)` JSON
  branch to the same success rollup so `rollup_status` no longer
  downgrades it to `"none"`.
- New module-scope `GhRunner` function-pointer abstraction with
  `default_gh_runner` for production and `GhCliAdapter::with_runner`
  (cfg(test)) for unit tests. Every `Self::run(&args)` call site in
  `github.rs` is now an instance-method `self.run(&args)`, and
  `pr_required_summary` is a `&self` method. New unit tests exercise
  the probe's "no required checks reported" stderr branch, the
  empty-array success branch, the one-required-pass branch, an
  unrecognised-failure-stderr branch, and a runner-spawn-failure
  branch — all without `gh` on PATH.
- Closeout-comment renderer in `crates/plan-issue-cli/src/lifecycle_record.rs`
  now picks one of five labels (`none required` / `pass (N)` /
  `fail (N)` / `none` / `unknown`) via the new
  `required_check_label` helper. The `closeout.v1` payload wire
  format is unchanged; historical closeout records (e.g.
  https://github.com/sympoies/nils-cli/issues/541#issuecomment-4543937296)
  remain immutable. CHANGELOG entry under
  `crates/plan-issue-cli/CHANGELOG.md` `[Unreleased] / Fixed`.
- GitLab adapter `(None, None)` fallback at
  `crates/plan-issue-cli/src/forge_cli_adapter.rs:353-354`
  intentionally left untouched and tracked separately at
  sympoies/nils-cli#557.

## Test plan

- [x] `cargo test -p nils-plan-issue-cli` — 232 + 6 new tests green
      (probe-injected: 5, renderer-label: 1; plus extended
      `record_close_fixture_passes_with_non_required_failure_when_zero_required`
      now asserts rendered closeout-body cell text).
- [x] `cargo nextest run --workspace` — 4041 passed.
- [x] `cargo clippy --workspace --all-targets --all-features --
      -D warnings` clean.
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
      green for the new plan bundle (the only remaining MD024 warning
      under `crates/plan-issue-cli/CHANGELOG.md:188` is pre-existing
      duplicate-heading drift; not introduced by this PR).
- [x] Manual: reproduced the upstream `gh` bug surface to confirm the
      fix targets the right contract — `gh pr checks 542 --required
      --json bucket,state,conclusion,name` exits 5 with `Unknown JSON
      field: "conclusion"`; `gh pr checks 553 --required --json
      name,state` exits 1 with stderr `no required checks reported
      on the '<branch>' branch` when the target branch has no
      branch-protection rule.
- [ ] Manual live re-run of `plan-issue record close --dry-run`
      against sympoies/nils-cli#541's PR list deferred — #541 is
      already closed so the close-gate refuses to re-render; coverage
      via fixture integration test instead (see CHANGELOG).
