### PR TITLE
Add derived plan archive catalog command

### DIFF
--- a/completions/bash/plan-archive
+++ b/completions/bash/plan-archive
@@ -16,6 +16,9 @@ _plan-archive() {
             ",$1")
                 cmd="plan__archive"
                 ;;
+            plan__archive,catalog)
+                cmd="plan__archive__catalog"
+                ;;
             plan__archive,completion)
                 cmd="plan__archive__completion"
                 ;;
@@ -39,6 +42,9 @@ _plan-archive() {
                 ;;
             plan__archive,validate-metadata)
                 cmd="plan__archive__validate__metadata"
+                ;;
+            plan__archive__help,catalog)
+                cmd="plan__archive__help__catalog"
                 ;;
             plan__archive__help,completion)
                 cmd="plan__archive__help__completion"
@@ -71,12 +77,46 @@ _plan-archive() {
 
     case "${cmd}" in
         plan__archive)
-            opts="-h -V --format --json --help --version validate-hosts validate-local validate-metadata migrate refresh completion query help"
+            opts="-h -V --format --json --help --version validate-hosts validate-local validate-metadata migrate refresh completion query catalog help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__archive__catalog)
+            opts="-h --write --grep --area --refs-to --archive --format --json --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --grep)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --area)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --refs-to)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --archive)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
                     return 0
@@ -107,8 +147,22 @@ _plan-archive() {
             return 0
             ;;
         plan__archive__help)
-            opts="validate-hosts validate-local validate-metadata migrate refresh completion query help"
+            opts="validate-hosts validate-local validate-metadata migrate refresh completion query catalog help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__archive__help__catalog)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi

--- a/completions/zsh/_plan-archive
+++ b/completions/zsh/_plan-archive
@@ -119,6 +119,20 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
 ;;
