### PR TITLE
fix(git-cli): own branch push and default-branch sync

### DIFF
--- a/crates/git-cli/README.md
+++ b/crates/git-cli/README.md
@@ -116,6 +116,26 @@ The managed layout (`repo-key`, the managed/external classification, and slug-ba
 anchored to the repository's primary worktree, so `worktree` commands behave identically whether run
 from the primary checkout or from inside any linked worktree.
 
+### push
+
+- `push`: Publish the checked-out branch to its own branch on the remote, using the fully
+  qualified refspec `refs/heads/<branch>:refs/heads/<branch>` so the destination cannot depend on
+  `push.default`, `remote.pushDefault`, or configured push refspecs. Sets the upstream on first
+  publish. Refuses the remote's default branch (`refuse-default-branch`), a detached HEAD, and an
+  unresolvable remote default (`default-branch-unresolved`).
+  Options: `--remote <name>`, `--expect-default <branch>`, `--force-with-lease`, `--dry-run`,
+  `--format text|json`.
+
+### sync-default
+
+- `sync-default`: Fast-forward the local default branch to its remote-tracking ref, and nothing
+  else. Uses `git merge --ff-only` when the default branch is checked out here, and a
+  compare-and-swap `git update-ref` when no worktree holds it. Refuses divergence
+  (`not-fast-forward`), a dirty checkout, and a default branch held by another worktree.
+  Options: `--remote <name>`, `--no-fetch`, `--dry-run`, `--format text|json`.
+
+See the [remote surfaces spec](docs/specs/git-cli-remote-surfaces.md) for the full contract.
+
 ### ci
 
 - `pick`: Create and push a `ci/<target>/<name>` branch with cherry-picked commits.
@@ -186,3 +206,4 @@ Rust implementation rather than spawning another binary.
 
 - [Docs index](docs/README.md)
 - [Worktree convention spec](docs/specs/git-cli-worktree-convention.md)
+- [Remote surfaces spec](docs/specs/git-cli-remote-surfaces.md)

--- a/crates/git-cli/docs/README.md
+++ b/crates/git-cli/docs/README.md
@@ -5,6 +5,7 @@
 ## Specs
 
 - [Dirty checkout adoption JSON contract v1](specs/dirty-checkout-adoption-json-contract-v1.md)
+- [git-cli remote surfaces](specs/git-cli-remote-surfaces.md)
 - [git-cli worktree convention](specs/git-cli-worktree-convention.md)
 
 ## Runbooks

--- a/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
+++ b/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
@@ -1,0 +1,118 @@
+# git-cli Remote Surfaces
+
+## Ownership
+
+This is a crate-local specification for `git-cli push` and
+`git-cli sync-default`.
+
+## Why These Exist
+
+Agent policy assigns an owner to every Git mutation an agent performs: commits
+go through `semantic-commit`, worktrees through `git-cli worktree`, PR/MR
+records and merges through `forge-cli pr`, and default-branch delivery through
+`semantic-commit default-branch` / `forge-cli repo push-default`.
+
+Two mutations had no owner:
+
+- publishing a feature branch, and
+- advancing the local default branch to a commit already on its remote.
+
+Both had to fall back to raw `git`, which the delivery guard is built to
+distrust because a raw invocation cannot prove what it will touch. These two
+commands close that gap by making the safe cases provable rather than inferred.
+
+## `git-cli push`
+
+```text
+git-cli push [--remote <name>] [--expect-default <branch>]
+             [--force-with-lease] [--dry-run] [--format text|json]
+```
+
+Publishes the checked-out branch to the same-named branch on `<remote>`
+(default `origin`).
+
+The push always uses the fully qualified refspec
+`refs/heads/<branch>:refs/heads/<branch>`. That is the point of the command: it
+removes every input that makes a bare `git push` unclassifiable — `push.default`,
+`remote.pushDefault`, configured push refspecs, and upstream inference all stop
+affecting the destination. The only way the command could reach the default
+branch is by being *on* it, which it refuses.
+
+It adds `--set-upstream` whenever the configured upstream is not already this
+branch's own ref on this remote. That covers first publish for a branch created
+by `git-cli worktree add --no-track`, and it repairs a branch created before
+that flag existed, which carries the *default* branch as its upstream. Checking
+only for the presence of an upstream would leave exactly the broken case
+unrepaired.
+
+Refusals:
+
+| `error.code` | Condition |
+| --- | --- |
+| `detached-head` | HEAD is not attached to a branch |
+| `default-branch-unresolved` | `refs/remotes/<remote>/HEAD` is not cached and no `--expect-default` was given |
+| `refuse-default-branch` | the checked-out branch is the remote's default branch |
+| `unknown-remote` | `<remote>` is not configured |
+
+`--expect-default` names what the default branch *is* when the remote HEAD is
+not cached locally, which is the offline path. It can only ever add a refusal:
+asserting `--expect-default main` while on `main` still refuses.
+
+Pushing the default branch is a delivery decision, not a publish step, so
+`refuse-default-branch` points at `forge-cli repo push-default` rather than
+offering a flag.
+
+## `git-cli sync-default`
+
+```text
+git-cli sync-default [--remote <name>] [--no-fetch] [--dry-run]
+                     [--format text|json]
+```
+
+Fast-forwards the local default branch to its remote-tracking ref. Fetches that
+one ref first unless `--no-fetch` is passed.
+
+The safety argument is that the local ref only ever moves forward onto a commit
+that is already published: nothing is authored, no content changes, nothing is
+published, and `git reset --hard @{1}` reverses it. Anything else is refused.
+
+Three strategies, selected by where the default branch is checked out:
+
+| `strategy` | Condition | Mechanism |
+| --- | --- | --- |
+| `noop` | local and remote refs already match | none |
+| `merge-ff-only` | the default branch is checked out here | `git merge --ff-only` after a clean-checkout check |
+| `update-ref` | no worktree holds the default branch | `git update-ref <ref> <new> <old>`, a compare-and-swap |
+
+`update-ref` is the everyday agent case — working on a topic branch while local
+`main` lags — and it moves the ref without touching any working tree.
+
+Refusals:
+
+| `error.code` | Condition |
+| --- | --- |
+| `not-fast-forward` | the local default branch carries commits the remote does not have |
+| `dirty-checkout` | the default branch is checked out here with staged or unstaged changes |
+| `default-branch-checked-out-elsewhere` | another worktree holds the default branch |
+| `local-default-branch-missing` | the repository has no local default branch |
+| `remote-default-branch-missing` | the remote-tracking ref does not resolve |
+| `default-branch-unresolved` | `refs/remotes/<remote>/HEAD` is not cached |
+| `git-fetch-failed` | the fetch failed; `--no-fetch` syncs against the already-fetched ref |
+
+## JSON Contract
+
+Both commands accept `--format text|json` and use the shared workspace envelope:
+
+- `cli.git-cli.push.v1`
+- `cli.git-cli.sync-default.v1`
+
+`push` returns `branch`, `remote`, `remote_branch`, `refspec`, `head`,
+`default_branch`, `pushed`, `dry_run`, `created_remote_branch`, `upstream`, and
+`forced`.
+
+`sync-default` returns `default_branch`, `remote`, `remote_ref`,
+`previous_head`, `new_head`, `strategy`, `already_current`, `fast_forward`,
+`dry_run`, and `fetched`.
+
+`--dry-run` performs every read-only check and reports the strategy and target
+head it would use, without mutating anything.

--- a/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
+++ b/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
@@ -51,12 +51,24 @@ Refusals:
 | --- | --- |
 | `detached-head` | HEAD is not attached to a branch |
 | `default-branch-unresolved` | `refs/remotes/<remote>/HEAD` is not cached and no `--expect-default` was given |
+| `default-branch-unverifiable` | the remote head is not cached and the checked-out branch is a conventional default-branch name |
+| `expect-default-mismatch` | `--expect-default` disagrees with the cached remote head |
 | `refuse-default-branch` | the checked-out branch is the remote's default branch |
 | `unknown-remote` | `<remote>` is not configured |
 
 `--expect-default` names what the default branch *is* when the remote HEAD is
-not cached locally, which is the offline path. It can only ever add a refusal:
-asserting `--expect-default main` while on `main` still refuses.
+not cached locally, which is the offline path. It is an escape hatch, never a
+second opinion, so it can only ever *add* a refusal:
+
+- when the remote head **is** cached, cached truth wins and a disagreeing
+  assertion is `expect-default-mismatch`;
+- when it is **not** cached, the assertion cannot clear a branch whose name is
+  conventionally a default (`main`, `master`, `trunk`, `develop`,
+  `development`, `default`) — that is `default-branch-unverifiable`.
+
+Without those two rules `--expect-default develop` while standing on `main`
+would publish the default branch, which is the thing this command exists to
+refuse.
 
 Pushing the default branch is a delivery decision, not a publish step, so
 `refuse-default-branch` points at `forge-cli repo push-default` rather than

--- a/crates/git-cli/docs/specs/git-cli-worktree-convention.md
+++ b/crates/git-cli/docs/specs/git-cli-worktree-convention.md
@@ -44,6 +44,19 @@ path so the caller can `cd` into it. `--shell` prints an evaluable
 `cd -- <path>` command instead of the bare path, mirroring `utils root --shell`;
 the committed `gxwcd` shell helper wraps it and adds worktree-name completion.
 
+## Upstream Tracking
+
+`add` creates the branch with `--no-track`. The default base ref is the cached
+remote default branch (`origin/main`), and Git's `branch.autoSetupMerge` default
+would otherwise record *that* as the new branch's upstream — leaving
+`branch.<new>.merge = refs/heads/main`. Every consumer that reads `@{upstream}`
+to find the branch head would then resolve the default branch instead, which is
+how `forge-cli pr deliver` came to report an already-pushed head as unpushed.
+
+A managed worktree branch is unpublished, so it has no upstream. The upstream is
+established at publish time by `git-cli push`, which sets it to the branch's own
+ref. See [git-cli remote surfaces](git-cli-remote-surfaces.md).
+
 ## Primary Worktree Resolution
 
 The managed layout — `<repo-key>`, the managed/external classification, and

--- a/crates/git-cli/src/cli.rs
+++ b/crates/git-cli/src/cli.rs
@@ -3,7 +3,7 @@ use clap::{Args, CommandFactory, Parser, Subcommand};
 use nils_common::cli_contract::exit;
 use std::ffi::OsString;
 
-use crate::{branch, ci, commit, completion, open, reset, utils, worktree};
+use crate::{branch, ci, commit, completion, open, publish, reset, utils, worktree};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -35,6 +35,13 @@ enum Group {
     Ci(CiGroup),
     #[command(about = "Open remote pages")]
     Open(OpenGroup),
+    #[command(about = "Publish the checked-out branch to its own remote branch")]
+    Push(RawArgs),
+    #[command(
+        name = "sync-default",
+        about = "Fast-forward the local default branch to its remote-tracking ref"
+    )]
+    SyncDefault(RawArgs),
     #[command(about = "Summarize repository history")]
     Summary(RawArgs),
     #[command(about = "Export shell completion script")]
