### PR TITLE
fix(plan-issue-cli): GitLab adapter reports zero required checks

### DIFF
--- a/crates/plan-issue-cli/CHANGELOG.md
+++ b/crates/plan-issue-cli/CHANGELOG.md
@@ -40,6 +40,18 @@ versioning.
 ### Fixed
 
 - `plan-issue record close` closeout-comment table renders the
+  `Required` column as `none required` for GitLab linked-PR rows
+  instead of the misleading `unknown` label that the GitLab adapter
+  produced before this fix. GitLab has no first-class required-check
+  concept, so `forge_cli_adapter::pr_merge_summary` now reports zero
+  required checks (`required_state=Some("success"), required_count=
+  Some(0)`) — the same shape the GitHub adapter returns for a branch
+  without a required-check rule — and the close gate treats this as a
+  clean resolve per the #502 "non-required failures never block close"
+  contract. The `closeout.v1` payload wire format is unchanged; only
+  the rendered Markdown cell changes. (sympoies/nils-cli#557, follow-up
+  to #563)
+- `plan-issue record close` closeout-comment table renders the
   `Required` column as `none required` (zero required checks defined),
   `pass (N)`, `fail (N)`, `none`, or `unknown` instead of collapsing
   every `required_state == None` cause into the single misleading

--- a/crates/plan-issue-cli/src/forge_cli_adapter.rs
+++ b/crates/plan-issue-cli/src/forge_cli_adapter.rs
@@ -342,16 +342,22 @@ impl ProviderAdapter for ForgeCliAdapter {
         };
         // GitLab has no first-class required-check concept: pipeline
         // jobs are either reported by `glab` as a single rolled-up
-        // status, or not at all. We leave the required fields at
-        // `None`/empty so the close gate falls back to the aggregate
-        // `checks` value (matching pre-#502 GitLab behavior).
+        // status, or not at all. Report zero required checks — the
+        // same shape `pr_required_summary` returns for a GitHub branch
+        // without a required-check rule — so the closeout-comment
+        // `Required` column renders `none required` (via
+        // `required_check_label` at
+        // `lifecycle_record.rs:2154-2160`) instead of `unknown`, and
+        // the close gate in `lifecycle_record.rs:2446-2469` treats it
+        // as a clean resolve per the #502 "non-required failures
+        // never block close" contract. Tracked at sympoies/nils-cli#557.
         Ok(PrMergeSummary {
             state,
             merged,
             merge_sha,
             checks,
-            required_state: None,
-            required_count: None,
+            required_state: Some("success".to_string()),
+            required_count: Some(0),
             non_required_failures: Vec::new(),
         })
     }
