### PR TITLE
feat(plan-archive): implement migrate, refresh, and query subcommands

### DIFF
--- a/completions/bash/plan-archive
+++ b/completions/bash/plan-archive
@@ -279,7 +279,7 @@ _plan-archive() {
             return 0
             ;;
         plan__archive__query)
-            opts="-h --ref --host --org --repo --plan --refs-from --format --json --help"
+            opts="-h --ref --host --org --repo --since --plan --refs-from --archive --format --json --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -301,11 +301,19 @@ _plan-archive() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --since)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --plan)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --refs-from)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --archive)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/bash/plan-archive
+++ b/completions/bash/plan-archive
@@ -233,12 +233,40 @@ _plan-archive() {
             return 0
             ;;
         plan__archive__migrate)
-            opts="-h --apply --format --json --help"
+            opts="-h --plan --source-repo --archive --hosts --issue --pr --mr --apply --format --json --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --plan)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --source-repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --archive)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --hosts)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --issue)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --mr)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0

--- a/completions/bash/plan-archive
+++ b/completions/bash/plan-archive
@@ -321,7 +321,7 @@ _plan-archive() {
             return 0
             ;;
         plan__archive__refresh)
-            opts="-h --ref --repo --since --format --json --help"
+            opts="-h --ref --repo --since --archive --hosts --format --json --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -336,6 +336,14 @@ _plan-archive() {
                     return 0
                     ;;
                 --since)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --archive)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --hosts)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/zsh/_plan-archive
+++ b/completions/zsh/_plan-archive
@@ -104,12 +104,14 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (query)
 _arguments "${_arguments_options[@]}" : \
