### PR TITLE
feat(forge-cli): make review-loop observe --dry-run faithful

### DIFF
--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -706,7 +706,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 (observe)
 _arguments "${_arguments_options[@]}" : \
 '--expected-head=[Exact provider head SHA whose review observation is being appended]:SHA:_default' \
-'--findings-file=[Delivery-mode review-specialists merge envelope or observation array]:PATH:_default' \
+'--findings-file=[Delivery-mode review-specialists merge envelope or observation array. Both shapes require a \`lifecycle_fingerprint\`; only the array accepts \`disposition\`. See this command'\''s help footer for the full schemas]:PATH:_default' \
 '--expected-state=[Exact current provider-visible state-chain tip; omit only for genesis]:DIGEST:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -633,8 +633,27 @@ backend mapping, validation rules, and output schema versions.
   the exact approval marker. The stop code must map to its canonical budget
   field and the proposal must match the active receipt. Each proposal is
   consumable once; retry and delivery paths cannot silently increase a budget.
+- An observation can only be appended at the current provider head, so history
+  cannot be backfilled, and a `fixed` disposition requires a repaired head.
+  Together those force the observation to precede the repair push: observe the
+  reviewed head as `open`, push the repair, observe the repaired head as
+  `fixed`, then merge at that head. Doing every repair first and then trying to
+  record the history is unrecoverable, because the pre-repair head is gone and
+  the round count cannot be reconstructed.
 - All three commands emit their own `cli.forge-cli.pr.review-loop.*.v1` schema.
-  Dry-run is offline and reports the command-specific read/transition plan.
+  `inspect` and `extend` dry-runs are offline and report the command-specific
+  read/transition plan.
+- `observe --dry-run` is a faithful non-mutating preflight. It reads and
+  validates the findings payload, resolves the pull request, performs the head
+  and state-tip compare-and-swap comparisons, and evaluates the transition,
+  reporting each verdict in `data.preflight[]` — the same element shape as
+  `pr deliver --dry-run`'s `local_preflight[]`, under a different name because
+  these rules include provider reads. `data.preflight_ok` is the conjunction and
+  `data.would_append` reports whether an accepted real run would append a new
+  generation. The sweep does not short-circuit, so the local payload verdict is
+  reported even when the provider is unreachable; that is the supported way to
+  check a findings file without writing durable provider-visible state, which a
+  live `observe` does on success.
 
 ### `pr pending-review delete` compatibility surface
 

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -649,8 +649,11 @@ backend mapping, validation rules, and output schema versions.
   reporting each verdict in `data.preflight[]` — the same element shape as
   `pr deliver --dry-run`'s `local_preflight[]`, under a different name because
   these rules include provider reads. `data.preflight_ok` is the conjunction and
-  `data.would_append` reports whether an accepted real run would append a new
-  generation. The sweep does not short-circuit, so the local payload verdict is
+  `data.would_append` reports whether the real run would append a new
+  generation — true for an accepted state-changing transition, and also for an
+  extendable budget error, which appends a durable hard-stop receipt before
+  failing, so predicting only "this fails" would understate it. The sweep does
+  not short-circuit, so the local payload verdict is
   reported even when the provider is unreachable; that is the supported way to
   check a findings file without writing durable provider-visible state, which a
   live `observe` does on success.

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -908,12 +908,38 @@ pub struct PrReviewLoopInspectArgs {
 }
 
 #[derive(Args, Debug, Clone)]
