### PR TITLE
refactor(nils-common): extract shared parse_git_remote_url primitive

### DIFF
--- a/crates/agent-out/src/lib.rs
+++ b/crates/agent-out/src/lib.rs
@@ -382,16 +382,8 @@ fn git_origin_url(repo: &Path) -> Option<String> {
 }
 
 pub fn project_slug_from_remote_url(remote: &str) -> Option<String> {
-    let trimmed = remote.trim().trim_end_matches(".git");
-    let path = if let Some((_, after_scheme)) = trimmed.split_once("://") {
-        after_scheme.split_once('/').map(|(_, rest)| rest)?
-    } else if let Some((_, scp_path)) = trimmed.split_once(':') {
-        scp_path
-    } else {
-        trimmed
-    };
-
-    project_slug_from_owner_repo(path)
+    let parsed = nils_common::git::parse_git_remote_url(remote)?;
+    project_slug_from_owner_repo(&parsed.path)
 }
 
 pub fn project_slug_from_owner_repo(value: &str) -> Option<String> {

--- a/crates/forge-cli/src/provider.rs
+++ b/crates/forge-cli/src/provider.rs
@@ -149,50 +149,12 @@ pub fn classify_host(host: &str) -> Option<Provider> {
     None
 }
 
-/// Parse the host out of a remote URL. Supports:
-/// - `https://[userinfo@]<host>/<owner>/<repo>(.git)?`
-/// - `ssh://[user@]<host>(:port)?/<owner>/<repo>(.git)?`
-/// - `git@<host>:<owner>/<repo>(.git)?`
+/// Parse the host out of a remote URL. Delegates to
+/// [`nils_common::git::parse_git_remote_url`] so the supported shapes match the
+/// rest of the workspace (https/http with optional userinfo+port, ssh with
+/// optional userinfo+port, SCP-style `user@host:path`).
 pub fn parse_host(url: &str) -> Option<String> {
-    let trimmed = url.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    if let Some(rest) = trimmed.strip_prefix("https://") {
-        return host_before_path(rest)
-            .map(|host| nils_common::git::strip_userinfo(&host).to_string())
-            .filter(|host| !host.is_empty());
-    }
-    if let Some(rest) = trimmed.strip_prefix("ssh://") {
-        // ssh://[user@]host[:port]/owner/repo
-        let after_user = nils_common::git::strip_userinfo(rest);
-        return host_before_path(after_user)
-            .map(strip_port)
-            .filter(|host| !host.is_empty());
-    }
-    if let Some((user_host, _)) = trimmed.split_once(':')
-        && let Some((_, host)) = user_host.rsplit_once('@')
-        && !host.is_empty()
-    {
-        return Some(host.to_string());
-    }
-    None
-}
-
-fn host_before_path(s: &str) -> Option<String> {
-    let host = s.split('/').next()?.trim();
-    if host.is_empty() {
-        None
-    } else {
-        Some(host.to_string())
-    }
-}
-
-fn strip_port(host: String) -> String {
-    match host.split_once(':') {
-        Some((h, _)) => h.to_string(),
-        None => host,
-    }
+    nils_common::git::parse_git_remote_url(url).map(|remote| remote.host)
 }
 
 /// Default `git remote get-url` lookup used in production. Returns `None`

--- a/crates/nils-common/src/git.rs
+++ b/crates/nils-common/src/git.rs
@@ -101,6 +101,83 @@ pub fn strip_userinfo(host: &str) -> &str {
     host.rsplit_once('@').map(|(_, tail)| tail).unwrap_or(host)
 }
 
+/// Host + path split out of a parsed git remote URL.
+///
+/// `host` carries the bare hostname (port and userinfo removed). `path` carries
+/// the URL path with leading/trailing slashes and a single optional trailing
+/// `.git` removed; callers split it into owner/repo or group/project segments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitRemoteUrl {
+    pub host: String,
+    pub path: String,
+}
+
+/// Parse a git remote URL into a `host`/`path` pair, accepting the four shapes
+/// git itself accepts:
+///
+/// - `git@<host>:<path>` (SCP-style; `<path>` carries the slashes)
+/// - `ssh://[userinfo@]<host>[:<port>]/<path>`
+/// - `https://[userinfo@]<host>[:<port>]/<path>`
+/// - `http://[userinfo@]<host>[:<port>]/<path>`
+///
+/// Userinfo (`user@`, `user:pass@`, …) is stripped, ports are stripped from
+/// `host`, surrounding slashes and a single trailing `.git` are trimmed from
+/// `path`. Returns `None` for unknown schemes, empty hosts, or empty paths.
+pub fn parse_git_remote_url(url: &str) -> Option<GitRemoteUrl> {
+    let trimmed = url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // SCP-style: [user@]host:path (host never contains `/`)
+    if !trimmed.contains("://")
+        && let Some((host_with_user, path)) = trimmed.split_once(':')
+        && !host_with_user.contains('/')
+        && !path.contains("://")
+    {
+        let host = strip_userinfo(host_with_user);
+        return finalize(host, path);
+    }
+
+    // ssh://[userinfo@]host[:port]/path
+    if let Some(rest) = trimmed.strip_prefix("ssh://") {
+        let after_user = strip_userinfo(rest);
+        let (host_port, path) = after_user.split_once('/')?;
+        let host = host_port
+            .split_once(':')
+            .map(|(h, _)| h)
+            .unwrap_or(host_port);
+        return finalize(host, path);
+    }
+
+    // https:// / http:// [userinfo@]host[:port]/path
+    for prefix in ["https://", "http://"] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            let (host_with_user, path) = rest.split_once('/')?;
+            let host_no_user = strip_userinfo(host_with_user);
+            let host = host_no_user
+                .split_once(':')
+                .map(|(h, _)| h)
+                .unwrap_or(host_no_user);
+            return finalize(host, path);
+        }
+    }
+
+    None
+}
+
+fn finalize(host: &str, path: &str) -> Option<GitRemoteUrl> {
+    let host = host.trim();
+    let path = path.trim_matches('/').trim_end_matches(".git");
+    if host.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some(GitRemoteUrl {
+        host: host.to_string(),
+        path: path.to_string(),
+    })
+}
+
 pub fn staged_name_only() -> io::Result<String> {
     staged_name_only_inner(None)
 }