@@ -755,6 +761,12 @@ mod tests {
         assert!(summary.merged);
         assert_eq!(summary.merge_sha.as_deref(), Some("deadbeef"));
         assert_eq!(summary.checks.as_deref(), Some("success"));
+        // GitLab parity (sympoies/nils-cli#557): the adapter reports
+        // zero required checks so closeout rendering lands on the
+        // `none required` label instead of `unknown`.
+        assert_eq!(summary.required_state.as_deref(), Some("success"));
+        assert_eq!(summary.required_count, Some(0));
+        assert!(summary.non_required_failures.is_empty());
         let calls = handle.calls();
         assert_eq!(calls.len(), 2);
         assert!(calls[0].windows(2).any(|w| w[0] == "pr" && w[1] == "view"));

--- a/docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-discussion-source.md
+++ b/docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-discussion-source.md
@@ -1,11 +1,11 @@
 # plan-issue closeout GitLab `Required` column parity — Source
 
-| Field              | Value                                                                                                                            |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| Status             | Ready for implementation                                                                                                         |
-| Date               | 2026-05-26                                                                                                                       |
-| Source             | sympoies/nils-cli#557 — GitLab adapter renders `Required: unknown`; follow-up to the GitHub-side render fix landed in #563        |
-| Intended next step | Implement the GitLab adapter change in a single small PR that closes #557                                                        |
+| Field              | Value                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| Status             | Ready for implementation                                                                                                   |
+| Date               | 2026-05-26                                                                                                                 |
+| Source             | sympoies/nils-cli#557 — GitLab adapter renders `Required: unknown`; follow-up to the GitHub-side render fix landed in #563 |
+| Intended next step | Implement the GitLab adapter change in a single small PR that closes #557                                                  |
 
 ## Purpose
 
@@ -25,10 +25,16 @@ for every PR, because GitLab has no first-class required-check concept and
 reads `Required: unknown` even when the pipeline is green and there is no
 required-check rule to satisfy.
 
-The fix is to make the GitLab adapter return the same label that the
-GitHub side now uses for branches without a required-check rule:
-`required_state: Some(CheckStatus::Pass), required_count: Some(0)`,
-yielding the `none required` render branch. The semantic intent of #502
+The fix is to make the GitLab adapter return the same shape the
+GitHub side now uses for branches without a required-check rule. At
+the `PrMergeSummary` layer (`crates/plan-issue-cli/src/github.rs:76`)
+`required_state` is an `Option<String>`; the rendering chain converts
+that via `check_status_from_state` (`execute.rs:595-604`) to
+`Option<CheckStatus>` before reaching the renderer. So the adapter
+returns `required_state: Some("success".to_string()), required_count:
+Some(0)`, the renderer's `required_check_label` then sees
+`(Some(CheckStatus::Pass), Some(0))` and produces the `none required`
+label. The semantic intent of #502
 (close gate keys on required checks only; non-required failures never
 block) is preserved — see Decision 2 for the explicit semantic shift this
 implies and why it is consistent with #502.
@@ -91,13 +97,16 @@ implies and why it is consistent with #502.
        merged,
        merge_sha,
        checks,
-       required_state: Some(CheckStatus::Pass),
+       required_state: Some("success".to_string()),
        required_count: Some(0),
        non_required_failures: Vec::new(),
    }
    ```
 
-   The renderer already produces `none required` for that triple, so no
+   `check_status_from_state` (`execute.rs:595-604`) converts the
+   `"success"` string to `CheckStatus::Pass` before the renderer's
+   `required_check_label` runs, and that helper already produces
+   `none required` for `(Some(CheckStatus::Pass), Some(0))`, so no
    render-layer change is needed. The label is the same one the GitHub
    adapter now emits for a branch without a required-check rule, which
    keeps the cross-provider closeout output consistent.
@@ -136,7 +145,7 @@ implies and why it is consistent with #502.
    `forge_cli_adapter.rs:748-766` so it also asserts:
 
    ```text
-   summary.required_state == Some(CheckStatus::Pass)
+   summary.required_state.as_deref() == Some("success")
    summary.required_count == Some(0)
    summary.non_required_failures.is_empty()
    ```
@@ -149,7 +158,7 @@ implies and why it is consistent with #502.
 
 5. **No schema change.** `closeout.v1` and the `LinkedPrEvidence` /
    `PrMergeSummary` Rust types are unchanged. The `Option<CheckStatus>`
-   /  `Option<u32>` field shapes carry the new values without any
+   / `Option<u32>` field shapes carry the new values without any
    serialization migration. Historical closeout records continue to
    parse, and their hex-encoded payloads do not need re-encoding.
 
@@ -161,7 +170,9 @@ implies and why it is consistent with #502.
 
 - `crates/plan-issue-cli/src/forge_cli_adapter.rs`:
   - Replace the `(None, None, [])` return triple in `pr_merge_summary`
-    with `(Some(CheckStatus::Pass), Some(0), Vec::new())`.
+    with `(Some("success".to_string()), Some(0), Vec::new())`. The
+    string is converted to `CheckStatus::Pass` downstream of the
+    adapter by `execute.rs::check_status_from_state`.
   - Replace the inline comment per Decision 3.
   - Extend `pr_merge_summary_composes_view_and_checks` (or add a sibling
     test in the same `#[cfg(test)] mod tests` block) to assert the new