+#[command(after_help = "APPEND ORDER\n  \
+      An observation can only be appended at the CURRENT provider head, so \
+      history cannot be backfilled, and a `fixed` disposition requires a \
+      repaired head. Observe the reviewed head BEFORE pushing the repair:\n    \
+      observe --expected-head <reviewed head>   (disposition: open)\n    \
+      repair, push\n    \
+      observe --expected-head <repaired head>   (disposition: fixed)\n    \
+      merge --expected-head <repaired head>\n\n\
+      --findings-file SHAPES\n  \
+      1. A `review-specialists merge --mode delivery` envelope. Each row needs \
+      `evidence`, `recommendation`, and a `lifecycle_fingerprint` of the form \
+      `<category>:<component>:<invariant>` whose category segment equals the \
+      row's `category`. The envelope schema REJECTS `disposition` as an unknown \
+      field.\n  \
+      2. A bare observation array. Each row needs `lifecycle_fingerprint` and \
+      accepts `disposition` (open | fixed | accepted | reopened), which is how \
+      dispositions are carried across rounds.\n\n\
+      With --dry-run this runs a faithful non-mutating preflight: it reads and \
+      validates the findings payload, resolves the pull request, performs the \
+      head and state-tip CAS comparisons, and evaluates the transition, then \
+      reports every verdict in data.preflight[] without appending. The sweep \
+      does not short-circuit, so the payload verdict is still reported when the \
+      provider is unreachable — use it to check a findings file without writing \
+      durable provider-visible state.")]
 pub struct PrReviewLoopObserveArgs {
     pub id: u64,
     /// Exact provider head SHA whose review observation is being appended.
     #[arg(long = "expected-head", value_name = "SHA", value_parser = clap::builder::NonEmptyStringValueParser::new())]
     pub expected_head: String,
     /// Delivery-mode review-specialists merge envelope or observation array.
+    /// Both shapes require a `lifecycle_fingerprint`; only the array accepts
+    /// `disposition`. See this command's help footer for the full schemas.
     #[arg(long = "findings-file", value_name = "PATH")]
     pub findings_file: String,
     /// Exact current provider-visible state-chain tip; omit only for genesis.

--- a/crates/forge-cli/src/ops/pr_review_loop.rs
+++ b/crates/forge-cli/src/ops/pr_review_loop.rs
@@ -59,8 +59,10 @@ struct ReviewLoopObserveDryRunPayload {
     provider: &'static str,
     plan: Vec<String>,
     preflight_ok: bool,
-    /// Whether an accepted real run would append a new generation, or find the
-    /// chain already current. `None` when the transition was not evaluated.
+    /// Whether the real run would append a new generation. True for an accepted
+    /// transition that changes state, and also for an extendable budget error,
+    /// which appends a durable hard-stop receipt before failing. False when the
+    /// chain is already current. `None` when the transition was not evaluated.
     #[serde(skip_serializing_if = "Option::is_none")]
     would_append: Option<bool>,
     preflight: Vec<RuleVerdict>,
@@ -924,10 +926,21 @@ fn emit_observe_dry_run<R: BackendRunner>(
                                         Ok(()),
                                     ));
                                 }