@@ -667,5 +744,64 @@ mod tests {
     fn strip_userinfo_drops_user_password_prefix() {
         assert_eq!(strip_userinfo("user:pass@github.com"), "github.com");
         assert_eq!(strip_userinfo("user:p@ss@gitlab.com"), "gitlab.com");
+    }
+
+    #[test]
+    fn parse_git_remote_url_handles_scp_form() {
+        let r = parse_git_remote_url("git@github.com:sympoies/nils-cli.git").expect("scp");
+        assert_eq!(r.host, "github.com");
+        assert_eq!(r.path, "sympoies/nils-cli");
+    }
+
+    #[test]
+    fn parse_git_remote_url_handles_scp_form_nested_gitlab_group() {
+        let r = parse_git_remote_url("git@gitlab.example.com:acme/platform/backend/ingest.git")
+            .expect("scp nested");
+        assert_eq!(r.host, "gitlab.example.com");
+        assert_eq!(r.path, "acme/platform/backend/ingest");
+    }
+
+    #[test]
+    fn parse_git_remote_url_handles_ssh_with_userinfo_and_port() {
+        let r = parse_git_remote_url("ssh://deploy@gitlab.example.com:2222/group/proj.git")
+            .expect("ssh");
+        assert_eq!(r.host, "gitlab.example.com");
+        assert_eq!(r.path, "group/proj");
+    }
+
+    #[test]
+    fn parse_git_remote_url_handles_https_with_basic_auth() {
+        let r = parse_git_remote_url("https://user:pass@github.com/sympoies/nils-cli.git")
+            .expect("https");
+        assert_eq!(r.host, "github.com");
+        assert_eq!(r.path, "sympoies/nils-cli");
+    }
+
+    #[test]
+    fn parse_git_remote_url_handles_https_with_port() {
+        let r = parse_git_remote_url("https://gitlab.example.com:8443/group/proj").expect("port");
+        assert_eq!(r.host, "gitlab.example.com");
+        assert_eq!(r.path, "group/proj");
+    }
+
+    #[test]
+    fn parse_git_remote_url_handles_http() {
+        let r = parse_git_remote_url("http://gitlab.example.com/group/proj.git").expect("http");
+        assert_eq!(r.host, "gitlab.example.com");
+        assert_eq!(r.path, "group/proj");
+    }
+
+    #[test]
+    fn parse_git_remote_url_rejects_unknown_schemes_and_empty() {
+        assert!(parse_git_remote_url("").is_none());
+        assert!(parse_git_remote_url("file:///tmp/x.git").is_none());
+        assert!(parse_git_remote_url("ftp://host/path").is_none());
+    }
+
+    #[test]
+    fn parse_git_remote_url_rejects_empty_host_or_path() {
+        assert!(parse_git_remote_url("https://user:pass@/owner/repo").is_none());
+        assert!(parse_git_remote_url("ssh://deploy@/owner/repo").is_none());
+        assert!(parse_git_remote_url("https://github.com/").is_none());
     }
 }

