### PR TITLE
Expand semantic-commit agent commit workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Completion obligations for those binaries are tracked in
 | Git tooling | `git-scope`, `git-cli`, `git-summary`, `git-lock` | Inspect changes, run Git helper flows, summarize commits, or manage repo-local commit locks. |
 | Forge automation | `forge-cli` | Drive PR/MR + Issue lifecycle and repository label catalog maintenance on GitHub (via `gh`) or GitLab (via `glab`) through a single provider-neutral surface; covers create / view / edit / comment / ready / merge / close, label list / audit / ensure, CI wait-checks, and the `pr deliver` macro. |
 | Agent policy and evidence | `agent-runtime`, `agent-docs`, `agent-out`, `agent-scope-lock`, `agent-run`, `test-first-evidence`, `web-evidence`, `browser-session`, `canary-check`, `docs-impact`, `heuristic-inbox`, `model-cross-check`, `repo-retro`, `review-evidence`, `review-specialists`, `skill-usage` | Render/install/audit runtime-kit surfaces, resolve agent policy docs, run project commands through explicit env handling, allocate artifact paths, enforce edit scope, inspect repo retrospectives, merge specialist review evidence, or persist deterministic workflow evidence. |
-| Planning and delivery | `plan-tooling`, `plan-issue`, `plan-issue-local`, `semantic-commit` | Validate/split implementation plans, orchestrate issue delivery, rehearse local plan flows, or create semantic commits. |
+| Planning and delivery | `plan-tooling`, `plan-issue`, `plan-issue-local`, `semantic-commit` | Validate/split implementation plans, orchestrate issue delivery, rehearse local plan flows, or run validated commit workflows. |
 | Provider lanes | `codex-cli`, `gemini-cli` | Run provider-specific diagnostics, auth checks, and workflow adapters. |
 | Markdown rendering | `md-render` | Render `.md.tera` templates from JSON view data through the shared `nils-markdown` engine. |
 | Desktop, media, and local utilities | `macos-agent`, `screen-record`, `image-processing`, `fzf-cli`, `memo-cli` | Automate local desktop tasks, capture media, convert images, use interactive shell helpers, or record/search local memos. |
@@ -97,7 +97,7 @@ Each crate is either a standalone CLI binary, a multi-binary crate, or a shared 
   with adapters over `nils-common::provider_runtime`.
 - [crates/gemini-cli](crates/gemini-cli): Provider-specific CLI lane for Gemini workflows, with adapters over
   `nils-common::provider_runtime`.
-- [crates/semantic-commit](crates/semantic-commit): Helper CLI for generating staged context and creating semantic commits.
+- [crates/semantic-commit](crates/semantic-commit): Helper CLI for staged context, Semantic Commit validation, commit amend, and cleanup commit workflows.
 - [crates/plan-tooling](crates/plan-tooling): Plan Format v1 tooling CLI (`to-json`, `validate`, `batches`, `artifact-audit`,
   `split-prs`, `scaffold`, `completion`), with bundle validation, advisory durable-artifact classification, deterministic/auto grouping
   primitives, and strict lane-metadata validation gates.

--- a/crates/semantic-commit/README.md
+++ b/crates/semantic-commit/README.md
@@ -2,110 +2,252 @@
 
 ## Overview
 
-semantic-commit validates commit messages and commits staged changes. It can also emit staged
-change context for message generation.
+`semantic-commit` is the agent-facing commit helper for staged-change
+workflows. It validates Semantic Commit messages, creates and amends commits,
+emits staged context for message generation, and supports machine-readable
+commit results for automation.
 
-## Usage
+The CLI is intentionally not a generic `git` wrapper. It owns commit-message
+validation and commit mutation. Callers still own staging decisions, task
+scope, branch policy, push/PR delivery, and any higher-level workflow checks.
+
+## Commands
 
 ```text
-Usage: semantic-commit <command> [args]
+Usage: semantic-commit [COMMAND]
 
 Commands:
-  staged-context    Print staged change context for commit message generation
-  commit            Commit staged changes with a prepared commit message
-  completion        Export shell completion script
-  help              Display help message
+  staged-context  Print staged change context for commit message generation
+  commit          Commit staged changes with a prepared commit message
+  fixup           Create a fixup! commit for staged changes
+  squash          Create a squash! commit for staged changes
+  completion      Export shell completion script
+  help            Display help message
 ```
 
-Use `semantic-commit --help` (or `semantic-commit <command> --help`) for CLI help text.
+Top-level options:
 
-### Top-level options
+- `-h`, `--help` - print help
+- `-V`, `--version` - print version
 
-- `-h`, `--help` — print help
-- `-V`, `--version` — print version
+Use `semantic-commit <command> --help` for command-specific help.
 
-## Commands and Flags
-
-### `staged-context`
+## `staged-context`
 
 Print staged change context for commit message generation.
 
-Flags:
+```text
+semantic-commit staged-context [--format <bundle|json|patch>] [--repo <path>]
+```
 
-- `--format <bundle|json|patch>` (default: `bundle`)
-- `--json` — equivalent to `--format json`
-- `--repo <path>` — run git commands against the repository path
+Options:
 
-Output formats:
+- `--format <bundle|json|patch>` - output format; default is `bundle`
+- `--json` - equivalent to `--format json`
+- `--repo <path>` - run git commands against a repository path
 
-- `bundle` (default): emits both `commit-context.json` and `staged.patch` to
-  stdout, separated by `===== commit-context.json =====` and
-  `===== staged.patch =====` banners.
-- `json`: emits the `commit-context.json` payload only.
-- `patch`: emits the `git diff --cached` patch only.
+Formats:
 
-### `commit`
+- `bundle`: prints `commit-context.json` and `staged.patch` sections.
+- `json`: prints only the JSON context payload.
+- `patch`: prints only `git diff --cached`.
 
-Commit staged changes with a prepared commit message.
+## `commit`
 
-Message sources (mutually exclusive):
-
-- `-m`, `--message <text>` — inline commit message
-- `-F`, `--message-file <path>` — read commit message from file
-- stdin — used when no message flag is supplied and stdin is non-TTY;
-  disabled by `--automation` / `--non-interactive`
-
-Flags:
-
-- `--message-out <path>` — write the resolved commit message to a file for recovery
-- `--summary <git-scope|git-show|none>` (default: `git-scope` with fallback to `git-show`)
-- `--no-summary` — equivalent to `--summary none`
-- `--repo <path>` — run git commands against the repository path
-- `--max-header-width <N>` — override the commit header width (default: `100`). When the flag is
-  absent, `SEMANTIC_COMMIT_HEADER_WIDTH` may set the default; the flag wins when both are present.
-- `--automation` (alias: `--non-interactive`) — disallow stdin message fallback
-- `--validate-only` — validate the commit message format and exit without committing
-- `--dry-run` — run validation and staged-change checks, then skip `git commit`
-- `--auto-fix` — normalize the message before validation: wrap body lines at `<= 100` columns
-  (whitespace breaks preferred; CJK / unbreakable runs use a codepoint hard-break), uppercase the
-  first character of `-` + space bullets, lowercase the header type and `(scope)`, insert a missing
-  blank line between header and body, and drop empty lines inside the body. Does **not** shorten
-  an over-length header or repair structural header errors — those still exit `4`.
-- `--no-progress` — disable the progress spinner
-- `--quiet` — suppress progress and summary output (implies `--no-progress` and `--no-summary`)
-
-### `completion`
-
-Print a shell completion script to stdout. Pipe the output into your shell's
-completion loader.
+Create a new commit or amend `HEAD` using a validated Semantic Commit message.
 
 ```text
-semantic-commit completion <bash|zsh>
+semantic-commit commit [--message <text>|--message-file <path>] [options]
 ```
+
+Message sources are mutually exclusive:
+
+- `-m`, `--message <text>` - inline commit message
+- `-F`, `--message-file <path>` - read commit message from a file
+- stdin - used when no message flag is supplied and stdin is non-TTY
+- structured fields - `--type`, optional `--scope`, `--subject`, and
+  repeatable `--body-bullet`
+
+Commit operation options:
+
+- `--amend` - amend `HEAD` instead of creating a new commit
+- `--no-edit` - with `--amend`, reuse and validate the `HEAD` message
+- `--message-only` - with `--amend`, update only the `HEAD` message and
+  require no staged changes
+- `--allow-empty` - allow a commit operation without staged changes
+- `--dry-run` - validate message and staged-state checks without committing
+- `--validate-only` - validate only the message; does not require a git repo
+
+Output and recovery options:
+
+- `--format <text|json>` - output mode; default is `text`
+- `--json` - equivalent to `--format json`
+- `--message-out <path>` - write the resolved message before mutation
+- `--summary <git-scope|git-show|none>` - summary mode; default is
+  `git-scope` with fallback to `git-show`
+- `--no-summary` - equivalent to `--summary none`
+- `--no-progress` - disable the progress spinner
+- `--quiet` - suppress progress and text summary output
+
+Safety options:
+
+- `--repo <path>` - run git commands against a repository path
+- `--require-clean` - require no unstaged or untracked changes
+- `--no-unstaged` - alias for `--require-clean`
+- `--expect-head <rev>` - require `HEAD` to match a revision before mutation
+- `--automation`, `--non-interactive` - disallow stdin message fallback
+
+Message-construction options:
+
+- `--auto-fix` - normalize body wrapping, bullet capitalization, header
+  type/scope case, and the blank separator before validation
+- `--max-header-width <N>` - override the active header width; default is
+  `100`, with `SEMANTIC_COMMIT_HEADER_WIDTH` as an environment default
+- `--signoff` - pass `--signoff` to `git commit`
+- `--trailer <token: value>` - add a git trailer; repeatable
+- `--type <type>` - structured message type
+- `--scope <scope>` - structured message scope
+- `--subject <subject>` - structured message subject
+- `--body-bullet <text>` - structured message body bullet; repeatable
+
+Examples:
+
+```bash
+semantic-commit staged-context
+
+semantic-commit commit \
+  --message "feat(cli): add commit result json"
+
+semantic-commit commit \
+  --amend \
+  --no-edit \
+  --expect-head HEAD \
+  --require-clean
+
+semantic-commit commit \
+  --amend \
+  --message-only \
+  --message "fix(cli): clarify amend help"
+
+semantic-commit commit \
+  --type feat \
+  --scope semantic-commit \
+  --subject "support amend flow" \
+  --body-bullet "Add no-edit amend support." \
+  --body-bullet "Return JSON commit metadata." \
+  --json
+
+semantic-commit commit \
+  --message "fix(cli): link tracker" \
+  --trailer "Refs: #573" \
+  --signoff
+```
+
+## `fixup` and `squash`
+
+Create review-cleanup commits without bypassing the `semantic-commit` staged
+checks and machine-readable output contract.
+
+```text
+semantic-commit fixup --target <rev> [options]
+semantic-commit squash --target <rev> [options]
+```
+
+These subcommands call git's cleanup-commit modes and intentionally do not
+validate the generated `fixup!` / `squash!` subject as a Semantic Commit
+header.
+
+Options:
+
+- `--target <rev>` - target commit revision; required
+- `--dry-run` - validate target and staged checks without committing
+- `--format <text|json>`, `--json` - output mode
+- `--summary <git-scope|git-show|none>`, `--no-summary` - text summary
+- `--allow-empty` - allow a cleanup commit without staged changes
+- `--require-clean`, `--no-unstaged` - require no unstaged or untracked
+  changes
+- `--expect-head <rev>` - require `HEAD` to match a revision before mutation
+- `--repo <path>` - run git commands against a repository path
+- `--no-progress`, `--quiet` - progress and summary controls
+
+Examples:
+
+```bash
+semantic-commit fixup --target HEAD~1
+semantic-commit squash --target abc123 --json --dry-run
+```
+
+## JSON Output
+
+`semantic-commit commit --json`, `semantic-commit fixup --json`, and
+`semantic-commit squash --json` emit a single JSON record on success:
+
+```json
+{
+  "schema_version": "cli.semantic-commit.commit.v1",
+  "ok": true,
+  "operation": "commit",
+  "validate_only": false,
+  "dry_run": false,
+  "commit": {
+    "sha": "012345...",
+    "subject": "feat(cli): add commit result json"
+  },
+  "target": null,
+  "staged": {
+    "file_count": 1,
+    "files": [
+      {
+        "status": "M",
+        "path": "crates/semantic-commit/src/commit.rs",
+        "old_path": null
+      }
+    ]
+  }
+}
+```
+
+For `fixup` and `squash`, the record also includes the resolved target commit
+and generated subject.
 
 ## Commit Message Validation
 