@@ -188,17 +199,23 @@ implies and why it is consistent with #502.
 - The change is a single struct-literal swap plus a comment rewrite plus
   one extended test. No new helper functions, no module reorganisation,
   no new dependencies.
-- The new values must reuse the existing `CheckStatus::Pass` enum
-  variant; do not introduce a new variant or a GitLab-specific marker.
+- The new adapter-layer values must reuse the canonical `"success"`
+  string (the same value `pr_required_summary` returns from `gh pr
+  checks --required` on GitHub) so `check_status_from_state` maps it to
+  `CheckStatus::Pass`; do not introduce a new string or a
+  GitLab-specific marker.
 - The test must run without `glab` on PATH (uses the existing fake-process
   adapter wiring at `adapter_with(vec![...])`).
 
 ## Requirements
 
 - **R1.** `pr_merge_summary` on the GitLab adapter returns
-  `required_state: Some(CheckStatus::Pass)`,
+  `required_state: Some("success".to_string())`,
   `required_count: Some(0)`, and an empty `non_required_failures` vector
-  for every PR, regardless of pipeline outcome.
+  for every PR, regardless of pipeline outcome. Downstream of the
+  adapter, `check_status_from_state` converts that to
+  `CheckStatus::Pass` so the renderer's `required_check_label` hits
+  the `(Some(Pass), Some(0)) → "none required"` arm.
 - **R2.** A closeout comment posted by `plan-issue record close` against
   a GitLab PR renders that PR's `Required` column as `none required`
   via the existing `required_check_label` mapping.
@@ -216,7 +233,7 @@ implies and why it is consistent with #502.
 - **AC-2.** A new (or extended) unit test in `forge_cli_adapter.rs`'s
   test module asserts the full new triple for
   `pr_merge_summary_composes_view_and_checks` (or a sibling test):
-  `summary.required_state == Some(CheckStatus::Pass)`,
+  `summary.required_state.as_deref() == Some("success")`,
   `summary.required_count == Some(0)`,
   `summary.non_required_failures.is_empty()`.
 - **AC-3.** The renderer test
@@ -227,6 +244,7 @@ implies and why it is consistent with #502.
 - **AC-4.** The diff does not modify `lifecycle_record.rs`,
   `github.rs`, or any `closeout.v1` serialization site.
 - **AC-5.** The new comment at `forge_cli_adapter.rs:343-347` cites
+
   #557 (and references the new contract: GitLab reports zero required
   checks; close-gate treats as clean resolve per #502).
 
@@ -249,13 +267,13 @@ implies and why it is consistent with #502.
 
 ## Findings table
 
-| ID  | Source                                                   | Disposition                                                                                     |
-| --- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| F-1 | `crates/plan-issue-cli/src/forge_cli_adapter.rs:343-356` | In scope — replace `(None, None, [])` with `(Some(Pass), Some(0), [])` plus comment refresh     |
-| F-2 | `crates/plan-issue-cli/src/forge_cli_adapter.rs:748-766` | In scope — extend the fixture-backed test to assert the new triple                              |
-| F-3 | `crates/plan-issue-cli/src/lifecycle_record.rs:2154-2160`| Confirmed read-only — label table already maps the new triple to `none required`                |
-| F-4 | `crates/plan-issue-cli/src/lifecycle_record.rs:2446-2469`| Confirmed read-only — semantic shift accepted per Decision 2; no code change needed             |
-| F-5 | sympoies/nils-cli#502 / #512 / #563                      | Read-first context — close-gate contract and GitHub render fix; this PR is the GitLab follow-up |
+| ID  | Source                                                    | Disposition                                                                                     |
+| --- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| F-1 | `crates/plan-issue-cli/src/forge_cli_adapter.rs:343-356`  | In scope — replace `(None, None, [])` with `(Some(Pass), Some(0), [])` plus comment refresh     |
+| F-2 | `crates/plan-issue-cli/src/forge_cli_adapter.rs:748-766`  | In scope — extend the fixture-backed test to assert the new triple                              |
+| F-3 | `crates/plan-issue-cli/src/lifecycle_record.rs:2154-2160` | Confirmed read-only — label table already maps the new triple to `none required`                |
+| F-4 | `crates/plan-issue-cli/src/lifecycle_record.rs:2446-2469` | Confirmed read-only — semantic shift accepted per Decision 2; no code change needed             |
+| F-5 | sympoies/nils-cli#502 / #512 / #563                       | Read-first context — close-gate contract and GitHub render fix; this PR is the GitLab follow-up |
 
 ## Risks and guardrails
 