-                                Err(error) => verdicts.push(RuleVerdict::from_result(
-                                    "observation_transition",
-                                    Err(error),
-                                )),
+                                Err(error) => {
+                                    // An extendable budget error is the one
+                                    // failure the real run still writes for: it
+                                    // appends a durable hard-stop receipt so a
+                                    // restart returns the same stop. Predicting
+                                    // "this fails" without that would understate
+                                    // what the real call does.
+                                    if review_state::stop_budget_field(error.kind()).is_some() {
+                                        would_append = Some(true);
+                                    }
+                                    verdicts.push(RuleVerdict::from_result(
+                                        "observation_transition",
+                                        Err(error),
+                                    ));
+                                }
                             }
                         }
                         None => verdicts.push(RuleVerdict::not_evaluated(

--- a/crates/forge-cli/src/ops/pr_review_loop.rs
+++ b/crates/forge-cli/src/ops/pr_review_loop.rs
@@ -16,6 +16,7 @@ use crate::ops::pr_comments::github_repo_slug_from_url;
 use crate::ops::{pr_review, pr_view, review_state};
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
+use crate::validations::RuleVerdict;
 
 const SCHEMA_INSPECT: &str = "pr.review-loop.inspect";
 const SCHEMA_OBSERVE: &str = "pr.review-loop.observe";
@@ -47,6 +48,22 @@ pub struct ReviewLoopMergeGate {
 struct ReviewLoopDryRunPayload {
     provider: &'static str,
     plan: Vec<String>,
+}
+
+/// `observe --dry-run`'s envelope: the same `plan` as before, plus the verdict
+/// of every read-only rule the real call enforces. `preflight` mirrors
+/// `pr deliver --dry-run`'s `local_preflight[]` element shape; the name differs
+/// because these rules include provider reads, never provider writes.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct ReviewLoopObserveDryRunPayload {
+    provider: &'static str,
+    plan: Vec<String>,
+    preflight_ok: bool,
+    /// Whether an accepted real run would append a new generation, or find the
+    /// chain already current. `None` when the transition was not evaluated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    would_append: Option<bool>,
+    preflight: Vec<RuleVerdict>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -116,12 +133,7 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 ) -> Result<i32, ForgeError> {
     let ctx = resolve_context(global, &remote_url_lookup)?;
     if global.dry_run {
-        return emit_dry_run(
-            &ctx,
-            "read the chain, evaluate one observation, and append with tip/head CAS",
-            SCHEMA_OBSERVE,
-            format,
-        );
+        return emit_observe_dry_run(runner, &ctx, &args, format);
     }
     let observations = read_observations(&args.findings_file)?;
     let (view, repository) = resolve_pr(runner, &ctx, args.id)?;
@@ -844,6 +856,142 @@ fn emit_state(
                 generation = payload.generation.unwrap_or(0),
                 appended = payload.appended,
             );
+        },
+    ))
+}
+
+/// Run every read-only check the real `observe` would run, in order, without
+/// short-circuiting and without appending anything.
+///
+/// Non-short-circuiting matters twice over. It reports every reason a real run
+/// would be rejected in one pass instead of one per attempt, and it keeps the
+/// local payload verdict available when the provider cannot be reached — which
+/// is what makes `--dry-run` usable as a schema check. Discovering the
+/// observation schema previously required a live `observe`, and a live
+/// `observe` appends durable, provider-visible state on success.
+fn emit_observe_dry_run<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    args: &PrReviewLoopObserveArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    let mut verdicts: Vec<RuleVerdict> = Vec::with_capacity(5);
+
+    // Local first, so it survives an unreachable provider.
+    let observations = match read_observations(&args.findings_file) {
+        Ok(observations) => {
+            verdicts.push(RuleVerdict::from_result("findings_file", Ok(())));
+            Some(observations)
+        }
+        Err(error) => {
+            verdicts.push(RuleVerdict::from_result("findings_file", Err(error)));
+            None
+        }
+    };
+
+    let mut would_append = None;
+    match resolve_pr(runner, ctx, args.id) {
+        Ok((view, repository)) => {
+            verdicts.push(RuleVerdict::from_result("provider_pull_request", Ok(())));
+            verdicts.push(RuleVerdict::from_result(
+                "expected_head",
+                ensure_expected_head(view.head_sha.as_deref(), &args.expected_head),
+            ));
+            match pr_review::read_review_loop_state_view(runner, ctx, &repository, view.number) {
+                Ok(state_view) => {
+                    verdicts.push(RuleVerdict::from_result("review_state_chain", Ok(())));
+                    verdicts.push(RuleVerdict::from_result(
+                        "expected_state_tip",
+                        ensure_expected_tip(
+                            state_view.chain.tip_digest.as_deref(),
+                            args.expected_state.as_deref(),
+                        ),
+                    ));
+                    match &observations {
+                        Some(observations) => {
+                            let previous =
+                                review_state::latest_review_loop_state(&state_view.chain);
+                            let transition = review_state::observe_review_loop(
+                                previous,
+                                &args.expected_head,
+                                observations,
+                            );
+                            match transition {
+                                Ok(transition) => {
+                                    would_append = Some(transition.changed);
+                                    verdicts.push(RuleVerdict::from_result(
+                                        "observation_transition",
+                                        Ok(()),
+                                    ));
+                                }
+                                Err(error) => verdicts.push(RuleVerdict::from_result(
+                                    "observation_transition",
+                                    Err(error),
+                                )),
+                            }
+                        }
+                        None => verdicts.push(RuleVerdict::not_evaluated(
+                            "observation_transition",
+                            "the findings file could not be read",
+                        )),
+                    }
+                }
+                Err(error) => {
+                    verdicts.push(RuleVerdict::from_result("review_state_chain", Err(error)));
+                    verdicts.push(RuleVerdict::not_evaluated(
+                        "expected_state_tip",
+                        "the review-state chain could not be read",
+                    ));
+                    verdicts.push(RuleVerdict::not_evaluated(
+                        "observation_transition",
+                        "the review-state chain could not be read",
+                    ));
+                }
+            }
+        }
+        Err(error) => {
+            verdicts.push(RuleVerdict::from_result(
+                "provider_pull_request",
+                Err(error),
+            ));
+            for rule in ["expected_head", "review_state_chain", "expected_state_tip"] {
+                verdicts.push(RuleVerdict::not_evaluated(
+                    rule,
+                    "the provider pull request could not be read",
+                ));
+            }
+            verdicts.push(RuleVerdict::not_evaluated(
+                "observation_transition",
+                "the provider pull request could not be read",
+            ));
+        }
+    }
+
+    let preflight_ok = verdicts.iter().all(|verdict| verdict.ok);
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA_OBSERVE, SCHEMA_VERSION),
+        ReviewLoopObserveDryRunPayload {
+            provider: ctx.provider.as_str(),
+            plan: vec![
+                "read the chain, evaluate one observation, and append with tip/head CAS"
+                    .to_string(),
+            ],
+            preflight_ok,
+            would_append,
+            preflight: verdicts,
+        },
+        format,
+        |payload| {
+            println!(
+                "would {plan} (preflight_ok={ok})",
+                plan = payload.plan.join(", then "),
+                ok = payload.preflight_ok,
+            );
+            for verdict in &payload.preflight {
+                let status = if verdict.ok { "ok" } else { "FAIL" };
+                let detail = verdict.message.as_deref().unwrap_or("");
+                println!("  {status} {rule} {detail}", rule = verdict.rule);
+            }
         },
     ))
 }

