### PR TITLE
Enforce no agent attribution in the CLIs that write commits and PRs

### DIFF
--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -43,6 +43,10 @@ validations_catalog:
     rule: "posted title/body/comment text must not embed a machine-local home path (/Users/<owner>/... or /home/<owner>/...); diagnostics name the source and line with a $HOME-relative fix without echoing the original path; allowlist /home/agent, /home/linuxbrew, /home/runner; bypass with FORGE_CLI_ALLOW_LOCAL_PATH=1"
     error_kind: local_path_present
     exit: DATA
+  no_agent_attribution:
+    rule: "posted title/body/comment text must not carry agent self-attribution: a generator marker (Generated with ... prose, claude.com/claude-code or claude.ai/code link) or a Co-Authored-By trailer naming the model family or noreply@anthropic.com; fenced blocks and inline code spans are stripped first so documenting the rule is allowed; forms shared with semantic-commit's claude-coauthor-trailer / claude-generated-marker rules; bypass with FORGE_CLI_ALLOW_AGENT_ATTRIBUTION=1"
+    error_kind: agent_attribution_present
+    exit: DATA
   worktree_clean:
     rule: "git status --porcelain is empty"
     error_kind: dirty_worktree
@@ -188,6 +192,7 @@ operations:
       - branch_kind_matches
       - title_length
       - no_local_path # title + body
+      - no_agent_attribution # title + body
       - body_summary
       - body_test_plan
       - label_catalog # only when --strict-labels is set
@@ -273,6 +278,7 @@ operations:
     validations:
       - title_length   # when --title supplied
       - no_local_path  # title when --title; body when --body / --body-file
+      - no_agent_attribution # title when --title; body when --body / --body-file
       - body_summary   # when --body or --body-file supplied
       - body_test_plan # when --body or --body-file supplied
     backends:
@@ -288,6 +294,7 @@ operations:
       - { name: --body-file, type: path,    required: false }
     validations:
       - no_local_path # comment body
+      - no_agent_attribution # comment body
     backends:
       github: { program: gh,   argv: [pr, comment, "{id}", --body, "{body_or_file}"] }
       gitlab: { program: glab, argv: [mr, note,    "{id}", --message, "{body_or_file}"] }
@@ -308,6 +315,7 @@ operations:
       - { name: --thread-file,    type: path,    required: false } # GitHub-only JSON array of actionable review-thread specs; requires --submit-review; max 256 KiB, 50 specs, 1024-byte paths, 16 KiB bodies. Use only for findings that should be repaired then resolved via pr review-threads resolve.
     validations:
       - no_local_path # review comment body, thread spec bodies/paths, AND the generated issue mirror (lens values are user-controlled), validated before any post
+      - no_agent_attribution # review comment body, thread spec bodies, AND the generated issue mirror, validated before any post (thread paths carry no prose)
       - no_escaped_control_markdown # review comment body, thread spec bodies/paths, AND the generated issue mirror, validated before any post
     # Op-specific error kinds:
     #   issue_required (DATA 65)       — --mirror-issue without --issue
@@ -381,6 +389,7 @@ operations:
       - { name: --check-diff,   type: bool,    default: false } # GitHub-only in v1; validates thread paths/lines against live PR diff
     validations:
       - no_local_path # review comment body plus thread spec bodies/paths
+      - no_agent_attribution # review comment body plus thread spec bodies
       - no_escaped_control_markdown # review comment body plus thread spec bodies/paths
     # Op-specific error kinds:
     #   invalid_review_thread_spec (DATA 65) — malformed, oversized, or locally invalid thread spec fields
@@ -450,6 +459,7 @@ operations:
       - { name: --note-file, type: path,    required: false }
     validations:
       - no_local_path # optional reply note
+      - no_agent_attribution # optional reply note
       - review_thread_pr_mismatch # live GitHub only: --thread must belong to <id> before mutation
     backends:
       # With a note: the reply mutation runs first, then resolve. Without a
@@ -477,6 +487,7 @@ operations:
       - { name: --body-file, type: path,    required: false }
     validations:
       - no_local_path # reply body
+      - no_agent_attribution # reply body
       - review_thread_pr_mismatch # live GitHub only: --thread must belong to <id> before mutation
     backends:
       github: { program: gh, argv: [api, graphql, "--hostname <host when host != github.com>", -f, "query=<addPullRequestReviewThreadReply>", -f, "tid={thread}", -f, "body={body_or_file}"] }
@@ -864,6 +875,7 @@ operations:
     validations:
       - title_length
       - no_local_path # title + body
+      - no_agent_attribution # title + body
     backends:
       github: { program: gh,   argv: [issue, create, --title, "{title}", --body-file, "{body_file_or_temp}"] }
       gitlab: { program: glab, argv: [issue, create, --title, "{title}", --description, "{body_or_file}"] }
@@ -910,6 +922,7 @@ operations:
     validations:
       - title_length   # when --title supplied
       - no_local_path  # title when --title; body when --body / --body-file
+      - no_agent_attribution # title when --title; body when --body / --body-file
     backends:
       github: { program: gh,   argv: [issue, edit,   "{id}"] }
       gitlab: { program: glab, argv: [issue, update, "{id}"] }
@@ -923,6 +936,7 @@ operations:
       - { name: --body-file, type: path,    required: false }
     validations:
       - no_local_path # comment body
+      - no_agent_attribution # comment body
     backends:
       github: { program: gh,   argv: [issue, comment, "{id}", --body, "{body_or_file}"] }
       gitlab: { program: glab, argv: [issue, note,    "{id}", --message, "{body_or_file}"] }

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -1174,6 +1174,27 @@ backend implementations cannot diverge.
     both user and GitHub App installation actors without `GET /user`. GitHub
     exposes no content CAS on delete/discard, so the documented
     final-read-to-delete race remains after exact snapshot guards.
+17. **No agent attribution.** PR/MR and issue title, body, and comment text
+    MUST NOT carry agent self-attribution: a generator marker line
+    (`Generated with …` prose, or a `claude.com/claude-code` /
+    `claude.ai/code` link) or a `Co-Authored-By` trailer whose value names the
+    model family or carries the vendor no-reply address
+    (`noreply@anthropic.com`). The marker forms are defined once in
+    `nils_common::agent_attribution` and shared with `semantic-commit`'s
+    `claude-coauthor-trailer` / `claude-generated-marker` blocked-message rules,
+    so the commit path and the provider path cannot diverge. Enforcement lives
+    in the CLI rather than in an agent-harness hook, so the rule holds whether or
+    not the calling runtime declares a matching hook of its own. Text *about*
+    the rule is allowed: fenced
+    code blocks and inline code spans are stripped before the scan, so a body
+    documenting `` `Co-Authored-By: Claude ...` `` passes while a bare
+    attribution line does not (commit messages get no such exemption — that
+    scan is verbatim). The error `detail` enumerates each offending line and its
+    fix without echoing the marker; set
+    `FORGE_CLI_ALLOW_AGENT_ATTRIBUTION=1` to bypass a verified false positive.
+    Enforced by `pr create`, `pr edit`, `issue create`, `issue edit`,
+    `pr comment`, `issue comment`, `pr review`, `pr review-threads reply`, and
+    `pr review-threads resolve`.
 
 Violations map to `DATA 65` with one of these `data.error.kind` values:
 
@@ -1220,6 +1241,7 @@ Violations map to `DATA 65` with one of these `data.error.kind` values:
 | `merge_method_unsupported`                 | 9                    |
 | `keep_branch_conflict`                     | 10                   |
 | `local_path_present`                       | 11                   |
