### PR TITLE
feat(heuristic-inbox): add non-skill-usage source modes to new

### DIFF
--- a/completions/bash/heuristic-inbox
+++ b/completions/bash/heuristic-inbox
@@ -204,13 +204,17 @@ _heuristic-inbox() {
             return 0
             ;;
         heuristic__inbox__new)
-            opts="-h --from-skill-usage --slug --out-dir --title --area --status --severity --next-action --log-dir --format --help"
+            opts="-h --from-skill-usage --from-evidence --manual --slug --out-dir --title --area --status --severity --next-action --log-dir --format --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --from-skill-usage)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --from-evidence)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/zsh/_heuristic-inbox
+++ b/completions/zsh/_heuristic-inbox
@@ -15,8 +15,8 @@ _heuristic-inbox() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" : \
-'-h[Print help]' \
-'--help[Print help]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \
 '--version[Print version]' \
 ":: :_heuristic-inbox_commands" \
@@ -32,25 +32,28 @@ _heuristic-inbox() {
 _arguments "${_arguments_options[@]}" : \
 '--inbox-dir=[Inbox directory]:DIR:_files -/' \
 '--status=[Comma-separated lifecycle status filter]:STATUS:_default' \
-'--format=[Output format]:FORMAT:(text json)' \
+'--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
 '--include-archived[Include archived entries]' \
-'-h[Print help]' \
-'--help[Print help]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
 ;;
 (verify)
 _arguments "${_arguments_options[@]}" : \
 '--inbox-dir=[Inbox directory used for duplicate detection]:DIR:_files -/' \
-'--format=[Output format]:FORMAT:(text json)' \
+'--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
 '--strict[Escalate ENTRY.md/RECORD.md body redaction findings to ok=false]' \
-'-h[Print help]' \
-'--help[Print help]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 ':entry -- Case folder or ENTRY.md/RECORD.md path:_files' \
 && ret=0
 ;;
 (new)
 _arguments "${_arguments_options[@]}" : \
-'--from-skill-usage=[Path to a skill-usage record file or its containing directory]:PATH:_files' \
+'--from-skill-usage=[Scaffold from a \`skill-usage.record.v1\` envelope (file or its directory)]:PATH:_files' \
+'--from-evidence=[Scaffold from an already-redacted evidence file (reuses ingest-evidence redaction)]:PATH:_files' \
 '--slug=[Slug for the new inbox case]:SLUG:_default' \
 '--out-dir=[Output inbox directory (defaults to heuristic-system/error-inbox)]:DIR:_files -/' \
 '--title=[Optional title override]:TITLE:_default' \
@@ -59,9 +62,11 @@ _arguments "${_arguments_options[@]}" : \
 '--severity=[Severity for the new entry]:SEVERITY:(low medium high)' \
 '--next-action=[Optional Next Action override]:NEXT_ACTION:_default' \
 '--log-dir=[Execution log directory override (defaults to agent-out topic heuristic-inbox)]:DIR:_files -/' \
-'--format=[Output format]:FORMAT:(text json)' \
-'-h[Print help]' \
-'--help[Print help]' \
+'--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--manual[Scaffold a manual-diagnosis skeleton with no captured raw evidence]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
 ;;
 (set-status)
@@ -70,9 +75,10 @@ _arguments "${_arguments_options[@]}" : \
 '--link=[Optional durable link to append to Next Action]:LINK:_default' \
 '--next-action=[Optional Next Action override]:NEXT_ACTION:_default' \
 '--log-dir=[Execution log directory override (defaults to agent-out topic heuristic-inbox)]:DIR:_files -/' \
-'--format=[Output format]:FORMAT:(text json)' \
-'-h[Print help]' \
-'--help[Print help]' \
+'--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 ':entry -- Case folder or ENTRY.md path:_files' \
 && ret=0
 ;;
@@ -84,12 +90,13 @@ _arguments "${_arguments_options[@]}" : \
 '--link=[Optional durable outcome link]:LINK:_default' \
 '--reason=[Optional archive reason]:REASON:_default' \
 '--log-dir=[Execution log directory override (defaults to agent-out topic heuristic-inbox)]:DIR:_files -/' \
-'--format=[Output format]:FORMAT:(text json)' \
+'--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
 '-y[Archive without prompting]' \
 '--yes[Archive without prompting]' \
 '--dry-run[Report destination without moving the case folder]' \
-'-h[Print help]' \
-'--help[Print help]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 ':entry -- Case folder or ENTRY.md path:_files' \
 && ret=0
 ;;
@@ -100,10 +107,11 @@ _arguments "${_arguments_options[@]}" : \
 '--suffix=[Evidence file suffix (default\: .md)]:SUFFIX:_default' \
 '--max-bytes=[Reject sources larger than this many bytes]:MAX_BYTES:_default' \
 '--log-dir=[Execution log directory override (defaults to agent-out topic heuristic-inbox)]:DIR:_files -/' \
-'--format=[Output format]:FORMAT:(text json)' \
+'--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
 '--force[Overwrite existing evidence with same label]' \
-'-h[Print help]' \
-'--help[Print help]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 ':case -- Case folder or ENTRY.md/RECORD.md path:_files' \
 && ret=0
 ;;
