### PR TITLE
chore(release): bump cli versions to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-runtime-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1538,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6835eea34fb6321b9b3aa7b685c2b433948c09447e389dc017fdf687d5d11e65"
+checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -1548,14 +1548,14 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c22e04db9c58f5136eb1757f3d5c49a7b187f49e52185228cbd2f5acdfcc08c"
+checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-docs"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-out"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-scope-lock"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-workflow-primitives"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-gql"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-grpc"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-rest"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1922,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-test"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-testing-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-websocket"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "nils-cli-template"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "nils-codex-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "nils-common"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "base64",
  "clap",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "nils-forge-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "nils-fzf-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "nils-gemini-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-lock"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-scope"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-summary"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "nils-image-processing"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "nils-macos-agent"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "nils-markdown"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "nils-memo-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-issue-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-tooling"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "nils-screen-record"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "block2",
  "chrono",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "nils-semantic-commit"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "nils-term"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "indicatif",
  "pretty_assertions",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "nils-test-support"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "nils-web-evidence"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ resolver = "2"
 # edition.
 edition = "2024"
 license = "MIT"
-version = "0.23.0"
+version = "0.24.0"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ This repo can publish prebuilt tarballs via GitHub Releases for both:
 - x86_64 (amd64)
 - aarch64 (arm64)
 
-To trigger a release build, push a tag like `v0.23.0`:
+To trigger a release build, push a tag like `v0.24.0`:
 
-- `git tag -a v0.23.0 -m "v0.23.0"`
-- `git push origin v0.23.0`
+- `git tag -a v0.24.0 -m "v0.24.0"`
+- `git push origin v0.24.0`
 
 Then download the matching `nils-cli-<tag>-<target>.tar.gz` asset, extract it, and add `<extract_dir>/bin` to your `PATH`.
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `fafbd98f4a6a3ce54528e2885d41672b51139b7d1eb4aed81edf5b3412345b12`
+- Cargo.lock SHA256: `25416cc34b53f76824cdf3a848c8f4f73057989559e3e21034776028f3f60e61`
 - Third-party crates (`source != null`): 465
 - Workspace crates (`source == null`, excluded below): 32
 
@@ -210,8 +210,8 @@ This file documents third-party Rust crate licenses used by this workspace.
 | jaq-core | 3.0.0 | MIT | crates.io |
 | jaq-json | 2.0.0 | MIT | crates.io |
 | jaq-std | 3.0.0 | MIT | crates.io |
-| jiff | 0.2.25 | Unlicense OR MIT | crates.io |
-| jiff-static | 0.2.25 | Unlicense OR MIT | crates.io |
+| jiff | 0.2.27 | Unlicense OR MIT | crates.io |
+| jiff-static | 0.2.27 | Unlicense OR MIT | crates.io |
 | jiff-tzdb | 0.1.6 | Unlicense OR MIT | crates.io |
 | jiff-tzdb-platform | 0.1.3 | Unlicense OR MIT | crates.io |
 | jni | 0.22.4 | MIT OR Apache-2.0 | crates.io |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `fafbd98f4a6a3ce54528e2885d41672b51139b7d1eb4aed81edf5b3412345b12`
+- Cargo.lock SHA256: `25416cc34b53f76824cdf3a848c8f4f73057989559e3e21034776028f3f60e61`
 - Third-party crates (`source != null`): 465
 
 ## Notice Extraction Policy
@@ -1394,7 +1394,7 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - Notice files: No explicit NOTICE file discovered.
 - License file reference: none declared
 
-### jiff 0.2.25
+### jiff 0.2.27
 
 - License: `Unlicense OR MIT`
 - Source: `crates.io`
@@ -1404,7 +1404,7 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `COPYING`
   - `UNLICENSE`
 
-### jiff-static 0.2.25
+### jiff-static 0.2.27
 
 - License: `Unlicense OR MIT`
 - Source: `crates.io`

