### PR TITLE
docs(plans): backfill closeout rendering execution-state to done

### DIFF
--- a/docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-execution-state.md
+++ b/docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-execution-state.md
@@ -3,41 +3,43 @@
 
 ## Execution State
 
-- Status: ready
+- Status: done
 - Target scope: whole plan
 - Execution window: whole plan (single sprint)
-- Current task: Task 1.1
-- Next task: Introduce `GhRunner` abstraction and migrate all `Self::run` call sites
+- Current task: complete
+- Next task: closeout via `plan-tracking-issue-closeout`
 - Last updated: 2026-05-26 Asia/Taipei
-- Branch/commit/PR/release: `feat/plan-issue-closeout-required-check-rendering-bundle`; PR pending
+- Branch/commit/PR/release: `feat/plan-issue-closeout-required-check-rendering-bundle`; PR sympoies/nils-cli#563 squash-merged at `f2666c4` on `main`
 - Source document: docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-plan.md
 - Discussion source document: docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-discussion-source.md
 - Source issue: sympoies/nils-cli#541 (post-merge closeout-comment observation; bug surfaces visible at <https://github.com/sympoies/nils-cli/issues/541#issuecomment-4543937296>)
-- Tracking issue: pending (this bundle drives `plan-issue record open`)
-- Source snapshot: pending
-- Plan snapshot: pending
-- Initial execution state snapshot: pending
+- Tracking issue: sympoies/nils-cli#561
+- Source snapshot: <https://github.com/sympoies/nils-cli/issues/561#issuecomment-4544094337>
+- Plan snapshot: <https://github.com/sympoies/nils-cli/issues/561#issuecomment-4544094477>
+- Initial execution state snapshot: <https://github.com/sympoies/nils-cli/issues/561#issuecomment-4544094583>
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger
 
-| ID       | Status  | Task                                                                    | Evidence | Notes                                                              |
-| -------- | ------- | ----------------------------------------------------------------------- | -------- | ------------------------------------------------------------------ |
-| Task 1.1 | pending | Introduce `GhRunner` abstraction and migrate all `Self::run` call sites | —        | scope expansion past `pr_required_summary` per Decision 5          |
-| Task 1.2 | pending | Repair `pr_required_summary` live probe                                 | —        | drops `conclusion` from `--json`; adds `no required checks` branch |
-| Task 1.3 | pending | Widen renderer to five-label `Required` column                          | —        | `none required` / `pass (N)` / `fail (N)` / `none` / `unknown`     |
-| Task 1.4 | pending | Probe and renderer integration coverage                                 | —        | injected-runner unit test + closeout-render integration assertions |
-| Task 1.5 | pending | CHANGELOG, manual live verification, and PR                             | —        | embeds before/after rendering of `Required` column                 |
+| ID       | Status | Task                                                                    | Evidence                                                                                              | Notes                                                              |
+| -------- | ------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Task 1.1 | done   | Introduce `GhRunner` abstraction and migrate all `Self::run` call sites | PR sympoies/nils-cli#563 commit `69a3fa6`; merged via squash at `f2666c4`                             | function-pointer `GhRunner`; 10 `Self::run` callers migrated       |
+| Task 1.2 | done   | Repair `pr_required_summary` live probe                                 | PR sympoies/nils-cli#563 commit `69a3fa6`                                                             | drops `conclusion` from `--json`; recognises `no required checks`  |
+| Task 1.3 | done   | Widen renderer to five-label `Required` column                          | PR sympoies/nils-cli#563 commit `69a3fa6`                                                             | new `required_check_label` helper covers all five branches         |
+| Task 1.4 | done   | Probe and renderer integration coverage                                 | PR sympoies/nils-cli#563 commit `69a3fa6`                                                             | 6 probe tests + 5 label tests + 1 fixture integration assertion    |
+| Task 1.5 | done   | CHANGELOG, manual live verification, and PR                             | CHANGELOG `[Unreleased] / Fixed` entry; PR sympoies/nils-cli#563 merged at `f2666c4`                  | post-push rustfmt fix landed as `f090667` before merge             |
 
 ## Validation
 