-'--ref=[Reference to look up (single-ref read)]:REF:_default' \
-'--host=[Filter by host FQDN]:HOST:_default' \
-'--org=[Filter by org or GitLab group path]:ORG:_default' \
-'--repo=[Filter by repo slug]:REPO:_default' \
-'--plan=[Filter by plan path inside the archive (link traversal)]:PLAN:_default' \
-'--refs-from=[Read refs from an archived \`metadata.yaml\`]:REFS_FROM:_default' \
+'(--plan --refs-from)--ref=[Reference to look up (single-ref read)]:REF:_default' \
+'(--ref --plan --refs-from)--host=[Filter by host FQDN (aggregate mode)]:HOST:_default' \
+'(--ref --plan --refs-from)--org=[Filter by org or GitLab group path (aggregate mode)]:ORG:_default' \
+'(--ref --plan --refs-from)--repo=[Filter by repo slug (aggregate mode)]:REPO:_default' \
+'(--ref --plan --refs-from)--since=[Only snapshots fetched on or after this \`YYYY-MM-DD\` (aggregate mode)]:SINCE:_default' \
+'(--ref --host --org --repo --since --refs-from)--plan=[Resolve refs from an archived plan path inside the archive (link traversal\: plan → refs)]:PLAN:_default' \
+'(--ref --host --org --repo --since --plan)--refs-from=[Read refs from a \`metadata.yaml\` path (link traversal\: metadata → refs)]:REFS_FROM:_default' \
+'--archive=[Archive clone path. Defaults to the machine-local config'\''s \`archive_clone_path\`]:ARCHIVE:_files' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '(--format)--json[Hidden alias for \`--format json\` kept for symmetry with neighbouring CLIs]' \
@@ -179,7 +181,7 @@ _plan-archive_commands() {
 'migrate:Migrate a closed plan folder into the archive repo. Dry-run by default; use \`--apply\` to write and commit' \
 'refresh:Fetch provider payloads and append scrubbed snapshots to \`_index/\`. Writes and scrubs but does not commit; the scrub log (if any) must be reviewed before committing' \
 'completion:Print a shell completion script for \`plan-archive\`' \
-'query:(Sprint 5) Read or aggregate cached snapshots' \
+'query:Read or aggregate cached \`_index/\` snapshots' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'plan-archive commands' commands "$@"
@@ -198,7 +200,7 @@ _plan-archive__subcmd__help_commands() {
 'migrate:Migrate a closed plan folder into the archive repo. Dry-run by default; use \`--apply\` to write and commit' \
 'refresh:Fetch provider payloads and append scrubbed snapshots to \`_index/\`. Writes and scrubs but does not commit; the scrub log (if any) must be reviewed before committing' \
 'completion:Print a shell completion script for \`plan-archive\`' \
-'query:(Sprint 5) Read or aggregate cached snapshots' \
+'query:Read or aggregate cached \`_index/\` snapshots' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'plan-archive help commands' commands "$@"

--- a/completions/zsh/_plan-archive
+++ b/completions/zsh/_plan-archive
@@ -63,6 +63,13 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (migrate)
 _arguments "${_arguments_options[@]}" : \
+'--plan=[Plan folder relative to the source repo root, e.g. \`docs/plans/2026-05-27-my-plan/\`]:PLAN:_files' \
+'--source-repo=[Source working repo. Defaults to the current git repo root]:SOURCE_REPO:_files' \
+'--archive=[Archive clone path. Defaults to the machine-local config'\''s \`archive_clone_path\`]:ARCHIVE:_files' \
+'--hosts=[Path to the archive \`config/hosts.yaml\`. Defaults to \`<archive>/config/hosts.yaml\`]:HOSTS:_files' \
+'--issue=[Issue URL to record in \`metadata.yaml\`]:ISSUE:_default' \
+'--pr=[Pull request URL to record in \`metadata.yaml\`]:PR:_default' \
+'--mr=[Merge request URL to record in \`metadata.yaml\`]:MR:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--apply[Apply the migration. Without this flag the command runs in dry-run mode]' \
@@ -167,7 +174,7 @@ _plan-archive_commands() {
 'validate-hosts:Validate an archive \`config/hosts.yaml\` document' \
 'validate-local:Validate a machine-local \`agent-plan-archive/config.yaml\` document. Missing files return documented defaults with exit code 0' \
 'validate-metadata:Validate an archived plan'\''s \`metadata.yaml\` document' \
-'migrate:(Sprint 3) Migrate a closed plan folder into the archive repo' \
+'migrate:Migrate a closed plan folder into the archive repo. Dry-run by default; use \`--apply\` to write and commit' \
 'refresh:(Sprint 4) Fetch provider payloads and append scrubbed snapshots to \`_index/\`' \
 'completion:Print a shell completion script for \`plan-archive\`' \
 'query:(Sprint 5) Read or aggregate cached snapshots' \
@@ -186,7 +193,7 @@ _plan-archive__subcmd__help_commands() {
 'validate-hosts:Validate an archive \`config/hosts.yaml\` document' \
 'validate-local:Validate a machine-local \`agent-plan-archive/config.yaml\` document. Missing files return documented defaults with exit code 0' \
 'validate-metadata:Validate an archived plan'\''s \`metadata.yaml\` document' \
-'migrate:(Sprint 3) Migrate a closed plan folder into the archive repo' \
+'migrate:Migrate a closed plan folder into the archive repo. Dry-run by default; use \`--apply\` to write and commit' \
 'refresh:(Sprint 4) Fetch provider payloads and append scrubbed snapshots to \`_index/\`' \
 'completion:Print a shell completion script for \`plan-archive\`' \
 'query:(Sprint 5) Read or aggregate cached snapshots' \

--- a/completions/zsh/_plan-archive
+++ b/completions/zsh/_plan-archive
@@ -80,9 +80,11 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (refresh)
 _arguments "${_arguments_options[@]}" : \
-'(--repo --since)--ref=[Reference to refresh (issue/PR/MR URL or shorthand)]:REF:_default' \
-'(--ref --since)--repo=[Refresh every reference for the given repo]:REPO:_default' \
-'(--ref --repo)--since=[Refresh every reference modified since the given date]:SINCE:_default' \
+'(--repo --since)--ref=[Reference to refresh (issue/PR/MR URL)]:REF:_default' \
+'(--ref --since)--repo=[Refresh every open reference for the given \`host/org/repo\`]:REPO:_default' \
+'(--ref)--since=[With \`--repo\`, only refresh refs updated on or after this \`YYYY-MM-DD\` date]:SINCE:_default' \
+'--archive=[Archive clone path. Defaults to the machine-local config'\''s \`archive_clone_path\`]:ARCHIVE:_files' \
+'--hosts=[Path to the archive \`config/hosts.yaml\`. Defaults to \`<archive>/config/hosts.yaml\`]:HOSTS:_files' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '(--format)--json[Hidden alias for \`--format json\` kept for symmetry with neighbouring CLIs]' \
@@ -175,7 +177,7 @@ _plan-archive_commands() {
 'validate-local:Validate a machine-local \`agent-plan-archive/config.yaml\` document. Missing files return documented defaults with exit code 0' \
 'validate-metadata:Validate an archived plan'\''s \`metadata.yaml\` document' \
 'migrate:Migrate a closed plan folder into the archive repo. Dry-run by default; use \`--apply\` to write and commit' \
-'refresh:(Sprint 4) Fetch provider payloads and append scrubbed snapshots to \`_index/\`' \
+'refresh:Fetch provider payloads and append scrubbed snapshots to \`_index/\`. Writes and scrubs but does not commit; the scrub log (if any) must be reviewed before committing' \
 'completion:Print a shell completion script for \`plan-archive\`' \
 'query:(Sprint 5) Read or aggregate cached snapshots' \
 'help:Print this message or the help of the given subcommand(s)' \
@@ -194,7 +196,7 @@ _plan-archive__subcmd__help_commands() {
 'validate-local:Validate a machine-local \`agent-plan-archive/config.yaml\` document. Missing files return documented defaults with exit code 0' \
 'validate-metadata:Validate an archived plan'\''s \`metadata.yaml\` document' \
 'migrate:Migrate a closed plan folder into the archive repo. Dry-run by default; use \`--apply\` to write and commit' \
-'refresh:(Sprint 4) Fetch provider payloads and append scrubbed snapshots to \`_index/\`' \
+'refresh:Fetch provider payloads and append scrubbed snapshots to \`_index/\`. Writes and scrubs but does not commit; the scrub log (if any) must be reviewed before committing' \
 'completion:Print a shell completion script for \`plan-archive\`' \
 'query:(Sprint 5) Read or aggregate cached snapshots' \
 'help:Print this message or the help of the given subcommand(s)' \

--- a/crates/plan-archive/README.md
+++ b/crates/plan-archive/README.md
@@ -62,6 +62,52 @@ earliest, widest span; the same secret is never reported twice. The
 scrub log itself never contains the secret value — only pattern id,
 byte offset, span length, and replacement length.
 
+## Sprint 3 surface
+
+Sprint 3 (Plan 1) lands `plan-archive migrate`, which moves a closed
+plan folder out of a working repo into the archive repo. Dry-run is
+the default; `--apply` performs the writes and commits.
+
+```bash
+plan-archive migrate \
+  --plan docs/plans/2026-05-27-my-plan \
+  --issue https://github.com/org/repo/issues/123 \
+  [--source-repo <path>] [--archive <path>] [--hosts <path>] \
+  [--pr <url>] [--mr <url>] [--apply]
+```
+
+- `--source-repo` defaults to the current git repo root; `--archive`
+  defaults to the machine-local config's `archive_clone_path`;
+  `--hosts` defaults to `<archive>/config/hosts.yaml`.
+- At least one of `--issue` / `--pr` / `--mr` is required so the
+  archived `metadata.yaml` always carries a provider reference.
+- Dry-run resolves the source identity from the `origin` remote
+  (host, org/group path, repo, branch, HEAD SHA), classifies the host
+  against `config/hosts.yaml`, enumerates the tracked plan files via
+  `git ls-files`, and assembles the `metadata.yaml` payload — without
+  touching any working tree.
+- Apply copies the files under
+  `plans/<host>/<org>/<repo>/<folder>/`, writes `metadata.yaml`,
+  commits the archive via the released `semantic-commit` binary,
+  pushes the archive, and only on push success deletes the source
+  folder and commits that deletion in the working repo.
+
+Stable error codes (Sprint 3):
+
+| Code | When |
+| --- | --- |
+| `migrate-source-repo-not-found` | source repo path is not a git repo |
+| `migrate-plan-folder-missing` | `--plan` folder absent in the source repo |
+| `migrate-archive-clone-missing` | archive clone path not found |
+| `migrate-unknown-host` | source host absent from `config/hosts.yaml` |
+| `migrate-hosts-load-failed` / `migrate-hosts-parse-failed` | hosts config unreadable/invalid |
+| `migrate-no-refs-supplied` | none of `--issue`/`--pr`/`--mr` given |
+| `migrate-identity-failed` | could not read remote/branch/HEAD |
+| `migrate-archive-target-exists` | archive target already present (apply) |
+| `migrate-source-repo-dirty` | uncommitted changes in the plan folder (apply) |
+| `migrate-subprocess-failed` | a git or semantic-commit subprocess failed |
+| `migrate-io-error` | filesystem failure |
+
 ## Output contracts
 
 Both human-readable text (default) and a versioned JSON envelope

--- a/crates/plan-archive/README.md
+++ b/crates/plan-archive/README.md
@@ -151,6 +151,49 @@ Stable error codes (Sprint 4):
 | `refresh-forge-fetch-failed` | forge-cli fetch failed (per-ref in batch) |
 | `refresh-io-error` | filesystem failure |
 
+## Sprint 5 surface
+
+Sprint 5 (Plan 1) lands `plan-archive query`, the read-only cache
+surface. It never fetches, writes, or commits. Three mutually
+exclusive modes:
+
+```bash
+plan-archive query --ref https://github.com/org/repo/issues/123
+plan-archive query --host github.com [--org <o>] [--repo <r>] [--since 2026-05-01]
+plan-archive query --plan plans/github.com/org/repo/2026-05-27-slug
+plan-archive query --refs-from path/to/metadata.yaml
+  [--archive <path>]
+```
+
+- single-ref (`--ref`): returns the latest snapshot for one
+  issue/PR/MR plus its `fetched_at`. A ref with no snapshots returns
+  a record with `latest_snapshot: null` (exit 0), not an error.
+- aggregate (`--host`/`--org`/`--repo`/`--since`): walks `_index/`
+  across every reachable host in one pass and returns each matching
+  ref's latest snapshot. A no-match query returns an empty array,
+  exit 0.
+- link traversal (`--plan` / `--refs-from`): reads an archived plan's
+  `metadata.yaml` (`--plan` resolves `<archive>/<plan>/metadata.yaml`;
+  `--refs-from` takes the metadata path directly) and resolves each
+  `refs.issue|pr|mr` to its latest snapshot.
+
+`fetched_at` is surfaced by default on every record (decoded from the
+basic-format snapshot filename into extended ISO8601). Latest is the
+lexically-last snapshot filename in the ref folder.
+
+Stable error codes (Sprint 5):
+
+| Code | When |
+| --- | --- |
+| `query-no-selector` | no `--ref`/filter/`--plan`/`--refs-from` supplied |
+| `query-unparseable-ref` | `--ref` is not an issue/PR/MR URL |
+| `query-invalid-since` | `--since` is not `YYYY-MM-DD` |
+| `query-archive-clone-missing` | archive clone path not found |
+| `query-metadata-not-found` | `--plan`/`--refs-from` metadata absent |
+| `query-metadata-read-failed` | metadata unreadable/invalid |
+| `query-metadata-no-refs` | metadata carries no refs to traverse |
+| `query-io-error` | filesystem failure |
+
 ## Output contracts
 
 Both human-readable text (default) and a versioned JSON envelope
@@ -199,6 +242,9 @@ Stable warning codes (Sprint 1):
 - The archive repository is treated as opaque storage; this CLI does
   not enforce repository-level governance beyond what the validators
   check.
+- `query` is strictly read-only: it never fetches, writes, or commits.
+  `refresh` writes and scrubs but holds the commit so any emitted
+  scrub log can be reviewed first.
 
 ## Tests
 

--- a/crates/plan-archive/README.md
+++ b/crates/plan-archive/README.md
@@ -108,6 +108,49 @@ Stable error codes (Sprint 3):
 | `migrate-subprocess-failed` | a git or semantic-commit subprocess failed |
 | `migrate-io-error` | filesystem failure |
 
+## Sprint 4 surface
+
+Sprint 4 (Plan 1) lands `plan-archive refresh`, which fetches
+provider payloads through `forge-cli`, scrubs them with the Sprint 2
+library, and appends an `<ISO8601>.json` snapshot under `_index/`.
+Refresh **writes and scrubs but never commits** — when a snapshot
+triggers redactions it emits the `.scrub.log` sibling and flags
+`requires_review: true`; the wrapping skill/user reviews the log and
+commits separately.
+
+```bash
+plan-archive refresh --ref https://github.com/org/repo/issues/123
+plan-archive refresh --repo github.com/org/repo [--since 2026-05-01]
+  [--archive <path>] [--hosts <path>]
+```
+
+- `--ref` refreshes a single issue/PR/MR URL. `--repo` lists open
+  refs through `forge-cli … list --state open` and refreshes each;
+  `--since YYYY-MM-DD` narrows the batch. The two selectors are
+  mutually exclusive.
+- Provider API access is delegated to `forge-cli` (override the binary
+  with `PLAN_ARCHIVE_FORGE_CLI`); the host is mapped to `github` for
+  `github.com` and `gitlab` otherwise. `config/hosts.yaml` gates which
+  hosts are allowed and drives the `_index/` path.
+- Snapshots are append-only: each refresh writes a new
+  `<ISO8601>.json` (basic-format UTC, no colons) and never overwrites
+  or deletes a prior one. A batch isolates per-ref failures into the
+  `failed` array instead of aborting.
+
+Stable error codes (Sprint 4):
+
+| Code | When |
+| --- | --- |
+| `refresh-no-selector` | neither `--ref` nor `--repo` supplied |
+| `refresh-unparseable-ref` | `--ref` is not an issue/PR/MR URL |
+| `refresh-unparseable-repo` | `--repo` is not `host/org/repo` |
+| `refresh-unknown-host` | host absent from `config/hosts.yaml` |
+| `refresh-invalid-since` | `--since` is not `YYYY-MM-DD` |
+| `refresh-archive-clone-missing` | archive clone path not found |
+| `refresh-hosts-load-failed` / `refresh-hosts-parse-failed` | hosts config unreadable/invalid |
+| `refresh-forge-fetch-failed` | forge-cli fetch failed (per-ref in batch) |
+| `refresh-io-error` | filesystem failure |
+
 ## Output contracts
 
 Both human-readable text (default) and a versioned JSON envelope

--- a/crates/plan-archive/src/cli.rs
+++ b/crates/plan-archive/src/cli.rs
@@ -74,8 +74,34 @@ enum Command {
         input: String,
     },
 
-    /// (Sprint 3) Migrate a closed plan folder into the archive repo.
+    /// Migrate a closed plan folder into the archive repo.
+    /// Dry-run by default; use `--apply` to write and commit.
     Migrate {
+        /// Plan folder relative to the source repo root, e.g.
+        /// `docs/plans/2026-05-27-my-plan/`.
+        #[arg(long)]
+        plan: PathBuf,
+        /// Source working repo. Defaults to the current git repo
+        /// root.
+        #[arg(long)]
+        source_repo: Option<PathBuf>,
+        /// Archive clone path. Defaults to the machine-local
+        /// config's `archive_clone_path`.
+        #[arg(long)]
+        archive: Option<PathBuf>,
+        /// Path to the archive `config/hosts.yaml`. Defaults to
+        /// `<archive>/config/hosts.yaml`.
+        #[arg(long)]
+        hosts: Option<PathBuf>,
+        /// Issue URL to record in `metadata.yaml`.
+        #[arg(long)]
+        issue: Option<String>,
+        /// Pull request URL to record in `metadata.yaml`.
+        #[arg(long)]
+        pr: Option<String>,
+        /// Merge request URL to record in `metadata.yaml`.
+        #[arg(long)]
+        mr: Option<String>,
         /// Apply the migration. Without this flag the command runs in
         /// dry-run mode.
         #[arg(long)]
@@ -154,9 +180,27 @@ pub fn run() -> i32 {
         Command::ValidateLocal { input } => dispatch_local(&input, format),
         Command::ValidateMetadata { input } => dispatch_metadata(&input, format),
         Command::Completion { shell } => crate::completion::run(shell),
-        Command::Migrate { .. } | Command::Refresh { .. } | Command::Query { .. } => {
-            unimplemented_subcommand(format)
-        }
+        Command::Migrate {
+            plan,
+            source_repo,
+            archive,
+            hosts,
+            issue,
+            pr,
+            mr,
+            apply,
+        } => crate::migrate::dispatch(crate::migrate::DispatchArgs {
+            plan,
+            source_repo,
+            archive,
+            hosts,
+            issue,
+            pr,
+            mr,
+            apply,
+            format,
+        }),
+        Command::Refresh { .. } | Command::Query { .. } => unimplemented_subcommand(format),
     }
 }
 

--- a/crates/plan-archive/src/cli.rs
+++ b/crates/plan-archive/src/cli.rs
@@ -136,26 +136,36 @@ enum Command {
         shell: crate::completion::CompletionShell,
     },
 
-    /// (Sprint 5) Read or aggregate cached snapshots.
+    /// Read or aggregate cached `_index/` snapshots.
     Query {
         /// Reference to look up (single-ref read).
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["plan", "refs_from"])]
         r#ref: Option<String>,
-        /// Filter by host FQDN.
-        #[arg(long)]
+        /// Filter by host FQDN (aggregate mode).
+        #[arg(long, conflicts_with_all = ["ref", "plan", "refs_from"])]
         host: Option<String>,
-        /// Filter by org or GitLab group path.
-        #[arg(long)]
+        /// Filter by org or GitLab group path (aggregate mode).
+        #[arg(long, conflicts_with_all = ["ref", "plan", "refs_from"])]
         org: Option<String>,
-        /// Filter by repo slug.
-        #[arg(long)]
+        /// Filter by repo slug (aggregate mode).
+        #[arg(long, conflicts_with_all = ["ref", "plan", "refs_from"])]
         repo: Option<String>,
-        /// Filter by plan path inside the archive (link traversal).
-        #[arg(long)]
+        /// Only snapshots fetched on or after this `YYYY-MM-DD`
+        /// (aggregate mode).
+        #[arg(long, conflicts_with_all = ["ref", "plan", "refs_from"])]
+        since: Option<String>,
+        /// Resolve refs from an archived plan path inside the archive
+        /// (link traversal: plan → refs).
+        #[arg(long, conflicts_with_all = ["ref", "host", "org", "repo", "since", "refs_from"])]
         plan: Option<String>,
-        /// Read refs from an archived `metadata.yaml`.
-        #[arg(long)]
+        /// Read refs from a `metadata.yaml` path (link traversal:
+        /// metadata → refs).
+        #[arg(long, conflicts_with_all = ["ref", "host", "org", "repo", "since", "plan"])]
         refs_from: Option<String>,
+        /// Archive clone path. Defaults to the machine-local config's
+        /// `archive_clone_path`.
+        #[arg(long)]
+        archive: Option<PathBuf>,
     },
 }
 
@@ -224,7 +234,26 @@ pub fn run() -> i32 {
             hosts,
             format,
         }),
-        Command::Query { .. } => unimplemented_subcommand(format),
+        Command::Query {
+            r#ref,
+            host,
+            org,
+            repo,
+            since,
+            plan,
+            refs_from,
+            archive,
+        } => crate::query::dispatch(crate::query::DispatchArgs {
+            r#ref,
+            host,
+            org,
+            repo,
+            since,
+            plan,
+            refs_from,
+            archive,
+            format,
+        }),
     }
 }
 
@@ -436,16 +465,6 @@ fn emit_error(
             exit::DATA
         }
     }
-}
-
-fn unimplemented_subcommand(format: OutputFormat) -> i32 {
-    emit_error(
-        format,
-        "subcommand",
-        "subcommand-not-implemented",
-        "this plan-archive subcommand lands in a later sprint (see docs/plans/plan-archive-nils-cli/)",
-        Some("Sprint 1 only ships the validate-* subcommands"),
-    )
 }
 
 fn detect_format_from_argv() -> OutputFormat {

--- a/crates/plan-archive/src/cli.rs
+++ b/crates/plan-archive/src/cli.rs
@@ -107,18 +107,28 @@ enum Command {
         #[arg(long)]
         apply: bool,
     },
-    /// (Sprint 4) Fetch provider payloads and append scrubbed snapshots
-    /// to `_index/`.
+    /// Fetch provider payloads and append scrubbed snapshots to
+    /// `_index/`. Writes and scrubs but does not commit; the scrub
+    /// log (if any) must be reviewed before committing.
     Refresh {
-        /// Reference to refresh (issue/PR/MR URL or shorthand).
+        /// Reference to refresh (issue/PR/MR URL).
         #[arg(long, conflicts_with_all = ["repo", "since"])]
         r#ref: Option<String>,
-        /// Refresh every reference for the given repo.
+        /// Refresh every open reference for the given `host/org/repo`.
         #[arg(long, conflicts_with_all = ["ref", "since"])]
         repo: Option<String>,
-        /// Refresh every reference modified since the given date.
-        #[arg(long, conflicts_with_all = ["ref", "repo"])]
+        /// With `--repo`, only refresh refs updated on or after this
+        /// `YYYY-MM-DD` date.
+        #[arg(long, requires = "repo", conflicts_with = "ref")]
         since: Option<String>,
+        /// Archive clone path. Defaults to the machine-local config's
+        /// `archive_clone_path`.
+        #[arg(long)]
+        archive: Option<PathBuf>,
+        /// Path to the archive `config/hosts.yaml`. Defaults to
+        /// `<archive>/config/hosts.yaml`.
+        #[arg(long)]
+        hosts: Option<PathBuf>,
     },
     /// Print a shell completion script for `plan-archive`.
     Completion {
@@ -200,7 +210,21 @@ pub fn run() -> i32 {
             apply,
             format,
         }),
-        Command::Refresh { .. } | Command::Query { .. } => unimplemented_subcommand(format),
+        Command::Refresh {
+            r#ref,
+            repo,
+            since,
+            archive,
+            hosts,
+        } => crate::refresh::dispatch(crate::refresh::DispatchArgs {
+            r#ref,
+            repo,
+            since,
+            archive,
+            hosts,
+            format,
+        }),
+        Command::Query { .. } => unimplemented_subcommand(format),
     }
 }
 

--- a/crates/plan-archive/src/lib.rs
+++ b/crates/plan-archive/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod cli;
 pub mod completion;
+pub mod migrate;
 pub mod scrub;
 pub mod validate;
 

--- a/crates/plan-archive/src/lib.rs
+++ b/crates/plan-archive/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod cli;
 pub mod completion;
 pub mod migrate;
+pub mod refresh;
 pub mod scrub;
 pub mod validate;
 

--- a/crates/plan-archive/src/lib.rs
+++ b/crates/plan-archive/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod cli;
 pub mod completion;
 pub mod migrate;
+pub mod query;
 pub mod refresh;
 pub mod scrub;
 pub mod validate;

--- a/crates/plan-archive/src/migrate/identity.rs
+++ b/crates/plan-archive/src/migrate/identity.rs
@@ -1,0 +1,212 @@
+//! Derive the working-repo identity (host, org/group path, repo,
+//! branch, commit SHA) for the migration metadata payload.
+//!
+//! Uses git plumbing exclusively — no provider auth required. The
+//! provider identity comes from the configured `origin` remote URL.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use nils_common::git as gitio;
+
+/// Source-repo identity captured at migration time.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SourceIdentity {
+    pub host: String,
+    pub org_or_group_path: String,
+    pub repo: String,
+    pub branch: String,
+    pub commit: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IdentityError {
+    #[error("git command failed: {0}")]
+    Io(String),
+    #[error("origin remote not configured")]
+    NoOriginRemote,
+    #[error("origin remote URL `{0}` does not match a known provider shape")]
+    UnparseableRemote(String),
+    #[error("could not determine current branch (detached HEAD?)")]
+    NoBranch,
+    #[error("could not resolve HEAD")]
+    NoCommit,
+}
+
+/// Top-level helper used from `migrate::prepare`. Reads remote +
+/// branch + HEAD and parses out the host triple.
+pub fn derive_source_identity(repo: &Path) -> Result<SourceIdentity, IdentityError> {
+    let remote = origin_url(repo)?;
+    let (host, org_or_group_path, repo_name) =
+        parse_remote_url(&remote).ok_or(IdentityError::UnparseableRemote(remote.clone()))?;
+    let branch = current_branch(repo)?;
+    let commit = head_commit(repo)?;
+    Ok(SourceIdentity {
+        host,
+        org_or_group_path,
+        repo: repo_name,
+        branch,
+        commit,
+    })
+}
+
+fn origin_url(repo: &Path) -> Result<String, IdentityError> {
+    let out = gitio::run_output_in(repo, &["remote", "get-url", "origin"])
+        .map_err(|e| IdentityError::Io(e.to_string()))?;
+    if !out.status.success() {
+        return Err(IdentityError::NoOriginRemote);
+    }
+    let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if url.is_empty() {
+        return Err(IdentityError::NoOriginRemote);
+    }
+    Ok(url)
+}
+
+fn current_branch(repo: &Path) -> Result<String, IdentityError> {
+    let out = gitio::run_output_in(repo, &["symbolic-ref", "--short", "HEAD"])
+        .map_err(|e| IdentityError::Io(e.to_string()))?;
+    if !out.status.success() {
+        return Err(IdentityError::NoBranch);
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn head_commit(repo: &Path) -> Result<String, IdentityError> {
+    let out = gitio::run_output_in(repo, &["rev-parse", "HEAD"])
+        .map_err(|e| IdentityError::Io(e.to_string()))?;
+    if !out.status.success() {
+        return Err(IdentityError::NoCommit);
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Parse a git remote URL into `(host, org_or_group_path, repo)`.
+/// Supports SSH (`git@github.com:org/repo.git`), HTTPS
+/// (`https://github.com/org/repo.git`), nested GitLab groups, and
+/// optional `.git` suffix.
+pub fn parse_remote_url(url: &str) -> Option<(String, String, String)> {
+    let (host, path) = if let Some(rest) = url.strip_prefix("git@") {
+        let (host, path) = rest.split_once(':')?;
+        (host.to_string(), path.to_string())
+    } else if let Some(rest) = url.strip_prefix("ssh://") {
+        let rest = rest.strip_prefix("git@").unwrap_or(rest);
+        let (host_port, path) = rest.split_once('/')?;
+        let host = host_port
+            .split_once(':')
+            .map(|(h, _)| h)
+            .unwrap_or(host_port);
+        (host.to_string(), path.to_string())
+    } else if let Some(rest) = url.strip_prefix("https://") {
+        let rest = strip_credentials_prefix(rest);
+        let (host, path) = rest.split_once('/')?;
+        (host.to_string(), path.to_string())
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        let rest = strip_credentials_prefix(rest);
+        let (host, path) = rest.split_once('/')?;
+        (host.to_string(), path.to_string())
+    } else {
+        return None;
+    };
+
+    let path = path.trim_end_matches(".git").trim_matches('/');
+    if path.is_empty() {
+        return None;
+    }
+    let mut segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.len() < 2 {
+        return None;
+    }
+    let repo = segments.pop()?.to_string();
+    let org_or_group_path = segments.join("/");
+    if org_or_group_path.is_empty() {
+        return None;
+    }
+    Some((host, org_or_group_path, repo))
+}
+
+fn strip_credentials_prefix(s: &str) -> &str {
+    if let Some(idx) = s.find('@')
+        && let Some(slash_idx) = s.find('/')
+        && idx < slash_idx
+    {
+        return &s[idx + 1..];
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_github_ssh() {
+        let r = parse_remote_url("git@github.com:graysurf/agent-runtime-kit.git").unwrap();
+        assert_eq!(r.0, "github.com");
+        assert_eq!(r.1, "graysurf");
+        assert_eq!(r.2, "agent-runtime-kit");
+    }
+
+    #[test]
+    fn parses_github_https_with_dotgit() {
+        let r = parse_remote_url("https://github.com/sympoies/nils-cli.git").unwrap();
+        assert_eq!(
+            r,
+            ("github.com".into(), "sympoies".into(), "nils-cli".into())
+        );
+    }
+
+    #[test]
+    fn parses_github_https_without_dotgit() {
+        let r = parse_remote_url("https://github.com/sympoies/nils-cli").unwrap();
+        assert_eq!(
+            r,
+            ("github.com".into(), "sympoies".into(), "nils-cli".into())
+        );
+    }
+
+    #[test]
+    fn parses_nested_gitlab_groups_ssh() {
+        let r =
+            parse_remote_url("git@gitlab.example.com:acme/platform/backend/ingest.git").unwrap();
+        assert_eq!(
+            r,
+            (
+                "gitlab.example.com".into(),
+                "acme/platform/backend".into(),
+                "ingest".into()
+            )
+        );
+    }
+
+    #[test]
+    fn parses_nested_gitlab_groups_https() {
+        let r =
+            parse_remote_url("https://gitlab.example.com/acme/platform/backend/ingest").unwrap();
+        assert_eq!(
+            r,
+            (
+                "gitlab.example.com".into(),
+                "acme/platform/backend".into(),
+                "ingest".into()
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_url_without_org() {
+        assert!(parse_remote_url("git@github.com:repo.git").is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_scheme() {
+        assert!(parse_remote_url("file:///tmp/x.git").is_none());
+    }
+
+    #[test]
+    fn parses_https_with_basic_auth_credentials() {
+        let r = parse_remote_url("https://user:pass@github.com/org/repo.git").unwrap();
+        assert_eq!(r, ("github.com".into(), "org".into(), "repo".into()));
+    }
+}

--- a/crates/plan-archive/src/migrate/mod.rs
+++ b/crates/plan-archive/src/migrate/mod.rs
@@ -1,0 +1,651 @@
+//! `plan-archive migrate` — dry-run and apply.
+//!
+//! Sprint 3 of Plan 1 ships the deterministic migration pipeline.
+//! Dry-run is the default; `--apply` shells out to the released
+//! `semantic-commit` binary for both the archive commit and the
+//! source-repo deletion commit, and pushes the archive only.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcCommand;
+
+use nils_common::cli_contract::{Envelope, EnvelopeError, OutputFormat, exit, schema_version_for};
+use serde::Serialize;
+
+use crate::validate;
+use crate::validate::hosts::{HostClass, HostEntry, HostsConfig, validate_hosts_yaml};
+
+pub mod identity;
+pub mod path;
+
+pub use identity::{SourceIdentity, derive_source_identity};
+pub use path::{archive_target_path, parse_plan_folder};
+
+const COMMAND: &str = "migrate";
+const BINARY: &str = "plan-archive";
+
+/// Args forwarded from `cli::run`.
+pub struct DispatchArgs {
+    pub plan: PathBuf,
+    pub source_repo: Option<PathBuf>,
+    pub archive: Option<PathBuf>,
+    pub hosts: Option<PathBuf>,
+    pub issue: Option<String>,
+    pub pr: Option<String>,
+    pub mr: Option<String>,
+    pub apply: bool,
+    pub format: OutputFormat,
+}
+
+/// Classification snapshot pulled out of `config/hosts.yaml`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ClassificationSnapshot {
+    pub host: String,
+    pub class: HostClass,
+    pub employer: Option<String>,
+    pub primary_identity: Option<String>,
+    pub retention: Option<String>,
+}
+
+impl ClassificationSnapshot {
+    fn from(host: &str, entry: &HostEntry) -> Self {
+        Self {
+            host: host.to_string(),
+            class: entry.class,
+            employer: entry.employer.clone(),
+            primary_identity: entry.primary_identity.clone(),
+            retention: entry.retention.clone(),
+        }
+    }
+}
+
+/// Metadata payload written under
+/// `plans/<host>/<org>/<repo>/<folder>/metadata.yaml`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct MetadataPayload {
+    pub version: u32,
+    pub source: MetadataSource,
+    pub captured_classification: ClassificationSnapshot,
+    pub refs: MetadataRefs,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct MetadataSource {
+    pub host: String,
+    pub org_or_group_path: String,
+    pub repo: String,
+    pub branch: String,
+    pub archive_commit: String,
+    pub original_path: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct MetadataRefs {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mr: Option<String>,
+}
+
+impl MetadataRefs {
+    fn any(&self) -> bool {
+        self.issue.is_some() || self.pr.is_some() || self.mr.is_some()
+    }
+}
+
+/// Result of a `migrate --dry-run` (also reused as the prelude of an
+/// apply).
+#[derive(Debug, Clone, Serialize)]
+pub struct DryRunReport {
+    pub plan_folder: String,
+    pub source: SourceIdentity,
+    pub classification: ClassificationSnapshot,
+    pub archive_target: ArchiveTarget,
+    pub files_to_copy: Vec<String>,
+    pub metadata: MetadataPayload,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ArchiveTarget {
+    pub absolute_path: String,
+    pub relative_path: String,
+    pub exists: bool,
+}
+
+/// Result of a successful `migrate --apply`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ApplyReport {
+    pub plan_folder: String,
+    pub archive_commit: String,
+    pub source_deletion_commit: String,
+    pub archive_target: String,
+    pub files_copied: usize,
+    pub scrub_log: Option<String>,
+}
+
+/// Errors produced by the migration pipeline.
+#[derive(Debug, thiserror::Error)]
+pub enum MigrateError {
+    #[error("source repo not found at `{0}`")]
+    SourceRepoNotFound(PathBuf),
+    #[error("plan folder `{0}` does not exist inside the source repo")]
+    PlanFolderMissing(String),
+    #[error(
+        "archive clone path not found at `{0}` (set `--archive` or seed `archive_clone_path` in the local config)"
+    )]
+    ArchiveCloneMissing(PathBuf),
+    #[error("`{0}` is not a recognised provider host in the archive `config/hosts.yaml`")]
+    UnknownHost(String),
+    #[error("failed to load archive `config/hosts.yaml`: {0}")]
+    HostsLoadFailed(String),
+    #[error("failed to parse archive `config/hosts.yaml`: {0}")]
+    HostsParseFailed(String),
+    #[error(
+        "at least one of `--issue`, `--pr`, `--mr` must be supplied so `metadata.yaml` carries a provider reference"
+    )]
+    NoRefsSupplied,
+    #[error("failed to read source repo identity: {0}")]
+    IdentityFailed(String),
+    #[error(
+        "archive target `{0}` already exists; remove it or re-run after resolving the conflict"
+    )]
+    ArchiveTargetExists(String),
+    #[error("source repo has uncommitted changes inside `{0}`; commit or stash them first")]
+    SourceRepoDirty(String),
+    #[error("io error during migration: {0}")]
+    Io(String),
+    #[error("subprocess `{0}` failed: {1}")]
+    Subprocess(String, String),
+}
+
+impl MigrateError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            MigrateError::SourceRepoNotFound(_) => "migrate-source-repo-not-found",
+            MigrateError::PlanFolderMissing(_) => "migrate-plan-folder-missing",
+            MigrateError::ArchiveCloneMissing(_) => "migrate-archive-clone-missing",
+            MigrateError::UnknownHost(_) => "migrate-unknown-host",
+            MigrateError::HostsLoadFailed(_) => "migrate-hosts-load-failed",
+            MigrateError::HostsParseFailed(_) => "migrate-hosts-parse-failed",
+            MigrateError::NoRefsSupplied => "migrate-no-refs-supplied",
+            MigrateError::IdentityFailed(_) => "migrate-identity-failed",
+            MigrateError::ArchiveTargetExists(_) => "migrate-archive-target-exists",
+            MigrateError::SourceRepoDirty(_) => "migrate-source-repo-dirty",
+            MigrateError::Io(_) => "migrate-io-error",
+            MigrateError::Subprocess(_, _) => "migrate-subprocess-failed",
+        }
+    }
+}
+
+/// Entry point called from `cli::run`.
+pub fn dispatch(args: DispatchArgs) -> i32 {
+    let format = args.format;
+    match prepare(&args) {
+        Ok(report) => {
+            if args.apply {
+                match apply(args, report) {
+                    Ok(applied) => emit_apply(format, applied),
+                    Err(err) => emit_error(format, err.code(), &err.to_string()),
+                }
+            } else {
+                emit_dry_run(format, report)
+            }
+        }
+        Err(err) => emit_error(format, err.code(), &err.to_string()),
+    }
+}
+
+/// Pure(ish) preparation. Resolves identities, validates host
+/// classification, enumerates files, and assembles the metadata
+/// payload. Performs no writes.
+pub fn prepare(args: &DispatchArgs) -> Result<DryRunReport, MigrateError> {
+    let source_repo = resolve_source_repo(args.source_repo.as_deref())?;
+    let archive = resolve_archive(args.archive.as_deref())?;
+    let plan_path_in_repo = normalise_plan_arg(&args.plan);
+
+    let absolute_plan = source_repo.join(&plan_path_in_repo);
+    if !absolute_plan.is_dir() {
+        return Err(MigrateError::PlanFolderMissing(
+            plan_path_in_repo.to_string_lossy().to_string(),
+        ));
+    }
+
+    let identity = derive_source_identity(&source_repo)
+        .map_err(|e| MigrateError::IdentityFailed(e.to_string()))?;
+
+    let hosts_path = args
+        .hosts
+        .clone()
+        .unwrap_or_else(|| archive.join("config").join("hosts.yaml"));
+    let hosts_config = load_hosts(&hosts_path)?;
+
+    let host_entry = hosts_config
+        .hosts
+        .get(&identity.host)
+        .ok_or_else(|| MigrateError::UnknownHost(identity.host.clone()))?;
+    let classification = ClassificationSnapshot::from(&identity.host, host_entry);
+
+    let folder_name = absolute_plan
+        .file_name()
+        .ok_or_else(|| MigrateError::PlanFolderMissing(plan_path_in_repo.display().to_string()))?
+        .to_string_lossy()
+        .to_string();
+
+    let archive_target_rel = archive_target_path(
+        &identity.host,
+        &identity.org_or_group_path,
+        &identity.repo,
+        &folder_name,
+    );
+    let archive_target_abs = archive.join(&archive_target_rel);
+    let target = ArchiveTarget {
+        absolute_path: archive_target_abs.display().to_string(),
+        relative_path: archive_target_rel.display().to_string(),
+        exists: archive_target_abs.exists(),
+    };
+
+    let files_to_copy = enumerate_plan_files(&source_repo, &plan_path_in_repo)?;
+
+    let refs = MetadataRefs {
+        issue: args.issue.clone(),
+        pr: args.pr.clone(),
+        mr: args.mr.clone(),
+    };
+    if !refs.any() {
+        return Err(MigrateError::NoRefsSupplied);
+    }
+
+    let metadata = MetadataPayload {
+        version: 1,
+        source: MetadataSource {
+            host: identity.host.clone(),
+            org_or_group_path: identity.org_or_group_path.clone(),
+            repo: identity.repo.clone(),
+            branch: identity.branch.clone(),
+            archive_commit: identity.commit.clone(),
+            original_path: format!(
+                "{}/",
+                plan_path_in_repo
+                    .display()
+                    .to_string()
+                    .trim_end_matches('/')
+            ),
+        },
+        captured_classification: classification.clone(),
+        refs,
+    };
+
+    Ok(DryRunReport {
+        plan_folder: folder_name,
+        source: identity,
+        classification,
+        archive_target: target,
+        files_to_copy: files_to_copy
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect(),
+        metadata,
+    })
+}
+
+fn resolve_source_repo(arg: Option<&Path>) -> Result<PathBuf, MigrateError> {
+    let candidate = match arg {
+        Some(p) => p.to_path_buf(),
+        None => std::env::current_dir().map_err(|e| MigrateError::Io(e.to_string()))?,
+    };
+    let root = nils_common::git::repo_root_in(&candidate)
+        .map_err(|e| MigrateError::Io(e.to_string()))?
+        .ok_or_else(|| MigrateError::SourceRepoNotFound(candidate.clone()))?;
+    if !root.is_dir() {
+        return Err(MigrateError::SourceRepoNotFound(root));
+    }
+    Ok(root)
+}
+
+fn resolve_archive(arg: Option<&Path>) -> Result<PathBuf, MigrateError> {
+    let candidate = match arg {
+        Some(p) => p.to_path_buf(),
+        None => default_archive_clone_path()?,
+    };
+    if !candidate.is_dir() {
+        return Err(MigrateError::ArchiveCloneMissing(candidate));
+    }
+    Ok(candidate)
+}
+
+fn default_archive_clone_path() -> Result<PathBuf, MigrateError> {
+    let local = validate::local::validate_local_path(&local_config_path())
+        .map_err(|e| MigrateError::Io(e.to_string()))?;
+    Ok(local.data.config.archive_clone_path)
+}
+
+fn local_config_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("PLAN_ARCHIVE_LOCAL_CONFIG") {
+        return PathBuf::from(p);
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        return PathBuf::from(xdg)
+            .join("agent-plan-archive")
+            .join("config.yaml");
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join(".config")
+            .join("agent-plan-archive")
+            .join("config.yaml");
+    }
+    PathBuf::from("/nonexistent/agent-plan-archive/config.yaml")
+}
+
+fn normalise_plan_arg(arg: &Path) -> PathBuf {
+    let s = arg.to_string_lossy().trim_end_matches('/').to_string();
+    PathBuf::from(s)
+}
+
+fn load_hosts(path: &Path) -> Result<HostsConfig, MigrateError> {
+    let raw = fs::read_to_string(path).map_err(|e| MigrateError::HostsLoadFailed(e.to_string()))?;
+    let v = validate_hosts_yaml(&raw).map_err(|e| MigrateError::HostsParseFailed(e.to_string()))?;
+    Ok(v.data.config)
+}
+
+fn enumerate_plan_files(
+    source_repo: &Path,
+    plan_path_in_repo: &Path,
+) -> Result<Vec<PathBuf>, MigrateError> {
+    let output = nils_common::git::run_output_in(
+        source_repo,
+        &["ls-files", "-z", &plan_path_in_repo.to_string_lossy()],
+    )
+    .map_err(|e| MigrateError::Io(e.to_string()))?;
+    if !output.status.success() {
+        return Err(MigrateError::Subprocess(
+            "git ls-files".to_string(),
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ));
+    }
+    let mut files: Vec<PathBuf> = output
+        .stdout
+        .split(|b| *b == 0)
+        .filter(|s| !s.is_empty())
+        .map(|s| PathBuf::from(std::str::from_utf8(s).unwrap_or("").to_string()))
+        .collect();
+    files.sort();
+    Ok(files)
+}
+
+fn emit_dry_run(format: OutputFormat, report: DryRunReport) -> i32 {
+    match format {
+        OutputFormat::Json => emit_json(&report),
+        OutputFormat::Text => {
+            println!("plan-archive migrate (dry-run)");
+            println!("  plan folder       : {}", report.plan_folder);
+            println!(
+                "  source repo       : {}/{}/{} @ {}",
+                report.source.host,
+                report.source.org_or_group_path,
+                report.source.repo,
+                report.source.branch
+            );
+            println!(
+                "  archive target    : {}",
+                report.archive_target.relative_path
+            );
+            println!(
+                "  archive exists?   : {}",
+                if report.archive_target.exists {
+                    "yes (would refuse on --apply)"
+                } else {
+                    "no"
+                }
+            );
+            println!(
+                "  classification    : {}{}",
+                match report.classification.class {
+                    HostClass::Personal => "personal",
+                    HostClass::Employer => "employer",
+                },
+                report
+                    .classification
+                    .employer
+                    .as_deref()
+                    .map(|e| format!(" ({e})"))
+                    .unwrap_or_default()
+            );
+            println!("  files to copy     : {}", report.files_to_copy.len());
+            for f in &report.files_to_copy {
+                println!("    - {f}");
+            }
+            println!("  refs              :");
+            if let Some(i) = &report.metadata.refs.issue {
+                println!("    issue : {i}");
+            }
+            if let Some(p) = &report.metadata.refs.pr {
+                println!("    pr    : {p}");
+            }
+            if let Some(m) = &report.metadata.refs.mr {
+                println!("    mr    : {m}");
+            }
+            println!("  (no files modified; pass --apply to commit)");
+            exit::SUCCESS
+        }
+    }
+}
+
+fn emit_apply(format: OutputFormat, report: ApplyReport) -> i32 {
+    match format {
+        OutputFormat::Json => emit_json(&report),
+        OutputFormat::Text => {
+            println!("plan-archive migrate (applied)");
+            println!("  plan folder            : {}", report.plan_folder);
+            println!("  archive target         : {}", report.archive_target);
+            println!("  files copied           : {}", report.files_copied);
+            println!("  archive commit         : {}", report.archive_commit);
+            println!(
+                "  source deletion commit : {}",
+                report.source_deletion_commit
+            );
+            exit::SUCCESS
+        }
+    }
+}
+
+fn emit_json<T: Serialize>(data: &T) -> i32 {
+    let envelope = Envelope::success(schema_version_for(BINARY, COMMAND, 1), data);
+    match serde_json::to_string(&envelope) {
+        Ok(s) => {
+            let stdout = std::io::stdout();
+            let mut handle = stdout.lock();
+            if writeln!(handle, "{s}").is_err() {
+                return exit::SOFTWARE;
+            }
+            exit::SUCCESS
+        }
+        Err(_) => exit::SOFTWARE,
+    }
+}
+
+fn emit_error(format: OutputFormat, code: &str, message: &str) -> i32 {
+    match format {
+        OutputFormat::Json => {
+            let envelope: Envelope<()> = Envelope::failure(
+                schema_version_for(BINARY, COMMAND, 1),
+                EnvelopeError::new(code, message),
+            );
+            if let Ok(s) = serde_json::to_string(&envelope) {
+                eprintln!("{s}");
+            }
+            exit::DATA
+        }
+        OutputFormat::Text => {
+            eprintln!("error [{code}]: {message}");
+            exit::DATA
+        }
+    }
+}
+
+// === Apply ===
+
+/// Apply path. Copies files, writes metadata, commits archive,
+/// pushes archive, and on success commits the source-repo deletion.
+fn apply(args: DispatchArgs, report: DryRunReport) -> Result<ApplyReport, MigrateError> {
+    let source_repo = resolve_source_repo(args.source_repo.as_deref())?;
+    let archive = resolve_archive(args.archive.as_deref())?;
+    let plan_path_in_repo = normalise_plan_arg(&args.plan);
+
+    if report.archive_target.exists {
+        return Err(MigrateError::ArchiveTargetExists(
+            report.archive_target.relative_path,
+        ));
+    }
+
+    if has_dirty_plan_folder(&source_repo, &plan_path_in_repo)? {
+        return Err(MigrateError::SourceRepoDirty(
+            plan_path_in_repo.display().to_string(),
+        ));
+    }
+
+    let archive_abs_target = PathBuf::from(&report.archive_target.absolute_path);
+    fs::create_dir_all(&archive_abs_target).map_err(|e| MigrateError::Io(e.to_string()))?;
+
+    let mut copied = 0usize;
+    for rel in &report.files_to_copy {
+        let src = source_repo.join(rel);
+        let rel_from_plan = pathdiff(rel, &plan_path_in_repo);
+        let dest = archive_abs_target.join(rel_from_plan);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).map_err(|e| MigrateError::Io(e.to_string()))?;
+        }
+        fs::copy(&src, &dest).map_err(|e| MigrateError::Io(e.to_string()))?;
+        copied += 1;
+    }
+
+    let metadata_yaml = serde_yaml_ng::to_string(&report.metadata)
+        .map_err(|e| MigrateError::Io(format!("metadata serialize: {e}")))?;
+    let metadata_path = archive_abs_target.join("metadata.yaml");
+    fs::write(&metadata_path, metadata_yaml).map_err(|e| MigrateError::Io(e.to_string()))?;
+
+    // Stage and commit in the archive repo.
+    let stage_args = ["add", "--", &report.archive_target.relative_path];
+    let stage_out = nils_common::git::run_output_in(&archive, &stage_args)
+        .map_err(|e| MigrateError::Io(e.to_string()))?;
+    if !stage_out.status.success() {
+        return Err(MigrateError::Subprocess(
+            "git add (archive)".to_string(),
+            String::from_utf8_lossy(&stage_out.stderr).to_string(),
+        ));
+    }
+
+    let archive_msg = format!(
+        "archive(plan): {}/{}/{} {}",
+        report.source.host, report.source.org_or_group_path, report.source.repo, report.plan_folder
+    );
+    run_semantic_commit(&archive, &archive_msg)?;
+    let archive_commit = head_sha(&archive)?;
+    push_archive(&archive)?;
+
+    // Source-repo deletion phase.
+    let rm_args = [
+        "rm",
+        "-r",
+        "--quiet",
+        "--",
+        &plan_path_in_repo.to_string_lossy(),
+    ];
+    let rm_out = nils_common::git::run_output_in(&source_repo, &rm_args)
+        .map_err(|e| MigrateError::Io(e.to_string()))?;
+    if !rm_out.status.success() {
+        return Err(MigrateError::Subprocess(
+            "git rm (source)".to_string(),
+            String::from_utf8_lossy(&rm_out.stderr).to_string(),
+        ));
+    }
+    let source_msg = format!(
+        "chore(plans): archive {} → agent-plan-archive",
+        report.plan_folder
+    );
+    run_semantic_commit(&source_repo, &source_msg)?;
+    let source_commit = head_sha(&source_repo)?;
+
+    Ok(ApplyReport {
+        plan_folder: report.plan_folder,
+        archive_commit,
+        source_deletion_commit: source_commit,
+        archive_target: report.archive_target.relative_path,
+        files_copied: copied,
+        scrub_log: None,
+    })
+}
+
+fn pathdiff(file_rel_to_repo: &str, plan_path: &Path) -> PathBuf {
+    let prefix = format!("{}/", plan_path.display());
+    PathBuf::from(
+        file_rel_to_repo
+            .strip_prefix(&prefix)
+            .unwrap_or(file_rel_to_repo),
+    )
+}
+
+fn has_dirty_plan_folder(repo: &Path, plan_path: &Path) -> Result<bool, MigrateError> {
+    let out = nils_common::git::run_output_in(
+        repo,
+        &["status", "--porcelain", "--", &plan_path.to_string_lossy()],
+    )
+    .map_err(|e| MigrateError::Io(e.to_string()))?;
+    if !out.status.success() {
+        return Err(MigrateError::Subprocess(
+            "git status".to_string(),
+            String::from_utf8_lossy(&out.stderr).to_string(),
+        ));
+    }
+    Ok(!out.stdout.is_empty())
+}
+
+fn run_semantic_commit(repo: &Path, message: &str) -> Result<(), MigrateError> {
+    let mut child = ProcCommand::new("semantic-commit")
+        .arg("commit")
+        .arg("-m")
+        .arg(message)
+        .arg("--quiet")
+        .arg("--no-summary")
+        .arg("--repo")
+        .arg(repo)
+        .spawn()
+        .map_err(|e| MigrateError::Subprocess("semantic-commit".to_string(), e.to_string()))?;
+    let status = child
+        .wait()
+        .map_err(|e| MigrateError::Subprocess("semantic-commit".to_string(), e.to_string()))?;
+    if !status.success() {
+        return Err(MigrateError::Subprocess(
+            "semantic-commit".to_string(),
+            format!("exit code {:?}", status.code()),
+        ));
+    }
+    Ok(())
+}
+
+fn head_sha(repo: &Path) -> Result<String, MigrateError> {
+    let out = nils_common::git::run_output_in(repo, &["rev-parse", "HEAD"])
+        .map_err(|e| MigrateError::Io(e.to_string()))?;
+    if !out.status.success() {
+        return Err(MigrateError::Subprocess(
+            "git rev-parse".to_string(),
+            String::from_utf8_lossy(&out.stderr).to_string(),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn push_archive(repo: &Path) -> Result<(), MigrateError> {
+    let out = nils_common::git::run_output_in(repo, &["push"])
+        .map_err(|e| MigrateError::Io(e.to_string()))?;
+    if !out.status.success() {
+        return Err(MigrateError::Subprocess(
+            "git push (archive)".to_string(),
+            String::from_utf8_lossy(&out.stderr).to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/plan-archive/src/migrate/path.rs
+++ b/crates/plan-archive/src/migrate/path.rs
@@ -1,0 +1,115 @@
+//! Pure path helpers for the migration pipeline.
+
+use std::path::PathBuf;
+
+/// Build the relative archive target path:
+/// `plans/<host>/<org_or_group_path>/<repo>/<folder_name>/`.
+///
+/// Paths are joined as-is; the host preserves dots, the
+/// org_or_group_path preserves nested GitLab group separators.
+pub fn archive_target_path(
+    host: &str,
+    org_or_group_path: &str,
+    repo: &str,
+    folder_name: &str,
+) -> PathBuf {
+    let mut p = PathBuf::from("plans");
+    p.push(host);
+    for segment in org_or_group_path.split('/').filter(|s| !s.is_empty()) {
+        p.push(segment);
+    }
+    p.push(repo);
+    p.push(folder_name);
+    p
+}
+
+/// Split a plan folder name into its `<YYYY-MM-DD>` prefix (if any)
+/// and the slug remainder. Returns `(None, full_name)` for pre-v1
+/// folders that have no date prefix.
+pub fn parse_plan_folder(folder_name: &str) -> (Option<String>, String) {
+    let mut iter = folder_name.splitn(2, '-');
+    let year = iter.next();
+    let rest = iter.next();
+    if let (Some(y), Some(rest)) = (year, rest)
+        && y.len() == 4
+        && y.chars().all(|c| c.is_ascii_digit())
+    {
+        let mut parts = rest.splitn(2, '-');
+        let month = parts.next();
+        let rest2 = parts.next();
+        if let (Some(m), Some(rest2)) = (month, rest2)
+            && m.len() == 2
+            && m.chars().all(|c| c.is_ascii_digit())
+        {
+            let mut parts = rest2.splitn(2, '-');
+            let day = parts.next();
+            let slug = parts.next();
+            if let (Some(d), Some(slug)) = (day, slug)
+                && d.len() == 2
+                && d.chars().all(|c| c.is_ascii_digit())
+            {
+                return (Some(format!("{y}-{m}-{d}")), slug.to_string());
+            }
+        }
+    }
+    (None, folder_name.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn archive_target_for_github() {
+        let p = archive_target_path(
+            "github.com",
+            "graysurf",
+            "agent-runtime-kit",
+            "2026-05-27-plan-archive-runtime-kit",
+        );
+        assert_eq!(
+            p,
+            PathBuf::from(
+                "plans/github.com/graysurf/agent-runtime-kit/2026-05-27-plan-archive-runtime-kit"
+            )
+        );
+    }
+
+    #[test]
+    fn archive_target_for_nested_gitlab_groups() {
+        let p = archive_target_path(
+            "gitlab.example.com",
+            "acme/platform/backend",
+            "ingest",
+            "2026-04-10-cleanup-pipeline",
+        );
+        assert_eq!(
+            p,
+            PathBuf::from(
+                "plans/gitlab.example.com/acme/platform/backend/ingest/2026-04-10-cleanup-pipeline"
+            )
+        );
+    }
+
+    #[test]
+    fn parse_dated_folder() {
+        let (date, slug) = parse_plan_folder("2026-05-27-plan-archive-runtime-kit");
+        assert_eq!(date.as_deref(), Some("2026-05-27"));
+        assert_eq!(slug, "plan-archive-runtime-kit");
+    }
+
+    #[test]
+    fn parse_pre_v1_folder() {
+        let (date, slug) = parse_plan_folder("skill-lifecycle-management");
+        assert!(date.is_none());
+        assert_eq!(slug, "skill-lifecycle-management");
+    }
+
+    #[test]
+    fn parse_almost_dated_folder() {
+        // Partial date prefix is not enough; treat as pre-v1 slug.
+        let (date, slug) = parse_plan_folder("2026-something-else");
+        assert!(date.is_none());
+        assert_eq!(slug, "2026-something-else");
+    }
+}

--- a/crates/plan-archive/src/query/index.rs
+++ b/crates/plan-archive/src/query/index.rs
@@ -1,0 +1,166 @@
+//! Walk the `_index/` tree and reconstruct ref identities from
+//! snapshot directory paths.
+
+use std::path::{Path, PathBuf};
+
+use crate::refresh::refparse::RefKind;
+
+/// A ref folder discovered under `_index/`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexEntry {
+    pub host: String,
+    pub org_or_group_path: String,
+    pub repo: String,
+    pub kind: RefKind,
+    pub number: u64,
+}
+
+impl IndexEntry {
+    /// Snapshot directory relative to the archive root.
+    pub fn index_dir(&self) -> PathBuf {
+        let mut p = PathBuf::from("_index");
+        p.push(&self.host);
+        for segment in self.org_or_group_path.split('/').filter(|s| !s.is_empty()) {
+            p.push(segment);
+        }
+        p.push(&self.repo);
+        p.push(self.kind.index_segment());
+        p.push(self.number.to_string());
+        p
+    }
+
+    /// Canonical provider URL for the ref.
+    pub fn canonical_url(&self) -> String {
+        let segment = match self.kind {
+            RefKind::Issue => "issues",
+            RefKind::Pull => "pull",
+            RefKind::MergeRequest => "-/merge_requests",
+        };
+        format!(
+            "https://{}/{}/{}/{}/{}",
+            self.host, self.org_or_group_path, self.repo, segment, self.number
+        )
+    }
+}
+
+/// Parse an `_index/`-relative path
+/// (`<host>/<org…>/<repo>/<kind>/<number>`) into an [`IndexEntry`].
+/// The kind segment (`issues`/`pulls`/`merge_requests`) splits the
+/// org/repo head from the number tail.
+pub fn parse_index_path(rel: &Path) -> Option<IndexEntry> {
+    let segments: Vec<String> = rel
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().to_string())
+        .collect();
+    // Need at least host, org, repo, kind, number.
+    if segments.len() < 5 {
+        return None;
+    }
+    // Locate the kind keyword from the tail (second-to-last).
+    let number: u64 = segments.last()?.parse().ok()?;
+    let kind = match segments[segments.len() - 2].as_str() {
+        "issues" => RefKind::Issue,
+        "pulls" => RefKind::Pull,
+        "merge_requests" => RefKind::MergeRequest,
+        _ => return None,
+    };
+    let head = &segments[..segments.len() - 2];
+    if head.len() < 3 {
+        return None;
+    }
+    let host = head[0].clone();
+    let repo = head[head.len() - 1].clone();
+    let org_or_group_path = head[1..head.len() - 1].join("/");
+    if org_or_group_path.is_empty() {
+        return None;
+    }
+    Some(IndexEntry {
+        host,
+        org_or_group_path,
+        repo,
+        kind,
+        number,
+    })
+}
+
+/// Walk an `_index/` root and return every ref folder found. A ref
+/// folder is a directory whose path matches the
+/// `<host>/<org…>/<repo>/<kind>/<number>` shape.
+pub fn walk_index(index_root: &Path) -> std::io::Result<Vec<IndexEntry>> {
+    let mut out = Vec::new();
+    if !index_root.is_dir() {
+        return Ok(out);
+    }
+    let mut stack = vec![index_root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let rel = path.strip_prefix(index_root).unwrap_or(&path);
+            if let Some(index_entry) = parse_index_path(rel) {
+                out.push(index_entry);
+                // A number folder is a leaf; do not descend further.
+            } else {
+                stack.push(path);
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_github_issue_path() {
+        let e = parse_index_path(Path::new(
+            "github.com/graysurf/agent-runtime-kit/issues/126",
+        ))
+        .unwrap();
+        assert_eq!(e.host, "github.com");
+        assert_eq!(e.org_or_group_path, "graysurf");
+        assert_eq!(e.repo, "agent-runtime-kit");
+        assert_eq!(e.kind, RefKind::Issue);
+        assert_eq!(e.number, 126);
+    }
+
+    #[test]
+    fn parses_nested_gitlab_mr_path() {
+        let e = parse_index_path(Path::new(
+            "gitlab.example.com/acme/platform/ingest/merge_requests/42",
+        ))
+        .unwrap();
+        assert_eq!(e.org_or_group_path, "acme/platform");
+        assert_eq!(e.repo, "ingest");
+        assert_eq!(e.kind, RefKind::MergeRequest);
+        assert_eq!(e.number, 42);
+    }
+
+    #[test]
+    fn round_trips_index_dir() {
+        let e = IndexEntry {
+            host: "github.com".into(),
+            org_or_group_path: "sympoies".into(),
+            repo: "nils-cli".into(),
+            kind: RefKind::Pull,
+            number: 574,
+        };
+        let dir = e.index_dir();
+        let rel = dir.strip_prefix("_index").unwrap();
+        assert_eq!(parse_index_path(rel).unwrap(), e);
+    }
+
+    #[test]
+    fn rejects_non_numeric_tail() {
+        assert!(parse_index_path(Path::new("github.com/org/repo/issues/x")).is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_kind() {
+        assert!(parse_index_path(Path::new("github.com/org/repo/wikis/1")).is_none());
+    }
+}

--- a/crates/plan-archive/src/query/mod.rs
+++ b/crates/plan-archive/src/query/mod.rs
@@ -1,0 +1,455 @@
+//! `plan-archive query` — read and aggregate `_index/` snapshots and
+//! traverse archived-plan ↔ ref links.
+//!
+//! Sprint 5 of Plan 1. Query is read-only: it never fetches, never
+//! writes, and never commits. Three modes, mutually exclusive at the
+//! CLI:
+//!
+//! - single-ref (`--ref`): latest snapshot for one issue/PR/MR.
+//! - aggregate (`--host`/`--org`/`--repo`/`--since`): every matching
+//!   ref's latest snapshot.
+//! - link traversal (`--plan` / `--refs-from`): the refs an archived
+//!   plan points at, each resolved to its latest snapshot.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use nils_common::cli_contract::{Envelope, EnvelopeError, OutputFormat, exit, schema_version_for};
+use serde::Serialize;
+
+use crate::refresh::refparse::{RefKind, parse_ref_url};
+
+pub mod index;
+
+pub use index::{IndexEntry, parse_index_path};
+
+const COMMAND: &str = "query";
+const BINARY: &str = "plan-archive";
+
+/// Args forwarded from `cli::run`.
+pub struct DispatchArgs {
+    pub r#ref: Option<String>,
+    pub host: Option<String>,
+    pub org: Option<String>,
+    pub repo: Option<String>,
+    pub since: Option<String>,
+    pub plan: Option<String>,
+    pub refs_from: Option<String>,
+    pub archive: Option<PathBuf>,
+    pub format: OutputFormat,
+}
+
+/// A single snapshot record returned by a query.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SnapshotRecord {
+    pub r#ref: String,
+    pub host: String,
+    pub org_or_group_path: String,
+    pub repo: String,
+    pub kind: RefKind,
+    pub number: u64,
+    /// Latest snapshot path relative to the archive root, or `None`
+    /// when the ref folder exists in a link but has no snapshots yet.
+    pub latest_snapshot: Option<String>,
+    /// `fetched_at` in ISO8601 (with colons), derived from the
+    /// latest snapshot filename. `None` when no snapshots exist.
+    pub fetched_at: Option<String>,
+}
+
+/// Top-level query result envelope payload.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum QueryResult {
+    SingleRef {
+        record: SnapshotRecord,
+    },
+    Aggregate {
+        records: Vec<SnapshotRecord>,
+    },
+    PlanLink {
+        plan: String,
+        records: Vec<SnapshotRecord>,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum QueryError {
+    #[error("no query selector supplied; pass `--ref`, a filter, `--plan`, or `--refs-from`")]
+    NoSelector,
+    #[error("`--ref` value `{0}` is not a parseable issue/PR/MR URL")]
+    UnparseableRef(String),
+    #[error("archive clone path not found at `{0}`")]
+    ArchiveCloneMissing(PathBuf),
+    #[error("invalid `--since` value `{0}`; expected YYYY-MM-DD")]
+    InvalidSince(String),
+    #[error("metadata file `{0}` not found")]
+    MetadataNotFound(String),
+    #[error("failed to read metadata `{0}`: {1}")]
+    MetadataReadFailed(String, String),
+    #[error("metadata `{0}` carries no refs to traverse")]
+    MetadataNoRefs(String),
+    #[error("io error during query: {0}")]
+    Io(String),
+}
+
+impl QueryError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            QueryError::NoSelector => "query-no-selector",
+            QueryError::UnparseableRef(_) => "query-unparseable-ref",
+            QueryError::ArchiveCloneMissing(_) => "query-archive-clone-missing",
+            QueryError::InvalidSince(_) => "query-invalid-since",
+            QueryError::MetadataNotFound(_) => "query-metadata-not-found",
+            QueryError::MetadataReadFailed(_, _) => "query-metadata-read-failed",
+            QueryError::MetadataNoRefs(_) => "query-metadata-no-refs",
+            QueryError::Io(_) => "query-io-error",
+        }
+    }
+}
+
+/// Entry point from `cli::run`.
+pub fn dispatch(args: DispatchArgs) -> i32 {
+    let format = args.format;
+    match run(&args) {
+        Ok(result) => emit(format, &result),
+        Err(err) => emit_error(format, err.code(), &err.to_string()),
+    }
+}
+
+/// Core read-only routine.
+pub fn run(args: &DispatchArgs) -> Result<QueryResult, QueryError> {
+    let archive = resolve_archive(args.archive.as_deref())?;
+
+    if let Some(ref_url) = &args.r#ref {
+        let target =
+            parse_ref_url(ref_url).ok_or_else(|| QueryError::UnparseableRef(ref_url.clone()))?;
+        let entry = IndexEntry {
+            host: target.host,
+            org_or_group_path: target.org_or_group_path,
+            repo: target.repo,
+            kind: target.kind,
+            number: target.number,
+        };
+        let record = record_for(&archive, &entry);
+        return Ok(QueryResult::SingleRef { record });
+    }
+
+    if let Some(plan) = &args.plan {
+        let metadata_path = archive.join(plan).join("metadata.yaml");
+        let records = traverse_metadata(&archive, &metadata_path, plan)?;
+        return Ok(QueryResult::PlanLink {
+            plan: plan.clone(),
+            records,
+        });
+    }
+
+    if let Some(refs_from) = &args.refs_from {
+        let metadata_path = PathBuf::from(refs_from);
+        let records = traverse_metadata(&archive, &metadata_path, refs_from)?;
+        return Ok(QueryResult::PlanLink {
+            plan: refs_from.clone(),
+            records,
+        });
+    }
+
+    // Aggregate mode (filters, all optional).
+    if args.host.is_some() || args.org.is_some() || args.repo.is_some() || args.since.is_some() {
+        if let Some(since) = &args.since {
+            validate_since(since)?;
+        }
+        let records = aggregate(&archive, args)?;
+        return Ok(QueryResult::Aggregate { records });
+    }
+
+    Err(QueryError::NoSelector)
+}
+
+fn record_for(archive: &Path, entry: &IndexEntry) -> SnapshotRecord {
+    let dir = archive.join(entry.index_dir());
+    let (latest_snapshot, fetched_at) = latest_snapshot_in(&dir, entry);
+    SnapshotRecord {
+        r#ref: entry.canonical_url(),
+        host: entry.host.clone(),
+        org_or_group_path: entry.org_or_group_path.clone(),
+        repo: entry.repo.clone(),
+        kind: entry.kind,
+        number: entry.number,
+        latest_snapshot,
+        fetched_at,
+    }
+}
+
+/// Find the lexically-last `*.json` snapshot in `dir`, returning its
+/// archive-relative path and decoded `fetched_at`.
+fn latest_snapshot_in(dir: &Path, _entry: &IndexEntry) -> (Option<String>, Option<String>) {
+    let Ok(read) = fs::read_dir(dir) else {
+        return (None, None);
+    };
+    let mut stamps: Vec<String> = read
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| n.ends_with(".json"))
+        .collect();
+    stamps.sort();
+    let Some(latest) = stamps.last() else {
+        return (None, None);
+    };
+    let stamp = latest.trim_end_matches(".json");
+    let fetched_at = decode_basic_stamp(stamp);
+    let rel = dir.join(latest);
+    (Some(rel.display().to_string()), fetched_at)
+}
+
+/// Decode a basic-format `YYYYMMDDThhmmssZ` stamp back into an
+/// extended ISO8601 `YYYY-MM-DDThh:mm:ssZ`. Returns the raw stamp
+/// when it does not match the expected shape.
+pub fn decode_basic_stamp(stamp: &str) -> Option<String> {
+    let bytes = stamp.as_bytes();
+    if bytes.len() == 16 && bytes[8] == b'T' && bytes[15] == b'Z' {
+        let digits =
+            |range: std::ops::Range<usize>| stamp[range].chars().all(|c| c.is_ascii_digit());
+        if digits(0..8) && digits(9..15) {
+            return Some(format!(
+                "{}-{}-{}T{}:{}:{}Z",
+                &stamp[0..4],
+                &stamp[4..6],
+                &stamp[6..8],
+                &stamp[9..11],
+                &stamp[11..13],
+                &stamp[13..15],
+            ));
+        }
+    }
+    Some(stamp.to_string())
+}
+
+fn aggregate(archive: &Path, args: &DispatchArgs) -> Result<Vec<SnapshotRecord>, QueryError> {
+    let index_root = archive.join("_index");
+    let entries = index::walk_index(&index_root).map_err(|e| QueryError::Io(e.to_string()))?;
+    let mut records = Vec::new();
+    for entry in entries {
+        if let Some(h) = &args.host
+            && &entry.host != h
+        {
+            continue;
+        }
+        if let Some(o) = &args.org
+            && &entry.org_or_group_path != o
+        {
+            continue;
+        }
+        if let Some(r) = &args.repo
+            && &entry.repo != r
+        {
+            continue;
+        }
+        let record = record_for(archive, &entry);
+        if let Some(since) = &args.since {
+            // Compare basic stamps lexically: derive the latest
+            // stamp from the record's fetched_at.
+            match &record.fetched_at {
+                Some(fetched) if iso_date_part(fetched) >= *since => {}
+                _ => continue,
+            }
+        }
+        records.push(record);
+    }
+    records.sort_by(|a, b| {
+        (&a.host, &a.org_or_group_path, &a.repo, a.number).cmp(&(
+            &b.host,
+            &b.org_or_group_path,
+            &b.repo,
+            b.number,
+        ))
+    });
+    Ok(records)
+}
+
+fn iso_date_part(iso: &str) -> String {
+    iso.split('T').next().unwrap_or(iso).to_string()
+}
+
+fn traverse_metadata(
+    archive: &Path,
+    metadata_path: &Path,
+    label: &str,
+) -> Result<Vec<SnapshotRecord>, QueryError> {
+    if !metadata_path.is_file() {
+        return Err(QueryError::MetadataNotFound(label.to_string()));
+    }
+    let raw = fs::read_to_string(metadata_path)
+        .map_err(|e| QueryError::MetadataReadFailed(label.to_string(), e.to_string()))?;
+    let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(&raw)
+        .map_err(|e| QueryError::MetadataReadFailed(label.to_string(), e.to_string()))?;
+
+    let refs = value.get("refs");
+    let mut urls = Vec::new();
+    if let Some(refs) = refs {
+        for key in ["issue", "pr", "mr"] {
+            if let Some(v) = refs.get(key).and_then(|v| v.as_str()) {
+                urls.push(v.to_string());
+            }
+        }
+    }
+    if urls.is_empty() {
+        return Err(QueryError::MetadataNoRefs(label.to_string()));
+    }
+
+    let mut records = Vec::new();
+    for url in urls {
+        if let Some(target) = parse_ref_url(&url) {
+            let entry = IndexEntry {
+                host: target.host,
+                org_or_group_path: target.org_or_group_path,
+                repo: target.repo,
+                kind: target.kind,
+                number: target.number,
+            };
+            records.push(record_for(archive, &entry));
+        }
+    }
+    Ok(records)
+}
+
+fn validate_since(s: &str) -> Result<(), QueryError> {
+    let parts: Vec<&str> = s.split('-').collect();
+    let ok = parts.len() == 3
+        && parts[0].len() == 4
+        && parts[1].len() == 2
+        && parts[2].len() == 2
+        && parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit()));
+    if ok {
+        Ok(())
+    } else {
+        Err(QueryError::InvalidSince(s.to_string()))
+    }
+}
+
+fn resolve_archive(arg: Option<&Path>) -> Result<PathBuf, QueryError> {
+    let candidate = match arg {
+        Some(p) => p.to_path_buf(),
+        None => default_archive_clone_path()?,
+    };
+    if !candidate.is_dir() {
+        return Err(QueryError::ArchiveCloneMissing(candidate));
+    }
+    Ok(candidate)
+}
+
+fn default_archive_clone_path() -> Result<PathBuf, QueryError> {
+    let local = crate::validate::local::validate_local_path(&local_config_path())
+        .map_err(|e| QueryError::Io(e.to_string()))?;
+    Ok(local.data.config.archive_clone_path)
+}
+
+fn local_config_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("PLAN_ARCHIVE_LOCAL_CONFIG") {
+        return PathBuf::from(p);
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        return PathBuf::from(xdg)
+            .join("agent-plan-archive")
+            .join("config.yaml");
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join(".config")
+            .join("agent-plan-archive")
+            .join("config.yaml");
+    }
+    PathBuf::from("/nonexistent/agent-plan-archive/config.yaml")
+}
+
+fn emit(format: OutputFormat, result: &QueryResult) -> i32 {
+    match format {
+        OutputFormat::Json => {
+            let envelope = Envelope::success(schema_version_for(BINARY, COMMAND, 1), result);
+            match serde_json::to_string(&envelope) {
+                Ok(s) => {
+                    println!("{s}");
+                    exit::SUCCESS
+                }
+                Err(_) => exit::SOFTWARE,
+            }
+        }
+        OutputFormat::Text => {
+            match result {
+                QueryResult::SingleRef { record } => print_record(record),
+                QueryResult::Aggregate { records } => {
+                    if records.is_empty() {
+                        println!("no matching snapshots");
+                    }
+                    for r in records {
+                        print_record(r);
+                    }
+                }
+                QueryResult::PlanLink { plan, records } => {
+                    println!("plan {plan} → {} ref(s)", records.len());
+                    for r in records {
+                        print_record(r);
+                    }
+                }
+            }
+            exit::SUCCESS
+        }
+    }
+}
+
+fn print_record(r: &SnapshotRecord) {
+    match (&r.latest_snapshot, &r.fetched_at) {
+        (Some(path), Some(at)) => {
+            println!("{}  fetched_at={}  {}", r.r#ref, at, path);
+        }
+        _ => {
+            println!("{}  (no snapshots)", r.r#ref);
+        }
+    }
+}
+
+fn emit_error(format: OutputFormat, code: &str, message: &str) -> i32 {
+    match format {
+        OutputFormat::Json => {
+            let envelope: Envelope<()> = Envelope::failure(
+                schema_version_for(BINARY, COMMAND, 1),
+                EnvelopeError::new(code, message),
+            );
+            if let Ok(s) = serde_json::to_string(&envelope) {
+                eprintln!("{s}");
+            }
+            exit::DATA
+        }
+        OutputFormat::Text => {
+            eprintln!("error [{code}]: {message}");
+            exit::DATA
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_stamp_extended() {
+        assert_eq!(
+            decode_basic_stamp("20260527T013045Z").as_deref(),
+            Some("2026-05-27T01:30:45Z")
+        );
+    }
+
+    #[test]
+    fn decode_stamp_passthrough_on_garbage() {
+        assert_eq!(decode_basic_stamp("weird").as_deref(), Some("weird"));
+    }
+
+    #[test]
+    fn since_validation() {
+        assert!(validate_since("2026-05-27").is_ok());
+        assert!(validate_since("2026-5-7").is_err());
+    }
+
+    #[test]
+    fn iso_date_part_splits_on_t() {
+        assert_eq!(iso_date_part("2026-05-27T01:30:45Z"), "2026-05-27");
+    }
+}

--- a/crates/plan-archive/src/refresh/forge.rs
+++ b/crates/plan-archive/src/refresh/forge.rs
@@ -1,0 +1,225 @@
+//! forge-cli integration for `plan-archive refresh`.
+//!
+//! All provider API access is delegated to the released `forge-cli`
+//! binary; no auth or host endpoint config lives here. The
+//! [`ForgeFetcher`] trait is the injection seam that lets tests stub
+//! the provider without a network.
+
+use std::process::Command;
+
+use super::refparse::{RefKind, RefTarget, parse_ref_url};
+
+/// Fetch provider payloads. Implemented by [`RealForge`] in
+/// production and by stubs in tests.
+pub trait ForgeFetcher {
+    /// Fetch the raw JSON payload for a single ref.
+    fn fetch_payload(&self, target: &RefTarget) -> Result<String, String>;
+
+    /// List open refs for `host/org/repo`, optionally limited to
+    /// those updated on or after `since` (`YYYY-MM-DD`).
+    fn list_open_refs(
+        &self,
+        host: &str,
+        org: &str,
+        repo: &str,
+        since: Option<&str>,
+    ) -> Result<Vec<RefTarget>, String>;
+}
+
+/// Real backend that shells out to `forge-cli`.
+pub struct RealForge {
+    binary: String,
+}
+
+impl RealForge {
+    /// Build from the environment. Honours `PLAN_ARCHIVE_FORGE_CLI`
+    /// so a wrapper or test harness can redirect the binary.
+    pub fn from_env() -> Self {
+        let binary =
+            std::env::var("PLAN_ARCHIVE_FORGE_CLI").unwrap_or_else(|_| "forge-cli".to_string());
+        Self { binary }
+    }
+
+    fn provider_for(host: &str) -> &'static str {
+        if host == "github.com" {
+            "github"
+        } else {
+            // Every non-github host is treated as a GitLab instance;
+            // forge-cli owns the actual endpoint resolution.
+            "gitlab"
+        }
+    }
+}
+
+impl ForgeFetcher for RealForge {
+    fn fetch_payload(&self, target: &RefTarget) -> Result<String, String> {
+        let provider = Self::provider_for(&target.host);
+        let repo_slug = format!("{}/{}", target.org_or_group_path, target.repo);
+        let number = target.number.to_string();
+        let subcommand = match target.kind {
+            RefKind::Issue => "issue",
+            RefKind::Pull | RefKind::MergeRequest => "pr",
+        };
+        let args = [
+            "--provider",
+            provider,
+            "--repo",
+            &repo_slug,
+            "--format",
+            "json",
+            subcommand,
+            "view",
+            &number,
+            "--with-comments",
+        ];
+        let out = Command::new(&self.binary)
+            .args(args)
+            .output()
+            .map_err(|e| format!("spawn {}: {e}", self.binary))?;
+        if !out.status.success() {
+            return Err(format!(
+                "forge-cli exited {:?}: {}",
+                out.status.code(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            ));
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).to_string())
+    }
+
+    fn list_open_refs(
+        &self,
+        host: &str,
+        org: &str,
+        repo: &str,
+        since: Option<&str>,
+    ) -> Result<Vec<RefTarget>, String> {
+        let provider = Self::provider_for(host);
+        let repo_slug = format!("{org}/{repo}");
+        let mut targets = Vec::new();
+        for (subcommand, _kind) in [("issue", RefKind::Issue), ("pr", RefKind::Pull)] {
+            let mut args = vec![
+                "--provider".to_string(),
+                provider.to_string(),
+                "--repo".to_string(),
+                repo_slug.clone(),
+                "--format".to_string(),
+                "json".to_string(),
+                subcommand.to_string(),
+                "list".to_string(),
+                "--state".to_string(),
+                "open".to_string(),
+            ];
+            if let Some(since) = since {
+                args.push("--since".to_string());
+                args.push(since.to_string());
+            }
+            let out = Command::new(&self.binary)
+                .args(&args)
+                .output()
+                .map_err(|e| format!("spawn {}: {e}", self.binary))?;
+            if !out.status.success() {
+                return Err(format!(
+                    "forge-cli {subcommand} list exited {:?}: {}",
+                    out.status.code(),
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ));
+            }
+            let body = String::from_utf8_lossy(&out.stdout);
+            targets.extend(parse_listing(&body, host, org, repo, subcommand));
+        }
+        Ok(targets)
+    }
+}
+
+/// Parse a `forge-cli … list` JSON envelope into ref targets. The
+/// envelope shape is `{ data: { items: [{ number, url, … }] } }`;
+/// we read `url` when present (authoritative) and fall back to
+/// reconstructing from `number`.
+fn parse_listing(
+    body: &str,
+    host: &str,
+    org: &str,
+    repo: &str,
+    subcommand: &str,
+) -> Vec<RefTarget> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return Vec::new();
+    };
+    let items = value
+        .get("data")
+        .and_then(|d| {
+            d.get("items")
+                .or_else(|| d.get("issues"))
+                .or_else(|| d.get("pulls"))
+        })
+        .or_else(|| value.get("items"))
+        .and_then(|i| i.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut out = Vec::new();
+    for item in items {
+        if let Some(url) = item.get("url").and_then(|u| u.as_str())
+            && let Some(target) = parse_ref_url(url)
+        {
+            out.push(target);
+            continue;
+        }
+        if let Some(number) = item.get("number").and_then(|n| n.as_u64()) {
+            let kind = if subcommand == "issue" {
+                RefKind::Issue
+            } else if host == "github.com" {
+                RefKind::Pull
+            } else {
+                RefKind::MergeRequest
+            };
+            out.push(RefTarget {
+                host: host.to_string(),
+                org_or_group_path: org.to_string(),
+                repo: repo.to_string(),
+                kind,
+                number,
+            });
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_mapping() {
+        assert_eq!(RealForge::provider_for("github.com"), "github");
+        assert_eq!(RealForge::provider_for("gitlab.com"), "gitlab");
+        assert_eq!(RealForge::provider_for("gitlab.example.com"), "gitlab");
+    }
+
+    #[test]
+    fn listing_reads_url_field() {
+        let body = r#"{"data":{"items":[
+            {"number":1,"url":"https://github.com/org/repo/issues/1"},
+            {"number":2,"url":"https://github.com/org/repo/issues/2"}
+        ]}}"#;
+        let targets = parse_listing(body, "github.com", "org", "repo", "issue");
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0].number, 1);
+        assert_eq!(targets[0].kind, RefKind::Issue);
+    }
+
+    #[test]
+    fn listing_falls_back_to_number() {
+        let body = r#"{"data":{"items":[{"number":9}]}}"#;
+        let targets = parse_listing(body, "gitlab.example.com", "g/p", "ingest", "pr");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].kind, RefKind::MergeRequest);
+        assert_eq!(targets[0].number, 9);
+        assert_eq!(targets[0].org_or_group_path, "g/p");
+    }
+
+    #[test]
+    fn listing_empty_on_garbage() {
+        assert!(parse_listing("not json", "github.com", "o", "r", "issue").is_empty());
+    }
+}

