### PR TITLE
test(coverage): restore the 85% line-coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,9 +363,7 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      # Temporary floor from native run 30743840826 (84.10%). After the runtime-kit
-      # delivery, restore 85 once native full-workspace coverage reaches at least 85%.
-      COVERAGE_FAIL_UNDER_LINES: "84"
+      COVERAGE_FAIL_UNDER_LINES: "85"
     steps:
       # Docs-only and proven release-only change sets skip coverage work at the
       # step level so the required `coverage` job still concludes `success`.

--- a/crates/agent-docs/src/config.rs
+++ b/crates/agent-docs/src/config.rs
@@ -953,3 +953,507 @@ fn byte_offset_to_line_column(raw: &str, offset: usize) -> ConfigErrorLocation {
     }
     ConfigErrorLocation { line, column }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::model::ConfigErrorKind;
+    use pretty_assertions::assert_eq;
+
+    const FILE: &str = "/repo/AGENT_DOCS.toml";
+
+    fn load(raw: &str) -> Result<ScopeCatalog, ConfigLoadError> {
+        load_scope_catalog_from_str(
+            Scope::Project,
+            CatalogOrigin::Repository,
+            Path::new("/repo"),
+            Path::new(FILE),
+            raw,
+        )
+    }
+
+    fn load_as(
+        source_scope: Scope,
+        origin: CatalogOrigin,
+        raw: &str,
+    ) -> Result<ScopeCatalog, ConfigLoadError> {
+        load_scope_catalog_from_str(
+            source_scope,
+            origin,
+            Path::new("/repo"),
+            Path::new(FILE),
+            raw,
+        )
+    }
+
+    /// Assert the failing field path without pinning the human wording.
+    fn field_error(raw: &str, expected_field: &str) -> ConfigLoadError {
+        let err = load(raw).expect_err("catalog must be rejected");
+        assert_eq!(err.kind, ConfigErrorKind::Validation);
+        assert_eq!(
+            err.field.as_deref(),
+            Some(expected_field),
+            "{}",
+            err.message
+        );
+        assert_eq!(err.file_path, PathBuf::from(FILE));
+        err
+    }
+
+    #[test]
+    fn a_full_catalog_round_trips_every_supported_field() {
+        let catalog = load(
+            r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "DEVELOPMENT.md"
+product = ["claude", "codex", "claude"]
+phase = ["review", "plan"]
+required = true
+when = "always"
+marker = "dev-marker"
+last-reviewed-within-days = 30
+notes = "keep in sync"
+
+[[validation]]
+context = "project-dev"
+commands = ["  cargo test  "]
+product = "codex"
+marker = "validation-marker"
+description = "run the suite"
+
+[skills]
+enforce_name_prefix = true
+allowed_prefixes = ["project", "private"]
+dir = "  .agents/skills  "
+"#,
+        )
+        .expect("catalog");
+
+        assert_eq!(catalog.source_scope, Scope::Project);
+        assert_eq!(catalog.root, PathBuf::from("/repo"));
+        assert_eq!(catalog.documents.len(), 1);
+        let document = &catalog.documents[0];
+        assert_eq!(document.context.as_str(), "project-dev");
+        assert_eq!(document.scope, Scope::Project);
+        assert_eq!(document.path, PathBuf::from("DEVELOPMENT.md"));
+        // Products and phases are sorted and de-duplicated so two catalogs that
+        // list the same set in a different order compare equal.
+        assert_eq!(document.products.len(), 2);
+        assert_eq!(
+            document
+                .phases
+                .iter()
+                .map(Phase::as_str)
+                .collect::<Vec<_>>(),
+            vec!["plan", "review"]
+        );
+        assert!(document.required);
+        assert_eq!(document.when_raw, "always");
+        assert_eq!(document.marker.as_deref(), Some("dev-marker"));
+        assert_eq!(document.freshness_days, Some(30));
+        assert_eq!(document.notes.as_deref(), Some("keep in sync"));
+
+        assert_eq!(catalog.validations.len(), 1);
+        assert_eq!(catalog.validations[0].commands, vec!["cargo test"]);
+        assert_eq!(
+            catalog.validations[0].description.as_deref(),
+            Some("run the suite")
+        );
+
+        let policy = catalog.skill_policy.expect("skill policy");
+        assert!(policy.enforce_name_prefix);
+        assert_eq!(policy.dir, ".agents/skills");
+        assert_eq!(policy.allowed_prefixes, SkillPolicy::default_prefixes());
+    }
+
+    #[test]
+    fn an_empty_catalog_yields_empty_sections() {
+        let catalog = load("").expect("empty catalog");
+
+        assert!(catalog.documents.is_empty());
+        assert!(catalog.validations.is_empty());
+        assert!(catalog.skill_policy.is_none());
+        assert!(catalog.path_classes.is_none());
+    }
+
+    #[test]
+    fn invalid_toml_reports_a_line_and_column() {
+        let err = load("[[document]\ncontext = \"x\"\n").expect_err("broken toml");
+
+        assert_eq!(err.kind, ConfigErrorKind::Parse);
+        let location = err.location.expect("location");
+        assert_eq!(location.line, 1);
+        assert!(err.message.contains(CONFIG_FILE_NAME), "{}", err.message);
+    }
+
+    #[test]
+    fn a_private_catalog_hides_the_raw_toml_error() {
+        let err = load_as(Scope::Project, CatalogOrigin::User, "not = toml =")
+            .expect_err("broken private toml");
+
+        assert_eq!(err.kind, ConfigErrorKind::Parse);
+        // The private catalog lives outside the repo, so its contents must not
+        // leak into an error surfaced in repository output.
+        assert_eq!(err.message, "invalid private catalog TOML");
+    }
+
+    #[test]
+    fn byte_offsets_translate_to_one_based_line_and_column() {
+        let raw = "abc\nde\n";
+        assert_eq!(byte_offset_to_line_column(raw, 0).line, 1);
+        assert_eq!(byte_offset_to_line_column(raw, 0).column, 1);
+        let second_line = byte_offset_to_line_column(raw, 5);
+        assert_eq!(second_line.line, 2);
+        assert_eq!(second_line.column, 2);
+        // An out-of-range offset is clamped rather than panicking.
+        let clamped = byte_offset_to_line_column(raw, 9999);
+        assert_eq!(clamped.line, 3);
+        assert_eq!(clamped.column, 1);
+    }
+
+    #[test]
+    fn document_and_validation_sections_must_be_arrays_of_tables() {
+        let err = load("document = 5").expect_err("scalar document");
+        assert_eq!(err.kind, ConfigErrorKind::Validation);
+        assert_eq!(err.field.as_deref(), Some("document"));
+        assert_eq!(err.entry_index, None);
+
+        let err = load("validation = \"x\"").expect_err("scalar validation");
+        assert_eq!(err.field.as_deref(), Some("validation"));
+
+        let err = load("document = [1]").expect_err("non-table entry");
+        assert_eq!(err.field.as_deref(), Some("document"));
+        assert_eq!(err.entry_index, Some(0));
+
+        let err = load("validation = [1]").expect_err("non-table entry");
+        assert_eq!(err.field.as_deref(), Some("validation"));
+        assert_eq!(err.entry_index, Some(0));
+    }
+
+    #[test]
+    fn unknown_fields_are_rejected_with_the_allowed_list() {
+        let err = field_error(
+            r#"
+[[document]]
+context = "x"
+scope = "project"
+path = "a.md"
+typo = true
+"#,
+            "typo",
+        );
+        assert!(err.message.contains("allowed fields:"), "{}", err.message);
+
+        field_error(
+            r#"
+[[validation]]
+context = "x"
+commands = ["a"]
+typo = true
+"#,
+            "typo",
+        );
+    }
+
+    #[test]
+    fn required_document_fields_are_enforced() {
+        field_error(
+            "[[document]]\nscope = \"project\"\npath = \"a.md\"\n",
+            "context",
+        );
+        field_error("[[document]]\ncontext = \"x\"\npath = \"a.md\"\n", "scope");
+        field_error(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\n",
+            "path",
+        );
+        field_error(
+            "[[document]]\ncontext = 5\nscope = \"project\"\npath = \"a.md\"\n",
+            "context",
+        );
+        field_error(
+            "[[document]]\ncontext = \"bad ctx\"\nscope = \"project\"\npath = \"a.md\"\n",
+            "context",
+        );
+        field_error(
+            "[[document]]\ncontext = \"x\"\nscope = \"nowhere\"\npath = \"a.md\"\n",
+            "scope",
+        );
+        field_error(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"   \"\n",
+            "path",
+        );
+    }
+
+    #[test]
+    fn scope_visibility_depends_on_the_catalog_source() {
+        let global_doc = "[[document]]\ncontext = \"x\"\nscope = \"global\"\npath = \"a.md\"\n";
+        // A repository catalog may not declare a global requirement.
+        field_error(global_doc, "scope");
+        // The home catalog may.
+        load_as(Scope::Home, CatalogOrigin::Home, global_doc).expect("home global scope");
+
+        // A private/user catalog is project-scoped only.
+        let err = load_as(
+            Scope::Project,
+            CatalogOrigin::User,
+            "[[document]]\ncontext = \"x\"\nscope = \"home\"\npath = \"a.md\"\n",
+        )
+        .expect_err("user catalog scope");
+        assert_eq!(err.field.as_deref(), Some("scope"));
+    }
+
+    #[test]
+    fn private_catalog_paths_must_stay_inside_the_project() {
+        let allowed = load_as(
+            Scope::Project,
+            CatalogOrigin::User,
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"docs/a.md\"\n",
+        )
+        .expect("relative private path");
+        assert_eq!(allowed.documents[0].path, PathBuf::from("docs/a.md"));
+
+        for escape in ["/etc/passwd", "../outside.md"] {
+            let err = load_as(
+                Scope::Project,
+                CatalogOrigin::User,
+                &format!(
+                    "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"{escape}\"\n"
+                ),
+            )
+            .expect_err("private path escape");
+            assert_eq!(err.field.as_deref(), Some("path"), "{escape}");
+        }
+
+        // A repository catalog is trusted to name absolute paths.
+        load("[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"/abs/a.md\"\n")
+            .expect("repository absolute path");
+    }
+
+    #[test]
+    fn product_accepts_string_or_array_and_rejects_everything_else() {
+        let single = load(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\nproduct = \"claude\"\n",
+        )
+        .expect("string product");
+        assert_eq!(single.documents[0].products.len(), 1);
+
+        for bad in [
+            "product = []",
+            "product = [1]",
+            "product = 5",
+            "product = \"nope\"",
+        ] {
+            field_error(
+                &format!(
+                    "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\n{bad}\n"
+                ),
+                "product",
+            );
+        }
+
+        // The same rules apply on the validation side.
+        field_error(
+            "[[validation]]\ncontext = \"x\"\ncommands = [\"a\"]\nproduct = 5\n",
+            "product",
+        );
+    }
+
+    #[test]
+    fn phase_accepts_string_or_array_and_rejects_everything_else() {
+        let single = load(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\nphase = \"plan\"\n",
+        )
+        .expect("string phase");
+        assert_eq!(single.documents[0].phases[0].as_str(), "plan");
+
+        for bad in [
+            "phase = []",
+            "phase = [1]",
+            "phase = 5",
+            "phase = \"bad phase\"",
+        ] {
+            field_error(
+                &format!(
+                    "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\n{bad}\n"
+                ),
+                "phase",
+            );
+        }
+    }
+
+    #[test]
+    fn optional_scalar_fields_are_type_checked() {
+        field_error(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\nrequired = \"yes\"\n",
+            "required",
+        );
+        field_error(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\nmarker = 5\n",
+            "marker",
+        );
+        field_error(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\nnotes = 5\n",
+            "notes",
+        );
+        field_error(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\nlast-reviewed-within-days = \"30\"\n",
+            "last-reviewed-within-days",
+        );
+        field_error(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\nlast-reviewed-within-days = 0\n",
+            "last-reviewed-within-days",
+        );
+        field_error(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\nwhen = 5\n",
+            "when",
+        );
+        field_error(
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\nwhen = \"?? invalid\"\n",
+            "when",
+        );
+    }
+
+    #[test]
+    fn validation_commands_must_be_a_non_empty_list_of_non_empty_strings() {
+        for bad in [
+            "",
+            "commands = \"cargo test\"",
+            "commands = []",
+            "commands = [1]",
+            "commands = [\"   \"]",
+        ] {
+            field_error(
+                &format!("[[validation]]\ncontext = \"x\"\n{bad}\n"),
+                "commands",
+            );
+        }
+    }
+
+    #[test]
+    fn skills_policy_defaults_and_validation() {
+        let defaults = load("[skills]\n").expect("empty skills table");
+        let policy = defaults.skill_policy.expect("policy");
+        assert!(!policy.enforce_name_prefix);
+        assert_eq!(policy.dir, SkillPolicy::DEFAULT_DIR);
+        assert_eq!(policy.allowed_prefixes, SkillPolicy::default_prefixes());
+
+        let root_errors = [
+            ("skills = 5", "skills"),
+            ("[skills]\ntypo = true", "skills.typo"),
+            (
+                "[skills]\nenforce_name_prefix = \"yes\"",
+                "skills.enforce_name_prefix",
+            ),
+            (
+                "[skills]\nallowed_prefixes = \"project\"",
+                "skills.allowed_prefixes",
+            ),
+            ("[skills]\nallowed_prefixes = []", "skills.allowed_prefixes"),
+            (
+                "[skills]\nallowed_prefixes = [1]",
+                "skills.allowed_prefixes",
+            ),
+            (
+                "[skills]\nallowed_prefixes = [\"  \"]",
+                "skills.allowed_prefixes",
+            ),
+            (
+                "[skills]\nallowed_prefixes = [\"Project\"]",
+                "skills.allowed_prefixes",
+            ),
+            ("[skills]\ndir = 5", "skills.dir"),
+            ("[skills]\ndir = \"   \"", "skills.dir"),
+        ];
+        for (raw, field) in root_errors {
+            let err = load(raw).expect_err("skills policy must be rejected");
+            assert_eq!(err.kind, ConfigErrorKind::Validation);
+            assert_eq!(err.field.as_deref(), Some(field), "raw={raw}");
+            assert_eq!(err.entry_index, None);
+        }
+
+        let custom = load("[skills]\nallowed_prefixes = [\" team-a \"]\ndir = \"skills\"\n")
+            .expect("custom policy");
+        let policy = custom.skill_policy.expect("policy");
+        assert_eq!(policy.allowed_prefixes, vec!["team-a".to_string()]);
+        assert_eq!(policy.dir, "skills");
+    }
+
+    #[test]
+    fn path_classes_must_be_a_table() {
+        let err = load("path_classes = 5").expect_err("scalar path_classes");
+        assert_eq!(err.kind, ConfigErrorKind::Validation);
+        assert_eq!(err.field.as_deref(), Some("path_classes"));
+    }
+
+    #[test]
+    fn value_type_names_every_toml_kind() {
+        assert_eq!(value_type(&Value::String(String::new())), "string");
+        assert_eq!(value_type(&Value::Integer(1)), "integer");
+        assert_eq!(value_type(&Value::Float(1.0)), "float");
+        assert_eq!(value_type(&Value::Boolean(true)), "boolean");
+        assert_eq!(value_type(&Value::Array(Vec::new())), "array");
+        assert_eq!(value_type(&Value::Table(toml::map::Map::new())), "table");
+    }
+
+    #[test]
+    fn scope_catalog_loading_is_optional_and_path_derived() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        assert_eq!(config_path_for_root(root), root.join(CONFIG_FILE_NAME));
+        assert!(
+            load_scope_catalog(Scope::Project, root)
+                .expect("missing catalog is not an error")
+                .is_none()
+        );
+
+        fs::write(
+            config_path_for_root(root),
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"a.md\"\n",
+        )
+        .unwrap();
+        let catalog = load_scope_catalog(Scope::Project, root)
+            .expect("catalog")
+            .expect("present");
+        assert_eq!(catalog.documents.len(), 1);
+
+        let external = load_external_project_catalog(root, &config_path_for_root(root))
+            .expect("external catalog");
+        assert_eq!(external.source_scope, Scope::Project);
+
+        let missing = load_external_project_catalog(root, &root.join("absent.toml"))
+            .expect_err("missing external catalog");
+        assert_eq!(missing.kind, ConfigErrorKind::Io);
+    }
+
+    #[test]
+    fn a_repo_that_is_its_own_docs_home_is_loaded_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        fs::write(
+            config_path_for_root(root),
+            "[[document]]\ncontext = \"x\"\nscope = \"home\"\npath = \"a.md\"\n",
+        )
+        .unwrap();
+
+        let loaded = load_catalog(root, root).expect("catalog");
+        assert!(loaded.home.is_some());
+        assert!(
+            loaded.project.is_none(),
+            "the shared catalog must not be counted twice"
+        );
+
+        let project_only = tempfile::tempdir().unwrap();
+        fs::write(
+            config_path_for_root(project_only.path()),
+            "[[document]]\ncontext = \"x\"\nscope = \"project\"\npath = \"b.md\"\n",
+        )
+        .unwrap();
+        let split = load_catalog(root, project_only.path()).expect("catalog");
+        assert!(split.home.is_some());
+        assert_eq!(split.project.expect("project").documents.len(), 1);
+    }
+}

--- a/crates/agent-docs/src/operation_effect.rs
+++ b/crates/agent-docs/src/operation_effect.rs
@@ -146,3 +146,208 @@ fn emit(format: OutputFormat, descriptor: OperationEffectDescriptor) -> i32 {
     }
     exit::SUCCESS
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    fn classify_argv(argv: &[&str]) -> (&'static str, Effect, ProviderEffect, Vec<&'static str>) {
+        let mut full = vec![OsString::from("agent-docs")];
+        full.extend(argv.iter().map(OsString::from));
+        let parsed = Cli::try_parse_from(full)
+            .unwrap_or_else(|error| panic!("argv {argv:?} must parse: {error}"));
+        classify(&parsed.command)
+    }
+
+    #[test]
+    fn read_only_commands_declare_their_managed_state_reads() {
+        for (argv, operation, reads) in [
+            (vec!["audit"], "audit", vec!["catalog", "filesystem"]),
+            (
+                vec!["preflight", "--intent", "project-dev"],
+                "preflight",
+                vec!["catalog", "filesystem"],
+            ),
+            (
+                vec!["explain", "--intent", "project-dev"],
+                "explain",
+                vec!["catalog", "filesystem"],
+            ),
+            (
+                vec!["integration", "resolve", "--product", "claude"],
+                "integration.resolve",
+                vec!["catalog", "user_config", "filesystem"],
+            ),
+            (vec!["list"], "list", vec!["catalog", "filesystem"]),
+        ] {
+            let (name, effect, provider, declared) = classify_argv(&argv);
+            assert_eq!(name, operation, "{argv:?}");
+            assert_eq!(effect, Effect::ReadOnly, "{argv:?}");
+            assert_eq!(provider, ProviderEffect::LocalRead, "{argv:?}");
+            assert_eq!(declared, reads, "{argv:?}");
+        }
+    }
+
+    #[test]
+    fn session_subcommands_split_read_from_mutation() {
+        let (name, effect, provider, reads) = classify_argv(&[
+            "session",
+            "status",
+            "--session-id",
+            "s1",
+            "--product",
+            "claude",
+            "--state-home",
+            "/tmp/state",
+        ]);
+        assert_eq!(name, "session.status");
+        assert_eq!(effect, Effect::ReadOnly);
+        assert_eq!(provider, ProviderEffect::LocalRead);
+        assert_eq!(reads, vec!["session_state"]);
+
+        let (name, effect, _, reads) = classify_argv(&[
+            "session",
+            "verify",
+            "--session-id",
+            "s1",
+            "--product",
+            "claude",
+            "--state-home",
+            "/tmp/state",
+            "--require-intent",
+            "project-dev",
+        ]);
+        assert_eq!(name, "session.verify");
+        assert_eq!(effect, Effect::ReadOnly);
+        assert_eq!(reads, vec!["session_state", "catalog", "filesystem"]);
+
+        // A mutation declares no managed-state reads and no provider effect.
+        for (subcommand, expected) in [
+            ("activate", "session.activate"),
+            ("prepare", "session.prepare"),
+        ] {
+            let (name, effect, provider, reads) = classify_argv(&[
+                "session",
+                subcommand,
+                "--session-id",
+                "s1",
+                "--product",
+                "claude",
+                "--state-home",
+                "/tmp/state",
+                "--intent",
+                "project-dev",
+            ]);
+            assert_eq!(name, expected);
+            assert_eq!(effect, Effect::Mutation);
+            assert_eq!(provider, ProviderEffect::None);
+            assert!(reads.is_empty());
+        }
+    }
+
+    #[test]
+    fn config_reads_are_distinguished_from_config_mutations() {
+        let (name, effect, _, reads) = classify_argv(&["config", "show"]);
+        assert_eq!(name, "config.show");
+        assert_eq!(effect, Effect::ReadOnly);
+        assert_eq!(reads, vec!["user_config"]);
+
+        let (name, effect, _, reads) = classify_argv(&["config", "list"]);
+        assert_eq!(name, "config.list");
+        assert_eq!(effect, Effect::ReadOnly);
+        assert_eq!(reads, vec!["user_config"]);
+
+        // Anything that is not an explicit read is classified as a mutation,
+        // so a newly added config subcommand fails closed.
+        for argv in [
+            vec!["config", "enroll", "--catalog", "/tmp/catalog.toml"],
+            vec!["config", "exclude"],
+            vec!["config", "remove"],
+        ] {
+            let (name, effect, provider, reads) = classify_argv(&argv);
+            assert_eq!(name, "config.mutation", "{argv:?}");
+            assert_eq!(effect, Effect::Mutation, "{argv:?}");
+            assert_eq!(provider, ProviderEffect::None, "{argv:?}");
+            assert!(reads.is_empty(), "{argv:?}");
+        }
+    }
+
+    #[test]
+    fn init_is_a_preview_until_it_is_forced() {
+        for argv in [
+            vec!["init", "--print"],
+            vec!["init", "--dry-run"],
+            vec!["init"],
+        ] {
+            let (name, effect, provider, reads) = classify_argv(&argv);
+            assert_eq!(name, "init.preview", "{argv:?}");
+            assert_eq!(effect, Effect::ReadOnly, "{argv:?}");
+            assert_eq!(provider, ProviderEffect::LocalRead, "{argv:?}");
+            assert_eq!(reads, vec!["filesystem"], "{argv:?}");
+        }
+
+        let (name, effect, provider, reads) = classify_argv(&["init", "--force"]);
+        assert_eq!(name, "init.write");
+        assert_eq!(effect, Effect::Mutation);
+        assert_eq!(provider, ProviderEffect::None);
+        assert!(reads.is_empty());
+    }
+
+    #[test]
+    fn remove_completion_and_self_description_are_classified() {
+        let (name, effect, provider, _) = classify_argv(&[
+            "remove",
+            "--context",
+            "project-dev",
+            "--scope",
+            "project",
+            "--path",
+            "DEVELOPMENT.md",
+        ]);
+        assert_eq!(name, "remove");
+        assert_eq!(effect, Effect::Mutation);
+        assert_eq!(provider, ProviderEffect::None);
+
+        let (name, effect, provider, reads) = classify_argv(&["completion", "zsh"]);
+        assert_eq!(name, "completion");
+        assert_eq!(effect, Effect::ReadOnly);
+        assert_eq!(provider, ProviderEffect::None);
+        assert!(reads.is_empty());
+
+        // Describing the describer cannot claim to know its own effect.
+        let (name, effect, _, _) = classify_argv(&["operation-effect", "--", "list"]);
+        assert_eq!(name, "operation-effect");
+        assert_eq!(effect, Effect::Unknown);
+    }
+
+    #[test]
+    fn a_descriptor_is_emitted_for_both_formats() {
+        let argv = vec![OsString::from("list")];
+        assert_eq!(run(argv.clone(), OutputFormat::Json), exit::SUCCESS);
+        assert_eq!(run(argv, OutputFormat::Text), exit::SUCCESS);
+    }
+
+    #[test]
+    fn unparseable_argv_fails_with_the_parse_error_contract() {
+        let argv = vec![OsString::from("definitely-not-a-subcommand")];
+
+        assert_eq!(run(argv.clone(), OutputFormat::Json), exit::USAGE);
+        assert_eq!(run(argv, OutputFormat::Text), exit::USAGE);
+    }
+
+    #[test]
+    fn explicit_roots_become_canonical_descriptor_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let argv = vec![
+            OsString::from("--docs-home"),
+            OsString::from(tmp.path()),
+            OsString::from("--project-path"),
+            OsString::from(tmp.path()),
+            OsString::from("list"),
+        ];
+
+        assert_eq!(run(argv, OutputFormat::Json), exit::SUCCESS);
+    }
+}

