### PR TITLE
feat(semantic-commit): block unwanted agent attribution

### DIFF
--- a/crates/semantic-commit/README.md
+++ b/crates/semantic-commit/README.md
@@ -224,6 +224,9 @@ Semantic Commit validation applies to `semantic-commit commit` message input:
 - Body and trailer lines must be at most `100` characters.
 - Git trailers may appear after the header or after a blank separator
   following bullet body lines.
+- Blocked message rules reject known unwanted agent attribution text, including
+  `Co-Authored-By: Claude ...` trailers from either message input or
+  `--trailer`.
 
 `fixup` and `squash` do not use this header validation because git generates
 subjects prefixed with `fixup!` or `squash!`.

--- a/crates/semantic-commit/src/commit.rs
+++ b/crates/semantic-commit/src/commit.rs
@@ -268,6 +268,10 @@ pub fn run(args: &[String]) -> i32 {
         return EXIT_ERROR;
     }
 
+    if let Err(code) = validate_blocked_message_rules(&message_contents, &options.trailers) {
+        return code;
+    }
+
     let tmpfile = match tempfile::NamedTempFile::new() {
         Ok(file) => file,
         Err(_) => {
@@ -1583,6 +1587,131 @@ fn validate_commit_message_with_width(path: &Path, max_header_width: usize) -> R
 fn fail_validation(message: &str) -> Result<(), i32> {
     eprintln!("error: {message}");
     Err(EXIT_VALIDATION_FAILED)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BlockedMessageRule {
+    id: &'static str,
+    reason: &'static str,
+    matched_hint: &'static str,
+    fix: &'static str,
+    patterns: &'static [BlockedMessagePattern],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BlockedMessagePattern {
+    TrailerValueStartsWith {
+        token: &'static str,
+        value_prefix: &'static str,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BlockedMessageSource {
+    MessageLine(usize),
+    TrailerFlag(usize),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct BlockedMessageMatch {
+    source: BlockedMessageSource,
+}
+
+const CLAUDE_COAUTHOR_PATTERNS: &[BlockedMessagePattern] =
+    &[BlockedMessagePattern::TrailerValueStartsWith {
+        token: "Co-Authored-By",
+        value_prefix: "Claude",
+    }];
+
+const BLOCKED_MESSAGE_RULES: &[BlockedMessageRule] = &[BlockedMessageRule {
+    id: "claude-coauthor-trailer",
+    reason: "do not attribute commits to any Claude model",
+    matched_hint: "Co-Authored-By: Claude ...",
+    fix: "remove the `Co-Authored-By: Claude ...` trailer",
+    patterns: CLAUDE_COAUTHOR_PATTERNS,
+}];
+
+fn validate_blocked_message_rules(message: &str, trailers: &[String]) -> Result<(), i32> {
+    for rule in BLOCKED_MESSAGE_RULES {
+        if let Some(blocked) = find_blocked_message_match(rule, message, trailers) {
+            return fail_validation(&format!(
+                "commit message is blocked by rule `{}`\n  source: {}\n  matched: {}\n  rule: {}\n  fix: {}",
+                rule.id,
+                blocked_message_source_label(blocked.source),
+                rule.matched_hint,
+                rule.reason,
+                rule.fix
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn find_blocked_message_match<'a>(
+    rule: &BlockedMessageRule,
+    message: &'a str,
+    trailers: &'a [String],
+) -> Option<BlockedMessageMatch> {
+    for (idx, line) in message.lines().enumerate() {
+        if rule.patterns.iter().any(|pattern| pattern.matches(line)) {
+            return Some(BlockedMessageMatch {
+                source: BlockedMessageSource::MessageLine(idx + 1),
+            });
+        }
+    }
+
+    for (idx, trailer) in trailers.iter().enumerate() {
+        if rule.patterns.iter().any(|pattern| pattern.matches(trailer)) {
+            return Some(BlockedMessageMatch {
+                source: BlockedMessageSource::TrailerFlag(idx + 1),
+            });
+        }
+    }
+
+    None
+}
+
+fn blocked_message_source_label(source: BlockedMessageSource) -> String {
+    match source {
+        BlockedMessageSource::MessageLine(line) => format!("message line {line}"),
+        BlockedMessageSource::TrailerFlag(idx) => format!("--trailer #{idx}"),
+    }
+}
+
+impl BlockedMessagePattern {
+    fn matches(self, line: &str) -> bool {
+        match self {
+            Self::TrailerValueStartsWith {
+                token,
+                value_prefix,
+            } => trailer_value_starts_with(line, token, value_prefix),
+        }
+    }
+}
+
+fn trailer_value_starts_with(line: &str, expected_token: &str, value_prefix: &str) -> bool {
+    let Some((token, value)) = split_trailer(line.trim()) else {
+        return false;
+    };
+    token.eq_ignore_ascii_case(expected_token)
+        && starts_with_ascii_word_ignore_case(value, value_prefix)
+}
+
+fn starts_with_ascii_word_ignore_case(value: &str, expected_word: &str) -> bool {
+    if expected_word.is_empty() {
+        return false;
+    }
+    let value = value.trim_start();
+    let Some(prefix) = value.get(..expected_word.len()) else {
+        return false;
+    };
+    if !prefix.eq_ignore_ascii_case(expected_word) {
+        return false;
+    }
+    value[expected_word.len()..]
+        .chars()
+        .next()
+        .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'))
 }
 
 fn is_valid_header(header: &str) -> bool {

--- a/crates/semantic-commit/tests/integration/commit.rs
+++ b/crates/semantic-commit/tests/integration/commit.rs
@@ -343,6 +343,135 @@ fn commit_validate_only_invalid_message_returns_4() {
     assert_eq!(output.status.code(), Some(4));
 }
 
+#[test]
+fn commit_validate_only_rejects_claude_coauthor_trailer_in_message() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    let stderr = as_str(&output.stderr);
+    assert!(
+        stderr.contains("blocked by rule `claude-coauthor-trailer`"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("matched: Co-Authored-By: Claude"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn commit_validate_only_rejects_claude_coauthor_trailer_flag() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing",
+            "--trailer",
+            "Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    let stderr = as_str(&output.stderr);
+    assert!(
+        stderr.contains("source: --trailer #1"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("blocked by rule `claude-coauthor-trailer`"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn commit_validate_only_rejects_claude_coauthor_equals_trailer_flag() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing",
+            "--trailer",
+            "Co-Authored-By=Claude Haiku <noreply@anthropic.com>",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    let stderr = as_str(&output.stderr);
+    assert!(
+        stderr.contains("matched: Co-Authored-By: Claude ..."),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn commit_validate_only_allows_non_claude_coauthor_trailers() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing\n\nCo-Authored-By: Jane Dev <jane@example.com>",
+            "--trailer",
+            "Co-Authored-By: Build Bot <bot@example.com>",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+}
+
+#[test]
+fn commit_validate_only_allows_claude_as_part_of_longer_word() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing\n\nCo-Authored-By: Claudette Dev <dev@example.com>",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+}
+
 fn header_with_total_len(total_len: usize) -> String {
     let prefix = "feat: ";
     assert!(total_len > prefix.len());


### PR DESCRIPTION
## Summary

Adds first-class blocked-message validation to `semantic-commit commit` so unwanted agent attribution trailers are rejected by the CLI itself instead of relying on a Claude-only hook.

## Changes

- Adds an extensible blocked-message rule table to `semantic-commit` validation.
- Rejects `Co-Authored-By: Claude ...` from both message content and repeatable `--trailer` arguments.
- Documents the rule and covers blocked, allowed, and word-boundary cases in integration tests.

## Test-First Evidence

Focused regression tests were added before delivery validation in `crates/semantic-commit/tests/integration/commit.rs` for the new blocked rule behavior.

## Test plan

- `agent-run exec --cwd /Users/terry/.codex/worktrees/4fda/nils-cli -- cargo fmt --check`
- `agent-run exec --cwd /Users/terry/.codex/worktrees/4fda/nils-cli -- cargo test -p nils-semantic-commit --locked`
- `agent-run exec --cwd /Users/terry/.codex/worktrees/4fda/nils-cli -- bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`

## Risk / Notes

- Low risk: change is scoped to semantic-commit message validation and covered by focused integration tests.
