### PR TITLE
Keep semantic-commit squash noninteractive

### DIFF
--- a/crates/semantic-commit/src/commit.rs
+++ b/crates/semantic-commit/src/commit.rs
@@ -13,6 +13,11 @@ const EXIT_MESSAGE_REQUIRED: i32 = 3;
 const EXIT_VALIDATION_FAILED: i32 = 4;
 const EXIT_DEPENDENCY_ERROR: i32 = 5;
 const CAT_PAGER_ENV: [(&str, &str); 2] = [("GIT_PAGER", "cat"), ("PAGER", "cat")];
+const NONINTERACTIVE_COMMIT_ENV: [(&str, &str); 3] = [
+    ("GIT_PAGER", "cat"),
+    ("PAGER", "cat"),
+    ("GIT_EDITOR", "true"),
+];
 const COMMIT_RESULT_SCHEMA_VERSION: &str = "cli.semantic-commit.commit.v1";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1177,7 +1182,11 @@ fn git_cleanup_commit(
     }
     args.push(format!("{}={target_sha}", operation.git_flag()));
 
-    let output = run_git_output_with_pager_owned(options.repo.as_deref(), &args)?;
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let output = match options.repo.as_deref() {
+        Some(repo) => common_git::run_output_in_with_env(repo, &refs, &NONINTERACTIVE_COMMIT_ENV),
+        None => common_git::run_output_with_env(&refs, &NONINTERACTIVE_COMMIT_ENV),
+    }?;
 
     if !output.stderr.is_empty() {
         std::io::stderr().write_all(&output.stderr)?;

--- a/crates/semantic-commit/tests/integration/commit.rs
+++ b/crates/semantic-commit/tests/integration/commit.rs
@@ -1214,6 +1214,47 @@ fn squash_json_dry_run_reports_target_without_committing() {
 }
 
 #[test]
+fn squash_creates_squash_commit_without_opening_editor() {
+    let repo = common::init_repo();
+    stage_file(repo.path(), "base.txt", "base\n");
+    let base = common::run_semantic_commit_output(
+        repo.path(),
+        &[
+            "commit",
+            "--message",
+            "feat(core): base change",
+            "--no-summary",
+        ],
+        &[],
+        None,
+    );
+    assert_eq!(base.status.code(), Some(0));
+
+    common::write_executable(repo.path(), "fail-editor.sh", "#!/bin/sh\nexit 42\n");
+    let editor = repo.path().join("fail-editor.sh");
+    stage_file(repo.path(), "squash.txt", "squash\n");
+    let output = common::run_semantic_commit_output(
+        repo.path(),
+        &["squash", "--target", "HEAD", "--json", "--no-summary"],
+        &[("GIT_EDITOR", editor.to_str().expect("editor path"))],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("squash json");
+    assert_eq!(json["operation"], "squash");
+    assert_eq!(
+        git_trim(repo.path(), &["show", "-s", "--format=%s", "HEAD"]),
+        "squash! feat(core): base change"
+    );
+}
+
+#[test]
 fn fixup_invalid_target_fails_without_commit() {
     let repo = common::init_repo();
     stage_file(repo.path(), "base.txt", "base\n");


### PR DESCRIPTION
## Summary

Fixes `semantic-commit squash` so it cannot open an editor during agent cleanup-commit workflows.

## Problem

- Expected: `semantic-commit squash --target <rev> --json` completes noninteractively like the rest of the agent-facing commit surface.
- Actual: `git commit --squash=<rev>` can open the configured editor and hang an agent session.
- Impact: The new cleanup-commit workflow is not safe to release until squash is noninteractive.

## Reproduction

Run the local debug binary against a temporary git repository with staged changes:

```bash
GIT_EDITOR=/bin/false semantic-commit squash --target HEAD --json --no-summary
```

Before the fix, the command delegated to `git commit --squash` without overriding editor behavior.

## Issues Found

- Refs sympoies/nils-cli#573.
- Discovered while validating graysurf/agent-runtime-kit#128 with the local semantic-commit binary.

## Fix Approach

Run cleanup commits with a noninteractive git environment that sets `GIT_EDITOR=true`, while retaining pager suppression. Added an integration test that sets `GIT_EDITOR` to a failing script and verifies `squash --json` still creates the generated `squash!` commit.

## Test-First Evidence

Failing-test evidence: the local binary smoke hung when `semantic-commit squash --target ... --json` opened the editor. The fix adds `squash_creates_squash_commit_without_opening_editor`, which would fail if the CLI honored a failing `GIT_EDITOR`.

## Test plan

- `cargo fmt --all -- --check`
- `cargo test -p nils-semantic-commit squash_creates_squash_commit_without_opening_editor -- --nocapture`
- `cargo test -p nils-semantic-commit`
- `cargo build -p nils-semantic-commit`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- Local agent-runtime-kit smoke using `/Users/terry/.codex/worktrees/8032/nils-cli/target/debug/semantic-commit` for structured commit, amend, message-only amend, fixup, and squash.

## Risk / Notes

- Low risk: only cleanup commit git environment is changed.
- The added test covers the interactive-editor failure mode directly.
