### PR TITLE
test(codex-cli): stop two temp-directory leaks in codex-cli tests

### DIFF
--- a/crates/codex-cli/tests/integration/prompt_segment_cached.rs
+++ b/crates/codex-cli/tests/integration/prompt_segment_cached.rs
@@ -91,6 +91,57 @@ fn write_prompt_segment_cache_kv(cache_root: &Path, key: &str, kv: &str) -> Path
     path
 }
 
+/// The refresh cooldown these tests hold open, in seconds.
+///
+/// Long enough that the marker written by [`RefreshCooldown::hold`] stays inside
+/// the window for the whole test, so the suppression cannot expire mid-run.
+const REFRESH_COOLDOWN_SECONDS: &str = "3600";
+
+/// Keeps a plain `prompt-segment` run from launching a detached refresh child.
+///
+/// A run whose cache is stale or expired calls `enqueue_background_refresh`,
+/// which spawns `prompt-segment --refresh` in its own process group and returns
+/// without waiting. That child outlives both the CLI and the test, and every
+/// path it takes — taking the refresh lock, writing the cache, stamping the
+/// marker — starts with `create_dir_all`, so it can recreate the fixture
+/// `TempDir` teardown has already removed and leave a `cache_root/` behind in
+/// `$TMPDIR` (class 3 in `docs/specs/test-temp-directory-policy.md`).
+///
+/// Tests whose subject is rendering rather than refreshing opt out through the
+/// production cooldown instead of racing the child: a recent `<key>.refresh.at`
+/// marker plus a long `CODEX_PROMPT_SEGMENT_REFRESH_MIN_SECONDS` makes
+/// `enqueue_background_refresh` return before it spawns anything.
+struct RefreshCooldown {
+    marker: PathBuf,
+    stamp: String,
+}
+
+impl RefreshCooldown {
+    fn hold(cache_root: &Path, key: &str) -> Self {
+        let dir = cache_root.join("codex").join("prompt-segment-rate-limits");
+        fs::create_dir_all(&dir).expect("cache dir");
+
+        let marker = dir.join(format!("{key}.refresh.at"));
+        let stamp = now_epoch().saturating_sub(5).max(1).to_string();
+        fs::write(&marker, &stamp).expect("write refresh marker");
+
+        Self { marker, stamp }
+    }
+
+    /// Fails when the run spawned a refresh child after all.
+    ///
+    /// `enqueue_background_refresh` rewrites the marker immediately before
+    /// spawning, so an unchanged marker is proof that it returned on the
+    /// cooldown and that no background writer can outlive this test.
+    fn assert_held(&self) {
+        assert_eq!(
+            fs::read_to_string(&self.marker).expect("read refresh marker"),
+            self.stamp,
+            "the run spawned a detached refresh child instead of honouring the cooldown"
+        );
+    }
+}
+
 #[test]
 fn prompt_segment_disabled_prints_nothing() {
     let dir = tempfile::TempDir::new().expect("tempdir");
@@ -439,6 +490,7 @@ fn prompt_segment_stale_cache_appends_suffix() {
             "fetched_at={fetched_at}\nnon_weekly_label=5h\nnon_weekly_remaining=1\nweekly_remaining=2\nweekly_reset_epoch=1700600000\n"
         ),
     );