--- a/crates/agent-docs/src/output.rs
+++ b/crates/agent-docs/src/output.rs
@@ -336,3 +336,295 @@ fn render_contract_line(contract: &ValidationContract) -> String {
 fn required_label(doc: &ResolvedDocument) -> &'static str {
     if doc.required { "required" } else { "optional" }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::model::{
+        Context as IntentContext, DocumentSource, DocumentStatus, DocumentValidation,
+        FreshnessCheck, RemoveOutcome, ResolveSummary, Scope,
+    };
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    fn intent(name: &str) -> IntentContext {
+        IntentContext::parse(name).expect("intent")
+    }
+
+    fn document(path: &str, required: bool, present: bool) -> ResolvedDocument {
+        ResolvedDocument {
+            context: intent("project-dev"),
+            scope: Scope::Project,
+            path: PathBuf::from(path),
+            products: Vec::new(),
+            phases: Vec::new(),
+            declared_required: required,
+            required,
+            when: "always".to_string(),
+            when_satisfied: true,
+            status: if present {
+                DocumentStatus::Present
+            } else {
+                DocumentStatus::Missing
+            },
+            validation: if present {
+                DocumentValidation {
+                    exists: true,
+                    non_empty: true,
+                    marker_present: None,
+                    freshness: FreshnessCheck::NotDeclared,
+                    valid: true,
+                }
+            } else {
+                DocumentValidation::missing()
+            },
+            source: DocumentSource::Project,
+            why: "declared in the project catalog".to_string(),
+            content: None,
+        }
+    }
+
+    fn contract(declared: bool) -> ValidationContract {
+        ValidationContract {
+            context: intent("project-dev"),
+            declared,
+            commands: if declared {
+                vec!["cargo test".to_string()]
+            } else {
+                Vec::new()
+            },
+            marker: declared.then(|| "test-marker".to_string()),
+            description: declared.then(|| "run the suite".to_string()),
+        }
+    }
+
+    fn preflight(documents: Vec<ResolvedDocument>) -> PreflightReport {
+        PreflightReport {
+            schema_version: PreflightReport::SCHEMA_VERSION,
+            intent: intent("project-dev"),
+            product: None,
+            phase: None,
+            strict: false,
+            docs_home: PathBuf::from("/home/docs"),
+            project_path: PathBuf::from("/repo"),
+            is_linked_worktree: false,
+            summary: ResolveSummary::from_documents(&documents),
+            documents,
+            validation: contract(true),
+        }
+    }
+
+    #[test]
+    fn json_rendering_is_pretty_printed_and_parses_back() {
+        let report = preflight(vec![document("DEVELOPMENT.md", true, true)]);
+
+        let json = render_preflight(OutputFormat::Json, &report).expect("json");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(
+            parsed["schema_version"].as_str(),
+            Some(PreflightReport::SCHEMA_VERSION)
+        );
+        assert!(json.contains('\n'), "json output must be pretty-printed");
+    }
+
+    #[test]
+    fn preflight_text_lists_documents_and_a_summary_line() {
+        let report = preflight(vec![
+            document("DEVELOPMENT.md", true, true),
+            document("OPTIONAL.md", false, false),
+        ]);
+
+        let text = render_preflight(OutputFormat::Text, &report).expect("text");
+
+        assert!(text.contains("DEVELOPMENT.md"), "{text}");
+        assert!(text.contains("OPTIONAL.md"), "{text}");
+        assert!(
+            text.contains(
+                "summary: required_total=1 satisfied_required=1 missing_required=0 invalid_required=0 strict=false"
+            ),
+            "{text}"
+        );
+        assert!(text.contains("validation contract (project-dev)"), "{text}");
+    }
+
+    #[test]
+    fn a_list_report_renders_every_section_even_when_empty() {
+        let empty = ListReport {
+            docs_home: PathBuf::from("/home/docs"),
+            project_path: PathBuf::from("/repo"),
+            intents: Vec::new(),
+            documents: Vec::new(),
+            validations: Vec::new(),
+        };
+
+        let text = render_list(OutputFormat::Text, &empty).expect("text");
+        assert!(text.contains("docs_home: /home/docs"), "{text}");
+        assert!(text.contains("project_path: /repo"), "{text}");
+        assert!(text.contains("intents: \n"), "{text}");
+        assert!(text.contains("documents:\n  - (none)"), "{text}");
+        assert!(text.contains("validation contracts:\n  - (none)"), "{text}");
+
+        let populated = ListReport {
+            intents: vec!["project-dev".to_string(), "task-tools".to_string()],
+            documents: vec![document("DEVELOPMENT.md", true, true)],
+            validations: vec![contract(true)],
+            ..empty
+        };
+        let text = render_list(OutputFormat::Text, &populated).expect("text");
+        assert!(text.contains("intents: project-dev, task-tools"), "{text}");
+        assert!(
+            text.contains(
+                "  [required] context=project-dev scope=project DEVELOPMENT.md status=present source=project"
+            ),
+            "{text}"
+        );
+        assert!(
+            text.contains("  context=project-dev commands=[\"cargo test\"]"),
+            "{text}"
+        );
+
+        let json = render_list(OutputFormat::Json, &populated).expect("json");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed["intents"].as_array().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn an_undeclared_intent_names_the_intents_that_do_exist() {
+        let available = vec!["project-dev".to_string(), "task-tools".to_string()];
+
+        let text =
+            render_undeclared_intent_error(OutputFormat::Text, "nope", &available).expect("text");
+        assert_eq!(
+            text,
+            "error: undeclared intent `nope`; available intents: project-dev, task-tools"
+        );
+
+        // With nothing declared the operator still gets an actionable message.
+        let text = render_undeclared_intent_error(OutputFormat::Text, "nope", &[]).expect("text");
+        assert_eq!(
+            text,
+            "error: undeclared intent `nope`; available intents: none"
+        );
+
+        let json =
+            render_undeclared_intent_error(OutputFormat::Json, "nope", &available).expect("json");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed["ok"].as_bool(), Some(false));
+        assert_eq!(parsed["error"]["code"].as_str(), Some("undeclared-intent"));
+        assert_eq!(
+            parsed["error"]["details"]["available_intents"]
+                .as_array()
+                .map(Vec::len),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn explain_renders_a_single_intent_and_the_intent_index() {
+        let documents = vec![document("DEVELOPMENT.md", true, true)];
+        let validation = contract(true);
+        let payload = ExplainIntent {
+            intent: "project-dev",
+            documents: &documents,
+            validation: &validation,
+        };
+
+        let text = render_explain_intent(OutputFormat::Text, &payload).expect("text");
+        assert!(text.starts_with("INTENT: project-dev"), "{text}");
+        assert!(text.contains("marker=test-marker"), "{text}");
+        assert!(text.contains("description=\"run the suite\""), "{text}");
+
+        let empty_validation = contract(false);
+        let empty = ExplainIntent {
+            intent: "project-dev",
+            documents: &[],
+            validation: &empty_validation,
+        };
+        let text = render_explain_intent(OutputFormat::Text, &empty).expect("text");
+        assert!(
+            text.contains("(no documents declared for this intent)"),
+            "{text}"
+        );
+        assert!(
+            text.contains("validation contract: none declared for intent project-dev"),
+            "{text}"
+        );
+
+        let json = render_explain_intent(OutputFormat::Json, &payload).expect("json");
+        assert!(serde_json::from_str::<serde_json::Value>(&json).is_ok());
+
+        let intents = vec!["project-dev".to_string()];
+        let text =
+            render_explain_intents(OutputFormat::Text, &ExplainIntents { intents: &intents })
+                .expect("text");
+        assert!(text.starts_with("INTENTS:\n  - project-dev"), "{text}");
+        let text = render_explain_intents(OutputFormat::Text, &ExplainIntents { intents: &[] })
+            .expect("text");
+        assert_eq!(text, "no intents declared in the catalog");
+        let json =
+            render_explain_intents(OutputFormat::Json, &ExplainIntents { intents: &intents })
+                .expect("json");
+        assert!(serde_json::from_str::<serde_json::Value>(&json).is_ok());
+    }
+
+    #[test]
+    fn remove_reports_its_outcome_on_one_line() {
+        let report = RemoveReport {
+            config_path: PathBuf::from("/repo/AGENT_DOCS.toml"),
+            outcome: RemoveOutcome::Removed,
+            context: "project-dev".to_string(),
+            scope: Scope::Project,
+            path: PathBuf::from("DEVELOPMENT.md"),
+            remaining_documents: 2,
+        };
+
+        let text = render_remove(OutputFormat::Text, &report).expect("text");
+        assert_eq!(
+            text,
+            "remove: outcome=removed context=project-dev scope=project path=DEVELOPMENT.md config=/repo/AGENT_DOCS.toml remaining_documents=2"
+        );
+
+        let json = render_remove(OutputFormat::Json, &report).expect("json");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed["outcome"].as_str(), Some("removed"));
+    }
+
+    #[test]
+    fn init_print_mode_emits_the_stub_verbatim_for_every_format() {
+        let report = InitReport {
+            mode: InitMode::Print,
+            target_path: PathBuf::from("/repo/AGENT_DOCS.toml"),
+            wrote: false,
+            stub: "# stub\n[[document]]\n".to_string(),
+        };
+
+        // Print mode is redirected straight into the catalog file, so `--format
+        // json` must not wrap it in an envelope.
+        for format in [OutputFormat::Text, OutputFormat::Json] {
+            assert_eq!(
+                render_init(format, &report).expect("init"),
+                "# stub\n[[document]]\n"
+            );
+        }
+
+        let wrote = InitReport {
+            mode: InitMode::Write,
+            wrote: true,
+            ..report
+        };
+        assert_eq!(
+            render_init(OutputFormat::Text, &wrote).expect("init"),
+            "init: mode=write target=/repo/AGENT_DOCS.toml wrote=true"
+        );
+        let json = render_init(OutputFormat::Json, &wrote).expect("json");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed["wrote"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn the_required_label_reflects_the_resolved_requirement() {
+        assert_eq!(required_label(&document("A.md", true, true)), "required");
+        assert_eq!(required_label(&document("A.md", false, true)), "optional");
+    }
+}

--- a/crates/agent-docs/src/resolver.rs
+++ b/crates/agent-docs/src/resolver.rs
@@ -818,3 +818,318 @@ fn push_unique_intent(intents: &mut Vec<String>, name: &str) {
         intents.push(name.to_string());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    struct Fixture {
+        _tmp: TempDir,
+        roots: ResolvedRoots,
+        project: PathBuf,
+    }
+
+    /// A docs-home and a separate project root, each with its own catalog.
+    fn fixture(home_catalog: &str, project_catalog: &str) -> Fixture {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path().join("docs-home");
+        let project = tmp.path().join("project");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&project).unwrap();
+        if !home_catalog.is_empty() {
+            fs::write(home.join("AGENT_DOCS.toml"), home_catalog).unwrap();
+        }
+        if !project_catalog.is_empty() {
+            fs::write(project.join("AGENT_DOCS.toml"), project_catalog).unwrap();
+        }
+        Fixture {
+            roots: ResolvedRoots::for_paths(home, project.clone()),
+            project,
+            _tmp: tmp,
+        }
+    }
+
+    fn intent(name: &str) -> Context {
+        Context::parse(name).expect("intent")
+    }
+
+    const PROJECT_CATALOG: &str = r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "DEVELOPMENT.md"
+required = true
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "OPTIONAL.md"
+
+[[validation]]
+context = "project-dev"
+commands = ["cargo test"]
+"#;
+
+    #[test]
+    fn a_present_required_document_is_reported_as_satisfied() {
+        let fixture = fixture("", PROJECT_CATALOG);
+        fs::write(fixture.project.join("DEVELOPMENT.md"), "# dev\n").unwrap();
+        fs::write(fixture.project.join("OPTIONAL.md"), "# optional\n").unwrap();
+
+        let report = resolve_intent(
+            &intent("project-dev"),
+            &fixture.roots,
+            false,
+            FallbackMode::Auto,
+            false,
+        )
+        .expect("resolve");
+
+        assert_eq!(report.schema_version, PreflightReport::SCHEMA_VERSION);
+        assert_eq!(report.intent.as_str(), "project-dev");
+        assert_eq!(report.documents.len(), 2);
+        assert_eq!(report.summary.required_total, 1);
+        assert_eq!(report.summary.satisfied_required, 1);
+        assert_eq!(report.summary.missing_required, 0);
+        assert!(!report.has_unsatisfied_required());
+        assert_eq!(report.validation.commands, vec!["cargo test"]);
+        assert!(
+            report.documents.iter().all(|doc| doc.content.is_none()),
+            "content is emitted only on request"
+        );
+    }
+
+    #[test]
+    fn a_missing_required_document_leaves_the_intent_unsatisfied() {
+        let fixture = fixture("", PROJECT_CATALOG);
+
+        let report = resolve_intent(
+            &intent("project-dev"),
+            &fixture.roots,
+            false,
+            FallbackMode::Auto,
+            false,
+        )
+        .expect("resolve");
+
+        let required = report
+            .documents
+            .iter()
+            .find(|doc| doc.required)
+            .expect("required document");
+        assert_eq!(required.status, DocumentStatus::Missing);
+        assert_eq!(report.summary.missing_required, 1);
+        assert!(report.has_unsatisfied_required());
+    }
+
+    #[test]
+    fn content_emission_is_opt_in_and_reads_the_resolved_file() {
+        let fixture = fixture("", PROJECT_CATALOG);
+        fs::write(fixture.project.join("DEVELOPMENT.md"), "# dev\nbody\n").unwrap();
+
+        let report = resolve_intent(
+            &intent("project-dev"),
+            &fixture.roots,
+            false,
+            FallbackMode::Auto,
+            true,
+        )
+        .expect("resolve");
+
+        let required = report
+            .documents
+            .iter()
+            .find(|doc| doc.required)
+            .expect("required document");
+        assert_eq!(required.content.as_deref(), Some("# dev\nbody\n"));
+        // A document that does not exist has no content to emit.
+        let optional = report
+            .documents
+            .iter()
+            .find(|doc| !doc.required)
+            .expect("optional document");
+        assert_eq!(optional.status, DocumentStatus::Missing);
+        assert_eq!(optional.content, None);
+    }
+
+    #[test]
+    fn an_unknown_intent_resolves_to_an_empty_document_set() {
+        let fixture = fixture("", PROJECT_CATALOG);
+
+        let report = resolve_intent(
+            &intent("no-such-intent"),
+            &fixture.roots,
+            false,
+            FallbackMode::Auto,
+            false,
+        )
+        .expect("resolve");
+
+        assert!(report.documents.is_empty());
+        assert_eq!(report.summary.required_total, 0);
+        assert!(!report.has_unsatisfied_required());
+        assert!(report.validation.commands.is_empty());
+    }
+
+    #[test]
+    fn a_product_filter_selects_only_matching_documents() {
+        let catalog = r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "CLAUDE.md"
+product = "claude"
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "CODEX.md"
+product = "codex"
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "SHARED.md"
+"#;
+        let fixture = fixture("", catalog);
+
+        let claude = resolve_intent_for_product(
+            &intent("project-dev"),
+            &fixture.roots,
+            Some(Product::Claude),
+            false,
+            FallbackMode::Auto,
+            false,
+        )
+        .expect("resolve");
+        let paths = |report: &PreflightReport| {
+            report
+                .documents
+                .iter()
+                .map(|doc| doc.path.file_name().unwrap().to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+        };
+        // A product-neutral document applies to every product.
+        assert_eq!(paths(&claude), vec!["CLAUDE.md", "SHARED.md"]);
+        assert_eq!(claude.product, Some(Product::Claude));
+
+        let codex = resolve_intent_for_product(
+            &intent("project-dev"),
+            &fixture.roots,
+            Some(Product::Codex),
+            false,
+            FallbackMode::Auto,
+            false,
+        )
+        .expect("resolve");
+        assert_eq!(paths(&codex), vec!["CODEX.md", "SHARED.md"]);
+
+        // With no product filter, every declared document is resolved.
+        let all = resolve_intent(
+            &intent("project-dev"),
+            &fixture.roots,
+            false,
+            FallbackMode::Auto,
+            false,
+        )
+        .expect("resolve");
+        assert_eq!(all.documents.len(), 3);
+        assert_eq!(all.product, None);
+    }
+
+    #[test]
+    fn a_pre_loaded_catalog_resolves_without_touching_the_filesystem_catalog() {
+        let fixture = fixture("", PROJECT_CATALOG);
+        fs::write(fixture.project.join("DEVELOPMENT.md"), "# dev\n").unwrap();
+        let catalog = load_catalog_from_roots(&fixture.roots).expect("catalog");
+
+        // Deleting the on-disk catalog proves the pre-loaded one is used.
+        fs::remove_file(fixture.project.join("AGENT_DOCS.toml")).unwrap();
+
+        let report = resolve_intent_with_catalog(
+            &intent("project-dev"),
+            &fixture.roots,
+            false,
+            FallbackMode::Auto,
+            false,
+            &catalog,
+        );
+
+        assert_eq!(report.documents.len(), 2);
+        assert_eq!(report.summary.satisfied_required, 1);
+    }
+
+    #[test]
+    fn a_broken_catalog_surfaces_the_config_error_instead_of_an_empty_report() {
+        let fixture = fixture("", "[[document]\n");
+
+        let err = resolve_intent(
+            &intent("project-dev"),
+            &fixture.roots,
+            false,
+            FallbackMode::Auto,
+            false,
+        )
+        .expect_err("broken catalog");
+
+        assert!(err.file_path.ends_with("AGENT_DOCS.toml"), "{err:?}");
+    }
+
+    #[test]
+    fn a_home_catalog_contributes_its_own_scoped_documents() {
+        let home_catalog = r#"
+[[document]]
+context = "project-dev"
+scope = "home"
+path = "HOME_POLICY.md"
+required = true
+"#;
+        let fixture = fixture(home_catalog, PROJECT_CATALOG);
+
+        let report = resolve_intent(
+            &intent("project-dev"),
+            &fixture.roots,
+            false,
+            FallbackMode::Auto,
+            false,
+        )
+        .expect("resolve");
+
+        assert_eq!(
+            report.documents.len(),
+            3,
+            "home and project catalogs both contribute: {:?}",
+            report.documents.iter().map(|d| &d.path).collect::<Vec<_>>()
+        );
+        assert!(
+            report
+                .documents
+                .iter()
+                .any(|doc| doc.scope == Scope::Home && doc.required),
+            "the home-scoped requirement must survive resolution"
+        );
+    }
+
+    #[test]
+    fn strict_mode_still_returns_a_report_for_a_satisfied_intent() {
+        let fixture = fixture("", PROJECT_CATALOG);
+        fs::write(fixture.project.join("DEVELOPMENT.md"), "# dev\n").unwrap();
+
+        let report = resolve_intent(
+            &intent("project-dev"),
+            &fixture.roots,
+            true,
+            FallbackMode::LocalOnly,
+            false,
+        )
+        .expect("resolve");
+
+        assert!(report.strict);
+        assert_eq!(report.docs_home, fixture.roots.docs_home);
+        assert_eq!(report.project_path, fixture.roots.project_path);
+        assert!(!report.is_linked_worktree);
+    }
+}

--- a/crates/agent-hook/src/strict_json.rs
+++ b/crates/agent-hook/src/strict_json.rs
@@ -97,3 +97,72 @@ impl<'de> Visitor<'de> for StrictValueVisitor {
         Ok(StrictValue(Value::Object(object)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    fn parse(input: &str) -> serde_json::Result<Value> {
+        from_slice(input.as_bytes())
+    }
+
+    #[test]
+    fn every_scalar_kind_round_trips() {
+        assert_eq!(parse("true").unwrap(), json!(true));
+        assert_eq!(parse("false").unwrap(), json!(false));
+        assert_eq!(parse("null").unwrap(), Value::Null);
+        assert_eq!(parse("\"text\"").unwrap(), json!("text"));
+        assert_eq!(parse("-7").unwrap(), json!(-7));
+        assert_eq!(parse("7").unwrap(), json!(7));
+        assert_eq!(parse("1.5").unwrap(), json!(1.5));
+        // A u64 above i64::MAX must not be narrowed.
+        assert_eq!(
+            parse("18446744073709551615").unwrap(),
+            json!(18_446_744_073_709_551_615_u64)
+        );
+    }
+
+    #[test]
+    fn nested_containers_are_reconstructed_in_order() {
+        let value = parse(r#"{"a":[1,{"b":"c"},[]],"d":{}}"#).unwrap();
+
+        assert_eq!(value, json!({"a": [1, {"b": "c"}, []], "d": {}}));
+        assert_eq!(parse("[]").unwrap(), json!([]));
+        assert_eq!(parse("{}").unwrap(), json!({}));
+    }
+
+    #[test]
+    fn a_duplicate_object_key_is_rejected_instead_of_last_write_wins() {
+        // serde_json's own parser silently keeps the last value; a hook payload
+        // must not be able to smuggle a second value past an earlier check.
+        let err = parse(r#"{"decision":"allow","decision":"deny"}"#)
+            .expect_err("duplicate key must be rejected");
+
+        assert!(
+            err.to_string().contains("duplicate object key: decision"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_duplicate_key_nested_inside_a_container_is_still_rejected() {
+        let err = parse(r#"{"outer":[{"k":1,"k":2}]}"#).expect_err("nested duplicate");
+        assert!(err.to_string().contains("duplicate object key: k"), "{err}");
+
+        // Distinct keys at the same depth stay valid.
+        assert_eq!(
+            parse(r#"{"outer":[{"k":1},{"k":2}]}"#).unwrap(),
+            json!({"outer": [{"k": 1}, {"k": 2}]}),
+        );
+    }
+
+    #[test]
+    fn malformed_input_still_surfaces_a_parse_error() {
+        assert!(parse("{").is_err());
+        assert!(parse("").is_err());
+        assert!(from_slice(&[0xff, 0xfe]).is_err());
+    }
+}

--- a/crates/agent-memory/src/add.rs
+++ b/crates/agent-memory/src/add.rs
@@ -152,3 +152,248 @@ fn temp_sibling(path: &Path) -> PathBuf {
     name.push(".tmp");
     path.with_file_name(name)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    use crate::{EXIT_RUNTIME, EXIT_USAGE};
+
+    struct Fixture {
+        _tmp: TempDir,
+        layout: Layout,
+        global: PathBuf,
+    }
+
+    fn fixture(with_index: bool) -> Fixture {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("agent-memory");
+        let global = root.join("global");
+        fs::create_dir_all(&global).unwrap();
+        if with_index {
+            fs::write(global.join("MEMORY.md"), "# Memory\n").unwrap();
+        }
+        Fixture {
+            layout: Layout { root },
+            global,
+            _tmp: tmp,
+        }
+    }
+
+    fn args(name: &str, kind: &str) -> AddArgs {
+        AddArgs {
+            scope: Some("global".to_string()),
+            name: name.to_string(),
+            r#type: kind.to_string(),
+            description: "one-line description".to_string(),
+            title: None,
+            hook: None,
+            body_file: None,
+            body: Some("the fact".to_string()),
+            session_id: None,
+            format: OutputFormat::Text,
+            json: false,
+        }
+    }
+
+    #[test]
+    fn a_note_and_its_index_line_are_written_together() {
+        let fixture = fixture(true);
+
+        let code = run(&fixture.layout, &args("my-note", "project")).expect("add");
+
+        assert_eq!(code, EXIT_OK);
+        let note = fs::read_to_string(fixture.global.join("my-note.md")).expect("note");
+        assert!(note.contains("name: my-note"), "{note}");
+        assert!(note.contains("the fact"), "{note}");
+        let index = fs::read_to_string(fixture.global.join("MEMORY.md")).expect("index");
+        assert!(
+            index.ends_with("- [my-note](my-note.md) — one-line description\n"),
+            "{index}"
+        );
+    }
+
+    #[test]
+    fn an_explicit_title_and_hook_override_the_defaults() {
+        let fixture = fixture(true);
+        let mut args = args("my-note", "reference");
+        args.title = Some("My Note".to_string());
+        args.hook = Some("where the dashboard lives".to_string());
+
+        run(&fixture.layout, &args).expect("add");
+
+        let index = fs::read_to_string(fixture.global.join("MEMORY.md")).expect("index");
+        assert!(
+            index.ends_with("- [My Note](my-note.md) — where the dashboard lives\n"),
+            "{index}"
+        );
+    }
+
+    #[test]
+    fn the_type_and_name_vocabularies_are_closed() {
+        let fixture = fixture(true);
+
+        let bad_type = run(&fixture.layout, &args("my-note", "musings")).expect_err("bad type");
+        assert_eq!(bad_type.exit_code, EXIT_USAGE);
+        assert!(bad_type.message.contains("invalid type 'musings'"));
+
+        for name in ["../escape", "with space", ""] {
+            let bad_name = run(&fixture.layout, &args(name, "project")).expect_err("bad name");
+            assert_eq!(bad_name.exit_code, EXIT_USAGE, "{name}");
+            assert!(bad_name.message.contains("invalid name"), "{name}");
+        }
+
+        for kind in ["user", "feedback", "project", "reference"] {
+            run(&fixture.layout, &args(&format!("note-{kind}"), kind))
+                .unwrap_or_else(|err| panic!("{kind} must be accepted: {}", err.message));
+        }
+    }
+
+    #[test]
+    fn a_missing_scope_or_index_is_refused_before_anything_is_written() {
+        let missing_scope = fixture(true);
+        let mut scoped = args("my-note", "project");
+        scoped.scope = Some("agents/absent".to_string());
+        let err = run(&missing_scope.layout, &scoped).expect_err("missing scope dir");
+        assert_eq!(err.exit_code, EXIT_RUNTIME);
+        assert!(err.message.starts_with("not found: "), "{}", err.message);
+
+        // A scope directory without MEMORY.md would leave an unindexed note.
+        let no_index = fixture(false);
+        let err = run(&no_index.layout, &args("my-note", "project")).expect_err("no index");
+        assert_eq!(err.exit_code, EXIT_RUNTIME);
+        assert!(
+            err.message.starts_with("no MEMORY.md in "),
+            "{}",
+            err.message
+        );
+        assert!(!no_index.global.join("my-note.md").exists());
+    }
+
+    #[test]
+    fn an_existing_note_is_never_overwritten() {
+        let fixture = fixture(true);
+        fs::write(fixture.global.join("my-note.md"), "original\n").unwrap();
+
+        let err = run(&fixture.layout, &args("my-note", "project")).expect_err("exists");
+
+        assert_eq!(err.exit_code, EXIT_RUNTIME);
+        assert!(
+            err.message.starts_with("already exists: "),
+            "{}",
+            err.message
+        );
+        assert_eq!(
+            fs::read_to_string(fixture.global.join("my-note.md")).unwrap(),
+            "original\n"
+        );
+    }
+
+    #[test]
+    fn a_failed_index_update_rolls_the_note_back() {
+        let fixture = fixture(true);
+        // The index itself must stay a real file so the early `is_file()` guard
+        // passes and the failure lands on the atomic write instead. Occupying
+        // the temp sibling with a directory is what makes that write fail,
+        // after the note has already been created.
+        fs::create_dir(fixture.global.join("MEMORY.md.tmp")).unwrap();
+
+        let err = run(&fixture.layout, &args("my-note", "project")).expect_err("index write fails");
+
+        assert_eq!(err.exit_code, EXIT_RUNTIME);
+        assert!(
+            !fixture.global.join("my-note.md").exists(),
+            "the note must be rolled back so the store never holds an unindexed note"
+        );
+        assert_eq!(
+            fs::read_to_string(fixture.global.join("MEMORY.md")).unwrap(),
+            "# Memory\n",
+            "the index must be untouched"
+        );
+    }
+
+    #[test]
+    fn an_index_without_a_trailing_newline_is_repaired_before_appending() {
+        let fixture = fixture(true);
+        fs::write(fixture.global.join("MEMORY.md"), "# Memory").unwrap();
+
+        run(&fixture.layout, &args("my-note", "project")).expect("add");
+
+        assert_eq!(
+            fs::read_to_string(fixture.global.join("MEMORY.md")).unwrap(),
+            "# Memory\n- [my-note](my-note.md) — one-line description\n"
+        );
+    }
+
+    #[test]
+    fn the_body_comes_from_the_flag_a_file_or_nothing() {
+        let fixture = fixture(true);
+
+        let mut inline = args("inline", "project");
+        inline.body = Some("inline body".to_string());
+        assert_eq!(read_body(&inline).expect("inline"), "inline body");
+
+        let mut empty = args("empty", "project");
+        empty.body = None;
+        assert_eq!(read_body(&empty).expect("empty"), "");
+
+        let body_file = fixture.global.join("body.md");
+        fs::write(&body_file, "from file\n").unwrap();
+        let mut from_file = args("from-file", "project");
+        from_file.body = None;
+        from_file.body_file = Some(body_file.to_string_lossy().into_owned());
+        assert_eq!(read_body(&from_file).expect("file"), "from file\n");
+
+        let mut missing = args("missing", "project");
+        missing.body = None;
+        missing.body_file = Some("/definitely/not/a/body.md".to_string());
+        let err = read_body(&missing).expect_err("missing body file");
+        assert_eq!(err.exit_code, EXIT_RUNTIME);
+        assert!(err.message.starts_with("failed to read body file"));
+    }
+
+    #[test]
+    fn json_output_is_selected_by_either_the_flag_or_the_alias() {
+        let fixture = fixture(true);
+        let mut json_flag = args("via-alias", "project");
+        json_flag.json = true;
+        run(&fixture.layout, &json_flag).expect("add");
+
+        let mut json_format = args("via-format", "project");
+        json_format.format = OutputFormat::Json;
+        run(&fixture.layout, &json_format).expect("add");
+
+        let index = fs::read_to_string(fixture.global.join("MEMORY.md")).expect("index");
+        assert!(index.contains("via-alias"), "{index}");
+        assert!(index.contains("via-format"), "{index}");
+    }
+
+    #[test]
+    fn the_temp_sibling_never_escapes_the_target_directory() {
+        assert_eq!(
+            temp_sibling(Path::new("/store/global/note.md")),
+            PathBuf::from("/store/global/note.md.tmp")
+        );
+        // A path with no file name still yields a sibling inside the parent.
+        assert_eq!(temp_sibling(Path::new("/")), PathBuf::from("/.tmp"));
+    }
+
+    #[test]
+    fn an_atomic_write_leaves_no_temp_file_behind() {
+        let fixture = fixture(true);
+        let target = fixture.global.join("atomic.md");
+
+        write_atomic(&target, "content\n").expect("write");
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "content\n");
+        assert!(!temp_sibling(&target).exists());
+
+        // A target whose parent does not exist fails without panicking.
+        let err = write_atomic(&fixture.global.join("absent").join("x.md"), "content")
+            .expect_err("no parent directory");
+        assert_eq!(err.exit_code, EXIT_RUNTIME);
+    }
+}

--- a/crates/agent-memory/src/search.rs
+++ b/crates/agent-memory/src/search.rs
@@ -101,3 +101,166 @@ pub(crate) fn run(layout: &Layout, args: &SearchArgs) -> Result<i32, CliError> {
         EXIT_OK
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    struct Fixture {
+        _tmp: TempDir,
+        layout: Layout,
+        global: PathBuf,
+    }
+
+    fn fixture() -> Fixture {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("agent-memory");
+        let global = root.join("global");
+        fs::create_dir_all(&global).unwrap();
+        fs::write(
+            global.join("MEMORY.md"),
+            "# Memory\n- [deploy](deploy.md) — how the deploy works\n",
+        )
+        .unwrap();
+        fs::write(
+            global.join("deploy.md"),
+            "---\nname: deploy\ndescription: How the DEPLOY pipeline works\n---\n\nRun the deploy script.\n",
+        )
+        .unwrap();
+        fs::write(
+            global.join("other.md"),
+            "---\nname: other\ndescription: unrelated\n---\n\nnothing to see\n",
+        )
+        .unwrap();
+        Fixture {
+            layout: Layout { root },
+            global,
+            _tmp: tmp,
+        }
+    }
+
+    fn args(term: &str) -> SearchArgs {
+        SearchArgs {
+            term: term.to_string(),
+            scope: Some("global".to_string()),
+            all: false,
+            format: OutputFormat::Text,
+            json: false,
+        }
+    }
+
+    #[test]
+    fn a_match_anywhere_in_a_note_is_case_insensitive() {
+        let fixture = fixture();
+
+        // The needle appears in the frontmatter description in a different case
+        // and in the body in yet another, and both must match.
+        assert_eq!(
+            run(&fixture.layout, &args("deploy")).expect("search"),
+            EXIT_OK
+        );
+        assert_eq!(
+            run(&fixture.layout, &args("DEPLOY")).expect("search"),
+            EXIT_OK
+        );
+        assert_eq!(
+            run(&fixture.layout, &args("PiPeLiNe")).expect("search"),
+            EXIT_OK
+        );
+    }
+
+    #[test]
+    fn no_match_is_reported_with_a_non_zero_exit() {
+        let fixture = fixture();
+
+        assert_eq!(
+            run(&fixture.layout, &args("absolutely-not-present")).expect("search"),
+            EXIT_RUNTIME
+        );
+    }
+
+    #[test]
+    fn the_index_file_is_never_searched() {
+        let fixture = fixture();
+        // Only MEMORY.md carries this text, so a hit would mean the index was
+        // scanned and every note would appear to match its own index line.
+        fs::write(
+            fixture.global.join("MEMORY.md"),
+            "# Memory\n- [x](x.md) — indexonlyneedle\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            run(&fixture.layout, &args("indexonlyneedle")).expect("search"),
+            EXIT_RUNTIME
+        );
+    }
+
+    #[test]
+    fn an_unreadable_note_is_skipped_rather_than_failing_the_search() {
+        let fixture = fixture();
+        // A directory named like a note cannot be read as text.
+        fs::create_dir(fixture.global.join("broken.md")).unwrap();
+
+        assert_eq!(
+            run(&fixture.layout, &args("deploy")).expect("search"),
+            EXIT_OK
+        );
+    }
+
+    #[test]
+    fn a_missing_scope_directory_is_a_runtime_error() {
+        let fixture = fixture();
+        let mut missing = args("deploy");
+        missing.scope = Some("agents/absent".to_string());
+
+        let err = run(&fixture.layout, &missing).expect_err("missing scope");
+
+        assert_eq!(err.exit_code, EXIT_RUNTIME);
+        assert!(err.message.starts_with("not found: "), "{}", err.message);
+    }
+
+    #[test]
+    fn json_output_is_selected_by_either_the_flag_or_the_alias() {
+        let fixture = fixture();
+
+        let mut alias = args("deploy");
+        alias.json = true;
+        assert_eq!(run(&fixture.layout, &alias).expect("search"), EXIT_OK);
+
+        let mut format = args("deploy");
+        format.format = OutputFormat::Json;
+        assert_eq!(run(&fixture.layout, &format).expect("search"), EXIT_OK);
+
+        // An empty result set still renders a well-formed report.
+        let mut empty = args("absolutely-not-present");
+        empty.format = OutputFormat::Json;
+        assert_eq!(run(&fixture.layout, &empty).expect("search"), EXIT_RUNTIME);
+    }
+
+    #[test]
+    fn searching_every_scope_covers_more_than_the_default_one() {
+        let fixture = fixture();
+        let agent_dir = fixture.layout.root.join("agents").join("claude");
+        fs::create_dir_all(&agent_dir).unwrap();
+        fs::write(agent_dir.join("MEMORY.md"), "# Memory\n").unwrap();
+        fs::write(
+            agent_dir.join("note.md"),
+            "---\nname: note\ndescription: agent-scoped\n---\n\nscopedneedle\n",
+        )
+        .unwrap();
+
+        // The default (global) scope cannot see it.
+        assert_eq!(
+            run(&fixture.layout, &args("scopedneedle")).expect("search"),
+            EXIT_RUNTIME
+        );
+
+        let mut all = args("scopedneedle");
+        all.all = true;
+        assert_eq!(run(&fixture.layout, &all).expect("search"), EXIT_OK);
+    }
+}

--- a/crates/agent-out/src/lib.rs
+++ b/crates/agent-out/src/lib.rs
@@ -1988,4 +1988,676 @@ mod tests {
             "/agent-home/out/projects/owner__repo/20260511-121314-bug-sweep"
         );
     }
+
+    // -----------------------------------------------------------------
+    // Cleanup apply is the only destructive surface in this binary. Every
+    // guard below is what keeps a reviewed plan from deleting something the
+    // reviewer never saw, so each one is pinned to its exact error code.
+    // -----------------------------------------------------------------
+
+    fn cache_item(path: &Path, size_bytes: u64, digest: Option<String>) -> CleanupItem {
+        CleanupItem {
+            name: path_name(path),
+            path: display_path(path),
+            kind: entry_kind(path),
+            category: CleanupCategory::Cache,
+            action: CleanupAction::Delete,
+            reason: "release cache is reproducible".to_string(),
+            size_bytes,
+            mtime_unix: path_mtime_unix(path),
+            content_digest: digest,
+            contains_skill_usage: false,
+            contains_test_first_evidence: false,
+        }
+    }
+
+    /// Build an `agent_home` with `out/nils-versions/<file>` populated, plus a
+    /// digest-consistent plan envelope on disk ready for `cleanup apply`.
+    struct ApplyFixture {
+        _tmp: tempfile::TempDir,
+        agent_home: PathBuf,
+        out_root: PathBuf,
+        cache_root: PathBuf,
+        plan_file: PathBuf,
+        plan_digest: String,
+    }
+
+    fn apply_fixture(mutate: impl FnOnce(&mut CleanupPlan)) -> ApplyFixture {
+        let tmp = tempfile::tempdir().unwrap();
+        // `fs::canonicalize` is used by the delete guard, so start from a
+        // canonical root or macOS `/var` -> `/private/var` breaks containment.
+        let agent_home = fs::canonicalize(tmp.path()).unwrap().join("agent-home");
+        let out_root = agent_home.join("out");
+        let cache_root = out_root.join(RELEASE_CACHE_ROOT);
+        fs::create_dir_all(cache_root.join("1.0.0")).unwrap();
+        fs::write(cache_root.join("1.0.0").join("bin"), b"payload").unwrap();
+
+        let item = cache_item(
+            &cache_root,
+            path_size_bytes(&cache_root).unwrap(),
+            Some(path_content_digest(&cache_root).unwrap()),
+        );
+        let mut plan = CleanupPlan {
+            agent_home: display_path(&agent_home),
+            out_root: display_path(&out_root),
+            out_root_exists: true,
+            include_projects: false,
+            summary: cleanup_summary(std::slice::from_ref(&item)),
+            items: vec![item],
+            plan_digest: String::new(),
+        };
+        plan.plan_digest = compute_cleanup_plan_digest(&plan).expect("digest");
+        mutate(&mut plan);
+        let plan_digest = plan.plan_digest.clone();
+
+        let plan_file = agent_home.join("plan.json");
+        fs::write(
+            &plan_file,
+            serde_json::to_string(&serde_json::json!({
+                "schema_version": CLEANUP_PLAN_SCHEMA_VERSION,
+                "command": CLEANUP_PLAN_COMMAND,
+                "ok": true,
+                "result": plan,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        ApplyFixture {
+            _tmp: tmp,
+            agent_home,
+            out_root,
+            cache_root,
+            plan_file,
+            plan_digest,
+        }
+    }
+
+    impl ApplyFixture {
+        fn args(&self, confirm_digest: &str) -> CleanupApplyArgs {
+            CleanupApplyArgs {
+                plan_file: self.plan_file.clone(),
+                confirm_digest: confirm_digest.to_string(),
+                agent_home: Some(self.agent_home.clone()),
+                format: CleanupFormat::Json,
+            }
+        }
+    }
+
+    #[test]
+    fn cleanup_apply_deletes_a_digest_confirmed_release_cache() {
+        let fixture = apply_fixture(|_| {});
+
+        let report = apply_cleanup_plan(&fixture.args(&fixture.plan_digest)).expect("apply");
+
+        assert!(report.applied);
+        assert_eq!(report.summary.deleted, 1);
+        assert_eq!(report.summary.skipped, 0);
+        assert!(report.summary.delete_bytes > 0);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].status, "deleted");
+        assert!(
+            !fixture.cache_root.exists(),
+            "the reviewed cache root must be gone"
+        );
+        assert!(
+            fixture.out_root.is_dir(),
+            "out_root itself is never deleted"
+        );
+    }
+
+    #[test]
+    fn cleanup_apply_rejects_a_plan_file_that_cannot_be_read() {
+        let fixture = apply_fixture(|_| {});
+        let mut args = fixture.args(&fixture.plan_digest);
+        args.plan_file = fixture.agent_home.join("missing-plan.json");
+
+        let err = apply_cleanup_plan(&args).expect_err("missing plan file");
+
+        assert_eq!(err.code, "cleanup-plan-read-failed");
+        assert_eq!(err.exit_code, EXIT_DATA);
+    }
+
+    #[test]
+    fn cleanup_apply_rejects_a_plan_file_that_is_not_json() {
+        let fixture = apply_fixture(|_| {});
+        fs::write(&fixture.plan_file, "{ not json").unwrap();
+
+        let err =
+            apply_cleanup_plan(&fixture.args(&fixture.plan_digest)).expect_err("invalid json");
+
+        assert_eq!(err.code, "cleanup-plan-invalid-json");
+    }
+
+    #[test]
+    fn cleanup_apply_rejects_an_envelope_from_another_command() {
+        let fixture = apply_fixture(|_| {});
+        let raw = fs::read_to_string(&fixture.plan_file).unwrap();
+        let mut value: Value = serde_json::from_str(&raw).unwrap();
+        value["command"] = serde_json::json!("agent-out audit");
+        fs::write(&fixture.plan_file, value.to_string()).unwrap();
+
+        let err =
+            apply_cleanup_plan(&fixture.args(&fixture.plan_digest)).expect_err("wrong envelope");
+
+        assert_eq!(err.code, "cleanup-plan-invalid");
+    }
+
+    #[test]
+    fn cleanup_apply_rejects_a_plan_whose_digest_does_not_cover_its_contents() {
+        // Tamper after the digest was computed: the recorded digest no longer
+        // describes the item list an operator would have reviewed.
+        let fixture = apply_fixture(|plan| {
+            plan.items[0].reason = "tampered".to_string();
+        });
+
+        let err = apply_cleanup_plan(&fixture.args(&fixture.plan_digest))
+            .expect_err("digest must cover contents");
+
+        assert_eq!(err.code, "cleanup-plan-digest-invalid");
+        assert!(
+            fixture.cache_root.exists(),
+            "nothing may be deleted once the digest check fails"
+        );
+    }
+
+    #[test]
+    fn cleanup_apply_requires_the_operator_to_confirm_the_exact_digest() {
+        let fixture = apply_fixture(|_| {});
+
+        let err = apply_cleanup_plan(&fixture.args("sha256:not-the-plan"))
+            .expect_err("confirmation mismatch");
+
+        assert_eq!(err.code, "cleanup-digest-mismatch");
+        assert!(fixture.cache_root.exists());
+    }
+
+    #[test]
+    fn cleanup_apply_rejects_a_plan_written_for_another_agent_home() {
+        let fixture = apply_fixture(|_| {});
+        let mut args = fixture.args(&fixture.plan_digest);
+        let other = fixture.agent_home.parent().unwrap().join("other-home");
+        fs::create_dir_all(other.join("out")).unwrap();
+        args.agent_home = Some(other);
+
+        let err = apply_cleanup_plan(&args).expect_err("agent home mismatch");
+
+        assert_eq!(err.code, "cleanup-agent-home-mismatch");
+        assert!(fixture.cache_root.exists());
+    }
+
+    #[test]
+    fn cleanup_apply_skips_a_path_that_disappeared_after_the_plan() {
+        let fixture = apply_fixture(|_| {});
+        fs::remove_dir_all(&fixture.cache_root).unwrap();
+
+        let report = apply_cleanup_plan(&fixture.args(&fixture.plan_digest)).expect("apply");
+
+        assert_eq!(report.summary.deleted, 0);
+        assert_eq!(report.summary.skipped, 1);
+        assert_eq!(report.entries[0].status, "skipped");
+        assert_eq!(report.entries[0].reason, "path no longer exists");
+    }
+
+    #[test]
+    fn cleanup_apply_skips_a_path_that_grew_evidence_after_the_plan() {
+        let fixture = apply_fixture(|_| {});
+        fs::write(fixture.cache_root.join(SKILL_USAGE_MARKER), b"{}").unwrap();
+
+        let report = apply_cleanup_plan(&fixture.args(&fixture.plan_digest)).expect("apply");
+
+        assert_eq!(report.summary.deleted, 0);
+        assert_eq!(report.summary.skipped, 1);
+        assert_eq!(
+            report.entries[0].reason,
+            "evidence marker appeared after the plan was created"
+        );
+        assert!(fixture.cache_root.exists());
+    }
+
+    #[test]
+    fn cleanup_apply_skips_a_path_whose_contents_changed_after_the_plan() {
+        let fixture = apply_fixture(|_| {});
+        fs::write(fixture.cache_root.join("1.0.0").join("bin"), b"changed!!!").unwrap();
+
+        let report = apply_cleanup_plan(&fixture.args(&fixture.plan_digest)).expect("apply");
+
+        assert_eq!(report.summary.deleted, 0);
+        assert_eq!(report.summary.skipped, 1);
+        assert_eq!(
+            report.entries[0].reason,
+            "path metadata changed after the plan was created"
+        );
+        assert!(fixture.cache_root.exists());
+    }
+
+    #[test]
+    fn cleanup_plan_digest_is_stable_and_content_sensitive() {
+        let fixture = apply_fixture(|_| {});
+        let raw = fs::read_to_string(&fixture.plan_file).unwrap();
+        let envelope: CleanupPlanEnvelope = serde_json::from_str(&raw).unwrap();
+        let mut plan = envelope.result;
+
+        assert_eq!(
+            compute_cleanup_plan_digest(&plan).unwrap(),
+            fixture.plan_digest
+        );
+        plan.include_projects = !plan.include_projects;
+        assert_ne!(
+            compute_cleanup_plan_digest(&plan).unwrap(),
+            fixture.plan_digest
+        );
+    }
+
+    #[test]
+    fn cleanup_plan_paths_must_be_absolute_and_free_of_parent_components() {
+        validate_cleanup_plan_path(Path::new("/out/cache"), "/out/cache").expect("absolute path");
+
+        let relative = validate_cleanup_plan_path(Path::new("out/cache"), "out/cache")
+            .expect_err("relative path");
+        assert_eq!(relative.code, "cleanup-path-outside-out-root");
+
+        let traversal = validate_cleanup_plan_path(Path::new("/out/../etc"), "/out/../etc")
+            .expect_err("parent component");
+        assert_eq!(traversal.code, "cleanup-path-outside-out-root");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_refuses_a_symlinked_out_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real-out");
+        fs::create_dir_all(&real).unwrap();
+        let link = tmp.path().join("out");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        // A missing out_root is not an error here; only a symlink is.
+        reject_cleanup_out_root_symlink_if_exists(&tmp.path().join("absent")).expect("absent ok");
+        reject_cleanup_out_root_symlink_if_exists(&real).expect("real directory ok");
+        let err = reject_cleanup_out_root_symlink_if_exists(&link).expect_err("symlink out_root");
+        assert_eq!(err.code, "cleanup-out-root-symlink-unsupported");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_delete_target_must_resolve_inside_out_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = fs::canonicalize(tmp.path()).unwrap();
+        let out_root = root.join("out");
+        let outside = root.join("outside");
+        fs::create_dir_all(&out_root).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+
+        let inside = out_root.join("cache");
+        fs::create_dir_all(&inside).unwrap();
+        let identity = validate_cleanup_delete_target(
+            &inside,
+            &out_root,
+            &fs::symlink_metadata(&inside).unwrap(),
+        )
+        .expect("contained path");
+        assert_eq!(identity, inside);
+
+        // A symlink is identified by its own parent, never by its target, so
+        // the symlink entry itself is what gets removed.
+        let link = out_root.join("link");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        let link_identity =
+            validate_cleanup_delete_target(&link, &out_root, &fs::symlink_metadata(&link).unwrap())
+                .expect("symlink inside out_root");
+        assert_eq!(link_identity, link);
+
+        // A real directory that lives outside out_root must be refused.
+        let err = validate_cleanup_delete_target(
+            &outside,
+            &out_root,
+            &fs::symlink_metadata(&outside).unwrap(),
+        )
+        .expect_err("escapes out_root");
+        assert_eq!(err.code, "cleanup-path-outside-out-root");
+    }
+
+    #[test]
+    fn cleanup_delete_eligibility_is_restricted_to_reviewed_categories() {
+        let out_root = Path::new("/home/tester/agent/out");
+        let cache = out_root.join(RELEASE_CACHE_ROOT);
+
+        let mut item = cache_item(&cache, 10, Some("sha256:x".to_string()));
+        validate_cleanup_delete_eligibility(&item, &cache, out_root).expect("reviewed cache root");
+
+        item.content_digest = None;
+        assert_eq!(
+            validate_cleanup_delete_eligibility(&item, &cache, out_root)
+                .expect_err("cache needs a digest")
+                .code,
+            "cleanup-delete-content-digest-required"
+        );
+
+        // A nested path is never a direct child of out_root.
+        let nested = cache.join("1.0.0");
+        let mut nested_item = cache_item(&nested, 10, Some("sha256:x".to_string()));
+        assert_eq!(
+            validate_cleanup_delete_eligibility(&nested_item, &nested, out_root)
+                .expect_err("nested delete")
+                .code,
+            "cleanup-delete-shape-invalid"
+        );
+
+        // A cache row that is not the release-cache root is refused outright.
+        let other_cache = out_root.join("something-else");
+        nested_item = cache_item(&other_cache, 10, Some("sha256:x".to_string()));
+        assert_eq!(
+            validate_cleanup_delete_eligibility(&nested_item, &other_cache, out_root)
+                .expect_err("non-release cache")
+                .code,
+            "cleanup-delete-shape-invalid"
+        );
+
+        for category in [
+            CleanupCategory::TopLevelNoncanonical,
+            CleanupCategory::AllowedRoot,
+            CleanupCategory::EvidenceSource,
+            CleanupCategory::ProjectArtifact,
+        ] {
+            let mut row = cache_item(&other_cache, 10, None);
+            row.category = category;
+            assert_eq!(
+                validate_cleanup_delete_eligibility(&row, &other_cache, out_root)
+                    .expect_err("category needs policy")
+                    .code,
+                "cleanup-delete-shape-invalid",
+                "category {category:?} must not be auto-deletable"
+            );
+        }
+
+        let elsewhere = Path::new("/tmp/elsewhere");
+        let stray = cache_item(elsewhere, 10, None);
+        assert_eq!(
+            validate_cleanup_delete_eligibility(&stray, elsewhere, out_root)
+                .expect_err("outside out_root")
+                .code,
+            "cleanup-path-outside-out-root"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn content_digest_distinguishes_files_dirs_and_symlink_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        let file = root.join("file");
+        fs::write(&file, b"payload").unwrap();
+        let same = root.join("same");
+        fs::write(&same, b"payload").unwrap();
+        let different = root.join("different");
+        fs::write(&different, b"payload!").unwrap();
+
+        // The digest is content-addressed relative to the digested root, so
+        // two identical files hash the same and a changed byte does not.
+        assert_eq!(
+            path_content_digest(&file).unwrap(),
+            path_content_digest(&same).unwrap()
+        );
+        assert_ne!(
+            path_content_digest(&file).unwrap(),
+            path_content_digest(&different).unwrap()
+        );
+
+        let link_a = root.join("link-a");
+        let link_b = root.join("link-b");
+        std::os::unix::fs::symlink("target-a", &link_a).unwrap();
+        std::os::unix::fs::symlink("target-b", &link_b).unwrap();
+        assert_ne!(
+            path_content_digest(&link_a).unwrap(),
+            path_content_digest(&link_b).unwrap(),
+            "a symlink digest must cover its target"
+        );
+
+        let dir = root.join("dir");
+        fs::create_dir_all(dir.join("nested")).unwrap();
+        fs::write(dir.join("nested").join("f"), b"x").unwrap();
+        let before = path_content_digest(&dir).unwrap();
+        fs::write(dir.join("nested").join("g"), b"y").unwrap();
+        assert_ne!(
+            before,
+            path_content_digest(&dir).unwrap(),
+            "an added child must change the directory digest"
+        );
+
+        let missing = path_content_digest(&root.join("absent")).expect_err("missing path");
+        assert_eq!(missing.code, "cleanup-stat-failed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn size_and_kind_helpers_describe_the_tree_without_following_symlinks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let dir = root.join("dir");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("a"), b"1234").unwrap();
+        fs::write(dir.join("b"), b"567").unwrap();
+        let link = root.join("link");
+        std::os::unix::fs::symlink(&dir, &link).unwrap();
+
+        assert_eq!(path_size_bytes(&dir).unwrap(), 7);
+        assert_eq!(path_size_bytes(&root.join("absent")).unwrap(), 0);
+        assert!(path_shallow_size_bytes(&dir).is_ok());
+        assert_eq!(
+            path_shallow_size_bytes(&root.join("absent"))
+                .expect_err("missing")
+                .code,
+            "cleanup-stat-failed"
+        );
+
+        assert_eq!(entry_kind(&dir), "directory");
+        assert_eq!(entry_kind(&dir.join("a")), "file");
+        assert_eq!(entry_kind(&link), "symlink");
+        assert_eq!(entry_kind(&root.join("absent")), "unknown");
+        assert_eq!(path_name(&dir), "dir");
+        assert_eq!(path_name(Path::new("/")), "");
+
+        assert!(path_mtime_unix(&dir).is_some());
+        assert_eq!(path_mtime_unix(&root.join("absent")), None);
+
+        let children = read_sorted_children(&dir, "cleanup-read-failed").unwrap();
+        assert_eq!(children, vec![dir.join("a"), dir.join("b")]);
+        assert_eq!(
+            read_sorted_children(&root.join("absent"), "cleanup-read-failed")
+                .expect_err("missing dir")
+                .code,
+            "cleanup-read-failed"
+        );
+    }
+
+    #[test]
+    fn marker_flags_find_evidence_anywhere_below_a_candidate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("run");
+        fs::create_dir_all(root.join("deep").join("deeper")).unwrap();
+
+        assert!(!marker_flags(&root).unwrap().has_evidence());
+        assert!(
+            !marker_flags(&tmp.path().join("absent"))
+                .unwrap()
+                .has_evidence(),
+            "a missing path carries no evidence"
+        );
+
+        fs::write(
+            root.join("deep").join("deeper").join(TEST_FIRST_MARKER),
+            b"{}",
+        )
+        .unwrap();
+        let flags = marker_flags(&root).unwrap();
+        assert!(flags.test_first_evidence);
+        assert!(!flags.skill_usage);
+        assert!(flags.has_evidence());
+
+        fs::write(root.join(SKILL_USAGE_MARKER), b"{}").unwrap();
+        let both = marker_flags(&root).unwrap();
+        assert!(both.skill_usage && both.test_first_evidence);
+    }
+
+    #[test]
+    fn text_renderers_cover_empty_and_populated_reports() {
+        let empty_audit = AuditReport {
+            agent_home: "/home".to_string(),
+            out_root: "/home/out".to_string(),
+            out_root_exists: false,
+            allowed_roots: Vec::new(),
+            violations: Vec::new(),
+            summary: AuditSummary {
+                allowed_roots: 0,
+                violations: 0,
+            },
+        };
+        let rendered = render_audit_text(&empty_audit);
+        assert!(rendered.contains("allowlisted:\n  none"), "{rendered}");
+        assert!(rendered.contains("violations:\n  none"), "{rendered}");
+        assert!(
+            rendered.ends_with("summary: allowed_roots=0 violations=0"),
+            "{rendered}"
+        );
+
+        let entry = AuditEntry {
+            name: "projects".to_string(),
+            path: "/home/out/projects".to_string(),
+            kind: "directory".to_string(),
+            classification: "canonical".to_string(),
+            reason: "canonical project root".to_string(),
+        };
+        let populated = AuditReport {
+            allowed_roots: vec![entry],
+            violations: vec![AuditEntry {
+                name: "stray".to_string(),
+                path: "/home/out/stray".to_string(),
+                kind: "file".to_string(),
+                classification: "noncanonical".to_string(),
+                reason: "not allowlisted".to_string(),
+            }],
+            summary: AuditSummary {
+                allowed_roots: 1,
+                violations: 1,
+            },
+            ..empty_audit
+        };
+        let rendered = render_audit_text(&populated);
+        assert!(
+            rendered.contains("  - projects (directory, canonical): canonical project root"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("  - stray (file, noncanonical): not allowlisted"),
+            "{rendered}"
+        );
+
+        let mut plan = CleanupPlan {
+            agent_home: "/home".to_string(),
+            out_root: "/home/out".to_string(),
+            out_root_exists: true,
+            include_projects: false,
+            items: Vec::new(),
+            summary: CleanupSummary::default(),
+            plan_digest: "sha256:abc".to_string(),
+        };
+        assert!(render_cleanup_plan_text(&plan).contains("items:\n  none"));
+        plan.items.push(cache_item(
+            Path::new("/home/out/nils-versions"),
+            42,
+            Some("sha256:x".to_string()),
+        ));
+        let rendered = render_cleanup_plan_text(&plan);
+        assert!(
+            rendered.contains("category=cache, action=delete, size=42"),
+            "{rendered}"
+        );
+
+        let mut report = CleanupApplyReport {
+            agent_home: "/home".to_string(),
+            out_root: "/home/out".to_string(),
+            plan_digest: "sha256:abc".to_string(),
+            applied: true,
+            entries: Vec::new(),
+            summary: CleanupApplySummary::default(),
+        };
+        assert!(render_cleanup_apply_text(&report).contains("entries:\n  none"));
+        report.entries.push(CleanupApplyEntry {
+            path: "/home/out/nils-versions".to_string(),
+            action: "delete".to_string(),
+            status: "deleted".to_string(),
+            reason: "release cache is reproducible".to_string(),
+        });
+        assert!(
+            render_cleanup_apply_text(&report)
+                .contains("  - /home/out/nils-versions (delete, deleted): release cache"),
+        );
+    }
+
+    #[test]
+    fn cleanup_labels_are_exhaustive_and_kebab_cased() {
+        assert_eq!(cleanup_action_label(CleanupAction::Delete), "delete");
+        assert_eq!(cleanup_action_label(CleanupAction::Preserve), "preserve");
+        assert_eq!(
+            cleanup_action_label(CleanupAction::NeedsPolicy),
+            "needs-policy"
+        );
+        assert_eq!(
+            cleanup_category_label(CleanupCategory::AllowedRoot),
+            "allowed-root"
+        );
+        assert_eq!(cleanup_category_label(CleanupCategory::Cache), "cache");
+        assert_eq!(
+            cleanup_category_label(CleanupCategory::TopLevelNoncanonical),
+            "top-level-noncanonical"
+        );
+        assert_eq!(
+            cleanup_category_label(CleanupCategory::EvidenceSource),
+            "evidence-source"
+        );
+        assert_eq!(
+            cleanup_category_label(CleanupCategory::ProjectArtifact),
+            "project-artifact"
+        );
+    }
+
+    #[test]
+    fn env_renderers_quote_every_value_for_shell_eval() {
+        let project = ProjectResult {
+            path: "/home/out/projects/o__r/run".to_string(),
+            agent_home: "/home".to_string(),
+            out_root: "/home/out".to_string(),
+            repo: "/repo".to_string(),
+            project_slug: "o__r".to_string(),
+            topic: "it's-tricky".to_string(),
+            run_id: "run".to_string(),
+            created: false,
+        };
+        let rendered = render_project_env(&project);
+        assert!(rendered.starts_with("AGENT_OUT_PATH='/home/out/projects/o__r/run'"));
+        assert!(
+            rendered.contains(r"AGENT_OUT_TOPIC='it'\''s-tricky'"),
+            "a single quote must be escaped for `eval`: {rendered}"
+        );
+        assert_eq!(rendered.lines().count(), 5);
+
+        let path_for = PathForResult {
+            path: project.path.clone(),
+            agent_home: project.agent_home.clone(),
+            out_root: project.out_root.clone(),
+            repo: project.repo.clone(),
+            project_slug: project.project_slug.clone(),
+            domain: "review".to_string(),
+            topic: project.topic.clone(),
+            run_id: project.run_id.clone(),
+            created: false,
+        };
+        let rendered = render_path_for_env(&path_for);
+        assert_eq!(rendered.lines().count(), 6);
+        assert!(rendered.contains("AGENT_OUT_DOMAIN='review'"));
+
+        assert_eq!(shell_quote("plain"), "'plain'");
+        assert_eq!(shell_quote(""), "''");
+    }
 }

--- a/crates/agent-out/tests/integration.rs
+++ b/crates/agent-out/tests/integration.rs
@@ -5,6 +5,8 @@
 
 #[path = "integration/cli.rs"]
 mod cli;
+#[path = "integration/completion_export.rs"]
+mod completion_export;
 #[path = "integration/exit_codes.rs"]
 mod exit_codes;
 #[path = "integration/help_snapshot.rs"]

--- a/crates/agent-out/tests/integration/completion_export.rs
+++ b/crates/agent-out/tests/integration/completion_export.rs
@@ -1,0 +1,66 @@
+//! Shell-completion export contract. Both shipped shells must render from a
+//! directory that is not a git repository, and the bash script must already be
+//! normalized when it reaches stdout.
+
+use std::process::{Command, Stdio};
+
+use nils_test_support::bin::resolve;
+
+fn run_completion(shell: &str) -> std::process::Output {
+    let temp = tempfile::TempDir::new().unwrap();
+    Command::new(resolve("agent-out"))
+        .args(["completion", shell])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap_or_else(|error| panic!("run agent-out completion {shell}: {error}"))
+}
+
+#[test]
+fn completion_zsh_export_succeeds_outside_git_repo() {
+    let output = run_completion("zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef agent-out"),
+        "missing zsh completion header: {stdout}"
+    );
+}
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let output = run_completion("bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_agent-out()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/agent-out` asset must not carry them,
+    // so the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}
+
+#[test]
+fn completion_rejects_an_unsupported_shell() {
+    let output = run_completion("fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+}

--- a/crates/agent-runtime/src/doctor/coverage.rs
+++ b/crates/agent-runtime/src/doctor/coverage.rs
@@ -460,3 +460,358 @@ fn is_executable_file(path: &Path) -> bool {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::TempDir;
+
+    const CLI_TOOLS: &str = r#"
+schema_version: 1
+profiles:
+  core: [ripgrep]
+  recommended: [ripgrep, jq]
+  full: [ripgrep, jq, absent-key]
+formulas:
+  ripgrep:
+    brew: ripgrep
+    command: rg
+    categories: [search]
+  jq:
+    brew: jq
+    command: jq
+    categories: [json]
+"#;
+
+    fn skills_yaml(required_clis: &str) -> String {
+        format!(
+            r#"
+schema_version: 1
+skills:
+  - id: sample.one
+    domain: sample
+    source: core/skills/sample
+    products:
+      codex:
+        name: /sample-one
+        render_to: skills/sample/SKILL.md
+    required_clis:
+{required_clis}
+"#
+        )
+    }
+
+    fn source_root(skills: &str, cli_tools: &str) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let manifests = tmp.path().join("manifests");
+        fs::create_dir_all(&manifests).unwrap();
+        fs::write(manifests.join("skills.yaml"), skills).unwrap();
+        fs::write(manifests.join("cli-tools.yaml"), cli_tools).unwrap();
+        tmp
+    }
+
+    #[test]
+    fn check_and_status_labels_are_the_published_wire_values() {
+        assert_eq!(CoverageKind::RequiredCli.check(), "required-cli");
+        assert_eq!(CoverageKind::CliTool.check(), "cli-tool");
+        assert_eq!(CoverageStatus::Ok.as_str(), "ok");
+        assert_eq!(CoverageStatus::Missing.as_str(), "missing");
+        assert_eq!(CoverageStatus::Outdated.as_str(), "outdated");
+        assert_eq!(CoverageStatus::Unparseable.as_str(), "unparseable");
+    }
+
+    #[test]
+    fn a_finding_renders_every_populated_field_into_the_doctor_message() {
+        let finding = CoverageFinding {
+            kind: CoverageKind::RequiredCli,
+            name: "agent-out".to_string(),
+            command: "agent-out".to_string(),
+            status: CoverageStatus::Outdated,
+            severity: DoctorSeverity::Warn,
+            required_version: Some(">=0.5.0".to_string()),
+            parsed_version: Some("0.4.0".to_string()),
+            formula: Some("nils-cli".to_string()),
+            message: "below floor".to_string(),
+        };
+
+        let doctor = finding.to_doctor_finding("codex");
+
+        assert_eq!(doctor.product, "codex");
+        assert_eq!(doctor.check, "required-cli");
+        assert_eq!(doctor.severity, DoctorSeverity::Warn);
+        assert_eq!(doctor.entry_id.as_deref(), Some("agent-out"));
+        assert_eq!(
+            doctor.message,
+            "status=outdated command=`agent-out` required=>=0.5.0 parsed=0.4.0 upgrade=`brew upgrade nils-cli`: below floor"
+        );
+    }
+
+    #[test]
+    fn severity_selects_the_doctor_finding_constructor() {
+        let base = CoverageFinding {
+            kind: CoverageKind::CliTool,
+            name: "ripgrep".to_string(),
+            command: "rg".to_string(),
+            status: CoverageStatus::Ok,
+            severity: DoctorSeverity::Ok,
+            required_version: None,
+            parsed_version: None,
+            formula: None,
+            message: String::new(),
+        };
+
+        let ok = base.to_doctor_finding("claude");
+        assert_eq!(ok.severity, DoctorSeverity::Ok);
+        // With every optional field absent the message stays minimal.
+        assert_eq!(ok.message, "status=ok command=`rg`");
+
+        let blocked = CoverageFinding {
+            severity: DoctorSeverity::Block,
+            status: CoverageStatus::Missing,
+            ..base
+        };
+        let blocked = blocked.to_doctor_finding("claude");
+        assert_eq!(blocked.severity, DoctorSeverity::Block);
+        assert_eq!(blocked.check, "cli-tool");
+    }
+
+    #[test]
+    fn a_missing_manifest_names_the_file_it_expected() {
+        let tmp = TempDir::new().unwrap();
+        let err = probe(tmp.path(), "core").expect_err("no manifests");
+
+        match err {
+            CoverageError::Missing { path } => {
+                assert!(path.ends_with("manifests/skills.yaml"), "{path:?}");
+            }
+            other => panic!("expected Missing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unparseable_manifest_reports_a_parse_error() {
+        let tmp = source_root("schema_version: 1\nskills: [\n", CLI_TOOLS);
+        let err = probe(tmp.path(), "core").expect_err("broken yaml");
+
+        assert!(
+            matches!(err, CoverageError::Parse { .. }),
+            "expected Parse, got {err:?}"
+        );
+        assert!(err.to_string().starts_with("parse error in"));
+    }
+
+    #[test]
+    fn schema_version_drift_is_reported_per_manifest_family() {
+        // skills.yaml accepts a set of versions, so drift lists all of them.
+        let tmp = source_root("schema_version: 9\nskills: []\n", CLI_TOOLS);
+        match probe(tmp.path(), "core").expect_err("skills drift") {
+            CoverageError::SchemaVersions {
+                expected, found, ..
+            } => {
+                assert_eq!(expected, SKILLS_SCHEMA_VERSIONS.to_vec());
+                assert_eq!(found, 9);
+            }
+            other => panic!("expected SchemaVersions, got {other:?}"),
+        }
+
+        // cli-tools.yaml pins exactly one version.
+        let tmp = source_root(
+            "schema_version: 1\nskills: []\n",
+            &CLI_TOOLS.replace("schema_version: 1", "schema_version: 7"),
+        );
+        match probe(tmp.path(), "core").expect_err("cli-tools drift") {
+            CoverageError::SchemaVersion {
+                expected, found, ..
+            } => {
+                assert_eq!(expected, SCHEMA_VERSION);
+                assert_eq!(found, 7);
+            }
+            other => panic!("expected SchemaVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_invalid_skills_contract_is_reported_before_any_probe() {
+        // schema_version 1 with v2-only fields is a contract violation.
+        let skills = r#"
+schema_version: 1
+skills:
+  - id: sample.one
+    domain: sample
+    source: core/skills/sample
+    invocation:
+      role: workflow
+      intents: [project-dev]
+      example_request: "do the thing"
+      admission_rationale: "because"
+    products:
+      codex:
+        name: /sample-one
+        render_to: skills/sample/SKILL.md
+    required_clis: {}
+"#;
+        let tmp = source_root(skills, CLI_TOOLS);
+
+        let err = probe(tmp.path(), "core").expect_err("invalid contract");
+
+        assert!(
+            matches!(err, CoverageError::InvalidSkills { .. }),
+            "expected InvalidSkills, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_profile_is_rejected_by_name() {
+        let tmp = source_root("schema_version: 1\nskills: []\n", CLI_TOOLS);
+
+        let err = probe(tmp.path(), "everything").expect_err("unknown profile");
+
+        assert_eq!(
+            err.to_string(),
+            "unknown cli-tools profile `everything`; expected core, recommended, or full"
+        );
+    }
+
+    #[test]
+    fn each_profile_selects_its_own_tool_list() {
+        let tmp = source_root("schema_version: 1\nskills: []\n", CLI_TOOLS);
+
+        let core = probe(tmp.path(), "core").expect("core");
+        let recommended = probe(tmp.path(), "recommended").expect("recommended");
+        let full = probe(tmp.path(), "full").expect("full");
+
+        assert_eq!(core.len(), 1);
+        assert_eq!(recommended.len(), 2);
+        assert_eq!(full.len(), 3);
+        assert!(core.iter().all(|f| f.kind == CoverageKind::CliTool));
+    }
+
+    #[test]
+    fn a_profile_key_without_a_formula_is_a_warning_not_a_hard_error() {
+        let tmp = source_root("schema_version: 1\nskills: []\n", CLI_TOOLS);
+
+        let findings = probe(tmp.path(), "full").expect("full profile");
+        let orphan = findings
+            .iter()
+            .find(|f| f.name == "absent-key")
+            .expect("orphan key finding");
+
+        assert_eq!(orphan.status, CoverageStatus::Missing);
+        assert_eq!(orphan.severity, DoctorSeverity::Warn);
+        assert_eq!(orphan.formula, None);
+        assert_eq!(
+            orphan.message,
+            "profile references a formula key that is not declared"
+        );
+    }
+
+    #[test]
+    fn a_required_cli_that_is_not_on_path_blocks() {
+        let tmp = source_root(
+            &skills_yaml("      nils-definitely-absent-binary: \">=1.0.0\""),
+            CLI_TOOLS,
+        );
+
+        let findings = probe(tmp.path(), "core").expect("probe");
+        let required = findings
+            .iter()
+            .find(|f| f.kind == CoverageKind::RequiredCli)
+            .expect("required-cli finding");
+
+        assert_eq!(required.name, "nils-definitely-absent-binary");
+        assert_eq!(required.status, CoverageStatus::Missing);
+        assert_eq!(required.severity, DoctorSeverity::Block);
+        assert_eq!(required.required_version.as_deref(), Some(">=1.0.0"));
+        assert_eq!(required.formula.as_deref(), Some("nils-cli"));
+    }
+
+    #[test]
+    fn the_highest_declared_floor_wins_across_skills() {
+        let skills = r#"
+schema_version: 1
+skills:
+  - id: sample.low
+    domain: sample
+    source: core/skills/low
+    products:
+      codex:
+        name: /low
+        render_to: skills/sample/LOW.md
+    required_clis:
+      agent-out: "0.5.0"
+  - id: sample.high
+    domain: sample
+    source: core/skills/high
+    products:
+      codex:
+        name: /high
+        render_to: skills/sample/HIGH.md
+    required_clis:
+      agent-out: "1.2.0"
+"#;
+        let manifest: SkillsManifest = serde_yaml_ng::from_str(skills).expect("skills");
+
+        let floors = required_cli_floors(&manifest);
+
+        assert_eq!(floors.len(), 1);
+        assert_eq!(floors.get("agent-out").map(String::as_str), Some("1.2.0"));
+    }
+
+    #[test]
+    fn floors_that_cannot_be_parsed_fall_back_to_lexical_order() {
+        assert!(floor_cmp("1.2.0", "1.10.0").is_lt(), "semver, not lexical");
+        assert!(floor_cmp("1.10.0", "1.2.0").is_gt());
+        assert!(floor_cmp("nightly", "stable").is_lt());
+        assert!(floor_cmp("1.0.0", "1.0.0").is_eq());
+    }
+
+    #[test]
+    fn an_explicit_path_is_probed_directly_instead_of_searching_path() {
+        let tmp = TempDir::new().unwrap();
+        let script = tmp.path().join("bin").join("tool");
+        fs::create_dir_all(script.parent().unwrap()).unwrap();
+        fs::write(&script, "#!/bin/sh\nexit 0\n").unwrap();
+
+        // A path-shaped program name is never looked up in PATH; before the
+        // executable bit is set it must not resolve.
+        let name = script.to_string_lossy().to_string();
+        assert_eq!(find_in_path(&name), None);
+        assert!(!is_executable_file(&script));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+            assert_eq!(find_in_path(&name), Some(script.clone()));
+            assert!(is_executable_file(&script));
+        }
+
+        // A directory and a missing path are never executables.
+        assert!(!is_executable_file(tmp.path()));
+        assert!(!is_executable_file(&tmp.path().join("absent")));
+        assert_eq!(find_in_path("nils-definitely-absent-binary"), None);
+    }
+
+    #[test]
+    fn windows_pathext_defaults_are_normalized_to_dotted_extensions() {
+        let extensions = windows_pathext_extensions();
+
+        assert!(
+            extensions
+                .iter()
+                .all(|ext| ext.to_string_lossy().starts_with('.')),
+            "every extension must be dotted: {extensions:?}"
+        );
+        assert!(!extensions.is_empty());
+    }
+
+    #[test]
+    fn brew_probe_is_inert_when_homebrew_is_absent() {
+        // Whatever the host looks like, the probe must return a bool rather
+        // than panicking or shelling out unconditionally.
+        let _ = brew_reports_outdated("definitely-not-a-formula");
+    }
+}

--- a/crates/agent-runtime/src/doctor/probes.rs
+++ b/crates/agent-runtime/src/doctor/probes.rs
@@ -317,3 +317,382 @@ fn finding_for_severity(
         DoctorSeverity::Block => DoctorFinding::block(product, check, entry_id, path, message),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::install::plan::SymlinkLinkMode;
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    const PRODUCT: &str = "codex";
+
+    fn roots(base: &Path, plugin_root: Option<PathBuf>) -> ResolvedRuntimeRoots {
+        ResolvedRuntimeRoots {
+            product: PRODUCT.to_string(),
+            live_home: base.join("live"),
+            docs_home: base.join("docs"),
+            state_home: base.join("state"),
+            plugin_root,
+        }
+    }
+
+    fn symlink_plan(actions: Vec<PlanAction>) -> InstallPlan {
+        InstallPlan {
+            product: PRODUCT.to_string(),
+            source_root: PathBuf::from("/source"),
+            home: PathBuf::from("/home"),
+            state_home: PathBuf::from("/state"),
+            actions,
+        }
+    }
+
+    #[test]
+    fn probe_reports_accumulate_counts_and_findings() {
+        let mut first = ProbeReport::default();
+        first.ok();
+        first.push(DoctorFinding::warn(
+            PRODUCT,
+            "runtime-root.docs_home",
+            None,
+            None,
+            "warned",
+        ));
+        let mut second = ProbeReport::default();
+        second.ok();
+
+        first.extend(second);
+
+        assert_eq!(first.ok, 2);
+        assert_eq!(first.findings.len(), 1);
+    }
+
+    #[test]
+    fn every_present_runtime_root_counts_as_ok() {
+        let tmp = TempDir::new().unwrap();
+        for name in ["live", "docs", "state", "plugins"] {
+            fs::create_dir_all(tmp.path().join(name)).unwrap();
+        }
+
+        let report = runtime_roots(&roots(tmp.path(), Some(tmp.path().join("plugins"))));
+
+        assert_eq!(report.ok, 4, "all four roots resolve");
+        assert!(report.findings.is_empty());
+    }
+
+    #[test]
+    fn an_absent_plugin_root_is_simply_not_probed() {
+        let tmp = TempDir::new().unwrap();
+        for name in ["live", "docs", "state"] {
+            fs::create_dir_all(tmp.path().join(name)).unwrap();
+        }
+
+        let report = runtime_roots(&roots(tmp.path(), None));
+
+        assert_eq!(report.ok, 3);
+        assert!(report.findings.is_empty());
+    }
+
+    #[test]
+    fn a_missing_live_home_blocks_while_the_others_only_warn() {
+        let tmp = TempDir::new().unwrap();
+
+        let report = runtime_roots(&roots(tmp.path(), None));
+
+        assert_eq!(report.ok, 0);
+        assert_eq!(report.findings.len(), 3);
+        let live = report
+            .findings
+            .iter()
+            .find(|f| f.check == "runtime-root.live_home")
+            .expect("live_home finding");
+        assert_eq!(live.severity, DoctorSeverity::Block);
+        assert_eq!(live.message, "runtime-root path does not exist");
+        assert!(
+            report
+                .findings
+                .iter()
+                .filter(|f| f.check != "runtime-root.live_home")
+                .all(|f| f.severity == DoctorSeverity::Warn),
+            "only the live home is fatal"
+        );
+    }
+
+    #[test]
+    fn a_relative_runtime_root_is_rejected_before_touching_the_filesystem() {
+        let report = runtime_roots(&ResolvedRuntimeRoots {
+            product: PRODUCT.to_string(),
+            live_home: PathBuf::from("relative/live"),
+            docs_home: PathBuf::from("relative/docs"),
+            state_home: PathBuf::from("relative/state"),
+            plugin_root: None,
+        });
+
+        assert_eq!(report.ok, 0);
+        assert!(
+            report
+                .findings
+                .iter()
+                .all(|f| f.message
+                    == "runtime-root path is not absolute after environment expansion"),
+            "{:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn a_runtime_root_that_is_a_file_is_not_a_directory() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("docs")).unwrap();
+        fs::create_dir_all(tmp.path().join("state")).unwrap();
+        fs::write(tmp.path().join("live"), b"not a dir").unwrap();
+
+        let report = runtime_roots(&roots(tmp.path(), None));
+
+        let live = report
+            .findings
+            .iter()
+            .find(|f| f.check == "runtime-root.live_home")
+            .expect("live_home finding");
+        assert_eq!(
+            live.message,
+            "runtime-root path exists but is not a directory"
+        );
+        assert_eq!(live.severity, DoctorSeverity::Block);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_runtime_root_reports_the_io_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        for name in ["live", "docs", "state"] {
+            fs::create_dir_all(tmp.path().join(name)).unwrap();
+        }
+        let live = tmp.path().join("live");
+        fs::set_permissions(&live, fs::Permissions::from_mode(0o000)).unwrap();
+        let readable_as_root = fs::read_dir(&live).is_ok();
+        if readable_as_root {
+            fs::set_permissions(&live, fs::Permissions::from_mode(0o755)).unwrap();
+            return;
+        }
+
+        let report = runtime_roots(&roots(tmp.path(), None));
+        fs::set_permissions(&live, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let live = report
+            .findings
+            .iter()
+            .find(|f| f.check == "runtime-root.live_home")
+            .expect("live_home finding");
+        assert!(
+            live.message
+                .starts_with("runtime-root path is not readable: "),
+            "{}",
+            live.message
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_correct_symlink_action_counts_as_ok() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp.path().join("source.md");
+        let dest = tmp.path().join("dest.md");
+        fs::write(&source, b"tracked").unwrap();
+        std::os::unix::fs::symlink(&source, &dest).unwrap();
+
+        let report = install_plan(
+            PRODUCT,
+            &symlink_plan(vec![PlanAction::Symlink {
+                entry_id: "entry".to_string(),
+                source,
+                dest,
+                link_mode: SymlinkLinkMode::File,
+                requires_backup: false,
+            }]),
+        );
+
+        assert_eq!(report.ok, 1);
+        assert!(report.findings.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_drift_is_reported_with_the_observed_target() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp.path().join("source.md");
+        let other = tmp.path().join("other.md");
+        let dest = tmp.path().join("dest.md");
+        fs::write(&source, b"tracked").unwrap();
+        fs::write(&other, b"stale").unwrap();
+        std::os::unix::fs::symlink(&other, &dest).unwrap();
+
+        let report = install_plan(
+            PRODUCT,
+            &symlink_plan(vec![PlanAction::Symlink {
+                entry_id: "entry".to_string(),
+                source: source.clone(),
+                dest,
+                link_mode: SymlinkLinkMode::File,
+                requires_backup: false,
+            }]),
+        );
+
+        assert_eq!(report.ok, 0);
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].severity, DoctorSeverity::Block);
+        assert!(
+            report.findings[0]
+                .message
+                .contains(&format!("expected {}", source.display())),
+            "{}",
+            report.findings[0].message
+        );
+    }
+
+    #[test]
+    fn a_symlink_action_reports_missing_source_destination_and_wrong_type() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp.path().join("source.md");
+        let dest = tmp.path().join("dest.md");
+
+        // Source missing: the tracked file is gone from the checkout.
+        let report = install_plan(
+            PRODUCT,
+            &symlink_plan(vec![PlanAction::Symlink {
+                entry_id: "entry".to_string(),
+                source: source.clone(),
+                dest: dest.clone(),
+                link_mode: SymlinkLinkMode::File,
+                requires_backup: false,
+            }]),
+        );
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(
+            report.findings[0].message,
+            "tracked source file does not exist"
+        );
+
+        // Source present, destination absent.
+        fs::write(&source, b"tracked").unwrap();
+        let report = install_plan(
+            PRODUCT,
+            &symlink_plan(vec![PlanAction::Symlink {
+                entry_id: "entry".to_string(),
+                source: source.clone(),
+                dest: dest.clone(),
+                link_mode: SymlinkLinkMode::File,
+                requires_backup: false,
+            }]),
+        );
+        assert_eq!(report.findings[0].message, "destination symlink is missing");
+
+        // Destination present but a regular file, not a link.
+        fs::write(&dest, b"hand-written").unwrap();
+        let report = install_plan(
+            PRODUCT,
+            &symlink_plan(vec![PlanAction::Symlink {
+                entry_id: "entry".to_string(),
+                source,
+                dest,
+                link_mode: SymlinkLinkMode::File,
+                requires_backup: true,
+            }]),
+        );
+        assert_eq!(
+            report.findings[0].message,
+            "destination exists but is not a symlink"
+        );
+    }
+
+    #[test]
+    fn a_managed_block_is_ok_only_when_its_markers_are_present() {
+        let tmp = TempDir::new().unwrap();
+        let config = tmp.path().join("config.toml");
+        let block = ManagedBlock::new("surface".to_string(), ManagedBlockStyle::Hash);
+        let rendered = block
+            .write("existing = true\n", "managed = true\n", true)
+            .expect("render managed block");
+        fs::write(&config, &rendered).unwrap();
+
+        let action = |file: PathBuf| PlanAction::ManagedBlock {
+            entry_id: "entry".to_string(),
+            config_file: file,
+            surface: "surface".to_string(),
+            comment_style: CommentStyle::Hash,
+            body: "managed = true\n".to_string(),
+        };
+
+        let report = install_plan(PRODUCT, &symlink_plan(vec![action(config.clone())]));
+        assert_eq!(report.ok, 1);
+        assert!(report.findings.is_empty());
+
+        // Markers stripped: the surface is no longer installed.
+        fs::write(&config, b"existing = true\n").unwrap();
+        let report = install_plan(PRODUCT, &symlink_plan(vec![action(config)]));
+        assert_eq!(report.ok, 0);
+        assert_eq!(
+            report.findings[0].message,
+            "managed-block markers for surface `surface` are missing"
+        );
+
+        // The config file itself is gone.
+        let report = install_plan(
+            PRODUCT,
+            &symlink_plan(vec![action(tmp.path().join("absent.toml"))]),
+        );
+        assert_eq!(report.findings[0].message, "config file is missing");
+        assert_eq!(report.findings[0].severity, DoctorSeverity::Block);
+    }
+
+    #[test]
+    fn a_double_slash_managed_block_uses_the_matching_comment_style() {
+        let tmp = TempDir::new().unwrap();
+        let config = tmp.path().join("config.js");
+        let block = ManagedBlock::new("surface".to_string(), ManagedBlockStyle::DoubleSlash);
+        fs::write(
+            &config,
+            block
+                .write("// existing\n", "managed();\n", true)
+                .expect("render"),
+        )
+        .unwrap();
+
+        let report = install_plan(
+            PRODUCT,
+            &symlink_plan(vec![PlanAction::ManagedBlock {
+                entry_id: "entry".to_string(),
+                config_file: config.clone(),
+                surface: "surface".to_string(),
+                comment_style: CommentStyle::DoubleSlash,
+                body: "managed();\n".to_string(),
+            }]),
+        );
+        assert_eq!(report.ok, 1);
+
+        // The hash style cannot see a `//`-delimited block, so it is missing.
+        let report = install_plan(
+            PRODUCT,
+            &symlink_plan(vec![PlanAction::ManagedBlock {
+                entry_id: "entry".to_string(),
+                config_file: config,
+                surface: "surface".to_string(),
+                comment_style: CommentStyle::Hash,
+                body: "managed();\n".to_string(),
+            }]),
+        );
+        assert_eq!(report.ok, 0);
+        assert_eq!(report.findings.len(), 1);
+    }
+
+    #[test]
+    fn an_empty_plan_probes_nothing() {
+        let report = install_plan(PRODUCT, &symlink_plan(Vec::new()));
+
+        assert_eq!(report.ok, 0);
+        assert!(report.findings.is_empty());
+    }
+}

--- a/crates/agent-runtime/src/doctor/project.rs
+++ b/crates/agent-runtime/src/doctor/project.rs
@@ -113,3 +113,147 @@ fn is_executable_file(path: &Path) -> bool {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_script(root: &Path, script: &str, executable: bool) -> PathBuf {
+        let path = root.join(".agents").join("scripts").join(script);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        if executable {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let _ = executable;
+        path
+    }
+
+    #[test]
+    fn status_labels_are_the_published_wire_values() {
+        assert_eq!(ProjectOverlayStatus::Wired.as_str(), "wired");
+        assert_eq!(ProjectOverlayStatus::Missing.as_str(), "missing");
+    }
+
+    #[test]
+    fn every_declared_overlay_script_is_probed_exactly_once() {
+        let tmp = TempDir::new().unwrap();
+
+        let findings = probe_project(tmp.path());
+
+        assert_eq!(findings.len(), PROJECT_OVERLAY_SCRIPTS.len());
+        assert_eq!(
+            findings
+                .iter()
+                .map(|f| f.script.as_str())
+                .collect::<Vec<_>>(),
+            PROJECT_OVERLAY_SCRIPTS.to_vec(),
+            "probe order must follow the declared script list"
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.status == ProjectOverlayStatus::Missing
+                    && f.severity == DoctorSeverity::Warn),
+            "an un-adopted project warns rather than blocks"
+        );
+        assert_eq!(findings[0].message, "project-local script is missing");
+        assert!(findings[0].path.ends_with(".agents/scripts/bench.sh"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_executable_script_is_wired_and_a_non_executable_one_is_not() {
+        let tmp = TempDir::new().unwrap();
+        write_script(tmp.path(), "deploy.sh", true);
+        write_script(tmp.path(), "release.sh", false);
+
+        let findings = probe_project(tmp.path());
+        let by_script = |name: &str| {
+            findings
+                .iter()
+                .find(|f| f.script == name)
+                .unwrap_or_else(|| panic!("finding for {name}"))
+        };
+
+        let deploy = by_script("deploy");
+        assert_eq!(deploy.status, ProjectOverlayStatus::Wired);
+        assert_eq!(deploy.severity, DoctorSeverity::Ok);
+        assert_eq!(
+            deploy.message,
+            "project-local script exists and is executable"
+        );
+
+        // Present but not executable is a distinct, actionable diagnosis.
+        let release = by_script("release");
+        assert_eq!(release.status, ProjectOverlayStatus::Missing);
+        assert_eq!(release.severity, DoctorSeverity::Warn);
+        assert_eq!(
+            release.message,
+            "project-local script exists but is not executable"
+        );
+    }
+
+    #[test]
+    fn a_directory_in_the_script_slot_is_never_wired() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".agents").join("scripts").join("demo.sh")).unwrap();
+
+        let findings = probe_project(tmp.path());
+        let demo = findings.iter().find(|f| f.script == "demo").expect("demo");
+
+        assert_eq!(demo.status, ProjectOverlayStatus::Missing);
+        assert_eq!(
+            demo.message,
+            "project-local script exists but is not executable"
+        );
+    }
+
+    #[test]
+    fn findings_render_into_the_shared_doctor_shape() {
+        let finding = ProjectOverlayFinding {
+            script: "deploy".to_string(),
+            status: ProjectOverlayStatus::Wired,
+            severity: DoctorSeverity::Ok,
+            path: PathBuf::from("/repo/.agents/scripts/deploy.sh"),
+            message: "project-local script exists and is executable".to_string(),
+        };
+
+        let doctor = finding.to_doctor_finding("codex");
+        assert_eq!(doctor.product, "codex");
+        assert_eq!(doctor.check, "project-overlay");
+        assert_eq!(doctor.severity, DoctorSeverity::Ok);
+        assert_eq!(doctor.entry_id.as_deref(), Some("deploy"));
+        assert_eq!(
+            doctor.message,
+            "status=wired: project-local script exists and is executable"
+        );
+
+        let warn = ProjectOverlayFinding {
+            status: ProjectOverlayStatus::Missing,
+            severity: DoctorSeverity::Warn,
+            message: "project-local script is missing".to_string(),
+            ..finding.clone()
+        }
+        .to_doctor_finding("claude");
+        assert_eq!(warn.severity, DoctorSeverity::Warn);
+        assert_eq!(
+            warn.message,
+            "status=missing: project-local script is missing"
+        );
+
+        let block = ProjectOverlayFinding {
+            severity: DoctorSeverity::Block,
+            ..finding
+        }
+        .to_doctor_finding("claude");
+        assert_eq!(block.severity, DoctorSeverity::Block);
+        assert_eq!(block.check, "project-overlay");
+    }
+}

--- a/crates/agent-runtime/src/render/writer.rs
+++ b/crates/agent-runtime/src/render/writer.rs
@@ -2030,4 +2030,211 @@ skills:
         assert!(report.skipped.is_empty());
         assert!(report.output_root.exists());
     }
+
+    // -----------------------------------------------------------------
+    // Path sandboxing. Every render-time path passes one of these guards;
+    // each is what stops a hostile manifest value or a planted symlink from
+    // reading or writing outside the source and build roots.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn a_relative_join_stays_under_its_base() {
+        let base = Path::new("/src");
+
+        assert_eq!(
+            sandboxed_join(base, "skills/a/SKILL.md").unwrap(),
+            PathBuf::from("/src/skills/a/SKILL.md")
+        );
+        // A `./` segment is normal navigation, not an escape.
+        assert_eq!(
+            sandboxed_join(base, "./skills/a").unwrap(),
+            PathBuf::from("/src/skills/a")
+        );
+
+        for hostile in ["../etc/passwd", "skills/../../etc", "/etc/passwd"] {
+            let err = sandboxed_join(base, hostile).expect_err("escape must be refused");
+            assert!(
+                err.to_string().contains("render must stay under /src"),
+                "{hostile}: {err}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_read_path_that_resolves_outside_the_source_root_is_refused() {
+        let tmp = TempDir::new().unwrap();
+        let base = fs::canonicalize(tmp.path()).unwrap();
+        let outside = base.join("outside");
+        let src = base.join("src");
+        fs::create_dir_all(&outside).unwrap();
+        fs::create_dir_all(&src).unwrap();
+        fs::write(outside.join("secret"), b"secret").unwrap();
+        fs::write(src.join("SKILL.md.tera"), b"body").unwrap();
+
+        let inside = canonicalize_under(&src, &src.join("SKILL.md.tera")).expect("inside");
+        assert_eq!(inside, src.join("SKILL.md.tera"));
+
+        // A symlink under the source root pointing outside it is the escape
+        // this guard exists for.
+        let planted = src.join("planted.tera");
+        std::os::unix::fs::symlink(outside.join("secret"), &planted).unwrap();
+        let err = canonicalize_under(&src, &planted).expect_err("symlink escape");
+        assert!(err.to_string().contains("likely a symlink escape"), "{err}");
+
+        // A path that does not exist cannot be read at all.
+        let err = canonicalize_under(&src, &src.join("absent")).expect_err("missing");
+        assert!(err.to_string().contains("canonicalize"), "{err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_write_path_is_guarded_through_its_parent_directory() {
+        let tmp = TempDir::new().unwrap();
+        let base = fs::canonicalize(tmp.path()).unwrap();
+        let build = base.join("build");
+        let outside = base.join("outside");
+        fs::create_dir_all(build.join("nested")).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+
+        // The file itself need not exist yet; only its parent must resolve
+        // inside the build root.
+        let target = build.join("nested").join("SKILL.md");
+        assert_eq!(guard_write_under(&build, &target).expect("inside"), target);
+
+        let escaped = base.join("escape");
+        std::os::unix::fs::symlink(&outside, &escaped).unwrap();
+        let err = guard_write_under(&build, &escaped.join("SKILL.md"))
+            .expect_err("parent symlink escape");
+        assert!(err.to_string().contains("likely a symlink escape"), "{err}");
+
+        // A parent that does not exist is refused rather than created.
+        let err = guard_write_under(&build, &build.join("absent").join("SKILL.md"))
+            .expect_err("missing parent");
+        assert!(err.to_string().contains("canonicalize parent"), "{err}");
+
+        let err = guard_write_under(&build, Path::new("/")).expect_err("root has no parent");
+        assert!(err.to_string().contains("has no parent"), "{err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_leaf_symlink_is_never_written_through() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let target = dir.join("real");
+        fs::write(&target, b"content").unwrap();
+
+        reject_leaf_symlink(&dir.join("absent")).expect("a missing output is fine");
+        reject_leaf_symlink(&target).expect("a regular file is fine");
+
+        let link = dir.join("link");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let err = reject_leaf_symlink(&link).expect_err("leaf symlink");
+        assert!(
+            err.to_string()
+                .contains("refusing to follow a leaf symlink"),
+            "{err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_render_root_is_refused_before_any_write() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let real = dir.join("real");
+        fs::create_dir_all(&real).unwrap();
+
+        reject_existing_symlink(&dir.join("absent"), "output root").expect("missing is fine");
+        reject_existing_symlink(&real, "output root").expect("real directory is fine");
+
+        let link = dir.join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let err = reject_existing_symlink(&link, "default render output root")
+            .expect_err("symlinked root");
+        assert!(
+            err.to_string()
+                .contains("refusing to use it as a render root"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn canonicalize_if_exists_distinguishes_absent_from_broken() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let real = dir.join("real");
+        fs::create_dir_all(&real).unwrap();
+
+        assert_eq!(
+            canonicalize_if_exists(&real).unwrap(),
+            Some(fs::canonicalize(&real).unwrap())
+        );
+        assert_eq!(canonicalize_if_exists(&dir.join("absent")).unwrap(), None);
+    }
+
+    #[test]
+    fn render_to_may_not_repeat_the_build_prefix() {
+        validate_render_to("s", "codex", "skills/a/SKILL.md").expect("relative render_to");
+        validate_render_to("s", "codex", "buildings/a.md")
+            .expect("a path that merely starts with the same letters is fine");
+
+        let err = validate_render_to("s", "codex", "build/codex/skills/a/SKILL.md")
+            .expect_err("doubled prefix");
+        assert!(err.to_string().contains("would double the prefix"), "{err}");
+    }
+
+    #[test]
+    fn the_tera_suffix_is_stripped_only_when_present() {
+        assert_eq!(
+            strip_tera_suffix(Path::new("skills/a/SKILL.md.tera")),
+            PathBuf::from("skills/a/SKILL.md")
+        );
+        assert_eq!(
+            strip_tera_suffix(Path::new("skills/a/SKILL.md")),
+            PathBuf::from("skills/a/SKILL.md")
+        );
+        assert_eq!(
+            strip_tera_suffix(Path::new("skills/a/plain")),
+            PathBuf::from("skills/a/plain")
+        );
+    }
+
+    #[test]
+    fn the_default_output_root_is_build_slash_product() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("manifests")).unwrap();
+        let root = SourceRoot::from_arg_or_cwd(Some(tmp.path())).expect("source root");
+
+        assert_eq!(
+            default_product_output_root(&root, "claude"),
+            root.path().join("build").join("claude")
+        );
+        // With no build directory yet there is nothing unsafe to reject.
+        reject_unsafe_default_output_root(&root, &default_product_output_root(&root, "claude"))
+            .expect("clean tree");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_build_directory_is_refused_as_a_default_output_root() {
+        let tmp = TempDir::new().unwrap();
+        let source = tmp.path().join("source");
+        let elsewhere = tmp.path().join("elsewhere");
+        fs::create_dir_all(source.join("manifests")).unwrap();
+        fs::create_dir_all(&elsewhere).unwrap();
+        std::os::unix::fs::symlink(&elsewhere, source.join("build")).unwrap();
+        let root = SourceRoot::from_arg_or_cwd(Some(&source)).expect("source root");
+
+        let err =
+            reject_unsafe_default_output_root(&root, &default_product_output_root(&root, "codex"))
+                .expect_err("symlinked build root");
+
+        assert!(
+            err.to_string()
+                .contains("refusing to use it as a render root"),
+            "{err}"
+        );
+    }
 }

--- a/crates/agent-workflow-primitives/src/agent_run.rs
+++ b/crates/agent-workflow-primitives/src/agent_run.rs
@@ -1108,4 +1108,148 @@ mod tests {
         assert_eq!(status_str(decision.status), "required-missing");
         assert_eq!(kind_str(decision.kind), "fail");
     }
+
+    #[test]
+    fn decision_labels_are_the_published_wire_values() {
+        assert_eq!(kind_str(DecisionKind::Direct), "direct");
+        assert_eq!(kind_str(DecisionKind::Direnv), "direnv");
+        assert_eq!(kind_str(DecisionKind::Dotenv), "direnv-dotenv");
+        assert_eq!(kind_str(DecisionKind::Fail), "fail");
+
+        assert_eq!(status_str(DecisionStatus::Absent), "absent");
+        assert_eq!(status_str(DecisionStatus::Bypassed), "bypassed");
+        assert_eq!(status_str(DecisionStatus::Active), "active");
+        assert_eq!(
+            status_str(DecisionStatus::RequiredMissing),
+            "required-missing"
+        );
+        assert_eq!(status_str(DecisionStatus::MissingDirenv), "missing-direnv");
+        assert_eq!(status_str(DecisionStatus::Blocked), "blocked");
+    }
+
+    #[test]
+    fn error_categories_round_trip_through_the_shared_cli_error() {
+        // `render_error` returns the exit code the CLI would exit with, so it
+        // is the observable proof that the category survived the conversion.
+        let rendered = |err: AgentRunError| {
+            render_error(
+                "cli.agent-run.operation-effect.v1",
+                "agent-run operation-effect",
+                OutputFormat::Json,
+                err.into_cli_error(),
+            )
+        };
+
+        let usage = AgentRunError::usage("invalid-cwd", "bad cwd", None);
+        assert_eq!(usage.exit_code, crate::common::EXIT_USAGE);
+        assert_eq!(rendered(usage), crate::common::EXIT_USAGE);
+
+        let unavailable = AgentRunError::unavailable(
+            "dotenv-parse-failed",
+            "no direnv",
+            Some(json!({"env_file": "/repo/.env"})),
+        );
+        assert_eq!(unavailable.exit_code, EXIT_UNAVAILABLE);
+        assert_eq!(unavailable.into_cli_error().code(), "dotenv-parse-failed");
+
+        // A path-resolution failure degrades to a runtime error, and the
+        // fallback arm of `into_cli_error` must preserve that exit code.
+        let runtime = AgentRunError::from_cli_error(CliError::runtime("x", "y", None));
+        assert_eq!(runtime.code, "path-resolution-failed");
+        assert_eq!(runtime.exit_code, EXIT_RUNTIME);
+        assert_eq!(rendered(runtime), EXIT_RUNTIME);
+    }
+
+    #[test]
+    fn resolve_cwd_requires_an_existing_directory() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let canonical = fs::canonicalize(tmp.path()).expect("canonical tempdir");
+
+        assert_eq!(resolve_cwd(tmp.path()).expect("existing dir"), canonical);
+
+        let missing = resolve_cwd(&tmp.path().join("absent")).expect_err("missing dir");
+        assert_eq!(missing.code, "invalid-cwd");
+        assert_eq!(missing.exit_code, crate::common::EXIT_USAGE);
+
+        let file = tmp.path().join("file");
+        fs::write(&file, b"x").expect("write file");
+        let not_a_dir = resolve_cwd(&file).expect_err("file is not a directory");
+        assert_eq!(not_a_dir.code, "invalid-cwd");
+    }
+
+    #[test]
+    fn execution_plan_with_direnv_off_never_probes_direnv() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        fs::write(tmp.path().join(".env"), "A=1\n").expect("env");
+
+        let plan = execution_plan(tmp.path(), DirenvMode::Off).expect("plan");
+
+        assert_eq!(plan.cwd, fs::canonicalize(tmp.path()).unwrap());
+        assert_eq!(kind_str(plan.decision.kind), "direct");
+        assert_eq!(status_str(plan.decision.status), "bypassed");
+        assert!(plan.env_file.is_some(), "the .env is still reported");
+    }
+
+    #[test]
+    fn operation_effect_for_inspect_binds_enforcement_or_fails_closed() {
+        // The descriptor may only claim a read-only inspection when the OS
+        // sandbox backend is verifiable. Where it is not — macOS, or a host
+        // without the required namespace support — the command must report
+        // `unavailable` rather than degrade to an unenforced success.
+        for format in [OutputFormat::Json, OutputFormat::Text] {
+            let code = run_operation_effect(OperationEffectArgs {
+                format,
+                argv: vec![
+                    OsString::from("inspect"),
+                    OsString::from("--"),
+                    OsString::from("true"),
+                ],
+            });
+            assert!(
+                code == exit::SUCCESS || code == EXIT_UNAVAILABLE,
+                "unexpected exit {code} for {format:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn operation_effect_fails_closed_for_any_non_inspection_command() {
+        // Anything that is not `inspect` must be reported as a mutation rather
+        // than silently described as read-only.
+        let code = run_operation_effect(OperationEffectArgs {
+            format: OutputFormat::Json,
+            argv: vec![
+                OsString::from("exec"),
+                OsString::from("--"),
+                OsString::from("true"),
+            ],
+        });
+
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn operation_effect_reports_argv_that_does_not_parse() {
+        for format in [OutputFormat::Json, OutputFormat::Text] {
+            let code = run_operation_effect(OperationEffectArgs {
+                format,
+                argv: vec![OsString::from("definitely-not-a-subcommand")],
+            });
+            assert_eq!(code, crate::common::EXIT_USAGE, "{format:?}");
+        }
+    }
+
+    #[test]
+    fn operation_effect_rejects_an_inspect_cwd_that_does_not_exist() {
+        let code = run_operation_effect(OperationEffectArgs {
+            format: OutputFormat::Json,
+            argv: vec![
+                OsString::from("inspect"),
+                OsString::from("--cwd"),
+                OsString::from("/definitely/not/a/directory"),
+            ],
+        });
+
+        assert_eq!(code, crate::common::EXIT_USAGE);
+    }
 }

--- a/crates/agent-workflow-primitives/src/review_specialists.rs
+++ b/crates/agent-workflow-primitives/src/review_specialists.rs
@@ -2476,4 +2476,368 @@ mod tests {
         let out = render_pr_comment(&mixed_merge_result(), RenderContext::default());
         assert_or_bless("pr_comment_mixed.md", &out);
     }
+
+    // -----------------------------------------------------------------
+    // Row-level normalization. A specialist writes JSONL by hand, so every
+    // field guard below is what keeps a malformed row out of the merged
+    // review rather than silently degrading it.
+    // -----------------------------------------------------------------
+
+    fn input() -> PathBuf {
+        PathBuf::from("/repo/findings.jsonl")
+    }
+
+    fn object(value: serde_json::Value) -> serde_json::Map<String, Value> {
+        value.as_object().expect("object").clone()
+    }
+
+    #[test]
+    fn a_required_string_field_must_be_present_and_non_blank() {
+        let row = object(serde_json::json!({"summary": "text", "blank": "  ", "number": 1}));
+
+        assert_eq!(
+            required_string(&row, "summary", &input(), 3).expect("present"),
+            "text"
+        );
+
+        let missing = required_string(&row, "absent", &input(), 3).expect_err("missing");
+        assert_eq!(missing.source_line, 3);
+        assert_eq!(missing.source_file, "/repo/findings.jsonl");
+        assert_eq!(missing.message, "absent must be a string");
+
+        assert_eq!(
+            required_string(&row, "number", &input(), 3)
+                .expect_err("wrong type")
+                .message,
+            "number must be a string"
+        );
+        assert_eq!(
+            required_string(&row, "blank", &input(), 3)
+                .expect_err("blank")
+                .message,
+            "blank must not be empty"
+        );
+    }
+
+    #[test]
+    fn an_optional_string_treats_null_and_blank_as_absent() {
+        assert_eq!(
+            optional_string(None, "note", &input(), 1).expect("absent"),
+            None
+        );
+        assert_eq!(
+            optional_string(Some(&Value::Null), "note", &input(), 1).expect("null"),
+            None
+        );
+        assert_eq!(
+            optional_string(Some(&serde_json::json!("  ")), "note", &input(), 1).expect("blank"),
+            None
+        );
+        assert_eq!(
+            optional_string(Some(&serde_json::json!("text")), "note", &input(), 1).expect("text"),
+            Some("text".to_string())
+        );
+        assert_eq!(
+            optional_string(Some(&serde_json::json!(7)), "note", &input(), 1)
+                .expect_err("wrong type")
+                .message,
+            "note must be a string"
+        );
+    }
+
+    #[test]
+    fn an_optional_line_number_must_be_a_positive_integer() {
+        assert_eq!(
+            optional_positive_u64(None, &input(), 1).expect("absent"),
+            None
+        );
+        assert_eq!(
+            optional_positive_u64(Some(&Value::Null), &input(), 1).expect("null"),
+            None
+        );
+        assert_eq!(
+            optional_positive_u64(Some(&serde_json::json!(12)), &input(), 1).expect("positive"),
+            Some(12)
+        );
+
+        for bad in [
+            serde_json::json!(0),
+            serde_json::json!(-1),
+            serde_json::json!(1.5),
+            serde_json::json!("12"),
+        ] {
+            assert_eq!(
+                optional_positive_u64(Some(&bad), &input(), 1)
+                    .expect_err("invalid line")
+                    .message,
+                "line must be a positive integer when present",
+                "{bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_severity_vocabulary_accepts_its_documented_aliases() {
+        for (raw, expected) in [
+            ("critical", Severity::Critical),
+            ("CRIT", Severity::Critical),
+            ("High", Severity::High),
+            ("medium", Severity::Medium),
+            (" med ", Severity::Medium),
+            ("low", Severity::Low),
+            ("info", Severity::Info),
+            ("informational", Severity::Info),
+        ] {
+            assert_eq!(
+                normalize_severity(raw, &input(), 1).expect("severity"),
+                expected,
+                "{raw}"
+            );
+        }
+
+        let error = normalize_severity("catastrophic", &input(), 4).expect_err("unknown severity");
+        assert_eq!(error.source_line, 4);
+        assert!(
+            error
+                .message
+                .contains("expected critical|high|medium|low|info"),
+            "{}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn confidence_must_be_a_number_within_the_unit_interval() {
+        for raw in [
+            serde_json::json!(0.0),
+            serde_json::json!(0.5),
+            serde_json::json!(1.0),
+            serde_json::json!(1),
+        ] {
+            normalize_confidence(&raw, &input(), 1)
+                .unwrap_or_else(|error| panic!("{raw}: {}", error.message));
+        }
+
+        assert_eq!(
+            normalize_confidence(&serde_json::json!("0.5"), &input(), 1)
+                .expect_err("string")
+                .message,
+            "confidence must be a number from 0.0 to 1.0"
+        );
+        for out_of_range in [serde_json::json!(-0.1), serde_json::json!(1.1)] {
+            assert_eq!(
+                normalize_confidence(&out_of_range, &input(), 1)
+                    .expect_err("out of range")
+                    .message,
+                "confidence must be from 0.0 to 1.0"
+            );
+        }
+    }
+
+    #[test]
+    fn the_display_threshold_is_bounded_to_the_unit_interval() {
+        validate_threshold(0.0).expect("lower bound");
+        validate_threshold(1.0).expect("upper bound");
+        assert_eq!(
+            validate_threshold(1.5).expect_err("above").code(),
+            "invalid-threshold"
+        );
+        assert_eq!(
+            validate_threshold(-0.5).expect_err("below").code(),
+            "invalid-threshold"
+        );
+    }
+
+    #[test]
+    fn a_stable_fingerprint_needs_three_lowercase_parts() {
+        validate_stable_fingerprint("correctness:parser:off-by-one", "fingerprint", &input(), 1)
+            .expect("stable");
+        validate_stable_fingerprint("a1:b2:c3", "fingerprint", &input(), 1).expect("digits");
+
+        for bad in [
+            "correctness",
+            "correctness:parser",
+            "a:b:c:d",
+            "Correctness:parser:x",
+            "correctness::x",
+            "-lead:parser:x",
+            "trail-:parser:x",
+            "correctness:parser:under_score",
+        ] {
+            let error =
+                validate_stable_fingerprint(bad, "fingerprint", &input(), 2).expect_err("unstable");
+            assert_eq!(
+                error.code.as_deref(),
+                Some("review_fingerprint_collision"),
+                "{bad}"
+            );
+            assert!(error.message.contains(bad), "{bad}");
+        }
+
+        assert!(stable_fingerprint_part("ok-1"));
+        assert!(!stable_fingerprint_part(""));
+    }
+
+    #[test]
+    fn path_validation_is_skipped_unless_it_is_requested() {
+        let off = PathPolicy {
+            repo: None,
+            validate_paths: false,
+            validate_lines: false,
+        };
+        validate_path_policy("anything/../escape", None, &off, &input(), 1)
+            .expect("no policy, no checks");
+
+        // Asking for validation without a repo root is a configuration error.
+        let no_repo = PathPolicy {
+            repo: None,
+            validate_paths: true,
+            validate_lines: false,
+        };
+        assert!(
+            validate_path_policy("src/lib.rs", None, &no_repo, &input(), 1)
+                .expect_err("no repo")
+                .message
+                .contains("--repo is required")
+        );
+    }
+
+    #[test]
+    fn a_validated_path_must_exist_inside_the_repo() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = tmp.path().to_path_buf();
+        fs::create_dir_all(repo.join("src")).unwrap();
+        fs::write(repo.join("src/lib.rs"), "one\ntwo\nthree\n").unwrap();
+        let policy = PathPolicy {
+            repo: Some(repo.clone()),
+            validate_paths: true,
+            validate_lines: true,
+        };
+
+        validate_path_policy("src/lib.rs", Some(3), &policy, &input(), 1).expect("in range");
+        validate_path_policy("src/lib.rs", None, &policy, &input(), 1)
+            .expect("no line to validate");
+
+        assert!(
+            validate_path_policy("../outside.rs", None, &policy, &input(), 1)
+                .expect_err("escape")
+                .message
+                .contains("path must be relative to the repo")
+        );
+        assert!(
+            validate_path_policy("src/absent.rs", None, &policy, &input(), 1)
+                .expect_err("missing file")
+                .message
+                .contains("path does not exist")
+        );
+        assert!(
+            validate_path_policy("src/lib.rs", Some(99), &policy, &input(), 1)
+                .expect_err("past end")
+                .message
+                .contains("line 99 is past end of")
+        );
+    }
+
+    #[test]
+    fn delivery_mode_rejects_one_fingerprint_with_two_identities() {
+        let finding = |fingerprint: &str, category: &str| NormalizedFinding {
+            severity: Severity::High,
+            confidence: 0.9,
+            path: "src/lib.rs".to_string(),
+            line: Some(1),
+            category: category.to_string(),
+            summary: "summary".to_string(),
+            evidence: "evidence".to_string(),
+            recommendation: "fix it".to_string(),
+            fingerprint: fingerprint.to_string(),
+            root_cause_fingerprint: None,
+            specialist: "reviewer-testing".to_string(),
+            test_suggestion: None,
+            source_file: "/repo/findings.jsonl".to_string(),
+            source_line: 1,
+        };
+
+        let consistent = vec![
+            finding("correctness:parser:one", "correctness"),
+            finding("correctness:parser:one", "correctness"),
+        ];
+        validate_delivery_collisions(&consistent, ReviewMode::Delivery).expect("same identity");
+
+        let conflicting = vec![
+            finding("correctness:parser:one", "correctness"),
+            finding("correctness:parser:one", "testing"),
+        ];
+        assert_eq!(
+            validate_delivery_collisions(&conflicting, ReviewMode::Delivery)
+                .expect_err("collision")
+                .code(),
+            "review_fingerprint_collision"
+        );
+
+        // Advisory mode does not carry lifecycle identity, so it is exempt.
+        validate_delivery_collisions(&conflicting, ReviewMode::Advisory)
+            .expect("advisory is exempt");
+    }
+
+    #[test]
+    fn severity_ranks_order_the_merged_report() {
+        assert!(severity_rank(Severity::Critical) < severity_rank(Severity::High));
+        assert!(severity_rank(Severity::High) < severity_rank(Severity::Medium));
+        assert!(severity_rank(Severity::Medium) < severity_rank(Severity::Low));
+        assert!(severity_rank(Severity::Low) < severity_rank(Severity::Info));
+    }
+
+    #[test]
+    fn the_computed_fingerprint_binds_path_line_category_and_summary() {
+        let base = computed_fingerprint("src/lib.rs", Some(10), "testing", "Missing test");
+
+        assert_ne!(
+            base,
+            computed_fingerprint("src/other.rs", Some(10), "testing", "Missing test")
+        );
+        assert_ne!(
+            base,
+            computed_fingerprint("src/lib.rs", Some(11), "testing", "Missing test")
+        );
+        assert_ne!(
+            base,
+            computed_fingerprint("src/lib.rs", Some(10), "security", "Missing test")
+        );
+        assert_ne!(
+            base,
+            computed_fingerprint("src/lib.rs", Some(10), "testing", "Other summary")
+        );
+        // A missing line is its own identity, not line zero.
+        assert_ne!(
+            base,
+            computed_fingerprint("src/lib.rs", None, "testing", "Missing test")
+        );
+        assert_eq!(
+            base.len(),
+            16,
+            "the fingerprint is a fixed-width hex digest"
+        );
+        assert_eq!(fnv1a64(b""), 0xcbf29ce484222325);
+    }
+
+    #[test]
+    fn a_validation_error_reports_the_first_typed_code_and_the_row_count() {
+        let untyped = validation_error(vec![RowError::new(
+            "/repo/findings.jsonl".to_string(),
+            1,
+            "bad".to_string(),
+        )]);
+        assert_eq!(untyped.code(), "invalid-findings");
+
+        let typed = validation_error(vec![
+            RowError::new("/repo/findings.jsonl".to_string(), 1, "bad".to_string()),
+            RowError::typed(
+                "/repo/findings.jsonl".to_string(),
+                2,
+                "review_fingerprint_collision",
+                "collision",
+            ),
+        ]);
+        assert_eq!(typed.code(), "review_fingerprint_collision");
+    }
 }

--- a/crates/agent-workflow-primitives/src/skill_usage.rs
+++ b/crates/agent-workflow-primitives/src/skill_usage.rs
@@ -1446,3 +1446,463 @@ impl Violation {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    /// A record that satisfies every v1 requirement. Tests mutate one field at
+    /// a time so a reported violation can only come from that mutation.
+    fn valid_v1() -> Value {
+        json!({
+            "schema": RECORD_SCHEMA_VERSION,
+            "skill": "review-evidence",
+            "producer": {"tool": "skill-usage", "nils_cli_version": "1.25.12"},
+            "started_at": "2026-08-03T00:00:00Z",
+            "ended_at": "2026-08-03T00:10:00Z",
+            "cwd": "/repo",
+            "trigger": "user_explicit",
+            "intent": "record review evidence",
+            "inputs": {
+                "user_request_summary": "review the diff",
+                "referenced_files": [],
+                "external_sources": []
+            },
+            "outcome": {"status": "pass", "summary": "completed"},
+            "artifacts": [],
+            "linked_records": [],
+            "validation": [
+                {"command": "cargo test", "status": "pass", "summary": "green"}
+            ],
+            "follow_up": [],
+            "failures": []
+        })
+    }
+
+    fn kinds(value: &Value) -> Vec<String> {
+        validate_record(value)
+            .into_iter()
+            .map(|violation| violation.kind)
+            .collect()
+    }
+
+    /// Assert the mutation produces exactly the expected violation kinds.
+    fn assert_kinds(value: &Value, expected: &[&str]) {
+        let mut actual = kinds(value);
+        actual.sort();
+        let mut expected = expected
+            .iter()
+            .map(|k| (*k).to_string())
+            .collect::<Vec<_>>();
+        expected.sort();
+        assert_eq!(actual, expected, "record: {value}");
+    }
+
+    #[test]
+    fn a_complete_v1_record_has_no_violations() {
+        assert_eq!(validate_record(&valid_v1()).len(), 0);
+    }
+
+    #[test]
+    fn a_complete_v2_record_uses_owner_instead_of_skill() {
+        let mut record = valid_v1();
+        record["schema"] = json!(RECORD_SCHEMA_VERSION_V2);
+        record.as_object_mut().unwrap().remove("skill");
+        record["owner"] = json!({"kind": "workflow", "id": "deliver-pr"});
+
+        assert_kinds(&record, &[]);
+
+        for kind in ["skill", "intent"] {
+            record["owner"]["kind"] = json!(kind);
+            assert_kinds(&record, &[]);
+        }
+    }
+
+    #[test]
+    fn a_non_object_root_is_rejected_before_any_field_check() {
+        let violations = validate_record(&json!([1, 2, 3]));
+
+        assert_eq!(violations.len(), 1, "one root violation, not a field sweep");
+        assert_eq!(violations[0].kind, "root_not_object");
+        assert_eq!(violations[0].path, "$");
+    }
+
+    #[test]
+    fn every_required_top_level_field_is_reported_when_absent() {
+        let violations = validate_record(&json!({}));
+        let kinds = violations
+            .iter()
+            .map(|v| v.kind.as_str())
+            .collect::<Vec<_>>();
+
+        for key in [
+            "schema",
+            "started_at",
+            "cwd",
+            "trigger",
+            "intent",
+            "inputs",
+            "outcome",
+            "artifacts",
+            "linked_records",
+            "validation",
+            "follow_up",
+        ] {
+            assert!(
+                kinds.contains(&format!("missing_{key}").as_str()),
+                "missing_{key} not reported: {kinds:?}"
+            );
+        }
+        assert!(kinds.contains(&"invalid_schema"));
+        assert!(kinds.contains(&"missing_final_validation"));
+    }
+
+    #[test]
+    fn the_schema_discriminator_is_closed() {
+        let mut record = valid_v1();
+        record["schema"] = json!("skill-usage.record.v99");
+
+        // An unknown schema disables owner checks, so only the schema is flagged.
+        assert_kinds(&record, &["invalid_schema"]);
+    }
+
+    #[test]
+    fn ownership_fields_are_bound_to_the_schema_version() {
+        // v1 must carry `skill` and must not carry `owner`.
+        let mut record = valid_v1();
+        record["owner"] = json!({"kind": "skill", "id": "x"});
+        assert_kinds(&record, &["unexpected_owner"]);
+
+        let mut record = valid_v1();
+        record["skill"] = json!("   ");
+        assert_kinds(&record, &["invalid_skill"]);
+
+        // v2 must carry `owner` and must not carry `skill`.
+        let mut record = valid_v1();
+        record["schema"] = json!(RECORD_SCHEMA_VERSION_V2);
+        assert_kinds(&record, &["unexpected_skill", "invalid_owner"]);
+
+        let mut record = valid_v1();
+        record["schema"] = json!(RECORD_SCHEMA_VERSION_V2);
+        record.as_object_mut().unwrap().remove("skill");
+        record["owner"] = json!({"kind": "team", "id": ""});
+        assert_kinds(&record, &["invalid_owner_kind", "invalid_owner_id"]);
+    }
+
+    #[test]
+    fn identity_strings_must_be_non_empty() {
+        for key in ["started_at", "cwd", "intent"] {
+            let mut record = valid_v1();
+            record[key] = json!("  ");
+            assert_kinds(&record, &[&format!("invalid_{key}")]);
+
+            let mut record = valid_v1();
+            record[key] = json!(42);
+            assert_kinds(&record, &[&format!("invalid_{key}")]);
+        }
+    }
+
+    #[test]
+    fn the_trigger_vocabulary_is_closed() {
+        for trigger in ["user_explicit", "agent_selected", "project_policy", "other"] {
+            let mut record = valid_v1();
+            record["trigger"] = json!(trigger);
+            assert_kinds(&record, &[]);
+        }
+
+        let mut record = valid_v1();
+        record["trigger"] = json!("vibes");
+        assert_kinds(&record, &["invalid_trigger"]);
+    }
+
+    #[test]
+    fn producer_is_additive_but_complete_when_present() {
+        // Records written before the field existed stay valid.
+        let mut record = valid_v1();
+        record.as_object_mut().unwrap().remove("producer");
+        assert_kinds(&record, &[]);
+
+        let mut record = valid_v1();
+        record["producer"] = json!("skill-usage");
+        assert_kinds(&record, &["invalid_producer"]);
+
+        let mut record = valid_v1();
+        record["producer"] = json!({});
+        assert_kinds(
+            &record,
+            &["missing_producer_tool", "missing_producer_nils_cli_version"],
+        );
+
+        let mut record = valid_v1();
+        record["producer"] = json!({"tool": "", "nils_cli_version": 1});
+        assert_kinds(
+            &record,
+            &["invalid_producer_tool", "invalid_producer_nils_cli_version"],
+        );
+    }
+
+    #[test]
+    fn inputs_require_the_full_provenance_triple() {
+        let mut record = valid_v1();
+        record["inputs"] = json!("summary");
+        assert_kinds(&record, &["invalid_inputs"]);
+
+        let mut record = valid_v1();
+        record["inputs"] = json!({});
+        assert_kinds(
+            &record,
+            &[
+                "missing_input_user_request_summary",
+                "missing_input_referenced_files",
+                "missing_input_external_sources",
+            ],
+        );
+
+        let mut record = valid_v1();
+        record["inputs"] = json!({
+            "user_request_summary": 1,
+            "referenced_files": "a.rs",
+            "external_sources": {}
+        });
+        assert_kinds(
+            &record,
+            &[
+                "invalid_user_request_summary",
+                "invalid_referenced_files",
+                "invalid_external_sources",
+            ],
+        );
+
+        // An empty summary is allowed; only a non-string is not.
+        let mut record = valid_v1();
+        record["inputs"]["user_request_summary"] = json!("");
+        assert_kinds(&record, &[]);
+    }
+
+    #[test]
+    fn the_outcome_status_vocabulary_is_closed() {
+        for status in ["pass", "skipped"] {
+            let mut record = valid_v1();
+            record["outcome"]["status"] = json!(status);
+            assert_kinds(&record, &[]);
+        }
+
+        let mut record = valid_v1();
+        record["outcome"] = json!("pass");
+        assert_kinds(&record, &["invalid_outcome"]);
+
+        let mut record = valid_v1();
+        record["outcome"] = json!({"summary": "done"});
+        assert_kinds(&record, &["missing_outcome_status"]);
+
+        let mut record = valid_v1();
+        record["outcome"] = json!({"status": "partial", "summary": ""});
+        assert_kinds(
+            &record,
+            &["invalid_outcome_status", "invalid_outcome_summary"],
+        );
+    }
+
+    #[test]
+    fn a_non_pass_outcome_must_carry_at_least_one_failure_record() {
+        for status in ["fail", "blocked", "worked_around", "accepted_risk"] {
+            let mut record = valid_v1();
+            record["outcome"]["status"] = json!(status);
+            assert_kinds(&record, &["missing_failure_record"]);
+
+            record["failures"] = json!([{
+                "phase": "execution",
+                "symptom": "it broke",
+                "classification": "script_bug",
+                "diagnosis": "off-by-one",
+                "handling": "fixed the loop",
+                "result": "fixed"
+            }]);
+            assert_kinds(&record, &[]);
+        }
+    }
+
+    #[test]
+    fn failure_entries_are_shape_and_vocabulary_checked() {
+        let mut record = valid_v1();
+        record["failures"] = json!("boom");
+        assert_kinds(&record, &["invalid_failures"]);
+
+        let mut record = valid_v1();
+        record["failures"] = json!(["boom"]);
+        assert_kinds(&record, &["invalid_failure"]);
+
+        let mut record = valid_v1();
+        record["failures"] = json!([{}]);
+        assert_kinds(
+            &record,
+            &[
+                "missing_failure_phase",
+                "missing_failure_symptom",
+                "missing_failure_classification",
+                "missing_failure_diagnosis",
+                "missing_failure_handling",
+                "missing_failure_result",
+            ],
+        );
+
+        let mut record = valid_v1();
+        record["failures"] = json!([{
+            "phase": "teatime",
+            "symptom": "  ",
+            "classification": "cosmic_rays",
+            "diagnosis": 5,
+            "handling": "",
+            "result": "ignored"
+        }]);
+        assert_kinds(
+            &record,
+            &[
+                "invalid_failure_phase",
+                "invalid_failure_classification",
+                "invalid_failure_result",
+                "invalid_failure_symptom",
+                "invalid_failure_diagnosis",
+                "invalid_failure_handling",
+            ],
+        );
+    }
+
+    #[test]
+    fn linked_records_must_name_a_type_and_a_path() {
+        let mut record = valid_v1();
+        record["linked_records"] = json!(["child.json"]);
+        assert_kinds(&record, &["invalid_linked_record"]);
+
+        let mut record = valid_v1();
+        record["linked_records"] = json!([{}]);
+        assert_kinds(
+            &record,
+            &["invalid_linked_record_type", "invalid_linked_record_path"],
+        );
+
+        let mut record = valid_v1();
+        record["linked_records"] = json!([{"type": "test-first-evidence", "path": "child.json"}]);
+        assert_kinds(&record, &[]);
+    }
+
+    #[test]
+    fn validation_is_required_unless_it_is_explicitly_waived() {
+        let mut record = valid_v1();
+        record["validation"] = json!([]);
+        assert_kinds(&record, &["missing_final_validation"]);
+
+        // Opting out requires a written waiver.
+        let mut record = valid_v1();
+        record["validation"] = json!([]);
+        record["validation_required"] = json!(false);
+        assert_kinds(&record, &["missing_validation_waiver"]);
+
+        let mut record = valid_v1();
+        record["validation"] = json!([]);
+        record["validation_required"] = json!(false);
+        record["validation_waiver"] = json!("no runnable suite in this repo");
+        assert_kinds(&record, &[]);
+
+        // A non-boolean flag fails closed to "required".
+        let mut record = valid_v1();
+        record["validation"] = json!([]);
+        record["validation_required"] = json!("false");
+        assert_kinds(
+            &record,
+            &["invalid_validation_required", "missing_final_validation"],
+        );
+    }
+
+    #[test]
+    fn validation_entries_are_shape_and_vocabulary_checked() {
+        let mut record = valid_v1();
+        record["validation"] = json!(["cargo test"]);
+        assert_kinds(&record, &["invalid_validation_item"]);
+
+        let mut record = valid_v1();
+        record["validation"] = json!([{}]);
+        assert_kinds(
+            &record,
+            &[
+                "invalid_validation_command",
+                "invalid_validation_status",
+                "invalid_validation_summary",
+            ],
+        );
+
+        for status in ["pass", "fail", "skipped"] {
+            let mut record = valid_v1();
+            record["validation"] = json!([{"command": "c", "status": status, "summary": "s"}]);
+            assert_kinds(&record, &[]);
+        }
+
+        let mut record = valid_v1();
+        record["validation"] = json!([{"command": "c", "status": "green", "summary": "s"}]);
+        assert_kinds(&record, &["invalid_validation_status"]);
+
+        // A non-array validation field is caught by the array check, and the
+        // item scan then sees nothing to count.
+        let mut record = valid_v1();
+        record["validation"] = json!("cargo test");
+        assert_kinds(&record, &["invalid_validation", "missing_final_validation"]);
+    }
+
+    #[test]
+    fn list_shaped_fields_must_actually_be_arrays() {
+        for key in ["artifacts", "linked_records", "follow_up"] {
+            let mut record = valid_v1();
+            record[key] = json!("not-a-list");
+            assert_kinds(&record, &[&format!("invalid_{key}")]);
+        }
+    }
+
+    #[test]
+    fn a_secret_like_value_anywhere_in_the_record_is_flagged_with_its_path() {
+        let mut record = valid_v1();
+        record["inputs"]["referenced_files"] = json!(["ghp_abcdefghijklmnop"]);
+
+        let violations = validate_record(&record);
+        let secret = violations
+            .iter()
+            .find(|v| v.kind == "secret_like_value")
+            .expect("secret must be reported");
+        assert_eq!(secret.path, "$.inputs.referenced_files[0]");
+
+        // Nested objects are scanned too, and the path names the exact key.
+        let mut record = valid_v1();
+        record["outcome"]["summary"] = json!("Authorization: Bearer abc123");
+        let violations = validate_record(&record);
+        assert_eq!(
+            violations
+                .iter()
+                .find(|v| v.kind == "secret_like_value")
+                .map(|v| v.path.as_str()),
+            Some("$.outcome.summary")
+        );
+
+        // Ordinary prose is not a secret.
+        assert_kinds(&valid_v1(), &[]);
+    }
+
+    #[test]
+    fn the_text_summary_reports_completeness_and_counts() {
+        let record = valid_v1();
+        let result = RecordResult::new(PathBuf::from("/out/skill-usage.record.json"), record);
+
+        assert!(result.complete);
+        assert_eq!(
+            result.text_summary(),
+            "skill-usage: complete=true status=pass validation=1 failures=0"
+        );
+
+        let incomplete = RecordResult::new(PathBuf::from("/out/x.json"), json!({}));
+        assert!(!incomplete.complete);
+        assert_eq!(
+            incomplete.text_summary(),
+            "skill-usage: complete=false status=unknown validation=0 failures=0"
+        );
+    }
+}

--- a/crates/agent-workflow-primitives/tests/integration.rs
+++ b/crates/agent-workflow-primitives/tests/integration.rs
@@ -8,6 +8,8 @@ mod agent_run_inspect;
 mod agent_run_inspect_unavailable;
 #[path = "integration/cli.rs"]
 mod cli;
+#[path = "integration/completion_export.rs"]
+mod completion_export;
 #[path = "integration/control_plane.rs"]
 mod control_plane;
 #[path = "integration/exit_codes.rs"]

--- a/crates/agent-workflow-primitives/tests/integration/completion_export.rs
+++ b/crates/agent-workflow-primitives/tests/integration/completion_export.rs
@@ -1,0 +1,66 @@
+//! Shell-completion export contract for the `agent-run` binary. Both shipped
+//! shells must render from a directory that is not a git repository, and the
+//! bash script must already be normalized when it reaches stdout.
+
+use std::process::{Command, Stdio};
+
+use nils_test_support::bin::resolve;
+
+fn run_completion(shell: &str) -> std::process::Output {
+    let temp = tempfile::TempDir::new().unwrap();
+    Command::new(resolve("agent-run"))
+        .args(["completion", shell])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap_or_else(|error| panic!("run agent-run completion {shell}: {error}"))
+}
+
+#[test]
+fn completion_zsh_export_succeeds_outside_git_repo() {
+    let output = run_completion("zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef agent-run"),
+        "missing zsh completion header: {stdout}"
+    );
+}
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let output = run_completion("bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_agent-run()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/agent-run` asset must not carry them,
+    // so the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}
+
+#[test]
+fn completion_rejects_an_unsupported_shell() {
+    let output = run_completion("fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+}

--- a/crates/api-gql/tests/integration/completion_outside_repo.rs
+++ b/crates/api-gql/tests/integration/completion_outside_repo.rs
@@ -52,3 +52,33 @@ fn completion_rejects_unknown_shell_outside_git_repo() {
         "missing invalid shell error: {stderr}"
     );
 }
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(api_gql_bin())
+        .args(["completion", "bash"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run api-gql completion bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_api-gql()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/api-gql` asset must not carry them,
+    // so the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}

--- a/crates/api-grpc/tests/integration/completion_outside_repo.rs
+++ b/crates/api-grpc/tests/integration/completion_outside_repo.rs
@@ -52,3 +52,33 @@ fn completion_rejects_unknown_shell_outside_git_repo() {
         "missing invalid shell error: {stderr}"
     );
 }
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(api_grpc_bin())
+        .args(["completion", "bash"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run api-grpc completion bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_api-grpc()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/api-grpc` asset must not carry them,
+    // so the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}

--- a/crates/api-rest/tests/integration/completion_outside_repo.rs
+++ b/crates/api-rest/tests/integration/completion_outside_repo.rs
@@ -52,3 +52,33 @@ fn completion_rejects_unknown_shell_outside_git_repo() {
         "missing invalid shell error: {stderr}"
     );
 }
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(api_rest_bin())
+        .args(["completion", "bash"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run api-rest completion bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_api-rest()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/api-rest` asset must not carry them,
+    // so the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}

--- a/crates/api-test/tests/integration/completion_outside_repo.rs
+++ b/crates/api-test/tests/integration/completion_outside_repo.rs
@@ -52,3 +52,33 @@ fn completion_rejects_unknown_shell_outside_git_repo() {
         "missing invalid shell error: {stderr}"
     );
 }
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(api_test_bin())
+        .args(["completion", "bash"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run api-test completion bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_api-test()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/api-test` asset must not carry them,
+    // so the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}

--- a/crates/api-websocket/tests/integration/completion_outside_repo.rs
+++ b/crates/api-websocket/tests/integration/completion_outside_repo.rs
@@ -52,3 +52,33 @@ fn completion_rejects_unknown_shell_outside_git_repo() {
         "missing invalid shell error: {stderr}"
     );
 }
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(api_websocket_bin())
+        .args(["completion", "bash"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run api-websocket completion bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_api-websocket()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/api-websocket` asset must not carry
+    // them, so the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}

--- a/crates/claude-cli/src/config.rs
+++ b/crates/claude-cli/src/config.rs
@@ -83,3 +83,85 @@ fn emit_quoted(key: &str, value: &str) -> i32 {
     );
     exit::SUCCESS
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn every_key_accepts_both_its_short_name_and_its_env_var_name() {
+        for key in ["model", "CLAUDE_CLI_MODEL"] {
+            assert_eq!(set(key, "claude-opus-5"), exit::SUCCESS, "{key}");
+        }
+        for key in ["effort", "CLAUDE_CLI_EFFORT"] {
+            assert_eq!(set(key, "HIGH"), exit::SUCCESS, "{key}");
+        }
+        for key in [
+            "agent-runtime",
+            "agent_runtime",
+            "runtime",
+            "CLAUDE_CLI_AGENT_RUNTIME",
+        ] {
+            assert_eq!(set(key, "safe"), exit::SUCCESS, "{key}");
+        }
+        for key in [
+            "no-session-persistence",
+            "no_session_persistence",
+            "CLAUDE_CLI_NO_SESSION_PERSISTENCE",
+        ] {
+            assert_eq!(set(key, "true"), exit::SUCCESS, "{key}");
+        }
+    }
+
+    #[test]
+    fn an_unknown_key_is_a_usage_error() {
+        assert_eq!(set("nope", "value"), exit::USAGE);
+        assert_eq!(set("", "value"), exit::USAGE);
+    }
+
+    #[test]
+    fn each_key_rejects_a_value_its_validator_does_not_accept() {
+        assert_eq!(set("model", "  "), exit::USAGE, "empty model");
+        assert_eq!(set("model", "bad\u{7}model"), exit::USAGE, "control char");
+        assert_eq!(set("effort", "turbo"), exit::USAGE);
+        assert_eq!(set("runtime", "sandboxed"), exit::USAGE);
+        assert_eq!(set("no-session-persistence", "maybe"), exit::USAGE);
+    }
+
+    #[test]
+    fn accepted_values_are_normalized_before_export() {
+        // These are the exact shell-eval'able lines the wrapper sources, so
+        // casing and aliasing must collapse to the canonical spelling.
+        assert_eq!(
+            super::wrapper_config::validate_effort("XHigh").unwrap(),
+            "xhigh"
+        );
+        assert_eq!(
+            super::wrapper_config::parse_runtime(" Inherited ")
+                .unwrap()
+                .as_str(),
+            "inherited"
+        );
+        assert!(super::wrapper_config::parse_bool("ON").unwrap());
+        assert!(!super::wrapper_config::parse_bool("Off").unwrap());
+    }
+
+    #[test]
+    fn a_model_containing_a_single_quote_stays_shell_safe() {
+        // `emit_quoted` is what protects `eval "$(claude-cli config set ...)"`
+        // from a value that would otherwise break out of its quoting.
+        assert_eq!(
+            emit_quoted("CLAUDE_CLI_MODEL", "it's-a-model"),
+            exit::SUCCESS
+        );
+        assert_eq!(set("model", "it's-a-model"), exit::SUCCESS);
+    }
+
+    #[test]
+    fn invalid_config_always_reports_usage() {
+        assert_eq!(invalid_config("boom"), exit::USAGE);
+        assert_eq!(invalid_config(String::from("boom")), exit::USAGE);
+    }
+}

--- a/crates/forge-cli/src/operation_effect.rs
+++ b/crates/forge-cli/src/operation_effect.rs
@@ -194,3 +194,178 @@ fn emit(format: OutputFormat, descriptor: OperationEffectDescriptor) -> i32 {
     }
     exit::SUCCESS
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use clap::Parser;
+    use pretty_assertions::assert_eq;
+
+    fn classify_argv(argv: &[&str]) -> (&'static str, Effect, ProviderEffect, Vec<&'static str>) {
+        let mut full = vec!["forge-cli"];
+        full.extend_from_slice(argv);
+        let cli = Cli::try_parse_from(full)
+            .unwrap_or_else(|error| panic!("argv {argv:?} must parse: {error}"));
+        classify(&cli)
+    }
+
+    /// Every read must declare a read-only effect; a network read must never
+    /// be classified as a write.
+    fn assert_network_read(argv: &[&str], operation: &str, reads: &[&str]) {
+        let (name, effect, provider, declared) = classify_argv(argv);
+        assert_eq!(name, operation, "{argv:?}");
+        assert_eq!(effect, Effect::ReadOnly, "{argv:?}");
+        assert_eq!(provider, ProviderEffect::NetworkRead, "{argv:?}");
+        assert_eq!(declared, reads.to_vec(), "{argv:?}");
+    }
+
+    #[test]
+    fn provider_reads_are_classified_as_read_only_network_calls() {
+        assert_network_read(&["auth", "status"], "auth.status", &["provider_auth"]);
+        assert_network_read(&["repo", "view"], "repo.view", &["git_remote", "provider"]);
+        assert_network_read(&["pr", "view", "7"], "pr.view", &["provider"]);
+        assert_network_read(&["pr", "list"], "pr.list", &["provider"]);
+        assert_network_read(&["pr", "comments", "7"], "pr.comments", &["provider"]);
+        assert_network_read(&["pr", "reviews", "7"], "pr.reviews", &["provider"]);
+        assert_network_read(&["pr", "tasks", "7"], "pr.tasks", &["provider"]);
+        assert_network_read(&["pr", "checks", "7"], "pr.checks", &["provider"]);
+        assert_network_read(&["pr", "wait-checks", "7"], "pr.wait-checks", &["provider"]);
+        assert_network_read(&["issue", "view", "7"], "issue.view", &["provider"]);
+        assert_network_read(&["issue", "list"], "issue.list", &["provider"]);
+        assert_network_read(&["label", "list"], "label.list", &["provider"]);
+        assert_network_read(
+            &["label", "audit", "--catalog", "/tmp/labels.yaml"],
+            "label.audit",
+            &["provider"],
+        );
+    }
+
+    #[test]
+    fn provider_writes_are_classified_as_network_mutations() {
+        for (argv, operation) in [
+            (
+                vec!["label", "ensure", "--catalog", "/tmp/labels.yaml"],
+                "label.ensure",
+            ),
+            (vec!["pr", "merge", "7"], "pr.mutation"),
+            (vec!["issue", "close", "7"], "issue.mutation"),
+        ] {
+            let (name, effect, provider, reads) = classify_argv(&argv);
+            assert_eq!(name, operation, "{argv:?}");
+            assert_eq!(effect, Effect::Mutation, "{argv:?}");
+            assert_eq!(provider, ProviderEffect::NetworkWrite, "{argv:?}");
+            assert!(reads.is_empty(), "{argv:?}");
+        }
+    }
+
+    #[test]
+    fn repo_bootstrap_declares_the_receipt_it_writes() {
+        let (name, effect, provider, reads) = classify_argv(&[
+            "repo",
+            "bootstrap",
+            "--owner-kind",
+            "user",
+            "--default-branch",
+            "main",
+            "--file",
+            "README.md",
+            "--message",
+            "init",
+            "--reason-file",
+            "/tmp/reason.md",
+        ]);
+
+        assert_eq!(name, "repo.bootstrap");
+        assert_eq!(effect, Effect::Mutation);
+        assert_eq!(provider, ProviderEffect::NetworkWrite);
+        assert_eq!(reads, vec!["provider", "user_config", "bootstrap_receipt"]);
+    }
+
+    #[test]
+    fn review_validation_only_reaches_the_provider_when_it_checks_the_diff() {
+        let (name, effect, provider, reads) = classify_argv(&["pr", "review", "validate"]);
+        assert_eq!(name, "pr.review.validate");
+        assert_eq!(effect, Effect::ReadOnly);
+        assert_eq!(provider, ProviderEffect::LocalRead);
+        assert_eq!(reads, vec!["local_inputs"]);
+
+        let (name, effect, provider, reads) =
+            classify_argv(&["pr", "review", "validate", "--check-diff"]);
+        assert_eq!(name, "pr.review.validate");
+        assert_eq!(effect, Effect::ReadOnly);
+        assert_eq!(provider, ProviderEffect::NetworkRead);
+        assert_eq!(reads, vec!["local_inputs", "provider"]);
+    }
+
+    #[test]
+    fn posting_a_review_is_a_provider_write() {
+        let (name, effect, provider, reads) = classify_argv(&["pr", "review"]);
+
+        assert_eq!(name, "pr.review.post");
+        assert_eq!(effect, Effect::Mutation);
+        assert_eq!(provider, ProviderEffect::NetworkWrite);
+        assert!(reads.is_empty());
+    }
+
+    #[test]
+    fn inbox_is_a_mutation_whenever_it_may_write_its_cache() {
+        // `--no-cache` keeps the command read-only.
+        let (name, effect, _, reads) = classify_argv(&["inbox", "list", "--no-cache"]);
+        assert_eq!(name, "inbox.query");
+        assert_eq!(effect, Effect::ReadOnly);
+        assert_eq!(reads, vec!["provider", "user_config"]);
+
+        // Without it the cache may be rewritten, so it must not claim to be a read.
+        let (name, effect, provider, reads) = classify_argv(&["inbox", "list"]);
+        assert_eq!(name, "inbox.cache-write");
+        assert_eq!(effect, Effect::Mutation);
+        assert_eq!(provider, ProviderEffect::NetworkRead);
+        assert_eq!(reads, vec!["provider", "user_config", "cache"]);
+
+        for subcommand in ["status", "next"] {
+            let (name, _, _, _) = classify_argv(&["inbox", subcommand, "--no-cache"]);
+            assert_eq!(name, "inbox.query", "{subcommand}");
+            let (name, _, _, _) = classify_argv(&["inbox", subcommand]);
+            assert_eq!(name, "inbox.cache-write", "{subcommand}");
+        }
+    }
+
+    #[test]
+    fn local_only_and_self_describing_commands_declare_no_provider_effect() {
+        let (name, effect, provider, reads) = classify_argv(&["completion", "zsh"]);
+        assert_eq!(name, "completion");
+        assert_eq!(effect, Effect::ReadOnly);
+        assert_eq!(provider, ProviderEffect::None);
+        assert!(reads.is_empty());
+
+        // Describing the describer cannot claim to know its own effect.
+        let (name, effect, provider, _) = classify_argv(&["operation-effect", "--", "pr", "list"]);
+        assert_eq!(name, "operation-effect");
+        assert_eq!(effect, Effect::Unknown);
+        assert_eq!(provider, ProviderEffect::None);
+
+        // A bare invocation with no subcommand is equally unknown.
+        let (name, effect, _, _) = classify_argv(&[]);
+        assert_eq!(name, "operation-effect");
+        assert_eq!(effect, Effect::Unknown);
+    }
+
+    #[test]
+    fn a_descriptor_is_emitted_for_both_formats() {
+        assert_eq!(
+            run(
+                vec![OsString::from("pr"), OsString::from("list")],
+                OutputFormat::Json
+            ),
+            exit::SUCCESS
+        );
+        assert_eq!(
+            run(
+                vec![OsString::from("pr"), OsString::from("list")],
+                OutputFormat::Text
+            ),
+            exit::SUCCESS
+        );
+    }
+}

--- a/crates/forge-cli/src/ops/pr_review_loop.rs
+++ b/crates/forge-cli/src/ops/pr_review_loop.rs
@@ -1034,6 +1034,8 @@ fn schema_err() -> String {
 mod tests {
     use super::*;
 
+    use crate::backend::BackendSuccess;
+
     #[test]
     fn delivery_merge_envelope_maps_to_lifecycle_observations() {
         let value = serde_json::json!({
@@ -1095,6 +1097,1166 @@ mod tests {
                 .expect_err("approval comment must belong to the target PR")
                 .kind(),
             "review_extension_approval_invalid"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Command-level coverage: inspect / observe / extend drive the durable
+    // provider chain through a stateful fake `gh`, so an appended state is
+    // visible to the very next read exactly as it would be on the provider.
+    // ---------------------------------------------------------------------
+
+    const REPO: &str = "acme/widgets";
+    const PR: u64 = 7;
+    const HEAD: &str = "head-7";
+    const NEXT_HEAD: &str = "head-8";
+    const VIEWER: &str = "forge-bot";
+    const TIP_CREATED_AT: &str = "2026-07-20T12:00:00Z";
+
+    fn view_json(head_sha: &str) -> String {
+        serde_json::json!({
+            "number": PR,
+            "url": "https://github.com/acme/widgets/pull/7",
+            "state": "OPEN",
+            "isDraft": false,
+            "title": "feat: sample",
+            "headRefName": "feat/sample",
+            "headRefOid": head_sha,
+            "baseRefName": "main",
+            "mergeable": "MERGEABLE",
+            "mergedAt": null,
+            "labels": []
+        })
+        .to_string()
+    }
+
+    fn comment_node(body: &str, created_at: &str) -> serde_json::Value {
+        serde_json::json!({
+            "author": {"login": VIEWER},
+            "authorAssociation": "MEMBER",
+            "body": body,
+            "createdAt": created_at
+        })
+    }
+
+    /// Stateful `gh` double: a posted review-state comment becomes part of the
+    /// next comment page, so append + read-back verification runs for real.
+    struct FakeGitHub {
+        view: String,
+        comments: std::cell::RefCell<Vec<serde_json::Value>>,
+        approval: Option<String>,
+        calls: std::cell::RefCell<Vec<Vec<String>>>,
+    }
+
+    impl FakeGitHub {
+        fn new(head_sha: &str) -> Self {
+            Self {
+                view: view_json(head_sha),
+                comments: std::cell::RefCell::new(Vec::new()),
+                approval: None,
+                calls: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+
+        fn with_state(self, state: &review_state::ReviewLoopState, head: &str) -> Self {
+            let record = review_state::ReviewStateRecord::new(
+                REPO,
+                PR,
+                head,
+                0,
+                None,
+                review_state::ReviewStatePayload::ReviewLoop {
+                    state: state.clone(),
+                },
+            )
+            .expect("seed record");
+            let marker = record.marker().expect("seed marker");
+            self.comments
+                .borrow_mut()
+                .push(comment_node(&marker, TIP_CREATED_AT));
+            self
+        }
+
+        fn with_approval(mut self, approval: serde_json::Value) -> Self {
+            self.approval = Some(approval.to_string());
+            self
+        }
+
+        fn tip_digest(&self) -> Option<String> {
+            let bodies: Vec<String> = self
+                .comments
+                .borrow()
+                .iter()
+                .map(|node| node["body"].as_str().unwrap_or_default().to_string())
+                .collect();
+            review_state::parse_chain(bodies.iter().map(String::as_str), REPO, PR)
+                .expect("seeded chain")
+                .tip_digest
+        }
+
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.calls.borrow().clone()
+        }
+
+        fn appended_bodies(&self) -> Vec<String> {
+            self.calls()
+                .iter()
+                .filter(|argv| argv.iter().any(|arg| arg == "--method"))
+                .filter_map(|argv| {
+                    argv.iter()
+                        .find_map(|arg| arg.strip_prefix("body="))
+                        .map(str::to_string)
+                })
+                .collect()
+        }
+    }
+
+    impl BackendRunner for FakeGitHub {
+        fn run(&self, call: &BackendCall) -> Result<BackendSuccess, ForgeError> {
+            let argv: Vec<String> = call
+                .argv
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect();
+            self.calls.borrow_mut().push(argv.clone());
+
+            if argv.first().map(String::as_str) == Some("pr") {
+                return Ok(BackendSuccess {
+                    stdout: self.view.clone(),
+                    stderr: String::new(),
+                });
+            }
+            if argv.get(1).map(String::as_str) == Some("graphql") {
+                let page = serde_json::json!({
+                    "data": {
+                        "viewer": {"login": VIEWER},
+                        "repository": {"pullRequest": {"comments": {
+                            "nodes": *self.comments.borrow(),
+                            "pageInfo": {"hasNextPage": false, "endCursor": "cursor-end"}
+                        }}}
+                    }
+                });
+                return Ok(BackendSuccess {
+                    stdout: page.to_string(),
+                    stderr: String::new(),
+                });
+            }
+            if argv.iter().any(|arg| arg == "--method") {
+                let body = argv
+                    .iter()
+                    .find_map(|arg| arg.strip_prefix("body="))
+                    .unwrap_or_default()
+                    .to_string();
+                self.comments
+                    .borrow_mut()
+                    .push(comment_node(&body, "2026-07-20T12:00:09Z"));
+                return Ok(BackendSuccess {
+                    stdout: "https://github.com/acme/widgets/pull/7#issuecomment-2".to_string(),
+                    stderr: String::new(),
+                });
+            }
+            match self.approval.as_ref() {
+                Some(body) => Ok(BackendSuccess {
+                    stdout: body.clone(),
+                    stderr: String::new(),
+                }),
+                None => Err(ForgeError::software(
+                    schema_err(),
+                    "unexpected backend call",
+                    Some(argv.join(" ")),
+                )),
+            }
+        }
+
+        fn run_raw(&self, call: &BackendCall) -> Result<crate::backend::BackendOutput, ForgeError> {
+            self.run(call).map(|success| crate::backend::BackendOutput {
+                stdout: success.stdout,
+                stderr: success.stderr,
+                status_success: true,
+                exit_code: 0,
+            })
+        }
+    }
+
+    fn flags(dry_run: bool) -> GlobalFlags {
+        GlobalFlags {
+            format: None,
+            remote: "origin".to_string(),
+            provider: None,
+            host: None,
+            repo: Some(REPO.to_string()),
+            store_root: None,
+            dry_run,
+        }
+    }
+
+    fn github_remote(_: &str) -> Option<String> {
+        Some("https://github.com/acme/widgets.git".to_string())
+    }
+
+    fn gitlab_remote(_: &str) -> Option<String> {
+        Some("https://gitlab.com/acme/widgets.git".to_string())
+    }
+
+    fn github_ctx() -> ProviderContext {
+        ProviderContext {
+            provider: Provider::GitHub,
+            host: "github.com".to_string(),
+            source: crate::provider::DetectionSource::Flag,
+            repo: Some(REPO.to_string()),
+        }
+    }
+
+    fn open_finding(fingerprint: &str) -> review_state::ReviewFindingObservation {
+        review_state::ReviewFindingObservation {
+            fingerprint: fingerprint.to_string(),
+            root_cause_fingerprint: None,
+            blocking: true,
+            status: review_state::ReviewFindingStatus::Open,
+            threads: Vec::new(),
+        }
+    }
+
+    fn genesis_state(
+        head: &str,
+        observations: &[review_state::ReviewFindingObservation],
+    ) -> review_state::ReviewLoopState {
+        review_state::observe_review_loop(None, head, observations)
+            .expect("genesis transition")
+            .state
+    }
+
+    fn findings_file(dir: &tempfile::TempDir, body: &str) -> String {
+        let path = dir.path().join("findings.json");
+        fs::write(&path, body).expect("write findings");
+        path.to_string_lossy().into_owned()
+    }
+
+    fn observe_args(
+        findings: &str,
+        expected_head: &str,
+        expected_state: Option<&str>,
+    ) -> PrReviewLoopObserveArgs {
+        PrReviewLoopObserveArgs {
+            id: PR,
+            expected_head: expected_head.to_string(),
+            findings_file: findings.to_string(),
+            expected_state: expected_state.map(str::to_string),
+        }
+    }
+
+    fn extend_args(
+        expected_head: &str,
+        expected_state: &str,
+        proposal: &str,
+    ) -> PrReviewLoopExtendArgs {
+        PrReviewLoopExtendArgs {
+            id: PR,
+            expected_head: expected_head.to_string(),
+            expected_state: expected_state.to_string(),
+            stop_code: "review_round_limit_exceeded".to_string(),
+            budget_field: "max_repair_rounds".to_string(),
+            increment: 1,
+            proposal_digest: proposal.to_string(),
+            approval_comment: 99,
+        }
+    }
+
+    fn stopped_state(head: &str, proposal: &str) -> review_state::ReviewLoopState {
+        review_state::ReviewLoopState {
+            head_sha: head.to_string(),
+            round: 1,
+            no_progress_rounds: 0,
+            budget: review_state::ReviewLoopBudget::default(),
+            findings: std::collections::BTreeMap::new(),
+            extensions: Vec::new(),
+            hard_stop: Some(review_state::ReviewLoopHardStop {
+                code: "review_round_limit_exceeded".to_string(),
+                budget_field: "max_repair_rounds".to_string(),
+                increment: 1,
+                proposal_digest: proposal.to_string(),
+                attempted_head_sha: head.to_string(),
+                observation_digest: "sha256:observation".to_string(),
+                extension_applied: false,
+            }),
+        }
+    }
+
+    fn approval_payload(created_at: &str, association: &str, body: &str) -> serde_json::Value {
+        serde_json::json!({
+            "html_url": "https://github.com/acme/widgets/pull/7#issuecomment-99",
+            "issue_url": "https://api.github.com/repos/acme/widgets/issues/7",
+            "user": {"login": "maintainer"},
+            "author_association": association,
+            "created_at": created_at,
+            "body": body
+        })
+    }
+
+    // --- inspect ---------------------------------------------------------
+
+    #[test]
+    fn inspect_dry_run_plans_without_touching_the_provider() {
+        let runner = FakeGitHub::new(HEAD);
+        let code = run_inspect_with(
+            &runner,
+            &flags(true),
+            PrReviewLoopInspectArgs { id: PR },
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect("dry run");
+
+        assert_eq!(code, 0);
+        assert_eq!(runner.calls(), Vec::<Vec<String>>::new());
+    }
+
+    #[test]
+    fn inspect_reports_the_existing_chain_without_appending() {
+        let state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+
+        let code = run_inspect_with(
+            &runner,
+            &flags(false),
+            PrReviewLoopInspectArgs { id: PR },
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect("inspect");
+
+        assert_eq!(code, 0);
+        assert_eq!(runner.appended_bodies(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn inspect_rejects_a_non_github_provider() {
+        let runner = FakeGitHub::new(HEAD);
+        let error = run_inspect_with(
+            &runner,
+            &flags(false),
+            PrReviewLoopInspectArgs { id: PR },
+            OutputFormat::Json,
+            gitlab_remote,
+        )
+        .expect_err("review-loop is GitHub-only in v1");
+
+        assert_eq!(error.kind(), "provider_unsupported");
+        assert_eq!(runner.calls(), Vec::<Vec<String>>::new());
+    }
+
+    // --- observe ---------------------------------------------------------
+
+    #[test]
+    fn observe_appends_the_genesis_observation() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(
+            &dir,
+            r#"{"data":{"findings":[{"lifecycle_fingerprint":"correctness:review-loop:one","primary":{"severity":"high"}}]}}"#,
+        );
+        let runner = FakeGitHub::new(HEAD);
+
+        let code = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args(&findings, HEAD, None),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect("genesis observation");
+
+        assert_eq!(code, 0);
+        assert_eq!(runner.appended_bodies().len(), 1);
+        let chain_state = review_state::parse_chain(
+            runner.appended_bodies().iter().map(String::as_str),
+            REPO,
+            PR,
+        )
+        .expect("appended chain");
+        let state = review_state::latest_review_loop_state(&chain_state).expect("state");
+        assert_eq!(state.head_sha, HEAD);
+        assert_eq!(state.round, 0);
+        assert!(state.findings.contains_key("correctness:review-loop:one"));
+    }
+
+    #[test]
+    fn observe_dry_run_reports_an_unreadable_findings_file_without_failing() {
+        let runner = FakeGitHub::new(HEAD);
+
+        let code = run_observe_with(
+            &runner,
+            &flags(true),
+            observe_args("/definitely/missing.json", HEAD, None),
+            OutputFormat::Text,
+            github_remote,
+        )
+        .expect("a failing preflight rule is reported, not returned as an error");
+
+        // The dry run is a faithful read-only preflight: it reaches the
+        // provider to evaluate the remaining rules even when the local
+        // findings file is unusable, and it still appends nothing.
+        assert_eq!(code, 0);
+        assert!(
+            !runner.calls().is_empty(),
+            "the preflight must actually read provider state"
+        );
+        assert_eq!(runner.appended_bodies(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn observe_dry_run_predicts_an_append_without_performing_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
+        let runner = FakeGitHub::new(HEAD);
+
+        let code = run_observe_with(
+            &runner,
+            &flags(true),
+            observe_args(&findings, HEAD, None),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect("clean preflight");
+
+        assert_eq!(code, 0);
+        assert_eq!(
+            runner.appended_bodies(),
+            Vec::<String>::new(),
+            "a dry run must never write the durable chain"
+        );
+    }
+
+    #[test]
+    fn observe_is_a_no_op_when_the_observation_matches_the_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
+        let state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let code = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args(&findings, HEAD, Some(&tip)),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect("unchanged observation");
+
+        assert_eq!(code, 0);
+        assert_eq!(
+            runner.appended_bodies(),
+            Vec::<String>::new(),
+            "an unchanged observation must not grow the durable chain"
+        );
+    }
+
+    #[test]
+    fn observe_rejects_a_head_that_the_provider_does_not_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
+        let runner = FakeGitHub::new(HEAD);
+
+        let error = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args(&findings, "head-mismatch", None),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("head mismatch");
+
+        assert_eq!(error.kind(), "review_state_conflict");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains("provider_head="),
+            "detail should name both heads: {:?}",
+            error.detail()
+        );
+        assert_eq!(runner.appended_bodies(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn observe_rejects_a_stale_expected_state_tip() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
+        let state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+
+        let error = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args(&findings, HEAD, Some("sha256:stale")),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("tip mismatch");
+
+        assert_eq!(error.kind(), "review_state_conflict");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains("expected_state=sha256:stale"),
+            "detail should name the stale tip: {:?}",
+            error.detail()
+        );
+    }
+
+    #[test]
+    fn observe_records_a_durable_hard_stop_before_failing_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
+        let mut state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        // Exhaust the repair-round budget so advancing to a new head stops.
+        state.budget.max_repair_rounds = 0;
+        let runner = FakeGitHub::new(NEXT_HEAD).with_state(&state, HEAD);
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let error = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args(&findings, NEXT_HEAD, Some(&tip)),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("budget exhausted");
+
+        assert_eq!(error.kind(), "review_round_limit_exceeded");
+        let detail = error.detail().unwrap_or_default();
+        assert!(
+            detail.contains("approval_marker=<!-- forge-cli:review-loop-extension:v1 "),
+            "the operator needs the exact approval marker: {detail}"
+        );
+        assert!(
+            detail.contains(&format!("attempted_head={NEXT_HEAD}")),
+            "detail should name the attempted head: {detail}"
+        );
+        assert_eq!(
+            runner.appended_bodies().len(),
+            1,
+            "the hard stop must be durable before the command fails"
+        );
+    }
+
+    #[test]
+    fn observe_replays_a_recorded_hard_stop_without_appending_again() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
+        let mut state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        state.budget.max_repair_rounds = 0;
+        let seeded = FakeGitHub::new(NEXT_HEAD).with_state(&state, HEAD);
+        let tip = seeded.tip_digest().expect("seeded tip");
+        run_observe_with(
+            &seeded,
+            &flags(false),
+            observe_args(&findings, NEXT_HEAD, Some(&tip)),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("first stop");
+        let stopped_tip = seeded.tip_digest().expect("stopped tip");
+        let appended_after_first = seeded.appended_bodies().len();
+
+        let error = run_observe_with(
+            &seeded,
+            &flags(false),
+            observe_args(&findings, NEXT_HEAD, Some(&stopped_tip)),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("stop is durable");
+
+        assert_eq!(error.kind(), "review_round_limit_exceeded");
+        assert_eq!(
+            seeded.appended_bodies().len(),
+            appended_after_first,
+            "a replayed hard stop must not append a second stop record"
+        );
+    }
+
+    #[test]
+    fn observe_rejects_an_unreadable_findings_file() {
+        let runner = FakeGitHub::new(HEAD);
+        let error = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args("/definitely/missing/findings.json", HEAD, None),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("missing findings file");
+
+        assert_eq!(error.kind(), "review_findings_invalid");
+        assert_eq!(runner.calls(), Vec::<Vec<String>>::new());
+    }
+
+    // --- extend ----------------------------------------------------------
+
+    #[test]
+    fn extend_dry_run_plans_without_touching_the_provider() {
+        let runner = FakeGitHub::new(HEAD);
+        let code = run_extend_with(
+            &runner,
+            &flags(true),
+            extend_args(HEAD, "sha256:tip", "sha256:proposal"),
+            OutputFormat::Text,
+            github_remote,
+        )
+        .expect("dry run");
+
+        assert_eq!(code, 0);
+        assert_eq!(runner.calls(), Vec::<Vec<String>>::new());
+    }
+
+    #[test]
+    fn extend_requires_an_existing_review_loop_state() {
+        let runner = FakeGitHub::new(HEAD);
+        let error = run_extend_with(
+            &runner,
+            &flags(false),
+            extend_args(HEAD, "sha256:tip", "sha256:proposal"),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("no chain to extend");
+
+        // A genesis chain has no tip, so the tip guard fires before the
+        // "state must exist" guard.
+        assert_eq!(error.kind(), "review_state_conflict");
+    }
+
+    #[test]
+    fn extend_rejects_a_state_without_a_durable_hard_stop() {
+        let state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let error = run_extend_with(
+            &runner,
+            &flags(false),
+            extend_args(HEAD, &tip, "sha256:proposal"),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("nothing to extend");
+
+        assert_eq!(error.kind(), "review_extension_invalid");
+    }
+
+    #[test]
+    fn extend_rejects_a_request_that_does_not_match_the_hard_stop() {
+        let state = stopped_state(HEAD, "sha256:proposal");
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let error = run_extend_with(
+            &runner,
+            &flags(false),
+            extend_args(HEAD, &tip, "sha256:other-proposal"),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("proposal digest mismatch");
+
+        assert_eq!(error.kind(), "review_extension_invalid");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains("expected_proposal=sha256:proposal"),
+            "detail should name the durable proposal: {:?}",
+            error.detail()
+        );
+    }
+
+    #[test]
+    fn extend_rejects_a_state_bound_to_a_different_head() {
+        let state = stopped_state(HEAD, "sha256:proposal");
+        let runner = FakeGitHub::new(NEXT_HEAD).with_state(&state, HEAD);
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let error = run_extend_with(
+            &runner,
+            &flags(false),
+            extend_args(NEXT_HEAD, &tip, "sha256:proposal"),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("head mismatch");
+
+        assert_eq!(error.kind(), "review_state_conflict");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains(&format!("state_head={HEAD}")),
+            "detail should name the bound head: {:?}",
+            error.detail()
+        );
+    }
+
+    #[test]
+    fn extend_rejects_an_approval_from_a_non_maintainer() {
+        let proposal = "sha256:proposal";
+        let state = stopped_state(HEAD, proposal);
+        let marker = extension_approval_marker(proposal, "max_repair_rounds", 1);
+        let runner = FakeGitHub::new(HEAD)
+            .with_state(&state, HEAD)
+            .with_approval(approval_payload("2026-07-20T12:00:01Z", "NONE", &marker));
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let error = run_extend_with(
+            &runner,
+            &flags(false),
+            extend_args(HEAD, &tip, proposal),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("outsider approval");
+
+        assert_eq!(error.kind(), "review_extension_approval_invalid");
+        assert_eq!(runner.appended_bodies(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn extend_rejects_an_approval_missing_required_metadata() {
+        let proposal = "sha256:proposal";
+        let state = stopped_state(HEAD, proposal);
+        let runner = FakeGitHub::new(HEAD)
+            .with_state(&state, HEAD)
+            .with_approval(serde_json::json!({
+                "html_url": "https://github.com/acme/widgets/pull/7#issuecomment-99",
+                "issue_url": "https://api.github.com/repos/acme/widgets/issues/7",
+                "user": {"login": "maintainer"},
+                "author_association": "MEMBER",
+                "created_at": "2026-07-20T12:00:01Z"
+            }));
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let error = run_extend_with(
+            &runner,
+            &flags(false),
+            extend_args(HEAD, &tip, proposal),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("approval body missing");
+
+        assert_eq!(error.kind(), "review_extension_approval_invalid");
+        assert!(
+            error.detail().unwrap_or_default().contains("field=/body"),
+            "detail should name the missing field: {:?}",
+            error.detail()
+        );
+    }
+
+    #[test]
+    fn extend_rejects_an_approval_on_another_pull_request() {
+        let proposal = "sha256:proposal";
+        let state = stopped_state(HEAD, proposal);
+        let marker = extension_approval_marker(proposal, "max_repair_rounds", 1);
+        let mut payload = approval_payload("2026-07-20T12:00:01Z", "MEMBER", &marker);
+        payload["issue_url"] =
+            serde_json::json!("https://api.github.com/repos/acme/widgets/issues/8");
+        let runner = FakeGitHub::new(HEAD)
+            .with_state(&state, HEAD)
+            .with_approval(payload);
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let error = run_extend_with(
+            &runner,
+            &flags(false),
+            extend_args(HEAD, &tip, proposal),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("approval belongs to another PR");
+
+        assert_eq!(error.kind(), "review_extension_approval_invalid");
+    }
+
+    #[test]
+    fn extend_applies_exactly_one_budget_increment() {
+        let proposal = "sha256:proposal";
+        let state = stopped_state(HEAD, proposal);
+        let marker = extension_approval_marker(proposal, "max_repair_rounds", 1);
+        let body = format!("Approving the extension.\n\n{marker}\n");
+        let runner = FakeGitHub::new(HEAD)
+            .with_state(&state, HEAD)
+            .with_approval(approval_payload("2026-07-20T12:00:01Z", "MEMBER", &body));
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let code = run_extend_with(
+            &runner,
+            &flags(false),
+            extend_args(HEAD, &tip, proposal),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect("extension applied");
+
+        assert_eq!(code, 0);
+        assert_eq!(runner.appended_bodies().len(), 1);
+        let bodies: Vec<String> = runner
+            .comments
+            .borrow()
+            .iter()
+            .map(|node| node["body"].as_str().unwrap_or_default().to_string())
+            .collect();
+        let chain = review_state::parse_chain(bodies.iter().map(String::as_str), REPO, PR)
+            .expect("extended chain");
+        let extended = review_state::latest_review_loop_state(&chain).expect("state");
+        assert_eq!(
+            extended.budget.max_repair_rounds,
+            review_state::ReviewLoopBudget::default().max_repair_rounds + 1
+        );
+        assert_eq!(extended.extensions.len(), 1);
+        assert_eq!(extended.extensions[0].proposal_digest, proposal);
+        assert!(
+            extended
+                .hard_stop
+                .as_ref()
+                .expect("stop retained")
+                .extension_applied,
+            "the consumed hard stop must be marked applied so it cannot be replayed"
+        );
+    }
+
+    // --- merge gates -----------------------------------------------------
+
+    #[test]
+    fn merge_gate_is_optional_without_a_ledger() {
+        let runner = FakeGitHub::new(HEAD);
+        let gate = ensure_merge_ready(
+            &runner,
+            &github_ctx(),
+            "https://github.com/acme/widgets/pull/7",
+            PR,
+            HEAD,
+            false,
+        )
+        .expect("no ledger is allowed when not required");
+
+        assert_eq!(gate, None);
+    }
+
+    #[test]
+    fn merge_gate_requires_a_genesis_ledger_when_bounded() {
+        let runner = FakeGitHub::new(HEAD);
+        let error = ensure_merge_ready(
+            &runner,
+            &github_ctx(),
+            "https://github.com/acme/widgets/pull/7",
+            PR,
+            HEAD,
+            true,
+        )
+        .expect_err("bounded delivery needs a ledger");
+
+        assert_eq!(error.kind(), "review_state_conflict");
+    }
+
+    #[test]
+    fn merge_gate_rejects_a_pull_request_url_without_a_repo_slug() {
+        let runner = FakeGitHub::new(HEAD);
+        let error = ensure_merge_ready(&runner, &github_ctx(), "not-a-url", PR, HEAD, false)
+            .expect_err("unusable URL");
+
+        assert_eq!(error.kind(), "software_error");
+    }
+
+    #[test]
+    fn merge_gate_blocks_on_a_durable_hard_stop() {
+        let state = stopped_state(HEAD, "sha256:proposal");
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+
+        let error = ensure_merge_ready(
+            &runner,
+            &github_ctx(),
+            "https://github.com/acme/widgets/pull/7",
+            PR,
+            HEAD,
+            true,
+        )
+        .expect_err("hard stop blocks merge");
+
+        assert_eq!(error.kind(), "review_round_limit_exceeded");
+    }
+
+    #[test]
+    fn merge_gate_rejects_a_ledger_bound_to_another_head() {
+        let state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+
+        let error = ensure_merge_ready(
+            &runner,
+            &github_ctx(),
+            "https://github.com/acme/widgets/pull/7",
+            PR,
+            NEXT_HEAD,
+            true,
+        )
+        .expect_err("ledger head mismatch");
+
+        assert_eq!(error.kind(), "review_state_conflict");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains("review_loop_head="),
+            "detail should name both heads: {:?}",
+            error.detail()
+        );
+    }
+
+    #[test]
+    fn merge_gate_rejects_open_blocking_findings() {
+        let state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+
+        let error = ensure_merge_ready(
+            &runner,
+            &github_ctx(),
+            "https://github.com/acme/widgets/pull/7",
+            PR,
+            HEAD,
+            true,
+        )
+        .expect_err("blocking findings stay open");
+
+        assert_eq!(error.kind(), "review_findings_open");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains("findings=correctness:review-loop:one"),
+            "detail should name the open finding: {:?}",
+            error.detail()
+        );
+    }
+
+    #[test]
+    fn merge_gate_reports_the_tip_for_a_clean_ledger() {
+        let mut observation = open_finding("correctness:review-loop:one");
+        observation.status = review_state::ReviewFindingStatus::Fixed;
+        let state = genesis_state(HEAD, &[observation]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let gate = ensure_merge_ready(
+            &runner,
+            &github_ctx(),
+            "https://github.com/acme/widgets/pull/7",
+            PR,
+            HEAD,
+            true,
+        )
+        .expect("clean ledger")
+        .expect("gate present");
+
+        assert_eq!(gate.state_tip_digest, tip);
+        assert_eq!(gate.head_sha, HEAD);
+        assert_eq!(gate.round, 0);
+        assert_eq!(gate.no_progress_rounds, 0);
+        assert_eq!(gate.open_blocking_findings, Vec::<String>::new());
+    }
+
+    #[test]
+    fn merge_recheck_accepts_an_unchanged_tip() {
+        let mut observation = open_finding("correctness:review-loop:one");
+        observation.status = review_state::ReviewFindingStatus::Fixed;
+        let state = genesis_state(HEAD, &[observation]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+        let previous = ensure_merge_ready(
+            &runner,
+            &github_ctx(),
+            "https://github.com/acme/widgets/pull/7",
+            PR,
+            HEAD,
+            true,
+        )
+        .expect("gate")
+        .expect("gate present");
+
+        let current = recheck_merge_ready(
+            &runner,
+            &github_ctx(),
+            "https://github.com/acme/widgets/pull/7",
+            PR,
+            HEAD,
+            &previous,
+        )
+        .expect("tip unchanged");
+
+        assert_eq!(current, previous);
+    }
+
+    #[test]
+    fn merge_recheck_rejects_a_tip_that_moved_before_merge() {
+        let mut observation = open_finding("correctness:review-loop:one");
+        observation.status = review_state::ReviewFindingStatus::Fixed;
+        let state = genesis_state(HEAD, &[observation]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+        let previous = ReviewLoopMergeGate {
+            state_tip_digest: "sha256:previous".to_string(),
+            head_sha: HEAD.to_string(),
+            round: 0,
+            no_progress_rounds: 0,
+            open_blocking_findings: Vec::new(),
+        };
+
+        let error = recheck_merge_ready(
+            &runner,
+            &github_ctx(),
+            "https://github.com/acme/widgets/pull/7",
+            PR,
+            HEAD,
+            &previous,
+        )
+        .expect_err("tip moved");
+
+        assert_eq!(error.kind(), "review_state_conflict");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains("expected_tip=sha256:previous"),
+            "detail should name both tips: {:?}",
+            error.detail()
+        );
+    }
+
+    // --- findings parsing ------------------------------------------------
+
+    #[test]
+    fn findings_input_accepts_envelope_wrapper_and_bare_array() {
+        let dir = tempfile::tempdir().unwrap();
+        let envelope = findings_file(
+            &dir,
+            r#"{"data":{"findings":[{"fingerprint":"a"},{"fingerprint":"b"}]}}"#,
+        );
+        assert_eq!(read_observations(&envelope).expect("envelope").len(), 2);
+
+        let dir = tempfile::tempdir().unwrap();
+        let bare = findings_file(&dir, r#"[{"fingerprint":"a"}]"#);
+        assert_eq!(read_observations(&bare).expect("bare array").len(), 1);
+
+        let dir = tempfile::tempdir().unwrap();
+        let findings_key = findings_file(&dir, r#"{"findings":[{"fingerprint":"a"}]}"#);
+        assert_eq!(
+            read_observations(&findings_key)
+                .expect("findings key")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn findings_input_rejects_invalid_json_and_non_array_shapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let broken = findings_file(&dir, "{ not json");
+        assert_eq!(
+            read_observations(&broken).expect_err("invalid JSON").kind(),
+            "review_findings_invalid"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let scalar = findings_file(&dir, r#"{"findings":42}"#);
+        assert_eq!(
+            read_observations(&scalar)
+                .expect_err("findings must be an array")
+                .kind(),
+            "review_findings_invalid"
+        );
+    }
+
+    #[test]
+    fn observation_requires_a_lifecycle_fingerprint() {
+        let error = observation_from_value(&serde_json::json!({"blocking": true}))
+            .expect_err("fingerprint is mandatory");
+        assert_eq!(error.kind(), "review_fingerprint_required");
+
+        let empty = observation_from_value(&serde_json::json!({"fingerprint": ""}))
+            .expect_err("empty fingerprint is not a fingerprint");
+        assert_eq!(empty.kind(), "review_fingerprint_required");
+    }
+
+    #[test]
+    fn observation_reads_disposition_severity_and_threads() {
+        let info_only = observation_from_value(&serde_json::json!({
+            "fingerprint": "style:review-loop:one",
+            "primary": {"severity": "info"}
+        }))
+        .expect("observation");
+        assert!(
+            !info_only.blocking,
+            "an info-severity finding must not block by default"
+        );
+
+        let explicit = observation_from_value(&serde_json::json!({
+            "fingerprint": "correctness:review-loop:two",
+            "blocking": false,
+            "disposition": "fixed",
+            "root_cause_fingerprint": "correctness:review-loop:root",
+            "threads": ["PRRT_1", 42]
+        }))
+        .expect("observation");
+        assert!(!explicit.blocking);
+        assert_eq!(explicit.status, review_state::ReviewFindingStatus::Fixed);
+        assert_eq!(
+            explicit.root_cause_fingerprint.as_deref(),
+            Some("correctness:review-loop:root")
+        );
+        assert_eq!(explicit.threads, vec!["PRRT_1".to_string()]);
+    }
+
+    #[test]
+    fn finding_status_parses_every_supported_disposition() {
+        assert_eq!(
+            parse_finding_status("open").expect("open"),
+            review_state::ReviewFindingStatus::Open
+        );
+        assert_eq!(
+            parse_finding_status("fixed").expect("fixed"),
+            review_state::ReviewFindingStatus::Fixed
+        );
+        assert_eq!(
+            parse_finding_status("accepted").expect("accepted"),
+            review_state::ReviewFindingStatus::Accepted
+        );
+        assert_eq!(
+            parse_finding_status("preference").expect("preference"),
+            review_state::ReviewFindingStatus::Preference
+        );
+        assert_eq!(
+            parse_finding_status("follow-up").expect("follow-up"),
+            review_state::ReviewFindingStatus::FollowUp
+        );
+        assert_eq!(
+            parse_finding_status("wontfix")
+                .expect_err("unsupported disposition")
+                .kind(),
+            "review_findings_invalid"
+        );
+    }
+
+    #[test]
+    fn expected_tip_guard_names_genesis_on_both_sides() {
+        ensure_expected_tip(None, None).expect("genesis matches genesis");
+        let error = ensure_expected_tip(Some("sha256:provider"), None)
+            .expect_err("provider is ahead of genesis");
+        assert_eq!(error.kind(), "review_state_conflict");
+        let detail = error.detail().unwrap_or_default();
+        assert!(
+            detail.contains("expected_state=<genesis>"),
+            "genesis must be spelled out: {detail}"
+        );
+        assert!(
+            detail.contains("provider_state=sha256:provider"),
+            "{detail}"
         );
     }
 }

--- a/crates/forge-cli/src/ops/repo_bootstrap.rs
+++ b/crates/forge-cli/src/ops/repo_bootstrap.rs
@@ -1471,3 +1471,473 @@ fn software_with_detail(message: impl Into<String>, detail: String) -> ForgeErro
 fn error_schema() -> String {
     schema_version_for(BINARY, "error", 1)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    fn receipt(files: Vec<ReceiptFile>) -> BootstrapReceipt {
+        BootstrapReceipt {
+            schema_version: RECEIPT_SCHEMA.to_string(),
+            provider: "forgejo".to_string(),
+            repository: "acme/widgets".to_string(),
+            owner_kind: RepoBootstrapOwnerKind::User,
+            default_branch: "main".to_string(),
+            message: "chore: bootstrap".to_string(),
+            reason: "new private repository".to_string(),
+            files,
+            create_attempted: false,
+            remote_created: false,
+            local_sha: None,
+            push_attempted: false,
+            default_branch_set: false,
+            complete: false,
+            reconciled: false,
+        }
+    }
+
+    fn write(dir: &Path, name: &str, contents: &[u8]) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn bootstrap_inputs_must_be_named_bounded_regular_files() {
+        let tmp = TempDir::new().unwrap();
+        let readme = write(tmp.path(), "README.md", b"# widgets\n");
+        let license = write(tmp.path(), "LICENSE", b"MIT\n");
+
+        let files = prepare_files(&[readme.clone(), license]).expect("two root files");
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].name, "README.md");
+        assert_eq!(files[0].bytes, 10);
+        assert_eq!(files[0].sha256, sha256_hex(b"# widgets\n"));
+        assert!(
+            Path::new(&files[0].source).is_absolute(),
+            "the receipt records a canonical source path"
+        );
+
+        // A directory, a missing path, and a duplicate root name are all refused.
+        assert_eq!(
+            prepare_files(&[tmp.path().to_path_buf()])
+                .expect_err("directory")
+                .kind(),
+            "bootstrap_file_invalid"
+        );
+        assert_eq!(
+            prepare_files(&[tmp.path().join("absent")])
+                .expect_err("missing")
+                .kind(),
+            "bootstrap_file_invalid"
+        );
+        let nested = tmp.path().join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        let duplicate = write(&nested, "README.md", b"other\n");
+        assert_eq!(
+            prepare_files(&[readme, duplicate])
+                .expect_err("duplicate root name")
+                .kind(),
+            "bootstrap_file_invalid"
+        );
+
+        assert!(prepare_files(&[]).expect("no files").is_empty());
+    }
+
+    #[test]
+    fn a_repository_root_name_may_not_collide_with_git_metadata() {
+        assert!(valid_root_name("README.md"));
+        assert!(valid_root_name("a"));
+        for reserved in ["", ".", "..", ".git", "dir/file", "with\0nul"] {
+            assert!(!valid_root_name(reserved), "{reserved:?}");
+        }
+        assert!(!valid_root_name(&"x".repeat(256)));
+        assert!(valid_root_name(&"x".repeat(255)));
+    }
+
+    #[test]
+    fn the_default_branch_must_be_a_safe_git_ref() {
+        for good in ["main", "release/1.0", "a-b_c.d"] {
+            validate_branch(good).unwrap_or_else(|error| panic!("{good}: {error:?}"));
+        }
+        for bad in [
+            "",
+            "/main",
+            "main/",
+            "main.",
+            "a..b",
+            "a//b",
+            "a/./b",
+            "a/b.lock",
+            "with space",
+            "with~tilde",
+            &"x".repeat(256),
+        ] {
+            assert_eq!(
+                validate_branch(bad).expect_err("unsafe branch").kind(),
+                "bootstrap_default_branch_invalid",
+                "{bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_commit_message_must_be_bounded_non_empty_text() {
+        validate_message("chore: bootstrap").expect("message");
+        for bad in ["", "   ", "with\0nul", &"x".repeat(10_001)] {
+            assert_eq!(
+                validate_message(bad).expect_err("invalid message").kind(),
+                "bootstrap_message_invalid",
+                "{bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_a_full_object_id_is_accepted_from_git() {
+        validate_oid(&"a".repeat(40)).expect("sha1");
+        validate_oid(&"F".repeat(64)).expect("sha256");
+        for bad in ["", "abc", &"z".repeat(40), &"a".repeat(41)] {
+            assert_eq!(
+                validate_oid(bad).expect_err("invalid oid").kind(),
+                "software_error",
+                "{bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_digest_helper_is_lowercase_hex() {
+        let digest = sha256_hex(b"payload");
+        assert_eq!(digest.len(), 64);
+        assert!(
+            digest
+                .bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        );
+        assert_ne!(digest, sha256_hex(b"payload2"));
+    }
+
+    #[test]
+    fn nul_separated_git_output_drops_empty_entries() {
+        assert_eq!(
+            nul_entries("README.md\0LICENSE\0"),
+            vec!["README.md".to_string(), "LICENSE".to_string()]
+        );
+        assert!(nul_entries("").is_empty());
+        assert!(nul_entries("\0\0").is_empty());
+    }
+
+    #[test]
+    fn an_authorization_file_must_be_bounded_non_empty_utf8() {
+        let tmp = TempDir::new().unwrap();
+        let path = write(tmp.path(), "reason.md", b"  bootstrap the repo \n");
+
+        assert_eq!(
+            read_small_regular_file(&path, 1024, "reason").expect("reason"),
+            "bootstrap the repo"
+        );
+
+        for (contents, label) in [
+            (b"".to_vec(), "empty"),
+            (b"   \n".to_vec(), "blank"),
+            (b"has a \x07 bell".to_vec(), "control byte"),
+        ] {
+            fs::write(&path, contents).unwrap();
+            assert_eq!(
+                read_small_regular_file(&path, 1024, "reason")
+                    .expect_err(label)
+                    .kind(),
+                "bootstrap_authorization_invalid",
+                "{label}"
+            );
+        }
+
+        fs::write(&path, b"x".repeat(2048)).unwrap();
+        assert_eq!(
+            read_small_regular_file(&path, 1024, "reason")
+                .expect_err("oversized")
+                .kind(),
+            "bootstrap_authorization_invalid"
+        );
+
+        assert_eq!(
+            read_small_regular_file(tmp.path(), 1024, "reason")
+                .expect_err("directory")
+                .kind(),
+            "bootstrap_authorization_invalid"
+        );
+        assert_eq!(
+            read_small_regular_file(&tmp.path().join("absent"), 1024, "reason")
+                .expect_err("missing")
+                .kind(),
+            "bootstrap_authorization_invalid"
+        );
+    }
+
+    #[test]
+    fn a_resumed_receipt_must_match_the_exact_requested_inputs() {
+        let expected = receipt(Vec::new());
+        validate_receipt_inputs(&receipt(Vec::new()), &expected).expect("identical inputs");
+
+        for mutate in [
+            (|r: &mut BootstrapReceipt| r.schema_version = "other.v9".to_string())
+                as fn(&mut BootstrapReceipt),
+            |r: &mut BootstrapReceipt| r.provider = "github".to_string(),
+            |r: &mut BootstrapReceipt| r.repository = "acme/other".to_string(),
+            |r: &mut BootstrapReceipt| r.owner_kind = RepoBootstrapOwnerKind::Org,
+            |r: &mut BootstrapReceipt| r.default_branch = "trunk".to_string(),
+            |r: &mut BootstrapReceipt| r.message = "chore: other".to_string(),
+            |r: &mut BootstrapReceipt| r.reason = "other".to_string(),
+            |r: &mut BootstrapReceipt| {
+                r.files = vec![ReceiptFile {
+                    source: "/tmp/README.md".to_string(),
+                    name: "README.md".to_string(),
+                    sha256: sha256_hex(b""),
+                    bytes: 0,
+                }]
+            },
+        ] {
+            let mut actual = receipt(Vec::new());
+            mutate(&mut actual);
+            assert_eq!(
+                validate_receipt_inputs(&actual, &expected)
+                    .expect_err("input drift")
+                    .kind(),
+                "bootstrap_receipt_mismatch"
+            );
+        }
+
+        // Progress fields are allowed to differ; only the inputs are pinned.
+        let mut resumed = receipt(Vec::new());
+        resumed.create_attempted = true;
+        resumed.remote_created = true;
+        resumed.local_sha = Some("a".repeat(40));
+        validate_receipt_inputs(&resumed, &expected).expect("progress may advance");
+    }
+
+    #[test]
+    fn a_provider_branch_read_back_must_carry_a_verified_signature() {
+        let sha = "a".repeat(40);
+        let verified = serde_json::json!({
+            "sha": sha,
+            "commit": {"verification": {"verified": true}}
+        });
+        verify_provider_signature(&verified, &sha).expect("verified");
+
+        let unverified = serde_json::json!({
+            "sha": sha,
+            "commit": {"verification": {"verified": false}}
+        });
+        assert_eq!(
+            verify_provider_signature(&unverified, &sha)
+                .expect_err("unverified")
+                .kind(),
+            "provider_signature_unverified"
+        );
+
+        let drifted = serde_json::json!({
+            "sha": "b".repeat(40),
+            "commit": {"verification": {"verified": true}}
+        });
+        assert_eq!(
+            verify_provider_signature(&drifted, &sha)
+                .expect_err("drift")
+                .kind(),
+            "remote_drift"
+        );
+        assert_eq!(
+            verify_provider_signature(&serde_json::json!({}), &sha)
+                .expect_err("missing sha")
+                .kind(),
+            "remote_drift"
+        );
+    }
+
+    #[test]
+    fn a_branch_read_back_must_expose_its_commit_id() {
+        assert_eq!(branch_sha(None).expect("absent branch"), None);
+        assert_eq!(
+            branch_sha(Some(serde_json::json!({"commit": {"id": "abc"}}))).expect("present"),
+            Some("abc".to_string())
+        );
+        assert_eq!(
+            branch_sha(Some(serde_json::json!({})))
+                .expect_err("missing commit id")
+                .kind(),
+            "software_error"
+        );
+    }
+
+    #[test]
+    fn a_receipt_round_trips_through_its_private_on_disk_form() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state").join("receipt.json");
+        let receipt = receipt(Vec::new());
+
+        assert!(load_receipt(&path).expect("absent receipt").is_none());
+
+        create_receipt(&path, &receipt).expect("create");
+        let loaded = load_receipt(&path).expect("load").expect("present");
+        assert_eq!(loaded.repository, receipt.repository);
+        assert_eq!(
+            fs::symlink_metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "the receipt must not be group- or world-readable"
+        );
+
+        // A second create races against the durable receipt and must ask for
+        // an explicit resume rather than overwrite it.
+        assert_eq!(
+            create_receipt(&path, &receipt)
+                .expect_err("already created")
+                .kind(),
+            "bootstrap_resume_required"
+        );
+
+        let mut advanced = receipt;
+        advanced.remote_created = true;
+        persist_receipt(&path, &advanced).expect("persist");
+        assert!(
+            load_receipt(&path)
+                .expect("load")
+                .expect("present")
+                .remote_created
+        );
+    }
+
+    #[test]
+    fn a_world_readable_or_malformed_receipt_is_refused() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("receipt.json");
+
+        fs::write(&path, b"{}").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(
+            load_receipt(&path).expect_err("world readable").kind(),
+            "bootstrap_receipt_unsafe"
+        );
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        assert_eq!(
+            load_receipt(&path).expect_err("not a receipt").kind(),
+            "bootstrap_receipt_invalid"
+        );
+
+        // A directory in the receipt slot is not a receipt at all.
+        let dir = tmp.path().join("dir-receipt");
+        fs::create_dir(&dir).unwrap();
+        assert_eq!(
+            load_receipt(&dir).expect_err("directory").kind(),
+            "bootstrap_receipt_unsafe"
+        );
+    }
+
+    #[test]
+    fn receipt_bytes_are_bounded_and_pretty_printed() {
+        let bytes = receipt_bytes(&receipt(Vec::new())).expect("bytes");
+
+        assert!(bytes.len() < MAX_RECEIPT_BYTES);
+        let text = String::from_utf8(bytes).expect("utf-8");
+        assert!(text.contains('\n'), "the receipt is pretty-printed");
+        assert!(text.contains(RECEIPT_SCHEMA));
+    }
+
+    #[test]
+    fn the_state_directory_must_be_a_real_private_directory() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("state");
+
+        create_private_dir(&dir).expect("create");
+        assert_eq!(
+            fs::symlink_metadata(&dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        create_private_dir(&dir).expect("idempotent");
+
+        let file = write(tmp.path(), "not-a-dir", b"x");
+        assert_eq!(
+            create_private_dir(&file)
+                .expect_err("file in the way")
+                .kind(),
+            "bootstrap_state_unsafe"
+        );
+    }
+
+    #[test]
+    fn a_managed_checkout_must_hold_exactly_the_receipt_files() {
+        let tmp = TempDir::new().unwrap();
+        let checkout = tmp.path().join("checkout");
+        fs::create_dir_all(checkout.join(".git")).unwrap();
+        fs::write(checkout.join("README.md"), b"# widgets\n").unwrap();
+        let files = vec![ReceiptFile {
+            source: "/tmp/README.md".to_string(),
+            name: "README.md".to_string(),
+            sha256: sha256_hex(b"# widgets\n"),
+            bytes: 10,
+        }];
+
+        validate_checkout_files(&checkout, &files).expect("exact match");
+
+        // An extra root file was never authorized.
+        fs::write(checkout.join("EXTRA"), b"x").unwrap();
+        assert_eq!(
+            validate_checkout_files(&checkout, &files)
+                .expect_err("extra file")
+                .kind(),
+            "bootstrap_checkout_mismatch"
+        );
+        fs::remove_file(checkout.join("EXTRA")).unwrap();
+
+        // Changed content must not be delivered under the reviewed digest.
+        fs::write(checkout.join("README.md"), b"# tampered\n").unwrap();
+        assert_eq!(
+            validate_checkout_files(&checkout, &files)
+                .expect_err("content drift")
+                .kind(),
+            "bootstrap_checkout_mismatch"
+        );
+
+        assert_eq!(
+            validate_checkout_files(&tmp.path().join("absent"), &files)
+                .expect_err("missing checkout")
+                .kind(),
+            "bootstrap_checkout_unavailable"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_checkout_entry_is_never_accepted() {
+        let tmp = TempDir::new().unwrap();
+        let checkout = tmp.path().join("checkout");
+        fs::create_dir_all(&checkout).unwrap();
+        let outside = write(tmp.path(), "outside", b"# widgets\n");
+        std::os::unix::fs::symlink(&outside, checkout.join("README.md")).unwrap();
+        let files = vec![ReceiptFile {
+            source: "/tmp/README.md".to_string(),
+            name: "README.md".to_string(),
+            sha256: sha256_hex(b"# widgets\n"),
+            bytes: 10,
+        }];
+
+        assert_eq!(
+            validate_checkout_files(&checkout, &files)
+                .expect_err("symlinked entry")
+                .kind(),
+            "bootstrap_checkout_mismatch"
+        );
+    }
+
+    #[test]
+    fn remote_drift_names_both_object_ids() {
+        let error = remote_drift("aaa", "bbb");
+
+        assert_eq!(error.kind(), "remote_drift");
+        assert!(error.message().contains("expected aaa"), "{error:?}");
+        assert!(error.message().contains("observed bbb"), "{error:?}");
+    }
+}

--- a/crates/forge-cli/src/ops/repo_push_default.rs
+++ b/crates/forge-cli/src/ops/repo_push_default.rs
@@ -1256,4 +1256,310 @@ mod tests {
         assert_eq!(locator, "internal.ghe.com/sympoies/demo");
         assert_eq!(locator.matches("internal.ghe.com").count(), 1);
     }
+
+    // -----------------------------------------------------------------
+    // Direct-main delivery is the one path that writes to a protected
+    // branch. Each guard below is what binds the push to the exact remote,
+    // repository, and reviewed reason the operator authorized.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn a_push_destination_must_be_exactly_one_url() {
+        assert_eq!(
+            unique_push_url("  git@github.com:acme/widgets.git \n", "origin").expect("single"),
+            "git@github.com:acme/widgets.git"
+        );
+
+        assert_eq!(
+            unique_push_url("\n  \n", "origin")
+                .expect_err("no destination")
+                .kind(),
+            "push_destination_missing"
+        );
+        assert_eq!(
+            unique_push_url("url-a\nurl-b\n", "origin")
+                .expect_err("two destinations")
+                .kind(),
+            "push_destination_ambiguous"
+        );
+    }
+
+    #[test]
+    fn an_http_push_url_may_not_embed_credentials() {
+        for allowed in [
+            "https://github.com/acme/widgets.git",
+            "git@github.com:acme/widgets.git",
+            "ssh://git@github.com/acme/widgets.git",
+            "/srv/mirrors/widgets.git",
+        ] {
+            reject_http_push_url_userinfo(allowed).unwrap_or_else(|error| {
+                panic!("{allowed} must be accepted: {error:?}");
+            });
+        }
+
+        for hostile in [
+            "https://user:token@github.com/acme/widgets.git",
+            "http://token@github.com/acme/widgets.git",
+            "HTTPS://user@github.com/acme/widgets.git",
+        ] {
+            assert_eq!(
+                reject_http_push_url_userinfo(hostile)
+                    .expect_err("userinfo")
+                    .kind(),
+                "push_destination_credentials_unsupported",
+                "{hostile}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_remote_slug_must_match_the_provider_repository() {
+        bind_remote_repository("git@github.com:acme/widgets.git", "acme/widgets")
+            .expect("exact slug");
+        bind_remote_repository("https://github.com/ACME/Widgets.git", "acme/widgets")
+            .expect("slug comparison is case-insensitive");
+
+        assert_eq!(
+            bind_remote_repository("git@github.com:acme/other.git", "acme/widgets")
+                .expect_err("different repo")
+                .kind(),
+            "repository_mismatch"
+        );
+        assert_eq!(
+            bind_remote_repository("not-a-remote-url", "acme/widgets")
+                .expect_err("unparseable remote")
+                .kind(),
+            "repository_mismatch"
+        );
+    }
+
+    #[test]
+    fn the_push_authority_must_match_the_resolved_forge_authority() {
+        bind_remote_authority(
+            Provider::GitHub,
+            "github.com",
+            "git@github.com:acme/widgets.git",
+        )
+        .expect("same authority");
+
+        assert_eq!(
+            bind_remote_authority(
+                Provider::GitHub,
+                "github.com",
+                "git@internal.ghe.com:acme/widgets.git"
+            )
+            .expect_err("different authority")
+            .kind(),
+            "provider_mismatch"
+        );
+        assert_eq!(
+            bind_remote_authority(Provider::GitHub, "github.com", "not-a-url")
+                .expect_err("unparseable push url")
+                .kind(),
+            "provider_mismatch"
+        );
+    }
+
+    #[test]
+    fn provider_metadata_must_describe_the_same_host_and_repository() {
+        bind_remote_metadata(
+            Provider::GitHub,
+            "git@github.com:acme/widgets.git",
+            "https://github.com/acme/widgets",
+            "acme/widgets",
+        )
+        .expect("matching metadata");
+
+        // A metadata record for another host or repository would let a push
+        // be authorized against the wrong destination.
+        for (push, metadata, repository) in [
+            (
+                "git@github.com:acme/widgets.git",
+                "https://internal.ghe.com/acme/widgets",
+                "acme/widgets",
+            ),
+            (
+                "git@github.com:acme/widgets.git",
+                "https://github.com/acme/other",
+                "acme/widgets",
+            ),
+            (
+                "not-a-url",
+                "https://github.com/acme/widgets",
+                "acme/widgets",
+            ),
+            (
+                "git@github.com:acme/widgets.git",
+                "not-a-url",
+                "acme/widgets",
+            ),
+        ] {
+            assert_eq!(
+                bind_remote_metadata(Provider::GitHub, push, metadata, repository)
+                    .expect_err("mismatch")
+                    .kind(),
+                "repository_mismatch",
+                "{push} vs {metadata}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_remote_host_must_agree_with_the_selected_provider() {
+        bind_remote_provider("git@github.com:acme/widgets.git", Provider::GitHub)
+            .expect("github remote with github provider");
+
+        assert_eq!(
+            bind_remote_provider("git@gitlab.com:acme/widgets.git", Provider::GitHub)
+                .expect_err("provider mismatch")
+                .kind(),
+            "provider_mismatch"
+        );
+        assert_eq!(
+            bind_remote_provider("not-a-url", Provider::GitHub)
+                .expect_err("unparseable remote")
+                .kind(),
+            "provider_mismatch"
+        );
+        // The local provider has no protected default branch to push to.
+        assert_eq!(
+            bind_remote_provider("git@github.com:acme/widgets.git", Provider::Local)
+                .expect_err("local provider")
+                .kind(),
+            "provider_unsupported"
+        );
+    }
+
+    #[test]
+    fn only_a_full_hexadecimal_object_id_is_accepted() {
+        let sha1 = "A".repeat(40);
+        assert_eq!(validate_object_id(&sha1).expect("sha1"), "a".repeat(40));
+        let sha256 = "0".repeat(64);
+        assert_eq!(
+            validate_object_id(&format!("  {sha256}\n")).expect("sha256"),
+            sha256
+        );
+
+        for bad in [
+            "".to_string(),
+            "abc".to_string(),
+            "z".repeat(40),
+            "a".repeat(41),
+            "a".repeat(63),
+        ] {
+            assert_eq!(
+                validate_object_id(&bad).expect_err("invalid").kind(),
+                "object_id_invalid",
+                "{bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_reason_file_must_be_a_small_regular_utf8_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("reason.md");
+
+        std::fs::write(&path, "  direct main because CI is down\n").unwrap();
+        assert_eq!(
+            read_reason(&path).expect("reason"),
+            "direct main because CI is down"
+        );
+
+        assert_eq!(
+            read_reason(&tmp.path().join("absent.md"))
+                .expect_err("missing file")
+                .kind(),
+            "reason_file_unreadable"
+        );
+
+        assert_eq!(
+            read_reason(tmp.path()).expect_err("directory").kind(),
+            "reason_invalid"
+        );
+
+        std::fs::write(&path, "   \n\t ").unwrap();
+        assert_eq!(
+            read_reason(&path).expect_err("blank").kind(),
+            "reason_invalid"
+        );
+
+        std::fs::write(&path, "x".repeat(MAX_REASON_BYTES + 1)).unwrap();
+        assert_eq!(
+            read_reason(&path).expect_err("oversized").kind(),
+            "reason_invalid"
+        );
+        // Exactly at the limit is still accepted.
+        std::fs::write(&path, "x".repeat(MAX_REASON_BYTES)).unwrap();
+        assert_eq!(
+            read_reason(&path).expect("at limit").len(),
+            MAX_REASON_BYTES
+        );
+
+        std::fs::write(&path, [0x66, 0xff, 0x66]).unwrap();
+        assert_eq!(
+            read_reason(&path).expect_err("invalid utf-8").kind(),
+            "reason_invalid"
+        );
+
+        std::fs::write(&path, "reason with a \u{7} bell").unwrap();
+        assert_eq!(
+            read_reason(&path).expect_err("control character").kind(),
+            "reason_invalid"
+        );
+        // Ordinary whitespace control characters stay allowed.
+        std::fs::write(&path, "line one\nline\ttwo\r\n").unwrap();
+        read_reason(&path).expect("newlines and tabs are fine");
+    }
+
+    #[test]
+    fn a_receipt_path_that_is_not_a_governed_receipt_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("receipt.json");
+        std::fs::write(&path, "{ not a receipt").unwrap();
+
+        let error = read_default_branch_receipt(&path).expect_err("invalid receipt");
+
+        assert_eq!(error.kind(), "default_branch_receipt_invalid");
+        assert!(
+            error.detail().is_some(),
+            "the parse failure must be reported"
+        );
+    }
+
+    #[test]
+    fn text_rendering_distinguishes_a_dry_run_from_a_real_push() {
+        let payload = RepoPushDefaultPayload {
+            provider: "github",
+            repository: "acme/widgets".to_string(),
+            remote: "origin".to_string(),
+            default_branch: "main".to_string(),
+            authoring_branch: "chore/direct".to_string(),
+            head: "chore/direct".to_string(),
+            head_sha: "a".repeat(40),
+            expected_base: "b".repeat(40),
+            reason: "CI is down".to_string(),
+            push_refspec: "HEAD:refs/heads/main".to_string(),
+            pushed: false,
+            observed_remote_sha: String::new(),
+        };
+
+        render_text(&payload);
+        render_text(&RepoPushDefaultPayload {
+            pushed: true,
+            observed_remote_sha: "a".repeat(40),
+            ..payload
+        });
+    }
+
+    #[test]
+    fn schema_versions_are_namespaced_to_this_command() {
+        assert!(schema_success().starts_with("cli.forge-cli."));
+        assert_eq!(schema_error(), "cli.forge-cli.error.v1");
+        assert_eq!(
+            os_args(&["ls-remote", "--exit-code"]),
+            vec![OsString::from("ls-remote"), OsString::from("--exit-code")]
+        );
+        assert_eq!(validation("kind", "message", None).kind(), "kind");
+    }
 }

--- a/crates/forge-cli/src/ops/review_state.rs
+++ b/crates/forge-cli/src/ops/review_state.rs
@@ -1594,4 +1594,762 @@ mod tests {
             );
         }
     }
+
+    // ---------------------------------------------------------------------
+    // The chain is the only durable proof that a bounded review ran. Every
+    // guard below is what stops a forged, replayed, or forked comment history
+    // from being accepted as that proof.
+    // ---------------------------------------------------------------------
+
+    const REPO: &str = "acme/widgets";
+    const PR: u64 = 7;
+    const FP: &str = "correctness:review-loop:one";
+
+    fn record(
+        head: &str,
+        generation: u64,
+        previous: Option<String>,
+        state: ReviewLoopState,
+    ) -> ReviewStateRecord {
+        ReviewStateRecord::new(
+            REPO,
+            PR,
+            head,
+            generation,
+            previous,
+            ReviewStatePayload::ReviewLoop { state },
+        )
+        .expect("record")
+    }
+
+    fn observed(fingerprint: &str, status: ReviewFindingStatus) -> ReviewFindingObservation {
+        ReviewFindingObservation {
+            fingerprint: fingerprint.to_string(),
+            root_cause_fingerprint: None,
+            blocking: true,
+            status,
+            threads: Vec::new(),
+        }
+    }
+
+    fn genesis_with(observations: &[ReviewFindingObservation]) -> ReviewLoopState {
+        observe_review_loop(None, "head", observations)
+            .expect("genesis")
+            .state
+    }
+
+    #[test]
+    fn an_empty_comment_history_is_a_valid_genesis_chain() {
+        let chain = parse_chain(Vec::<&str>::new(), REPO, PR).expect("empty chain");
+
+        assert!(chain.records.is_empty());
+        assert_eq!(chain.tip_digest, None);
+        assert_eq!(latest_review_loop_state(&chain), None);
+    }
+
+    #[test]
+    fn a_record_for_another_pull_request_is_refused() {
+        let marker = record("head", 0, None, fixture_loop_state(0))
+            .marker()
+            .expect("marker");
+
+        let wrong_repo =
+            parse_chain([marker.as_str()], "acme/other", PR).expect_err("repository mismatch");
+        assert_eq!(wrong_repo.kind(), "review_state_conflict");
+
+        let wrong_pr = parse_chain([marker.as_str()], REPO, 8).expect_err("pr mismatch");
+        assert!(
+            wrong_pr
+                .detail()
+                .unwrap_or_default()
+                .contains("expected=acme/widgets#8"),
+            "detail should name both identities: {:?}",
+            wrong_pr.detail()
+        );
+    }
+
+    #[test]
+    fn a_tampered_record_digest_is_refused() {
+        let mut forged = record("head", 0, None, fixture_loop_state(0));
+        forged.record_digest = "sha256:forged".to_string();
+        let marker = forged.marker().expect("marker");
+
+        let error = parse_chain([marker.as_str()], REPO, PR).expect_err("forged digest");
+
+        assert_eq!(error.kind(), "review_state_conflict");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains("record_digest=sha256:forged"),
+            "{:?}",
+            error.detail()
+        );
+    }
+
+    #[test]
+    fn an_identical_record_seen_twice_is_deduplicated() {
+        // A provider can echo the same comment on two pages; that must not be
+        // read as a competing generation.
+        let marker = record("head", 0, None, fixture_loop_state(0))
+            .marker()
+            .expect("marker");
+
+        let chain =
+            parse_chain([marker.as_str(), marker.as_str()], REPO, PR).expect("deduplicated");
+
+        assert_eq!(chain.records.len(), 1);
+    }
+
+    #[test]
+    fn a_chain_without_exactly_one_genesis_is_refused() {
+        let orphan = record(
+            "head",
+            1,
+            Some("sha256:absent".to_string()),
+            fixture_loop_state(1),
+        )
+        .marker()
+        .expect("marker");
+        let error = parse_chain([orphan.as_str()], REPO, PR).expect_err("no genesis");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains("genesis_count=0"),
+            "{:?}",
+            error.detail()
+        );
+
+        let genesis_a = record("head", 0, None, fixture_loop_state(0));
+        let mut forked = fixture_loop_state(0);
+        forked.no_progress_rounds = 1;
+        let genesis_b = record("head", 0, None, forked);
+        let error = parse_chain(
+            [
+                genesis_a.marker().unwrap().as_str(),
+                genesis_b.marker().unwrap().as_str(),
+            ],
+            REPO,
+            PR,
+        )
+        .expect_err("two genesis records");
+        // Two roots are a fork, which the competing-generation guard catches
+        // before the genesis count is ever consulted.
+        assert_eq!(
+            error.message(),
+            "review-state chain contains competing generations"
+        );
+        assert_eq!(error.kind(), "review_state_conflict");
+    }
+
+    #[test]
+    fn a_non_contiguous_generation_is_refused() {
+        let genesis = record("head", 0, None, fixture_loop_state(0));
+        let skipped = record(
+            "head",
+            5,
+            Some(genesis.record_digest.clone()),
+            fixture_loop_state(1),
+        );
+
+        let error = parse_chain(
+            [
+                genesis.marker().unwrap().as_str(),
+                skipped.marker().unwrap().as_str(),
+            ],
+            REPO,
+            PR,
+        )
+        .expect_err("generation gap");
+
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains("expected_generation=1; observed_generation=5"),
+            "{:?}",
+            error.detail()
+        );
+    }
+
+    #[test]
+    fn a_review_loop_state_bound_to_another_head_is_refused() {
+        let mut state = fixture_loop_state(0);
+        state.head_sha = "other-head".to_string();
+        let marker = record("head", 0, None, state).marker().expect("marker");
+
+        let error = parse_chain([marker.as_str()], REPO, PR).expect_err("head mismatch");
+
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains("record_head=head; state_head=other-head"),
+            "{:?}",
+            error.detail()
+        );
+    }
+
+    #[test]
+    fn a_receipt_record_does_not_shadow_the_latest_loop_state() {
+        let loop_state = genesis_with(&[observed(FP, ReviewFindingStatus::Open)]);
+        let genesis = record("head", 0, None, loop_state.clone());
+        let receipt = ReviewStateRecord::new(
+            REPO,
+            PR,
+            "head",
+            1,
+            Some(genesis.record_digest.clone()),
+            ReviewStatePayload::ReviewRunReceipt {
+                receipt: fixture_receipt(),
+            },
+        )
+        .expect("receipt record");
+
+        let chain = parse_chain(
+            [
+                genesis.marker().unwrap().as_str(),
+                receipt.marker().unwrap().as_str(),
+            ],
+            REPO,
+            PR,
+        )
+        .expect("chain");
+
+        assert_eq!(chain.records.len(), 2);
+        assert_eq!(chain.tip_digest.as_deref(), Some(&*receipt.record_digest));
+        assert_eq!(
+            latest_review_loop_state(&chain),
+            Some(&loop_state),
+            "the newest loop state must be found behind the receipt"
+        );
+    }
+
+    #[test]
+    fn state_markers_are_only_recognized_when_they_are_well_formed() {
+        assert_eq!(parse_state_marker("no marker here").expect("none"), None);
+
+        let unterminated = format!("{STATE_MARKER_OPEN}deadbeef");
+        assert_eq!(
+            parse_state_marker(&unterminated)
+                .expect_err("unterminated")
+                .kind(),
+            "review_state_conflict"
+        );
+
+        for payload in ["", "xyz", "abc"] {
+            let body = format!("{STATE_MARKER_OPEN}{payload}{STATE_MARKER_CLOSE}");
+            assert!(
+                parse_state_marker(&body).is_err(),
+                "payload {payload:?} is not canonical hex"
+            );
+        }
+
+        // Canonical hex that decodes to non-JSON is still refused.
+        let not_json = format!("{STATE_MARKER_OPEN}7b7b{STATE_MARKER_CLOSE}");
+        assert!(parse_state_marker(&not_json).is_err());
+
+        // Canonical hex that decodes to invalid UTF-8 is refused too.
+        let not_utf8 = format!("{STATE_MARKER_OPEN}ff{STATE_MARKER_CLOSE}");
+        assert!(parse_state_marker(&not_utf8).is_err());
+    }
+
+    #[test]
+    fn a_lifecycle_fingerprint_must_be_three_stable_parts() {
+        for bad in [
+            "correctness",
+            "correctness:review-loop",
+            "correctness:review-loop:one:extra",
+            "Correctness:review-loop:one",
+            "correctness::one",
+            "-lead:review-loop:one",
+            "trail-:review-loop:one",
+        ] {
+            let error =
+                observe_review_loop(None, "head", &[observed(bad, ReviewFindingStatus::Open)])
+                    .expect_err("bad fingerprint");
+            assert_eq!(error.kind(), "review_fingerprint_collision", "{bad}");
+        }
+
+        observe_review_loop(
+            None,
+            "head",
+            &[observed(
+                "perf-2:review-loop:n-1",
+                ReviewFindingStatus::Open,
+            )],
+        )
+        .expect("digits and inner dashes are stable");
+    }
+
+    #[test]
+    fn one_lifecycle_identity_cannot_describe_two_different_observations() {
+        let mut second = observed(FP, ReviewFindingStatus::Open);
+        second.threads = vec!["PRRT_1".to_string()];
+
+        let error = observe_review_loop(
+            None,
+            "head",
+            &[observed(FP, ReviewFindingStatus::Open), second.clone()],
+        )
+        .expect_err("collision");
+        assert_eq!(error.kind(), "review_fingerprint_collision");
+
+        // The same observation repeated is collapsed, not rejected.
+        observe_review_loop(None, "head", &[second.clone(), second]).expect("idempotent repeat");
+    }
+
+    #[test]
+    fn an_empty_head_is_refused_before_any_observation_work() {
+        let error = observe_review_loop(None, "  ", &[observed(FP, ReviewFindingStatus::Open)]);
+        assert_eq!(
+            error.expect_err("empty head").kind(),
+            "review_state_conflict"
+        );
+    }
+
+    #[test]
+    fn a_same_head_observation_cannot_drop_or_silently_clear_an_open_finding() {
+        let previous = genesis_with(&[observed(FP, ReviewFindingStatus::Open)]);
+
+        let omitted =
+            observe_review_loop(Some(&previous), "head", &[]).expect_err("omitted open finding");
+        assert!(
+            omitted
+                .detail()
+                .unwrap_or_default()
+                .contains(&format!("fingerprint={FP}")),
+            "{:?}",
+            omitted.detail()
+        );
+
+        // Declaring it fixed at the same head means nothing was repaired.
+        let cleared = observe_review_loop(
+            Some(&previous),
+            "head",
+            &[observed(FP, ReviewFindingStatus::Fixed)],
+        )
+        .expect_err("fixed without a new head");
+        assert_eq!(cleared.kind(), "review_state_conflict");
+
+        // Downgrading it to non-blocking at the same head is the same trick.
+        let mut downgraded = observed(FP, ReviewFindingStatus::Open);
+        downgraded.blocking = false;
+        let error = observe_review_loop(Some(&previous), "head", &[downgraded])
+            .expect_err("silent downgrade");
+        assert_eq!(error.kind(), "review_state_conflict");
+    }
+
+    #[test]
+    fn advancing_the_head_marks_unobserved_open_findings_fixed() {
+        let previous = genesis_with(&[observed(FP, ReviewFindingStatus::Open)]);
+
+        let transition =
+            observe_review_loop(Some(&previous), "head-2", &[]).expect("repaired head");
+
+        assert!(transition.changed);
+        assert_eq!(transition.state.round, 1);
+        assert_eq!(
+            transition.state.findings[FP].status,
+            ReviewFindingStatus::Fixed
+        );
+        // The sweep only flips the status; the finding's last observed head and
+        // seen count stay pinned to the round that actually saw it.
+        assert_eq!(transition.state.findings[FP].last_seen_head, "head");
+        assert_eq!(transition.state.findings[FP].seen_count, 1);
+    }
+
+    #[test]
+    fn a_reopened_finding_stops_the_loop_when_no_reopen_budget_remains() {
+        let first = genesis_with(&[observed(FP, ReviewFindingStatus::Open)]);
+        let fixed = observe_review_loop(Some(&first), "head-2", &[])
+            .expect("repair")
+            .state;
+
+        // The default budget allows zero automatic reopens.
+        let error = observe_review_loop(
+            Some(&fixed),
+            "head-3",
+            &[observed(FP, ReviewFindingStatus::Open)],
+        )
+        .expect_err("reopened");
+        assert_eq!(error.kind(), "review_finding_reopened");
+        assert_eq!(
+            stop_budget_field(error.kind()),
+            Some("max_auto_reopens_per_fingerprint")
+        );
+
+        // With budget, the reopen is absorbed and counted.
+        let mut generous = fixed;
+        generous.budget.max_auto_reopens_per_fingerprint = 1;
+        let transition = observe_review_loop(
+            Some(&generous),
+            "head-3",
+            &[observed(FP, ReviewFindingStatus::Open)],
+        )
+        .expect("reopen within budget");
+        assert_eq!(transition.state.findings[FP].reopen_count, 1);
+        assert_eq!(
+            transition.state.findings[FP].status,
+            ReviewFindingStatus::Open
+        );
+    }
+
+    #[test]
+    fn a_repeated_identical_observation_reports_no_change() {
+        let previous = genesis_with(&[observed(FP, ReviewFindingStatus::Open)]);
+
+        let transition = observe_review_loop(
+            Some(&previous),
+            "head",
+            &[observed(FP, ReviewFindingStatus::Open)],
+        )
+        .expect("unchanged");
+
+        assert!(!transition.changed);
+        assert_eq!(transition.state, previous);
+    }
+
+    #[test]
+    fn an_extension_proposal_digest_is_bound_to_every_input() {
+        let base = extension_proposal_digest(
+            "sha256:tip",
+            "review_round_limit_exceeded",
+            "max_repair_rounds",
+            1,
+        )
+        .expect("digest");
+        assert!(base.starts_with("sha256:"));
+
+        for (tip, code, field, increment) in [
+            (
+                "sha256:other",
+                "review_round_limit_exceeded",
+                "max_repair_rounds",
+                1,
+            ),
+            ("sha256:tip", "review_no_progress", "max_repair_rounds", 1),
+            (
+                "sha256:tip",
+                "review_round_limit_exceeded",
+                "max_no_progress_rounds",
+                1,
+            ),
+            (
+                "sha256:tip",
+                "review_round_limit_exceeded",
+                "max_repair_rounds",
+                2,
+            ),
+        ] {
+            assert_ne!(
+                extension_proposal_digest(tip, code, field, increment).expect("digest"),
+                base,
+                "digest must change for ({tip}, {code}, {field}, {increment})"
+            );
+        }
+
+        for increment in [0, 101] {
+            assert_eq!(
+                extension_proposal_digest(
+                    "sha256:tip",
+                    "review_round_limit_exceeded",
+                    "max_repair_rounds",
+                    increment
+                )
+                .expect_err("out of range")
+                .kind(),
+                "review_extension_invalid"
+            );
+        }
+        assert_eq!(
+            extension_proposal_digest(
+                "sha256:tip",
+                "review_round_limit_exceeded",
+                "max_everything",
+                1
+            )
+            .expect_err("unknown field")
+            .kind(),
+            "review_extension_invalid"
+        );
+    }
+
+    #[test]
+    fn only_a_budget_stop_can_be_recorded_for_extension() {
+        let previous = genesis_with(&[observed(FP, ReviewFindingStatus::Open)]);
+        let not_a_budget_stop = ForgeError::validation(
+            error_schema(),
+            "review_state_conflict",
+            "something else",
+            None,
+        );
+
+        let error = record_review_loop_hard_stop(
+            &previous,
+            "head-2",
+            &[observed(FP, ReviewFindingStatus::Open)],
+            "sha256:tip",
+            &not_a_budget_stop,
+        )
+        .expect_err("not a budget stop");
+        assert_eq!(error.kind(), "review_state_conflict");
+
+        let budget_stop = ForgeError::validation(
+            error_schema(),
+            "review_round_limit_exceeded",
+            "budget exhausted",
+            None,
+        );
+        let stopped = record_review_loop_hard_stop(
+            &previous,
+            "head-2",
+            &[observed(FP, ReviewFindingStatus::Open)],
+            "sha256:tip",
+            &budget_stop,
+        )
+        .expect("hard stop");
+        let stop = stopped.hard_stop.as_ref().expect("stop recorded");
+        assert_eq!(stop.code, "review_round_limit_exceeded");
+        assert_eq!(stop.budget_field, "max_repair_rounds");
+        assert_eq!(stop.increment, 1);
+        assert_eq!(stop.attempted_head_sha, "head-2");
+        assert!(!stop.extension_applied);
+        assert!(!stop.observation_digest.is_empty());
+    }
+
+    #[test]
+    fn an_extension_proposal_cannot_be_consumed_twice() {
+        let previous = genesis_with(&[observed(FP, ReviewFindingStatus::Open)]);
+        let budget_stop = ForgeError::validation(
+            error_schema(),
+            "review_round_limit_exceeded",
+            "budget exhausted",
+            None,
+        );
+        let stopped = record_review_loop_hard_stop(
+            &previous,
+            "head-2",
+            &[observed(FP, ReviewFindingStatus::Open)],
+            "sha256:tip",
+            &budget_stop,
+        )
+        .expect("hard stop");
+        let proposal = stopped
+            .hard_stop
+            .as_ref()
+            .expect("stop")
+            .proposal_digest
+            .clone();
+
+        let extended = apply_review_loop_extension(
+            &stopped,
+            proposal.clone(),
+            "https://github.com/acme/widgets/pull/7#issuecomment-1".to_string(),
+            "review_round_limit_exceeded",
+            "max_repair_rounds",
+            1,
+        )
+        .expect("extension applied");
+        assert_eq!(
+            extended.budget.max_repair_rounds,
+            previous.budget.max_repair_rounds + 1
+        );
+        assert!(extended.hard_stop.as_ref().expect("stop").extension_applied);
+
+        // Applying it again is refused because the stop is already consumed.
+        assert_eq!(
+            apply_review_loop_extension(
+                &extended,
+                proposal.clone(),
+                "https://example.invalid/2".to_string(),
+                "review_round_limit_exceeded",
+                "max_repair_rounds",
+                1,
+            )
+            .expect_err("already applied")
+            .kind(),
+            "review_extension_invalid"
+        );
+
+        // A state with no hard stop has nothing to extend.
+        assert_eq!(
+            apply_review_loop_extension(
+                &previous,
+                proposal,
+                "https://example.invalid/3".to_string(),
+                "review_round_limit_exceeded",
+                "max_repair_rounds",
+                1,
+            )
+            .expect_err("no stop")
+            .kind(),
+            "review_extension_invalid"
+        );
+    }
+
+    #[test]
+    fn budget_field_mapping_is_closed() {
+        assert_eq!(
+            stop_budget_field("review_round_limit_exceeded"),
+            Some("max_repair_rounds")
+        );
+        assert_eq!(
+            stop_budget_field("review_no_progress"),
+            Some("max_no_progress_rounds")
+        );
+        assert_eq!(
+            stop_budget_field("review_finding_reopened"),
+            Some("max_auto_reopens_per_fingerprint")
+        );
+        assert_eq!(stop_budget_field("review_state_conflict"), None);
+        assert_eq!(stop_budget_field(""), None);
+    }
+
+    #[test]
+    fn owned_markers_are_recognized_and_stripped_without_touching_prose() {
+        let run = "sha256:run";
+        let body = format!(
+            "Review body\n{}\n{}\n{}\nTrailing prose\n",
+            review_run_marker(run),
+            finding_marker(run, "sha256:digest"),
+            thread_disposition_marker("PRRT_1"),
+        );
+
+        assert_eq!(parse_review_run_id(&body).as_deref(), Some(run));
+        assert_eq!(
+            parse_finding_marker(&body),
+            Some((run.to_string(), "sha256:digest".to_string()))
+        );
+        assert!(has_thread_disposition_marker(&body));
+        assert_eq!(strip_owned_markers(&body), "Review body\nTrailing prose");
+
+        // A body with no markers is left byte-identical apart from trailing space.
+        assert_eq!(strip_owned_markers("just prose\n"), "just prose");
+        assert_eq!(parse_review_run_id("just prose"), None);
+        assert_eq!(parse_finding_marker("just prose"), None);
+        assert!(!has_thread_disposition_marker("just prose"));
+    }
+
+    #[test]
+    fn malformed_markers_are_not_recognized() {
+        // An empty id, or one carrying whitespace, is not a usable run id.
+        assert_eq!(parse_review_run_id(&review_run_marker("")), None);
+        assert_eq!(parse_review_run_id(&review_run_marker("two words")), None);
+        assert!(!has_thread_disposition_marker(&thread_disposition_marker(
+            ""
+        )));
+
+        // A finding marker needs both halves.
+        assert_eq!(parse_finding_marker(&finding_marker("", "sha256:d")), None);
+        assert_eq!(parse_finding_marker(&finding_marker("run", "")), None);
+    }
+
+    #[test]
+    fn a_review_run_id_is_bound_to_every_preimage_field() {
+        let base = compute_review_run_id(
+            REPO,
+            PR,
+            "head",
+            0,
+            &["testing".to_string()],
+            "comments-only",
+            "sha256:summary",
+            &[],
+        )
+        .expect("run id");
+        assert!(base.starts_with("sha256:"));
+
+        let variants = [
+            compute_review_run_id(
+                "acme/other",
+                PR,
+                "head",
+                0,
+                &["testing".to_string()],
+                "comments-only",
+                "sha256:summary",
+                &[],
+            ),
+            compute_review_run_id(
+                REPO,
+                8,
+                "head",
+                0,
+                &["testing".to_string()],
+                "comments-only",
+                "sha256:summary",
+                &[],
+            ),
+            compute_review_run_id(
+                REPO,
+                PR,
+                "head-2",
+                0,
+                &["testing".to_string()],
+                "comments-only",
+                "sha256:summary",
+                &[],
+            ),
+            compute_review_run_id(
+                REPO,
+                PR,
+                "head",
+                1,
+                &["testing".to_string()],
+                "comments-only",
+                "sha256:summary",
+                &[],
+            ),
+            compute_review_run_id(
+                REPO,
+                PR,
+                "head",
+                0,
+                &["security".to_string()],
+                "comments-only",
+                "sha256:summary",
+                &[],
+            ),
+            compute_review_run_id(
+                REPO,
+                PR,
+                "head",
+                0,
+                &["testing".to_string()],
+                "approve",
+                "sha256:summary",
+                &[],
+            ),
+            compute_review_run_id(
+                REPO,
+                PR,
+                "head",
+                0,
+                &["testing".to_string()],
+                "comments-only",
+                "sha256:other",
+                &[],
+            ),
+        ];
+        for variant in variants {
+            assert_ne!(variant.expect("run id"), base);
+        }
+    }
+
+    #[test]
+    fn the_digest_helper_is_prefixed_and_lowercase_hex() {
+        let digest = sha256_digest(b"payload");
+
+        assert!(digest.starts_with("sha256:"));
+        let hex = digest.trim_start_matches("sha256:");
+        assert_eq!(hex.len(), 64);
+        assert!(
+            hex.bytes()
+                .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        );
+        assert_eq!(sha256_digest(b"payload"), digest, "digest is deterministic");
+        assert_ne!(sha256_digest(b"payload2"), digest);
+    }
 }

--- a/crates/git-lock/tests/integration/completion_outside_repo.rs
+++ b/crates/git-lock/tests/integration/completion_outside_repo.rs
@@ -50,3 +50,37 @@ fn completion_rejects_unknown_shell_outside_git_repo() {
         "unexpected repo warning: {stderr}"
     );
 }
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let output = Command::new(common::git_lock_bin())
+        .args(["completion", "bash"])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run git-lock completion bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_git-lock()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/git-lock` asset must not carry them,
+    // so the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+    assert!(
+        !stdout.contains("Not a Git repository"),
+        "unexpected repo warning: {stdout}"
+    );
+}

--- a/crates/git-scope/tests/integration.rs
+++ b/crates/git-scope/tests/integration.rs
@@ -11,6 +11,8 @@ mod characterization_warnings;
 mod commit_mode;
 #[path = "integration/common.rs"]
 pub mod common;
+#[path = "integration/completion_export.rs"]
+mod completion_export;
 #[path = "integration/edge_cases.rs"]
 mod edge_cases;
 #[path = "integration/exit_codes.rs"]

--- a/crates/git-scope/tests/integration/completion_export.rs
+++ b/crates/git-scope/tests/integration/completion_export.rs
@@ -1,0 +1,66 @@
+//! Shell-completion export contract. Both shipped shells must render from a
+//! directory that is not a git repository, and the bash script must already be
+//! normalized when it reaches stdout.
+
+use std::process::{Command, Stdio};
+
+use nils_test_support::bin::resolve;
+
+fn run_completion(shell: &str) -> std::process::Output {
+    let temp = tempfile::TempDir::new().unwrap();
+    Command::new(resolve("git-scope"))
+        .args(["completion", shell])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap_or_else(|error| panic!("run git-scope completion {shell}: {error}"))
+}
+
+#[test]
+fn completion_zsh_export_succeeds_outside_git_repo() {
+    let output = run_completion("zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef git-scope"),
+        "missing zsh completion header: {stdout}"
+    );
+}
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let output = run_completion("bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_git-scope()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/git-scope` asset must not carry them,
+    // so the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}
+
+#[test]
+fn completion_rejects_an_unsupported_shell() {
+    let output = run_completion("fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+}

--- a/crates/github-app-cli/src/github.rs
+++ b/crates/github-app-cli/src/github.rs
@@ -163,6 +163,239 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    /// Serve a fixed sequence of raw HTTP responses on loopback, recording the
+    /// request lines so pagination and endpoint shape can be asserted.
+    struct StubApi {
+        base: String,
+        handle: Option<thread::JoinHandle<Vec<String>>>,
+    }
+
+    impl StubApi {
+        fn start(responses: Vec<String>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+            let base = format!("http://{}", listener.local_addr().unwrap());
+            let handle = thread::spawn(move || {
+                let mut requests = Vec::new();
+                for response in responses {
+                    let Ok((mut stream, _)) = listener.accept() else {
+                        break;
+                    };
+                    let mut reader = BufReader::new(stream.try_clone().unwrap());
+                    let mut request_line = String::new();
+                    reader.read_line(&mut request_line).ok();
+                    // Drain headers so the client is not left blocked on write.
+                    loop {
+                        let mut header = String::new();
+                        match reader.read_line(&mut header) {
+                            Ok(0) => break,
+                            Ok(_) if header.trim().is_empty() => break,
+                            Ok(_) => {}
+                            Err(_) => break,
+                        }
+                    }
+                    requests.push(request_line.trim().to_string());
+                    stream.write_all(response.as_bytes()).ok();
+                    stream.flush().ok();
+                }
+                requests
+            });
+            Self {
+                base,
+                handle: Some(handle),
+            }
+        }
+
+        fn requests(&mut self) -> Vec<String> {
+            self.handle
+                .take()
+                .expect("server joined once")
+                .join()
+                .expect("server thread")
+        }
+    }
+
+    fn http_response(status: &str, body: &str, extra_headers: &[&str]) -> String {
+        let mut response = format!("HTTP/1.1 {status}\r\nContent-Type: application/json\r\n");
+        for header in extra_headers {
+            response.push_str(header);
+            response.push_str("\r\n");
+        }
+        response.push_str(&format!(
+            "Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        ));
+        response
+    }
+
+    #[test]
+    fn list_installations_follows_link_pagination_to_the_last_page() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().unwrap();
+        // The advertised `next` URL points back at this same stub, which is
+        // what the client must follow to reach the second page.
+        let next_link = format!("Link: <http://{addr}/app/installations?page=2>; rel=\"next\"");
+        let base = format!("http://{addr}");
+        let handle = thread::spawn(move || {
+            let responses = [
+                http_response(
+                    "200 OK",
+                    r#"[{"id":1,"account":{"login":"acme"},"repository_selection":"all"}]"#,
+                    &[&next_link],
+                ),
+                http_response(
+                    "200 OK",
+                    r#"[{"id":2,"account":{"login":"widgets"},"permissions":{"contents":"read"}}]"#,
+                    &[],
+                ),
+            ];
+            let mut seen = Vec::new();
+            for response in responses {
+                let (mut stream, _) = listener.accept().expect("accept");
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                let mut request_line = String::new();
+                reader.read_line(&mut request_line).ok();
+                loop {
+                    let mut header = String::new();
+                    match reader.read_line(&mut header) {
+                        Ok(0) => break,
+                        Ok(_) if header.trim().is_empty() => break,
+                        Ok(_) => {}
+                        Err(_) => break,
+                    }
+                }
+                seen.push(request_line.trim().to_string());
+                stream.write_all(response.as_bytes()).ok();
+                stream.flush().ok();
+            }
+            seen
+        });
+
+        let client = Client::new(&base).expect("client");
+        let installations = client.list_installations("jwt-token").expect("list");
+        let requests = handle.join().expect("server");
+
+        assert_eq!(installations.len(), 2, "both pages must be returned");
+        assert_eq!(installations[0].id, 1);
+        assert_eq!(
+            installations[0].account.as_ref().map(|a| a.login.as_str()),
+            Some("acme")
+        );
+        assert_eq!(installations[1].id, 2);
+        assert_eq!(requests.len(), 2);
+        assert!(
+            requests[0].contains("/app/installations?per_page=100"),
+            "{:?}",
+            requests[0]
+        );
+        assert!(requests[1].contains("page=2"), "{:?}", requests[1]);
+    }
+
+    #[test]
+    fn mint_installation_token_posts_to_the_installation_endpoint() {
+        let mut stub = StubApi::start(vec![http_response(
+            "201 Created",
+            r#"{"token":"ghs_example","expires_at":"2026-08-03T01:00:00Z","repository_selection":"selected"}"#,
+            &[],
+        )]);
+
+        let client = Client::new(&format!("{}/", stub.base)).expect("client");
+        let token = client
+            .mint_installation_token("jwt-token", "12345")
+            .expect("token");
+        let requests = stub.requests();
+
+        assert_eq!(token.token, "ghs_example");
+        assert_eq!(token.expires_at, "2026-08-03T01:00:00Z");
+        assert_eq!(token.repository_selection.as_deref(), Some("selected"));
+        assert_eq!(
+            requests,
+            vec!["POST /app/installations/12345/access_tokens HTTP/1.1".to_string()],
+            "a trailing slash in api_base must not double up in the path"
+        );
+    }
+
+    #[test]
+    fn a_github_error_body_is_surfaced_without_the_credential() {
+        let mut stub = StubApi::start(vec![http_response(
+            "401 Unauthorized",
+            r#"{"message":"A JWT could not be decoded"}"#,
+            &[],
+        )]);
+
+        let client = Client::new(&stub.base).expect("client");
+        let err = client
+            .mint_installation_token("jwt-token", "1")
+            .expect_err("unauthorized");
+        stub.requests();
+
+        let rendered = format!("{err:?}");
+        assert!(rendered.contains("HTTP 401"), "{rendered}");
+        assert!(
+            rendered.contains("A JWT could not be decoded"),
+            "{rendered}"
+        );
+        assert!(
+            !rendered.contains("jwt-token"),
+            "the App JWT must never appear in an error: {rendered}"
+        );
+    }
+
+    #[test]
+    fn a_non_json_error_body_degrades_to_the_status_code() {
+        let mut stub = StubApi::start(vec![http_response("502 Bad Gateway", "upstream down", &[])]);
+
+        let client = Client::new(&stub.base).expect("client");
+        let err = client.list_installations("jwt").expect_err("bad gateway");
+        stub.requests();
+
+        assert!(format!("{err:?}").contains("GitHub API returned HTTP 502"));
+    }
+
+    #[test]
+    fn an_undecodable_success_body_is_reported_as_unavailable() {
+        let mut stub = StubApi::start(vec![http_response("200 OK", "{not json", &[])]);
+
+        let client = Client::new(&stub.base).expect("client");
+        let err = client.list_installations("jwt").expect_err("bad payload");
+        stub.requests();
+
+        assert!(format!("{err:?}").contains("decode installations response"));
+    }
+
+    #[test]
+    fn a_refused_connection_is_reported_as_a_network_failure() {
+        // Bind then drop so nothing is listening on the port.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("probe port");
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        // Another process can win that ephemeral port between the drop and the
+        // request; if anything is listening the connect-refused branch is
+        // unreachable rather than wrong, so skip instead of failing.
+        if std::net::TcpStream::connect(addr).is_ok() {
+            return;
+        }
+
+        let client = Client::new(&format!("http://{addr}")).expect("client");
+        let err = client.list_installations("jwt").expect_err("no server");
+
+        assert!(format!("{err:?}").contains("request failed"));
+    }
+
+    #[test]
+    fn github_message_reads_only_a_string_message_field() {
+        assert_eq!(
+            github_message(r#"{"message":"Bad credentials"}"#).as_deref(),
+            Some("Bad credentials")
+        );
+        assert!(github_message("not json").is_none());
+        assert!(github_message(r#"{"other":"value"}"#).is_none());
+        assert!(github_message(r#"{"message":42}"#).is_none());
+    }
+
     #[test]
     fn parse_next_link_picks_the_next_rel() {
         let header = "<https://api.github.com/app/installations?per_page=100&page=2>; rel=\"next\", \

--- a/crates/github-app-cli/src/lib.rs
+++ b/crates/github-app-cli/src/lib.rs
@@ -27,3 +27,22 @@ pub fn now_unix() -> u64 {
         .map(|d| d.as_secs())
         .unwrap_or(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binary_name_backs_the_schema_version_prefix() {
+        assert_eq!(BINARY, "github-app-cli");
+    }
+
+    #[test]
+    fn now_unix_is_a_monotonic_wall_clock_second_count() {
+        let first = now_unix();
+        // Well past the 2020 epoch floor: a zero here would mean the clock
+        // fallback fired and JWT `iat`/`exp` claims would be nonsense.
+        assert!(first > 1_600_000_000, "unexpected clock value: {first}");
+        assert!(now_unix() >= first);
+    }
+}

--- a/crates/image-processing/tests/integration.rs
+++ b/crates/image-processing/tests/integration.rs
@@ -5,6 +5,8 @@
 
 #[path = "integration/common.rs"]
 pub mod common;
+#[path = "integration/completion_export.rs"]
+mod completion_export;
 #[path = "integration/core_flows.rs"]
 mod core_flows;
 #[path = "integration/dry_run_paths.rs"]

--- a/crates/image-processing/tests/integration/completion_export.rs
+++ b/crates/image-processing/tests/integration/completion_export.rs
@@ -1,0 +1,66 @@
+//! Shell-completion export contract. Both shipped shells must render from a
+//! directory that is not a git repository, and the bash script must already be
+//! normalized when it reaches stdout.
+
+use std::process::{Command, Stdio};
+
+use nils_test_support::bin::resolve;
+
+fn run_completion(shell: &str) -> std::process::Output {
+    let temp = tempfile::TempDir::new().unwrap();
+    Command::new(resolve("image-processing"))
+        .args(["completion", shell])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap_or_else(|error| panic!("run image-processing completion {shell}: {error}"))
+}
+
+#[test]
+fn completion_zsh_export_succeeds_outside_git_repo() {
+    let output = run_completion("zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef image-processing"),
+        "missing zsh completion header: {stdout}"
+    );
+}
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let output = run_completion("bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_image-processing()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/image-processing` asset must not
+    // carry them, so the normalizer rewrites them before stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}
+
+#[test]
+fn completion_rejects_an_unsupported_shell() {
+    let output = run_completion("fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+}

--- a/crates/macos-agent/tests/integration.rs
+++ b/crates/macos-agent/tests/integration.rs
@@ -6,6 +6,8 @@ mod backend;
 mod cli_contract;
 #[path = "integration/common.rs"]
 pub mod common;
+#[path = "integration/completion_export.rs"]
+mod completion_export;
 #[path = "integration/journal.rs"]
 mod journal;
 #[path = "integration/mcp.rs"]

--- a/crates/macos-agent/tests/integration/completion_export.rs
+++ b/crates/macos-agent/tests/integration/completion_export.rs
@@ -1,0 +1,66 @@
+//! Shell-completion export contract. `macos-agent` ships completion assets for
+//! both shells, and rendering them must not depend on macOS automation
+//! permissions or on being run inside a git repository.
+
+use std::process::{Command, Stdio};
+
+use nils_test_support::bin::resolve;
+
+fn run_completion(shell: &str) -> std::process::Output {
+    let temp = tempfile::TempDir::new().unwrap();
+    Command::new(resolve("macos-agent"))
+        .args(["completion", shell])
+        .current_dir(temp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap_or_else(|error| panic!("run macos-agent completion {shell}: {error}"))
+}
+
+#[test]
+fn completion_zsh_export_succeeds_outside_git_repo() {
+    let output = run_completion("zsh");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("#compdef macos-agent"),
+        "missing zsh completion header: {stdout}"
+    );
+}
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let output = run_completion("bash");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("_macos-agent()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/macos-agent` asset must not carry
+    // them, so the normalizer rewrites them before stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}
+
+#[test]
+fn completion_rejects_an_unsupported_shell() {
+    let output = run_completion("fish");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit code for unknown shell, got: {output:?}"
+    );
+}

--- a/crates/memo/tests/integration/completion_outside_repo.rs
+++ b/crates/memo/tests/integration/completion_outside_repo.rs
@@ -30,3 +30,24 @@ fn completion_rejects_unknown_shell_outside_git_repo() {
         "missing invalid shell error: {stderr}"
     );
 }
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let options = cmd::CmdOptions::default().with_cwd(temp.path());
+    let output = cmd::run_resolved("memo", &["completion", "bash"], &options);
+
+    assert_eq!(output.code, 0, "expected exit code 0, got: {output:?}");
+    let stdout = output.stdout_text();
+    assert!(
+        stdout.contains("_memo()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/memo` asset must not carry them, so
+    // the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}

--- a/crates/nils-evidence/src/cli.rs
+++ b/crates/nils-evidence/src/cli.rs
@@ -748,4 +748,129 @@ mod tests {
         let cli = Cli::try_parse_from(["evidence", "catalog", "--json"]).expect("parses");
         assert!(matches!(cli.output_format(), OutputFormat::Json));
     }
+
+    // -----------------------------------------------------------------
+    // Validator dispatch. Each surface must return the shared exit-code
+    // contract (0 on success, `EX_DATAERR` on bad input) for both formats,
+    // and an unreadable input must be an IO error rather than a panic.
+    // -----------------------------------------------------------------
+
+    const VALID_HOSTS: &str = "version: 1\nhosts:\n  github.com:\n    class: personal\n";
+
+    const VALID_ROLLUP: &str = r#"{
+  "schema": "skill-usage.rollup.v1",
+  "id": "id-pass",
+  "archived_at": "2026-06-14T11:00:00Z",
+  "skill": "deliver-pr",
+  "intent": "deliver the rollback plan",
+  "trigger": "user_explicit",
+  "repo": { "host": "github.com", "org": "graysurf", "repo": "kit" },
+  "cwd": "~/Project/kit",
+  "started_at": "2026-06-14T10:00:00Z",
+  "ended_at": "2026-06-14T10:30:00Z",
+  "outcome": { "status": "pass", "summary": "completed via a clean rebase" },
+  "producer": { "tool": "skill-usage", "nils_cli_version": "1.4.0" },
+  "counts": { "validation": 2, "failures": 0 },
+  "linked_evidence": [],
+  "source_digest": "sha256:p"
+}"#;
+
+    fn write(dir: &tempfile::TempDir, name: &str, contents: &str) -> String {
+        let path = dir.path().join(name);
+        std::fs::write(&path, contents).unwrap();
+        path.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn hosts_validation_reports_success_and_failure_for_both_formats() {
+        let tmp = tempfile::tempdir().unwrap();
+        let good = write(&tmp, "hosts.yaml", VALID_HOSTS);
+
+        assert_eq!(dispatch_hosts(&good, OutputFormat::Json), exit::SUCCESS);
+        assert_eq!(dispatch_hosts(&good, OutputFormat::Text), exit::SUCCESS);
+
+        let bad = write(&tmp, "bad.yaml", "version: 1\nhosts: not-a-map\n");
+        assert_eq!(dispatch_hosts(&bad, OutputFormat::Json), exit::DATA);
+        assert_eq!(dispatch_hosts(&bad, OutputFormat::Text), exit::DATA);
+    }
+
+    #[test]
+    fn record_validation_reports_success_and_failure_for_both_formats() {
+        let tmp = tempfile::tempdir().unwrap();
+        let good = write(&tmp, "rollup.json", VALID_ROLLUP);
+
+        assert_eq!(dispatch_record(&good, OutputFormat::Json), exit::SUCCESS);
+        assert_eq!(dispatch_record(&good, OutputFormat::Text), exit::SUCCESS);
+
+        let bad = write(&tmp, "bad.json", "{ not a rollup }");
+        assert_eq!(dispatch_record(&bad, OutputFormat::Json), exit::DATA);
+        assert_eq!(dispatch_record(&bad, OutputFormat::Text), exit::DATA);
+    }
+
+    #[test]
+    fn local_config_validation_reports_both_formats() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp
+            .path()
+            .join("absent.yaml")
+            .to_string_lossy()
+            .into_owned();
+
+        // A missing machine-local config is not a failure: the validator
+        // reports the documented defaults.
+        assert_eq!(dispatch_local(&missing, OutputFormat::Json), exit::SUCCESS);
+        assert_eq!(dispatch_local(&missing, OutputFormat::Text), exit::SUCCESS);
+
+        let bad = write(&tmp, "local.yaml", "archive_clone_path: []\n");
+        assert_eq!(dispatch_local(&bad, OutputFormat::Json), exit::DATA);
+        assert_eq!(dispatch_local(&bad, OutputFormat::Text), exit::DATA);
+    }
+
+    #[test]
+    fn an_unreadable_input_is_an_io_error_not_a_panic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp
+            .path()
+            .join("absent.yaml")
+            .to_string_lossy()
+            .into_owned();
+
+        assert_eq!(dispatch_hosts(&missing, OutputFormat::Json), exit::DATA);
+        assert_eq!(dispatch_record(&missing, OutputFormat::Text), exit::DATA);
+
+        let error = load_input("hosts", &missing).expect_err("missing file");
+        assert!(
+            error.starts_with("failed to read hosts input `"),
+            "the message must name the label and the path: {error}"
+        );
+    }
+
+    #[test]
+    fn error_emission_uses_the_data_exit_code_for_both_formats() {
+        assert_eq!(
+            emit_error(OutputFormat::Json, "validate-hosts", "some-code", "boom"),
+            exit::DATA
+        );
+        assert_eq!(
+            emit_error(OutputFormat::Text, "validate-hosts", "some-code", "boom"),
+            exit::DATA
+        );
+    }
+
+    #[test]
+    fn clap_errors_render_as_one_leading_line_without_the_error_prefix() {
+        let Err(err) = Cli::try_parse_from(["evidence", "definitely-not-a-subcommand"]) else {
+            panic!("an unknown subcommand must not parse");
+        };
+
+        let message = render_clap_message(&err);
+
+        assert!(!message.is_empty());
+        assert!(!message.starts_with("error:"), "{message}");
+        assert!(!message.contains('\n'), "{message}");
+        assert!(
+            message.contains("definitely-not-a-subcommand"),
+            "the offending argument must survive: {message}"
+        );
+    }
 }

--- a/crates/nils-evidence/tests/discover.rs
+++ b/crates/nils-evidence/tests/discover.rs
@@ -1,0 +1,511 @@
+//! Contract coverage for `evidence discover` — the read-only scan that
+//! classifies agent-out `skill-usage.record.json` files as `eligible`,
+//! `blocked` (already in the archive catalog), or `unknown`.
+//!
+//! The command must never mutate the source tree or the archive, so every test
+//! asserts the classification contract and, where a mutation would be visible,
+//! that the fixture bytes survive the run unchanged.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+
+fn evidence_bin() -> PathBuf {
+    nils_test_support::bin::resolve("evidence")
+}
+
+struct Out {
+    code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+fn run(args: &[&str]) -> Out {
+    let output = Command::new(evidence_bin())
+        .args(args)
+        .output()
+        .expect("evidence command");
+    Out {
+        code: output.status.code().unwrap_or(1),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for byte in digest {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn v1_record(skill: &str) -> String {
+    format!(
+        r#"{{
+  "schema": "skill-usage.record.v1",
+  "producer": {{ "tool": "skill-usage", "nils_cli_version": "1.11.2" }},
+  "skill": "{skill}",
+  "started_at": "2026-06-20T01:00:00Z",
+  "ended_at": "2026-06-20T01:05:00Z",
+  "cwd": "/Users/tester/Project/kit",
+  "trigger": "user_explicit",
+  "intent": "intent",
+  "inputs": {{ "user_request_summary": "x", "referenced_files": [], "external_sources": [] }},
+  "outcome": {{ "status": "pass", "summary": "done" }},
+  "artifacts": [],
+  "linked_records": [],
+  "validation": [],
+  "failures": []
+}}"#
+    )
+}
+
+/// Write a raw record body at `<source_out>/<project>/<run>/skill-usage.record.json`
+/// and return its `sha256:` digest, which is the archive dedup key.
+fn write_record_at(source_out: &Path, project: &str, run_id: &str, body: &str) -> String {
+    let dir = source_out.join(project).join(run_id);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("skill-usage.record.json"), body).unwrap();
+    format!("sha256:{}", sha256_hex(body.as_bytes()))
+}
+
+fn write_catalog_for_digests(archive: &Path, digests: &[&str]) {
+    let rows = digests
+        .iter()
+        .map(|digest| serde_json::json!({ "source_digest": digest }))
+        .collect::<Vec<_>>();
+    let body = serde_json::json!({
+        "schema_version": "evidence.catalog.v1",
+        "records": rows
+    });
+    fs::write(
+        archive.join("catalog.json"),
+        serde_json::to_string_pretty(&body).unwrap(),
+    )
+    .unwrap();
+}
+
+/// An empty source tree plus an empty archive clone, both real directories so
+/// resolution succeeds and only the classification logic is under test.
+fn discover_fixture() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let source_out = tmp.path().join("out").join("projects");
+    let archive = tmp.path().join("archive");
+    fs::create_dir_all(&source_out).unwrap();
+    fs::create_dir_all(archive.join("evidence")).unwrap();
+    (tmp, source_out, archive)
+}
+
+fn discover_json(source_out: &Path, archive: &Path, extra: &[&str]) -> (i32, Value) {
+    let mut args = vec![
+        "discover".to_string(),
+        "--source-out".to_string(),
+        source_out.to_string_lossy().to_string(),
+        "--archive".to_string(),
+        archive.to_string_lossy().to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+    ];
+    args.extend(extra.iter().map(|s| (*s).to_string()));
+    let borrowed = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let out = run(&borrowed);
+    let value = serde_json::from_str(out.stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "json parse {e}: stdout={} stderr={}",
+            out.stdout, out.stderr
+        )
+    });
+    (out.code, value)
+}
+
+fn summary(value: &Value) -> (u64, u64, u64) {
+    let summary = &value["data"]["summary"];
+    (
+        summary["eligible"].as_u64().unwrap(),
+        summary["blocked"].as_u64().unwrap(),
+        summary["unknown"].as_u64().unwrap(),
+    )
+}
+
+#[test]
+fn discover_json_separates_eligible_from_catalog_blocked() {
+    let (_tmp, source_out, archive) = discover_fixture();
+    let blocked_digest =
+        write_record_at(&source_out, "kit", "run-blocked", &v1_record("deliver-pr"));
+    write_record_at(
+        &source_out,
+        "kit",
+        "run-eligible",
+        &v1_record("code-review"),
+    );
+    write_catalog_for_digests(&archive, &[blocked_digest.as_str()]);
+
+    let (code, value) = discover_json(&source_out, &archive, &[]);
+
+    assert_eq!(code, 0);
+    assert_eq!(
+        value["schema_version"].as_str().unwrap(),
+        "cli.evidence.discover.v1"
+    );
+    assert_eq!(value["ok"].as_bool().unwrap(), true);
+    assert_eq!(summary(&value), (1, 1, 0));
+    assert_eq!(
+        value["data"]["source_out"].as_str().unwrap(),
+        source_out.to_string_lossy()
+    );
+    assert_eq!(
+        value["data"]["archive"].as_str().unwrap(),
+        archive.to_string_lossy()
+    );
+
+    let candidates = value["data"]["candidates"].as_array().unwrap();
+    assert_eq!(candidates.len(), 2);
+    let blocked = candidates
+        .iter()
+        .find(|c| c["classification"] == "blocked")
+        .expect("blocked candidate");
+    assert_eq!(blocked["skill"].as_str().unwrap(), "deliver-pr");
+    assert_eq!(blocked["source_digest"].as_str().unwrap(), blocked_digest);
+    assert_eq!(
+        blocked["reason"].as_str().unwrap(),
+        "already archived (catalog)"
+    );
+
+    let eligible = candidates
+        .iter()
+        .find(|c| c["classification"] == "eligible")
+        .expect("eligible candidate");
+    assert_eq!(eligible["skill"].as_str().unwrap(), "code-review");
+    assert!(
+        eligible["source_digest"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:")
+    );
+    // `reason` is skipped when absent, so an eligible row carries no reason.
+    assert_eq!(eligible.get("reason"), None);
+}
+
+#[test]
+fn discover_counts_unknown_records_but_hides_them_by_default() {
+    let (_tmp, source_out, archive) = discover_fixture();
+    write_record_at(&source_out, "kit", "run-ok", &v1_record("deliver-pr"));
+    write_record_at(&source_out, "kit", "run-bad-json", "{ not json");
+
+    let (code, value) = discover_json(&source_out, &archive, &[]);
+
+    assert_eq!(code, 0);
+    // The unknown record is still counted; only the row is withheld.
+    assert_eq!(summary(&value), (1, 0, 1));
+    let candidates = value["data"]["candidates"].as_array().unwrap();
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0]["classification"], "eligible");
+}
+
+#[test]
+fn discover_include_unknown_reports_each_rejection_reason() {
+    let (_tmp, source_out, archive) = discover_fixture();
+    write_record_at(&source_out, "kit", "run-bad-json", "{ not json");
+    write_record_at(&source_out, "kit", "run-no-skill", &v1_record(""));
+    write_record_at(
+        &source_out,
+        "kit",
+        "run-future",
+        &v1_record("x").replace("skill-usage.record.v1", "skill-usage.record.v9"),
+    );
+
+    let (code, value) = discover_json(&source_out, &archive, &["--include-unknown"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(summary(&value), (0, 0, 3));
+    let candidates = value["data"]["candidates"].as_array().unwrap();
+    assert_eq!(candidates.len(), 3);
+    for candidate in candidates {
+        assert_eq!(candidate["classification"], "unknown");
+        // An unknown row can name neither an owner nor a dedup digest.
+        assert_eq!(candidate.get("skill"), None);
+        assert_eq!(candidate.get("source_digest"), None);
+    }
+
+    let reason_for = |run_id: &str| -> String {
+        candidates
+            .iter()
+            .find(|c| c["source_path"].as_str().unwrap().contains(run_id))
+            .unwrap_or_else(|| panic!("candidate for {run_id}"))["reason"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+    assert!(
+        reason_for("run-bad-json").starts_with("skill-usage.record.json parse:"),
+        "unexpected reason: {}",
+        reason_for("run-bad-json")
+    );
+    assert_eq!(
+        reason_for("run-no-skill"),
+        "v1 record is missing skill ownership"
+    );
+    assert_eq!(
+        reason_for("run-future"),
+        "unsupported source schema `skill-usage.record.v9`"
+    );
+}
+
+#[test]
+fn discover_reports_unreadable_records_as_unknown() {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_tmp, source_out, archive) = discover_fixture();
+        write_record_at(&source_out, "kit", "run-locked", &v1_record("deliver-pr"));
+        let locked = source_out
+            .join("kit")
+            .join("run-locked")
+            .join("skill-usage.record.json");
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+
+        // A privileged test runner can still read a 0o000 file, which would make
+        // the read-failure branch unreachable rather than wrong.
+        if fs::read(&locked).is_ok() {
+            fs::set_permissions(&locked, fs::Permissions::from_mode(0o644)).unwrap();
+            return;
+        }
+
+        let (code, value) = discover_json(&source_out, &archive, &["--include-unknown"]);
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert_eq!(code, 0);
+        assert_eq!(summary(&value), (0, 0, 1));
+        let candidates = value["data"]["candidates"].as_array().unwrap();
+        assert!(
+            candidates[0]["reason"]
+                .as_str()
+                .unwrap()
+                .starts_with("read failed:"),
+            "unexpected reason: {}",
+            candidates[0]["reason"]
+        );
+    }
+}
+
+#[test]
+fn discover_leaves_source_and_archive_untouched() {
+    let (_tmp, source_out, archive) = discover_fixture();
+    let body = v1_record("deliver-pr");
+    write_record_at(&source_out, "kit", "run-a", &body);
+    write_catalog_for_digests(&archive, &["sha256:unrelated"]);
+    let record_path = source_out
+        .join("kit")
+        .join("run-a")
+        .join("skill-usage.record.json");
+    let catalog_path = archive.join("catalog.json");
+    let record_before = fs::read(&record_path).unwrap();
+    let catalog_before = fs::read(&catalog_path).unwrap();
+
+    let (code, value) = discover_json(&source_out, &archive, &["--include-unknown"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(summary(&value), (1, 0, 0));
+    assert_eq!(fs::read(&record_path).unwrap(), record_before);
+    assert_eq!(fs::read(&catalog_path).unwrap(), catalog_before);
+    // Discovery must not create an archive entry for the eligible record.
+    assert_eq!(fs::read_dir(archive.join("evidence")).unwrap().count(), 0);
+}
+
+#[test]
+fn discover_text_lists_every_classification() {
+    let (_tmp, source_out, archive) = discover_fixture();
+    let blocked_digest =
+        write_record_at(&source_out, "kit", "run-blocked", &v1_record("deliver-pr"));
+    write_record_at(
+        &source_out,
+        "kit",
+        "run-eligible",
+        &v1_record("code-review"),
+    );
+    write_record_at(&source_out, "kit", "run-bad", "{ not json");
+    write_catalog_for_digests(&archive, &[blocked_digest.as_str()]);
+
+    let out = run(&[
+        "discover",
+        "--source-out",
+        &source_out.to_string_lossy(),
+        "--archive",
+        &archive.to_string_lossy(),
+        "--include-unknown",
+        "--format",
+        "text",
+    ]);
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let mut lines = out.stdout.lines();
+    assert_eq!(
+        lines.next().unwrap(),
+        "discover: 1 eligible, 1 blocked, 1 unknown"
+    );
+    let rest = lines.collect::<Vec<_>>();
+    assert_eq!(rest.len(), 3);
+    assert!(rest.iter().any(|l| l.starts_with("  [eligible] ")));
+    assert!(rest.iter().any(|l| l.starts_with("  [blocked] ")));
+    assert!(rest.iter().any(|l| l.starts_with("  [unknown] ")));
+}
+
+#[test]
+fn discover_text_omits_unknown_rows_without_the_flag() {
+    let (_tmp, source_out, archive) = discover_fixture();
+    write_record_at(&source_out, "kit", "run-bad", "{ not json");
+
+    let out = run(&[
+        "discover",
+        "--source-out",
+        &source_out.to_string_lossy(),
+        "--archive",
+        &archive.to_string_lossy(),
+        "--format",
+        "text",
+    ]);
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert_eq!(out.stdout, "discover: 0 eligible, 0 blocked, 1 unknown\n");
+}
+
+#[test]
+fn discover_missing_source_out_fails_closed() {
+    let (tmp, _source_out, archive) = discover_fixture();
+    let missing = tmp.path().join("no-such-out");
+
+    let out = run(&[
+        "discover",
+        "--source-out",
+        &missing.to_string_lossy(),
+        "--archive",
+        &archive.to_string_lossy(),
+        "--format",
+        "json",
+    ]);
+
+    assert_eq!(out.code, 65);
+    let value: Value = serde_json::from_str(out.stderr.trim()).expect("json on stderr");
+    assert_eq!(value["ok"].as_bool().unwrap(), false);
+    assert_eq!(
+        value["schema_version"].as_str().unwrap(),
+        "cli.evidence.discover.v1"
+    );
+    assert_eq!(
+        value["error"]["code"].as_str().unwrap(),
+        "discover-source-out-missing"
+    );
+    assert!(
+        value["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains(&*missing.to_string_lossy()),
+        "message should name the missing path"
+    );
+}
+
+#[test]
+fn discover_missing_archive_fails_closed_in_text_mode() {
+    let (tmp, source_out, _archive) = discover_fixture();
+    let missing = tmp.path().join("no-such-archive");
+
+    let out = run(&[
+        "discover",
+        "--source-out",
+        &source_out.to_string_lossy(),
+        "--archive",
+        &missing.to_string_lossy(),
+        "--format",
+        "text",
+    ]);
+
+    assert_eq!(out.code, 65);
+    assert_eq!(out.stdout, "");
+    assert!(
+        out.stderr
+            .starts_with("error [discover-archive-clone-missing]: "),
+        "unexpected stderr: {}",
+        out.stderr
+    );
+}
+
+#[test]
+fn discover_unreadable_catalog_is_an_io_error() {
+    let (_tmp, source_out, archive) = discover_fixture();
+    write_record_at(&source_out, "kit", "run-a", &v1_record("deliver-pr"));
+    fs::write(archive.join("catalog.json"), "{ not json").unwrap();
+
+    let out = run(&[
+        "discover",
+        "--source-out",
+        &source_out.to_string_lossy(),
+        "--archive",
+        &archive.to_string_lossy(),
+        "--format",
+        "json",
+    ]);
+
+    assert_eq!(out.code, 65);
+    let value: Value = serde_json::from_str(out.stderr.trim()).expect("json on stderr");
+    assert_eq!(
+        value["error"]["code"].as_str().unwrap(),
+        "discover-io-error"
+    );
+    assert!(
+        value["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("catalog parse"),
+        "unexpected message: {}",
+        value["error"]["message"]
+    );
+}
+
+#[test]
+fn discover_finds_records_nested_under_a_workflow_run_directory() {
+    let (_tmp, source_out, archive) = discover_fixture();
+    let nested = source_out.join("kit").join("run-a").join("skill-usage");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(
+        nested.join("skill-usage.record.json"),
+        v1_record("deliver-pr"),
+    )
+    .unwrap();
+
+    let (code, value) = discover_json(&source_out, &archive, &[]);
+
+    assert_eq!(code, 0);
+    assert_eq!(summary(&value), (1, 0, 0));
+    assert!(
+        value["data"]["candidates"][0]["source_path"]
+            .as_str()
+            .unwrap()
+            .ends_with("skill-usage/skill-usage.record.json")
+    );
+}
+
+#[test]
+fn discover_empty_source_tree_reports_an_empty_inventory() {
+    let (_tmp, source_out, archive) = discover_fixture();
+
+    let (code, value) = discover_json(&source_out, &archive, &["--include-unknown"]);
+
+    assert_eq!(code, 0);
+    assert_eq!(summary(&value), (0, 0, 0));
+    assert_eq!(
+        value["data"]["candidates"].as_array().unwrap().len(),
+        0,
+        "an empty tree must still emit the candidates array"
+    );
+}

--- a/crates/plan-archive/src/search.rs
+++ b/crates/plan-archive/src/search.rs
@@ -233,3 +233,165 @@ fn emit_error(format: OutputFormat, code: &str, message: &str) -> i32 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    fn args(term: &str, archive: Option<PathBuf>) -> DispatchArgs {
+        DispatchArgs {
+            term: term.to_string(),
+            archive,
+            format: OutputFormat::Json,
+        }
+    }
+
+    #[test]
+    fn every_error_maps_to_a_stable_machine_code() {
+        assert_eq!(SearchError::EmptyTerm.code(), "search-empty-term");
+        assert_eq!(
+            SearchError::ArchiveCloneMissing(PathBuf::from("/nope")).code(),
+            "search-archive-clone-missing"
+        );
+        assert_eq!(SearchError::Io("boom".into()).code(), "search-io-error");
+        assert_eq!(
+            SearchError::ArchiveCloneMissing(PathBuf::from("/nope")).to_string(),
+            "archive clone path not found at `/nope`"
+        );
+    }
+
+    #[test]
+    fn an_empty_or_whitespace_term_is_refused_before_any_io() {
+        // The guard must fire before archive resolution, so an unusable
+        // archive path cannot mask the real complaint.
+        let missing = PathBuf::from("/definitely/not/an/archive");
+        assert_eq!(
+            run(&args("", Some(missing.clone())))
+                .expect_err("empty term")
+                .code(),
+            "search-empty-term"
+        );
+        assert_eq!(
+            run(&args("   \t ", Some(missing)))
+                .expect_err("whitespace term")
+                .code(),
+            "search-empty-term"
+        );
+    }
+
+    #[test]
+    fn a_missing_archive_clone_fails_closed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("absent");
+
+        let err = resolve_archive(Some(&missing)).expect_err("missing archive");
+        assert_eq!(err.code(), "search-archive-clone-missing");
+        assert!(
+            err.to_string().contains(&*missing.to_string_lossy()),
+            "the error must name the path it looked for"
+        );
+
+        // A real directory resolves to itself, unchanged.
+        assert_eq!(
+            resolve_archive(Some(tmp.path())).expect("existing archive"),
+            tmp.path().to_path_buf()
+        );
+    }
+
+    #[test]
+    fn an_archive_without_an_index_yields_an_empty_result() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let result = run(&args("anything", Some(tmp.path().to_path_buf())))
+            .expect("empty archive is not an error");
+
+        assert_eq!(result.term, "anything");
+        assert_eq!(result.total_hits, 0);
+        assert!(result.hits.is_empty());
+    }
+
+    #[test]
+    fn the_term_is_trimmed_into_the_result_payload() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let result = run(&args("  spaced  ", Some(tmp.path().to_path_buf()))).expect("search");
+
+        assert_eq!(result.term, "spaced");
+    }
+
+    #[test]
+    fn match_fields_render_with_their_wire_labels() {
+        assert_eq!(field_label(MatchField::Body), "body");
+        assert_eq!(field_label(MatchField::Comment), "comment");
+    }
+
+    #[test]
+    fn emit_reports_success_for_both_formats() {
+        let empty = SearchResult {
+            term: "term".to_string(),
+            total_hits: 0,
+            hits: Vec::new(),
+        };
+        assert_eq!(emit(OutputFormat::Json, &empty), exit::SUCCESS);
+        assert_eq!(emit(OutputFormat::Text, &empty), exit::SUCCESS);
+
+        let populated = SearchResult {
+            term: "term".to_string(),
+            total_hits: 2,
+            hits: vec![
+                SearchHit {
+                    plan: Some("plan-slug".to_string()),
+                    r#ref: "https://github.com/acme/widgets/pull/7".to_string(),
+                    field: MatchField::Body,
+                    snippet: "…term…".to_string(),
+                },
+                SearchHit {
+                    // An unattributed hit still renders; plan attribution is
+                    // best-effort and must never suppress a match.
+                    plan: None,
+                    r#ref: "https://github.com/acme/widgets/issues/8".to_string(),
+                    field: MatchField::Comment,
+                    snippet: "…term…".to_string(),
+                },
+            ],
+        };
+        assert_eq!(emit(OutputFormat::Json, &populated), exit::SUCCESS);
+        assert_eq!(emit(OutputFormat::Text, &populated), exit::SUCCESS);
+    }
+
+    #[test]
+    fn emit_error_uses_the_data_exit_code_for_both_formats() {
+        assert_eq!(
+            emit_error(OutputFormat::Json, "search-empty-term", "empty"),
+            exit::DATA
+        );
+        assert_eq!(
+            emit_error(OutputFormat::Text, "search-empty-term", "empty"),
+            exit::DATA
+        );
+    }
+
+    #[test]
+    fn dispatch_returns_the_emitted_exit_code() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            dispatch(args("term", Some(tmp.path().to_path_buf()))),
+            exit::SUCCESS
+        );
+        assert_eq!(
+            dispatch(args("", Some(tmp.path().to_path_buf()))),
+            exit::DATA
+        );
+    }
+
+    #[test]
+    fn plan_attribution_is_best_effort_for_an_archive_without_a_catalog() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // No catalog to build from: hits would still be emitted, just
+        // unattributed, so the map is empty rather than an error.
+        assert!(plan_map(tmp.path()).is_empty());
+    }
+}

--- a/crates/screen-record/src/types.rs
+++ b/crates/screen-record/src/types.rs
@@ -136,3 +136,152 @@ pub struct RecordingDiagnosticsArtifacts {
     pub interval_count: usize,
 }
 use std::path::PathBuf;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permission_state_labels_are_stable_and_lowercase() {
+        assert_eq!(PermissionState::Ready.as_str(), "ready");
+        assert_eq!(PermissionState::Blocked.as_str(), "blocked");
+        assert_eq!(PermissionState::Unknown.as_str(), "unknown");
+        assert_eq!(PermissionState::default(), PermissionState::Unknown);
+
+        assert!(PermissionState::Blocked.is_blocked());
+        assert!(!PermissionState::Ready.is_blocked());
+        assert!(!PermissionState::Unknown.is_blocked());
+    }
+
+    #[test]
+    fn readiness_needs_one_granted_permission_and_no_denial() {
+        use PermissionState::{Blocked, Ready, Unknown};
+
+        // Nothing observed yet is not readiness.
+        assert!(!PermissionStatusSchema::compute_ready(
+            Unknown, Unknown, Unknown
+        ));
+        // One confirmed grant with no denial is enough to proceed.
+        assert!(PermissionStatusSchema::compute_ready(
+            Ready, Unknown, Unknown
+        ));
+        assert!(PermissionStatusSchema::compute_ready(
+            Unknown, Ready, Unknown
+        ));
+        assert!(PermissionStatusSchema::compute_ready(
+            Unknown, Unknown, Ready
+        ));
+        assert!(PermissionStatusSchema::compute_ready(Ready, Ready, Ready));
+        // A single denial disqualifies the whole probe, whatever else is granted.
+        assert!(!PermissionStatusSchema::compute_ready(
+            Ready, Blocked, Unknown
+        ));
+        assert!(!PermissionStatusSchema::compute_ready(
+            Blocked, Ready, Ready
+        ));
+        assert!(!PermissionStatusSchema::compute_ready(
+            Ready, Ready, Blocked
+        ));
+    }
+
+    #[test]
+    fn status_schema_derives_readiness_and_de_duplicates_hints() {
+        let status = PermissionStatusSchema::from_components(
+            PermissionState::Ready,
+            PermissionState::Unknown,
+            PermissionState::Unknown,
+            vec![
+                "grant screen recording".to_string(),
+                "grant screen recording".to_string(),
+                "grant accessibility".to_string(),
+            ],
+        );
+
+        assert!(status.ready);
+        assert_eq!(status.screen_recording, PermissionState::Ready);
+        // Hints keep first-seen order so the operator reads them in the order
+        // the probes produced them, with repeats collapsed.
+        assert_eq!(
+            status.hints,
+            vec![
+                "grant screen recording".to_string(),
+                "grant accessibility".to_string()
+            ]
+        );
+
+        let default = PermissionStatusSchema::default();
+        assert!(!default.ready);
+        assert!(default.hints.is_empty());
+        assert_eq!(default.automation, PermissionState::Unknown);
+    }
+
+    #[test]
+    fn geometry_and_inventory_types_have_usable_defaults() {
+        let rect = Rect::default();
+        assert_eq!((rect.x, rect.y, rect.width, rect.height), (0, 0, 0, 0));
+        assert_eq!(
+            Rect {
+                x: 1,
+                y: 2,
+                width: 3,
+                height: 4
+            },
+            Rect {
+                x: 1,
+                y: 2,
+                width: 3,
+                height: 4
+            }
+        );
+
+        let content = ShareableContent::default();
+        assert!(content.displays.is_empty());
+        assert!(content.windows.is_empty());
+        assert!(content.apps.is_empty());
+
+        let window = WindowInfo {
+            id: 7,
+            owner_name: "Terminal".to_string(),
+            title: "zsh".to_string(),
+            bounds: rect,
+            on_screen: true,
+            active: false,
+            owner_pid: 42,
+            z_order: 0,
+        };
+        assert_eq!(window.clone(), window);
+
+        let populated = ShareableContent {
+            displays: vec![DisplayInfo {
+                id: 1,
+                width: 1920,
+                height: 1080,
+            }],
+            windows: vec![window],
+            apps: vec![AppInfo {
+                name: "Terminal".to_string(),
+                pid: 42,
+                bundle_id: "com.apple.Terminal".to_string(),
+            }],
+        };
+        assert_eq!(populated.displays[0].width, 1920);
+        assert_eq!(populated.apps[0].bundle_id, "com.apple.Terminal");
+    }
+
+    #[test]
+    fn diagnostics_artifact_names_are_pinned_to_the_published_contract() {
+        assert_eq!(RECORDING_DIAGNOSTICS_SCHEMA_VERSION, 1);
+        assert_eq!(RECORDING_DIAGNOSTICS_CONTRACT_VERSION, "1.0");
+        assert_eq!(RECORDING_DIAGNOSTICS_ARTIFACT_DIR_SUFFIX, "diagnostics");
+        assert_eq!(CONTACT_SHEET_ARTIFACT_SUFFIX, "contact-sheet.svg");
+        assert_eq!(MOTION_INTERVALS_ARTIFACT_SUFFIX, "motion-intervals.json");
+
+        let artifacts = RecordingDiagnosticsArtifacts {
+            contact_sheet_path: PathBuf::from("/out/run-contact-sheet.svg"),
+            motion_intervals_path: PathBuf::from("/out/run-motion-intervals.json"),
+            interval_count: 3,
+        };
+        assert_eq!(artifacts.clone(), artifacts);
+        assert_eq!(artifacts.interval_count, 3);
+    }
+}

--- a/crates/screen-record/tests/integration/completion_outside_repo.rs
+++ b/crates/screen-record/tests/integration/completion_outside_repo.rs
@@ -21,3 +21,24 @@ fn completion_rejects_unknown_shell_outside_git_repo() {
     assert!(out.stderr_text().contains("unsupported completion shell"));
     assert!(out.stderr_text().contains("fish"));
 }
+
+#[test]
+fn completion_bash_export_is_normalized() {
+    let harness = common::ScreenRecordHarness::new();
+    let dir = TempDir::new().expect("tempdir");
+    let out = harness.run(dir.path(), &["completion", "bash"]);
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+    let stdout = out.stdout_text();
+    assert!(
+        stdout.contains("_screen-record()"),
+        "missing bash completion entry point: {stdout}"
+    );
+    // clap_complete emits `__subcmd__` separators in its generated command
+    // ids; the shipped `completions/bash/screen-record` asset must not carry
+    // them, so the normalizer rewrites them before the script reaches stdout.
+    assert!(
+        !stdout.contains("__subcmd__"),
+        "bash completion leaked an un-normalized subcommand separator"
+    );
+}

--- a/scripts/ci/nils-cli-checks-entrypoint.sh
+++ b/scripts/ci/nils-cli-checks-entrypoint.sh
@@ -31,7 +31,7 @@ Options:
 
 Environment:
   NILS_CLI_COVERAGE_FAIL_UNDER_LINES
-    Override coverage threshold used with --with-coverage (default: 84).
+    Override coverage threshold used with --with-coverage (default: 85).
 USAGE
 }
 
@@ -183,9 +183,8 @@ if ! cargo llvm-cov --version >/dev/null 2>&1; then
   exit 2
 fi
 
-# Keep the temporary native-run 30743840826 floor aligned with CI. After the
-# runtime-kit delivery, restore 85 once native full-workspace coverage reaches 85%.
-coverage_fail_under="${NILS_CLI_COVERAGE_FAIL_UNDER_LINES:-84}"
+# Keep this floor aligned with the `coverage` job in .github/workflows/ci.yml.
+coverage_fail_under="${NILS_CLI_COVERAGE_FAIL_UNDER_LINES:-85}"
 
 run mkdir -p target/coverage
 run cargo llvm-cov nextest --profile ci --workspace --no-fail-fast --lcov --output-path target/coverage/lcov.info --fail-under-lines "$coverage_fail_under"


### PR DESCRIPTION
## Summary

Restore the workspace line-coverage gate to 85%. #1397 lowered it to a temporary
84% floor to unblock delivery; this change earns the point back by testing the
worst-covered production surfaces first, then flips
`COVERAGE_FAIL_UNDER_LINES` back to 85 in the CI `coverage` job and the local
checks entrypoint.

Coverage evidence came from the CI `coverage` artifact at the current base
`85c43c61` (84.10%, 262642/312308 lines). Targets were selected by ranking that
LCOV report by per-file line coverage, so the lowest-covered production files
were addressed first rather than whatever was cheapest to test.

## Test-First Evidence

Waiver: this is a test-coverage change, so the added tests *are* the deliverable
rather than a regression harness for a behavior change. No production behavior
is modified — the only non-test edits are the two `COVERAGE_FAIL_UNDER_LINES`
values and their comments.

Each new test was written against the observed contract and confirmed to
exercise a previously uncovered branch: every module below moved from its
recorded baseline coverage upward in a re-measured local LCOV run, and several
tests were corrected mid-review when the real contract differed from the
expected one (for example two genesis review-state records fail the
competing-generation guard before the genesis-count guard, and `agent-run
operation-effect inspect` fails closed as `unavailable` where OS sandbox
enforcement cannot be proven).

## Test plan

### Coverage evidence

- Baseline: CI `coverage` artifact `coverage-lcov` from run `30766673124`
  (base `85c43c61`, macOS) — **84.10%** (262642/312308 lines). Clearing 85%
  therefore needs **+2820** covered lines net of newly instrumented lines.
- Targets ranked from that artifact by per-file line coverage, worst first
  (`crates/nils-evidence/src/discover/mod.rs` at 0.00%,
  `crates/screen-record/src/types.rs` at 0.00%,
  `crates/macos-agent/src/completion.rs` at 0.00%,
  `crates/github-app-cli/src/github.rs` at 25.71%,
  `crates/forge-cli/src/ops/pr_review_loop.rs` at 39.60%,
  `crates/plan-archive/src/search.rs` at 44.12%, then the 50%-band
  `completion.rs` modules and the doctor / config / operation-effect surfaces).
- Re-measured locally over every touched crate after the change:

  ```
  cargo llvm-cov nextest --ignore-run-fail \
    -p nils-evidence -p nils-forge-cli -p nils-agent-out -p nils-agent-docs \
    -p nils-screen-record -p nils-plan-archive -p nils-github-app-cli \
    -p nils-agent-runtime -p nils-agent-hook -p nils-claude-cli \
    -p nils-agent-workflow-primitives -p nils-agent-memory -p nils-api-gql \
    -p nils-api-grpc -p nils-api-rest -p nils-api-test -p nils-api-websocket \
    -p nils-memo -p nils-git-lock -p nils-git-scope -p nils-image-processing \
    -p nils-macos-agent --lcov --output-path <lcov>
  ```

  Applying the per-file deltas to the CI baseline gives **+7996 covered lines
  against +5639 instrumented lines** (surplus **+3203** vs the +2820 required),
  i.e. a projected workspace total of **~85.12%** (270638/317947). The macOS
  `coverage` job on this PR is the authoritative number.

Largest per-file gains (baseline coverage / uncovered production lines before):

| file | baseline | uncovered before |
| --- | ---: | ---: |
| `crates/forge-cli/src/ops/pr_review_loop.rs` | 39.60% | 485 |
| `crates/agent-out/src/lib.rs` | 69.32% | 420 |
| `crates/forge-cli/src/ops/repo_bootstrap.rs` | 66.53% | 406 |
| `crates/agent-docs/src/config.rs` | 67.00% | 265 |
| `crates/forge-cli/src/ops/repo_push_default.rs` | 74.32% | 275 |
| `crates/agent-workflow-primitives/src/skill_usage.rs` | 67.71% | 248 |
| `crates/forge-cli/src/ops/review_state.rs` | 81.24% | 229 |
| `crates/agent-workflow-primitives/src/review_specialists.rs` | 80.60% | 328 |
| `crates/agent-runtime/src/doctor/coverage.rs` | 55.14% | 144 |
| `crates/nils-evidence/src/discover/mod.rs` | 0.00% | 141 |
| `crates/agent-runtime/src/doctor/probes.rs` | 53.39% | 110 |
| `crates/github-app-cli/src/github.rs` | 25.71% | 78 |
| `crates/plan-archive/src/search.rs` | 44.12% | 76 |
| `crates/screen-record/src/types.rs` | 0.00% | 52 |

### Validation

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — pass
  (fmt, clippy `-D warnings`, docs hygiene, third-party artifact audit,
  **8253 tests run, 8253 passed, 0 skipped**).
- Focused loops used while iterating, all green:
  `cargo test -p nils-forge-cli --lib`,
  `cargo test -p nils-agent-docs --lib`,
  `cargo test -p nils-agent-out --lib`,
  `cargo test -p nils-agent-runtime --lib doctor::`,
  `cargo test -p nils-agent-runtime --lib render::writer`,
  `cargo test -p nils-agent-workflow-primitives --lib`,
  `cargo test -p nils-agent-memory --lib`,
  `cargo test -p nils-github-app-cli --lib`,
  `cargo test -p nils-evidence --lib cli::`,
  `cargo test -p nils-evidence --test discover`,
  and the `--test integration completion` filter across the eleven CLIs whose
  bash completion export gained coverage.
- Full CI parity and the authoritative coverage percentage are owned by the
  `test`, `test_macos`, and `coverage` required checks on this PR.

### Rebase note

The first push was based on `bb75cdaf`. #1406 landed meanwhile and made
`pr review-loop observe --dry-run` a faithful read-only preflight, which
invalidated one new test that had asserted the old plan-only contract. This
branch is rebased onto `85c43c61` and that test now asserts the current
behaviour: the dry run reads provider state to evaluate its preflight rules,
reports a failing `findings_file` verdict instead of erroring, and still
appends nothing. A second test pins that a clean preflight likewise performs
no write.

## Risk / Notes

- The gate is the risk: if the macOS `coverage` job measures below 85%, this PR
  fails its own check rather than silently regressing. The projection above has
  ~0.12pp of headroom (surplus +3203 vs the +2820 required), computed by applying locally measured per-file deltas to
  the macOS CI baseline, so a macOS/Linux divergence larger than that would need
  more tests before merge.
- No production behavior changes. The only non-test edits are the two
  `COVERAGE_FAIL_UNDER_LINES` values (`.github/workflows/ci.yml` and
  `scripts/ci/nils-cli-checks-entrypoint.sh`) and their comments.
- New tests avoid environment coupling: no network beyond a loopback HTTP stub
  in `github-app-cli`, no env-var mutation, no sleeps. Permission-dependent
  assertions (`0o000` reads) skip themselves when the runner is privileged, and
  symlink assertions are `#[cfg(unix)]`.
- `crates/agent-out/tests/integration/completion_export.rs` had to be
  force-added: a local `.git/info/exclude` `agent-out/` rule (not part of the
  repository) hides new files under `crates/agent-out/`.