+| `agent_attribution_present`                | 17                   |
 | `review_changes_requested`                 | 12                   |
 | `review_convergence_head_missing`          | 12                   |
 | `review_convergence_head_changed`          | 12                   |

--- a/crates/forge-cli/src/ops/issue_comment.rs
+++ b/crates/forge-cli/src/ops/issue_comment.rs
@@ -19,7 +19,7 @@ use crate::error::ForgeError;
 use crate::ops::issue_view;
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
-use crate::validations::{no_escaped_control_markdown, no_local_path};
+use crate::validations::{no_agent_attribution, no_escaped_control_markdown, no_local_path};
 
 const SCHEMA: &str = "issue.comment";
 const SCHEMA_VERSION: u32 = 1;
@@ -67,6 +67,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         ));
     }
     no_local_path(&body, "comment")?;
+    no_agent_attribution(&body, "comment")?;
     no_escaped_control_markdown(&body)?;
     let call = build_comment_call(&ctx, args.id, &body);
 

--- a/crates/forge-cli/src/ops/issue_create.rs
+++ b/crates/forge-cli/src/ops/issue_create.rs
@@ -22,7 +22,9 @@ use crate::error::ForgeError;
 use crate::ops::issue_view;
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
-use crate::validations::{no_escaped_control_markdown, no_local_path, title_length};
+use crate::validations::{
+    no_agent_attribution, no_escaped_control_markdown, no_local_path, title_length,
+};
 
 const SCHEMA: &str = "issue.create";
 const SCHEMA_VERSION: u32 = 1;
@@ -66,9 +68,11 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     )?;
     title_length(&args.title)?;
     no_local_path(&args.title, "title")?;
+    no_agent_attribution(&args.title, "title")?;
     no_escaped_control_markdown(&args.title)?;
     let body = read_body(args.body.as_deref(), args.body_file.as_deref())?;
     no_local_path(&body, "body")?;
+    no_agent_attribution(&body, "body")?;
     no_escaped_control_markdown(&body)?;
     let body_tempfile = write_body_tempfile(&body)?;
     let body_path = body_tempfile.path().to_path_buf();

--- a/crates/forge-cli/src/ops/issue_edit.rs
+++ b/crates/forge-cli/src/ops/issue_edit.rs
@@ -19,7 +19,9 @@ use crate::error::ForgeError;
 use crate::ops::issue_view;
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
-use crate::validations::{no_escaped_control_markdown, no_local_path, title_length};
+use crate::validations::{
+    no_agent_attribution, no_escaped_control_markdown, no_local_path, title_length,
+};
 
 const SCHEMA: &str = "issue.edit";
 const SCHEMA_VERSION: u32 = 1;
@@ -64,6 +66,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     if let Some(ref t) = args.title {
         title_length(t)?;
         no_local_path(t, "title")?;
+        no_agent_attribution(t, "title")?;
         no_escaped_control_markdown(t)?;
     }
     let body = if args.body.is_some() || args.body_file.is_some() {
@@ -73,6 +76,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     };
     if let Some(ref b) = body {
         no_local_path(b, "body")?;
+        no_agent_attribution(b, "body")?;
         no_escaped_control_markdown(b)?;
     }
     let call = build_edit_call(&ctx, &args, body.as_deref());

--- a/crates/forge-cli/src/ops/pr_comment.rs
+++ b/crates/forge-cli/src/ops/pr_comment.rs
@@ -21,7 +21,7 @@ use crate::error::ForgeError;
 use crate::ops::pr_view;
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
-use crate::validations::no_local_path;
+use crate::validations::{no_agent_attribution, no_local_path};
 
 const SCHEMA: &str = "pr.comment";
 const SCHEMA_VERSION: u32 = 1;
@@ -65,6 +65,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         ));
     }
     no_local_path(&body, "comment")?;
