### PR TITLE
fix(plan-archive): shorten archive commit header to fit 100-char limit

### DIFF
--- a/crates/plan-archive/src/migrate/mod.rs
+++ b/crates/plan-archive/src/migrate/mod.rs
@@ -538,10 +538,7 @@ fn apply(args: DispatchArgs, report: DryRunReport) -> Result<ApplyReport, Migrat
         ));
     }
 
-    let archive_msg = format!(
-        "archive(plan): {}/{}/{} {}",
-        report.source.host, report.source.org_or_group_path, report.source.repo, report.plan_folder
-    );
+    let archive_msg = archive_commit_message(&report.source.repo, &report.plan_folder);
     run_semantic_commit(&archive, &archive_msg)?;
     let archive_commit = head_sha(&archive)?;
     push_archive(&archive)?;
@@ -586,6 +583,14 @@ fn pathdiff(file_rel_to_repo: &str, plan_path: &Path) -> PathBuf {
             .strip_prefix(&prefix)
             .unwrap_or(file_rel_to_repo),
     )
+}
+
+/// Build the archive commit header. Keeps only `<repo>/<folder>` so the
+/// header stays within semantic-commit's 100-char limit even for long
+/// date-prefixed plan folder names; the full host/org/repo path is already
+/// recorded in the archive path and `metadata.yaml`.
+fn archive_commit_message(repo: &str, plan_folder: &str) -> String {
+    format!("archive(plan): {repo}/{plan_folder}")
 }
 
 fn has_dirty_plan_folder(repo: &Path, plan_path: &Path) -> Result<bool, MigrateError> {
@@ -648,4 +653,32 @@ fn push_archive(repo: &Path) -> Result<(), MigrateError> {
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::archive_commit_message;
+
+    #[test]
+    fn archive_commit_message_format() {
+        assert_eq!(
+            archive_commit_message("agent-runtime-kit", "2026-05-27-plan-archive-nils-cli"),
+            "archive(plan): agent-runtime-kit/2026-05-27-plan-archive-nils-cli"
+        );
+    }
+
+    #[test]
+    fn archive_commit_header_within_semantic_commit_limit() {
+        // The longest dated plan folder migrated to date; the header must stay
+        // within semantic-commit's 100-char header limit.
+        let msg = archive_commit_message(
+            "agent-runtime-kit",
+            "2026-05-26-plan-issue-lifecycle-ordering-regression",
+        );
+        assert!(
+            msg.len() <= 100,
+            "archive commit header is {} chars: {msg}",
+            msg.len()
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Shorten the `plan-archive migrate` archive commit header so long dated plan-folder names no longer exceed semantic-commit's 100-char header limit.

## Problem

`plan-archive migrate --apply` built the archive commit header as `archive(plan): <host>/<org>/<repo> <folder>`. For long dated folder names this exceeds semantic-commit's 100-char header limit, aborting the migration with `migrate-subprocess-failed` (semantic-commit exit 4).

## Reproduction

Run `plan-archive migrate --apply` on a plan whose dated folder name is >= 48 chars (e.g. `2026-05-26-plan-issue-lifecycle-ordering-regression`) with a GitHub-hosted source repo. The archive commit fails: `commit header exceeds 100 characters (max 100)`.

## Issues Found

Found while bulk-migrating closed plans from `graysurf/agent-runtime-kit` into the plan archive; 3 of 21 plans had folder names long enough to trip the gate.

## Fix Approach

Drop the redundant `<host>/<org>` from the header (already recorded in the archive path and `metadata.yaml`) and emit `archive(plan): <repo>/<folder>`, which stays within 100 chars even for the longest folder names. Extracted into a testable `archive_commit_message` helper.

## Test-First Evidence

Added `archive_commit_header_within_semantic_commit_limit` (asserts <=100 for the longest dated folder) and a format test alongside the fix; no pre-existing failing test covered the header length.

## Test plan

- `cargo test -p nils-plan-archive` — 117 tests green (incl. the 2 new header tests).
- `cargo fmt -p nils-plan-archive -- --check` and `cargo clippy -p nils-plan-archive --all-targets` clean.

## Risk / Notes

Low. Commit-message text only; archived files, `metadata.yaml`, and the archive path are unchanged. Existing archived commits keep their longer headers.
