### PR TITLE
fix(plan-issue-cli): default tracking run timestamps to wall-clock UTC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,6 +2239,7 @@ dependencies = [
 name = "nils-plan-issue-cli"
 version = "0.25.2"
 dependencies = [
+ "chrono",
  "clap",
  "clap_complete",
  "nils-common",

--- a/crates/plan-issue-cli/Cargo.toml
+++ b/crates/plan-issue-cli/Cargo.toml
@@ -21,6 +21,7 @@ name = "plan-issue-local"
 path = "src/bin/plan-issue-local.rs"
 
 [dependencies]
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 serde = { workspace = true }

--- a/crates/plan-issue-cli/src/commands/tracking.rs
+++ b/crates/plan-issue-cli/src/commands/tracking.rs
@@ -98,6 +98,8 @@ pub struct TrackingRunInitArgs {
     pub run_id: Option<String>,
 
     /// Override the recorded timestamp (`created_at` / `updated_at`).
+    /// Defaults to the current UTC time; pass an explicit value for
+    /// deterministic tests/fixtures.
     #[arg(long = "now", value_name = "rfc3339")]
     pub now: Option<String>,
 
@@ -153,6 +155,8 @@ pub struct TrackingRunUpdateArgs {
     pub note: Option<String>,
 
     /// Override the recorded `updated_at` timestamp.
+    /// Defaults to the current UTC time; pass an explicit value for
+    /// deterministic tests/fixtures.
     #[arg(long = "now", value_name = "rfc3339")]
     pub now: Option<String>,
 }

--- a/crates/plan-issue-cli/src/execute.rs
+++ b/crates/plan-issue-cli/src/execute.rs
@@ -1713,11 +1713,11 @@ fn run_tracking_run_init(
     use crate::tracking::events::{self, ExecutionEvent, ExecutionEventKind};
     use crate::tracking::run_state::{ExecutionRun, RunPhase, RunRoot, SelectedScope};
 
+    let now = args.now.clone().unwrap_or_else(default_now);
     let run_id = args
         .run_id
         .clone()
-        .unwrap_or_else(|| default_run_id(args.issue, args.now.as_deref()));
-    let now = args.now.clone().unwrap_or_else(default_now);
+        .unwrap_or_else(|| default_run_id(args.issue, &now));
     let mut run = ExecutionRun::new(
         run_id.clone(),
         args.provider_repo.clone(),
@@ -2425,22 +2425,20 @@ fn resolve_close_ready_inputs(
     Ok((body, comments))
 }
 
-fn default_run_id(issue: u64, now: Option<&str>) -> String {
+fn default_run_id(issue: u64, now: &str) -> String {
     let mut id = String::new();
-    let timestamp = now.unwrap_or("00000000-000000");
-    let clean: String = timestamp
-        .chars()
-        .filter(|c| c.is_ascii_alphanumeric())
-        .collect();
+    let clean: String = now.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
     id.push_str(&clean);
     id.push_str(&format!("-issue-{issue}"));
     id
 }
 
 fn default_now() -> String {
-    // Deterministic placeholder when no `--now` is supplied. Tests can pass
-    // `--now` for stable values.
-    "1970-01-01T00:00:00Z".to_string()
+    // Safe default when no `--now` is supplied: real wall-clock UTC time, so a
+    // live `tracking run init`/`update` never records the 1970 epoch placeholder
+    // into run-state (issue #588). Tests and deterministic fixtures pass an
+    // explicit `--now` to override this.
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
 fn run_tracking_status(

--- a/crates/plan-issue-cli/tests/integration/tracking_run_update.rs
+++ b/crates/plan-issue-cli/tests/integration/tracking_run_update.rs
@@ -61,6 +61,53 @@ fn tracking_run_update_init_writes_run_state_and_events() {
 }
 
 #[test]
+fn tracking_run_init_defaults_now_to_wallclock_when_now_omitted() {
+    // Regression (issue #588): omitting `--now` must not write the 1970 epoch
+    // placeholder into live run-state. The safe default is the current UTC time,
+    // and `run_id` is derived from it rather than the `00000000…` placeholder.
+    let tmp = TempDir::new().expect("tmp");
+    let run_state_path = tmp.path().join("run-state.json");
+
+    let out = common::run_plan_issue(&[
+        "--format",
+        "json",
+        "tracking",
+        "run",
+        "init",
+        "--provider-repo",
+        "owner/repo",
+        "--issue",
+        "123",
+        "--out",
+        run_state_path.to_str().expect("path"),
+    ]);
+    assert_eq!(out.code, 0, "stderr: {}", out.stderr);
+
+    let run = run_state::read_run_state(&run_state_path).expect("read");
+    assert_ne!(
+        run.created_at, "1970-01-01T00:00:00Z",
+        "init without --now must not record the 1970 placeholder"
+    );
+    assert_eq!(run.created_at, run.updated_at, "init seeds both timestamps");
+    // RFC3339 UTC form with `Z` suffix, matching the workspace convention.
+    assert!(
+        run.created_at.contains('T') && run.created_at.ends_with('Z'),
+        "created_at should be RFC3339 UTC: {}",
+        run.created_at
+    );
+
+    let envelope = json_stdout(&out);
+    let run_id = envelope["payload"]["result"]["run_id"]
+        .as_str()
+        .expect("run_id");
+    assert!(
+        !run_id.starts_with("00000000000000"),
+        "run_id should derive from a real timestamp, not the placeholder: {run_id}"
+    );
+    assert!(run_id.ends_with("-issue-123"), "run_id: {run_id}");
+}
+
+#[test]
 fn tracking_run_update_changes_phase_and_appends_event() {
     let tmp = TempDir::new().expect("tmp");
     let run_state_path = tmp.path().join("run-state.json");


### PR DESCRIPTION
## Summary

Harden `tracking run init` and `tracking run update` so that omitting `--now`
records real wall-clock UTC time instead of the `1970-01-01T00:00:00Z` epoch
placeholder. Production callers that forgot `--now` previously wrote a 1970
`created_at`/`updated_at` and a `00000000…` `run_id` into live run-state — a
silent footgun that can poison downstream staleness/reconcile logic comparing
run-state timestamps against provider comment timestamps. The safe behavior is
now the default; `--now` remains the deterministic override for tests and
fixtures.

Closes #588.

## Changes

- `default_now()` now returns `chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)` (e.g. `2026-05-27T16:05:03Z`) instead of the hardcoded 1970 placeholder; both `run init` and `run update` consume it.
- `run_tracking_run_init` computes `now` first and derives `run_id` from it, so the generated id reflects real time instead of the `00000000-000000` placeholder. `default_run_id` drops the now-dead placeholder branch (signature `Option<&str>` → `&str`).
- Adds `chrono` to `plan-issue-cli` (matching the workspace's existing `features = ["clock", "std"]` form). `Cargo.lock` gains a single dependency edge; no new third-party crate, so `THIRD_PARTY_LICENSES.md` / `THIRD_PARTY_NOTICES.md` are unchanged.
- `--now` help text on both `run init` and `run update` documents the new "defaults to current UTC time" behavior.

## Test-First Evidence

Added integration regression test
`tracking_run_init_defaults_now_to_wallclock_when_now_omitted`
(`crates/plan-issue-cli/tests/integration/tracking_run_update.rs`), which runs
the real `plan-issue` binary.

- **RED** on the pre-change binary: assertion failed with
  `left: "1970-01-01T00:00:00Z"`.
- **GREEN** after the fix.

The test asserts `created_at != "1970-01-01T00:00:00Z"`, that `created_at`
equals `updated_at`, RFC3339 UTC `Z` form, and that the generated `run_id`
does not start with the `00000000…` placeholder and ends with `-issue-123`.

## Test plan

- `cargo test -p nils-plan-issue-cli --test integration tracking_run_update` → 5 passed (new regression test + existing init/update coverage, no regressions).
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` → escalated to the workspace Rust gate (because `Cargo.lock` changed); `cargo fmt --all --check`, clippy, full-workspace `nextest`, and workspace doctests all green.
- Manual smoke (real binary): `plan-issue tracking run init` without `--now` → `created_at = 2026-05-27T16:05:03Z`, `run_id = 20260527T160503Z-issue-42`; with `--now 2026-05-26T00:00:00Z` → `run_id = 20260526T000000Z-issue-7` (deterministic override preserved).

## Risk / Notes

- Low. The behavior change is confined to the implicit default when `--now` is omitted; every existing test and fixture passes `--now` explicitly and is unaffected.
- The new default is intentionally non-deterministic (wall-clock UTC) — that is the desired safe behavior for live run-state. Deterministic output still requires (and honors) an explicit `--now`.
- No new third-party crate: `chrono` is already in the workspace lockfile, so license/notice artifacts and the third-party CI gate are unaffected.