+    no_agent_attribution(&body, "comment")?;
     let call = build_comment_call(&ctx, args.id, &body);
 
     if global.dry_run {

--- a/crates/forge-cli/src/ops/pr_create.rs
+++ b/crates/forge-cli/src/ops/pr_create.rs
@@ -37,7 +37,8 @@ use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
 use crate::validations::{
     BodyHeadings, PrKind, body_sections, branch_kind_matches, branch_name, branch_pushed,
-    git_branch_state, git_status_porcelain, no_local_path, title_length, worktree_clean,
+    git_branch_state, git_status_porcelain, no_agent_attribution, no_local_path, title_length,
+    worktree_clean,
 };
 
 const SCHEMA: &str = "pr.create";
@@ -409,8 +410,10 @@ pub fn run_with<R: BackendRunner>(
     branch_kind_matches(prefix, kind)?;
     title_length(&args.title)?;
     no_local_path(&args.title, "title")?;
+    no_agent_attribution(&args.title, "title")?;
     body_sections(&body, &env.headings)?;
     no_local_path(&body, "body")?;
+    no_agent_attribution(&body, "body")?;
     let label_target = match ctx.provider {
         Provider::GitHub | Provider::Local => LabelTarget::Pr,
         Provider::GitLab => LabelTarget::Mr,
@@ -542,8 +545,10 @@ fn compute_with_subject_inner<R: BackendRunner>(
     branch_kind_matches(prefix, kind)?;
     title_length(&args.title)?;
     no_local_path(&args.title, "title")?;
+    no_agent_attribution(&args.title, "title")?;
     body_sections(&body, &env.headings)?;
     no_local_path(&body, "body")?;
+    no_agent_attribution(&body, "body")?;
     if prevalidated_ctx.is_none() {
         let label_target = match ctx.provider {
             Provider::GitHub | Provider::Local => LabelTarget::Pr,

--- a/crates/forge-cli/src/ops/pr_edit.rs
+++ b/crates/forge-cli/src/ops/pr_edit.rs
@@ -21,7 +21,9 @@ use crate::error::ForgeError;
 use crate::ops::pr_view::{self, PrViewPayload};
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
-use crate::validations::{BodyHeadings, body_summary, body_test_plan, no_local_path, title_length};
+use crate::validations::{
+    BodyHeadings, body_summary, body_test_plan, no_agent_attribution, no_local_path, title_length,
+};
 
 const SCHEMA: &str = "pr.edit";
 const SCHEMA_VERSION: u32 = 1;
@@ -61,12 +63,14 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     if let Some(title) = &args.title {
         title_length(title)?;
         no_local_path(title, "title")?;
+        no_agent_attribution(title, "title")?;
     }
     if let Some(body) = &new_body {
         let headings = BodyHeadings::default();
         body_summary(body, &headings)?;
         body_test_plan(body, &headings)?;
         no_local_path(body, "body")?;
+        no_agent_attribution(body, "body")?;
     }
 
     let body_tempfile = match (&ctx.provider, &new_body) {

--- a/crates/forge-cli/src/ops/pr_review.rs
+++ b/crates/forge-cli/src/ops/pr_review.rs
@@ -24,7 +24,7 @@ use crate::error::ForgeError;
 use crate::ops::{pr_comment, pr_review_threads, pr_reviews, review_state};
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
-use crate::validations::{no_escaped_control_markdown, no_local_path};
+use crate::validations::{no_agent_attribution, no_escaped_control_markdown, no_local_path};
 
 const SCHEMA: &str = "pr.review";
 const SCHEMA_VERSION: u32 = 1;
@@ -363,6 +363,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     }
     if body_present {
         no_local_path(&body, "review comment")?;
+        no_agent_attribution(&body, "review comment")?;
         no_escaped_control_markdown(&body)?;
     }
 
@@ -381,6 +382,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             MIRROR_URL_PENDING,
         );
         no_local_path(&preview, "issue mirror")?;
+        no_agent_attribution(&preview, "issue mirror")?;
         no_escaped_control_markdown(&preview)?;
         Some(issue_number)
     } else {
@@ -741,6 +743,7 @@ fn run_validate_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     let body_present = !body.trim().is_empty();
     if body_present {
         no_local_path(&body, "review comment")?;
+        no_agent_attribution(&body, "review comment")?;
         no_escaped_control_markdown(&body)?;
     }
 
@@ -951,6 +954,7 @@ fn prepare_review_thread_spec(
     }
     no_local_path(&path, "review thread path")?;
     no_local_path(&spec.body, "review thread body")?;
+    no_agent_attribution(&spec.body, "review thread body")?;
     no_escaped_control_markdown(&path)?;
     no_escaped_control_markdown(&spec.body)?;
 

--- a/crates/forge-cli/src/ops/pr_review_thread_reply.rs
+++ b/crates/forge-cli/src/ops/pr_review_thread_reply.rs
@@ -23,7 +23,7 @@ use crate::ops::pr_comment::read_body;
 use crate::ops::pr_review_threads;
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
-use crate::validations::no_local_path;
+use crate::validations::{no_agent_attribution, no_local_path};
 
 const SCHEMA: &str = "pr.review-threads.reply";
 const SCHEMA_VERSION: u32 = 1;
@@ -75,6 +75,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         ));
     }
     no_local_path(&body, "reply")?;
+    no_agent_attribution(&body, "reply")?;
 
     let call = build_reply_call(&ctx, &args.thread, &body);
 

--- a/crates/forge-cli/src/ops/pr_review_thread_resolve.rs
+++ b/crates/forge-cli/src/ops/pr_review_thread_resolve.rs
@@ -26,7 +26,7 @@ use crate::ops::pr_comment::read_body_with_file_flag;
 use crate::ops::{pr_review_threads, review_state};
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
-use crate::validations::no_local_path;
+use crate::validations::{no_agent_attribution, no_local_path};
 
 const SCHEMA: &str = "pr.review-threads.resolve";
 const SCHEMA_VERSION: u32 = 1;
@@ -83,6 +83,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         None
     } else {
         no_local_path(&note, "note")?;
+        no_agent_attribution(&note, "note")?;
         Some(format!(
             "{}\n{}",
             note.trim_end(),

--- a/crates/forge-cli/src/validations.rs
+++ b/crates/forge-cli/src/validations.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use std::process::Command;
 
 use nils_common::cli_contract::schema_version_for;
-use nils_common::{markdown, provider_payload};
+use nils_common::{agent_attribution, markdown, provider_payload};
 use serde::Serialize;
 
 use crate::cli::BINARY;
@@ -341,6 +341,32 @@ pub fn no_local_path(text: &str, field: &str) -> Result<(), ForgeError> {
     ))
 }
 
+/// Rule 17 — posted text (title / body / comment) MUST NOT carry agent
+/// self-attribution: a generator marker line (`Generated with …` plus its
+/// claude-code link) or a co-author trailer naming the model or its vendor
+/// no-reply address. The forms are defined once in
+/// [`nils_common::agent_attribution`], shared with `semantic-commit`'s
+/// `claude-coauthor-trailer` / `claude-generated-marker` blocked-message rules,
+/// so the commit path and the provider path cannot diverge — and so the rule
+/// holds regardless of whether the calling agent runtime declares a matching
+/// harness hook of its own. Text *about*
+/// the rule is allowed: fenced blocks and inline code spans are stripped before
+/// the scan. `field` names the offending input without echoing the marker; the
+/// `detail` enumerates each offending line plus its fix. Set
+/// `FORGE_CLI_ALLOW_AGENT_ATTRIBUTION=1` to bypass a verified false positive.
+pub fn no_agent_attribution(text: &str, field: &str) -> Result<(), ForgeError> {
+    let err = match agent_attribution::validate_no_agent_attribution(text, field) {
+        Ok(()) => return Ok(()),
+        Err(err) => err,
+    };
+    Err(ForgeError::validation(
+        schema(),
+        agent_attribution::AGENT_ATTRIBUTION_ERROR_KIND,
+        err.message(),
+        Some(err.detail()),
+    ))
+}
+
 /// Escaped-control markdown guard — posted text (title / body / comment) MUST
 /// NOT embed literal escaped-control artifacts (`\n`, `\r`, `\t`) in prose or
 /// structure. These usually mean a payload was double-escaped before being
@@ -506,7 +532,7 @@ pub struct PreflightInputs<'a> {
     pub headings: &'a BodyHeadings,
 }
 
-/// Evaluate the non-mutating lock-down rules (1a, 1b, 3, 2a, 2b, 4, 5)
+/// Evaluate the non-mutating lock-down rules (1a, 1b, 3, 2a, 2b, 4, 5, 11, 17)
 /// without returning early on the first failure, collecting a per-rule
 /// verdict for each. This is the faithful-preflight runner behind
 /// `pr deliver --dry-run`: it never invokes a provider backend, only local
@@ -523,7 +549,7 @@ where
     FS: FnOnce(&Path) -> Result<String, ForgeError>,
     FH: FnOnce(&Path, &str) -> Result<HeadState, ForgeError>,
 {
-    let mut verdicts = Vec::with_capacity(9);
+    let mut verdicts = Vec::with_capacity(11);
 
     // Rule 1a — branch name. Capture the prefix for Rule 1b.
     let branch_result = branch_name(inputs.branch);
@@ -554,6 +580,12 @@ where
         no_local_path(inputs.title, "title"),
     ));
 
+    // Rule 17 (title) — no agent self-attribution in the title.
+    verdicts.push(RuleVerdict::from_result(
+        "title_agent_attribution",
+        no_agent_attribution(inputs.title, "title"),
+    ));
+
     // Rules 2a / 2b — body sections, reported individually so the preflight
     // surfaces every missing section at once.
     verdicts.push(RuleVerdict::from_result(
@@ -569,6 +601,12 @@ where
     verdicts.push(RuleVerdict::from_result(
         "body_local_path",
         no_local_path(inputs.body, "body"),
+    ));
+
+    // Rule 17 (body) — no agent self-attribution in the body.
+    verdicts.push(RuleVerdict::from_result(
+        "body_agent_attribution",
+        no_agent_attribution(inputs.body, "body"),
     ));
 
     // Rule 4 — clean worktree (local git read).
@@ -1021,7 +1059,7 @@ mod tests {
             headings: &headings,
         };
         let verdicts = run_local_preflight(&inputs, Path::new("."), clean_status, pushed_head);
-        assert_eq!(verdicts.len(), 9);
+        assert_eq!(verdicts.len(), 11);
         assert!(verdicts.iter().all(|v| v.ok), "{verdicts:?}");
     }
 
@@ -1130,6 +1168,61 @@ mod tests {
             "{}",
             err.message()
         );
+    }
+
+    #[test]
+    fn no_agent_attribution_accepts_clean_text() {
+        no_agent_attribution("## Summary\n\nfix the thing\n", "body").expect("clean body");
+        no_agent_attribution("fix(core): drop the stale gate", "title").expect("clean title");
+        no_agent_attribution("", "body").expect("empty");
+    }
+
+    #[test]
+    fn no_agent_attribution_rejects_generator_marker() {
+        let err = no_agent_attribution(
+            "## Summary\n\nfix it\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)",
+            "body",
+        )
+        .expect_err("generator marker");
+        assert_eq!(err.kind(), "agent_attribution_present");
+        assert!(
+            err.message().starts_with("body contains 1"),
+            "{}",
+            err.message()
+        );
+        let detail = err.detail().expect("detail present");
+        assert!(
+            detail.contains("line 5: agent generator marker"),
+            "{detail}"
+        );
+        assert!(
+            detail.contains("FORGE_CLI_ALLOW_AGENT_ATTRIBUTION"),
+            "{detail}"
+        );
+    }
+
+    #[test]
+    fn no_agent_attribution_rejects_coauthor_trailer() {
+        let err = no_agent_attribution(
+            "Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>",
+            "comment",
+        )
+        .expect_err("coauthor trailer");
+        assert_eq!(err.kind(), "agent_attribution_present");
+        let detail = err.detail().expect("detail present");
+        assert!(
+            detail.contains("line 1: agent co-author trailer"),
+            "{detail}"
+        );
+    }
+
+    #[test]
+    fn no_agent_attribution_allows_documenting_the_rule_in_code_spans() {
+        no_agent_attribution(
+            "## Summary\n\nReject `Co-Authored-By: Claude ...` trailers on the egress path.\n",
+            "body",
+        )
+        .expect("code span exempt");
     }
 
     #[test]

