### PR TITLE
fix(api-gql): include config dir in history replay

### DIFF
--- a/crates/api-gql/src/commands/call.rs
+++ b/crates/api-gql/src/commands/call.rs
@@ -1,13 +1,17 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use api_testing_core::cli_history::{
+    RequestCallHistoryAuth, RequestCallHistoryRecord,
+    build_request_call_history_record_with_extra_args,
+};
 use api_testing_core::{Result, cli_endpoint, config, history};
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 
 use crate::cli::CallArgs;
 use api_testing_core::cli_util::{
-    bool_from_env, history_timestamp_now, list_available_suffixes, maybe_relpath,
-    parse_u64_default, shell_quote, trim_non_empty,
+    bool_from_env, history_timestamp_now, list_available_suffixes, parse_u64_default,
+    trim_non_empty,
 };
 
 #[derive(Debug, Clone)]
@@ -304,71 +308,43 @@ fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32, stderr: 
     let history_writer = &ctx.history_writer;
 
     let stamp = history_timestamp_now().unwrap_or_default();
-    let setup_rel = maybe_relpath(&ctx.setup_dir, &ctx.invocation_dir);
-
-    let mut record = String::new();
-    record.push_str(&format!("# {stamp} exit={exit_code} setup_dir={setup_rel}"));
-
-    if !ctx.endpoint_label_used.is_empty() {
-        if ctx.endpoint_label_used == "url" && !ctx.log_url {
-            record.push_str(" url=<omitted>");
-        } else {
-            record.push_str(&format!(
-                " {}={}",
-                ctx.endpoint_label_used, ctx.endpoint_value_used
-            ));
-        }
-    }
-
-    match &ctx.auth_source_used {
+    let auth = match &ctx.auth_source_used {
         api_testing_core::graphql::auth::GraphqlAuthSourceUsed::JwtProfile { name } => {
-            if !name.is_empty() {
-                record.push_str(&format!(" jwt={name}"));
+            RequestCallHistoryAuth::HeaderAndFlag {
+                header_key: "jwt",
+                header_value: name,
+                flag_name: "jwt",
+                flag_value: name,
             }
         }
         api_testing_core::graphql::auth::GraphqlAuthSourceUsed::EnvFallback { env_name } => {
-            record.push_str(&format!(" token={env_name}"));
+            RequestCallHistoryAuth::HeaderOnly {
+                key: "token",
+                value: env_name,
+            }
         }
-        api_testing_core::graphql::auth::GraphqlAuthSourceUsed::None => {}
-    }
-
-    let op_arg_path = Path::new(&ctx.op_arg);
-    let op_rel = if op_arg_path.is_absolute() {
-        maybe_relpath(op_arg_path, &ctx.invocation_dir)
-    } else {
-        ctx.op_arg.clone()
+        api_testing_core::graphql::auth::GraphqlAuthSourceUsed::None => {
+            RequestCallHistoryAuth::None
+        }
     };
+    let extra_args: Vec<&str> = ctx.vars_arg.as_deref().into_iter().collect();
 
-    record.push_str("\n\napi-gql call \\\n");
-    if !ctx.endpoint_label_used.is_empty() && (ctx.endpoint_label_used != "url" || ctx.log_url) {
-        record.push_str(&format!(
-            "  --{} {} \\\n",
-            ctx.endpoint_label_used,
-            shell_quote(&ctx.endpoint_value_used)
-        ));
-    }
-
-    if let api_testing_core::graphql::auth::GraphqlAuthSourceUsed::JwtProfile { name } =
-        &ctx.auth_source_used
-        && !name.is_empty()
-    {
-        record.push_str(&format!("  --jwt {} \\\n", shell_quote(name)));
-    }
-
-    if let Some(vars_arg) = ctx.vars_arg.as_deref() {
-        let vars_arg_path = Path::new(vars_arg);
-        let vars_rel = if vars_arg_path.is_absolute() {
-            maybe_relpath(vars_arg_path, &ctx.invocation_dir)
-        } else {
-            vars_arg.to_string()
-        };
-        record.push_str(&format!("  {} \\\n", shell_quote(&op_rel)));
-        record.push_str(&format!("  {} \\\n", shell_quote(&vars_rel)));
-        record.push_str("| jq .\n\n");
-    } else {
-        record.push_str(&format!("  {} \\\n", shell_quote(&op_rel)));
-        record.push_str("| jq .\n\n");
-    }
+    let record = build_request_call_history_record_with_extra_args(
+        RequestCallHistoryRecord {
+            stamp: &stamp,
+            exit_code,
+            setup_dir: &ctx.setup_dir,
+            invocation_dir: &ctx.invocation_dir,
+            command_name: "api-gql",
+            endpoint_label_used: &ctx.endpoint_label_used,
+            endpoint_value_used: &ctx.endpoint_value_used,
+            log_url: ctx.log_url,
+            auth,
+            request_arg: &ctx.op_arg,
+            extra_flags: &[],
+        },
+        &extra_args,
+    );
 
     if let Err(err) = history_writer.append(&record) {
         let _ = writeln!(stderr, "warning: failed to append api-gql history: {err}");

--- a/crates/api-gql/tests/integration/history.rs
+++ b/crates/api-gql/tests/integration/history.rs
@@ -126,6 +126,7 @@ fn history_records_service_token_env_source() {
 
     let server = start_server();
     write_text(&root.join("q.graphql"), "query Q { ok }\n");
+    write_text(&root.join("vars.json"), r#"{"id":7}"#);
 
     let out = run_api_gql_with(
         root,
@@ -136,6 +137,7 @@ fn history_records_service_token_env_source() {
             "--url",
             &server.url(),
             "q.graphql",
+            "vars.json",
         ],
         &[
             ("GQL_HISTORY_ENABLED", "true"),
@@ -148,6 +150,9 @@ fn history_records_service_token_env_source() {
 
     let history_file = setup_dir.join(".gql_history");
     let content = std::fs::read_to_string(&history_file).expect("read history");
+    assert!(content.contains("--config-dir 'setup/graphql'"));
+    assert!(content.contains("'q.graphql'"));
+    assert!(content.contains("'vars.json'"));
     assert!(content.contains("token=SERVICE_TOKEN"));
     assert!(!content.contains("token=ACCESS_TOKEN"));
 }

--- a/crates/api-rest/src/commands/call.rs
+++ b/crates/api-rest/src/commands/call.rs
@@ -2,13 +2,13 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use api_testing_core::cli_history::{
-    RequestCallHistoryAuth, RequestCallHistoryRecord, build_request_call_history_record,
+    RequestCallHistoryAppend, append_request_call_history_best_effort,
 };
 use api_testing_core::{Result, auth_env, cli_endpoint, cli_io, cli_util, config, history, jwt};
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 
 use crate::cli::CallArgs;
-use api_testing_core::cli_util::{history_timestamp_now, parse_u64_default, trim_non_empty};
+use api_testing_core::cli_util::{parse_u64_default, trim_non_empty};
 
 #[derive(Debug, Clone)]
 pub(crate) struct EndpointSelection {
@@ -344,43 +344,25 @@ struct CallHistoryContext {
 }
 
 fn append_history_best_effort(ctx: &CallHistoryContext, exit_code: i32, stderr: &mut dyn Write) {
-    if !ctx.enabled {
-        return;
-    }
-
-    let history_writer = &ctx.history_writer;
-    let stamp = history_timestamp_now().unwrap_or_default();
-    let auth = match &ctx.auth_source_used {
-        AuthSourceUsed::TokenProfile => RequestCallHistoryAuth::HeaderAndFlag {
-            header_key: "token",
-            header_value: &ctx.token_name_for_log,
-            flag_name: "token",
-            flag_value: &ctx.token_name_for_log,
+    append_request_call_history_best_effort(
+        RequestCallHistoryAppend {
+            enabled: ctx.enabled,
+            history_writer: &ctx.history_writer,
+            exit_code,
+            setup_dir: &ctx.setup_dir,
+            invocation_dir: &ctx.invocation_dir,
+            command_name: "api-rest",
+            endpoint_label_used: &ctx.endpoint_label_used,
+            endpoint_value_used: &ctx.endpoint_value_used,
+            log_url: ctx.log_url,
+            auth_source: &ctx.auth_source_used,
+            token_name_for_log: &ctx.token_name_for_log,
+            request_arg: &ctx.request_arg,
+            extra_flags: &[],
+            warning_label: "api-rest",
         },
-        AuthSourceUsed::EnvFallback { env_name } => RequestCallHistoryAuth::HeaderOnly {
-            key: "auth",
-            value: env_name,
-        },
-        AuthSourceUsed::None => RequestCallHistoryAuth::None,
-    };
-
-    let record = build_request_call_history_record(RequestCallHistoryRecord {
-        stamp: &stamp,
-        exit_code,
-        setup_dir: &ctx.setup_dir,
-        invocation_dir: &ctx.invocation_dir,
-        command_name: "api-rest",
-        endpoint_label_used: &ctx.endpoint_label_used,
-        endpoint_value_used: &ctx.endpoint_value_used,
-        log_url: ctx.log_url,
-        auth,
-        request_arg: &ctx.request_arg,
-        extra_flags: &[],
-    });
-
-    if let Err(err) = history_writer.append(&record) {
-        let _ = writeln!(stderr, "warning: failed to append api-rest history: {err}");
-    }
+        stderr,
+    );
 }
 
 #[cfg(test)]

--- a/crates/api-testing-core/src/cli_history.rs
+++ b/crates/api-testing-core/src/cli_history.rs
@@ -199,6 +199,13 @@ pub fn append_request_call_history_best_effort(
 }
 
 pub fn build_request_call_history_record(spec: RequestCallHistoryRecord<'_>) -> String {
+    build_request_call_history_record_with_extra_args(spec, &[])
+}
+
+pub fn build_request_call_history_record_with_extra_args(
+    spec: RequestCallHistoryRecord<'_>,
+    extra_args: &[&str],
+) -> String {
     let setup_rel = cli_util::maybe_relpath(spec.setup_dir, spec.invocation_dir);
     let config_rel = cli_util::shell_quote(&setup_rel);
     let request_rel = relative_cli_arg(spec.request_arg, spec.invocation_dir);
@@ -287,6 +294,10 @@ pub fn build_request_call_history_record(spec: RequestCallHistoryRecord<'_>) -> 
     }
 
     record.push_str(&format!("  {} \\\n", cli_util::shell_quote(&request_rel)));
+    for arg in extra_args {
+        let rel = relative_cli_arg(arg, spec.invocation_dir);
+        record.push_str(&format!("  {} \\\n", cli_util::shell_quote(&rel)));
+    }
     record.push_str("| jq .\n\n");
     record
 }
@@ -304,7 +315,7 @@ fn relative_cli_arg(arg: &str, invocation_dir: &Path) -> String {
 mod tests {
     use super::{
         RequestCallHistoryAuth, RequestCallHistoryFlag, RequestCallHistoryRecord,
-        build_request_call_history_record,
+        build_request_call_history_record, build_request_call_history_record_with_extra_args,
     };
     use pretty_assertions::assert_eq;
     use std::path::Path;
@@ -400,6 +411,46 @@ mod tests {
                 "  --config-dir 'setup/websocket' \\\n",
                 "  --format json \\\n",
                 "  'requests/health.ws.json' \\\n",
+                "| jq .\n\n",
+            )
+        );
+    }
+
+    #[test]
+    fn request_call_history_appends_extra_positional_args_after_request_arg() {
+        let extra_args = ["vars.json"];
+        let record = build_request_call_history_record_with_extra_args(
+            RequestCallHistoryRecord {
+                stamp: "2026-03-06T10:00:00Z",
+                exit_code: 0,
+                setup_dir: Path::new("/tmp/ws/setup/graphql"),
+                invocation_dir: Path::new("/tmp/ws"),
+                command_name: "api-gql",
+                endpoint_label_used: "url",
+                endpoint_value_used: "https://api.example/graphql",
+                log_url: true,
+                auth: RequestCallHistoryAuth::HeaderAndFlag {
+                    header_key: "jwt",
+                    header_value: "admin",
+                    flag_name: "jwt",
+                    flag_value: "admin",
+                },
+                request_arg: "q.graphql",
+                extra_flags: &[],
+            },
+            &extra_args,
+        );
+
+        assert_eq!(
+            record,
+            concat!(
+                "# 2026-03-06T10:00:00Z exit=0 setup_dir=setup/graphql url=https://api.example/graphql jwt=admin\n",
+                "api-gql call \\\n",
+                "  --config-dir 'setup/graphql' \\\n",
+                "  --url 'https://api.example/graphql' \\\n",
+                "  --jwt 'admin' \\\n",
+                "  'q.graphql' \\\n",
+                "  'vars.json' \\\n",
                 "| jq .\n\n",
             )
         );


### PR DESCRIPTION
## Summary

Fixes api-gql history replay snippets so calls made with a config directory can be replayed from history with the same setup and variables files. The change routes api-gql history rendering through the shared API history helper and keeps api-rest on the same append path without changing the public history record shape.

## Problem

api-gql could execute a request using --config-dir, but the generated history entry omitted that flag. Replaying the saved command could therefore resolve auth, endpoint, and request files from a different directory than the original call.

The same code path also left variables file replay outside the shared API history renderer, increasing drift risk across API CLIs.

## Reproduction

The regression is covered by `history_records_service_token_env_source` in `crates/api-gql/tests/integration/history.rs`.

Before the production change, `cargo test -p nils-api-gql --test integration history_records_service_token_env_source` failed because the saved history content did not contain `--config-dir 'setup/graphql'`.

## Issues Found

No linked issue.

## Fix Approach

Add a shared `build_request_call_history_record_with_extra_args` helper in `nils-api-testing-core` so API CLIs can append extra replay arguments after the request path while preserving shell quoting and path relativization.

Update api-gql call history rendering to map GraphQL auth context into the shared request history model and include the optional variables path. Update api-rest to use the shared best-effort append helper instead of maintaining a parallel manual append implementation.

## Test-First Evidence

Added the api-gql regression assertion before changing production code. The targeted test failed first at the missing `--config-dir 'setup/graphql'` history replay assertion.

## Test plan

Validation run:

- `cargo test -p nils-api-gql --test integration history_records_service_token_env_source`
- `cargo test -p nils-api-testing-core cli_history`
- `cargo test -p nils-api-rest --test integration history::`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast --plan-only`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`

The final local-fast run passed against the current `origin/main`, including fmt, clippy, nextest for `nils-api-gql`, `nils-api-rest`, and `nils-api-testing-core`, plus doctest coverage for the changed package set.

## Risk / Notes

Risk is low. The change is scoped to generated history replay snippets and keeps the existing public history record types intact. Existing REST history behavior is covered by the api-rest integration history tests, and the shared helper is covered in nils-api-testing-core.
