### PR TITLE
refactor(plan-archive): align git remote URL handling across parsers

### DIFF
--- a/crates/plan-archive/src/migrate/identity.rs
+++ b/crates/plan-archive/src/migrate/identity.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use nils_common::git as gitio;
+use nils_common::git::{self as gitio, strip_userinfo};
 
 /// Source-repo identity captured at migration time.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -91,21 +91,19 @@ pub fn parse_remote_url(url: &str) -> Option<(String, String, String)> {
         let (host, path) = rest.split_once(':')?;
         (host.to_string(), path.to_string())
     } else if let Some(rest) = url.strip_prefix("ssh://") {
-        let rest = rest.strip_prefix("git@").unwrap_or(rest);
         let (host_port, path) = rest.split_once('/')?;
+        let host_port = strip_userinfo(host_port);
         let host = host_port
             .split_once(':')
             .map(|(h, _)| h)
             .unwrap_or(host_port);
         (host.to_string(), path.to_string())
     } else if let Some(rest) = url.strip_prefix("https://") {
-        let rest = strip_credentials_prefix(rest);
         let (host, path) = rest.split_once('/')?;
-        (host.to_string(), path.to_string())
+        (strip_userinfo(host).to_string(), path.to_string())
     } else if let Some(rest) = url.strip_prefix("http://") {
-        let rest = strip_credentials_prefix(rest);
         let (host, path) = rest.split_once('/')?;
-        (host.to_string(), path.to_string())
+        (strip_userinfo(host).to_string(), path.to_string())
     } else {
         return None;
     };
@@ -124,16 +122,6 @@ pub fn parse_remote_url(url: &str) -> Option<(String, String, String)> {
         return None;
     }
     Some((host, org_or_group_path, repo))
-}
-
-fn strip_credentials_prefix(s: &str) -> &str {
-    if let Some(idx) = s.find('@')
-        && let Some(slash_idx) = s.find('/')
-        && idx < slash_idx
-    {
-        return &s[idx + 1..];
-    }
-    s
 }
 
 #[cfg(test)]
@@ -208,5 +196,23 @@ mod tests {
     fn parses_https_with_basic_auth_credentials() {
         let r = parse_remote_url("https://user:pass@github.com/org/repo.git").unwrap();
         assert_eq!(r, ("github.com".into(), "org".into(), "repo".into()));
+    }
+
+    #[test]
+    fn parses_ssh_with_non_git_user() {
+        let r = parse_remote_url("ssh://deploy@gitlab.example.com/group/proj.git").unwrap();
+        assert_eq!(
+            r,
+            ("gitlab.example.com".into(), "group".into(), "proj".into())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_with_userinfo_and_port() {
+        let r = parse_remote_url("ssh://deploy@gitlab.example.com:2222/group/proj.git").unwrap();
+        assert_eq!(
+            r,
+            ("gitlab.example.com".into(), "group".into(), "proj".into())
+        );
     }
 }

--- a/crates/plan-issue-cli/src/provider.rs
+++ b/crates/plan-issue-cli/src/provider.rs
@@ -224,7 +224,8 @@ fn is_group_project_path(value: &str) -> bool {
 }
 
 fn classify_host(host: &str) -> Option<Provider> {
-    if host == "github.com" || host.ends_with(".github.com") {
+    let host = host.trim().to_ascii_lowercase();
+    if host == "github.com" || host.ends_with(".github.com") || host.ends_with(".ghe.com") {
         Some(Provider::GitHub)
     } else if host == "gitlab.com" || host.starts_with("gitlab.") || host.contains(".gitlab.") {
         Some(Provider::GitLab)
@@ -319,6 +320,18 @@ mod tests {
         assert_eq!(classify_host("github.com"), Some(Provider::GitHub));
         assert_eq!(classify_host("gitlab.com"), Some(Provider::GitLab));
         assert_eq!(classify_host("bitbucket.org"), None);
+    }
+
+    #[test]
+    fn classify_host_is_case_insensitive_and_trims() {
+        assert_eq!(classify_host("GitHub.com"), Some(Provider::GitHub));
+        assert_eq!(classify_host("  GitLab.com  "), Some(Provider::GitLab));
+    }
+
+    #[test]
+    fn classify_host_recognises_github_enterprise_hosts() {
+        assert_eq!(classify_host("internal.ghe.com"), Some(Provider::GitHub));
+        assert_eq!(classify_host("corp.ghe.com"), Some(Provider::GitHub));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the URL-parser tail of #599. Section A of #600:

- A.1 — Migrate `plan-archive::migrate::identity::parse_remote_url` to `nils_common::git::strip_userinfo`. Drop the local `strip_credentials_prefix`. The ssh branch now accepts non-`git@` userinfo (`ssh://deploy@host/...` and `ssh://deploy@host:2222/...`), matching forge-cli and plan-issue-cli after #599.
- A.2 — Normalize `plan-issue-cli::provider::classify_host`: trim + lowercase the input and recognize `*.ghe.com` (GitHub Enterprise), matching forge-cli's classify_host so case-variant or enterprise remotes don't silently fall through.

## Changes

- `crates/plan-archive/src/migrate/identity.rs` — replace inline `strip_credentials_prefix` with shared `strip_userinfo`; cover `ssh://deploy@host[:port]/...` in the ssh branch; add two characterization tests.
- `crates/plan-issue-cli/src/provider.rs::classify_host` — apply `.trim().to_ascii_lowercase()`; add `*.ghe.com` to the GitHub matcher; add two characterization tests (case-insensitive + ghe.com).

## Test plan

- `cargo test -p nils-plan-archive --lib migrate::identity` — 10 tests pass, including the two new ssh-userinfo cases.
- `cargo test -p nils-plan-issue-cli --lib provider` — 11 tests pass, including the two new classify_host cases.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — workspace Rust gate green.

## Risk

- Pure correctness extension. Existing happy-path remotes (no userinfo, lowercase host) keep the same outcome. The classify_host normalization is additive: any host that used to classify continues to, plus new variants that previously returned `None` now classify correctly.
- `plan-archive::migrate::identity` callers see no shape change — return type and segment rules are unchanged.

Refs #600.