--- a/docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-execution-state.md
+++ b/docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-execution-state.md
@@ -3,13 +3,13 @@
 
 ## Execution State
 
-- Status: ready
+- Status: in-progress
 - Target scope: whole plan
 - Execution window: whole plan (single sprint)
-- Current task: Task 1.1
-- Next task: Task 1.1
+- Current task: Task 1.2
+- Next task: open PR for review + delivery
 - Last updated: 2026-05-26 Asia/Taipei
-- Branch/commit/PR/release: `fix/plan-issue-557-gitlab-required-none` (init via `tracking run init`; not yet pushed)
+- Branch/commit/PR/release: `fix/plan-issue-557-gitlab-required-none`; PR pending
 - Source document: docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-plan.md
 - Discussion source document: docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-discussion-source.md
 - Source issue: sympoies/nils-cli#557
@@ -21,21 +21,21 @@
 
 ## Task Ledger
 
-| ID       | Status  | Task                                                  | Evidence                          | Notes                                                                                  |
-| -------- | ------- | ----------------------------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------- |
-| Task 1.1 | pending | Swap GitLab adapter return triple and refresh comment | pending implementation            | struct literal swap at `forge_cli_adapter.rs:343-356`; comment refresh references #557 |
-| Task 1.2 | pending | Extend adapter unit test and CHANGELOG entry          | pending after Task 1.1            | extend `pr_merge_summary_composes_view_and_checks`; CHANGELOG `[Unreleased]` entry     |
+| ID       | Status | Task                                                  | Evidence                  | Notes                                                                                                                                                                              |
+| -------- | ------ | ----------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task 1.1 | done   | Swap GitLab adapter return triple and refresh comment | local commit pending push | struct literal swap at `forge_cli_adapter.rs:343-356`; comment refresh references #557; returns `Some("success".to_string()), Some(0), Vec::new()`                                 |
+| Task 1.2 | done   | Extend adapter unit test and CHANGELOG entry          | local commit pending push | extended `pr_merge_summary_composes_view_and_checks` with `required_state.as_deref()==Some("success")` + `required_count==Some(0)`; CHANGELOG `[Unreleased] ### Fixed` entry added |
 
 ## Validation
 
-| Command                                                                                                                                                       | Status  | Summary                                                          | Artifact |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------- | -------- |
-| `plan-tooling validate --file docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-plan.md --format text --explain` | pending | bundle gate (run during `record open`)                           | pending  |
-| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`                                                                                                   | pending | docs hygiene, placement, rumdl, plan-bundle, cli-output-contract | pending  |
-| `cargo test -p nils-plan-issue-cli`                                                                                                                           | pending | per-crate gate                                                   | pending  |
-| `cargo clippy -p nils-plan-issue-cli --all-targets --all-features -- -D warnings`                                                                             | pending | per-crate clippy                                                 | pending  |
-| `cargo build -p nils-plan-issue-cli --locked`                                                                                                                 | pending | Cargo.lock locked-build CI lane                                  | pending  |
-| `cargo nextest run --workspace`                                                                                                                               | pending | workspace gate                                                   | pending  |
+| Command                                                                                                                                                         | Status | Summary                                                          | Artifact |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------------------------------------------------------------- | -------- |
+| `plan-tooling validate --file docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-plan.md --format text --explain` | pass   | bundle gate                                                      | exit 0   |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`                                                                                                     | pass   | docs hygiene, placement, rumdl, plan-bundle, cli-output-contract | green    |
+| `cargo test -p nils-plan-issue-cli`                                                                                                                             | pass   | per-crate gate (127+11+7+6+232 = 383 tests pass)                 | green    |
+| `cargo clippy -p nils-plan-issue-cli --all-targets --all-features -- -D warnings`                                                                               | pass   | per-crate clippy                                                 | green    |
+| `cargo build -p nils-plan-issue-cli --locked`                                                                                                                   | pass   | Cargo.lock locked-build CI lane                                  | green    |
+| `cargo nextest run --workspace`                                                                                                                                 | pass   | workspace gate (4041/4041 pass in 11.3s)                         | green    |
 
 ## Blockers
 