--- a/crates/plan-archive/src/refresh/mod.rs
+++ b/crates/plan-archive/src/refresh/mod.rs
@@ -1,0 +1,451 @@
+//! `plan-archive refresh` — fetch provider payloads through forge-cli
+//! and append scrubbed, append-only snapshots to `_index/`.
+//!
+//! Sprint 4 of Plan 1. Refresh writes and scrubs but never commits:
+//! the snapshot constraint requires that any emitted `.scrub.log` is
+//! reviewed before the snapshot is committed, so the commit is left
+//! to the wrapping skill / user.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use nils_common::cli_contract::{Envelope, EnvelopeError, OutputFormat, exit, schema_version_for};
+use serde::Serialize;
+
+use crate::scrub;
+use crate::validate;
+use crate::validate::hosts::{HostsConfig, validate_hosts_yaml};
+
+pub mod forge;
+pub mod refparse;
+
+pub use forge::{ForgeFetcher, RealForge};
+pub use refparse::{RefKind, RefTarget, parse_ref_url};
+
+const COMMAND: &str = "refresh";
+const BINARY: &str = "plan-archive";
+
+/// Args forwarded from `cli::run`.
+pub struct DispatchArgs {
+    pub r#ref: Option<String>,
+    pub repo: Option<String>,
+    pub since: Option<String>,
+    pub archive: Option<PathBuf>,
+    pub hosts: Option<PathBuf>,
+    pub format: OutputFormat,
+}
+
+/// Per-ref refresh outcome.
+#[derive(Debug, Clone, Serialize)]
+pub struct SnapshotResult {
+    pub r#ref: String,
+    pub snapshot_path: String,
+    pub scrub_log_path: Option<String>,
+    pub redaction_count: usize,
+    pub requires_review: bool,
+}
+
+/// One ref that failed inside a batch without aborting the batch.
+#[derive(Debug, Clone, Serialize)]
+pub struct FailedRef {
+    pub r#ref: String,
+    pub code: String,
+    pub message: String,
+}
+
+/// Aggregate refresh report.
+#[derive(Debug, Clone, Serialize)]
+pub struct RefreshReport {
+    pub snapshots: Vec<SnapshotResult>,
+    pub failed: Vec<FailedRef>,
+    pub requires_review: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RefreshError {
+    #[error("one of `--ref` or `--repo` is required")]
+    NoSelector,
+    #[error("`--ref` value `{0}` is not a parseable issue/PR/MR URL")]
+    UnparseableRef(String),
+    #[error("`--repo` value `{0}` must be `host/org/repo`")]
+    UnparseableRepo(String),
+    #[error("archive clone path not found at `{0}`")]
+    ArchiveCloneMissing(PathBuf),
+    #[error("`{0}` is not a recognised provider host in the archive `config/hosts.yaml`")]
+    UnknownHost(String),
+    #[error("failed to load archive `config/hosts.yaml`: {0}")]
+    HostsLoadFailed(String),
+    #[error("failed to parse archive `config/hosts.yaml`: {0}")]
+    HostsParseFailed(String),
+    #[error("forge-cli fetch failed for `{0}`: {1}")]
+    ForgeFetchFailed(String, String),
+    #[error("invalid `--since` value `{0}`; expected YYYY-MM-DD")]
+    InvalidSince(String),
+    #[error("io error during refresh: {0}")]
+    Io(String),
+}
+
+impl RefreshError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            RefreshError::NoSelector => "refresh-no-selector",
+            RefreshError::UnparseableRef(_) => "refresh-unparseable-ref",
+            RefreshError::UnparseableRepo(_) => "refresh-unparseable-repo",
+            RefreshError::ArchiveCloneMissing(_) => "refresh-archive-clone-missing",
+            RefreshError::UnknownHost(_) => "refresh-unknown-host",
+            RefreshError::HostsLoadFailed(_) => "refresh-hosts-load-failed",
+            RefreshError::HostsParseFailed(_) => "refresh-hosts-parse-failed",
+            RefreshError::ForgeFetchFailed(_, _) => "refresh-forge-fetch-failed",
+            RefreshError::InvalidSince(_) => "refresh-invalid-since",
+            RefreshError::Io(_) => "refresh-io-error",
+        }
+    }
+}
+
+/// Entry point from `cli::run`. Uses the real forge-cli backend.
+pub fn dispatch(args: DispatchArgs) -> i32 {
+    let format = args.format;
+    let fetcher = RealForge::from_env();
+    let clock = SystemClock;
+    match run(&args, &fetcher, &clock) {
+        Ok(report) => emit(format, report),
+        Err(err) => emit_error(format, err.code(), &err.to_string()),
+    }
+}
+
+/// Abstracted clock so snapshot file names are deterministic in
+/// tests.
+pub trait Clock {
+    /// Basic-format UTC ISO8601 with no colons, e.g.
+    /// `20260527T013045Z`.
+    fn now_basic_utc(&self) -> String;
+}
+
+/// Wall-clock implementation.
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_basic_utc(&self) -> String {
+        // Avoid a chrono dependency: derive a UTC basic timestamp
+        // from the system clock.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        format_unix_basic_utc(now)
+    }
+}
+
+/// Core, testable refresh routine. The fetcher and clock are
+/// injected so unit tests can stub forge-cli and freeze time.
+pub fn run<F: ForgeFetcher, C: Clock>(
+    args: &DispatchArgs,
+    fetcher: &F,
+    clock: &C,
+) -> Result<RefreshReport, RefreshError> {
+    let archive = resolve_archive(args.archive.as_deref())?;
+    let hosts_path = args
+        .hosts
+        .clone()
+        .unwrap_or_else(|| archive.join("config").join("hosts.yaml"));
+    let hosts = load_hosts(&hosts_path)?;
+
+    let targets = resolve_targets(args, fetcher, &hosts)?;
+
+    let mut snapshots = Vec::new();
+    let mut failed = Vec::new();
+    for target in targets {
+        match refresh_one(&archive, &hosts, fetcher, clock, &target) {
+            Ok(snap) => snapshots.push(snap),
+            Err(err) => failed.push(FailedRef {
+                r#ref: target.canonical_url(),
+                code: err.code().to_string(),
+                message: err.to_string(),
+            }),
+        }
+    }
+
+    let requires_review = snapshots.iter().any(|s| s.requires_review);
+    Ok(RefreshReport {
+        snapshots,
+        failed,
+        requires_review,
+    })
+}
+
+fn resolve_targets<F: ForgeFetcher>(
+    args: &DispatchArgs,
+    fetcher: &F,
+    hosts: &HostsConfig,
+) -> Result<Vec<RefTarget>, RefreshError> {
+    if let Some(ref_url) = &args.r#ref {
+        let target =
+            parse_ref_url(ref_url).ok_or_else(|| RefreshError::UnparseableRef(ref_url.clone()))?;
+        ensure_known_host(hosts, &target.host)?;
+        return Ok(vec![target]);
+    }
+
+    if let Some(repo) = &args.repo {
+        let (host, org, repo_name) =
+            parse_repo_triple(repo).ok_or_else(|| RefreshError::UnparseableRepo(repo.clone()))?;
+        ensure_known_host(hosts, &host)?;
+        if let Some(since) = &args.since {
+            validate_since(since)?;
+        }
+        let listed = fetcher
+            .list_open_refs(&host, &org, &repo_name, args.since.as_deref())
+            .map_err(|e| RefreshError::ForgeFetchFailed(repo.clone(), e))?;
+        return Ok(listed);
+    }
+
+    Err(RefreshError::NoSelector)
+}
+
+fn refresh_one<F: ForgeFetcher, C: Clock>(
+    archive: &Path,
+    _hosts: &HostsConfig,
+    fetcher: &F,
+    clock: &C,
+    target: &RefTarget,
+) -> Result<SnapshotResult, RefreshError> {
+    let payload = fetcher
+        .fetch_payload(target)
+        .map_err(|e| RefreshError::ForgeFetchFailed(target.canonical_url(), e))?;
+
+    let scrubbed = scrub::scrub_text(&payload);
+
+    let dir = archive.join(target.index_dir());
+    fs::create_dir_all(&dir).map_err(|e| RefreshError::Io(e.to_string()))?;
+    let stamp = clock.now_basic_utc();
+    let snapshot_path = dir.join(format!("{stamp}.json"));
+    fs::write(&snapshot_path, scrubbed.redacted.as_bytes())
+        .map_err(|e| RefreshError::Io(e.to_string()))?;
+
+    let scrub_log_path = if scrubbed.matches.is_empty() {
+        None
+    } else {
+        let log_path = dir.join(format!("{stamp}.scrub.log"));
+        scrub::write_log_if_any(&log_path, &scrubbed.matches)
+            .map_err(|e| RefreshError::Io(e.to_string()))?;
+        Some(log_path.display().to_string())
+    };
+
+    let redaction_count = scrubbed.matches.len();
+    Ok(SnapshotResult {
+        r#ref: target.canonical_url(),
+        snapshot_path: snapshot_path.display().to_string(),
+        scrub_log_path,
+        redaction_count,
+        requires_review: redaction_count > 0,
+    })
+}
+
+fn ensure_known_host(hosts: &HostsConfig, host: &str) -> Result<(), RefreshError> {
+    if hosts.hosts.contains_key(host) {
+        Ok(())
+    } else {
+        Err(RefreshError::UnknownHost(host.to_string()))
+    }
+}
+
+fn parse_repo_triple(s: &str) -> Option<(String, String, String)> {
+    let mut segments: Vec<&str> = s.split('/').filter(|p| !p.is_empty()).collect();
+    if segments.len() < 3 {
+        return None;
+    }
+    let repo = segments.pop()?.to_string();
+    let host = segments.remove(0).to_string();
+    let org = segments.join("/");
+    if host.is_empty() || org.is_empty() {
+        return None;
+    }
+    Some((host, org, repo))
+}
+
+fn validate_since(s: &str) -> Result<(), RefreshError> {
+    let parts: Vec<&str> = s.split('-').collect();
+    let ok = parts.len() == 3
+        && parts[0].len() == 4
+        && parts[1].len() == 2
+        && parts[2].len() == 2
+        && parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit()));
+    if ok {
+        Ok(())
+    } else {
+        Err(RefreshError::InvalidSince(s.to_string()))
+    }
+}
+
+fn resolve_archive(arg: Option<&Path>) -> Result<PathBuf, RefreshError> {
+    let candidate = match arg {
+        Some(p) => p.to_path_buf(),
+        None => default_archive_clone_path()?,
+    };
+    if !candidate.is_dir() {
+        return Err(RefreshError::ArchiveCloneMissing(candidate));
+    }
+    Ok(candidate)
+}
+
+fn default_archive_clone_path() -> Result<PathBuf, RefreshError> {
+    let local = validate::local::validate_local_path(&local_config_path())
+        .map_err(|e| RefreshError::Io(e.to_string()))?;
+    Ok(local.data.config.archive_clone_path)
+}
+
+fn local_config_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("PLAN_ARCHIVE_LOCAL_CONFIG") {
+        return PathBuf::from(p);
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        return PathBuf::from(xdg)
+            .join("agent-plan-archive")
+            .join("config.yaml");
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join(".config")
+            .join("agent-plan-archive")
+            .join("config.yaml");
+    }
+    PathBuf::from("/nonexistent/agent-plan-archive/config.yaml")
+}
+
+fn load_hosts(path: &Path) -> Result<HostsConfig, RefreshError> {
+    let raw = fs::read_to_string(path).map_err(|e| RefreshError::HostsLoadFailed(e.to_string()))?;
+    let v = validate_hosts_yaml(&raw).map_err(|e| RefreshError::HostsParseFailed(e.to_string()))?;
+    Ok(v.data.config)
+}
+
+fn emit(format: OutputFormat, report: RefreshReport) -> i32 {
+    match format {
+        OutputFormat::Json => {
+            let envelope = Envelope::success(schema_version_for(BINARY, COMMAND, 1), &report);
+            match serde_json::to_string(&envelope) {
+                Ok(s) => {
+                    println!("{s}");
+                    exit::SUCCESS
+                }
+                Err(_) => exit::SOFTWARE,
+            }
+        }
+        OutputFormat::Text => {
+            for s in &report.snapshots {
+                println!("refreshed {} → {}", s.r#ref, s.snapshot_path);
+                if let Some(log) = &s.scrub_log_path {
+                    println!(
+                        "  ⚠ {} redaction(s); review {} before committing",
+                        s.redaction_count, log
+                    );
+                }
+            }
+            for f in &report.failed {
+                eprintln!("failed {} [{}]: {}", f.r#ref, f.code, f.message);
+            }
+            if report.requires_review {
+                println!(
+                    "review required: at least one snapshot emitted a scrub log; commit only after acknowledging it"
+                );
+            }
+            exit::SUCCESS
+        }
+    }
+}
+
+fn emit_error(format: OutputFormat, code: &str, message: &str) -> i32 {
+    match format {
+        OutputFormat::Json => {
+            let envelope: Envelope<()> = Envelope::failure(
+                schema_version_for(BINARY, COMMAND, 1),
+                EnvelopeError::new(code, message),
+            );
+            if let Ok(s) = serde_json::to_string(&envelope) {
+                eprintln!("{s}");
+            }
+            exit::DATA
+        }
+        OutputFormat::Text => {
+            eprintln!("error [{code}]: {message}");
+            exit::DATA
+        }
+    }
+}
+
+/// Format a Unix epoch seconds value as basic-format UTC ISO8601
+/// (`YYYYMMDDThhmmssZ`). Civil-date conversion via the standard
+/// days-from-epoch algorithm.
+pub fn format_unix_basic_utc(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    let (hh, mm, ss) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+    let (y, m, d) = civil_from_days(days);
+    format!("{y:04}{m:02}{d:02}T{hh:02}{mm:02}{ss:02}Z")
+}
+
+// Howard Hinnant's days->civil algorithm.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_repo_triple_simple() {
+        let r = parse_repo_triple("github.com/graysurf/agent-runtime-kit").unwrap();
+        assert_eq!(
+            r,
+            (
+                "github.com".into(),
+                "graysurf".into(),
+                "agent-runtime-kit".into()
+            )
+        );
+    }
+
+    #[test]
+    fn parses_repo_triple_nested_group() {
+        let r = parse_repo_triple("gitlab.example.com/acme/platform/ingest").unwrap();
+        assert_eq!(
+            r,
+            (
+                "gitlab.example.com".into(),
+                "acme/platform".into(),
+                "ingest".into()
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_repo_triple_too_short() {
+        assert!(parse_repo_triple("github.com/org").is_none());
+    }
+
+    #[test]
+    fn validates_since_format() {
+        assert!(validate_since("2026-05-27").is_ok());
+        assert!(validate_since("2026-5-27").is_err());
+        assert!(validate_since("not-a-date").is_err());
+    }
+
+    #[test]
+    fn unix_basic_utc_known_epoch() {
+        // 2026-05-27T01:30:45Z = 1779annotated; verify round numbers
+        // via a known timestamp: 2021-01-01T00:00:00Z = 1609459200.
+        assert_eq!(format_unix_basic_utc(1_609_459_200), "20210101T000000Z");
+        // 1970-01-01T00:00:00Z
+        assert_eq!(format_unix_basic_utc(0), "19700101T000000Z");
+        // 2000-02-29T12:34:56Z (leap day) = 951827696
+        assert_eq!(format_unix_basic_utc(951_827_696), "20000229T123456Z");
+    }
+}

--- a/crates/plan-archive/src/refresh/refparse.rs
+++ b/crates/plan-archive/src/refresh/refparse.rs
@@ -1,0 +1,192 @@
+//! Parse issue / PR / MR URLs into a structured refresh target and
+//! derive the append-only `_index/` snapshot directory.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// The kind of provider reference being refreshed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefKind {
+    Issue,
+    Pull,
+    MergeRequest,
+}
+
+impl RefKind {
+    /// `_index/` sub-directory name for this kind.
+    pub fn index_segment(self) -> &'static str {
+        match self {
+            RefKind::Issue => "issues",
+            RefKind::Pull => "pulls",
+            RefKind::MergeRequest => "merge_requests",
+        }
+    }
+}
+
+/// A fully-resolved refresh target.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RefTarget {
+    pub host: String,
+    pub org_or_group_path: String,
+    pub repo: String,
+    pub kind: RefKind,
+    pub number: u64,
+}
+
+impl RefTarget {
+    /// Canonical provider URL for this target (used in reports and
+    /// for the failed-ref list).
+    pub fn canonical_url(&self) -> String {
+        let segment = match self.kind {
+            RefKind::Issue => "issues",
+            RefKind::Pull => "pull",
+            RefKind::MergeRequest => "-/merge_requests",
+        };
+        format!(
+            "https://{}/{}/{}/{}/{}",
+            self.host, self.org_or_group_path, self.repo, segment, self.number
+        )
+    }
+
+    /// Append-only directory under `_index/` for this target's
+    /// snapshots.
+    pub fn index_dir(&self) -> PathBuf {
+        let mut p = PathBuf::from("_index");
+        p.push(&self.host);
+        for segment in self.org_or_group_path.split('/').filter(|s| !s.is_empty()) {
+            p.push(segment);
+        }
+        p.push(&self.repo);
+        p.push(self.kind.index_segment());
+        p.push(self.number.to_string());
+        p
+    }
+}
+
+/// Parse a provider issue / PR / MR URL into a [`RefTarget`].
+///
+/// Supports:
+/// - `https://github.com/org/repo/issues/123`
+/// - `https://github.com/org/repo/pull/123`
+/// - `https://gitlab.example.com/group/sub/repo/-/issues/123`
+/// - `https://gitlab.example.com/group/sub/repo/-/merge_requests/123`
+pub fn parse_ref_url(url: &str) -> Option<RefTarget> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let (host, path) = rest.split_once('/')?;
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.len() < 4 {
+        return None;
+    }
+
+    // Locate the kind keyword and number from the tail.
+    let number: u64 = segments.last()?.parse().ok()?;
+    let kind_kw = segments.get(segments.len() - 2)?;
+    let kind = match *kind_kw {
+        "issues" => RefKind::Issue,
+        "pull" | "pulls" => RefKind::Pull,
+        "merge_requests" => RefKind::MergeRequest,
+        _ => return None,
+    };
+
+    // Everything before the kind keyword (minus an optional GitLab
+    // `-` separator) is org/group-path + repo.
+    let mut head = &segments[..segments.len() - 2];
+    if head.last() == Some(&"-") {
+        head = &head[..head.len() - 1];
+    }
+    if head.len() < 2 {
+        return None;
+    }
+    let repo = head[head.len() - 1].to_string();
+    let org_or_group_path = head[..head.len() - 1].join("/");
+    if org_or_group_path.is_empty() {
+        return None;
+    }
+
+    Some(RefTarget {
+        host: host.to_string(),
+        org_or_group_path,
+        repo,
+        kind,
+        number,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_github_issue() {
+        let t = parse_ref_url("https://github.com/graysurf/agent-runtime-kit/issues/126").unwrap();
+        assert_eq!(t.host, "github.com");
+        assert_eq!(t.org_or_group_path, "graysurf");
+        assert_eq!(t.repo, "agent-runtime-kit");
+        assert_eq!(t.kind, RefKind::Issue);
+        assert_eq!(t.number, 126);
+        assert_eq!(
+            t.index_dir(),
+            PathBuf::from("_index/github.com/graysurf/agent-runtime-kit/issues/126")
+        );
+    }
+
+    #[test]
+    fn parses_github_pull() {
+        let t = parse_ref_url("https://github.com/sympoies/nils-cli/pull/574").unwrap();
+        assert_eq!(t.kind, RefKind::Pull);
+        assert_eq!(t.number, 574);
+        assert_eq!(
+            t.index_dir(),
+            PathBuf::from("_index/github.com/sympoies/nils-cli/pulls/574")
+        );
+    }
+
+    #[test]
+    fn parses_gitlab_merge_request_with_dash_and_nested_group() {
+        let t =
+            parse_ref_url("https://gitlab.example.com/acme/platform/ingest/-/merge_requests/42")
+                .unwrap();
+        assert_eq!(t.host, "gitlab.example.com");
+        assert_eq!(t.org_or_group_path, "acme/platform");
+        assert_eq!(t.repo, "ingest");
+        assert_eq!(t.kind, RefKind::MergeRequest);
+        assert_eq!(t.number, 42);
+        assert_eq!(
+            t.index_dir(),
+            PathBuf::from("_index/gitlab.example.com/acme/platform/ingest/merge_requests/42")
+        );
+    }
+
+    #[test]
+    fn parses_gitlab_issue_with_dash() {
+        let t = parse_ref_url("https://gitlab.example.com/acme/ingest/-/issues/7").unwrap();
+        assert_eq!(t.org_or_group_path, "acme");
+        assert_eq!(t.repo, "ingest");
+        assert_eq!(t.kind, RefKind::Issue);
+    }
+
+    #[test]
+    fn rejects_non_numeric_id() {
+        assert!(parse_ref_url("https://github.com/org/repo/issues/abc").is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_kind() {
+        assert!(parse_ref_url("https://github.com/org/repo/wiki/123").is_none());
+    }
+
+    #[test]
+    fn rejects_missing_repo() {
+        assert!(parse_ref_url("https://github.com/org/issues/1").is_none());
+    }
+
+    #[test]
+    fn canonical_url_round_trips_kind() {
+        let t = parse_ref_url("https://github.com/org/repo/pull/9").unwrap();
+        assert_eq!(t.canonical_url(), "https://github.com/org/repo/pull/9");
+    }
+}

--- a/crates/plan-archive/tests/migrate.rs
+++ b/crates/plan-archive/tests/migrate.rs
@@ -1,0 +1,212 @@
+//! Integration coverage for `plan-archive migrate` dry-run.
+//!
+//! Builds a throwaway git repo + archive clone + `hosts.yaml`, then
+//! drives `migrate::prepare` to assert the dry-run report.
+//!
+//! Apply-path coverage is intentionally minimal: it exercises the
+//! semantic-commit-driven commit pipeline, which is gated on the
+//! released `semantic-commit` binary being present in `$PATH`. The
+//! shipped tests cover the pure prepare/dispatch logic; the apply
+//! path is exercised through the runtime-smoke fixtures in the
+//! agent-runtime-kit Plan 3 work.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use nils_common::cli_contract::OutputFormat;
+use plan_archive::migrate::{self, DispatchArgs, MetadataPayload};
+use plan_archive::validate::hosts::HostClass;
+
+struct Scenario {
+    _tmp: tempfile::TempDir,
+    source_repo: PathBuf,
+    archive: PathBuf,
+    hosts: PathBuf,
+    plan_path: PathBuf,
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_AUTHOR_NAME", "tester")
+        .env("GIT_AUTHOR_EMAIL", "tester@example.com")
+        .env("GIT_COMMITTER_NAME", "tester")
+        .env("GIT_COMMITTER_EMAIL", "tester@example.com")
+        .output()
+        .unwrap_or_else(|e| panic!("spawn git {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed:\nstderr={}\nstdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout),
+    );
+}
+
+fn build_scenario() -> Scenario {
+    let tmp = tempfile::tempdir().unwrap();
+    let source_repo = tmp.path().join("source");
+    let archive = tmp.path().join("archive");
+    fs::create_dir_all(&source_repo).unwrap();
+    fs::create_dir_all(&archive).unwrap();
+
+    // Source repo with a plan folder that contains two files.
+    git(&source_repo, &["init", "-q", "-b", "main"]);
+    git(
+        &source_repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:graysurf/agent-runtime-kit.git",
+        ],
+    );
+    let plan = source_repo.join("docs/plans/2026-05-27-demo-plan");
+    fs::create_dir_all(&plan).unwrap();
+    fs::write(plan.join("PLAN.md"), "# demo plan\n").unwrap();
+    fs::write(plan.join("notes.md"), "notes\n").unwrap();
+    git(&source_repo, &["add", "docs/plans"]);
+    git(&source_repo, &["commit", "-q", "-m", "seed plan"]);
+
+    // Archive clone with config/hosts.yaml.
+    git(&archive, &["init", "-q", "-b", "main"]);
+    let config_dir = archive.join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+    let hosts = config_dir.join("hosts.yaml");
+    fs::write(
+        &hosts,
+        "version: 1\nhosts:\n  github.com:\n    class: personal\n    primary_identity: graysurf\n",
+    )
+    .unwrap();
+    git(&archive, &["add", "config/hosts.yaml"]);
+    git(&archive, &["commit", "-q", "-m", "seed hosts"]);
+
+    Scenario {
+        _tmp: tmp,
+        source_repo,
+        archive,
+        hosts,
+        plan_path: PathBuf::from("docs/plans/2026-05-27-demo-plan"),
+    }
+}
+
+fn args_for(scenario: &Scenario) -> DispatchArgs {
+    DispatchArgs {
+        plan: scenario.plan_path.clone(),
+        source_repo: Some(scenario.source_repo.clone()),
+        archive: Some(scenario.archive.clone()),
+        hosts: Some(scenario.hosts.clone()),
+        issue: Some("https://github.com/sympoies/nils-cli/issues/571".to_string()),
+        pr: None,
+        mr: None,
+        apply: false,
+        format: OutputFormat::Json,
+    }
+}
+
+#[test]
+fn dry_run_resolves_identity_target_and_files() {
+    let scenario = build_scenario();
+    let args = args_for(&scenario);
+    let report = migrate::prepare(&args).expect("dry-run prepare ok");
+
+    assert_eq!(report.plan_folder, "2026-05-27-demo-plan");
+    assert_eq!(report.source.host, "github.com");
+    assert_eq!(report.source.org_or_group_path, "graysurf");
+    assert_eq!(report.source.repo, "agent-runtime-kit");
+    assert_eq!(report.source.branch, "main");
+    assert_eq!(report.source.commit.len(), 40);
+    assert!(matches!(report.classification.class, HostClass::Personal));
+    assert_eq!(
+        report.classification.primary_identity.as_deref(),
+        Some("graysurf")
+    );
+    assert_eq!(
+        report.archive_target.relative_path,
+        "plans/github.com/graysurf/agent-runtime-kit/2026-05-27-demo-plan"
+    );
+    assert!(!report.archive_target.exists);
+
+    let mut files = report.files_to_copy.clone();
+    files.sort();
+    assert_eq!(
+        files,
+        vec![
+            "docs/plans/2026-05-27-demo-plan/PLAN.md".to_string(),
+            "docs/plans/2026-05-27-demo-plan/notes.md".to_string(),
+        ]
+    );
+
+    assert_serialized_metadata(&report.metadata);
+}
+
+fn assert_serialized_metadata(m: &MetadataPayload) {
+    assert_eq!(m.version, 1);
+    assert_eq!(m.source.host, "github.com");
+    assert_eq!(m.source.org_or_group_path, "graysurf");
+    assert_eq!(m.source.repo, "agent-runtime-kit");
+    assert_eq!(m.source.branch, "main");
+    assert_eq!(m.source.original_path, "docs/plans/2026-05-27-demo-plan/");
+    assert!(matches!(
+        m.captured_classification.class,
+        HostClass::Personal
+    ));
+    assert_eq!(
+        m.refs.issue.as_deref(),
+        Some("https://github.com/sympoies/nils-cli/issues/571")
+    );
+    assert!(m.refs.pr.is_none() && m.refs.mr.is_none());
+
+    let yaml = serde_yaml_ng::to_string(m).unwrap();
+    assert!(yaml.contains("version: 1"));
+    assert!(yaml.contains("captured_classification:"));
+    assert!(yaml.contains("class: personal"));
+}
+
+#[test]
+fn dry_run_rejects_missing_plan_folder() {
+    let scenario = build_scenario();
+    let mut args = args_for(&scenario);
+    args.plan = PathBuf::from("docs/plans/does-not-exist");
+    let err = migrate::prepare(&args).unwrap_err();
+    assert_eq!(err.code(), "migrate-plan-folder-missing");
+}
+
+#[test]
+fn dry_run_rejects_unknown_host() {
+    let scenario = build_scenario();
+    // Rewrite hosts.yaml to remove github.com so the resolver can't
+    // classify the source.
+    fs::write(
+        &scenario.hosts,
+        "version: 1\nhosts:\n  gitlab.com:\n    class: personal\n",
+    )
+    .unwrap();
+    let args = args_for(&scenario);
+    let err = migrate::prepare(&args).unwrap_err();
+    assert_eq!(err.code(), "migrate-unknown-host");
+}
+
+#[test]
+fn dry_run_requires_at_least_one_ref() {
+    let scenario = build_scenario();
+    let mut args = args_for(&scenario);
+    args.issue = None;
+    args.pr = None;
+    args.mr = None;
+    let err = migrate::prepare(&args).unwrap_err();
+    assert_eq!(err.code(), "migrate-no-refs-supplied");
+}
+
+#[test]
+fn dry_run_flags_archive_target_collision() {
+    let scenario = build_scenario();
+    let target = scenario
+        .archive
+        .join("plans/github.com/graysurf/agent-runtime-kit/2026-05-27-demo-plan");
+    fs::create_dir_all(&target).unwrap();
+    let args = args_for(&scenario);
+    let report = migrate::prepare(&args).expect("dry-run still completes");
+    assert!(report.archive_target.exists);
+}

--- a/crates/plan-archive/tests/query.rs
+++ b/crates/plan-archive/tests/query.rs
@@ -1,0 +1,243 @@
+//! Integration coverage for `plan-archive query` against a seeded
+//! `_index/` tree and archived plan metadata.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use nils_common::cli_contract::OutputFormat;
+use plan_archive::query::{self, DispatchArgs, QueryResult};
+
+struct Archive {
+    _tmp: tempfile::TempDir,
+    path: PathBuf,
+}
+
+fn seed_snapshot(archive: &Path, rel_dir: &str, stamp: &str, body: &str) {
+    let dir = archive.join("_index").join(rel_dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join(format!("{stamp}.json")), body).unwrap();
+}
+
+fn build_archive() -> Archive {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("archive");
+    fs::create_dir_all(&path).unwrap();
+
+    // github.com/graysurf/agent-runtime-kit issue 126 — two snapshots.
+    seed_snapshot(
+        &path,
+        "github.com/graysurf/agent-runtime-kit/issues/126",
+        "20260527T010000Z",
+        r#"{"title":"older"}"#,
+    );
+    seed_snapshot(
+        &path,
+        "github.com/graysurf/agent-runtime-kit/issues/126",
+        "20260527T020000Z",
+        r#"{"title":"newer"}"#,
+    );
+    // github.com/graysurf/agent-runtime-kit pull 127 — one snapshot.
+    seed_snapshot(
+        &path,
+        "github.com/graysurf/agent-runtime-kit/pulls/127",
+        "20260527T030000Z",
+        r#"{"title":"pr"}"#,
+    );
+    // gitlab.example.com/acme/platform/ingest MR 42 — one snapshot.
+    seed_snapshot(
+        &path,
+        "gitlab.example.com/acme/platform/ingest/merge_requests/42",
+        "20260101T120000Z",
+        r#"{"title":"mr"}"#,
+    );
+
+    Archive { _tmp: tmp, path }
+}
+
+fn base_args(archive: &Path) -> DispatchArgs {
+    DispatchArgs {
+        r#ref: None,
+        host: None,
+        org: None,
+        repo: None,
+        since: None,
+        plan: None,
+        refs_from: None,
+        archive: Some(archive.to_path_buf()),
+        format: OutputFormat::Json,
+    }
+}
+
+#[test]
+fn single_ref_returns_latest_snapshot_with_fetched_at() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.r#ref = Some("https://github.com/graysurf/agent-runtime-kit/issues/126".to_string());
+
+    let result = query::run(&args).unwrap();
+    let QueryResult::SingleRef { record } = result else {
+        panic!("expected single-ref result");
+    };
+    assert_eq!(record.number, 126);
+    assert_eq!(record.fetched_at.as_deref(), Some("2026-05-27T02:00:00Z"));
+    assert!(
+        record
+            .latest_snapshot
+            .as_deref()
+            .unwrap()
+            .ends_with("20260527T020000Z.json")
+    );
+}
+
+#[test]
+fn single_ref_missing_returns_no_snapshot_not_error() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.r#ref = Some("https://github.com/graysurf/agent-runtime-kit/issues/9999".to_string());
+
+    let result = query::run(&args).unwrap();
+    let QueryResult::SingleRef { record } = result else {
+        panic!("expected single-ref result");
+    };
+    assert!(record.latest_snapshot.is_none());
+    assert!(record.fetched_at.is_none());
+}
+
+#[test]
+fn aggregate_by_host_returns_all_repos_one_pass() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.host = Some("github.com".to_string());
+
+    let result = query::run(&args).unwrap();
+    let QueryResult::Aggregate { records } = result else {
+        panic!("expected aggregate result");
+    };
+    assert_eq!(records.len(), 2); // issue 126 + pull 127
+    assert!(records.iter().all(|r| r.host == "github.com"));
+}
+
+#[test]
+fn aggregate_cross_host_returns_every_reachable_host() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    // No host filter, but a repo filter that matches nothing forces
+    // the empty path; instead use since far in the past to match all.
+    args.since = Some("2020-01-01".to_string());
+
+    let result = query::run(&args).unwrap();
+    let QueryResult::Aggregate { records } = result else {
+        panic!("expected aggregate result");
+    };
+    // issue 126 + pull 127 + gitlab MR 42 = 3
+    assert_eq!(records.len(), 3);
+    let hosts: Vec<&str> = records.iter().map(|r| r.host.as_str()).collect();
+    assert!(hosts.contains(&"github.com"));
+    assert!(hosts.contains(&"gitlab.example.com"));
+}
+
+#[test]
+fn aggregate_no_match_returns_empty_array() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.repo = Some("does-not-exist".to_string());
+
+    let result = query::run(&args).unwrap();
+    let QueryResult::Aggregate { records } = result else {
+        panic!("expected aggregate result");
+    };
+    assert!(records.is_empty());
+}
+
+#[test]
+fn aggregate_since_filters_out_older_snapshots() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.since = Some("2026-05-01".to_string());
+
+    let result = query::run(&args).unwrap();
+    let QueryResult::Aggregate { records } = result else {
+        panic!("expected aggregate result");
+    };
+    // The gitlab MR snapshot is from 2026-01-01, filtered out.
+    assert_eq!(records.len(), 2);
+    assert!(records.iter().all(|r| r.host == "github.com"));
+}
+
+#[test]
+fn aggregate_invalid_since_rejected() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.since = Some("2026/05/01".to_string());
+    let err = query::run(&args).unwrap_err();
+    assert_eq!(err.code(), "query-invalid-since");
+}
+
+#[test]
+fn plan_link_resolves_metadata_refs_to_snapshots() {
+    let archive = build_archive();
+    // Seed an archived plan with metadata pointing at issue 126 + pull 127.
+    let plan_rel = "plans/github.com/graysurf/agent-runtime-kit/2026-05-27-demo";
+    let plan_dir = archive.path.join(plan_rel);
+    fs::create_dir_all(&plan_dir).unwrap();
+    fs::write(
+        plan_dir.join("metadata.yaml"),
+        "version: 1\nrefs:\n  issue: https://github.com/graysurf/agent-runtime-kit/issues/126\n  pr: https://github.com/graysurf/agent-runtime-kit/pull/127\n",
+    )
+    .unwrap();
+
+    let mut args = base_args(&archive.path);
+    args.plan = Some(plan_rel.to_string());
+
+    let result = query::run(&args).unwrap();
+    let QueryResult::PlanLink { plan, records } = result else {
+        panic!("expected plan-link result");
+    };
+    assert_eq!(plan, plan_rel);
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].number, 126);
+    assert!(records[0].fetched_at.is_some());
+    assert_eq!(records[1].number, 127);
+}
+
+#[test]
+fn refs_from_reads_metadata_file_directly() {
+    let archive = build_archive();
+    let meta = archive.path.join("scratch-metadata.yaml");
+    fs::write(
+        &meta,
+        "version: 1\nrefs:\n  mr: https://gitlab.example.com/acme/platform/ingest/-/merge_requests/42\n",
+    )
+    .unwrap();
+
+    let mut args = base_args(&archive.path);
+    args.refs_from = Some(meta.display().to_string());
+
+    let result = query::run(&args).unwrap();
+    let QueryResult::PlanLink { records, .. } = result else {
+        panic!("expected plan-link result");
+    };
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].number, 42);
+    assert_eq!(
+        records[0].fetched_at.as_deref(),
+        Some("2026-01-01T12:00:00Z")
+    );
+}
+
+#[test]
+fn plan_link_missing_metadata_errors() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.plan = Some("plans/nope".to_string());
+    let err = query::run(&args).unwrap_err();
+    assert_eq!(err.code(), "query-metadata-not-found");
+}
+
+#[test]
+fn no_selector_is_rejected() {
+    let archive = build_archive();
+    let args = base_args(&archive.path);
+    let err = query::run(&args).unwrap_err();
+    assert_eq!(err.code(), "query-no-selector");
+}

