### PR TITLE
feat(plan-archive): add read-only discover candidate scanner

### DIFF
--- a/completions/bash/plan-archive
+++ b/completions/bash/plan-archive
@@ -22,6 +22,9 @@ _plan-archive() {
             plan__archive,completion)
                 cmd="plan__archive__completion"
                 ;;
+            plan__archive,discover)
+                cmd="plan__archive__discover"
+                ;;
             plan__archive,help)
                 cmd="plan__archive__help"
                 ;;
@@ -48,6 +51,9 @@ _plan-archive() {
                 ;;
             plan__archive__help,completion)
                 cmd="plan__archive__help__completion"
+                ;;
+            plan__archive__help,discover)
+                cmd="plan__archive__help__discover"
                 ;;
             plan__archive__help,help)
                 cmd="plan__archive__help__help"
@@ -77,7 +83,7 @@ _plan-archive() {
 
     case "${cmd}" in
         plan__archive)
-            opts="-h -V --format --json --help --version validate-hosts validate-local validate-metadata migrate refresh completion query catalog help"
+            opts="-h -V --format --json --help --version validate-hosts validate-local validate-metadata migrate discover refresh completion query catalog help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -146,8 +152,42 @@ _plan-archive() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        plan__archive__discover)
+            opts="-h --source-repo --plans-root --archive --hosts --include-unknown --format --json --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --source-repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --plans-root)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --archive)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --hosts)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         plan__archive__help)
-            opts="validate-hosts validate-local validate-metadata migrate refresh completion query catalog help"
+            opts="validate-hosts validate-local validate-metadata migrate discover refresh completion query catalog help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -175,6 +215,20 @@ _plan-archive() {
             return 0
             ;;
         plan__archive__help__completion)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        plan__archive__help__discover)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/completions/zsh/_plan-archive
+++ b/completions/zsh/_plan-archive
@@ -78,6 +78,20 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
 ;;
+(discover)
+_arguments "${_arguments_options[@]}" : \
+'--source-repo=[Source working repo. Defaults to the current git repo root]:SOURCE_REPO:_files' \
+'--plans-root=[Plan-folder root, relative to the source repo. Defaults to \`docs/plans\`]:PLANS_ROOT:_files' \
+'--archive=[Archive clone path. Defaults to the machine-local config'\''s \`archive_clone_path\`]:ARCHIVE:_files' \
+'--hosts=[Path to the archive \`config/hosts.yaml\`. Defaults to \`<archive>/config/hosts.yaml\`]:HOSTS:_files' \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--include-unknown[Include \`unknown\` candidates in the output (default\: eligible + blocked only). Counts always report all three]' \
+'(--format)--json[Hidden alias for \`--format json\` kept for symmetry with neighbouring CLIs]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
 (refresh)
 _arguments "${_arguments_options[@]}" : \
 '(--repo --since)--ref=[Reference to refresh (issue/PR/MR URL)]:REF:_default' \
@@ -161,6 +175,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(discover)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
 (refresh)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -197,6 +215,7 @@ _plan-archive_commands() {
 'validate-local:Validate a machine-local \`agent-plan-archive/config.yaml\` document. Missing files return documented defaults with exit code 0' \
 'validate-metadata:Validate an archived plan'\''s \`metadata.yaml\` document' \
 'migrate:Migrate a closed plan folder into the archive repo. Dry-run by default; use \`--apply\` to write and commit' \
+'discover:Read-only scan of plan folders for archive candidates. Classifies each folder as eligible, blocked, or unknown and suggests a \`plan-archive migrate\` command for eligible folders. Never mutates the source or archive repos' \
 'refresh:Fetch provider payloads and append scrubbed snapshots to \`_index/\`. Writes and scrubs but does not commit; the scrub log (if any) must be reviewed before committing' \
 'completion:Print a shell completion script for \`plan-archive\`' \
 'query:Read or aggregate cached \`_index/\` snapshots' \
@@ -215,6 +234,11 @@ _plan-archive__subcmd__completion_commands() {
     local commands; commands=()
     _describe -t commands 'plan-archive completion commands' commands "$@"
 }
+(( $+functions[_plan-archive__subcmd__discover_commands] )) ||
+_plan-archive__subcmd__discover_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-archive discover commands' commands "$@"
+}
 (( $+functions[_plan-archive__subcmd__help_commands] )) ||
 _plan-archive__subcmd__help_commands() {
     local commands; commands=(
@@ -222,6 +246,7 @@ _plan-archive__subcmd__help_commands() {
 'validate-local:Validate a machine-local \`agent-plan-archive/config.yaml\` document. Missing files return documented defaults with exit code 0' \
 'validate-metadata:Validate an archived plan'\''s \`metadata.yaml\` document' \
 'migrate:Migrate a closed plan folder into the archive repo. Dry-run by default; use \`--apply\` to write and commit' \
+'discover:Read-only scan of plan folders for archive candidates. Classifies each folder as eligible, blocked, or unknown and suggests a \`plan-archive migrate\` command for eligible folders. Never mutates the source or archive repos' \
 'refresh:Fetch provider payloads and append scrubbed snapshots to \`_index/\`. Writes and scrubs but does not commit; the scrub log (if any) must be reviewed before committing' \
 'completion:Print a shell completion script for \`plan-archive\`' \
 'query:Read or aggregate cached \`_index/\` snapshots' \
@@ -239,6 +264,11 @@ _plan-archive__subcmd__help__subcmd__catalog_commands() {
 _plan-archive__subcmd__help__subcmd__completion_commands() {
     local commands; commands=()
     _describe -t commands 'plan-archive help completion commands' commands "$@"
+}
+(( $+functions[_plan-archive__subcmd__help__subcmd__discover_commands] )) ||
+_plan-archive__subcmd__help__subcmd__discover_commands() {
+    local commands; commands=()
+    _describe -t commands 'plan-archive help discover commands' commands "$@"
 }
 (( $+functions[_plan-archive__subcmd__help__subcmd__help_commands] )) ||
 _plan-archive__subcmd__help__subcmd__help_commands() {

--- a/crates/plan-archive/README.md
+++ b/crates/plan-archive/README.md
@@ -66,7 +66,9 @@ byte offset, span length, and replacement length.
 
 Sprint 3 (Plan 1) lands `plan-archive migrate`, which moves a closed
 plan folder out of a working repo into the archive repo. Dry-run is
-the default; `--apply` performs the writes and commits.
+the default; `--apply` performs the writes and commits. To enumerate
+which folders look ready before migrating one, use the read-only
+[`discover`](#discover-surface) preselection scan described below.
 
 ```bash
 plan-archive migrate \
@@ -107,6 +109,157 @@ Stable error codes (Sprint 3):
 | `migrate-source-repo-dirty` | uncommitted changes in the plan folder (apply) |
 | `migrate-subprocess-failed` | a git or semantic-commit subprocess failed |
 | `migrate-io-error` | filesystem failure |