-| Command                                                                                                                                                             | Status  | Summary                                                                              | Artifact |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------ | -------- |
-| `plan-tooling validate --file docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-plan.md --format text --explain` | pending | bundle gate                                                                          | —        |
-| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`                                                                                                         | pending | docs hygiene, placement, rumdl, plan-bundle, cli-output-contract, forge-cli fixture  | —        |
-| `cargo test -p plan-issue-cli`                                                                                                                                      | pending | per-crate gate (must pass without workspace `serde_json/preserve_order` unification) | —        |
-| `cargo nextest run --workspace`                                                                                                                                     | pending | workspace gate                                                                       | —        |
-| `cargo clippy -p plan-issue-cli --all-targets --all-features -- -D warnings`                                                                                        | pending | crate-scope clippy                                                                   | —        |
+| Command                                                                                                                                                             | Status | Summary                                                                              | Artifact                                            |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| `plan-tooling validate --file docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-plan.md --format text --explain` | pass   | bundle gate                                                                          | run via tracking-issue open                          |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`                                                                                                         | pass   | docs hygiene, placement, rumdl, plan-bundle, cli-output-contract, forge-cli fixture  | green                                                |
+| `cargo test -p nils-plan-issue-cli`                                                                                                                                 | pass   | per-crate gate (238 tests; 232 prior + 6 new probe tests)                            | green                                                |
+| `cargo nextest run --workspace`                                                                                                                                     | pass   | workspace gate (4041 tests post-merge)                                               | green                                                |
+| `cargo clippy --workspace --all-targets --all-features -- -D warnings`                                                                                              | pass   | workspace clippy                                                                     | green                                                |
+| `cargo fmt --all -- --check`                                                                                                                                        | pass   | rustfmt (initial push failed; repaired by `f090667`)                                 | green after repair                                   |
+| GitHub Actions on PR sympoies/nils-cli#563 (`test`, `test_macos`, `coverage`, CodeQL × 4)                                                                            | pass   | full CI re-ran after rustfmt repair                                                  | run 26449744549                                      |
 
 ## Blockers
 
@@ -53,3 +55,9 @@
   sympoies/nils-cli#557). Repository sweep confirms no other consumer
   of the closeout-table `Required` cell strings (free-form Markdown
   only).
+- 2026-05-26: All 5 tasks landed as a single bundled implementation
+  commit (`69a3fa6`) on `feat/plan-issue-closeout-required-check-rendering-bundle`.
+  CI failed on rustfmt on first push; repaired with `f090667`.
+  PR sympoies/nils-cli#563 squash-merged at `f2666c4`. Post-merge
+  `cargo nextest run --workspace` 4041/4041 pass. Ready for closeout
+  handoff to `plan-tracking-issue-closeout`.

--- a/docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-execution-state.md
+++ b/docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-execution-state.md
@@ -9,7 +9,9 @@
 - Current task: complete
 - Next task: closeout via `plan-tracking-issue-closeout`
 - Last updated: 2026-05-26 Asia/Taipei
-- Branch/commit/PR/release: `feat/plan-issue-closeout-required-check-rendering-bundle`; PR sympoies/nils-cli#563 squash-merged at `f2666c4` on `main`
+- Branch/commit/PR/release:
+  `feat/plan-issue-closeout-required-check-rendering-bundle`;
+  PR sympoies/nils-cli#563 squash-merged at `f2666c4` on `main`
 - Source document: docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-plan.md
 - Discussion source document: docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-discussion-source.md
 - Source issue: sympoies/nils-cli#541 (post-merge closeout-comment observation; bug surfaces visible at <https://github.com/sympoies/nils-cli/issues/541#issuecomment-4543937296>)
@@ -21,25 +23,25 @@
 
 ## Task Ledger
 
-| ID       | Status | Task                                                                    | Evidence                                                                                              | Notes                                                              |
-| -------- | ------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Task 1.1 | done   | Introduce `GhRunner` abstraction and migrate all `Self::run` call sites | PR sympoies/nils-cli#563 commit `69a3fa6`; merged via squash at `f2666c4`                             | function-pointer `GhRunner`; 10 `Self::run` callers migrated       |
-| Task 1.2 | done   | Repair `pr_required_summary` live probe                                 | PR sympoies/nils-cli#563 commit `69a3fa6`                                                             | drops `conclusion` from `--json`; recognises `no required checks`  |
-| Task 1.3 | done   | Widen renderer to five-label `Required` column                          | PR sympoies/nils-cli#563 commit `69a3fa6`                                                             | new `required_check_label` helper covers all five branches         |
-| Task 1.4 | done   | Probe and renderer integration coverage                                 | PR sympoies/nils-cli#563 commit `69a3fa6`                                                             | 6 probe tests + 5 label tests + 1 fixture integration assertion    |
-| Task 1.5 | done   | CHANGELOG, manual live verification, and PR                             | CHANGELOG `[Unreleased] / Fixed` entry; PR sympoies/nils-cli#563 merged at `f2666c4`                  | post-push rustfmt fix landed as `f090667` before merge             |
+| ID       | Status | Task                                                                    | Evidence                                                                             | Notes                                                             |
+| -------- | ------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| Task 1.1 | done   | Introduce `GhRunner` abstraction and migrate all `Self::run` call sites | PR sympoies/nils-cli#563 commit `69a3fa6`; merged via squash at `f2666c4`            | function-pointer `GhRunner`; 10 `Self::run` callers migrated      |
+| Task 1.2 | done   | Repair `pr_required_summary` live probe                                 | PR sympoies/nils-cli#563 commit `69a3fa6`                                            | drops `conclusion` from `--json`; recognises `no required checks` |
+| Task 1.3 | done   | Widen renderer to five-label `Required` column                          | PR sympoies/nils-cli#563 commit `69a3fa6`                                            | new `required_check_label` helper covers all five branches        |
+| Task 1.4 | done   | Probe and renderer integration coverage                                 | PR sympoies/nils-cli#563 commit `69a3fa6`                                            | 6 probe tests + 5 label tests + 1 fixture integration assertion   |
+| Task 1.5 | done   | CHANGELOG, manual live verification, and PR                             | CHANGELOG `[Unreleased] / Fixed` entry; PR sympoies/nils-cli#563 merged at `f2666c4` | post-push rustfmt fix landed as `f090667` before merge            |
 
 ## Validation
 
