### PR TITLE
refactor(api): share call validation helpers

### DIFF
--- a/crates/api-grpc/src/commands/call.rs
+++ b/crates/api-grpc/src/commands/call.rs
@@ -2,13 +2,13 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use api_testing_core::cli_history::{
-    RequestCallHistoryAuth, RequestCallHistoryRecord, build_request_call_history_record,
+    RequestCallHistoryAppend, append_request_call_history_best_effort,
 };
-use api_testing_core::{Result, auth_env, cli_endpoint, cli_io, cli_util, config, history, jwt};
+use api_testing_core::{Result, auth_env, cli_endpoint, cli_io, cli_util, config, history};
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 
 use crate::cli::CallArgs;
-use api_testing_core::cli_util::{history_timestamp_now, parse_u64_default, trim_non_empty};
+use api_testing_core::cli_util::{parse_u64_default, trim_non_empty};
 
 #[derive(Debug, Clone)]
 pub(crate) struct EndpointSelection {
@@ -88,42 +88,18 @@ pub(crate) fn validate_bearer_token_if_jwt(
     token_name: &str,
     stderr: &mut dyn Write,
 ) -> Result<()> {
-    let enabled = cli_util::bool_from_env(
-        std::env::var("GRPC_JWT_VALIDATE_ENABLED").ok(),
-        "GRPC_JWT_VALIDATE_ENABLED",
-        true,
-        Some("api-grpc"),
+    auth_env::validate_cli_bearer_jwt(
+        bearer_token,
+        auth_source,
+        token_name,
+        auth_env::CliJwtValidationEnv {
+            enabled_var: "GRPC_JWT_VALIDATE_ENABLED",
+            strict_var: "GRPC_JWT_VALIDATE_STRICT",
+            leeway_var: "GRPC_JWT_VALIDATE_LEEWAY_SECONDS",
+            tool_label: "api-grpc",
+        },
         stderr,
-    );
-    let strict = cli_util::bool_from_env(
-        std::env::var("GRPC_JWT_VALIDATE_STRICT").ok(),
-        "GRPC_JWT_VALIDATE_STRICT",
-        false,
-        Some("api-grpc"),
-        stderr,
-    );
-    let leeway_seconds =
-        parse_u64_default(std::env::var("GRPC_JWT_VALIDATE_LEEWAY_SECONDS").ok(), 0, 0);
-
-    let label = match auth_source {
-        AuthSourceUsed::TokenProfile => format!("token profile '{token_name}'"),
-        AuthSourceUsed::EnvFallback { env_name } => env_name.to_string(),
-        AuthSourceUsed::None => "token".to_string(),
-    };
-
-    let opts = jwt::JwtValidationOptions {
-        enabled,
-        strict,
-        leeway_seconds: i64::try_from(leeway_seconds).unwrap_or(i64::MAX),
-    };
-
-    match jwt::check_bearer_jwt(bearer_token, &label, opts)? {
-        jwt::JwtCheck::Ok => Ok(()),
-        jwt::JwtCheck::Warn(msg) => {
-            let _ = writeln!(stderr, "api-grpc: warning: {msg}");
-            Ok(())
-        }
-    }
+    )
 }
 
 pub(crate) fn cmd_call(
@@ -328,43 +304,25 @@ struct CallHistoryContext {
 }
 
 fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32, stderr: &mut dyn Write) {
-    if !ctx.enabled {
-        return;
-    }
-
-    let history_writer = &ctx.history_writer;
-    let stamp = history_timestamp_now().unwrap_or_default();
-    let auth = match &ctx.auth_source_used {
-        AuthSourceUsed::TokenProfile => RequestCallHistoryAuth::HeaderAndFlag {
-            header_key: "token",
-            header_value: &ctx.token_name_for_log,
-            flag_name: "token",
-            flag_value: &ctx.token_name_for_log,
+    append_request_call_history_best_effort(
+        RequestCallHistoryAppend {
+            enabled: ctx.enabled,
+            history_writer: &ctx.history_writer,
+            exit_code,
+            setup_dir: &ctx.setup_dir,
+            invocation_dir: &ctx.invocation_dir,
+            command_name: "api-grpc",
+            endpoint_label_used: &ctx.endpoint_label_used,
+            endpoint_value_used: &ctx.endpoint_value_used,
+            log_url: ctx.log_url,
+            auth_source: &ctx.auth_source_used,
+            token_name_for_log: &ctx.token_name_for_log,
+            request_arg: &ctx.request_arg,
+            extra_flags: &[],
+            warning_label: "api-grpc",
         },
-        AuthSourceUsed::EnvFallback { env_name } => RequestCallHistoryAuth::HeaderOnly {
-            key: "auth",
-            value: env_name,
-        },
-        AuthSourceUsed::None => RequestCallHistoryAuth::None,
-    };
-
-    let record = build_request_call_history_record(RequestCallHistoryRecord {
-        stamp: &stamp,
-        exit_code,
-        setup_dir: &ctx.setup_dir,
-        invocation_dir: &ctx.invocation_dir,
-        command_name: "api-grpc",
-        endpoint_label_used: &ctx.endpoint_label_used,
-        endpoint_value_used: &ctx.endpoint_value_used,
-        log_url: ctx.log_url,
-        auth,
-        request_arg: &ctx.request_arg,
-        extra_flags: &[],
-    });
-
-    if let Err(err) = history_writer.append(&record) {
-        let _ = writeln!(stderr, "warning: failed to append api-grpc history: {err}");
-    }
+        stderr,
+    );
 }
 
 #[cfg(test)]

--- a/crates/api-testing-core/src/auth_env.rs
+++ b/crates/api-testing-core/src/auth_env.rs
@@ -1,6 +1,7 @@
+use std::io::Write;
 use std::path::Path;
 
-use crate::{Result, cli_util, env_file};
+use crate::{Result, cli_util, env_file, jwt};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProfileTokenSource {
@@ -16,12 +17,69 @@ pub enum CliAuthSource {
     EnvFallback { env_name: String },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CliJwtValidationEnv<'a> {
+    pub enabled_var: &'a str,
+    pub strict_var: &'a str,
+    pub leeway_var: &'a str,
+    pub tool_label: &'a str,
+}
+
 impl From<ProfileTokenSource> for CliAuthSource {
     fn from(value: ProfileTokenSource) -> Self {
         match value {
             ProfileTokenSource::None => Self::None,
             ProfileTokenSource::Profile => Self::TokenProfile,
             ProfileTokenSource::EnvFallback { env_name } => Self::EnvFallback { env_name },
+        }
+    }
+}
+
+pub fn validate_cli_bearer_jwt(
+    bearer_token: &str,
+    auth_source: &CliAuthSource,
+    token_name: &str,
+    env: CliJwtValidationEnv<'_>,
+    stderr: &mut dyn Write,
+) -> Result<()> {
+    let enabled = cli_util::bool_from_env(
+        std::env::var(env.enabled_var).ok(),
+        env.enabled_var,
+        true,
+        Some(env.tool_label),
+        stderr,
+    );
+    let strict = cli_util::bool_from_env(
+        std::env::var(env.strict_var).ok(),
+        env.strict_var,
+        false,
+        Some(env.tool_label),
+        stderr,
+    );
+    let leeway_seconds = cli_util::parse_u64_default(std::env::var(env.leeway_var).ok(), 0, 0);
+
+    let label = match auth_source {
+        CliAuthSource::TokenProfile => format!("token profile '{token_name}'"),
+        CliAuthSource::EnvFallback { env_name } => env_name.to_string(),
+        CliAuthSource::None => "token".to_string(),
+    };
+
+    let opts = jwt::JwtValidationOptions {
+        enabled,
+        strict,
+        leeway_seconds: i64::try_from(leeway_seconds).unwrap_or(i64::MAX),
+    };
+
+    match jwt::check_bearer_jwt(bearer_token, &label, opts)? {
+        jwt::JwtCheck::Ok => Ok(()),
+        jwt::JwtCheck::Warn(msg) => {
+            let tool_label = env.tool_label.trim();
+            if tool_label.is_empty() {
+                let _ = writeln!(stderr, "warning: {msg}");
+            } else {
+                let _ = writeln!(stderr, "{tool_label}: warning: {msg}");
+            }
+            Ok(())
         }
     }
 }
@@ -150,6 +208,15 @@ mod tests {
         std::fs::write(path, contents).expect("write");
     }
 
+    fn test_jwt_env() -> CliJwtValidationEnv<'static> {
+        CliJwtValidationEnv {
+            enabled_var: "TEST_JWT_VALIDATE_ENABLED",
+            strict_var: "TEST_JWT_VALIDATE_STRICT",
+            leeway_var: "TEST_JWT_VALIDATE_LEEWAY_SECONDS",
+            tool_label: "api-test",
+        }
+    }
+
     #[test]
     fn resolve_env_fallback_prefers_order() {
         let lock = GlobalStateLock::new();
@@ -179,6 +246,51 @@ mod tests {
             CliAuthSource::EnvFallback {
                 env_name: "ACCESS_TOKEN".to_string()
             }
+        );
+    }
+
+    #[test]
+    fn validate_cli_bearer_jwt_warns_when_non_strict() {
+        let lock = GlobalStateLock::new();
+        let _enabled = EnvGuard::set(&lock, "TEST_JWT_VALIDATE_ENABLED", "true");
+        let _strict = EnvGuard::set(&lock, "TEST_JWT_VALIDATE_STRICT", "false");
+        let _leeway = EnvGuard::remove(&lock, "TEST_JWT_VALIDATE_LEEWAY_SECONDS");
+
+        let mut stderr = Vec::new();
+        validate_cli_bearer_jwt(
+            "not.a.jwt",
+            &CliAuthSource::None,
+            "default",
+            test_jwt_env(),
+            &mut stderr,
+        )
+        .expect("non-strict invalid token should warn");
+
+        let msg = String::from_utf8(stderr).expect("utf8");
+        assert!(msg.contains("api-test: warning:"));
+        assert!(msg.contains("token for token is not a valid JWT"));
+    }
+
+    #[test]
+    fn validate_cli_bearer_jwt_errors_when_strict_invalid() {
+        let lock = GlobalStateLock::new();
+        let _enabled = EnvGuard::set(&lock, "TEST_JWT_VALIDATE_ENABLED", "true");
+        let _strict = EnvGuard::set(&lock, "TEST_JWT_VALIDATE_STRICT", "true");
+        let _leeway = EnvGuard::remove(&lock, "TEST_JWT_VALIDATE_LEEWAY_SECONDS");
+
+        let mut stderr = Vec::new();
+        let err = validate_cli_bearer_jwt(
+            "not.a.jwt",
+            &CliAuthSource::TokenProfile,
+            "svc",
+            test_jwt_env(),
+            &mut stderr,
+        )
+        .expect_err("strict invalid token should fail");
+
+        assert!(
+            err.to_string()
+                .contains("invalid JWT for token profile 'svc'")
         );
     }
 

--- a/crates/api-testing-core/src/cli_history.rs
+++ b/crates/api-testing-core/src/cli_history.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use crate::{Result, cli_util, history};
+use crate::{Result, auth_env::CliAuthSource, cli_util, history};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RequestCallHistoryAuth<'a> {
@@ -56,6 +56,24 @@ pub struct RequestCallHistoryRecord<'a> {
     pub auth: RequestCallHistoryAuth<'a>,
     pub request_arg: &'a str,
     pub extra_flags: &'a [RequestCallHistoryFlag<'a>],
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RequestCallHistoryAppend<'a> {
+    pub enabled: bool,
+    pub history_writer: &'a history::HistoryWriter,
+    pub exit_code: i32,
+    pub setup_dir: &'a Path,
+    pub invocation_dir: &'a Path,
+    pub command_name: &'a str,
+    pub endpoint_label_used: &'a str,
+    pub endpoint_value_used: &'a str,
+    pub log_url: bool,
+    pub auth_source: &'a CliAuthSource,
+    pub token_name_for_log: &'a str,
+    pub request_arg: &'a str,
+    pub extra_flags: &'a [RequestCallHistoryFlag<'a>],
+    pub warning_label: &'a str,
 }
 
 pub fn resolve_history_file<F>(
@@ -127,6 +145,57 @@ pub fn run_history_command(
     }
 
     0
+}
+
+pub fn append_request_call_history_best_effort(
+    spec: RequestCallHistoryAppend<'_>,
+    stderr: &mut dyn Write,
+) {
+    if !spec.enabled {
+        return;
+    }
+
+    let stamp = cli_util::history_timestamp_now().unwrap_or_default();
+    let auth = match spec.auth_source {
+        CliAuthSource::TokenProfile => RequestCallHistoryAuth::HeaderAndFlag {
+            header_key: "token",
+            header_value: spec.token_name_for_log,
+            flag_name: "token",
+            flag_value: spec.token_name_for_log,
+        },
+        CliAuthSource::EnvFallback { env_name } => RequestCallHistoryAuth::HeaderOnly {
+            key: "auth",
+            value: env_name,
+        },
+        CliAuthSource::None => RequestCallHistoryAuth::None,
+    };
+
+    let record = build_request_call_history_record(RequestCallHistoryRecord {
+        stamp: &stamp,
+        exit_code: spec.exit_code,
+        setup_dir: spec.setup_dir,
+        invocation_dir: spec.invocation_dir,
+        command_name: spec.command_name,
+        endpoint_label_used: spec.endpoint_label_used,
+        endpoint_value_used: spec.endpoint_value_used,
+        log_url: spec.log_url,
+        auth,
+        request_arg: spec.request_arg,
+        extra_flags: spec.extra_flags,
+    });
+
+    if let Err(err) = spec.history_writer.append(&record) {
+        let warning_label = spec.warning_label.trim();
+        let warning_label = if warning_label.is_empty() {
+            spec.command_name
+        } else {
+            warning_label
+        };
+        let _ = writeln!(
+            stderr,
+            "warning: failed to append {warning_label} history: {err}"
+        );
+    }
 }
 
 pub fn build_request_call_history_record(spec: RequestCallHistoryRecord<'_>) -> String {

--- a/crates/api-testing-core/tests/integration/cli_history.rs
+++ b/crates/api-testing-core/tests/integration/cli_history.rs
@@ -1,4 +1,11 @@
-use api_testing_core::cli_history::{resolve_history_file, run_history_command};
+use api_testing_core::{
+    auth_env::CliAuthSource,
+    cli_history::{
+        RequestCallHistoryAppend, RequestCallHistoryFlag, append_request_call_history_best_effort,
+        resolve_history_file, run_history_command,
+    },
+    history::{HistoryWriter, RotationPolicy},
+};
 use nils_test_support::{EnvGuard, GlobalStateLock};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
@@ -64,4 +71,49 @@ fn cli_history_resolves_env_override_under_setup_dir() {
 
     let setup_dir_abs = std::fs::canonicalize(&setup_dir).unwrap();
     assert_eq!(history_file, setup_dir_abs.join("custom.history"));
+}
+
+#[test]
+fn cli_history_appends_shared_request_call_record() {
+    let tmp = TempDir::new().unwrap();
+    let setup_dir = tmp.path().join("setup/websocket");
+    std::fs::create_dir_all(&setup_dir).unwrap();
+    let history_file = tmp.path().join(".ws_history");
+    let history_writer = HistoryWriter::new(
+        history_file.clone(),
+        RotationPolicy {
+            max_mb: 10,
+            keep: 5,
+        },
+    );
+    let format_flag = [RequestCallHistoryFlag::raw("format", "json")];
+    let auth_source = CliAuthSource::TokenProfile;
+
+    append_request_call_history_best_effort(
+        RequestCallHistoryAppend {
+            enabled: true,
+            history_writer: &history_writer,
+            exit_code: 0,
+            setup_dir: &setup_dir,
+            invocation_dir: tmp.path(),
+            command_name: "api-websocket",
+            endpoint_label_used: "url",
+            endpoint_value_used: "ws://127.0.0.1:9001/ws",
+            log_url: false,
+            auth_source: &auth_source,
+            token_name_for_log: "svc",
+            request_arg: "/abs/requests/health.ws.json",
+            extra_flags: &format_flag,
+            warning_label: "api-websocket",
+        },
+        &mut std::io::sink(),
+    );
+
+    let text = std::fs::read_to_string(&history_file).unwrap();
+    assert!(text.contains("api-websocket call \\"));
+    assert!(text.contains("url=<omitted>"));
+    assert!(text.contains("token=svc"));
+    assert!(text.contains("--token 'svc'"));
+    assert!(text.contains("--format json"));
+    assert!(!text.contains("--url "));
 }

--- a/crates/api-websocket/src/commands/call.rs
+++ b/crates/api-websocket/src/commands/call.rs
@@ -2,14 +2,13 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use api_testing_core::cli_history::{
-    RequestCallHistoryAuth, RequestCallHistoryFlag, RequestCallHistoryRecord,
-    build_request_call_history_record,
+    RequestCallHistoryAppend, RequestCallHistoryFlag, append_request_call_history_best_effort,
 };
-use api_testing_core::{Result, auth_env, cli_endpoint, cli_util, config, history, jwt};
+use api_testing_core::{Result, auth_env, cli_endpoint, cli_util, config, history};
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 
 use crate::cli::{CallArgs, OutputFormat};
-use api_testing_core::cli_util::{history_timestamp_now, parse_u64_default, trim_non_empty};
+use api_testing_core::cli_util::{parse_u64_default, trim_non_empty};
 
 const CALL_SCHEMA_VERSION: &str = "cli.api-websocket.call.v1";
 
@@ -107,42 +106,18 @@ pub(crate) fn validate_bearer_token_if_jwt(
     token_name: &str,
     stderr: &mut dyn Write,
 ) -> Result<()> {
-    let enabled = cli_util::bool_from_env(
-        std::env::var("WS_JWT_VALIDATE_ENABLED").ok(),
-        "WS_JWT_VALIDATE_ENABLED",
-        true,
-        Some("api-websocket"),
+    auth_env::validate_cli_bearer_jwt(
+        bearer_token,
+        auth_source,
+        token_name,
+        auth_env::CliJwtValidationEnv {
+            enabled_var: "WS_JWT_VALIDATE_ENABLED",
+            strict_var: "WS_JWT_VALIDATE_STRICT",
+            leeway_var: "WS_JWT_VALIDATE_LEEWAY_SECONDS",
+            tool_label: "api-websocket",
+        },
         stderr,
-    );
-    let strict = cli_util::bool_from_env(
-        std::env::var("WS_JWT_VALIDATE_STRICT").ok(),
-        "WS_JWT_VALIDATE_STRICT",
-        false,
-        Some("api-websocket"),
-        stderr,
-    );
-    let leeway_seconds =
-        parse_u64_default(std::env::var("WS_JWT_VALIDATE_LEEWAY_SECONDS").ok(), 0, 0);
-
-    let label = match auth_source {
-        AuthSourceUsed::TokenProfile => format!("token profile '{token_name}'"),
-        AuthSourceUsed::EnvFallback { env_name } => env_name.to_string(),
-        AuthSourceUsed::None => "token".to_string(),
-    };
-
-    let opts = jwt::JwtValidationOptions {
-        enabled,
-        strict,
-        leeway_seconds: i64::try_from(leeway_seconds).unwrap_or(i64::MAX),
-    };
-
-    match jwt::check_bearer_jwt(bearer_token, &label, opts)? {
-        jwt::JwtCheck::Ok => Ok(()),
-        jwt::JwtCheck::Warn(msg) => {
-            let _ = writeln!(stderr, "api-websocket: warning: {msg}");
-            Ok(())
-        }
-    }
+    )
 }
 
 pub(crate) fn cmd_call(
@@ -475,25 +450,6 @@ struct CallHistoryContext {
 }
 
 fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32, stderr: &mut dyn Write) {
-    if !ctx.enabled {
-        return;
-    }
-
-    let history_writer = &ctx.history_writer;
-    let stamp = history_timestamp_now().unwrap_or_default();
-    let auth = match &ctx.auth_source_used {
-        AuthSourceUsed::TokenProfile => RequestCallHistoryAuth::HeaderAndFlag {
-            header_key: "token",
-            header_value: &ctx.token_name_for_log,
-            flag_name: "token",
-            flag_value: &ctx.token_name_for_log,
-        },
-        AuthSourceUsed::EnvFallback { env_name } => RequestCallHistoryAuth::HeaderOnly {
-            key: "auth",
-            value: env_name,
-        },
-        AuthSourceUsed::None => RequestCallHistoryAuth::None,
-    };
     let json_flag = [RequestCallHistoryFlag::raw("format", "json")];
     let extra_flags: &[RequestCallHistoryFlag<'_>] =
         if matches!(ctx.output_format, OutputFormat::Json) {
@@ -502,26 +458,25 @@ fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32, stderr: 
             &[]
         };
 
-    let record = build_request_call_history_record(RequestCallHistoryRecord {
-        stamp: &stamp,
-        exit_code,
-        setup_dir: &ctx.setup_dir,
-        invocation_dir: &ctx.invocation_dir,
-        command_name: "api-websocket",
-        endpoint_label_used: &ctx.endpoint_label_used,
-        endpoint_value_used: &ctx.endpoint_value_used,
-        log_url: ctx.log_url,
-        auth,
-        request_arg: &ctx.request_arg,
-        extra_flags,
-    });
-
-    if let Err(err) = history_writer.append(&record) {
-        let _ = writeln!(
-            stderr,
-            "warning: failed to append api-websocket history: {err}"
-        );
-    }
+    append_request_call_history_best_effort(
+        RequestCallHistoryAppend {
+            enabled: ctx.enabled,
+            history_writer: &ctx.history_writer,
+            exit_code,
+            setup_dir: &ctx.setup_dir,
+            invocation_dir: &ctx.invocation_dir,
+            command_name: "api-websocket",
+            endpoint_label_used: &ctx.endpoint_label_used,
+            endpoint_value_used: &ctx.endpoint_value_used,
+            log_url: ctx.log_url,
+            auth_source: &ctx.auth_source_used,
+            token_name_for_log: &ctx.token_name_for_log,
+            request_arg: &ctx.request_arg,
+            extra_flags,
+            warning_label: "api-websocket",
+        },
+        stderr,
+    );
 }
 
 fn maybe_print_failure_body_to_stderr(

--- a/scripts/ci/nils-cli-local-fast.sh
+++ b/scripts/ci/nils-cli-local-fast.sh
@@ -189,10 +189,13 @@ metadata_raw = subprocess.check_output(
 metadata = json.loads(metadata_raw)
 
 crate_roots = []
+package_has_doctests = {}
 for package in metadata["packages"]:
     manifest = pathlib.Path(package["manifest_path"])
     root = manifest.parent.relative_to(repo).as_posix()
+    has_doctests = any(target.get("doctest") for target in package.get("targets", []))
     crate_roots.append((root, package["name"]))
+    package_has_doctests[package["name"]] = has_doctests
 crate_roots.sort(key=lambda item: len(item[0]), reverse=True)
 
 shared_packages = {"nils-common", "nils-term", "nils-test-support"}
@@ -253,6 +256,9 @@ for path in changed:
     emit("changed", path)
 for package_name in sorted(packages):
     emit("package", package_name)
+for package_name in sorted(packages):
+    if package_has_doctests.get(package_name, False):
+        emit("package_doctest", package_name)
 for reason in sorted(set(workspace_reasons)):
     emit("reason", reason)
 for shell_file in sorted(set(shell_files)):
@@ -263,6 +269,7 @@ mode=""
 docs_checks=0
 changed_count=0
 declare -a packages=()
+declare -a package_doctests=()
 declare -a reasons=()
 declare -a changed_files=()
 declare -a shell_files=()
@@ -273,6 +280,7 @@ while IFS=$'\t' read -r key value; do
     docs_checks) docs_checks="$value" ;;
     changed_count) changed_count="$value" ;;
     package) packages+=("$value") ;;
+    package_doctest) package_doctests+=("$value") ;;
     reason) reasons+=("$value") ;;
     changed) changed_files+=("$value") ;;
     shell) shell_files+=("$value") ;;