+
+## Discover surface
+
+`plan-archive discover` is a **read-only** scanner that enumerates plan
+folders under a working repo and classifies each as an archive
+candidate. It never copies, deletes, writes, commits, pushes, or
+refreshes provider state — it only reads local files and previews where
+each folder *would* land in the archive. It reuses the same source
+identity, host classification, and archive-target derivation as
+`migrate` (`plans/<host>/<org>/<repo>/<folder>/`), so the two commands
+cannot drift.
+
+```bash
+plan-archive discover \
+  [--source-repo <path>] [--plans-root docs/plans] \
+  [--archive <path>] [--hosts <path>] \
+  [--include-unknown] [--format json|text]
+```
+
+- `--source-repo` defaults to the current git repo root; `--plans-root`
+  is repo-relative and defaults to `docs/plans`; `--archive` and
+  `--hosts` resolve exactly as for `migrate`.
+- `--include-unknown` adds `unknown` candidates to the listing (they are
+  omitted by default). The summary always reports `scanned`, `eligible`,
+  `blocked`, and `unknown` counts, so nothing is silently hidden.
+
+### Status classes
+
+| Status | Meaning |
+| --- | --- |
+| `eligible` | ≥1 inferred provider ref, a free archive target, a clean plan folder, a known host, and confident closeout evidence. Carries a ready-to-review `suggested_migrate_command`. |
+| `blocked` | Has at least one actionable blocker: `archive-target-exists`, `source-plan-folder-dirty`, `unknown-host`, or `no-provider-refs`. |
+| `unknown` | Otherwise migrate-able, but closeout evidence could not be confidently inferred from local files (`closeout-evidence-uncertain`). |
+
+Provider refs are inferred by parsing issue/PR/MR URLs out of the
+folder's top-level Markdown; each ref records whether it points at the
+source repo or is cross-repo. Discovery never calls a provider.
+
+### Closeout evidence
+
+A folder counts as closed (and so `eligible`, given no blockers) when a
+top-level Markdown file carries either:
+
+- a Markdown **Closeout** heading (`## Closeout`, `# Close-out`, …), or
+- a `Status:` line whose value contains a terminal keyword
+  (`complete`, `completed`, `closed`, `done`, `delivered`, `merged`,
+  `archived`, `shipped`, `ready for close`) **and** no in-flight keyword
+  (`active`, `in progress`, `not started`, `pending`, `wip`, `todo`,
+  `blocked`, `ongoing`, `draft`, `ready to implement`).
+
+The in-flight veto keeps sprint-level notes such as
+`Status: Sprint 2 complete; Sprint 3 active` out of `eligible`. When the
+signal is absent or ambiguous the folder stays `unknown` rather than
+being promoted — discover never invents closeout evidence.
+
+### Example (`--format json`)
+
+```json
+{
+  "schema_version": "cli.plan-archive.discover.v1",
+  "data": {
+    "source": {
+      "host": "github.com",
+      "org_or_group_path": "graysurf",
+      "repo": "agent-runtime-kit",
+      "branch": "main",
+      "commit": "…"
+    },
+    "plans_root": "docs/plans",
+    "archive": "/abs/agent-plan-archive",
+    "host_known": true,
+    "summary": {
+      "scanned": 2,
+      "eligible": 1,
+      "blocked": 1,
+      "unknown": 0,
+      "included_unknown": false
+    },
+    "candidates": [
+      {
+        "plan_folder": "2026-05-01-ready-plan",
+        "source_path": "docs/plans/2026-05-01-ready-plan/",
+        "status": "eligible",
+        "reasons": [],
+        "refs": [
+          {
+            "url": "https://github.com/graysurf/agent-runtime-kit/issues/10",
+            "kind": "issue",
+            "source_file": "docs/plans/2026-05-01-ready-plan/plan.md",
+            "matches_source_repo": true
+          }
+        ],
+        "archive_target": {
+          "relative_path": "plans/github.com/graysurf/agent-runtime-kit/2026-05-01-ready-plan",
+          "absolute_path": "/abs/agent-plan-archive/plans/github.com/graysurf/agent-runtime-kit/2026-05-01-ready-plan",
+          "exists": false
+        },
+        "closeout_evidence": {
+          "marker": "complete; all sprints delivered",
+          "source_file": "docs/plans/2026-05-01-ready-plan/execution-state.md"
+        },
+        "dirty": false,
+        "suggested_migrate_command": "plan-archive migrate --plan docs/plans/2026-05-01-ready-plan --issue https://github.com/graysurf/agent-runtime-kit/issues/10 --format json"
+      },
+      {
+        "plan_folder": "2026-05-02-stuck-plan",
+        "source_path": "docs/plans/2026-05-02-stuck-plan/",
+        "status": "blocked",
+        "reasons": [
+          {
+            "code": "archive-target-exists",
+            "detail": "archive target already exists; resolve the collision before migrating"
+          }
+        ],
+        "refs": [
+          {
+            "url": "https://github.com/graysurf/agent-runtime-kit/issues/11",
+            "kind": "issue",
+            "source_file": "docs/plans/2026-05-02-stuck-plan/plan.md",
+            "matches_source_repo": true
+          }
+        ],
+        "archive_target": {
+          "relative_path": "plans/github.com/graysurf/agent-runtime-kit/2026-05-02-stuck-plan",
+          "absolute_path": "/abs/agent-plan-archive/plans/github.com/graysurf/agent-runtime-kit/2026-05-02-stuck-plan",
+          "exists": true
+        },
+        "dirty": false
+      }
+    ]
+  }
+}
+```
+
+`discover` is a **preselection helper only**. It suggests a
+`plan-archive migrate …` command for each eligible folder, but applying a
+migration stays with `migrate`, which is dry-run-first and gated on
+explicit confirmation. Review each folder's migrate dry-run before
+`--apply`; there is no bulk-apply path and discovery never refreshes
+provider state.
+
+Stable error codes (discover):
+
+| Code | When |
+| --- | --- |
+| `discover-source-repo-not-found` | `--source-repo` is not a git repo |
+| `discover-archive-clone-missing` | archive clone path not found |
+| `discover-hosts-load-failed` / `discover-hosts-parse-failed` | hosts config unreadable/invalid |
+| `discover-identity-failed` | could not read source remote/branch/HEAD |
+| `discover-plans-root-outside-repo` | `--plans-root` resolves outside the source repo |
+| `discover-io-error` | filesystem failure |
 
 ## Sprint 4 surface
 

--- a/crates/plan-archive/src/cli.rs
+++ b/crates/plan-archive/src/cli.rs
@@ -107,6 +107,31 @@ enum Command {
         #[arg(long)]
         apply: bool,
     },
+    /// Read-only scan of plan folders for archive candidates.
+    /// Classifies each folder as eligible, blocked, or unknown and
+    /// suggests a `plan-archive migrate` command for eligible folders.
+    /// Never mutates the source or archive repos.
+    Discover {
+        /// Source working repo. Defaults to the current git repo root.
+        #[arg(long)]
+        source_repo: Option<PathBuf>,
+        /// Plan-folder root, relative to the source repo. Defaults to
+        /// `docs/plans`.
+        #[arg(long)]
+        plans_root: Option<PathBuf>,
+        /// Archive clone path. Defaults to the machine-local config's
+        /// `archive_clone_path`.
+        #[arg(long)]
+        archive: Option<PathBuf>,
+        /// Path to the archive `config/hosts.yaml`. Defaults to
+        /// `<archive>/config/hosts.yaml`.
+        #[arg(long)]
+        hosts: Option<PathBuf>,
+        /// Include `unknown` candidates in the output (default:
+        /// eligible + blocked only). Counts always report all three.
+        #[arg(long)]
+        include_unknown: bool,
+    },
     /// Fetch provider payloads and append scrubbed snapshots to
     /// `_index/`. Writes and scrubs but does not commit; the scrub
     /// log (if any) must be reviewed before committing.
@@ -237,6 +262,20 @@ pub fn run() -> i32 {
             pr,
             mr,
             apply,
+            format,
+        }),
+        Command::Discover {
+            source_repo,
+            plans_root,
+            archive,
+            hosts,
+            include_unknown,
+        } => crate::discover::dispatch(crate::discover::DispatchArgs {
+            source_repo,
+            plans_root,
+            archive,
+            hosts,
+            include_unknown,
             format,
         }),
         Command::Refresh {

--- a/crates/plan-archive/src/cli.rs
+++ b/crates/plan-archive/src/cli.rs
@@ -574,3 +574,74 @@ fn render_clap_message(err: &clap::Error) -> String {
         })
         .unwrap_or_else(|| "command-line parse failed".to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_surface_is_valid() {
+        // Validates the whole derived command tree, including the
+        // `discover` subcommand and its arguments.
+        Cli::command().debug_assert();
+        let names: Vec<String> = Cli::command()
+            .get_subcommands()
+            .map(|c| c.get_name().to_string())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "discover"),
+            "discover wired: {names:?}"
+        );
+    }
+
+    #[test]
+    fn discover_parses_all_flags() {
+        let cli = Cli::try_parse_from([
+            "plan-archive",
+            "discover",
+            "--source-repo",
+            "/repo",
+            "--plans-root",
+            "docs/plans",
+            "--archive",
+            "/arch",
+            "--hosts",
+            "/arch/config/hosts.yaml",
+            "--include-unknown",
+            "--format",
+            "json",
+        ])
+        .expect("discover parses");
+        assert!(matches!(cli.output_format(), OutputFormat::Json));
+        match cli.command {
+            Command::Discover {
+                source_repo,
+                plans_root,
+                archive,
+                hosts,
+                include_unknown,
+            } => {
+                assert_eq!(source_repo, Some(PathBuf::from("/repo")));
+                assert_eq!(plans_root, Some(PathBuf::from("docs/plans")));
+                assert_eq!(archive, Some(PathBuf::from("/arch")));
+                assert_eq!(hosts, Some(PathBuf::from("/arch/config/hosts.yaml")));
+                assert!(include_unknown);
+            }
+            _ => panic!("expected the Discover subcommand"),
+        }
+    }
+
+    #[test]
+    fn discover_defaults_are_optional() {
+        let cli = Cli::try_parse_from(["plan-archive", "discover"]).expect("parses with defaults");
+        assert!(matches!(
+            cli.command,
+            Command::Discover {
+                include_unknown: false,
+                source_repo: None,
+                plans_root: None,
+                ..
+            }
+        ));
+    }
+}