-- Header must be non-empty, no longer than the active header width, and use a lowercase type. The
-  default active header width is `100`.
-- Header format: `type(scope): subject` or `type: subject`.
-- If a body exists, line 2 must be blank and each body line must start with `-` + space, followed by an
-  uppercase letter and be `<= 100` characters. A bullet may wrap onto a following line by prefixing that
-  continuation line with two spaces (the same indent used on this README bullet); continuation lines
-  also have the `<= 100` character cap.
+Semantic Commit validation applies to `semantic-commit commit` message input:
 
-## Exit codes
+- Header format is `type(scope): subject` or `type: subject`.
+- Header type must be lowercase and start with an ASCII lowercase letter.
+- Scope, when present, may contain lowercase letters, digits, `.`, `_`, and
+  `-`.
+- Header length must not exceed the active header width.
+- Body lines must be bullet lines that start with `-` plus a space followed by an
+  uppercase ASCII letter, or continuation lines that start with two spaces.
+- Body and trailer lines must be at most `100` characters.
+- Git trailers may appear after the header or after a blank separator
+  following bullet body lines.
+
+`fixup` and `squash` do not use this header validation because git generates
+subjects prefixed with `fixup!` or `squash!`.
+
+## Exit Codes
 
 - `0`: success and help output.
 - `1`: usage errors or operational errors.
 - `2`: no staged changes.
-- `3`: commit message missing/empty.
+- `3`: commit message missing or empty.
 - `4`: commit message validation failed.
-- `5`: required dependency missing (for example, `git`).
+- `5`: required dependency missing, such as `git`.
 
 ## Dependencies
 
 - `git` is required.
-- `git-scope` is optional; when unavailable, commit summary falls back to `git show -1`.
+- `git-scope` is optional. When unavailable, text summaries fall back to
+  `git show -1`.
+
+## Non-Goals
+
+`semantic-commit` does not push, force-push, rebase, create PRs, choose branch
+names, or stage files implicitly. Those decisions belong to the surrounding
+agent workflow.
 
 ## Docs
 

--- a/crates/semantic-commit/docs/README.md
+++ b/crates/semantic-commit/docs/README.md
@@ -1,19 +1,22 @@
 # semantic-commit Docs Index
 
-> Ownership: Maintained by the `semantic-commit` crate maintainers. Keep this index updated when docs are added, moved, or removed.
+> Ownership: Maintained by the `semantic-commit` crate maintainers. Keep this
+> index updated when docs are added, moved, or removed.
+
+## Primary Documentation
+
+- [Crate README](../README.md) - command behavior, examples, JSON output,
+  validation rules, and non-goals.
 
 ## Specs
 
-- None yet. Add documents under `docs/specs/` and register them here.
+- None yet. The current JSON result contract is documented in the crate
+  README until a dedicated versioned spec is needed.
 
 ## Runbooks
 
-- None yet. Add documents under `docs/runbooks/` and register them here.
+- None yet.
 
 ## Reports
 
-- None yet. Add documents under `docs/reports/` and register them here.
-
-## Links
-
-- Back to crate README: [`../README.md`](../README.md)
+- None yet.

