### PR TITLE
fix(release): filter required-features bins from release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           while IFS= read -r bin; do
             [[ -n "${bin}" ]] || continue
             bins+=( "${bin}" )
-          done < <(bash scripts/workspace-bins.sh)
+          done < <(bash scripts/workspace-bins.sh --release-default)
 
           if [[ ${#bins[@]} -eq 0 ]]; then
             echo "error: no workspace binaries found" >&2

--- a/scripts/install-local-release-binaries.sh
+++ b/scripts/install-local-release-binaries.sh
@@ -94,7 +94,7 @@ if [[ ${#bins[@]} -eq 0 ]]; then
   while IFS= read -r bin; do
     [[ -n "$bin" ]] || continue
     bins+=( "$bin" )
-  done < <(bash "$bins_script")
+  done < <(bash "$bins_script" --release-default)
 
   if [[ ${#bins[@]} -eq 0 ]]; then
     echo "error: no workspace binaries found" >&2

--- a/scripts/workspace-bins.sh
+++ b/scripts/workspace-bins.sh
@@ -1,25 +1,63 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/workspace-bins.sh [--release-default]
+
+Lists workspace bin target names from `cargo metadata`, sorted unique.
+
+Options:
+  --release-default  Exclude bins gated by `[[bin]] required-features`
+                     (i.e. bins not produced by `cargo build --workspace`
+                     without explicit --features). Use this for release
+                     packaging and the default local-release install,
+                     which build with default features only.
+  -h, --help         Show this help.
+USAGE
+}
+
+release_default=0
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --release-default)
+      release_default=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: ${1:-}" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 
 metadata_json="$(cargo metadata --no-deps --format-version 1 --manifest-path "$repo_root/Cargo.toml" | tr -d '\n')"
 
 printf '%s\n' "$metadata_json" \
-  | awk '
+  | awk -v release_default="$release_default" '
       {
         text = $0
-        while (match(text, /"kind":\[[^][]*\],"crate_types":\[[^][]*\],"name":"[^"]+"/)) {
+        while (match(text, /"kind":\[[^][]*\],"crate_types":\[[^][]*\],"name":"[^"]+"[^{}]*/)) {
           block = substr(text, RSTART, RLENGTH)
           text = substr(text, RSTART + RLENGTH)
 
-          if (block ~ /"kind":\[[^]]*"bin"[^]]*\]/) {
-            name = block
-            sub(/^.*"name":"/, "", name)
-            sub(/".*$/, "", name)
-            print name
-          }
+          if (block !~ /"kind":\[[^]]*"bin"[^]]*\]/) continue
+
+          if (release_default == "1" && block ~ /"required-features":\[[^][]+\]/) continue
+
+          name = block
+          sub(/^.*"name":"/, "", name)
+          sub(/".*$/, "", name)
+          print name
         }
       }
     ' \


### PR DESCRIPTION
## Summary
- Add `--release-default` flag to `scripts/workspace-bins.sh` that filters out `[[bin]]` targets gated by non-empty `required-features`.
- Point `.github/workflows/release.yml` Package step and `scripts/install-local-release-binaries.sh` at the new flag so `md-render` (behind `nils-markdown/bin-cli`) no longer breaks release packaging with `error: missing binary: target/<target>/release/md-render`.
- Default `workspace-bins.sh` output is unchanged, so `scripts/ci/completion-asset-audit.sh` keeps validating the full declared-bin universe (matrix still asserts `md-render` as `required`).

## Why
The `v0.24.0` release run (https://github.com/sympoies/nils-cli/actions/runs/26458805379) failed on every platform's Package step because `md-render` was listed by `workspace-bins.sh` but never produced by `cargo build --workspace` (no `--features bin-cli`). Tag and bump commit (#568) are already on `main`; this fix unblocks retriggering `release.yml` on `v0.24.0` so the homebrew-tap bump can follow.

## Test plan
- [x] `bash scripts/workspace-bins.sh` still lists `md-render` (39 bins).
- [x] `bash scripts/workspace-bins.sh --release-default` omits only `md-render` (38 bins).
- [x] `bash scripts/ci/completion-asset-audit.sh --strict` passes.
- [x] `cargo check --workspace --locked` clean.
- [ ] CI required checks green on this PR.
- [ ] After merge: retrigger `release.yml` on tag `v0.24.0` and confirm Package step succeeds.