### PR TITLE
fix(forge-cli): isolate the push fixture from a global core.hooksPath

### DIFF
--- a/crates/forge-cli/tests/integration/repo_push_default.rs
+++ b/crates/forge-cli/tests/integration/repo_push_default.rs
@@ -553,6 +553,23 @@ fn setup_real_git(race: RealGitRace, inherited_push_config: bool) -> RealGitScen
     fs::write(&reason, "Explicitly authorized direct-main hotfix.").expect("reason");
 
     git_output(&["init", "--bare", remote.to_str().expect("remote")]);
+    // A global `core.hooksPath` applies to every repository, including this
+    // fixture's bare remote, so an inherited value silently redirects git away
+    // from the `pre-receive` hook written below and the push-option capture never
+    // appears. Pin the remote to its own hooks directory so the fixture proves
+    // the push contract rather than the developer's git configuration. Agent
+    // runtimes install exactly such a global hooksPath, so without this the test
+    // passes on CI and fails on a managed workstation.
+    git_output(&[
+        "--git-dir",
+        remote.to_str().expect("remote"),
+        "config",
+        "core.hooksPath",
+        remote
+            .join("hooks")
+            .to_str()
+            .expect("remote hooks directory"),
+    ]);
     git_output(&[
         "init",
         "--initial-branch=main",


### PR DESCRIPTION
## Summary

Makes the `push.default` real-git fixture hermetic. It wrote a `pre-receive` hook
into its own bare remote but did not neutralize an inherited global
`core.hooksPath`, so on any machine that sets one the hook never ran and the test
asserted nothing while failing on a missing capture file.

## Problem

`core.hooksPath` applies to **every** repository when set globally, including a
bare remote created inside a test fixture.

`setup_real_git` writes `remote.git/hooks/pre-receive`, which records
`$GIT_PUSH_OPTION_COUNT` into a capture file so
`push_default_disables_inherited_real_git_push_expansion` can assert that
`push.pushOption` was disabled. With a global `core.hooksPath` present, git looks
for hooks in that directory instead, the fixture hook never executes, and the
capture file is never created.

The test then fails on `fs::read_to_string(...).expect("push option capture")`
with `NotFound` — before reaching the assertion it exists to make. So it is both a
false failure and, on a machine without a global hooksPath, a check that passes
for the right reason only by luck of configuration.

This is not a `forge-cli` defect. The shim, the wrapper, and the push path all
behave correctly.

## Reproduction

On this host, where an agent runtime installs
`core.hooksPath = ~/.config/git/hooks` globally:

```
$ cargo test -p nils-forge-cli --test integration \
    push_default_disables_inherited_real_git_push_expansion
panicked at crates/forge-cli/tests/integration/repo_push_default.rs:943:14:
push option capture: Os { code: 2, kind: NotFound }
```

Reproduces identically on unmodified `main` at `d40e3980`, and the mechanism is
confirmed by removing the global config:

```
$ GIT_CONFIG_GLOBAL=/dev/null cargo test ... push_default_disables_...
test result: ok. 1 passed
```

It passes on CI because the runner has no global `core.hooksPath`, which is why
this stayed invisible: green on CI, red on a managed workstation. The hooks
directory on this host was created part-way through a session, which is why the
same suite was clean earlier and failing later.

## Issues Found

- Found while validating sympoies/nils-cli#1416. Not related to that change and
  deliberately split out so it can be reviewed on its own.

## Fix Approach

Pin the fixture's bare remote to its own hooks directory immediately after
`git init --bare`, so an inherited value cannot win:

```rust
git_output(&["--git-dir", remote, "config", "core.hooksPath",
             remote.join("hooks")]);
```

Local to the fixture, minimal, and exactly matching its existing intent — it
already writes the hook it wants git to run.

Verified both ways, because a fix that only passes in one environment would just
move the fragility:

| Environment | Result |
| --- | --- |
| global `core.hooksPath` present (previously failed) | 40 passed |
| `GIT_CONFIG_GLOBAL=/dev/null` | 40 passed |

A repository-wide sweep found no other fixture that writes git hooks, and no
existing `hooksPath` defense anywhere, so this is the only affected site.

## Test-First Evidence

Testable. The failure was observed against bound baseline `d40e3980` with the
exact command and output above, the mechanism was confirmed by toggling
`GIT_CONFIG_GLOBAL`, and the affected suite was re-run green in both environments
after the fixture edit.

No new test case is added: the defect was that an existing assertion never reached
its subject, and the fix restores it. The two-environment run is the substitute
evidence for hermeticity, which a single-environment case cannot show.

## Test plan

- `cargo test -p nils-forge-cli --test integration repo_push_default` — 40 passed
  with the global `core.hooksPath` that previously broke it.
- `GIT_CONFIG_GLOBAL=/dev/null cargo test -p nils-forge-cli --test integration
  repo_push_default` — 40 passed, proving the fix does not depend on the ambient
  configuration either.

## Risk / Notes

- N/A