@@ -60,3 +60,15 @@
   `record audit --expect-visible` returns `overall_pass: true` with
   all three lifecycle markers (source / plan / state) recognized.
   Ready to hand off to `deliver-plan-tracking-issue`.
+- 2026-05-26: Implementation landed locally on branch
+  `fix/plan-issue-557-gitlab-required-none`. `forge_cli_adapter.rs`
+  GitLab branch of `pr_merge_summary` returns `Some("success"),
+  Some(0), []` and the inline comment now references #557 / #502.
+  `pr_merge_summary_composes_view_and_checks` extended to assert the
+  full new triple. CHANGELOG `[Unreleased] ### Fixed` entry added.
+  Source / plan docs corrected to spell the adapter-layer type
+  (`Option<String>` with the `"success"` literal) explicitly instead
+  of the renderer-layer `CheckStatus::Pass`. Full validation matrix
+  passes locally: `plan-tooling validate`, docs-only CI gate, per-crate
+  `cargo test` / `clippy` / locked-build, and workspace `cargo nextest`
+  (4041/4041). PR pending.

--- a/docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-plan.md
+++ b/docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-plan.md
@@ -7,12 +7,16 @@ the GitLab branch of
 `crates/plan-issue-cli/src/forge_cli_adapter.rs::pr_merge_summary` from
 returning `required_state: None, required_count: None,
 non_required_failures: []` to returning
