### PR TITLE
fix(release): recover squash-tag release workflows

### DIFF
--- a/.github/scripts/release-ci-gate.cjs
+++ b/.github/scripts/release-ci-gate.cjs
@@ -129,7 +129,7 @@ async function findTrustedPullRequestCi({
       pull.merged_at &&
       pull.merge_commit_sha === sha &&
       pull.head?.ref === branch &&
-      pull.head?.sha === sha &&
+      /^[0-9a-f]{40}$/i.test(pull.head?.sha || "") &&
       pull.head?.repo?.full_name === fullName &&
       pull.base?.ref === "main" &&
       pull.base?.repo?.full_name === fullName,
@@ -138,6 +138,32 @@ async function findTrustedPullRequestCi({
     return null;
   }
   const trustedPull = trustedPulls[0];
+  const pullHeadSha = trustedPull.head.sha;
+
+  if (pullHeadSha !== sha) {
+    const [taggedCommit, pullHeadCommit] = await Promise.all([
+      github.rest.repos.getCommit({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: sha,
+      }),
+      github.rest.repos.getCommit({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: pullHeadSha,
+      }),
+    ]);
+    const taggedTree = taggedCommit.data?.commit?.tree?.sha;
+    const pullHeadTree = pullHeadCommit.data?.commit?.tree?.sha;
+    if (
+      taggedCommit.data?.sha !== sha ||
+      pullHeadCommit.data?.sha !== pullHeadSha ||
+      !/^[0-9a-f]{40}$/i.test(taggedTree || "") ||
+      taggedTree !== pullHeadTree
+    ) {
+      return null;
+    }
+  }
 
   const runs = await listAll(
     github,
@@ -147,7 +173,7 @@ async function findTrustedPullRequestCi({
       repo: context.repo.repo,
       workflow_id: "ci.yml",
       event: "pull_request",
-      head_sha: sha,
+      head_sha: pullHeadSha,
       per_page: 100,
     },
     "workflow_runs",
@@ -158,13 +184,13 @@ async function findTrustedPullRequestCi({
       run.status === "completed" &&
       run.conclusion === "success" &&
       run.head_branch === branch &&
-      run.head_sha === sha &&
+      run.head_sha === pullHeadSha &&
       run.repository?.full_name === fullName &&
       run.head_repository?.full_name === fullName &&
       ((run.pull_requests || []).length === 0 ||
         ((run.pull_requests || []).length === 1 &&
           run.pull_requests[0].number === trustedPull.number &&
-          run.pull_requests[0].head?.sha === sha &&
+          run.pull_requests[0].head?.sha === pullHeadSha &&
           run.pull_requests[0].base?.ref === "main")),
   );
   if (trustedRuns.length !== 1) {

--- a/.github/scripts/validate-release-invocation.sh
+++ b/.github/scripts/validate-release-invocation.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+event_name="${1:-}"
+actor="${2:-}"
+triggering_actor="${3:-}"
+run_attempt="${4:-}"
+release_ref="${5:-}"
+
+is_broker_identity() {
+  case "$1" in
+    xsin4880|"dobi-bot[bot]") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+[[ "$run_attempt" =~ ^[1-9][0-9]*$ ]] || {
+  echo "error: release workflow run attempt is invalid" >&2
+  exit 1
+}
+
+case "$event_name" in
+  push)
+    if ((run_attempt > 1)) && ! is_broker_identity "$triggering_actor"; then
+      echo "error: release workflow reruns are restricted to trusted broker identities" >&2
+      exit 1
+    fi
+    ;;
+  workflow_dispatch)
+    if ! is_broker_identity "$actor" || ! is_broker_identity "$triggering_actor"; then
+      echo "error: workflow_dispatch release recovery is restricted to trusted broker identities" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "error: unsupported release workflow event" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! "$release_ref" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: release workflow requires a stable v-prefixed tag ref, got $release_ref" >&2
+  exit 1
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   verify_ci:
@@ -18,6 +19,21 @@ jobs:
     steps:
       - name: Checkout release gate
         uses: actions/checkout@v7
+
+      - name: Authorize release invocation
+        shell: bash
+        env:
+          RELEASE_ACTOR: ${{ github.actor }}
+          RELEASE_EVENT: ${{ github.event_name }}
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          RELEASE_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          bash .github/scripts/validate-release-invocation.sh \
+            "${RELEASE_EVENT}" \
+            "${RELEASE_ACTOR}" \
+            "${RELEASE_TRIGGERING_ACTOR}" \
+            "${RELEASE_RUN_ATTEMPT}" \
+            "${GITHUB_REF}"
 
       - name: Require green CI on tagged commit
         uses: actions/github-script@v9

--- a/scripts/ci/tests/release-ci-gate.test.cjs
+++ b/scripts/ci/tests/release-ci-gate.test.cjs
@@ -31,6 +31,8 @@ if (fs.existsSync(modulePath)) {
   const fullName = `${owner}/${repo}`;
   const releaseSha = "a".repeat(40);
   const baseSha = "b".repeat(40);
+  const pullHeadSha = "c".repeat(40);
+  const releaseTreeSha = "d".repeat(40);
   const branch = "chore/release-1-22-10";
   const context = {
     ref: "refs/tags/v1.22.10",
@@ -100,6 +102,10 @@ if (fs.existsSync(modulePath)) {
         conclusion: "success",
         completed_at: "2026-07-16T12:00:00Z",
       })),
+      commitsByRef: {
+        [releaseSha]: { sha: releaseSha, commit: { tree: { sha: releaseTreeSha } } },
+        [pullHeadSha]: { sha: pullHeadSha, commit: { tree: { sha: releaseTreeSha } } },
+      },
       ...overrides,
     };
     return {
@@ -124,6 +130,9 @@ if (fs.existsSync(modulePath)) {
           checks: {
             listForRef: async () => ({ data: { check_runs: state.checkRuns } }),
           },
+          repos: {
+            getCommit: async ({ ref }) => ({ data: state.commitsByRef[ref] }),
+          },
         },
       },
     };
@@ -144,6 +153,36 @@ if (fs.existsSync(modulePath)) {
       runId: 100,
       runUrl: `https://github.com/${fullName}/actions/runs/100`,
     });
+  });
+
+  test("a squash-merged release PR is trusted when its tested head tree matches the tagged tree", async () => {
+    const { state, github } = fixture();
+    state.pulls[0].head.sha = pullHeadSha;
+    state.workflowRuns[0].head_sha = pullHeadSha;
+    state.workflowRuns[0].pull_requests = [
+      {
+        number: 1253,
+        head: { sha: pullHeadSha },
+        base: { ref: "main" },
+      },
+    ];
+
+    const trusted = await findTrustedPullRequestCi({ github, context, sha: releaseSha });
+
+    assert.deepEqual(trusted, {
+      prNumber: 1253,
+      runId: 100,
+      runUrl: `https://github.com/${fullName}/actions/runs/100`,
+    });
+  });
+
+  test("a squash-merged release PR fails closed when its tested tree differs from the tagged tree", async () => {
+    const { state, github } = fixture();
+    state.pulls[0].head.sha = pullHeadSha;
+    state.workflowRuns[0].head_sha = pullHeadSha;
+    state.commitsByRef[pullHeadSha].commit.tree.sha = "e".repeat(40);
+
+    assert.equal(await findTrustedPullRequestCi({ github, context, sha: releaseSha }), null);
   });
 
   test("ambiguous workflow runs fail closed", async () => {
@@ -182,6 +221,11 @@ if (fs.existsSync(modulePath)) {
             base: { ref: "main" },
           },
         ];
+      },
+      "missing tagged commit evidence": (state) => {
+        state.pulls[0].head.sha = pullHeadSha;
+        state.workflowRuns[0].head_sha = pullHeadSha;
+        delete state.commitsByRef[releaseSha];
       },
     };
 

