### PR TITLE
chore(release): bump cli versions to 0.25.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-runtime-cli"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1739,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-docs"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-out"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "chrono",
  "clap",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-scope-lock"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-workflow-primitives"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-gql"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-grpc"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-rest"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1922,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-test"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-testing-core"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-websocket"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "nils-cli-template"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "nils-codex-cli"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "nils-common"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "base64",
  "clap",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "nils-forge-cli"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "nils-fzf-cli"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "nils-gemini-cli"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-cli"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-lock"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-scope"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-summary"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "nils-image-processing"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "nils-macos-agent"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "nils-markdown"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "nils-memo-cli"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-archive"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-issue-cli"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-tooling"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "nils-screen-record"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "block2",
  "chrono",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "nils-semantic-commit"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "nils-term"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "indicatif",
  "pretty_assertions",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "nils-test-support"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "nils-web-evidence"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ resolver = "2"
 # edition.
 edition = "2024"
 license = "MIT"
-version = "0.25.0"
+version = "0.25.1"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ This repo can publish prebuilt tarballs via GitHub Releases for both:
 - x86_64 (amd64)
 - aarch64 (arm64)
 
-To trigger a release build, push a tag like `v0.25.0`:
+To trigger a release build, push a tag like `v0.25.1`:
 
-- `git tag -a v0.25.0 -m "v0.25.0"`
-- `git push origin v0.25.0`
+- `git tag -a v0.25.1 -m "v0.25.1"`
+- `git push origin v0.25.1`
 
 Then download the matching `nils-cli-<tag>-<target>.tar.gz` asset, extract it, and add `<extract_dir>/bin` to your `PATH`.
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `abaa3342bbbadfe66d4eb76b575c05bcb1633eb99850da12662b938eceae2905`
+- Cargo.lock SHA256: `b2d194c1597e7d915649b9ee4b4cb8fc1e6e5a26fe1ffb5207d4c3b4573b1023`
 - Third-party crates (`source != null`): 465
 - Workspace crates (`source == null`, excluded below): 33
 
@@ -232,7 +232,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | log | 0.4.30 | MIT OR Apache-2.0 | crates.io |
 | lru-slab | 0.1.2 | MIT OR Apache-2.0 OR Zlib | crates.io |
 | matchers | 0.2.0 | MIT | crates.io |
-| memchr | 2.8.0 | Unlicense OR MIT | crates.io |
+| memchr | 2.8.1 | Unlicense OR MIT | crates.io |
 | memmap2 | 0.9.10 | MIT OR Apache-2.0 | crates.io |
 | memoffset | 0.9.1 | MIT | crates.io |
 | mime | 0.3.17 | MIT OR Apache-2.0 | crates.io |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `abaa3342bbbadfe66d4eb76b575c05bcb1633eb99850da12662b938eceae2905`
+- Cargo.lock SHA256: `b2d194c1597e7d915649b9ee4b4cb8fc1e6e5a26fe1ffb5207d4c3b4573b1023`
 - Third-party crates (`source != null`): 465
 
 ## Notice Extraction Policy
@@ -1587,7 +1587,7 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - License file references:
   - `LICENSE`
 
-### memchr 2.8.0
+### memchr 2.8.1
 
 - License: `Unlicense OR MIT`
 - Source: `crates.io`