--- a/crates/semantic-commit/src/cli.rs
+++ b/crates/semantic-commit/src/cli.rs
@@ -24,6 +24,10 @@ enum Command {
     StagedContext(RawArgs),
     #[command(about = "Commit staged changes with a prepared commit message")]
     Commit(RawArgs),
+    #[command(about = "Create a fixup! commit for staged changes")]
+    Fixup(RawArgs),
+    #[command(about = "Create a squash! commit for staged changes")]
+    Squash(RawArgs),
     #[command(about = "Export shell completion script")]
     Completion(RawArgs),
     #[command(about = "Display help message")]
@@ -54,6 +58,8 @@ where
     match cli.command {
         Some(Command::StagedContext(raw)) => staged_context::run(&raw.args),
         Some(Command::Commit(raw)) => commit::run(&raw.args),
+        Some(Command::Fixup(raw)) => commit::run_fixup(&raw.args),
+        Some(Command::Squash(raw)) => commit::run_squash(&raw.args),
         Some(Command::Completion(raw)) => completion::run(&raw.args),
         Some(Command::Help) | None => print_help_stdout(),
     }
@@ -122,6 +128,23 @@ mod tests {
         assert_eq!(
             raw.args,
             ["--message", "feat: test", "--validate-only"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn clap_dispatches_fixup_subcommand_raw_args() {
+        let cli = Cli::try_parse_from(["semantic-commit", "fixup", "--target", "HEAD"])
+            .expect("parse fixup command");
+
+        let Some(Command::Fixup(raw)) = cli.command else {
+            panic!("expected fixup command");
+        };
+        assert_eq!(
+            raw.args,
+            ["--target", "HEAD"]
                 .iter()
                 .map(|s| s.to_string())
                 .collect::<Vec<_>>()

--- a/crates/semantic-commit/src/commit.rs
+++ b/crates/semantic-commit/src/commit.rs
@@ -1,6 +1,7 @@
 use crate::git;
 use nils_common::git as common_git;
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
+use serde_json::json;
 use std::fs::File;
 use std::io::{BufRead, BufReader, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
@@ -12,6 +13,7 @@ const EXIT_MESSAGE_REQUIRED: i32 = 3;
 const EXIT_VALIDATION_FAILED: i32 = 4;
 const EXIT_DEPENDENCY_ERROR: i32 = 5;
 const CAT_PAGER_ENV: [(&str, &str); 2] = [("GIT_PAGER", "cat"), ("PAGER", "cat")];
+const COMMIT_RESULT_SCHEMA_VERSION: &str = "cli.semantic-commit.commit.v1";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SummaryMode {
@@ -31,18 +33,158 @@ impl SummaryMode {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OutputFormat {
+    Text,
+    Json,
+}
+
+impl OutputFormat {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "text" => Some(Self::Text),
+            "json" => Some(Self::Json),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CommitOperation {
+    Create,
+    Amend,
+    MessageOnlyAmend,
+}
+
+impl CommitOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Create => "commit",
+            Self::Amend => "amend",
+            Self::MessageOnlyAmend => "message_only_amend",
+        }
+    }
+
+    fn progress_label(self) -> &'static str {
+        match self {
+            Self::Create => "git commit",
+            Self::Amend | Self::MessageOnlyAmend => "git commit --amend",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct StructuredMessage {
+    typ: Option<String>,
+    scope: Option<String>,
+    subject: Option<String>,
+    body_bullets: Vec<String>,
+}
+
+impl StructuredMessage {
+    fn has_any(&self) -> bool {
+        self.typ.is_some()
+            || self.scope.is_some()
+            || self.subject.is_some()
+            || !self.body_bullets.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CommitMetadata {
+    sha: String,
+    subject: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct StagedEntry {
+    status: String,
+    path: String,
+    old_path: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CleanupOperation {
+    Fixup,
+    Squash,
+}
+
+impl CleanupOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Fixup => "fixup",
+            Self::Squash => "squash",
+        }
+    }
+
+    fn git_flag(self) -> &'static str {
+        match self {
+            Self::Fixup => "--fixup",
+            Self::Squash => "--squash",
+        }
+    }
+
+    fn subject_prefix(self) -> &'static str {
+        match self {
+            Self::Fixup => "fixup!",
+            Self::Squash => "squash!",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CleanupOptions {
+    target: Option<String>,
+    summary_mode: SummaryMode,
+    output_format: OutputFormat,
+    no_progress: bool,
+    quiet: bool,
+    dry_run: bool,
+    allow_empty: bool,
+    require_clean: bool,
+    expect_head: Option<String>,
+    repo: Option<PathBuf>,
+}
+
+impl CleanupOptions {
+    fn new(_operation: CleanupOperation) -> Self {
+        Self {
+            target: None,
+            summary_mode: SummaryMode::GitScope,
+            output_format: OutputFormat::Text,
+            no_progress: false,
+            quiet: false,
+            dry_run: false,
+            allow_empty: false,
+            require_clean: false,
+            expect_head: None,
+            repo: None,
+        }
+    }
+}
+
 #[derive(Debug)]
 struct CommitOptions {
     message: Option<String>,
     message_file: Option<String>,
     message_out: Option<PathBuf>,
     summary_mode: SummaryMode,
+    output_format: OutputFormat,
     no_progress: bool,
     quiet: bool,
     automation: bool,
     validate_only: bool,
     dry_run: bool,
     auto_fix: bool,
+    amend: bool,
+    no_edit: bool,
+    message_only: bool,
+    allow_empty: bool,
+    require_clean: bool,
+    expect_head: Option<String>,
+    signoff: bool,
+    trailers: Vec<String>,
+    structured: StructuredMessage,
     repo: Option<PathBuf>,
     max_header_width: usize,
 }
@@ -54,12 +196,27 @@ impl Default for CommitOptions {
             message_file: None,
             message_out: None,
             summary_mode: SummaryMode::GitScope,
+            output_format: OutputFormat::Text,
             no_progress: false,
             quiet: false,
             automation: false,
             validate_only: false,
             dry_run: false,
             auto_fix: false,
+            amend: false,
+            no_edit: false,
+            message_only: false,
+            allow_empty: false,
+            require_clean: false,
+            expect_head: None,
+            signoff: false,
+            trailers: Vec::new(),
+            structured: StructuredMessage {
+                typ: None,
+                scope: None,
+                subject: None,
+                body_bullets: Vec::new(),
+            },
             repo: None,
             max_header_width: DEFAULT_MAX_HEADER_WIDTH,
         }
@@ -71,15 +228,23 @@ pub fn run(args: &[String]) -> i32 {
         Ok(options) => options,
         Err(code) => return code,
     };
+    let operation = commit_operation(&options);
 
     if !git::command_exists("git") {
         eprintln!("error: git is required (ensure it is installed and on PATH)");
         return EXIT_DEPENDENCY_ERROR;
     }
 
-    if options.quiet {
+    if options.output_format == OutputFormat::Json {
         options.no_progress = true;
         options.summary_mode = SummaryMode::None;
+    }
+
+    if options.quiet {
+        options.no_progress = true;
+        if options.output_format == OutputFormat::Text {
+            options.summary_mode = SummaryMode::None;
+        }
     }
 
     let mut message_contents = match read_message_contents(&options) {
@@ -117,6 +282,9 @@ pub fn run(args: &[String]) -> i32 {
     }
 
     if options.validate_only {
+        if options.output_format == OutputFormat::Json {
+            print_commit_json_result(operation, true, false, None, None, Vec::new());
+        }
         return 0;
     }
 
@@ -125,19 +293,56 @@ pub fn run(args: &[String]) -> i32 {
         return EXIT_ERROR;
     }
 
-    match git::has_staged_changes(options.repo.as_deref()) {
-        Ok(true) => {}
-        Ok(false) => {
-            eprintln!("error: no staged changes (stage files with git add first)");
-            return EXIT_NO_STAGED_CHANGES;
-        }
+    if let Some(expected) = options.expect_head.as_deref()
+        && let Err(code) = ensure_expected_head(options.repo.as_deref(), expected)
+    {
+        return code;
+    }
+
+    if options.require_clean
+        && let Err(code) = ensure_no_unstaged_or_untracked(options.repo.as_deref())
+    {
+        return code;
+    }
+
+    let has_staged_changes = match git::has_staged_changes(options.repo.as_deref()) {
+        Ok(value) => value,
         Err(err) => {
             eprintln!("{err:#}");
             return EXIT_ERROR;
         }
+    };
+
+    if operation == CommitOperation::MessageOnlyAmend && has_staged_changes {
+        eprintln!("error: --message-only requires no staged changes");
+        return EXIT_ERROR;
     }
 
+    if !has_staged_changes && !options.allow_empty && operation != CommitOperation::MessageOnlyAmend
+    {
+        eprintln!("error: no staged changes (stage files with git add first)");
+        return EXIT_NO_STAGED_CHANGES;
+    }
+
+    let staged_entries = match staged_entries(options.repo.as_deref()) {
+        Ok(entries) => entries,
+        Err(err) => {
+            eprintln!("{err:#}");
+            return EXIT_ERROR;
+        }
+    };
+
     if options.dry_run {
+        if options.output_format == OutputFormat::Json {
+            print_commit_json_result(
+                operation,
+                false,
+                true,
+                current_head_metadata(options.repo.as_deref()),
+                None,
+                staged_entries,
+            );
+        }
         return 0;
     }
 
@@ -152,11 +357,11 @@ pub fn run(args: &[String]) -> i32 {
     };
 
     if let Some(progress) = &progress {
-        progress.set_message("git commit");
+        progress.set_message(operation.progress_label());
         progress.tick();
     }
 
-    let status = git_commit(tmpfile.path(), options.repo.as_deref());
+    let status = git_commit(tmpfile.path(), &options, operation);
 
     if let Some(progress) = &progress {
         progress.finish_and_clear();
@@ -173,6 +378,148 @@ pub fn run(args: &[String]) -> i32 {
             eprintln!("{err:#}");
             return EXIT_ERROR;
         }
+    }
+
+    let commit = current_head_metadata(options.repo.as_deref());
+    if options.output_format == OutputFormat::Json {
+        print_commit_json_result(operation, false, false, commit, None, staged_entries);
+        return 0;
+    }
+
+    print_summary(options.summary_mode, options.repo.as_deref())
+}
+
+fn commit_operation(options: &CommitOptions) -> CommitOperation {
+    if options.message_only {
+        CommitOperation::MessageOnlyAmend
+    } else if options.amend {
+        CommitOperation::Amend
+    } else {
+        CommitOperation::Create
+    }
+}
+
+pub fn run_fixup(args: &[String]) -> i32 {
+    run_cleanup(args, CleanupOperation::Fixup)
+}
+
+pub fn run_squash(args: &[String]) -> i32 {
+    run_cleanup(args, CleanupOperation::Squash)
+}
+
+fn run_cleanup(args: &[String], operation: CleanupOperation) -> i32 {
+    let mut options = match parse_cleanup_args(args, operation) {
+        Ok(options) => options,
+        Err(code) => return code,
+    };
+
+    if !git::command_exists("git") {
+        eprintln!("error: git is required (ensure it is installed and on PATH)");
+        return EXIT_DEPENDENCY_ERROR;
+    }
+
+    if options.output_format == OutputFormat::Json {
+        options.no_progress = true;
+        options.summary_mode = SummaryMode::None;
+    }
+
+    if options.quiet {
+        options.no_progress = true;
+        if options.output_format == OutputFormat::Text {
+            options.summary_mode = SummaryMode::None;
+        }
+    }
+
+    if !git::is_inside_work_tree(options.repo.as_deref()) {
+        eprintln!("error: must run inside a git work tree");
+        return EXIT_ERROR;
+    }
+
+    let target = match resolve_target_metadata(options.repo.as_deref(), options.target.as_deref()) {
+        Ok(target) => target,
+        Err(code) => return code,
+    };
+
+    if let Some(expected) = options.expect_head.as_deref()
+        && let Err(code) = ensure_expected_head(options.repo.as_deref(), expected)
+    {
+        return code;
+    }
+
+    if options.require_clean
+        && let Err(code) = ensure_no_unstaged_or_untracked(options.repo.as_deref())
+    {
+        return code;
+    }
+
+    let has_staged_changes = match git::has_staged_changes(options.repo.as_deref()) {
+        Ok(value) => value,
+        Err(err) => {
+            eprintln!("{err:#}");
+            return EXIT_ERROR;
+        }
+    };
+    if !has_staged_changes && !options.allow_empty {
+        eprintln!("error: no staged changes (stage files with git add first)");
+        return EXIT_NO_STAGED_CHANGES;
+    }
+
+    let staged_entries = match staged_entries(options.repo.as_deref()) {
+        Ok(entries) => entries,
+        Err(err) => {
+            eprintln!("{err:#}");
+            return EXIT_ERROR;
+        }
+    };
+
+    if options.dry_run {
+        if options.output_format == OutputFormat::Json {
+            print_cleanup_json_result(operation, true, None, target, staged_entries);
+        }
+        return 0;
+    }
+
+    let progress = if !options.no_progress {
+        Some(Progress::spinner(
+            ProgressOptions::default()
+                .with_prefix("semantic-commit ")
+                .with_finish(ProgressFinish::Clear),
+        ))
+    } else {
+        None
+    };
+
+    if let Some(progress) = &progress {
+        progress.set_message(format!("git commit --{}", operation.as_str()));
+        progress.tick();
+    }
+
+    let status = git_cleanup_commit(&options, operation, &target.sha);
+
+    if let Some(progress) = &progress {
+        progress.finish_and_clear();
+    }
+
+    match status {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            let rc = status.code().unwrap_or(EXIT_ERROR);
+            eprintln!(
+                "error: git commit --{} failed (exit code: {rc})",
+                operation.as_str()
+            );
+            return rc;
+        }
+        Err(err) => {
+            eprintln!("{err:#}");
+            return EXIT_ERROR;
+        }
+    }
+
+    let commit = current_head_metadata(options.repo.as_deref());
+    if options.output_format == OutputFormat::Json {
+        print_cleanup_json_result(operation, false, commit, target, staged_entries);
+        return 0;
     }
 
     print_summary(options.summary_mode, options.repo.as_deref())
@@ -250,6 +597,27 @@ fn parse_args(args: &[String]) -> Result<CommitOptions, i32> {
                 options.summary_mode = SummaryMode::None;
                 i += 1;
             }
+            "--format" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value,
+                    None => {
+                        eprintln!("error: --format requires a value");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                let Some(format) = OutputFormat::parse(value) else {
+                    eprintln!("error: invalid --format value: {value} (expected: text, json)");
+                    print_usage_stderr();
+                    return Err(EXIT_ERROR);
+                };
+                options.output_format = format;
+                i += 2;
+            }
+            "--json" => {
+                options.output_format = OutputFormat::Json;
+                i += 1;
+            }
             "--no-progress" => {
                 options.no_progress = true;
                 i += 1;
@@ -273,6 +641,102 @@ fn parse_args(args: &[String]) -> Result<CommitOptions, i32> {
             "--auto-fix" => {
                 options.auto_fix = true;
                 i += 1;
+            }
+            "--amend" => {
+                options.amend = true;
+                i += 1;
+            }
+            "--no-edit" => {
+                options.no_edit = true;
+                i += 1;
+            }
+            "--message-only" => {
+                options.message_only = true;
+                i += 1;
+            }
+            "--allow-empty" => {
+                options.allow_empty = true;
+                i += 1;
+            }
+            "--require-clean" | "--no-unstaged" => {
+                options.require_clean = true;
+                i += 1;
+            }
+            "--expect-head" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --expect-head requires a revision");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.expect_head = Some(value);
+                i += 2;
+            }
+            "--signoff" => {
+                options.signoff = true;
+                i += 1;
+            }
+            "--trailer" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --trailer requires a value");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.trailers.push(value);
+                i += 2;
+            }
+            "--type" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --type requires a value");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.structured.typ = Some(value);
+                i += 2;
+            }
+            "--scope" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --scope requires a value");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.structured.scope = Some(value);
+                i += 2;
+            }
+            "--subject" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --subject requires a value");
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.structured.subject = Some(value);
+                i += 2;
+            }
+            "--body-bullet" | "--bullet" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: {} requires a value", args[i]);
+                        print_usage_stderr();
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.structured.body_bullets.push(value);
+                i += 2;
             }
             "--repo" => {
                 let value = match args.get(i + 1) {
@@ -312,8 +776,180 @@ fn parse_args(args: &[String]) -> Result<CommitOptions, i32> {
         return Err(EXIT_ERROR);
     }
 
+    if options.no_edit && !options.amend {
+        eprintln!("error: --no-edit requires --amend");
+        return Err(EXIT_ERROR);
+    }
+
+    if options.message_only && !options.amend {
+        eprintln!("error: --message-only requires --amend");
+        return Err(EXIT_ERROR);
+    }
+
+    if options.no_edit && options.message_only {
+        eprintln!("error: use only one of --no-edit or --message-only");
+        return Err(EXIT_ERROR);
+    }
+
+    if options.no_edit
+        && (options.message.is_some()
+            || options.message_file.is_some()
+            || options.structured.has_any()
+            || options.auto_fix)
+    {
+        eprintln!("error: --no-edit cannot be combined with message input or --auto-fix");
+        return Err(EXIT_ERROR);
+    }
+
+    if options.structured.has_any() && (options.message.is_some() || options.message_file.is_some())
+    {
+        eprintln!(
+            "error: structured message fields cannot be combined with --message or --message-file"
+        );
+        return Err(EXIT_ERROR);
+    }
+
+    if options.structured.has_any()
+        && (options.structured.typ.is_none() || options.structured.subject.is_none())
+    {
+        eprintln!("error: structured message fields require --type and --subject");
+        return Err(EXIT_ERROR);
+    }
+
+    if let Err(message) = validate_trailers(&options.trailers) {
+        eprintln!("error: {message}");
+        return Err(EXIT_ERROR);
+    }
+
     if !max_header_width_from_flag {
         options.max_header_width = env_header_width()?;
+    }
+
+    Ok(options)
+}
+
+fn parse_cleanup_args(args: &[String], operation: CleanupOperation) -> Result<CleanupOptions, i32> {
+    let mut options = CleanupOptions::new(operation);
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-h" | "--help" => {
+                print_cleanup_usage_stdout(operation);
+                return Err(0);
+            }
+            "--target" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --target requires a revision");
+                        print_cleanup_usage_stderr(operation);
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.target = Some(value);
+                i += 2;
+            }
+            "--summary" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value,
+                    None => {
+                        eprintln!("error: --summary requires a value");
+                        print_cleanup_usage_stderr(operation);
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                let Some(mode) = SummaryMode::parse(value) else {
+                    eprintln!(
+                        "error: invalid --summary value: {value} (expected: git-scope, git-show, none)"
+                    );
+                    print_cleanup_usage_stderr(operation);
+                    return Err(EXIT_ERROR);
+                };
+                options.summary_mode = mode;
+                i += 2;
+            }
+            "--no-summary" => {
+                options.summary_mode = SummaryMode::None;
+                i += 1;
+            }
+            "--format" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value,
+                    None => {
+                        eprintln!("error: --format requires a value");
+                        print_cleanup_usage_stderr(operation);
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                let Some(format) = OutputFormat::parse(value) else {
+                    eprintln!("error: invalid --format value: {value} (expected: text, json)");
+                    print_cleanup_usage_stderr(operation);
+                    return Err(EXIT_ERROR);
+                };
+                options.output_format = format;
+                i += 2;
+            }
+            "--json" => {
+                options.output_format = OutputFormat::Json;
+                i += 1;
+            }
+            "--dry-run" => {
+                options.dry_run = true;
+                i += 1;
+            }
+            "--allow-empty" => {
+                options.allow_empty = true;
+                i += 1;
+            }
+            "--require-clean" | "--no-unstaged" => {
+                options.require_clean = true;
+                i += 1;
+            }
+            "--expect-head" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --expect-head requires a revision");
+                        print_cleanup_usage_stderr(operation);
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.expect_head = Some(value);
+                i += 2;
+            }
+            "--repo" => {
+                let value = match args.get(i + 1) {
+                    Some(value) => value.clone(),
+                    None => {
+                        eprintln!("error: --repo requires a path");
+                        print_cleanup_usage_stderr(operation);
+                        return Err(EXIT_ERROR);
+                    }
+                };
+                options.repo = Some(PathBuf::from(value));
+                i += 2;
+            }
+            "--no-progress" => {
+                options.no_progress = true;
+                i += 1;
+            }
+            "--quiet" => {
+                options.quiet = true;
+                i += 1;
+            }
+            other => {
+                eprintln!("error: unknown argument: {other}");
+                print_cleanup_usage_stderr(operation);
+                return Err(EXIT_ERROR);
+            }
+        }
+    }
+
+    if options.target.is_none() {
+        eprintln!("error: --target is required");
+        print_cleanup_usage_stderr(operation);
+        return Err(EXIT_ERROR);
     }
 
     Ok(options)
@@ -350,7 +986,79 @@ fn parse_positive_width(value: &str, label: &str) -> Result<usize, i32> {
     Ok(parsed)
 }
 
+fn validate_trailers(trailers: &[String]) -> Result<(), String> {
+    for trailer in trailers {
+        if !is_valid_trailer_line(trailer) {
+            return Err(format!(
+                "invalid --trailer value: {trailer} (expected 'Token: value' or 'Token=value')"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn build_structured_message(structured: &StructuredMessage) -> Result<String, i32> {
+    let typ = structured
+        .typ
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            eprintln!("error: --type must not be empty");
+            EXIT_MESSAGE_REQUIRED
+        })?;
+    let subject = structured
+        .subject
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            eprintln!("error: --subject must not be empty");
+            EXIT_MESSAGE_REQUIRED
+        })?;
+
+    let typ = typ.to_ascii_lowercase();
+    let header = match structured
+        .scope
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(scope) => format!("{}({}): {subject}", typ, scope.to_ascii_lowercase()),
+        None => format!("{typ}: {subject}"),
+    };
+
+    let mut lines = vec![header];
+    if !structured.body_bullets.is_empty() {
+        lines.push(String::new());
+        for bullet in &structured.body_bullets {
+            let trimmed = bullet.trim();
+            if trimmed.is_empty() {
+                eprintln!("error: --body-bullet must not be empty");
+                return Err(EXIT_MESSAGE_REQUIRED);
+            }
+            let body = trimmed.strip_prefix("- ").unwrap_or(trimmed);
+            let line = capitalize_bullet_first_char(&format!("- {body}"));
+            lines.extend(wrap_body_line(&line, BODY_LINE_WIDTH));
+        }
+    }
+
+    Ok(lines.join("\n"))
+}
+
 fn read_message_contents(options: &CommitOptions) -> Result<String, i32> {
+    if options.no_edit {
+        let Some(contents) = commit_message_for_rev(options.repo.as_deref(), "HEAD")? else {
+            eprintln!("error: --no-edit requires an existing HEAD commit");
+            return Err(EXIT_ERROR);
+        };
+        return Ok(contents);
+    }
+
+    if options.structured.has_any() {
+        return build_structured_message(&options.structured);
+    }
+
     let message_contents = match (&options.message, &options.message_file) {
         (Some(text), None) => text.clone(),
         (None, Some(path)) => match std::fs::read_to_string(path) {
@@ -401,6 +1109,14 @@ fn run_git_output_with_pager(repo: Option<&Path>, args: &[&str]) -> std::io::Res
     }
 }
 
+fn run_git_output_with_pager_owned(
+    repo: Option<&Path>,
+    args: &[String],
+) -> std::io::Result<Output> {
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    run_git_output_with_pager(repo, &refs)
+}
+
 fn run_git_status_inherit_with_pager(
     repo: Option<&Path>,
     args: &[&str],
@@ -413,16 +1129,267 @@ fn run_git_status_inherit_with_pager(
 
 fn git_commit(
     message_path: &Path,
-    repo: Option<&Path>,
+    options: &CommitOptions,
+    operation: CommitOperation,
 ) -> anyhow::Result<std::process::ExitStatus> {
     let message_path = message_path.to_string_lossy();
-    let output = run_git_output_with_pager(repo, &["commit", "-F", message_path.as_ref()])?;
+    let mut args = vec!["commit".to_string()];
+    if matches!(
+        operation,
+        CommitOperation::Amend | CommitOperation::MessageOnlyAmend
+    ) {
+        args.push("--amend".to_string());
+    }
+    if options.allow_empty {
+        args.push("--allow-empty".to_string());
+    }
+    if options.signoff {
+        args.push("--signoff".to_string());
+    }
+    for trailer in &options.trailers {
+        args.push("--trailer".to_string());
+        args.push(trailer.clone());
+    }
+    if options.no_edit {
+        args.push("--no-edit".to_string());
+    } else {
+        args.push("-F".to_string());
+        args.push(message_path.to_string());
+    }
+
+    let output = run_git_output_with_pager_owned(options.repo.as_deref(), &args)?;
 
     if !output.stderr.is_empty() {
         std::io::stderr().write_all(&output.stderr)?;
     }
 
     Ok(output.status)
+}
+
+fn git_cleanup_commit(
+    options: &CleanupOptions,
+    operation: CleanupOperation,
+    target_sha: &str,
+) -> anyhow::Result<std::process::ExitStatus> {
+    let mut args = vec!["commit".to_string()];
+    if options.allow_empty {
+        args.push("--allow-empty".to_string());
+    }
+    args.push(format!("{}={target_sha}", operation.git_flag()));
+
+    let output = run_git_output_with_pager_owned(options.repo.as_deref(), &args)?;
+
+    if !output.stderr.is_empty() {
+        std::io::stderr().write_all(&output.stderr)?;
+    }
+
+    Ok(output.status)
+}
+
+fn resolve_target_metadata(
+    repo: Option<&Path>,
+    target: Option<&str>,
+) -> Result<CommitMetadata, i32> {
+    let target = target.expect("target checked by parser");
+    let rev = format!("{target}^{{commit}}");
+    let Some(sha) = git_stdout(repo, &["rev-parse", "--verify", &rev]) else {
+        eprintln!("error: target revision not found: {target}");
+        return Err(EXIT_ERROR);
+    };
+    let Some(subject) = git_stdout(repo, &["show", "-s", "--format=%s", &sha]) else {
+        eprintln!("error: failed to read target subject: {target}");
+        return Err(EXIT_ERROR);
+    };
+    Ok(CommitMetadata { sha, subject })
+}
+
+fn current_head_metadata(repo: Option<&Path>) -> Option<CommitMetadata> {
+    let sha = git_stdout(repo, &["rev-parse", "--verify", "HEAD"])?;
+    let subject = git_stdout(repo, &["show", "-s", "--format=%s", "HEAD"])?;
+    Some(CommitMetadata { sha, subject })
+}
+
+fn commit_message_for_rev(repo: Option<&Path>, rev: &str) -> Result<Option<String>, i32> {
+    let output =
+        run_git_output_with_pager(repo, &["log", "-1", "--format=%B", rev]).map_err(|err| {
+            eprintln!("error: failed to read {rev} commit message: {err}");
+            EXIT_ERROR
+        })?;
+    if output.status.success() {
+        Ok(Some(String::from_utf8_lossy(&output.stdout).to_string()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn git_stdout(repo: Option<&Path>, args: &[&str]) -> Option<String> {
+    let output = run_git_output_with_pager(repo, args).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn ensure_expected_head(repo: Option<&Path>, expected: &str) -> Result<(), i32> {
+    let Some(current) = git_stdout(repo, &["rev-parse", "--verify", "HEAD"]) else {
+        eprintln!("error: --expect-head requires an existing HEAD commit");
+        return Err(EXIT_ERROR);
+    };
+    let rev = format!("{expected}^{{commit}}");
+    let Some(expected_sha) = git_stdout(repo, &["rev-parse", "--verify", &rev]) else {
+        eprintln!("error: --expect-head revision not found: {expected}");
+        return Err(EXIT_ERROR);
+    };
+    if current != expected_sha {
+        eprintln!("error: HEAD mismatch (expected {expected_sha}, found {current})");
+        return Err(EXIT_ERROR);
+    }
+    Ok(())
+}
+
+fn ensure_no_unstaged_or_untracked(repo: Option<&Path>) -> Result<(), i32> {
+    if has_unstaged_or_untracked(repo)? {
+        eprintln!("error: unstaged or untracked changes present");
+        return Err(EXIT_ERROR);
+    }
+    Ok(())
+}
+
+fn has_unstaged_or_untracked(repo: Option<&Path>) -> Result<bool, i32> {
+    let output =
+        run_git_output_with_pager(repo, &["status", "--porcelain", "--untracked-files=all"])
+            .map_err(|err| {
+                eprintln!("error: failed to inspect worktree status: {err}");
+                EXIT_ERROR
+            })?;
+    if !output.status.success() {
+        eprintln!("error: failed to inspect worktree status");
+        return Err(EXIT_ERROR);
+    }
+    let status = String::from_utf8_lossy(&output.stdout);
+    Ok(status
+        .lines()
+        .any(|line| line.starts_with("??") || line.as_bytes().get(1).is_some_and(|b| *b != b' ')))
+}
+
+fn staged_entries(repo: Option<&Path>) -> anyhow::Result<Vec<StagedEntry>> {
+    let output = run_git_output_with_pager(
+        repo,
+        &[
+            "-c",
+            "core.quotepath=false",
+            "diff",
+            "--cached",
+            "--name-status",
+            "-z",
+        ],
+    )?;
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+    let entries =
+        common_git::parse_name_status_z(&output.stdout).map_err(|err| anyhow::anyhow!("{err}"))?;
+    Ok(entries
+        .into_iter()
+        .map(|entry| StagedEntry {
+            status: String::from_utf8_lossy(entry.status_raw).to_string(),
+            path: String::from_utf8_lossy(entry.path).to_string(),
+            old_path: entry
+                .old_path
+                .map(|path| String::from_utf8_lossy(path).to_string()),
+        })
+        .collect())
+}
+
+fn print_commit_json_result(
+    operation: CommitOperation,
+    validate_only: bool,
+    dry_run: bool,
+    commit: Option<CommitMetadata>,
+    target: Option<CommitMetadata>,
+    staged_entries: Vec<StagedEntry>,
+) {
+    let files: Vec<_> = staged_entries
+        .iter()
+        .map(|entry| {
+            json!({
+                "status": entry.status,
+                "path": entry.path,
+                "old_path": entry.old_path,
+            })
+        })
+        .collect();
+    let commit_json = commit.map(|commit| {
+        json!({
+            "sha": commit.sha,
+            "subject": commit.subject,
+        })
+    });
+    let target_json = target.map(|target| {
+        json!({
+            "sha": target.sha,
+            "subject": target.subject,
+        })
+    });
+    let payload = json!({
+        "schema_version": COMMIT_RESULT_SCHEMA_VERSION,
+        "ok": true,
+        "operation": operation.as_str(),
+        "validate_only": validate_only,
+        "dry_run": dry_run,
+        "commit": commit_json,
+        "target": target_json,
+        "staged": {
+            "file_count": files.len(),
+            "files": files,
+        },
+    });
+    println!("{payload}");
+}
+
+fn print_cleanup_json_result(
+    operation: CleanupOperation,
+    dry_run: bool,
+    commit: Option<CommitMetadata>,
+    target: CommitMetadata,
+    staged_entries: Vec<StagedEntry>,
+) {
+    let generated_subject = format!("{} {}", operation.subject_prefix(), target.subject);
+    let files: Vec<_> = staged_entries
+        .iter()
+        .map(|entry| {
+            json!({
+                "status": entry.status,
+                "path": entry.path,
+                "old_path": entry.old_path,
+            })
+        })
+        .collect();
+    let commit_json = commit.map(|commit| {
+        json!({
+            "sha": commit.sha,
+            "subject": commit.subject,
+        })
+    });
+    let payload = json!({
+        "schema_version": COMMIT_RESULT_SCHEMA_VERSION,
+        "ok": true,
+        "operation": operation.as_str(),
+        "validate_only": false,
+        "dry_run": dry_run,
+        "commit": commit_json,
+        "target": {
+            "sha": target.sha,
+            "subject": target.subject,
+        },
+        "generated_subject": generated_subject,
+        "staged": {
+            "file_count": files.len(),
+            "files": files,
+        },
+    });
+    println!("{payload}");
 }
 
 fn print_summary(summary_mode: SummaryMode, repo: Option<&Path>) -> i32 {
@@ -553,17 +1520,37 @@ fn validate_commit_message_with_width(path: &Path, max_header_width: usize) -> R
         }
 
         let mut prev_was_body_line = false;
+        let mut trailer_mode = false;
         for (idx, line) in lines.iter().enumerate().skip(2) {
             let line_no = idx + 1;
             if line.is_empty() {
+                if prev_was_body_line && !trailer_mode {
+                    trailer_mode = true;
+                    prev_was_body_line = false;
+                    continue;
+                }
                 return fail_validation(&format!(
-                    "commit body line {line_no} is empty; body lines must start with '- ' followed by uppercase letter (or '  ' to continue the previous bullet)"
+                    "commit body line {line_no} is empty; body lines must start with '- ' followed by uppercase letter, a trailer, or '  ' to continue the previous bullet"
                 ));
             }
             if line.chars().count() > BODY_LINE_WIDTH {
                 return fail_validation(&format!(
                     "commit body line {line_no} exceeds {BODY_LINE_WIDTH} characters (max {BODY_LINE_WIDTH})"
                 ));
+            }
+
+            if trailer_mode {
+                if !is_valid_trailer_line(line) {
+                    return fail_validation(&format!(
+                        "commit trailer line {line_no} must use 'Token: value' or 'Token=value'"
+                    ));
+                }
+                continue;
+            }
+
+            if !prev_was_body_line && is_valid_trailer_line(line) {
+                trailer_mode = true;
+                continue;
             }
 
             let is_bullet = line.starts_with("- ")
@@ -574,7 +1561,7 @@ fn validate_commit_message_with_width(path: &Path, max_header_width: usize) -> R
 
             if !is_bullet && !is_continuation {
                 return fail_validation(&format!(
-                    "commit body line {line_no} must start with '- ' followed by uppercase letter (or '  ' to continue the previous bullet)"
+                    "commit body line {line_no} must start with '- ' followed by uppercase letter, a trailer, or '  ' to continue the previous bullet"
                 ));
             }
             prev_was_body_line = true;
@@ -630,6 +1617,28 @@ fn is_valid_header(header: &str) -> bool {
     }
 
     true
+}
+
+fn is_valid_trailer_line(line: &str) -> bool {
+    let Some((token, value)) = split_trailer(line) else {
+        return false;
+    };
+    !token.is_empty()
+        && token.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        && !value.trim().is_empty()
+}
+
+fn split_trailer(line: &str) -> Option<(&str, &str)> {
+    let colon = line.find(':');
+    let equals = line.find('=');
+    let idx = match (colon, equals) {
+        (Some(colon), Some(equals)) => colon.min(equals),
+        (Some(colon), None) => colon,
+        (None, Some(equals)) => equals,
+        (None, None) => return None,
+    };
+    let (token, rest) = line.split_at(idx);
+    Some((token.trim(), rest[1..].trim()))
 }
 
 const DEFAULT_MAX_HEADER_WIDTH: usize = 100;
@@ -808,6 +1817,14 @@ fn print_usage(stderr: bool) {
     );
     let _ = writeln!(
         out,
+        "      --format <mode>          Output mode: text | json"
+    );
+    let _ = writeln!(
+        out,
+        "      --json                   Equivalent to --format json"
+    );
+    let _ = writeln!(
+        out,
         "      --repo <path>            Run git commands against repo path"
     );
     let _ = writeln!(
@@ -832,6 +1849,58 @@ fn print_usage(stderr: bool) {
     );
     let _ = writeln!(
         out,
+        "      --amend                  Amend HEAD instead of creating a new commit"
+    );
+    let _ = writeln!(
+        out,
+        "      --no-edit                Reuse HEAD message with --amend"
+    );
+    let _ = writeln!(
+        out,
+        "      --message-only           Amend only the HEAD message and require no staged changes"
+    );
+    let _ = writeln!(
+        out,
+        "      --allow-empty            Allow a commit operation without staged changes"
+    );
+    let _ = writeln!(
+        out,
+        "      --require-clean          Require no unstaged or untracked changes"
+    );
+    let _ = writeln!(
+        out,
+        "      --no-unstaged            Alias for --require-clean"
+    );
+    let _ = writeln!(
+        out,
+        "      --expect-head <rev>      Require HEAD to match rev before committing"
+    );
+    let _ = writeln!(
+        out,
+        "      --signoff                Pass --signoff to git commit"
+    );
+    let _ = writeln!(
+        out,
+        "      --trailer <token: value> Add a git trailer (repeatable)"
+    );
+    let _ = writeln!(
+        out,
+        "      --type <type>            Structured message type"
+    );
+    let _ = writeln!(
+        out,
+        "      --scope <scope>          Structured message scope"
+    );
+    let _ = writeln!(
+        out,
+        "      --subject <subject>      Structured message subject"
+    );
+    let _ = writeln!(
+        out,
+        "      --body-bullet <text>     Structured message body bullet (repeatable)"
+    );
+    let _ = writeln!(
+        out,
         "      --no-progress            Disable progress spinner"
     );
     let _ = writeln!(
@@ -849,6 +1918,82 @@ fn print_usage(stderr: bool) {
     let _ = writeln!(
         out,
         "  semantic-commit commit -F ./message.txt --summary git-show"
+    );
+}
+
+fn print_cleanup_usage_stdout(operation: CleanupOperation) {
+    print_cleanup_usage(operation, false);
+}
+
+fn print_cleanup_usage_stderr(operation: CleanupOperation) {
+    print_cleanup_usage(operation, true);
+}
+
+fn print_cleanup_usage(operation: CleanupOperation, stderr: bool) {
+    let out: &mut dyn std::io::Write = if stderr {
+        &mut std::io::stderr()
+    } else {
+        &mut std::io::stdout()
+    };
+    let name = operation.as_str();
+    let _ = writeln!(out, "Usage:");
+    let _ = writeln!(out, "  semantic-commit {name} --target <rev> [options]");
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "Create a {}! commit for staged changes.",
+        operation.as_str()
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Options:");
+    let _ = writeln!(out, "      --target <rev>          Target commit revision");
+    let _ = writeln!(
+        out,
+        "      --summary <mode>        Summary mode: git-scope | git-show | none"
+    );
+    let _ = writeln!(
+        out,
+        "      --no-summary            Equivalent to --summary none"
+    );
+    let _ = writeln!(
+        out,
+        "      --format <mode>         Output mode: text | json"
+    );
+    let _ = writeln!(
+        out,
+        "      --json                  Equivalent to --format json"
+    );
+    let _ = writeln!(
+        out,
+        "      --dry-run               Validate target and staged checks without committing"
+    );
+    let _ = writeln!(
+        out,
+        "      --allow-empty           Allow a cleanup commit without staged changes"
+    );
+    let _ = writeln!(
+        out,
+        "      --require-clean         Require no unstaged or untracked changes"
+    );
+    let _ = writeln!(
+        out,
+        "      --no-unstaged           Alias for --require-clean"
+    );
+    let _ = writeln!(
+        out,
+        "      --expect-head <rev>     Require HEAD to match rev before committing"
+    );
+    let _ = writeln!(
+        out,
+        "      --repo <path>           Run git commands against repo path"
+    );
+    let _ = writeln!(
+        out,
+        "      --no-progress           Disable progress spinner"
+    );
+    let _ = writeln!(
+        out,
+        "      --quiet                 Suppress progress and summary output"
     );
 }
 

--- a/crates/semantic-commit/src/completion.rs
+++ b/crates/semantic-commit/src/completion.rs
@@ -113,6 +113,19 @@ fn build_completion_command() -> Command {
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
+                    Arg::new("format")
+                        .long("format")
+                        .help("Output format")
+                        .value_name("text|json")
+                        .value_parser(["text", "json"]),
+                )
+                .arg(
+                    Arg::new("json")
+                        .long("json")
+                        .help("Alias for --format json")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
                     Arg::new("repo")
                         .long("repo")
                         .help("Repository path override")
@@ -156,6 +169,87 @@ fn build_completion_command() -> Command {
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
+                    Arg::new("amend")
+                        .long("amend")
+                        .help("Amend HEAD instead of creating a new commit")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("no-edit")
+                        .long("no-edit")
+                        .help("Reuse the HEAD message with --amend")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("message-only")
+                        .long("message-only")
+                        .help("Amend only the HEAD message and require no staged changes")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("allow-empty")
+                        .long("allow-empty")
+                        .help("Allow commit operation without staged changes")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("require-clean")
+                        .long("require-clean")
+                        .help("Require no unstaged or untracked changes")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("no-unstaged")
+                        .long("no-unstaged")
+                        .help("Alias for --require-clean")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("expect-head")
+                        .long("expect-head")
+                        .help("Require HEAD to match revision before committing")
+                        .value_name("rev"),
+                )
+                .arg(
+                    Arg::new("signoff")
+                        .long("signoff")
+                        .help("Pass --signoff to git commit")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("trailer")
+                        .long("trailer")
+                        .help("Add a git trailer")
+                        .value_name("token: value")
+                        .action(ArgAction::Append),
+                )
+                .arg(
+                    Arg::new("type")
+                        .long("type")
+                        .help("Structured message type")
+                        .value_name("type"),
+                )
+                .arg(
+                    Arg::new("scope")
+                        .long("scope")
+                        .help("Structured message scope")
+                        .value_name("scope"),
+                )
+                .arg(
+                    Arg::new("subject")
+                        .long("subject")
+                        .help("Structured message subject")
+                        .value_name("subject"),
+                )
+                .arg(
+                    Arg::new("body-bullet")
+                        .long("body-bullet")
+                        .alias("bullet")
+                        .help("Structured message body bullet")
+                        .value_name("text")
+                        .action(ArgAction::Append),
+                )
+                .arg(
                     Arg::new("no-progress")
                         .long("no-progress")
                         .help("Disable progress UI")
@@ -168,6 +262,14 @@ fn build_completion_command() -> Command {
                         .action(ArgAction::SetTrue),
                 ),
         )
+        .subcommand(cleanup_completion_command(
+            "fixup",
+            "Create a fixup! commit for staged changes",
+        ))
+        .subcommand(cleanup_completion_command(
+            "squash",
+            "Create a squash! commit for staged changes",
+        ))
         .subcommand(
             Command::new("completion")
                 .about("Export shell completion script")
@@ -179,4 +281,90 @@ fn build_completion_command() -> Command {
                 ),
         )
         .subcommand(Command::new("help").about("Display help message"))
+}
+
+fn cleanup_completion_command(name: &'static str, about: &'static str) -> Command {
+    Command::new(name)
+        .about(about)
+        .arg(
+            Arg::new("target")
+                .long("target")
+                .help("Target commit revision")
+                .value_name("rev"),
+        )
+        .arg(
+            Arg::new("summary")
+                .long("summary")
+                .help("Summary provider")
+                .value_name("git-scope|git-show|none")
+                .value_parser(["git-scope", "git-show", "none"]),
+        )
+        .arg(
+            Arg::new("no-summary")
+                .long("no-summary")
+                .help("Disable summary section")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("format")
+                .long("format")
+                .help("Output format")
+                .value_name("text|json")
+                .value_parser(["text", "json"]),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Alias for --format json")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("dry-run")
+                .long("dry-run")
+                .help("Validate target and staged checks without committing")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("allow-empty")
+                .long("allow-empty")
+                .help("Allow cleanup commit without staged changes")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("require-clean")
+                .long("require-clean")
+                .help("Require no unstaged or untracked changes")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("no-unstaged")
+                .long("no-unstaged")
+                .help("Alias for --require-clean")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("expect-head")
+                .long("expect-head")
+                .help("Require HEAD to match revision before committing")
+                .value_name("rev"),
+        )
+        .arg(
+            Arg::new("repo")
+                .long("repo")
+                .help("Repository path override")
+                .value_name("path")
+                .value_hint(ValueHint::DirPath),
+        )
+        .arg(
+            Arg::new("no-progress")
+                .long("no-progress")
+                .help("Disable progress UI")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("quiet")
+                .long("quiet")
+                .help("Reduce non-error output")
+                .action(ArgAction::SetTrue),
+        )
 }

--- a/crates/semantic-commit/tests/integration/commit.rs
+++ b/crates/semantic-commit/tests/integration/commit.rs
@@ -1,4 +1,5 @@
 use crate::common;
+use serde_json::Value;
 use std::fs;
 use std::path::Path;
 
@@ -11,6 +12,10 @@ fn as_str(output: &[u8]) -> String {
 fn stage_file(repo: &Path, name: &str, contents: &str) {
     common::write_file(repo, name, contents);
     common::git(repo, &["add", name]);
+}
+
+fn git_trim(repo: &Path, args: &[&str]) -> String {
+    common::git(repo, args).trim().to_string()
 }
 
 fn deterministic_env(path: &str) -> Vec<(&'static str, String)> {
@@ -82,6 +87,10 @@ fn commit_help_flag_prints_usage() {
         as_str(&output.stdout)
             .contains("semantic-commit commit [--message <text>|--message-file <path>] [options]")
     );
+    assert!(as_str(&output.stdout).contains("--amend"));
+    assert!(as_str(&output.stdout).contains("--message-only"));
+    assert!(as_str(&output.stdout).contains("--format <mode>"));
+    assert!(as_str(&output.stdout).contains("--body-bullet <text>"));
 }
 
 #[test]
@@ -453,6 +462,313 @@ fn commit_dry_run_validates_and_checks_staged_without_committing() {
 }
 
 #[test]
+fn commit_json_outputs_result_metadata() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &["commit", "--json", "--message", "feat(core): add thing"],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("commit json");
+    assert_eq!(json["schema_version"], "cli.semantic-commit.commit.v1");
+    assert_eq!(json["operation"], "commit");
+    assert_eq!(json["dry_run"], false);
+    assert_eq!(json["staged"]["file_count"], 1);
+    assert_eq!(json["staged"]["files"][0]["path"], "a.txt");
+    assert_eq!(
+        json["commit"]["sha"].as_str().expect("sha"),
+        git_trim(repo.path(), &["rev-parse", "HEAD"])
+    );
+    assert!(as_str(&output.stderr).trim().is_empty());
+}
+
+#[test]
+fn commit_amend_no_edit_reuses_head_message() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+    let first = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): add thing",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+    assert_eq!(first.status.code(), Some(0));
+
+    stage_file(repo.path(), "b.txt", "world\n");
+    let amend = common::run_semantic_commit_output(
+        repo.path(),
+        &["commit", "--amend", "--no-edit", "--no-summary"],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        amend.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&amend.stderr)
+    );
+    assert_eq!(git_trim(repo.path(), &["rev-list", "--count", "HEAD"]), "1");
+    assert_eq!(
+        git_trim(repo.path(), &["show", "-s", "--format=%s", "HEAD"]),
+        "feat(core): add thing"
+    );
+    assert_eq!(git_trim(repo.path(), &["show", "HEAD:b.txt"]), "world");
+}
+
+#[test]
+fn commit_message_only_amend_updates_message_without_staged_changes() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+    let first = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): add thing",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+    assert_eq!(first.status.code(), Some(0));
+
+    let amend = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--amend",
+            "--message-only",
+            "--message",
+            "fix(core): improve subject",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        amend.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&amend.stderr)
+    );
+    assert_eq!(git_trim(repo.path(), &["rev-list", "--count", "HEAD"]), "1");
+    assert_eq!(
+        git_trim(repo.path(), &["show", "-s", "--format=%s", "HEAD"]),
+        "fix(core): improve subject"
+    );
+}
+
+#[test]
+fn commit_message_only_rejects_staged_changes() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+    let first = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): add thing",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+    assert_eq!(first.status.code(), Some(0));
+
+    stage_file(repo.path(), "b.txt", "world\n");
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--amend",
+            "--message-only",
+            "--message",
+            "fix(core): improve subject",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("--message-only requires no staged changes"));
+}
+
+#[test]
+fn commit_require_clean_rejects_unstaged_changes() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+    common::write_file(repo.path(), "b.txt", "unstaged\n");
+
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--dry-run",
+            "--require-clean",
+            "--message",
+            "feat(core): add thing",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("unstaged or untracked changes present"));
+}
+
+#[test]
+fn commit_expect_head_rejects_mismatch() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+    let first = common::run_semantic_commit_output(
+        repo.path(),
+        &["commit", "--message", "feat(core): first", "--no-summary"],
+        &[],
+        None,
+    );
+    assert_eq!(first.status.code(), Some(0));
+    let first_sha = git_trim(repo.path(), &["rev-parse", "HEAD"]);
+
+    stage_file(repo.path(), "b.txt", "world\n");
+    let second = common::run_semantic_commit_output(
+        repo.path(),
+        &["commit", "--message", "feat(core): second", "--no-summary"],
+        &[],
+        None,
+    );
+    assert_eq!(second.status.code(), Some(0));
+
+    stage_file(repo.path(), "c.txt", "again\n");
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--dry-run",
+            "--expect-head",
+            &first_sha,
+            "--message",
+            "feat(core): third",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("HEAD mismatch"));
+}
+
+#[test]
+fn commit_structured_message_builds_valid_commit_message() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--type",
+            "Feat",
+            "--scope",
+            "Core",
+            "--subject",
+            "add thing",
+            "--body-bullet",
+            "add supporting behavior",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+    assert_eq!(
+        git_trim(repo.path(), &["show", "-s", "--format=%s", "HEAD"]),
+        "feat(core): add thing"
+    );
+    let body = common::git(repo.path(), &["show", "-s", "--format=%B", "HEAD"]);
+    assert!(body.contains("- Add supporting behavior"));
+}
+
+#[test]
+fn commit_trailer_appends_git_trailer() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): add thing",
+            "--trailer",
+            "Refs: #573",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+    let body = common::git(repo.path(), &["show", "-s", "--format=%B", "HEAD"]);
+    assert!(body.contains("Refs: #573"));
+}
+
+#[test]
+fn commit_signoff_appends_committer_signoff() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "a.txt", "hello\n");
+
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): add thing",
+            "--signoff",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+    let body = common::git(repo.path(), &["show", "-s", "--format=%B", "HEAD"]);
+    assert!(body.contains("Signed-off-by: Test User <test@example.com>"));
+}
+
+#[test]
 fn commit_default_summary_falls_back_to_git_show_when_git_scope_missing() {
     let repo = common::init_repo();
     stage_file(repo.path(), "a.txt", "hello\n");
@@ -818,4 +1134,112 @@ fn commit_repo_flag_commits_from_external_cwd() {
         head.status.success(),
         "expected commit to be created in --repo target"
     );
+}
+
+#[test]
+fn fixup_creates_fixup_commit_for_target() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "base.txt", "base\n");
+    let base = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): base change",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+    assert_eq!(base.status.code(), Some(0));
+
+    stage_file(repo.path(), "fix.txt", "fix\n");
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &["fixup", "--target", "HEAD", "--no-summary"],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+    assert_eq!(
+        git_trim(repo.path(), &["show", "-s", "--format=%s", "HEAD"]),
+        "fixup! feat(core): base change"
+    );
+}
+
+#[test]
+fn squash_json_dry_run_reports_target_without_committing() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "base.txt", "base\n");
+    let base = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): base change",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+    assert_eq!(base.status.code(), Some(0));
+    let base_sha = git_trim(repo.path(), &["rev-parse", "HEAD"]);
+
+    stage_file(repo.path(), "squash.txt", "squash\n");
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &["squash", "--target", "HEAD", "--json", "--dry-run"],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("squash json");
+    assert_eq!(json["operation"], "squash");
+    assert_eq!(json["dry_run"], true);
+    assert_eq!(json["target"]["sha"], base_sha);
+    assert_eq!(json["generated_subject"], "squash! feat(core): base change");
+    assert_eq!(git_trim(repo.path(), &["rev-parse", "HEAD"]), base_sha);
+}
+
+#[test]
+fn fixup_invalid_target_fails_without_commit() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "base.txt", "base\n");
+    let base = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): base change",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+    assert_eq!(base.status.code(), Some(0));
+    let base_sha = git_trim(repo.path(), &["rev-parse", "HEAD"]);
+
+    stage_file(repo.path(), "fix.txt", "fix\n");
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &["fixup", "--target", "missing-target"],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(as_str(&output.stderr).contains("target revision not found"));
+    assert_eq!(git_trim(repo.path(), &["rev-parse", "HEAD"]), base_sha);
 }

