### PR TITLE
fix(agent-session): pin AGENT_SESSION_BIN into new tmux sessions

### DIFF
--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -10165,6 +10165,18 @@ fn add_runtime_tmux_environment(
         assignment.push(path);
         command.arg("-e").arg(assignment);
     }
+    // Pinning PATH alone is not enough: AGENT_SESSION_BIN outranks PATH when
+    // agent-hook resolves the activity helper, so a value cached by the tmux
+    // server survives the PATH pin and fail-closes every UserPromptSubmit and
+    // Stop in a session created long after the helper moved. Pin the executable
+    // that is launching this session, which `HELD_LAUNCH_SCRIPT` already binds
+    // as `broker_bin` for the session's whole life, so this adds no lifetime
+    // coupling the runtime does not already have. See sympoies/nils-cli#1414.
+    if let Ok(helper) = resolve_agent_session_executable() {
+        let mut assignment = OsString::from("AGENT_SESSION_BIN=");
+        assignment.push(helper);
+        command.arg("-e").arg(assignment);
+    }
     Ok(())
 }
 

--- a/crates/agent-session/tests/integration/cli.rs
+++ b/crates/agent-session/tests/integration/cli.rs
@@ -1584,6 +1584,18 @@ fn activity_events_are_runtime_bound_private_and_deterministic() {
             .any(|pair| { pair == ["-e", &format!("PATH={inherited_path}")] }),
         "new tmux sessions must receive the daemon PATH instead of inheriting a stale tmux-server PATH: {new_session:?}"
     );
+    let launching_helper = nils_test_support::bin::resolve("agent-session");
+    assert!(
+        new_session.windows(2).any(|pair| {
+            pair == [
+                "-e",
+                &format!("AGENT_SESSION_BIN={}", launching_helper.display()),
+            ]
+        }),
+        "AGENT_SESSION_BIN outranks PATH in agent-hook helper resolution, so a new tmux \
+         session must be pinned to the launching executable instead of inheriting a stale \
+         tmux-server value: {new_session:?}"
+    );
 
     let event = |event_id: &str,
                  kind: &str,
@@ -4028,6 +4040,8 @@ fn start_creates_session_state_without_printing_prompt() {
             "AGENT_SESSION_ATTENTION_AUTHORITY=hook".to_string(),
             "-e".to_string(),
             format!("PATH={inherited_path}"),
+            "-e".to_string(),
+            format!("AGENT_SESSION_BIN={agent_session_bin}"),
             "--".to_string(),
             "sh".to_string(),
             "-c".to_string(),
@@ -9391,6 +9405,8 @@ fn resume_recreates_tmux_runtime_from_exact_provider_identity() {
             "AGENT_SESSION_ATTENTION_AUTHORITY=hook".to_string(),
             "-e".to_string(),
             format!("PATH={inherited_path}"),
+            "-e".to_string(),
+            format!("AGENT_SESSION_BIN={agent_session_bin}"),
             "--".to_string(),
             "sh".to_string(),
             "-c".to_string(),


### PR DESCRIPTION
## Summary

Closes the first half of #1414.

`add_runtime_tmux_environment` already pins `PATH` into every new tmux session,
with a comment naming the exact failure mode: *"A long-lived tmux server keeps
the environment from when that server started. Pin each new session to the
current daemon PATH so provider hooks cannot resolve an older agent-session
helper after a staged daemon upgrade."*

That mitigation was incomplete. `AGENT_SESSION_BIN` **outranks** `PATH` in
`crates/agent-hook/src/evaluator.rs:1052`:

```rust
let binary = std::env::var_os("AGENT_SESSION_BIN").unwrap_or_else(|| "agent-session".into());
```

So a tmux server that cached `AGENT_SESSION_BIN` before a relocation silently
defeats the `PATH` pin, and every session it creates afterwards fail-closes on
its first `UserPromptSubmit` with
`coord.activity.prompt-stop:capability-failure-closed` — unrecoverable from
inside the session, because that rule is `failure_posture = "closed"` +
`override_class = "locked"`. Observed in the field on a session created 63
minutes *after* the relocation completed, by a healthy current-build launcher.

This pins the launching executable as `AGENT_SESSION_BIN` next to the `PATH`
pin, reusing `resolve_agent_session_executable()`.

### Why the launching executable rather than a `PATH` lookup

Pinning a build-exact path looks like it would widen exposure to #1409's
chain 1 (a session outliving an upgrade that deletes its keg). It does not:
`HELD_LAUNCH_SCRIPT` already binds that **same** resolved path as `broker_bin`
and uses it for the session's entire life — the heartbeat at start and
`broker stop` at teardown. If that path disappears the session's broker is
already dead, so the pin adds no lifetime coupling the runtime does not
already carry, and it keeps the hook helper on exactly the build that created
the session.

The resolution is best effort: if the executable cannot be resolved, no
assignment is emitted rather than failing session start.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — pass (exit 0).
- `cli::activity_events_are_runtime_bound_private_and_deterministic` gains an
  assertion for the new `-e` assignment, next to the existing `PATH` one. It
  was confirmed red against unmodified production code before the fix.
- The two exact launch-argument list assertions
  (`cli::resume_recreates_tmux_runtime_from_exact_provider_identity` and its
  start-path sibling) are updated for the added assignment. These caught the
  contract change on the first gate run, which is what they are for.

## Scope

Deliberately **not** in this PR, and left with #1409 as recorded in #1414:

- agent-hook falling back to `PATH` when `AGENT_SESSION_BIN` is empty or does
  not resolve. That changes a fail-closed security boundary, and its correct
  shape depends on #1409 workstream 1's typed classification for a missing
  helper.
- An `agent-hook doctor` probe that actually resolves and executes the
  `agent-session.activity.v1` helper. Today `doctor` reports `converged` while
  the capability is unexecutable.

The infrastructure half — reconciling a tmux server that a fleet upgrade
already invalidated — shipped separately in serenvia/sympoies-infra#154.
