### PR TITLE
fix(agent-session): stabilize macOS late bootstrap recovery fixture

### DIFF
--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -22324,23 +22324,7 @@ fn wait_for_barrier_or_child_exit_with_timeout(
 ) {
     let deadline = Instant::now() + timeout;
     while !barrier.join("ready").is_file() {
-        if let Some(status) = child.try_wait().expect("poll barrier child") {
-            let mut stdout = String::new();
-            let mut stderr = String::new();
-            if let Some(stream) = child.stdout.as_mut() {
-                stream
-                    .read_to_string(&mut stdout)
-                    .expect("read barrier child stdout");
-            }
-            if let Some(stream) = child.stderr.as_mut() {
-                stream
-                    .read_to_string(&mut stderr)
-                    .expect("read barrier child stderr");
-            }
-            panic!(
-                "{label} child exited before barrier: status={status} stdout={stdout} stderr={stderr}"
-            );
-        }
+        panic_if_child_exited(child, label);
         if Instant::now() >= deadline {
             let _ = child.kill();
             let status = child.wait().expect("reap timed-out barrier child");
@@ -22361,6 +22345,24 @@ fn wait_for_barrier_or_child_exit_with_timeout(
             );
         }
         std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn panic_if_child_exited(child: &mut Child, label: &str) {
+    if let Some(status) = child.try_wait().expect("poll fixture child") {
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        if let Some(stream) = child.stdout.as_mut() {
+            stream
+                .read_to_string(&mut stdout)
+                .expect("read fixture child stdout");
+        }
+        if let Some(stream) = child.stderr.as_mut() {
+            stream
+                .read_to_string(&mut stderr)
+                .expect("read fixture child stderr");
+        }
+        panic!("{label} child exited early: status={status} stdout={stdout} stderr={stderr}");
     }
 }
 
@@ -35232,7 +35234,7 @@ fn main_agent_worker_start_waits_for_late_bootstrap_after_recovery_failure() {
     let tmux_log_arg = tmux_log.to_string_lossy().into_owned();
     let codex_arg = codex_bin.to_string_lossy().into_owned();
 
-    let start = Command::new(bin::resolve("main-agent"))
+    let mut start = Command::new(bin::resolve("main-agent"))
         .current_dir(&checkout)
         .args([
             "--state-dir",
@@ -35270,14 +35272,12 @@ fn main_agent_worker_start_waits_for_late_bootstrap_after_recovery_failure() {
         .spawn()
         .expect("spawn worker start");
 
-    let barrier_deadline = Instant::now() + synchronization_timeout;
-    while !barrier.join("ready").is_file() {
-        assert!(
-            Instant::now() < barrier_deadline,
-            "readiness recovery never reached the serialized send boundary"
-        );
-        std::thread::sleep(Duration::from_millis(10));
-    }
+    wait_for_barrier_or_child_exit_with_timeout(
+        &barrier,
+        &mut start,
+        "readiness recovery serialized send boundary",
+        synchronization_timeout,
+    );
     let worker_record: serde_json::Value = serde_json::from_slice(
         &fs::read(state_dir.join(format!("sessions/{worker_id}/session.json")))
             .expect("worker session"),
@@ -35302,6 +35302,7 @@ fn main_agent_worker_start_waits_for_late_bootstrap_after_recovery_failure() {
     fs::write(barrier.join("release"), b"continue").expect("release recovery");
     let recovery_deadline = Instant::now() + synchronization_timeout;
     loop {
+        panic_if_child_exited(&mut start, "readiness recovery durable failure record");
         let registry = orchestration_registry(&state_dir);
         let assignment = &registry["assignments"][assignment_id];
         if assignment["submit_recovery"]["state"] == "failed" {

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -35171,6 +35171,10 @@ AGENT_SESSION_CAPABILITY_FILE={main_capability} \
 
 #[test]
 fn main_agent_worker_start_waits_for_late_bootstrap_after_recovery_failure() {
+    // Coverage-instrumented same-release subprocess startup can take longer
+    // than ten seconds on macOS. Keep fixture synchronization generous while
+    // preserving the four-second readiness deadline exercised below.
+    let synchronization_timeout = Duration::from_secs(120);
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");
     let checkout = tmp.path().join("checkout");
@@ -35266,7 +35270,7 @@ fn main_agent_worker_start_waits_for_late_bootstrap_after_recovery_failure() {
         .spawn()
         .expect("spawn worker start");
 
-    let barrier_deadline = Instant::now() + Duration::from_secs(10);
+    let barrier_deadline = Instant::now() + synchronization_timeout;
     while !barrier.join("ready").is_file() {
         assert!(
             Instant::now() < barrier_deadline,
@@ -35296,7 +35300,7 @@ fn main_agent_worker_start_waits_for_late_bootstrap_after_recovery_failure() {
         serde_json::Value::Null,
     );
     fs::write(barrier.join("release"), b"continue").expect("release recovery");
-    let recovery_deadline = Instant::now() + Duration::from_secs(10);
+    let recovery_deadline = Instant::now() + synchronization_timeout;
     loop {
         let registry = orchestration_registry(&state_dir);
         let assignment = &registry["assignments"][assignment_id];


### PR DESCRIPTION
## Summary

Stabilize the macOS release gate for the late-bootstrap recovery fixture without changing agent-session runtime behavior or its four-second readiness deadline.

## Problem

- Expected: coverage-instrumented macOS CI reaches the fixture's serialized send boundary and validates late authenticated bootstrap.
- Actual: the fixture stopped waiting after ten seconds even though same-release subprocess startup can exceed 70 seconds under CI load.
- Impact: all three nextest attempts failed and blocked the 1.25.13 release PR.

## Reproduction

1. Run GitHub Actions CI run 30761878378 on the 1.25.13 release PR.
2. Inspect macOS job 91533784396.
3. Observe all three attempts fail with `readiness recovery never reached the serialized send boundary` after about ten seconds.

## Issues Found

- No linked tracking issue; this fixes the concrete 1.25.13 release-gate failure.

## Fix Approach

- Raise only the fixture synchronization ceiling from 10 seconds to 120 seconds.
- Reuse that ceiling for the send-boundary and durable-failure waits.
- Preserve `--await-ready 4s` and every recovery assertion.

## Test-First Evidence

- Before fix: macOS CI run 30761878378, job 91533784396, failed the target fixture on all three attempts at the ten-second synchronization boundary.
- Evidence is bound to baseline `bb75cdaf903ce2e8a5fea0c0900133ede08c3060` and delivery head `96c962f807bbc545f960aa4ea95740461bae9b0a`.

## Test plan

- PASS: focused nextest run for `main_agent_worker_start_waits_for_late_bootstrap_after_recovery_failure`.
- PASS: `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (1,122 tests plus fmt, clippy, docs and tempdir audits).
- PASS: `.agents/scripts/pre-pr.sh`.
- REQUIRED BEFORE MERGE: GitHub Actions `test`, `test_macos`, and `coverage` on the exact PR head.

## Risk / Notes

- Test-only timing change; the production readiness deadline and recovery state machine are unchanged.
- CI must still prove the macOS fixture reaches the same boundary and assertions.