--- a/crates/semantic-commit/tests/integration/completion_outside_repo.rs
+++ b/crates/semantic-commit/tests/integration/completion_outside_repo.rs
@@ -17,6 +17,10 @@ fn completion_export_succeeds_outside_git_repo() {
         as_str(&output.stderr)
     );
     assert!(as_str(&output.stdout).contains("#compdef semantic-commit"));
+    assert!(as_str(&output.stdout).contains("fixup"));
+    assert!(as_str(&output.stdout).contains("squash"));
+    assert!(as_str(&output.stdout).contains("--amend"));
+    assert!(as_str(&output.stdout).contains("--body-bullet"));
 }
 
 #[test]

--- a/docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-discussion-source.md
+++ b/docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-discussion-source.md
@@ -1,0 +1,69 @@
+# Discussion Source: `semantic-commit` Agent Commit Flow
+
+## Source Summary
+
+User intent: make `semantic-commit` the complete agent-facing commit
+surface for common commit creation and commit-editing flows, so agents do
+not need to fall back to direct `git commit` for amend, structured
+message construction, trailers, JSON result capture, or fixup/squash
+commits.
+
+## Current State
+
+- `semantic-commit staged-context` emits staged change context in bundle,
+  JSON, or patch form.
+- `semantic-commit commit` validates Semantic Commit messages and commits
+  staged changes.
+- Existing `commit` options include inline or file message input,
+  `--message-out`, summary modes, `--repo`, `--max-header-width`,
+  automation mode, `--validate-only`, `--dry-run`, `--auto-fix`,
+  `--no-progress`, and `--quiet`.
+- The current commit execution path runs `git commit -F <message>` and
+  does not support amend, message-only amend, fixup, squash, trailers,
+  signoff, structured JSON output, or structured message assembly.
+
+## Target Outcome
+
+Agents can use `semantic-commit` for the full set of commit operations
+that are part of normal agent-owned development workflows:
+
+- create a Semantic Commit from staged changes
+- amend the previous commit, either with a new validated message or with
+  `--no-edit`
+- edit only the previous commit message
+- produce machine-readable commit results after create or amend
+- add standard trailers and signoff without hand-editing the message
+- build a validated message from structured CLI fields
+- create fixup and squash commits for review cleanup workflows
+
+## Explicit Non-Goals
+
+- Do not turn `semantic-commit` into a generic `git` wrapper.
+- Do not add raw passthrough options such as `--git-arg`.
+- Do not add a generic `--no-verify` bypass.
+- Do not add push, force-push, rebase, or PR delivery behavior.
+- Do not add implicit staging or hidden `git add -A` behavior.
+
+## Design Notes
+
+- Keep `commit` as the Semantic Commit surface. Add amend, JSON output,
+  guard flags, trailers, and structured message fields there.
+- Add fixup and squash as separate subcommands because their generated
+  commit subjects intentionally use `fixup!` / `squash!` prefixes and
+  should not pass through Semantic Commit header validation.
+- Preserve the existing staged-only boundary by default. Any empty commit
+  or message-only amend behavior must be explicit.
+- Prefer structured output that agents can parse directly instead of
+  requiring follow-up `git rev-parse`, `git show`, or ad hoc parsing.
+
+## Open Questions
+
+None for initial implementation. Names may be adjusted during execution
+when a clearer CLI contract emerges from tests and help text.
+
+## Execution
+
+- Recommended plan:
+  docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-plan.md
+- Recommended execution state:
+  docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-execution-state.md