--- a/crates/forge-cli/src/validations.rs
+++ b/crates/forge-cli/src/validations.rs
@@ -484,7 +484,7 @@ impl RuleVerdict {
         }
     }
 
-    fn not_evaluated(rule: &'static str, why: &str) -> Self {
+    pub(crate) fn not_evaluated(rule: &'static str, why: &str) -> Self {
         Self {
             rule,
             ok: false,

--- a/crates/forge-cli/tests/integration.rs
+++ b/crates/forge-cli/tests/integration.rs
@@ -26,6 +26,7 @@ mod integration {
     mod pr_merge;
     mod pr_pending_review;
     mod pr_review;
+    mod pr_review_loop;
     mod pr_reviews;
     mod pr_wait_checks;
     mod provider_registry;

--- a/crates/forge-cli/tests/integration/pr_review_loop.rs
+++ b/crates/forge-cli/tests/integration/pr_review_loop.rs
@@ -1,0 +1,288 @@
+//! `pr review-loop observe --dry-run` must be a faithful, non-mutating
+//! preflight.
+//!
+//! The ledger's `observe` is a provider-mutating call with a multi-field input
+//! schema. Before this suite, its dry-run announced "read the chain, evaluate
+//! one observation, and append with tip/head CAS" and then returned before
+//! reading anything, so it predicted nothing about whether the real call would
+//! be accepted — and the only way to discover the observation schema was to run
+//! a live `observe`, which appends durable provider-visible state on success.
+
+use std::fs;
+
+use pretty_assertions::assert_eq;
+
+use super::support::{StubEnv, parse_envelope, run_forge_cli};
+
+/// A `gh` stub that answers `pr view` with a fixed head and records every
+/// invocation, so a test can prove no mutation was attempted.
+fn gh_stub_with_head(stub: &StubEnv, head: &str) -> String {
+    let args_log = stub.tempdir.path().join("gh-args.log");
+    format!(
+        r#"#!/bin/sh
+echo "$*" >> "{args_log}"
+case "$1 $2" in
+  "pr view")
+    cat <<'JSON'
+{{
+  "number": 7,
+  "url": "https://github.com/acme/widgets/pull/7",
+  "state": "OPEN",
+  "isDraft": false,
+  "title": "example",
+  "headRefName": "feat/example",
+  "headRefOid": "{head}",
+  "headRepository": {{"name": "widgets"}},
+  "baseRefName": "main",
+  "mergeable": "MERGEABLE",
+  "mergedAt": "",
+  "mergeCommit": null,
+  "labels": [],
+  "body": "",
+  "closingIssuesReferences": []
+}}
+JSON
+    exit 0
+    ;;
+esac
+echo "stub: unscripted gh args: $*" >&2
+exit 99
+"#,
+        args_log = args_log.display(),
+        head = head,
+    )
+}
+
+fn gh_args_log(stub: &StubEnv) -> String {
+    fs::read_to_string(stub.tempdir.path().join("gh-args.log")).unwrap_or_default()
+}
+
+fn write_findings(stub: &StubEnv, name: &str, body: &str) -> String {
+    let path = stub.tempdir.path().join(name);
+    fs::write(&path, body).expect("write findings file");
+    path.to_string_lossy().to_string()
+}
+
+fn preflight_verdict<'a>(envelope: &'a serde_json::Value, rule: &str) -> &'a serde_json::Value {
+    envelope["data"]["preflight"]
+        .as_array()
+        .unwrap_or_else(|| panic!("data.preflight array, got: {envelope}"))
+        .iter()
+        .find(|verdict| verdict["rule"] == rule)
+        .unwrap_or_else(|| panic!("no preflight verdict for {rule}, got: {envelope}"))
+}
+
+const VALID_FINDINGS: &str = r#"[
+  {
+    "lifecycle_fingerprint": "correctness:review-loop:head-cas",
+    "blocking": true,
+    "disposition": "open"
+  }
+]"#;
+
+#[test]
+fn observe_dry_run_performs_the_head_cas_it_advertises() {
+    let stub = StubEnv::new();
+    let body = gh_stub_with_head(&stub, "provider-head");
+    let findings = write_findings(&stub, "findings.json", VALID_FINDINGS);
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "stale-head",
+            "--findings-file",
+            &findings,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(
+        envelope["schema_version"],
+        "cli.forge-cli.pr.review-loop.observe.v1"
+    );
+
+    // The whole point: a dry run against a drifted head must predict the
+    // `review_state_conflict` the real call would return, instead of reporting
+    // a plan it never evaluated.
+    let verdict = preflight_verdict(&envelope, "expected_head");
+    assert_eq!(verdict["ok"], false, "verdict={verdict}");
+    assert_eq!(verdict["code"], "review_state_conflict");
+    assert_eq!(envelope["data"]["preflight_ok"], false);
+
+    // Reads are expected — the CAS needs them. Writes are not. The chain read
+    // is a read-only GraphQL `query(...)`, so the write signal is a mutating
+    // HTTP verb, a GraphQL `mutation`, or a comment-posting subcommand.
+    let log = gh_args_log(&stub);
+    for write_marker in [
+        "-X POST",
+        "-X PATCH",
+        "-X PUT",
+        "-X DELETE",
+        "mutation",
+        "pr comment",
+    ] {
+        assert!(
+            !log.contains(write_marker),
+            "a dry run must not attempt a provider write ({write_marker}), log={log}"
+        );
+    }
+}
+
+#[test]
+fn observe_dry_run_accepts_a_matching_head() {
+    let stub = StubEnv::new();
+    let body = gh_stub_with_head(&stub, "provider-head");
+    let findings = write_findings(&stub, "findings.json", VALID_FINDINGS);
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "provider-head",
+            "--findings-file",
+            &findings,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    let verdict = preflight_verdict(&envelope, "expected_head");
+    assert_eq!(verdict["ok"], true, "verdict={verdict}");
+}
+
+#[test]
+fn observe_dry_run_validates_the_findings_payload() {
+    let stub = StubEnv::new();
+    let body = gh_stub_with_head(&stub, "provider-head");
+    // A merge-envelope row with no lifecycle fingerprint: the exact shape whose
+    // rejection previously could only be discovered by a live, state-appending
+    // `observe`.
+    let findings = write_findings(
+        &stub,
+        "findings.json",
+        r#"{"data": {"findings": [{"category": "correctness", "primary": {"severity": "high"}}]}}"#,
+    );
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "provider-head",
+            "--findings-file",
+            &findings,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    let verdict = preflight_verdict(&envelope, "findings_file");
+    assert_eq!(verdict["ok"], false, "verdict={verdict}");
+    assert_eq!(verdict["code"], "review_fingerprint_required");
+}
+
+#[test]
+fn observe_dry_run_reports_the_payload_verdict_when_the_provider_is_unreachable() {
+    // The sweep does not short-circuit, so the local payload check is reported
+    // even when no provider call can succeed. That is what makes `--dry-run`
+    // usable as a schema check without writing durable state.
+    let stub = StubEnv::new();
+    let findings = write_findings(&stub, "findings.json", VALID_FINDINGS);
+    let stub = stub.gh_stub("#!/bin/sh\necho 'provider unreachable' >&2\nexit 99\n");
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "any-head",
+            "--findings-file",
+            &findings,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(preflight_verdict(&envelope, "findings_file")["ok"], true);
+    assert_eq!(
+        preflight_verdict(&envelope, "provider_pull_request")["ok"],
+        false
+    );
+    // Rules that depend on a failed lookup are reported as unevaluated rather
+    // than silently omitted or guessed.
+    let head_rule = preflight_verdict(&envelope, "expected_head");
+    assert_eq!(head_rule["ok"], false);
+    assert!(
+        head_rule["message"]
+            .as_str()
+            .unwrap_or_default()
+            .starts_with("not evaluated:"),
+        "verdict={head_rule}"
+    );
+}
+
+#[test]
+fn observe_help_documents_both_findings_file_shapes() {
+    let stub = StubEnv::new();
+    let out = run_forge_cli(&stub, &["pr", "review-loop", "observe", "--help"]);
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    for expected in [
+        "lifecycle_fingerprint",
+        "<category>:<component>:<invariant>",
+        "disposition",
+        "--dry-run",
+    ] {
+        assert!(
+            out.stdout.contains(expected),
+            "observe --help missing {expected:?}: stdout={}",
+            out.stdout
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`pr review-loop observe` is a provider-mutating call with a multi-field input
schema, and there was no way to learn or check that schema without writing
durable state. Its `--dry-run` announced "read the chain, evaluate one
observation, and append with tip/head CAS" and then returned before reading
anything, so it predicted nothing about whether the real call would be accepted.
This makes the dry run perform the read-only half of the real call and report a
verdict per rule.

## Issues

- Refs sympoies/agent-runtime-kit#9 — `pr review-loop observe` has no faithful
  preflight or validation

## Changes

- `observe --dry-run` now reads and validates the findings payload, resolves the
  pull request, runs the head and state-tip compare-and-swap comparisons, and
  evaluates the transition, reporting each verdict in `data.preflight[]`. It
  still appends nothing; an integration test asserts no mutating HTTP verb,
  GraphQL `mutation`, or comment-posting subcommand reaches the backend.
- `data.preflight[]` reuses the `RuleVerdict` element shape from
  `pr deliver --dry-run`'s `local_preflight[]`. The field name differs because
  these rules include provider *reads* — never writes. `data.preflight_ok` is
  the conjunction, and `data.would_append` reports whether an accepted real run
  would append a new generation or find the chain already current.
- The sweep does not short-circuit. Every reason a real run would be rejected is
  reported in one pass instead of one per attempt, and the local payload verdict
  survives an unreachable provider — which is what makes `--dry-run` usable as a
  findings-file schema check without writing durable state.
- Rules that depend on a failed lookup are reported as `not evaluated:` rather
  than omitted or guessed.
- `observe --help` now documents both `--findings-file` shapes, the
  `<category>:<component>:<invariant>` fingerprint form, the fact that the merge
  envelope rejects `disposition` while the observation array accepts it, and the
  observe-before-repair append order the ledger's two head rules force.
- The spec records the same append order and the new dry-run contract.

## Test-First Evidence

Test-first, with a captured red. `tests/integration/pr_review_loop.rs` was
written against the unfaithful dry run, and four of its five behavioural tests
failed on the missing contract:

```text
data.preflight array, got: {"schema_version":"cli.forge-cli.pr.review-loop.observe.v1",
"ok":true,"data":{"provider":"github","plan":["read the chain, evaluate one
observation, and append with tip/head CAS"]}}
```

The headline case, `observe_dry_run_performs_the_head_cas_it_advertises`, points
a stub provider at a head that differs from `--expected-head` and requires the
dry run to predict the same `review_state_conflict` the real call returns. That
is the exact failure a live run produced on serenvia/agent-console#377 after a
dry run with identical arguments had reported success.

One assertion was corrected during the run rather than weakened: the first
version treated any `graphql` call as a write, but the chain read is a read-only
GraphQL `query(...)`. It now checks for mutating HTTP verbs, `mutation`, and
`pr comment`, which is what a write actually looks like.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — pass
- `cargo test -p nils-forge-cli` — 455 tests, all passing
- `cargo test -p nils-forge-cli --test integration pr_review_loop` — 6 passed
- `bash scripts/ci/markdownlint-audit.sh --strict` — `PASS (strict=1)`
- `bash scripts/ci/docs-hygiene-audit.sh --strict` — `PASS (strict=1, warnings=0)`
- Checked-in shell completions regenerated, so `completion_sync` stays green
  after the `observe --help` footer changed

## Risk / Notes

- `observe --dry-run` now makes provider reads where it previously made none.
  This is additive latency and a new failure surface for a command that
  previously always succeeded offline, but the sweep reports read failures as
  verdicts rather than aborting, so the command still exits 0 and still reports
  the local payload verdict.
- `data.preflight[]`, `data.preflight_ok`, and `data.would_append` are additive
  fields on an existing schema version; `data.plan` is unchanged, so existing
  consumers keep working.
- `inspect` and `extend` dry-runs are untouched and remain offline plan-only.
  `extend` is also mutating, so the same faithfulness gap exists there; it is
  out of scope here because it is only reachable after a durable hard stop.