--- a/crates/forge-cli/tests/integration.rs
+++ b/crates/forge-cli/tests/integration.rs
@@ -3,6 +3,7 @@
 
 mod integration {
     mod activity;
+    mod agent_attribution_guard;
     mod auth_status;
     mod cli;
     mod completion_sync;

--- a/crates/forge-cli/tests/integration/agent_attribution_guard.rs
+++ b/crates/forge-cli/tests/integration/agent_attribution_guard.rs
@@ -1,0 +1,189 @@
+//! CLI-boundary coverage for the `no_agent_attribution` lock-down rule (spec
+//! §"Lock-down policy" item 17, `error.kind = agent_attribution_present`).
+//!
+//! These tests drive real ops through the binary with a backend stub that
+//! aborts if invoked, proving attribution is rejected *before* any provider
+//! call. The rule lives in the CLI rather than in an agent-harness hook, so it
+//! holds whether or not the calling runtime declares a matching hook.
+
+use pretty_assertions::assert_eq;
+
+use super::support::{StubEnv, parse_envelope, run_forge_cli};
+
+/// Exit class for lock-down violations (BSD sysexits `EX_DATAERR`).
+const DATA: i32 = 65;
+
+/// A backend stub that fails loudly: a blocked-before-backend op must never
+/// reach it.
+const NEVER_RUN: &str =
+    "#!/bin/sh\necho 'agent-attribution guard must block before backend' >&2\nexit 99\n";
+
+#[test]
+fn issue_comment_with_generator_marker_exits_data_65() {
+    let stub = StubEnv::new().gh_stub(NEVER_RUN);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "issue",
+            "comment",
+            "1",
+            "--body",
+            "Done.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)",
+        ],
+    );
+    assert_eq!(out.code, DATA, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["ok"], false);
+    assert_eq!(env["error"]["code"], "agent_attribution_present");
+    let detail = env["error"]["details"]["detail"]
+        .as_str()
+        .expect("detail string");
+    assert!(
+        detail.contains("line 3: agent generator marker"),
+        "{detail}"
+    );
+}
+
+#[test]
+fn pr_comment_with_coauthor_trailer_exits_data_65_before_backend() {
+    let stub = StubEnv::new().glab_stub(NEVER_RUN);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "gitlab",
+            "--format",
+            "json",
+            "pr",
+            "comment",
+            "3",
+            "--body",
+            "Ship it.\n\nCo-Authored-By: Claude Opus 5 <noreply@anthropic.com>",
+        ],
+    );
+    assert_eq!(out.code, DATA, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["error"]["code"], "agent_attribution_present");
+    let detail = env["error"]["details"]["detail"]
+        .as_str()
+        .expect("detail string");
+    assert!(
+        detail.contains("line 3: agent co-author trailer"),
+        "{detail}"
+    );
+}
+
+#[test]
+fn issue_create_with_marker_in_title_exits_data_65() {
+    let stub = StubEnv::new().gh_stub(NEVER_RUN);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "issue",
+            "create",
+            "--title",
+            "generated with claude code",
+        ],
+    );
+    assert_eq!(out.code, DATA, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["error"]["code"], "agent_attribution_present");
+    assert!(
+        env["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("title contains"),
+        "{}",
+        env["error"]["message"]
+    );
+}
+
+#[test]
+fn text_format_surfaces_kind_and_fix_on_stderr() {
+    let stub = StubEnv::new().gh_stub(NEVER_RUN);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "text",
+            "issue",
+            "comment",
+            "1",
+            "--body",
+            "🤖 Generated with Claude Code",
+        ],
+    );
+    assert_eq!(out.code, DATA);
+    assert!(
+        out.stderr.contains("agent_attribution_present"),
+        "{}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("delete the generator marker line"),
+        "{}",
+        out.stderr
+    );
+}
+
+#[test]
+fn documenting_the_rule_in_a_code_span_is_not_blocked() {
+    // The scan strips fenced blocks and inline code spans, so a comment that
+    // documents the rule dry-runs cleanly.
+    let stub = StubEnv::new().gh_stub(NEVER_RUN);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+            "issue",
+            "comment",
+            "1",
+            "--body",
+            "The gate rejects `Co-Authored-By: Claude ...` trailers.",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["ok"], true);
+}
+
+#[test]
+fn escape_hatch_env_bypasses_the_guard() {
+    // FORGE_CLI_ALLOW_AGENT_ATTRIBUTION=1 disables the scan for a verified
+    // false positive; the same body dry-runs cleanly.
+    let stub = StubEnv::new()
+        .gh_stub(NEVER_RUN)
+        .env("FORGE_CLI_ALLOW_AGENT_ATTRIBUTION", "1");
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+            "issue",
+            "comment",
+            "1",
+            "--body",
+            "quoting a historical footer: 🤖 Generated with Claude Code",
+        ],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["ok"], true);
+}