@@ -124,7 +132,7 @@ _heuristic-inbox_commands() {
     local commands; commands=(
 'list:List inbox entries' \
 'verify:Verify one inbox or operation-record case folder' \
-'new:Create a curated entry from a skill usage record' \
+'new:Create a curated entry from a skill-usage record, redacted evidence, or manual diagnosis' \
 'set-status:Update an inbox entry lifecycle status' \
 'archive:Move a completed inbox case folder out of the active inbox' \
 'ingest-evidence:Redact and write an evidence file inside a case folder' \

--- a/crates/agent-workflow-primitives/src/heuristic_inbox.rs
+++ b/crates/agent-workflow-primitives/src/heuristic_inbox.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use clap::{Args, Parser, Subcommand, ValueEnum, ValueHint};
+use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum, ValueHint};
 use nils_markdown::Engine;
 use nils_term::prompt::{self, PromptError, PromptOptions};
 use regex::Regex;
@@ -1427,13 +1427,81 @@ fn run_new(args: &NewArgs) -> Result<NewResult, CliError> {
         ));
     }
 
-    let (record_file, record) = load_skill_usage_record(&args.from_skill_usage)?;
+    // Exactly one source is guaranteed by the `new_source` ArgGroup.
+    let resolved = if let Some(path) = &args.from_skill_usage {
+        resolve_skill_usage_source(path)?
+    } else if let Some(path) = &args.from_evidence {
+        resolve_evidence_source(path)?
+    } else {
+        resolve_manual_source()
+    };
 
     let title = if args.title.is_empty() {
         title_from_slug(slug)
     } else {
         args.title.clone()
     };
