### PR TITLE
fix(agent-session): isolate recovery timeout fixtures

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -38,7 +38,7 @@ threads-required = "num-test-threads"
 # and transcript-observation windows. Give each the complete CI thread pool so
 # unrelated coverage work cannot consume the process admission they validate.
 [[profile.ci.overrides]]
-filter = 'package(nils-agent-session) & test(/(main_agent_worker_start_(definitive_recovery_failure_converges_at_one_terminal_boundary|preserves_ambiguous_initial_enter_without_redelivery|timeout_reports_exact_submitted_prompt|waits_for_late_bootstrap_after_recovery_failure))/)'
+filter = 'package(nils-agent-session) & test(/(main_agent_worker_start_(definitive_recovery_failure_converges_at_(deadline|final_checkpoint|takeover)_boundary|preserves_ambiguous_initial_enter_without_redelivery|timeout_reports_exact_submitted_prompt|waits_for_late_bootstrap_after_recovery_failure))/)'
 threads-required = "num-test-threads"
 
 [profile.ci.junit]

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -35369,17 +35369,27 @@ fn main_agent_worker_start_waits_for_late_bootstrap_after_recovery_failure() {
 }
 
 #[test]
-fn main_agent_worker_start_definitive_recovery_failure_converges_at_one_terminal_boundary() {
-    for mode in ["deadline", "final-checkpoint", "takeover"] {
-        exercise_definitive_recovery_failure_boundary(mode);
-    }
+fn main_agent_worker_start_definitive_recovery_failure_converges_at_deadline_boundary() {
+    exercise_definitive_recovery_failure_boundary("deadline");
+}
+
+#[test]
+fn main_agent_worker_start_definitive_recovery_failure_converges_at_final_checkpoint_boundary() {
+    exercise_definitive_recovery_failure_boundary("final-checkpoint");
+}
+
+#[test]
+fn main_agent_worker_start_definitive_recovery_failure_converges_at_takeover_boundary() {
+    exercise_definitive_recovery_failure_boundary("takeover");
 }
 
 fn exercise_definitive_recovery_failure_boundary(mode: &str) {
     // Coverage instrumentation makes each same-release subprocess startup
-    // materially slower on macOS. Keep synchronization waits generous without
-    // changing the four-second readiness deadline this fixture validates.
-    let synchronization_timeout = Duration::from_secs(60);
+    // materially slower on macOS: a neighboring serialized fixture took more
+    // than 72 seconds in CI before this barrier. Keep synchronization waits
+    // generous without changing the four-second readiness deadline this
+    // fixture validates.
+    let synchronization_timeout = Duration::from_secs(120);
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");
     let checkout = tmp.path().join("checkout");


### PR DESCRIPTION
## Summary

Prevent coverage-instrumented macOS CI from exhausting one shared timeout across three definitive recovery-boundary scenarios. This changes test orchestration only; agent-session runtime behavior and its four-second readiness contract remain unchanged.

## Problem

- Expected: deadline, final-checkpoint, and takeover recovery modes each reach one authoritative terminal boundary under CI coverage.
- Actual: all three modes shared one nextest test timeout, and the macOS coverage job exhausted its 60-second synchronization barrier.
- Impact: the 1.25.12 release PR could not pass the required coverage gate.

## Reproduction

1. Open GitHub Actions run 30750001148, coverage job 91502248137.
2. Observe `main_agent_worker_start_definitive_recovery_failure_converges_at_one_terminal_boundary` time out on all three tries at about 60.1 seconds.
3. Observe the neighboring serialized coverage fixture require 72.640 seconds, demonstrating that the old synchronization ceiling was below measured coverage startup time.

## Issues Found

- Refs #1398

## Fix Approach

Split the combined loop into three independently named fixtures, retain exact full-thread nextest scheduling for each fixture, and raise only the test synchronization ceiling to 120 seconds. The semantic four-second readiness deadline and all terminal-boundary assertions are preserved.

## Test-First Evidence

- Before fix: GitHub Actions run 30750001148, coverage job 91502248137, failed after three approximately 60.1-second attempts.
- Evidence: `test-first-evidence.json` verifies against commit `0f8e9cc98f4bfff9217a857c2f9dc2e882705878`.

## Test plan

- PASS: `TMPDIR=/tmp/nct.Bo5COf RUSTC_WRAPPER= cargo nextest run --profile ci -p nils-agent-session --test integration -E 'test(~definitive_recovery_failure_converges_at_)'`
- PASS: `TMPDIR=/tmp/nct.Bo5COf RUSTC_WRAPPER= bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- REQUIRED BEFORE MERGE: GitHub Actions `test`, `test_macos`, and `coverage` on the exact PR head.

## Risk / Notes

- The 120-second value is a test-fixture synchronization ceiling only; it does not weaken runtime deadlines.
- Exact nextest selectors avoid unintentionally serializing future similarly named tests.