--- a/docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-execution-state.md
+++ b/docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-execution-state.md
@@ -3,47 +3,58 @@
 
 ## Execution State
 
-- Status: planned
+- Status: implemented
 - Target scope: whole issue
 - Execution window: whole issue
-- Current task: create tracking issue
-- Next task: open tracking issue and begin Sprint 1
+- Current task: update tracking issue state and prepare delivery
+- Next task: open PR and run provider checks
 - Last updated: 2026-05-27 Asia/Taipei
-- Branch/commit/PR/release: `feat/semantic-commit-agent-flow`
+- Branch/commit/PR/release: `feat/semantic-commit-agent-flow`;
+  plan-bundle commit `f97cd8d`; PR pending
 - Source document:
   docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-plan.md
 - Discussion source document:
   docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-discussion-source.md
 - Source issue: user request in Codex session
-- Tracking issue: pending
-- Source snapshot: pending
-- Plan snapshot: pending
-- Initial execution state snapshot: pending
+- Tracking issue: <https://github.com/sympoies/nils-cli/issues/573>
+- Source snapshot:
+  <https://github.com/sympoies/nils-cli/issues/573#issuecomment-4546641295>
+- Plan snapshot:
+  <https://github.com/sympoies/nils-cli/issues/573#issuecomment-4546641546>
+- Initial execution state snapshot:
+  <https://github.com/sympoies/nils-cli/issues/573#issuecomment-4546641889>
 - Direct source-doc execution waiver: not applicable
 
 ## Task Ledger
 
 | ID | Status | Task | Evidence | Notes |
 | --- | --- | --- | --- | --- |