@@ -286,6 +293,10 @@ where
         Some(Group::Worktree(group)) => run_worktree(group),
         Some(Group::Ci(group)) => run_ci(group),
         Some(Group::Open(group)) => run_open(group),
+        Some(Group::Push(raw)) => publish::dispatch("push", &raw.args).unwrap_or(exit::USAGE),
+        Some(Group::SyncDefault(raw)) => {
+            publish::dispatch("sync-default", &raw.args).unwrap_or(exit::USAGE)
+        }
         Some(Group::Summary(raw)) => git_summary::cli::run_embedded(&raw.args),
         Some(Group::Completion(raw)) => run_completion(raw),
         Some(Group::Help) | None => print_root_help(),

--- a/crates/git-cli/src/lib.rs
+++ b/crates/git-cli/src/lib.rs
@@ -8,6 +8,7 @@ pub mod commit_shared;
 pub mod completion;
 pub mod open;
 pub mod prompt;
+pub mod publish;
 pub mod reset;
 pub mod utils;
 pub mod worktree;

--- a/crates/git-cli/src/publish.rs
+++ b/crates/git-cli/src/publish.rs
@@ -35,6 +35,16 @@ pub fn dispatch(cmd: &str, args: &[String]) -> Option<i32> {
 }
 
 const DEFAULT_REMOTE: &str = "origin";
+/// Branch names conventionally used as a repository default. Used only to refuse
+/// an *unverifiable* push, never to admit one.
+const WELL_KNOWN_DEFAULT_BRANCHES: &[&str] = &[
+    "main",
+    "master",
+    "trunk",
+    "develop",
+    "development",
+    "default",
+];
 const PUSH_DEFAULT_HINT: &str = "pushing the default branch is a delivery decision, not a publish step; use \
      `forge-cli repo push-default` with the expected base and reason file when \
      direct-main delivery was explicitly authorized";
@@ -137,10 +147,50 @@ fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
     // it, because the refspec below is pinned to the checked-out branch. So the
     // default branch is the single fact that has to be established before any
     // mutation, and failing to establish it is a refusal, not a warning.
