### PR TITLE
fix(ci): restore required main checks

### DIFF
--- a/.agents/skills/project-verify-required-checks/scripts/project-verify-required-checks.sh
+++ b/.agents/skills/project-verify-required-checks/scripts/project-verify-required-checks.sh
@@ -152,6 +152,7 @@ run bash scripts/ci/tests/release-workflow-contract.test.sh
 run bash scripts/ci/tests/shared-helper-adoption-audit.test.sh
 run bash scripts/ci/tests/publish-order-audit.test.sh
 run bash scripts/ci/tests/docs-hygiene-audit.test.sh
+run bash scripts/ci/tests/workspace-test-stale-audit.test.sh
 run bash scripts/ci/tests/prepare-private-release-workflow.test.sh
 run bash scripts/ci/skill-shell-suites.sh
 run bash scripts/ci/test-stale-audit.sh --strict

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,12 +27,11 @@ threads-required = "num-test-threads"
 filter = 'package(nils-git-cli) & test(concurrent_adoption_consumes_a_challenge_exactly_once)'
 threads-required = "num-test-threads"
 
-# This test asserts a 75 ms caller-visible admission bound while spawning and
-# observing worker subprocesses. Coverage instrumentation plus full-workspace
-# process pressure can exhaust that deliberately narrow margin before the
-# behavior under test runs.
+# This fixture verifies two products by invoking same-release descriptor
+# producers and runtime handlers. Reserve process capacity so full-workspace
+# pressure cannot turn OS child-spawn availability into a semantic failure.
 [[profile.ci.overrides]]
-filter = 'package(nils-agent-session) & test(worker_prompt_observation_has_a_fixed_time_and_admission_bound)'
+filter = 'package(nils-agent-hook) & test(enforce_valid_read_only_bypasses_only_the_declared_fallback_handler)'
 threads-required = "num-test-threads"
 
 [profile.ci.junit]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,5 +34,12 @@ threads-required = "num-test-threads"
 filter = 'package(nils-agent-hook) & test(enforce_valid_read_only_bypasses_only_the_declared_fallback_handler)'
 threads-required = "num-test-threads"
 
+# These fixtures coordinate same-release subprocesses across bounded barrier
+# and transcript-observation windows. Give each the complete CI thread pool so
+# unrelated coverage work cannot consume the process admission they validate.
+[[profile.ci.overrides]]
+filter = 'package(nils-agent-session) & test(/(main_agent_worker_start_preserves_ambiguous_initial_enter_without_redelivery|main_agent_worker_start_timeout_reports_exact_submitted_prompt)/)'
+threads-required = "num-test-threads"
+
 [profile.ci.junit]
 path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,12 +34,11 @@ threads-required = "num-test-threads"
 filter = 'package(nils-agent-hook) & test(enforce_valid_read_only_bypasses_only_the_declared_fallback_handler)'
 threads-required = "num-test-threads"
 
-# These fixtures exercise prompt-observation and serialized recovery deadlines
-# through multiple subprocesses. Keep unrelated workspace load from exhausting
-# their deliberately bounded reader and hook windows before the contract under
-# test can run.
+# These fixtures exercise prompt-observation deadlines through multiple
+# subprocesses. Keep unrelated workspace load from exhausting their deliberately
+# bounded reader windows before the contract under test can run.
 [[profile.ci.overrides]]
-filter = 'package(nils-agent-session) & test(/main_agent_(worker_start_await_ready_(stops_on_authoritative_terminal_turns|folds_timeout_into_readiness_failed)|submit_recovery_rechecks_authority_inside_the_serialized_send_boundary)/)'
+filter = 'package(nils-agent-session) & test(/main_agent_worker_start_await_ready_(stops_on_authoritative_terminal_turns|folds_timeout_into_readiness_failed)/)'
 threads-required = "num-test-threads"
 
 [profile.ci.junit]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,12 +27,12 @@ threads-required = "num-test-threads"
 filter = 'package(nils-git-cli) & test(concurrent_adoption_consumes_a_challenge_exactly_once)'
 threads-required = "num-test-threads"
 
-# These tests assert bounded observer latency and exercise repeated streamed
-# subprocess output. Coverage instrumentation plus full-workspace process
-# pressure can otherwise exhaust their deliberately narrow timing and spawn
-# margins before the behavior under test runs.
+# This test asserts a 75 ms caller-visible admission bound while spawning and
+# observing worker subprocesses. Coverage instrumentation plus full-workspace
+# process pressure can exhaust that deliberately narrow margin before the
+# behavior under test runs.
 [[profile.ci.overrides]]
-filter = 'package(nils-agent-session) & test(/(worker_prompt_observation_has_a_fixed_time_and_admission_bound|worktree_fingerprint_streaming_boundaries_and_untracked_aggregate_are_explicit)/)'
+filter = 'package(nils-agent-session) & test(worker_prompt_observation_has_a_fixed_time_and_admission_bound)'
 threads-required = "num-test-threads"
 
 [profile.ci.junit]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,5 +34,13 @@ threads-required = "num-test-threads"
 filter = 'package(nils-agent-hook) & test(enforce_valid_read_only_bypasses_only_the_declared_fallback_handler)'
 threads-required = "num-test-threads"
 
+# These fixtures exercise prompt-observation and serialized recovery deadlines
+# through multiple subprocesses. Keep unrelated workspace load from exhausting
+# their deliberately bounded reader and hook windows before the contract under
+# test can run.
+[[profile.ci.overrides]]
+filter = 'package(nils-agent-session) & test(/main_agent_(worker_start_await_ready_(stops_on_authoritative_terminal_turns|folds_timeout_into_readiness_failed)|submit_recovery_rechecks_authority_inside_the_serialized_send_boundary)/)'
+threads-required = "num-test-threads"
+
 [profile.ci.junit]
 path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,12 +34,5 @@ threads-required = "num-test-threads"
 filter = 'package(nils-agent-hook) & test(enforce_valid_read_only_bypasses_only_the_declared_fallback_handler)'
 threads-required = "num-test-threads"
 
-# These fixtures exercise prompt-observation deadlines through multiple
-# subprocesses. Keep unrelated workspace load from exhausting their deliberately
-# bounded reader windows before the contract under test can run.
-[[profile.ci.overrides]]
-filter = 'package(nils-agent-session) & test(/main_agent_worker_start_await_ready_(stops_on_authoritative_terminal_turns|folds_timeout_into_readiness_failed)/)'
-threads-required = "num-test-threads"
-
 [profile.ci.junit]
 path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,5 +27,13 @@ threads-required = "num-test-threads"
 filter = 'package(nils-git-cli) & test(concurrent_adoption_consumes_a_challenge_exactly_once)'
 threads-required = "num-test-threads"
 
+# These tests assert bounded observer latency and exercise repeated streamed
+# subprocess output. Coverage instrumentation plus full-workspace process
+# pressure can otherwise exhaust their deliberately narrow timing and spawn
+# margins before the behavior under test runs.
+[[profile.ci.overrides]]
+filter = 'package(nils-agent-session) & test(/(worker_prompt_observation_has_a_fixed_time_and_admission_bound|worktree_fingerprint_streaming_boundaries_and_untracked_aggregate_are_explicit)/)'
+threads-required = "num-test-threads"
+
 [profile.ci.junit]
 path = "junit.xml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,11 +881,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `2b23ff33436b118d31877a3072a00accd4175f0d654c1cec0c7d655d74df0179`
+- Cargo.lock SHA256: `32b3933a401492235700d4f5acfd44fc35995a372caab62a0960f54b7cd1fd77`
 - Third-party crates (`source != null`): 497
 - Workspace crates (`source == null`, excluded below): 46
 
@@ -148,7 +148,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | equivalent | 1.0.2 | Apache-2.0 OR MIT | crates.io |
 | errno | 0.3.14 | MIT OR Apache-2.0 | crates.io |
 | euclid | 0.22.14 | MIT OR Apache-2.0 | crates.io |
-| event-listener | 5.4.1 | Apache-2.0 OR MIT | crates.io |
+| event-listener | 5.4.2 | Apache-2.0 OR MIT | crates.io |
 | event-listener-strategy | 0.5.4 | Apache-2.0 OR MIT | crates.io |
 | fallible-iterator | 0.3.0 | MIT/Apache-2.0 | crates.io |
 | fallible-streaming-iterator | 0.1.9 | MIT/Apache-2.0 | crates.io |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `2b23ff33436b118d31877a3072a00accd4175f0d654c1cec0c7d655d74df0179`
+- Cargo.lock SHA256: `32b3933a401492235700d4f5acfd44fc35995a372caab62a0960f54b7cd1fd77`
 - Third-party crates (`source != null`): 497
 
 ## Notice Extraction Policy
@@ -832,7 +832,7 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
 
-### event-listener 5.4.1
+### event-listener 5.4.2
 
 - License: `Apache-2.0 OR MIT`
 - Source: `crates.io`

--- a/completions/bash/agent-session
+++ b/completions/bash/agent-session
@@ -49,6 +49,12 @@ _agent-session() {
             agent__session,message)
                 cmd="agent__session__message"
                 ;;
+            agent__session,provider-stop-canary-guardian)
+                cmd="agent__session__provider__stop__canary__guardian"
+                ;;
+            agent__session,provider-stop-canary-supervisor)
+                cmd="agent__session__provider__stop__canary__supervisor"
+                ;;
             agent__session,resume)
                 cmd="agent__session__resume"
                 ;;
@@ -164,7 +170,7 @@ _agent-session() {
 
     case "${cmd}" in
         agent__session)
-            opts="-h -V --state-dir --host --help --version start run list command attach logs send glance resume activity work-context broker message serve codex-app-server-proxy delete completion"
+            opts="-h -V --state-dir --host --help --version start run list command attach logs send glance resume activity work-context broker message serve codex-app-server-proxy provider-stop-canary-supervisor provider-stop-canary-guardian delete completion"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1447,6 +1453,80 @@ _agent-session() {
                     ;;
                 --format)
                     COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                --host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__session__provider__stop__canary__guardian)
+            opts="-h --id --cgroup-device --cgroup-inode --state-dir --host --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --cgroup-device)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --cgroup-inode)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                --host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__session__provider__stop__canary__supervisor)
+            opts="-h --id --cgroup-device --cgroup-inode --state-dir --host --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --cgroup-device)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --cgroup-inode)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --state-dir)

--- a/completions/bash/main-agent
+++ b/completions/bash/main-agent
@@ -34,6 +34,9 @@ _main-agent() {
             main__agent,close)
                 cmd="main__agent__close"
                 ;;
+            main__agent,closeout)
+                cmd="main__agent__closeout"
+                ;;
             main__agent,collaborate)
                 cmd="main__agent__collaborate"
                 ;;
@@ -115,8 +118,14 @@ _main-agent() {
             main__agent__worker,reconcile-stopped)
                 cmd="main__agent__worker__reconcile__stopped"
                 ;;
+            main__agent__worker,reenter)
+                cmd="main__agent__worker__reenter"
+                ;;
             main__agent__worker,release)
                 cmd="main__agent__worker__release"
+                ;;
+            main__agent__worker,release-provider-canary)
+                cmd="main__agent__worker__release__provider__canary"
                 ;;
             main__agent__worker,request-changes)
                 cmd="main__agent__worker__request__changes"
@@ -135,6 +144,9 @@ _main-agent() {
                 ;;
             main__agent__worker,stop-claimed-runtime)
                 cmd="main__agent__worker__stop__claimed__runtime"
+                ;;
+            main__agent__worker,stop-provider-canary)
+                cmd="main__agent__worker__stop__provider__canary"
                 ;;
             main__agent__worker,stop-runtime)
                 cmd="main__agent__worker__stop__runtime"
@@ -155,7 +167,7 @@ _main-agent() {
 
     case "${cmd}" in
         main__agent)
-            opts="-h -V --state-dir --host --help --version capabilities init rebind self rehydrate status checkpoint bootstrap worker collaborate borrow handoff adopt close quick packet-schema completion"
+            opts="-h -V --state-dir --host --help --version capabilities init rebind self rehydrate status checkpoint bootstrap worker collaborate borrow handoff adopt close closeout quick packet-schema completion"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -388,6 +400,58 @@ _main-agent() {
             case "${prev}" in
                 --if-revision)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --idempotency-key)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                --host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        main__agent__closeout)
+            opts="-h --if-run-revision --checkpoint-file --idempotency-key --format --state-dir --host --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --if-run-revision)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --checkpoint-file)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
                     return 0
                     ;;
                 --idempotency-key)
@@ -872,7 +936,7 @@ _main-agent() {
             return 0
             ;;
         main__agent__worker)
-            opts="-h --state-dir --host --help start list show wait message guidance-reconcile guidance-quarantine account-handoff account-handoff-cancel request-changes accept release delete retire diagnose supervise submit-recovery reconcile-recovery stop-runtime stop-claimed-runtime reconcile-stopped revoke-claim cancel reassign"
+            opts="-h --state-dir --host --help start list show wait message guidance-reconcile guidance-quarantine account-handoff account-handoff-cancel request-changes reenter accept release delete retire diagnose supervise submit-recovery reconcile-recovery stop-runtime stop-claimed-runtime stop-provider-canary release-provider-canary reconcile-stopped revoke-claim cancel reassign"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1423,6 +1487,51 @@ _main-agent() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        main__agent__worker__reenter)
+            opts="-h --worker-incarnation --if-revision --if-notification-generation --idempotency-key --format --state-dir --host --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --worker-incarnation)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --if-revision)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --if-notification-generation)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --idempotency-key)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                --host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         main__agent__worker__release)
             opts="-h --if-revision --idempotency-key --format --state-dir --host --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
@@ -1430,6 +1539,47 @@ _main-agent() {
                 return 0
             fi
             case "${prev}" in
+                --if-revision)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --idempotency-key)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                --host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        main__agent__worker__release__provider__canary)
+            opts="-h --worker-incarnation --if-revision --idempotency-key --format --state-dir --host --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --worker-incarnation)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --if-revision)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -1676,6 +1826,47 @@ _main-agent() {
             return 0
             ;;
         main__agent__worker__stop__claimed__runtime)
+            opts="-h --worker-incarnation --if-revision --idempotency-key --format --state-dir --host --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --worker-incarnation)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --if-revision)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --idempotency-key)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                --host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        main__agent__worker__stop__provider__canary)
             opts="-h --worker-incarnation --if-revision --idempotency-key --format --state-dir --host --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/completions/zsh/_agent-session
+++ b/completions/zsh/_agent-session
@@ -683,6 +683,28 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 && ret=0
 ;;
+(provider-stop-canary-supervisor)
+_arguments "${_arguments_options[@]}" : \
+'--id=[Managed session id whose exact Codex child this supervisor owns]:ID:_default' \
+'--cgroup-device=[Internal pinned cgroup device passed only from supervisor to guardian]:CGROUP_DEVICE:_default' \
+'--cgroup-inode=[Internal pinned cgroup inode passed only from supervisor to guardian]:CGROUP_INODE:_default' \
+'--state-dir=[State directory. Defaults to AGENT_SESSION_STATE_DIR, XDG_STATE_HOME/agent-session, or ~/.local/state/agent-session]:PATH:_files -/' \
+'--host=[Hostname used in generated ssh attach commands]:HOST:_default' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(provider-stop-canary-guardian)
+_arguments "${_arguments_options[@]}" : \
+'--id=[Managed session id whose exact Codex child this supervisor owns]:ID:_default' \
+'--cgroup-device=[Internal pinned cgroup device passed only from supervisor to guardian]:CGROUP_DEVICE:_default' \
+'--cgroup-inode=[Internal pinned cgroup inode passed only from supervisor to guardian]:CGROUP_INODE:_default' \
+'--state-dir=[State directory. Defaults to AGENT_SESSION_STATE_DIR, XDG_STATE_HOME/agent-session, or ~/.local/state/agent-session]:PATH:_files -/' \
+'--host=[Hostname used in generated ssh attach commands]:HOST:_default' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
 (delete)
 _arguments "${_arguments_options[@]}" : \
 '--tmux-bin=[tmux binary override]:PATH:_files' \
@@ -727,6 +749,8 @@ _agent-session_commands() {
 'message:Exchange bounded private coordination mailbox messages' \
 'serve:Serve the control plane (HTTP) and PTY attach (WebSocket) over loopback' \
 'codex-app-server-proxy:Internal metadata-only bridge for a managed Codex remote TUI' \
+'provider-stop-canary-supervisor:Internal exact-child supervisor for an explicitly armed Main Agent canary' \
+'provider-stop-canary-guardian:Internal crash guardian for the exact provider-owned process session' \
 'delete:Delete session state and kill the tmux session if it is still alive' \
 'completion:Print shell completion script' \
     )