+    let cooldown = RefreshCooldown::hold(&cache_root, "alpha");
 
     let output = run(
         &[
@@ -456,6 +508,14 @@ fn prompt_segment_stale_cache_appends_suffix() {
         &[
             ("CODEX_PROMPT_SEGMENT_ENABLED", "true"),
             ("CODEX_PROMPT_SEGMENT_STALE_SUFFIX", " (STALE)"),
+            (
+                "CODEX_PROMPT_SEGMENT_REFRESH_MIN_SECONDS",
+                REFRESH_COOLDOWN_SECONDS,
+            ),
+            // Belt and braces: the cooldown already stops the spawn, and a dead
+            // loopback port keeps a regression from reaching the real backend
+            // instead of turning into a leak.
+            ("CODEX_CHATGPT_BASE_URL", "http://127.0.0.1:9"),
         ],
     );
     assert_exit(&output, 0);
@@ -463,6 +523,7 @@ fn prompt_segment_stale_cache_appends_suffix() {
         stdout(&output),
         "alpha 5h:1% W:2% 2023-11-21T20:53Z (STALE)\n"
     );
+    cooldown.assert_held();
 }
 
 #[test]
@@ -478,6 +539,7 @@ fn prompt_segment_does_not_render_cache_at_max_stale_age() {
             "fetched_at={fetched_at}\nnon_weekly_label=5h\nnon_weekly_remaining=1\nweekly_remaining=2\nweekly_reset_epoch=1700600000\n"
         ),
     );
+    let cooldown = RefreshCooldown::hold(&cache_root, "alpha");
 
     let output = run(
         &["prompt-segment", "--ttl", "1h"],
@@ -491,6 +553,10 @@ fn prompt_segment_does_not_render_cache_at_max_stale_age() {
             ("CODEX_CHATGPT_BASE_URL", "http://127.0.0.1:9"),
             ("CODEX_PROMPT_SEGMENT_CURL_CONNECT_TIMEOUT_SECONDS", "1"),
             ("CODEX_PROMPT_SEGMENT_CURL_MAX_TIME_SECONDS", "1"),
+            (
+                "CODEX_PROMPT_SEGMENT_REFRESH_MIN_SECONDS",
+                REFRESH_COOLDOWN_SECONDS,
+            ),
         ],
     );
 
@@ -500,6 +566,7 @@ fn prompt_segment_does_not_render_cache_at_max_stale_age() {
         cache_file.is_file(),
         "max-stale handling must not delete cache"
     );
+    cooldown.assert_held();
 }
 
 #[test]

--- a/crates/codex-cli/tests/integration/rate_limits_async.rs
+++ b/crates/codex-cli/tests/integration/rate_limits_async.rs
@@ -1,6 +1,8 @@
 use nils_test_support::bin;
 use nils_test_support::cmd::{self, CmdOptions, CmdOutput};
 use nils_test_support::http::{HttpResponse, LoopbackServer, TestServer};
+#[cfg(unix)]
+use nils_test_support::tempdir::ScopedTempDir;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use std::fs;
@@ -72,9 +74,54 @@ fn now_epoch() -> i64 {
         .unwrap_or(0)
 }
 