--- a/crates/agent-docs/Cargo.toml
+++ b/crates/agent-docs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-docs"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -19,12 +19,12 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 directories = { workspace = true }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 toml_edit = "0.25"
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/agent-out/Cargo.toml
+++ b/crates/agent-out/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-out"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -19,11 +19,11 @@ path = "src/main.rs"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-runtime-cli/Cargo.toml
+++ b/crates/agent-runtime-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-runtime-cli"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -19,7 +19,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 indexmap = { workspace = true }
-nils-markdown = { version = "0.25.0", path = "../nils-markdown", package = "nils-markdown" }
+nils-markdown = { version = "0.25.1", path = "../nils-markdown", package = "nils-markdown" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
@@ -29,5 +29,5 @@ tera = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/agent-scope-lock/Cargo.toml
+++ b/crates/agent-scope-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-scope-lock"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -14,11 +14,11 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-workflow-primitives/Cargo.toml
+++ b/crates/agent-workflow-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-workflow-primitives"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -58,16 +58,16 @@ path = "src/bin/test-first-evidence.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-agent-out = { version = "0.25.0", path = "../agent-out" }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
-nils-markdown = { version = "0.25.0", path = "../nils-markdown", package = "nils-markdown" }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-agent-out = { version = "0.25.1", path = "../agent-out" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
+nils-markdown = { version = "0.25.1", path = "../nils-markdown", package = "nils-markdown" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-gql/Cargo.toml
+++ b/crates/api-gql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-gql"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -12,13 +12,13 @@ name = "api-gql"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.25.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.25.1", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-grpc/Cargo.toml
+++ b/crates/api-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-grpc"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-grpc"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.25.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.25.1", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.22"
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-rest/Cargo.toml
+++ b/crates/api-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-rest"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-rest"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.25.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.25.1", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.22"
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-test/Cargo.toml
+++ b/crates/api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-test"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -16,14 +16,14 @@ name = "api-test"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.25.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.25.1", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-testing-core/Cargo.toml
+++ b/crates/api-testing-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-testing-core"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -24,10 +24,10 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-websocket/Cargo.toml
+++ b/crates/api-websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-websocket"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "api-websocket"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-api-testing-core = { version = "0.25.0", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "0.25.1", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }

--- a/crates/cli-template/Cargo.toml
+++ b/crates/cli-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-cli-template"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -13,13 +13,13 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/codex-cli/Cargo.toml
+++ b/crates/codex-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-codex-cli"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -23,10 +23,10 @@ reqwest = { version = "0.13", default-features = false, features = ["blocking", 
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.11"
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/forge-cli/Cargo.toml
+++ b/crates/forge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-forge-cli"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -20,7 +20,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 libc = "0.2"
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_yaml_ng = { workspace = true }
@@ -29,5 +29,5 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/fzf-cli/Cargo.toml
+++ b/crates/fzf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-fzf-cli"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -14,14 +14,14 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
 walkdir = "2"
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/gemini-cli/Cargo.toml
+++ b/crates/gemini-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-gemini-cli"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -21,9 +21,9 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/git-cli/Cargo.toml
+++ b/crates/git-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-cli"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -18,12 +18,12 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 serde_json = { workspace = true, features = ["preserve_order"] }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/git-lock/Cargo.toml
+++ b/crates/git-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-lock"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -15,10 +15,10 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 chrono = { version = "0.4", features = ["clock"] }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 tempfile = "3"
 pretty_assertions = { workspace = true }

--- a/crates/git-scope/Cargo.toml
+++ b/crates/git-scope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-scope"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -14,9 +14,9 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 tempfile = "3"
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }

--- a/crates/git-summary/Cargo.toml
+++ b/crates/git-summary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-summary"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -15,10 +15,10 @@ anyhow = { workspace = true }
 chrono = { version = "0.4", features = ["clock"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/image-processing/Cargo.toml
+++ b/crates/image-processing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-image-processing"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -20,8 +20,8 @@ serde_json = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 globset = "0.4"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 resvg = "0.47"
 roxmltree = "0.21"
 usvg = "0.47"
@@ -29,6 +29,6 @@ uuid = { version = "1", features = ["v4"] }
 walkdir = "2"
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/macos-agent/Cargo.toml
+++ b/crates/macos-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-macos-agent"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -20,11 +20,11 @@ clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 regex = "1"
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
-screen-record = { version = "0.25.0", path = "../screen-record", package = "nils-screen-record" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
+screen-record = { version = "0.25.1", path = "../screen-record", package = "nils-screen-record" }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/memo-cli/Cargo.toml
+++ b/crates/memo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-memo-cli"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -24,10 +24,10 @@ chrono-tz = "0.10"
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-common/Cargo.toml
+++ b/crates/nils-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-common"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 description = "Library crate for nils-common in the nils-cli workspace."
@@ -15,6 +15,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-markdown/Cargo.toml
+++ b/crates/nils-markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-markdown"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 description = "Shared Tera-backed Markdown template layer for the nils-cli workspace."
@@ -26,7 +26,7 @@ anyhow = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 clap_complete = { workspace = true, optional = true }
 indexmap = { workspace = true }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 pretty_assertions = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -35,6 +35,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-nils-markdown = { version = "0.25.0", path = ".", features = ["bin-cli", "test-support"] }
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-markdown = { version = "0.25.1", path = ".", features = ["bin-cli", "test-support"] }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/nils-term/Cargo.toml
+++ b/crates/nils-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-term"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 description = "Library crate for nils-term in the nils-cli workspace."

--- a/crates/nils-test-support/Cargo.toml
+++ b/crates/nils-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-test-support"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/plan-archive/Cargo.toml
+++ b/crates/plan-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-archive"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -20,8 +20,8 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 indexmap = { workspace = true }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -29,6 +29,6 @@ serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/plan-issue-cli/Cargo.toml
+++ b/crates/plan-issue-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-issue-cli"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 default-run = "plan-issue"
@@ -25,12 +25,12 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
-nils-markdown = { version = "0.25.0", path = "../nils-markdown", package = "nils-markdown" }
-plan-tooling = { version = "0.25.0", path = "../plan-tooling", package = "nils-plan-tooling" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
+nils-markdown = { version = "0.25.1", path = "../nils-markdown", package = "nils-markdown" }
+plan-tooling = { version = "0.25.1", path = "../plan-tooling", package = "nils-plan-tooling" }
 
 [dev-dependencies]
-nils-markdown = { version = "0.25.0", path = "../nils-markdown", package = "nils-markdown", features = ["test-support"] }
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-markdown = { version = "0.25.1", path = "../nils-markdown", package = "nils-markdown", features = ["test-support"] }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/plan-tooling/Cargo.toml
+++ b/crates/plan-tooling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-tooling"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -16,14 +16,14 @@ name = "plan-tooling"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/screen-record/Cargo.toml
+++ b/crates/screen-record/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-screen-record"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 build = "build.rs"
@@ -20,7 +20,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 ctrlc = "3.5.1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.13", features = ["randr"] }
@@ -41,7 +41,7 @@ block2 = "0.6.2"
 dispatch2 = "0.3.0"
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 tempfile = "3"
 
 [lints.rust]

--- a/crates/semantic-commit/Cargo.toml
+++ b/crates/semantic-commit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-semantic-commit"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -21,9 +21,9 @@ clap_complete = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
 time = { version = "0.3", features = ["formatting"] }
-nils-term = { version = "0.25.0", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "0.25.1", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/web-evidence/Cargo.toml
+++ b/crates/web-evidence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-web-evidence"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 license.workspace = true
 
@@ -18,12 +18,12 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-common = { version = "0.25.0", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "0.25.1", path = "../nils-common", package = "nils-common" }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "0.25.0", path = "../nils-test-support" }
+nils-test-support = { version = "0.25.1", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"


### PR DESCRIPTION
## Summary

- Bump workspace and CLI crate versions to 0.25.1
- Update README release tag example to v0.25.1
- Refresh Cargo.lock for workspace package versions
- Regenerate third-party artifacts for updated lockfile inputs

## Test plan

- [ ] CI: required status checks green
- [ ] After merge: tag v0.25.1 and confirm release.yml publishes artifacts
- [ ] Tap stage updates homebrew formula