-| Task 1.1 | pending | Model commit operations and parser options | n/a | commit options, help, completion metadata |
-| Task 1.2 | pending | Implement amend, no-edit, and message-only amend | n/a | include integration coverage |
-| Task 1.3 | pending | Add JSON commit result output | n/a | versioned snake_case output |
-| Task 1.4 | pending | Add guard flags, trailers, signoff, and structured message assembly | n/a | preserve staged-only default |
-| Task 2.1 | pending | Add fixup and squash dispatch | n/a | separate subcommands |
-| Task 2.2 | pending | Align fixup/squash JSON and guard behavior | n/a | target metadata in JSON |
-| Task 3.1 | pending | Regenerate completion assets | n/a | bash and zsh syntax checks |
-| Task 3.2 | pending | Rewrite `semantic-commit` documentation | n/a | crate README and docs index |
-| Task 3.3 | pending | Run final validation and prepare delivery | n/a | focused tests plus local fast gate |
+| Task 1.1 | done | Model commit operations and parser options | `crates/semantic-commit/src/cli.rs`, `crates/semantic-commit/src/commit.rs` | Added commit operation parsing for amend, message-only amend, JSON, clean guards, HEAD guard, trailers, signoff, and structured messages. |
+| Task 1.2 | done | Implement amend, no-edit, and message-only amend | `crates/semantic-commit/tests/integration/commit.rs` | Covered amend no-edit and message-only amend behavior. |
+| Task 1.3 | done | Add JSON commit result output | `crates/semantic-commit/src/commit.rs` | Added `cli.semantic-commit.commit.v1` output for commit, fixup, squash, dry-run, and validate-only paths. |
+| Task 1.4 | done | Add guard flags, trailers, signoff, and structured message assembly | `crates/semantic-commit/tests/integration/commit.rs` | Preserved staged-only default; added explicit opt-ins for empty commits and clean-tree guards. |
+| Task 2.1 | done | Add fixup and squash dispatch | `crates/semantic-commit/src/commit.rs` | Added dedicated `fixup` and `squash` subcommands backed by git cleanup commit modes. |
+| Task 2.2 | done | Align fixup/squash JSON and guard behavior | `crates/semantic-commit/tests/integration/commit.rs` | Shared dry-run, staged checks, target metadata, and guard handling. |
+| Task 3.1 | done | Regenerate completion assets | `crates/semantic-commit/src/completion.rs` | Runtime completion export now includes new subcommands and flags; adapter syntax checks pass. |
+| Task 3.2 | done | Rewrite `semantic-commit` documentation | `README.md`, `crates/semantic-commit/README.md`, `crates/semantic-commit/docs/README.md` | Rewrote the public command surface around agent commit workflows. |
+| Task 3.3 | done | Run final validation and prepare delivery | validation table below | Local fast gate passed after the Clippy cleanup. |
 
 ## Validation
 
 | Command | Status | Summary | Artifact |
 | --- | --- | --- | --- |