--- a/scripts/ci/tests/release-workflow-contract.test.sh
+++ b/scripts/ci/tests/release-workflow-contract.test.sh
@@ -35,6 +35,36 @@ assert_not_contains() {
 assert_contains .github/workflows/release.yml \
   'require("./.github/scripts/release-ci-gate.cjs")' \
   "release workflow uses checked-in provenance gate"
+assert_contains .github/workflows/release.yml "workflow_dispatch:" \
+  "release workflow supports exact-tag recovery dispatch"
+assert_contains .github/workflows/release.yml "RELEASE_TRIGGERING_ACTOR" \
+  "release reruns bind the triggering identity"
+assert_contains .github/workflows/release.yml \
+  'bash .github/scripts/validate-release-invocation.sh' \
+  "release recovery uses the tested invocation validator"
+
+validator=.github/scripts/validate-release-invocation.sh
+bash "$validator" push graysurf graysurf 1 refs/tags/v1.22.10
+bash "$validator" workflow_dispatch xsin4880 xsin4880 1 refs/tags/v1.22.10
+bash "$validator" workflow_dispatch 'dobi-bot[bot]' 'dobi-bot[bot]' 1 refs/tags/v1.22.10
+bash "$validator" push graysurf xsin4880 2 refs/tags/v1.22.10
+assert_invocation_rejected() {
+  if bash "$validator" "$@" >/dev/null 2>&1; then
+    echo "FAIL: release invocation validator accepted: $*" >&2
+    exit 1
+  fi
+}
+assert_invocation_rejected workflow_dispatch xsin4880 untrusted-writer 2 refs/tags/v1.22.10
+assert_invocation_rejected workflow_dispatch untrusted-writer untrusted-writer 1 refs/tags/v1.22.10
+assert_invocation_rejected workflow_dispatch xsin4880 "" 1 refs/tags/v1.22.10
+assert_invocation_rejected push graysurf untrusted-writer 2 refs/tags/v1.22.10
+assert_invocation_rejected schedule xsin4880 xsin4880 1 refs/tags/v1.22.10
+for invalid_ref in refs/heads/main refs/tags/v1.22.10-rc.1 refs/tags/1.22.10; do
+  if bash "$validator" push graysurf graysurf 1 "$invalid_ref" >/dev/null 2>&1; then
+    echo "FAIL: release ref validator accepted $invalid_ref" >&2
+    exit 1
+  fi
+done
 assert_contains .github/workflows/release.yml "pull-requests: read" \
   "release gate can verify the canonical merged PR"
 assert_contains .github/workflows/release.yml "- runs_on: ubuntu-24.04-arm" \


### PR DESCRIPTION
## Summary

The public release workflow now recognizes canonical squash-merged release PRs by exact merge commit plus Git tree equivalence, and supports a tightly authorized exact-tag recovery dispatch without weakening existing provenance checks.

## Problem

- Expected: a canonical same-repository release PR should supply trusted CI evidence after squash merge when its head and the tag resolve to identical trees.
- Actual: the release gate required the PR head SHA to equal the squash merge/tag SHA, so the v1.25.12 release was rejected despite valid PR CI.
- Impact: stable release publication could not complete through the normal workflow, and an absent run had no safe public recovery entrypoint.

## Reproduction

1. Merge a canonical release PR with GitHub squash merge.
2. Tag the resulting merge commit.
3. Run the stable release workflow.
4. Observe the previous gate reject the differing PR head SHA before comparing the trees.

## Issues Found

- Reproduced by the failed v1.25.12 public release workflow.

## Fix Approach

Require a unique merged canonical PR whose merge commit is the tagged SHA; when the PR head differs, fetch both commits and require identical Git tree SHAs before reading CI from the actual PR head. Add a tested invocation validator that permits stable-tag dispatch and rerun recovery only for explicitly trusted actor and triggering-actor identities.

## Test-First Evidence

- Before fix: public release run 30758142418 failed because the gate bound trusted PR CI to an exact PR-head/tag SHA match.
- Regression ownership: release-ci-gate.test.cjs now covers squash tree equivalence and mismatch; release-workflow-contract.test.sh executes the actor, rerun, event, and stable-ref authorization matrix.

## Test plan

- node scripts/ci/tests/release-ci-gate.test.cjs — pass (19 cases)
- bash scripts/ci/tests/release-workflow-contract.test.sh — pass
- bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast — pass (7,889 tests plus doctests)
- Security, testing, and maintainability specialist reviews — pass

## Risk / Notes

- Moderate release-path risk. The new path remains fail-closed, requires exact repository/PR/run/job/tree binding, and restricts recovery identities to an explicit allowlist.