--- a/crates/plan-archive/src/migrate/identity.rs
+++ b/crates/plan-archive/src/migrate/identity.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use nils_common::git::{self as gitio, strip_userinfo};
+use nils_common::git::{self as gitio, parse_git_remote_url};
 
 /// Source-repo identity captured at migration time.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -87,32 +87,8 @@ fn head_commit(repo: &Path) -> Result<String, IdentityError> {
 /// (`https://github.com/org/repo.git`), nested GitLab groups, and
 /// optional `.git` suffix.
 pub fn parse_remote_url(url: &str) -> Option<(String, String, String)> {
-    let (host, path) = if let Some(rest) = url.strip_prefix("git@") {
-        let (host, path) = rest.split_once(':')?;
-        (host.to_string(), path.to_string())
-    } else if let Some(rest) = url.strip_prefix("ssh://") {
-        let (host_port, path) = rest.split_once('/')?;
-        let host_port = strip_userinfo(host_port);
-        let host = host_port
-            .split_once(':')
-            .map(|(h, _)| h)
-            .unwrap_or(host_port);
-        (host.to_string(), path.to_string())
-    } else if let Some(rest) = url.strip_prefix("https://") {
-        let (host, path) = rest.split_once('/')?;
-        (strip_userinfo(host).to_string(), path.to_string())
-    } else if let Some(rest) = url.strip_prefix("http://") {
-        let (host, path) = rest.split_once('/')?;
-        (strip_userinfo(host).to_string(), path.to_string())
-    } else {
-        return None;
-    };
-
-    let path = path.trim_end_matches(".git").trim_matches('/');
-    if path.is_empty() {
-        return None;
-    }
-    let mut segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    let parsed = parse_git_remote_url(url)?;
+    let mut segments: Vec<&str> = parsed.path.split('/').filter(|s| !s.is_empty()).collect();
     if segments.len() < 2 {
         return None;
     }
@@ -121,7 +97,7 @@ pub fn parse_remote_url(url: &str) -> Option<(String, String, String)> {
     if org_or_group_path.is_empty() {
         return None;
     }
-    Some((host, org_or_group_path, repo))
+    Some((parsed.host, org_or_group_path, repo))
 }
 
 #[cfg(test)]

--- a/crates/plan-issue-cli/src/provider.rs
+++ b/crates/plan-issue-cli/src/provider.rs
@@ -148,49 +148,15 @@ pub fn select_adapter(repo: &Repo, force: bool) -> Box<dyn ProviderAdapter> {
 }
 
 fn parse_repo_with_host(raw: &str) -> Option<Repo> {
-    let trimmed = raw.trim().trim_end_matches('/');
-
-    // SSH `git@host:owner/repo(.git)` form uses `:` instead of `/` to
-    // separate host from path. Handle it before the generic split-on-`/`
-    // path so the colon does not contaminate the host segment.
-    if let Some(rest) = trimmed.strip_prefix("git@")
-        && let Some((host, path)) = rest.split_once(':')
-    {
-        return finalize_with_host(host, path);
-    }
-
-    // Strip URL scheme from `https://` / `http://` / `ssh://` form, leaving
-    // `[userinfo@]<host>/<path>`. Any userinfo is dropped below via
-    // `strip_userinfo`.
-    let host_and_path = trimmed
-        .strip_prefix("https://")
-        .or_else(|| trimmed.strip_prefix("http://"))
-        .or_else(|| trimmed.strip_prefix("ssh://"))
-        .map(|rest| rest.trim_start_matches('/'))
-        .unwrap_or(trimmed);
-
-    let (host, path) = host_and_path.split_once('/')?;
-    let host = common_git::strip_userinfo(host);
-    if !host.contains('.') {
-        // Bare `owner/repo` without a host segment.
-        return None;
-    }
-    finalize_with_host(host, path)
-}
-
-fn finalize_with_host(host: &str, path: &str) -> Option<Repo> {
-    let provider = classify_host(host)?;
-    let slug = path
-        .trim_start_matches('/')
-        .trim_end_matches('/')
-        .trim_end_matches(".git");
-    if !is_owner_repo(slug) && !is_group_project_path(slug) {
+    let parsed = common_git::parse_git_remote_url(raw)?;
+    let provider = classify_host(&parsed.host)?;
+    if !is_owner_repo(&parsed.path) && !is_group_project_path(&parsed.path) {
         return None;
     }
     Some(Repo {
         provider,
-        slug: slug.to_string(),
-        host: Some(host.to_string()),
+        slug: parsed.path,
+        host: Some(parsed.host),
     })
 }
 
@@ -266,49 +232,12 @@ fn remote_provider() -> Option<(Provider, Option<String>)> {
 }
 
 fn parse_remote_url(remote: &str) -> Option<(String, String, Provider)> {
-    let trimmed = remote.trim().trim_end_matches('/');
-    if trimmed.is_empty() {
+    let parsed = common_git::parse_git_remote_url(remote)?;
+    let provider = classify_host(&parsed.host)?;
+    if !is_owner_repo(&parsed.path) && !is_group_project_path(&parsed.path) {
         return None;
     }
-
-    // git@host:owner/repo(.git)
-    if let Some(rest) = trimmed.strip_prefix("git@")
-        && let Some((host, path)) = rest.split_once(':')
-    {
-        return finalize_remote(host, path);
-    }
-
-    // ssh://[userinfo@]host/owner/repo(.git)
-    if let Some(rest) = trimmed.strip_prefix("ssh://")
-        && let Some((host, path)) = rest.split_once('/')
-    {
-        let host = common_git::strip_userinfo(host);
-        return finalize_remote(host, path);
-    }
-
-    // https://host/owner/repo(.git) or http://...
-    for prefix in ["https://", "http://"] {
-        if let Some(rest) = trimmed.strip_prefix(prefix)
-            && let Some((host, path)) = rest.split_once('/')
-        {
-            let host = common_git::strip_userinfo(host);
-            return finalize_remote(host, path);
-        }
-    }
-
-    None
-}
-
-fn finalize_remote(host: &str, path: &str) -> Option<(String, String, Provider)> {
-    let provider = classify_host(host)?;
-    let slug = path
-        .trim_start_matches('/')
-        .trim_end_matches('/')
-        .trim_end_matches(".git");
-    if !is_owner_repo(slug) && !is_group_project_path(slug) {
-        return None;
-    }
-    Some((slug.to_string(), host.to_string(), provider))
+    Some((parsed.path, parsed.host, provider))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Section B of #600. Extract a single domain-neutral git remote URL parser into `nils-common` and route the five workspace callsites through it, so each consumer keeps only its own provider classification / slug rules on top.

## Changes

- `crates/nils-common/src/git.rs` — add `GitRemoteUrl { host, path }` and `parse_git_remote_url(url) -> Option<GitRemoteUrl>` covering:
  - SCP-style `[user@]host:path` (rejects host segments with `/`)
  - `ssh://[userinfo@]<host>[:<port>]/<path>`
  - `https://[userinfo@]<host>[:<port>]/<path>`
  - `http://[userinfo@]<host>[:<port>]/<path>`
  - Userinfo + port stripped from `host`; surrounding slashes and a single trailing `.git` trimmed from `path`. Eight new characterization tests.
- `crates/forge-cli/src/provider.rs::parse_host` — collapsed to one-liner that maps the primitive's `host`. All 14 existing parser/detect tests continue to pass.
- `crates/plan-issue-cli/src/provider.rs` — `parse_remote_url` and `parse_repo_with_host` now delegate URL parsing to the primitive and only own `classify_host` + slug-shape validation. All 11 provider tests continue to pass.
- `crates/plan-archive/src/migrate/identity.rs::parse_remote_url` — delegates URL parsing; keeps its own `path` → `(org_or_group_path, repo)` split. All 10 identity tests continue to pass.
- `crates/agent-out/src/lib.rs::project_slug_from_remote_url` — delegates URL parsing; keeps `project_slug_from_owner_repo` for slug normalization. All 5 lib tests continue to pass.

## Test plan

- `cargo test -p nils-common --lib git::tests::parse_git_remote_url` — 8 new primitive tests pass.
- `cargo test -p nils-forge-cli --lib provider` — 37 tests pass.
- `cargo test -p nils-plan-issue-cli --lib provider` — 11 tests pass.
- `cargo test -p nils-plan-archive --lib migrate::identity` — 10 tests pass.
- `cargo test -p nils-agent-out --lib` — 5 tests pass.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — workspace Rust gate green.

## Risk

- Pure consolidation. The primitive's behavior is the union of the four prior parsers' behaviors; each crate's existing test set still passes, and the primitive picks up the strictest of the previous validations (rejects empty host/path, rejects host with `/` in SCP form, rejects unknown schemes).
- `git-cli/src/open.rs::normalize_remote_url_from_raw` is intentionally left alone — it rewrites `ssh://` to `https://` for browser-open and has shape-changing semantics outside the primitive's `(host, path)` contract.

Refs #600.
