### PR TITLE
feat(plan-archive): add v1 secret-scrub library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,6 +2227,7 @@ dependencies = [
  "nils-term",
  "nils-test-support",
  "pretty_assertions",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `42f029293cfe7d15f51ea8ed980fd744936cdce30520c0d4218b2e7a3d1f95f7`
+- Cargo.lock SHA256: `0a31e8548508c21e9191d992d21617ff1337a86064f127e7d22c517a4ad40349`
 - Third-party crates (`source != null`): 465
 - Workspace crates (`source == null`, excluded below): 33
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `42f029293cfe7d15f51ea8ed980fd744936cdce30520c0d4218b2e7a3d1f95f7`
+- Cargo.lock SHA256: `0a31e8548508c21e9191d992d21617ff1337a86064f127e7d22c517a4ad40349`
 - Third-party crates (`source != null`): 465
 
 ## Notice Extraction Policy

--- a/crates/plan-archive/Cargo.toml
+++ b/crates/plan-archive/Cargo.toml
@@ -22,6 +22,7 @@ clap_complete = { workspace = true }
 indexmap = { workspace = true }
 nils-common = { version = "0.24.1", path = "../nils-common", package = "nils-common" }
 nils-term = { version = "0.24.1", path = "../nils-term", package = "nils-term" }
+regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }

--- a/crates/plan-archive/README.md
+++ b/crates/plan-archive/README.md
@@ -30,6 +30,38 @@ validators that later subcommands depend on:
 respond with `subcommand-not-implemented` in Sprint 1; their bodies
 land in Sprints 3–5.
 