-`required_state: Some(CheckStatus::Pass), required_count: Some(0),
-non_required_failures: []`. The render-layer five-label table (landed in
-sympoies/nils-cli#563) already maps the new triple to `none required`,
-so the closeout-comment `Required` column will stop reading `unknown`
-for every GitLab PR while the wire format (`closeout.v1`) and the
-close-gate match arms in `lifecycle_record.rs:2446-2469` stay unchanged.
+`required_state: Some("success".to_string()), required_count: Some(0),
+non_required_failures: []`. The `PrMergeSummary.required_state` field
+is `Option<String>` at the adapter boundary; downstream of the adapter
+`execute.rs::check_status_from_state` converts `"success"` to
+`CheckStatus::Pass`, and the render-layer five-label table (landed in
+sympoies/nils-cli#563) already maps `(Some(Pass), Some(0))` to
+`none required`. So the closeout-comment `Required` column will stop
+reading `unknown` for every GitLab PR while the wire format
+(`closeout.v1`) and the close-gate match arms in
+`lifecycle_record.rs:2446-2469` stay unchanged.
 
 The change is a single struct-literal swap plus a comment rewrite plus
 one extended adapter test. No new helpers, no module reorganisation, no
@@ -38,7 +42,7 @@ schema bump. Source: this bundle's discussion source doc.
 - In scope:
   - Replace the `(None, None, [])` return triple in
     `crates/plan-issue-cli/src/forge_cli_adapter.rs::pr_merge_summary`
-    (GitLab branch) with `(Some(CheckStatus::Pass), Some(0), [])`.
+    (GitLab branch) with `(Some("success".to_string()), Some(0), [])`.
   - Refresh the inline comment at
     `crates/plan-issue-cli/src/forge_cli_adapter.rs:343-347` to state
     the new contract (GitLab reports zero required checks; close-gate
@@ -103,7 +107,9 @@ format.
   - `crates/plan-issue-cli/src/forge_cli_adapter.rs:343-356`
 - **Description**: Replace the `(None, None, [])` triple in the GitLab
   branch of `pr_merge_summary` with
-  `(Some(CheckStatus::Pass), Some(0), Vec::new())`. Rewrite the inline
+  `(Some("success".to_string()), Some(0), Vec::new())`. The string is
+  converted to `CheckStatus::Pass` downstream of the adapter by
+  `execute.rs::check_status_from_state`. Rewrite the inline
   comment at `forge_cli_adapter.rs:343-347` to state the new contract:
   GitLab has no first-class required-check concept, so the adapter
   reports zero required checks (mirroring the shape the GitHub adapter
@@ -115,7 +121,7 @@ format.
 - **Complexity**: 1
 - **Acceptance criteria**:
   - `pr_merge_summary` on the GitLab adapter returns
-    `required_state == Some(CheckStatus::Pass)`,
+    `required_state.as_deref() == Some("success")`,
     `required_count == Some(0)`, and an empty `non_required_failures`
     vector for every PR.
   - The inline comment cites #557 and states the new contract; the
@@ -133,7 +139,7 @@ format.
 - **Description**: Extend `pr_merge_summary_composes_view_and_checks`
   (or add a focused sibling test) to assert the new triple alongside
   the existing `state` / `merged` / `merge_sha` / `checks` assertions:
-  `summary.required_state == Some(CheckStatus::Pass)`,
+  `summary.required_state.as_deref() == Some("success")`,
   `summary.required_count == Some(0)`,
   `summary.non_required_failures.is_empty()`. Add a CHANGELOG entry
   under the `[Unreleased]` `### Fixed` (or equivalent) block referencing


### PR DESCRIPTION
## Summary

- Switch the GitLab branch of `forge_cli_adapter::pr_merge_summary` from
  `required_state=None, required_count=None` to
  `required_state=Some("success".to_string()), required_count=Some(0)` so
  the closeout-comment `Required` column renders `none required` for
  GitLab linked-PR rows instead of the misleading `unknown` label. The
  string is converted to `CheckStatus::Pass` downstream of the adapter
  by `execute.rs::check_status_from_state` and then maps via
  `required_check_label` (`lifecycle_record.rs:2154-2160`) to the
  five-label rendering landed in #563.
- Extend `pr_merge_summary_composes_view_and_checks` to assert the new
  triple. Refresh the adapter inline comment and add a CHANGELOG
  `[Unreleased] ### Fixed` entry. Update the source / plan /
  execution-state docs to spell the adapter-layer type (`Option<String>`)
  and the conversion to `CheckStatus::Pass` explicitly.

The wire format (`closeout.v1`) and the close-gate match arms in
`lifecycle_record.rs:2446-2469` stay unchanged. The
semantic shift — GitLab MRs now land in the
`Some(CheckStatus::Pass | CheckStatus::None)` arm of `:2450` instead of
the conservative `None` arm at `:2455`, so a GitLab pipeline `state=
failure` no longer blocks close on aggregate `checks=Fail` — is
acknowledged in the source doc Decision 2 / Risk R-1 and is consistent
with the #502 "non-required failures never block close" contract.

## Read First

- Source doc:
  [docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-discussion-source.md](docs/plans/plan-issue-closeout-gitlab-required-parity/plan-issue-closeout-gitlab-required-parity-discussion-source.md)
- Sibling fix already on `main`: #563 (GitHub-side render fix + five-label
  table) and the supporting docs PRs #558 / #564.
- Close-gate contract: #502 / #512.
- Tracking issue: #565.

## Test plan

- [x] `cargo test -p nils-plan-issue-cli` — 127 + 11 + 7 + 6 + 232 = 383
  tests pass.
- [x] `cargo clippy -p nils-plan-issue-cli --all-targets --all-features
  -- -D warnings` — clean.
- [x] `cargo build -p nils-plan-issue-cli --locked` — Cargo.lock
  locked-build CI lane.
- [x] `cargo nextest run --workspace` — 4041 / 4041 pass in 11.3s.
- [x] `plan-tooling validate --file ...-plan.md --format text` — exit 0.
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` —
  docs hygiene, rumdl, plan-bundle, cli-output-contract green.

Closes #557.