+    let area = if !args.area.is_empty() {
+        args.area.clone()
+    } else {
+        resolved.area_default
+    };
+    let next_action = if args.next_action.is_empty() {
+        "Triage this gap and route any implementation work to a focused plan or domain workflow."
+            .to_string()
+    } else {
+        args.next_action.clone()
+    };
+
+    let text = compose_entry(EntryParts {
+        title: &title,
+        status: args.status.as_str(),
+        first_observed: &resolved.first_observed,
+        area: &area,
+        severity: args.severity.as_str(),
+        signal: &resolved.signal,
+        raw_record_display: &resolved.raw_record_display,
+        evidence_summary: &resolved.evidence_summary,
+        next_action: &next_action,
+    });
+
+    write_text(&target, &text)?;
+    fs::create_dir_all(&evidence_dir).map_err(|err| {
+        CliError::runtime(
+            "create-dir-failed",
+            format!("failed to create {}: {err}", evidence_dir.display()),
+            Some(json!({ "path": display_path(&evidence_dir) })),
+        )
+    })?;
+    for (filename, body) in &resolved.evidence_files {
+        write_text(&evidence_dir.join(filename), body)?;
+    }
+    Ok(NewResult {
+        ok: true,
+        path: display_path(&target),
+        folder: display_path(&case_folder),
+        status: args.status.as_str().to_string(),
+        severity: args.severity.as_str().to_string(),
+    })
+}
+
+/// Resolved per-source content used to compose an inbox `ENTRY.md`.
+struct ResolvedSource {
+    /// Fallback `Area` value when `--area` is not supplied.
+    area_default: String,
+    first_observed: String,
+    /// Body of the `## Signal` section.
+    signal: String,
+    /// Rendered value after `- Raw record: ` (already escaped/quoted as needed).
+    raw_record_display: String,
+    /// Trailing summary line under `## Evidence`.
+    evidence_summary: String,
+    /// Files to write under the case `evidence/` directory: `(filename, body)`.
+    evidence_files: Vec<(String, String)>,
+}
+
+fn resolve_skill_usage_source(path: &Path) -> Result<ResolvedSource, CliError> {
+    let (record_file, record) = load_skill_usage_record(path)?;
     let skill = record
         .get("skill")
         .and_then(Value::as_str)
@@ -1449,49 +1517,93 @@ fn run_new(args: &NewArgs) -> Result<NewResult, CliError> {
         .and_then(Value::as_str)
         .unwrap_or("See linked skill usage record.");
     let outcome_summary = redact_summary(outcome_summary_raw);
-    let area = if args.area.is_empty() {
-        skill.clone()
-    } else {
-        args.area.clone()
-    };
-    let first_observed = today_from_record(&record);
-    let next_action = if args.next_action.is_empty() {
-        "Triage this gap and route any implementation work to a focused plan or domain workflow."
-            .to_string()
-    } else {
-        args.next_action.clone()
-    };
     let raw_record_pointer = normalize_home_paths(&display_path(&record_file));
-
-    let text = format!(
-        "# {title}\n\n## Status\n\n- Status: {status}\n- First observed: {first_observed}\n- Area: {area}\n- Severity: {severity}\n\n## Signal\n\nSkill `{skill}` ended with `{outcome_status}`. Summary: {outcome_summary}\n\n## Evidence\n\n- Raw record: `{raw_record_pointer}`\n- Summary: linked `skill-usage.record.v1` envelope; raw runtime details remain in the evidence location.\n\n## Impact\n\nFuture agents may repeat this workflow gap unless the retained entry is triaged,\nrouted, and later promoted into a durable fix, runbook, test, script, or skill\npolicy.\n\n## Current Workaround\n\nUse the linked raw record for details, apply the safest manual workaround for\nthe affected workflow, and avoid copying raw logs or secrets into this entry.\n\n## Promotion Criteria\n\nPromote after the durable fix or accepted-risk decision is implemented,\nvalidated, and linked from this entry.\n\n## Next Action\n\n{next_action}\n",
-        title = title,
-        status = args.status.as_str(),
-        first_observed = first_observed,
-        area = area,
-        severity = args.severity.as_str(),
-        skill = skill,
-        outcome_status = outcome_status,
-        outcome_summary = outcome_summary,
-        raw_record_pointer = raw_record_pointer,
-        next_action = next_action,
-    );
-
-    write_text(&target, &text)?;
-    fs::create_dir_all(&evidence_dir).map_err(|err| {
-        CliError::runtime(
-            "create-dir-failed",
-            format!("failed to create {}: {err}", evidence_dir.display()),
-            Some(json!({ "path": display_path(&evidence_dir) })),
-        )
-    })?;
-    Ok(NewResult {
-        ok: true,
-        path: display_path(&target),
-        folder: display_path(&case_folder),
-        status: args.status.as_str().to_string(),
-        severity: args.severity.as_str().to_string(),
+    Ok(ResolvedSource {
+        area_default: skill.clone(),
+        first_observed: today_from_record(&record),
+        signal: format!("Skill `{skill}` ended with `{outcome_status}`. Summary: {outcome_summary}"),
+        raw_record_display: format!("`{raw_record_pointer}`"),
+        evidence_summary:
+            "linked `skill-usage.record.v1` envelope; raw runtime details remain in the evidence location."
+                .to_string(),
+        evidence_files: Vec::new(),
     })
+}
+
+fn resolve_evidence_source(path: &Path) -> Result<ResolvedSource, CliError> {
+    let (redacted, violations) = redact_ingest_source(path, DEFAULT_EVIDENCE_MAX_BYTES)?;
+    if !violations.is_empty() {
+        let messages: Vec<String> = violations.iter().map(|v| v.message.clone()).collect();
+        return Err(CliError::usage(
+            "evidence-not-redactable",
+            format!(
+                "evidence source cannot be ingested safely: {}",
+                messages.join("; ")
+            ),
+            Some(json!({ "violations": violations })),
+        ));
+    }
+    let filename = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("evidence.md")
+        .to_string();
+    Ok(ResolvedSource {
+        area_default: "uncategorized".to_string(),
+        first_observed: today_utc(),
+        signal:
+            "Workflow gap captured from an ingested evidence file. See the Evidence section for the redacted source."
+                .to_string(),
+        raw_record_display: format!("`evidence/{filename}`"),
+        evidence_summary:
+            "redacted evidence ingested at creation time; raw logs and secrets were stripped before commit."
+                .to_string(),
+        evidence_files: vec![(filename, redacted)],
+    })
+}
+
+fn resolve_manual_source() -> ResolvedSource {
+    let today = today_utc();
+    ResolvedSource {
+        area_default: "uncategorized".to_string(),
+        first_observed: today.clone(),
+        signal:
+            "Workflow gap diagnosed manually during a live session; no skill-usage record was captured. See Next Action for the triage and routing plan."
+                .to_string(),
+        raw_record_display: format!("not captured (manual diagnosis, {today})"),
+        evidence_summary:
+            "manual diagnosis with no captured raw record; attach redacted evidence later via `heuristic-inbox ingest-evidence`."
+                .to_string(),
+        evidence_files: Vec::new(),
+    }
+}
+
+/// Named arguments for [`compose_entry`].
+struct EntryParts<'a> {
+    title: &'a str,
+    status: &'a str,
+    first_observed: &'a str,
+    area: &'a str,
+    severity: &'a str,
+    signal: &'a str,
+    raw_record_display: &'a str,
+    evidence_summary: &'a str,
+    next_action: &'a str,
+}
+
+fn compose_entry(parts: EntryParts<'_>) -> String {
+    format!(
+        "# {title}\n\n## Status\n\n- Status: {status}\n- First observed: {first_observed}\n- Area: {area}\n- Severity: {severity}\n\n## Signal\n\n{signal}\n\n## Evidence\n\n- Raw record: {raw_record_display}\n- Summary: {evidence_summary}\n\n## Impact\n\nFuture agents may repeat this workflow gap unless the retained entry is triaged,\nrouted, and later promoted into a durable fix, runbook, test, script, or skill\npolicy.\n\n## Current Workaround\n\nApply the safest manual workaround for the affected workflow until the durable\nfix lands, and avoid copying raw logs or secrets into this entry.\n\n## Promotion Criteria\n\nPromote after the durable fix or accepted-risk decision is implemented,\nvalidated, and linked from this entry.\n\n## Next Action\n\n{next_action}\n",
+        title = parts.title,
+        status = parts.status,
+        first_observed = parts.first_observed,
+        area = parts.area,
+        severity = parts.severity,
+        signal = parts.signal,
+        raw_record_display = parts.raw_record_display,
+        evidence_summary = parts.evidence_summary,
+        next_action = parts.next_action,
+    )
 }
 
 fn replace_next_action(text: &str, link: &str, next_action: &str) -> String {
@@ -2320,7 +2432,7 @@ fn dispatch_ingest(args: IngestArgs, argv: &[String], started_at: &str) -> i32 {
     about = "Manage curated HEURISTIC_SYSTEM error-inbox and operation-record case folders.",
     long_about = "Manage curated heuristic-system inbox cases, operation records, evidence ingestion, and archival transitions.",
     disable_help_subcommand = true,
-    after_help = "EXAMPLES:\n  heuristic-inbox list --format json\n  heuristic-inbox verify heuristic-system/error-inbox/<slug>/ --format json\n  heuristic-inbox new --from-skill-usage out/.../skill-usage.record.json --slug pipeline-gap\n  heuristic-inbox set-status heuristic-system/error-inbox/<slug>/ --status promoted --link docs/plans/foo.md\n  heuristic-inbox archive heuristic-system/error-inbox/<slug>/ --date 2026-05-18\n  heuristic-inbox ingest-evidence heuristic-system/error-inbox/<slug>/ --from validation.md\n  heuristic-inbox completion zsh\n\nENVIRONMENT:\n  HOME  Fallback base path when expanding home-relative paths.\n\nEXIT CODES:\n  0   success\n  1   runtime error\n  64  command-line usage error\n  65  invalid input data"
+    after_help = "EXAMPLES:\n  heuristic-inbox list --format json\n  heuristic-inbox verify heuristic-system/error-inbox/<slug>/ --format json\n  heuristic-inbox new --from-skill-usage out/.../skill-usage.record.json --slug pipeline-gap\n  heuristic-inbox new --from-evidence out/.../diagnosis.md --slug worktree-signing-gap\n  heuristic-inbox new --manual --slug live-diagnosis-gap --area cli --severity high\n  heuristic-inbox set-status heuristic-system/error-inbox/<slug>/ --status promoted --link docs/plans/foo.md\n  heuristic-inbox archive heuristic-system/error-inbox/<slug>/ --date 2026-05-18\n  heuristic-inbox ingest-evidence heuristic-system/error-inbox/<slug>/ --from validation.md\n  heuristic-inbox completion zsh\n\nENVIRONMENT:\n  HOME  Fallback base path when expanding home-relative paths.\n\nEXIT CODES:\n  0   success\n  1   runtime error\n  64  command-line usage error\n  65  invalid input data"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -2334,7 +2446,7 @@ enum Command {
     List(ListArgs),
     /// Verify one inbox or operation-record case folder.
     Verify(VerifyArgs),
-    /// Create a curated entry from a skill usage record.
+    /// Create a curated entry from a skill-usage record, redacted evidence, or manual diagnosis.
     New(NewArgs),
     /// Update an inbox entry lifecycle status.
     SetStatus(SetStatusArgs),
@@ -2385,10 +2497,23 @@ struct VerifyArgs {
 }
 
 #[derive(Debug, Args)]
+#[command(group(
+    ArgGroup::new("new_source")
+        .required(true)
+        .args(["from_skill_usage", "from_evidence", "manual"]),
+))]
 struct NewArgs {
-    /// Path to a skill-usage record file or its containing directory.
+    /// Scaffold from a `skill-usage.record.v1` envelope (file or its directory).
     #[arg(long = "from-skill-usage", value_name = "PATH", value_hint = ValueHint::AnyPath)]
-    from_skill_usage: PathBuf,
+    from_skill_usage: Option<PathBuf>,
+
+    /// Scaffold from an already-redacted evidence file (reuses ingest-evidence redaction).
+    #[arg(long = "from-evidence", value_name = "PATH", value_hint = ValueHint::AnyPath)]
+    from_evidence: Option<PathBuf>,
+
+    /// Scaffold a manual-diagnosis skeleton with no captured raw evidence.
+    #[arg(long = "manual")]
+    manual: bool,
 
     /// Slug for the new inbox case.
     #[arg(long)]

--- a/crates/agent-workflow-primitives/tests/integration/cli.rs
+++ b/crates/agent-workflow-primitives/tests/integration/cli.rs
@@ -1459,6 +1459,143 @@ Promote after a durable fix and validation are linked.\n\n\
     }
 
     #[test]
+    fn new_from_evidence_redacts_and_passes_verify() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let inbox = inbox_root(tmp.path());
+        let evidence = tmp.path().join("diagnosis.md");
+        fs::write(
+            &evidence,
+            "# Worktree signing diagnosis\n\nRan validation under /Users/example/Project/x; signing failed.\n",
+        )
+        .expect("write evidence");
+        let out = run(
+            "heuristic-inbox",
+            tmp.path(),
+            &[
+                "new",
+                "--from-evidence",
+                evidence.to_str().unwrap(),
+                "--slug",
+                "worktree-signing-gap",
+                "--out-dir",
+                inbox.to_str().unwrap(),
+                "--format",
+                "json",
+            ],
+        );
+        assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+        let payload = json_stdout(&out);
+        let entry = PathBuf::from(payload["data"]["path"].as_str().unwrap());
+        let folder = entry.parent().unwrap();
+        let entry_text = fs::read_to_string(&entry).unwrap();
+        assert!(entry_text.contains("- Raw record: `evidence/diagnosis.md`"));
+        let evidence_copy =
+            fs::read_to_string(folder.join("evidence").join("diagnosis.md")).unwrap();
+        assert!(
+            evidence_copy.contains("<workspace>/Project/x"),
+            "absolute home path not redacted: {evidence_copy}"
+        );
+
+        let verify = run(
+            "heuristic-inbox",
+            tmp.path(),
+            &[
+                "verify",
+                folder.to_str().unwrap(),
+                "--strict",
+                "--format",
+                "json",
+            ],
+        );
+        assert_eq!(verify.code, 0, "stderr={}", verify.stderr_text());
+        assert_eq!(json_stdout(&verify)["data"]["ok"], true);
+    }
+
+    #[test]
+    fn new_manual_passes_verify_with_uncaptured_pointer() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let inbox = inbox_root(tmp.path());
+        let out = run(
+            "heuristic-inbox",
+            tmp.path(),
+            &[
+                "new",
+                "--manual",
+                "--slug",
+                "live-diagnosis-gap",
+                "--out-dir",
+                inbox.to_str().unwrap(),
+                "--area",
+                "cli",
+                "--severity",
+                "high",
+                "--format",
+                "json",
+            ],
+        );
+        assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+        let payload = json_stdout(&out);
+        let entry = PathBuf::from(payload["data"]["path"].as_str().unwrap());
+        let folder = entry.parent().unwrap();
+        let entry_text = fs::read_to_string(&entry).unwrap();
+        assert!(entry_text.contains("- Area: cli"));
+        assert!(entry_text.contains("- Raw record: not captured (manual diagnosis,"));
+
+        let verify = run(
+            "heuristic-inbox",
+            tmp.path(),
+            &[
+                "verify",
+                folder.to_str().unwrap(),
+                "--strict",
+                "--format",
+                "json",
+            ],
+        );
+        assert_eq!(verify.code, 0, "stderr={}", verify.stderr_text());
+        assert_eq!(json_stdout(&verify)["data"]["ok"], true);
+    }
+
+    #[test]
+    fn new_requires_exactly_one_source() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let inbox = inbox_root(tmp.path());
+
+        // No source provided.
+        let none = run(
+            "heuristic-inbox",
+            tmp.path(),
+            &[
+                "new",
+                "--slug",
+                "no-source",
+                "--out-dir",
+                inbox.to_str().unwrap(),
+            ],
+        );
+        assert_ne!(none.code, 0, "missing source should fail");
+
+        // Two sources provided.
+        let record_dir = tmp.path().join("out").join("skill-usage");
+        write_skill_usage_record(&record_dir);
+        let both = run(
+            "heuristic-inbox",
+            tmp.path(),
+            &[
+                "new",
+                "--manual",
+                "--from-skill-usage",
+                record_dir.to_str().unwrap(),
+                "--slug",
+                "two-sources",
+                "--out-dir",
+                inbox.to_str().unwrap(),
+            ],
+        );
+        assert_ne!(both.code, 0, "conflicting sources should fail");
+    }
+
+    #[test]
     fn set_status_updates_status_and_link() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let inbox = inbox_root(tmp.path());