--- a/crates/forge-cli/tests/integration/pr_deliver.rs
+++ b/crates/forge-cli/tests/integration/pr_deliver.rs
@@ -487,6 +487,9 @@ fn pr_deliver_dry_run_reports_local_preflight_without_backend() {
     // Rule 11 — the local-path verdicts are present and pass for portable text.
     assert_eq!(lookup("title_local_path")["ok"], true);
     assert_eq!(lookup("body_local_path")["ok"], true);
+    // Rule 17 — the attribution verdicts are present and pass for unattributed text.
+    assert_eq!(lookup("title_agent_attribution")["ok"], true);
+    assert_eq!(lookup("body_agent_attribution")["ok"], true);
     // The worktree/head rules are present too (their verdict depends on the
     // local git state, so only presence is asserted here).
     assert!(preflight.iter().any(|v| v["rule"] == "worktree_clean"));

--- a/crates/forge-cli/tests/integration/validations.rs
+++ b/crates/forge-cli/tests/integration/validations.rs
@@ -10,7 +10,8 @@
 use forge_cli::error::ForgeError;
 use forge_cli::validations::{
     BodyHeadings, BranchPrefix, HeadState, PrKind, body_summary, body_test_plan,
-    branch_kind_matches, branch_name, head_pushed, no_local_path, title_length, worktree_clean,
+    branch_kind_matches, branch_name, head_pushed, no_agent_attribution, no_local_path,
+    title_length, worktree_clean,
 };
 
 #[test]
@@ -27,6 +28,10 @@ fn validation_kinds_match_spec_catalog() {
         ("worktree_clean (dirty)", "dirty_worktree"),
         ("head_pushed (no upstream)", "head_not_pushed"),
         ("no_local_path (home path)", "local_path_present"),
+        (
+            "no_agent_attribution (generator marker)",
+            "agent_attribution_present",
+        ),
     ];
 
     let errs: Vec<&'static str> = vec![
@@ -53,6 +58,9 @@ fn validation_kinds_match_spec_catalog() {
         .unwrap_err()
         .kind(),
         no_local_path("clone into /Users/dev/repo", "body")
+            .unwrap_err()
+            .kind(),
+        no_agent_attribution("🤖 Generated with Claude Code", "body")
             .unwrap_err()
             .kind(),
     ];

--- a/crates/nils-common/README.md
+++ b/crates/nils-common/README.md
@@ -40,6 +40,9 @@ Workspace-level keep/delete ownership decisions are tracked in
 - `fs`: atomic write, timestamp write/remove, UTF-8 text write, SHA-256 hashing, and cross-platform replace helpers with structured errors.
 - `markdown`: markdown payload validation (with violation reporting), markdown-table-safe cell canonicalization, markdown heading/code-block
   rendering, and stable JSON pretty-format helpers used by orchestration/reporting CLIs.
+- `agent_attribution`: the single definition of agent self-attribution markers (generator marker lines, model / vendor `Co-Authored-By`
+  trailers) plus a markdown-aware scan and a verbatim per-line predicate pair, shared by `semantic-commit`'s blocked-message rules and
+  `forge-cli`'s provider-egress Rule 17.
 - `provider_runtime`: provider-runtime substrate (paths, profiles, auth persistence, exec invocation, JSON/JWT helpers, structured errors)
   shared by Codex/Gemini-style CLIs without provider-specific UX copy.
 - `provider_usage`: stable provider-neutral usage failure reasons plus HTTP/message classification; callers retain provider-specific UX copy.

--- a/crates/nils-common/src/agent_attribution.rs
+++ b/crates/nils-common/src/agent_attribution.rs
@@ -1,0 +1,432 @@
+//! Shared agent self-attribution scan for provider-bound text and commit
+//! messages.
+//!
+//! Coding agents default to stamping their own identity onto the artifacts they
+//! produce: a generator marker line in a PR body, a co-author trailer on a
+//! commit. This module owns the single definition of what that attribution
+//! looks like so every egress layer agrees — `semantic-commit` blocks it on the
+//! commit path (see its `claude-coauthor-trailer` / `claude-generated-marker`
+//! blocked-message rules) and `forge-cli` blocks it on the provider path
+//! (Rule 17). Enforcement lives in the CLIs rather than in an agent-harness
+//! hook: a harness hook is per-runtime and absent from any runtime that has not
+//! declared it, so the CLI is the layer that holds no matter which runtime, or
+//! which harness, is driving the command.
+//!
+//! The scan is per line and, for markdown payloads, code-segment aware:
+//! [`scan_agent_attribution`] strips fenced blocks and inline code spans first,
+//! so documenting the rule (`` `Co-Authored-By: Claude ...` ``) is allowed while
+//! a bare attribution line is not. Callers that scan structured, non-markdown
+//! input use the per-line predicates directly and get no such exemption.
+
+use std::fmt;
+
+use crate::markdown::strip_code_segments;
+
+/// Case-insensitive needles that identify a generator marker. The URL forms are
+/// the stable part of the default marker; the prose form catches a marker whose
+/// link was stripped.
+const GENERATOR_MARKER_NEEDLES: &[&str] = &[
+    "generated with claude code",
+    "claude.com/claude-code",
+    "claude.ai/code",
+];
+
+/// Trailer token whose value is checked for agent attribution.
+const COAUTHOR_TRAILER_TOKEN: &str = "Co-Authored-By";
+
+/// Blocked co-author value forms: a value whose first word is the model family,
+/// or any value carrying the vendor's no-reply address.
+const COAUTHOR_BLOCKED_VALUE_WORD: &str = "Claude";
+const COAUTHOR_BLOCKED_VALUE_NEEDLE: &str = "noreply@anthropic.com";
+
+/// Cap on enumerated hits in the error `detail`, mirroring
+/// [`crate::provider_payload::LOCAL_PATH_MAX_HITS`] so a pathological body
+/// cannot produce an unbounded message.
+pub const AGENT_ATTRIBUTION_MAX_HITS: usize = 20;
+
+/// Env var that disables the scan after a verified false positive. Deliberately
+/// distinct from `FORGE_CLI_ALLOW_LOCAL_PATH` so bypassing one payload rule
+/// never silently disables the other.
+pub const ALLOW_AGENT_ATTRIBUTION_ENV: &str = "FORGE_CLI_ALLOW_AGENT_ATTRIBUTION";
+
+/// Stable machine-readable error kind for attribution failures.
+pub const AGENT_ATTRIBUTION_ERROR_KIND: &str = "agent_attribution_present";
+
+/// Which attribution form a line carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentAttributionMarker {
+    /// A generator advertisement line, e.g. a `Generated with ...` footer.
+    Generator,
+    /// A co-author trailer attributing the work to the agent or its vendor.
+    Coauthor,
+}
+
+impl AgentAttributionMarker {
+    /// Short human label naming the offending form. Never echoes the matched
+    /// text, so diagnostics cannot reproduce the marker they reject.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Generator => "agent generator marker",
+            Self::Coauthor => "agent co-author trailer",
+        }
+    }
+
+    /// Operator-facing remedy for this form.
+    pub fn fix(self) -> &'static str {
+        match self {
+            Self::Generator => "delete the generator marker line",
+            Self::Coauthor => "delete the co-author trailer line",
+        }
+    }
+}
+
+impl fmt::Display for AgentAttributionMarker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// One attribution marker found in scanned text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentAttributionHit {
+    /// 1-based line number within the scanned text.
+    pub line: usize,
+    /// The attribution form found on that line.
+    pub marker: AgentAttributionMarker,
+}
+
+/// Attribution violation report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentAttributionError {
+    source: String,
+    hits: Vec<AgentAttributionHit>,
+}
+
+impl AgentAttributionError {
+    pub fn new(source: impl Into<String>, hits: Vec<AgentAttributionHit>) -> Self {
+        Self {
+            source: source.into(),
+            hits,
+        }
+    }
+
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    pub fn hits(&self) -> &[AgentAttributionHit] {
+        &self.hits
+    }
+
+    pub fn message(&self) -> String {
+        format!(
+            "{source} contains {n} agent self-attribution marker(s); \
+             deliver the work without agent attribution",
+            source = self.source,
+            n = self.hits.len()
+        )
+    }
+
+    pub fn detail(&self) -> String {
+        render_agent_attribution_detail(&self.hits)
+    }
+
+    pub fn full_message(&self) -> String {
+        format!("{}.\n{}", self.message(), self.detail())
+    }
+}
+
+impl fmt::Display for AgentAttributionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.full_message())
+    }
+}
+
+impl std::error::Error for AgentAttributionError {}
+
+/// True when `line` advertises the generating agent. Case-insensitive; the
+/// needles are ASCII so byte-wise lowercasing is sufficient.
+pub fn line_has_generator_marker(line: &str) -> bool {
+    let lowered = line.to_ascii_lowercase();
+    GENERATOR_MARKER_NEEDLES
+        .iter()
+        .any(|needle| lowered.contains(needle))
+}
+
+/// True when `line` is a co-author trailer attributing the work to the agent or
+/// its vendor. Accepts both `Token: value` and `Token=value` because
+/// `semantic-commit --trailer` accepts either separator.
+pub fn line_is_blocked_coauthor_trailer(line: &str) -> bool {
+    let Some((token, value)) = split_trailer(line.trim()) else {
+        return false;
+    };
+    if !token.eq_ignore_ascii_case(COAUTHOR_TRAILER_TOKEN) {
+        return false;
+    }
+    starts_with_ascii_word_ignore_case(value, COAUTHOR_BLOCKED_VALUE_WORD)
+        || value
+            .to_ascii_lowercase()
+            .contains(COAUTHOR_BLOCKED_VALUE_NEEDLE)
+}
+
+/// Classify a single line, checking the co-author form first so a trailer that
+/// also carries a marker URL is reported as the trailer it is.
+pub fn classify_line(line: &str) -> Option<AgentAttributionMarker> {
+    if line_is_blocked_coauthor_trailer(line) {
+        Some(AgentAttributionMarker::Coauthor)
+    } else if line_has_generator_marker(line) {
+        Some(AgentAttributionMarker::Generator)
+    } else {
+        None
+    }
+}
+
+/// Scan a markdown payload for attribution markers. Fenced code blocks and
+/// inline code spans are removed first, so text *about* the rule is allowed
+/// while an actual attribution line is not. Stripping preserves line counts, so
+/// reported line numbers still index the original text. Pure: no env gate and
+/// no I/O, so every detection branch is unit-testable.
+pub fn scan_agent_attribution(text: &str) -> Vec<AgentAttributionHit> {
+    scan_lines(&strip_code_segments(text))
+}
+
+/// Scan text verbatim, with no code-segment exemption. For structured,
+/// non-markdown input where a backticked value is still a real value.
+pub fn scan_agent_attribution_verbatim(text: &str) -> Vec<AgentAttributionHit> {
+    scan_lines(text)
+}
+
+fn scan_lines(text: &str) -> Vec<AgentAttributionHit> {
+    text.lines()
+        .enumerate()
+        .filter_map(|(idx, line)| {
+            classify_line(line).map(|marker| AgentAttributionHit {
+                line: idx + 1,
+                marker,
+            })
+        })
+        .collect()
+}
+
+/// Validate a markdown payload, honoring [`ALLOW_AGENT_ATTRIBUTION_ENV`].
+/// `source` names the offending input (`title` / `body` / `comment`).
+pub fn validate_no_agent_attribution(
+    text: &str,
+    source: &str,
+) -> Result<(), AgentAttributionError> {
+    if agent_attribution_scan_disabled() {
+        return Ok(());
+    }
+    let hits = scan_agent_attribution(text);
+    if hits.is_empty() {
+        Ok(())
+    } else {
+        Err(AgentAttributionError::new(source, hits))
+    }
+}
+
+pub fn agent_attribution_scan_disabled() -> bool {
+    matches!(std::env::var(ALLOW_AGENT_ATTRIBUTION_ENV), Ok(v) if v == "1")
+}
+
+pub fn render_agent_attribution_detail(hits: &[AgentAttributionHit]) -> String {
+    let mut lines: Vec<String> = hits
+        .iter()
+        .take(AGENT_ATTRIBUTION_MAX_HITS)
+        .map(|hit| {
+            format!(
+                "line {line}: {label} — {fix}",
+                line = hit.line,
+                label = hit.marker.label(),
+                fix = hit.marker.fix(),
+            )
+        })
+        .collect();
+    let extra = hits.len().saturating_sub(AGENT_ATTRIBUTION_MAX_HITS);
+    if extra > 0 {
+        lines.push(format!("... {extra} more marker(s) omitted"));
+    }
+    lines.push(format!(
+        "set {ALLOW_AGENT_ATTRIBUTION_ENV}=1 to bypass after verifying a false positive"
+    ));
+    lines.join("\n")
+}
+
+/// Split `Token: value` / `Token=value` on whichever separator comes first.
+/// Mirrors `semantic-commit`'s trailer split so both layers accept the same
+/// trailer shapes.
+fn split_trailer(line: &str) -> Option<(&str, &str)> {
+    let colon = line.find(':');
+    let equals = line.find('=');
+    let idx = match (colon, equals) {
+        (Some(colon), Some(equals)) => colon.min(equals),
+        (Some(colon), None) => colon,
+        (None, Some(equals)) => equals,
+        (None, None) => return None,
+    };
+    let (token, rest) = line.split_at(idx);
+    Some((token.trim(), rest[1..].trim()))
+}
+
+/// True when `value` starts with `expected_word` as a whole ASCII word, so
+/// `Claudette` does not match `Claude`.
+fn starts_with_ascii_word_ignore_case(value: &str, expected_word: &str) -> bool {
+    if expected_word.is_empty() {
+        return false;
+    }
+    let value = value.trim_start();
+    let Some(prefix) = value.get(..expected_word.len()) else {
+        return false;
+    };
+    if !prefix.eq_ignore_ascii_case(expected_word) {
+        return false;
+    }
+    value[expected_word.len()..]
+        .chars()
+        .next()
+        .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn generator_marker_matches_default_footer() {
+        assert!(line_has_generator_marker(
+            "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+        ));
+    }
+
+    #[test]
+    fn generator_marker_matches_legacy_link_and_prose_forms() {
+        assert!(line_has_generator_marker("see https://claude.ai/code"));
+        assert!(line_has_generator_marker("Generated With Claude Code"));
+    }
+
+    #[test]
+    fn generator_marker_ignores_unrelated_mentions() {
+        assert!(!line_has_generator_marker(
+            "reviewed by a coding agent before merge"
+        ));
+        assert!(!line_has_generator_marker("claude-code-guide agent"));
+    }
+
+    #[test]
+    fn coauthor_trailer_matches_colon_and_equals_separators() {
+        assert!(line_is_blocked_coauthor_trailer(
+            "Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+        ));
+        assert!(line_is_blocked_coauthor_trailer("co-authored-by=Claude"));
+    }
+
+    #[test]
+    fn coauthor_trailer_matches_vendor_noreply_for_any_name() {
+        assert!(line_is_blocked_coauthor_trailer(
+            "Co-Authored-By: Some Agent <noreply@anthropic.com>"
+        ));
+    }
+
+    #[test]
+    fn coauthor_trailer_allows_human_and_longer_word_values() {
+        assert!(!line_is_blocked_coauthor_trailer(
+            "Co-Authored-By: Jane Dev <jane@example.com>"
+        ));
+        assert!(!line_is_blocked_coauthor_trailer(
+            "Co-Authored-By: Claudette Dev <claudette@example.com>"
+        ));
+        assert!(!line_is_blocked_coauthor_trailer("Reviewed-By: Claude"));
+        assert!(!line_is_blocked_coauthor_trailer("no separator here"));
+    }
+
+    #[test]
+    fn classify_line_prefers_the_coauthor_form() {
+        assert_eq!(
+            classify_line("Co-Authored-By: Claude <noreply@anthropic.com>"),
+            Some(AgentAttributionMarker::Coauthor)
+        );
+        assert_eq!(
+            classify_line("🤖 Generated with [Claude Code](https://claude.com/claude-code)"),
+            Some(AgentAttributionMarker::Generator)
+        );
+        assert_eq!(classify_line("## Summary"), None);
+    }
+
+    #[test]
+    fn scan_reports_original_line_numbers() {
+        let body = "## Summary\n\nfix the thing\n\n🤖 Generated with Claude Code\n";
+        assert_eq!(
+            scan_agent_attribution(body),
+            vec![AgentAttributionHit {
+                line: 5,
+                marker: AgentAttributionMarker::Generator,
+            }]
+        );
+    }
+
+    #[test]
+    fn scan_exempts_fenced_and_inline_code() {
+        let body = "The rule blocks `Co-Authored-By: Claude ...` trailers.\n\
+                    \n\
+                    ```text\n\
+                    🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\
+                    ```\n";
+        assert_eq!(scan_agent_attribution(body), Vec::new());
+    }
+
+    #[test]
+    fn verbatim_scan_has_no_code_exemption() {
+        let body = "```text\nCo-Authored-By: Claude\n```\n";
+        assert_eq!(scan_agent_attribution(body), Vec::new());
+        assert_eq!(
+            scan_agent_attribution_verbatim(body),
+            vec![AgentAttributionHit {
+                line: 2,
+                marker: AgentAttributionMarker::Coauthor,
+            }]
+        );
+    }
+
+    #[test]
+    fn validate_names_the_source_and_enumerates_hits() {
+        let err = validate_no_agent_attribution(
+            "## Summary\nCo-Authored-By: Claude\n🤖 Generated with Claude Code\n",
+            "body",
+        )
+        .expect_err("attribution present");
+        assert_eq!(err.source(), "body");
+        assert_eq!(err.hits().len(), 2);
+        assert!(err.message().contains("body contains 2"), "{err}");
+        assert!(
+            err.detail().contains("line 2: agent co-author trailer"),
+            "{err}"
+        );
+        assert!(
+            err.detail().contains("line 3: agent generator marker"),
+            "{err}"
+        );
+        assert!(err.detail().contains(ALLOW_AGENT_ATTRIBUTION_ENV), "{err}");
+    }
+
+    #[test]
+    fn validate_accepts_clean_text() {
+        validate_no_agent_attribution("## Summary\n\nfix the thing\n", "body").expect("clean");
+    }
+
+    #[test]
+    fn detail_caps_enumerated_hits() {
+        let hits: Vec<AgentAttributionHit> = (1..=AGENT_ATTRIBUTION_MAX_HITS + 3)
+            .map(|line| AgentAttributionHit {
+                line,
+                marker: AgentAttributionMarker::Generator,
+            })
+            .collect();
+        let detail = render_agent_attribution_detail(&hits);
+        assert!(detail.contains("... 3 more marker(s) omitted"), "{detail}");
+        assert!(
+            !detail.contains(&format!("line {}:", AGENT_ATTRIBUTION_MAX_HITS + 1)),
+            "{detail}"
+        );
+    }
+}

--- a/crates/nils-common/src/lib.rs
+++ b/crates/nils-common/src/lib.rs
@@ -22,6 +22,7 @@
 //! → Resolved Decision #9.
 #![deny(clippy::disallowed_types, clippy::disallowed_methods)]
 
+pub mod agent_attribution;
 pub mod cli_contract;
 pub mod clipboard;
 pub mod coordination_projection;

--- a/crates/nils-common/src/markdown.rs
+++ b/crates/nils-common/src/markdown.rs
@@ -60,7 +60,11 @@ pub fn markdown_payload_violations(markdown: &str) -> Vec<MarkdownPayloadViolati
 /// replaced with a space (and skipped fenced lines with a newline) so that
 /// neighbouring characters cannot glue into a literal `\n`-style sequence that
 /// was not present in the source.
-fn strip_code_segments(markdown: &str) -> String {
+///
+/// Line count is preserved, so a scan over the stripped text can report line
+/// numbers that still index the original markdown. Shared with
+/// [`crate::agent_attribution`], which needs the same prose-only view.
+pub fn strip_code_segments(markdown: &str) -> String {
     let mut out = String::with_capacity(markdown.len());
     let mut open_fence: Option<(char, usize)> = None;
 

--- a/crates/semantic-commit/README.md
+++ b/crates/semantic-commit/README.md
@@ -277,9 +277,16 @@ Semantic Commit validation applies to `semantic-commit commit` message input:
 - Body and trailer lines must be at most `100` characters.
 - Git trailers may appear after the header or after a blank separator
   following bullet body lines.
-- Blocked message rules reject known unwanted agent attribution text, including
-  `Co-Authored-By: Claude ...` trailers from either message input or
-  `--trailer`.
+- Blocked message rules reject known unwanted agent attribution text from either
+  message input or `--trailer`:
+  - `claude-coauthor-trailer`: a `Co-Authored-By` trailer whose value names the
+    model family or carries `noreply@anthropic.com`.
+  - `claude-generated-marker`: a generator marker line (`Generated with …`
+    prose, or a `claude.com/claude-code` / `claude.ai/code` link).
+  Both forms are defined in `nils_common::agent_attribution` and shared with
+  `forge-cli`'s Rule 17, so the commit path and the provider path cannot
+  diverge. The commit scan is verbatim — unlike the markdown payload scan it has
+  no code-span exemption, so attribution cannot hide behind backticks.
 
 `fixup` and `squash` do not use this header validation because git generates
 subjects prefixed with `fixup!` or `squash!`.

--- a/crates/semantic-commit/src/commit.rs
+++ b/crates/semantic-commit/src/commit.rs
@@ -1,4 +1,5 @@
 use crate::git;
+use nils_common::agent_attribution;
 use nils_common::git as common_git;
 use nils_term::progress::{Progress, ProgressFinish, ProgressOptions};
 use serde_json::json;
@@ -1620,12 +1621,15 @@ struct BlockedMessageRule {
     patterns: &'static [BlockedMessagePattern],
 }
 
+/// Blocked-line shapes. Both delegate to
+/// [`nils_common::agent_attribution`] so the commit path and forge-cli's
+/// provider path (Rule 17) reject the exact same attribution forms. Matching
+/// here is verbatim — unlike the markdown payload scan, a commit message gets no
+/// code-span exemption, so an attribution line cannot hide behind backticks.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BlockedMessagePattern {
-    TrailerValueStartsWith {
-        token: &'static str,
-        value_prefix: &'static str,
-    },
+    AgentCoauthorTrailer,
+    AgentGeneratorMarker,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1640,18 +1644,27 @@ struct BlockedMessageMatch {
 }
 
 const CLAUDE_COAUTHOR_PATTERNS: &[BlockedMessagePattern] =
-    &[BlockedMessagePattern::TrailerValueStartsWith {
-        token: "Co-Authored-By",
-        value_prefix: "Claude",
-    }];
+    &[BlockedMessagePattern::AgentCoauthorTrailer];
 
-const BLOCKED_MESSAGE_RULES: &[BlockedMessageRule] = &[BlockedMessageRule {
-    id: "claude-coauthor-trailer",
-    reason: "do not attribute commits to any Claude model",
-    matched_hint: "Co-Authored-By: Claude ...",
-    fix: "remove the `Co-Authored-By: Claude ...` trailer",
-    patterns: CLAUDE_COAUTHOR_PATTERNS,
-}];
+const CLAUDE_GENERATED_MARKER_PATTERNS: &[BlockedMessagePattern] =
+    &[BlockedMessagePattern::AgentGeneratorMarker];
+
+const BLOCKED_MESSAGE_RULES: &[BlockedMessageRule] = &[
+    BlockedMessageRule {
+        id: "claude-coauthor-trailer",
+        reason: "do not attribute commits to any Claude model",
+        matched_hint: "Co-Authored-By: Claude ...",
+        fix: "remove the `Co-Authored-By: Claude ...` trailer",
+        patterns: CLAUDE_COAUTHOR_PATTERNS,
+    },
+    BlockedMessageRule {
+        id: "claude-generated-marker",
+        reason: "do not advertise the generating agent in commit messages",
+        matched_hint: "agent generator marker line",
+        fix: "remove the generator marker line, including its claude-code link",
+        patterns: CLAUDE_GENERATED_MARKER_PATTERNS,
+    },
+];
 
 fn validate_blocked_message_rules(message: &str, trailers: &[String]) -> Result<(), i32> {
     for rule in BLOCKED_MESSAGE_RULES {
@@ -1703,37 +1716,10 @@ fn blocked_message_source_label(source: BlockedMessageSource) -> String {
 impl BlockedMessagePattern {
     fn matches(self, line: &str) -> bool {
         match self {
-            Self::TrailerValueStartsWith {
-                token,
-                value_prefix,
-            } => trailer_value_starts_with(line, token, value_prefix),
+            Self::AgentCoauthorTrailer => agent_attribution::line_is_blocked_coauthor_trailer(line),
+            Self::AgentGeneratorMarker => agent_attribution::line_has_generator_marker(line),
         }
     }
-}
-
-fn trailer_value_starts_with(line: &str, expected_token: &str, value_prefix: &str) -> bool {
-    let Some((token, value)) = split_trailer(line.trim()) else {
-        return false;
-    };
-    token.eq_ignore_ascii_case(expected_token)
-        && starts_with_ascii_word_ignore_case(value, value_prefix)
-}
-
-fn starts_with_ascii_word_ignore_case(value: &str, expected_word: &str) -> bool {
-    if expected_word.is_empty() {
-        return false;
-    }
-    let value = value.trim_start();
-    let Some(prefix) = value.get(..expected_word.len()) else {
-        return false;
-    };
-    if !prefix.eq_ignore_ascii_case(expected_word) {
-        return false;
-    }
-    value[expected_word.len()..]
-        .chars()
-        .next()
-        .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'))
 }
 
 fn is_valid_header(header: &str) -> bool {

--- a/crates/semantic-commit/tests/integration/commit.rs
+++ b/crates/semantic-commit/tests/integration/commit.rs
@@ -472,6 +472,110 @@ fn commit_validate_only_allows_claude_as_part_of_longer_word() {
     );
 }
 
+#[test]
+fn commit_validate_only_rejects_vendor_noreply_coauthor_trailer() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing",
+            "--trailer",
+            "Co-Authored-By: Some Agent <noreply@anthropic.com>",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    let stderr = as_str(&output.stderr);
+    assert!(
+        stderr.contains("blocked by rule `claude-coauthor-trailer`"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn commit_validate_only_rejects_generator_marker_in_message() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing\n\n- Ship the thing\n\nX-Origin: https://claude.com/claude-code",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    let stderr = as_str(&output.stderr);
+    assert!(
+        stderr.contains("blocked by rule `claude-generated-marker`"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("source: message line 5"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn commit_validate_only_rejects_generator_marker_trailer_flag() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing",
+            "--trailer",
+            "X-Origin: https://claude.ai/code",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    let stderr = as_str(&output.stderr);
+    assert!(
+        stderr.contains("blocked by rule `claude-generated-marker`"),
+        "stderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("source: --trailer #1"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn commit_validate_only_allows_unrelated_agent_prose() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let output = common::run_semantic_commit_output(
+        dir.path(),
+        &[
+            "commit",
+            "--validate-only",
+            "--message",
+            "feat(core): add thing\n\n- Reject agent attribution markers on both egress paths",
+        ],
+        &[],
+        None,
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr was: {}",
+        as_str(&output.stderr)
+    );
+}
+
 fn header_with_total_len(total_len: usize) -> String {
     let prefix = "feat: ";
     assert!(total_len > prefix.len());


### PR DESCRIPTION
## Summary

Move the "no agent self-attribution in delivered work" rule out of per-runtime
harness hooks and into the CLIs that actually write the artifacts, so it holds
whichever runtime is driving. `semantic-commit` already blocked one shape of it
(a co-author trailer naming the model); this defines every shape once in
`nils-common`, closes the gaps on the commit path, and adds the missing
provider-path rule to `forge-cli`.

## Changes

- `nils-common`: new `agent_attribution` module owning the marker definitions —
  generator marker needles (prose plus both link forms), co-author trailer
  predicates (`:` and `=` separators, model-family first word, vendor no-reply
  address), a markdown-aware scan that strips fenced blocks and inline code
  spans, and a verbatim scan for structured input. `markdown::strip_code_segments`
  becomes public so both scans share one prose-only view with stable line numbers.
- `semantic-commit`: new `claude-generated-marker` blocked-message rule (a
  generator marker in the message or a `--trailer` value was previously
  unchecked), and `claude-coauthor-trailer` widened to a trailer carrying the
  vendor no-reply address under any name. Both patterns now delegate to the
  shared module; matching stays verbatim, with no code-span exemption.
- `forge-cli`: new lock-down Rule 17 `no_agent_attribution`
  (`agent_attribution_present`, `DATA 65`) beside `no_local_path`, enforced on
  every posted title, body, comment, review body, thread reply, and resolve note
  across `pr create`, `pr edit`, `issue create`, `issue edit`, `pr comment`,
  `issue comment`, `pr review`, and both `pr review-threads` writes; two new
  verdicts in the `pr deliver --dry-run` preflight; a
  `FORGE_CLI_ALLOW_AGENT_ATTRIBUTION` escape hatch mirroring the local-path one.
- Docs and contracts: Rule 17 and its `error.kind` row in
  `forge-cli-spec-v1.md`, a `validations_catalog` entry plus per-op
  `validations:` lists in `forge-cli-ops-v1.yaml`, and the rule set in the
  `semantic-commit` / `nils-common` READMEs.

Deliberate asymmetry, documented in both READMEs and the spec: markdown payloads
exempt fenced blocks and inline code spans, so a PR body that documents the rule
still posts; commit messages get no exemption.

## Test-First Evidence

- Rules were written test-first per layer: `nils-common` unit tests pinned every
  detection branch (marker forms, word-boundary non-match, code-span exemption,
  verbatim contrast, hit cap) before the consumers were wired.
- `semantic-commit`: the new integration tests fail on `main` — `main` accepts a
  generator marker in both message and `--trailer` positions, and accepts a
  vendor-no-reply co-author trailer.
- `forge-cli`: `tests/integration/agent_attribution_guard.rs` fails on `main`
  (`main` posts the marker; there is no `agent_attribution_present` kind), as do
  the added `validations` catalog row and the two dry-run preflight assertions.
- No waiver required.

## Test plan

- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — exit 0 (one
  retried `agent-session` tmux-coordination flake, unrelated to this change)
- [x] `cargo test -p nils-common agent_attribution` — 13 passed
- [x] `cargo test -p nils-semantic-commit` — 111 passed, including 4 new rule tests
- [x] `cargo test -p nils-forge-cli` — 815 lib + 466 integration passed
- [x] Local-build smoke: a `git commit` and a `forge-cli` post carrying each
  marker shape are rejected; the same content inside a code span posts cleanly

## Risk / Notes

- Low-medium: this rejects content that previously posted, so an existing body or
  commit message that quotes a marker outside a code span now fails with
  `agent_attribution_present` / a blocked-message rule. The code-span exemption
  covers the documentation case, and `FORGE_CLI_ALLOW_AGENT_ATTRIBUTION=1` covers
  a verified false positive on the provider path.
- `claude-coauthor-trailer` keeps its rule id, `matched_hint`, and `fix` text, so
  existing consumers matching on that output are unaffected; only the matched set
  widens.
- No behaviour change for any other validation: Rule 17 is additive and shares
  `no_local_path`'s `DATA 65` class, and the new preflight verdicts are additive
  (the dry-run consumer looks rules up by name).