@@ -891,6 +915,16 @@ _agent-session__subcmd__message__subcmd__show_commands() {
 _agent-session__subcmd__message__subcmd__wait_commands() {
     local commands; commands=()
     _describe -t commands 'agent-session message wait commands' commands "$@"
+}
+(( $+functions[_agent-session__subcmd__provider-stop-canary-guardian_commands] )) ||
+_agent-session__subcmd__provider-stop-canary-guardian_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-session provider-stop-canary-guardian commands' commands "$@"
+}
+(( $+functions[_agent-session__subcmd__provider-stop-canary-supervisor_commands] )) ||
+_agent-session__subcmd__provider-stop-canary-supervisor_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-session provider-stop-canary-supervisor commands' commands "$@"
 }
 (( $+functions[_agent-session__subcmd__resume_commands] )) ||
 _agent-session__subcmd__resume_commands() {

--- a/completions/zsh/_main-agent
+++ b/completions/zsh/_main-agent
@@ -315,6 +315,21 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ':assignment_id:_default' \
 && ret=0
 ;;
+(reenter)
+_arguments "${_arguments_options[@]}" : \
+'--worker-incarnation=[Exact worker incarnation currently bound to the assignment]:WORKER_INCARNATION:_default' \
+'--if-revision=[Expected current assignment revision; stale values fail closed and report current_revision.]:IF_REVISION:_default' \
+'--if-notification-generation=[Exact existing mailbox notification generation to retry without allocating or sending another message generation]:IF_NOTIFICATION_GENERATION:_default' \
+'--idempotency-key=[Retry an ambiguous outcome with the same idempotency key and the same logical request; use a new key for a changed request.]:IDEMPOTENCY_KEY:_default' \
+'--format=[]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--state-dir=[agent-session state directory]:PATH:_files -/' \
+'--host=[Advisory machine label for public projections]:HOST:_default' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':assignment_id:_default' \
+&& ret=0
+;;
 (accept)
 _arguments "${_arguments_options[@]}" : \
 '--if-revision=[Expected current assignment revision; stale values fail closed and report current_revision.]:IF_REVISION:_default' \
@@ -431,6 +446,34 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 && ret=0
 ;;
 (stop-claimed-runtime)
+_arguments "${_arguments_options[@]}" : \
+'--worker-incarnation=[Exact worker incarnation currently bound to the assignment]:WORKER_INCARNATION:_default' \
+'--if-revision=[Expected current assignment revision; stale values fail closed and report current_revision.]:IF_REVISION:_default' \
+'--idempotency-key=[Retry an ambiguous outcome with the same idempotency key and the same logical request; use a new key for a changed request.]:IDEMPOTENCY_KEY:_default' \
+'--format=[]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--state-dir=[agent-session state directory]:PATH:_files -/' \
+'--host=[Advisory machine label for public projections]:HOST:_default' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':assignment_id:_default' \
+&& ret=0
+;;
+(stop-provider-canary)
+_arguments "${_arguments_options[@]}" : \
+'--worker-incarnation=[Exact worker incarnation currently bound to the assignment]:WORKER_INCARNATION:_default' \
+'--if-revision=[Expected current assignment revision; stale values fail closed and report current_revision.]:IF_REVISION:_default' \
+'--idempotency-key=[Retry an ambiguous outcome with the same idempotency key and the same logical request; use a new key for a changed request.]:IDEMPOTENCY_KEY:_default' \
+'--format=[]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--state-dir=[agent-session state directory]:PATH:_files -/' \
+'--host=[Advisory machine label for public projections]:HOST:_default' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+':assignment_id:_default' \
+&& ret=0
+;;
+(release-provider-canary)
 _arguments "${_arguments_options[@]}" : \
 '--worker-incarnation=[Exact worker incarnation currently bound to the assignment]:WORKER_INCARNATION:_default' \
 '--if-revision=[Expected current assignment revision; stale values fail closed and report current_revision.]:IF_REVISION:_default' \
@@ -575,6 +618,19 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
 ;;
+(closeout)
+_arguments "${_arguments_options[@]}" : \
+'--if-run-revision=[Expected run revision before the closeout macro performs any stage]:IF_RUN_REVISION:_default' \
+'--checkpoint-file=[Private final checkpoint JSON file]:PATH:_files' \
+'--idempotency-key=[Retry an ambiguous outcome with the same idempotency key and the same logical request; use a new key for a changed request.]:IDEMPOTENCY_KEY:_default' \
+'--format=[]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--state-dir=[agent-session state directory]:PATH:_files -/' \
+'--host=[Advisory machine label for public projections]:HOST:_default' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
 (quick)
 _arguments "${_arguments_options[@]}" : \
 '--assignment-file=[Private assignment packet JSON file]:PATH:_files' \
@@ -630,6 +686,7 @@ _main-agent_commands() {
 'handoff:Transfer primary assignment routing after quiescence checks' \
 'adopt:Adopt an orphaned assignment into this Main Agent'\''s run' \
 'close:Close this run after all assignments are terminal' \
+'closeout:Persist the final checkpoint, retire terminal workers, close the run, and release only the controller claim bound to this run' \
 'quick:Fast-path\: create an ephemeral run, single assignment, and launch in one call. The run auto-closes once the worker is torn down' \
 'packet-schema:Print an example objective packet (schema, required fields, and the nested work-context) that \`init --packet-file\` accepts' \
 'completion:Print shell completion script' \
@@ -665,6 +722,11 @@ _main-agent__subcmd__checkpoint_commands() {
 _main-agent__subcmd__close_commands() {
     local commands; commands=()
     _describe -t commands 'main-agent close commands' commands "$@"
+}
+(( $+functions[_main-agent__subcmd__closeout_commands] )) ||
+_main-agent__subcmd__closeout_commands() {
+    local commands; commands=()
+    _describe -t commands 'main-agent closeout commands' commands "$@"
 }
 (( $+functions[_main-agent__subcmd__collaborate_commands] )) ||
 _main-agent__subcmd__collaborate_commands() {
@@ -748,6 +810,7 @@ _main-agent__subcmd__worker_commands() {
 'account-handoff:Apply an explicitly authorized account handoff to the exact worker' \
 'account-handoff-cancel:Safely cancel a failed, superseded, or queued account-handoff reservation without changing the bound account' \
 'request-changes:Return a submitted assignment to its exact worker for bounded revisions' \
+'reenter:Re-enter an exact idle Codex worker through its existing unread notification generation without resending assignment content' \
 'accept:Accept a submitted worker result after Main Agent review' \
 'release:Mark an accepted assignment terminal before worker deletion' \
 'delete:Delete a released worker through guarded agent-session cleanup' \
@@ -758,6 +821,8 @@ _main-agent__subcmd__worker_commands() {
 'reconcile-recovery:Terminalize an unknown recovery without sending input after the exact worker runtime is stopped and coordination state is quiescent' \
 'stop-runtime:Stop the exact live runtime after bounded worker-start readiness is durably exhausted, preserving the assignment, session, and worktree' \
 'stop-claimed-runtime:Stop an authoritative-idle working worker'\''s exact live runtime with an active assignment-derived claim, preserving the claim for reconcile-stopped' \
+'stop-provider-canary:Stop only the exact Codex child of an explicitly armed canary worker, leaving its bounded supervisor and tmux runtime live for classification' \
+'release-provider-canary:Release an exact stopped canary wrapper so the worker runtime exits' \
 'reconcile-stopped:Terminalize a working assignment whose exact worker runtime is durably stopped, revoking only that worker'\''s claim without sending input, deleting the run, or touching its managed worktree' \
 'revoke-claim:Revoke only the exact authoritative-idle worker claim when that worker cannot finish its own release, preserving its session and worktree' \
 'cancel:Terminalize only a proven failed pre-claim assignment' \
@@ -830,10 +895,20 @@ _main-agent__subcmd__worker__subcmd__reconcile-stopped_commands() {
     local commands; commands=()
     _describe -t commands 'main-agent worker reconcile-stopped commands' commands "$@"
 }
+(( $+functions[_main-agent__subcmd__worker__subcmd__reenter_commands] )) ||
+_main-agent__subcmd__worker__subcmd__reenter_commands() {
+    local commands; commands=()
+    _describe -t commands 'main-agent worker reenter commands' commands "$@"
+}
 (( $+functions[_main-agent__subcmd__worker__subcmd__release_commands] )) ||
 _main-agent__subcmd__worker__subcmd__release_commands() {
     local commands; commands=()
     _describe -t commands 'main-agent worker release commands' commands "$@"
+}
+(( $+functions[_main-agent__subcmd__worker__subcmd__release-provider-canary_commands] )) ||
+_main-agent__subcmd__worker__subcmd__release-provider-canary_commands() {
+    local commands; commands=()
+    _describe -t commands 'main-agent worker release-provider-canary commands' commands "$@"
 }
 (( $+functions[_main-agent__subcmd__worker__subcmd__request-changes_commands] )) ||
 _main-agent__subcmd__worker__subcmd__request-changes_commands() {
@@ -864,6 +939,11 @@ _main-agent__subcmd__worker__subcmd__start_commands() {
 _main-agent__subcmd__worker__subcmd__stop-claimed-runtime_commands() {
     local commands; commands=()
     _describe -t commands 'main-agent worker stop-claimed-runtime commands' commands "$@"
+}
+(( $+functions[_main-agent__subcmd__worker__subcmd__stop-provider-canary_commands] )) ||
+_main-agent__subcmd__worker__subcmd__stop-provider-canary_commands() {
+    local commands; commands=()
+    _describe -t commands 'main-agent worker stop-provider-canary commands' commands "$@"
 }
 (( $+functions[_main-agent__subcmd__worker__subcmd__stop-runtime_commands] )) ||
 _main-agent__subcmd__worker__subcmd__stop-runtime_commands() {

--- a/crates/agent-hook/tests/coordination_ingress.rs
+++ b/crates/agent-hook/tests/coordination_ingress.rs
@@ -92,7 +92,7 @@ priority = 10
 mode = "enforce"
 failure_posture = "closed"
 override_class = "locked"
-capability = {{ id = "agent-session.owner-liveness.v1", reason_code = "owner", legacy_ttl_seconds = 300 }}
+capability = {{ id = "agent-session.owner-liveness.v1", reason_code = "owner", legacy_ttl_seconds = 300 }} # stale-audit: keep-contract
 
 {extra_rule}
 

--- a/crates/agent-hook/tests/read_only_capability.rs
+++ b/crates/agent-hook/tests/read_only_capability.rs
@@ -296,7 +296,8 @@ fn enforce_valid_read_only_bypasses_only_the_declared_fallback_handler() {
         assert_eq!(
             output.code,
             0,
-            "product={product}; stderr={}",
+            "product={product}; stdout={}; stderr={}",
+            output.stdout_text(),
             output.stderr_text()
         );
         assert_eq!(output.stdout_json()["data"]["action"], "allow");

--- a/crates/agent-session/src/activity.rs
+++ b/crates/agent-session/src/activity.rs
@@ -1384,6 +1384,93 @@ pub(crate) fn activate_runtime(
     activate_runtime_in_dir(&session_dir(context, &record.id), record)
 }
 
+#[cfg(all(unix, not(target_os = "linux")))]
+pub(crate) fn activate_new_runtime_with(
+    record: &SessionRecord,
+    mut write: impl FnMut(&str, &[u8]) -> Result<(), CliError>,
+) -> Result<TurnState, CliError> {
+    let runtime = record.runtime.as_ref().ok_or_else(|| {
+        CliError::data(
+            "runtime-id-missing",
+            "session runtime is missing its launch id",
+            Some(json!({ "id": record.id })),
+        )
+    })?;
+    if runtime.launch_id.is_empty() {
+        return Err(CliError::data(
+            "runtime-id-missing",
+            "session runtime is missing its launch id",
+            Some(json!({ "id": record.id })),
+        ));
+    }
+
+    let state = starting_state(runtime.started_at.clone(), 1, None);
+    let document = activity_document_for_runtime(
+        record,
+        &runtime.launch_id,
+        runtime.generation,
+        state.clone(),
+        Map::new(),
+    )?;
+
+    let expected_len = REPLAY_HEADER_BYTES + REPLAY_SLOT_COUNT * REPLAY_SLOT_BYTES;
+    let mut replay = vec![0_u8; expected_len];
+    replay[..REPLAY_HEADER_BYTES]
+        .copy_from_slice(&replay_header(&runtime.launch_id, runtime.generation));
+    write(ACTIVITY_REPLAY_FILE, &replay)?;
+    let bytes = serde_json::to_vec_pretty(&document).map_err(|err| {
+        CliError::runtime(
+            "activity-render-failed",
+            format!("failed to render activity snapshot: {err}"),
+            None,
+        )
+    })?;
+    write(ACTIVITY_FILE, &bytes)?;
+    Ok(state)
+}
+
+fn activity_document_for_runtime(
+    record: &SessionRecord,
+    runtime_id: &str,
+    runtime_generation: u64,
+    state: TurnState,
+    extra: Map<String, Value>,
+) -> Result<ActivityDocument, CliError> {
+    Ok(ActivityDocument {
+        schema_version: ACTIVITY_DOCUMENT_VERSION.to_string(),
+        runtime_id: runtime_id.to_string(),
+        runtime_generation,
+        state,
+        pending_attention: Vec::new(),
+        overflow_attention: None,
+        seen_event_count: 0,
+        last_semantic_event: None,
+        last_semantic_event_at: None,
+        last_provider_event_kind: None,
+        last_provider_event_provider: None,
+        last_provider_event_at: None,
+        last_provider_event_turn_id: None,
+        provider_session_id: record
+            .provider_resume
+            .as_ref()
+            .filter(|resume| resume.provider == record.agent)
+            .map(|resume| {
+                projected_provider_identifier(
+                    runtime_id,
+                    AgentKind::from_name(&record.agent).expect("validated session agent"),
+                    "session",
+                    &resume.session_id,
+                )
+            })
+            .transpose()?,
+        last_event_at: None,
+        pending_journal: None,
+        runtime_unhealthy_reason: None,
+        operator_provider_turn_receipts: Vec::new(),
+        extra,
+    })
+}
+
 pub(crate) fn activate_runtime_in_dir(
     dir: &Path,
     record: &SessionRecord,
@@ -1476,41 +1563,11 @@ pub(crate) fn activate_runtime_in_dir(
         state.extra = document.state.extra.clone();
         state.source.extra = document.state.source.extra.clone();
     }
-    let mut document = ActivityDocument {
-        schema_version: ACTIVITY_DOCUMENT_VERSION.to_string(),
-        runtime_id: runtime_id.to_string(),
-        runtime_generation,
-        state,
-        pending_attention: Vec::new(),
-        overflow_attention: None,
-        seen_event_count: 0,
-        last_semantic_event: None,
-        last_semantic_event_at: None,
-        last_provider_event_kind: None,
-        last_provider_event_provider: None,
-        last_provider_event_at: None,
-        last_provider_event_turn_id: None,
-        provider_session_id: record
-            .provider_resume
-            .as_ref()
-            .filter(|resume| resume.provider == record.agent)
-            .map(|resume| {
-                projected_provider_identifier(
-                    runtime_id,
-                    AgentKind::from_name(&record.agent).expect("validated session agent"),
-                    "session",
-                    &resume.session_id,
-                )
-            })
-            .transpose()?,
-        last_event_at: None,
-        pending_journal: None,
-        runtime_unhealthy_reason: None,
-        operator_provider_turn_receipts: Vec::new(),
-        extra: existing
-            .take()
-            .map_or_else(Map::new, |document| document.extra),
-    };
+    let extra = existing
+        .take()
+        .map_or_else(Map::new, |document| document.extra);
+    let mut document =
+        activity_document_for_runtime(record, runtime_id, runtime_generation, state, extra)?;
     write_document(&path, &mut document)?;
     remove_runtime_unhealthy_marker(dir)?;
     Ok(document.state)

--- a/crates/agent-session/src/coordination/mod.rs
+++ b/crates/agent-session/src/coordination/mod.rs
@@ -1799,6 +1799,7 @@ pub(crate) fn prepare(context: &CliContext, record: &SessionRecord) -> Result<()
     broker::prepare(context, record)
 }
 
+#[cfg(target_os = "linux")]
 pub(crate) fn prepare_in_dir(session_dir: &Path, _record: &SessionRecord) -> Result<(), CliError> {
     broker::prepare_in_dir(session_dir)
 }

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -18,8 +18,10 @@ use std::fs::{self, OpenOptions};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::{self, Read, Write};
 use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
 #[cfg(target_os = "linux")]
-use std::os::fd::{FromRawFd, OwnedFd};
+use std::os::fd::OwnedFd;
 #[cfg(target_os = "linux")]
 use std::os::linux::net::SocketAddrExt;
 #[cfg(target_os = "linux")]
@@ -2600,19 +2602,7 @@ impl PrivateSessionDirGuard {
         {
             use std::os::unix::ffi::OsStrExt;
 
-            let descriptor_path = self.session_descriptor_path();
-            if let Ok(entries) = fs::read_dir(&descriptor_path) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    let result = match entry.file_type() {
-                        Ok(file_type) if file_type.is_dir() && !file_type.is_symlink() => {
-                            fs::remove_dir_all(path)
-                        }
-                        _ => fs::remove_file(path),
-                    };
-                    let _ = result;
-                }
-            }
+            clear_private_directory_at(&self.session_directory);
             let name = self
                 .session_path
                 .file_name()
@@ -2627,18 +2617,34 @@ impl PrivateSessionDirGuard {
         }
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn session_descriptor_path(&self) -> PathBuf {
-        #[cfg(target_os = "linux")]
-        let descriptor_root = Path::new("/proc/self/fd");
-        #[cfg(not(target_os = "linux"))]
-        let descriptor_root = Path::new("/dev/fd");
-        descriptor_root.join(self.session_directory.as_raw_fd().to_string())
+        Path::new("/proc/self/fd").join(self.session_directory.as_raw_fd().to_string())
     }
 
     #[cfg(not(unix))]
     fn session_descriptor_path(&self) -> PathBuf {
         self.session_path.clone()
+    }
+
+    #[cfg(unix)]
+    fn write_private_file(&self, name: &str, bytes: &[u8]) -> Result<(), CliError> {
+        write_private_file_at(
+            &self.session_directory,
+            &self.session_path.join(name),
+            name,
+            bytes,
+        )
+    }
+
+    #[cfg(not(unix))]
+    fn write_private_file(&self, name: &str, bytes: &[u8]) -> Result<(), CliError> {
+        write_private_file(&self.session_path.join(name), bytes)
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    fn create_private_dir(&self, name: &str) -> Result<(), CliError> {
+        create_private_dir_at(&self.session_directory, &self.session_path.join(name), name)
     }
 }
 
@@ -2716,10 +2722,7 @@ fn create_record_with_guard(
     let prompt_file = match request.prompt {
         Some(prompt) => {
             let path = session_dir.join("prompt.md");
-            if let Err(error) = write_private_file(
-                &session_storage.session_descriptor_path().join("prompt.md"),
-                prompt.as_bytes(),
-            ) {
+            if let Err(error) = session_storage.write_private_file("prompt.md", prompt.as_bytes()) {
                 session_storage.cleanup_if_current();
                 return Err(error);
             }
@@ -2780,9 +2783,17 @@ fn create_record_with_guard(
         session_storage.cleanup_if_current();
         return Err(error);
     }
-    if let Err(err) =
-        activity::activate_runtime_in_dir(&session_storage.session_descriptor_path(), &record)
-    {
+    #[cfg(target_os = "linux")]
+    let activity_result =
+        activity::activate_runtime_in_dir(&session_storage.session_descriptor_path(), &record);
+    #[cfg(all(unix, not(target_os = "linux")))]
+    let activity_result = activity::activate_new_runtime_with(&record, |name, bytes| {
+        session_storage.write_private_file(name, bytes)
+    });
+    #[cfg(not(unix))]
+    let activity_result =
+        activity::activate_runtime_in_dir(&session_storage.session_descriptor_path(), &record);
+    if let Err(err) = activity_result {
         session_storage.cleanup_if_current();
         return Err(err);
     }
@@ -2790,9 +2801,15 @@ fn create_record_with_guard(
         session_storage.cleanup_if_current();
         return Err(error);
     }
-    if let Err(err) =
-        coordination::prepare_in_dir(&session_storage.session_descriptor_path(), &record)
-    {
+    #[cfg(target_os = "linux")]
+    let coordination_result =
+        coordination::prepare_in_dir(&session_storage.session_descriptor_path(), &record);
+    #[cfg(all(unix, not(target_os = "linux")))]
+    let coordination_result = session_storage.create_private_dir("coordination");
+    #[cfg(not(unix))]
+    let coordination_result =
+        coordination::prepare_in_dir(&session_storage.session_descriptor_path(), &record);
+    if let Err(err) = coordination_result {
         session_storage.cleanup_if_current();
         return Err(err);
     }
@@ -2852,7 +2869,6 @@ fn write_initial_session_record(
             None,
         )
     })?;
-    let directory = storage.session_descriptor_path();
     if let Some(sidecar) = durable_resume_record(record) {
         let sidecar_bytes = serde_json::to_vec_pretty(&sidecar).map_err(|err| {
             CliError::runtime(
@@ -2861,9 +2877,9 @@ fn write_initial_session_record(
                 None,
             )
         })?;
-        write_private_file(&directory.join(SESSION_RESUME_FILE), &sidecar_bytes)?;
+        storage.write_private_file(SESSION_RESUME_FILE, &sidecar_bytes)?;
     }
-    write_private_file(&directory.join("session.json"), &bytes)
+    storage.write_private_file("session.json", &bytes)
 }
 
 #[derive(Debug, Default)]
@@ -16624,6 +16640,174 @@ fn ensure_private_dir(path: &Path) -> Result<(), CliError> {
         })?;
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn write_private_file_at(
+    directory: &fs::File,
+    display_target: &Path,
+    name: &str,
+    bytes: &[u8],
+) -> Result<(), CliError> {
+    use std::ffi::CString;
+
+    let target = CString::new(name).map_err(|_| {
+        CliError::runtime(
+            "file-write-failed",
+            format!(
+                "failed to write {}: invalid file name",
+                display_target.display()
+            ),
+            Some(json!({ "path": display_path(display_target) })),
+        )
+    })?;
+    let temporary_name = format!(".{name}.tmp-{}", uuid::Uuid::new_v4());
+    let temporary = CString::new(temporary_name.as_str()).expect("UUID temp name has no null byte");
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            temporary.as_ptr(),
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            SECRET_FILE_MODE as libc::c_uint,
+        )
+    };
+    if descriptor < 0 {
+        return Err(private_file_io_error(
+            display_target,
+            io::Error::last_os_error(),
+        ));
+    }
+    let mut file = unsafe { fs::File::from_raw_fd(descriptor) };
+    let write_result = file
+        .write_all(bytes)
+        .and_then(|()| file.sync_all())
+        .and_then(|()| {
+            if unsafe { libc::fchmod(file.as_raw_fd(), SECRET_FILE_MODE as libc::mode_t) } == 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        });
+    if let Err(error) = write_result {
+        drop(file);
+        let _ = unsafe { libc::unlinkat(directory.as_raw_fd(), temporary.as_ptr(), 0) };
+        return Err(private_file_io_error(display_target, error));
+    }
+    drop(file);
+    if unsafe {
+        libc::renameat(
+            directory.as_raw_fd(),
+            temporary.as_ptr(),
+            directory.as_raw_fd(),
+            target.as_ptr(),
+        )
+    } != 0
+    {
+        let error = io::Error::last_os_error();
+        let _ = unsafe { libc::unlinkat(directory.as_raw_fd(), temporary.as_ptr(), 0) };
+        return Err(private_file_io_error(display_target, error));
+    }
+    let _ = directory.sync_all();
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn create_private_dir_at(
+    directory: &fs::File,
+    display_target: &Path,
+    name: &str,
+) -> Result<(), CliError> {
+    use std::ffi::CString;
+
+    let name = CString::new(name).map_err(|_| {
+        CliError::runtime(
+            "directory-create-failed",
+            format!(
+                "failed to create {}: invalid directory name",
+                display_target.display()
+            ),
+            Some(json!({ "path": display_path(display_target) })),
+        )
+    })?;
+    if unsafe { libc::mkdirat(directory.as_raw_fd(), name.as_ptr(), 0o700) } != 0 {
+        return Err(CliError::runtime(
+            "directory-create-failed",
+            format!(
+                "failed to create {}: {}",
+                display_target.display(),
+                io::Error::last_os_error()
+            ),
+            Some(json!({ "path": display_path(display_target) })),
+        ));
+    }
+    let child = open_session_ancestor_at(directory, &name, "session")?;
+    child
+        .set_permissions(fs::Permissions::from_mode(0o700))
+        .map_err(|error| {
+            CliError::runtime(
+                "directory-permissions-failed",
+                format!(
+                    "failed to set permissions on {}: {error}",
+                    display_target.display()
+                ),
+                Some(json!({ "path": display_path(display_target) })),
+            )
+        })
+}
+
+#[cfg(unix)]
+fn clear_private_directory_at(directory: &fs::File) {
+    use std::ffi::{CStr, CString};
+
+    let duplicate = unsafe { libc::dup(directory.as_raw_fd()) };
+    if duplicate < 0 {
+        return;
+    }
+    let stream = unsafe { libc::fdopendir(duplicate) };
+    if stream.is_null() {
+        let _ = unsafe { libc::close(duplicate) };
+        return;
+    }
+    let mut names = Vec::<CString>::new();
+    loop {
+        let entry = unsafe { libc::readdir(stream) };
+        if entry.is_null() {
+            break;
+        }
+        let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) };
+        if name.to_bytes() != b"." && name.to_bytes() != b".." {
+            names.push(name.to_owned());
+        }
+    }
+    let _ = unsafe { libc::closedir(stream) };
+
+    for name in names {
+        let child_descriptor = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if child_descriptor >= 0 {
+            let child = unsafe { fs::File::from_raw_fd(child_descriptor) };
+            clear_private_directory_at(&child);
+            drop(child);
+            let _ =
+                unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
+        } else {
+            let _ = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
+        }
+    }
+}
+
+#[cfg(unix)]
+fn private_file_io_error(path: &Path, error: io::Error) -> CliError {
+    CliError::runtime(
+        "file-write-failed",
+        format!("failed to write {}: {error}", path.display()),
+        Some(json!({ "path": display_path(path) })),
+    )
 }
 
 fn write_private_file(path: &Path, bytes: &[u8]) -> Result<(), CliError> {

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -1819,6 +1819,7 @@ struct StartLifecycleGuards<'a> {
     pre_runtime_release: PreRuntimeReleaseGuard<'a>,
     post_runtime_release: SessionStartGuard<'a>,
     post_prompt_delivery: SessionStartGuard<'a>,
+    ambiguous_prompt_delivery: SessionStartGuard<'a>,
     definitive_failure: SessionStartGuard<'a>,
 }
 
@@ -2152,20 +2153,37 @@ fn start_session_with_create_guard(
             }
         }
     }
-    if created.record.provider_resume.is_none()
-        && let Some(provider_resume) =
-            capture_provider_resume_after_launch(args.agent, &created.record, launch_started_at)
-    {
-        let persisted_before_capture = created.record.clone();
-        created.record.provider_resume = Some(provider_resume);
-        if write_session_record(context, &created.record).is_err() {
-            created.record = load_session_record(context, &created.record.id)
-                .unwrap_or(persisted_before_capture);
-        }
+    let provider_resume_persistence = if prompt_delivery_error.is_some() {
+        ProviderResumePersistence::ReceiptOnly
+    } else {
+        ProviderResumePersistence::BestEffort
+    };
+    capture_and_persist_provider_resume_after_launch(
+        context,
+        args.agent,
+        &mut created.record,
+        launch_started_at,
+        provider_resume_persistence,
+    )?;
+    if prompt_delivery_error.is_some() && created.record.provider_resume.is_none() {
+        capture_and_persist_provider_resume_after_launch(
+            context,
+            args.agent,
+            &mut created.record,
+            launch_started_at,
+            provider_resume_persistence,
+        )?;
     }
-
     let status = session_status(&tmux_bin, &created.record);
-    reconcile_owned_startup_projection(context, &mut created.record, &status);
+    if prompt_delivery_error.is_none() {
+        reconcile_owned_startup_projection(context, &mut created.record, &status);
+    }
+    if prompt_delivery_error.is_some()
+        && let Some(guard) = lifecycle_guards.ambiguous_prompt_delivery.as_mut()
+        && let Err(error) = guard(&created.record)
+    {
+        return Err(error);
+    }
     let result = session_view(context, &created.record, Some(status), Some(&tmux_bin));
     record_workdir_usage(context, &cwd);
     // Keep the app-server bootstrap marker valid for the entire create-lock
@@ -8235,6 +8253,40 @@ fn capture_provider_resume_after_launch(
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProviderResumePersistence {
+    BestEffort,
+    ReceiptOnly,
+}
+
+fn capture_and_persist_provider_resume_after_launch(
+    context: &CliContext,
+    agent: AgentKind,
+    record: &mut SessionRecord,
+    launch_started_at: SystemTime,
+    persistence: ProviderResumePersistence,
+) -> Result<(), CliError> {
+    if record.provider_resume.is_some() {
+        return Ok(());
+    }
+    let Some(provider_resume) =
+        capture_provider_resume_after_launch(agent, record, launch_started_at)
+    else {
+        return Ok(());
+    };
+    let persisted_before_capture = record.clone();
+    record.provider_resume = Some(provider_resume);
+    if persistence == ProviderResumePersistence::ReceiptOnly {
+        pause_session_ancestor_for_test("ambiguous-prompt-after-resume-capture")?;
+        return Ok(());
+    }
+    if write_session_record(context, record).is_ok() {
+        return Ok(());
+    }
+    *record = load_session_record(context, &record.id).unwrap_or(persisted_before_capture);
+    Ok(())
+}
+
 #[derive(Debug)]
 struct CodexResumeCandidate {
     session_id: String,
@@ -11342,6 +11394,9 @@ fn merge_resume_sidecar(path: &Path, record: &mut SessionRecord) -> Result<(), C
     if sidecar.schema_version != SESSION_RESUME_DOCUMENT_VERSION {
         return Ok(());
     }
+    if !resume_sidecar_matches_session_identity(&sidecar, record) {
+        return Ok(());
+    }
     if let Some(provider_resume) = sidecar.provider_resume.clone() {
         if let Some(existing) = record.provider_resume.as_mut() {
             merge_extra_fields(&mut existing.extra, provider_resume.extra);
@@ -11364,6 +11419,37 @@ fn merge_resume_sidecar(path: &Path, record: &mut SessionRecord) -> Result<(), C
     }
     record.resume_sidecar_extra = sidecar.extra;
     Ok(())
+}
+
+fn resume_sidecar_matches_session_identity(
+    sidecar: &DurableResumeRecord,
+    record: &SessionRecord,
+) -> bool {
+    let provider_identity_matches = sidecar
+        .provider_resume
+        .as_ref()
+        .zip(record.provider_resume.as_ref())
+        .is_some_and(|(sidecar, current)| {
+            sidecar.provider == current.provider && sidecar.session_id == current.session_id
+        });
+    let runtime_identity_matches = sidecar
+        .runtime
+        .as_ref()
+        .zip(record.runtime.as_ref())
+        .is_some_and(|(sidecar, current)| same_runtime_identity(Some(sidecar), Some(current)));
+    let never_launched_identity_matches = sidecar
+        .runtime
+        .as_ref()
+        .map(|runtime| runtime.launch_id.as_str())
+        .filter(|launch_id| !launch_id.is_empty())
+        .is_some_and(|launch_id| {
+            record
+                .extra
+                .get(TMUX_RUNTIME_NEVER_LAUNCHED_KEY)
+                .and_then(Value::as_str)
+                == Some(launch_id)
+        });
+    provider_identity_matches || runtime_identity_matches || never_launched_identity_matches
 }
 
 fn merge_extra_fields(target: &mut BTreeMap<String, Value>, source: BTreeMap<String, Value>) {

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -85,6 +85,7 @@ const PROVIDER_STOP_CANARY_STOPPED_FILE: &str = ".provider-stop-canary-stopped.j
 const PROVIDER_STOP_CANARY_RELEASE_FILE: &str = ".provider-stop-canary-release.json";
 const PROVIDER_STOP_CANARY_STARTUP_FAILURE_FILE: &str = ".provider-stop-canary-startup-failed.json";
 const PROVIDER_STOP_CANARY_RUNTIME_FAILURE_FILE: &str = ".provider-stop-canary-runtime-failed.json";
+#[cfg(target_os = "linux")]
 const PROVIDER_STOP_CANARY_CONTROL_SOCKET_PREFIX: &str = "nils-provider-stop-canary-control-";
 const PROVIDER_STOP_CANARY_SUPERVISOR_LOCK_FILE: &str = ".provider-stop-canary-supervisor.lock";
 const PROVIDER_STOP_CANARY_HOLD: Duration = Duration::from_secs(120);
@@ -3270,6 +3271,7 @@ fn current_runtime_helper() -> Result<PathBuf, CliError> {
     Ok(executable)
 }
 
+#[cfg(target_os = "linux")]
 fn configure_provider_stop_canary(
     context: &CliContext,
     record: &mut SessionRecord,
@@ -3279,12 +3281,6 @@ fn configure_provider_stop_canary(
     if !armed {
         return Ok(());
     }
-    #[cfg(not(target_os = "linux"))]
-    return Err(CliError::usage(
-        "provider-stop-canary-platform-unsupported",
-        "the provider stop canary requires Linux exact-process identity evidence",
-        None,
-    ));
     if AgentKind::from_name(&record.agent) != Some(AgentKind::Codex) {
         return Err(CliError::usage(
             "provider-stop-canary-agent-unsupported",
@@ -3324,6 +3320,23 @@ fn configure_provider_stop_canary(
         }),
     );
     write_session_record(context, record)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn configure_provider_stop_canary(
+    _context: &CliContext,
+    _record: &mut SessionRecord,
+    armed: bool,
+    _assignment_id: Option<&str>,
+) -> Result<(), CliError> {
+    if armed {
+        return Err(CliError::usage(
+            "provider-stop-canary-platform-unsupported",
+            "the provider stop canary requires Linux exact-process identity evidence",
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn provider_stop_canary_armed(record: &SessionRecord) -> bool {
@@ -3574,12 +3587,12 @@ pub(crate) fn provider_stop_canary_startup_error(stage: &str, failure_code: &str
     )
 }
 
+#[cfg(target_os = "linux")]
 pub(crate) fn await_provider_stop_canary_startup(
     context: &CliContext,
     record: &SessionRecord,
     timeout: Duration,
 ) -> Result<(u32, u64), CliError> {
-    #[cfg(target_os = "linux")]
     let ((controller_session_id, controller_session_incarnation), address) = {
         let controller = provider_stop_canary_controller_reference(context, record)
             .map_err(|error| provider_stop_canary_startup_error("controller", error.code()))?;
@@ -3601,7 +3614,6 @@ pub(crate) fn await_provider_stop_canary_startup(
                 "provider-stop-canary-startup-timeout",
             ));
         }
-        #[cfg(target_os = "linux")]
         match query_provider_stop_canary_startup(
             context,
             record,
@@ -3616,17 +3628,24 @@ pub(crate) fn await_provider_stop_canary_startup(
                 return Err(provider_stop_canary_startup_error("guardian", error.code()));
             }
         }
-        #[cfg(not(target_os = "linux"))]
-        return Err(provider_stop_canary_startup_error(
-            "controller",
-            "provider-stop-canary-platform-unsupported",
-        ));
         thread::sleep(
             deadline
                 .saturating_duration_since(Instant::now())
                 .min(Duration::from_millis(25)),
         );
     }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn await_provider_stop_canary_startup(
+    _context: &CliContext,
+    _record: &SessionRecord,
+    _timeout: Duration,
+) -> Result<(u32, u64), CliError> {
+    Err(provider_stop_canary_startup_error(
+        "controller",
+        "provider-stop-canary-platform-unsupported",
+    ))
 }
 
 pub(crate) fn provider_stop_canary_startup_wait() -> Duration {
@@ -3821,6 +3840,7 @@ fn acquire_provider_stop_canary_supervisor_lock(
     Ok(file)
 }
 
+#[cfg(target_os = "linux")]
 fn wait_for_provider_stop_canary_wrapper_identity(
     context: &CliContext,
     initial: &SessionRecord,
@@ -3878,6 +3898,19 @@ fn wait_for_provider_stop_canary_wrapper_identity(
     }
 }
 
+#[cfg(not(target_os = "linux"))]
+fn wait_for_provider_stop_canary_wrapper_identity(
+    _context: &CliContext,
+    _initial: &SessionRecord,
+) -> Result<SessionRecord, CliError> {
+    Err(CliError::data(
+        "provider-stop-canary-platform-unsupported",
+        "the provider stop canary wrapper is supported only on Linux",
+        None,
+    ))
+}
+
+#[cfg(target_os = "linux")]
 fn provider_stop_canary_wrapper_identity_wait() -> Duration {
     #[cfg(debug_assertions)]
     if let Ok(value) = env::var("NILS_AGENT_SESSION_TEST_PROVIDER_STOP_CANARY_WRAPPER_IDENTITY_MS")
@@ -6698,6 +6731,23 @@ pub(crate) fn authorize_provider_stop_canary_transition(
     Ok(())
 }
 
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn authorize_provider_stop_canary_transition(
+    _context: &CliContext,
+    _record: &SessionRecord,
+    _controller_session_id: &str,
+    _controller_session_incarnation: &str,
+    _action: &str,
+    _request_digest: &str,
+    _idempotency_key: &str,
+) -> Result<(), CliError> {
+    Err(CliError::data(
+        "provider-stop-canary-platform-unsupported",
+        "provider stop canary transitions are supported only on Linux",
+        None,
+    ))
+}
+
 fn run_provider_stop_canary_supervisor(
     context: &CliContext,
     args: cli::ProviderStopCanarySupervisorArgs,
@@ -7243,6 +7293,7 @@ fn run_provider_stop_canary_guardian(
                         &provider_process_pins,
                         Some(child_pid as libc::pid_t),
                     )?;
+                    #[cfg(target_os = "linux")]
                     remove_empty_provider_stop_canary_cgroup(&provider_cgroup)?;
                     let mut stopped = provider_stop_canary_marker(&record, "stopped", child_pid);
                     stopped["child_exit_success"] = Value::Bool(status.success());
@@ -8022,9 +8073,12 @@ fn run_tmux_new_session(
             Some(json!({ "id": record.id })),
         )
     })?;
+    #[cfg(target_os = "linux")]
     let cgroup_mount = control_group
         .as_ref()
         .and_then(|_| capture_linux_cgroup_mount_identity());
+    #[cfg(not(target_os = "linux"))]
+    let cgroup_mount = None;
     let pid_namespace = linux_process_identity_namespace(pane_pid).map_err(|_| {
         CliError::runtime(
             "tmux-runtime-identity-invalid",
@@ -12892,9 +12946,12 @@ fn capture_tmux_runtime_identity(
     let process_session_id = process_session_id(pane_pid)?;
     let process_session_members = process_session_members(process_session_id, pane_pid)?;
     let control_group = linux_process_control_group(pane_pid)?;
+    #[cfg(target_os = "linux")]
     let cgroup_mount = control_group
         .as_ref()
         .and_then(|_| capture_linux_cgroup_mount_identity());
+    #[cfg(not(target_os = "linux"))]
+    let cgroup_mount = None;
     let pid_namespace = linux_process_identity_namespace(pane_pid)?;
 
     if !tmux_pane_identity_matches(tmux_bin, record, session_id, pane_id, pane_pid, timeout) {
@@ -13045,24 +13102,17 @@ fn linux_process_control_group(
     }
 }
 
+#[cfg(target_os = "linux")]
 fn linux_process_pid_namespace(
     pane_pid: libc::pid_t,
 ) -> Result<Option<TmuxPidNamespaceIdentity>, SessionTerminationFailure> {
-    #[cfg(target_os = "linux")]
-    {
-        let metadata = fs::metadata(format!("/proc/{pane_pid}/ns/pid"))
-            .map_err(|_| SessionTerminationFailure::VerificationFailed)?;
-        Ok(Some(TmuxPidNamespaceIdentity {
-            device: metadata.dev(),
-            inode: metadata.ino(),
-            boot_id: linux_boot_id()?,
-        }))
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = pane_pid;
-        Ok(None)
-    }
+    let metadata = fs::metadata(format!("/proc/{pane_pid}/ns/pid"))
+        .map_err(|_| SessionTerminationFailure::VerificationFailed)?;
+    Ok(Some(TmuxPidNamespaceIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        boot_id: linux_boot_id()?,
+    }))
 }
 
 fn linux_process_identity_namespace(
@@ -17381,6 +17431,35 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
+    fn persist_current_process_as_canary_wrapper(
+        context: &CliContext,
+        id: &str,
+    ) -> super::SessionRecord {
+        let mut record = load_session_record(context, id).expect("canary session record");
+        let current = super::read_linux_process_identity(std::process::id() as libc::pid_t)
+            .expect("current process identity")
+            .expect("live current process");
+        let identity = super::TmuxRuntimeIdentity {
+            launch_id: Some(record.runtime.as_ref().expect("runtime").launch_id.clone()),
+            session_id: "$91".to_string(),
+            pane_id: "%91".to_string(),
+            pane_pid: current.pid,
+            pane_start_time: Some(current.start_time),
+            process_group_id: Some(current.process_group_id),
+            process_session_id: Some(current.session_id),
+            process_session_members: Vec::new(),
+            control_group_members: Vec::new(),
+            control_group: None,
+            cgroup_mount: None,
+            pid_namespace: super::linux_process_pid_namespace(current.pid)
+                .expect("current process PID namespace"),
+        };
+        super::persist_launched_tmux_identity(context, &mut record, &identity)
+            .expect("persist canary wrapper identity");
+        load_session_record(context, id).expect("persisted canary session record")
+    }
+
+    #[cfg(target_os = "linux")]
     #[test]
     fn provider_stop_canary_defers_cgroup_removal_until_children_are_reaped() {
         let tmp = tempfile::TempDir::new().expect("temporary state");
@@ -17391,7 +17470,7 @@ mod tests {
             None,
             Some("provider-stop-canary-deferred-removal"),
         );
-        let record = load_session_record(&context, &id).expect("canary session record");
+        let record = persist_current_process_as_canary_wrapper(&context, &id);
         let cgroup = match super::prepare_provider_stop_canary_cgroup(&context, &record) {
             Ok(cgroup) => cgroup,
             Err(error) if env::var("AGENT_SESSION_TEST_REQUIRE_CGROUP").as_deref() != Ok("1") => {
@@ -17442,7 +17521,7 @@ mod tests {
             None,
             Some("provider-stop-canary-member-injection"),
         );
-        let record = load_session_record(&context, &id).expect("canary session record");
+        let record = persist_current_process_as_canary_wrapper(&context, &id);
         let cgroup = match super::prepare_provider_stop_canary_cgroup(&context, &record) {
             Ok(cgroup) => cgroup,
             Err(error) if env::var("AGENT_SESSION_TEST_REQUIRE_CGROUP").as_deref() != Ok("1") => {

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -3345,14 +3345,26 @@ fn configure_provider_stop_canary(
     armed: bool,
     _assignment_id: Option<&str>,
 ) -> Result<(), CliError> {
-    if armed {
-        return Err(CliError::usage(
-            "provider-stop-canary-platform-unsupported",
-            "the provider stop canary requires Linux exact-process identity evidence",
-            None,
-        ));
+    ensure_provider_stop_canary_platform_supported(armed)
+}
+
+pub(crate) fn ensure_provider_stop_canary_platform_supported(armed: bool) -> Result<(), CliError> {
+    #[cfg(target_os = "linux")]
+    {
+        let _ = armed;
+        Ok(())
     }
-    Ok(())
+    #[cfg(not(target_os = "linux"))]
+    {
+        if armed {
+            return Err(CliError::usage(
+                "provider-stop-canary-platform-unsupported",
+                "the provider stop canary requires Linux exact-process identity evidence",
+                None,
+            ));
+        }
+        Ok(())
+    }
 }
 
 fn provider_stop_canary_armed(record: &SessionRecord) -> bool {

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -65,7 +65,7 @@ const WORKER_PROMPT_OBSERVATION_TIMEOUT: Duration = Duration::from_millis(500);
 const WORKER_PROMPT_OBSERVATION_MAX_READERS: usize = 4;
 static ACTIVE_WORKER_PROMPT_OBSERVATION_READERS: AtomicUsize = AtomicUsize::new(0);
 #[cfg(test)]
-static WORKER_PROMPT_OBSERVATION_STALL_MILLIS_FOR_TEST: AtomicUsize = AtomicUsize::new(0);
+static WORKER_PROMPT_OBSERVATION_BLOCK_FOR_TEST: AtomicUsize = AtomicUsize::new(0);
 const MAIN_AGENT_AFTER_HELP: &str = "SAFE LIFECYCLE:\n  init -> rehydrate/status -> worker start --await-ready -> worker bootstrap\n  worker supervise -> accept -> closeout (retires terminal workers and closes)\n\nMACRO-FIRST RECOVERY:\n  Use worker supervise for repeatable diagnosis. Use self recover only for this\n  exact Main Agent controller's stale broker. Guidance continuity and managed\n  account handoff use their typed worker actions. Use worker reassign only when\n  supervision proves safe reassignment. If a macro stops, continue from its\n  last_proven_safe_state with worker diagnose, submit-recovery, cancel,\n  account-handoff-cancel, retire, or exact closeout replay. Account handoff\n  cancellation requires the current assignment revision and\n  --authorize-account-change. Never resend a prompt or inject an\n  unbounded/manual Enter.\n\nREVISION AND RETRY RULES:\n  Read the current run or assignment revision before each mutation. Retry an\n  ambiguous outcome with the identical request and idempotency key. After a\n  confirmed revision conflict, re-read state and use a new key for the revised\n  request. A partial closeout reuses its original run revision, checkpoint,\n  and key because its progress receipt owns later stage revisions.\n\nEXAMPLES:\n  main-agent init --packet-file objective.json --if-absent --idempotency-key init-001 --format json\n  main-agent self recover --idempotency-key controller-recover-001 --format json\n  main-agent worker start --assignment-file assignment.json --await-ready 5m --idempotency-key start-001 --format json\n  main-agent worker supervise ASSIGNMENT_ID --format json\n  main-agent worker reassign ASSIGNMENT_ID --assignment-file replacement.json --if-revision 3 --reason \"pre-claim bootstrap failure\" --idempotency-key reassign-001 --format json\n  main-agent closeout --if-run-revision 7 --checkpoint-file final.json --idempotency-key closeout-001 --format json\n\nOPERATOR RUNBOOK:\n  crates/agent-session/docs/runbooks/main-agent-orchestration.md\n\nEXIT CODES:\n  0   success\n  1   runtime error\n  64  command-line usage error\n  65  invalid or stale data\n  69  temporarily unavailable";
 
 #[derive(Debug, Parser)]
@@ -6881,12 +6881,8 @@ fn worker_prompt_observed_with_timeout(
         .spawn(move || {
             let _permit = permit;
             #[cfg(test)]
-            {
-                let stall =
-                    WORKER_PROMPT_OBSERVATION_STALL_MILLIS_FOR_TEST.swap(0, Ordering::AcqRel);
-                if stall > 0 {
-                    thread::sleep(Duration::from_millis(stall as u64));
-                }
+            while WORKER_PROMPT_OBSERVATION_BLOCK_FOR_TEST.load(Ordering::Acquire) != 0 {
+                thread::sleep(Duration::from_millis(1));
             }
             let result = worker_prompt_observed_inner(&context, &worker);
             let _ = sender.send(result);
@@ -8915,12 +8911,27 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
     );
     let worker_unreachable =
         assignment.worker.is_some() && matches!(&session_evidence, DiagnosticEvidence::Absent(_));
+    let durable_runtime_status = session_evidence
+        .value()
+        .and_then(|record| crate::coordination_runtime_evidence(record).ok())
+        .map(|evidence| evidence.status);
+    let stopped_runtime_unverified = !cfg!(target_os = "linux")
+        && assignment.worker.is_some()
+        && worker_status == "stopped"
+        && !matches!(
+            durable_runtime_status,
+            Some(
+                crate::CoordinationRuntimeStatus::Stopped
+                    | crate::CoordinationRuntimeStatus::Running
+            )
+        );
     let evidence_unavailable = packet_evidence.is_unavailable_or_mismatched()
         || session_evidence.is_unavailable_or_mismatched()
         || activity_evidence.is_unavailable_or_mismatched()
         || coordination_evidence.is_unavailable_or_mismatched()
         || worktree_unavailable
         || guidance_unavailable
+        || stopped_runtime_unverified
         || raw_rate_limit_diagnostic.is_unavailable();
     let preclaim_blocker = assignment_has_preclaim_blocker(&assignment);
     let terminal_recovery_reconciled =
@@ -8941,10 +8952,6 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
     // tmux query: a live or unknown runtime fails closed, and this is the same
     // combined cgroup/process-session/process-group proof the terminalization
     // re-establishes under the session-record lock.
-    let durable_runtime_status = session_evidence
-        .value()
-        .and_then(|record| crate::coordination_runtime_evidence(record).ok())
-        .map(|evidence| evidence.status);
     let durable_runtime_stopped =
         durable_runtime_status == Some(crate::CoordinationRuntimeStatus::Stopped);
     let durable_runtime_running =
@@ -28662,6 +28669,14 @@ mod tests {
     fn worker_prompt_observation_has_a_fixed_time_and_admission_bound() {
         use std::os::unix::fs::PermissionsExt;
 
+        struct ObservationBlocker;
+
+        impl Drop for ObservationBlocker {
+            fn drop(&mut self) {
+                WORKER_PROMPT_OBSERVATION_BLOCK_FOR_TEST.store(0, Ordering::Release);
+            }
+        }
+
         let temporary = tempfile::TempDir::new().expect("temporary state");
         let context = CliContext {
             state_dir: temporary.path().join("state"),
@@ -28677,16 +28692,13 @@ mod tests {
         fs::set_permissions(&prompt_path, fs::Permissions::from_mode(0o600))
             .expect("private prompt");
         worker.prompt_file = Some(prompt_path.to_string_lossy().into_owned());
-        WORKER_PROMPT_OBSERVATION_STALL_MILLIS_FOR_TEST.store(100, Ordering::Release);
-        let started = Instant::now();
+        WORKER_PROMPT_OBSERVATION_BLOCK_FOR_TEST.store(1, Ordering::Release);
+        let blocker = ObservationBlocker;
         assert_eq!(
             worker_prompt_observed_with_timeout(context, worker, Duration::from_millis(10),),
             None
         );
-        assert!(
-            started.elapsed() < Duration::from_millis(75),
-            "the caller must not wait for the blocked transcript reader"
-        );
+        drop(blocker);
         let deadline = Instant::now() + Duration::from_secs(1);
         while ACTIVE_WORKER_PROMPT_OBSERVATION_READERS.load(Ordering::Acquire) != 0
             && Instant::now() < deadline

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -29019,6 +29019,7 @@ mod tests {
 
     #[test]
     fn worktree_fingerprint_detects_same_status_edits_deletions_and_untracked_material() {
+        let _fixture_ownership = GlobalStateLock::new();
         let temporary = tempfile::TempDir::new().expect("temporary repository");
         let repository = temporary.path();
         git_stdout(repository, &["init", "--quiet"]);
@@ -29072,6 +29073,7 @@ mod tests {
 
     #[test]
     fn worktree_fingerprint_streams_oversize_tracked_patch_for_healthy_supervision() {
+        let _fixture_ownership = GlobalStateLock::new();
         let temporary = tempfile::TempDir::new().expect("temporary repository");
         let repository = temporary.path();
         git_stdout(repository, &["init", "--quiet"]);
@@ -29209,6 +29211,7 @@ mod tests {
 
     #[test]
     fn worktree_fingerprint_streaming_boundaries_and_untracked_aggregate_are_explicit() {
+        let _fixture_ownership = GlobalStateLock::new();
         let temporary = tempfile::TempDir::new().expect("temporary repository");
         let repository = temporary.path();
         git_stdout(repository, &["init", "--quiet"]);
@@ -29301,6 +29304,7 @@ mod tests {
 
     #[test]
     fn worktree_fingerprint_rejects_large_untracked_sets_before_path_walk() {
+        let _fixture_ownership = GlobalStateLock::new();
         let temporary = tempfile::TempDir::new().expect("temporary repository");
         let repository = temporary.path();
         git_stdout(repository, &["init", "--quiet"]);
@@ -29402,6 +29406,7 @@ mod tests {
 
     #[test]
     fn worktree_fingerprint_hashes_1024_small_files_without_per_file_processes() {
+        let _fixture_ownership = GlobalStateLock::new();
         let temporary = tempfile::TempDir::new().expect("temporary repository");
         let repository = temporary.path();
         git_stdout(repository, &["init", "--quiet"]);
@@ -29445,19 +29450,19 @@ mod tests {
         fs::set_permissions(&fake_git, fs::Permissions::from_mode(0o700))
             .expect("file-reader git mode");
 
-        stall_next_fingerprint_file_read_for_test(Duration::from_millis(250));
+        stall_next_fingerprint_file_read_for_test(Duration::from_secs(2));
         let started = Instant::now();
         assert_eq!(
             worktree_material_fingerprint_with_git(
                 repository,
                 b"?? blocked.txt\0",
                 &fake_git,
-                Duration::from_millis(50),
+                Duration::from_millis(500),
             ),
             None
         );
         assert!(
-            started.elapsed() < Duration::from_millis(150),
+            started.elapsed() < Duration::from_secs(1),
             "a stalled regular-file read must not hold supervision past its deadline"
         );
         assert_eq!(
@@ -29465,7 +29470,7 @@ mod tests {
             1,
             "a timed-out reader retains bounded admission until its descriptor work ends"
         );
-        let release_deadline = Instant::now() + Duration::from_secs(1);
+        let release_deadline = Instant::now() + Duration::from_secs(3);
         while ACTIVE_FINGERPRINT_FILE_READERS.load(Ordering::Acquire) != 0
             && Instant::now() < release_deadline
         {
@@ -29480,6 +29485,7 @@ mod tests {
 
     #[test]
     fn worktree_fingerprint_fails_closed_for_oversize_special_path_escape_and_timeout_inputs() {
+        let _fixture_ownership = GlobalStateLock::new();
         use std::ffi::CString;
         use std::os::unix::ffi::OsStrExt;
         use std::os::unix::fs::symlink;

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -3311,6 +3311,7 @@ fn run_worker_start_single_input(
         &request_digest,
         &legacy_request_digest,
     )?;
+    let pending_prompt_outcome_unknown = parse_ambiguous_worker_start_evidence(replay.as_ref())?;
     let pending_start = match replay {
         Some(value) if worker_start_readiness_is_pending(&value) => {
             drop(locked);
@@ -3743,12 +3744,71 @@ fn run_worker_start_single_input(
         renew_worker_start_batch_lane(context, batch_lane)?;
     }
     let existing = match load_session_record(context, &worker_session_id) {
-        Ok(worker) if runtime_is_proven_never_launched(&worker) => {
+        Ok(worker)
+            if pending_prompt_outcome_unknown.is_none()
+                && runtime_is_proven_never_launched(&worker) =>
+        {
             ensure_worker_launch_matches(context, &worker, &launch_input, &replay_prompts)?;
             delete_session(context, &worker_session_id, resolve_tmux_bin(None))?;
             None
         }
-        Ok(worker) => Some(worker),
+        Ok(mut worker) => {
+            if let Some(evidence) = pending_prompt_outcome_unknown.as_ref() {
+                let expected_worker = &evidence.worker;
+                let worker_incarnation = worker
+                    .runtime
+                    .as_ref()
+                    .map(|runtime| runtime.launch_id.as_str())
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| invalid_input("worker session incarnation is unavailable"))?;
+                if session_ref(context, &worker, worker_incarnation) != *expected_worker {
+                    return Err(CliError::data(
+                        "assignment-start-conflict",
+                        "persisted ambiguous worker start changed its exact session evidence",
+                        Some(json!({ "assignment_id": assignment_id })),
+                    ));
+                }
+                if worker.provider_resume.is_none()
+                    && let Some(provider_resume) = evidence.provider_resume.as_ref()
+                {
+                    let expected_worker = expected_worker.clone();
+                    let provider_resume = provider_resume.clone();
+                    worker = crate::mutate_session_record(context, &worker.id, |current| {
+                        let current_incarnation = current
+                            .runtime
+                            .as_ref()
+                            .map(|runtime| runtime.launch_id.as_str())
+                            .filter(|value| !value.is_empty())
+                            .ok_or_else(|| {
+                                invalid_input("worker session incarnation is unavailable")
+                            })?;
+                        if session_ref(context, current, current_incarnation) != expected_worker {
+                            return Err(CliError::data(
+                                "assignment-start-conflict",
+                                "persisted ambiguous worker start changed its exact session evidence",
+                                Some(json!({ "assignment_id": assignment_id })),
+                            ));
+                        }
+                        current.provider_resume = Some(provider_resume);
+                        Ok(current.clone())
+                    })?;
+                    pause_batch_lane_for_test("after_ambiguous_resume_backfill")?;
+                }
+            }
+            Some(worker)
+        }
+        Err(error)
+            if error.code() == "session-not-found" && pending_prompt_outcome_unknown.is_some() =>
+        {
+            return Err(CliError::runtime(
+                "managed-worker-prompt-delivery-outcome-unknown",
+                "the exact ambiguous worker session is unavailable; preserve the transaction and do not redeliver",
+                Some(json!({
+                    "assignment_id": assignment_id,
+                    "worker": pending_prompt_outcome_unknown.map(|evidence| evidence.worker)
+                })),
+            ));
+        }
         Err(error) if error.code() == "session-not-found" => None,
         Err(error) => return Err(error),
     };
@@ -4021,6 +4081,43 @@ fn run_worker_start_single_input(
             )?;
             locked.save()
         };
+        let mut ambiguous_prompt_delivery_guard = |worker: &SessionRecord| {
+            let worker_incarnation = worker
+                .runtime
+                .as_ref()
+                .map(|runtime| runtime.launch_id.as_str())
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| invalid_input("worker session incarnation is unavailable"))?;
+            let expected_worker = session_ref(context, worker, worker_incarnation);
+            ensure_active_claim(context, &record)?;
+            let mut locked = orchestration::lock_registry(context)?;
+            validate_worker_start_authority_locked(
+                &locked.registry,
+                &record,
+                &incarnation,
+                &assignment_id,
+                &worker_session_id,
+                &expected_packet_digest,
+                &args.idempotency_key,
+                &request_digest,
+                &legacy_request_digest,
+                &launch_input.launch.cwd,
+                launch_provider_config_dir.as_deref(),
+                Some(&expected_worker),
+                launch_input.provider_stop_canary.is_some(),
+            )?;
+            store_worker_start_ambiguous_launch_phase_locked(
+                &mut locked.registry,
+                &record,
+                &incarnation,
+                &args.idempotency_key,
+                &request_digest,
+                &legacy_request_digest,
+                &expected_worker,
+                worker.provider_resume.as_ref(),
+            )?;
+            locked.save()
+        };
         let mut definitive_failure_guard = |worker: &SessionRecord| {
             let worker_incarnation = worker
                 .runtime
@@ -4100,62 +4197,13 @@ fn run_worker_start_single_input(
                 pre_runtime_release: pre_runtime_release_guard,
                 post_runtime_release: post_runtime_release_guard,
                 post_prompt_delivery: post_prompt_delivery_guard,
+                ambiguous_prompt_delivery: Some(&mut ambiguous_prompt_delivery_guard),
                 definitive_failure: definitive_failure_guard,
             },
         );
         let started = match started {
             Ok(started) => started,
             Err(error) => {
-                if launch_input.provider_stop_canary.is_some()
-                    && error.code() == "managed-worker-prompt-delivery-outcome-unknown"
-                {
-                    let phase_update = (|| {
-                        let worker = load_session_record(context, &worker_session_id)?;
-                        let worker_incarnation = worker
-                            .runtime
-                            .as_ref()
-                            .map(|runtime| runtime.launch_id.as_str())
-                            .filter(|value| !value.is_empty())
-                            .ok_or_else(|| {
-                                invalid_input("worker session incarnation is unavailable")
-                            })?;
-                        let expected_worker = session_ref(context, &worker, worker_incarnation);
-                        ensure_active_claim(context, &record)?;
-                        let mut locked = orchestration::lock_registry(context)?;
-                        validate_worker_start_authority_locked(
-                            &locked.registry,
-                            &record,
-                            &incarnation,
-                            &assignment_id,
-                            &worker_session_id,
-                            &expected_packet_digest,
-                            &args.idempotency_key,
-                            &request_digest,
-                            &legacy_request_digest,
-                            &launch_input.launch.cwd,
-                            launch_provider_config_dir.as_deref(),
-                            Some(&expected_worker),
-                            true,
-                        )?;
-                        store_worker_start_launch_phase_locked(
-                            &mut locked.registry,
-                            &record,
-                            &incarnation,
-                            &args.idempotency_key,
-                            &request_digest,
-                            &legacy_request_digest,
-                            WORKER_START_PHASE_PROMPT_OUTCOME_UNKNOWN,
-                            Some(&expected_worker),
-                        )?;
-                        locked.save()
-                    })();
-                    if let Err(phase_error) = phase_update {
-                        if let Some(fence) = worker_start_fence.take() {
-                            fence.finish(context, false)?;
-                        }
-                        return Err(phase_error);
-                    }
-                }
                 if let Some(fence) = worker_start_fence.take() {
                     fence.finish(context, false)?;
                 }
@@ -4665,15 +4713,15 @@ fn run_worker_start_single_input(
                         Some(&expected_worker),
                         true,
                     )?;
-                    store_worker_start_launch_phase_locked(
+                    store_worker_start_ambiguous_launch_phase_locked(
                         &mut locked.registry,
                         &record,
                         &incarnation,
                         &args.idempotency_key,
                         &request_digest,
                         &legacy_request_digest,
-                        WORKER_START_PHASE_PROMPT_OUTCOME_UNKNOWN,
-                        Some(&expected_worker),
+                        &expected_worker,
+                        worker_record.provider_resume.as_ref(),
                     )?;
                     locked.save()?;
                     Err(error)
@@ -5969,6 +6017,48 @@ fn worker_start_is_pending(value: &Value) -> bool {
         && value["acceptance"] == "pending"
 }
 
+#[derive(Debug)]
+struct AmbiguousWorkerStartEvidence {
+    worker: SessionRef,
+    provider_resume: Option<crate::ProviderResume>,
+}
+
+fn parse_ambiguous_worker_start_evidence(
+    value: Option<&Value>,
+) -> Result<Option<AmbiguousWorkerStartEvidence>, CliError> {
+    let Some(value) = value.filter(|value| {
+        worker_start_is_pending(value)
+            && value["launch_phase"] == WORKER_START_PHASE_PROMPT_OUTCOME_UNKNOWN
+    }) else {
+        return Ok(None);
+    };
+    let worker = serde_json::from_value::<SessionRef>(value["worker"].clone()).map_err(|_| {
+        CliError::data(
+            "assignment-start-conflict",
+            "persisted ambiguous worker start has no exact session evidence",
+            None,
+        )
+    })?;
+    let provider_resume = match value.get("provider_resume") {
+        None | Some(Value::Null) => None,
+        Some(provider_resume) => Some(
+            serde_json::from_value::<crate::ProviderResume>(provider_resume.clone()).map_err(
+                |_| {
+                    CliError::data(
+                        "assignment-start-conflict",
+                        "persisted ambiguous worker start has invalid resume evidence",
+                        None,
+                    )
+                },
+            )?,
+        ),
+    };
+    Ok(Some(AmbiguousWorkerStartEvidence {
+        worker,
+        provider_resume,
+    }))
+}
+
 const WORKER_START_PHASE_ASSIGNMENT_CREATED: &str = "assignment-created";
 const WORKER_START_PHASE_RUNTIME_HELD: &str = "worker-bound-runtime-held";
 const WORKER_START_PHASE_CANARY_STARTUP_PENDING: &str = "worker-bound-canary-startup-pending";
@@ -6061,6 +6151,36 @@ fn store_worker_start_launch_phase_locked(
     phase: &str,
     worker: Option<&SessionRef>,
 ) -> Result<(), CliError> {
+    if phase == WORKER_START_PHASE_PROMPT_OUTCOME_UNKNOWN {
+        return Err(invalid_input(
+            "ambiguous worker start evidence requires the dedicated receipt writer",
+        ));
+    }
+    store_worker_start_launch_phase_evidence_locked(
+        registry,
+        record,
+        incarnation,
+        idempotency_key,
+        request_digest,
+        legacy_request_digest,
+        phase,
+        worker,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn store_worker_start_launch_phase_evidence_locked(
+    registry: &mut orchestration::Registry,
+    record: &SessionRecord,
+    incarnation: &str,
+    idempotency_key: &str,
+    request_digest: &str,
+    legacy_request_digest: &str,
+    phase: &str,
+    worker: Option<&SessionRef>,
+    provider_resume: Option<&crate::ProviderResume>,
+) -> Result<(), CliError> {
     let mut pending = worker_start_idempotency_replay(
         registry,
         record,
@@ -6079,6 +6199,11 @@ fn store_worker_start_launch_phase_locked(
     })?;
     pending["launch_phase"] = json!(phase);
     pending["worker"] = worker.map_or(Value::Null, |worker| json!(worker));
+    if phase == WORKER_START_PHASE_PROMPT_OUTCOME_UNKNOWN {
+        pending["provider_resume"] = provider_resume.map_or(Value::Null, |resume| json!(resume));
+    } else if let Some(pending) = pending.as_object_mut() {
+        pending.remove("provider_resume");
+    }
     store_receipt(
         registry,
         record,
@@ -6087,6 +6212,30 @@ fn store_worker_start_launch_phase_locked(
         "worker-start",
         request_digest,
         pending,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn store_worker_start_ambiguous_launch_phase_locked(
+    registry: &mut orchestration::Registry,
+    record: &SessionRecord,
+    incarnation: &str,
+    idempotency_key: &str,
+    request_digest: &str,
+    legacy_request_digest: &str,
+    worker: &SessionRef,
+    provider_resume: Option<&crate::ProviderResume>,
+) -> Result<(), CliError> {
+    store_worker_start_launch_phase_evidence_locked(
+        registry,
+        record,
+        incarnation,
+        idempotency_key,
+        request_digest,
+        legacy_request_digest,
+        WORKER_START_PHASE_PROMPT_OUTCOME_UNKNOWN,
+        Some(worker),
+        provider_resume,
     )
 }
 

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -3292,6 +3292,7 @@ fn run_worker_start_single_input(
     validate_idempotency_key(&args.idempotency_key)?;
     let await_ready = parse_await_ready(&args.await_ready)?;
     validate_assignment_input(&input)?;
+    crate::ensure_provider_stop_canary_platform_supported(input.provider_stop_canary.is_some())?;
     let (record, incarnation) = authenticated_self(context)?;
     ensure_active_claim(context, &record)?;
     let (packet_value, request_digest, legacy_request_digest) =

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -29241,7 +29241,9 @@ mod tests {
                      2) size=\"$2\" ;;\n\
                      *) size=\"$1\" ;;\n\
                    esac\n\
-                   head -c \"$size\" /dev/zero\n\
+                   if [ \"$size\" -gt 0 ]; then\n\
+                     head -c \"$size\" /dev/zero\n\
+                   fi\n\
                  fi\n",
                 output_size_file.display()
             ),

--- a/crates/agent-session/src/orchestration.rs
+++ b/crates/agent-session/src/orchestration.rs
@@ -7509,7 +7509,12 @@ mod tests {
 
                         let fifo = CString::new(path.as_os_str().as_bytes())
                             .expect("fifo private target path");
-                        assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), SECRET_FILE_MODE) }, 0);
+                        assert_eq!(
+                            unsafe {
+                                libc::mkfifo(fifo.as_ptr(), SECRET_FILE_MODE as libc::mode_t)
+                            },
+                            0
+                        );
                         let fifo_path = path.to_path_buf();
                         thread::spawn(move || {
                             let deadline = Instant::now() + Duration::from_millis(500);
@@ -7591,7 +7596,12 @@ mod tests {
 
                             let fifo = CString::new(path.as_os_str().as_bytes())
                                 .expect("fifo marker path");
-                            assert_eq!(unsafe { libc::mkfifo(fifo.as_ptr(), SECRET_FILE_MODE) }, 0);
+                            assert_eq!(
+                                unsafe {
+                                    libc::mkfifo(fifo.as_ptr(), SECRET_FILE_MODE as libc::mode_t)
+                                },
+                                0
+                            );
                             let fifo_path = path.to_path_buf();
                             thread::spawn(move || {
                                 let deadline = Instant::now() + Duration::from_millis(500);
@@ -8045,7 +8055,7 @@ mod tests {
         fs::remove_file(&registry).expect("remove registry symlink");
         let registry_c = CString::new(registry.as_os_str().as_bytes()).expect("registry path");
         assert_eq!(
-            unsafe { libc::mkfifo(registry_c.as_ptr(), SECRET_FILE_MODE) },
+            unsafe { libc::mkfifo(registry_c.as_ptr(), SECRET_FILE_MODE as libc::mode_t) },
             0,
             "create registry fifo fixture"
         );
@@ -8104,7 +8114,9 @@ mod tests {
                     let rollback_c =
                         CString::new(rollback.as_os_str().as_bytes()).expect("rollback path");
                     assert_eq!(
-                        unsafe { libc::mkfifo(rollback_c.as_ptr(), SECRET_FILE_MODE) },
+                        unsafe {
+                            libc::mkfifo(rollback_c.as_ptr(), SECRET_FILE_MODE as libc::mode_t)
+                        },
                         0,
                         "create rollback fifo fixture"
                     );
@@ -8160,7 +8172,9 @@ mod tests {
                     let rollback_c =
                         CString::new(rollback.as_os_str().as_bytes()).expect("rollback path");
                     assert_eq!(
-                        unsafe { libc::mkfifo(rollback_c.as_ptr(), SECRET_FILE_MODE) },
+                        unsafe {
+                            libc::mkfifo(rollback_c.as_ptr(), SECRET_FILE_MODE as libc::mode_t)
+                        },
                         0,
                         "replacement rollback fifo"
                     );

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -14522,7 +14522,7 @@ case "$1" in
     ;;
   if-shell)
     pid="$(cat {pane_pid})"
-    kill -KILL "-$pid" 2>/dev/null || true
+    kill -KILL "$pid" 2>/dev/null || true
     rm -f {running}
     ;;
   kill-session)

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -22309,34 +22309,65 @@ exit 0
                 serde_json::to_vec(&request).expect("operator request"),
             ))
             .expect("operator request");
+        #[cfg(not(target_os = "linux"))]
+        let before_operator =
+            fs::read(&registry_path).expect("registry before operator reconciliation");
         let (status, reconciled) = call(router(state.clone()), operator_request).await;
-        assert_eq!(status, StatusCode::OK, "{reconciled}");
-        assert_eq!(
-            reconciled["data"]["coordination"]["operation_reconciliation"]["state"],
-            "abandoned"
-        );
-        assert_eq!(
-            reconciled["data"]["coordination"]["operation_reconciliation"]["revision"],
-            8
-        );
         assert!(
             !reconciled
                 .to_string()
                 .contains("PRIVATE-EXECUTION-TOKEN-DIGEST")
         );
-
-        let replay = Request::builder()
-            .method("POST")
-            .uri("/sessions/alpha/operations/orphaned-lease/operator-reconcile/v1")
-            .header(AUTHORIZATION, format!("Bearer {TOKEN}"))
-            .header("content-type", "application/json")
-            .body(Body::from(
-                serde_json::to_vec(&request).expect("operator replay"),
-            ))
-            .expect("operator replay");
-        let (status, replayed) = call(router(state), replay).await;
-        assert_eq!(status, StatusCode::OK, "{replayed}");
-        assert_eq!(replayed, reconciled);
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{reconciled}");
+            assert_eq!(reconciled["error"]["code"], "operation-still-running");
+            assert_eq!(
+                fs::read(&registry_path).expect("registry after unverified reconciliation"),
+                before_operator,
+                "unknown non-Linux runtime evidence must not mutate the operation"
+            );
+            let replay = Request::builder()
+                .method("POST")
+                .uri("/sessions/alpha/operations/orphaned-lease/operator-reconcile/v1")
+                .header(AUTHORIZATION, format!("Bearer {TOKEN}"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&request).expect("operator replay"),
+                ))
+                .expect("operator replay");
+            let (replay_status, replayed) = call(router(state), replay).await;
+            assert_eq!(
+                replay_status,
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "{replayed}"
+            );
+            assert_eq!(replayed, reconciled);
+        }
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(status, StatusCode::OK, "{reconciled}");
+            assert_eq!(
+                reconciled["data"]["coordination"]["operation_reconciliation"]["state"],
+                "abandoned"
+            );
+            assert_eq!(
+                reconciled["data"]["coordination"]["operation_reconciliation"]["revision"],
+                8
+            );
+            let replay = Request::builder()
+                .method("POST")
+                .uri("/sessions/alpha/operations/orphaned-lease/operator-reconcile/v1")
+                .header(AUTHORIZATION, format!("Bearer {TOKEN}"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&request).expect("operator replay"),
+                ))
+                .expect("operator replay");
+            let (replay_status, replayed) = call(router(state), replay).await;
+            assert_eq!(replay_status, StatusCode::OK, "{replayed}");
+            assert_eq!(replayed, reconciled);
+        }
     }
 
     #[tokio::test]

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -14504,6 +14504,9 @@ case "$1" in
   display-message)
     printf '%s\t%s\t%s\n' '$77' '%77' "$(cat {pane_pid})"
     ;;
+  kill-session)
+    rm -f {running}
+    ;;
   *) exit 0 ;;
 esac
 "#,

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -8762,19 +8762,35 @@ mod tests {
             self.child.as_ref().expect("live test child").id()
         }
 
-        fn wait_for_exit(&mut self, timeout: Duration) -> bool {
-            let started_at = Instant::now();
-            loop {
-                match self.child.as_mut().expect("test child").try_wait() {
-                    Ok(Some(_)) => {
-                        self.child.take();
-                        return true;
+        fn into_background_reaper(mut self) -> TestProcessReaper {
+            let mut child = self.child.take().expect("live test child");
+            let process_group_id = self.process_group_id;
+            let (cleanup, cleanup_requested) = std::sync::mpsc::channel();
+            TestProcessReaper {
+                cleanup,
+                reaper: Some(std::thread::spawn(move || {
+                    loop {
+                        match child.try_wait() {
+                            Ok(Some(status)) => return Ok(status),
+                            Err(error) => return Err(error),
+                            Ok(None) => {}
+                        }
+                        match cleanup_requested.recv_timeout(Duration::from_millis(10)) {
+                            Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                                if let Some(status) = child.try_wait()? {
+                                    return Ok(status);
+                                }
+                                // SAFETY: this thread still owns the live leader of
+                                // the dedicated test-only process group.
+                                unsafe {
+                                    libc::kill(-process_group_id, libc::SIGKILL);
+                                }
+                                return child.wait();
+                            }
+                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                        }
                     }
-                    Ok(None) if started_at.elapsed() < timeout => {
-                        std::thread::sleep(Duration::from_millis(10));
-                    }
-                    Ok(None) | Err(_) => return false,
-                }
+                })),
             }
         }
     }
@@ -8789,6 +8805,38 @@ mod tests {
                 libc::kill(-self.process_group_id, libc::SIGKILL);
             }
             let _ = child.wait();
+        }
+    }
+
+    struct TestProcessReaper {
+        cleanup: std::sync::mpsc::Sender<()>,
+        reaper: Option<std::thread::JoinHandle<io::Result<std::process::ExitStatus>>>,
+    }
+
+    impl TestProcessReaper {
+        fn wait_for_exit(&mut self, timeout: Duration) -> bool {
+            let started_at = Instant::now();
+            while self
+                .reaper
+                .as_ref()
+                .is_some_and(|reaper| !reaper.is_finished())
+                && started_at.elapsed() < timeout
+            {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            let Some(reaper) = self.reaper.take_if(|reaper| reaper.is_finished()) else {
+                return false;
+            };
+            matches!(reaper.join(), Ok(Ok(_)))
+        }
+    }
+
+    impl Drop for TestProcessReaper {
+        fn drop(&mut self) {
+            if let Some(reaper) = self.reaper.take() {
+                let _ = self.cleanup.send(());
+                let _ = reaper.join();
+            }
         }
     }
 
@@ -14587,8 +14635,12 @@ esac
         assert_eq!(stopped["cwd"], cwd.to_string_lossy().as_ref());
         assert_eq!(stopped["agent_profile"], "codex-profile");
 
-        let mut resumed_pane = TestProcessGroup::spawn();
+        let resumed_pane = TestProcessGroup::spawn();
         fs::write(&pane_pid, resumed_pane.pid().to_string()).unwrap();
+        // Real tmux reaps its pane child after kill-session. Keep a concurrent
+        // waiter so macOS does not report the terminated child as a live zombie
+        // process group while the resume path verifies the boundary is empty.
+        let mut resumed_pane = resumed_pane.into_background_reaper();
         let (resume_status, resume_body) = call(
             router(st),
             post_json("/sessions/fresh-profile/resume", Some(TOKEN), json!({})),

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -22034,7 +22034,7 @@ exit 0
             .expect("alpha runtime")
             .launch_id
             .clone();
-        let mut stopped_runtime = json!({
+        let stopped_runtime = json!({
             "launch_id": incarnation,
             "session_id": "$77",
             "pane_id": "%77",
@@ -22042,7 +22042,8 @@ exit 0
             "process_group_id": i32::MAX
         });
         #[cfg(target_os = "linux")]
-        {
+        let stopped_runtime = {
+            let mut stopped_runtime = stopped_runtime;
             let namespace = fs::metadata("/proc/self/ns/pid").expect("PID namespace metadata");
             stopped_runtime["pid_namespace"] = json!({
                 "device": namespace.st_dev(),
@@ -22051,7 +22052,8 @@ exit 0
                     .expect("boot id")
                     .trim()
             });
-        }
+            stopped_runtime
+        };
         alpha
             .extra
             .insert("delete_tmux_identity".to_string(), stopped_runtime);

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -14511,7 +14511,7 @@ esac
     }
 
     #[tokio::test]
-    async fn fresh_profile_session_stops_and_resumes_with_its_durable_context() {
+    async fn fresh_profile_session_resume_preserves_context_or_fails_closed_without_proof() {
         let tmp = tempfile::TempDir::new().unwrap();
         let cwd = tmp.path().join("worktrees/issue-362");
         let config_dir = tmp.path().join("codex-profile");
@@ -14646,16 +14646,6 @@ esac
             post_json("/sessions/fresh-profile/resume", Some(TOKEN), json!({})),
         )
         .await;
-        assert_eq!(resume_status, StatusCode::OK, "body={resume_body}");
-        assert_eq!(
-            resume_body["data"]["session"]["cwd"],
-            cwd.to_string_lossy().as_ref()
-        );
-        assert_eq!(
-            resume_body["data"]["session"]["agent_profile"],
-            "codex-profile"
-        );
-
         let calls = fs::read_to_string(log).unwrap();
         assert_eq!(
             calls
@@ -14681,28 +14671,70 @@ esac
             calls.contains("resume fresh-provider-id"),
             "managed resume must use the captured provider id: {calls:?}"
         );
-        let terminate = ProcessCommand::new(&tmux)
-            .args([
-                "if-shell",
-                "-F",
-                "-t",
-                "%77",
-                "true",
-                "kill-session -t $77",
-                "false",
-            ])
-            .status()
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert_eq!(
+                resume_status,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "body={resume_body}"
+            );
+            assert_eq!(
+                resume_body["error"]["code"],
+                "coordination-runtime-unverified"
+            );
+            assert!(
+                resumed_pane.wait_for_exit(Duration::from_secs(1)),
+                "failed-launch cleanup must reap the replacement pane"
+            );
+            assert!(
+                !running.exists(),
+                "failed-launch cleanup must clear tmux liveness"
+            );
+            let retained: Value = serde_json::from_str(
+                &fs::read_to_string(tmp.path().join("sessions/fresh-profile/session.json"))
+                    .unwrap(),
+            )
             .unwrap();
-        assert!(terminate.success());
-        assert!(
-            resumed_pane.wait_for_exit(Duration::from_secs(1)),
-            "identity-bound fixture termination must stop the pane process group"
-        );
-        assert!(
-            !running.exists(),
-            "identity-bound fixture termination must clear tmux liveness"
-        );
-        drop(resumed_pane);
+            assert_eq!(retained["cwd"], cwd.to_string_lossy().as_ref());
+            assert_eq!(retained["runtime"]["agent_profile"], "codex-profile");
+            assert_eq!(
+                retained["provider_resume"]["session_id"],
+                "fresh-provider-id"
+            );
+        }
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(resume_status, StatusCode::OK, "body={resume_body}");
+            assert_eq!(
+                resume_body["data"]["session"]["cwd"],
+                cwd.to_string_lossy().as_ref()
+            );
+            assert_eq!(
+                resume_body["data"]["session"]["agent_profile"],
+                "codex-profile"
+            );
+            let terminate = ProcessCommand::new(&tmux)
+                .args([
+                    "if-shell",
+                    "-F",
+                    "-t",
+                    "%77",
+                    "true",
+                    "kill-session -t $77",
+                    "false",
+                ])
+                .status()
+                .unwrap();
+            assert!(terminate.success());
+            assert!(
+                resumed_pane.wait_for_exit(Duration::from_secs(1)),
+                "identity-bound fixture termination must stop the pane process group"
+            );
+            assert!(
+                !running.exists(),
+                "identity-bound fixture termination must clear tmux liveness"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -8761,6 +8761,22 @@ mod tests {
         fn pid(&self) -> u32 {
             self.child.as_ref().expect("live test child").id()
         }
+
+        fn wait_for_exit(&mut self, timeout: Duration) -> bool {
+            let started_at = Instant::now();
+            loop {
+                match self.child.as_mut().expect("test child").try_wait() {
+                    Ok(Some(_)) => {
+                        self.child.take();
+                        return true;
+                    }
+                    Ok(None) if started_at.elapsed() < timeout => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Ok(None) | Err(_) => return false,
+                }
+            }
+        }
     }
 
     impl Drop for TestProcessGroup {
@@ -14504,6 +14520,11 @@ case "$1" in
   display-message)
     printf '%s\t%s\t%s\n' '$77' '%77' "$(cat {pane_pid})"
     ;;
+  if-shell)
+    pid="$(cat {pane_pid})"
+    /bin/kill -KILL -- "-$pid" 2>/dev/null || true
+    rm -f {running}
+    ;;
   kill-session)
     rm -f {running}
     ;;
@@ -14529,7 +14550,7 @@ esac
             .to_string(),
         )
         .unwrap();
-        let mut st = state(tmp.path(), Some(TOKEN), tmux);
+        let mut st = state(tmp.path(), Some(TOKEN), tmux.clone());
         Arc::get_mut(&mut st).unwrap().launch_profiles = profiles;
         let first_pane = TestProcessGroup::spawn();
         fs::write(&pane_pid, first_pane.pid().to_string()).unwrap();
@@ -14566,7 +14587,7 @@ esac
         assert_eq!(stopped["cwd"], cwd.to_string_lossy().as_ref());
         assert_eq!(stopped["agent_profile"], "codex-profile");
 
-        let resumed_pane = TestProcessGroup::spawn();
+        let mut resumed_pane = TestProcessGroup::spawn();
         fs::write(&pane_pid, resumed_pane.pid().to_string()).unwrap();
         let (resume_status, resume_body) = call(
             router(st),
@@ -14607,6 +14628,27 @@ esac
         assert!(
             calls.contains("resume fresh-provider-id"),
             "managed resume must use the captured provider id: {calls:?}"
+        );
+        let terminate = ProcessCommand::new(&tmux)
+            .args([
+                "if-shell",
+                "-F",
+                "-t",
+                "%77",
+                "true",
+                "kill-session -t $77",
+                "false",
+            ])
+            .status()
+            .unwrap();
+        assert!(terminate.success());
+        assert!(
+            resumed_pane.wait_for_exit(Duration::from_secs(1)),
+            "identity-bound fixture termination must stop the pane process group"
+        );
+        assert!(
+            !running.exists(),
+            "identity-bound fixture termination must clear tmux liveness"
         );
         drop(resumed_pane);
     }

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -14522,7 +14522,7 @@ case "$1" in
     ;;
   if-shell)
     pid="$(cat {pane_pid})"
-    /bin/kill -KILL -- "-$pid" 2>/dev/null || true
+    kill -KILL "-$pid" 2>/dev/null || true
     rm -f {running}
     ;;
   kill-session)

--- a/crates/agent-session/tests/integration/cli.rs
+++ b/crates/agent-session/tests/integration/cli.rs
@@ -2682,7 +2682,7 @@ fn codex_activity_doctor_accepts_the_converged_agent_hook_control_plane() {
         &hook,
         r#"#!/usr/bin/env sh
 test "$*" = "doctor --product codex --format json" || exit 64
-printf '%s\n' '{"schema_version":"cli.agent-hook.doctor.v1","ok":true,"data":[{"schema_version":"agent-hook.doctor.v1","product":"codex","status":"converged","supported":true,"owned_count":7,"expected_owned_count":7,"legacy_residue_count":0,"unrelated_count":0,"config_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","recovery":"challenge-authorize-consume"}]}'
+printf '%s\n' '{"schema_version":"cli.agent-hook.doctor.v1","ok":true,"data":[{"schema_version":"agent-hook.doctor.v1","product":"codex","status":"converged","supported":true,"owned_count":7,"expected_owned_count":7,"legacy_residue_count":0,"unrelated_count":0,"config_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","recovery":"challenge-authorize-consume"}]}' # stale-audit: keep-contract
 "#,
     );
     let codex_bin = tmp.path().join("codex");
@@ -2743,7 +2743,7 @@ exit "${AGENT_HOOK_EXIT_CODE:-0}"
             "supported":true,
             "owned_count":7,
             "expected_owned_count":7,
-            "legacy_residue_count":0,
+            "legacy_residue_count":0, // stale-audit: keep-contract
             "unrelated_count":0,
             "config_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             "policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
@@ -2819,7 +2819,7 @@ exit "${AGENT_HOOK_EXIT_CODE:-0}"
         None,
     ));
     let mut residue_case = valid;
-    residue_case["data"][0]["legacy_residue_count"] = json!(1);
+    residue_case["data"][0]["legacy_residue_count"] = json!(1); // stale-audit: keep-contract
     cases.push(("retired-residue", residue_case.to_string(), "0", None));
 
     for (name, response, exit_code, expected_error) in cases {
@@ -2866,7 +2866,7 @@ fn codex_activity_doctor_rejects_agent_hook_output_beyond_the_strict_cap() {
     write_executable(
         &hook,
         r#"#!/usr/bin/env sh
-printf '%s\n' '{"schema_version":"cli.agent-hook.doctor.v1","ok":true,"data":[{"schema_version":"agent-hook.doctor.v1","product":"codex","status":"converged","supported":true,"owned_count":7,"expected_owned_count":7,"legacy_residue_count":0,"unrelated_count":0,"config_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","recovery":"challenge-authorize-consume"}]}'
+printf '%s\n' '{"schema_version":"cli.agent-hook.doctor.v1","ok":true,"data":[{"schema_version":"agent-hook.doctor.v1","product":"codex","status":"converged","supported":true,"owned_count":7,"expected_owned_count":7,"legacy_residue_count":0,"unrelated_count":0,"config_digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","policy_digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","recovery":"challenge-authorize-consume"}]}' # stale-audit: keep-contract
 dd if=/dev/zero bs=1048577 count=1 2>/dev/null | tr '\000' ' '
 printf '%s\n' '{"schema_version":"cli.agent-hook.doctor.v1","ok":false}'
 "#,

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -17336,7 +17336,23 @@ fn main_agent_post_claim_stopped_worker_fails_closed_without_exact_runtime_proof
             data(&observed)["recovery_action"]["kind"],
             "identity_evidence_reconciliation"
         );
-        assert_eq!(data(&observed)["recovery_action"]["executable"], false);
+        assert_eq!(
+            data(&observed)["recovery_action"]["executable"],
+            true,
+            "the bounded read-only supervision recheck remains safe to execute"
+        );
+        assert_eq!(
+            data(&observed)["recovery_action"]["argv"],
+            json!([
+                "main-agent",
+                "worker",
+                "supervise",
+                "assignment-stopped",
+                "--format",
+                "json"
+            ]),
+            "fail-closed diagnosis must not advertise a mutating recovery command"
+        );
     };
     for command in ["supervise", "diagnose"] {
         assert_fail_closed_diagnosis(command);

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -1225,6 +1225,7 @@ fn load_coordination_registry(state_dir: &Path) -> serde_json::Value {
     .expect("coordination registry json")
 }
 
+#[cfg(target_os = "linux")]
 fn released_v1_claim_renew_fixture(state_dir: &Path, session_id: &str) -> Result<(), &'static str> {
     let path = state_dir.join("coordination/registry.json");
     let bytes = fs::read(&path).map_err(|_| "unavailable")?;
@@ -16265,6 +16266,7 @@ fn main_agent_failed_preclaim_worker_is_cancelled_retired_and_reassigned_in_isol
     );
 }
 
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 struct StoppedPostClaimFixture {
     _tmp: tempfile::TempDir,
     state_dir: PathBuf,
@@ -16672,6 +16674,7 @@ impl StoppedPostClaimFixture {
         )
     }
 
+    #[cfg(target_os = "linux")]
     fn spawn_claimed_runtime_stop_at_fence_activation_barrier(
         &self,
         runtime: &TestProcessGroup,
@@ -17067,6 +17070,60 @@ fn claimed_runtime_stop_rejects_insufficient_controller_claim_ttl_before_reserva
 }
 
 #[test]
+#[cfg(not(target_os = "linux"))]
+fn claimed_runtime_stop_fails_closed_without_exact_stopped_runtime_proof() {
+    let fixture = StoppedPostClaimFixture::new();
+    seed_activity_state(
+        &fixture.state_dir,
+        "worker-stopped",
+        "worker-stopped-incarnation",
+        "waiting",
+        serde_json::Value::Null,
+        json!({
+            "provider_turn_id": "claimed-stop-non-linux-proof",
+            "started_at": "2030-01-01T00:00:00Z",
+            "completed_at": "2030-01-01T00:00:01Z",
+            "outcome": "completed"
+        }),
+    );
+    let runtime = seed_live_runtime_identity(
+        &fixture.state_dir,
+        "worker-stopped",
+        "worker-stopped-incarnation",
+        91,
+    );
+
+    let stopped = fixture.run_claimed_runtime_stop(&runtime, "claimed-stop-non-linux-proof-0001");
+    assert_eq!(stopped.code, 1, "outcome={}", stopped.stdout_text());
+    assert_eq!(
+        stopped.stdout_json()["error"]["code"],
+        "coordination-runtime-unverified"
+    );
+    assert!(
+        !runtime.is_running(),
+        "tmux termination may stop the pane without creating exact coordination proof"
+    );
+    let registry = orchestration_registry(&fixture.state_dir);
+    assert_eq!(
+        registry["assignments"]["assignment-stopped"]["state"], "working",
+        "unverified non-Linux absence must not advance the assignment"
+    );
+    assert!(
+        load_coordination_registry(&fixture.state_dir)["claims"]
+            .as_array()
+            .expect("claims")
+            .iter()
+            .any(|claim| {
+                claim["session_id"] == "worker-stopped"
+                    && claim["session_incarnation"] == "worker-stopped-incarnation"
+                    && claim["state"] == "active"
+            }),
+        "unverified non-Linux absence must preserve the active worker claim"
+    );
+}
+
+#[test]
+#[cfg(target_os = "linux")]
 fn claimed_runtime_stop_identity_only_interruption_projects_exact_replay() {
     let fixture = StoppedPostClaimFixture::new();
     seed_activity_state(
@@ -17412,6 +17469,7 @@ fn claimed_runtime_stop_refuses_controller_claim_drift_before_runtime_stop() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn claimed_runtime_stop_fences_exact_claim_mutation_without_blocking_unrelated_coordination() {
     let fixture = StoppedPostClaimFixture::new();
     seed_activity_state(
@@ -17607,6 +17665,7 @@ fn claimed_runtime_stop_fences_exact_claim_mutation_without_blocking_unrelated_c
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn claimed_runtime_stop_v2_activation_is_fail_closed_at_every_crash_boundary() {
     for stage in [
         "after_registry_v2",
@@ -17705,6 +17764,7 @@ fn claimed_runtime_stop_v2_activation_is_fail_closed_at_every_crash_boundary() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn claimed_runtime_stop_reacquires_process_owned_fence_after_owner_crash() {
     let fixture = StoppedPostClaimFixture::new();
     seed_activity_state(
@@ -17895,6 +17955,7 @@ fn claimed_runtime_stop_refuses_expired_authority_at_termination_boundary() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn claimed_runtime_stop_waiter_replays_terminal_result_after_assignment_advances() {
     let fixture = StoppedPostClaimFixture::new();
     seed_activity_state(
@@ -18007,6 +18068,7 @@ fn claimed_runtime_stop_waiter_replays_terminal_result_after_assignment_advances
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn claimed_runtime_stop_replay_degrades_safely_after_stopped_claim_expires() {
     let fixture = StoppedPostClaimFixture::new();
     seed_activity_state(
@@ -18112,6 +18174,7 @@ fn claimed_runtime_stop_replay_degrades_safely_after_stopped_claim_expires() {
     assert_eq!(data(&reconciled)["worker_claim_active_after"], false);
 }
 
+#[cfg(target_os = "linux")]
 fn assert_claimed_runtime_stop_pending_successor_loss(stage: &str) {
     let fixture = StoppedPostClaimFixture::new();
     seed_activity_state(
@@ -18364,6 +18427,7 @@ fn assert_claimed_runtime_stop_pending_successor_loss(stage: &str) {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn claimed_runtime_stop_successor_adopt_reconcile_and_delete_preserve_lineage() {
     for stage in [
         "after_identity",
@@ -18375,6 +18439,7 @@ fn claimed_runtime_stop_successor_adopt_reconcile_and_delete_preserve_lineage() 
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn claimed_runtime_stop_preserves_the_active_claim_for_reconcile_stopped() {
     let fixture = StoppedPostClaimFixture::new();
     seed_activity_state(
@@ -21760,6 +21825,7 @@ fn post_json_over_http(address: &str, path: &str, token: &str) -> serde_json::Va
     serde_json::from_slice(body).expect("HTTP JSON response")
 }
 
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 struct ExhaustedReadinessRuntimeStopFixture {
     tmp: tempfile::TempDir,
     state_dir: PathBuf,
@@ -22221,6 +22287,33 @@ fn runtime_stop_projects_typed_executable_action() {
 }
 
 #[test]
+#[cfg(not(target_os = "linux"))]
+fn runtime_stop_fails_closed_without_exact_stopped_runtime_proof() {
+    let fixture = ExhaustedReadinessRuntimeStopFixture::new();
+    let stopped = run_main_agent(
+        &fixture.main_checkout,
+        &fixture.stop_args(),
+        &fixture.envs(),
+    );
+
+    assert_eq!(stopped.code, 1, "outcome={}", stopped.stdout_text());
+    assert_eq!(
+        stopped.stdout_json()["error"]["code"],
+        "coordination-runtime-unverified"
+    );
+    assert!(
+        !fixture.runtime.is_running(),
+        "tmux termination may stop the pane without creating exact coordination proof"
+    );
+    let registry = orchestration_registry(&fixture.state_dir);
+    assert_eq!(
+        registry["assignments"]["assignment-exhausted"]["state"], "starting",
+        "unverified non-Linux absence must not advance the assignment"
+    );
+}
+
+#[test]
+#[cfg(target_os = "linux")]
 fn runtime_stop_marker_first_crash_fences_worker_claim_and_is_adoptable() {
     let fixture = ExhaustedReadinessRuntimeStopFixture::new();
     let barrier = fixture.tmp.path().join("runtime-stop-marker-first");
@@ -22381,6 +22474,7 @@ fn runtime_stop_releases_global_registries_after_authority_seal() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn runtime_stop_crash_after_authority_seal_replays_exactly() {
     let fixture = ExhaustedReadinessRuntimeStopFixture::new();
     let barrier = fixture.tmp.path().join("runtime-stop-sealed-crash");
@@ -22419,6 +22513,7 @@ fn runtime_stop_crash_after_authority_seal_replays_exactly() {
     assert!(!fixture.runtime.is_running());
 }
 
+#[cfg(target_os = "linux")]
 fn assert_runtime_stop_orphan_recovery(stage: &str) {
     let fixture = ExhaustedReadinessRuntimeStopFixture::new();
     let barrier = fixture
@@ -22480,16 +22575,19 @@ fn assert_runtime_stop_orphan_recovery(stage: &str) {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn runtime_stop_orphan_after_authority_seal_transfers_exact_replay() {
     assert_runtime_stop_orphan_recovery("after_authority_seal");
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn runtime_stop_orphan_after_process_stop_transfers_finalization_only() {
     assert_runtime_stop_orphan_recovery("after_runtime_stop");
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn runtime_stop_partial_fence_rebind_survives_pending_successor_loss() {
     let fixture = ExhaustedReadinessRuntimeStopFixture::new();
     let stop_barrier = fixture.tmp.path().join("runtime-stop-repeat-orphan");
@@ -22628,6 +22726,7 @@ fn runtime_stop_partial_fence_rebind_survives_pending_successor_loss() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn runtime_stop_crash_after_process_stop_finalizes_without_second_kill() {
     let fixture = ExhaustedReadinessRuntimeStopFixture::new();
     let barrier = fixture.tmp.path().join("runtime-stop-process-stopped");
@@ -22662,6 +22761,7 @@ fn runtime_stop_crash_after_process_stop_finalizes_without_second_kill() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn runtime_stop_then_cancel_keeps_completed_replay_stable() {
     let fixture = ExhaustedReadinessRuntimeStopFixture::new();
     let stopped = run_main_agent(

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, OpenOptions};
-#[cfg(target_os = "linux")]
 use std::io::Read;
 use std::io::Write;
 #[cfg(target_os = "linux")]
@@ -8764,41 +8763,33 @@ fn main_agent_worker_start_preserves_ambiguous_initial_enter_without_redelivery(
     let codex_home = tmp.path().join("codex-home");
     let codex_session = codex_home.join("sessions/2026/07/26/session.jsonl");
     let assignment_path = tmp.path().join("assignment-ambiguous-enter.json");
-    write_private_json(
-        &assignment_path,
-        &json!({
-            "schema_version": "main-agent.assignment-input.v1",
-            "assignment_id": "assignment-ambiguous-enter",
-            "task_summary": "Preserve an ambiguous initial Enter",
-            "task": {},
-            "launch": {
-                "agent": "codex",
-                "cwd": checkout,
-                "title": null,
-                "session_id": "worker-ambiguous-enter",
-                "coordination_mode": "enforce",
-                "agent_args": []
-            },
-            "repository": "example/repository",
-            "worktree": null,
-            "base_ref": "main",
-            "scopes": ["crates/agent-session"],
-            "durable_refs": [],
-            "provider_stop_canary": {
-                "schema_version": "main-agent.provider-process-stop-canary.v1"
-            }
-        }),
-    );
+    let assignment = json!({
+        "schema_version": "main-agent.assignment-input.v1",
+        "assignment_id": "assignment-ambiguous-enter",
+        "task_summary": "Preserve an ambiguous initial Enter",
+        "task": {},
+        "launch": {
+            "agent": "codex",
+            "cwd": checkout,
+            "title": null,
+            "session_id": "worker-ambiguous-enter",
+            "coordination_mode": "enforce",
+            "agent_args": []
+        },
+        "repository": "example/repository",
+        "worktree": null,
+        "base_ref": "main",
+        "scopes": ["crates/agent-session"],
+        "durable_refs": []
+    });
+    write_private_json(&assignment_path, &assignment);
     write_trusted_codex_config(&codex_home, &[&checkout]);
     let state_arg = state_dir.to_string_lossy().into_owned();
     let tmux_arg = tmux_bin.to_string_lossy().into_owned();
     let tmux_log_arg = tmux_log.to_string_lossy().into_owned();
     let codex_arg = codex_bin.to_string_lossy().into_owned();
     let codex_home_arg = codex_home.to_string_lossy().into_owned();
-    let codex_session_arg = codex_session.to_string_lossy().into_owned();
-    let checkout_arg = checkout.to_string_lossy().into_owned();
     let fail_once_dir = tmp.path().join("fail-after-initial-enter-once");
-    let fail_once_arg = fail_once_dir.to_string_lossy().into_owned();
     let args = [
         "--state-dir",
         state_arg.as_str(),
@@ -8813,34 +8804,84 @@ fn main_agent_worker_start_preserves_ambiguous_initial_enter_without_redelivery(
         "--format",
         "json",
     ];
-    let failed = run_main_agent(
-        &checkout,
-        &args,
-        &[
-            ("AGENT_SESSION_CAPABILITY_FILE", main_capability.as_str()),
-            ("AGENT_SESSION_TMUX_BIN", tmux_arg.as_str()),
-            ("AGENT_SESSION_CODEX_BIN", codex_arg.as_str()),
-            ("AGENT_SESSION_FAKE_TMUX_LOG", tmux_log_arg.as_str()),
-            ("CODEX_HOME", codex_home_arg.as_str()),
-            (
-                "AGENT_SESSION_FAKE_CODEX_SESSION_FILE",
-                codex_session_arg.as_str(),
-            ),
-            (
-                "AGENT_SESSION_FAKE_CODEX_SESSION_ID",
-                "codex-ambiguous-enter-resume",
-            ),
-            ("AGENT_SESSION_FAKE_CODEX_CWD", checkout_arg.as_str()),
-            ("AGENT_SESSION_CODEX_CAPTURE_TIMEOUT_MS", "250"),
-            ("AGENT_SESSION_CODEX_CAPTURE_POLL_MS", "10"),
-            ("AGENT_SESSION_CODEX_AMBIGUITY_WINDOW_MS", "40"),
-            ("AGENT_SESSION_FAKE_TMUX_FAIL_AFTER", "send-keys"),
-            (
-                "AGENT_SESSION_FAKE_TMUX_FAIL_AFTER_ONCE_DIR",
-                fail_once_arg.as_str(),
-            ),
-        ],
+    let checkpoint_path = Path::new(&main_capability).with_file_name(format!(
+        "main-agent-checkpoint-{}.json",
+        Path::new(&main_capability)
+            .file_name()
+            .and_then(|value| value.to_str())
+            .and_then(|value| value.strip_prefix("capability-"))
+            .expect("main capability name")
+    ));
+    let identity_race_barrier = tmp.path().join("ambiguous-prompt-identity-race");
+    fs::create_dir(&identity_race_barrier).expect("identity race barrier");
+    let mut start = Command::new(bin::resolve("main-agent"));
+    start
+        .current_dir(&checkout)
+        .args(args)
+        .env("AGENT_SESSION_CAPABILITY_FILE", &main_capability)
+        .env("AGENT_SESSION_CHECKPOINT_FILE", &checkpoint_path)
+        .env("AGENT_SESSION_TMUX_BIN", &tmux_bin)
+        .env("AGENT_SESSION_CODEX_BIN", &codex_bin)
+        .env("AGENT_SESSION_FAKE_TMUX_LOG", &tmux_log)
+        .env("CODEX_HOME", &codex_home)
+        .env("AGENT_SESSION_FAKE_CODEX_SESSION_FILE", &codex_session)
+        .env(
+            "AGENT_SESSION_FAKE_CODEX_SESSION_ID",
+            "codex-ambiguous-enter-resume",
+        )
+        .env("AGENT_SESSION_FAKE_CODEX_CWD", &checkout)
+        // llvm-cov instrumentation can spend several seconds in the first
+        // history scan before the fixture observes its synchronously-created
+        // session metadata. Keep this test-only capture budget above that
+        // startup cost so the identity-race barrier owns the asserted branch.
+        .env("AGENT_SESSION_CODEX_CAPTURE_TIMEOUT_MS", "5000")
+        .env("AGENT_SESSION_CODEX_CAPTURE_POLL_MS", "10")
+        .env("AGENT_SESSION_CODEX_AMBIGUITY_WINDOW_MS", "40")
+        .env("AGENT_SESSION_FAKE_TMUX_FAIL_AFTER", "send-keys")
+        .env(
+            "AGENT_SESSION_FAKE_TMUX_FAIL_AFTER_ONCE_DIR",
+            &fail_once_dir,
+        )
+        .env(
+            "NILS_AGENT_SESSION_TEST_STATE_ANCESTOR_BARRIER_STAGE",
+            "ambiguous-prompt-after-resume-capture",
+        )
+        .env(
+            "NILS_AGENT_SESSION_TEST_STATE_ANCESTOR_BARRIER_DIR",
+            &identity_race_barrier,
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = start.spawn().expect("spawn ambiguous worker start");
+    wait_for_barrier_or_child_exit_with_timeout(
+        &identity_race_barrier,
+        &mut child,
+        "ambiguous prompt identity race",
+        Duration::from_secs(30),
     );
+    let retained_session = state_dir.join("sessions/worker-ambiguous-enter");
+    let session_path = retained_session.join("session.json");
+    let exact_session = fs::read(&session_path).expect("read exact ambiguous worker record");
+    let exact_session_json: serde_json::Value =
+        serde_json::from_slice(&exact_session).expect("ambiguous worker record json");
+    let exact_launch_id = exact_session_json["runtime"]["launch_id"]
+        .as_str()
+        .expect("exact ambiguous worker incarnation")
+        .to_string();
+    let mut changed_session = exact_session_json.clone();
+    changed_session["runtime"]["launch_id"] = json!("changed-ambiguous-worker-incarnation");
+    changed_session["provider_resume"] = serde_json::Value::Null;
+    write_private_json(&session_path, &changed_session);
+    fs::write(identity_race_barrier.join("release"), b"release")
+        .expect("release identity race barrier");
+    let failed_output = child
+        .wait_with_output()
+        .expect("wait ambiguous worker start");
+    let failed = CmdOutput {
+        code: failed_output.status.code().unwrap_or(-1),
+        stdout: failed_output.stdout,
+        stderr: failed_output.stderr,
+    };
     assert_eq!(failed.code, 1, "outcome={}", failed.stdout_text());
     assert_eq!(
         failed.stdout_json()["error"]["code"],
@@ -8855,15 +8896,29 @@ fn main_agent_worker_start_preserves_ambiguous_initial_enter_without_redelivery(
     let ambiguous_registry = orchestration_registry(&state_dir);
     assert_eq!(
         ambiguous_registry["assignments"]["assignment-ambiguous-enter"]["revision"],
-        2
+        1
     );
     assert_eq!(
         ambiguous_registry["receipts"]["main-one:main-incarnation-one:worker-start-ambiguous-enter-0001"]
             ["outcome"]["launch_phase"],
         "prompt-outcome-unknown"
     );
+    assert_eq!(
+        ambiguous_registry["receipts"]["main-one:main-incarnation-one:worker-start-ambiguous-enter-0001"]
+            ["outcome"]["worker"]["session_incarnation"],
+        exact_launch_id,
+        "the ambiguity receipt must retain the pre-race worker identity"
+    );
+    assert!(
+        serde_json::from_slice::<serde_json::Value>(
+            &fs::read(&session_path).expect("changed ambiguous worker record")
+        )
+        .expect("changed ambiguous worker json")["provider_resume"]
+            .is_null(),
+        "resume metadata must not be written onto the replacement identity"
+    );
 
-    let resumed = run_main_agent(
+    let changed_identity_replay = run_main_agent(
         &checkout,
         &args,
         &[
@@ -8874,10 +8929,179 @@ fn main_agent_worker_start_preserves_ambiguous_initial_enter_without_redelivery(
             ("CODEX_HOME", codex_home_arg.as_str()),
         ],
     );
+    assert_eq!(
+        changed_identity_replay.code,
+        65,
+        "outcome={}",
+        changed_identity_replay.stdout_text()
+    );
+    assert_eq!(
+        changed_identity_replay.stdout_json()["error"]["code"],
+        "assignment-start-conflict"
+    );
+    let calls = tmux_calls(&tmux_log);
+    for (operation, expected) in [
+        ("new-session", 1),
+        ("load-buffer", 1),
+        ("paste-buffer", 1),
+        ("send-keys", 1),
+    ] {
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.first().is_some_and(|arg| arg == operation))
+                .count(),
+            expected,
+            "a changed ambiguous worker must fail closed without another {operation}: {calls:?}"
+        );
+    }
+    fs::write(&session_path, &exact_session).expect("restore exact ambiguous worker record");
+
+    let unavailable_session = state_dir.join("worker-ambiguous-enter-unavailable");
+    fs::rename(&retained_session, &unavailable_session)
+        .expect("simulate loss of the retained ambiguous worker");
+    let unavailable_replay = run_main_agent(
+        &checkout,
+        &args,
+        &[
+            ("AGENT_SESSION_CAPABILITY_FILE", main_capability.as_str()),
+            ("AGENT_SESSION_TMUX_BIN", tmux_arg.as_str()),
+            ("AGENT_SESSION_CODEX_BIN", codex_arg.as_str()),
+            ("AGENT_SESSION_FAKE_TMUX_LOG", tmux_log_arg.as_str()),
+            ("CODEX_HOME", codex_home_arg.as_str()),
+        ],
+    );
+    assert_eq!(
+        unavailable_replay.code,
+        1,
+        "outcome={}",
+        unavailable_replay.stdout_text()
+    );
+    assert_eq!(
+        unavailable_replay.stdout_json()["error"]["code"],
+        "managed-worker-prompt-delivery-outcome-unknown"
+    );
+    let calls = tmux_calls(&tmux_log);
+    for (operation, expected) in [
+        ("new-session", 1),
+        ("load-buffer", 1),
+        ("paste-buffer", 1),
+        ("send-keys", 1),
+    ] {
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.first().is_some_and(|arg| arg == operation))
+                .count(),
+            expected,
+            "a missing ambiguous worker must fail closed without another {operation}: {calls:?}"
+        );
+    }
+    fs::rename(&unavailable_session, &retained_session)
+        .expect("restore the retained ambiguous worker");
+
+    let replay_identity_race_barrier = tmp.path().join("ambiguous-replay-identity-race");
+    fs::create_dir(&replay_identity_race_barrier).expect("replay identity race barrier");
+    let mut replay = Command::new(bin::resolve("main-agent"));
+    replay
+        .current_dir(&checkout)
+        .args(args)
+        .env("AGENT_SESSION_CAPABILITY_FILE", &main_capability)
+        .env("AGENT_SESSION_CHECKPOINT_FILE", &checkpoint_path)
+        .env("AGENT_SESSION_TMUX_BIN", &tmux_bin)
+        .env("AGENT_SESSION_CODEX_BIN", &codex_bin)
+        .env("AGENT_SESSION_FAKE_TMUX_LOG", &tmux_log)
+        .env("CODEX_HOME", &codex_home)
+        .env(
+            "NILS_AGENT_SESSION_TEST_BATCH_LANE_BARRIER_STAGE",
+            "after_ambiguous_resume_backfill",
+        )
+        .env(
+            "NILS_AGENT_SESSION_TEST_BATCH_LANE_BARRIER_DIR",
+            &replay_identity_race_barrier,
+        )
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut replay_child = replay.spawn().expect("spawn ambiguous worker replay");
+    wait_for_barrier_or_child_exit_with_timeout(
+        &replay_identity_race_barrier,
+        &mut replay_child,
+        "ambiguous replay identity race",
+        Duration::from_secs(30),
+    );
+    let backfilled_session = fs::read(&session_path).expect("backfilled ambiguous worker record");
+    let backfilled_session_json: serde_json::Value =
+        serde_json::from_slice(&backfilled_session).expect("backfilled ambiguous worker json");
+    assert_eq!(
+        backfilled_session_json["provider_resume"]["session_id"], "codex-ambiguous-enter-resume",
+        "exact replay must backfill the captured resume evidence under the identity lock"
+    );
+    let resume_path = retained_session.join("resume.json");
+    let backfilled_resume = fs::read(&resume_path).expect("backfilled ambiguous resume sidecar");
+    let resume_sidecar: serde_json::Value = serde_json::from_slice(&backfilled_resume)
+        .expect("backfilled ambiguous resume sidecar json");
+    assert_eq!(
+        resume_sidecar["runtime"]["launch_id"], exact_launch_id,
+        "resume sidecar evidence must remain bound to the original runtime incarnation"
+    );
+    let mut replay_replacement = backfilled_session_json.clone();
+    replay_replacement["runtime"]["launch_id"] = json!("changed-after-resume-backfill");
+    replay_replacement["provider_resume"] = serde_json::Value::Null;
+    write_private_json(&session_path, &replay_replacement);
+    let replacement_list = run(
+        &checkout,
+        &[
+            "--state-dir",
+            state_arg.as_str(),
+            "list",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(
+        replacement_list.code,
+        0,
+        "stderr={}",
+        replacement_list.stderr_text()
+    );
+    let replacement_list_data = data(&replacement_list);
+    let replacement_view = replacement_list_data
+        .as_array()
+        .expect("replacement session list")
+        .iter()
+        .find(|session| session["id"] == "worker-ambiguous-enter")
+        .expect("replacement worker view");
+    assert!(
+        replacement_view["provider_resume"].is_null(),
+        "a stale resume sidecar must not bind provider metadata to a replacement runtime"
+    );
+    assert_eq!(
+        replacement_view["resumable"], false,
+        "a replacement runtime must not become resumable through the prior identity's sidecar"
+    );
+    assert!(
+        !resume_path.exists(),
+        "loading and reconciling a replacement must remove the stale resume sidecar"
+    );
+    fs::write(replay_identity_race_barrier.join("release"), b"release")
+        .expect("release replay identity race barrier");
+    let replay_output = replay_child
+        .wait_with_output()
+        .expect("wait ambiguous worker replay");
+    let resumed = CmdOutput {
+        code: replay_output.status.code().unwrap_or(-1),
+        stdout: replay_output.stdout,
+        stderr: replay_output.stderr,
+    };
     assert_eq!(resumed.code, 0, "stderr={}", resumed.stderr_text());
     assert_eq!(
         data(&resumed)["worker"]["session_id"],
         "worker-ambiguous-enter"
+    );
+    assert_eq!(
+        data(&resumed)["worker"]["session_incarnation"],
+        exact_launch_id,
+        "replay must continue with the identity-checked record returned by the locked backfill"
     );
     let calls = tmux_calls(&tmux_log);
     for (operation, expected) in [
@@ -8902,6 +9126,16 @@ fn main_agent_worker_start_preserves_ambiguous_initial_enter_without_redelivery(
         }),
         "an outcome-unknown Enter must never tear down its worker: {calls:?}"
     );
+    assert!(
+        serde_json::from_slice::<serde_json::Value>(
+            &fs::read(&session_path).expect("post-backfill replacement record")
+        )
+        .expect("post-backfill replacement json")["provider_resume"]
+            .is_null(),
+        "replay must not attach metadata to a replacement installed after the locked backfill"
+    );
+    fs::write(&session_path, &backfilled_session).expect("restore backfilled worker record");
+    fs::write(&resume_path, &backfilled_resume).expect("restore backfilled resume sidecar");
     let worker_record: serde_json::Value = serde_json::from_slice(
         &fs::read(state_dir.join("sessions/worker-ambiguous-enter/session.json"))
             .expect("retained worker record"),
@@ -22040,11 +22274,15 @@ fn provider_stop_canary_fence_blocks_http_resume_before_authority_provisioning()
 }
 
 fn wait_for_barrier(barrier: &Path) {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    wait_for_barrier_with_timeout(barrier, Duration::from_secs(10), "reconcile-stopped");
+}
+
+fn wait_for_barrier_with_timeout(barrier: &Path, timeout: Duration, label: &str) {
+    let deadline = Instant::now() + timeout;
     while !barrier.join("ready").is_file() {
         assert!(
             Instant::now() < deadline,
-            "reconcile-stopped did not reach its stage barrier"
+            "{label} did not reach its stage barrier"
         );
         std::thread::sleep(Duration::from_millis(10));
     }
@@ -22052,7 +22290,16 @@ fn wait_for_barrier(barrier: &Path) {
 
 #[cfg(target_os = "linux")]
 fn wait_for_barrier_or_child_exit(barrier: &Path, child: &mut Child, label: &str) {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    wait_for_barrier_or_child_exit_with_timeout(barrier, child, label, Duration::from_secs(10));
+}
+
+fn wait_for_barrier_or_child_exit_with_timeout(
+    barrier: &Path,
+    child: &mut Child,
+    label: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
     while !barrier.join("ready").is_file() {
         if let Some(status) = child.try_wait().expect("poll barrier child") {
             let mut stdout = String::new();
@@ -22071,10 +22318,25 @@ fn wait_for_barrier_or_child_exit(barrier: &Path, child: &mut Child, label: &str
                 "{label} child exited before barrier: status={status} stdout={stdout} stderr={stderr}"
             );
         }
-        assert!(
-            Instant::now() < deadline,
-            "{label} did not reach its stage barrier"
-        );
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let status = child.wait().expect("reap timed-out barrier child");
+            let mut stdout = String::new();
+            let mut stderr = String::new();
+            if let Some(stream) = child.stdout.as_mut() {
+                stream
+                    .read_to_string(&mut stdout)
+                    .expect("read timed-out barrier child stdout");
+            }
+            if let Some(stream) = child.stderr.as_mut() {
+                stream
+                    .read_to_string(&mut stderr)
+                    .expect("read timed-out barrier child stderr");
+            }
+            panic!(
+                "{label} did not reach its stage barrier: status={status} stdout={stdout} stderr={stderr}"
+            );
+        }
         std::thread::sleep(Duration::from_millis(10));
     }
 }
@@ -32604,20 +32866,59 @@ fn main_agent_worker_start_finalizer_takeover_resumes_the_same_recovery_attempt(
             successor["data"]["readiness"]["prompt_observation"].is_object(),
             "every terminal readiness takeover branch must retain typed prompt evidence: {crash_stage}"
         );
+        let actual_attempt_count =
+            successor["data"]["readiness"]["submit_key_recovery"]["attempt_count"]
+                .as_u64()
+                .expect("typed recovery attempt count");
+        let pre_reservation_recovery_not_admitted =
+            crash_stage == "before_reserve" && actual_attempt_count == 0;
+        if pre_reservation_recovery_not_admitted {
+            assert_eq!(
+                successor["data"]["readiness"]["classification"],
+                "prompt_observation_unavailable"
+            );
+            assert_eq!(
+                successor["data"]["readiness"]["prompt_observation"]["prompt"],
+                json!({
+                    "state": "unavailable",
+                    "proof": "provider-transcript-unavailable"
+                }),
+                "a pre-reservation takeover may decline recovery only when bounded transcript proof is unavailable"
+            );
+        }
+        let expected_attempt_count = if pre_reservation_recovery_not_admitted {
+            0
+        } else {
+            1
+        };
         assert_eq!(
-            successor["data"]["readiness"]["submit_key_recovery"]["attempt_count"], 1,
-            "successor must resume the persisted recovery reservation"
+            successor["data"]["readiness"]["submit_key_recovery"]["attempt_count"],
+            expected_attempt_count,
+            "successor recovery attempt must match the durable reservation boundary: {crash_stage}"
         );
         assert_eq!(
             successor["data"]["readiness"]["submit_key_recovery"]["attempted"],
-            true
+            !pre_reservation_recovery_not_admitted,
+            "only a proof-unavailable takeover before reservation may decline recovery: {crash_stage}"
         );
         let registry = orchestration_registry(&state_dir);
-        assert_eq!(
-            registry["assignments"][&assignment_id]["submit_recovery"]["attempt_count"],
-            1
-        );
-        let expected_enter_count = if crash_stage == "sending" { 1 } else { 2 };
+        if pre_reservation_recovery_not_admitted {
+            assert!(
+                registry["assignments"][&assignment_id]["submit_recovery"].is_null(),
+                "proof-unavailable takeover before reservation must not create recovery state"
+            );
+        } else {
+            assert_eq!(
+                registry["assignments"][&assignment_id]["submit_recovery"]["attempt_count"],
+                1
+            );
+        }
+        let expected_enter_count =
+            if crash_stage == "sending" || pre_reservation_recovery_not_admitted {
+                1
+            } else {
+                2
+            };
         assert_eq!(
             tmux_calls(&tmux_log)
                 .iter()

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -1,6 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, OpenOptions};
-use std::io::{Read, Write};
+#[cfg(target_os = "linux")]
+use std::io::Read;
+use std::io::Write;
+#[cfg(target_os = "linux")]
 use std::net::{TcpListener, TcpStream};
 use std::os::fd::AsRawFd;
 #[cfg(target_os = "linux")]
@@ -805,6 +808,35 @@ fn write_private_json(path: &Path, value: &serde_json::Value) {
     fs::set_permissions(path, fs::Permissions::from_mode(0o600)).expect("private json mode");
 }
 
+#[cfg(not(target_os = "linux"))]
+fn directory_file_snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    fn visit(root: &Path, current: &Path, snapshot: &mut BTreeMap<PathBuf, Vec<u8>>) {
+        let mut entries = fs::read_dir(current)
+            .expect("snapshot directory")
+            .map(|entry| entry.expect("snapshot entry"))
+            .collect::<Vec<_>>();
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let file_type = entry.file_type().expect("snapshot file type");
+            let path = entry.path();
+            if file_type.is_dir() {
+                visit(root, &path, snapshot);
+            } else if file_type.is_file() {
+                snapshot.insert(
+                    path.strip_prefix(root)
+                        .expect("snapshot relative path")
+                        .to_path_buf(),
+                    fs::read(path).expect("snapshot file"),
+                );
+            }
+        }
+    }
+
+    let mut snapshot = BTreeMap::new();
+    visit(root, root, &mut snapshot);
+    snapshot
+}
+
 #[cfg(target_os = "linux")]
 fn assert_authority_quarantine_released(path: &Path) {
     assert!(
@@ -1250,6 +1282,7 @@ fn released_v1_claim_renew_fixture(state_dir: &Path, session_id: &str) -> Result
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 fn coordination_authority_snapshot(
     registry: &serde_json::Value,
     session_id: &str,
@@ -16703,6 +16736,7 @@ impl StoppedPostClaimFixture {
         run_main_agent(&self.checkout, &self.reconcile_args(), &self.envs())
     }
 
+    #[cfg(target_os = "linux")]
     fn run_reconcile_with_extra_env(&self, extra: &[(&str, &str)]) -> CmdOutput {
         let mut env = self.envs().to_vec();
         env.extend_from_slice(extra);
@@ -16887,6 +16921,7 @@ impl StoppedPostClaimFixture {
         command.spawn().expect("spawn claimed runtime stop")
     }
 
+    #[cfg(target_os = "linux")]
     fn spawn_reconcile_at_barrier(&self, barrier: &Path, stage: &str) -> Child {
         let mut command = Command::new(bin::resolve("main-agent"));
         command
@@ -17258,6 +17293,114 @@ fn claimed_runtime_stop_fails_closed_without_exact_stopped_runtime_proof() {
                     && claim["state"] == "active"
             }),
         "unverified non-Linux absence must preserve the active worker claim"
+    );
+}
+
+#[test]
+#[cfg(not(target_os = "linux"))]
+fn main_agent_post_claim_stopped_worker_fails_closed_without_exact_runtime_proof() {
+    let fixture = StoppedPostClaimFixture::new();
+    let orchestration_before = orchestration_registry(&fixture.state_dir);
+    let coordination_before = load_coordination_registry(&fixture.state_dir);
+    let worker_checkout = PathBuf::from(
+        orchestration_before["assignments"]["assignment-stopped"]["worktree"]
+            .as_str()
+            .expect("worker worktree"),
+    );
+    let retained_progress = worker_checkout.join("non-linux-progress-to-preserve");
+    fs::write(&retained_progress, "unaccepted worker output").expect("worker progress");
+    let worker_session_dir = fixture.state_dir.join("sessions/worker-stopped");
+    let session_before_unverified = directory_file_snapshot(&worker_session_dir);
+
+    let assert_fail_closed_diagnosis = |command: &str| {
+        let observed = run_main_agent(
+            &fixture.checkout,
+            &[
+                "--state-dir",
+                fixture.state_dir.to_str().expect("state dir"),
+                "worker",
+                command,
+                "assignment-stopped",
+                "--format",
+                "json",
+            ],
+            &fixture.envs(),
+        );
+        assert_eq!(observed.code, 0, "outcome={}", observed.stdout_text());
+        assert_eq!(
+            data(&observed)["classification"],
+            "evidence_unavailable",
+            "{command} must not call an unproved stopped runtime healthy"
+        );
+        assert_eq!(
+            data(&observed)["recovery_action"]["kind"],
+            "identity_evidence_reconciliation"
+        );
+        assert_eq!(data(&observed)["recovery_action"]["executable"], false);
+    };
+    for command in ["supervise", "diagnose"] {
+        assert_fail_closed_diagnosis(command);
+    }
+
+    let reconciled = fixture.run_reconcile();
+    assert_eq!(reconciled.code, 1, "outcome={}", reconciled.stdout_text());
+    assert_eq!(
+        reconciled.stdout_json()["error"]["code"],
+        "coordination-runtime-unverified"
+    );
+    assert_eq!(
+        directory_file_snapshot(&worker_session_dir),
+        session_before_unverified,
+        "unverified diagnosis and reconciliation must not mutate worker session authority"
+    );
+
+    let worker_record_path = worker_session_dir.join("session.json");
+    let mut worker_record: serde_json::Value =
+        serde_json::from_slice(&fs::read(&worker_record_path).expect("worker session record"))
+            .expect("worker session json");
+    worker_record
+        .as_object_mut()
+        .expect("worker session object")
+        .remove("delete_tmux_identity");
+    write_private_json(&worker_record_path, &worker_record);
+    let session_before_missing_identity = directory_file_snapshot(&worker_session_dir);
+    for command in ["supervise", "diagnose"] {
+        assert_fail_closed_diagnosis(command);
+    }
+    let missing_identity_reconcile = fixture.run_reconcile();
+    assert_eq!(
+        missing_identity_reconcile.code,
+        1,
+        "outcome={}",
+        missing_identity_reconcile.stdout_text()
+    );
+    assert_eq!(
+        missing_identity_reconcile.stdout_json()["error"]["code"],
+        "coordination-runtime-unverified"
+    );
+    assert_eq!(
+        directory_file_snapshot(&worker_session_dir),
+        session_before_missing_identity,
+        "missing-identity diagnosis and reconciliation must not mutate worker session authority"
+    );
+    assert_eq!(
+        orchestration_registry(&fixture.state_dir),
+        orchestration_before,
+        "unverified non-Linux absence must not terminalize the assignment"
+    );
+    assert_eq!(
+        load_coordination_registry(&fixture.state_dir),
+        coordination_before,
+        "unverified non-Linux absence must preserve the active worker claim"
+    );
+    assert!(
+        worker_session_dir.is_dir(),
+        "unverified non-Linux absence must preserve the worker session"
+    );
+    assert_eq!(
+        fs::read_to_string(retained_progress).expect("retained worker progress"),
+        "unaccepted worker output",
+        "fail-closed diagnosis and reconciliation must preserve the worker worktree"
     );
 }
 
@@ -21944,6 +22087,7 @@ fn terminate_at_barrier(child: Child, label: &str) {
     child.0 = None;
 }
 
+#[cfg(target_os = "linux")]
 fn post_json_over_http(address: &str, path: &str, token: &str) -> serde_json::Value {
     let mut stream = TcpStream::connect(address).expect("connect HTTP server");
     let request = format!(
@@ -24952,6 +25096,7 @@ fn main_agent_revoke_claim_keeps_accepted_assignment_retirable() {
 /// closes such a lane while preserving the worker worktree, the run, and the
 /// Main Agent session.
 #[test]
+#[cfg(target_os = "linux")]
 fn main_agent_post_claim_stopped_worker_is_terminalized_without_deleting_the_run() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");
@@ -25718,6 +25863,7 @@ fn main_agent_post_claim_stopped_worker_is_terminalized_without_deleting_the_run
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_identical_replay_converges_from_typed_progress() {
     let fixture = StoppedPostClaimFixture::new();
     let barrier = fixture._tmp.path().join("reconcile-progress-barrier");
@@ -25790,6 +25936,7 @@ fn reconcile_stopped_identical_replay_converges_from_typed_progress() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_observational_path_skips_operation_renewal_probes() {
     let fixture = StoppedPostClaimFixture::new();
     seed_operation(
@@ -25849,6 +25996,7 @@ fn reconcile_stopped_observational_path_skips_operation_renewal_probes() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_normal_and_after_seal_retry_share_stable_claim_truth() {
     let normal_fixture = StoppedPostClaimFixture::new();
     let normal = normal_fixture.run_reconcile();
@@ -25993,6 +26141,7 @@ fn reconcile_stopped_normal_and_after_seal_retry_share_stable_claim_truth() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_same_main_successor_claim_authorizes_roll_forward() {
     let fixture = StoppedPostClaimFixture::new();
     let barrier = fixture
@@ -26158,6 +26307,7 @@ fn reconcile_stopped_same_main_successor_claim_authorizes_roll_forward() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_controller_claim_revision_change_cannot_authorize_seal() {
     let fixture = StoppedPostClaimFixture::new();
     let barrier = fixture
@@ -26221,6 +26371,7 @@ fn reconcile_stopped_controller_claim_revision_change_cannot_authorize_seal() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_expired_original_accepts_same_main_successor_claim() {
     let fixture = StoppedPostClaimFixture::new();
     let barrier = fixture
@@ -26313,6 +26464,7 @@ fn reconcile_stopped_expired_original_accepts_same_main_successor_claim() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_different_session_cannot_take_over_progress() {
     let fixture = StoppedPostClaimFixture::new();
     let barrier = fixture
@@ -26358,6 +26510,7 @@ fn reconcile_stopped_different_session_cannot_take_over_progress() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_prior_external_release_reports_stable_terminal_claim_truth() {
     let fixture = StoppedPostClaimFixture::new();
     let barrier = fixture
@@ -26402,6 +26555,7 @@ fn reconcile_stopped_prior_external_release_reports_stable_terminal_claim_truth(
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_completed_v1_receipt_replays_byte_stably() {
     let fixture = StoppedPostClaimFixture::new();
     let completed = fixture.run_reconcile();
@@ -26442,6 +26596,7 @@ fn reconcile_stopped_completed_v1_receipt_replays_byte_stably() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_fresh_replay_does_not_renew_expired_controller_claim() {
     let fixture = StoppedPostClaimFixture::new();
     let barrier = fixture
@@ -26503,6 +26658,7 @@ fn reconcile_stopped_fresh_replay_does_not_renew_expired_controller_claim() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_controller_claim_release_before_seal_preserves_target_authority() {
     let fixture = StoppedPostClaimFixture::new();
     let barrier = fixture
@@ -26601,6 +26757,7 @@ fn reconcile_stopped_controller_claim_release_before_seal_preserves_target_autho
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_controller_claim_expiry_before_seal_preserves_target_authority() {
     let fixture = StoppedPostClaimFixture::new();
     let barrier = fixture
@@ -26656,6 +26813,7 @@ fn reconcile_stopped_controller_claim_expiry_before_seal_preserves_target_author
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_malformed_progress_fails_before_target_cleanup() {
     let fixture = StoppedPostClaimFixture::new();
     let barrier = fixture._tmp.path().join("reconcile-malformed-barrier");
@@ -26741,6 +26899,7 @@ fn reconcile_stopped_malformed_progress_fails_before_target_cleanup() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn reconcile_stopped_quarantine_blocks_http_resume_before_authority_provisioning() {
     let fixture = StoppedPostClaimFixture::new();
     let terminalized = fixture.run_reconcile();

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -18298,7 +18298,21 @@ fn assert_claimed_runtime_stop_pending_successor_loss(stage: &str) {
             "--format",
             "json",
         ],
-        &second_successor_env,
+        &[
+            (
+                "AGENT_SESSION_CAPABILITY_FILE",
+                fixture.second_successor_capability.as_str(),
+            ),
+            (
+                "AGENT_SESSION_TMUX_BIN",
+                fixture.tmux_bin.to_str().expect("tmux bin"),
+            ),
+            (
+                "AGENT_SESSION_FAKE_TMUX_LOG",
+                fixture.tmux_log.to_str().expect("tmux log"),
+            ),
+            ("AGENT_SESSION_FAKE_TMUX_ABSENT", "1"),
+        ],
     );
     assert_eq!(
         deleted.code,

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -22,10 +22,17 @@ use pretty_assertions::assert_eq;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
+#[cfg(target_os = "linux")]
+use super::cli::spawn_test_process_group;
 use super::cli::{
-    TestProcessGroup, fake_agent, fake_tmux, spawn_scoped_test_process_group,
-    spawn_test_process_group, tmux_calls,
+    TestProcessGroup, fake_agent, fake_tmux, spawn_scoped_test_process_group, tmux_calls,
 };
+
+// Linux production termination deliberately proves it can stop a captured process
+// boundary even when tmux does not. Other Unix targets cannot pin that boundary,
+// so their success fixtures must model real tmux by terminating the pane group.
+const FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP: &str =
+    if cfg!(target_os = "linux") { "1" } else { "0" };
 
 #[cfg(target_os = "linux")]
 fn provider_stop_canary_test_capability() -> Result<(), String> {
@@ -11511,6 +11518,7 @@ fn main_agent_canary_startup_admits_only_authenticated_guardian_status() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn main_agent_canary_startup_failure_precedes_prompt_transport() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");
@@ -11588,7 +11596,10 @@ fn main_agent_canary_startup_failure_precedes_prompt_transport() {
             ("AGENT_SESSION_FAKE_TMUX_LOG", &tmux_log_arg),
             ("AGENT_SESSION_FAKE_TMUX_PANE_PID", &runtime_pid_arg),
             ("AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID", &runtime_pid_arg),
-            ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+            (
+                "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+                FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+            ),
             (
                 "AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID",
                 "worker-canary-startup-failure",
@@ -11655,7 +11666,10 @@ fn main_agent_canary_startup_failure_precedes_prompt_transport() {
             ("AGENT_SESSION_FAKE_TMUX_LOG", &tmux_log_arg),
             ("AGENT_SESSION_FAKE_TMUX_PANE_PID", &runtime_pid_arg),
             ("AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID", &runtime_pid_arg),
-            ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+            (
+                "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+                FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+            ),
             (
                 "AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID",
                 "worker-canary-startup-failure",
@@ -16014,7 +16028,10 @@ fn main_agent_failed_preclaim_worker_is_cancelled_retired_and_reassigned_in_isol
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             pane_pid_arg.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$77"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-failed"),
         (
@@ -16103,7 +16120,10 @@ fn main_agent_failed_preclaim_worker_is_cancelled_retired_and_reassigned_in_isol
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             pane_pid_arg.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$77"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-failed"),
         (
@@ -16615,7 +16635,10 @@ impl StoppedPostClaimFixture {
                     "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
                     runtime_pid.as_str(),
                 ),
-                ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+                (
+                    "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+                    FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+                ),
                 ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$91"),
                 ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%91"),
                 ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -16699,7 +16722,10 @@ impl StoppedPostClaimFixture {
             .env("AGENT_SESSION_FAKE_TMUX_LOG", &self.tmux_log)
             .env("AGENT_SESSION_FAKE_TMUX_PANE_PID", &runtime_pid)
             .env("AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID", &runtime_pid)
-            .env("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1")
+            .env(
+                "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+                FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+            )
             .env("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$91")
             .env("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%91")
             .env("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped")
@@ -17082,7 +17108,10 @@ fn claimed_runtime_stop_identity_only_interruption_projects_exact_replay() {
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             runtime_pid.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$91"),
         ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%91"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -17261,7 +17290,10 @@ fn claimed_runtime_stop_refuses_controller_claim_drift_before_runtime_stop() {
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             runtime_pid.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$91"),
         ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%91"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -17421,7 +17453,10 @@ fn claimed_runtime_stop_fences_exact_claim_mutation_without_blocking_unrelated_c
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             runtime_pid.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$91"),
         ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%91"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -17901,7 +17936,10 @@ fn claimed_runtime_stop_waiter_replays_terminal_result_after_assignment_advances
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             runtime_pid.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$91"),
         ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%91"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -18378,7 +18416,10 @@ fn claimed_runtime_stop_preserves_the_active_claim_for_reconcile_stopped() {
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             runtime_pid.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$91"),
         ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%91"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -19534,7 +19575,10 @@ fn provider_stop_canary_supervisor_admits_stalled_scope_empty_turn_and_releases(
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             supervisor_pid_arg.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$91"),
         ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%91"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -19861,7 +19905,10 @@ fn provider_stop_canary_rejects_same_uid_request_from_inside_provider_cgroup() {
         .env("AGENT_SESSION_CAPABILITY_FILE", &fixture.main_capability)
         .env("AGENT_SESSION_TMUX_BIN", &fixture.tmux_bin)
         .env("AGENT_SESSION_FAKE_TMUX_LOG", &fixture.tmux_log)
-        .env("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1")
+        .env(
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        )
         .env("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$91")
         .env("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%91")
         .env("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped")
@@ -20053,7 +20100,10 @@ fn provider_stop_canary_rejects_same_uid_request_from_inside_provider_cgroup() {
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             supervisor_pid_arg.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$91"),
         ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%91"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -20422,7 +20472,10 @@ fn compiled_provider_stop_canary_hold_expiry_converges_through_reconcile() {
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             supervisor_pid_arg.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$95"),
         ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%95"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -20517,7 +20570,10 @@ fn typed_provider_stop_canary_stops_only_the_armed_child_boundary() {
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             runtime_pid.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$92"),
         ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%92"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -21425,7 +21481,10 @@ fn provider_stop_canary_timeout_replays_the_exact_durable_reservation() {
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             runtime_pid.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$93"),
         ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%93"),
         ("AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID", "worker-stopped"),
@@ -22071,7 +22130,10 @@ impl ExhaustedReadinessRuntimeStopFixture {
                 "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
                 self.runtime_pid_arg.as_str(),
             ),
-            ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+            (
+                "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+                FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+            ),
             ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$77"),
             (
                 "AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID",
@@ -22669,7 +22731,10 @@ fn runtime_stop_admission_guards_are_fail_closed() {
             "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
             runtime_pid_arg.as_str(),
         ),
-        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP",
+            FAKE_TMUX_KEEP_GROUP_FOR_VERIFIED_STOP,
+        ),
         ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$77"),
         (
             "AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID",

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -31831,10 +31831,8 @@ fn main_agent_worker_start_await_ready_folds_timeout_into_readiness_failed() {
     assert_eq!(started.code, 0, "stderr={}", started.stderr_text());
     let readiness = data(&started)["readiness"].clone();
     assert_eq!(readiness["state"], "readiness_failed");
-    assert_eq!(readiness["classification"], "composer_not_ready");
-    assert_eq!(
-        readiness["prompt_observation"],
-        json!({
+    let expected_prompt_observation = match readiness["classification"].as_str() {
+        Some("composer_not_ready") => json!({
             "schema_version": "main-agent.worker-prompt-observation.v1",
             "prompt": {
                 "state": "not_present",
@@ -31844,8 +31842,21 @@ fn main_agent_worker_start_await_ready_folds_timeout_into_readiness_failed() {
                 "state": "unchanged_after_paste",
                 "proof": "tmux-pane-digest-before-submit"
             }
-        })
-    );
+        }),
+        Some("prompt_observation_unavailable") => json!({
+            "schema_version": "main-agent.worker-prompt-observation.v1",
+            "prompt": {
+                "state": "unavailable",
+                "proof": "provider-transcript-unavailable"
+            },
+            "composer": {
+                "state": "unchanged_after_paste",
+                "proof": "tmux-pane-digest-before-submit"
+            }
+        }),
+        classification => panic!("unexpected readiness classification: {classification:?}"),
+    };
+    assert_eq!(readiness["prompt_observation"], expected_prompt_observation);
     assert_eq!(readiness["assignment_state"], "starting");
     assert_eq!(readiness["worker_launched"], true);
     assert_eq!(readiness["delivery"]["state"], "unverified");
@@ -34489,11 +34500,27 @@ fn assert_main_agent_worker_start_stops_on_authoritative_turn(kind: &str) {
         serde_json::from_slice(&output.stdout).expect("worker start json");
     let readiness = &envelope["data"]["readiness"];
     assert_eq!(readiness["state"], "readiness_failed");
-    assert_eq!(readiness["classification"], "bootstrap_failure");
-    assert_eq!(
-        readiness["prompt_observation"]["prompt"]["state"],
-        "submitted"
-    );
+    match readiness["classification"].as_str() {
+        Some("bootstrap_failure") => {
+            assert_eq!(
+                readiness["prompt_observation"]["prompt"],
+                json!({
+                    "state": "submitted",
+                    "proof": "provider-transcript-exact-match"
+                })
+            );
+        }
+        Some("prompt_observation_unavailable") => {
+            assert_eq!(
+                readiness["prompt_observation"]["prompt"],
+                json!({
+                    "state": "unavailable",
+                    "proof": "provider-transcript-unavailable"
+                })
+            );
+        }
+        classification => panic!("unexpected readiness classification: {classification:?}"),
+    }
     assert_eq!(
         readiness["delivery"]["proof"],
         "authoritative-provider-turn-terminated"

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -27881,27 +27881,33 @@ fn main_agent_supervise_exposes_the_fail_closed_classification_matrix_without_mu
             "updated_at": "2030-01-01T00:00:00Z"
         });
     });
-    let legacy_cancel = run_managed_account_handoff_cancel(
+    let compatibility_cancel = run_managed_account_handoff_cancel(
         &main_checkout,
         &state_dir,
         &main_capability,
         "matrix-managed-v1-reservation-cancel-0001",
     );
     assert_eq!(
-        legacy_cancel.code,
+        compatibility_cancel.code,
         0,
         "v1 serialized reservation must load and recover: {}",
-        legacy_cancel.stdout_text()
+        compatibility_cancel.stdout_text()
     );
-    assert_eq!(data(&legacy_cancel)["legacy_reservation_recovered"], true);
-    assert_eq!(data(&legacy_cancel)["newer_account_intent_preserved"], true);
-    let legacy_registry = orchestration_registry(&state_dir);
+    assert_eq!(
+        data(&compatibility_cancel)["legacy_reservation_recovered"], // stale-audit: keep-contract
+        true
+    );
+    assert_eq!(
+        data(&compatibility_cancel)["newer_account_intent_preserved"],
+        true
+    );
+    let compatibility_registry = orchestration_registry(&state_dir);
     assert!(
-        legacy_registry["assignments"]["assignment-matrix"]["account_handoff"].is_null(),
+        compatibility_registry["assignments"]["assignment-matrix"]["account_handoff"].is_null(),
         "v1 recovery clears only the assignment-local unbound reservation"
     );
     assert_eq!(
-        legacy_registry["runs"]["run-one"], unrelated_run_before,
+        compatibility_registry["runs"]["run-one"], unrelated_run_before,
         "v1 recovery must preserve unrelated run state"
     );
     assert_eq!(

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -808,7 +808,6 @@ fn write_private_json(path: &Path, value: &serde_json::Value) {
     fs::set_permissions(path, fs::Permissions::from_mode(0o600)).expect("private json mode");
 }
 
-#[cfg(not(target_os = "linux"))]
 fn session_authority_snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
     fn visit(root: &Path, current: &Path, snapshot: &mut BTreeMap<PathBuf, Vec<u8>>) {
         let mut entries = fs::read_dir(current)
@@ -33346,6 +33345,71 @@ fn main_agent_submit_recovery_rechecks_authority_inside_the_serialized_send_boun
                     "pid_namespace": current_pid_namespace_identity()
                 });
                 write_private_json(&worker_record_path, &worker_record);
+                if !cfg!(target_os = "linux") {
+                    let orchestration_before = orchestration_registry(&state_dir);
+                    let coordination_before = load_coordination_registry(&state_dir);
+                    let session_before =
+                        session_authority_snapshot(&state_dir.join("sessions/worker-race"));
+                    let tmux_before = tmux_calls(&tmux_log);
+                    let unverified = run_main_agent(
+                        &checkout,
+                        &[
+                            "--state-dir",
+                            &state_arg,
+                            "worker",
+                            "reconcile-recovery",
+                            "assignment-race",
+                            "--if-revision",
+                            "3",
+                            "--idempotency-key",
+                            "refuse-non-linux-unverified-recovery-0001",
+                            "--format",
+                            "json",
+                        ],
+                        &[
+                            ("AGENT_SESSION_CAPABILITY_FILE", &main_capability),
+                            ("AGENT_SESSION_TMUX_BIN", &tmux_arg),
+                            ("AGENT_SESSION_FAKE_TMUX_LOG", &tmux_log_arg),
+                            ("AGENT_SESSION_FAKE_TMUX_ABSENT", "1"),
+                        ],
+                    );
+                    assert_eq!(unverified.code, 1, "outcome={}", unverified.stdout_text());
+                    assert_eq!(
+                        unverified.stdout_json()["error"]["code"],
+                        "coordination-runtime-unverified"
+                    );
+                    let registry = orchestration_registry(&state_dir);
+                    assert_eq!(
+                        registry["assignments"]["assignment-race"]["revision"], 3,
+                        "failed-closed reconciliation must not mutate the assignment"
+                    );
+                    assert_eq!(
+                        registry["assignments"]["assignment-race"]["submit_recovery"]["state"],
+                        "attempting",
+                        "failed-closed reconciliation must preserve the ambiguous-send fence"
+                    );
+                    assert_eq!(
+                        orchestration_registry(&state_dir),
+                        orchestration_before,
+                        "failed-closed reconciliation must preserve all orchestration authority"
+                    );
+                    assert_eq!(
+                        load_coordination_registry(&state_dir),
+                        coordination_before,
+                        "failed-closed reconciliation must preserve all coordination authority"
+                    );
+                    assert_eq!(
+                        session_authority_snapshot(&state_dir.join("sessions/worker-race")),
+                        session_before,
+                        "failed-closed reconciliation must preserve all worker session authority"
+                    );
+                    assert_eq!(
+                        tmux_calls(&tmux_log),
+                        tmux_before,
+                        "failed-closed reconciliation must not emit any terminal input"
+                    );
+                    continue;
+                }
                 for quiescence_case in ["active-claim", "active-operation", "uncertain-operation"] {
                     match quiescence_case {
                         "active-claim" => seed_active_claim(

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -809,7 +809,7 @@ fn write_private_json(path: &Path, value: &serde_json::Value) {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn directory_file_snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+fn session_authority_snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
     fn visit(root: &Path, current: &Path, snapshot: &mut BTreeMap<PathBuf, Vec<u8>>) {
         let mut entries = fs::read_dir(current)
             .expect("snapshot directory")
@@ -819,15 +819,17 @@ fn directory_file_snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
         for entry in entries {
             let file_type = entry.file_type().expect("snapshot file type");
             let path = entry.path();
+            let relative = path
+                .strip_prefix(root)
+                .expect("snapshot relative path")
+                .to_path_buf();
+            if relative == Path::new("activity.json") {
+                continue;
+            }
             if file_type.is_dir() {
                 visit(root, &path, snapshot);
             } else if file_type.is_file() {
-                snapshot.insert(
-                    path.strip_prefix(root)
-                        .expect("snapshot relative path")
-                        .to_path_buf(),
-                    fs::read(path).expect("snapshot file"),
-                );
+                snapshot.insert(relative, fs::read(path).expect("snapshot file"));
             }
         }
     }
@@ -17310,7 +17312,8 @@ fn main_agent_post_claim_stopped_worker_fails_closed_without_exact_runtime_proof
     let retained_progress = worker_checkout.join("non-linux-progress-to-preserve");
     fs::write(&retained_progress, "unaccepted worker output").expect("worker progress");
     let worker_session_dir = fixture.state_dir.join("sessions/worker-stopped");
-    let session_before_unverified = directory_file_snapshot(&worker_session_dir);
+    let worker_record_path = worker_session_dir.join("session.json");
+    let session_before_unverified = session_authority_snapshot(&worker_session_dir);
 
     let assert_fail_closed_diagnosis = |command: &str| {
         let observed = run_main_agent(
@@ -17365,12 +17368,11 @@ fn main_agent_post_claim_stopped_worker_fails_closed_without_exact_runtime_proof
         "coordination-runtime-unverified"
     );
     assert_eq!(
-        directory_file_snapshot(&worker_session_dir),
+        session_authority_snapshot(&worker_session_dir),
         session_before_unverified,
-        "unverified diagnosis and reconciliation must not mutate worker session authority"
+        "unverified diagnosis and reconciliation must not mutate worker session authority files"
     );
 
-    let worker_record_path = worker_session_dir.join("session.json");
     let mut worker_record: serde_json::Value =
         serde_json::from_slice(&fs::read(&worker_record_path).expect("worker session record"))
             .expect("worker session json");
@@ -17379,7 +17381,7 @@ fn main_agent_post_claim_stopped_worker_fails_closed_without_exact_runtime_proof
         .expect("worker session object")
         .remove("delete_tmux_identity");
     write_private_json(&worker_record_path, &worker_record);
-    let session_before_missing_identity = directory_file_snapshot(&worker_session_dir);
+    let session_before_missing_identity = session_authority_snapshot(&worker_session_dir);
     for command in ["supervise", "diagnose"] {
         assert_fail_closed_diagnosis(command);
     }
@@ -17395,9 +17397,9 @@ fn main_agent_post_claim_stopped_worker_fails_closed_without_exact_runtime_proof
         "coordination-runtime-unverified"
     );
     assert_eq!(
-        directory_file_snapshot(&worker_session_dir),
+        session_authority_snapshot(&worker_session_dir),
         session_before_missing_identity,
-        "missing-identity diagnosis and reconciliation must not mutate worker session authority"
+        "missing-identity diagnosis and reconciliation must not mutate worker session authority files"
     );
     assert_eq!(
         orchestration_registry(&fixture.state_dir),

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -23844,11 +23844,22 @@ fn main_agent_revoke_claim_fences_exact_idle_live_worker_without_input() {
         "pid_namespace": current_pid_namespace_identity()
     }));
     let stopped_runtime = invoke("3", "worker-f31-incarnation", "f31-stopped-runtime-0001");
-    assert_eq!(stopped_runtime.code, 65);
-    assert_eq!(
-        stopped_runtime.stdout_json()["error"]["code"],
-        "worker-runtime-stopped"
-    );
+    #[cfg(target_os = "linux")]
+    {
+        assert_eq!(stopped_runtime.code, 65);
+        assert_eq!(
+            stopped_runtime.stdout_json()["error"]["code"],
+            "worker-runtime-stopped"
+        );
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert_eq!(stopped_runtime.code, 1);
+        assert_eq!(
+            stopped_runtime.stdout_json()["error"]["code"],
+            "coordination-runtime-unverified"
+        );
+    }
     set_runtime_identity(json!({
         "launch_id": "worker-f31-incarnation",
         "session_id": "$73",
@@ -24165,11 +24176,22 @@ fn main_agent_revoke_claim_fences_exact_idle_live_worker_without_input() {
     });
     set_runtime_identity(stopped_identity);
     let runtime_drift_replay = invoke("3", "worker-f31-incarnation", "f31-revoke-0001");
-    assert_eq!(runtime_drift_replay.code, 65);
-    assert_eq!(
-        runtime_drift_replay.stdout_json()["error"]["code"],
-        "worker-runtime-stopped"
-    );
+    #[cfg(target_os = "linux")]
+    {
+        assert_eq!(runtime_drift_replay.code, 65);
+        assert_eq!(
+            runtime_drift_replay.stdout_json()["error"]["code"],
+            "worker-runtime-stopped"
+        );
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert_eq!(runtime_drift_replay.code, 1);
+        assert_eq!(
+            runtime_drift_replay.stdout_json()["error"]["code"],
+            "coordination-runtime-unverified"
+        );
+    }
     assert!(
         !state_dir
             .join("sessions/worker-f31/authority-quarantine.json")

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -805,6 +805,7 @@ fn write_private_json(path: &Path, value: &serde_json::Value) {
     fs::set_permissions(path, fs::Permissions::from_mode(0o600)).expect("private json mode");
 }
 
+#[cfg(target_os = "linux")]
 fn assert_authority_quarantine_released(path: &Path) {
     assert!(
         !path.exists(),
@@ -8885,6 +8886,7 @@ fn main_agent_worker_start_preserves_ambiguous_initial_enter_without_redelivery(
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn main_agent_canary_worker_start_cleans_prelock_quarantine_failure_before_retry() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");
@@ -9033,6 +9035,7 @@ fn main_agent_canary_worker_start_cleans_prelock_quarantine_failure_before_retry
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn main_agent_canary_worker_start_rolls_back_post_save_hook_failure_before_retry() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");
@@ -9178,6 +9181,7 @@ fn main_agent_canary_worker_start_rolls_back_post_save_hook_failure_before_retry
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn main_agent_canary_worker_start_preserves_committed_attachment_when_rollback_fails() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");
@@ -9348,6 +9352,7 @@ fn main_agent_canary_worker_start_preserves_committed_attachment_when_rollback_f
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn main_agent_canary_bootstrap_waits_for_matching_startup_quarantine_clear() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");
@@ -9942,6 +9947,7 @@ fn main_agent_canary_bootstrap_waits_for_matching_startup_quarantine_clear() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn main_agent_canary_worker_start_never_completes_an_interrupted_prompt_attempt() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");
@@ -11516,6 +11522,139 @@ fn main_agent_canary_startup_admits_only_authenticated_guardian_status() {
     }
     assert!(!Path::new(&format!("/proc/{child_pid}")).exists());
     assert!(!Path::new(&format!("/proc/{descendant_pid}")).exists());
+}
+
+#[test]
+#[cfg(not(target_os = "linux"))]
+fn main_agent_worker_start_rejects_provider_stop_canary_before_durable_side_effects() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let state_dir = tmp.path().join("state");
+    let checkout = tmp.path().join("checkout");
+    fs::create_dir(&state_dir).expect("state");
+    init_checkout(&checkout, "https://example.invalid/example/repository.git");
+    seed_brokers_at(
+        &state_dir,
+        &[(
+            "main-one",
+            "main-incarnation-one",
+            "main-private-capability-material-0000000001",
+            checkout.as_path(),
+            Some("enforce"),
+        )],
+    );
+    let main_capability = init_main_run(tmp.path(), &state_dir, &checkout, "main-one", "run-one");
+    let assignment_path = tmp
+        .path()
+        .join("assignment-canary-platform-unsupported.json");
+    write_private_json(
+        &assignment_path,
+        &json!({
+            "schema_version": "main-agent.assignment-input.v1",
+            "assignment_id": "assignment-canary-platform-unsupported",
+            "task_summary": "Reject an unsupported canary before worker launch",
+            "task": {},
+            "launch": {
+                "agent": "codex",
+                "cwd": checkout,
+                "title": null,
+                "session_id": "worker-canary-platform-unsupported",
+                "coordination_mode": "enforce",
+                "agent_args": []
+            },
+            "repository": "example/repository",
+            "worktree": checkout,
+            "base_ref": "main",
+            "scopes": ["crates/agent-session"],
+            "durable_refs": [],
+            "provider_stop_canary": {
+                "schema_version": "main-agent.provider-process-stop-canary.v1"
+            }
+        }),
+    );
+    let (tmux_bin, tmux_log) = fake_tmux(tmp.path());
+    let codex_bin = fake_agent(tmp.path(), "codex-canary-platform-unsupported");
+    let tmux_arg = tmux_bin.to_string_lossy().into_owned();
+    let tmux_log_arg = tmux_log.to_string_lossy().into_owned();
+    let codex_arg = codex_bin.to_string_lossy().into_owned();
+    let codex_home = tmp.path().join("codex-home");
+    let args = [
+        "--state-dir",
+        state_dir.to_str().expect("state dir"),
+        "worker",
+        "start",
+        "--assignment-file",
+        assignment_path.to_str().expect("assignment path"),
+        "--if-run-revision",
+        "1",
+        "--await-ready",
+        "0",
+        "--idempotency-key",
+        "worker-start-canary-platform-unsupported-0001",
+        "--format",
+        "json",
+    ];
+    let env = [
+        ("AGENT_SESSION_CAPABILITY_FILE", main_capability.as_str()),
+        ("AGENT_SESSION_TMUX_BIN", tmux_arg.as_str()),
+        ("AGENT_SESSION_CODEX_BIN", codex_arg.as_str()),
+        ("AGENT_SESSION_FAKE_TMUX_LOG", tmux_log_arg.as_str()),
+    ];
+    let orchestration_before_rejection = fs::read(state_dir.join("orchestration/registry.json"))
+        .expect("orchestration registry before rejection");
+    let coordination_before_rejection = fs::read(state_dir.join("coordination/registry.json"))
+        .expect("coordination registry before rejection");
+    let refused =
+        run_main_agent_with_codex_trust(&checkout, &args, &env, &codex_home, &[&checkout]);
+    assert_eq!(refused.code, 64, "outcome={}", refused.stdout_text());
+    assert_eq!(
+        refused.stdout_json()["error"]["code"],
+        "provider-stop-canary-platform-unsupported"
+    );
+    assert!(
+        orchestration_registry(&state_dir)["assignments"]
+            .get("assignment-canary-platform-unsupported")
+            .is_none(),
+        "platform admission must precede assignment persistence"
+    );
+    assert!(
+        !state_dir
+            .join("sessions/worker-canary-platform-unsupported")
+            .exists(),
+        "platform admission must not create worker state or capability material"
+    );
+    assert!(
+        tmux_calls(&tmux_log).is_empty(),
+        "platform admission must precede tmux and prompt transport"
+    );
+    assert_eq!(
+        fs::read(state_dir.join("orchestration/registry.json"))
+            .expect("orchestration registry after rejection"),
+        orchestration_before_rejection,
+        "platform rejection must not mutate orchestration state"
+    );
+    assert_eq!(
+        fs::read(state_dir.join("coordination/registry.json"))
+            .expect("coordination registry after rejection"),
+        coordination_before_rejection,
+        "platform rejection must not create an operation fence"
+    );
+
+    let replay = run_main_agent_with_codex_trust(&checkout, &args, &env, &codex_home, &[&checkout]);
+    assert_eq!(replay.code, 64, "outcome={}", replay.stdout_text());
+    assert_eq!(replay.stdout_text(), refused.stdout_text());
+    assert_eq!(
+        fs::read(state_dir.join("orchestration/registry.json"))
+            .expect("orchestration registry after replay"),
+        orchestration_before_rejection,
+        "replay must not advance orchestration state"
+    );
+    assert_eq!(
+        fs::read(state_dir.join("coordination/registry.json"))
+            .expect("coordination registry after replay"),
+        coordination_before_rejection,
+        "replay must not create an operation fence"
+    );
+    assert!(tmux_calls(&tmux_log).is_empty());
 }
 
 #[test]

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -17313,7 +17313,6 @@ fn main_agent_post_claim_stopped_worker_fails_closed_without_exact_runtime_proof
     fs::write(&retained_progress, "unaccepted worker output").expect("worker progress");
     let worker_session_dir = fixture.state_dir.join("sessions/worker-stopped");
     let worker_record_path = worker_session_dir.join("session.json");
-    let session_before_unverified = session_authority_snapshot(&worker_session_dir);
 
     let assert_fail_closed_diagnosis = |command: &str| {
         let observed = run_main_agent(
@@ -17361,6 +17360,10 @@ fn main_agent_post_claim_stopped_worker_fails_closed_without_exact_runtime_proof
         assert_fail_closed_diagnosis(command);
     }
 
+    // Diagnosis may refresh observation evidence and materialize its owner-local
+    // read-only capability. Freeze the complete authority tree immediately
+    // before crossing the rejected reconciliation mutation boundary.
+    let session_before_unverified = session_authority_snapshot(&worker_session_dir);
     let reconciled = fixture.run_reconcile();
     assert_eq!(reconciled.code, 1, "outcome={}", reconciled.stdout_text());
     assert_eq!(
@@ -17381,10 +17384,10 @@ fn main_agent_post_claim_stopped_worker_fails_closed_without_exact_runtime_proof
         .expect("worker session object")
         .remove("delete_tmux_identity");
     write_private_json(&worker_record_path, &worker_record);
-    let session_before_missing_identity = session_authority_snapshot(&worker_session_dir);
     for command in ["supervise", "diagnose"] {
         assert_fail_closed_diagnosis(command);
     }
+    let session_before_missing_identity = session_authority_snapshot(&worker_session_dir);
     let missing_identity_reconcile = fixture.run_reconcile();
     assert_eq!(
         missing_identity_reconcile.code,

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -455,6 +455,7 @@ fn seed_activity_state(
     );
 }
 
+#[cfg(target_os = "linux")]
 fn seed_stalled_codex_provider_hook_activity_state(
     state_dir: &Path,
     id: &str,
@@ -827,12 +828,14 @@ fn assert_authority_quarantine_released(path: &Path) {
     );
 }
 
+#[cfg(target_os = "linux")]
 fn provider_stop_canary_reservation_path(state_dir: &Path, assignment_id: &str) -> PathBuf {
     state_dir
         .join("orchestration/provider-stop-canary-reservations")
         .join(digest(assignment_id))
 }
 
+#[cfg(target_os = "linux")]
 fn write_provider_stop_canary_reservation(
     state_dir: &Path,
     assignment_id: &str,
@@ -846,6 +849,7 @@ fn write_provider_stop_canary_reservation(
     write_private_json(&path, value);
 }
 
+#[cfg(target_os = "linux")]
 fn provider_stop_canary_reservation(
     state_dir: &Path,
     assignment_id: &str,
@@ -857,6 +861,7 @@ fn provider_stop_canary_reservation(
     })
 }
 
+#[cfg(target_os = "linux")]
 fn provider_stop_canary_fence_path(state_dir: &Path, session_id: &str) -> PathBuf {
     state_dir
         .join("sessions")
@@ -16258,6 +16263,7 @@ impl StoppedPostClaimFixture {
         Self::new_with_canary_scopes(false, &["docs/stopped-focused"])
     }
 
+    #[cfg(target_os = "linux")]
     fn new_with_canary(canary: bool) -> Self {
         Self::new_with_canary_scopes(canary, &["docs/stopped-focused"])
     }
@@ -16542,6 +16548,7 @@ impl StoppedPostClaimFixture {
         run_main_agent(&self.checkout, &self.reconcile_args(), &env)
     }
 
+    #[cfg(target_os = "linux")]
     fn set_canary_supervisor_binding_starting(&self) {
         rewrite_orchestration_registry(&self.state_dir, |registry| {
             let assignment = &mut registry["assignments"]["assignment-stopped"];
@@ -16551,6 +16558,7 @@ impl StoppedPostClaimFixture {
         });
     }
 
+    #[cfg(target_os = "linux")]
     fn set_canary_supervisor_binding_working(&self) {
         rewrite_orchestration_registry(&self.state_dir, |registry| {
             let assignment = &mut registry["assignments"]["assignment-stopped"];
@@ -21602,6 +21610,7 @@ fn wait_for_barrier(barrier: &Path) {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn wait_for_barrier_or_child_exit(barrier: &Path, child: &mut Child, label: &str) {
     let deadline = Instant::now() + Duration::from_secs(10);
     while !barrier.join("ready").is_file() {

--- a/crates/git-cli/src/worktree/dirty_checkout_adoption.rs
+++ b/crates/git-cli/src/worktree/dirty_checkout_adoption.rs
@@ -11079,11 +11079,11 @@ mod tests {
 
         let late_task = proc_root.path().join("10/task/20");
         fs::create_dir_all(&late_task).expect("create late synthetic task");
-        fs::write(
+        fs::write(late_task.join("children"), b"11\n").expect("write initial late-task metadata");
+        let task_children = [
+            proc_root.path().join("10/task/10/children"),
             late_task.join("children"),
-            vec![b' '; MAX_PROC_CHILDREN_BYTES + 1],
-        )
-        .expect("write oversized late-task metadata");
+        ];
         let mut streamed_prefix = Vec::new();
         descendant_processes_at(
             proc_root.path(),
@@ -11093,7 +11093,13 @@ mod tests {
                 metadata_bytes: MAX_PROC_CHILDREN_BYTES * 2,
                 ..limits
             },
-            |identity| streamed_prefix.push(identity),
+            |identity| {
+                streamed_prefix.push(identity);
+                for path in &task_children {
+                    fs::write(path, vec![b' '; MAX_PROC_CHILDREN_BYTES + 1])
+                        .expect("inject oversized remaining-task metadata");
+                }
+            },
         )
         .expect_err("a later task metadata overflow must fail closed");
         assert_eq!(

--- a/crates/semantic-commit/tests/integration/default_branch.rs
+++ b/crates/semantic-commit/tests/integration/default_branch.rs
@@ -630,7 +630,7 @@ fn removed_flags_are_unknown_and_never_mutate() {
             "docs(policy): reject removed flag",
             &head,
             None,
-            &[removed, "obsolete", "--dry-run"],
+            &[removed, "unsupported", "--dry-run"],
         );
 
         assert_eq!(

--- a/deny.toml
+++ b/deny.toml
@@ -49,10 +49,6 @@ skip = [
     { crate = "untrusted@0.7.1", reason = "older untrusted via a TLS dependency path" },
     # wasm bindgen for the image-webp decode path.
     { crate = "wit-bindgen@0.51.0", reason = "image-webp wasm decode; upstream transition" },
-    # clap_complete `unstable-dynamic` needs `shlex ^1`; the workspace already
-    # carries `shlex 2.0.1` (via cc -> cmake -> aws-lc-sys) and the two majors
-    # cannot unify. Skip the duplicate rather than relax `multiple-versions`.
-    { crate = "shlex@1.3.0", reason = "clap_complete unstable-dynamic pulls shlex 1.x; workspace also has shlex 2.x" },
     # `unstable-dynamic` also pulls `is_executable 1.0.6`, whose Windows-target
     # dependency is `windows-sys 0.60`; the workspace mainline is `windows-sys
     # 0.61` (via clap -> anstyle). Skip the lagging 0.60 line (checked across

--- a/release/crates-io-publish-order.txt
+++ b/release/crates-io-publish-order.txt
@@ -20,6 +20,7 @@ nils-screen-record
 nils-secrets
 nils-api-testing-core
 nils-cli-template
+nils-scrub
 nils-claude-cli
 nils-codex-cli
 nils-opencode-cli
@@ -30,7 +31,6 @@ nils-git-lock
 nils-git-scope
 nils-image-processing
 nils-zsh-kit
-nils-scrub
 nils-evidence
 nils-plan-archive
 nils-plan-tooling

--- a/scripts/ci/tests/workspace-test-stale-audit.test.sh
+++ b/scripts/ci/tests/workspace-test-stale-audit.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
+  echo "error: must run inside the nils-cli git work tree" >&2
+  exit 2
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/workspace-test-stale-audit-test.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+fixture="$tmp_dir/repo"
+agent_home="$tmp_dir/agent-home"
+mkdir -p "$fixture/crates/demo/tests" "$agent_home/out/workspace-test-cleanup"
+: >"$fixture/Cargo.toml"
+cat >"$fixture/crates/demo/tests/contracts.rs" <<'RS'
+fn legacy_helper() {}
+const RETAINED_FIELD: &str = "legacy_contract"; // stale-audit: keep-contract
+// TODO: remove superseded fixture
+RS
+
+inventory="$agent_home/out/workspace-test-cleanup/stale-tests.tsv"
+AGENT_HOME="$agent_home" bash "$repo_root/scripts/dev/workspace-test-stale-audit.sh" \
+  --root "$fixture" \
+  --out "$inventory" \
+  >/dev/null
+
+if ! rg -q $'demo\tcrates/demo/tests/contracts.rs\tline:1\tdeprecated_path_marker' "$inventory"; then
+  echo "error: unannotated stale marker was not reported" >&2
+  exit 1
+fi
+if rg -q $'demo\tcrates/demo/tests/contracts.rs\tline:2\tdeprecated_path_marker' "$inventory"; then
+  echo "error: retained compatibility contract was reported" >&2
+  exit 1
+fi
+if ! rg -q $'demo\tcrates/demo/tests/contracts.rs\tline:3\tdeprecated_path_marker' "$inventory"; then
+  echo "error: TODO removal marker was not reported" >&2
+  exit 1
+fi
+
+if ! rg -qF 'run bash scripts/ci/tests/workspace-test-stale-audit.test.sh' \
+  "$repo_root/.agents/skills/project-verify-required-checks/scripts/project-verify-required-checks.sh"; then
+  echo "error: required checks do not invoke the stale-audit self-test" >&2
+  exit 1
+fi
+
+echo "ok: workspace stale-audit tests passed"

--- a/scripts/dev/workspace-test-stale-audit.sh
+++ b/scripts/dev/workspace-test-stale-audit.sh
@@ -279,6 +279,9 @@ scan_crate() {
       while IFS= read -r marker_hit; do
         [[ -z "$marker_hit" ]] && continue
         marker_line="${marker_hit%%:*}"
+        if sed -n "${marker_line}p" "$test_file" | rg -q 'stale-audit: keep-contract'; then
+          continue
+        fi
         add_row "$crate" "$rel_path" "line:${marker_line}" "deprecated_path_marker" "rewrite" "0.65"
       done <<<"$marker_hits"
     fi


### PR DESCRIPTION
## Summary

Restore the required main checks that currently block normal nils-cli delivery: repair Linux provider-stop canary fixtures, make Unix session initialization portable and descriptor-safe, clear the event-listener advisory, correct the crates.io publish order, make strict stale-test auditing distinguish explicit compatibility contracts, and stabilize platform-specific runtime proof plus subprocess-heavy CI fixtures.

## Problem

- Expected: Required Linux, macOS, cargo-deny, and publish-order checks pass from main.
- Actual: The canary fixture lacked its wrapper identity, macOS compiled Linux-only references and could not create session state through `/dev/fd`, event-listener 5.4.1 was advisory-blocked, nils-claude-cli preceded nils-scrub in publish order, the strict stale audit flagged compatibility field names, four shell-completion assets were stale, and later full CI exposed Linux-only stopped-runtime proof assumptions plus two process-pressure timing failures.
- Impact: PR #1358 and subsequent nils-cli delivery cannot converge on required checks.

## Reproduction

1. Run the delegated-cgroup provider-stop canary regression with `AGENT_SESSION_TEST_REQUIRE_CGROUP=1`.
2. Cross-check `nils-agent-session` for `x86_64-apple-darwin`.
3. Run the native macOS coverage job and observe session initialization fail while creating `resume.json` below `/dev/fd/<dirfd>`.
4. Run `scripts/ci/cargo-deny-audit.sh`, `scripts/ci/tests/publish-order-audit.test.sh`, and `scripts/ci/test-stale-audit.sh --strict` from the original main head.
5. Observe the wrapper-record failure, macOS build and session-initialization errors, RUSTSEC-2026-0221, publish-order violation, and compatibility-name false positives.
6. In Actions run 30722487958, observe four completion freshness diffs and the macOS coverage fingerprint reader failing to become active inside its original 25 ms caller bound.
7. In Actions runs 30723268377 and 30724086574, observe the streamed fingerprint boundary test fail on macOS because the fake-git fixture invokes BSD `head` for a zero-byte output case.
8. In the same run's Linux job, observe the successor-lineage fixture reconcile through its fake tmux backend but perform final deletion against ambient tmux, which cannot prove the synthetic session absent.
9. In Actions runs 30724594334 and 30725182329, observe the fresh-profile fake tmux treat production's identity-bound `if-shell` kill as a successful no-op; in runs 30725604255 and 30725879986, observe the sentinel clear while negative-PGID shell kill forms leave the single-process fixture runtime live on macOS.
10. In Actions run 30729098403, observe macOS classify a stopped worker without exact non-Linux runtime proof as healthy, a prompt timeout test exceed its scheduler wall-clock assertion after returning the expected result, and the Linux agent-hook subprocess fixture exit without diagnostics under full-workspace pressure.

## Issues Found

- No tracking issue; this repairs required-check failures observed on PR #1358.

## Fix Approach

- Persist a valid wrapper identity in the two delegated-cgroup fixtures while preserving their injected-process safety assertions.
- Split Linux-only canary, process identity, and cgroup code behind explicit cfg boundaries with fail-closed non-Linux stubs.
- Initialize and clean Unix session state through validated directory descriptors using `openat`, `renameat`, `mkdirat`, and `unlinkat`, without traversing mutable ancestor paths.
- Update event-listener to 5.4.2, remove its obsolete duplicate skip, regenerate notices, and place nils-scrub before nils-claude-cli.
- Require an explicit same-line annotation for compatibility-only stale markers and regression-test the scanner plus required-check wiring.
- Regenerate the bash and zsh completion assets for `agent-session` and `main-agent`.
- Serialize shared fingerprint fixtures for in-process `cargo test`, widen only injected fingerprint timing separation so coverage instrumentation cannot invert the intended deadline ordering, and make the fake-git boundary fixture return success without invoking `head` when the requested output size is zero.
- Keep successor-lineage deletion on the fixture-owned absent tmux backend, matching the immediately preceding reconciliation step and isolating the test from runner tmux state.
- Make the fresh-profile fake tmux execute the matched identity-bound `if-shell` termination by stopping its retained single-process fixture runtime by PID and removing its running sentinel; production still verifies that the recorded process-group boundary is empty. Retain direct `kill-session` handling for the same state model.
- Treat a non-Linux stopped worker without exact durable runtime proof as evidence-unavailable, preserve its authority and worktree, and keep Linux exact-proof behavior unchanged.
- Replace the prompt-observation wall-clock assertion with deterministic blocked-reader synchronization, reserve exclusive nextest admission for the subprocess-heavy agent-hook descriptor/handler fixture and the two agent-session fixtures whose contracts require bounded barriers or exact transcript proof, and require the remaining readiness integrations to pair exact transcript proof with its precise classification while accepting the bounded fail-closed unavailable proof.
- Keep ambiguous recovery reconciliation success on Linux exact stopped-runtime proof; on non-Linux, require `coordination-runtime-unverified` while preserving the assignment revision, recovery fence, and exactly-once Enter boundary.
- Arm the Linux-only provider-stop canary only on the Linux version of the generic ambiguous-initial-Enter fixture; retain the dedicated non-Linux pre-side-effect rejection owner test.
- Keep the generic ambiguous-Enter contract non-canary on every platform, persist its exact worker and `prompt-outcome-unknown` receipt before returning, and fail closed without relaunch or redelivery if that retained session later becomes unavailable; dedicated Linux tests continue to own canary ambiguity.
- At that immediate ambiguous-launch boundary, retry missing Codex resume capture from the exact launch start using the existing bounded, unique same-cwd candidate rules, keep the captured metadata receipt-only, and persist exact worker plus resume evidence through a lifecycle guard that still owns the original in-memory session identity. Replay validates that exact identity before locked metadata backfill and continues from the record returned by that lock, so a replacement can neither receive metadata nor become the receipt authority.
- Bind durable `resume.json` data to exact runtime identity (or an already-matching inline provider identity / explicit never-launched recovery marker), so a stale sidecar cannot make a replacement runtime resumable.
- Permit a finalizer takeover before recovery reservation to decline creating a new attempt only when bounded transcript proof is unavailable; persisted reserved/sending/sent takeovers still resume exactly one attempt and never resend Enter.

## Test-First Evidence

- Before: delegated-cgroup regression failed with `provider-stop-canary-wrapper-record-missing`.
- Before: macOS target check failed with seven missing or out-of-scope Linux symbols.
- Before: native macOS coverage failed to create session state through `/dev/fd/<dirfd>`.
- Before: cargo-deny reported RUSTSEC-2026-0221 and publish-order audit rejected nils-claude-cli before nils-scrub.
- Before: strict stale-test auditing reported 14 compatibility identifiers as deprecated markers.
- Before: Actions runs 30722487958, 30723268377, and 30724086574 reported four stale completion assets, one coverage-only timing failure, and a deterministic macOS zero-byte fake-git failure.
- Before: Actions run 30723268377 also showed the Linux lineage fixture's final deletion leaking onto ambient tmux and failing closed.
- Before: Actions runs 30724594334 and 30725182329 showed the fresh-profile fixture treating identity-bound recovery termination as a no-op and retaining a live process group plus stale running sentinel.
- Before: Actions run 30729098403 exposed the non-Linux stopped-runtime classification gap, scheduler-dependent prompt timing assertion, and full-workspace agent-hook subprocess pressure.
- Before: Actions run 30730446243 proved the new fail-closed classification but exposed an incorrect test expectation that marked its bounded read-only supervise recheck as unexecutable; the final assertion now freezes the exact non-mutating argv.
- Before: Actions run 30730862327 then exposed the regression snapshot treating refreshable `activity.json` as immutable authority; the final test excludes only that observation file while keeping every session authority record and sidecar byte-stable.
- Before: Actions run 30731214523 showed diagnostic initialization materializing its owner-local `coordination/capability-*`; the final baseline is now taken after diagnosis and immediately before rejected reconciliation, so the complete initialized authority tree remains frozen across the actual mutation boundary.
- Before: Actions run 30731494751 passed the new non-Linux authority regression, then exposed two existing revoke-claim assertions that still required Linux-only exact stopped-runtime proof on macOS; the final platform split preserves Linux `worker-runtime-stopped`/65 and requires non-Linux fail-closed `coordination-runtime-unverified`/1.
- Before: Actions run 30731872437 passed the final revoke-claim split, then showed two subprocess-heavy prompt-observation fixtures exhausting bounded reader windows under the 7,690-test coverage load and an initially ambiguous recovery-reconcile failure.
- Before: Actions run 30732311904 proved the isolated recovery-reconcile failure was deterministic platform drift, not process pressure: macOS correctly returned `coordination-runtime-unverified` before Linux-only quiescence and stopped-runtime success assertions. The final test now owns that non-Linux no-mutation boundary explicitly while retaining the complete Linux success flow.
- Before: Actions run 30732858091 passed the complete recovery-reconcile test on macOS, then proved exclusive nextest capacity cannot and should not override the production 500 ms transcript-observation bound under coverage instrumentation. The final readiness tests accept only the exact proof/classification pairs for observed versus bounded-unavailable transcripts while keeping typed failure, delivery proof, and no-resend assertions strict.
- Before: Actions run 30733244208 passed both paired readiness fixtures and progressed beyond their prior fail-fast boundary, then exposed a generic ambiguous-Enter fixture arming the Linux-only canary on macOS. The same run showed a pre-reservation finalizer takeover safely returning attempt 0 when transcript proof was unavailable; the final spec distinguishes that no-attempt branch from the exact attempt-1 requirement after reservation.
- Before: Actions run 30733755779 passed the readiness, recovery-reconcile, and finalizer regressions, then showed the generic ambiguous-Enter fixture still requiring the Linux canary's revision 2 on macOS. Removing the canary from this generic contract exposed the underlying portable non-canary lifecycle at revision 1.
- Before: Actions run 30734196551 advanced past that revision assertion and exposed a real exactly-once gap: the non-canary ambiguous path retained its initial `assignment-created` receipt, so loss of the session record could make replay eligible to relaunch and redeliver. The final implementation persists exact `prompt-outcome-unknown` authority for every managed-worker ambiguous Enter, rejects missing or changed session evidence before launch, and regression-tests zero additional tmux prompt operations before safely resuming the restored worker.
- Before: Actions run 30734973573 passed the new missing-session and changed-identity fail-closed branches, then showed native macOS coverage could finish the safe replay without the available Codex resume ID. The final lifecycle boundary performs one strict capture retry, commits exact worker plus resume evidence from the original locked record without writing session storage, and backfills only after replay revalidates that identity under the session lock. Deterministic replacement races before receipt commit and after locked backfill prove the original identity remains authoritative; a public loader check additionally proves the stale sidecar is rejected and removed instead of making the replacement resumable.
- Before: Actions run 30736682406 reached the final coverage suite, then showed unrelated 7,690-test process pressure exhausting the new identity-race barrier and degrading the existing exact-prompt fixture to `prompt_observation_unavailable`. Both contracts pass together under the final narrowly named nextest admission override.
- Before: Actions run 30737198915 confirmed the override isolated the ambiguous-Enter fixture, but macOS llvm-cov instrumentation still exceeded its fixed 10-second internal race-barrier wait on all three retries before semantic assertions ran. The final fixture grants only its two identity-race barriers a bounded 30-second wait, reports early child exits with captured output, and kills/reaps the child on timeout.
- Before: Actions run 30737908131 used the new child-aware diagnostics and proved the child was not stuck: it returned the expected prompt-outcome-unknown result in about three seconds before reaching the post-capture race barrier. The fixture's 250 ms Codex metadata capture budget was below macOS llvm-cov scan overhead, so the final test-only budget is five seconds while uniqueness, same-CWD filtering, the ambiguity window, and every identity assertion remain unchanged.
- After: each focused regression and the full workspace gate passes; retained evidence is bound to this delivery head.

## Test plan

- `bash .agents/scripts/pre-pr.sh`
- `bash scripts/ci/cargo-deny-audit.sh`
- `cargo clippy -p nils-agent-session --all-targets --all-features --target x86_64-apple-darwin -- -D warnings`
- `cargo test -p nils-agent-session --lib --tests`
- Delegated-cgroup canary injection and cgroup-removal exact tests with `AGENT_SESSION_TEST_REQUIRE_CGROUP=1`
- `bash scripts/ci/tests/publish-order-audit.test.sh`
- `bash scripts/ci/tests/workspace-test-stale-audit.test.sh`
- `bash scripts/ci/completion-freshness-audit.sh --strict`
- `cargo test -p nils-agent-session --lib worktree_fingerprint_ -- --nocapture --test-threads=8`
- `cargo llvm-cov nextest --profile ci -p nils-agent-session --no-report -E 'test(worktree_fingerprint_stalled_regular_file_read_respects_caller_deadline) | test(worktree_fingerprint_streaming_boundaries_and_untracked_aggregate_are_explicit)'`
- `cargo test -p nils-agent-session --test integration coordination::claimed_runtime_stop_successor_adopt_reconcile_and_delete_preserve_lineage -- --exact --nocapture`
- `cargo nextest run -p nils-agent-session -E 'test(worker_prompt_observation_has_a_fixed_time_and_admission_bound)' --stress-count 100`
- `cargo nextest run --profile ci -p nils-agent-session -E 'test(/main_agent_worker_start_await_ready_(stops_on_authoritative_terminal_turns|folds_timeout_into_readiness_failed)/)' --no-capture`
- `NILS_AGENT_SESSION_TEST_RECOVERY_CASE=tmux-timeout-terminal-reconcile cargo nextest run --profile ci -p nils-agent-session -E 'test(main_agent_submit_recovery_rechecks_authority_inside_the_serialized_send_boundary)' --no-capture`
- `cargo nextest run --profile ci -p nils-agent-session -E 'test(/main_agent_worker_start_(preserves_ambiguous_initial_enter_without_redelivery|finalizer_takeover_resumes_the_same_recovery_attempt)/)' --no-capture`
- `cargo fmt --all -- --check && cargo nextest run --profile ci -p nils-agent-session -E 'test(/main_agent_worker_start_(preserves_ambiguous_initial_enter_without_redelivery|timeout_reports_exact_submitted_prompt)/)' --no-capture`
- `cargo fmt --all -- --check && cargo clippy -p nils-agent-session --tests --target x86_64-apple-darwin -- -D warnings`
- `cargo fmt --all -- --check && cargo llvm-cov nextest --profile ci -p nils-agent-session --no-report -E 'test(main_agent_worker_start_preserves_ambiguous_initial_enter_without_redelivery)'`
- `cargo nextest run -p nils-agent-hook -E 'test(enforce_valid_read_only_bypasses_only_the_declared_fallback_handler)' --stress-count 20`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (7,886 tests plus doctests)
- Four broad specialist reviews plus incremental testing, maintainability, and security reviews; no verified findings.

## Risk / Notes

- Low delivery risk. Linux authorization logic remains unchanged; non-Linux Unix initialization now keeps the same validated-ancestor and atomic-write guarantees without relying on Linux procfs behavior. CI retains the authoritative delegated-cgroup and native macOS execution.