--- a/crates/plan-archive/src/discover/mod.rs
+++ b/crates/plan-archive/src/discover/mod.rs
@@ -1,0 +1,734 @@
+//! `plan-archive discover` — read-only archive-candidate scanner.
+//!
+//! Enumerates plan folders under the source repo's `docs/plans/` (or an
+//! explicit `--plans-root`), infers provider refs and closeout evidence
+//! from local files, previews each folder's archive target, and
+//! classifies it as `eligible`, `blocked`, or `unknown`.
+//!
+//! Discover is strictly read-only: it never copies, deletes, writes,
+//! commits, pushes, or refreshes provider state. It reuses the same
+//! source-identity, host-classification, and archive-target derivation
+//! as `migrate` (via [`crate::source`], [`crate::migrate`]) so the two
+//! commands cannot drift, and it only *suggests* a `plan-archive
+//! migrate` command — applying a migration remains migrate's job,
+//! dry-run-first and gated on explicit confirmation.
+
+use std::collections::HashSet;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use nils_common::cli_contract::{Envelope, EnvelopeError, OutputFormat, exit, schema_version_for};
+use regex::Regex;
+use serde::Serialize;
+
+use crate::migrate::{SourceIdentity, archive_target_path, derive_source_identity};
+use crate::refresh::refparse::{RefKind, parse_ref_url};
+use crate::source::{self, SourceError};
+
+const COMMAND: &str = "discover";
+const BINARY: &str = "plan-archive";
+
+/// Status keywords that signal a plan is finished. Matched
+/// case-insensitively inside a `Status:` value.
+const TERMINAL_KEYWORDS: &[&str] = &[
+    "complete",
+    "completed",
+    "closed",
+    "done",
+    "delivered",
+    "merged",
+    "archived",
+    "shipped",
+    "ready for close",
+    "ready_for_close",
+    "ready-for-close",
+];
+
+/// Status keywords that signal a plan is still in flight. Their
+/// presence vetoes a closeout match so sprint-level "complete" notes
+/// (e.g. "Sprint 2 complete; Sprint 3 active") do not promote a folder
+/// to `eligible`.
+const ACTIVE_KEYWORDS: &[&str] = &[
+    "active",
+    "in progress",
+    "in-progress",
+    "not started",
+    "not-started",
+    "pending",
+    "ready to implement",
+    "wip",
+    "todo",
+    "blocked",
+    "ongoing",
+    "draft",
+];
+
+/// Args forwarded from `cli::run`.
+pub struct DispatchArgs {
+    pub source_repo: Option<PathBuf>,
+    pub plans_root: Option<PathBuf>,
+    pub archive: Option<PathBuf>,
+    pub hosts: Option<PathBuf>,
+    pub include_unknown: bool,
+    pub format: OutputFormat,
+}
+
+/// Candidate classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiscoverStatus {
+    /// Has ≥1 provider ref, a free archive target, a clean folder, a
+    /// known host, and confident closeout evidence.
+    Eligible,
+    /// Has at least one actionable blocker that must be resolved before
+    /// migration.
+    Blocked,
+    /// Otherwise migrate-able, but closeout evidence could not be
+    /// confidently inferred from local files.
+    Unknown,
+}
+
+/// Why a candidate landed in `blocked` or `unknown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscoverReason {
+    ArchiveTargetExists,
+    SourcePlanFolderDirty,
+    UnknownHost,
+    NoProviderRefs,
+    CloseoutEvidenceUncertain,
+}
+
+impl DiscoverReason {
+    pub fn code(self) -> &'static str {
+        match self {
+            DiscoverReason::ArchiveTargetExists => "archive-target-exists",
+            DiscoverReason::SourcePlanFolderDirty => "source-plan-folder-dirty",
+            DiscoverReason::UnknownHost => "unknown-host",
+            DiscoverReason::NoProviderRefs => "no-provider-refs",
+            DiscoverReason::CloseoutEvidenceUncertain => "closeout-evidence-uncertain",
+        }
+    }
+
+    pub fn detail(self) -> &'static str {
+        match self {
+            DiscoverReason::ArchiveTargetExists => {
+                "archive target already exists; resolve the collision before migrating"
+            }
+            DiscoverReason::SourcePlanFolderDirty => {
+                "plan folder has uncommitted or untracked changes; commit or stash them first"
+            }
+            DiscoverReason::UnknownHost => {
+                "source host is absent from the archive `config/hosts.yaml`"
+            }
+            DiscoverReason::NoProviderRefs => {
+                "no issue/PR/MR reference could be inferred from the plan folder"
+            }
+            DiscoverReason::CloseoutEvidenceUncertain => {
+                "no confident closeout marker found in the plan folder; review before migrating"
+            }
+        }
+    }
+}
+
+/// Serializable `{code, detail}` reason row.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReasonDetail {
+    pub code: String,
+    pub detail: String,
+}
+
+impl From<DiscoverReason> for ReasonDetail {
+    fn from(r: DiscoverReason) -> Self {
+        Self {
+            code: r.code().to_string(),
+            detail: r.detail().to_string(),
+        }
+    }
+}
+
+/// A provider reference inferred from a plan folder's Markdown.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct InferredRef {
+    /// Canonical provider URL.
+    pub url: String,
+    pub kind: RefKind,
+    /// Source-repo-relative path of the file the ref was found in.
+    pub source_file: String,
+    /// Whether the ref points at the source repo itself (vs. a
+    /// cross-repo reference).
+    pub matches_source_repo: bool,
+}
+
+/// Local evidence that a plan is finished.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CloseoutEvidence {
+    /// The matched marker text (a closeout heading or a terminal
+    /// `Status:` value).
+    pub marker: String,
+    /// Source-repo-relative path of the file the marker was found in.
+    pub source_file: String,
+}
+
+/// Preview of where a plan folder would land in the archive.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArchiveTargetPreview {
+    pub relative_path: String,
+    pub absolute_path: String,
+    pub exists: bool,
+}
+
+/// One classified plan folder.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiscoverCandidate {
+    /// Folder name, e.g. `2026-05-27-my-plan`.
+    pub plan_folder: String,
+    /// Source-repo-relative folder path with a trailing slash.
+    pub source_path: String,
+    pub status: DiscoverStatus,
+    pub reasons: Vec<ReasonDetail>,
+    pub refs: Vec<InferredRef>,
+    pub archive_target: ArchiveTargetPreview,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub closeout_evidence: Option<CloseoutEvidence>,
+    pub dirty: bool,
+    /// A ready-to-review `plan-archive migrate …` command. Present only
+    /// for `eligible` candidates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_migrate_command: Option<String>,
+}
+
+/// Aggregate counts. Always reports true totals even when `unknown`
+/// candidates are omitted from `candidates`.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiscoverSummary {
+    pub scanned: usize,
+    pub eligible: usize,
+    pub blocked: usize,
+    pub unknown: usize,
+    pub included_unknown: bool,
+}
+
+/// Full discovery report.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiscoverReport {
+    pub source: SourceIdentity,
+    /// Source-repo-relative plan-folder root.
+    pub plans_root: String,
+    /// Absolute archive clone path.
+    pub archive: String,
+    pub host_known: bool,
+    pub summary: DiscoverSummary,
+    pub candidates: Vec<DiscoverCandidate>,
+}
+
+/// Failure modes for `plan-archive discover`.
+#[derive(Debug, thiserror::Error)]
+pub enum DiscoverError {
+    #[error("source repo not found at `{0}`")]
+    SourceRepoNotFound(PathBuf),
+    #[error(
+        "archive clone path not found at `{0}` (set `--archive` or seed `archive_clone_path` in the local config)"
+    )]
+    ArchiveCloneMissing(PathBuf),
+    #[error("failed to load archive `config/hosts.yaml`: {0}")]
+    HostsLoadFailed(String),
+    #[error("failed to parse archive `config/hosts.yaml`: {0}")]
+    HostsParseFailed(String),
+    #[error("failed to read source repo identity: {0}")]
+    IdentityFailed(String),
+    #[error("plans root `{0}` resolves outside the source repo")]
+    PlansRootOutsideRepo(PathBuf),
+    #[error("io error during discovery: {0}")]
+    Io(String),
+}
+
+impl DiscoverError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            DiscoverError::SourceRepoNotFound(_) => "discover-source-repo-not-found",
+            DiscoverError::ArchiveCloneMissing(_) => "discover-archive-clone-missing",
+            DiscoverError::HostsLoadFailed(_) => "discover-hosts-load-failed",
+            DiscoverError::HostsParseFailed(_) => "discover-hosts-parse-failed",
+            DiscoverError::IdentityFailed(_) => "discover-identity-failed",
+            DiscoverError::PlansRootOutsideRepo(_) => "discover-plans-root-outside-repo",
+            DiscoverError::Io(_) => "discover-io-error",
+        }
+    }
+}
+
+impl From<SourceError> for DiscoverError {
+    fn from(err: SourceError) -> Self {
+        match err {
+            SourceError::SourceRepoNotFound(p) => DiscoverError::SourceRepoNotFound(p),
+            SourceError::ArchiveCloneMissing(p) => DiscoverError::ArchiveCloneMissing(p),
+            SourceError::HostsLoadFailed(s) => DiscoverError::HostsLoadFailed(s),
+            SourceError::HostsParseFailed(s) => DiscoverError::HostsParseFailed(s),
+            SourceError::Io(s) => DiscoverError::Io(s),
+        }
+    }
+}
+
+/// Entry point called from `cli::run`.
+pub fn dispatch(args: DispatchArgs) -> i32 {
+    let format = args.format;
+    match scan(&args) {
+        Ok(report) => emit(format, &report),
+        Err(err) => emit_error(format, err.code(), &err.to_string()),
+    }
+}
+
+/// Read-only scan. Resolves the source repo, archive, and hosts config,
+/// enumerates plan folders, and classifies each. Performs no writes.
+///
+/// The returned `candidates` honour `args.include_unknown` (unknowns are
+/// omitted unless requested); `summary` always carries true totals.
+pub fn scan(args: &DispatchArgs) -> Result<DiscoverReport, DiscoverError> {
+    let source_repo = source::resolve_source_repo(args.source_repo.as_deref())?;
+    let archive = source::resolve_archive(args.archive.as_deref())?;
+    let hosts_path = source::hosts_path_for(&archive, args.hosts.as_deref());
+    let hosts = source::load_hosts(&hosts_path)?;
+
+    let identity = derive_source_identity(&source_repo)
+        .map_err(|e| DiscoverError::IdentityFailed(e.to_string()))?;
+    let host_known = hosts.hosts.contains_key(&identity.host);
+
+    let plans_root_rel = resolve_plans_root_rel(&source_repo, args.plans_root.as_deref())?;
+    let plans_root_abs = source_repo.join(&plans_root_rel);
+
+    let url_re = url_regex();
+    let status_re = status_regex();
+    let closeout_heading_re = closeout_heading_regex();
+
+    let mut all: Vec<DiscoverCandidate> = Vec::new();
+    if plans_root_abs.is_dir() {
+        for dir in sorted_subdirs(&plans_root_abs)? {
+            let folder = match dir.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            let rel_dir = plans_root_rel.join(&folder);
+            let source_path = format!("{}/", rel_dir.to_string_lossy().trim_end_matches('/'));
+
+            let (refs, closeout) = scan_folder_files(
+                &dir,
+                &source_path,
+                &identity,
+                &url_re,
+                &status_re,
+                &closeout_heading_re,
+            );
+
+            let target_rel = archive_target_path(
+                &identity.host,
+                &identity.org_or_group_path,
+                &identity.repo,
+                &folder,
+            );
+            let target_abs = archive.join(&target_rel);
+            let archive_target = ArchiveTargetPreview {
+                relative_path: target_rel.to_string_lossy().to_string(),
+                absolute_path: target_abs.to_string_lossy().to_string(),
+                exists: target_abs.exists(),
+            };
+
+            let dirty = source::has_dirty_path(&source_repo, &rel_dir)?;
+
+            // Accumulate blockers, then fall through to the
+            // eligible/unknown split.
+            let mut reasons: Vec<DiscoverReason> = Vec::new();
+            if archive_target.exists {
+                reasons.push(DiscoverReason::ArchiveTargetExists);
+            }
+            if dirty {
+                reasons.push(DiscoverReason::SourcePlanFolderDirty);
+            }
+            if !host_known {
+                reasons.push(DiscoverReason::UnknownHost);
+            }
+            if refs.is_empty() {
+                reasons.push(DiscoverReason::NoProviderRefs);
+            }
+
+            let status = if !reasons.is_empty() {
+                DiscoverStatus::Blocked
+            } else if closeout.is_some() {
+                DiscoverStatus::Eligible
+            } else {
+                reasons.push(DiscoverReason::CloseoutEvidenceUncertain);
+                DiscoverStatus::Unknown
+            };
+
+            let suggested_migrate_command = if status == DiscoverStatus::Eligible {
+                Some(build_migrate_command(
+                    rel_dir.to_string_lossy().trim_end_matches('/'),
+                    &refs,
+                ))
+            } else {
+                None
+            };
+
+            all.push(DiscoverCandidate {
+                plan_folder: folder,
+                source_path,
+                status,
+                reasons: reasons.into_iter().map(ReasonDetail::from).collect(),
+                refs,
+                archive_target,
+                closeout_evidence: closeout,
+                dirty,
+                suggested_migrate_command,
+            });
+        }
+    }
+
+    let scanned = all.len();
+    let eligible = all
+        .iter()
+        .filter(|c| c.status == DiscoverStatus::Eligible)
+        .count();
+    let blocked = all
+        .iter()
+        .filter(|c| c.status == DiscoverStatus::Blocked)
+        .count();
+    let unknown = all
+        .iter()
+        .filter(|c| c.status == DiscoverStatus::Unknown)
+        .count();
+
+    if !args.include_unknown {
+        all.retain(|c| c.status != DiscoverStatus::Unknown);
+    }
+
+    Ok(DiscoverReport {
+        source: identity,
+        plans_root: plans_root_rel.to_string_lossy().to_string(),
+        archive: archive.to_string_lossy().to_string(),
+        host_known,
+        summary: DiscoverSummary {
+            scanned,
+            eligible,
+            blocked,
+            unknown,
+            included_unknown: args.include_unknown,
+        },
+        candidates: all,
+    })
+}
+
+/// Resolve `--plans-root` to a source-repo-relative path. Defaults to
+/// `docs/plans`. An absolute path must live under the source repo.
+fn resolve_plans_root_rel(
+    source_repo: &Path,
+    arg: Option<&Path>,
+) -> Result<PathBuf, DiscoverError> {
+    match arg {
+        None => Ok(PathBuf::from("docs/plans")),
+        Some(p) if p.is_absolute() => p
+            .strip_prefix(source_repo)
+            .map(Path::to_path_buf)
+            .map_err(|_| DiscoverError::PlansRootOutsideRepo(p.to_path_buf())),
+        Some(p) => Ok(p.to_path_buf()),
+    }
+}
+
+/// Immediate sub-directories of `root`, sorted, skipping dot-entries.
+fn sorted_subdirs(root: &Path) -> Result<Vec<PathBuf>, DiscoverError> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for entry in fs::read_dir(root).map_err(|e| DiscoverError::Io(e.to_string()))? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        if let Some(name) = path.file_name().and_then(|n| n.to_str())
+            && name.starts_with('.')
+        {
+            continue;
+        }
+        dirs.push(path);
+    }
+    dirs.sort();
+    Ok(dirs)
+}
+
+/// Scan a plan folder's top-level Markdown files for provider refs and
+/// closeout evidence. Reads only; never mutates.
+fn scan_folder_files(
+    dir: &Path,
+    source_path: &str,
+    identity: &SourceIdentity,
+    url_re: &Regex,
+    status_re: &Regex,
+    closeout_heading_re: &Regex,
+) -> (Vec<InferredRef>, Option<CloseoutEvidence>) {
+    let mut refs: Vec<InferredRef> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut closeout: Option<CloseoutEvidence> = None;
+
+    for (file_name, content) in read_markdown_files(dir) {
+        let source_file = format!("{source_path}{file_name}");
+
+        for cap in url_re.find_iter(&content) {
+            let raw = cap.as_str().trim_end_matches(['.', ',', ';', ':']);
+            if let Some(target) = parse_ref_url(raw) {
+                let url = target.canonical_url();
+                if seen.insert(url.clone()) {
+                    let matches_source_repo = target.host == identity.host
+                        && target.org_or_group_path == identity.org_or_group_path
+                        && target.repo == identity.repo;
+                    refs.push(InferredRef {
+                        url,
+                        kind: target.kind,
+                        source_file: source_file.clone(),
+                        matches_source_repo,
+                    });
+                }
+            }
+        }
+
+        if closeout.is_none()
+            && let Some(marker) = detect_closeout(&content, status_re, closeout_heading_re)
+        {
+            closeout = Some(CloseoutEvidence {
+                marker,
+                source_file,
+            });
+        }
+    }
+
+    (refs, closeout)
+}
+
+/// Top-level `*.md` files in `dir` as `(file_name, content)`, sorted by
+/// file name. Unreadable or non-UTF-8 files are skipped.
+fn read_markdown_files(dir: &Path) -> Vec<(String, String)> {
+    let mut files: Vec<(String, String)> = Vec::new();
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return files,
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && p.extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| e.eq_ignore_ascii_case("md"))
+        })
+        .collect();
+    paths.sort();
+    for path in paths {
+        if let (Some(name), Ok(content)) = (
+            path.file_name().and_then(|n| n.to_str()),
+            fs::read_to_string(&path),
+        ) {
+            files.push((name.to_string(), content));
+        }
+    }
+    files
+}
+
+/// Return the first confident closeout marker in `content`, or `None`.
+///
+/// A Markdown "Closeout" heading is authoritative. Otherwise a
+/// `Status:` value counts only when it carries a terminal keyword and
+/// no active keyword, so sprint-level "complete" notes alongside an
+/// active sprint do not qualify.
+fn detect_closeout(
+    content: &str,
+    status_re: &Regex,
+    closeout_heading_re: &Regex,
+) -> Option<String> {
+    if let Some(m) = closeout_heading_re.find(content) {
+        return Some(m.as_str().trim().to_string());
+    }
+    for cap in status_re.captures_iter(content) {
+        let value = cap.get(1).map(|m| m.as_str().trim()).unwrap_or_default();
+        if value.is_empty() {
+            continue;
+        }
+        let lower = value.to_ascii_lowercase();
+        let has_terminal = TERMINAL_KEYWORDS.iter().any(|k| lower.contains(k));
+        let has_active = ACTIVE_KEYWORDS.iter().any(|k| lower.contains(k));
+        if has_terminal && !has_active {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+/// Build a single combined `plan-archive migrate` command for an
+/// eligible folder, preferring self-referential refs for each kind.
+fn build_migrate_command(plan_rel: &str, refs: &[InferredRef]) -> String {
+    let mut cmd = format!("plan-archive migrate --plan {plan_rel}");
+    if let Some(r) = pick_ref(refs, RefKind::Issue) {
+        cmd.push_str(&format!(" --issue {}", r.url));
+    }
+    if let Some(r) = pick_ref(refs, RefKind::Pull) {
+        cmd.push_str(&format!(" --pr {}", r.url));
+    }
+    if let Some(r) = pick_ref(refs, RefKind::MergeRequest) {
+        cmd.push_str(&format!(" --mr {}", r.url));
+    }
+    cmd.push_str(" --format json");
+    cmd
+}
+
+/// First ref of `kind`, preferring one that matches the source repo.
+fn pick_ref(refs: &[InferredRef], kind: RefKind) -> Option<&InferredRef> {
+    refs.iter()
+        .filter(|r| r.kind == kind)
+        .find(|r| r.matches_source_repo)
+        .or_else(|| refs.iter().find(|r| r.kind == kind))
+}
+
+fn url_regex() -> Regex {
+    // Static, validated pattern: a `expect` here is a programmer error,
+    // not a runtime input failure.
+    Regex::new(r#"https?://[^\s<>()\[\]"'`]+"#).expect("valid url regex")
+}
+
+fn status_regex() -> Regex {
+    Regex::new(r"(?im)^[ \t>]*[-*]?[ \t]*status[ \t]*:[ \t]*(.+)$").expect("valid status regex")
+}
+
+fn closeout_heading_regex() -> Regex {
+    Regex::new(r"(?im)^[ \t>]*#{1,6}[ \t]*close[ _-]?out\b").expect("valid closeout regex")
+}
+
+fn emit(format: OutputFormat, report: &DiscoverReport) -> i32 {
+    match format {
+        OutputFormat::Json => emit_json(report),
+        OutputFormat::Text => emit_text(report),
+    }
+}
+
+fn emit_text(report: &DiscoverReport) -> i32 {
+    println!("plan-archive discover (read-only)");
+    println!(
+        "  source     : {}/{}/{} @ {}",
+        report.source.host,
+        report.source.org_or_group_path,
+        report.source.repo,
+        report.source.branch
+    );
+    println!("  plans root : {}", report.plans_root);
+    println!("  archive    : {}", report.archive);
+    if !report.host_known {
+        println!("  host       : NOT in config/hosts.yaml (every folder is blocked)");
+    }
+    let s = &report.summary;
+    println!(
+        "  scanned {} — {} eligible, {} blocked, {} unknown",
+        s.scanned, s.eligible, s.blocked, s.unknown
+    );
+    if !s.included_unknown && s.unknown > 0 {
+        println!(
+            "  ({} unknown hidden; pass --include-unknown to list them)",
+            s.unknown
+        );
+    }
+
+    for (label, status) in [
+        ("eligible", DiscoverStatus::Eligible),
+        ("blocked", DiscoverStatus::Blocked),
+        ("unknown", DiscoverStatus::Unknown),
+    ] {
+        let group: Vec<&DiscoverCandidate> = report
+            .candidates
+            .iter()
+            .filter(|c| c.status == status)
+            .collect();
+        if group.is_empty() {
+            continue;
+        }
+        println!("\n{label} ({}):", group.len());
+        for c in group {
+            println!("  • {}", c.plan_folder);
+            if !c.reasons.is_empty() {
+                let codes: Vec<&str> = c.reasons.iter().map(|r| r.code.as_str()).collect();
+                println!("    reasons : {}", codes.join(", "));
+            }
+            if c.refs.is_empty() {
+                println!("    refs    : (none inferred)");
+            } else {
+                for r in &c.refs {
+                    let scope = if r.matches_source_repo {
+                        ""
+                    } else {
+                        " (cross-repo)"
+                    };
+                    println!(
+                        "    ref     : {} {}{}",
+                        ref_kind_label(r.kind),
+                        r.url,
+                        scope
+                    );
+                }
+            }
+            println!(
+                "    target  : {} ({})",
+                c.archive_target.relative_path,
+                if c.archive_target.exists {
+                    "exists"
+                } else {
+                    "free"
+                }
+            );
+            if let Some(co) = &c.closeout_evidence {
+                println!("    closeout: {} [{}]", co.marker, co.source_file);
+            }
+            if let Some(cmd) = &c.suggested_migrate_command {
+                println!("    migrate : {cmd}");
+            }
+        }
+    }
+    exit::SUCCESS
+}
+
+fn ref_kind_label(kind: RefKind) -> &'static str {
+    match kind {
+        RefKind::Issue => "issue",
+        RefKind::Pull => "pr",
+        RefKind::MergeRequest => "mr",
+    }
+}
+
+fn emit_json(report: &DiscoverReport) -> i32 {
+    let envelope = Envelope::success(schema_version_for(BINARY, COMMAND, 1), report);
+    match serde_json::to_string(&envelope) {
+        Ok(s) => {
+            let stdout = std::io::stdout();
+            let mut handle = stdout.lock();
+            if writeln!(handle, "{s}").is_err() {
+                return exit::SOFTWARE;
+            }
+            exit::SUCCESS
+        }
+        Err(_) => exit::SOFTWARE,
+    }
+}
+
+fn emit_error(format: OutputFormat, code: &str, message: &str) -> i32 {
+    match format {
+        OutputFormat::Json => {
+            let envelope: Envelope<()> = Envelope::failure(
+                schema_version_for(BINARY, COMMAND, 1),
+                EnvelopeError::new(code, message),
+            );
+            if let Ok(s) = serde_json::to_string(&envelope) {
+                eprintln!("{s}");
+            }
+            exit::DATA
+        }
+        OutputFormat::Text => {
+            eprintln!("error [{code}]: {message}");
+            exit::DATA
+        }
+    }
+}

--- a/crates/plan-archive/src/lib.rs
+++ b/crates/plan-archive/src/lib.rs
@@ -9,10 +9,12 @@
 pub mod catalog;
 pub mod cli;
 pub mod completion;
+pub mod discover;
 pub mod migrate;
 pub mod query;
 pub mod refresh;
 pub mod scrub;
+pub mod source;
 pub mod validate;
 
 pub use scrub::{Match, PATTERN_SET, REDACTION_TOKEN, ScrubResult, pattern_ids, scrub_text};

--- a/crates/plan-archive/src/migrate/mod.rs
+++ b/crates/plan-archive/src/migrate/mod.rs
@@ -13,8 +13,8 @@ use std::process::Command as ProcCommand;
 use nils_common::cli_contract::{Envelope, EnvelopeError, OutputFormat, exit, schema_version_for};
 use serde::Serialize;
 
-use crate::validate;
-use crate::validate::hosts::{HostClass, HostEntry, HostsConfig, validate_hosts_yaml};
+use crate::source::{self, SourceError};
+use crate::validate::hosts::{HostClass, HostEntry};
 
 pub mod identity;
 pub mod path;
@@ -180,6 +180,18 @@ impl MigrateError {
     }
 }
 
+impl From<SourceError> for MigrateError {
+    fn from(err: SourceError) -> Self {
+        match err {
+            SourceError::SourceRepoNotFound(p) => MigrateError::SourceRepoNotFound(p),
+            SourceError::ArchiveCloneMissing(p) => MigrateError::ArchiveCloneMissing(p),
+            SourceError::HostsLoadFailed(s) => MigrateError::HostsLoadFailed(s),
+            SourceError::HostsParseFailed(s) => MigrateError::HostsParseFailed(s),
+            SourceError::Io(s) => MigrateError::Io(s),
+        }
+    }
+}
+
 /// Entry point called from `cli::run`.
 pub fn dispatch(args: DispatchArgs) -> i32 {
     let format = args.format;
@@ -202,8 +214,8 @@ pub fn dispatch(args: DispatchArgs) -> i32 {
 /// classification, enumerates files, and assembles the metadata
 /// payload. Performs no writes.
 pub fn prepare(args: &DispatchArgs) -> Result<DryRunReport, MigrateError> {
-    let source_repo = resolve_source_repo(args.source_repo.as_deref())?;
-    let archive = resolve_archive(args.archive.as_deref())?;
+    let source_repo = source::resolve_source_repo(args.source_repo.as_deref())?;
+    let archive = source::resolve_archive(args.archive.as_deref())?;
     let plan_path_in_repo = normalise_plan_arg(&args.plan);
 
     let absolute_plan = source_repo.join(&plan_path_in_repo);
@@ -216,11 +228,8 @@ pub fn prepare(args: &DispatchArgs) -> Result<DryRunReport, MigrateError> {
     let identity = derive_source_identity(&source_repo)
         .map_err(|e| MigrateError::IdentityFailed(e.to_string()))?;
 
-    let hosts_path = args
-        .hosts
-        .clone()
-        .unwrap_or_else(|| archive.join("config").join("hosts.yaml"));
-    let hosts_config = load_hosts(&hosts_path)?;
+    let hosts_path = source::hosts_path_for(&archive, args.hosts.as_deref());
+    let hosts_config = source::load_hosts(&hosts_path)?;
 
     let host_entry = hosts_config
         .hosts
@@ -291,64 +300,9 @@ pub fn prepare(args: &DispatchArgs) -> Result<DryRunReport, MigrateError> {
     })
 }
 
-fn resolve_source_repo(arg: Option<&Path>) -> Result<PathBuf, MigrateError> {
-    let candidate = match arg {
-        Some(p) => p.to_path_buf(),
-        None => std::env::current_dir().map_err(|e| MigrateError::Io(e.to_string()))?,
-    };
-    let root = nils_common::git::repo_root_in(&candidate)
-        .map_err(|e| MigrateError::Io(e.to_string()))?
-        .ok_or_else(|| MigrateError::SourceRepoNotFound(candidate.clone()))?;
-    if !root.is_dir() {
-        return Err(MigrateError::SourceRepoNotFound(root));
-    }
-    Ok(root)
-}
-
-fn resolve_archive(arg: Option<&Path>) -> Result<PathBuf, MigrateError> {
-    let candidate = match arg {
-        Some(p) => p.to_path_buf(),
-        None => default_archive_clone_path()?,
-    };
-    if !candidate.is_dir() {
-        return Err(MigrateError::ArchiveCloneMissing(candidate));
-    }
-    Ok(candidate)
-}
-
-fn default_archive_clone_path() -> Result<PathBuf, MigrateError> {
-    let local = validate::local::validate_local_path(&local_config_path())
-        .map_err(|e| MigrateError::Io(e.to_string()))?;
-    Ok(local.data.config.archive_clone_path)
-}
-
-fn local_config_path() -> PathBuf {
-    if let Some(p) = std::env::var_os("PLAN_ARCHIVE_LOCAL_CONFIG") {
-        return PathBuf::from(p);
-    }
-    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
-        return PathBuf::from(xdg)
-            .join("agent-plan-archive")
-            .join("config.yaml");
-    }
-    if let Some(home) = std::env::var_os("HOME") {
-        return PathBuf::from(home)
-            .join(".config")
-            .join("agent-plan-archive")
-            .join("config.yaml");
-    }
-    PathBuf::from("/nonexistent/agent-plan-archive/config.yaml")
-}
-
 fn normalise_plan_arg(arg: &Path) -> PathBuf {
     let s = arg.to_string_lossy().trim_end_matches('/').to_string();
     PathBuf::from(s)
-}
-
-fn load_hosts(path: &Path) -> Result<HostsConfig, MigrateError> {
-    let raw = fs::read_to_string(path).map_err(|e| MigrateError::HostsLoadFailed(e.to_string()))?;
-    let v = validate_hosts_yaml(&raw).map_err(|e| MigrateError::HostsParseFailed(e.to_string()))?;
-    Ok(v.data.config)
 }
 
 fn enumerate_plan_files(
@@ -491,8 +445,8 @@ fn emit_error(format: OutputFormat, code: &str, message: &str) -> i32 {
 /// Apply path. Copies files, writes metadata, commits archive,
 /// pushes archive, and on success commits the source-repo deletion.
 fn apply(args: DispatchArgs, report: DryRunReport) -> Result<ApplyReport, MigrateError> {
-    let source_repo = resolve_source_repo(args.source_repo.as_deref())?;
-    let archive = resolve_archive(args.archive.as_deref())?;
+    let source_repo = source::resolve_source_repo(args.source_repo.as_deref())?;
+    let archive = source::resolve_archive(args.archive.as_deref())?;
     let plan_path_in_repo = normalise_plan_arg(&args.plan);
 
     if report.archive_target.exists {
@@ -501,7 +455,7 @@ fn apply(args: DispatchArgs, report: DryRunReport) -> Result<ApplyReport, Migrat
         ));
     }
 
-    if has_dirty_plan_folder(&source_repo, &plan_path_in_repo)? {
+    if source::has_dirty_path(&source_repo, &plan_path_in_repo)? {
         return Err(MigrateError::SourceRepoDirty(
             plan_path_in_repo.display().to_string(),
         ));
@@ -597,21 +551,6 @@ fn pathdiff(file_rel_to_repo: &str, plan_path: &Path) -> PathBuf {
 /// recorded in the archive path and `metadata.yaml`.
 fn archive_commit_message(repo: &str, plan_folder: &str) -> String {
     format!("archive(plan): {repo}/{plan_folder}")
-}
-
-fn has_dirty_plan_folder(repo: &Path, plan_path: &Path) -> Result<bool, MigrateError> {
-    let out = nils_common::git::run_output_in(
-        repo,
-        &["status", "--porcelain", "--", &plan_path.to_string_lossy()],
-    )
-    .map_err(|e| MigrateError::Io(e.to_string()))?;
-    if !out.status.success() {
-        return Err(MigrateError::Subprocess(
-            "git status".to_string(),
-            String::from_utf8_lossy(&out.stderr).to_string(),
-        ));
-    }
-    Ok(!out.stdout.is_empty())
 }
 
 fn run_semantic_commit(repo: &Path, message: &str) -> Result<(), MigrateError> {

--- a/crates/plan-archive/src/source.rs
+++ b/crates/plan-archive/src/source.rs
@@ -1,0 +1,120 @@
+//! Shared source-repo / archive / hosts resolution.
+//!
+//! Both `migrate` and `discover` locate the working repo, the archive
+//! clone, and the host-classification config through these helpers so
+//! the two commands cannot drift on resolution semantics. Every helper
+//! here is read-only; nothing copies, writes, or commits.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::validate;
+use crate::validate::hosts::{HostsConfig, validate_hosts_yaml};
+
+/// Resolution failures shared by `migrate` and `discover`. Callers map
+/// these onto their own command-scoped error codes.
+#[derive(Debug, thiserror::Error)]
+pub enum SourceError {
+    #[error("source repo not found at `{0}`")]
+    SourceRepoNotFound(PathBuf),
+    #[error(
+        "archive clone path not found at `{0}` (set `--archive` or seed `archive_clone_path` in the local config)"
+    )]
+    ArchiveCloneMissing(PathBuf),
+    #[error("failed to load archive `config/hosts.yaml`: {0}")]
+    HostsLoadFailed(String),
+    #[error("failed to parse archive `config/hosts.yaml`: {0}")]
+    HostsParseFailed(String),
+    #[error("io error: {0}")]
+    Io(String),
+}
+
+/// Resolve the source working repo: an explicit override or the git
+/// repo root containing the current directory.
+pub fn resolve_source_repo(arg: Option<&Path>) -> Result<PathBuf, SourceError> {
+    let candidate = match arg {
+        Some(p) => p.to_path_buf(),
+        None => std::env::current_dir().map_err(|e| SourceError::Io(e.to_string()))?,
+    };
+    let root = nils_common::git::repo_root_in(&candidate)
+        .map_err(|e| SourceError::Io(e.to_string()))?
+        .ok_or_else(|| SourceError::SourceRepoNotFound(candidate.clone()))?;
+    if !root.is_dir() {
+        return Err(SourceError::SourceRepoNotFound(root));
+    }
+    Ok(root)
+}
+
+/// Resolve the archive clone path: an explicit override or the
+/// machine-local config's `archive_clone_path`.
+pub fn resolve_archive(arg: Option<&Path>) -> Result<PathBuf, SourceError> {
+    let candidate = match arg {
+        Some(p) => p.to_path_buf(),
+        None => default_archive_clone_path()?,
+    };
+    if !candidate.is_dir() {
+        return Err(SourceError::ArchiveCloneMissing(candidate));
+    }
+    Ok(candidate)
+}
+
+/// Read `archive_clone_path` from the machine-local config (which
+/// returns documented defaults when the file is absent).
+pub fn default_archive_clone_path() -> Result<PathBuf, SourceError> {
+    let local = validate::local::validate_local_path(&local_config_path())
+        .map_err(|e| SourceError::Io(e.to_string()))?;
+    Ok(local.data.config.archive_clone_path)
+}
+
+/// Machine-local config path, honouring `PLAN_ARCHIVE_LOCAL_CONFIG`,
+/// then `XDG_CONFIG_HOME`, then `$HOME/.config`.
+pub fn local_config_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("PLAN_ARCHIVE_LOCAL_CONFIG") {
+        return PathBuf::from(p);
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        return PathBuf::from(xdg)
+            .join("agent-plan-archive")
+            .join("config.yaml");
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join(".config")
+            .join("agent-plan-archive")
+            .join("config.yaml");
+    }
+    PathBuf::from("/nonexistent/agent-plan-archive/config.yaml")
+}
+
+/// `config/hosts.yaml` path for an archive clone, honouring an explicit
+/// `--hosts` override.
+pub fn hosts_path_for(archive: &Path, override_path: Option<&Path>) -> PathBuf {
+    match override_path {
+        Some(p) => p.to_path_buf(),
+        None => archive.join("config").join("hosts.yaml"),
+    }
+}
+
+/// Load and validate the archive `config/hosts.yaml`.
+pub fn load_hosts(path: &Path) -> Result<HostsConfig, SourceError> {
+    let raw = fs::read_to_string(path).map_err(|e| SourceError::HostsLoadFailed(e.to_string()))?;
+    let v = validate_hosts_yaml(&raw).map_err(|e| SourceError::HostsParseFailed(e.to_string()))?;
+    Ok(v.data.config)
+}
+
+/// Whether `git status --porcelain` reports any tracked-or-untracked
+/// change under `rel` inside `repo`. Read-only; never mutates the repo.
+pub fn has_dirty_path(repo: &Path, rel: &Path) -> Result<bool, SourceError> {
+    let out = nils_common::git::run_output_in(
+        repo,
+        &["status", "--porcelain", "--", &rel.to_string_lossy()],
+    )
+    .map_err(|e| SourceError::Io(e.to_string()))?;
+    if !out.status.success() {
+        return Err(SourceError::Io(format!(
+            "git status failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(!out.stdout.is_empty())
+}

--- a/crates/plan-archive/tests/discover.rs
+++ b/crates/plan-archive/tests/discover.rs
@@ -1,0 +1,457 @@
+//! Integration coverage for `plan-archive discover` (read-only).
+//!
+//! Builds a throwaway source repo + archive clone + `hosts.yaml`, lays
+//! down plan folders that exercise every classification path, and
+//! drives `discover::scan` to assert the candidate model. Mirrors the
+//! fixture style of `tests/migrate.rs` and reuses the shared
+//! `archive_target_path` derivation so discover and migrate cannot
+//! drift on archive targets.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use nils_common::cli_contract::OutputFormat;
+use plan_archive::discover::{
+    self, DiscoverCandidate, DiscoverReport, DiscoverStatus, DispatchArgs,
+};
+use plan_archive::migrate::archive_target_path;
+use plan_archive::refresh::refparse::RefKind;
+
+struct Scenario {
+    _tmp: tempfile::TempDir,
+    source_repo: PathBuf,
+    archive: PathBuf,
+    hosts: PathBuf,
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_AUTHOR_NAME", "tester")
+        .env("GIT_AUTHOR_EMAIL", "tester@example.com")
+        .env("GIT_COMMITTER_NAME", "tester")
+        .env("GIT_COMMITTER_EMAIL", "tester@example.com")
+        .output()
+        .unwrap_or_else(|e| panic!("spawn git {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed:\nstderr={}\nstdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout),
+    );
+}
+
+/// Source repo (github.com/graysurf/agent-runtime-kit) + archive clone
+/// with a `github.com: personal` hosts entry. No plan folders yet.
+fn build_base() -> Scenario {
+    build_with_host("github.com")
+}
+
+fn build_with_host(host: &str) -> Scenario {
+    let tmp = tempfile::tempdir().unwrap();
+    let source_repo = tmp.path().join("source");
+    let archive = tmp.path().join("archive");
+    fs::create_dir_all(&source_repo).unwrap();
+    fs::create_dir_all(&archive).unwrap();
+
+    git(&source_repo, &["init", "-q", "-b", "main"]);
+    git(&source_repo, &["config", "commit.gpgsign", "false"]);
+    git(
+        &source_repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:graysurf/agent-runtime-kit.git",
+        ],
+    );
+    // An initial commit so HEAD/branch resolve like a real repo.
+    fs::write(source_repo.join("README.md"), "# source\n").unwrap();
+    git(&source_repo, &["add", "README.md"]);
+    git(&source_repo, &["commit", "-q", "-m", "init"]);
+
+    git(&archive, &["init", "-q", "-b", "main"]);
+    git(&archive, &["config", "commit.gpgsign", "false"]);
+    let config_dir = archive.join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+    let hosts = config_dir.join("hosts.yaml");
+    fs::write(
+        &hosts,
+        format!(
+            "version: 1\nhosts:\n  {host}:\n    class: personal\n    primary_identity: graysurf\n"
+        ),
+    )
+    .unwrap();
+    git(&archive, &["add", "config/hosts.yaml"]);
+    git(&archive, &["commit", "-q", "-m", "seed hosts"]);
+
+    Scenario {
+        _tmp: tmp,
+        source_repo,
+        archive,
+        hosts,
+    }
+}
+
+/// Write a plan folder with the given top-level files (not committed).
+fn write_plan(s: &Scenario, folder: &str, files: &[(&str, &str)]) {
+    let dir = s.source_repo.join("docs/plans").join(folder);
+    fs::create_dir_all(&dir).unwrap();
+    for (name, body) in files {
+        fs::write(dir.join(name), body).unwrap();
+    }
+}
+
+fn commit_all(s: &Scenario, msg: &str) {
+    git(&s.source_repo, &["add", "-A"]);
+    git(&s.source_repo, &["commit", "-q", "-m", msg]);
+}
+
+fn args(s: &Scenario, include_unknown: bool) -> DispatchArgs {
+    DispatchArgs {
+        source_repo: Some(s.source_repo.clone()),
+        plans_root: None,
+        archive: Some(s.archive.clone()),
+        hosts: Some(s.hosts.clone()),
+        include_unknown,
+        format: OutputFormat::Json,
+    }
+}
+
+fn find<'a>(r: &'a DiscoverReport, folder: &str) -> &'a DiscoverCandidate {
+    r.candidates
+        .iter()
+        .find(|c| c.plan_folder == folder)
+        .unwrap_or_else(|| panic!("no candidate `{folder}` in {:?}", folder_names(r)))
+}
+
+fn folder_names(r: &DiscoverReport) -> Vec<String> {
+    r.candidates.iter().map(|c| c.plan_folder.clone()).collect()
+}
+
+fn reason_codes(c: &DiscoverCandidate) -> Vec<&str> {
+    c.reasons.iter().map(|r| r.code.as_str()).collect()
+}
+
+const ISSUE_URL: &str = "https://github.com/graysurf/agent-runtime-kit/issues/10";
+const CROSSREPO_PR: &str = "https://github.com/sympoies/nils-cli/pull/42";
+
+/// Build the full classification matrix in one source repo.
+fn build_matrix() -> Scenario {
+    let s = build_base();
+    write_plan(
+        &s,
+        "2026-05-01-eligible",
+        &[
+            ("plan.md", &format!("# plan\n\nTracking: {ISSUE_URL}\n")),
+            (
+                "state.md",
+                "# state\n\n- Status: complete; all sprints delivered\n",
+            ),
+        ],
+    );
+    write_plan(
+        &s,
+        "2026-05-02-target-exists",
+        &[
+            ("plan.md", &format!("Tracking: {ISSUE_URL}\n")),
+            ("state.md", "- Status: done\n"),
+        ],
+    );
+    write_plan(
+        &s,
+        "2026-05-03-no-refs",
+        &[("state.md", "- Status: complete; shipped\n")],
+    );
+    write_plan(
+        &s,
+        "2026-05-04-dirty",
+        &[
+            ("plan.md", &format!("Tracking: {ISSUE_URL}\n")),
+            ("state.md", "- Status: done\n"),
+        ],
+    );
+    write_plan(
+        &s,
+        "2026-05-05-uncertain",
+        &[
+            ("plan.md", &format!("Tracking: {ISSUE_URL}\n")),
+            ("state.md", "- Status: in progress\n"),
+        ],
+    );
+    write_plan(
+        &s,
+        "2026-05-06-sprint-active",
+        &[
+            ("plan.md", &format!("Tracking: {ISSUE_URL}\n")),
+            (
+                "state.md",
+                "- Status: Sprint 2 Task 2.4 complete; Sprint 2 closed; Sprint 3 active\n",
+            ),
+        ],
+    );
+    write_plan(
+        &s,
+        "2026-05-07-crossrepo",
+        &[
+            ("plan.md", &format!("Implementation PR: {CROSSREPO_PR}\n")),
+            ("state.md", "## Closeout\n\nAll lanes merged.\n"),
+        ],
+    );
+    commit_all(&s, "seed plan matrix");
+
+    // Pre-create the archive target for the collision case.
+    let collision = s
+        .archive
+        .join("plans/github.com/graysurf/agent-runtime-kit/2026-05-02-target-exists");
+    fs::create_dir_all(&collision).unwrap();
+
+    // Make the dirty folder dirty with an untracked file.
+    fs::write(
+        s.source_repo.join("docs/plans/2026-05-04-dirty/scratch.md"),
+        "wip\n",
+    )
+    .unwrap();
+
+    s
+}
+
+#[test]
+fn classification_matrix() {
+    let s = build_matrix();
+    let report = discover::scan(&args(&s, true)).expect("scan ok");
+
+    assert_eq!(report.source.host, "github.com");
+    assert_eq!(report.source.repo, "agent-runtime-kit");
+    assert!(report.host_known);
+    assert_eq!(report.plans_root, "docs/plans");
+
+    assert_eq!(report.summary.scanned, 7);
+    assert_eq!(report.summary.eligible, 2);
+    assert_eq!(report.summary.blocked, 3);
+    assert_eq!(report.summary.unknown, 2);
+
+    // eligible: refs + closeout + free target + clean + known host
+    let elig = find(&report, "2026-05-01-eligible");
+    assert_eq!(elig.status, DiscoverStatus::Eligible);
+    assert!(elig.reasons.is_empty());
+    assert_eq!(elig.refs.len(), 1);
+    assert_eq!(elig.refs[0].url, ISSUE_URL);
+    assert_eq!(elig.refs[0].kind, RefKind::Issue);
+    assert!(elig.refs[0].matches_source_repo);
+    assert!(!elig.archive_target.exists);
+    assert!(elig.closeout_evidence.is_some());
+    assert!(!elig.dirty);
+    let cmd = elig
+        .suggested_migrate_command
+        .as_deref()
+        .expect("eligible has a suggested command");
+    assert!(cmd.contains("--plan docs/plans/2026-05-01-eligible"));
+    assert!(cmd.contains(&format!("--issue {ISSUE_URL}")));
+    assert!(cmd.contains("--format json"));
+    assert!(!cmd.contains("migrate --plan docs/plans/2026-05-01-eligible/")); // no trailing slash
+
+    // blocked: archive target collision
+    let coll = find(&report, "2026-05-02-target-exists");
+    assert_eq!(coll.status, DiscoverStatus::Blocked);
+    assert!(coll.archive_target.exists);
+    assert!(reason_codes(coll).contains(&"archive-target-exists"));
+    assert!(coll.suggested_migrate_command.is_none());
+
+    // blocked: no provider refs
+    let norefs = find(&report, "2026-05-03-no-refs");
+    assert_eq!(norefs.status, DiscoverStatus::Blocked);
+    assert!(norefs.refs.is_empty());
+    assert!(reason_codes(norefs).contains(&"no-provider-refs"));
+
+    // blocked: dirty plan folder
+    let dirty = find(&report, "2026-05-04-dirty");
+    assert_eq!(dirty.status, DiscoverStatus::Blocked);
+    assert!(dirty.dirty);
+    assert!(reason_codes(dirty).contains(&"source-plan-folder-dirty"));
+
+    // unknown: refs present but no closeout evidence
+    let uncertain = find(&report, "2026-05-05-uncertain");
+    assert_eq!(uncertain.status, DiscoverStatus::Unknown);
+    assert!(reason_codes(uncertain).contains(&"closeout-evidence-uncertain"));
+    assert!(uncertain.closeout_evidence.is_none());
+
+    // unknown: sprint-level "complete" alongside an active sprint must
+    // NOT be promoted to eligible.
+    let sprint = find(&report, "2026-05-06-sprint-active");
+    assert_eq!(sprint.status, DiscoverStatus::Unknown);
+    assert!(sprint.closeout_evidence.is_none());
+
+    // eligible via a Closeout heading; the only ref is cross-repo.
+    let cross = find(&report, "2026-05-07-crossrepo");
+    assert_eq!(cross.status, DiscoverStatus::Eligible);
+    assert_eq!(cross.refs.len(), 1);
+    assert_eq!(cross.refs[0].kind, RefKind::Pull);
+    assert!(!cross.refs[0].matches_source_repo);
+    let ccmd = cross.suggested_migrate_command.as_deref().unwrap();
+    assert!(ccmd.contains(&format!("--pr {CROSSREPO_PR}")));
+    assert!(!ccmd.contains("--issue"));
+}
+
+#[test]
+fn include_unknown_gates_listing_but_not_counts() {
+    let s = build_matrix();
+
+    let hidden = discover::scan(&args(&s, false)).expect("scan ok");
+    assert_eq!(hidden.summary.scanned, 7);
+    assert_eq!(hidden.summary.unknown, 2, "count still reports unknowns");
+    assert!(!hidden.summary.included_unknown);
+    assert_eq!(hidden.candidates.len(), 5, "unknowns omitted from listing");
+    assert!(
+        !hidden
+            .candidates
+            .iter()
+            .any(|c| c.status == DiscoverStatus::Unknown)
+    );
+
+    let shown = discover::scan(&args(&s, true)).expect("scan ok");
+    assert!(shown.summary.included_unknown);
+    assert_eq!(shown.candidates.len(), 7);
+}
+
+#[test]
+fn shared_archive_target_derivation_matches_migrate_helper() {
+    let s = build_matrix();
+    let report = discover::scan(&args(&s, true)).expect("scan ok");
+    let elig = find(&report, "2026-05-01-eligible");
+    let expected = archive_target_path(
+        "github.com",
+        "graysurf",
+        "agent-runtime-kit",
+        "2026-05-01-eligible",
+    );
+    assert_eq!(
+        elig.archive_target.relative_path,
+        expected.to_string_lossy()
+    );
+}
+
+#[test]
+fn discovery_never_mutates_source_or_archive() {
+    let s = build_matrix();
+
+    // Capture archive listing before scanning.
+    let before = archive_listing(&s.archive);
+    let report = discover::scan(&args(&s, true)).expect("scan ok");
+    let after = archive_listing(&s.archive);
+    assert_eq!(before, after, "discover must not write to the archive");
+
+    // The eligible folder's archive target must not have been created.
+    let elig_target = s
+        .archive
+        .join("plans/github.com/graysurf/agent-runtime-kit/2026-05-01-eligible");
+    assert!(
+        !elig_target.exists(),
+        "discover created an archive target it should only have previewed"
+    );
+
+    // The only working-tree change in source is the intentionally-dirty
+    // folder's untracked file — scan added nothing.
+    let status = Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(&s.source_repo)
+        .output()
+        .unwrap();
+    let dirty_lines: Vec<String> = String::from_utf8_lossy(&status.stdout)
+        .lines()
+        .map(|l| l.to_string())
+        .collect();
+    assert_eq!(
+        dirty_lines.len(),
+        1,
+        "unexpected source changes: {dirty_lines:?}"
+    );
+    assert!(dirty_lines[0].contains("2026-05-04-dirty/scratch.md"));
+
+    // sanity: the scan still classified something.
+    assert_eq!(report.summary.scanned, 7);
+}
+
+fn archive_listing(archive: &Path) -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        if let Ok(entries) = fs::read_dir(dir) {
+            for e in entries.flatten() {
+                let p = e.path();
+                if p.file_name().and_then(|n| n.to_str()) == Some(".git") {
+                    continue;
+                }
+                if p.is_dir() {
+                    walk(&p, out);
+                } else {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(archive, &mut out);
+    out.sort();
+    out
+}
+
+#[test]
+fn unknown_host_blocks_every_folder() {
+    let s = build_with_host("gitlab.com"); // github.com absent
+    write_plan(
+        &s,
+        "2026-05-01-eligible-shape",
+        &[
+            ("plan.md", &format!("Tracking: {ISSUE_URL}\n")),
+            ("state.md", "- Status: done\n"),
+        ],
+    );
+    commit_all(&s, "seed");
+
+    let report = discover::scan(&args(&s, true)).expect("scan ok");
+    assert!(!report.host_known);
+    assert_eq!(report.summary.scanned, 1);
+    assert_eq!(report.summary.blocked, 1);
+    let c = find(&report, "2026-05-01-eligible-shape");
+    assert_eq!(c.status, DiscoverStatus::Blocked);
+    assert!(reason_codes(c).contains(&"unknown-host"));
+}
+
+#[test]
+fn empty_plans_root_yields_zero_candidates() {
+    let s = build_base(); // no docs/plans created
+    let report = discover::scan(&args(&s, true)).expect("scan ok");
+    assert_eq!(report.summary.scanned, 0);
+    assert!(report.candidates.is_empty());
+}
+
+#[test]
+fn plans_root_outside_repo_is_rejected() {
+    let s = build_base();
+    let mut a = args(&s, true);
+    a.plans_root = Some(PathBuf::from("/definitely/not/under/the/source/repo"));
+    let err = discover::scan(&a).unwrap_err();
+    assert_eq!(err.code(), "discover-plans-root-outside-repo");
+}
+
+#[test]
+fn duplicate_refs_are_deduplicated_across_files() {
+    let s = build_base();
+    write_plan(
+        &s,
+        "2026-05-01-dupes",
+        &[
+            (
+                "plan.md",
+                &format!("see {ISSUE_URL} and again {ISSUE_URL}\n"),
+            ),
+            ("state.md", &format!("- Status: done\n\nref {ISSUE_URL}\n")),
+        ],
+    );
+    commit_all(&s, "seed");
+    let report = discover::scan(&args(&s, true)).expect("scan ok");
+    let c = find(&report, "2026-05-01-dupes");
+    assert_eq!(c.refs.len(), 1, "same URL inferred once");
+    assert_eq!(c.status, DiscoverStatus::Eligible);
+}

--- a/crates/plan-archive/tests/discover.rs
+++ b/crates/plan-archive/tests/discover.rs
@@ -455,3 +455,101 @@ fn duplicate_refs_are_deduplicated_across_files() {
     assert_eq!(c.refs.len(), 1, "same URL inferred once");
     assert_eq!(c.status, DiscoverStatus::Eligible);
 }
+
+/// Dispatch args with an explicit format and `--hosts` left to default
+/// to `<archive>/config/hosts.yaml`.
+fn dispatch_args(s: &Scenario, include_unknown: bool, format: OutputFormat) -> DispatchArgs {
+    DispatchArgs {
+        source_repo: Some(s.source_repo.clone()),
+        plans_root: None,
+        archive: Some(s.archive.clone()),
+        hosts: None,
+        include_unknown,
+        format,
+    }
+}
+
+#[test]
+fn dispatch_text_and_json_emit_successfully() {
+    let s = build_matrix();
+    // Text path drives the full renderer across all three status groups,
+    // refs, cross-repo labels, closeout markers, and reason codes.
+    assert_eq!(
+        discover::dispatch(dispatch_args(&s, true, OutputFormat::Text)),
+        0
+    );
+    // JSON path drives the envelope emitter.
+    assert_eq!(
+        discover::dispatch(dispatch_args(&s, false, OutputFormat::Json)),
+        0
+    );
+
+    // host-not-known prints the dedicated warning line.
+    let g = build_with_host("gitlab.com");
+    write_plan(
+        &g,
+        "2026-05-01-x",
+        &[
+            ("plan.md", &format!("Tracking: {ISSUE_URL}\n")),
+            ("state.md", "- Status: done\n"),
+        ],
+    );
+    commit_all(&g, "seed");
+    assert_eq!(
+        discover::dispatch(dispatch_args(&g, true, OutputFormat::Text)),
+        0
+    );
+}
+
+#[test]
+fn error_paths_cover_codes_and_emitters() {
+    let s = build_base();
+    let missing_archive = s.source_repo.join("no-such-archive");
+
+    // archive clone missing — typed code + both emitter arms.
+    let mut a = args(&s, true);
+    a.archive = Some(missing_archive.clone());
+    assert_eq!(
+        discover::scan(&a).unwrap_err().code(),
+        "discover-archive-clone-missing"
+    );
+    let mut json = args(&s, true);
+    json.archive = Some(missing_archive.clone());
+    assert_ne!(discover::dispatch(json), 0);
+    let mut text = dispatch_args(&s, true, OutputFormat::Text);
+    text.archive = Some(missing_archive);
+    assert_ne!(discover::dispatch(text), 0);
+
+    // hosts file missing → load-failed.
+    let mut hl = args(&s, true);
+    hl.hosts = Some(s.source_repo.join("no-hosts.yaml"));
+    assert_eq!(
+        discover::scan(&hl).unwrap_err().code(),
+        "discover-hosts-load-failed"
+    );
+
+    // malformed hosts file (unknown class) → parse-failed.
+    let bad = s.source_repo.join("bad-hosts.yaml");
+    fs::write(
+        &bad,
+        "version: 1\nhosts:\n  github.com:\n    class: bogus\n",
+    )
+    .unwrap();
+    let mut hp = args(&s, true);
+    hp.hosts = Some(bad);
+    assert_eq!(
+        discover::scan(&hp).unwrap_err().code(),
+        "discover-hosts-parse-failed"
+    );
+
+    // source repo that is not a git repo → not-found.
+    let tmp = tempfile::tempdir().unwrap();
+    let plain = tmp.path().join("plain");
+    fs::create_dir_all(&plain).unwrap();
+    let mut sr = args(&s, true);
+    sr.source_repo = Some(plain);
+    assert_eq!(
+        discover::scan(&sr).unwrap_err().code(),
+        "discover-source-repo-not-found"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `plan-archive discover`, a read-only command that enumerates plan folders under a working repo and classifies each as an archive candidate (`eligible` / `blocked` / `unknown`) — a safe preselection step before the existing single-folder `plan-archive migrate`.

This is **Sprint 1** of the "Plan Archive Discover" plan tracked in graysurf/agent-runtime-kit (issue: <https://github.com/graysurf/agent-runtime-kit/issues/135>). Sprint 2 (a thin runtime-kit skill wrapper) is gated on a released nils-cli that contains this command.

## What changed

- **`plan-archive discover`** (`src/discover/`): read-only scan that infers issue/PR/MR refs and closeout evidence from each folder's Markdown, previews the archive target, checks target collisions and dirty folders, and emits a stable JSON/text report with a suggested `plan-archive migrate …` command for eligible folders. It never copies, writes, commits, pushes, or refreshes provider state.
- **Shared `source.rs`**: extracted source-repo / archive / hosts resolution so `discover` and `migrate` cannot drift; `migrate` now delegates to it with its existing error codes preserved.
- Regenerated shell completions; added a README `Discover surface` section (status classes, closeout-marker contract, stable error codes, eligible + blocked JSON examples); 8 new integration tests.

## Classification

- `eligible` — ≥1 provider ref, a free archive target, a clean folder, a known host, and confident closeout evidence (carries a suggested migrate command).
- `blocked` — `archive-target-exists`, `source-plan-folder-dirty`, `unknown-host`, or `no-provider-refs`.
- `unknown` — otherwise migrate-able, but closeout evidence is uncertain. Conservative by design: a sprint-level "complete; … Sprint N active" note is **not** promoted to eligible, and discovery never invents closeout evidence.

## Boundary

`discover` is a preselection helper only. Applying a migration stays with `migrate`, which is dry-run-first and gated on explicit confirmation. There is no bulk-apply path.

## Test plan

- `cargo test -p nils-plan-archive` — 8 new `discover` tests + 5 `migrate` regression tests + full crate suite green.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`.
- `completion-asset-audit --strict`, `completion-flag-parity-audit`, `cli-output-contract-lint`.
- `rumdl` / `markdownlint-audit` / `docs-hygiene-audit` / `docs-placement-audit`.
- Real-repo smoke test against `agent-runtime-kit` `docs/plans/` (4 folders classified; in-progress plans correctly stay `unknown`/`blocked`).
- `Cargo.lock` unchanged (no new dependencies).