-| `plan-tooling validate --file docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-plan.md --format text --explain` | pending | plan bundle gate | n/a |
-| `cargo test -p nils-semantic-commit` | pending | focused crate tests | n/a |
-| `zsh -n completions/zsh/_semantic-commit` | pending | zsh completion syntax | n/a |
-| `bash -n completions/bash/semantic-commit` | pending | bash completion syntax | n/a |
-| `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` | pending | final local gate | n/a |
+| `plan-tooling validate --file docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-plan.md --format text` | pass | plan bundle gate | n/a |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` | pass | documentation, markdown, plan bundle, and fixture audits | n/a |
+| `cargo fmt --all -- --check` | pass | Rust formatting | n/a |
+| `cargo test -p nils-semantic-commit` | pass | focused crate tests; 39 unit tests and 71 integration tests passed | n/a |
+| `zsh -n completions/zsh/_semantic-commit` | pass | zsh completion adapter syntax | n/a |
+| `bash -n completions/bash/semantic-commit` | pass | bash completion adapter syntax | n/a |
+| `cargo run -q -p nils-semantic-commit -- completion zsh` | pass | exported completion includes new commit flags and cleanup subcommands | n/a |
+| `cargo run -q -p nils-semantic-commit -- completion bash` | pass | exported completion includes new commit flags and cleanup subcommands | n/a |
+| `cargo clippy -p nils-semantic-commit --all-targets --all-features -- -D warnings` | pass | package Clippy gate from local-fast | n/a |
+| `cargo nextest run --profile ci -p nils-semantic-commit` | pass | package nextest gate from local-fast; 110 tests passed | n/a |
+| `cargo test -p nils-semantic-commit --doc` | pass | package doctest gate from local-fast; 0 doctests | n/a |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` | pass | final local gate passed | n/a |
 
 ## Blockers
 
@@ -57,3 +68,13 @@
   assembly, fixup/squash subcommands, tests, completions, and refreshed
   documentation. Explicitly excluded generic git passthrough, `--no-verify`,
   push, force-push, rebase, and implicit staging behavior.
+- 2026-05-27: Opened tracking issue
+  <https://github.com/sympoies/nils-cli/issues/573>, committed the initial plan
+  bundle, implemented the CLI expansion, refreshed the command documentation,
+  and added focused integration coverage.
+- 2026-05-27: Opened follow-up issue
+  <https://github.com/graysurf/agent-runtime-kit/issues/128> so the
+  `semantic-commit` runtime skill can be updated after this CLI issue is
+  completed and released.
+- 2026-05-27: Ran the final local-fast gate. It passed docs-only checks,
+  formatting, Clippy with `-D warnings`, nextest package tests, and doctests.

--- a/docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-execution-state.md
+++ b/docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-execution-state.md
@@ -3,14 +3,15 @@
 
 ## Execution State
 
-- Status: implemented
+- Status: reviewing
 - Target scope: whole issue
 - Execution window: whole issue
-- Current task: update tracking issue state and prepare delivery
-- Next task: open PR and run provider checks
+- Current task: PR review and provider checks
+- Next task: address review or merge outcome
 - Last updated: 2026-05-27 Asia/Taipei
 - Branch/commit/PR/release: `feat/semantic-commit-agent-flow`;
-  plan-bundle commit `f97cd8d`; PR pending
+  plan-bundle commit `f97cd8d`; implementation commit `ee8f29d`;
+  draft PR <https://github.com/sympoies/nils-cli/pull/576>
 - Source document:
   docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-plan.md
 - Discussion source document:
@@ -78,3 +79,5 @@
   completed and released.
 - 2026-05-27: Ran the final local-fast gate. It passed docs-only checks,
   formatting, Clippy with `-D warnings`, nextest package tests, and doctests.
+- 2026-05-27: Opened draft PR
+  <https://github.com/sympoies/nils-cli/pull/576> for provider review.