@@ -294,6 +302,9 @@ print_plan() {
   done
   for package in "${packages[@]}"; do
     echo "LOCAL_FAST_PACKAGE=$package"
+  done
+  for package in "${package_doctests[@]}"; do
+    echo "LOCAL_FAST_PACKAGE_DOCTEST=$package"
   done
   for reason in "${reasons[@]}"; do
     echo "LOCAL_FAST_REASON=$reason"
@@ -355,6 +366,17 @@ select_test_runner() {
   esac
 }
 
+package_has_doctest() {
+  local package="$1"
+  local candidate
+  for candidate in "${package_doctests[@]}"; do
+    if [[ "$candidate" == "$package" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 case "$mode" in
   none)
     echo "ok: local-fast found no changed files"
@@ -405,7 +427,9 @@ done
 for package in "${packages[@]}"; do
   if [[ "$test_runner" == "nextest" ]]; then
     run cargo nextest run --profile ci -p "$package"
-    run cargo test -p "$package" --doc
+    if package_has_doctest "$package"; then
+      run cargo test -p "$package" --doc
+    fi
   else
     run cargo test -p "$package"
   fi

--- a/scripts/ci/tests/local-fast-checks.test.sh
+++ b/scripts/ci/tests/local-fast-checks.test.sh
@@ -35,12 +35,44 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  if grep -qF "$needle" <<<"$haystack"; then
+    echo "FAIL: $label"
+    echo "unexpected: $needle"
+    echo "$haystack"
+    exit 1
+  fi
+}
+
 assert_package_crate_uses_package_mode() {
   echo "== package crate uses package mode =="
   local output
   output="$(plan_for --changed-file crates/plan-tooling/src/validate.rs)"
   assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_MODE=packages"
   assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_PACKAGE=nils-plan-tooling"
+  echo "ok"
+}
+
+assert_bin_only_package_skips_doctests() {
+  echo "== bin-only package skips doctests =="
+  local output
+  output="$(plan_for --changed-file crates/api-grpc/src/commands/call.rs)"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_MODE=packages"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_PACKAGE=nils-api-grpc"
+  assert_not_contains "$FUNCNAME" "$output" "LOCAL_FAST_PACKAGE_DOCTEST=nils-api-grpc"
+  echo "ok"
+}
+
+assert_library_package_keeps_doctests() {
+  echo "== library package keeps doctests =="
+  local output
+  output="$(plan_for --changed-file crates/api-testing-core/src/auth_env.rs)"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_MODE=packages"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_PACKAGE=nils-api-testing-core"
+  assert_contains "$FUNCNAME" "$output" "LOCAL_FAST_PACKAGE_DOCTEST=nils-api-testing-core"
   echo "ok"
 }
 
@@ -118,6 +150,8 @@ assert_shell_script_is_reported() {
 }
 
 assert_package_crate_uses_package_mode
+assert_bin_only_package_skips_doctests
+assert_library_package_keeps_doctests
 assert_shared_crate_escalates_to_workspace
 assert_docs_only_uses_docs_mode
 assert_docs_only_plan_does_not_require_cargo


### PR DESCRIPTION
## Summary

Refactors duplicated api-grpc and api-websocket call-path behavior into api-testing-core shared helpers, while preserving the existing user-facing JWT validation and call history contracts. The validation loop also exposed a local-fast false failure for bin-only package doctests, so this includes the narrow planner fix and coverage for that case.

## Changes

- Added shared api-testing-core helpers for CLI JWT validation and request-call history appends.
- Switched api-grpc and api-websocket to the shared helpers without changing their env var names, warning labels, history command shape, or JSON format flag handling.
- Updated local-fast package planning to run doctests only for packages with doctestable targets, with script-level coverage for bin-only and library packages.

## Test-First Evidence

Added failing-test evidence before production changes with `cargo test -p nils-api-testing-core validate_cli_bearer_jwt`, which initially failed because the shared JWT validation helper did not exist yet.

## Test plan

- `cargo test -p nils-api-testing-core validate_cli_bearer_jwt`
- `cargo test -p nils-api-testing-core cli_history_appends_shared_request_call_record`
- `cargo test -p nils-api-grpc`
- `cargo test -p nils-api-websocket`
- `cargo test -p nils-api-testing-core`
- `bash -n scripts/ci/nils-cli-local-fast.sh`
- `bash -n scripts/ci/tests/local-fast-checks.test.sh`
- `bash scripts/ci/tests/local-fast-checks.test.sh`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`

## Risk / Notes

- Low risk: shared helper extraction preserves existing call-site constants and behavior, and local-fast now avoids only an invalid doctest command for bin-only packages.