--- a/crates/agent-docs/Cargo.toml
+++ b/crates/agent-docs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-docs"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -19,12 +19,12 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 directories = { workspace = true }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 toml_edit = "0.25"
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/agent-out/Cargo.toml
+++ b/crates/agent-out/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-out"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -19,11 +19,11 @@ path = "src/main.rs"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-runtime-cli/Cargo.toml
+++ b/crates/agent-runtime-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-runtime-cli"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -19,7 +19,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 indexmap = { workspace = true }
-nils-markdown = { version = "0.23.0", path = "../nils-markdown", package = "nils-markdown" }
+nils-markdown = { version = "0.24.0", path = "../nils-markdown", package = "nils-markdown" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
@@ -29,5 +29,5 @@ tera = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/agent-scope-lock/Cargo.toml
+++ b/crates/agent-scope-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-scope-lock"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -14,11 +14,11 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-workflow-primitives/Cargo.toml
+++ b/crates/agent-workflow-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-workflow-primitives"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -58,16 +58,16 @@ path = "src/bin/test-first-evidence.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-agent-out = { version = "0.23.0", path = "../agent-out" }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
-nils-markdown = { version = "0.23.0", path = "../nils-markdown", package = "nils-markdown" }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
+nils-agent-out = { version = "0.24.0", path = "../agent-out" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
+nils-markdown = { version = "0.24.0", path = "../nils-markdown", package = "nils-markdown" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-gql/Cargo.toml
+++ b/crates/api-gql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-gql"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,13 +12,13 @@ name = "api-gql"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.23.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.24.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-grpc/Cargo.toml
+++ b/crates/api-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-grpc"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-grpc"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.23.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.24.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.22"
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-rest/Cargo.toml
+++ b/crates/api-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-rest"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-rest"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.23.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.24.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.22"
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-test/Cargo.toml
+++ b/crates/api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-test"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -16,14 +16,14 @@ name = "api-test"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.23.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.24.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-testing-core/Cargo.toml
+++ b/crates/api-testing-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-testing-core"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -24,10 +24,10 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-websocket/Cargo.toml
+++ b/crates/api-websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-websocket"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-websocket"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.23.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.24.0", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }

--- a/crates/cli-template/Cargo.toml
+++ b/crates/cli-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-cli-template"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -13,13 +13,13 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/codex-cli/Cargo.toml
+++ b/crates/codex-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-codex-cli"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -23,10 +23,10 @@ reqwest = { version = "0.13", default-features = false, features = ["blocking", 
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.11"
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/forge-cli/Cargo.toml
+++ b/crates/forge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-forge-cli"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -20,7 +20,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 libc = "0.2"
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_yaml_ng = { workspace = true }
@@ -29,5 +29,5 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/fzf-cli/Cargo.toml
+++ b/crates/fzf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-fzf-cli"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -14,14 +14,14 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
 walkdir = "2"
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/gemini-cli/Cargo.toml
+++ b/crates/gemini-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-gemini-cli"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -21,9 +21,9 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/git-cli/Cargo.toml
+++ b/crates/git-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-cli"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -18,12 +18,12 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/git-lock/Cargo.toml
+++ b/crates/git-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-lock"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -15,10 +15,10 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 chrono = { version = "0.4", features = ["clock"] }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 tempfile = "3"
 pretty_assertions = { workspace = true }

--- a/crates/git-scope/Cargo.toml
+++ b/crates/git-scope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-scope"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -14,9 +14,9 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 tempfile = "3"
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }

--- a/crates/git-summary/Cargo.toml
+++ b/crates/git-summary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-summary"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -15,10 +15,10 @@ anyhow = { workspace = true }
 chrono = { version = "0.4", features = ["clock"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/image-processing/Cargo.toml
+++ b/crates/image-processing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-image-processing"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -20,8 +20,8 @@ serde_json = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 globset = "0.4"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
 resvg = "0.47"
 roxmltree = "0.21"
 usvg = "0.47"
@@ -29,6 +29,6 @@ uuid = { version = "1", features = ["v4"] }
 walkdir = "2"
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/macos-agent/Cargo.toml
+++ b/crates/macos-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-macos-agent"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -20,11 +20,11 @@ clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 regex = "1"
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
-screen-record = { version = "0.23.0", path = "../screen-record", package = "nils-screen-record" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
+screen-record = { version = "0.24.0", path = "../screen-record", package = "nils-screen-record" }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/memo-cli/Cargo.toml
+++ b/crates/memo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-memo-cli"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -24,10 +24,10 @@ chrono-tz = "0.10"
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-common/Cargo.toml
+++ b/crates/nils-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-common"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 description = "Library crate for nils-common in the nils-cli workspace."
@@ -15,6 +15,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-markdown/Cargo.toml
+++ b/crates/nils-markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-markdown"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 description = "Shared Tera-backed Markdown template layer for the nils-cli workspace."
@@ -26,7 +26,7 @@ anyhow = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 clap_complete = { workspace = true, optional = true }
 indexmap = { workspace = true }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 pretty_assertions = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -35,6 +35,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-nils-markdown = { path = ".", features = ["bin-cli", "test-support"] }
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-markdown = { version = "0.24.0", path = ".", features = ["bin-cli", "test-support"] }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/nils-term/Cargo.toml
+++ b/crates/nils-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-term"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 description = "Library crate for nils-term in the nils-cli workspace."

--- a/crates/nils-test-support/Cargo.toml
+++ b/crates/nils-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-test-support"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/plan-issue-cli/Cargo.toml
+++ b/crates/plan-issue-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-issue-cli"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 default-run = "plan-issue"
@@ -25,12 +25,12 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
-nils-markdown = { version = "0.23.0", path = "../nils-markdown", package = "nils-markdown" }
-plan-tooling = { version = "0.23.0", path = "../plan-tooling", package = "nils-plan-tooling" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
+nils-markdown = { version = "0.24.0", path = "../nils-markdown", package = "nils-markdown" }
+plan-tooling = { version = "0.24.0", path = "../plan-tooling", package = "nils-plan-tooling" }
 
 [dev-dependencies]
-nils-markdown = { version = "0.23.0", path = "../nils-markdown", package = "nils-markdown", features = ["test-support"] }
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-markdown = { version = "0.24.0", path = "../nils-markdown", package = "nils-markdown", features = ["test-support"] }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/plan-tooling/Cargo.toml
+++ b/crates/plan-tooling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-tooling"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -16,14 +16,14 @@ name = "plan-tooling"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/screen-record/Cargo.toml
+++ b/crates/screen-record/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-screen-record"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 build = "build.rs"
@@ -20,7 +20,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 ctrlc = "3.5.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.13", features = ["randr"] }
@@ -41,7 +41,7 @@ block2 = "0.6.2"
 dispatch2 = "0.3.0"
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 tempfile = "3"
 
 [lints.rust]

--- a/crates/semantic-commit/Cargo.toml
+++ b/crates/semantic-commit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-semantic-commit"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -21,9 +21,9 @@ clap_complete = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
 time = { version = "0.3", features = ["formatting"] }
-nils-term = { version = "0.23.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.24.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/web-evidence/Cargo.toml
+++ b/crates/web-evidence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-web-evidence"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 license.workspace = true
 
@@ -18,12 +18,12 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.23.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.24.0", path = "../nils-common", package = "nils-common" }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.23.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.24.0", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"


### PR DESCRIPTION
## Summary

- Bump workspace and CLI crate versions to 0.24.0
- Update README release tag example to v0.24.0
- Refresh Cargo.lock for workspace package versions
- Regenerate third-party artifacts for updated lockfile inputs

## Test plan

- [ ] CI: required status checks green
- [ ] After merge: tag v0.24.0 and confirm release.yml publishes artifacts
- [ ] Tap stage updates homebrew formula