+(catalog)
+_arguments "${_arguments_options[@]}" : \
+'--grep=[Filter records by case-insensitive substring]:GREP:_default' \
+'--area=[Filter records by area tag]:AREA:_default' \
+'--refs-to=[Return plans that reference this issue/PR/MR URL]:REFS_TO:_default' \
+'--archive=[Archive clone path. Defaults to the machine-local config'\''s \`archive_clone_path\`]:ARCHIVE:_files' \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--write[Write deterministic \`<archive>/catalog.json\`]' \
+'(--format)--json[Hidden alias for \`--format json\` kept for symmetry with neighbouring CLIs]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
 (help)
 _arguments "${_arguments_options[@]}" : \
 ":: :_plan-archive__subcmd__help_commands" \
@@ -159,6 +173,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(catalog)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (help)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -182,9 +200,15 @@ _plan-archive_commands() {
 'refresh:Fetch provider payloads and append scrubbed snapshots to \`_index/\`. Writes and scrubs but does not commit; the scrub log (if any) must be reviewed before committing' \
 'completion:Print a shell completion script for \`plan-archive\`' \
 'query:Read or aggregate cached \`_index/\` snapshots' \
+'catalog:Generate, write, or filter the derived archive catalog' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'plan-archive commands' commands "$@"
+}
+(( $+functions[_plan-archive__subcmd__catalog_commands] )) ||
+_plan-archive__subcmd__catalog_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-archive catalog commands' commands "$@"
 }
 (( $+functions[_plan-archive__subcmd__completion_commands] )) ||
 _plan-archive__subcmd__completion_commands() {
@@ -201,9 +225,15 @@ _plan-archive__subcmd__help_commands() {
 'refresh:Fetch provider payloads and append scrubbed snapshots to \`_index/\`. Writes and scrubs but does not commit; the scrub log (if any) must be reviewed before committing' \
 'completion:Print a shell completion script for \`plan-archive\`' \
 'query:Read or aggregate cached \`_index/\` snapshots' \
+'catalog:Generate, write, or filter the derived archive catalog' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'plan-archive help commands' commands "$@"
+}
+(( $+functions[_plan-archive__subcmd__help__subcmd__catalog_commands] )) ||
+_plan-archive__subcmd__help__subcmd__catalog_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-archive help catalog commands' commands "$@"
 }
 (( $+functions[_plan-archive__subcmd__help__subcmd__completion_commands] )) ||
 _plan-archive__subcmd__help__subcmd__completion_commands() {

--- a/crates/plan-archive/src/catalog/mod.rs
+++ b/crates/plan-archive/src/catalog/mod.rs
@@ -1,0 +1,568 @@
+//! Deterministic derived catalog for archived plans.
+//!
+//! The catalog is a committed text projection built from authoritative
+//! `plans/**/metadata.yaml` files plus the latest scrubbed `_index/` snapshots.
+//! It is rebuildable and intentionally mirrors the row shape that the future
+//! SQLite index will consume.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use nils_common::cli_contract::{Envelope, EnvelopeError, OutputFormat, exit, schema_version_for};
+use serde::{Deserialize, Serialize};
+
+use crate::query::decode_basic_stamp;
+use crate::refresh::refparse::{RefKind, RefTarget, parse_ref_url};
+use crate::validate;
+
+const BINARY: &str = "plan-archive";
+const COMMAND: &str = "catalog";
+const CATALOG_SCHEMA: &str = "plan-archive.catalog.v1";
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CatalogDocument {
+    pub schema_version: String,
+    pub records: Vec<CatalogRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CatalogRecord {
+    pub slug: String,
+    pub host: String,
+    pub org: String,
+    pub repo: String,
+    pub date: String,
+    pub original_path: String,
+    pub archive_commit: String,
+    pub title: String,
+    pub summary: String,
+    pub area: Vec<String>,
+    pub refs: Vec<CatalogRef>,
+    pub files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CatalogRef {
+    pub url: String,
+    pub kind: RefKind,
+    pub number: u64,
+    pub state: String,
+    pub title: String,
+    pub latest_snapshot: Option<String>,
+    pub fetched_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CatalogReport {
+    pub catalog_path: String,
+    pub wrote: bool,
+    pub total_records: usize,
+    pub records: Vec<CatalogRecord>,
+}
+
+pub struct DispatchArgs {
+    pub write: bool,
+    pub grep: Option<String>,
+    pub area: Option<String>,
+    pub refs_to: Option<String>,
+    pub archive: Option<PathBuf>,
+    pub format: OutputFormat,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CatalogError {
+    #[error("archive clone path not found at `{0}`")]
+    ArchiveCloneMissing(PathBuf),
+    #[error("`--refs-to` value `{0}` is not a parseable issue/PR/MR URL")]
+    UnparseableRef(String),
+    #[error("failed to read plan metadata `{0}`: {1}")]
+    MetadataReadFailed(String, String),
+    #[error("failed to parse plan metadata `{0}`: {1}")]
+    MetadataParseFailed(String, String),
+    #[error("plan metadata `{0}` is missing required source field `{1}`")]
+    MetadataMissingSourceField(String, &'static str),
+    #[error("io error during catalog generation: {0}")]
+    Io(String),
+}
+
+impl CatalogError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            CatalogError::ArchiveCloneMissing(_) => "catalog-archive-clone-missing",
+            CatalogError::UnparseableRef(_) => "catalog-unparseable-ref",
+            CatalogError::MetadataReadFailed(_, _) => "catalog-metadata-read-failed",
+            CatalogError::MetadataParseFailed(_, _) => "catalog-metadata-parse-failed",
+            CatalogError::MetadataMissingSourceField(_, _) => "catalog-metadata-missing-source",
+            CatalogError::Io(_) => "catalog-io-error",
+        }
+    }
+}
+
+pub fn dispatch(args: DispatchArgs) -> i32 {
+    let format = args.format;
+    match run(&args) {
+        Ok(report) => emit(format, &report),
+        Err(err) => emit_error(format, err.code(), &err.to_string()),
+    }
+}
+
+pub fn run(args: &DispatchArgs) -> Result<CatalogReport, CatalogError> {
+    let archive = resolve_archive(args.archive.as_deref())?;
+    let document = build_document(&archive)?;
+    let filtered = filter_records(
+        &document.records,
+        args.grep.as_deref(),
+        args.area.as_deref(),
+        args.refs_to.as_deref(),
+    )?;
+    let catalog_path = archive.join("catalog.json");
+    if args.write {
+        write_document(&catalog_path, &document)?;
+    }
+    Ok(CatalogReport {
+        catalog_path: catalog_path.display().to_string(),
+        wrote: args.write,
+        total_records: document.records.len(),
+        records: filtered,
+    })
+}
+
+pub fn write_catalog(archive: &Path) -> Result<PathBuf, CatalogError> {
+    let document = build_document(archive)?;
+    let path = archive.join("catalog.json");
+    write_document(&path, &document)?;
+    Ok(path)
+}
+
+pub fn build_document(archive: &Path) -> Result<CatalogDocument, CatalogError> {
+    let mut records = Vec::new();
+    let plans_root = archive.join("plans");
+    if plans_root.is_dir() {
+        let mut metadata_paths = Vec::new();
+        collect_metadata_paths(&plans_root, &mut metadata_paths)?;
+        metadata_paths.sort();
+        for metadata_path in metadata_paths {
+            records.push(record_from_metadata(archive, &metadata_path)?);
+        }
+    }
+    records.sort_by(|a, b| {
+        (&a.host, &a.org, &a.repo, &a.date, &a.slug)
+            .cmp(&(&b.host, &b.org, &b.repo, &b.date, &b.slug))
+    });
+    Ok(CatalogDocument {
+        schema_version: CATALOG_SCHEMA.to_string(),
+        records,
+    })
+}
+
+pub fn to_catalog_json(document: &CatalogDocument) -> Result<String, CatalogError> {
+    let mut body = serde_json::to_string_pretty(document)
+        .map_err(|e| CatalogError::Io(format!("catalog serialize: {e}")))?;
+    body.push('\n');
+    Ok(body)
+}
+
+fn collect_metadata_paths(root: &Path, out: &mut Vec<PathBuf>) -> Result<(), CatalogError> {
+    for entry in fs::read_dir(root).map_err(|e| CatalogError::Io(e.to_string()))? {
+        let entry = entry.map_err(|e| CatalogError::Io(e.to_string()))?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_metadata_paths(&path, out)?;
+        } else if path.file_name().and_then(|n| n.to_str()) == Some("metadata.yaml") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn record_from_metadata(
+    archive: &Path,
+    metadata_path: &Path,
+) -> Result<CatalogRecord, CatalogError> {
+    let label = metadata_path.display().to_string();
+    let raw = fs::read_to_string(metadata_path)
+        .map_err(|e| CatalogError::MetadataReadFailed(label.clone(), e.to_string()))?;
+    let metadata: RawMetadata = serde_yaml_ng::from_str(&raw)
+        .map_err(|e| CatalogError::MetadataParseFailed(label.clone(), e.to_string()))?;
+    let source = metadata
+        .source
+        .ok_or(CatalogError::MetadataMissingSourceField(
+            label.clone(),
+            "source",
+        ))?;
+    let host = required_source_field(&label, "host", source.host)?;
+    let org = required_source_field(&label, "org_or_group_path", source.org_or_group_path)?;
+    let repo = required_source_field(&label, "repo", source.repo)?;
+    let original_path = required_source_field(&label, "original_path", source.original_path)?;
+    let archive_commit = required_source_field(&label, "archive_commit", source.archive_commit)?;
+    let slug = metadata_path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("")
+        .to_string();
+    let date = date_from_slug(&slug);
+
+    let mut refs = Vec::new();
+    if let Some(raw_refs) = metadata.refs {
+        for url in raw_refs.urls() {
+            if let Some(target) = parse_ref_url(&url) {
+                refs.push(catalog_ref_for(archive, target));
+            }
+        }
+    }
+    refs.sort_by(|a, b| (&a.url, a.number).cmp(&(&b.url, b.number)));
+    let title = refs
+        .iter()
+        .find_map(|r| non_empty(&r.title))
+        .unwrap_or_else(|| slug.clone());
+
+    Ok(CatalogRecord {
+        slug,
+        host,
+        org,
+        repo,
+        date,
+        original_path,
+        archive_commit,
+        title,
+        summary: String::new(),
+        area: Vec::new(),
+        refs,
+        files: Vec::new(),
+    })
+}
+
+fn required_source_field(
+    label: &str,
+    field: &'static str,
+    value: Option<String>,
+) -> Result<String, CatalogError> {
+    match value {
+        Some(v) if !v.trim().is_empty() => Ok(v),
+        _ => Err(CatalogError::MetadataMissingSourceField(
+            label.to_string(),
+            field,
+        )),
+    }
+}
+
+fn catalog_ref_for(archive: &Path, target: RefTarget) -> CatalogRef {
+    let url = target.canonical_url();
+    let (latest_snapshot, fetched_at, snapshot_value) = latest_snapshot(archive, &target);
+    let title = snapshot_string(&snapshot_value, "title").unwrap_or_default();
+    let state = snapshot_string(&snapshot_value, "state").unwrap_or_default();
+    CatalogRef {
+        url,
+        kind: target.kind,
+        number: target.number,
+        state,
+        title,
+        latest_snapshot,
+        fetched_at,
+    }
+}
+
+fn latest_snapshot(
+    archive: &Path,
+    target: &RefTarget,
+) -> (Option<String>, Option<String>, Option<serde_json::Value>) {
+    let rel_dir = target.index_dir();
+    let dir = archive.join(&rel_dir);
+    let Ok(read) = fs::read_dir(&dir) else {
+        return (None, None, None);
+    };
+    let mut files: Vec<String> = read
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|name| name.ends_with(".json"))
+        .collect();
+    files.sort();
+    let Some(file_name) = files.last() else {
+        return (None, None, None);
+    };
+    let stamp = file_name.trim_end_matches(".json");
+    let fetched_at = decode_basic_stamp(stamp);
+    let rel = rel_dir.join(file_name);
+    let value = fs::read_to_string(archive.join(&rel))
+        .ok()
+        .and_then(|body| serde_json::from_str(&body).ok());
+    (Some(rel.display().to_string()), fetched_at, value)
+}
+
+fn snapshot_string(value: &Option<serde_json::Value>, key: &str) -> Option<String> {
+    let value = value.as_ref()?;
+    value
+        .get("data")
+        .and_then(|data| data.get(key))
+        .or_else(|| value.get(key))
+        .and_then(|v| v.as_str())
+        .map(ToString::to_string)
+}
+
+fn filter_records(
+    records: &[CatalogRecord],
+    grep: Option<&str>,
+    area: Option<&str>,
+    refs_to: Option<&str>,
+) -> Result<Vec<CatalogRecord>, CatalogError> {
+    let grep = grep.map(|s| s.to_ascii_lowercase());
+    let refs_to = refs_to
+        .map(|url| {
+            parse_ref_url(url)
+                .map(|target| target.canonical_url())
+                .ok_or_else(|| CatalogError::UnparseableRef(url.to_string()))
+        })
+        .transpose()?;
+
+    Ok(records
+        .iter()
+        .filter(|record| match grep.as_deref() {
+            Some(term) => record_matches_grep(record, term),
+            None => true,
+        })
+        .filter(|record| match area {
+            Some(area) => record.area.iter().any(|a| a == area),
+            None => true,
+        })
+        .filter(|record| match refs_to.as_deref() {
+            Some(url) => record.refs.iter().any(|r| r.url == url),
+            None => true,
+        })
+        .cloned()
+        .collect())
+}
+
+fn record_matches_grep(record: &CatalogRecord, term: &str) -> bool {
+    let fields = [
+        record.slug.as_str(),
+        record.title.as_str(),
+        record.summary.as_str(),
+        record.original_path.as_str(),
+        record.host.as_str(),
+        record.org.as_str(),
+        record.repo.as_str(),
+    ];
+    fields
+        .iter()
+        .any(|field| field.to_ascii_lowercase().contains(term))
+        || record.refs.iter().any(|r| {
+            r.url.to_ascii_lowercase().contains(term)
+                || r.title.to_ascii_lowercase().contains(term)
+                || r.state.to_ascii_lowercase().contains(term)
+        })
+}
+
+fn write_document(path: &Path, document: &CatalogDocument) -> Result<(), CatalogError> {
+    let body = to_catalog_json(document)?;
+    fs::write(path, body).map_err(|e| CatalogError::Io(e.to_string()))
+}
+
+fn date_from_slug(slug: &str) -> String {
+    let candidate = slug.get(0..10).unwrap_or_default();
+    let parts: Vec<&str> = candidate.split('-').collect();
+    if parts.len() == 3
+        && parts[0].len() == 4
+        && parts[1].len() == 2
+        && parts[2].len() == 2
+        && parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit()))
+    {
+        candidate.to_string()
+    } else {
+        String::new()
+    }
+}
+
+fn non_empty(value: &str) -> Option<String> {
+    if value.trim().is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn resolve_archive(arg: Option<&Path>) -> Result<PathBuf, CatalogError> {
+    let candidate = match arg {
+        Some(p) => p.to_path_buf(),
+        None => default_archive_clone_path()?,
+    };
+    if !candidate.is_dir() {
+        return Err(CatalogError::ArchiveCloneMissing(candidate));
+    }
+    Ok(candidate)
+}
+
+fn default_archive_clone_path() -> Result<PathBuf, CatalogError> {
+    let local = validate::local::validate_local_path(&local_config_path())
+        .map_err(|e| CatalogError::Io(e.to_string()))?;
+    Ok(local.data.config.archive_clone_path)
+}
+
+fn local_config_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("PLAN_ARCHIVE_LOCAL_CONFIG") {
+        return PathBuf::from(p);
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        return PathBuf::from(xdg)
+            .join("agent-plan-archive")
+            .join("config.yaml");
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join(".config")
+            .join("agent-plan-archive")
+            .join("config.yaml");
+    }
+    PathBuf::from("/nonexistent/agent-plan-archive/config.yaml")
+}
+
+fn emit(format: OutputFormat, report: &CatalogReport) -> i32 {
+    match format {
+        OutputFormat::Json => {
+            let envelope = Envelope::success(schema_version_for(BINARY, COMMAND, 1), report);
+            match serde_json::to_string(&envelope) {
+                Ok(s) => {
+                    println!("{s}");
+                    exit::SUCCESS
+                }
+                Err(_) => exit::SOFTWARE,
+            }
+        }
+        OutputFormat::Text => {
+            if report.wrote {
+                println!(
+                    "catalog written: {} ({} record(s))",
+                    report.catalog_path, report.total_records
+                );
+            }
+            if report.records.is_empty() {
+                println!("no matching archived plans");
+            }
+            for record in &report.records {
+                println!(
+                    "{}  {}/{}/{}  refs={}",
+                    record.slug,
+                    record.host,
+                    record.org,
+                    record.repo,
+                    record.refs.len()
+                );
+            }
+            exit::SUCCESS
+        }
+    }
+}
+
+fn emit_error(format: OutputFormat, code: &str, message: &str) -> i32 {
+    match format {
+        OutputFormat::Json => {
+            let envelope: Envelope<()> = Envelope::failure(
+                schema_version_for(BINARY, COMMAND, 1),
+                EnvelopeError::new(code, message),
+            );
+            if let Ok(s) = serde_json::to_string(&envelope) {
+                eprintln!("{s}");
+            }
+            exit::DATA
+        }
+        OutputFormat::Text => {
+            eprintln!("error [{code}]: {message}");
+            exit::DATA
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMetadata {
+    #[serde(default)]
+    source: Option<RawSource>,
+    #[serde(default)]
+    refs: Option<RawRefs>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSource {
+    #[serde(default)]
+    host: Option<String>,
+    #[serde(default)]
+    org_or_group_path: Option<String>,
+    #[serde(default)]
+    repo: Option<String>,
+    #[serde(default)]
+    archive_commit: Option<String>,
+    #[serde(default)]
+    original_path: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawRefs {
+    #[serde(default)]
+    issue: Option<String>,
+    #[serde(default)]
+    pr: Option<String>,
+    #[serde(default)]
+    mr: Option<String>,
+}
+
+impl RawRefs {
+    fn urls(self) -> Vec<String> {
+        [self.issue, self.pr, self.mr]
+            .into_iter()
+            .flatten()
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn date_from_slug_reads_date_prefix() {
+        assert_eq!(
+            date_from_slug("2026-05-27-plan-archive-search-layer"),
+            "2026-05-27"
+        );
+        assert_eq!(date_from_slug("undated-plan"), "");
+    }
+
+    #[test]
+    fn grep_matches_ref_title() {
+        let record = CatalogRecord {
+            slug: "s".into(),
+            host: "github.com".into(),
+            org: "o".into(),
+            repo: "r".into(),
+            date: "2026-05-27".into(),
+            original_path: "docs/plans/s/".into(),
+            archive_commit: "abc".into(),
+            title: "fallback".into(),
+            summary: String::new(),
+            area: vec!["archive".into()],
+            refs: vec![CatalogRef {
+                url: "https://github.com/o/r/issues/1".into(),
+                kind: RefKind::Issue,
+                number: 1,
+                state: "open".into(),
+                title: "Search layer".into(),
+                latest_snapshot: None,
+                fetched_at: None,
+            }],
+            files: Vec::new(),
+        };
+
+        assert_eq!(
+            filter_records(std::slice::from_ref(&record), Some("search"), None, None).unwrap(),
+            vec![record.clone()]
+        );
+        assert_eq!(
+            filter_records(std::slice::from_ref(&record), None, Some("archive"), None).unwrap(),
+            vec![record.clone()]
+        );
+        assert!(
+            filter_records(&[record], None, Some("other"), None)
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/crates/plan-archive/src/cli.rs
+++ b/crates/plan-archive/src/cli.rs
@@ -167,6 +167,25 @@ enum Command {
         #[arg(long)]
         archive: Option<PathBuf>,
     },
+    /// Generate, write, or filter the derived archive catalog.
+    Catalog {
+        /// Write deterministic `<archive>/catalog.json`.
+        #[arg(long)]
+        write: bool,
+        /// Filter records by case-insensitive substring.
+        #[arg(long)]
+        grep: Option<String>,
+        /// Filter records by area tag.
+        #[arg(long)]
+        area: Option<String>,
+        /// Return plans that reference this issue/PR/MR URL.
+        #[arg(long = "refs-to")]
+        refs_to: Option<String>,
+        /// Archive clone path. Defaults to the machine-local config's
+        /// `archive_clone_path`.
+        #[arg(long)]
+        archive: Option<PathBuf>,
+    },
 }
 
 pub fn run() -> i32 {
@@ -251,6 +270,20 @@ pub fn run() -> i32 {
             since,
             plan,
             refs_from,
+            archive,
+            format,
+        }),
+        Command::Catalog {
+            write,
+            grep,
+            area,
+            refs_to,
+            archive,
+        } => crate::catalog::dispatch(crate::catalog::DispatchArgs {
+            write,
+            grep,
+            area,
+            refs_to,
             archive,
             format,
         }),

--- a/crates/plan-archive/src/lib.rs
+++ b/crates/plan-archive/src/lib.rs
@@ -6,6 +6,7 @@
 //! (`plan-archive-nils-cli`) lands the three schema validators that the
 //! later `migrate`, `refresh`, and `query` subcommands build on.
 
+pub mod catalog;
 pub mod cli;
 pub mod completion;
 pub mod migrate;

--- a/crates/plan-archive/src/migrate/mod.rs
+++ b/crates/plan-archive/src/migrate/mod.rs
@@ -526,9 +526,15 @@ fn apply(args: DispatchArgs, report: DryRunReport) -> Result<ApplyReport, Migrat
         .map_err(|e| MigrateError::Io(format!("metadata serialize: {e}")))?;
     let metadata_path = archive_abs_target.join("metadata.yaml");
     fs::write(&metadata_path, metadata_yaml).map_err(|e| MigrateError::Io(e.to_string()))?;
+    crate::catalog::write_catalog(&archive).map_err(|e| MigrateError::Io(e.to_string()))?;
 
     // Stage and commit in the archive repo.
-    let stage_args = ["add", "--", &report.archive_target.relative_path];
+    let stage_args = [
+        "add",
+        "--",
+        &report.archive_target.relative_path,
+        "catalog.json",
+    ];
     let stage_out = nils_common::git::run_output_in(&archive, &stage_args)
         .map_err(|e| MigrateError::Io(e.to_string()))?;
     if !stage_out.status.success() {

--- a/crates/plan-archive/src/refresh/mod.rs
+++ b/crates/plan-archive/src/refresh/mod.rs
@@ -59,6 +59,7 @@ pub struct RefreshReport {
     pub snapshots: Vec<SnapshotResult>,
     pub failed: Vec<FailedRef>,
     pub requires_review: bool,
+    pub catalog_path: Option<String>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -165,11 +166,16 @@ pub fn run<F: ForgeFetcher, C: Clock>(
         }
     }
 
+    let catalog_path = crate::catalog::write_catalog(&archive)
+        .map_err(|e| RefreshError::Io(e.to_string()))?
+        .display()
+        .to_string();
     let requires_review = snapshots.iter().any(|s| s.requires_review);
     Ok(RefreshReport {
         snapshots,
         failed,
         requires_review,
+        catalog_path: Some(catalog_path),
     })
 }
 
@@ -346,6 +352,9 @@ fn emit(format: OutputFormat, report: RefreshReport) -> i32 {
                 println!(
                     "review required: at least one snapshot emitted a scrub log; commit only after acknowledging it"
                 );
+            }
+            if let Some(path) = &report.catalog_path {
+                println!("catalog regenerated: {path}");
             }
             exit::SUCCESS
         }

--- a/crates/plan-archive/tests/catalog.rs
+++ b/crates/plan-archive/tests/catalog.rs
@@ -1,0 +1,144 @@
+//! Integration coverage for the derived `plan-archive catalog` projection.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use nils_common::cli_contract::OutputFormat;
+use plan_archive::catalog::{self, DispatchArgs};
+
+struct Archive {
+    _tmp: tempfile::TempDir,
+    path: PathBuf,
+}
+
+fn seed_snapshot(archive: &Path, rel_dir: &str, stamp: &str, body: &str) {
+    let dir = archive.join("_index").join(rel_dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join(format!("{stamp}.json")), body).unwrap();
+}
+
+fn seed_metadata(archive: &Path, slug: &str, refs: &str) {
+    let dir = archive
+        .join("plans/github.com/graysurf/agent-runtime-kit")
+        .join(slug);
+    fs::create_dir_all(&dir).unwrap();
+    let refs_section = if refs.is_empty() {
+        String::new()
+    } else {
+        format!("refs:\n{refs}")
+    };
+    fs::write(
+        dir.join("metadata.yaml"),
+        format!(
+            "version: 1\nsource:\n  host: github.com\n  org_or_group_path: graysurf\n  repo: agent-runtime-kit\n  branch: main\n  archive_commit: abc123\n  original_path: docs/plans/{slug}/\ncaptured_classification:\n  class: personal\n{refs_section}"
+        ),
+    )
+    .unwrap();
+}
+
+fn build_archive() -> Archive {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("archive");
+    fs::create_dir_all(&path).unwrap();
+    seed_snapshot(
+        &path,
+        "github.com/graysurf/agent-runtime-kit/issues/126",
+        "20260527T010000Z",
+        r#"{"data":{"title":"Catalog issue","state":"open"}}"#,
+    );
+    seed_snapshot(
+        &path,
+        "github.com/graysurf/agent-runtime-kit/pulls/127",
+        "20260527T020000Z",
+        r#"{"title":"Catalog PR","state":"merged"}"#,
+    );
+    seed_metadata(
+        &path,
+        "2026-05-27-plan-archive-search-layer",
+        "  issue: https://github.com/graysurf/agent-runtime-kit/issues/126\n  pr: https://github.com/graysurf/agent-runtime-kit/pull/127\n",
+    );
+    seed_metadata(
+        &path,
+        "2026-05-28-plan-with-missing-snapshot",
+        "  issue: https://github.com/graysurf/agent-runtime-kit/issues/999\n",
+    );
+    seed_metadata(&path, "2026-05-29-plan-without-refs", "");
+    Archive { _tmp: tmp, path }
+}
+
+fn base_args(archive: &Path) -> DispatchArgs {
+    DispatchArgs {
+        write: false,
+        grep: None,
+        area: None,
+        refs_to: None,
+        archive: Some(archive.to_path_buf()),
+        format: OutputFormat::Json,
+    }
+}
+
+#[test]
+fn catalog_document_includes_plans_refs_and_latest_snapshots() {
+    let archive = build_archive();
+    let document = catalog::build_document(&archive.path).unwrap();
+
+    assert_eq!(document.records.len(), 3);
+    let first = &document.records[0];
+    assert_eq!(first.slug, "2026-05-27-plan-archive-search-layer");
+    assert_eq!(first.date, "2026-05-27");
+    assert_eq!(first.title, "Catalog issue");
+    assert_eq!(first.refs.len(), 2);
+    assert_eq!(first.refs[0].state, "open");
+    assert_eq!(
+        first.refs[0].latest_snapshot.as_deref(),
+        Some("_index/github.com/graysurf/agent-runtime-kit/issues/126/20260527T010000Z.json")
+    );
+    assert_eq!(
+        first.refs[0].fetched_at.as_deref(),
+        Some("2026-05-27T01:00:00Z")
+    );
+
+    let missing = document
+        .records
+        .iter()
+        .find(|r| r.slug == "2026-05-28-plan-with-missing-snapshot")
+        .unwrap();
+    assert!(missing.refs[0].latest_snapshot.is_none());
+}
+
+#[test]
+fn catalog_serialization_is_deterministic() {
+    let archive = build_archive();
+    let first = catalog::to_catalog_json(&catalog::build_document(&archive.path).unwrap()).unwrap();
+    let second =
+        catalog::to_catalog_json(&catalog::build_document(&archive.path).unwrap()).unwrap();
+    assert_eq!(first, second);
+}
+
+#[test]
+fn refs_to_returns_referencing_plans() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.refs_to = Some("https://github.com/graysurf/agent-runtime-kit/issues/126".into());
+
+    let report = catalog::run(&args).unwrap();
+    assert_eq!(report.records.len(), 1);
+    assert_eq!(
+        report.records[0].slug,
+        "2026-05-27-plan-archive-search-layer"
+    );
+}
+
+#[test]
+fn write_catalog_persists_deterministic_json() {
+    let archive = build_archive();
+    let mut args = base_args(&archive.path);
+    args.write = true;
+
+    let report = catalog::run(&args).unwrap();
+    let written = fs::read_to_string(archive.path.join("catalog.json")).unwrap();
+    let rebuilt =
+        catalog::to_catalog_json(&catalog::build_document(&archive.path).unwrap()).unwrap();
+    assert_eq!(written, rebuilt);
+    assert_eq!(report.total_records, 3);
+}


### PR DESCRIPTION
## Summary

- Add `plan-archive catalog` with deterministic `CatalogRecord` / `CatalogRef` derivation from archived metadata and latest `_index` snapshots.
- Wire catalog regeneration into migrate/refresh and add refs-to, grep, write, and completion coverage.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- `cargo fmt --all -- --check`
- `cargo test -p nils-plan-archive`
- `cargo clippy -p nils-plan-archive --all-targets -- -D warnings`
- `zsh -n completions/zsh/_plan-archive && bash -n completions/bash/plan-archive`
- Live archive `plan-archive catalog --write` deterministic rerun; `catalog.json` committed in `graysurf/agent-plan-archive@4107980`.

## Tracking

- graysurf/agent-runtime-kit#132