--- a/docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-discussion-source.md
+++ b/docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-discussion-source.md
@@ -1,0 +1,71 @@
+# heuristic-inbox `new` non-skill-usage source mode — Source
+
+| Field              | Value                                                                                                                       |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| Status             | Ready for implementation                                                                                                    |
+| Date               | 2026-05-28                                                                                                                  |
+| Source             | sympoies/nils-cli#585: `heuristic-inbox new` only accepts `--from-skill-usage`, so non-skill-usage findings cannot scaffold |
+| Intended next step | Implement the `--from-evidence` / `--manual` source modes in a single small PR that closes #585                             |
+
+## Purpose
+
+`heuristic-inbox new` requires `--from-skill-usage <PATH>`, so it can only
+scaffold a curated error-inbox entry from a `skill-usage.record.v1` envelope.
+Findings diagnosed mid-session that do not originate from a single named-skill
+invocation have no scaffolding path: they must be hand-authored, which then
+trips the non-obvious `verify --strict` `missing raw evidence pointer` check
+(`crates/agent-workflow-primitives/src/heuristic_inbox.rs` `verify_case`, the
+`raw_records.is_empty()` branch).
+
+## Why this is a gap
+
+The Heuristic System Promotion Ladder treats "important unresolved workflow
+gap -> curated error-inbox entry" **without** requiring a skill-usage envelope;
+skill-usage is only the preferred path when friction happens inside an active
+named-skill workflow. So the CLI requirement is narrower than the policy.
+`ingest-evidence` already offers a non-skill-usage evidence path, so decoupling
+`new` from skill-usage is consistent with the existing design.
+
+## Concrete instance
+
+2026-05-27: a worktree-signing root-cause case was diagnosed live with no
+skill-usage record. `new` could not be used; the entry was hand-written and
+first failed `verify --strict` with `missing raw evidence pointer` until a
+`Raw record:` line was added by hand.
+
+## Confirmed facts
+
+- `NewArgs.from_skill_usage` is a required `PathBuf`; there is no other source
+  flag on `new`.
+- `redact_ingest_source` (used by `ingest-evidence`) already performs
+  home-path normalization, raw-skill-usage rejection, size, binary, and
+  secret-pattern checks and returns redacted text plus violations.
+- `verify_case` requires, for an inbox `ENTRY.md`: the seven required sections,
+  non-empty `Status` fields (status / first observed / area / severity), a
+  valid status and severity, and at least one `- Raw record:` pointer line.
+
+## Decision (locked at this source doc)
+
+Implement the issue's option 3 framing — all three sources, mutually exclusive:
+
+1. `--from-evidence <PATH>`: scaffold from an arbitrary, already-redacted
+   evidence file, reusing `ingest-evidence` redaction; copy the redacted file
+   under the case `evidence/` directory and point `Raw record:` at it.
+2. `--manual`: scaffold a skeleton, auto-filling
+   `Raw record: not captured (manual diagnosis, <date>)` so `verify --strict`
+   passes while recording the absence of evidence.
+3. Exactly one of `--from-skill-usage | --from-evidence | --manual` is
+   required (clap `ArgGroup`). Skill-usage stays the documented preferred path.
+
+## Out of scope
+
+- The heuristic-inbox SKILL / `HEURISTIC_SYSTEM.md` doc update describing the
+  non-skill-usage path — those docs live in `agent-runtime-kit`, tracked as a
+  runtime-kit follow-up after this CLI change lands (matching the established
+  CLI-then-runtime split).
+- Any change to `ingest-evidence`, `verify`, or the redaction rules themselves.
+
+## Execution
+
+- Recommended plan: docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-plan.md
+- Recommended execution state: docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-execution-state.md