--- a/docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-execution-state.md
+++ b/docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-execution-state.md
@@ -1,0 +1,59 @@
+<!-- execute-from-tracking-issue:state:v1 -->
+# `semantic-commit` Agent Commit Flow Execution State
+
+## Execution State
+
+- Status: planned
+- Target scope: whole issue
+- Execution window: whole issue
+- Current task: create tracking issue
+- Next task: open tracking issue and begin Sprint 1
+- Last updated: 2026-05-27 Asia/Taipei
+- Branch/commit/PR/release: `feat/semantic-commit-agent-flow`
+- Source document:
+  docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-plan.md
+- Discussion source document:
+  docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-discussion-source.md
+- Source issue: user request in Codex session
+- Tracking issue: pending
+- Source snapshot: pending
+- Plan snapshot: pending
+- Initial execution state snapshot: pending
+- Direct source-doc execution waiver: not applicable
+
+## Task Ledger
+
+| ID | Status | Task | Evidence | Notes |
+| --- | --- | --- | --- | --- |
+| Task 1.1 | pending | Model commit operations and parser options | n/a | commit options, help, completion metadata |
+| Task 1.2 | pending | Implement amend, no-edit, and message-only amend | n/a | include integration coverage |
+| Task 1.3 | pending | Add JSON commit result output | n/a | versioned snake_case output |
+| Task 1.4 | pending | Add guard flags, trailers, signoff, and structured message assembly | n/a | preserve staged-only default |
+| Task 2.1 | pending | Add fixup and squash dispatch | n/a | separate subcommands |
+| Task 2.2 | pending | Align fixup/squash JSON and guard behavior | n/a | target metadata in JSON |
+| Task 3.1 | pending | Regenerate completion assets | n/a | bash and zsh syntax checks |
+| Task 3.2 | pending | Rewrite `semantic-commit` documentation | n/a | crate README and docs index |
+| Task 3.3 | pending | Run final validation and prepare delivery | n/a | focused tests plus local fast gate |
+
+## Validation
+
+| Command | Status | Summary | Artifact |
+| --- | --- | --- | --- |
+| `plan-tooling validate --file docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-plan.md --format text --explain` | pending | plan bundle gate | n/a |
+| `cargo test -p nils-semantic-commit` | pending | focused crate tests | n/a |
+| `zsh -n completions/zsh/_semantic-commit` | pending | zsh completion syntax | n/a |
+| `bash -n completions/bash/semantic-commit` | pending | bash completion syntax | n/a |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` | pending | final local gate | n/a |
+
+## Blockers
+
+- none
+
+## Session Log
+
+- 2026-05-27: Created the plan bundle for the user-requested
+  `semantic-commit` agent commit workflow expansion. Scope includes amend,
+  JSON output, explicit safety guards, trailers/signoff, structured message
+  assembly, fixup/squash subcommands, tests, completions, and refreshed
+  documentation. Explicitly excluded generic git passthrough, `--no-verify`,
+  push, force-push, rebase, and implicit staging behavior.

--- a/docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-plan.md
+++ b/docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-plan.md
@@ -1,0 +1,302 @@
+# Plan: `semantic-commit` Agent Commit Flow
+
+## Overview
+
+Expand `semantic-commit` so it remains the audited agent-facing commit
+surface for normal commit creation, amend, message-edit, structured
+message, trailer, JSON result, and fixup/squash workflows. The work keeps
+the existing staged-only default and deliberately avoids generic git
+passthrough, hook bypasses, push, force-push, rebase, and implicit
+staging.
+
+This is a user-facing CLI behavior change with tests, completions, and
+refreshed documentation. The implementation should preserve existing
+message validation behavior unless a new mode explicitly opts out because
+Git itself defines non-semantic subjects such as `fixup!`.
+
+## Read First
+
+- Primary source:
+  docs/plans/semantic-commit-agent-flow/semantic-commit-agent-flow-discussion-source.md
+- Source type: discussion-to-implementation-doc
+- Open questions carried into execution: none
+
+## Scope
+
+- In scope:
+  - `semantic-commit commit --amend`.
+  - `semantic-commit commit --amend --no-edit`.
+  - `semantic-commit commit --amend --message-only`.
+  - `semantic-commit commit --format json` and `--json`.
+  - Explicit guard flags for agent safety, including no-unstaged,
+    allow-empty, and expected-HEAD checks when they fit the local code
+    shape.
+  - `--signoff` and repeatable `--trailer <token: value>` handling.
+  - Structured message assembly fields such as `--type`, `--scope`,
+    `--subject`, and repeatable body bullet fields.
+  - Separate `semantic-commit fixup` and `semantic-commit squash`
+    subcommands.
+  - Unit and integration coverage for new behavior and regression
+    boundaries.
+  - Regenerated bash and zsh completion assets.
+  - A complete review and rewrite of `semantic-commit` documentation
+    surfaces, including crate README and crate docs index.
+- Out of scope:
+  - Raw git passthrough flags.
+  - A generic `--no-verify` bypass.
+  - Push, force-push, rebase, or PR delivery behavior.
+  - Implicit staging, autostage, or hidden `git add -A`.
+  - Changes to unrelated CLI crates.
+
+## Assumptions
+
+1. Existing `semantic-commit` integration test helpers can create enough
+   temporary git repositories to cover create, amend, message-only amend,
+   fixup, squash, and JSON output behavior.
+2. The local fast check entrypoint is sufficient final validation for this
+   crate-scoped behavior change, with additional package tests and shell
+   completion syntax checks run during development.
+3. `fixup` and `squash` should intentionally bypass Semantic Commit
+   header validation while still preserving staged-change checks,
+   optional guard flags, and JSON result output.
+
+## Sprint 1: Design and implement commit-mode expansion
+
+**Goal**: Add agent-safe amend, message assembly, trailer, guard, and JSON
+result support to `semantic-commit commit`.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-semantic-commit commit`
+  - `semantic-commit commit --help`
+  - `semantic-commit completion zsh`
+  - `semantic-commit completion bash`
+- Verify:
+  - `--amend`, `--no-edit`, `--message-only`, `--format json`, `--json`,
+    guard flags, `--signoff`, `--trailer`, and structured message fields
+    appear in help and completion metadata.
+  - Amend and message-only amend run through validation and do not require
+    direct `git commit --amend` use by agents.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 1.1: Model commit operations and parser options
+
+- **Location**:
+  - `crates/semantic-commit/src/commit.rs`
+  - `crates/semantic-commit/src/completion.rs`
+- **Description**: Extend commit options with operation mode, JSON output
+  mode, guard flags, trailer/signoff fields, and structured message
+  fields. Reject ambiguous combinations such as `--no-edit` with explicit
+  message input.
+- **Dependencies**: none
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - Parser rejects incompatible options with actionable errors.
+  - Existing options retain current behavior.
+  - Help and completion metadata expose the new flags.
+- **Validation**:
+  - `cargo test -p nils-semantic-commit commit_help_includes`
+  - `semantic-commit commit --help`
+
+### Task 1.2: Implement amend, no-edit, and message-only amend
+
+- **Location**:
+  - `crates/semantic-commit/src/commit.rs`
+  - `crates/semantic-commit/tests/integration/commit.rs`
+- **Description**: Implement `--amend` using validated message input,
+  `--amend --no-edit` using the previous commit message, and
+  `--amend --message-only` for message-only HEAD edits without staged
+  changes.
+- **Dependencies**: Task 1.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - New amend commits preserve staged-only behavior unless
+    `--message-only` or `--allow-empty` explicitly changes the staged
+    requirement.
+  - `--no-edit` preserves the HEAD message and does not require stdin.
+  - `--message-only` rejects staged content unless the final design
+    deliberately documents how it combines with staged changes.
+- **Validation**:
+  - `cargo test -p nils-semantic-commit amend`
+
+### Task 1.3: Add JSON commit result output
+
+- **Location**:
+  - `crates/semantic-commit/src/commit.rs`
+  - `docs/specs/cli-output-contract-v1.md` if a new contract note is
+    needed
+  - `crates/semantic-commit/tests/integration/commit.rs`
+- **Description**: Add a versioned JSON result for create, amend,
+  message-only amend, dry-run, and validation-only flows where appropriate.
+  Include operation, dry-run status, commit SHA and subject when a commit
+  exists, and enough staged file summary for agents to avoid follow-up
+  shell parsing.
+- **Dependencies**: Task 1.2
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - JSON output is valid, snake_case, and versioned.
+  - Successful live commit/amend output includes the resulting HEAD SHA.
+  - `--quiet` and JSON output have deterministic precedence.
+- **Validation**:
+  - `cargo test -p nils-semantic-commit json`
+
+### Task 1.4: Add guard flags, trailers, signoff, and structured message assembly
+
+- **Location**:
+  - `crates/semantic-commit/src/commit.rs`
+  - `crates/semantic-commit/tests/integration/commit.rs`
+- **Description**: Add explicit guard and message-construction features so
+  agents can express common safety and formatting needs without hand-built
+  message files or direct git fallback.
+- **Dependencies**: Task 1.3
+- **Complexity**: 4
+- **Acceptance criteria**:
+  - Guard flags fail before commit mutation when their condition is not
+    met.
+  - `--signoff` and repeatable `--trailer` append validated trailers.
+  - Structured fields generate the same message shape accepted by normal
+    validation.
+  - Explicit message input and structured fields are mutually exclusive
+    unless the final design has a documented merge rule.
+- **Validation**:
+  - `cargo test -p nils-semantic-commit guard`
+  - `cargo test -p nils-semantic-commit trailer`
+  - `cargo test -p nils-semantic-commit structured`
+
+## Sprint 2: Add fixup/squash commit subcommands
+
+**Goal**: Let agents create review-cleanup commits without dropping to
+direct `git commit --fixup` or `git commit --squash`.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-semantic-commit fixup`
+  - `cargo test -p nils-semantic-commit squash`
+  - `semantic-commit fixup --help`
+  - `semantic-commit squash --help`
+- Verify:
+  - Subcommands create `fixup!` and `squash!` subjects from a validated
+    target revision.
+  - Subcommands support staged checks, dry-run, JSON output, repo
+    override, and quiet/no-progress behavior where relevant.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 2.1: Add fixup and squash dispatch
+
+- **Location**:
+  - `crates/semantic-commit/src/cli.rs`
+  - `crates/semantic-commit/src/commit.rs` or a new focused module
+  - `crates/semantic-commit/src/completion.rs`
+- **Description**: Add `fixup` and `squash` subcommands with shared
+  target revision resolution and staged-change validation.
+- **Dependencies**: Task 1.4
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - `semantic-commit fixup --target <rev>` creates a `fixup!` commit.
+  - `semantic-commit squash --target <rev>` creates a `squash!` commit.
+  - Invalid targets fail without creating a commit.
+- **Validation**:
+  - `cargo test -p nils-semantic-commit fixup`
+  - `cargo test -p nils-semantic-commit squash`
+
+### Task 2.2: Align fixup/squash JSON and guard behavior
+
+- **Location**:
+  - `crates/semantic-commit/src/commit.rs` or new focused module
+  - `crates/semantic-commit/tests/integration/commit.rs`
+- **Description**: Share the JSON result and guard behavior with the
+  regular commit path where that behavior is meaningful.
+- **Dependencies**: Task 2.1
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - JSON output includes operation, target revision, resulting SHA, and
+    generated subject.
+  - Guard failures occur before mutation.
+  - Dry-run validates target and staged state without committing.
+- **Validation**:
+  - `cargo test -p nils-semantic-commit fixup_json`
+  - `cargo test -p nils-semantic-commit squash_json`
+
+## Sprint 3: Refresh docs, completions, and full validation
+
+**Goal**: Keep the `semantic-commit` documentation current with the new
+agent-oriented behavior and finish with repo-standard validation.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-semantic-commit`
+  - `zsh -n completions/zsh/_semantic-commit`
+  - `bash -n completions/bash/semantic-commit`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
+- Verify:
+  - Generated completions include all new flags and subcommands.
+  - Crate README documents the intended agent workflow, examples, exit
+    codes, and non-goals.
+  - Crate docs index points to the current README and any new detailed
+    doc surface.
+
+**PR grouping intent**: `group`
+**Execution Profile**: `serial`
+
+### Task 3.1: Regenerate completion assets
+
+- **Location**:
+  - `completions/zsh/_semantic-commit`
+  - `completions/bash/semantic-commit`
+- **Description**: Regenerate bash and zsh completion assets after CLI
+  metadata changes.
+- **Dependencies**: Task 2.2
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Completion assets include new subcommands and flags.
+  - Shell syntax checks pass.
+- **Validation**:
+  - `zsh -n completions/zsh/_semantic-commit`
+  - `bash -n completions/bash/semantic-commit`
+
+### Task 3.2: Rewrite `semantic-commit` documentation
+
+- **Location**:
+  - `crates/semantic-commit/README.md`
+  - `crates/semantic-commit/docs/README.md`
+  - Related root docs only if they contain stale `semantic-commit`
+    behavior claims
+- **Description**: Review every active `semantic-commit` documentation
+  surface and rewrite stale content so it explains the current agent
+  workflow, command modes, examples, JSON output, safety guardrails,
+  non-goals, and exit codes.
+- **Dependencies**: Task 3.1
+- **Complexity**: 3
+- **Acceptance criteria**:
+  - No active doc surface claims `semantic-commit` only creates new
+    commits.
+  - Docs distinguish Semantic Commit validation from fixup/squash modes.
+  - Docs avoid local machine paths and keep repository text in English.
+- **Validation**:
+  - `rg -n "semantic-commit|fixup|squash|amend" README.md docs crates/semantic-commit`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
+
+### Task 3.3: Run final validation and prepare delivery
+
+- **Location**:
+  - Entire changed scope
+- **Description**: Run focused tests during implementation and finish with
+  the local fast check entrypoint. Record any validation caveats in the
+  execution state before PR delivery.
+- **Dependencies**: Task 3.2
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - Focused `nils-semantic-commit` tests pass.
+  - Completion syntax checks pass.
+  - `--local-fast` passes or any failure is documented with exact blocker
+    evidence.
+- **Validation**:
+  - `cargo test -p nils-semantic-commit`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`


### PR DESCRIPTION
## Summary

Expands `semantic-commit` so agents can stay inside the semantic commit surface for amend, cleanup commit, structured-message, JSON, and guard-driven workflows. Refs #573 and adds a follow-up record for the runtime skill update in graysurf/agent-runtime-kit#128.

## Changes

- Adds `commit --amend`, `--no-edit`, `--message-only`, JSON output, clean-tree and HEAD guards, `--allow-empty`, trailers, signoff, and structured message flags.
- Adds dedicated `fixup` and `squash` subcommands with shared staged-change, clean-tree, target, dry-run, and JSON handling.
- Updates generated completion metadata for the new subcommands and flags while keeping the static bash/zsh adapters as runtime loaders.
- Rewrites the root and crate-level `semantic-commit` documentation around the refreshed agent workflow surface.
- Records issue #573 execution state and the `agent-runtime-kit` skill follow-up issue.

## Test-First Evidence

Waiver: this was an additive CLI workflow expansion over an existing command surface, so I used focused behavior coverage instead of first committing a red test. The final diff adds integration tests for amend, message-only amend, JSON output, guards, trailers, signoff, structured messages, and fixup/squash cleanup commits.

## Test plan

- `cargo test -p nils-semantic-commit`
- `zsh -n completions/zsh/_semantic-commit`
- `bash -n completions/bash/semantic-commit`
- `cargo run -q -p nils-semantic-commit -- completion zsh`
- `cargo run -q -p nils-semantic-commit -- completion bash`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only`
- `git diff --check`

## Risk / Notes

- Medium risk: `semantic-commit commit` now has more option combinations and JSON output paths.
- Mitigation: existing staged-only default remains unchanged, risky operations require explicit flags, and focused integration tests cover the new command branches.