--- a/crates/plan-archive/tests/refresh.rs
+++ b/crates/plan-archive/tests/refresh.rs
@@ -1,0 +1,240 @@
+//! Integration coverage for `plan-archive refresh`, driving the
+//! pipeline through a stub `ForgeFetcher` and a frozen clock so the
+//! snapshot writes are fully deterministic with no network.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use nils_common::cli_contract::OutputFormat;
+use plan_archive::refresh::{self, Clock, DispatchArgs, ForgeFetcher, RefTarget};
+
+struct FrozenClock(String);
+impl Clock for FrozenClock {
+    fn now_basic_utc(&self) -> String {
+        self.0.clone()
+    }
+}
+
+#[derive(Default)]
+struct StubForge {
+    payloads: HashMap<String, String>,
+    listing: Vec<RefTarget>,
+    list_calls: RefCell<u32>,
+}
+
+impl ForgeFetcher for StubForge {
+    fn fetch_payload(&self, target: &RefTarget) -> Result<String, String> {
+        self.payloads
+            .get(&target.canonical_url())
+            .cloned()
+            .ok_or_else(|| format!("no stub payload for {}", target.canonical_url()))
+    }
+
+    fn list_open_refs(
+        &self,
+        _host: &str,
+        _org: &str,
+        _repo: &str,
+        _since: Option<&str>,
+    ) -> Result<Vec<RefTarget>, String> {
+        *self.list_calls.borrow_mut() += 1;
+        Ok(self.listing.clone())
+    }
+}
+
+struct Archive {
+    _tmp: tempfile::TempDir,
+    path: PathBuf,
+}
+
+fn build_archive() -> Archive {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("archive");
+    let config = path.join("config");
+    fs::create_dir_all(&config).unwrap();
+    fs::write(
+        config.join("hosts.yaml"),
+        "version: 1\nhosts:\n  github.com:\n    class: personal\n",
+    )
+    .unwrap();
+    Archive { _tmp: tmp, path }
+}
+
+fn ref_target(url: &str) -> RefTarget {
+    refresh::parse_ref_url(url).unwrap()
+}
+
+fn base_args(archive: &Path) -> DispatchArgs {
+    DispatchArgs {
+        r#ref: None,
+        repo: None,
+        since: None,
+        archive: Some(archive.to_path_buf()),
+        hosts: None,
+        format: OutputFormat::Json,
+    }
+}
+
+#[test]
+fn single_ref_clean_payload_writes_snapshot_no_log() {
+    let archive = build_archive();
+    let url = "https://github.com/graysurf/agent-runtime-kit/issues/126";
+    let mut forge = StubForge::default();
+    forge.payloads.insert(
+        url.to_string(),
+        r#"{"title":"hello","body":"no secrets"}"#.to_string(),
+    );
+    let clock = FrozenClock("20260527T010000Z".to_string());
+
+    let mut args = base_args(&archive.path);
+    args.r#ref = Some(url.to_string());
+
+    let report = refresh::run(&args, &forge, &clock).expect("refresh ok");
+    assert_eq!(report.snapshots.len(), 1);
+    assert!(report.failed.is_empty());
+    assert!(!report.requires_review);
+
+    let snap = &report.snapshots[0];
+    assert!(snap.scrub_log_path.is_none());
+    assert_eq!(snap.redaction_count, 0);
+
+    let expected = archive
+        .path
+        .join("_index/github.com/graysurf/agent-runtime-kit/issues/126/20260527T010000Z.json");
+    assert!(expected.exists(), "missing {expected:?}");
+    let body = fs::read_to_string(&expected).unwrap();
+    assert!(body.contains("no secrets"));
+}
+
+#[test]
+fn single_ref_dirty_payload_emits_scrub_log_and_requires_review() {
+    let archive = build_archive();
+    let url = "https://github.com/graysurf/agent-runtime-kit/pull/127";
+    let mut forge = StubForge::default();
+    forge.payloads.insert(
+        url.to_string(),
+        r#"{"body":"token: ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#.to_string(),
+    );
+    let clock = FrozenClock("20260527T020000Z".to_string());
+
+    let mut args = base_args(&archive.path);
+    args.r#ref = Some(url.to_string());
+
+    let report = refresh::run(&args, &forge, &clock).expect("refresh ok");
+    assert!(report.requires_review);
+    let snap = &report.snapshots[0];
+    assert_eq!(snap.redaction_count, 1);
+    let log = snap.scrub_log_path.as_ref().expect("scrub log emitted");
+    assert!(PathBuf::from(log).exists());
+
+    // Snapshot must be scrubbed on disk.
+    let dir = archive
+        .path
+        .join("_index/github.com/graysurf/agent-runtime-kit/pulls/127");
+    let snap_file = dir.join("20260527T020000Z.json");
+    let body = fs::read_to_string(&snap_file).unwrap();
+    assert!(!body.contains("ghp_"), "snapshot leaked secret: {body}");
+    assert!(body.contains("[REDACTED]"));
+
+    // Scrub log never carries the secret.
+    let log_body = fs::read_to_string(dir.join("20260527T020000Z.scrub.log")).unwrap();
+    assert!(!log_body.contains("ghp_"));
+    assert!(log_body.contains("pattern=github-token"));
+}
+
+#[test]
+fn snapshots_are_append_only_across_two_refreshes() {
+    let archive = build_archive();
+    let url = "https://github.com/graysurf/agent-runtime-kit/issues/126";
+    let mut forge = StubForge::default();
+    forge
+        .payloads
+        .insert(url.to_string(), r#"{"title":"v"}"#.to_string());
+
+    let mut args = base_args(&archive.path);
+    args.r#ref = Some(url.to_string());
+
+    refresh::run(&args, &forge, &FrozenClock("20260527T030000Z".into())).unwrap();
+    refresh::run(&args, &forge, &FrozenClock("20260527T040000Z".into())).unwrap();
+
+    let dir = archive
+        .path
+        .join("_index/github.com/graysurf/agent-runtime-kit/issues/126");
+    let mut files: Vec<String> = fs::read_dir(&dir)
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+        .collect();
+    files.sort();
+    assert_eq!(
+        files,
+        vec!["20260527T030000Z.json", "20260527T040000Z.json"]
+    );
+}
+
+#[test]
+fn unknown_host_is_rejected() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.r#ref = Some("https://gitlab.com/g/r/issues/1".to_string());
+    let forge = StubForge::default();
+    let err = refresh::run(&args, &forge, &FrozenClock("20260527T050000Z".into())).unwrap_err();
+    assert_eq!(err.code(), "refresh-unknown-host");
+}
+
+#[test]
+fn batch_repo_mode_refreshes_each_listed_ref_and_isolates_failures() {
+    let archive = build_archive();
+    let ok_url = "https://github.com/graysurf/agent-runtime-kit/issues/1";
+    let missing_url = "https://github.com/graysurf/agent-runtime-kit/issues/2";
+
+    // Only the first ref has a stub payload; the second fails to
+    // fetch and must not abort the batch.
+    let mut payloads = HashMap::new();
+    payloads.insert(ok_url.to_string(), r#"{"title":"ok"}"#.to_string());
+    let forge = StubForge {
+        payloads,
+        listing: vec![ref_target(ok_url), ref_target(missing_url)],
+        list_calls: RefCell::new(0),
+    };
+
+    let mut args = base_args(&archive.path);
+    args.repo = Some("github.com/graysurf/agent-runtime-kit".to_string());
+
+    let report = refresh::run(&args, &forge, &FrozenClock("20260527T060000Z".into())).unwrap();
+    assert_eq!(report.snapshots.len(), 1);
+    assert_eq!(report.failed.len(), 1);
+    assert_eq!(report.failed[0].code, "refresh-forge-fetch-failed");
+    assert_eq!(*forge.list_calls.borrow(), 1);
+}
+
+#[test]
+fn batch_with_invalid_since_is_rejected() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.repo = Some("github.com/graysurf/agent-runtime-kit".to_string());
+    args.since = Some("2026/05/27".to_string());
+    let forge = StubForge::default();
+    let err = refresh::run(&args, &forge, &FrozenClock("20260527T070000Z".into())).unwrap_err();
+    assert_eq!(err.code(), "refresh-invalid-since");
+}
+
+#[test]
+fn missing_selector_is_rejected() {
+    let archive = build_archive();
+    let args = base_args(&archive.path);
+    let forge = StubForge::default();
+    let err = refresh::run(&args, &forge, &FrozenClock("20260527T080000Z".into())).unwrap_err();
+    assert_eq!(err.code(), "refresh-no-selector");
+}
+
+#[test]
+fn unparseable_ref_is_rejected() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.r#ref = Some("https://github.com/org/repo/wiki/3".to_string());
+    let forge = StubForge::default();
+    let err = refresh::run(&args, &forge, &FrozenClock("20260527T090000Z".into())).unwrap_err();
+    assert_eq!(err.code(), "refresh-unparseable-ref");
+}