+## Sprint 2 surface
+
+Sprint 2 (Plan 1) lands the secret-scrub library that
+`plan-archive refresh` consumes before it writes a snapshot to
+`_index/`. The library is exported from the crate root and has no
+CLI subcommand of its own:
+
+- `plan_archive::scrub_text(input)` — scan `input` against the v1
+  pattern set, return the redacted text plus per-match metadata.
+- `plan_archive::scrub::write_log_if_any(path, matches)` — write the
+  stable `<ISO8601>.scrub.log` sibling when at least one redaction
+  occurred. No file is written for clean payloads.
+- `plan_archive::scrub::pattern_ids()` — read-only view of the
+  configured pattern set, stable across patch versions of the same
+  `PATTERN_SET` major.
+
+v1 pattern set:
+
+| Pattern id | Detects | Capture |
+| --- | --- | --- |
+| `github-token` | GitHub personal/OAuth/app tokens (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`) | entire token |
+| `gitlab-token` | GitLab personal access tokens (`glpat-`) | entire token |
+| `bitbucket-app-password` | Bitbucket app passwords (`ATBB…`) | entire token |
+| `aws-access-key-id` | AWS access key ids (`AKIA`, `ASIA`, …) | entire id |
+| `generic-secret-kv` | `secret/token/password/api_key`-style key-value pairs | value only |
+| `pem-private-key` | `-----BEGIN … PRIVATE KEY-----` blocks | entire block |
+
+Replacement token is `[REDACTED]`. Overlapping matches keep the
+earliest, widest span; the same secret is never reported twice. The
+scrub log itself never contains the secret value — only pattern id,
+byte offset, span length, and replacement length.
+
 ## Output contracts
 
 Both human-readable text (default) and a versioned JSON envelope
@@ -92,6 +124,12 @@ Validator behaviour is covered by:
 - Unit tests inside `src/validate/{hosts,local,metadata}.rs`.
 - Integration tests in `tests/validators.rs` driving the shipped
   fixture set under `tests/fixtures/{hosts,local,metadata}/`.
+
+Scrub behaviour is covered by:
+
+- Unit tests inside `src/scrub/{mod,log}.rs`.
+- Integration tests in `tests/scrub.rs` driving
+  `tests/fixtures/scrub/{all-patterns,clean}.txt`.
 
 ## Related
 

--- a/crates/plan-archive/src/lib.rs
+++ b/crates/plan-archive/src/lib.rs
@@ -8,8 +8,10 @@
 
 pub mod cli;
 pub mod completion;
+pub mod scrub;
 pub mod validate;
 
+pub use scrub::{Match, PATTERN_SET, REDACTION_TOKEN, ScrubResult, pattern_ids, scrub_text};
 pub use validate::{
     hosts::{HostsConfig, HostsValidation, HostsValidationData, validate_hosts_yaml},
     local::{

--- a/crates/plan-archive/src/scrub/log.rs
+++ b/crates/plan-archive/src/scrub/log.rs
@@ -1,0 +1,112 @@
+//! Scrub-log emitter.
+//!
+//! Writes the `<ISO8601>.scrub.log` sibling file for every snapshot
+//! whose payload had at least one secret redacted. The format is
+//! line-oriented and stable so reviewers can diff successive snapshot
+//! logs by eye and so downstream tooling can grep it without parsing.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use super::{Match, PATTERN_SET};
+
+/// Format the scrub log body. Stable so fixture goldens can diff.
+pub fn format_log(matches: &[Match]) -> String {
+    let mut out = String::new();
+    out.push_str("# plan-archive scrub log\n");
+    out.push_str(&format!("# pattern_set: {PATTERN_SET}\n"));
+    for m in matches {
+        out.push_str(&format!(
+            "match pattern={} offset={} length={} redaction={}\n",
+            m.pattern_id, m.offset, m.length, m.redaction_length
+        ));
+    }
+    let total = matches.len();
+    let mut triggered: Vec<String> = matches.iter().map(|m| m.pattern_id.clone()).collect();
+    triggered.sort();
+    triggered.dedup();
+    out.push_str(&format!(
+        "summary patterns_triggered={} total_matches={}\n",
+        if triggered.is_empty() {
+            "none".to_string()
+        } else {
+            triggered.join(",")
+        },
+        total
+    ));
+    out
+}
+
+/// Write the scrub log to `path` if and only if `matches` is non-empty.
+///
+/// Returns `Ok(true)` when a log was written, `Ok(false)` when no log
+/// was needed.
+pub fn write_log_if_any(path: &Path, matches: &[Match]) -> std::io::Result<bool> {
+    if matches.is_empty() {
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let body = format_log(matches);
+    let mut f = fs::File::create(path)?;
+    f.write_all(body.as_bytes())?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scrub::scrub_text;
+    use std::fs;
+
+    #[test]
+    fn empty_matches_produces_summary_with_none() {
+        let body = format_log(&[]);
+        assert!(body.contains("# plan-archive scrub log"));
+        assert!(body.contains("# pattern_set: v1"));
+        assert!(body.contains("summary patterns_triggered=none total_matches=0"));
+    }
+
+    #[test]
+    fn formats_one_line_per_match_and_a_summary() {
+        let result = scrub_text("auth: ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let body = format_log(&result.matches);
+        // One match line, plus the two header lines + one summary line.
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 4, "log:\n{body}");
+        assert!(lines[2].starts_with("match pattern=github-token offset="));
+        assert!(lines[3].starts_with("summary patterns_triggered=github-token"));
+    }
+
+    #[test]
+    fn write_log_if_any_skips_when_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snap.scrub.log");
+        let wrote = write_log_if_any(&path, &[]).unwrap();
+        assert!(!wrote);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn write_log_if_any_writes_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snap.scrub.log");
+        let result = scrub_text("secret: abcdef1234567890");
+        let wrote = write_log_if_any(&path, &result.matches).unwrap();
+        assert!(wrote);
+        let body = fs::read_to_string(&path).unwrap();
+        assert!(body.contains("match pattern=generic-secret-kv"));
+        assert!(body.contains("total_matches=1"));
+    }
+
+    #[test]
+    fn log_never_contains_the_secret_itself() {
+        let secret = "topsecretvalue9999";
+        let payload = format!("password: {secret}");
+        let result = scrub_text(&payload);
+        let body = format_log(&result.matches);
+        assert!(!body.contains(secret), "log leaked secret: {body}");
+    }
+}

--- a/crates/plan-archive/src/scrub/mod.rs
+++ b/crates/plan-archive/src/scrub/mod.rs
@@ -1,0 +1,306 @@
+//! Secret-scrub library v1.
+//!
+//! Used by `plan-archive refresh` to redact provider payloads before
+//! the JSON snapshot is written into `_index/`. The pattern set is
+//! intentionally small and stable so the resulting `.scrub.log`
+//! sibling stays diffable across refreshes.
+
+use regex::Regex;
+use serde::Serialize;
+use std::sync::OnceLock;
+
+pub mod log;
+
+pub use log::{format_log, write_log_if_any};
+
+/// Pattern set identifier embedded in scrub-log headers and the
+/// `cli.plan-archive.refresh.v1` JSON envelope.
+pub const PATTERN_SET: &str = "v1";
+
+/// Placeholder text inserted in place of the matched secret.
+pub const REDACTION_TOKEN: &str = "[REDACTED]";
+
+/// A single secret match found in the input payload.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Match {
+    /// Stable pattern id (`github-token`, `aws-access-key-id`, ...).
+    pub pattern_id: String,
+    /// Byte offset in the original input where the redacted span
+    /// starts.
+    pub offset: usize,
+    /// Byte length of the redacted span.
+    pub length: usize,
+    /// Byte length of the replacement token.
+    pub redaction_length: usize,
+}
+
+/// Result of running [`scrub_text`] on a payload.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ScrubResult {
+    /// Payload with every matched span replaced by [`REDACTION_TOKEN`].
+    pub redacted: String,
+    /// Matches in original-payload byte order.
+    pub matches: Vec<Match>,
+}
+
+impl ScrubResult {
+    /// Distinct pattern ids that triggered at least one match.
+    pub fn triggered_patterns(&self) -> Vec<String> {
+        let mut ids: Vec<String> = self.matches.iter().map(|m| m.pattern_id.clone()).collect();
+        ids.sort();
+        ids.dedup();
+        ids
+    }
+}
+
+struct Pattern {
+    id: &'static str,
+    regex: Regex,
+    /// Which capture group to redact. `0` means the entire match.
+    capture: usize,
+}
+
+fn patterns() -> &'static [Pattern] {
+    static P: OnceLock<Vec<Pattern>> = OnceLock::new();
+    P.get_or_init(|| {
+        vec![
+            Pattern {
+                id: "github-token",
+                regex: Regex::new(r"gh[opusr]_[A-Za-z0-9_]{36,}").unwrap(),
+                capture: 0,
+            },
+            Pattern {
+                id: "gitlab-token",
+                regex: Regex::new(r"glpat-[A-Za-z0-9_\-]{20,}").unwrap(),
+                capture: 0,
+            },
+            Pattern {
+                id: "bitbucket-app-password",
+                regex: Regex::new(r"ATBB[A-Za-z0-9]{16,}").unwrap(),
+                capture: 0,
+            },
+            Pattern {
+                id: "aws-access-key-id",
+                regex: Regex::new(
+                    r"(?:AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|A3T[A-Z0-9])[A-Z0-9]{16}",
+                )
+                .unwrap(),
+                capture: 0,
+            },
+            Pattern {
+                id: "generic-secret-kv",
+                regex: Regex::new(
+                    r#"(?i)(?:secret|token|password|api[_-]?key)\s*[:=]\s*["']?([A-Za-z0-9_\-\.+/=]{12,})["']?"#,
+                )
+                .unwrap(),
+                capture: 1,
+            },
+            Pattern {
+                id: "pem-private-key",
+                regex: Regex::new(
+                    r"(?s)-----BEGIN [A-Z ]+PRIVATE KEY-----.*?-----END [A-Z ]+PRIVATE KEY-----",
+                )
+                .unwrap(),
+                capture: 0,
+            },
+        ]
+    })
+}
+
+/// Public read-only view of the configured v1 patterns. Stable for
+/// downstream `--list-patterns` style flags.
+pub fn pattern_ids() -> Vec<&'static str> {
+    patterns().iter().map(|p| p.id).collect()
+}
+
+/// Scan `input` for secrets in the v1 pattern set, replace every
+/// matched span with [`REDACTION_TOKEN`], and return both the
+/// redacted text and per-match metadata.
+pub fn scrub_text(input: &str) -> ScrubResult {
+    let mut spans: Vec<(usize, usize, &'static str)> = Vec::new();
+    for p in patterns() {
+        for caps in p.regex.captures_iter(input) {
+            let Some(m) = caps.get(p.capture) else {
+                continue;
+            };
+            spans.push((m.start(), m.end(), p.id));
+        }
+    }
+
+    // Earliest span wins on overlap. Order by (offset asc, length
+    // desc) so two patterns matching the same offset prefer the
+    // wider one.
+    spans.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| (b.1 - b.0).cmp(&(a.1 - a.0))));
+    let mut kept: Vec<(usize, usize, &'static str)> = Vec::new();
+    for span in spans {
+        if let Some(last) = kept.last()
+            && span.0 < last.1
+        {
+            continue;
+        }
+        kept.push(span);
+    }
+
+    let matches: Vec<Match> = kept
+        .iter()
+        .map(|(start, end, id)| Match {
+            pattern_id: (*id).to_string(),
+            offset: *start,
+            length: end - start,
+            redaction_length: REDACTION_TOKEN.len(),
+        })
+        .collect();
+
+    let mut redacted = input.to_string();
+    for (start, end, _) in kept.iter().rev() {
+        redacted.replace_range(start..end, REDACTION_TOKEN);
+    }
+
+    ScrubResult { redacted, matches }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_github_token() {
+        let payload = "auth: ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa next";
+        let result = scrub_text(payload);
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].pattern_id, "github-token");
+        assert!(result.redacted.contains(REDACTION_TOKEN));
+        assert!(!result.redacted.contains("ghp_"));
+    }
+
+    #[test]
+    fn detects_gitlab_pat() {
+        let payload = "url: https://oauth2:glpat-AAAAAAAAAAAAAAAAAAAA@example.com/x.git";
+        let result = scrub_text(payload);
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].pattern_id, "gitlab-token");
+        assert!(!result.redacted.contains("glpat-"));
+    }
+
+    #[test]
+    fn detects_bitbucket_app_password() {
+        let payload = "pass=ATBB1234567890abcdefXYZ end";
+        let result = scrub_text(payload);
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].pattern_id, "bitbucket-app-password");
+    }
+
+    #[test]
+    fn detects_aws_access_key_id() {
+        let payload = "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE end";
+        let result = scrub_text(payload);
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].pattern_id, "aws-access-key-id");
+    }
+
+    #[test]
+    fn detects_generic_secret_kv_value_only() {
+        let payload = "password: \"supersecretvalue12\" trailing";
+        let result = scrub_text(payload);
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].pattern_id, "generic-secret-kv");
+        assert!(result.redacted.starts_with("password: \"[REDACTED]\""));
+    }
+
+    #[test]
+    fn detects_pem_private_key_block() {
+        let payload = "before\n-----BEGIN RSA PRIVATE KEY-----\nlines\nlines\n-----END RSA PRIVATE KEY-----\nafter";
+        let result = scrub_text(payload);
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].pattern_id, "pem-private-key");
+        assert!(result.redacted.contains("before\n[REDACTED]\nafter"));
+    }
+
+    #[test]
+    fn negative_short_token_not_matched() {
+        let payload = "ghp_tooshort and glpat-short and no_aws_here";
+        let result = scrub_text(payload);
+        assert!(
+            result.matches.is_empty(),
+            "got matches: {:?}",
+            result.matches
+        );
+    }
+
+    #[test]
+    fn negative_random_word_not_secret() {
+        let payload = "the password is in the doc";
+        let result = scrub_text(payload);
+        assert!(
+            result.matches.is_empty(),
+            "got matches: {:?}",
+            result.matches
+        );
+    }
+
+    #[test]
+    fn end_to_end_all_patterns_in_one_payload() {
+        let payload = "\
+A: ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+B: glpat-AAAAAAAAAAAAAAAAAAAA
+C: ATBB1234567890abcdefXYZ
+D: AKIAIOSFODNN7EXAMPLE
+E: secret=topsecretvalue42
+F: -----BEGIN OPENSSH PRIVATE KEY-----\nbody\n-----END OPENSSH PRIVATE KEY-----
+";
+        let result = scrub_text(payload);
+        let ids = result.triggered_patterns();
+        assert_eq!(
+            ids,
+            vec![
+                "aws-access-key-id".to_string(),
+                "bitbucket-app-password".to_string(),
+                "generic-secret-kv".to_string(),
+                "github-token".to_string(),
+                "gitlab-token".to_string(),
+                "pem-private-key".to_string(),
+            ]
+        );
+        assert!(!result.redacted.contains("ghp_"));
+        assert!(!result.redacted.contains("glpat-"));
+        assert!(!result.redacted.contains("AKIA"));
+        assert!(!result.redacted.contains("ATBB"));
+        assert!(!result.redacted.contains("topsecretvalue42"));
+        assert!(!result.redacted.contains("PRIVATE KEY"));
+    }
+
+    #[test]
+    fn empty_input_returns_empty_result() {
+        let result = scrub_text("");
+        assert!(result.matches.is_empty());
+        assert_eq!(result.redacted, "");
+    }
+
+    #[test]
+    fn overlapping_matches_prefer_earliest_widest() {
+        // `password: glpat-AAAAAAAAAAAAAAAAAAAA` triggers both
+        // generic-secret-kv (value-only) and gitlab-token (full token).
+        // Earliest+widest wins → generic-secret-kv covers the same
+        // bytes; the result should not double-redact.
+        let payload = "password: glpat-AAAAAAAAAAAAAAAAAAAA";
+        let result = scrub_text(payload);
+        let redaction_count = result.redacted.matches(REDACTION_TOKEN).count();
+        assert_eq!(redaction_count, 1, "redacted: {}", result.redacted);
+    }
+
+    #[test]
+    fn pattern_ids_listing_is_stable() {
+        let ids = pattern_ids();
+        assert_eq!(
+            ids,
+            vec![
+                "github-token",
+                "gitlab-token",
+                "bitbucket-app-password",
+                "aws-access-key-id",
+                "generic-secret-kv",
+                "pem-private-key",
+            ]
+        );
+    }
+}

--- a/crates/plan-archive/tests/fixtures/scrub/all-patterns.txt
+++ b/crates/plan-archive/tests/fixtures/scrub/all-patterns.txt
@@ -1,0 +1,10 @@
+GitHub token: ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+GitLab token: glpat-AAAAAAAAAAAAAAAAAAAA
+Bitbucket app password: ATBB1234567890abcdefXYZ
+AWS access key id: AKIAIOSFODNN7EXAMPLE
+Inline secret: api_key="abcd1234efgh5678"
+PEM block follows:
+-----BEGIN RSA PRIVATE KEY-----
+MIIE-not-a-real-key-body
+-----END RSA PRIVATE KEY-----
+End of fixture.

--- a/crates/plan-archive/tests/fixtures/scrub/clean.txt
+++ b/crates/plan-archive/tests/fixtures/scrub/clean.txt
@@ -1,0 +1,3 @@
+No secrets in this payload. Just regular text content.
+Some words: token, password, secret — but no actual values.
+The end.

--- a/crates/plan-archive/tests/scrub.rs
+++ b/crates/plan-archive/tests/scrub.rs
@@ -1,0 +1,85 @@
+//! Integration coverage for the scrub library against on-disk
+//! fixture payloads.
+
+use std::fs;
+use std::path::PathBuf;
+
+use plan_archive::scrub;
+
+fn fixture(name: &str) -> String {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("fixtures");
+    path.push("scrub");
+    path.push(name);
+    fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {path:?}: {err}"))
+}
+
+#[test]
+fn all_patterns_fixture_redacts_every_expected_id() {
+    let payload = fixture("all-patterns.txt");
+    let result = scrub::scrub_text(&payload);
+    let ids = result.triggered_patterns();
+    assert_eq!(
+        ids,
+        vec![
+            "aws-access-key-id".to_string(),
+            "bitbucket-app-password".to_string(),
+            "generic-secret-kv".to_string(),
+            "github-token".to_string(),
+            "gitlab-token".to_string(),
+            "pem-private-key".to_string(),
+        ]
+    );
+    // The fixture must not leak any of its secret bodies into the
+    // redacted output.
+    let forbidden = [
+        "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "glpat-AAAAAAAAAAAAAAAAAAAA",
+        "ATBB1234567890abcdefXYZ",
+        "AKIAIOSFODNN7EXAMPLE",
+        "abcd1234efgh5678",
+        "MIIE-not-a-real-key-body",
+    ];
+    for needle in &forbidden {
+        assert!(
+            !result.redacted.contains(needle),
+            "leaked `{needle}` in:\n{}",
+            result.redacted
+        );
+    }
+}
+
+#[test]
+fn clean_fixture_produces_zero_matches() {
+    let payload = fixture("clean.txt");
+    let result = scrub::scrub_text(&payload);
+    assert!(result.matches.is_empty(), "matches: {:?}", result.matches);
+    assert_eq!(result.redacted, payload);
+}
+
+#[test]
+fn log_format_is_stable_for_fixture() {
+    let payload = fixture("all-patterns.txt");
+    let result = scrub::scrub_text(&payload);
+    let body = scrub::format_log(&result.matches);
+    // The header pair is fixed and the summary line carries the
+    // sorted distinct pattern set.
+    assert!(body.starts_with("# plan-archive scrub log\n"));
+    assert!(body.contains("# pattern_set: v1\n"));
+    assert!(body.lines().last().unwrap().starts_with(
+        "summary patterns_triggered=aws-access-key-id,bitbucket-app-password,generic-secret-kv,github-token,gitlab-token,pem-private-key"
+    ));
+}
+
+#[test]
+fn write_log_round_trips_through_tempfile() {
+    let payload = fixture("all-patterns.txt");
+    let result = scrub::scrub_text(&payload);
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("20260527T012345Z.scrub.log");
+    let wrote = scrub::write_log_if_any(&path, &result.matches).unwrap();
+    assert!(wrote);
+    let body = fs::read_to_string(&path).unwrap();
+    assert_eq!(body, scrub::format_log(&result.matches));
+}


### PR DESCRIPTION
## Summary

Land Plan 1 Sprint 2 of the plan-archive system: the v1 secret-scrub
library that `plan-archive refresh` (Sprint 4) will compose with the
forge-cli payload fetch before any `<ISO8601>.json` snapshot is
written into `_index/`. Pure library work, no new CLI subcommand —
the existing `Refresh` placeholder still returns
`subcommand-not-implemented`.

## Changes

- New module `crates/plan-archive/src/scrub/` with `mod.rs` carrying
  the v1 pattern set (`github-token`, `gitlab-token`,
  `bitbucket-app-password`, `aws-access-key-id`, `generic-secret-kv`,
  `pem-private-key`) and `scrub_text` returning per-match metadata
  plus a `[REDACTED]`-replaced payload. Earliest-widest overlap rule
  keeps the same secret from being reported twice.
- `crates/plan-archive/src/scrub/log.rs` writes the stable
  `<ISO8601>.scrub.log` sibling via `write_log_if_any`. The log body
  carries `# pattern_set: v1`, one `match pattern=… offset=…` line
  per redaction, and a `summary patterns_triggered=… total_matches=…`
  trailer; it never embeds the secret value.
- `crates/plan-archive/Cargo.toml`: adds `regex = "1"` (already used
  by three sibling crates; not promoted to a workspace dep).
- `crates/plan-archive/src/lib.rs`: re-exports `Match`, `ScrubResult`,
  `PATTERN_SET`, `REDACTION_TOKEN`, `pattern_ids`, `scrub_text`.
- Fixtures under `tests/fixtures/scrub/` (`all-patterns.txt` plus
  `clean.txt`) plus `tests/scrub.rs` covering the end-to-end pattern
  triggering, the no-secret happy path, the stable log format, and
  the round-trip through `write_log_if_any`.
- README adds a Sprint 2 surface table documenting the pattern set,
  capture semantics, replacement token, and where the scrub log
  sibling lives.
- Regenerated `THIRD_PARTY_LICENSES.md` / `THIRD_PARTY_NOTICES.md`
  for the new direct `regex` dep so
  `third-party-artifacts-audit --strict` stays green.

## Test-First Evidence

- Wrote pattern-by-pattern unit tests inside `src/scrub/mod.rs`
  (`detects_github_token`, `detects_gitlab_pat`,
  `detects_bitbucket_app_password`, `detects_aws_access_key_id`,
  `detects_generic_secret_kv_value_only`,
  `detects_pem_private_key_block`) and negative-coverage tests
  (`negative_short_token_not_matched`,
  `negative_random_word_not_secret`) before the redaction engine was
  wired in.
- Added `empty_input_returns_empty_result` and
  `overlapping_matches_prefer_earliest_widest` to nail down the
  edge-case behaviour the Sprint 4 refresh pipeline will depend on.
- Authored `tests/scrub.rs` fixture-driven coverage against
  `tests/fixtures/scrub/all-patterns.txt` so a regression that broke
  any one pattern would surface as a concrete fixture failure rather
  than a unit-test rewrite.
- `log_format_is_stable_for_fixture` pins the human-readable log
  shape so reviewers can diff successive snapshot logs without
  surprises, and `log_never_contains_the_secret_itself` asserts the
  audit invariant directly.

## Test plan

- [x] `cargo test -p nils-plan-archive` — 38 unit + 4 scrub
  integration + 10 validator integration = 52 tests pass.
- [x] `cargo fmt -p nils-plan-archive` clean.
- [x] `cargo clippy -p nils-plan-archive --all-targets -- -D warnings`
  clean.
- [x] `bash scripts/ci/third-party-artifacts-audit.sh --strict` — pass
  after regen.
- [x] `bash scripts/ci/docs-hygiene-audit.sh --strict` — pass.
- [x] `bash scripts/ci/docs-placement-audit.sh --strict` — pass.
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` —
  workspace gate pass.
- [ ] Remote CI green on PR.

## Risk / Notes

- Pattern set is intentionally conservative; v1 will under-match
  rather than over-match. Sprint 4 review against real provider
  payloads can extend the set if needed without breaking the
  on-disk log format (the `pattern_set: v1` header gates future
  additions).
- `generic-secret-kv` only redacts the value capture, so reviewers
  still see the `password: …` key in the log — intentional, to make
  scrub-log review feasible. The unit test
  `log_never_contains_the_secret_itself` pins this invariant.
- Overlap resolution prefers earliest+widest so the same secret is
  never double-counted; the new
  `overlapping_matches_prefer_earliest_widest` test pins it.
- `regex = "1"` is added as a direct dep but it was already pulled
  in transitively by three sibling crates — no net license impact;
  third-party artifacts regenerated to keep the audit green.
- Refs #571.
