### PR TITLE
refactor(nils-common): share git remote userinfo stripping

### DIFF
--- a/crates/forge-cli/src/provider.rs
+++ b/crates/forge-cli/src/provider.rs
@@ -150,8 +150,8 @@ pub fn classify_host(host: &str) -> Option<Provider> {
 }
 
 /// Parse the host out of a remote URL. Supports:
-/// - `https://<host>/<owner>/<repo>(.git)?`
-/// - `ssh://git@<host>(:port)?/<owner>/<repo>(.git)?`
+/// - `https://[userinfo@]<host>/<owner>/<repo>(.git)?`
+/// - `ssh://[user@]<host>(:port)?/<owner>/<repo>(.git)?`
 /// - `git@<host>:<owner>/<repo>(.git)?`
 pub fn parse_host(url: &str) -> Option<String> {
     let trimmed = url.trim();
@@ -159,11 +159,12 @@ pub fn parse_host(url: &str) -> Option<String> {
         return None;
     }
     if let Some(rest) = trimmed.strip_prefix("https://") {
-        return host_before_path(rest);
+        return host_before_path(rest)
+            .map(|host| nils_common::git::strip_userinfo(&host).to_string());
     }
     if let Some(rest) = trimmed.strip_prefix("ssh://") {
         // ssh://[user@]host[:port]/owner/repo
-        let after_user = rest.rsplit_once('@').map(|(_, h)| h).unwrap_or(rest);
+        let after_user = nils_common::git::strip_userinfo(rest);
         return host_before_path(after_user).map(strip_port);
     }
     if let Some((user_host, _)) = trimmed.split_once(':')
@@ -265,6 +266,26 @@ mod tests {
     fn parse_host_rejects_empty() {
         assert_eq!(parse_host(""), None);
         assert_eq!(parse_host("   "), None);
+    }
+
+    #[test]
+    fn parse_host_strips_basic_auth_userinfo_from_https() {
+        assert_eq!(
+            parse_host("https://user:pass@github.com/sympoies/nils-cli.git"),
+            Some("github.com".to_string())
+        );
+        assert_eq!(
+            parse_host("https://x-access-token:TOKEN@gitlab.com/group/proj.git"),
+            Some("gitlab.com".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_host_strips_userinfo_from_ssh_scheme_with_port() {
+        assert_eq!(
+            parse_host("ssh://deploy@gitlab.example.com:2222/group/proj.git"),
+            Some("gitlab.example.com".to_string())
+        );
     }
 
     #[test]

--- a/crates/forge-cli/src/provider.rs
+++ b/crates/forge-cli/src/provider.rs
@@ -160,12 +160,15 @@ pub fn parse_host(url: &str) -> Option<String> {
     }
     if let Some(rest) = trimmed.strip_prefix("https://") {
         return host_before_path(rest)
-            .map(|host| nils_common::git::strip_userinfo(&host).to_string());
+            .map(|host| nils_common::git::strip_userinfo(&host).to_string())
+            .filter(|host| !host.is_empty());
     }
     if let Some(rest) = trimmed.strip_prefix("ssh://") {
         // ssh://[user@]host[:port]/owner/repo
         let after_user = nils_common::git::strip_userinfo(rest);
-        return host_before_path(after_user).map(strip_port);
+        return host_before_path(after_user)
+            .map(strip_port)
+            .filter(|host| !host.is_empty());
     }
     if let Some((user_host, _)) = trimmed.split_once(':')
         && let Some((_, host)) = user_host.rsplit_once('@')
@@ -286,6 +289,20 @@ mod tests {
             parse_host("ssh://deploy@gitlab.example.com:2222/group/proj.git"),
             Some("gitlab.example.com".to_string())
         );
+    }
+
+    #[test]
+    fn parse_host_then_classify_recovers_provider_for_userinfo_remotes() {
+        let host = parse_host("https://user:pass@github.com/owner/repo.git").expect("host");
+        assert_eq!(classify_host(&host), Some(Provider::GitHub));
+        let host = parse_host("ssh://deploy@gitlab.example.com:22/group/proj.git").expect("host");
+        assert_eq!(classify_host(&host), Some(Provider::GitLab));
+    }
+
+    #[test]
+    fn parse_host_rejects_empty_after_userinfo() {
+        assert_eq!(parse_host("https://user:pass@/owner/repo"), None);
+        assert_eq!(parse_host("ssh://deploy@/owner/repo"), None);
     }
 
     #[test]

--- a/crates/git-cli/src/open.rs
+++ b/crates/git-cli/src/open.rs
@@ -1,3 +1,4 @@
+use nils_common::git::strip_userinfo;
 use nils_common::process;
 use std::io::{self, Write};
 use std::process::Output;
@@ -903,10 +904,6 @@ fn host_from_url(url: &str) -> String {
         .next()
         .unwrap_or("")
         .to_ascii_lowercase()
-}
-
-fn strip_userinfo(host: &str) -> &str {
-    host.rsplit_once('@').map(|(_, tail)| tail).unwrap_or(host)
 }
 
 fn percent_encode(value: &str, keep_slash: bool) -> String {

--- a/crates/nils-common/src/git.rs
+++ b/crates/nils-common/src/git.rs
@@ -93,6 +93,15 @@ pub fn trim_trailing_newlines(input: &str) -> String {
     input.trim_end_matches(['\n', '\r']).to_string()
 }
 
+/// Strip the `userinfo@` prefix from the host segment of a parsed git remote
+/// URL. Returns the input unchanged when no `@` is present. Splits at the
+/// last `@` so embedded `@` characters inside basic-auth credentials are
+/// removed alongside the userinfo. Callers must pass the host segment after
+/// the scheme has been removed; passing a full URL is not supported.
+pub fn strip_userinfo(host: &str) -> &str {
+    host.rsplit_once('@').map(|(_, tail)| tail).unwrap_or(host)
+}
+
 pub fn staged_name_only() -> io::Result<String> {
     staged_name_only_inner(None)
 }
@@ -637,5 +646,27 @@ mod tests {
 
         let staged = staged_name_only().expect("staged names");
         assert!(staged.contains("docs.md"));
+    }
+
+    #[test]
+    fn strip_userinfo_passthrough_when_no_at() {
+        assert_eq!(strip_userinfo("github.com"), "github.com");
+        assert_eq!(
+            strip_userinfo("gitlab.example.com:2222"),
+            "gitlab.example.com:2222"
+        );
+        assert_eq!(strip_userinfo(""), "");
+    }
+
+    #[test]
+    fn strip_userinfo_drops_user_only_prefix() {
+        assert_eq!(strip_userinfo("git@github.com"), "github.com");
+        assert_eq!(strip_userinfo("x-access-token@gitlab.com"), "gitlab.com");
+    }
+
+    #[test]
+    fn strip_userinfo_drops_user_password_prefix() {
+        assert_eq!(strip_userinfo("user:pass@github.com"), "github.com");
+        assert_eq!(strip_userinfo("user:p@ss@gitlab.com"), "gitlab.com");
     }
 }

--- a/crates/nils-common/src/git.rs
+++ b/crates/nils-common/src/git.rs
@@ -93,11 +93,10 @@ pub fn trim_trailing_newlines(input: &str) -> String {
     input.trim_end_matches(['\n', '\r']).to_string()
 }
 
-/// Strip the `userinfo@` prefix from the host segment of a parsed git remote
-/// URL. Returns the input unchanged when no `@` is present. Splits at the
-/// last `@` so embedded `@` characters inside basic-auth credentials are
-/// removed alongside the userinfo. Callers must pass the host segment after
-/// the scheme has been removed; passing a full URL is not supported.
+/// Return the substring after the last `@`, or the input unchanged when no
+/// `@` is present. Used by git remote URL parsers to drop the `userinfo@`
+/// prefix from a host segment (or a host+path string, since `/` cannot appear
+/// inside userinfo, splitting at the last `@` is safe for both shapes).
 pub fn strip_userinfo(host: &str) -> &str {
     host.rsplit_once('@').map(|(_, tail)| tail).unwrap_or(host)
 }

--- a/crates/plan-issue-cli/src/provider.rs
+++ b/crates/plan-issue-cli/src/provider.rs
@@ -159,12 +159,13 @@ fn parse_repo_with_host(raw: &str) -> Option<Repo> {
         return finalize_with_host(host, path);
     }
 
-    // Strip URL scheme + optional `git@` prefix from `ssh://` form, leaving
-    // `<host>/<path>`.
+    // Strip URL scheme from `https://` / `http://` / `ssh://` form, leaving
+    // `[userinfo@]<host>/<path>`. Any userinfo is dropped below via
+    // `strip_userinfo`.
     let host_and_path = trimmed
         .strip_prefix("https://")
         .or_else(|| trimmed.strip_prefix("http://"))
-        .or_else(|| trimmed.strip_prefix("ssh://git@"))
+        .or_else(|| trimmed.strip_prefix("ssh://"))
         .map(|rest| rest.trim_start_matches('/'))
         .unwrap_or(trimmed);
 
@@ -276,10 +277,11 @@ fn parse_remote_url(remote: &str) -> Option<(String, String, Provider)> {
         return finalize_remote(host, path);
     }
 
-    // ssh://git@host/owner/repo(.git)
-    if let Some(rest) = trimmed.strip_prefix("ssh://git@")
+    // ssh://[userinfo@]host/owner/repo(.git)
+    if let Some(rest) = trimmed.strip_prefix("ssh://")
         && let Some((host, path)) = rest.split_once('/')
     {
+        let host = common_git::strip_userinfo(host);
         return finalize_remote(host, path);
     }
 
@@ -410,6 +412,24 @@ mod tests {
         assert_eq!(repo.provider, Provider::GitHub);
         assert_eq!(repo.slug, "sympoies/nils-cli");
         assert_eq!(repo.host.as_deref(), Some("github.com"));
+    }
+
+    #[test]
+    fn parse_remote_url_strips_userinfo_from_ssh_scheme() {
+        let (slug, host, provider) =
+            parse_remote_url("ssh://deploy@gitlab.example.com/group/proj.git").expect("parse");
+        assert_eq!(slug, "group/proj");
+        assert_eq!(host, "gitlab.example.com");
+        assert_eq!(provider, Provider::GitLab);
+    }
+
+    #[test]
+    fn parse_repo_with_host_strips_userinfo_from_ssh_scheme() {
+        let repo =
+            parse_repo_with_host("ssh://deploy@gitlab.example.com/group/proj").expect("parse");
+        assert_eq!(repo.provider, Provider::GitLab);
+        assert_eq!(repo.slug, "group/proj");
+        assert_eq!(repo.host.as_deref(), Some("gitlab.example.com"));
     }
 
     #[test]

--- a/crates/plan-issue-cli/src/provider.rs
+++ b/crates/plan-issue-cli/src/provider.rs
@@ -169,6 +169,7 @@ fn parse_repo_with_host(raw: &str) -> Option<Repo> {
         .unwrap_or(trimmed);
 
     let (host, path) = host_and_path.split_once('/')?;
+    let host = common_git::strip_userinfo(host);
     if !host.contains('.') {
         // Bare `owner/repo` without a host segment.
         return None;
@@ -287,6 +288,7 @@ fn parse_remote_url(remote: &str) -> Option<(String, String, Provider)> {
         if let Some(rest) = trimmed.strip_prefix(prefix)
             && let Some((host, path)) = rest.split_once('/')
         {
+            let host = common_git::strip_userinfo(host);
             return finalize_remote(host, path);
         }
     }
@@ -375,6 +377,39 @@ mod tests {
             assert_eq!(h, host);
             assert_eq!(p, provider);
         }
+    }
+
+    #[test]
+    fn parse_remote_url_strips_basic_auth_userinfo() {
+        let cases = [
+            (
+                "https://user:pass@github.com/sympoies/nils-cli.git",
+                "sympoies/nils-cli",
+                "github.com",
+                Provider::GitHub,
+            ),
+            (
+                "https://x-access-token:TOKEN@gitlab.com/group/proj.git",
+                "group/proj",
+                "gitlab.com",
+                Provider::GitLab,
+            ),
+        ];
+        for (remote, slug, host, provider) in cases {
+            let (s, h, p) = parse_remote_url(remote).unwrap_or_else(|| panic!("parse {remote}"));
+            assert_eq!(s, slug);
+            assert_eq!(h, host);
+            assert_eq!(p, provider);
+        }
+    }
+
+    #[test]
+    fn parse_repo_with_host_strips_basic_auth_userinfo() {
+        let repo =
+            parse_repo_with_host("https://user:pass@github.com/sympoies/nils-cli").expect("parse");
+        assert_eq!(repo.provider, Provider::GitHub);
+        assert_eq!(repo.slug, "sympoies/nils-cli");
+        assert_eq!(repo.host.as_deref(), Some("github.com"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Share a single domain-neutral `nils_common::git::strip_userinfo` primitive so git remote URLs that carry userinfo (e.g. `https://user:pass@github.com/...`, `https://x-access-token:TOKEN@gitlab.com/...`, or `ssh://deploy@gitlab.example.com:2222/...`) resolve their host correctly across forge-cli, plan-issue-cli, and git-cli. Two of the four workspace remote-URL parsers — `forge-cli::provider::parse_host` and `plan-issue-cli::provider::parse_remote_url` / `parse_repo_with_host` — had drifted from `plan-archive` and `git-cli`, silently dropping userinfo-bearing remotes back to `provider_unsupported` instead of detecting GitHub vs GitLab.

## Changes

- Add `nils_common::git::strip_userinfo(host: &str) -> &str` with unit tests covering passthrough, user-only, and `user:pass@host` shapes (`crates/nils-common/src/git.rs`).
- Apply the helper in `forge-cli::provider::parse_host` for the `https://` and `ssh://` branches so `https://user:pass@github.com/...` and `ssh://deploy@gitlab.example.com:2222/...` parse their host correctly (`crates/forge-cli/src/provider.rs`).
- Apply the helper in `plan-issue-cli::provider::parse_remote_url` (`https://`/`http://`) and `parse_repo_with_host` (`--repo` flag path) so basic-auth remotes no longer fall back to `invalid --repo value` (`crates/plan-issue-cli/src/provider.rs`).
- Drop the duplicate `git-cli/open.rs::strip_userinfo` helper and route `open.rs` through the shared primitive (`crates/git-cli/src/open.rs`).
- Add characterization tests for the userinfo paths in forge-cli and plan-issue-cli; existing git-cli `normalize_remote_url_*` tests continue to pass against the shared primitive.

## Test-First Evidence

- Added `parse_host_strips_basic_auth_userinfo_from_https` and `parse_host_strips_userinfo_from_ssh_scheme_with_port` in `crates/forge-cli/src/provider.rs` before completing the helper wiring; both fail against `main` (parse_host returns `Some("user:pass@github.com")`) and pass after the helper lands.
- Added `parse_remote_url_strips_basic_auth_userinfo` and `parse_repo_with_host_strips_basic_auth_userinfo` in `crates/plan-issue-cli/src/provider.rs`; both fail against `main` (host segment carries the userinfo so `classify_host` returns `None`) and pass after the helper lands.
- Added `strip_userinfo_passthrough_when_no_at`, `strip_userinfo_drops_user_only_prefix`, and `strip_userinfo_drops_user_password_prefix` in `crates/nils-common/src/git.rs` to lock the primitive's contract.
- No production-behavior waiver required; the new tests document the broken-before / fixed-after contract directly.

## Test plan

- `cargo test -p nils-common --lib git::tests::strip_userinfo` — 3 new helper tests pass.
- `cargo test -p nils-forge-cli --lib provider` — 35 tests pass, including the 2 new userinfo characterization tests.
- `cargo test -p nils-plan-issue-cli --lib provider` — 7 tests pass, including the 2 new userinfo characterization tests.
- `cargo test -p nils-git-cli --lib open` — 13 tests pass; existing `normalize_remote_url_*` paths continue to work after `strip_userinfo` is sourced from `nils_common::git`.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — full local-fast workspace Rust gate green (fmt, clippy, build, doctests, nextest).

## Risk / Notes

- Behavior change is additive for remote URLs that already worked (no `@` present in the host segment means `strip_userinfo` returns the input unchanged). Existing characterization tests in all four crates continue to pass.
- Helper splits at the last `@` (`rsplit_once`), so embedded `@` in passwords (`user:p@ss@gitlab.com`) is stripped correctly. Documented in the helper's doc comment.
- `plan-archive::migrate::identity::strip_credentials_prefix` is intentionally left alone — its `find('@')` semantics (strip before the first `/`) are subtly different and its caller already handles credentials correctly.
