### PR TITLE
fix(agent-hook): allow unmanaged terminal sessions

### DIFF
--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -143,6 +143,17 @@ Owner-liveness evaluates every distinct target checkout plus the execution
 checkout and returns the strongest result; an active foreign owner therefore
 cannot be masked by a self-owned or unclaimed target.
 
+Built-in semantic-conflict and owner-liveness admission applies only to a
+managed process. When `AGENT_SESSION_ID`, `AGENT_SESSION_RUNTIME_ID`,
+`AGENT_SESSION_STATE_DIR`, `AGENT_SESSION_COORDINATION_MODE`,
+`AGENT_SESSION_CAPABILITY_FILE`, and `AGENT_SESSION_CHECKPOINT_FILE` are all
+absent, both capabilities return `allow` with `coordination-unmanaged` without
+loading or classifying registry owners, and the coordination transaction is not
+invoked. Presence of any of those selectors without a complete session ID and
+runtime incarnation is not unmanaged; it retains the conservative managed
+failure posture. Environment-only advisory or off hints never downgrade an
+untrusted managed identity.
+
 A matcher on any other product/event pair is rejected during policy validation.
 A policy matcher is either
 one literal token or an anchored alternation expression such as

--- a/crates/agent-hook/src/evaluator.rs
+++ b/crates/agent-hook/src/evaluator.rs
@@ -71,6 +71,34 @@ pub struct PreparedEvaluation<'a> {
     session_coordination: Option<&'a crate::model::PolicyRule>,
 }
 