-| Command                                                                                                                                                             | Status | Summary                                                                              | Artifact                                            |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------ | --------------------------------------------------- |
-| `plan-tooling validate --file docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-plan.md --format text --explain` | pass   | bundle gate                                                                          | run via tracking-issue open                          |
-| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`                                                                                                         | pass   | docs hygiene, placement, rumdl, plan-bundle, cli-output-contract, forge-cli fixture  | green                                                |
-| `cargo test -p nils-plan-issue-cli`                                                                                                                                 | pass   | per-crate gate (238 tests; 232 prior + 6 new probe tests)                            | green                                                |
-| `cargo nextest run --workspace`                                                                                                                                     | pass   | workspace gate (4041 tests post-merge)                                               | green                                                |
-| `cargo clippy --workspace --all-targets --all-features -- -D warnings`                                                                                              | pass   | workspace clippy                                                                     | green                                                |
-| `cargo fmt --all -- --check`                                                                                                                                        | pass   | rustfmt (initial push failed; repaired by `f090667`)                                 | green after repair                                   |
-| GitHub Actions on PR sympoies/nils-cli#563 (`test`, `test_macos`, `coverage`, CodeQL × 4)                                                                            | pass   | full CI re-ran after rustfmt repair                                                  | run 26449744549                                      |
+| Command                                                                                                                                                             | Status | Summary                                                                             | Artifact                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ----------------------------------------------------------------------------------- | --------------------------- |
+| `plan-tooling validate --file docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-plan.md --format text --explain` | pass   | bundle gate                                                                         | run via tracking-issue open |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`                                                                                                         | pass   | docs hygiene, placement, rumdl, plan-bundle, cli-output-contract, forge-cli fixture | green                       |
+| `cargo test -p nils-plan-issue-cli`                                                                                                                                 | pass   | per-crate gate (238 tests; 232 prior + 6 new probe tests)                           | green                       |
+| `cargo nextest run --workspace`                                                                                                                                     | pass   | workspace gate (4041 tests post-merge)                                              | green                       |
+| `cargo clippy --workspace --all-targets --all-features -- -D warnings`                                                                                              | pass   | workspace clippy                                                                    | green                       |
+| `cargo fmt --all -- --check`                                                                                                                                        | pass   | rustfmt (initial push failed; repaired by `f090667`)                                | green after repair          |
+| GitHub Actions on PR sympoies/nils-cli#563 (`test`, `test_macos`, `coverage`, CodeQL × 4)                                                                           | pass   | full CI re-ran after rustfmt repair                                                 | run 26449744549             |
 
 ## Blockers
 


### PR DESCRIPTION
## Summary

- Reflect the completed plan in
  `docs/plans/plan-issue-closeout-required-check-rendering/plan-issue-closeout-required-check-rendering-execution-state.md`:
  status `done`, all 5 Task ledger rows `done` with PR #563 + merge SHA evidence,
  validation matrix populated with the post-merge `cargo nextest run --workspace`
  / `cargo clippy ... -D warnings` / `cargo fmt --all -- --check` rows, and a
  session-log entry covering the rustfmt repair commit (`f090667`) and the
  squash-merge at `f2666c4`.

## Test plan

- [ ] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` (CI runs it under `test` / `test_macos`)
- [ ] docs hygiene / placement / plan-bundle audits stay green

Tracking issue: sympoies/nils-cli#561.
