### PR TITLE
refactor(api-websocket): share history record selection

### DIFF
--- a/crates/api-testing-core/src/cli_history.rs
+++ b/crates/api-testing-core/src/cli_history.rs
@@ -127,24 +127,41 @@ pub fn run_history_command(
         return 3;
     }
 
-    let n = tail.unwrap_or(1).max(1) as usize;
-    let start = records.len().saturating_sub(n);
-    for record in &records[start..] {
-        if command_only && record.starts_with('#') {
-            let trimmed = record
-                .split_once('\n')
-                .map(|(_first, rest)| rest)
-                .unwrap_or_default();
-            let _ = stdout.write_all(trimmed.as_bytes());
-            if trimmed.is_empty() {
-                let _ = stdout.write_all(b"\n\n");
-            }
-        } else {
-            let _ = stdout.write_all(record.as_bytes());
-        }
+    for record in select_history_records(&records, tail, command_only) {
+        let _ = stdout.write_all(record.as_bytes());
     }
 
     0
+}
+
+pub fn select_history_records(
+    records: &[String],
+    tail: Option<u32>,
+    command_only: bool,
+) -> Vec<String> {
+    let n = tail.unwrap_or(1).max(1) as usize;
+    let start = records.len().saturating_sub(n);
+    records[start..]
+        .iter()
+        .map(|record| render_history_record(record, command_only))
+        .collect()
+}
+
+pub fn render_history_record(record: &str, command_only: bool) -> String {
+    if !command_only || !record.starts_with('#') {
+        return record.to_string();
+    }
+
+    let trimmed = record
+        .split_once('\n')
+        .map(|(_first, rest)| rest)
+        .unwrap_or_default();
+
+    if trimmed.is_empty() {
+        "\n\n".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 pub fn append_request_call_history_best_effort(

--- a/crates/api-testing-core/tests/integration/cli_history.rs
+++ b/crates/api-testing-core/tests/integration/cli_history.rs
@@ -2,7 +2,7 @@ use api_testing_core::{
     auth_env::CliAuthSource,
     cli_history::{
         RequestCallHistoryAppend, RequestCallHistoryFlag, append_request_call_history_best_effort,
-        resolve_history_file, run_history_command, select_history_records,
+        render_history_record, resolve_history_file, run_history_command, select_history_records,
     },
     history::{HistoryWriter, RotationPolicy},
 };
@@ -47,6 +47,13 @@ fn cli_history_selects_tail_and_strips_metadata_for_command_only() {
     assert_eq!(selected.len(), 1);
     assert!(selected[0].contains("two.request.json"));
     assert!(!selected[0].contains("# two"));
+}
+
+#[test]
+fn cli_history_render_record_preserves_original_when_not_command_only() {
+    let record = "# meta\napi-rest call \\\n  req.request.json \\\n| jq .\n\n";
+
+    assert_eq!(render_history_record(record, false), record);
 }
 
 #[test]

--- a/crates/api-testing-core/tests/integration/cli_history.rs
+++ b/crates/api-testing-core/tests/integration/cli_history.rs
@@ -2,7 +2,7 @@ use api_testing_core::{
     auth_env::CliAuthSource,
     cli_history::{
         RequestCallHistoryAppend, RequestCallHistoryFlag, append_request_call_history_best_effort,
-        resolve_history_file, run_history_command,
+        resolve_history_file, run_history_command, select_history_records,
     },
     history::{HistoryWriter, RotationPolicy},
 };
@@ -33,6 +33,20 @@ fn cli_history_command_only_and_empty_records() {
     let mut stderr = Vec::new();
     let code = run_history_command(&history_file, Some(1), true, &mut stdout, &mut stderr);
     assert_eq!(code, 3);
+}
+
+#[test]
+fn cli_history_selects_tail_and_strips_metadata_for_command_only() {
+    let records = vec![
+        "# one\napi-rest call \\\n  one.request.json \\\n| jq .\n\n".to_string(),
+        "# two\napi-rest call \\\n  two.request.json \\\n| jq .\n\n".to_string(),
+    ];
+
+    let selected = select_history_records(&records, Some(1), true);
+
+    assert_eq!(selected.len(), 1);
+    assert!(selected[0].contains("two.request.json"));
+    assert!(!selected[0].contains("# two"));
 }
 
 #[test]

--- a/crates/api-websocket/src/commands/history.rs
+++ b/crates/api-websocket/src/commands/history.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use api_testing_core::cli_history::resolve_history_file;
+use api_testing_core::cli_history::{resolve_history_file, select_history_records};
 use api_testing_core::config;
 
 use crate::cli::{HistoryArgs, OutputFormat};
@@ -87,16 +87,8 @@ pub(crate) fn cmd_history(
         );
     }
 
-    let n = if args.last {
-        1
-    } else {
-        args.tail.unwrap_or(1).max(1) as usize
-    };
-    let start = records.len().saturating_sub(n);
-    let selected: Vec<String> = records[start..]
-        .iter()
-        .map(|record| render_record(record, args.command_only))
-        .collect();
+    let tail = if args.last { Some(1) } else { args.tail };
+    let selected = select_history_records(&records, tail, args.command_only);
 
     if matches!(args.format, OutputFormat::Json) {
         let payload = serde_json::json!({
@@ -118,23 +110,6 @@ pub(crate) fn cmd_history(
     }
 
     0
-}
-
-fn render_record(record: &str, command_only: bool) -> String {
-    if !command_only || !record.starts_with('#') {
-        return record.to_string();
-    }
-
-    let trimmed = record
-        .split_once('\n')
-        .map(|(_first, rest)| rest)
-        .unwrap_or_default();
-
-    if trimmed.is_empty() {
-        "\n\n".to_string()
-    } else {
-        trimmed.to_string()
-    }
 }
 
 fn fail_history(
@@ -165,23 +140,4 @@ fn fail_history(
         let _ = writeln!(stderr, "{message}");
     }
     exit_code
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn render_record_returns_original_when_not_command_only() {
-        let input = "# meta\napi-websocket call \\\n  req.ws.json\n\n";
-        assert_eq!(render_record(input, false), input);
-    }
-
-    #[test]
-    fn render_record_strips_metadata_line_in_command_only_mode() {
-        let input = "# meta\napi-websocket call \\\n  req.ws.json\n\n";
-        let rendered = render_record(input, true);
-        assert!(rendered.starts_with("api-websocket call"));
-        assert!(!rendered.starts_with("#"));
-    }
 }


### PR DESCRIPTION
## Summary

Move history tail selection and command-only record rendering into `nils-api-testing-core`, then reuse that shared helper from `api-websocket history` while preserving the WebSocket JSON envelope contract.

## Changes

- Added `select_history_records` and `render_history_record` to the shared API history helper module.
- Updated `run_history_command` to use the shared selection path.
- Replaced `api-websocket`'s crate-local history selection/render helper with the shared core helper.
- Kept WebSocket-specific JSON success/error envelopes in the WebSocket command adapter.

## Test-First Evidence

Added a public `nils-api-testing-core` integration test for shared history tail selection and command-only metadata stripping before implementing the helper. The first targeted test failed to compile because `select_history_records` did not exist yet.

## Test plan

Validation run:

- `cargo test -p nils-api-testing-core cli_history_selects_tail_and_strips_metadata_for_command_only`
- `cargo test -p nils-api-websocket --test integration history_`
- `cargo test -p nils-api-testing-core cli_history`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast --plan-only`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`

The first `local-fast` attempt stopped at `cargo fmt --check`; after `cargo fmt --all`, the final local-fast run passed for `nils-api-testing-core` and `nils-api-websocket`, including fmt, clippy, nextest, and doctest coverage for the changed package set.

## Risk / Notes

Risk is low. This is a shared-foundation extraction of existing selection/render behavior, with WebSocket JSON envelopes intentionally left crate-local and covered by existing integration tests.