--- a/docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-execution-state.md
+++ b/docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-execution-state.md
@@ -1,0 +1,51 @@
+<!-- execute-from-tracking-issue:state:v1 -->
+# heuristic-inbox `new` non-skill-usage source mode — Execution State
+
+## Execution State
+
+- Status: in-progress
+- Target scope: whole plan
+- Execution window: whole plan (single sprint)
+- Current task: Sprint 1 delivery (PR + merge)
+- Next task: Open and deliver the implementation PR closing #585
+- Last updated: 2026-05-28 Asia/Taipei
+- Branch/commit/PR/release: `feat/585-heuristic-inbox-non-skill-usage-source`; commit `34cd315`; PR pending
+- Source document: docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-plan.md
+- Discussion source document: docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-discussion-source.md
+- Source issue: sympoies/nils-cli#585
+- Tracking issue: pending (this bundle drives `plan-issue record open`)
+- Source snapshot: pending
+- Plan snapshot: pending
+- Initial execution state snapshot: pending
+- Direct source-doc execution waiver: not applicable
+
+## Task Ledger
+
+| ID       | Status   | Task                                                              | Evidence       | Notes                                                            |
+| -------- | -------- | ---------------------------------------------------------------- | -------------- | --------------------------------------------------------------- |
+| Task 1.1 | complete | Add `--from-evidence` / `--manual` sources and exclusivity gate  | commit 34cd315 | `new_source` ArgGroup; `from_skill_usage` now `Option<PathBuf>` |
+| Task 1.2 | complete | Resolve each source and compose the entry                        | commit 34cd315 | per-source resolvers + shared `compose_entry`; reuses redaction |
+| Task 1.3 | complete | Help, completions, and tests                                     | commit 34cd315 | regenerated zsh/bash assets; 3 new integration tests            |
+
+## Validation
+
+| Command                                                                | Status | Summary                                            | Artifact                |
+| ---------------------------------------------------------------------- | ------ | -------------------------------------------------- | ----------------------- |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`           | pass   | fmt + clippy -D warnings + 4189 nextest tests pass | 585-validation/local-fast.log |
+| `cargo test -p nils-agent-workflow-primitives --test integration`      | pass   | heuristic_inbox suite incl. 3 new tests green      | 585-validation/local-fast.log |
+| `bash scripts/ci/completion-flag-parity-audit.sh --strict`             | pass   | 38 required binaries, 0 failures with new flags    | —                       |
+| `bash scripts/ci/completion-asset-audit.sh --strict`                   | pass   | asset matrix coverage intact                       | —                       |
+
+## Blockers
+
+- none
+
+## Session Log
+
+- 2026-05-28: Bundle drafted retroactively against an already-implemented and
+  locally-validated change (commit `34cd315` on
+  `feat/585-heuristic-inbox-non-skill-usage-source`). All three Sprint 1 tasks
+  are complete; local-fast, completion flag-parity, and asset audits are green
+  with no Cargo.lock drift (no new dependencies). Remaining work is provider
+  delivery: `record open` of the tracking issue closing #585, lifecycle
+  checkpoints, PR open + squash-merge, and close-ready handoff.

--- a/docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-execution-state.md
+++ b/docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-execution-state.md
@@ -21,20 +21,20 @@
 
 ## Task Ledger
 
-| ID       | Status   | Task                                                              | Evidence       | Notes                                                            |
-| -------- | -------- | ---------------------------------------------------------------- | -------------- | --------------------------------------------------------------- |
-| Task 1.1 | complete | Add `--from-evidence` / `--manual` sources and exclusivity gate  | commit 34cd315 | `new_source` ArgGroup; `from_skill_usage` now `Option<PathBuf>` |
-| Task 1.2 | complete | Resolve each source and compose the entry                        | commit 34cd315 | per-source resolvers + shared `compose_entry`; reuses redaction |
-| Task 1.3 | complete | Help, completions, and tests                                     | commit 34cd315 | regenerated zsh/bash assets; 3 new integration tests            |
+| ID       | Status   | Task                                                            | Evidence       | Notes                                                           |
+| -------- | -------- | --------------------------------------------------------------- | -------------- | --------------------------------------------------------------- |
+| Task 1.1 | complete | Add `--from-evidence` / `--manual` sources and exclusivity gate | commit 34cd315 | `new_source` ArgGroup; `from_skill_usage` now `Option<PathBuf>` |
+| Task 1.2 | complete | Resolve each source and compose the entry                       | commit 34cd315 | per-source resolvers + shared `compose_entry`; reuses redaction |
+| Task 1.3 | complete | Help, completions, and tests                                    | commit 34cd315 | regenerated zsh/bash assets; 3 new integration tests            |
 
 ## Validation
 
-| Command                                                                | Status | Summary                                            | Artifact                |
-| ---------------------------------------------------------------------- | ------ | -------------------------------------------------- | ----------------------- |
-| `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`           | pass   | fmt + clippy -D warnings + 4189 nextest tests pass | 585-validation/local-fast.log |
-| `cargo test -p nils-agent-workflow-primitives --test integration`      | pass   | heuristic_inbox suite incl. 3 new tests green      | 585-validation/local-fast.log |
-| `bash scripts/ci/completion-flag-parity-audit.sh --strict`             | pass   | 38 required binaries, 0 failures with new flags    | —                       |
-| `bash scripts/ci/completion-asset-audit.sh --strict`                   | pass   | asset matrix coverage intact                       | —                       |
+| Command                                                           | Status | Summary                                            | Artifact                      |
+| ----------------------------------------------------------------- | ------ | -------------------------------------------------- | ----------------------------- |
+| `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`      | pass   | fmt + clippy -D warnings + 4189 nextest tests pass | 585-validation/local-fast.log |
+| `cargo test -p nils-agent-workflow-primitives --test integration` | pass   | heuristic_inbox suite incl. 3 new tests green      | 585-validation/local-fast.log |
+| `bash scripts/ci/completion-flag-parity-audit.sh --strict`        | pass   | 38 required binaries, 0 failures with new flags    | —                             |
+| `bash scripts/ci/completion-asset-audit.sh --strict`              | pass   | asset matrix coverage intact                       | —                             |
 
 ## Blockers
 

--- a/docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-plan.md
+++ b/docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-plan.md
@@ -1,0 +1,176 @@
+# Plan: heuristic-inbox `new` non-skill-usage source mode
+
+## Overview
+
+Decouple `heuristic-inbox new` from its mandatory `--from-skill-usage`
+argument so that workflow gaps diagnosed outside a single named-skill
+invocation can scaffold a `verify --strict`-passing curated error-inbox
+entry. The change adds two sources and a mutual-exclusivity gate:
+
+- `--from-evidence <PATH>`: reuse the existing `ingest-evidence`
+  redaction (`redact_ingest_source`) to read and redact an arbitrary
+  evidence file, copy the redacted file under the new case's
+  `evidence/` directory, and point the entry's `Raw record:` line at
+  it.
+- `--manual`: scaffold a skeleton with no captured raw evidence,
+  auto-filling `Raw record: not captured (manual diagnosis, <date>)`
+  so the entry still satisfies the `verify --strict`
+  `missing raw evidence pointer` check while honestly recording that
+  no evidence was captured.
+- A clap `ArgGroup` makes exactly one of
+  `--from-skill-usage | --from-evidence | --manual` required, so the
+  existing skill-usage path is preserved and the two new modes cannot
+  be combined.
+
+The entry-body shape, the seven required sections, and the redaction
+guarantees are unchanged. The skill-usage path stays byte-compatible
+for its `Status`, `Signal`, and `Evidence` rendering.
+
+Source: this bundle's discussion source doc (Read First, below).
+
+## Read First
+
+- Primary source:
+  `docs/plans/heuristic-inbox-non-skill-usage-source/heuristic-inbox-non-skill-usage-source-discussion-source.md`
+- Source type: discussion-to-implementation-doc
+- Source issue: sympoies/nils-cli#585
+- Open questions carried into execution: none (option 3 — all three
+  mutually exclusive sources — locked at the source doc).
+- Implementation surface:
+  `crates/agent-workflow-primitives/src/heuristic_inbox.rs`
+  (`NewArgs`, `run_new`), reusing `redact_ingest_source`.
+- Out of scope (tracked separately): the heuristic-inbox SKILL /
+  `HEURISTIC_SYSTEM.md` doc update in `agent-runtime-kit`.
+
+## Scope
+
+- In scope:
+  - `--from-evidence <PATH>` and `--manual` flags on `NewArgs`, plus a
+    `new_source` `ArgGroup` requiring exactly one source.
+  - Refactor of `run_new` into per-source resolvers
+    (`resolve_skill_usage_source` / `resolve_evidence_source` /
+    `resolve_manual_source`) and a shared `compose_entry`.
+  - Copying redacted evidence under the case `evidence/` directory for
+    `--from-evidence`; refusal when the source fails redaction
+    (reusing `redact_ingest_source` violations, including the raw
+    skill-usage record guard).
+  - Updated `new` subcommand doc string and root `EXAMPLES` help.
+  - Regenerated `completions/zsh/_heuristic-inbox` and
+    `completions/bash/heuristic-inbox`.
+  - Integration tests for `--from-evidence`, `--manual`, and source
+    mutual-exclusivity.
+- Out of scope:
+  - Any change to `ingest-evidence`, `verify`, or the redaction rules.
+  - Any change to the entry-body section set or the `verify_case`
+    contract.
+  - The `agent-runtime-kit` SKILL / `HEURISTIC_SYSTEM.md` doc update.
+
+## Assumptions
+
+- `redact_ingest_source` is the correct shared redaction primitive for
+  arbitrary evidence; its existing violation set (raw skill-usage,
+  too-large, binary, secret-pattern) is the right gate for
+  `--from-evidence`.
+- A `uncategorized` default `Area` (overridable via `--area`) and a
+  `today_utc()` `First observed` are acceptable for the two new modes,
+  which have no skill name or record timestamp to derive from.
+- The `manual` `Raw record: not captured (manual diagnosis, <date>)`
+  pointer is acceptable to `verify --strict` (non-empty raw-record
+  line) and clearly signals the absence of evidence to a reader.
+
+## Sprint 1: Non-skill-usage source modes
+
+**Goal**: `heuristic-inbox new` accepts `--from-evidence` and
+`--manual` as alternatives to `--from-skill-usage`, requires exactly
+one, and every mode produces a `verify --strict`-passing entry, with
+the skill-usage path unchanged.
+
+**Demo/Validation**:
+
+- Commands:
+  - `cargo test -p nils-agent-workflow-primitives --test integration`
+  - `heuristic-inbox new --manual --slug live-gap --area cli --severity high`
+  - `heuristic-inbox new --from-evidence <file> --slug ev-gap`
+  - `heuristic-inbox verify <case> --strict --format json`
+- Verify: both new modes emit `ok: true` and `verify --strict` returns
+  `ok: true`; supplying two sources or none fails with a usage error.
+
+### Task 1.1: Add `--from-evidence` / `--manual` sources and mutual-exclusivity gate
+
+- **Location**:
+  - `crates/agent-workflow-primitives/src/heuristic_inbox.rs`
+    (`NewArgs`)
+- **Description**: Make `from_skill_usage` an `Option<PathBuf>`, add
+  `from_evidence: Option<PathBuf>` and `manual: bool`, and attach a
+  `new_source` `ArgGroup` (`required(true)`) over the three so clap
+  enforces exactly one. Update the `new` subcommand doc string.
+- **Dependencies**: none
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - `new` with no source fails with the clap required-argument error.
+  - `new` with two sources fails with the clap conflict error.
+  - `--from-skill-usage` continues to parse as before.
+- **Validation**:
+  - `cargo test -p nils-agent-workflow-primitives --test integration cli::heuristic_inbox`
+
+### Task 1.2: Resolve each source and compose the entry
+
+- **Location**:
+  - `crates/agent-workflow-primitives/src/heuristic_inbox.rs`
+    (`run_new` and new resolver helpers)
+- **Description**: Split `run_new` into per-source resolvers returning
+  a `ResolvedSource` (area default, first-observed, signal,
+  raw-record display, evidence summary, evidence files) and a shared
+  `compose_entry`. `resolve_evidence_source` calls
+  `redact_ingest_source`, errors with `evidence-not-redactable` on any
+  violation, and writes the redacted copy under the case `evidence/`
+  directory with the `Raw record:` line pointing at
+  `evidence/<filename>`. `resolve_manual_source` emits
+  `Raw record: not captured (manual diagnosis, <date>)`.
+- **Dependencies**: Task 1.1
+- **Complexity**: 2
+- **Acceptance criteria**:
+  - `--from-evidence` copies a redacted evidence file into the case and
+    the entry passes `verify --strict`.
+  - `--from-evidence` on a raw `skill-usage.record.json` is refused.
+  - `--manual` produces a `verify --strict`-passing entry with the
+    uncaptured raw-record pointer.
+  - The skill-usage path renders the same `Status` / `Signal` /
+    `Evidence` content as before and never leaks a raw secret.
+- **Validation**:
+  - `cargo test -p nils-agent-workflow-primitives --test integration cli::heuristic_inbox`
+
+### Task 1.3: Help, completions, and tests
+
+- **Location**:
+  - `crates/agent-workflow-primitives/src/heuristic_inbox.rs`
+    (root `EXAMPLES`)
+  - `completions/zsh/_heuristic-inbox`,
+    `completions/bash/heuristic-inbox`
+  - `crates/agent-workflow-primitives/tests/integration/cli.rs`
+- **Description**: Add `--from-evidence` / `--manual` examples to the
+  root help `EXAMPLES`, regenerate the zsh and bash completion assets
+  from the rebuilt binary, and add integration tests for the two new
+  modes and for source mutual-exclusivity.
+- **Dependencies**: Task 1.2
+- **Complexity**: 1
+- **Acceptance criteria**:
+  - Completion flag-parity and asset audits pass with the new flags.
+  - New integration tests assert redaction, the uncaptured pointer,
+    `verify --strict` success, and the required/conflict source errors.
+- **Validation**:
+  - `bash scripts/ci/completion-flag-parity-audit.sh --strict`
+  - `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
+
+## Risks
+
+- **R-1**: `--from-evidence` could copy unredacted secrets into the
+  case. Mitigation: reuse `redact_ingest_source`, which fails closed on
+  any violation before the file is written; covered by the
+  raw-skill-usage refusal test.
+- **R-2**: A `--manual` skeleton with no real evidence could become a
+  low-signal entry. Mitigation: the entry records an explicit
+  `not captured (manual diagnosis, <date>)` pointer and the summary
+  directs the author to attach redacted evidence later via
+  `ingest-evidence`; `--manual` is never a default and requires the
+  explicit flag.