+/// Restores a directory's mode when it drops.
+///
+/// `remove_dir_all` cannot unlink entries from a `0o555` directory, so a fixture
+/// left read-only survives `TempDir` teardown — silently, because `Drop` discards
+/// the error (class 2 in `docs/specs/test-temp-directory-policy.md`). Restoring
+/// from `Drop` instead of an inline statement means an unwinding assertion or a
+/// panic inside `run` cannot leave the fixture unremovable.
+#[cfg(unix)]
+struct RestoredMode {
+    dir: PathBuf,
+    mode: u32,
+}
+
+#[cfg(unix)]
+impl RestoredMode {
+    fn read_only(dir: &Path) -> Self {
+        let permissions = fs::metadata(dir).expect("cache metadata").permissions();
+        let guard = Self {
+            dir: dir.to_path_buf(),
+            mode: permissions.mode() & 0o7777,
+        };
+
+        let mut read_only = permissions;
+        read_only.set_mode(0o555);
+        fs::set_permissions(dir, read_only).expect("make cache read-only");
+
+        guard
+    }
+}
+
+#[cfg(unix)]
+impl Drop for RestoredMode {
+    fn drop(&mut self) {
+        let Ok(metadata) = fs::metadata(&self.dir) else {
+            return;
+        };
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(self.mode);
+        let _ = fs::set_permissions(&self.dir, permissions);
+    }
+}
+
 #[cfg(unix)]
 fn assert_partial_live_ignores_invalid_reset_cache(fetched_at: i64) {
-    let dir = tempfile::TempDir::new().expect("tempdir");
+    // The fixture below is deliberately made read-only for the duration of the
+    // run, which is exactly the shape whose teardown can fail, so it uses the
+    // handle that reports a failed cleanup instead of leaking quietly.
+    let dir = ScopedTempDir::new();
     let secret_dir = dir.path().join("secrets");
     fs::create_dir_all(&secret_dir).expect("secret dir");
     fs::write(
@@ -99,11 +146,7 @@ fn assert_partial_live_ignores_invalid_reset_cache(fetched_at: i64) {
     // Keep the invalid entry readable while preventing the successful live
     // request from replacing it before collect_async_round performs reset
     // metadata backfill.
-    let mut read_only = fs::metadata(cache_dir)
-        .expect("cache metadata")
-        .permissions();
-    read_only.set_mode(0o555);
-    fs::set_permissions(cache_dir, read_only).expect("make cache read-only");
+    let restored_mode = RestoredMode::read_only(cache_dir);
 
     let server = LoopbackServer::new().expect("server");
     server.add_route(
@@ -132,11 +175,9 @@ fn assert_partial_live_ignores_invalid_reset_cache(fetched_at: i64) {
         ],
     );
 
-    let mut writable = fs::metadata(cache_dir)
-        .expect("cache metadata")
-        .permissions();
-    writable.set_mode(0o700);
-    fs::set_permissions(cache_dir, writable).expect("restore cache permissions");
+    // Restore before asserting so a failing assertion reports the behaviour
+    // under test rather than a fixture that cannot be cleaned up.
+    drop(restored_mode);
 
     assert_exit(&output, 0);
     let out = stdout(&output);

--- a/docs/specs/test-temp-directory-policy.md
+++ b/docs/specs/test-temp-directory-policy.md
@@ -47,6 +47,20 @@ The common shape: the fixture is removed while something still holds a path into
 it, and the writer calls `create_dir_all` before writing. One marker write is
 enough to resurrect the whole tree.
 
+### Class 2 usually means a permission the test set itself
+
+A fixture is rarely read-only by accident. The shape is a test that chmods a
+directory to `0o555` to prove the code under test cannot write to it, then
+restores the mode in a plain statement afterwards. `remove_dir_all` cannot unlink
+entries from a read-only directory, so any panic between those two statements —
+an unwinding assertion, a `Command::spawn` that fails under load — hands teardown
+a directory it cannot empty, and the survivors are whatever sits under it.
+Restore from `Drop` instead, so the unwinding path restores it too:
+`RestoredMode` in `crates/codex-cli/tests/integration/rate_limits_async.rs`.
+Note that `remove_dir_all` stops at the first error, so the leftovers name the
+read-only subtree and nothing else — sibling fixture directories removed before
+it are already gone.
+
 ### Class 4 is a placement bug, not a timing bug
 
 `RemoteSessionAllocationLock` names its lock after the directory it guards and
@@ -71,6 +85,14 @@ no race involved. Give any such API a parent the fixture owns.
    released rather than for the cache file, because the child writes its marker
    and releases its lock after the cache. Waiting on an intermediate artifact
    returns while writes are still pending.
+   **Better still, do not start it.** When the background work is incidental to
+   what the test asserts, hold the production cooldown open so nothing is
+   spawned: `RefreshCooldown` in
+   `crates/codex-cli/tests/integration/prompt_segment_cached.rs` writes a recent
+   `<key>.refresh.at` marker, sets `CODEX_PROMPT_SEGMENT_REFRESH_MIN_SECONDS`
+   past the test's lifetime, and then asserts the marker is untouched —
+   `enqueue_background_refresh` rewrites it immediately before spawning, so a
+   regression fails the test instead of leaking a directory.
 4. **`abort()` is not a barrier; `await` is.** Aborting a task only schedules
    cancellation. Where a shutdown path already exists, use it — the projection
    tests call `finish_fail_close`, the broker tests call
@@ -109,7 +131,10 @@ measuring by hand instead:
 
 The contents of a leaked directory identify the writer: `usage.refresh.at` is the
 `claude-cli` refresh child, an empty `sessions/` is the activity broker re-arming,
-and a stray `*.allocation.lock` is a sibling-placed lock.
+and a stray `*.allocation.lock` is a sibling-placed lock. A lone `cache_root/` is
+the `codex-cli` prompt-segment cache, and it has two possible writers — the
+detached refresh child recreating it (class 3) or a read-only cache directory
+teardown could not empty (class 2) — so check both before concluding.
 
 ## Do not redirect `TMPDIR` into the build tree
 


### PR DESCRIPTION
## Summary

Close the two `codex-cli` test hazards that can leave a `cache_root/` behind in
`$TMPDIR`. A workspace `tempdir-leak-probe` run intermittently reported
`.tmpXXXXXX/  contains: cache_root` — a fixture that survived `TempDir`
teardown with everything but the prompt-segment cache already removed. Both
writers that produce exactly that signature live in `codex-cli` tests, and each
is fixed at its source rather than allow-listed in the probe.

Attribution first: `cache_root` (underscore) is `codex-cli`; `gemini-cli` names
its fixture `cache-root`. The `.tmp` prefix means a `tempfile::TempDir`, which
rules out `gemini-cli`'s named fixtures. Within `codex-cli` the two candidates
are a class-3 resurrection by the detached prompt-segment refresh child and a
class-2 teardown failure on a read-only cache directory.

## Test-First Evidence

A deterministic failing test for the leak itself is not practical: both classes
are races that only lose under parallel load, and the policy says so explicitly
("Treat a probe failure as conclusive and a probe pass as evidence"). A test that
waits for the leak to appear would pass for the wrong reason. Substitute
evidence, captured before the fix was locked in:

**Class 3 — the spawn is real, and the new assertion detects it.** With
`REFRESH_COOLDOWN_SECONDS` temporarily set to `"0"` (cooldown disabled, i.e. the
behaviour on `main`), both new assertions fail, because the parent rewrites the
marker immediately before spawning:

```
thread 'prompt_segment_cached::prompt_segment_stale_cache_appends_suffix' panicked at
crates/codex-cli/tests/integration/prompt_segment_cached.rs:137:9:
assertion failed: `(left == right)`: the run spawned a detached refresh child
instead of honouring the cooldown
<1785726447
>1785726442

Summary [0.039s] 2 tests run: 0 passed, 2 failed, 468 skipped
```

Restoring the cooldown to `"3600"` turns both green. So the assertion has teeth
and pins the contract rather than the timing.

The spawn was also confirmed directly: running the CLI by hand with that test's
fixture leaves `cache_root/codex/prompt-segment-rate-limits/alpha.refresh.at`,
which only `enqueue_background_refresh` writes, and it writes it on the line
before `cmd.spawn()`. That test set no `CODEX_CHATGPT_BASE_URL` at all, so the
child was reaching the real ChatGPT backend.

**Class 3 coverage is now exhaustive.** With a temporary probe wired into
`enqueue_background_refresh`, every one of the 470 `codex-cli` tests was run
alone and checked for a spawn. Exactly six still spawn, all in
`prompt_segment_refresh.rs`, and every one of those already waits for the child
to settle before its fixture drops:

```
prompt_segment_background_refresh_survives_prompt_shell_hup
prompt_segment_expired_cache_refreshes_in_background_before_next_render
prompt_segment_refresh_respects_min_interval
prompt_segment_stale_cache_401_refreshes_auth_in_background
prompt_segment_stale_cache_401_respects_disabled_auto_refresh
prompt_segment_stale_cache_triggers_background_refresh
```

The two fixed tests no longer appear. The probe was reverted before this commit;
`crates/codex-cli/src/prompt_segment/refresh.rs` is untouched by this PR.

**Class 2 — the teardown failure reproduces exactly, on demand.** A read-only
`0o555` cache directory makes `remove_dir_all` stop at its first error, and
because it stops there the survivors are precisely the observed signature —
`cache_root/...` present, sibling `secrets/` already gone:

```
$ chmod 0555 "$t/fixture/cache_root/codex/prompt-segment-rate-limits"
$ rm -rf "$t/fixture"
rm: cannot remove '.../prompt-segment-rate-limits/alpha.kv': Permission denied
$ find "$t"
/fixture
/fixture/cache_root
/fixture/cache_root/codex
/fixture/cache_root/codex/prompt-segment-rate-limits
/fixture/cache_root/codex/prompt-segment-rate-limits/alpha.kv
```

On `main` the mode is restored by a plain statement after `run(...)`, so any
panic in between — an unwinding assertion, or the `cmd.output().expect("run
command")` in `nils-test-support` failing to spawn under load — skips it. The
`RestoredMode` guard restores from `Drop`, and `ScopedTempDir` turns a cleanup
failure that does happen into a test failure instead of a silent leak.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — pass. Packages
  mode (`LOCAL_FAST_PACKAGE=nils-codex-cli`, the only changed crate): docs
  placement, docs hygiene, markdownlint, shell syntax, tempdir-leak-audit and
  both audit self-tests, `cargo fmt --check`, `cargo clippy -p nils-codex-cli
  --all-targets --all-features -D warnings`, **470 tests run, 470 passed, 0
  skipped**, plus the crate doctests.
- `bash scripts/ci/tempdir-leak-probe.sh --runs 3 -- --profile ci -p
  nils-codex-cli` — `ok — nothing left behind`, 470/470 passing on each of the
  three runs. This is the detector for the classes this PR fixes.
- `cargo nextest run --profile ci -p nils-codex-cli -E 'test(/prompt_segment/) +
  test(/rate_limits_async/)'` — 76 passed, 394 skipped.
- The before/after failure capture is in the Test-First section: the new
  assertions fail with the cooldown disabled and pass with it held.

One note for reproducing locally: `-p nils-codex-cli` alone does not build the
`gemini-cli` binary, and the `parity_oracle` tests resolve it at runtime, so a
package-scoped probe run fails 129 tests with `gemini-cli binary path:
NotPresent` until `cargo build -p nils-gemini-cli --bins` has run. That is a
build-scope artifact, not a regression; the numbers above are from after that
build.

## Risk / Notes

- Test-only. No production code changes: `refresh.rs` and every other `src/`
  file are untouched, so no behaviour reaches a shipped binary.
- The suppressed `enqueue_background_refresh` spawn path keeps its coverage. It
  is exercised by the six `prompt_segment_refresh.rs` tests listed above, which
  do assert on the refresh; the two tests changed here assert on rendering and
  never looked at the child. The cooldown early-return they now take is itself
  covered by `prompt_segment_refresh_respects_min_interval`.
- `RefreshCooldown` depends on a production contract
  (`CODEX_PROMPT_SEGMENT_REFRESH_MIN_SECONDS` plus the `<key>.refresh.at`
  marker), so if that contract changes the marker assertion fails loudly instead
  of the suppression silently lapsing back into a leak.
- `ScopedTempDir` makes a real cleanup failure a test failure. That is the
  intent — the policy calls silent cleanup failure the reason the original leak
  reached ~280 GB — and the `RestoredMode` guard removes the failure mode that
  could trip it here.
- The probe is a sampler, not a proof: classes 2 and 3 are races, so a clean
  probe run is evidence rather than a guarantee. The per-test spawn enumeration
  above is the stronger claim, since it does not depend on winning or losing a
  race.
- `RestoredMode` and the `ScopedTempDir` fixture are `#[cfg(unix)]`, matching the
  helper they replace; Windows behaviour is unchanged.