-    let default_branch = match args.expect_default.clone() {
-        Some(expected) => expected,
-        None => cached_default_branch(&args.remote).ok_or_else(|| {
-            CliError::data(
+    //
+    // `--expect-default` is an escape hatch for an uncached remote head, never a
+    // second opinion that can widen admission. Cached truth always wins, and a
+    // disagreeing assertion is a mismatch: otherwise `--expect-default develop`
+    // while standing on `main` would publish the default branch.
+    let default_branch = match (cached_default_branch(&args.remote), &args.expect_default) {
+        (Some(cached), Some(expected)) if cached != *expected => {
+            return Err(CliError::data(
+                "expect-default-mismatch",
+                format!(
+                    "--expect-default '{expected}' disagrees with the cached default \
+                     branch '{cached}' of remote '{}'",
+                    args.remote
+                ),
+            )
+            .with_hint(
+                "drop `--expect-default`; it names the default branch only when the \
+                 remote head is not cached locally",
+            ));
+        }
+        (Some(cached), _) => cached,
+        (None, Some(expected)) => {
+            // The assertion is unverifiable here, so it cannot be trusted to
+            // clear a branch that plausibly *is* a default branch.
+            if WELL_KNOWN_DEFAULT_BRANCHES.contains(&branch.as_str()) {
+                return Err(CliError::data(
+                    "default-branch-unverifiable",
+                    format!(
+                        "'{branch}' is a conventional default-branch name and the \
+                         default branch of remote '{}' is not cached, so this push \
+                         cannot be proven safe",
+                        args.remote
+                    ),
+                )
+                .with_hint(format!(
+                    "run `git remote set-head {} --auto` to establish the real \
+                     default branch; `--expect-default` cannot admit this push",
+                    args.remote
+                )));
+            }
+            expected.clone()
+        }
+        (None, None) => {
+            return Err(CliError::data(
                 "default-branch-unresolved",
                 format!(
                     "cannot resolve the default branch of remote '{}'",
@@ -151,8 +201,8 @@ fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
                 "run `git remote set-head {} --auto` to cache it, or pass \
                  `--expect-default <branch>` to name it offline",
                 args.remote
-            ))
-        })?,
+            )));
+        }
     };
 
     if branch == default_branch {

--- a/crates/git-cli/src/publish.rs
+++ b/crates/git-cli/src/publish.rs
@@ -1,0 +1,700 @@
+//! Governed remote surfaces: publish a feature branch, and adopt the remote's
+//! default branch locally.
+//!
+//! Both operations are ordinary Git mutations that agent policy still has to
+//! account for, and neither had an owner before. Raw `git push` cannot prove it
+//! leaves the default branch alone, and raw `git merge --ff-only origin/main`
+//! cannot prove it publishes nothing — so the delivery guard has to distrust
+//! both on sight. These two commands make the safe cases provable:
+//!
+//! * [`run_push`] resolves one fully qualified refspec for the checked-out
+//!   branch and refuses outright when that branch is the remote's default.
+//! * [`run_sync_default`] only ever fast-forwards the local default branch to a
+//!   commit that is already published, and refuses anything else.
+//!
+//! Every refusal is a typed envelope error, so a caller can tell "this is
+//! forbidden" from "this could not be proven" without parsing prose.
+
+use crate::commit_shared::{
+    git_output, git_status_success, git_stdout_trimmed, git_stdout_trimmed_optional,
+};
+use crate::worktree::{
+    CliError, detect_format, emit_error, emit_success, ensure_inside_git_repo,
+    linked_worktrees_by_branch, summarize_git_error, take_format, take_help,
+};
+use nils_common::cli_contract::OutputFormat;
+use serde::Serialize;
+use serde_json::json;
+
+pub fn dispatch(cmd: &str, args: &[String]) -> Option<i32> {
+    match cmd {
+        "push" => Some(run_push(args)),
+        "sync-default" => Some(run_sync_default(args)),
+        _ => None,
+    }
+}
+
+const DEFAULT_REMOTE: &str = "origin";
+const PUSH_DEFAULT_HINT: &str = "pushing the default branch is a delivery decision, not a publish step; use \
+     `forge-cli repo push-default` with the expected base and reason file when \
+     direct-main delivery was explicitly authorized";
+
+#[derive(Debug)]
+struct PushArgs {
+    remote: String,
+    expect_default: Option<String>,
+    force_with_lease: bool,
+    dry_run: bool,
+    format: OutputFormat,
+}
+
+#[derive(Debug)]
+struct SyncArgs {
+    remote: String,
+    fetch: bool,
+    dry_run: bool,
+    format: OutputFormat,
+}
+
+#[derive(Debug, Serialize)]
+struct PushOutput {
+    branch: String,
+    remote: String,
+    remote_branch: String,
+    refspec: String,
+    head: String,
+    default_branch: String,
+    pushed: bool,
+    dry_run: bool,
+    created_remote_branch: bool,
+    upstream: String,
+    forced: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SyncOutput {
+    default_branch: String,
+    remote: String,
+    remote_ref: String,
+    previous_head: String,
+    new_head: String,
+    strategy: &'static str,
+    already_current: bool,
+    fast_forward: bool,
+    dry_run: bool,
+    fetched: bool,
+}
+
+// ------------------------------------------------------------------ push
+
+fn run_push(args: &[String]) -> i32 {
+    let requested_format = detect_format(args);
+    if take_help(args) {
+        print_push_help();
+        return 0;
+    }
+    let parsed = match parse_push_args(args) {
+        Ok(parsed) => parsed,
+        Err(err) => return emit_error("push", requested_format, err),
+    };
+
+    match push_branch(&parsed) {
+        Ok(output) => emit_success("push", parsed.format, &output, || {
+            if output.dry_run {
+                format!(
+                    "Would push {} -> {}/{}\nHead: {}",
+                    output.branch,
+                    output.remote,
+                    output.remote_branch,
+                    short(&output.head)
+                )
+            } else {
+                format!(
+                    "Pushed {} -> {}/{}\nHead: {}\nUpstream: {}",
+                    output.branch,
+                    output.remote,
+                    output.remote_branch,
+                    short(&output.head),
+                    output.upstream
+                )
+            }
+        }),
+        Err(err) => emit_error("push", parsed.format, err),
+    }
+}
+
+fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
+    ensure_inside_git_repo()?;
+    require_remote(&args.remote)?;
+
+    let branch = current_branch().ok_or_else(|| {
+        CliError::data("detached-head", "HEAD is not attached to a branch").with_hint(
+            "check out the branch you want to publish; a detached HEAD has no branch to push",
+        )
+    })?;
+
+    // The only way this command can touch the default branch is by being *on*
+    // it, because the refspec below is pinned to the checked-out branch. So the
+    // default branch is the single fact that has to be established before any
+    // mutation, and failing to establish it is a refusal, not a warning.
+    let default_branch = match args.expect_default.clone() {
+        Some(expected) => expected,
+        None => cached_default_branch(&args.remote).ok_or_else(|| {
+            CliError::data(
+                "default-branch-unresolved",
+                format!(
+                    "cannot resolve the default branch of remote '{}'",
+                    args.remote
+                ),
+            )
+            .with_hint(format!(
+                "run `git remote set-head {} --auto` to cache it, or pass \
+                 `--expect-default <branch>` to name it offline",
+                args.remote
+            ))
+        })?,
+    };
+
+    if branch == default_branch {
+        return Err(CliError::data(
+            "refuse-default-branch",
+            format!(
+                "'{branch}' is the default branch of remote '{}'",
+                args.remote
+            ),
+        )
+        .with_hint(PUSH_DEFAULT_HINT)
+        .with_details(json!({
+            "branch": branch,
+            "remote": args.remote,
+            "default_branch": default_branch,
+        })));
+    }
+
+    let head = git_stdout_trimmed(&["rev-parse", "HEAD"]).map_err(|err| {
+        CliError::runtime("head-unresolved", summarize_git_error(&err.to_string()))
+    })?;
+
+    let remote_ref = format!("refs/remotes/{}/{branch}", args.remote);
+    let created_remote_branch =
+        !git_status_success(&["show-ref", "--verify", "--quiet", &remote_ref]);
+
+    // A fully qualified refspec removes every source of ambiguity that makes a
+    // bare `git push` unclassifiable: `push.default`, `remote.pushDefault`,
+    // configured push refspecs, and upstream inference all stop mattering.
+    let refspec = format!("refs/heads/{branch}:refs/heads/{branch}");
+    let upstream = format!("{}/{branch}", args.remote);
+
+    if args.dry_run {
+        return Ok(PushOutput {
+            branch,
+            remote: args.remote.clone(),
+            remote_branch: refspec
+                .rsplit_once("refs/heads/")
+                .map(|(_, name)| name.to_string())
+                .unwrap_or_default(),
+            refspec,
+            head,
+            default_branch,
+            pushed: false,
+            dry_run: true,
+            created_remote_branch,
+            upstream,
+            forced: args.force_with_lease,
+        });
+    }
+
+    let mut argv: Vec<&str> = vec!["push", "--quiet"];
+    if args.force_with_lease {
+        argv.push("--force-with-lease");
+    }
+    // Set the upstream whenever it is not already this branch's own ref on this
+    // remote. "Has an upstream" is not good enough: a branch created before
+    // `worktree add` passed `--no-track` carries the *default* branch as its
+    // upstream, and that is exactly the state worth repairing on publish.
+    if !upstream_is_own_ref(&args.remote, &branch) {
+        argv.push("--set-upstream");
+    }
+    argv.push(&args.remote);
+    argv.push(&refspec);
+    git_output(&argv).map_err(|err| {
+        CliError::runtime("git-push-failed", summarize_git_error(&err.to_string()))
+    })?;
+
+    Ok(PushOutput {
+        remote_branch: branch.clone(),
+        branch,
+        remote: args.remote.clone(),
+        refspec,
+        head,
+        default_branch,
+        pushed: true,
+        dry_run: false,
+        created_remote_branch,
+        upstream,
+        forced: args.force_with_lease,
+    })
+}
+
+// ---------------------------------------------------------- sync-default
+
+fn run_sync_default(args: &[String]) -> i32 {
+    let requested_format = detect_format(args);
+    if take_help(args) {
+        print_sync_help();
+        return 0;
+    }
+    let parsed = match parse_sync_args(args) {
+        Ok(parsed) => parsed,
+        Err(err) => return emit_error("sync-default", requested_format, err),
+    };
+
+    match sync_default(&parsed) {
+        Ok(output) => emit_success("sync-default", parsed.format, &output, || {
+            if output.already_current {
+                format!(
+                    "Already current: {} at {}",
+                    output.default_branch,
+                    short(&output.new_head)
+                )
+            } else if output.dry_run {
+                format!(
+                    "Would fast-forward {} {}..{} ({})",
+                    output.default_branch,
+                    short(&output.previous_head),
+                    short(&output.new_head),
+                    output.strategy
+                )
+            } else {
+                format!(
+                    "Fast-forwarded {} {}..{} ({})",
+                    output.default_branch,
+                    short(&output.previous_head),
+                    short(&output.new_head),
+                    output.strategy
+                )
+            }
+        }),
+        Err(err) => emit_error("sync-default", parsed.format, err),
+    }
+}
+
+fn sync_default(args: &SyncArgs) -> Result<SyncOutput, CliError> {
+    ensure_inside_git_repo()?;
+    require_remote(&args.remote)?;
+
+    let default_branch = cached_default_branch(&args.remote).ok_or_else(|| {
+        CliError::data(
+            "default-branch-unresolved",
+            format!(
+                "cannot resolve the default branch of remote '{}'",
+                args.remote
+            ),
+        )
+        .with_hint(format!(
+            "run `git remote set-head {} --auto` to cache it",
+            args.remote
+        ))
+    })?;
+
+    let remote_ref = format!("refs/remotes/{}/{default_branch}", args.remote);
+    let local_ref = format!("refs/heads/{default_branch}");
+
+    if args.fetch {
+        let refspec = format!("+refs/heads/{default_branch}:{remote_ref}");
+        git_output(&["fetch", "--quiet", &args.remote, &refspec]).map_err(|err| {
+            CliError::runtime("git-fetch-failed", summarize_git_error(&err.to_string()))
+                .with_hint("pass `--no-fetch` to sync against the already-fetched remote ref")
+        })?;
+    }
+
+    let previous_head = rev_parse_commit(&local_ref).ok_or_else(|| {
+        CliError::data(
+            "local-default-branch-missing",
+            format!("the repository has no local branch '{default_branch}'"),
+        )
+    })?;
+    let new_head = rev_parse_commit(&remote_ref).ok_or_else(|| {
+        CliError::data(
+            "remote-default-branch-missing",
+            format!("'{remote_ref}' does not resolve to a commit"),
+        )
+        .with_hint("fetch the remote default branch first, or drop `--no-fetch`")
+    })?;
+
+    if previous_head == new_head {
+        return Ok(SyncOutput {
+            default_branch,
+            remote: args.remote.clone(),
+            remote_ref,
+            previous_head: previous_head.clone(),
+            new_head: previous_head,
+            strategy: "noop",
+            already_current: true,
+            fast_forward: true,
+            dry_run: args.dry_run,
+            fetched: args.fetch,
+        });
+    }
+
+    // This is the whole safety argument for the command: the local ref only ever
+    // moves forward onto a commit that is already published, so nothing is
+    // authored, nothing is overwritten, and `git reset --hard @{1}` undoes it.
+    if !git_status_success(&["merge-base", "--is-ancestor", &previous_head, &new_head]) {
+        return Err(CliError::data(
+            "not-fast-forward",
+            format!(
+                "'{default_branch}' has diverged from '{remote_ref}'; adopting the \
+                 remote head would discard local commits"
+            ),
+        )
+        .with_hint(
+            "the local default branch carries commits the remote does not have; \
+             deliver or move them off the default branch first",
+        )
+        .with_details(json!({
+            "local_head": previous_head,
+            "remote_head": new_head,
+        })));
+    }
+
+    let checked_out_here = current_branch().as_deref() == Some(default_branch.as_str());
+    let strategy = if checked_out_here {
+        "merge-ff-only"
+    } else {
+        if let Some(path) = worktree_holding(&default_branch)? {
+            return Err(CliError::data(
+                "default-branch-checked-out-elsewhere",
+                format!("'{default_branch}' is checked out in another worktree: {path}"),
+            )
+            .with_hint("run `git-cli sync-default` from that worktree")
+            .with_details(json!({ "worktree": path })));
+        }
+        "update-ref"
+    };
+
+    if args.dry_run {
+        return Ok(SyncOutput {
+            default_branch,
+            remote: args.remote.clone(),
+            remote_ref,
+            previous_head,
+            new_head,
+            strategy,
+            already_current: false,
+            fast_forward: true,
+            dry_run: true,
+            fetched: args.fetch,
+        });
+    }
+
+    match strategy {
+        "merge-ff-only" => {
+            require_clean_checkout()?;
+            git_output(&["merge", "--ff-only", "--quiet", &remote_ref]).map_err(|err| {
+                CliError::runtime("git-merge-failed", summarize_git_error(&err.to_string()))
+            })?;
+        }
+        _ => {
+            // Compare-and-swap on the old value, so a concurrent update loses
+            // instead of being silently overwritten.
+            git_output(&["update-ref", &local_ref, &new_head, &previous_head]).map_err(|err| {
+                CliError::runtime(
+                    "git-update-ref-failed",
+                    summarize_git_error(&err.to_string()),
+                )
+            })?;
+        }
+    }
+
+    Ok(SyncOutput {
+        default_branch,
+        remote: args.remote.clone(),
+        remote_ref,
+        previous_head,
+        new_head,
+        strategy,
+        already_current: false,
+        fast_forward: true,
+        dry_run: false,
+        fetched: args.fetch,
+    })
+}
+
+// ----------------------------------------------------------------- git
+
+fn current_branch() -> Option<String> {
+    git_stdout_trimmed_optional(&["symbolic-ref", "--quiet", "--short", "HEAD"])
+}
+
+/// Whether the branch's configured upstream is already its own ref on `remote`.
+///
+/// Read from config rather than `@{upstream}`, because the remote-tracking ref
+/// does not exist yet on a first publish and would make the check fail for the
+/// wrong reason.
+fn upstream_is_own_ref(remote: &str, branch: &str) -> bool {
+    let configured_remote =
+        git_stdout_trimmed_optional(&["config", "--get", &format!("branch.{branch}.remote")]);
+    let configured_merge =
+        git_stdout_trimmed_optional(&["config", "--get", &format!("branch.{branch}.merge")]);
+    configured_remote.as_deref() == Some(remote)
+        && configured_merge.as_deref() == Some(format!("refs/heads/{branch}").as_str())
+}
+
+fn cached_default_branch(remote: &str) -> Option<String> {
+    let cached = git_stdout_trimmed_optional(&[
+        "symbolic-ref",
+        "--quiet",
+        "--short",
+        &format!("refs/remotes/{remote}/HEAD"),
+    ])?;
+    cached
+        .strip_prefix(&format!("{remote}/"))
+        .map(str::to_string)
+}
+
+fn rev_parse_commit(reference: &str) -> Option<String> {
+    git_stdout_trimmed_optional(&[
+        "rev-parse",
+        "--verify",
+        "--quiet",
+        &format!("{reference}^{{commit}}"),
+    ])
+}
+
+fn require_remote(remote: &str) -> Result<(), CliError> {
+    if git_status_success(&["config", "--get", &format!("remote.{remote}.url")]) {
+        return Ok(());
+    }
+    Err(
+        CliError::data("unknown-remote", format!("no remote named '{remote}'"))
+            .with_hint("pass `--remote <name>` to select a configured remote"),
+    )
+}
+
+fn require_clean_checkout() -> Result<(), CliError> {
+    let status =
+        git_stdout_trimmed(&["status", "--porcelain", "--untracked-files=no"]).map_err(|err| {
+            CliError::runtime("git-status-failed", summarize_git_error(&err.to_string()))
+        })?;
+    if status.trim().is_empty() {
+        return Ok(());
+    }
+    Err(CliError::data(
+        "dirty-checkout",
+        "the checkout has staged or unstaged changes",
+    )
+    .with_hint("commit or stash the changes before moving the default branch"))
+}
+
+/// Which other worktree, if any, holds `branch` checked out.
+fn worktree_holding(branch: &str) -> Result<Option<String>, CliError> {
+    let by_branch = linked_worktrees_by_branch()
+        .map_err(|err| CliError::runtime("git-worktree-list-failed", err.to_string()))?;
+    Ok(by_branch.get(branch).cloned())
+}
+
+fn short(sha: &str) -> String {
+    sha.chars().take(12).collect()
+}
+
+// ----------------------------------------------------------------- args
+
+fn parse_push_args(args: &[String]) -> Result<PushArgs, CliError> {
+    let mut rest: Vec<String> = args.to_vec();
+    let format = take_format(&mut rest)?;
+    let mut remote = DEFAULT_REMOTE.to_string();
+    let mut expect_default = None;
+    let mut force_with_lease = false;
+    let mut dry_run = false;
+
+    let mut index = 0usize;
+    while index < rest.len() {
+        match rest[index].as_str() {
+            "--remote" => {
+                remote = take_value(&rest, index, "--remote")?;
+                index += 2;
+            }
+            value if value.starts_with("--remote=") => {
+                remote = value.trim_start_matches("--remote=").to_string();
+                index += 1;
+            }
+            "--expect-default" => {
+                expect_default = Some(take_value(&rest, index, "--expect-default")?);
+                index += 2;
+            }
+            value if value.starts_with("--expect-default=") => {
+                expect_default = Some(value.trim_start_matches("--expect-default=").to_string());
+                index += 1;
+            }
+            "--force-with-lease" => {
+                force_with_lease = true;
+                index += 1;
+            }
+            "--dry-run" => {
+                dry_run = true;
+                index += 1;
+            }
+            other => {
+                return Err(CliError::usage(
+                    "unknown-argument",
+                    format!("unknown argument: {other}"),
+                )
+                .with_hint("run `git-cli push --help` for the accepted flags"));
+            }
+        }
+    }
+
+    if remote.is_empty() {
+        return Err(CliError::usage(
+            "missing-remote",
+            "--remote requires a value",
+        ));
+    }
+    if expect_default.as_deref() == Some("") {
+        return Err(CliError::usage(
+            "missing-expect-default",
+            "--expect-default requires a branch name",
+        ));
+    }
+
+    Ok(PushArgs {
+        remote,
+        expect_default,
+        force_with_lease,
+        dry_run,
+        format,
+    })
+}
+
+fn parse_sync_args(args: &[String]) -> Result<SyncArgs, CliError> {
+    let mut rest: Vec<String> = args.to_vec();
+    let format = take_format(&mut rest)?;
+    let mut remote = DEFAULT_REMOTE.to_string();
+    let mut fetch = true;
+    let mut dry_run = false;
+
+    let mut index = 0usize;
+    while index < rest.len() {
+        match rest[index].as_str() {
+            "--remote" => {
+                remote = take_value(&rest, index, "--remote")?;
+                index += 2;
+            }
+            value if value.starts_with("--remote=") => {
+                remote = value.trim_start_matches("--remote=").to_string();
+                index += 1;
+            }
+            "--no-fetch" => {
+                fetch = false;
+                index += 1;
+            }
+            "--dry-run" => {
+                dry_run = true;
+                index += 1;
+            }
+            other => {
+                return Err(CliError::usage(
+                    "unknown-argument",
+                    format!("unknown argument: {other}"),
+                )
+                .with_hint("run `git-cli sync-default --help` for the accepted flags"));
+            }
+        }
+    }
+
+    if remote.is_empty() {
+        return Err(CliError::usage(
+            "missing-remote",
+            "--remote requires a value",
+        ));
+    }
+
+    Ok(SyncArgs {
+        remote,
+        fetch,
+        dry_run,
+        format,
+    })
+}
+
+fn take_value(args: &[String], index: usize, flag: &str) -> Result<String, CliError> {
+    args.get(index + 1)
+        .cloned()
+        .ok_or_else(|| CliError::usage("missing-value", format!("{flag} requires a value")))
+}
+
+fn print_push_help() {
+    println!(
+        "Usage: git-cli push [--remote <name>] [--expect-default <branch>] [--force-with-lease] [--dry-run] [--format text|json]"
+    );
+    println!("  Publish the checked-out branch to its own branch on <remote> (default: origin).");
+    println!("  Refuses the remote's default branch; that is `forge-cli repo push-default`'s job.");
+    println!("  Sets the upstream on first publish, so the branch tracks its own ref.");
+    println!(
+        "  --expect-default names the default branch when `refs/remotes/<remote>/HEAD` is not cached."
+    );
+}
+
+fn print_sync_help() {
+    println!(
+        "Usage: git-cli sync-default [--remote <name>] [--no-fetch] [--dry-run] [--format text|json]"
+    );
+    println!("  Fast-forward the local default branch to its remote-tracking ref.");
+    println!(
+        "  Refuses anything that is not a pure fast-forward onto an already-published commit."
+    );
+    println!("  Moves the ref directly when no worktree holds the default branch checked out.");
+    println!(
+        "  --no-fetch syncs against the already-fetched remote ref instead of contacting the remote."
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_args_default_to_origin_and_no_mutation_modifiers() {
+        let parsed = parse_push_args(&[]).expect("parse");
+        assert_eq!(parsed.remote, "origin");
+        assert!(!parsed.force_with_lease);
+        assert!(!parsed.dry_run);
+        assert!(parsed.expect_default.is_none());
+    }
+
+    #[test]
+    fn push_args_accept_inline_and_separated_values() {
+        let inline =
+            parse_push_args(&["--remote=upstream".into(), "--expect-default=trunk".into()])
+                .expect("parse inline");
+        assert_eq!(inline.remote, "upstream");
+        assert_eq!(inline.expect_default.as_deref(), Some("trunk"));
+
+        let separated = parse_push_args(&[
+            "--remote".into(),
+            "upstream".into(),
+            "--expect-default".into(),
+            "trunk".into(),
+        ])
+        .expect("parse separated");
+        assert_eq!(separated.remote, "upstream");
+        assert_eq!(separated.expect_default.as_deref(), Some("trunk"));
+    }
+
+    #[test]
+    fn push_args_reject_unknown_flags() {
+        let err = parse_push_args(&["--force".into()]).expect_err("reject");
+        assert_eq!(err.code, "unknown-argument");
+    }
+
+    #[test]
+    fn sync_args_fetch_by_default_and_honor_no_fetch() {
+        assert!(parse_sync_args(&[]).expect("parse").fetch);
+        assert!(
+            !parse_sync_args(&["--no-fetch".into()])
+                .expect("parse")
+                .fetch
+        );
+    }
+}

--- a/crates/git-cli/src/worktree.rs
+++ b/crates/git-cli/src/worktree.rs
@@ -78,8 +78,8 @@ struct GoArgs {
 }
 
 #[derive(Debug, Clone)]
-struct CliError {
-    code: &'static str,
+pub(crate) struct CliError {
+    pub(crate) code: &'static str,
     message: Box<str>,
     hint: Option<Box<str>>,
     exit_code: i32,
@@ -140,7 +140,7 @@ struct GoOutput {
 }
 
 impl CliError {
-    fn usage(code: &'static str, message: impl Into<String>) -> Self {
+    pub(crate) fn usage(code: &'static str, message: impl Into<String>) -> Self {
         Self {
             code,
             message: message.into().into_boxed_str(),
@@ -150,7 +150,7 @@ impl CliError {
         }
     }
 
-    fn runtime(code: &'static str, message: impl Into<String>) -> Self {
+    pub(crate) fn runtime(code: &'static str, message: impl Into<String>) -> Self {
         Self {
             code,
             message: message.into().into_boxed_str(),
@@ -160,7 +160,7 @@ impl CliError {
         }
     }
 
-    fn data(code: &'static str, message: impl Into<String>) -> Self {
+    pub(crate) fn data(code: &'static str, message: impl Into<String>) -> Self {
         Self {
             code,
             message: message.into().into_boxed_str(),
@@ -170,12 +170,12 @@ impl CliError {
         }
     }
 
-    fn with_hint(mut self, hint: impl Into<String>) -> Self {
+    pub(crate) fn with_hint(mut self, hint: impl Into<String>) -> Self {
         self.hint = Some(hint.into().into_boxed_str());
         self
     }
 
-    fn with_details(mut self, details: serde_json::Value) -> Self {
+    pub(crate) fn with_details(mut self, details: serde_json::Value) -> Self {
         self.details = Some(Box::new(details));
         self
     }
@@ -835,7 +835,7 @@ fn parse_go_args(args: &[String]) -> Result<GoArgs, CliError> {
     })
 }
 
-fn take_format(args: &mut Vec<String>) -> Result<OutputFormat, CliError> {
+pub(crate) fn take_format(args: &mut Vec<String>) -> Result<OutputFormat, CliError> {
     let mut format = OutputFormat::Text;
     let mut i = 0usize;
     while i < args.len() {
@@ -872,7 +872,7 @@ fn parse_format_value(value: &str) -> Result<OutputFormat, CliError> {
     }
 }
 
-fn detect_format(args: &[String]) -> OutputFormat {
+pub(crate) fn detect_format(args: &[String]) -> OutputFormat {
     let mut i = 0usize;
     while i < args.len() {
         match args[i].as_str() {
@@ -887,7 +887,7 @@ fn detect_format(args: &[String]) -> OutputFormat {
     OutputFormat::Text
 }
 
-fn take_help(args: &[String]) -> bool {
+pub(crate) fn take_help(args: &[String]) -> bool {
     args.iter()
         .any(|arg| matches!(arg.as_str(), "-h" | "--help"))
 }
@@ -953,7 +953,7 @@ fn resolve_layout() -> Result<WorktreeLayout, CliError> {
     })
 }
 
-fn ensure_inside_git_repo() -> Result<(), CliError> {
+pub(crate) fn ensure_inside_git_repo() -> Result<(), CliError> {
     if git_status_success(&["rev-parse", "--is-inside-work-tree"]) {
         Ok(())
     } else {
@@ -1159,7 +1159,7 @@ fn run_git_worktree_prune() -> Result<(), CliError> {
     Ok(())
 }
 
-fn emit_success<T: Serialize, F: FnOnce() -> String>(
+pub(crate) fn emit_success<T: Serialize, F: FnOnce() -> String>(
     command: &str,
     format: OutputFormat,
     payload: &T,
@@ -1197,7 +1197,7 @@ fn error_envelope(command: &str, err: &CliError) -> Envelope<()> {
     Envelope::failure(schema_version_for(BINARY, command, 1), envelope_error)
 }
 
-fn emit_error(command: &str, format: OutputFormat, err: CliError) -> i32 {
+pub(crate) fn emit_error(command: &str, format: OutputFormat, err: CliError) -> i32 {
     if err.code == "help" {
         return exit::SUCCESS;
     }
@@ -1234,7 +1234,7 @@ fn render_list_text(output: &ListOutput) -> String {
     lines.join("\n")
 }
 
-fn summarize_git_error(message: &str) -> String {
+pub(crate) fn summarize_git_error(message: &str) -> String {
     let trimmed = message.trim();
     let summary = trimmed
         .rsplit_once(" failed: ")

--- a/crates/git-cli/src/worktree.rs
+++ b/crates/git-cli/src/worktree.rs
@@ -421,9 +421,15 @@ fn add_worktree(args: &AddArgs) -> Result<AddOutput, CliError> {
     })?;
 
     let path_arg = display_path(&path);
+    // `--no-track` because the default base ref is a remote-tracking branch, and
+    // Git's `branch.autoSetupMerge` default would then record the default branch
+    // as this branch's upstream. A managed worktree branch is unpublished: it has
+    // no upstream until it is pushed, and claiming one makes every `@{upstream}`
+    // reader resolve the default branch instead of this branch's head.
     git_output(&[
         "worktree",
         "add",
+        "--no-track",
         "-b",
         branch.as_str(),
         path_arg.as_str(),

--- a/crates/git-cli/tests/integration.rs
+++ b/crates/git-cli/tests/integration.rs
@@ -19,6 +19,8 @@ mod dirty_checkout_adoption;
 mod dispatcher;
 #[path = "integration/open.rs"]
 mod open;
+#[path = "integration/publish.rs"]
+mod publish;
 #[path = "integration/reset.rs"]
 mod reset;
 #[path = "integration/trusted_binary_cache.rs"]

--- a/crates/git-cli/tests/integration/dispatcher.rs
+++ b/crates/git-cli/tests/integration/dispatcher.rs
@@ -10,13 +10,37 @@ fn assert_contains(text: &str, needle: &str) {
     );
 }
 
+/// Assert one `Commands:` row, ignoring clap's column padding. The padding
+/// reflows whenever a longer command name is added, which says nothing about
+/// whether the row is present.
+fn assert_command_row(stdout: &str, name: &str, description: &str) {
+    let expected = format!("{name} {description}");
+    let found = stdout
+        .lines()
+        .any(|line| line.split_whitespace().collect::<Vec<_>>().join(" ") == expected);
+    assert!(
+        found,
+        "expected a command row for {name:?} described as {description:?}\n\n{stdout}"
+    );
+}
+
 fn assert_top_level_help(stdout: &str) {
     assert_contains(stdout, "Git helper CLI");
     assert_contains(stdout, "Usage: git-cli <group> <command> [args]");
     assert_contains(stdout, "Commands:");
-    assert_contains(stdout, "utils       Utility helpers");
-    assert_contains(stdout, "summary     Summarize repository history");
-    assert_contains(stdout, "completion  Export shell completion script");
+    assert_command_row(stdout, "utils", "Utility helpers");
+    assert_command_row(stdout, "summary", "Summarize repository history");
+    assert_command_row(stdout, "completion", "Export shell completion script");
+    assert_command_row(
+        stdout,
+        "push",
+        "Publish the checked-out branch to its own remote branch",
+    );
+    assert_command_row(
+        stdout,
+        "sync-default",
+        "Fast-forward the local default branch to its remote-tracking ref",
+    );
     assert_contains(stdout, "-V, --version  Print version");
 }
 

--- a/crates/git-cli/tests/integration/publish.rs
+++ b/crates/git-cli/tests/integration/publish.rs
@@ -1,0 +1,398 @@
+use crate::common;
+use common::{GitCliHarness, git, init_bare_remote, init_repo};
+use nils_test_support::cmd::CmdOutput;
+use nils_test_support::git::{commit_file, git_output};
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn parse_json(output: &CmdOutput) -> Value {
+    serde_json::from_str(output.stdout_text().trim()).expect("valid json output")
+}
+
+/// A repository with `origin` wired, `main` published, and `origin/HEAD` cached,
+/// which is the shape every real agent checkout has after a clone.
+fn repo_with_published_main() -> (TempDir, TempDir) {
+    let repo = init_repo();
+    let remote = init_bare_remote();
+    let remote_path = remote.path().to_string_lossy().to_string();
+    git(repo.path(), &["remote", "add", "origin", &remote_path]);
+    git(repo.path(), &["push", "-u", "origin", "main"]);
+    git(repo.path(), &["remote", "set-head", "origin", "main"]);
+    (repo, remote)
+}
+
+fn git_config_optional(repo: &Path, key: &str) -> Option<String> {
+    let output = git_output(repo, &["config", "--get", key]);
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn rev_parse(repo: &Path, rev: &str) -> String {
+    git(repo, &["rev-parse", rev]).trim().to_string()
+}
+
+// ---------------------------------------------------------------- push
+
+#[test]
+fn push_publishes_the_current_branch_and_sets_its_own_upstream() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+
+    git(
+        repo.path(),
+        &["checkout", "-q", "--no-track", "-b", "feat/topic"],
+    );
+    commit_file(repo.path(), "topic.txt", "one\n", "add topic");
+    let head = rev_parse(repo.path(), "HEAD");
+
+    let output = harness.run(repo.path(), &["push", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+
+    let json = parse_json(&output);
+    assert_eq!(json["schema_version"], "cli.git-cli.push.v1");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["branch"], "feat/topic");
+    assert_eq!(json["data"]["remote"], "origin");
+    assert_eq!(json["data"]["remote_branch"], "feat/topic");
+    assert_eq!(json["data"]["head"], head);
+    assert_eq!(json["data"]["pushed"], true);
+    assert_eq!(json["data"]["created_remote_branch"], true);
+    assert_eq!(json["data"]["default_branch"], "main");
+
+    assert_eq!(
+        rev_parse(remote.path(), "refs/heads/feat/topic"),
+        head,
+        "the remote branch holds the pushed head"
+    );
+
+    // The upstream is established at publish time and points at this branch's
+    // own ref, which is what `worktree add --no-track` deliberately leaves unset.
+    assert_eq!(
+        git_config_optional(repo.path(), "branch.feat/topic.merge").as_deref(),
+        Some("refs/heads/feat/topic")
+    );
+    assert_eq!(
+        git_config_optional(repo.path(), "branch.feat/topic.remote").as_deref(),
+        Some("origin")
+    );
+}
+
+#[test]
+fn push_repairs_an_upstream_that_points_at_the_default_branch() {
+    let harness = GitCliHarness::new();
+    let (repo, _remote) = repo_with_published_main();
+
+    // Exactly what `worktree add` produced before it passed `--no-track`: the
+    // branch exists, and its upstream is the default branch. "Has an upstream"
+    // is true here, so publishing must look at *which* ref it names.
+    git(repo.path(), &["checkout", "-q", "-b", "feat/inherited"]);
+    git(
+        repo.path(),
+        &["config", "branch.feat/inherited.remote", "origin"],
+    );
+    git(
+        repo.path(),
+        &["config", "branch.feat/inherited.merge", "refs/heads/main"],
+    );
+    commit_file(repo.path(), "inherited.txt", "one\n", "add inherited");
+
+    let output = harness.run(repo.path(), &["push", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+
+    assert_eq!(
+        git_config_optional(repo.path(), "branch.feat/inherited.merge").as_deref(),
+        Some("refs/heads/feat/inherited"),
+        "publishing repairs an upstream inherited from the default branch"
+    );
+}
+
+#[test]
+fn push_refuses_the_default_branch() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+    let published = rev_parse(repo.path(), "HEAD");
+    commit_file(repo.path(), "local.txt", "local\n", "local only");
+
+    let output = harness.run(repo.path(), &["push", "--format", "json"]);
+    assert_ne!(output.code, 0);
+
+    let json = parse_json(&output);
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "refuse-default-branch");
+    let hint = json["error"]["hint"].as_str().unwrap_or_default();
+    assert!(
+        hint.contains("forge-cli repo push-default"),
+        "the refusal names the governed default-branch surface, got: {hint}"
+    );
+
+    assert_eq!(
+        rev_parse(remote.path(), "refs/heads/main"),
+        published,
+        "the remote default branch is untouched"
+    );
+}
+
+#[test]
+fn push_dry_run_reports_the_plan_without_publishing() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+
+    git(
+        repo.path(),
+        &["checkout", "-q", "--no-track", "-b", "feat/dry"],
+    );
+    commit_file(repo.path(), "dry.txt", "one\n", "add dry");
+
+    let output = harness.run(repo.path(), &["push", "--dry-run", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+
+    let json = parse_json(&output);
+    assert_eq!(json["data"]["pushed"], false);
+    assert_eq!(json["data"]["dry_run"], true);
+    assert_eq!(json["data"]["branch"], "feat/dry");
+
+    assert!(
+        !git_output(
+            remote.path(),
+            &["rev-parse", "--verify", "refs/heads/feat/dry"]
+        )
+        .status
+        .success(),
+        "a dry run publishes nothing"
+    );
+}
+
+#[test]
+fn push_refuses_a_detached_head() {
+    let harness = GitCliHarness::new();
+    let (repo, _remote) = repo_with_published_main();
+    git(repo.path(), &["checkout", "-q", "--detach"]);
+
+    let output = harness.run(repo.path(), &["push", "--format", "json"]);
+    assert_ne!(output.code, 0);
+    assert_eq!(parse_json(&output)["error"]["code"], "detached-head");
+}
+
+#[test]
+fn push_refuses_when_the_remote_default_branch_is_unknown() {
+    let harness = GitCliHarness::new();
+    let repo = init_repo();
+    let remote = init_bare_remote();
+    let remote_path = remote.path().to_string_lossy().to_string();
+    git(repo.path(), &["remote", "add", "origin", &remote_path]);
+    git(repo.path(), &["push", "origin", "main"]);
+    git(
+        repo.path(),
+        &["checkout", "-q", "--no-track", "-b", "feat/unknown"],
+    );
+    commit_file(repo.path(), "x.txt", "x\n", "add x");
+
+    let output = harness.run(repo.path(), &["push", "--format", "json"]);
+    assert_ne!(output.code, 0, "an unprovable default branch fails closed");
+
+    let json = parse_json(&output);
+    assert_eq!(json["error"]["code"], "default-branch-unresolved");
+    let hint = json["error"]["hint"].as_str().unwrap_or_default();
+    assert!(
+        hint.contains("--expect-default"),
+        "the refusal names the offline escape hatch, got: {hint}"
+    );
+
+    // The escape hatch names what the default *is*, so it can admit this push
+    // without ever admitting a push of the default branch itself.
+    let admitted = harness.run(
+        repo.path(),
+        &["push", "--expect-default", "main", "--format", "json"],
+    );
+    assert_eq!(admitted.code, 0, "stderr: {}", admitted.stderr_text());
+    assert_eq!(parse_json(&admitted)["data"]["pushed"], true);
+}
+
+#[test]
+fn push_expect_default_still_refuses_the_default_branch() {
+    let harness = GitCliHarness::new();
+    let repo = init_repo();
+    let remote = init_bare_remote();
+    let remote_path = remote.path().to_string_lossy().to_string();
+    git(repo.path(), &["remote", "add", "origin", &remote_path]);
+    git(repo.path(), &["push", "origin", "main"]);
+    commit_file(repo.path(), "local.txt", "local\n", "local only");
+
+    let output = harness.run(
+        repo.path(),
+        &["push", "--expect-default", "main", "--format", "json"],
+    );
+    assert_ne!(output.code, 0);
+    assert_eq!(
+        parse_json(&output)["error"]["code"],
+        "refuse-default-branch"
+    );
+}
+
+// -------------------------------------------------------- sync-default
+
+/// Advance the remote's default branch by one commit, from a scratch clone, so
+/// the repository under test genuinely lags behind its remote.
+fn advance_remote_main(remote: &TempDir) -> String {
+    let scratch = TempDir::new().expect("scratch clone");
+    let remote_path = remote.path().to_string_lossy().to_string();
+    let scratch_path = scratch.path().to_string_lossy().to_string();
+    // `git init --bare` leaves the remote HEAD on `master`, so the clone has to
+    // name the branch it wants rather than inherit an unborn one.
+    git(
+        remote.path(),
+        &[
+            "clone",
+            "-q",
+            "--branch",
+            "main",
+            &remote_path,
+            &scratch_path,
+        ],
+    );
+    git(
+        scratch.path(),
+        &["config", "user.email", "test@example.com"],
+    );
+    git(scratch.path(), &["config", "user.name", "Test"]);
+    commit_file(scratch.path(), "remote.txt", "remote\n", "advance remote");
+    git(scratch.path(), &["push", "-q", "origin", "main"]);
+    rev_parse(scratch.path(), "HEAD")
+}
+
+#[test]
+fn sync_default_fast_forwards_the_checked_out_default_branch() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+    let previous = rev_parse(repo.path(), "HEAD");
+    let advanced = advance_remote_main(&remote);
+
+    let output = harness.run(repo.path(), &["sync-default", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+
+    let json = parse_json(&output);
+    assert_eq!(json["schema_version"], "cli.git-cli.sync-default.v1");
+    assert_eq!(json["data"]["default_branch"], "main");
+    assert_eq!(json["data"]["strategy"], "merge-ff-only");
+    assert_eq!(json["data"]["previous_head"], previous);
+    assert_eq!(json["data"]["new_head"], advanced);
+    assert_eq!(json["data"]["already_current"], false);
+    assert_eq!(json["data"]["fetched"], true);
+
+    assert_eq!(rev_parse(repo.path(), "refs/heads/main"), advanced);
+}
+
+#[test]
+fn sync_default_updates_the_ref_when_the_default_branch_is_not_checked_out() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+    let previous = rev_parse(repo.path(), "HEAD");
+    let advanced = advance_remote_main(&remote);
+
+    // The everyday agent shape: working on a topic branch while local `main`
+    // lags. No working tree holds `main`, so its ref can move on its own.
+    git(
+        repo.path(),
+        &["checkout", "-q", "--no-track", "-b", "feat/side"],
+    );
+    commit_file(repo.path(), "side.txt", "side\n", "add side");
+    let side = rev_parse(repo.path(), "HEAD");
+
+    let output = harness.run(repo.path(), &["sync-default", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+
+    let json = parse_json(&output);
+    assert_eq!(json["data"]["strategy"], "update-ref");
+    assert_eq!(json["data"]["previous_head"], previous);
+    assert_eq!(json["data"]["new_head"], advanced);
+
+    assert_eq!(rev_parse(repo.path(), "refs/heads/main"), advanced);
+    assert_eq!(
+        rev_parse(repo.path(), "HEAD"),
+        side,
+        "the checked-out topic branch is untouched"
+    );
+}
+
+#[test]
+fn sync_default_is_a_noop_when_already_current() {
+    let harness = GitCliHarness::new();
+    let (repo, _remote) = repo_with_published_main();
+    let head = rev_parse(repo.path(), "HEAD");
+
+    let output = harness.run(repo.path(), &["sync-default", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+
+    let json = parse_json(&output);
+    assert_eq!(json["data"]["already_current"], true);
+    assert_eq!(json["data"]["strategy"], "noop");
+    assert_eq!(json["data"]["previous_head"], head);
+    assert_eq!(json["data"]["new_head"], head);
+}
+
+#[test]
+fn sync_default_refuses_a_non_fast_forward() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+    advance_remote_main(&remote);
+
+    // Diverge locally: local `main` gains a commit the remote does not have, so
+    // adopting the remote head would discard local work.
+    commit_file(repo.path(), "local.txt", "local\n", "local only");
+    let diverged = rev_parse(repo.path(), "HEAD");
+
+    let output = harness.run(repo.path(), &["sync-default", "--format", "json"]);
+    assert_ne!(output.code, 0);
+
+    let json = parse_json(&output);
+    assert_eq!(json["error"]["code"], "not-fast-forward");
+    assert_eq!(
+        rev_parse(repo.path(), "refs/heads/main"),
+        diverged,
+        "a refused sync never moves the default branch"
+    );
+}
+
+#[test]
+fn sync_default_refuses_a_dirty_checked_out_default_branch() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+    let previous = rev_parse(repo.path(), "HEAD");
+    advance_remote_main(&remote);
+
+    std::fs::write(repo.path().join("dirty.txt"), "dirty\n").expect("write dirty file");
+    git(repo.path(), &["add", "dirty.txt"]);
+
+    let output = harness.run(repo.path(), &["sync-default", "--format", "json"]);
+    assert_ne!(output.code, 0);
+    assert_eq!(parse_json(&output)["error"]["code"], "dirty-checkout");
+    assert_eq!(rev_parse(repo.path(), "refs/heads/main"), previous);
+}
+
+#[test]
+fn sync_default_dry_run_reports_the_plan_without_moving_the_ref() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+    let previous = rev_parse(repo.path(), "HEAD");
+    let advanced = advance_remote_main(&remote);
+
+    let output = harness.run(
+        repo.path(),
+        &["sync-default", "--dry-run", "--format", "json"],
+    );
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+
+    let json = parse_json(&output);
+    assert_eq!(json["data"]["dry_run"], true);
+    assert_eq!(json["data"]["strategy"], "merge-ff-only");
+    assert_eq!(json["data"]["new_head"], advanced);
+    assert_eq!(
+        rev_parse(repo.path(), "refs/heads/main"),
+        previous,
+        "a dry run moves nothing"
+    );
+}

--- a/crates/git-cli/tests/integration/publish.rs
+++ b/crates/git-cli/tests/integration/publish.rs
@@ -213,6 +213,51 @@ fn push_refuses_when_the_remote_default_branch_is_unknown() {
 }
 
 #[test]
+fn push_expect_default_cannot_widen_admission() {
+    // `--expect-default` exists so an offline caller can name the default branch
+    // when the remote head is not cached. It must never be able to *admit* a
+    // push that would otherwise be refused, or it is a bypass rather than an
+    // escape hatch: asserting some other branch while standing on the real
+    // default would publish the default branch.
+    let harness = GitCliHarness::new();
+    let repo = init_repo();
+    let remote = init_bare_remote();
+    let remote_path = remote.path().to_string_lossy().to_string();
+    git(repo.path(), &["remote", "add", "origin", &remote_path]);
+    git(repo.path(), &["push", "origin", "main"]);
+    let published = rev_parse(repo.path(), "HEAD");
+    commit_file(repo.path(), "local.txt", "local\n", "local only");
+
+    // No cached `origin/HEAD`, standing on `main`, asserting a different branch.
+    let output = harness.run(
+        repo.path(),
+        &["push", "--expect-default", "develop", "--format", "json"],
+    );
+    assert_ne!(
+        output.code, 0,
+        "a wrong --expect-default must not admit a push of a default-looking branch"
+    );
+    assert_eq!(
+        rev_parse(remote.path(), "refs/heads/main"),
+        published,
+        "the remote default branch is untouched"
+    );
+
+    // With the real default cached, a disagreeing assertion is a mismatch, not a
+    // second opinion that wins.
+    git(repo.path(), &["remote", "set-head", "origin", "main"]);
+    let mismatch = harness.run(
+        repo.path(),
+        &["push", "--expect-default", "develop", "--format", "json"],
+    );
+    assert_ne!(mismatch.code, 0);
+    assert_eq!(
+        parse_json(&mismatch)["error"]["code"],
+        "expect-default-mismatch"
+    );
+}
+
+#[test]
 fn push_expect_default_still_refuses_the_default_branch() {
     let harness = GitCliHarness::new();
     let repo = init_repo();
@@ -222,13 +267,29 @@ fn push_expect_default_still_refuses_the_default_branch() {
     git(repo.path(), &["push", "origin", "main"]);
     commit_file(repo.path(), "local.txt", "local\n", "local only");
 
-    let output = harness.run(
+    // Uncached remote head: refused before the assertion is even consulted,
+    // because a conventional default-branch name cannot be cleared by an
+    // unverifiable claim.
+    let unverifiable = harness.run(
         repo.path(),
         &["push", "--expect-default", "main", "--format", "json"],
     );
-    assert_ne!(output.code, 0);
+    assert_ne!(unverifiable.code, 0);
     assert_eq!(
-        parse_json(&output)["error"]["code"],
+        parse_json(&unverifiable)["error"]["code"],
+        "default-branch-unverifiable"
+    );
+
+    // Cached remote head: the assertion agrees, and the push is refused for the
+    // plain reason that this *is* the default branch.
+    git(repo.path(), &["remote", "set-head", "origin", "main"]);
+    let refused = harness.run(
+        repo.path(),
+        &["push", "--expect-default", "main", "--format", "json"],
+    );
+    assert_ne!(refused.code, 0);
+    assert_eq!(
+        parse_json(&refused)["error"]["code"],
         "refuse-default-branch"
     );
 }

--- a/crates/git-cli/tests/integration/worktree.rs
+++ b/crates/git-cli/tests/integration/worktree.rs
@@ -1,6 +1,7 @@
 use crate::common;
-use common::{GitCliHarness, git, init_repo};
+use common::{GitCliHarness, git, init_bare_remote, init_repo};
 use nils_test_support::cmd::{CmdOutput, run_with};
+use nils_test_support::git::git_output;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use std::fs;
@@ -19,6 +20,15 @@ fn run_with_agent_home(
 
 fn parse_json(output: &CmdOutput) -> Value {
     serde_json::from_str(output.stdout_text().trim()).expect("valid json output")
+}
+
+/// Read one config key, distinguishing "unset" from "set to the empty string".
+fn git_config_optional(repo: &Path, key: &str) -> Option<String> {
+    let output = git_output(repo, &["config", "--get", key]);
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 #[test]
@@ -524,4 +534,64 @@ fn worktree_remove_refuses_primary_and_removes_managed_slug() {
     assert_eq!(remove_json["ok"], true);
     assert_eq!(remove_json["data"]["removed_path"], path);
     assert!(!Path::new(path).exists(), "worktree path should be removed");
+}
+
+#[test]
+fn worktree_add_does_not_adopt_the_base_ref_as_upstream() {
+    let harness = GitCliHarness::new();
+    let repo = init_repo();
+    let remote = init_bare_remote();
+    let agent_home = tempfile::TempDir::new().expect("agent home");
+
+    let remote_path = remote.path().to_string_lossy().to_string();
+    git(repo.path(), &["remote", "add", "origin", &remote_path]);
+    git(repo.path(), &["push", "-u", "origin", "main"]);
+    git(repo.path(), &["remote", "set-head", "origin", "main"]);
+
+    let add = run_with_agent_home(
+        &harness,
+        repo.path(),
+        agent_home.path(),
+        &["worktree", "add", "topic-upstream", "--format", "json"],
+    );
+    assert_eq!(add.code, 0, "stderr: {}", add.stderr_text());
+
+    let add_json = parse_json(&add);
+    assert_eq!(
+        add_json["data"]["base_ref"], "origin/main",
+        "the default base ref stays the cached remote default branch"
+    );
+    assert_eq!(add_json["data"]["branch"], "feat/topic-upstream");
+
+    // Branching from `origin/main` must not make the default branch this
+    // branch's upstream. A managed worktree branch is unpublished, so any
+    // consumer that reads `@{upstream}` to find the branch head — `forge-cli pr
+    // deliver` among them — would resolve the default branch instead and report
+    // the head as unpushed.
+    assert_eq!(
+        git_config_optional(repo.path(), "branch.feat/topic-upstream.merge"),
+        None,
+        "a new managed branch must not inherit an upstream ref"
+    );
+    assert_eq!(
+        git_config_optional(repo.path(), "branch.feat/topic-upstream.remote"),
+        None,
+        "a new managed branch must not inherit an upstream remote"
+    );
+
+    let worktree_path = add_json["data"]["path"].as_str().expect("path");
+    let upstream = git_output(
+        Path::new(worktree_path),
+        &[
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ],
+    );
+    assert!(
+        !upstream.status.success(),
+        "an unpublished managed branch has no upstream, got {}",
+        String::from_utf8_lossy(&upstream.stdout).trim()
+    );
 }

--- a/docs/specs/workspace-doc-retention-matrix-v1.md
+++ b/docs/specs/workspace-doc-retention-matrix-v1.md
@@ -78,6 +78,7 @@ because BSD-style `-path` lets `*` cross slash boundaries.
 - `crates/gemini-cli/docs/runbooks/json-consumers.md`
 - `crates/gemini-cli/docs/specs/gemini-cli-diag-rate-limits-and-auth-json-contract-v1.md`
 - `crates/git-cli/docs/specs/dirty-checkout-adoption-json-contract-v1.md`
+- `crates/git-cli/docs/specs/git-cli-remote-surfaces.md`
 - `crates/git-cli/docs/specs/git-cli-worktree-convention.md`
 - `crates/macos-agent/docs/specs/macos-agent-journal-v2.md`
 - `crates/memo/docs/runbooks/memo-agent-workflow.md`


### PR DESCRIPTION
## Summary

Repository policy assigns an owner to every Git mutation an agent performs, but
two of them had none: publishing a feature branch, and advancing the local
default branch to a commit already on its remote. Both had to fall back to raw
`git`, which the delivery guard is built to distrust because a raw invocation
cannot prove what it will touch. This adds `git-cli push` and
`git-cli sync-default` to close that gap, and fixes the `worktree add` upstream
bug that made the push path fail in the first place.

## Problem

**Expected.** A branch created by `git-cli worktree add` has no upstream until
it is published, and an agent has a governed command for publishing it and for
syncing the local default branch.

**Actual.** `git-cli worktree add` branches from the cached remote default ref
(`origin/main`), so Git's `branch.autoSetupMerge` default recorded
`branch.<new>.merge = refs/heads/main`. Every consumer that reads `@{upstream}`
to locate the branch head resolved the default branch instead. Neither
publishing a branch nor syncing the default branch had any governed surface at
all.

**Impact.** `forge-cli pr deliver` reported an already-pushed head as
`head_not_pushed`, and the repair was a hand-written `git config` call. With no
`git-cli push` or `git-cli sync-default`, the two operations the delivery path
needs most were reachable only through raw `git`, which the default-branch
guard treats as unclassifiable by design.

## Reproduction

1. In a repository whose `origin/HEAD` is cached, run
   `git-cli worktree add <slug> --format json`.
2. Read the new branch's tracking config:
   `git config --get-regexp '^branch\.<prefix>/<slug>\.'`.
3. Observe `branch.<prefix>/<slug>.merge refs/heads/main`, and
   `git -C <worktree> rev-parse --abbrev-ref '@{upstream}'` resolving to
   `origin/main` for a branch that has never been pushed.

## Issues Found

- Refs sympoies/agent-runtime-kit#5 — `git-cli worktree add` leaves the new
  branch tracking the default branch
- Refs sympoies/agent-runtime-kit#7 — no governed surface for branch push or
  default-branch sync

## Fix Approach

- Pass `--no-track` to `git worktree add`. An unpublished branch has no
  upstream, so the accurate state is none at all rather than a wrong one.
- Add `git-cli push`, which publishes through the fully qualified refspec
  `refs/heads/<branch>:refs/heads/<branch>`. That removes every input which
  makes a bare `git push` unclassifiable — `push.default`, `remote.pushDefault`,
  configured push refspecs, and upstream inference stop affecting the
  destination — so the only way the command could reach the default branch is
  by being on it, which it refuses. It establishes the upstream at publish time
  whenever the configured upstream is not already the branch's own ref, which
  also repairs branches created before `--no-track`.
- Add `git-cli sync-default`, which only ever fast-forwards the local default
  branch onto an already-published commit: nothing is authored, no content
  changes, nothing is published, and `git reset --hard @{1}` reverses it. When
  no worktree holds the default branch it moves the ref by compare-and-swap
  `git update-ref`, which is the everyday case of working on a topic branch
  while local `main` lags.
- Fail closed where the default branch cannot be proven. `--expect-default`
  names it offline and can only ever add a refusal: asserting
  `--expect-default main` while on `main` still refuses.

## Test-First Evidence

Test-first, with a captured red for the bug fix.

`worktree_add_does_not_adopt_the_base_ref_as_upstream` was written and run
against the unfixed `add_worktree`, and failed on the real defect:

```text
assertion failed: `(left == right)`: a new managed branch must not inherit an upstream ref
< Some("refs/heads/main")
> None
```

It passes after `--no-track`. The same defect was confirmed outside the test
suite on the very worktree this branch was authored in: `git-cli worktree add`
produced `branch.fix/worktree-upstream.merge refs/heads/main`, and
`rev-parse --abbrev-ref '@{upstream}'` resolved `origin/main` for a branch with
no remote ref.

The new surfaces are covered by 13 integration tests written before the module
existed (`crates/git-cli/tests/integration/publish.rs`), plus 4 unit tests for
argument parsing. `push_repairs_an_upstream_that_points_at_the_default_branch`
was added after dogfooding found that checking only for the *presence* of an
upstream leaves the inherited-wrong-upstream case unrepaired.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — pass, 396 tests
  run, 396 passed (fmt, clippy, nextest, doc tests)
- `bash scripts/ci/docs-hygiene-audit.sh` — `PASS (strict=0, warnings=0)`
- `cargo test -p nils-git-cli --test integration publish` — 13 passed
- `cargo test -p nils-git-cli --test integration worktree` — 19 passed
- Dogfooded end to end: this branch was published with the `git-cli push` it
  adds, which reported `"pushed": true` and repaired the branch's inherited
  `branch.<name>.merge` from `refs/heads/main` to `refs/heads/fix/worktree-upstream`

## Risk / Notes

- `--no-track` changes the state of every newly created managed worktree
  branch. Nothing in the workspace reads a managed branch's `@{upstream}`, and
  `git-cli push` sets it correctly at publish time, but any external tooling
  that assumed an upstream existed before publish would now see none. That
  assumption was already producing wrong answers.
- `sync-default`'s `update-ref` path writes a branch ref that no working tree
  holds. It is guarded by an ancestry check and a compare-and-swap on the old
  value, so a concurrent update loses rather than being overwritten.
- `push` refuses rather than guesses when the remote default branch cannot be
  resolved. In a repository without a cached `origin/HEAD` this is a new
  refusal where raw `git push` would have proceeded; `--expect-default` is the
  offline path.
- Two dispatcher help assertions were rewritten to match on content instead of
  clap's column padding. They previously encoded the padding width, which any
  added command reflows.