### PR DESCRIPTION
## Summary

`heuristic-inbox new` previously required `--from-skill-usage <PATH>`, so it
could only scaffold a curated error-inbox entry from a `skill-usage.record.v1`
envelope. Findings diagnosed mid-session without a single named-skill
invocation had no scaffolding path and had to be hand-authored, which tripped
the non-obvious `verify --strict` `missing raw evidence pointer` check.

This adds two non-skill-usage sources and a mutual-exclusivity gate
(issue #585 option 3):

- `--from-evidence <PATH>`: reuse the existing `ingest-evidence` redaction
  (`redact_ingest_source`) to read and redact an arbitrary evidence file, copy
  the redacted file under the new case's `evidence/` directory, and point the
  entry's `Raw record:` line at it. Refuses sources that fail redaction
  (including raw `skill-usage.record.json`).
- `--manual`: scaffold a skeleton with no captured raw evidence, auto-filling
  `Raw record: not captured (manual diagnosis, <date>)` so the entry still
  passes `verify --strict` while honestly recording the absence of evidence.
- A clap `ArgGroup` makes exactly one of
  `--from-skill-usage | --from-evidence | --manual` required. Skill-usage stays
  the documented preferred path and its rendered output is unchanged.

`run_new` is refactored into per-source resolvers plus a shared
`compose_entry`; the seven required sections, status fields, and redaction
guarantees are unchanged.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — fmt, clippy
  `-D warnings`, and 4189 nextest tests pass.
- `completion-flag-parity-audit.sh --strict` and `completion-asset-audit.sh
  --strict` pass with the regenerated zsh/bash assets.
- New integration tests cover `--from-evidence` redaction + `verify --strict`,
  `--manual` uncaptured pointer + `verify --strict`, and source
  mutual-exclusivity. No `Cargo.lock` drift (no new dependencies).

## Notes

- The heuristic-inbox SKILL / `HEURISTIC_SYSTEM.md` doc update describing the
  non-skill-usage path lives in `agent-runtime-kit` and is tracked as a
  runtime-kit follow-up (the established CLI-then-runtime split).

Closes #585.
Tracking: #594.