### PR DESCRIPTION
## Summary

Land Plan 1 Sprints 3–5 of the plan-archive system: the three
`plan-archive` subcommands the runtime-kit skills wrap — `migrate`,
`refresh`, and `query`. Built on the Sprint 1 validators and Sprint 2
scrub library already on `main`. Refresh composes the scrub library;
query reads what refresh writes.

## Changes

- **migrate** (`migrate/{mod,path,identity}.rs`): dry-run by default,
  `--apply` to write. Resolves source identity from the `origin`
  remote, classifies the host against `config/hosts.yaml`, enumerates
  tracked files via `git ls-files`, assembles `metadata.yaml`. Apply
  copies under `plans/<host>/<org>/<repo>/<folder>/`, commits + pushes
  the archive via `semantic-commit`, then deletes + commits the
  source folder only after the archive push succeeds.
- **refresh** (`refresh/{mod,refparse,forge}.rs`): `--ref` for one
  issue/PR/MR and `--repo`/`--since` for batch. Fetches through
  `forge-cli` (overridable via `PLAN_ARCHIVE_FORGE_CLI`), scrubs with
  the Sprint 2 library, and appends an `<ISO8601>.json` snapshot under
  `_index/`. Writes and scrubs but never commits; a redaction emits a
  `.scrub.log` sibling and flags `requires_review`. Batch isolates
  per-ref failures.