+#[derive(Clone, Copy)]
+struct CoordinationEvaluation<'a> {
+    snapshot: Option<&'a liveness::Snapshot>,
+    mode_override: Option<nils_common::coordination_projection::CoordinationMode>,
+    unmanaged: bool,
+}
+
+#[derive(Clone, Copy)]
+pub struct CoordinationExecution {
+    mode: Option<nils_common::coordination_projection::CoordinationMode>,
+    operation_effect: OperationEffectClass,
+    unmanaged: bool,
+}
+
+impl CoordinationExecution {
+    pub fn new(
+        mode: Option<nils_common::coordination_projection::CoordinationMode>,
+        operation_effect: OperationEffectClass,
+        unmanaged: bool,
+    ) -> Self {
+        Self {
+            mode,
+            operation_effect,
+            unmanaged,
+        }
+    }
+}
+
 impl PreparedEvaluation<'_> {
     pub fn needs_coordination(&self) -> bool {
         self.needs_coordination
@@ -248,14 +276,18 @@ pub fn evaluate(
     prepared: &PreparedEvaluation<'_>,
     coordination: Option<&liveness::Snapshot>,
     coordination_mode_override: Option<nils_common::coordination_projection::CoordinationMode>,
+    unmanaged: bool,
 ) -> Result<NormalizedDecision, HookError> {
     evaluate_with_io(
         loaded,
         request,
         raw,
         prepared,
-        coordination,
-        coordination_mode_override,
+        CoordinationEvaluation {
+            snapshot: coordination,
+            mode_override: coordination_mode_override,
+            unmanaged,
+        },
         liveness::system_io(),
     )
 }
@@ -265,16 +297,20 @@ fn evaluate_with_io(
     request: &mut NormalizedRequest,
     raw: &[u8],
     prepared: &PreparedEvaluation<'_>,
-    coordination: Option<&liveness::Snapshot>,
-    coordination_mode_override: Option<nils_common::coordination_projection::CoordinationMode>,
+    coordination: CoordinationEvaluation<'_>,
     liveness_io: &dyn liveness::LivenessIo,
 ) -> Result<NormalizedDecision, HookError> {
     // Terminal correlation is evidence maintenance, not an admission gate.
     let _ = crate::degraded::complete_terminal(raw, request);
     let liveness = prepared.needs_coordination.then(|| {
-        liveness::DispatchProjection::new(coordination, coordination_mode_override, liveness_io)
+        liveness::DispatchProjection::new(
+            coordination.snapshot,
+            coordination.mode_override,
+            coordination.unmanaged,
+            liveness_io,
+        )
     });
-    request.semantic_conflict = coordination.map(|_| {
+    request.semantic_conflict = coordination.snapshot.map(|_| {
         liveness::derive_semantic_conflict(
             request,
             liveness
@@ -421,8 +457,7 @@ fn evaluate_with_io(
         request,
         raw,
         prepared.session_coordination,
-        coordination_mode,
-        operation_effect,
+        CoordinationExecution::new(coordination_mode, operation_effect, coordination.unmanaged),
     )
 }
 
@@ -522,13 +557,19 @@ fn evaluate_capability(
             replacement: Some(replacement.clone()),
             provider_output: None,
         },
-        Capability::SemanticConflict { reason_code } => simple(
-            liveness::semantic_conflict_action(
-                request.semantic_conflict,
-                liveness.and_then(liveness::DispatchProjection::mode),
-            ),
-            reason_code,
-        ),
+        Capability::SemanticConflict { reason_code } => {
+            if liveness.is_some_and(liveness::DispatchProjection::is_unmanaged) {
+                simple(DecisionAction::Allow, "coordination-unmanaged")
+            } else {
+                simple(
+                    liveness::semantic_conflict_action(
+                        request.semantic_conflict,
+                        liveness.and_then(liveness::DispatchProjection::mode),
+                    ),
+                    reason_code,
+                )
+            }
+        }
         Capability::OwnerLiveness {
             reason_code: _,
             legacy_ttl_seconds,
@@ -583,12 +624,14 @@ pub fn apply_session_coordination(
     request: &NormalizedRequest,
     raw: &[u8],
     rule: Option<&crate::model::PolicyRule>,
-    coordination_mode: Option<nils_common::coordination_projection::CoordinationMode>,
-    operation_effect: OperationEffectClass,
+    execution: CoordinationExecution,
 ) -> Result<NormalizedDecision, HookError> {
     let Some(rule) = rule else {
         return Ok(decision);
     };
+    if execution.unmanaged {
+        return Ok(decision);
+    }
     let typed_bootstrap_may_supersede_owner =
         exact_bootstrap_candidate_for_session_coordination(request, raw, true)
             && owner_active_foreign_is_only_block(loaded, &decision);
@@ -615,8 +658,8 @@ pub fn apply_session_coordination(
             loaded,
             request,
             rule,
-            coordination_mode,
-            operation_effect,
+            execution.mode,
+            execution.operation_effect,
             raw,
         ),
         Err(_) => failure_outcome(rule.failure_posture, &rule.id),
@@ -1487,9 +1530,19 @@ mod tests {
             let prepared = prepare(&loaded, &request, false, &BTreeSet::new())
                 .expect("valid reason cardinality");
             let io = CountingLivenessIo::default();
-            let decision =
-                evaluate_with_io(&loaded, &mut request, b"{}", &prepared, None, None, &io)
-                    .expect("evaluate owner rules");
+            let decision = evaluate_with_io(
+                &loaded,
+                &mut request,
+                b"{}",
+                &prepared,
+                CoordinationEvaluation {
+                    snapshot: None,
+                    mode_override: None,
+                    unmanaged: false,
+                },
+                &io,
+            )
+            .expect("evaluate owner rules");
             assert_eq!(decision.reasons.len(), cardinality);
             assert_eq!(io.session_reads.get(), 1, "rules={cardinality}");
             assert_eq!(io.dirty_probes.get(), 1, "rules={cardinality}");
@@ -1530,8 +1583,19 @@ mod tests {
             age_seconds: 60,
             ..Default::default()
         };
-        let decision = evaluate_with_io(&loaded, &mut request, b"{}", &prepared, None, None, &io)
-            .expect("evaluate TTL rules");
+        let decision = evaluate_with_io(
+            &loaded,
+            &mut request,
+            b"{}",
+            &prepared,
+            CoordinationEvaluation {
+                snapshot: None,
+                mode_override: None,
+                unmanaged: false,
+            },
+            &io,
+        )
+        .expect("evaluate TTL rules");
         assert_eq!(
             decision.reasons[0].code,
             concat!("leg", "acy-owner-stale-clean-reclaim")

--- a/crates/agent-hook/src/lib.rs
+++ b/crates/agent-hook/src/lib.rs
@@ -312,6 +312,7 @@ fn run_dispatch(
         Ok(request) => request,
         Err(error) => return emit_dispatch_error(args.format, &error, None),
     };
+    let unmanaged = liveness::current_process_is_unmanaged();
     let grant = match recovery::consume_for_dispatch(
         &layout.state_root,
         args.capability_file.as_deref(),
@@ -333,8 +334,11 @@ fn run_dispatch(
                 &request,
                 &raw,
                 coordination_rule,
-                None,
-                OperationEffectClass::Unknown,
+                evaluator::CoordinationExecution::new(
+                    None,
+                    OperationEffectClass::Unknown,
+                    unmanaged,
+                ),
             ) {
                 Ok(decision) => decision,
                 Err(error) => return emit_dispatch_error(args.format, &error, Some(&request)),
@@ -349,7 +353,7 @@ fn run_dispatch(
     };
     let mut coordination_mode_override = None;
     let coordination = if prepared.needs_coordination() {
-        match liveness::load_snapshot() {
+        match liveness::load_snapshot(unmanaged) {
             Ok(snapshot) => snapshot,
             Err(error) => match liveness::coordination_failure_mode() {
                 Some(mode) => {
@@ -369,6 +373,7 @@ fn run_dispatch(
         &prepared,
         coordination.as_ref(),
         coordination_mode_override,
+        unmanaged,
     ) {
         Ok(decision) => decision,
         Err(error) => return emit_dispatch_error(args.format, &error, Some(&request)),

--- a/crates/agent-hook/src/liveness.rs
+++ b/crates/agent-hook/src/liveness.rs
@@ -37,6 +37,25 @@ impl CurrentPrincipal {
     }
 }
 
+const MANAGED_METADATA_ENV: [&str; 6] = [
+    "AGENT_SESSION_ID",
+    "AGENT_SESSION_RUNTIME_ID",
+    "AGENT_SESSION_STATE_DIR",
+    "AGENT_SESSION_COORDINATION_MODE",
+    "AGENT_SESSION_CAPABILITY_FILE",
+    "AGENT_SESSION_CHECKPOINT_FILE",
+];
+
+fn managed_metadata_present() -> bool {
+    MANAGED_METADATA_ENV
+        .iter()
+        .any(|name| std::env::var_os(name).is_some())
+}
+
+pub(crate) fn current_process_is_unmanaged() -> bool {
+    !managed_metadata_present()
+}
+
 #[derive(Clone, Copy, Debug)]
 struct RootInputs {
     dirty: Option<bool>,
@@ -92,6 +111,7 @@ pub(crate) struct DispatchProjection<'snapshot, 'io> {
     mode: Option<CoordinationMode>,
     now: i64,
     principal: Option<CurrentPrincipal>,
+    unmanaged: bool,
     roots: RefCell<BTreeMap<PathBuf, RootInputs>>,
     io: &'io dyn LivenessIo,
 }
@@ -100,6 +120,7 @@ impl<'snapshot, 'io> DispatchProjection<'snapshot, 'io> {
     pub(crate) fn new(
         snapshot: Option<&'snapshot Snapshot>,
         mode_override: Option<CoordinationMode>,
+        unmanaged: bool,
         io: &'io dyn LivenessIo,
     ) -> Self {
         let now = now_epoch();
@@ -110,6 +131,7 @@ impl<'snapshot, 'io> DispatchProjection<'snapshot, 'io> {
             mode,
             now,
             principal,
+            unmanaged,
             roots: RefCell::new(BTreeMap::new()),
             io,
         }
@@ -117,6 +139,10 @@ impl<'snapshot, 'io> DispatchProjection<'snapshot, 'io> {
 
     pub(crate) fn mode(&self) -> Option<CoordinationMode> {
         self.mode
+    }
+
+    pub(crate) fn is_unmanaged(&self) -> bool {
+        self.unmanaged
     }
 
     fn root_inputs(&self, checkout: &Path) -> RootInputs {
@@ -155,7 +181,10 @@ pub struct OwnerLiveness {
     pub dirty: Option<bool>,
 }
 
-pub fn load_snapshot() -> Result<Option<Snapshot>, HookError> {
+pub fn load_snapshot(unmanaged: bool) -> Result<Option<Snapshot>, HookError> {
+    if unmanaged {
+        return Ok(None);
+    }
     let state_root = agent_session_state_root()?;
     coordination_projection::load(&state_root)
         .map(|registry| {
@@ -325,6 +354,15 @@ pub fn classify(
     legacy_ttl_seconds: u64,
     projection: &DispatchProjection<'_, '_>,
 ) -> OwnerLiveness {
+    if projection.is_unmanaged() {
+        return result(
+            LivenessClass::Unclaimed,
+            "clear",
+            DecisionAction::Allow,
+            "coordination-unmanaged",
+            Some(false),
+        );
+    }
     let mode = projection.mode;
     if mode == Some(CoordinationMode::Off) {
         return result(

--- a/crates/agent-hook/tests/security_review.rs
+++ b/crates/agent-hook/tests/security_review.rs
@@ -47,6 +47,49 @@ capability = {{ id = "agent-session.owner-liveness.v1", reason_code = "owner", {
     )
 }
 
+fn coordination_policy() -> String {
+    format!(
+        r#"schema_version = "agent-hook.policy.v1"
+bundle_id = "runtime-kit"
+version = "2026.07.20.1"
+
+[[rules]]
+id = "runtime.semantic"
+products = ["codex"]
+events = ["PreToolUse"]
+matcher = "Write|Edit|NotebookEdit|apply_patch"
+priority = 10
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = {{ id = "agent-session.semantic-conflict.v1", reason_code = "semantic-conflict" }}
+
+[[rules]]
+id = "runtime.owner"
+products = ["codex"]
+events = ["PreToolUse"]
+matcher = "Write|Edit|NotebookEdit|apply_patch"
+priority = 20
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = {{ id = "agent-session.owner-liveness.v1", reason_code = "owner", {} = 300 }}
+
+[[rules]]
+id = "runtime.coordination"
+products = ["codex"]
+events = ["PreToolUse"]
+matcher = "Write|Edit|NotebookEdit|apply_patch"
+priority = 30
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = {{ id = "agent-session.coordination.v1", reason_code = "coordination" }}
+"#,
+        concat!("leg", "acy_ttl_seconds")
+    )
+}
+
 #[test]
 fn provider_json_rejects_duplicate_security_relevant_keys_at_every_depth() {
     let fixture = Fixture::new(BLOCK_POLICY);
@@ -455,6 +498,146 @@ fn matching_session_id_requires_exact_runtime_incarnation_for_self_ownership() {
         mismatched.stdout_json()["data"]["reasons"][0]["code"],
         "owner-active-foreign"
     );
+}
+
+#[test]
+fn fully_unmanaged_process_bypasses_coordination_capabilities() {
+    let fixture = Fixture::new(&coordination_policy());
+    let target = fixture.root.join("unmanaged-checkout");
+    fs::create_dir_all(&target).expect("target");
+    let now = now_epoch();
+    let key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let fallback_state = fixture.state_home.join("agent-session");
+    let brokers = json!({
+        "peer": {
+            "session_id":"peer",
+            "incarnation":"inc-peer",
+            "state":"ready",
+            "heartbeat_epoch":now
+        }
+    });
+    let claims = json!([{
+        "schema_version":"agent-session.work-context.v1",
+        "session_id":"peer",
+        "session_incarnation":"inc-peer",
+        "state":"active",
+        "worktrees":[fingerprint(key, 1, &target)],
+        "repositories":["owner/repo"],
+        "provider_refs":[],
+        "scopes":[],
+        "expires_at_epoch":now+300
+    }]);
+    write_registry_at(&fallback_state, key, brokers.clone(), claims.clone());
+    write_registry_at(&fixture.session_state, key, brokers, claims);
+    for state_root in [&fallback_state, &fixture.session_state] {
+        let heartbeat = heartbeat_path_at(state_root, "peer");
+        fs::create_dir_all(heartbeat.parent().expect("heartbeat parent")).expect("heartbeat dir");
+        fs::write(&heartbeat, format!("inc-peer:{now}\n")).expect("heartbeat");
+        Fixture::set_private(&heartbeat);
+    }
+    let payload = json!({
+        "hook_event_name":"PreToolUse",
+        "tool_name":"Write",
+        "cwd":target,
+        "tool_input":{"path":target.join("file.txt")}
+    })
+    .to_string();
+
+    let managed_selectors = [
+        ("AGENT_SESSION_ID", "partial-session".to_string()),
+        (
+            "AGENT_SESSION_RUNTIME_ID",
+            "partial-incarnation".to_string(),
+        ),
+        (
+            "AGENT_SESSION_STATE_DIR",
+            fixture.session_state.to_string_lossy().into_owned(),
+        ),
+        ("AGENT_SESSION_COORDINATION_MODE", "enforce".to_string()),
+        (
+            "AGENT_SESSION_CAPABILITY_FILE",
+            "/nonexistent/partial-capability".to_string(),
+        ),
+        (
+            "AGENT_SESSION_CHECKPOINT_FILE",
+            "/nonexistent/partial-checkpoint".to_string(),
+        ),
+    ];
+    let selector_names = managed_selectors
+        .iter()
+        .map(|(name, _)| *name)
+        .collect::<Vec<_>>();
+    for (selector, configured_value) in &managed_selectors {
+        let removals = selector_names
+            .iter()
+            .copied()
+            .filter(|name| name != selector)
+            .collect::<Vec<_>>();
+        for value in [configured_value.as_str(), ""] {
+            let output = fixture.run_with_env_and_removals(
+                &["dispatch", "--product", "codex", "--format", "json"],
+                Some(&payload),
+                &[(*selector, value)],
+                &removals,
+            );
+            assert_ne!(output.code, 0, "selector={selector} value={value:?}");
+            assert!(
+                !output.stdout_text().contains("coordination-unmanaged"),
+                "selector={selector} value={value:?} stdout={}",
+                output.stdout_text()
+            );
+            if !value.is_empty() {
+                let decision = output.stdout_json();
+                assert_eq!(decision["data"]["action"], "block");
+                assert!(
+                    decision["data"]["reasons"]
+                        .as_array()
+                        .is_some_and(|reasons| {
+                            reasons.iter().any(|reason| {
+                                reason["code"] == "owner-active-foreign"
+                                    && reason["disposition"] == "block"
+                            })
+                        })
+                );
+            }
+        }
+    }
+
+    let removals = selector_names;
+    let output = fixture.run_with_env_and_removals(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(&payload),
+        &[],
+        &removals,
+    );
+    assert_eq!(
+        output.code,
+        0,
+        "stdout={} stderr={}",
+        output.stdout_text(),
+        output.stderr_text()
+    );
+    let decision = output.stdout_json();
+    assert_eq!(decision["data"]["action"], "allow");
+    let reasons = decision["data"]["reasons"]
+        .as_array()
+        .expect("decision reasons");
+    assert_eq!(reasons.len(), 2);
+    assert!(reasons.iter().all(|reason| {
+        reason["code"] == "coordination-unmanaged" && reason["disposition"] == "allow"
+    }));
+
+    let registry = fallback_state.join("coordination/registry.json");
+    fs::write(&registry, b"{").expect("malformed registry");
+    Fixture::set_private(&registry);
+    let malformed = fixture.run_with_env_and_removals(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(&payload),
+        &[("AGENT_SESSION_BIN", "/nonexistent/agent-session")],
+        &removals,
+    );
+    assert_eq!(malformed.code, 0, "stdout={}", malformed.stdout_text());
+    assert_eq!(malformed.stdout_json()["data"]["action"], "allow");
 }
 
 #[test]
@@ -973,7 +1156,11 @@ fn assert_foreign_target_blocks(
 }
 
 fn write_registry(fixture: &Fixture, key: &str, brokers: Value, claims: Value) {
-    let coordination = fixture.session_state.join("coordination");
+    write_registry_at(&fixture.session_state, key, brokers, claims);
+}
+
+fn write_registry_at(state_root: &Path, key: &str, brokers: Value, claims: Value) {
+    let coordination = state_root.join("coordination");
     fs::create_dir_all(&coordination).expect("coordination dir");
     let path = coordination.join("registry.json");
     fs::write(
@@ -992,8 +1179,11 @@ fn write_registry(fixture: &Fixture, key: &str, brokers: Value, claims: Value) {
 }
 
 fn heartbeat_path(fixture: &Fixture, session: &str) -> std::path::PathBuf {
-    fixture
-        .session_state
+    heartbeat_path_at(&fixture.session_state, session)
+}
+
+fn heartbeat_path_at(state_root: &Path, session: &str) -> std::path::PathBuf {
+    state_root
         .join("sessions")
         .join(session)
         .join("coordination/heartbeat")

--- a/crates/agent-hook/tests/support/mod.rs
+++ b/crates/agent-hook/tests/support/mod.rs
@@ -92,12 +92,19 @@ impl Fixture {
             .with_env(
                 "XDG_STATE_HOME",
                 self.state_home.to_str().expect("state UTF-8"),
-            )
-            .with_env(
+            );
+        let state_overridden = envs
+            .iter()
+            .any(|(name, _)| *name == "AGENT_SESSION_STATE_DIR");
+        let options = if removals.contains(&"AGENT_SESSION_STATE_DIR") || state_overridden {
+            options
+        } else {
+            options.with_env(
                 "AGENT_SESSION_STATE_DIR",
                 self.session_state.to_str().expect("session state UTF-8"),
             )
-            .with_envs(envs);
+        };
+        let options = options.with_envs(envs);
         let options = removals
             .iter()
             .fold(options, |options, name| options.with_env_remove(name));

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -10966,10 +10966,16 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
         })
     );
 
-    let spawn_supervisor = |binding_timeout_ms: &str| {
-        let mut command = Command::new(&launch[helper_index]);
+    let spawn_supervisor = |binding_timeout_ms: &str, gate_name: &str| {
+        let start_gate = state_dir.join(gate_name);
+        let mut command = Command::new("sh");
         command
             .current_dir(&checkout)
+            .arg("-c")
+            .arg("while [ ! -e \"$1\" ]; do sleep 0.01; done; shift; exec \"$@\"")
+            .arg("canary-supervisor-start-gate")
+            .arg(&start_gate)
+            .arg(&launch[helper_index])
             .args(&launch[helper_index + 1..])
             .env("AGENT_SESSION_ID", "worker-canary-supervisor")
             .env("CANARY_DESCENDANT_PID_FILE", &descendant_pid_file)
@@ -10994,7 +11000,13 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
                 }
             });
         }
-        command.spawn().expect("execute emitted canary command")
+        (
+            command.spawn().expect("execute emitted canary command"),
+            start_gate,
+        )
+    };
+    let release_supervisor = |start_gate: &Path| {
+        fs::write(start_gate, b"start").expect("release canary supervisor start gate");
     };
     let registry_path = state_dir.join("orchestration/registry.json");
     let write_registry = |value: &serde_json::Value| {
@@ -11010,7 +11022,8 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
     registry["assignments"]["assignment-canary-supervisor"]["revision"] = json!(1);
     write_registry(&registry);
 
-    let unbound_supervisor = spawn_supervisor("500");
+    let (unbound_supervisor, unbound_start_gate) =
+        spawn_supervisor("500", ".unbound-supervisor-start");
     let unbound_supervisor_pid = unbound_supervisor.id();
     let mut unbound_record: serde_json::Value =
         serde_json::from_slice(&fs::read(&record_path).expect("worker record"))
@@ -11028,6 +11041,7 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
         }]
     });
     write_private_json(&record_path, &unbound_record);
+    release_supervisor(&unbound_start_gate);
     let unbound_output = unbound_supervisor
         .wait_with_output()
         .expect("wait unbound canary supervisor");
@@ -11042,7 +11056,8 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
     registry["assignments"]["assignment-canary-supervisor"]["state"] = json!("working");
     registry["assignments"]["assignment-canary-supervisor"]["revision"] = json!(3);
     write_registry(&registry);
-    let working_supervisor = spawn_supervisor("500");
+    let (working_supervisor, working_start_gate) =
+        spawn_supervisor("500", ".working-supervisor-start");
     let working_supervisor_pid = working_supervisor.id();
     let mut working_record: serde_json::Value =
         serde_json::from_slice(&fs::read(&record_path).expect("worker record"))
@@ -11060,6 +11075,7 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
         }]
     });
     write_private_json(&record_path, &working_record);
+    release_supervisor(&working_start_gate);
     let working_output = working_supervisor
         .wait_with_output()
         .expect("wait working-state canary supervisor");
@@ -11084,7 +11100,8 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
     registry["assignments"]["assignment-canary-supervisor"]["state"] = json!("starting");
     registry["assignments"]["assignment-canary-supervisor"]["revision"] = json!(2);
     write_registry(&registry);
-    let stale_created_supervisor = spawn_supervisor("500");
+    let (stale_created_supervisor, stale_created_start_gate) =
+        spawn_supervisor("500", ".stale-created-supervisor-start");
     let stale_created_supervisor_pid = stale_created_supervisor.id();
     let mut stale_created_record: serde_json::Value =
         serde_json::from_slice(&fs::read(&record_path).expect("worker record"))
@@ -11102,6 +11119,7 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
         }]
     });
     write_private_json(&record_path, &stale_created_record);
+    release_supervisor(&stale_created_start_gate);
     let stale_created_output = stale_created_supervisor
         .wait_with_output()
         .expect("wait stale-created-at canary supervisor");
@@ -11125,7 +11143,8 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
     registry["assignments"]["assignment-canary-supervisor"]["revision"] = json!(1);
     write_registry(&registry);
 
-    let mut delayed_binding_supervisor = spawn_supervisor("15000");
+    let (mut delayed_binding_supervisor, delayed_binding_start_gate) =
+        spawn_supervisor("15000", ".delayed-binding-supervisor-start");
     let delayed_binding_supervisor_pid = delayed_binding_supervisor.id();
     let mut delayed_record: serde_json::Value =
         serde_json::from_slice(&fs::read(&record_path).expect("worker record"))
@@ -11143,6 +11162,7 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
         }]
     });
     write_private_json(&record_path, &delayed_record);
+    release_supervisor(&delayed_binding_start_gate);
     std::thread::sleep(Duration::from_millis(100));
     assert!(
         delayed_binding_supervisor
@@ -11204,7 +11224,8 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
     fs::remove_file(&ready).expect("remove delayed-binding ready marker");
     fs::remove_file(&descendant_pid_file).expect("remove delayed-binding descendant marker");
 
-    let mut stale_identity_supervisor = spawn_supervisor("500");
+    let (mut stale_identity_supervisor, stale_identity_start_gate) =
+        spawn_supervisor("500", ".stale-identity-supervisor-start");
     let stale_identity_pid = stale_identity_supervisor.id();
     let mut stale_record: serde_json::Value =
         serde_json::from_slice(&fs::read(&record_path).expect("worker record"))
@@ -11222,6 +11243,7 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
         }]
     });
     write_private_json(&record_path, &stale_record);
+    release_supervisor(&stale_identity_start_gate);
     let stale_status = stale_identity_supervisor
         .wait()
         .expect("wait stale-identity supervisor");
@@ -11229,7 +11251,8 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
         !stale_status.success(),
         "a reused numeric pane PID with different start ticks must fail before provider launch"
     );
-    let mut supervisor = spawn_supervisor("500");
+    let (mut supervisor, supervisor_start_gate) =
+        spawn_supervisor("500", ".emitted-supervisor-start");
     let supervisor_pid = supervisor.id();
     let mut record: serde_json::Value =
         serde_json::from_slice(&fs::read(&record_path).expect("worker record"))
@@ -11248,6 +11271,7 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
         "pid_namespace": current_pid_namespace_identity()
     });
     write_private_json(&record_path, &record);
+    release_supervisor(&supervisor_start_gate);
     let ready =
         state_dir.join("sessions/worker-canary-supervisor/.provider-stop-canary-ready.json");
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -11351,7 +11375,8 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
 
     fs::remove_file(&ready).expect("remove first ready marker");
     fs::remove_file(&descendant_pid_file).expect("remove first descendant marker");
-    let mut guardian_crash_supervisor = spawn_supervisor("500");
+    let (mut guardian_crash_supervisor, guardian_crash_start_gate) =
+        spawn_supervisor("500", ".guardian-crash-supervisor-start");
     let guardian_crash_supervisor_pid = guardian_crash_supervisor.id();
     let mut record: serde_json::Value =
         serde_json::from_slice(&fs::read(&record_path).expect("worker record"))
@@ -11369,6 +11394,7 @@ fn main_agent_worker_start_emits_and_executes_exact_compiled_canary_supervisor()
         }]
     });
     write_private_json(&record_path, &record);
+    release_supervisor(&guardian_crash_start_gate);
     let deadline = Instant::now() + Duration::from_secs(5);
     while !ready.is_file() || !descendant_pid_file.is_file() {
         assert!(


### PR DESCRIPTION
## Summary

Allow Codex and Claude launched directly from an ordinary terminal to use agent-runtime-kit hooks without requiring an agent-session identity, while preserving conservative coordination for managed and partially managed launches.

## Problem

- Expected: A process with no agent-session identity remains outside managed-session ownership coordination.
- Actual: Owner-liveness loaded the shared registry and blocked the terminal as `owner-active-foreign` whenever another managed session owned the checkout.
- Impact: Direct iTerm2 Codex and Claude sessions could not run even read-only shell commands in affected checkouts.

## Reproduction

1. Keep a managed agent-session claim active for a checkout.
2. Launch Codex directly from a terminal with all six agent-session identity selectors absent.
3. Dispatch a matching pre-tool-use request and observe `owner-active-foreign` instead of an unmanaged allow result.

## Issues Found

- GitHub Actions run 30745910875 exposed a scheduler race in the canary supervisor integration fixture after this branch was rebased onto repaired main: the fixture spawned the supervisor before persisting its exact PID/start-time identity.

## Fix Approach

- Detect unmanaged execution only when all six identity selectors are absent.
- Skip registry loading and coordination transactions for unmanaged execution.
- Keep every partial selector combination, including empty values, on the managed fail-closed path.
- Gate direct canary fixture startup until the test has persisted the exact supervisor PID and start time, then `exec` the same process identity; production canary behavior is unchanged.

## Test-First Evidence

- Added the unmanaged coordination regression before production changes and observed the expected `owner-active-foreign` failure.
- Run 30745910875 failed the ungated canary fixture at its 100 ms delayed-binding liveness assertion; the gated fixture passed 10/10 delegated-cgroup stress iterations.
- The bound test-first evidence record verifies the committed delivery head.

## Test plan

- `bash .agents/scripts/pre-pr.sh` — passed all package, documentation, formatting, clippy, nextest, and doc-test gates.
- `cargo test -p nils-agent-hook --test security_review fully_unmanaged_process_bypasses_coordination_capabilities -- --exact --nocapture` — passed.
- Delegated-cgroup canary fixture stress, 10 iterations — passed.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — passed all 149 agent-hook tests, clippy, docs/audits, formatting, and doctests (one existing recovery test passed on retry).
- Runtime consumer executable contract for Codex and Claude — passed against the fixed binary.

## Risk / Notes

- Managed and partially managed identities remain fail-closed. Independent checkout, secret, delivery, and policy guards are unchanged.
- The canary follow-up is test-only and preserves shell argument boundaries plus the supervisor PID/start-time identity across `exec`.