- **query** (`query/{mod,index}.rs`): read-only. single-ref, aggregate
  (`--host`/`--org`/`--repo`/`--since`, cross-host one pass), and link
  traversal (`--plan` / `--refs-from`). Surfaces `fetched_at` by
  default; missing refs return a null record, no-match aggregates
  return an empty array.
- Drops the `subcommand-not-implemented` placeholder; regenerates the
  completion assets for the three subcommands' final flag shapes.
- README documents each sprint's surface and stable error codes.

## Test-First Evidence

- Migrate: wrote remote-URL parsing, archive-path derivation, and
  folder date-prefix parsing unit tests, then 5 dry-run integration
  tests over a synthetic git repo + archive clone before wiring the
  apply path.
- Refresh: drove the pipeline through a stub `ForgeFetcher` + frozen
  clock so snapshot writes are deterministic; tests pin the clean vs
  dirty (scrub-log) paths, append-only behaviour across two refreshes,
  unknown-host rejection, and batch failure isolation before the real
  forge-cli backend.
- Query: seeded an `_index/` tree and asserted single-ref latest +
  fetched_at, cross-host aggregate, empty-array on no match, since
  filtering, and plan→refs / refs→plan traversal.

## Test plan

- [x] `cargo test -p nils-plan-archive` — 77 unit + 38 integration
  (migrate 5, refresh 8, query 11, scrub 4, validators 10) = 115 pass.
- [x] `cargo clippy -p nils-plan-archive --all-targets -- -D warnings`.
- [x] `bash scripts/ci/completion-asset-audit.sh --strict`.
- [x] `bash scripts/ci/docs-hygiene-audit.sh --strict`.
- [x] `bash scripts/ci/docs-placement-audit.sh --strict`.
- [ ] Remote CI green.

## Risk / Notes

- migrate `--apply` and refresh's real forge backend shell out to
  `git` / `semantic-commit` / `forge-cli`; the shipped automated tests
  cover the pure logic via injected seams (synthetic repos, stub
  fetcher, frozen clock). The live subprocess paths are exercised by
  the end-to-end demo and the runtime-kit Plan 3 runtime-smoke
  fixtures.
- No new dependency beyond the `regex` already added in Sprint 2.
- Refs #571.
