### PR TITLE
fix(forge-cli): make review ledger comments visible and consolidated

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -5068,7 +5068,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__review__loop__observe)
-            opts="-h --expected-head --findings-file --expected-state --format --remote --provider --host --repo --store-root --dry-run --help"
+            opts="-h --expected-head --findings-file --expected-state --body --body-file --format --remote --provider --host --repo --store-root --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5083,6 +5083,14 @@ _forge-cli() {
                     return 0
                     ;;
                 --expected-state)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --body-file)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -708,6 +708,8 @@ _arguments "${_arguments_options[@]}" : \
 '--expected-head=[Exact provider head SHA whose review observation is being appended]:SHA:_default' \
 '--findings-file=[Delivery-mode review-specialists merge envelope or observation array. Both shapes require a \`lifecycle_fingerprint\`; only the array accepts \`disposition\`. See this command'\''s help footer for the full schemas]:PATH:_default' \
 '--expected-state=[Exact current provider-visible state-chain tip; omit only for genesis]:DIGEST:_default' \
+'(--body-file)--body=[Human-readable delivery outcome to post in the same comment as this ledger record. Mutually exclusive with \`--body-file\`]:BODY:_default' \
+'--body-file=[Read the delivery outcome body from PATH (\`-\` reads stdin)]:PATH:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -151,10 +151,10 @@ provider_resolution:
 review_state_contract:
   schema: forge-cli.review-loop.v1
   storage: "append-only provider-visible PR issue comments authored by the current viewer or an OWNER/MEMBER/COLLABORATOR; marker-shaped comments from unprivileged actors are ignored"
-  provider_marker_limit: "64 KiB per encoded state marker (review_state_record_too_large) and 64 KiB per complete rendered comment body (review_state_comment_too_large), both validated before provider mutation"
+  provider_marker_limit: "64 KiB per encoded state marker (review_state_record_too_large) and 64 KiB per complete rendered comment body (review_state_comment_too_large), both validated before provider mutation. The complete-body limit is the binding one, so the effective marker budget is reduced by the rendered wrapper; a chain whose next record would need the top ~80 bytes of the marker budget cannot be appended and has no pruning path, because the ledger is append-only"
   canonical_digest: "sha256:<lowercase hex> over compact UTF-8 JSON in declared field order"
-  comment_body: "visible metadata line `forge-cli review ledger · generation <n> · <payload-kind> · head <short-sha>` followed by the unchanged marker on its own trailing line; GitHub hides HTML comments when rendering Markdown, so a marker-only body renders blank. Presentation never enters a digest, chain order, or the parser, so historical bare-marker comments and rendered comments validate as one chain with no migration and no edit or deletion of history. The abbreviated head is filtered to [0-9A-Za-z._-] and truncated to twelve characters so the line stays one line of plain Markdown"
-  combined_outcome: "pr.review-loop.observe --body/--body-file appends the record and a human-readable delivery outcome in ONE comment; the outcome inherits the append's idempotency, so an unchanged observation posts neither and an identical retry cannot duplicate either. A hard-stop receipt is always appended without an outcome body. An outcome body containing a review-state marker is refused as review_state_comment_invalid because the parser takes the first marker in a body"
+  comment_body: "visible metadata line `forge-cli review ledger · generation <n> · <payload-kind> · head <short-sha>` FIRST, then the unchanged marker on its own line, then — only for a combined delivery outcome — a `---` rule and the outcome. GitHub hides HTML comments when rendering Markdown, so a marker-only body renders blank. The label-first ordering is load-bearing: a Markdown HTML block opened in caller text runs until a line containing `-->`, so caller text above the label could swallow the label and the marker. Presentation never enters a digest, chain order, or the parser, so historical bare-marker comments and rendered comments validate as one chain with no migration and no edit or deletion of history. The abbreviated head is filtered to [0-9A-Za-z._-] and truncated to twelve characters so the line stays one line of plain Markdown"
+  combined_outcome: "pr.review-loop.observe --body/--body-file appends the record and a human-readable delivery outcome in ONE comment. Deduplication is by RECORD, not by comment body, so two concurrent sessions computing the identical transition converge on one record even with divergent outcomes; each session confirms only its own. outcome_posted is set only after a post-write read-back finds a privileged comment carrying both this record's marker and this outcome, and a durable record whose outcome is not visible fails as review_outcome_not_posted. An unchanged observation appends nothing, so a supplied outcome is either already present (outcome_posted true, appended false) or fails closed as review_outcome_not_posted rather than being dropped. A hard-stop receipt is always appended without an outcome body. An outcome body containing any HTML comment is refused as review_state_comment_invalid: a review-state marker of its own would shadow the record, and an unterminated `<!--` would hide the label"
   record:
     required: [schema, repository, pr, expected_head, generation, previous_digest, payload, record_digest]
     chain: "one genesis; zero-based contiguous generations; previous_digest binds the unique prior record; byte-identical append retries are deduplicated, while conflicting duplicates, forks, stale, missing, or unreachable records fail as review_state_conflict"
@@ -717,20 +717,21 @@ operations:
       - review_round_limit_exceeded
       - review_state_comment_invalid
       - review_state_comment_too_large
+      - review_outcome_not_posted
       - local_path_present
       - markdown_escaped_control
     backends:
       github:
         - { program: gh, argv: [pr, view, "{id}", --json, "number,url,...,headRefOid"] }
         - { program: gh, argv: [api, graphql, -f, "query=<complete privileged review-state comments>", -F, "pr={id}"] }
-        - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body=<optional delivery outcome, then visible ledger metadata line, then canonical state marker>"] } # one comment carries both halves; with no --body/--body-file it is metadata plus marker
+        - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body=<visible ledger metadata line, then canonical state marker, then optional `---` and delivery outcome>"] } # one comment carries both halves; with no --body/--body-file it is metadata plus marker
         - { program: gh, argv: [api, graphql, -f, "query=<complete privileged review-state comments>", -F, "pr={id}"] }
       gitlab: unsupported
       local: unsupported
     output:
       data: object<{provider,number,url,state_tip_digest,generation,state,appended,outcome_posted}>
       dry_run_data: object<{provider,plan,preflight_ok,would_append?,planned_comment?:{visible_metadata,includes_outcome_body,bytes},preflight}>
-    notes: "Defaults are five repair rounds, two consecutive no-progress rounds, and zero automatic reopens. Same-head/same-finding retries append nothing; a same-head subset cannot clear an open finding. Observation rows may carry status/disposition open|fixed|accepted|preference|follow-up, with terminal dispositions recorded non-blocking. A new head advances one round; strict cardinality shrink is the only mechanical progress signal. Extendable terminal errors append a durable hard-stop receipt before returning the exact extension proposal; they never approve, resolve, or merge. --body/--body-file posts the delivery outcome in the same comment as the appended record, so outcome_posted is never true without appended; the outcome body is read and validated before the first provider call, and planned_comment/state_comment_body appear in a dry run only when a write is planned."
+    notes: "Defaults are five repair rounds, two consecutive no-progress rounds, and zero automatic reopens. Same-head/same-finding retries append nothing; a same-head subset cannot clear an open finding. Observation rows may carry status/disposition open|fixed|accepted|preference|follow-up, with terminal dispositions recorded non-blocking. A new head advances one round; strict cardinality shrink is the only mechanical progress signal. Extendable terminal errors append a durable hard-stop receipt before returning the exact extension proposal; they never approve, resolve, or merge. --body/--body-file posts the delivery outcome in the same comment as the appended record, so outcome_posted is never true without appended; every outcome-body rule is enforced before the first provider call, and planned_comment/state_comment_body appear in a dry run only when a write is planned — including the unextended-hard-stop case, where the live path returns the stop without appending. See review_state_contract.combined_outcome for the record-vs-comment deduplication boundary. --body-file - consumes stdin once, so a dry-run-then-live sequence must not share a piped body."
 
   - id: pr.review-loop.extend
     schema_version: cli.forge-cli.pr.review-loop.extend.v1
@@ -749,10 +750,11 @@ operations:
       - review_extension_invalid
       - review_extension_replayed
       - review_extension_approval_invalid
+      - review_state_comment_too_large
     backends:
       github:
         - { program: gh, argv: [api, "repos/{repo}/issues/comments/{approval_comment}"] }
-        - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body=<canonical state marker>"] }
+        - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body=<visible ledger metadata line plus canonical state marker>"] } # extend never carries a delivery outcome
       gitlab: unsupported
       local: unsupported
     output:

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -151,8 +151,10 @@ provider_resolution:
 review_state_contract:
   schema: forge-cli.review-loop.v1
   storage: "append-only provider-visible PR issue comments authored by the current viewer or an OWNER/MEMBER/COLLABORATOR; marker-shaped comments from unprivileged actors are ignored"
-  provider_marker_limit: "64 KiB per encoded state marker, validated before provider mutation"
+  provider_marker_limit: "64 KiB per encoded state marker (review_state_record_too_large) and 64 KiB per complete rendered comment body (review_state_comment_too_large), both validated before provider mutation"
   canonical_digest: "sha256:<lowercase hex> over compact UTF-8 JSON in declared field order"
+  comment_body: "visible metadata line `forge-cli review ledger · generation <n> · <payload-kind> · head <short-sha>` followed by the unchanged marker on its own trailing line; GitHub hides HTML comments when rendering Markdown, so a marker-only body renders blank. Presentation never enters a digest, chain order, or the parser, so historical bare-marker comments and rendered comments validate as one chain with no migration and no edit or deletion of history. The abbreviated head is filtered to [0-9A-Za-z._-] and truncated to twelve characters so the line stays one line of plain Markdown"
+  combined_outcome: "pr.review-loop.observe --body/--body-file appends the record and a human-readable delivery outcome in ONE comment; the outcome inherits the append's idempotency, so an unchanged observation posts neither and an identical retry cannot duplicate either. A hard-stop receipt is always appended without an outcome body. An outcome body containing a review-state marker is refused as review_state_comment_invalid because the parser takes the first marker in a body"
   record:
     required: [schema, repository, pr, expected_head, generation, previous_digest, payload, record_digest]
     chain: "one genesis; zero-based contiguous generations; previous_digest binds the unique prior record; byte-identical append retries are deduplicated, while conflicting duplicates, forks, stale, missing, or unreachable records fail as review_state_conflict"
@@ -342,7 +344,7 @@ operations:
         - { program: gh, argv: [api, "repos/{repo}/pulls/{id}/reviews", --method, POST, --raw-field, "body={comment_or_file}", --raw-field, "event={EVENT}", --raw-field, "commit_id={expected_head}", --jq, ".html_url"] } # with --submit-review (native review event); body field omitted for a body-less APPROVE; commit_id binds the mutation to --expected-head; review authored by the inherited gh token's identity
         - { program: gh, argv: [api, graphql, -f, "query=<pull request id lookup>", -f, "owner={owner}", -f, "name={repo}", -F, "number={id}"] } # with --thread-file: resolve the PR node id
         - { program: gh, argv: [api, graphql, -f, "query=<authenticated viewer plus paginated PR issue comments with author association>", -f, "owner={owner}", -f, "name={repo}", -F, "pr={id}", "-f after={cursor}?"] } # with --thread-file: retain the current viewer's and privileged collaborators' comments, then read and validate the forge-cli.review-loop.v1 append-only state chain
-        - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body=<immutable review-run receipt marker>", --jq, ".html_url"] } # append one provider-bounded receipt before native-review mutation, then verify from the prior cursor/tail; semantically identical append retries and reruns reuse it
+        - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body=<visible ledger metadata line plus immutable review-run receipt marker>", --jq, ".html_url"] } # append one provider-bounded receipt before native-review mutation, then verify from the prior cursor/tail; semantically identical append retries and reruns reuse it. The prewrite stays a distinct comment because recovery needs durable state before the mutation, so it carries no delivery outcome
         - { program: gh, argv: [api, graphql, -f, "query=<complete submitted native reviews plus authenticated viewer>", -f, "owner={owner}", -f, "name={repo}", -F, "pr={id}", "-f after={cursor}?"] } # only when an exact receipt exists: idempotent success and lost-submit response detection require viewer author, expected head/state, untruncated marker, and complete receipt-bound thread manifest
         - { program: gh, argv: [api, graphql, -f, "query=<complete exact pending review and inline-comment manifest>", -f, "review={review_id}", "-f after={cursor}?"] } # exact receipt/body/head/commit/identity/manifest validation before any resumed mutation
         - { program: gh, argv: [api, graphql, -f, "query=<addPullRequestReview>", -f, "pullRequestId={pull_request_id}", -f, "commitOID={expected_head}", -f, "body={summary plus review-run marker}"] } # create only when no viewer-owned draft exists
@@ -694,7 +696,7 @@ operations:
       gitlab: unsupported
       local: unsupported
     output:
-      data: object<{provider,number,url,state_tip_digest?,generation?,state?,appended:false}>
+      data: object<{provider,number,url,state_tip_digest?,generation?,state?,appended:false,outcome_posted:false}>
     notes: "The append-only forge-cli.review-loop.v1 chain is completely paginated, hash-validated, and fork-checked. ReviewRunReceipt and ReviewLoop records share one chain; no second provider store is created."
 
   - id: pr.review-loop.observe
@@ -705,23 +707,30 @@ operations:
       - { name: --expected-head, type: string, required: true }
       - { name: --findings-file, type: path, required: true }
       - { name: --expected-state, type: string, required: conditional }
+      - { name: --body, type: string, required: false, conflicts_with: --body-file }
+      - { name: --body-file, type: path, required: false, notes: "`-` reads stdin" }
     validations:
       - review_state_conflict
       - review_fingerprint_collision
       - review_finding_reopened
       - review_no_progress
       - review_round_limit_exceeded
+      - review_state_comment_invalid
+      - review_state_comment_too_large
+      - local_path_present
+      - markdown_escaped_control
     backends:
       github:
         - { program: gh, argv: [pr, view, "{id}", --json, "number,url,...,headRefOid"] }
         - { program: gh, argv: [api, graphql, -f, "query=<complete privileged review-state comments>", -F, "pr={id}"] }
-        - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body=<canonical state marker>"] }
+        - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body=<optional delivery outcome, then visible ledger metadata line, then canonical state marker>"] } # one comment carries both halves; with no --body/--body-file it is metadata plus marker
         - { program: gh, argv: [api, graphql, -f, "query=<complete privileged review-state comments>", -F, "pr={id}"] }
       gitlab: unsupported
       local: unsupported
     output:
-      data: object<{provider,number,url,state_tip_digest,generation,state,appended}>
-    notes: "Defaults are five repair rounds, two consecutive no-progress rounds, and zero automatic reopens. Same-head/same-finding retries append nothing; a same-head subset cannot clear an open finding. Observation rows may carry status/disposition open|fixed|accepted|preference|follow-up, with terminal dispositions recorded non-blocking. A new head advances one round; strict cardinality shrink is the only mechanical progress signal. Extendable terminal errors append a durable hard-stop receipt before returning the exact extension proposal; they never approve, resolve, or merge."
+      data: object<{provider,number,url,state_tip_digest,generation,state,appended,outcome_posted}>
+      dry_run_data: object<{provider,plan,preflight_ok,would_append?,planned_comment?:{visible_metadata,includes_outcome_body,bytes},preflight}>
+    notes: "Defaults are five repair rounds, two consecutive no-progress rounds, and zero automatic reopens. Same-head/same-finding retries append nothing; a same-head subset cannot clear an open finding. Observation rows may carry status/disposition open|fixed|accepted|preference|follow-up, with terminal dispositions recorded non-blocking. A new head advances one round; strict cardinality shrink is the only mechanical progress signal. Extendable terminal errors append a durable hard-stop receipt before returning the exact extension proposal; they never approve, resolve, or merge. --body/--body-file posts the delivery outcome in the same comment as the appended record, so outcome_posted is never true without appended; the outcome body is read and validated before the first provider call, and planned_comment/state_comment_body appear in a dry run only when a write is planned."
 
   - id: pr.review-loop.extend
     schema_version: cli.forge-cli.pr.review-loop.extend.v1
@@ -747,7 +756,7 @@ operations:
       gitlab: unsupported
       local: unsupported
     output:
-      data: object<{provider,number,url,state_tip_digest,generation,state,appended:true}>
+      data: object<{provider,number,url,state_tip_digest,generation,state,appended:true,outcome_posted:false}>
     notes: "This command is separate from delivery retry paths. It requires an active durable hard-stop receipt, the canonical stop-code/budget-field pair and exact one-step proposal, plus an OWNER/MEMBER/COLLABORATOR approval comment on the same PR that is newer than the stopped state tip and carries the exact marker. One proposal can be consumed once."
 
   - id: pr.tasks

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -567,19 +567,27 @@ backend mapping, validation rules, and output schema versions.
   lets a later authorized session resume the same provider-visible chain
   without a machine-local ledger.
 - Record encoding and comment presentation are separate. Every state comment the
-  CLI posts renders as a visible metadata line followed by the unchanged marker
-  on its own trailing line:
+  CLI posts leads with a visible metadata line, followed by the unchanged marker
+  on its own line:
   `forge-cli review ledger · generation <n> · <payload-kind> · head <short-sha>`.
   GitHub hides HTML comments when it renders Markdown, so a marker-only body
   appears in the timeline as a blank comment under the operator's identity; the
   visible line makes the same append-only record identifiable as machine
-  metadata. Presentation text never enters a record digest, the chain order, or
-  the parser, so historical bare-marker comments and new wrapped comments
-  validate as one chain with no migration and no edit or deletion of existing
-  comments. The visible line carries only facts already public on the pull
-  request: generation, payload kind, and an abbreviated head. The head is
-  filtered to `[0-9A-Za-z._-]` and truncated to twelve characters so the line can
-  never become more than one line of plain Markdown.
+  metadata. A combined delivery outcome is appended *after* both, separated by a
+  `---` rule. That ordering is load-bearing, not cosmetic: a Markdown HTML block
+  opened in caller text runs until a line containing `-->`, so caller text placed
+  above the label could swallow both the label and the marker.
+- Presentation text never enters a record digest, the chain order, or the parser,
+  so historical bare-marker comments and new rendered comments validate as one
+  chain with no migration and no edit or deletion of existing comments. The
+  chain therefore deduplicates by *record*, not by comment body: two concurrent
+  sessions that compute the identical transition converge on one record even if
+  their comments differ, so a divergent concurrent outcome is possible and is
+  detected only for the writing session (see `review_outcome_not_posted` below).
+- The visible line carries only facts already public on the pull request:
+  generation, payload kind, and an abbreviated head. The head is filtered to
+  `[0-9A-Za-z._-]` and truncated to twelve characters so the line can never
+  become more than one line of plain Markdown.
 - Receipt fields intentionally exclude authentication tokens, credentials,
   environment-variable values, local paths, and private identity/profile names.
   The durable identity route contains only portable lens names and the semantic
@@ -635,18 +643,32 @@ backend mapping, validation rules, and output schema versions.
   both the exact PR head and state tip as compare-and-swap inputs.
 - `observe --body <text>` / `--body-file <path>` (`-` reads stdin; mutually
   exclusive) posts a human-readable delivery outcome in the SAME provider comment
-  as the appended ledger record, replacing a separate final outcome comment. The
-  outcome body must be non-empty and is held to the same portability rules as a
-  review comment (`local_path_present`, `markdown_escaped_control`); a body
-  carrying its own review-state marker is refused as
-  `review_state_comment_invalid`, because the parser takes the first marker in a
-  body and an embedded one would shadow the record. Both are checked before the
-  first provider call. Because the outcome rides the append, it inherits the
-  append's idempotency: an unchanged observation appends nothing and therefore
-  posts no outcome, so an identical retry cannot create a duplicate outcome or
-  ledger comment. `data.outcome_posted` reports which happened alongside
-  `data.appended`. A durable hard-stop receipt is always appended without an
-  outcome body.
+  as the appended ledger record, replacing a separate final outcome comment.
+  Every rule on the body runs before the first provider call, so a dry run
+  returns the same verdict a live run would and a rejected body costs no provider
+  round trip. The body must be non-empty, within the comment-body limit
+  (`review_state_comment_too_large`), free of any HTML comment
+  (`review_state_comment_invalid` — a review-state marker of its own would shadow
+  this record because the parser takes the first marker in a body, and an
+  unterminated `<!--` would hide the visible label), and held to the same
+  portability rules as a review comment (`local_path_present`,
+  `markdown_escaped_control`). Those portability rules are the shared
+  provider-payload guard, which is pattern-based and allowlisted; the outcome body
+  is operator-attested text, not a machine-derived receipt field, so the stronger
+  "review state excludes local paths" clause above is not a guarantee about it.
+  `--body-file -` consumes stdin once, so a dry-run-then-live sequence must not
+  share a piped body.
+- Because the outcome rides the append, it inherits the append's idempotency: an
+  unchanged observation appends nothing, so a supplied outcome is either already
+  present on the pull request from the earlier attempt — reported as
+  `outcome_posted: true` with `appended: false` — or would be silently dropped,
+  which fails closed as `review_outcome_not_posted` instead. An identical retry
+  therefore cannot create a duplicate outcome or ledger comment, and cannot lose
+  one either. `outcome_posted` is never inferred from the flag: it is set only
+  after a post-write read-back confirms a privileged comment carrying both this
+  record's marker and this outcome, and a durable record whose outcome is not
+  visible fails as `review_outcome_not_posted`. A durable hard-stop receipt is
+  always appended without an outcome body.
 - Observation-array rows may include `status` or `disposition` with `open`,
   `fixed`, `accepted`, `preference`, or `follow-up`. Terminal dispositions are
   durable and non-blocking. Omitting an open finding or changing its blocking
@@ -687,7 +709,10 @@ backend mapping, validation rules, and output schema versions.
   `data.would_append` reports whether the real run would append a new
   generation — true for an accepted state-changing transition, and also for an
   extendable budget error, which appends a durable hard-stop receipt before
-  failing, so predicting only "this fails" would understate it.
+  failing, so predicting only "this fails" would understate it. When an
+  unextended durable hard stop already exists the live path returns that stop
+  *without* appending, and the dry run mirrors that: `would_append` is false and
+  no comment is planned.
   `data.planned_comment` reports the planned write as
   `{visible_metadata, includes_outcome_body, bytes}`, where `bytes` is the
   complete rendered body the size limit binds. It is present only when a write is

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -549,7 +549,10 @@ backend mapping, validation rules, and output schema versions.
   conflicting duplicates, forks, missing/unreachable generations, target
   mismatches, malformed markers, or digest mismatches fail as
   `review_state_conflict` before native-review mutation. Encoded state markers
-  are limited to 64 KiB before provider mutation.
+  are limited to 64 KiB before provider mutation, and the complete rendered
+  comment body — visible text plus marker — is limited to 64 KiB before provider
+  mutation. An oversized marker returns `review_state_record_too_large`; an
+  oversized complete body returns `review_state_comment_too_large`.
 - Provider marker grammar is versioned and deterministic:
   `<!-- forge-cli:review-state:v1 <lowercase-hex-record-json> -->`,
   `<!-- forge-cli:review-run:v1 run=<review_run_id> -->`, and
@@ -563,6 +566,20 @@ backend mapping, validation rules, and output schema versions.
   from unprivileged actors cannot extend or poison the transaction chain. This
   lets a later authorized session resume the same provider-visible chain
   without a machine-local ledger.
+- Record encoding and comment presentation are separate. Every state comment the
+  CLI posts renders as a visible metadata line followed by the unchanged marker
+  on its own trailing line:
+  `forge-cli review ledger · generation <n> · <payload-kind> · head <short-sha>`.
+  GitHub hides HTML comments when it renders Markdown, so a marker-only body
+  appears in the timeline as a blank comment under the operator's identity; the
+  visible line makes the same append-only record identifiable as machine
+  metadata. Presentation text never enters a record digest, the chain order, or
+  the parser, so historical bare-marker comments and new wrapped comments
+  validate as one chain with no migration and no edit or deletion of existing
+  comments. The visible line carries only facts already public on the pull
+  request: generation, payload kind, and an abbreviated head. The head is
+  filtered to `[0-9A-Za-z._-]` and truncated to twelve characters so the line can
+  never become more than one line of plain Markdown.
 - Receipt fields intentionally exclude authentication tokens, credentials,
   environment-variable values, local paths, and private identity/profile names.
   The durable identity route contains only portable lens names and the semantic
@@ -611,10 +628,25 @@ backend mapping, validation rules, and output schema versions.
 - These GitHub-only commands make the repair/re-review loop resumable from the
   append-only `forge-cli.review-loop.v1` chain. `inspect <id>` validates the
   complete chain and emits its typed latest state. `observe <id>
-  --expected-head <sha> --findings-file <path> [--expected-state <digest>]`
+  --expected-head <sha> --findings-file <path> [--expected-state <digest>]
+  [--body <text> | --body-file <path>]`
   accepts either a delivery-mode `review-specialists merge` envelope or a
   finding-observation array, evaluates one deterministic transition, and uses
   both the exact PR head and state tip as compare-and-swap inputs.
+- `observe --body <text>` / `--body-file <path>` (`-` reads stdin; mutually
+  exclusive) posts a human-readable delivery outcome in the SAME provider comment
+  as the appended ledger record, replacing a separate final outcome comment. The
+  outcome body must be non-empty and is held to the same portability rules as a
+  review comment (`local_path_present`, `markdown_escaped_control`); a body
+  carrying its own review-state marker is refused as
+  `review_state_comment_invalid`, because the parser takes the first marker in a
+  body and an embedded one would shadow the record. Both are checked before the
+  first provider call. Because the outcome rides the append, it inherits the
+  append's idempotency: an unchanged observation appends nothing and therefore
+  posts no outcome, so an identical retry cannot create a duplicate outcome or
+  ledger comment. `data.outcome_posted` reports which happened alongside
+  `data.appended`. A durable hard-stop receipt is always appended without an
+  outcome body.
 - Observation-array rows may include `status` or `disposition` with `open`,
   `fixed`, `accepted`, `preference`, or `follow-up`. Terminal dispositions are
   durable and non-blocking. Omitting an open finding or changing its blocking
@@ -640,19 +672,28 @@ backend mapping, validation rules, and output schema versions.
   `fixed`, then merge at that head. Doing every repair first and then trying to
   record the history is unrecoverable, because the pre-repair head is gone and
   the round count cannot be reconstructed.
-- All three commands emit their own `cli.forge-cli.pr.review-loop.*.v1` schema.
-  `inspect` and `extend` dry-runs are offline and report the command-specific
-  read/transition plan.
+- All three commands emit their own `cli.forge-cli.pr.review-loop.*.v1` schema
+  with `data.appended` and `data.outcome_posted`. Only `observe` can set
+  `outcome_posted`, and never without `appended`. `inspect` and `extend`
+  dry-runs are offline and report the command-specific read/transition plan.
 - `observe --dry-run` is a faithful non-mutating preflight. It reads and
-  validates the findings payload, resolves the pull request, performs the head
-  and state-tip compare-and-swap comparisons, and evaluates the transition,
-  reporting each verdict in `data.preflight[]` — the same element shape as
+  validates the findings payload and any outcome body, resolves the pull request,
+  performs the head
+  and state-tip compare-and-swap comparisons, evaluates the transition, and
+  renders the exact comment the live append would post, then reports each
+  verdict in `data.preflight[]` — the same element shape as
   `pr deliver --dry-run`'s `local_preflight[]`, under a different name because
   these rules include provider reads. `data.preflight_ok` is the conjunction and
   `data.would_append` reports whether the real run would append a new
   generation — true for an accepted state-changing transition, and also for an
   extendable budget error, which appends a durable hard-stop receipt before
-  failing, so predicting only "this fails" would understate it. The sweep does
+  failing, so predicting only "this fails" would understate it.
+  `data.planned_comment` reports the planned write as
+  `{visible_metadata, includes_outcome_body, bytes}`, where `bytes` is the
+  complete rendered body the size limit binds. It is present only when a write is
+  planned, and the `state_comment_body` verdict is likewise reported only then: an
+  already-current chain writes nothing, so there is no body to check and no
+  outcome to post. The sweep does
   not short-circuit, so the local payload verdict is
   reported even when the provider is unreachable; that is the supported way to
   check a findings file without writing durable provider-visible state, which a

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -925,9 +925,21 @@ pub struct PrReviewLoopInspectArgs {
       2. A bare observation array. Each row needs `lifecycle_fingerprint` and \
       accepts `disposition` (open | fixed | accepted | reopened), which is how \
       dispositions are carried across rounds.\n\n\
+      COMBINED DELIVERY OUTCOME\n  \
+      Every appended ledger comment carries a visible \
+      `forge-cli review ledger · generation N · <kind> · head <short-sha>` line \
+      above its machine marker, so it never renders as a blank comment.\n  \
+      --body / --body-file additionally posts a human-readable delivery outcome \
+      in that SAME comment, replacing a separate final outcome comment. The \
+      outcome rides the append, so it inherits the append's idempotency: when \
+      the observation changes nothing the ledger is not appended and the outcome \
+      is NOT posted either (data.outcome_posted reports which happened). An \
+      identical retry therefore cannot leave a duplicate outcome behind. A \
+      durable hard-stop receipt is always appended without an outcome body.\n\n\
       With --dry-run this runs a faithful non-mutating preflight: it reads and \
-      validates the findings payload, resolves the pull request, performs the \
-      head and state-tip CAS comparisons, and evaluates the transition, then \
+      validates the findings payload and any outcome body, resolves the pull \
+      request, performs the head and state-tip CAS comparisons, evaluates the \
+      transition, and renders the exact provider comment it would post, then \
       reports every verdict in data.preflight[] without appending. The sweep \
       does not short-circuit, so the payload verdict is still reported when the \
       provider is unreachable — use it to check a findings file without writing \
@@ -945,6 +957,13 @@ pub struct PrReviewLoopObserveArgs {
     /// Exact current provider-visible state-chain tip; omit only for genesis.
     #[arg(long = "expected-state", value_name = "DIGEST")]
     pub expected_state: Option<String>,
+    /// Human-readable delivery outcome to post in the same comment as this
+    /// ledger record. Mutually exclusive with `--body-file`.
+    #[arg(long, conflicts_with = "body_file")]
+    pub body: Option<String>,
+    /// Read the delivery outcome body from PATH (`-` reads stdin).
+    #[arg(long = "body-file", value_name = "PATH")]
+    pub body_file: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -926,16 +926,23 @@ pub struct PrReviewLoopInspectArgs {
       accepts `disposition` (open | fixed | accepted | reopened), which is how \
       dispositions are carried across rounds.\n\n\
       COMBINED DELIVERY OUTCOME\n  \
-      Every appended ledger comment carries a visible \
+      Every appended ledger comment leads with a visible \
       `forge-cli review ledger · generation N · <kind> · head <short-sha>` line \
       above its machine marker, so it never renders as a blank comment.\n  \
       --body / --body-file additionally posts a human-readable delivery outcome \
-      in that SAME comment, replacing a separate final outcome comment. The \
-      outcome rides the append, so it inherits the append's idempotency: when \
-      the observation changes nothing the ledger is not appended and the outcome \
-      is NOT posted either (data.outcome_posted reports which happened). An \
-      identical retry therefore cannot leave a duplicate outcome behind. A \
-      durable hard-stop receipt is always appended without an outcome body.\n\n\
+      in that SAME comment, after the marker, replacing a separate final outcome \
+      comment. An outcome body may not contain an HTML comment, and is checked \
+      before the first provider call.\n  \
+      The outcome rides the append, so it inherits the append's idempotency. When \
+      the observation changes nothing the ledger is not appended, so the outcome \
+      is either ALREADY present from the earlier attempt (data.outcome_posted \
+      true, data.appended false) or would be dropped, which fails closed as \
+      `review_outcome_not_posted`. An identical retry therefore cannot duplicate \
+      the outcome, and cannot lose it either. data.outcome_posted is confirmed by \
+      a post-write read-back, never assumed from the flag. A durable hard-stop \
+      receipt is always appended without an outcome body.\n  \
+      --body-file - consumes stdin once, so do not pipe the same body into a \
+      --dry-run and then a live run.\n\n\
       With --dry-run this runs a faithful non-mutating preflight: it reads and \
       validates the findings payload and any outcome body, resolves the pull \
       request, performs the head and state-tip CAS comparisons, evaluates the \

--- a/crates/forge-cli/src/ops/pr_review.rs
+++ b/crates/forge-cli/src/ops/pr_review.rs
@@ -488,7 +488,11 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
                         build_issue_comment_call(
                             &ctx,
                             id,
-                            "<!-- forge-cli:review-state:v1 <record-dependent-on-provider-chain-tip> -->",
+                            // Mirrors the live receipt prewrite body: a visible
+                            // ledger label above the canonical marker. A plan that
+                            // still showed a bare marker would advertise a body the
+                            // live call no longer writes.
+                            "forge-cli review ledger · generation <n> · review-run-receipt · head <short-sha>\n<!-- forge-cli:review-state:v1 <record-dependent-on-provider-chain-tip> -->",
                         )
                         .plan_argv(),
                     ),
@@ -1884,6 +1888,10 @@ pub(crate) fn read_review_state_chain<R: BackendRunner>(
 pub(crate) struct ReviewLoopStateView {
     pub chain: review_state::ReviewStateChain,
     pub tip_created_at: Option<String>,
+    /// Raw bodies of the privileged comments this chain was parsed from. Needed
+    /// to answer presentation questions the chain deliberately cannot, such as
+    /// whether a delivery outcome was already posted alongside the tip record.
+    pub trusted_comment_bodies: Vec<String>,
 }
 
 pub(crate) fn read_review_loop_state_view<R: BackendRunner>(
@@ -1902,9 +1910,15 @@ pub(crate) fn read_review_loop_state_view<R: BackendRunner>(
                 .map(|_| comment.created_at.clone())
         })
     });
+    let trusted_comment_bodies = snapshot
+        .trusted_comments
+        .iter()
+        .map(|comment| comment.body.clone())
+        .collect();
     Ok(ReviewLoopStateView {
         chain: snapshot.chain,
         tip_created_at,
+        trusted_comment_bodies,
     })
 }
 
@@ -1925,12 +1939,23 @@ pub(crate) struct ReviewLoopAppend<'a> {
     pub visible_outcome: Option<&'a str>,
 }
 
+/// The result of one ledger append.
+#[derive(Debug, Clone)]
+pub(crate) struct ReviewLoopAppendResult {
+    pub chain: review_state::ReviewStateChain,
+    /// Whether a supplied delivery outcome is confirmed visible on the provider.
+    /// Never inferred from the request: the chain deduplicates by record, and a
+    /// record digest excludes presentation, so a digest-only read-back can be
+    /// satisfied by another session's comment for the same record.
+    pub outcome_posted: bool,
+}
+
 /// Appends one review-loop generation with head and tip compare-and-swap.
 pub(crate) fn append_review_loop_state<R: BackendRunner>(
     runner: &R,
     ctx: &ProviderContext,
     append: ReviewLoopAppend<'_>,
-) -> Result<review_state::ReviewStateChain, ForgeError> {
+) -> Result<ReviewLoopAppendResult, ForgeError> {
     let ReviewLoopAppend {
         repository,
         number,
@@ -1960,6 +1985,7 @@ pub(crate) fn append_review_loop_state<R: BackendRunner>(
         before.chain.tip_digest.clone(),
         review_state::ReviewStatePayload::ReviewLoop { state },
     )?;
+    let marker = record.marker()?;
     let body = review_state::render_state_comment_body(&record, visible_outcome)?;
     let append_result = runner.run(&build_issue_comment_call(ctx, number, &body));
     let after = read_review_state_snapshot(runner, ctx, repository, number)?;
@@ -1969,7 +1995,35 @@ pub(crate) fn append_review_loop_state<R: BackendRunner>(
         .iter()
         .any(|observed| observed.record_digest == record.record_digest)
     {
-        return Ok(after.chain);
+        // The record is durable. When an outcome shares the comment, confirm the
+        // outcome itself is visible too: the record could have been made durable
+        // by a concurrent session's outcome-free comment while this session's own
+        // POST failed, and reporting a delivery outcome that reached nobody is
+        // worse than failing.
+        let outcome_posted = match visible_outcome {
+            None => false,
+            Some(outcome) => {
+                let posted = after.trusted_comments.iter().any(|comment| {
+                    review_state::comment_carries_outcome(&comment.body, &marker, outcome)
+                });
+                if !posted {
+                    return Err(ForgeError::validation(
+                        schema_err(),
+                        "review_outcome_not_posted",
+                        "the review-loop record is durable but its delivery outcome is not visible after provider write",
+                        Some(format!(
+                            "record_digest={}; recovery=inspect the pull request and post the outcome separately, or rerun the identical observe against the new tip",
+                            record.record_digest
+                        )),
+                    ));
+                }
+                true
+            }
+        };
+        return Ok(ReviewLoopAppendResult {
+            chain: after.chain,
+            outcome_posted,
+        });
     }
     Err(match append_result {
         Ok(_) => ForgeError::validation(
@@ -3465,7 +3519,7 @@ mod tests {
             calls: RefCell::new(Vec::new()),
         };
 
-        let chain = append_review_loop_state(
+        let appended = append_review_loop_state(
             &runner,
             &ctx(Some("acme/widgets")),
             ReviewLoopAppend {
@@ -3479,9 +3533,10 @@ mod tests {
         )
         .expect("append and read back");
 
-        assert_eq!(chain.records.len(), 1);
+        assert_eq!(appended.chain.records.len(), 1);
+        assert!(!appended.outcome_posted, "no outcome body was supplied");
         assert_eq!(
-            chain.tip_digest.as_deref(),
+            appended.chain.tip_digest.as_deref(),
             Some(record.record_digest.as_str())
         );
         let calls = runner.calls.borrow();
@@ -3544,7 +3599,7 @@ mod tests {
             calls: RefCell::new(Vec::new()),
         };
 
-        let chain = append_review_loop_state(
+        let appended = append_review_loop_state(
             &runner,
             &ctx(Some("acme/widgets")),
             ReviewLoopAppend {
@@ -3573,8 +3628,91 @@ mod tests {
             calls[1]
         );
         assert_eq!(
-            chain.tip_digest.as_deref(),
+            appended.chain.tip_digest.as_deref(),
             Some(record.record_digest.as_str())
+        );
+        assert!(
+            appended.outcome_posted,
+            "the read-back saw the outcome in the appended comment"
+        );
+    }
+
+    #[test]
+    fn a_durable_record_without_its_outcome_fails_instead_of_claiming_delivery() {
+        // The chain deduplicates by record and a digest excludes presentation, so
+        // a concurrent session's outcome-free comment can satisfy the read-back
+        // while this session's own POST failed. Reporting a delivery outcome that
+        // reached nobody is worse than failing.
+        let state = review_state::observe_review_loop(None, "head-44", &[])
+            .expect("genesis transition")
+            .state;
+        let record = review_state::ReviewStateRecord::new(
+            "acme/widgets",
+            44,
+            "head-44",
+            0,
+            None,
+            review_state::ReviewStatePayload::ReviewLoop {
+                state: state.clone(),
+            },
+        )
+        .expect("record");
+        let snapshot = |nodes: serde_json::Value| crate::backend::BackendSuccess {
+            stdout: serde_json::json!({
+                "data": {
+                    "viewer": {"login": "next-session-bot"},
+                    "repository": {"pullRequest": {"comments": {
+                        "nodes": nodes,
+                        "pageInfo": {"hasNextPage": false, "endCursor": null}
+                    }}}
+                }
+            })
+            .to_string(),
+            stderr: String::new(),
+        };
+        // The post-write snapshot carries the same record WITHOUT this session's
+        // outcome — the shape a concurrent outcome-free append leaves behind.
+        let other_session = review_state::render_state_comment_body(&record, None)
+            .expect("outcome-free body for the same record");
+        let runner = ReceiptRunner {
+            outputs: RefCell::new(vec![
+                snapshot(serde_json::json!([])),
+                crate::backend::BackendSuccess {
+                    stdout: "https://github.com/acme/widgets/issues/44#issuecomment-1".to_string(),
+                    stderr: String::new(),
+                },
+                snapshot(serde_json::json!([{
+                    "author": {"login": "next-session-bot"},
+                    "authorAssociation": "OWNER",
+                    "body": other_session,
+                    "createdAt": "2026-07-20T00:00:01Z"
+                }])),
+            ]),
+            calls: RefCell::new(Vec::new()),
+        };
+
+        let error = append_review_loop_state(
+            &runner,
+            &ctx(Some("acme/widgets")),
+            ReviewLoopAppend {
+                repository: "acme/widgets",
+                number: 44,
+                expected_head: "head-44",
+                expected_tip: None,
+                state,
+                visible_outcome: Some("## Delivery outcome"),
+            },
+        )
+        .expect_err("an unconfirmed outcome must not be reported as posted");
+
+        assert_eq!(error.kind(), "review_outcome_not_posted");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains(&record.record_digest),
+            "{:?}",
+            error.detail()
         );
     }
 
@@ -3673,5 +3811,17 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert!(calls[0].contains("issues/44/comments"), "{}", calls[0]);
         assert!(calls[1].contains("after=state-tip"), "{}", calls[1]);
+        // The prewrite stays its own comment for recovery ordering, but it is not
+        // a bare marker: that is what rendered as a blank GitHub comment.
+        assert!(
+            calls[0].contains(&review_state::state_comment_visible_metadata(&next_record)),
+            "{}",
+            calls[0]
+        );
+        assert!(
+            calls[0].contains(&next_marker),
+            "the canonical marker is unchanged: {}",
+            calls[0]
+        );
     }
 }

--- a/crates/forge-cli/src/ops/pr_review.rs
+++ b/crates/forge-cli/src/ops/pr_review.rs
@@ -1814,8 +1814,12 @@ fn ensure_review_run_receipt<R: BackendRunner>(
             receipt: receipt.clone(),
         },
     )?;
-    let marker = record.marker()?;
-    let append_result = runner.run(&build_issue_comment_call(ctx, number, &marker));
+    // The receipt prewrite stays its own comment: transaction recovery requires
+    // durable state to exist before the native-review mutation, so it has no
+    // human-readable outcome to share a body with yet. It still gets the visible
+    // metadata label so the timeline never shows a blank comment.
+    let body = review_state::render_state_comment_body(&record, None)?;
+    let append_result = runner.run(&build_issue_comment_call(ctx, number, &body));
     let observed = read_review_state_after(
         runner,
         ctx,
@@ -1904,15 +1908,37 @@ pub(crate) fn read_review_loop_state_view<R: BackendRunner>(
     })
 }
 
+/// One review-loop ledger append, with its compare-and-swap inputs and the
+/// optional visible outcome that shares its comment.
+#[derive(Debug, Clone)]
+pub(crate) struct ReviewLoopAppend<'a> {
+    pub repository: &'a str,
+    pub number: u64,
+    pub expected_head: &'a str,
+    pub expected_tip: Option<&'a str>,
+    pub state: review_state::ReviewLoopState,
+    /// A human-readable delivery outcome posted in the same provider comment as
+    /// the ledger marker. Because the outcome rides the append, it inherits the
+    /// append's idempotency: a transition that changes nothing is not appended
+    /// and therefore posts no outcome either, so an identical retry cannot leave
+    /// a duplicate outcome comment behind.
+    pub visible_outcome: Option<&'a str>,
+}
+
+/// Appends one review-loop generation with head and tip compare-and-swap.
 pub(crate) fn append_review_loop_state<R: BackendRunner>(
     runner: &R,
     ctx: &ProviderContext,
-    repository: &str,
-    number: u64,
-    expected_head: &str,
-    expected_tip: Option<&str>,
-    state: review_state::ReviewLoopState,
+    append: ReviewLoopAppend<'_>,
 ) -> Result<review_state::ReviewStateChain, ForgeError> {
+    let ReviewLoopAppend {
+        repository,
+        number,
+        expected_head,
+        expected_tip,
+        state,
+        visible_outcome,
+    } = append;
     let before = read_review_state_snapshot(runner, ctx, repository, number)?;
     if before.chain.tip_digest.as_deref() != expected_tip {
         return Err(ForgeError::validation(
@@ -1934,8 +1960,8 @@ pub(crate) fn append_review_loop_state<R: BackendRunner>(
         before.chain.tip_digest.clone(),
         review_state::ReviewStatePayload::ReviewLoop { state },
     )?;
-    let marker = record.marker()?;
-    let append_result = runner.run(&build_issue_comment_call(ctx, number, &marker));
+    let body = review_state::render_state_comment_body(&record, visible_outcome)?;
+    let append_result = runner.run(&build_issue_comment_call(ctx, number, &body));
     let after = read_review_state_snapshot(runner, ctx, repository, number)?;
     if after
         .chain
@@ -3442,11 +3468,14 @@ mod tests {
         let chain = append_review_loop_state(
             &runner,
             &ctx(Some("acme/widgets")),
-            "acme/widgets",
-            44,
-            "head-44",
-            None,
-            state,
+            ReviewLoopAppend {
+                repository: "acme/widgets",
+                number: 44,
+                expected_head: "head-44",
+                expected_tip: None,
+                state,
+                visible_outcome: None,
+            },
         )
         .expect("append and read back");
 
@@ -3458,6 +3487,95 @@ mod tests {
         let calls = runner.calls.borrow();
         assert_eq!(calls.len(), 3);
         assert!(calls[1].contains("issues/44/comments"), "{}", calls[1]);
+        // The posted body carries the visible label, not a bare marker: a
+        // marker-only body renders as a blank GitHub comment.
+        assert!(
+            calls[1].contains(&review_state::state_comment_visible_metadata(&record)),
+            "{}",
+            calls[1]
+        );
+    }
+
+    #[test]
+    fn a_combined_append_posts_one_comment_carrying_outcome_and_ledger() {
+        let state = review_state::observe_review_loop(None, "head-44", &[])
+            .expect("genesis transition")
+            .state;
+        let record = review_state::ReviewStateRecord::new(
+            "acme/widgets",
+            44,
+            "head-44",
+            0,
+            None,
+            review_state::ReviewStatePayload::ReviewLoop {
+                state: state.clone(),
+            },
+        )
+        .expect("record");
+        let empty_snapshot = |nodes: serde_json::Value| crate::backend::BackendSuccess {
+            stdout: serde_json::json!({
+                "data": {
+                    "viewer": {"login": "next-session-bot"},
+                    "repository": {"pullRequest": {"comments": {
+                        "nodes": nodes,
+                        "pageInfo": {"hasNextPage": false, "endCursor": null}
+                    }}}
+                }
+            })
+            .to_string(),
+            stderr: String::new(),
+        };
+        let body = review_state::render_state_comment_body(&record, Some("## Delivery outcome"))
+            .expect("combined body");
+        let runner = ReceiptRunner {
+            outputs: RefCell::new(vec![
+                empty_snapshot(serde_json::json!([])),
+                crate::backend::BackendSuccess {
+                    stdout: "https://github.com/acme/widgets/issues/44#issuecomment-1".to_string(),
+                    stderr: String::new(),
+                },
+                empty_snapshot(serde_json::json!([{
+                    "author": {"login": "next-session-bot"},
+                    "authorAssociation": "OWNER",
+                    "body": body,
+                    "createdAt": "2026-07-20T00:00:01Z"
+                }])),
+            ]),
+            calls: RefCell::new(Vec::new()),
+        };
+
+        let chain = append_review_loop_state(
+            &runner,
+            &ctx(Some("acme/widgets")),
+            ReviewLoopAppend {
+                repository: "acme/widgets",
+                number: 44,
+                expected_head: "head-44",
+                expected_tip: None,
+                state,
+                visible_outcome: Some("## Delivery outcome"),
+            },
+        )
+        .expect("combined append");
+
+        // One provider mutation carries both halves, and the chain still reads
+        // the exact record out of the wrapped body.
+        let calls = runner.calls.borrow();
+        let mutations = calls
+            .iter()
+            .filter(|call| call.contains("issues/44/comments"))
+            .count();
+        assert_eq!(mutations, 1);
+        assert!(calls[1].contains("## Delivery outcome"), "{}", calls[1]);
+        assert!(
+            calls[1].contains(&record.marker().expect("marker")),
+            "{}",
+            calls[1]
+        );
+        assert_eq!(
+            chain.tip_digest.as_deref(),
+            Some(record.record_digest.as_str())
+        );
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_review_loop.rs
+++ b/crates/forge-cli/src/ops/pr_review_loop.rs
@@ -13,10 +13,10 @@ use crate::cli::{
 use crate::envelope::emit_success;
 use crate::error::ForgeError;
 use crate::ops::pr_comments::github_repo_slug_from_url;
-use crate::ops::{pr_review, pr_view, review_state};
+use crate::ops::{pr_comment, pr_review, pr_view, review_state};
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
-use crate::validations::RuleVerdict;
+use crate::validations::{RuleVerdict, no_escaped_control_markdown, no_local_path};
 
 const SCHEMA_INSPECT: &str = "pr.review-loop.inspect";
 const SCHEMA_OBSERVE: &str = "pr.review-loop.observe";
@@ -33,6 +33,11 @@ pub struct PrReviewLoopPayload {
     pub generation: Option<u64>,
     pub state: Option<review_state::ReviewLoopState>,
     pub appended: bool,
+    /// Whether a supplied `--body` / `--body-file` delivery outcome was posted.
+    /// Only `observe` can set this, and only together with an append: the outcome
+    /// shares the appended comment, so `appended: false` always means the outcome
+    /// was not posted (the ledger was already current).
+    pub outcome_posted: bool,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -65,7 +70,27 @@ struct ReviewLoopObserveDryRunPayload {
     /// chain is already current. `None` when the transition was not evaluated.
     #[serde(skip_serializing_if = "Option::is_none")]
     would_append: Option<bool>,
+    /// The exact provider comment the live append would post. Present only when
+    /// the transition was evaluated and would append; absent when the chain is
+    /// already current, because then nothing is written at all.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    planned_comment: Option<PlannedStateComment>,
     preflight: Vec<RuleVerdict>,
+}
+
+/// The rendered shape of one planned ledger comment.
+///
+/// The rendered body is reported by size and visible label rather than verbatim:
+/// a combined outcome body can approach the provider's 64 KiB comment limit, and
+/// the caller already owns the outcome bytes it supplied.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct PlannedStateComment {
+    /// The visible metadata line rendered above the machine marker.
+    visible_metadata: String,
+    /// Whether the supplied delivery outcome shares this one comment.
+    includes_outcome_body: bool,
+    /// Complete rendered body size, the value checked against the safe limit.
+    bytes: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -112,6 +137,7 @@ pub fn run_inspect_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         view.url,
         state_view.chain,
         false,
+        false,
         SCHEMA_INSPECT,
         format,
     )
@@ -138,6 +164,10 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         return emit_observe_dry_run(runner, &ctx, &args, format);
     }
     let observations = read_observations(&args.findings_file)?;
+    // Read and validate the outcome body before the first provider call, so an
+    // unreadable path or a non-portable body cannot fail between the ledger read
+    // and the append.
+    let outcome_body = read_outcome_body(&args)?;
     let (view, repository) = resolve_pr(runner, &ctx, args.id)?;
     ensure_expected_head(view.head_sha.as_deref(), &args.expected_head)?;
     let state_view =
@@ -182,14 +212,19 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
                     .hard_stop
                     .clone()
                     .expect("recorded hard stop exists");
+                // A hard stop is a failure receipt, never a delivery outcome, so
+                // the outcome body is deliberately not attached here.
                 let chain = pr_review::append_review_loop_state(
                     runner,
                     &ctx,
-                    &repository,
-                    view.number,
-                    &args.expected_head,
-                    state_view.chain.tip_digest.as_deref(),
-                    stopped,
+                    pr_review::ReviewLoopAppend {
+                        repository: &repository,
+                        number: view.number,
+                        expected_head: &args.expected_head,
+                        expected_tip: state_view.chain.tip_digest.as_deref(),
+                        state: stopped,
+                        visible_outcome: None,
+                    },
                 )?;
                 return Err(durable_hard_stop_error(
                     &error,
@@ -201,11 +236,15 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         };
 
     if !transition.changed {
+        // The ledger is already current, so there is nothing to append and no
+        // comment to carry an outcome. Posting the outcome on its own here would
+        // reintroduce exactly the duplicate an identical retry must not create.
         return emit_state(
             &ctx,
             view.number,
             view.url,
             state_view.chain,
+            false,
             false,
             SCHEMA_OBSERVE,
             format,
@@ -214,11 +253,14 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     let chain = pr_review::append_review_loop_state(
         runner,
         &ctx,
-        &repository,
-        view.number,
-        &args.expected_head,
-        state_view.chain.tip_digest.as_deref(),
-        transition.state,
+        pr_review::ReviewLoopAppend {
+            repository: &repository,
+            number: view.number,
+            expected_head: &args.expected_head,
+            expected_tip: state_view.chain.tip_digest.as_deref(),
+            state: transition.state,
+            visible_outcome: outcome_body.as_deref(),
+        },
     )?;
     emit_state(
         &ctx,
@@ -226,9 +268,38 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         view.url,
         chain,
         true,
+        outcome_body.is_some(),
         SCHEMA_OBSERVE,
         format,
     )
+}
+
+/// Reads and validates the optional visible delivery outcome body.
+///
+/// Returns `None` when neither flag was supplied. When one was, the body must be
+/// present and portable: the same no-local-path and escaped-control rules the
+/// review comment surfaces enforce apply, because this text becomes a permanent
+/// provider-visible comment.
+fn read_outcome_body(args: &PrReviewLoopObserveArgs) -> Result<Option<String>, ForgeError> {
+    if args.body.is_none() && args.body_file.is_none() {
+        return Ok(None);
+    }
+    let body = pr_comment::read_body_with_file_flag(
+        args.body.as_deref(),
+        args.body_file.as_deref(),
+        "--body-file",
+    )?;
+    if body.trim().is_empty() {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "review_state_comment_invalid",
+            "the review-loop outcome body is empty (supply --body or --body-file)",
+            None,
+        ));
+    }
+    no_local_path(&body, "review-loop outcome body")?;
+    no_escaped_control_markdown(&body)?;
+    Ok(Some(body))
 }
 
 pub fn run_extend(
@@ -340,11 +411,14 @@ pub fn run_extend_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     let chain = pr_review::append_review_loop_state(
         runner,
         &ctx,
-        &repository,
-        view.number,
-        &args.expected_head,
-        state_view.chain.tip_digest.as_deref(),
-        extended,
+        pr_review::ReviewLoopAppend {
+            repository: &repository,
+            number: view.number,
+            expected_head: &args.expected_head,
+            expected_tip: state_view.chain.tip_digest.as_deref(),
+            state: extended,
+            visible_outcome: None,
+        },
     )?;
     emit_state(
         &ctx,
@@ -352,6 +426,7 @@ pub fn run_extend_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         view.url,
         chain,
         true,
+        false,
         SCHEMA_EXTEND,
         format,
     )
@@ -827,12 +902,14 @@ fn validate_approval(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn emit_state(
     ctx: &ProviderContext,
     number: u64,
     url: String,
     chain: review_state::ReviewStateChain,
     appended: bool,
+    outcome_posted: bool,
     schema: &str,
     format: OutputFormat,
 ) -> Result<i32, ForgeError> {
@@ -848,15 +925,17 @@ fn emit_state(
             generation,
             state,
             appended,
+            outcome_posted,
         },
         format,
         |payload| {
             println!(
-                "review loop #{number}: round={round} generation={generation} appended={appended}",
+                "review loop #{number}: round={round} generation={generation} appended={appended} outcome_posted={outcome_posted}",
                 number = payload.number,
                 round = payload.state.as_ref().map(|state| state.round).unwrap_or(0),
                 generation = payload.generation.unwrap_or(0),
                 appended = payload.appended,
+                outcome_posted = payload.outcome_posted,
             );
         },
     ))
@@ -877,7 +956,7 @@ fn emit_observe_dry_run<R: BackendRunner>(
     args: &PrReviewLoopObserveArgs,
     format: OutputFormat,
 ) -> Result<i32, ForgeError> {
-    let mut verdicts: Vec<RuleVerdict> = Vec::with_capacity(5);
+    let mut verdicts: Vec<RuleVerdict> = Vec::with_capacity(7);
 
     // Local first, so it survives an unreachable provider.
     let observations = match read_observations(&args.findings_file) {
@@ -890,8 +969,21 @@ fn emit_observe_dry_run<R: BackendRunner>(
             None
         }
     };
+    let outcome_body = match read_outcome_body(args) {
+        Ok(body) => {
+            if args.body.is_some() || args.body_file.is_some() {
+                verdicts.push(RuleVerdict::from_result("outcome_body", Ok(())));
+            }
+            body
+        }
+        Err(error) => {
+            verdicts.push(RuleVerdict::from_result("outcome_body", Err(error)));
+            None
+        }
+    };
 
     let mut would_append = None;
+    let mut planned_comment = None;
     match resolve_pr(runner, ctx, args.id) {
         Ok((view, repository)) => {
             verdicts.push(RuleVerdict::from_result("provider_pull_request", Ok(())));
@@ -918,6 +1010,11 @@ fn emit_observe_dry_run<R: BackendRunner>(
                                 &args.expected_head,
                                 observations,
                             );
+                            // `state_comment_body` is reported only when a write
+                            // is actually planned. A current chain writes
+                            // nothing, so there is no body to size-check and an
+                            // unconditional verdict would wrongly fail the
+                            // preflight of a legitimate no-op observation.
                             match transition {
                                 Ok(transition) => {
                                     would_append = Some(transition.changed);
@@ -925,6 +1022,28 @@ fn emit_observe_dry_run<R: BackendRunner>(
                                         "observation_transition",
                                         Ok(()),
                                     ));
+                                    if transition.changed {
+                                        match plan_state_comment(
+                                            &repository,
+                                            view.number,
+                                            &args.expected_head,
+                                            &state_view.chain,
+                                            transition.state,
+                                            outcome_body.as_deref(),
+                                        ) {
+                                            Ok(planned) => {
+                                                planned_comment = Some(planned);
+                                                verdicts.push(RuleVerdict::from_result(
+                                                    "state_comment_body",
+                                                    Ok(()),
+                                                ));
+                                            }
+                                            Err(error) => verdicts.push(RuleVerdict::from_result(
+                                                "state_comment_body",
+                                                Err(error),
+                                            )),
+                                        }
+                                    }
                                 }
                                 Err(error) => {
                                     // An extendable budget error is the one
@@ -932,9 +1051,19 @@ fn emit_observe_dry_run<R: BackendRunner>(
                                     // appends a durable hard-stop receipt so a
                                     // restart returns the same stop. Predicting
                                     // "this fails" without that would understate
-                                    // what the real call does.
+                                    // what the real call does. That receipt never
+                                    // carries the outcome body.
                                     if review_state::stop_budget_field(error.kind()).is_some() {
                                         would_append = Some(true);
+                                        planned_comment = plan_hard_stop_comment(
+                                            &repository,
+                                            view.number,
+                                            &args.expected_head,
+                                            &state_view.chain,
+                                            previous,
+                                            observations,
+                                            &error,
+                                        );
                                     }
                                     verdicts.push(RuleVerdict::from_result(
                                         "observation_transition",
@@ -981,16 +1110,20 @@ fn emit_observe_dry_run<R: BackendRunner>(
     }
 
     let preflight_ok = verdicts.iter().all(|verdict| verdict.ok);
+    let combined = args.body.is_some() || args.body_file.is_some();
     Ok(emit_success(
         schema_version_for(BINARY, SCHEMA_OBSERVE, SCHEMA_VERSION),
         ReviewLoopObserveDryRunPayload {
             provider: ctx.provider.as_str(),
             plan: vec![
-                "read the chain, evaluate one observation, and append with tip/head CAS"
-                    .to_string(),
+                match combined {
+                    true => "read the chain, evaluate one observation, and append the ledger record together with the delivery outcome in one comment using tip/head CAS".to_string(),
+                    false => "read the chain, evaluate one observation, and append with tip/head CAS".to_string(),
+                },
             ],
             preflight_ok,
             would_append,
+            planned_comment,
             preflight: verdicts,
         },
         format,
@@ -1000,6 +1133,14 @@ fn emit_observe_dry_run<R: BackendRunner>(
                 plan = payload.plan.join(", then "),
                 ok = payload.preflight_ok,
             );
+            if let Some(planned) = payload.planned_comment.as_ref() {
+                println!(
+                    "  comment {bytes} bytes, outcome_body={outcome}: {metadata}",
+                    bytes = planned.bytes,
+                    outcome = planned.includes_outcome_body,
+                    metadata = planned.visible_metadata,
+                );
+            }
             for verdict in &payload.preflight {
                 let status = if verdict.ok { "ok" } else { "FAIL" };
                 let detail = verdict.message.as_deref().unwrap_or("");
@@ -1007,6 +1148,54 @@ fn emit_observe_dry_run<R: BackendRunner>(
             }
         },
     ))
+}
+
+/// Renders the exact comment a live append would post, without posting it.
+fn plan_state_comment(
+    repository: &str,
+    number: u64,
+    expected_head: &str,
+    chain: &review_state::ReviewStateChain,
+    state: review_state::ReviewLoopState,
+    outcome_body: Option<&str>,
+) -> Result<PlannedStateComment, ForgeError> {
+    let record = review_state::ReviewStateRecord::new(
+        repository,
+        number,
+        expected_head,
+        chain.records.len() as u64,
+        chain.tip_digest.clone(),
+        review_state::ReviewStatePayload::ReviewLoop { state },
+    )?;
+    let body = review_state::render_state_comment_body(&record, outcome_body)?;
+    Ok(PlannedStateComment {
+        visible_metadata: review_state::state_comment_visible_metadata(&record),
+        includes_outcome_body: outcome_body.is_some(),
+        bytes: body.len(),
+    })
+}
+
+/// Renders the durable hard-stop receipt an extendable budget failure would
+/// append. Returns `None` when the receipt itself cannot be built, because the
+/// reported `observation_transition` failure is already the actionable verdict.
+fn plan_hard_stop_comment(
+    repository: &str,
+    number: u64,
+    expected_head: &str,
+    chain: &review_state::ReviewStateChain,
+    previous: Option<&review_state::ReviewLoopState>,
+    observations: &[review_state::ReviewFindingObservation],
+    error: &ForgeError,
+) -> Option<PlannedStateComment> {
+    let stopped = review_state::record_review_loop_hard_stop(
+        previous?,
+        expected_head,
+        observations,
+        chain.tip_digest.as_deref()?,
+        error,
+    )
+    .ok()?;
+    plan_state_comment(repository, number, expected_head, chain, stopped, None).ok()
 }
 
 fn emit_dry_run(
@@ -1342,6 +1531,20 @@ mod tests {
             expected_head: expected_head.to_string(),
             findings_file: findings.to_string(),
             expected_state: expected_state.map(str::to_string),
+            body: None,
+            body_file: None,
+        }
+    }
+
+    fn observe_args_with_body(
+        findings: &str,
+        expected_head: &str,
+        expected_state: Option<&str>,
+        body: &str,
+    ) -> PrReviewLoopObserveArgs {
+        PrReviewLoopObserveArgs {
+            body: Some(body.to_string()),
+            ..observe_args(findings, expected_head, expected_state)
         }
     }
 
@@ -1549,6 +1752,254 @@ mod tests {
             Vec::<String>::new(),
             "an unchanged observation must not grow the durable chain"
         );
+    }
+
+    // --- combined delivery outcome ---------------------------------------
+
+    #[test]
+    fn observe_posts_the_delivery_outcome_and_the_ledger_in_one_comment() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, "[]");
+        let runner = FakeGitHub::new(HEAD);
+
+        let code = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args_with_body(&findings, HEAD, None, "## Delivery outcome\n\napproved"),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect("combined observation");
+
+        assert_eq!(code, 0);
+        let bodies = runner.appended_bodies();
+        assert_eq!(
+            bodies.len(),
+            1,
+            "one comment carries both halves: {bodies:?}"
+        );
+        let body = &bodies[0];
+        assert!(body.contains("## Delivery outcome"), "{body}");
+        assert!(
+            body.contains("forge-cli review ledger · generation 0"),
+            "{body}"
+        );
+        // The ledger half is still an exact, parseable record.
+        let chain = review_state::parse_chain([body.as_str()], REPO, PR).expect("appended chain");
+        assert_eq!(chain.records.len(), 1);
+        assert_eq!(
+            review_state::latest_review_loop_state(&chain)
+                .expect("state")
+                .head_sha,
+            HEAD
+        );
+    }
+
+    #[test]
+    fn an_identical_observe_retry_posts_neither_a_ledger_nor_an_outcome_comment() {
+        // The outcome rides the append, so the append's deduplication is also
+        // the outcome's: a retry after a lost response must not leave a second
+        // outcome comment behind.
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
+        let state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let code = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args_with_body(&findings, HEAD, Some(&tip), "## Delivery outcome"),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect("unchanged observation");
+
+        assert_eq!(code, 0);
+        assert_eq!(
+            runner.appended_bodies(),
+            Vec::<String>::new(),
+            "an already-current ledger writes nothing at all"
+        );
+    }
+
+    #[test]
+    fn observe_rejects_a_non_portable_outcome_body_before_any_provider_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, "[]");
+        let runner = FakeGitHub::new(HEAD);
+
+        let error = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args_with_body(
+                &findings,
+                HEAD,
+                None,
+                "outcome recorded at /home/operator/work/report.md",
+            ),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("a local path must not reach a permanent provider comment");
+
+        assert_eq!(error.kind(), "local_path_present");
+        assert_eq!(
+            runner.calls(),
+            Vec::<Vec<String>>::new(),
+            "the body is validated before the first provider read"
+        );
+    }
+
+    #[test]
+    fn observe_rejects_an_outcome_body_flag_with_no_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, "[]");
+        let runner = FakeGitHub::new(HEAD);
+
+        let error = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args_with_body(&findings, HEAD, None, "   \n  "),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("an empty outcome body is a caller error, not an omission");
+
+        assert_eq!(error.kind(), "review_state_comment_invalid");
+        assert_eq!(runner.calls(), Vec::<Vec<String>>::new());
+    }
+
+    #[test]
+    fn observe_dry_run_plans_the_combined_comment_without_posting_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, "[]");
+        let runner = FakeGitHub::new(HEAD);
+
+        let code = run_observe_with(
+            &runner,
+            &flags(true),
+            observe_args_with_body(&findings, HEAD, None, "## Delivery outcome"),
+            OutputFormat::Text,
+            github_remote,
+        )
+        .expect("clean combined preflight");
+
+        assert_eq!(code, 0);
+        assert_eq!(
+            runner.appended_bodies(),
+            Vec::<String>::new(),
+            "planning a combined comment must not post one"
+        );
+        assert!(
+            !runner.calls().is_empty(),
+            "the preflight still reads provider state"
+        );
+    }
+
+    #[test]
+    fn observe_dry_run_reports_an_unreadable_outcome_body_file_without_failing() {
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, "[]");
+        let runner = FakeGitHub::new(HEAD);
+        let args = PrReviewLoopObserveArgs {
+            body_file: Some("/definitely/missing-outcome.md".to_string()),
+            ..observe_args(&findings, HEAD, None)
+        };
+
+        let code = run_observe_with(
+            &runner,
+            &flags(true),
+            args,
+            OutputFormat::Text,
+            github_remote,
+        )
+        .expect("a failing preflight rule is reported, not returned as an error");
+
+        assert_eq!(code, 0);
+        assert_eq!(runner.appended_bodies(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn a_durable_hard_stop_receipt_is_appended_without_the_outcome_body() {
+        // A hard stop is a failure receipt. Attaching the delivery outcome to it
+        // would publish an approval narrative on a run that did not converge.
+        const REPAIRED: &str = "head-repaired";
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
+        let mut state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        state.budget.max_repair_rounds = 0;
+        let runner = FakeGitHub::new(REPAIRED).with_state(&state, HEAD);
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let error = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args_with_body(&findings, REPAIRED, Some(&tip), "## Delivery outcome"),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("an exhausted round budget stops the loop");
+
+        assert_eq!(error.kind(), "review_round_limit_exceeded");
+        let bodies = runner.appended_bodies();
+        assert_eq!(bodies.len(), 1, "the stop receipt is still durable");
+        assert!(
+            !bodies[0].contains("## Delivery outcome"),
+            "a stop receipt must not carry the delivery outcome: {}",
+            bodies[0]
+        );
+        assert!(
+            bodies[0].contains("forge-cli review ledger ·"),
+            "the stop receipt still carries visible metadata: {}",
+            bodies[0]
+        );
+    }
+
+    #[test]
+    fn a_forked_ledger_history_fails_closed_before_any_append() {
+        // Two sessions that each appended generation 1 from the same genesis are
+        // a fork. It must be refused on read, with the supplied outcome body
+        // never reaching the provider.
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, "[]");
+        let genesis = genesis_state(HEAD, &[]);
+        let runner = FakeGitHub::new(HEAD).with_state(&genesis, HEAD);
+        let genesis_digest = runner.tip_digest().expect("genesis tip");
+        for no_progress in [0, 1] {
+            let mut competing = genesis.clone();
+            competing.no_progress_rounds = no_progress;
+            let record = review_state::ReviewStateRecord::new(
+                REPO,
+                PR,
+                HEAD,
+                1,
+                Some(genesis_digest.clone()),
+                review_state::ReviewStatePayload::ReviewLoop { state: competing },
+            )
+            .expect("competing record");
+            runner.comments.borrow_mut().push(comment_node(
+                &review_state::render_state_comment_body(&record, None).expect("body"),
+                TIP_CREATED_AT,
+            ));
+        }
+
+        let error = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args_with_body(
+                &findings,
+                HEAD,
+                Some(&genesis_digest),
+                "## Delivery outcome",
+            ),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("a forked chain must fail closed");
+
+        assert_eq!(error.kind(), "review_state_conflict");
+        assert_eq!(runner.appended_bodies(), Vec::<String>::new());
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_review_loop.rs
+++ b/crates/forge-cli/src/ops/pr_review_loop.rs
@@ -214,7 +214,7 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
                     .expect("recorded hard stop exists");
                 // A hard stop is a failure receipt, never a delivery outcome, so
                 // the outcome body is deliberately not attached here.
-                let chain = pr_review::append_review_loop_state(
+                let appended = pr_review::append_review_loop_state(
                     runner,
                     &ctx,
                     pr_review::ReviewLoopAppend {
@@ -229,7 +229,7 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
                 return Err(durable_hard_stop_error(
                     &error,
                     &stop,
-                    chain.tip_digest.as_deref(),
+                    appended.chain.tip_digest.as_deref(),
                 ));
             }
             Err(error) => return Err(error),
@@ -239,18 +239,27 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         // The ledger is already current, so there is nothing to append and no
         // comment to carry an outcome. Posting the outcome on its own here would
         // reintroduce exactly the duplicate an identical retry must not create.
+        // But silently dropping it would lose the caller's only copy, so when an
+        // outcome was supplied we must say which of the two happened.
+        let outcome_posted = match outcome_body.as_deref() {
+            None => false,
+            Some(outcome) => {
+                ensure_outcome_already_posted(&state_view, outcome, &args.expected_head)?;
+                true
+            }
+        };
         return emit_state(
             &ctx,
             view.number,
             view.url,
             state_view.chain,
             false,
-            false,
+            outcome_posted,
             SCHEMA_OBSERVE,
             format,
         );
     }
-    let chain = pr_review::append_review_loop_state(
+    let appended = pr_review::append_review_loop_state(
         runner,
         &ctx,
         pr_review::ReviewLoopAppend {
@@ -266,9 +275,9 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         &ctx,
         view.number,
         view.url,
-        chain,
+        appended.chain,
         true,
-        outcome_body.is_some(),
+        appended.outcome_posted,
         SCHEMA_OBSERVE,
         format,
     )
@@ -276,9 +285,12 @@ pub fn run_observe_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 
 /// Reads and validates the optional visible delivery outcome body.
 ///
-/// Returns `None` when neither flag was supplied. When one was, the body must be
-/// present and portable: the same no-local-path and escaped-control rules the
-/// review comment surfaces enforce apply, because this text becomes a permanent
+/// Returns `None` when neither flag was supplied. Every rule that governs the
+/// body runs here, before the first provider call, so a rejected body never
+/// costs a provider round trip and a dry run reports the same verdict a live run
+/// returns. The body must be structurally safe ([`review_state::validate_outcome_body`])
+/// and portable: the same no-local-path and escaped-control rules the review
+/// comment surfaces enforce apply, because this text becomes a permanent
 /// provider-visible comment.
 fn read_outcome_body(args: &PrReviewLoopObserveArgs) -> Result<Option<String>, ForgeError> {
     if args.body.is_none() && args.body_file.is_none() {
@@ -289,17 +301,50 @@ fn read_outcome_body(args: &PrReviewLoopObserveArgs) -> Result<Option<String>, F
         args.body_file.as_deref(),
         "--body-file",
     )?;
-    if body.trim().is_empty() {
-        return Err(ForgeError::validation(
-            schema_err(),
-            "review_state_comment_invalid",
-            "the review-loop outcome body is empty (supply --body or --body-file)",
-            None,
-        ));
-    }
+    let body = review_state::validate_outcome_body(&body)?.to_string();
     no_local_path(&body, "review-loop outcome body")?;
     no_escaped_control_markdown(&body)?;
     Ok(Some(body))
+}
+
+/// Confirms a supplied outcome is already on the pull request when the ledger is
+/// already current.
+///
+/// The append is what carries an outcome, so an unchanged observation has no
+/// comment to put one in. That is exactly right for the retry this feature is
+/// built for — the first attempt already posted the combined comment — and
+/// exactly wrong to do silently otherwise, because the caller's outcome would
+/// vanish with a success exit code.
+fn ensure_outcome_already_posted(
+    state_view: &pr_review::ReviewLoopStateView,
+    outcome: &str,
+    expected_head: &str,
+) -> Result<(), ForgeError> {
+    let tip = state_view.chain.records.last().ok_or_else(|| {
+        ForgeError::validation(
+            schema_err(),
+            "review_state_conflict",
+            "an unchanged observation requires an existing review-loop chain tip",
+            None,
+        )
+    })?;
+    let marker = tip.marker()?;
+    if state_view
+        .trusted_comment_bodies
+        .iter()
+        .any(|body| review_state::comment_carries_outcome(body, &marker, outcome))
+    {
+        return Ok(());
+    }
+    Err(ForgeError::validation(
+        schema_err(),
+        "review_outcome_not_posted",
+        "the review-loop ledger is already current, so the supplied delivery outcome was not posted",
+        Some(format!(
+            "expected_head={expected_head}; state_tip_digest={}; recovery=this observation appends nothing, so post the outcome separately or observe a new reviewed head",
+            tip.record_digest
+        )),
+    ))
 }
 
 pub fn run_extend(
@@ -408,7 +453,7 @@ pub fn run_extend_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         &args.budget_field,
         args.increment,
     )?;
-    let chain = pr_review::append_review_loop_state(
+    let appended = pr_review::append_review_loop_state(
         runner,
         &ctx,
         pr_review::ReviewLoopAppend {
@@ -424,7 +469,7 @@ pub fn run_extend_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         &ctx,
         view.number,
         view.url,
-        chain,
+        appended.chain,
         true,
         false,
         SCHEMA_EXTEND,
@@ -1053,17 +1098,29 @@ fn emit_observe_dry_run<R: BackendRunner>(
                                     // "this fails" without that would understate
                                     // what the real call does. That receipt never
                                     // carries the outcome body.
+                                    //
+                                    // But an unextended durable stop already
+                                    // exists on the same guard the live path
+                                    // checks first, and the live path then returns
+                                    // WITHOUT appending. Mirror that here, or the
+                                    // preflight advertises an exact provider write
+                                    // that provably never happens.
+                                    let stop_already_durable = previous
+                                        .and_then(|state| state.hard_stop.as_ref())
+                                        .is_some_and(|stop| !stop.extension_applied);
                                     if review_state::stop_budget_field(error.kind()).is_some() {
-                                        would_append = Some(true);
-                                        planned_comment = plan_hard_stop_comment(
-                                            &repository,
-                                            view.number,
-                                            &args.expected_head,
-                                            &state_view.chain,
-                                            previous,
-                                            observations,
-                                            &error,
-                                        );
+                                        would_append = Some(!stop_already_durable);
+                                        if !stop_already_durable {
+                                            planned_comment = plan_hard_stop_comment(
+                                                &repository,
+                                                view.number,
+                                                &args.expected_head,
+                                                &state_view.chain,
+                                                previous,
+                                                observations,
+                                                &error,
+                                            );
+                                        }
                                     }
                                     verdicts.push(RuleVerdict::from_result(
                                         "observation_transition",
@@ -1348,6 +1405,26 @@ mod tests {
         }
 
         fn with_state(self, state: &review_state::ReviewLoopState, head: &str) -> Self {
+            self.seed_state(state, head, None)
+        }
+
+        /// Seeds the same genesis record as a COMBINED comment, i.e. the exact
+        /// comment a prior successful `observe --body` left behind.
+        fn with_state_and_outcome(
+            self,
+            state: &review_state::ReviewLoopState,
+            head: &str,
+            outcome: &str,
+        ) -> Self {
+            self.seed_state(state, head, Some(outcome))
+        }
+
+        fn seed_state(
+            self,
+            state: &review_state::ReviewLoopState,
+            head: &str,
+            outcome: Option<&str>,
+        ) -> Self {
             let record = review_state::ReviewStateRecord::new(
                 REPO,
                 PR,
@@ -1359,10 +1436,11 @@ mod tests {
                 },
             )
             .expect("seed record");
-            let marker = record.marker().expect("seed marker");
+            let body =
+                review_state::render_state_comment_body(&record, outcome).expect("seed body");
             self.comments
                 .borrow_mut()
-                .push(comment_node(&marker, TIP_CREATED_AT));
+                .push(comment_node(&body, TIP_CREATED_AT));
             self
         }
 
@@ -1799,21 +1877,23 @@ mod tests {
     fn an_identical_observe_retry_posts_neither_a_ledger_nor_an_outcome_comment() {
         // The outcome rides the append, so the append's deduplication is also
         // the outcome's: a retry after a lost response must not leave a second
-        // outcome comment behind.
+        // outcome comment behind. The seeded comment is the combined comment the
+        // first attempt already posted.
+        const OUTCOME: &str = "## Delivery outcome";
         let dir = tempfile::tempdir().unwrap();
         let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
         let state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
-        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+        let runner = FakeGitHub::new(HEAD).with_state_and_outcome(&state, HEAD, OUTCOME);
         let tip = runner.tip_digest().expect("seeded tip");
 
         let code = run_observe_with(
             &runner,
             &flags(false),
-            observe_args_with_body(&findings, HEAD, Some(&tip), "## Delivery outcome"),
+            observe_args_with_body(&findings, HEAD, Some(&tip), OUTCOME),
             OutputFormat::Json,
             github_remote,
         )
-        .expect("unchanged observation");
+        .expect("the retry finds its own prior combined comment");
 
         assert_eq!(code, 0);
         assert_eq!(
@@ -1821,6 +1901,35 @@ mod tests {
             Vec::<String>::new(),
             "an already-current ledger writes nothing at all"
         );
+    }
+
+    #[test]
+    fn an_unchanged_observation_refuses_to_silently_drop_a_new_outcome() {
+        // The append is what carries an outcome, so an unchanged observation has
+        // no comment to put one in. Exiting 0 while discarding the caller's only
+        // copy would lose the delivery outcome; this must fail closed instead.
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
+        let state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        let runner = FakeGitHub::new(HEAD).with_state(&state, HEAD);
+        let tip = runner.tip_digest().expect("seeded tip");
+
+        let error = run_observe_with(
+            &runner,
+            &flags(false),
+            observe_args_with_body(&findings, HEAD, Some(&tip), "## Delivery outcome"),
+            OutputFormat::Json,
+            github_remote,
+        )
+        .expect_err("an outcome that cannot be posted must not be dropped silently");
+
+        assert_eq!(error.kind(), "review_outcome_not_posted");
+        assert!(
+            error.detail().unwrap_or_default().contains(&tip),
+            "the detail names the tip that blocks the append: {:?}",
+            error.detail()
+        );
+        assert_eq!(runner.appended_bodies(), Vec::<String>::new());
     }
 
     #[test]
@@ -1849,6 +1958,84 @@ mod tests {
             Vec::<Vec<String>>::new(),
             "the body is validated before the first provider read"
         );
+    }
+
+    #[test]
+    fn observe_rejects_a_marker_carrying_outcome_body_before_any_provider_call() {
+        // `parse_state_marker` takes the first marker in a body, so an embedded
+        // one would shadow the record the comment claims to append. The rule must
+        // hold before the first provider call, so a dry run reports the same
+        // verdict a live run returns.
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, "[]");
+        let forged = review_state::ReviewStateRecord::new(
+            REPO,
+            PR,
+            HEAD,
+            0,
+            None,
+            review_state::ReviewStatePayload::ReviewLoop {
+                state: genesis_state(HEAD, &[]),
+            },
+        )
+        .expect("forged record")
+        .marker()
+        .expect("forged marker");
+
+        for hostile in [forged.as_str(), "Approved.\n\n<!--"] {
+            let runner = FakeGitHub::new(HEAD);
+            let error = run_observe_with(
+                &runner,
+                &flags(false),
+                observe_args_with_body(&findings, HEAD, None, hostile),
+                OutputFormat::Json,
+                github_remote,
+            )
+            .expect_err("a hidden-HTML outcome body must fail closed");
+
+            assert_eq!(error.kind(), "review_state_comment_invalid", "{hostile}");
+            assert_eq!(
+                runner.calls(),
+                Vec::<Vec<String>>::new(),
+                "no provider round trip may be spent on a rejected body"
+            );
+        }
+    }
+
+    #[test]
+    fn observe_dry_run_does_not_plan_a_hard_stop_receipt_that_already_exists() {
+        // The live path checks the durable unextended stop FIRST and returns
+        // without appending. A dry run that advertises an exact provider write
+        // here would be predicting a mutation that provably never happens.
+        const REPAIRED: &str = "head-repaired";
+        let dir = tempfile::tempdir().unwrap();
+        let findings = findings_file(&dir, r#"[{"fingerprint":"correctness:review-loop:one"}]"#);
+        let mut state = genesis_state(HEAD, &[open_finding("correctness:review-loop:one")]);
+        state.budget.max_repair_rounds = 0;
+        let attempted = [open_finding("correctness:review-loop:one")];
+        let error = review_state::observe_review_loop(Some(&state), REPAIRED, &attempted)
+            .expect_err("round budget exhausted");
+        let stopped = review_state::record_review_loop_hard_stop(
+            &state,
+            REPAIRED,
+            &attempted,
+            "sha256:state-tip",
+            &error,
+        )
+        .expect("durable stop");
+        let runner = FakeGitHub::new(REPAIRED).with_state(&stopped, HEAD);
+
+        let code = run_observe_with(
+            &runner,
+            &flags(true),
+            observe_args(&findings, REPAIRED, None),
+            OutputFormat::Text,
+            github_remote,
+        )
+        .expect("the preflight reports the stop instead of erroring");
+
+        assert_eq!(code, 0);
+        assert_eq!(runner.appended_bodies(), Vec::<String>::new());
     }
 
     #[test]
@@ -1998,7 +2185,14 @@ mod tests {
         )
         .expect_err("a forked chain must fail closed");
 
+        // `review_state_conflict` covers every chain fault, so pin the message:
+        // deleting the competing-generation guard would still fail with this kind
+        // (as an unreachable-record error) and leave the test green.
         assert_eq!(error.kind(), "review_state_conflict");
+        assert_eq!(
+            error.message(),
+            "review-state chain contains competing generations"
+        );
         assert_eq!(runner.appended_bodies(), Vec::<String>::new());
     }
 

--- a/crates/forge-cli/src/ops/review_state.rs
+++ b/crates/forge-cli/src/ops/review_state.rs
@@ -4,6 +4,12 @@
 //! in an owned HTML marker; each record binds its previous digest and expected
 //! PR head. This module deliberately contains no provider I/O so parsing,
 //! privacy, and fork rules stay deterministic.
+//!
+//! Encoding and presentation are separate concerns here. [`ReviewStateRecord::marker`]
+//! owns the canonical machine encoding that digests and chain validation depend
+//! on; [`render_state_comment_body`] owns the human-facing comment body that
+//! wraps it. Presentation text never reaches a digest, so a rendering change can
+//! never fork or invalidate an existing chain.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -17,6 +23,13 @@ pub const REVIEW_STATE_SCHEMA: &str = "forge-cli.review-loop.v1";
 const STATE_MARKER_OPEN: &str = "<!-- forge-cli:review-state:v1 ";
 const STATE_MARKER_CLOSE: &str = " -->";
 const MAX_PROVIDER_STATE_MARKER_BYTES: usize = 64 * 1024;
+/// GitHub caps an issue-comment body at 65536 bytes, and the marker is only one
+/// part of that body once visible text wraps it. The complete rendered body is
+/// what the provider actually stores, so it carries the binding limit.
+const MAX_PROVIDER_STATE_COMMENT_BYTES: usize = 64 * 1024;
+const STATE_COMMENT_LABEL: &str = "forge-cli review ledger";
+/// Abbreviated-SHA width for the visible metadata line.
+const STATE_COMMENT_HEAD_CHARS: usize = 12;
 const REVIEW_RUN_MARKER_PREFIX: &str = "<!-- forge-cli:review-run:v1 run=";
 const FINDING_MARKER_PREFIX: &str = "<!-- forge-cli:review-finding:v1 run=";
 const THREAD_DISPOSITION_MARKER_PREFIX: &str = "<!-- forge-cli:thread-disposition:v1 thread=";
@@ -150,6 +163,17 @@ pub enum ReviewStatePayload {
     ReviewLoop { state: ReviewLoopState },
 }
 
+impl ReviewStatePayload {
+    /// The serialized `kind` tag, reused verbatim in the visible metadata line so
+    /// the timeline names the same payload kind the record encodes.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::ReviewRunReceipt { .. } => "review-run-receipt",
+            Self::ReviewLoop { .. } => "review-loop",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReviewStateRecord {
     pub schema: String,
@@ -246,6 +270,106 @@ impl ReviewStateRecord {
             ));
         }
         Ok(marker)
+    }
+}
+
+/// The one-line, non-sensitive description of a ledger record shown in the
+/// provider timeline.
+///
+/// Everything here is already public on the pull request: the generation index,
+/// the payload kind, and an abbreviated head SHA. No credential, environment
+/// value, local path, private identity, or finding body is representable.
+pub fn state_comment_visible_metadata(record: &ReviewStateRecord) -> String {
+    format!(
+        "{STATE_COMMENT_LABEL} · generation {generation} · {kind} · head {head}",
+        generation = record.generation,
+        kind = record.payload.kind(),
+        head = abbreviated_head(&record.expected_head),
+    )
+}
+
+/// Renders the complete provider comment body for one ledger record, optionally
+/// carrying a human-readable delivery outcome in the same comment.
+///
+/// GitHub hides HTML comments when it renders Markdown, so a body that is only
+/// the canonical marker appears in the timeline as a blank comment authored by
+/// the operator. Prefixing the visible metadata line keeps the same append-only
+/// record identifiable as machine metadata. The marker itself is emitted
+/// unchanged and on its own trailing line, so [`parse_state_marker`] — which
+/// already searches within a larger body — reads new and historical bare-marker
+/// comments identically, with no migration.
+///
+/// `visible_outcome`, when supplied, makes the ledger append and the delivery
+/// outcome one provider mutation instead of two. It is rejected if it carries a
+/// state marker of its own: [`parse_state_marker`] takes the first marker in the
+/// body, so an embedded one would silently shadow this record's.
+pub fn render_state_comment_body(
+    record: &ReviewStateRecord,
+    visible_outcome: Option<&str>,
+) -> Result<String, ForgeError> {
+    let marker = record.marker()?;
+    let metadata = state_comment_visible_metadata(record);
+    let body = match visible_outcome {
+        Some(outcome) => {
+            let outcome = validate_visible_outcome(outcome)?;
+            format!("{outcome}\n\n---\n\n{metadata}\n{marker}")
+        }
+        None => format!("{metadata}\n{marker}"),
+    };
+    if body.len() > MAX_PROVIDER_STATE_COMMENT_BYTES {
+        return Err(ForgeError::validation(
+            error_schema(),
+            "review_state_comment_too_large",
+            "the complete provider review-state comment body exceeds the safe comment-body limit",
+            Some(format!(
+                "comment_bytes={}; marker_bytes={}; max_bytes={MAX_PROVIDER_STATE_COMMENT_BYTES}",
+                body.len(),
+                marker.len()
+            )),
+        ));
+    }
+    Ok(body)
+}
+
+/// Validates a caller-supplied visible outcome body for combined posting.
+///
+/// Only structural safety is checked here; portability rules (local paths,
+/// escaped control markdown) belong to the command layer that owns the flag.
+fn validate_visible_outcome(outcome: &str) -> Result<&str, ForgeError> {
+    let trimmed = outcome.trim();
+    if trimmed.is_empty() {
+        return Err(ForgeError::validation(
+            error_schema(),
+            "review_state_comment_invalid",
+            "the review-loop outcome body is empty",
+            None,
+        ));
+    }
+    if trimmed.contains(STATE_MARKER_OPEN) {
+        return Err(ForgeError::validation(
+            error_schema(),
+            "review_state_comment_invalid",
+            "the review-loop outcome body must not contain a review-state marker",
+            Some(format!("marker_prefix={}", STATE_MARKER_OPEN.trim_end())),
+        ));
+    }
+    Ok(trimmed)
+}
+
+/// Abbreviates a head SHA for the single-line visible metadata.
+///
+/// The provider supplies the head, so the visible line filters it to characters
+/// that cannot break out of one line of plain Markdown.
+fn abbreviated_head(head: &str) -> String {
+    let abbreviated = head
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+        .take(STATE_COMMENT_HEAD_CHARS)
+        .collect::<String>();
+    if abbreviated.is_empty() {
+        "-".to_string()
+    } else {
+        abbreviated
     }
 }
 
@@ -1264,6 +1388,248 @@ mod tests {
         );
         let marker = record.marker().expect("marker");
         assert_eq!(parse_state_marker(&marker).expect("parse"), Some(record));
+    }
+
+    // ---------------------------------------------------------------------
+    // A marker-only body is what GitHub renders as a blank comment. These
+    // guards keep the visible wrapper honest without letting presentation
+    // reach the digest, the chain, or the parser.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn a_rendered_state_comment_is_visibly_identified_and_still_parses() {
+        let record = ReviewStateRecord::new(
+            "acme/widgets",
+            7,
+            "0123456789abcdef0123456789abcdef01234567",
+            3,
+            Some("sha256:previous".to_string()),
+            ReviewStatePayload::ReviewLoop {
+                state: fixture_loop_state(1),
+            },
+        )
+        .expect("record");
+
+        let body = render_state_comment_body(&record, None).expect("rendered body");
+
+        assert_eq!(
+            body,
+            format!(
+                "forge-cli review ledger · generation 3 · review-loop · head 0123456789ab\n{}",
+                record.marker().expect("marker")
+            )
+        );
+        // The visible line is real Markdown text, so the comment can never
+        // render empty.
+        assert!(!body.lines().next().expect("first line").starts_with("<!--"),);
+        assert_eq!(parse_state_marker(&body).expect("parse"), Some(record));
+    }
+
+    #[test]
+    fn a_receipt_comment_names_its_own_payload_kind() {
+        let record = ReviewStateRecord::new(
+            "acme/widgets",
+            7,
+            "head-abc",
+            0,
+            None,
+            ReviewStatePayload::ReviewRunReceipt {
+                receipt: fixture_receipt(),
+            },
+        )
+        .expect("record");
+
+        assert_eq!(
+            state_comment_visible_metadata(&record),
+            "forge-cli review ledger · generation 0 · review-run-receipt · head head-abc"
+        );
+    }
+
+    #[test]
+    fn historical_bare_markers_and_rendered_bodies_validate_as_one_chain() {
+        // Existing history is bare markers; new appends are wrapped. A chain
+        // that mixes both must be indistinguishable from either, with no
+        // migration and no rewrite of historical comments.
+        let genesis = record("head", 0, None, fixture_loop_state(0));
+        let child = record(
+            "head",
+            1,
+            Some(genesis.record_digest.clone()),
+            fixture_loop_state(1),
+        );
+        let historical = genesis.marker().expect("historical marker");
+        let rendered = render_state_comment_body(&child, None).expect("rendered body");
+
+        let mixed =
+            parse_chain([historical.as_str(), rendered.as_str()], REPO, PR).expect("mixed history");
+        let all_legacy = parse_chain(
+            [
+                historical.as_str(),
+                child.marker().expect("marker").as_str(),
+            ],
+            REPO,
+            PR,
+        )
+        .expect("recorded history");
+
+        assert_eq!(mixed, all_legacy);
+        assert_eq!(mixed.tip_digest.as_deref(), Some(&*child.record_digest));
+    }
+
+    #[test]
+    fn visible_presentation_never_reaches_the_record_digest() {
+        let record = record("head", 0, None, fixture_loop_state(0));
+        let plain = render_state_comment_body(&record, None).expect("plain body");
+        let combined =
+            render_state_comment_body(&record, Some("## Approved\n\nEvidence.")).expect("combined");
+
+        let from_plain = parse_state_marker(&plain).expect("parse").expect("record");
+        let from_combined = parse_state_marker(&combined)
+            .expect("parse")
+            .expect("record");
+
+        assert_eq!(from_plain, from_combined);
+        assert_eq!(from_plain.record_digest, record.record_digest);
+        // Two different presentations of one record are still one logical
+        // append, not a fork.
+        let chain =
+            parse_chain([plain.as_str(), combined.as_str()], REPO, PR).expect("deduplicated");
+        assert_eq!(chain.records, vec![record]);
+    }
+
+    #[test]
+    fn a_combined_comment_keeps_the_outcome_visible_and_the_marker_exact() {
+        let record = record("head", 0, None, fixture_loop_state(0));
+        let outcome = "## Delivery outcome\n\n- decision: approve";
+
+        let body = render_state_comment_body(&record, Some(outcome)).expect("combined body");
+
+        assert!(body.starts_with(outcome), "{body}");
+        assert!(body.ends_with(&record.marker().expect("marker")), "{body}");
+        // Stripping owned markers leaves the human-readable outcome intact.
+        assert!(strip_owned_markers(&body).starts_with(outcome));
+        assert_eq!(
+            parse_state_marker(&body).expect("parse").as_ref(),
+            Some(&record)
+        );
+    }
+
+    #[test]
+    fn an_outcome_body_carrying_a_state_marker_is_refused() {
+        // `parse_state_marker` takes the FIRST marker in the body, so an
+        // embedded one would shadow this record's and silently corrupt the
+        // chain the comment claims to extend.
+        let forged = record("head", 0, None, fixture_loop_state(9))
+            .marker()
+            .expect("marker");
+        let record = record("head", 0, None, fixture_loop_state(0));
+
+        for outcome in [
+            forged.clone(),
+            format!("Quoted history: {forged} — see above"),
+            format!("{STATE_MARKER_OPEN}deadbeef{STATE_MARKER_CLOSE}"),
+        ] {
+            let error = render_state_comment_body(&record, Some(&outcome))
+                .expect_err("marker injection must fail closed");
+            assert_eq!(error.kind(), "review_state_comment_invalid");
+        }
+
+        let empty = render_state_comment_body(&record, Some("   \n\t "))
+            .expect_err("an empty outcome is not an outcome");
+        assert_eq!(empty.kind(), "review_state_comment_invalid");
+    }
+
+    #[test]
+    fn the_complete_rendered_body_is_size_checked_before_any_mutation() {
+        let record = record("head", 0, None, fixture_loop_state(0));
+        let marker_bytes = record.marker().expect("marker").len();
+
+        // A marker that fits on its own can still overflow once visible text
+        // wraps it, which is why the limit binds the complete body.
+        let headroom = MAX_PROVIDER_STATE_COMMENT_BYTES - marker_bytes;
+        let error = render_state_comment_body(&record, Some(&"o".repeat(headroom)))
+            .expect_err("oversized combined body must fail before post");
+        assert_eq!(error.kind(), "review_state_comment_too_large");
+        assert!(
+            error
+                .detail()
+                .unwrap_or_default()
+                .contains(&format!("max_bytes={MAX_PROVIDER_STATE_COMMENT_BYTES}")),
+            "{:?}",
+            error.detail()
+        );
+
+        // Just inside the limit still renders.
+        let fitted = render_state_comment_body(&record, Some(&"o".repeat(headroom / 2)))
+            .expect("a body within the limit renders");
+        assert!(fitted.len() <= MAX_PROVIDER_STATE_COMMENT_BYTES);
+    }
+
+    #[test]
+    fn visible_metadata_exposes_nothing_beyond_public_pull_request_facts() {
+        let record = ReviewStateRecord::new(
+            "acme/widgets",
+            7,
+            "abcdef0123456789abcdef0123456789abcdef01",
+            2,
+            Some("sha256:previous".to_string()),
+            ReviewStatePayload::ReviewRunReceipt {
+                receipt: fixture_receipt(),
+            },
+        )
+        .expect("record");
+
+        let metadata = state_comment_visible_metadata(&record);
+
+        assert_eq!(metadata.lines().count(), 1, "{metadata}");
+        for forbidden in [
+            "token",
+            "secret",
+            "credential",
+            "profile",
+            "/home/",
+            "/Users/",
+            "C:\\",
+            "@",
+            "sha256:",
+        ] {
+            assert!(!metadata.contains(forbidden), "{forbidden} in {metadata}");
+        }
+        // The abbreviated head is a prefix of the public head, never the whole
+        // record or any digest.
+        assert!(record.expected_head.starts_with("abcdef012345"));
+        assert!(metadata.ends_with("head abcdef012345"));
+    }
+
+    #[test]
+    fn an_unusable_head_still_renders_one_plain_line() {
+        // The head comes from the provider. Nothing it contains may break the
+        // visible line into extra Markdown.
+        for (head, expected) in [
+            ("", "-"),
+            ("  ", "-"),
+            ("a\nb", "ab"),
+            ("**bold**", "bold"),
+            ("héad-1234567890", "had-12345678"),
+        ] {
+            let record = ReviewStateRecord::new(
+                "acme/widgets",
+                7,
+                head,
+                0,
+                None,
+                ReviewStatePayload::ReviewRunReceipt {
+                    receipt: fixture_receipt(),
+                },
+            )
+            .expect("record");
+            let metadata = state_comment_visible_metadata(&record);
+            assert_eq!(metadata.lines().count(), 1, "{metadata}");
+            assert!(
+                metadata.ends_with(&format!("head {expected}")),
+                "{metadata}"
+            );
+        }
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/review_state.rs
+++ b/crates/forge-cli/src/ops/review_state.rs
@@ -28,6 +28,7 @@ const MAX_PROVIDER_STATE_MARKER_BYTES: usize = 64 * 1024;
 /// what the provider actually stores, so it carries the binding limit.
 const MAX_PROVIDER_STATE_COMMENT_BYTES: usize = 64 * 1024;
 const STATE_COMMENT_LABEL: &str = "forge-cli review ledger";
+const HTML_COMMENT_OPEN: &str = "<!--";
 /// Abbreviated-SHA width for the visible metadata line.
 const STATE_COMMENT_HEAD_CHARS: usize = 12;
 const REVIEW_RUN_MARKER_PREFIX: &str = "<!-- forge-cli:review-run:v1 run=";
@@ -293,16 +294,19 @@ pub fn state_comment_visible_metadata(record: &ReviewStateRecord) -> String {
 ///
 /// GitHub hides HTML comments when it renders Markdown, so a body that is only
 /// the canonical marker appears in the timeline as a blank comment authored by
-/// the operator. Prefixing the visible metadata line keeps the same append-only
-/// record identifiable as machine metadata. The marker itself is emitted
-/// unchanged and on its own trailing line, so [`parse_state_marker`] — which
-/// already searches within a larger body — reads new and historical bare-marker
-/// comments identically, with no migration.
+/// the operator. The visible metadata line fixes that, and it is emitted FIRST,
+/// with the marker immediately under it, so no caller-supplied byte can ever
+/// precede the label. That ordering is load-bearing rather than cosmetic: a
+/// Markdown HTML block opened in caller text runs until a line containing
+/// `-->`, so an outcome ending in an unterminated `<!--` placed above the label
+/// would swallow both the label and the marker and render a machine ledger
+/// record as ordinary human prose. The marker stays byte-identical and on its own
+/// line, so [`parse_state_marker`] — which already searches within a larger body
+/// — reads new and historical bare-marker comments identically, with no
+/// migration.
 ///
 /// `visible_outcome`, when supplied, makes the ledger append and the delivery
-/// outcome one provider mutation instead of two. It is rejected if it carries a
-/// state marker of its own: [`parse_state_marker`] takes the first marker in the
-/// body, so an embedded one would silently shadow this record's.
+/// outcome one provider mutation instead of two.
 pub fn render_state_comment_body(
     record: &ReviewStateRecord,
     visible_outcome: Option<&str>,
@@ -310,10 +314,12 @@ pub fn render_state_comment_body(
     let marker = record.marker()?;
     let metadata = state_comment_visible_metadata(record);
     let body = match visible_outcome {
-        Some(outcome) => {
-            let outcome = validate_visible_outcome(outcome)?;
-            format!("{outcome}\n\n---\n\n{metadata}\n{marker}")
-        }
+        // Defence in depth: the command layer validates the same body before its
+        // first provider call, but every writer funnels through here.
+        Some(outcome) => format!(
+            "{metadata}\n{marker}\n\n---\n\n{outcome}",
+            outcome = validate_outcome_body(outcome)?
+        ),
         None => format!("{metadata}\n{marker}"),
     };
     if body.len() > MAX_PROVIDER_STATE_COMMENT_BYTES {
@@ -331,29 +337,74 @@ pub fn render_state_comment_body(
     Ok(body)
 }
 
-/// Validates a caller-supplied visible outcome body for combined posting.
+/// Validates a caller-supplied delivery outcome body and returns it trimmed.
 ///
-/// Only structural safety is checked here; portability rules (local paths,
-/// escaped control markdown) belong to the command layer that owns the flag.
-fn validate_visible_outcome(outcome: &str) -> Result<&str, ForgeError> {
+/// Structural safety only; portability rules (local paths, escaped control
+/// markdown) belong to the command layer that owns the flag. Callers must run
+/// this before their first provider call so a rejected body never costs a
+/// provider round trip, and so a dry run reports the same verdict a live run
+/// would return.
+///
+/// Any HTML comment is refused. Two distinct hazards share that one shape: a
+/// review-state marker of its own would shadow this record's, because
+/// [`parse_state_marker`] takes the first marker in a body; and an unterminated
+/// `<!--` opens a Markdown HTML block that hides whatever follows it.
+pub fn validate_outcome_body(outcome: &str) -> Result<&str, ForgeError> {
     let trimmed = outcome.trim();
     if trimmed.is_empty() {
-        return Err(ForgeError::validation(
-            error_schema(),
-            "review_state_comment_invalid",
+        return Err(comment_invalid(
             "the review-loop outcome body is empty",
             None,
         ));
     }
     if trimmed.contains(STATE_MARKER_OPEN) {
-        return Err(ForgeError::validation(
-            error_schema(),
-            "review_state_comment_invalid",
+        return Err(comment_invalid(
             "the review-loop outcome body must not contain a review-state marker",
             Some(format!("marker_prefix={}", STATE_MARKER_OPEN.trim_end())),
         ));
     }
+    if trimmed.contains(HTML_COMMENT_OPEN) {
+        return Err(comment_invalid(
+            "the review-loop outcome body must not contain an HTML comment",
+            Some(format!(
+                "html_comment_prefix={HTML_COMMENT_OPEN}; reason=an HTML comment can hide the visible ledger label and the machine marker"
+            )),
+        ));
+    }
+    if trimmed.len() > MAX_PROVIDER_STATE_COMMENT_BYTES {
+        return Err(ForgeError::validation(
+            error_schema(),
+            "review_state_comment_too_large",
+            "the review-loop outcome body exceeds the safe comment-body limit",
+            Some(format!(
+                "outcome_bytes={}; max_bytes={MAX_PROVIDER_STATE_COMMENT_BYTES}",
+                trimmed.len()
+            )),
+        ));
+    }
     Ok(trimmed)
+}
+
+/// Whether `body` is the provider comment that carries both this record's marker
+/// and `outcome`.
+///
+/// The ledger deduplicates by record, and a record digest deliberately excludes
+/// presentation, so a read-back that only matches the digest can be satisfied by
+/// another session's comment for the same record. Confirming the outcome text is
+/// what proves this session's own delivery outcome actually reached the provider.
+/// Containment rather than byte equality keeps the check robust against provider
+/// whitespace normalization.
+pub fn comment_carries_outcome(body: &str, marker: &str, outcome: &str) -> bool {
+    body.contains(marker) && body.contains(outcome.trim())
+}
+
+fn comment_invalid(message: &str, detail: Option<String>) -> ForgeError {
+    ForgeError::validation(
+        error_schema(),
+        "review_state_comment_invalid",
+        message,
+        detail,
+    )
 }
 
 /// Abbreviates a head SHA for the single-line visible metadata.
@@ -1504,14 +1555,84 @@ mod tests {
 
         let body = render_state_comment_body(&record, Some(outcome)).expect("combined body");
 
-        assert!(body.starts_with(outcome), "{body}");
-        assert!(body.ends_with(&record.marker().expect("marker")), "{body}");
+        // The label and marker lead the body; caller text can only follow them.
+        assert!(
+            body.starts_with(&state_comment_visible_metadata(&record)),
+            "{body}"
+        );
+        assert!(body.contains(&record.marker().expect("marker")), "{body}");
+        assert!(body.ends_with(outcome), "{body}");
         // Stripping owned markers leaves the human-readable outcome intact.
-        assert!(strip_owned_markers(&body).starts_with(outcome));
+        assert!(strip_owned_markers(&body).ends_with(outcome));
         assert_eq!(
             parse_state_marker(&body).expect("parse").as_ref(),
             Some(&record)
         );
+    }
+
+    #[test]
+    fn no_outcome_body_can_hide_the_visible_label_or_the_marker() {
+        // A Markdown HTML block opened in caller text runs until a line
+        // containing `-->`. An outcome ending in an unterminated `<!--` placed
+        // above the label would swallow both the label and the marker, rendering
+        // a machine ledger record as ordinary human prose — worse than the blank
+        // comment this change exists to fix. Two independent guards apply.
+        let record = record("head", 0, None, fixture_loop_state(0));
+
+        for hostile in [
+            "Approved.\n\n<!--",
+            "Approved.\n\n<!-- hide the rest",
+            "<!-- forge-cli:review-state:v1 deadbeef -->",
+        ] {
+            let error = render_state_comment_body(&record, Some(hostile))
+                .expect_err("an HTML comment in the outcome must fail closed");
+            assert_eq!(error.kind(), "review_state_comment_invalid", "{hostile}");
+        }
+
+        // Structural guard: even for accepted bodies, nothing precedes the label.
+        let body = render_state_comment_body(&record, Some("Approved.\n\n```\nunclosed fence"))
+            .expect("an unbalanced fence is the caller's own rendering problem");
+        let metadata = state_comment_visible_metadata(&record);
+        assert!(body.starts_with(&metadata), "{body}");
+        assert!(
+            body.find(&record.marker().expect("marker")) < body.find("unclosed fence"),
+            "the marker must precede every caller byte: {body}"
+        );
+    }
+
+    #[test]
+    fn an_outcome_body_is_bounded_before_it_reaches_a_provider() {
+        let oversized = "o".repeat(MAX_PROVIDER_STATE_COMMENT_BYTES + 1);
+
+        let error = validate_outcome_body(&oversized).expect_err("an oversized outcome is refused");
+
+        assert_eq!(error.kind(), "review_state_comment_too_large");
+        assert_eq!(
+            validate_outcome_body("  Approved.  ").expect("trimmed"),
+            "Approved."
+        );
+    }
+
+    #[test]
+    fn an_outcome_is_only_confirmed_when_its_comment_carries_both_halves() {
+        let record = record("head", 0, None, fixture_loop_state(0));
+        let marker = record.marker().expect("marker");
+        let outcome = "## Delivery outcome";
+        let combined = render_state_comment_body(&record, Some(outcome)).expect("combined");
+        let marker_only = render_state_comment_body(&record, None).expect("marker only");
+
+        assert!(comment_carries_outcome(&combined, &marker, outcome));
+        // The same record without this session's outcome must not count: the chain
+        // deduplicates by record, so another session's comment can satisfy a
+        // digest-only read-back.
+        assert!(!comment_carries_outcome(&marker_only, &marker, outcome));
+        assert!(!comment_carries_outcome(outcome, &marker, outcome));
+        // Provider whitespace normalization must not flip the answer.
+        assert!(comment_carries_outcome(
+            &combined,
+            &marker,
+            "  ## Delivery outcome\n"
+        ));
     }
 
     #[test]
@@ -1540,15 +1661,24 @@ mod tests {
     }
 
     #[test]
-    fn the_complete_rendered_body_is_size_checked_before_any_mutation() {
+    fn the_complete_rendered_body_is_size_checked_at_the_exact_boundary() {
         let record = record("head", 0, None, fixture_loop_state(0));
-        let marker_bytes = record.marker().expect("marker").len();
+        // Everything the renderer adds around the caller's outcome: the label,
+        // the marker, and the `\n` + `\n\n---\n\n` separators.
+        let wrapper = render_state_comment_body(&record, Some("x"))
+            .expect("wrapper")
+            .len()
+            - 1;
+        let exact = MAX_PROVIDER_STATE_COMMENT_BYTES - wrapper;
 
         // A marker that fits on its own can still overflow once visible text
         // wraps it, which is why the limit binds the complete body.
-        let headroom = MAX_PROVIDER_STATE_COMMENT_BYTES - marker_bytes;
-        let error = render_state_comment_body(&record, Some(&"o".repeat(headroom)))
-            .expect_err("oversized combined body must fail before post");
+        let fitted = render_state_comment_body(&record, Some(&"o".repeat(exact)))
+            .expect("a body at exactly the limit renders");
+        assert_eq!(fitted.len(), MAX_PROVIDER_STATE_COMMENT_BYTES);
+
+        let error = render_state_comment_body(&record, Some(&"o".repeat(exact + 1)))
+            .expect_err("one byte over the limit must fail before post");
         assert_eq!(error.kind(), "review_state_comment_too_large");
         assert!(
             error
@@ -1558,11 +1688,6 @@ mod tests {
             "{:?}",
             error.detail()
         );
-
-        // Just inside the limit still renders.
-        let fitted = render_state_comment_body(&record, Some(&"o".repeat(headroom / 2)))
-            .expect("a body within the limit renders");
-        assert!(fitted.len() <= MAX_PROVIDER_STATE_COMMENT_BYTES);
     }
 
     #[test]

--- a/crates/forge-cli/tests/integration.rs
+++ b/crates/forge-cli/tests/integration.rs
@@ -15,6 +15,7 @@ mod integration {
     mod inbox;
     mod issue_atoms;
     mod label_ops;
+    mod ledger_blank_comment_probe;
     mod local_ops;
     mod local_path_guard;
     mod operation_effect;

--- a/crates/forge-cli/tests/integration/ledger_blank_comment_probe.rs
+++ b/crates/forge-cli/tests/integration/ledger_blank_comment_probe.rs
@@ -1,0 +1,103 @@
+//! Pre-fix probe for sympoies/nils-cli#1417.
+//!
+//! Captures the user-visible defect against the unmodified baseline: the body
+//! `pr review-loop observe` posts for a ledger append is only an HTML comment,
+//! which GitHub hides when it renders Markdown, so the PR timeline shows a blank
+//! comment authored by the operator.
+//!
+//! Uses only pre-existing APIs so it compiles against the baseline. It asserts on
+//! the recorded `gh` argv rather than the exit code, because the stub returns an
+//! unchanged comment page and the append's read-back verification therefore fails
+//! after the POST has already been recorded.
+
+use std::fs;
+
+use super::support::{StubEnv, run_forge_cli};
+
+#[test]
+fn a_posted_ledger_comment_body_is_not_only_a_hidden_html_comment() {
+    let stub = StubEnv::new();
+    let args_log = stub.tempdir.path().join("gh-args.log");
+    let script = format!(
+        r#"#!/bin/sh
+echo "$*" >> "{args_log}"
+case "$1 $2" in
+  "pr view")
+    cat <<'JSON'
+{{
+  "number": 7,
+  "url": "https://github.com/acme/widgets/pull/7",
+  "state": "OPEN",
+  "isDraft": false,
+  "title": "example",
+  "headRefName": "feat/example",
+  "headRefOid": "provider-head",
+  "headRepository": {{"name": "widgets"}},
+  "baseRefName": "main",
+  "mergeable": "MERGEABLE",
+  "mergedAt": "",
+  "mergeCommit": null,
+  "labels": [],
+  "body": "",
+  "closingIssuesReferences": []
+}}
+JSON
+    exit 0
+    ;;
+  "api graphql")
+    cat <<'JSON'
+{{"data":{{"viewer":{{"login":"forge-bot"}},"repository":{{"pullRequest":{{"comments":{{"nodes":[],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}}}}}}}}}}
+JSON
+    exit 0
+    ;;
+esac
+case "$1" in
+  api)
+    echo "https://github.com/acme/widgets/pull/7#issuecomment-9"
+    exit 0
+    ;;
+esac
+echo "stub: unscripted gh args: $*" >&2
+exit 99
+"#,
+        args_log = args_log.display(),
+    );
+    let findings = stub.tempdir.path().join("findings.json");
+    fs::write(&findings, "[]").expect("write findings");
+    let findings = findings.to_string_lossy().to_string();
+    let stub = stub.gh_stub(&script);
+
+    let _ = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "provider-head",
+            "--findings-file",
+            &findings,
+        ],
+    );
+
+    let log = fs::read_to_string(&args_log).unwrap_or_default();
+    let posted = log
+        .lines()
+        .find_map(|line| line.split_once("body=").map(|(_, body)| body))
+        .unwrap_or_else(|| panic!("no comment body was posted; log={log}"));
+
+    // The defect: every visible byte of the posted body is inside an HTML
+    // comment, so GitHub renders the comment as empty.
+    assert!(
+        !posted.trim_start().starts_with("<!--"),
+        "a ledger comment must carry human-visible text, not only a hidden marker; \
+         GitHub renders this body as a blank comment. posted={posted}"
+    );
+}

--- a/crates/forge-cli/tests/integration/pr_review_loop.rs
+++ b/crates/forge-cli/tests/integration/pr_review_loop.rs
@@ -53,21 +53,172 @@ exit 99
     )
 }
 
-/// The same stub, plus an empty privileged review-state comment page, so a
-/// genesis observation can reach a completely clean preflight.
-fn gh_stub_with_empty_ledger(stub: &StubEnv, head: &str) -> String {
+/// The same stub, plus one privileged review-state comment page carrying
+/// `comment_bodies`, so a preflight can reach a real chain instead of only a
+/// resolvable pull request.
+fn gh_stub_with_ledger(stub: &StubEnv, head: &str, comment_bodies: &[String]) -> String {
+    let nodes = comment_bodies
+        .iter()
+        .map(|body| {
+            serde_json::json!({
+                "author": {"login": "forge-bot"},
+                "authorAssociation": "OWNER",
+                "body": body,
+                "createdAt": "2026-07-20T12:00:00Z"
+            })
+        })
+        .collect::<Vec<_>>();
+    let page = serde_json::json!({"data": {
+        "viewer": {"login": "forge-bot"},
+        "repository": {"pullRequest": {"comments": {
+            "nodes": nodes,
+            "pageInfo": {"hasNextPage": false, "endCursor": null}
+        }}}
+    }});
     gh_stub_with_head(stub, head).replace(
         r#"esac
 echo "stub: unscripted gh args: $*" >&2"#,
-        r#"  "api graphql")
+        &format!(
+            r#"  "api graphql")
     cat <<'JSON'
-{"data":{"viewer":{"login":"forge-bot"},"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+{page}
 JSON
     exit 0
     ;;
 esac
-echo "stub: unscripted gh args: $*" >&2"#,
+echo "stub: unscripted gh args: $*" >&2"#
+        ),
     )
+}
+
+/// An empty ledger, so a genesis observation can reach a clean preflight.
+fn gh_stub_with_empty_ledger(stub: &StubEnv, head: &str) -> String {
+    gh_stub_with_ledger(stub, head, &[])
+}
+
+/// A stateful stub for the LIVE append: the ledger reads empty until the comment
+/// POST lands, then returns `appended_body`. That ordering is what makes the
+/// post-write read-back — and therefore `outcome_posted` — run for real.
+fn gh_stub_that_accepts_one_append(stub: &StubEnv, head: &str, appended_body: &str) -> String {
+    let posted_flag = stub.tempdir.path().join("posted.flag");
+    let page = |nodes: serde_json::Value| {
+        serde_json::json!({"data": {
+            "viewer": {"login": "forge-bot"},
+            "repository": {"pullRequest": {"comments": {
+                "nodes": nodes,
+                "pageInfo": {"hasNextPage": false, "endCursor": null}
+            }}}
+        }})
+        .to_string()
+    };
+    let after = page(serde_json::json!([{
+        "author": {"login": "forge-bot"},
+        "authorAssociation": "OWNER",
+        "body": appended_body,
+        "createdAt": "2026-07-20T12:00:01Z"
+    }]));
+    let before = page(serde_json::json!([]));
+    gh_stub_with_head(stub, head).replace(
+        r#"esac
+echo "stub: unscripted gh args: $*" >&2"#,
+        &format!(
+            r#"  "api graphql")
+    if [ -f "{flag}" ]; then
+      cat <<'AFTER'
+{after}
+AFTER
+    else
+      cat <<'BEFORE'
+{before}
+BEFORE
+    fi
+    exit 0
+    ;;
+esac
+case "$1" in
+  api)
+    : > "{flag}"
+    echo "https://github.com/acme/widgets/pull/7#issuecomment-9"
+    exit 0
+    ;;
+esac
+echo "stub: unscripted gh args: $*" >&2"#,
+            flag = posted_flag.display(),
+        ),
+    )
+}
+
+/// The exact comment body a genesis `VALID_FINDINGS` observation at `head`
+/// produces, plus its record digest, so a stub can seed a chain that is already
+/// current and a test can assert the exact planned write.
+///
+/// `outcome` mirrors what `--body` would carry; `None` is the marker-only form.
+fn ledger_comment(head: &str, outcome: Option<&str>) -> (String, String) {
+    use forge_cli::ops::review_state::{
+        ReviewFindingObservation, ReviewFindingStatus, ReviewStatePayload, ReviewStateRecord,
+        observe_review_loop, render_state_comment_body,
+    };
+
+    let state = observe_review_loop(
+        None,
+        head,
+        &[ReviewFindingObservation {
+            fingerprint: "correctness:review-loop:head-cas".to_string(),
+            root_cause_fingerprint: None,
+            blocking: true,
+            status: ReviewFindingStatus::Open,
+            threads: Vec::new(),
+        }],
+    )
+    .expect("genesis transition")
+    .state;
+    let record = ReviewStateRecord::new(
+        "acme/widgets",
+        7,
+        head,
+        0,
+        None,
+        ReviewStatePayload::ReviewLoop { state },
+    )
+    .expect("genesis record");
+    let body = render_state_comment_body(&record, outcome).expect("rendered body");
+    (body, record.record_digest)
+}
+
+fn current_ledger_comment(head: &str) -> (String, String) {
+    ledger_comment(head, None)
+}
+
+/// The genesis body for an EMPTY findings envelope, optionally carrying
+/// `outcome`. This is the record a clean review round appends, so it is what the
+/// combined dry-run and live-append tests predict.
+fn empty_findings_ledger_comment(head: &str, outcome: Option<&str>) -> (String, String) {
+    use forge_cli::ops::review_state::{
+        ReviewStatePayload, ReviewStateRecord, observe_review_loop, render_state_comment_body,
+    };
+
+    let state = observe_review_loop(None, head, &[])
+        .expect("genesis transition")
+        .state;
+    let record = ReviewStateRecord::new(
+        "acme/widgets",
+        7,
+        head,
+        0,
+        None,
+        ReviewStatePayload::ReviewLoop { state },
+    )
+    .expect("genesis record");
+    let body = render_state_comment_body(&record, outcome).expect("rendered body");
+    (body, record.record_digest)
+}
+
+fn combined_ledger_comment(head: &str, outcome: &str) -> (String, String) {
+    empty_findings_ledger_comment(head, Some(outcome))
+}
+
+fn ledger_comment_for_empty_findings(head: &str) -> (String, String) {
+    empty_findings_ledger_comment(head, None)
 }
 
 fn gh_args_log(stub: &StubEnv) -> String {
@@ -88,6 +239,26 @@ fn preflight_verdict<'a>(envelope: &'a serde_json::Value, rule: &str) -> &'a ser
         .find(|verdict| verdict["rule"] == rule)
         .unwrap_or_else(|| panic!("no preflight verdict for {rule}, got: {envelope}"))
 }
+
+/// Argv fragments that would mean a provider write was attempted.
+///
+/// These must match the shapes this crate actually emits, not generic `curl`
+/// idioms: the ledger append is
+/// `gh api repos/<repo>/issues/<n>/comments --method POST --raw-field body=…`
+/// (`--method`, never `-X`), so a guard listing only `-X POST` can never fail.
+/// The chain read is a read-only GraphQL `query(...)`, so `mutation` is the
+/// GraphQL write signal.
+const PROVIDER_WRITE_MARKERS: [&str; 7] = [
+    "--method POST",
+    "--method PATCH",
+    "--method PUT",
+    "--method DELETE",
+    "--raw-field body=",
+    "mutation",
+    "pr comment",
+];
+
+const OUTCOME_BODY: &str = "## Delivery outcome\n\nApproved: bounded review converged.";
 
 const VALID_FINDINGS: &str = r#"[
   {
@@ -144,14 +315,7 @@ fn observe_dry_run_performs_the_head_cas_it_advertises() {
     // is a read-only GraphQL `query(...)`, so the write signal is a mutating
     // HTTP verb, a GraphQL `mutation`, or a comment-posting subcommand.
     let log = gh_args_log(&stub);
-    for write_marker in [
-        "-X POST",
-        "-X PATCH",
-        "-X PUT",
-        "-X DELETE",
-        "mutation",
-        "pr comment",
-    ] {
+    for write_marker in PROVIDER_WRITE_MARKERS {
         assert!(
             !log.contains(write_marker),
             "a dry run must not attempt a provider write ({write_marker}), log={log}"
@@ -294,11 +458,7 @@ fn observe_dry_run_renders_the_exact_combined_comment_it_would_post() {
     let body = gh_stub_with_empty_ledger(&stub, "provider-head");
     let findings = write_findings(&stub, "findings.json", "[]");
     let outcome = stub.tempdir.path().join("outcome.md");
-    fs::write(
-        &outcome,
-        "## Delivery outcome\n\nApproved: bounded review converged.\n",
-    )
-    .expect("write outcome body");
+    fs::write(&outcome, format!("{OUTCOME_BODY}\n")).expect("write outcome body");
     let outcome = outcome.to_string_lossy().to_string();
     let stub = stub.gh_stub(&body);
 
@@ -342,9 +502,12 @@ fn observe_dry_run_renders_the_exact_combined_comment_it_would_post() {
         "forge-cli review ledger · generation 0 · review-loop · head provider-hea"
     );
     // The reported size is the complete body that would be posted, which is what
-    // the provider limit is checked against.
-    assert!(
-        planned["bytes"].as_u64().unwrap_or_default() > 0,
+    // the provider limit is checked against — so it must equal the byte length of
+    // the exact rendered body, not the marker or the outcome alone.
+    let (expected_body, _) = combined_ledger_comment("provider-head", OUTCOME_BODY);
+    assert_eq!(
+        planned["bytes"].as_u64().unwrap_or_default(),
+        expected_body.len() as u64,
         "{envelope}"
     );
     assert!(
@@ -356,7 +519,7 @@ fn observe_dry_run_renders_the_exact_combined_comment_it_would_post() {
     );
 
     let log = gh_args_log(&stub);
-    for write_marker in ["-X POST", "-X PATCH", "-X PUT", "mutation", "pr comment"] {
+    for write_marker in PROVIDER_WRITE_MARKERS {
         assert!(
             !log.contains(write_marker),
             "a combined dry run must not write ({write_marker}), log={log}"
@@ -365,10 +528,10 @@ fn observe_dry_run_renders_the_exact_combined_comment_it_would_post() {
 }
 
 #[test]
-fn observe_dry_run_omits_a_planned_comment_when_the_ledger_is_already_current() {
-    // Nothing is appended, so nothing is planned — and the supplied outcome is
-    // therefore not posted either. This is the retry-deduplication signal the
-    // caller reads instead of guessing.
+fn observe_dry_run_plans_nothing_when_the_transition_could_not_be_evaluated() {
+    // With a drifted head the chain read still runs and fails, so the transition
+    // is never evaluated. Nothing may be planned on the strength of a rule that
+    // did not run, and the outcome body must still be validated locally.
     let stub = StubEnv::new();
     let body = gh_stub_with_head(&stub, "provider-head");
     let findings = write_findings(&stub, "findings.json", VALID_FINDINGS);
@@ -393,7 +556,7 @@ fn observe_dry_run_omits_a_planned_comment_when_the_ledger_is_already_current() 
             "--findings-file",
             &findings,
             "--body",
-            "## Delivery outcome",
+            OUTCOME_BODY,
         ],
     );
 
@@ -403,8 +566,262 @@ fn observe_dry_run_omits_a_planned_comment_when_the_ledger_is_already_current() 
         envelope["data"].get("planned_comment").is_none(),
         "no write is planned, so no comment shape is reported: {envelope}"
     );
+    assert!(
+        envelope["data"].get("would_append").is_none(),
+        "an unevaluated transition must not predict an append: {envelope}"
+    );
     // The outcome body itself is still validated, independently of the provider.
     assert_eq!(preflight_verdict(&envelope, "outcome_body")["ok"], true);
+}
+
+#[test]
+fn observe_dry_run_fails_the_outcome_verdict_for_a_body_a_live_run_would_reject() {
+    // Delivery gates on `preflight_ok`, so a body the live run refuses must fail
+    // here too. All three rules are enforced before the first provider call, which
+    // is why an unreachable provider does not hide them.
+    let stub = StubEnv::new();
+    let findings = write_findings(&stub, "findings.json", VALID_FINDINGS);
+    let missing = stub
+        .tempdir
+        .path()
+        .join("absent-outcome.md")
+        .to_string_lossy()
+        .to_string();
+    let stub = stub.gh_stub("#!/bin/sh\necho 'provider unreachable' >&2\nexit 99\n");
+
+    for (label, args, expected_code) in [
+        (
+            "marker injection",
+            vec!["--body", "<!-- forge-cli:review-state:v1 deadbeef -->"],
+            Some("review_state_comment_invalid"),
+        ),
+        (
+            "hidden html comment",
+            vec!["--body", "Approved.\n\n<!--"],
+            Some("review_state_comment_invalid"),
+        ),
+        (
+            "local path leak",
+            vec!["--body", "outcome at /home/operator/report.md"],
+            Some("local_path_present"),
+        ),
+        (
+            "unreadable body file",
+            vec!["--body-file", missing.as_str()],
+            None,
+        ),
+    ] {
+        let mut argv = vec![
+            "--format",
+            "json",
+            "--dry-run",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "provider-head",
+            "--findings-file",
+            &findings,
+        ];
+        argv.extend(args);
+
+        let out = run_forge_cli(&stub, &argv);
+
+        assert_eq!(out.code, 0, "{label}: stderr={}", out.stderr);
+        let envelope = parse_envelope(&out.stdout);
+        let verdict = preflight_verdict(&envelope, "outcome_body");
+        assert_eq!(verdict["ok"], false, "{label}: verdict={verdict}");
+        assert_eq!(envelope["data"]["preflight_ok"], false, "{label}");
+        if let Some(code) = expected_code {
+            assert_eq!(verdict["code"], code, "{label}: verdict={verdict}");
+        }
+        // The findings payload verdict still survives an unreachable provider.
+        assert_eq!(
+            preflight_verdict(&envelope, "findings_file")["ok"],
+            true,
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn an_already_current_ledger_still_reports_a_clean_combined_preflight() {
+    // Delivery gates on `preflight_ok == true` before a live append. A rerun
+    // whose ledger is already current must therefore stay clean while still
+    // reporting that nothing — including the outcome — would be posted.
+    let stub = StubEnv::new();
+    let (seeded, tip) = current_ledger_comment("provider-head");
+    let body = gh_stub_with_ledger(&stub, "provider-head", &[seeded]);
+    let findings = write_findings(&stub, "findings.json", VALID_FINDINGS);
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "provider-head",
+            "--expected-state",
+            &tip,
+            "--findings-file",
+            &findings,
+            "--body",
+            "## Delivery outcome",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["data"]["preflight_ok"], true, "{envelope}");
+    assert_eq!(envelope["data"]["would_append"], false, "{envelope}");
+    assert_eq!(preflight_verdict(&envelope, "outcome_body")["ok"], true);
+    assert_eq!(
+        preflight_verdict(&envelope, "expected_state_tip")["ok"],
+        true
+    );
+    assert_eq!(
+        preflight_verdict(&envelope, "observation_transition")["ok"],
+        true
+    );
+    // Nothing is written, so no comment shape is reported and the conditional
+    // `state_comment_body` rule is absent rather than a spurious failure.
+    assert!(
+        envelope["data"].get("planned_comment").is_none(),
+        "{envelope}"
+    );
+    assert!(
+        envelope["data"]["preflight"]
+            .as_array()
+            .expect("preflight array")
+            .iter()
+            .all(|verdict| verdict["rule"] != "state_comment_body"),
+        "{envelope}"
+    );
+
+    let log = gh_args_log(&stub);
+    for write_marker in PROVIDER_WRITE_MARKERS {
+        assert!(
+            !log.contains(write_marker),
+            "a dry run must not write ({write_marker}), log={log}"
+        );
+    }
+}
+
+#[test]
+fn a_live_combined_observe_reports_appended_and_outcome_posted() {
+    // The envelope is the delivery contract: `outcome_posted` must reflect a
+    // confirmed provider write, and the posted comment must carry the visible
+    // label, the exact marker, and the outcome in ONE body.
+    let stub = StubEnv::new();
+    let (combined, tip) = combined_ledger_comment("provider-head", OUTCOME_BODY);
+    let body = gh_stub_that_accepts_one_append(&stub, "provider-head", &combined);
+    let findings = write_findings(&stub, "findings.json", "[]");
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "provider-head",
+            "--findings-file",
+            &findings,
+            "--body",
+            OUTCOME_BODY,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(
+        envelope["schema_version"],
+        "cli.forge-cli.pr.review-loop.observe.v1"
+    );
+    assert_eq!(envelope["data"]["appended"], true, "{envelope}");
+    assert_eq!(envelope["data"]["outcome_posted"], true, "{envelope}");
+    assert_eq!(envelope["data"]["state_tip_digest"], tip, "{envelope}");
+
+    // Exactly one comment mutation, and its body carries all three parts.
+    let log = gh_args_log(&stub);
+    assert_eq!(
+        log.matches("--method POST").count(),
+        1,
+        "one comment mutation only, log={log}"
+    );
+    for expected in [
+        "forge-cli review ledger \u{b7} generation 0 \u{b7} review-loop \u{b7} head provider-hea",
+        "<!-- forge-cli:review-state:v1 ",
+        "Approved: bounded review converged.",
+    ] {
+        assert!(log.contains(expected), "missing {expected:?} in log={log}");
+    }
+}
+
+#[test]
+fn a_live_observe_without_an_outcome_body_reports_outcome_posted_false() {
+    let stub = StubEnv::new();
+    let (marker_only, _) = combined_ledger_comment("provider-head", OUTCOME_BODY);
+    // Seed the read-back with the marker-only body the run actually writes.
+    let (appended, _) = ledger_comment_for_empty_findings("provider-head");
+    assert_ne!(marker_only, appended);
+    let body = gh_stub_that_accepts_one_append(&stub, "provider-head", &appended);
+    let findings = write_findings(&stub, "findings.json", "[]");
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "provider-head",
+            "--findings-file",
+            &findings,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["data"]["appended"], true, "{envelope}");
+    assert_eq!(envelope["data"]["outcome_posted"], false, "{envelope}");
+    // Even with no outcome, the ledger comment is never a bare marker.
+    let log = gh_args_log(&stub);
+    assert!(
+        log.contains("forge-cli review ledger \u{b7} generation 0"),
+        "{log}"
+    );
 }
 
 #[test]

--- a/crates/forge-cli/tests/integration/pr_review_loop.rs
+++ b/crates/forge-cli/tests/integration/pr_review_loop.rs
@@ -53,6 +53,23 @@ exit 99
     )
 }
 
+/// The same stub, plus an empty privileged review-state comment page, so a
+/// genesis observation can reach a completely clean preflight.
+fn gh_stub_with_empty_ledger(stub: &StubEnv, head: &str) -> String {
+    gh_stub_with_head(stub, head).replace(
+        r#"esac
+echo "stub: unscripted gh args: $*" >&2"#,
+        r#"  "api graphql")
+    cat <<'JSON'
+{"data":{"viewer":{"login":"forge-bot"},"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+    exit 0
+    ;;
+esac
+echo "stub: unscripted gh args: $*" >&2"#,
+    )
+}
+
 fn gh_args_log(stub: &StubEnv) -> String {
     fs::read_to_string(stub.tempdir.path().join("gh-args.log")).unwrap_or_default()
 }
@@ -269,7 +286,165 @@ fn observe_dry_run_reports_the_payload_verdict_when_the_provider_is_unreachable(
 }
 
 #[test]
-fn observe_help_documents_both_findings_file_shapes() {
+fn observe_dry_run_renders_the_exact_combined_comment_it_would_post() {
+    // A marker-only ledger comment renders blank on GitHub, and the final
+    // outcome used to need a second comment. The dry run must show the one
+    // comment that now carries both, and still write nothing.
+    let stub = StubEnv::new();
+    let body = gh_stub_with_empty_ledger(&stub, "provider-head");
+    let findings = write_findings(&stub, "findings.json", "[]");
+    let outcome = stub.tempdir.path().join("outcome.md");
+    fs::write(
+        &outcome,
+        "## Delivery outcome\n\nApproved: bounded review converged.\n",
+    )
+    .expect("write outcome body");
+    let outcome = outcome.to_string_lossy().to_string();
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "provider-head",
+            "--findings-file",
+            &findings,
+            "--body-file",
+            &outcome,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["data"]["preflight_ok"], true, "{envelope}");
+    assert_eq!(envelope["data"]["would_append"], true);
+    assert_eq!(preflight_verdict(&envelope, "outcome_body")["ok"], true);
+    assert_eq!(
+        preflight_verdict(&envelope, "state_comment_body")["ok"],
+        true
+    );
+
+    let planned = &envelope["data"]["planned_comment"];
+    assert_eq!(planned["includes_outcome_body"], true, "{envelope}");
+    assert_eq!(
+        planned["visible_metadata"],
+        "forge-cli review ledger · generation 0 · review-loop · head provider-hea"
+    );
+    // The reported size is the complete body that would be posted, which is what
+    // the provider limit is checked against.
+    assert!(
+        planned["bytes"].as_u64().unwrap_or_default() > 0,
+        "{envelope}"
+    );
+    assert!(
+        envelope["data"]["plan"][0]
+            .as_str()
+            .unwrap_or_default()
+            .contains("in one comment"),
+        "{envelope}"
+    );
+
+    let log = gh_args_log(&stub);
+    for write_marker in ["-X POST", "-X PATCH", "-X PUT", "mutation", "pr comment"] {
+        assert!(
+            !log.contains(write_marker),
+            "a combined dry run must not write ({write_marker}), log={log}"
+        );
+    }
+}
+
+#[test]
+fn observe_dry_run_omits_a_planned_comment_when_the_ledger_is_already_current() {
+    // Nothing is appended, so nothing is planned — and the supplied outcome is
+    // therefore not posted either. This is the retry-deduplication signal the
+    // caller reads instead of guessing.
+    let stub = StubEnv::new();
+    let body = gh_stub_with_head(&stub, "provider-head");
+    let findings = write_findings(&stub, "findings.json", VALID_FINDINGS);
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--dry-run",
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "stale-head",
+            "--findings-file",
+            &findings,
+            "--body",
+            "## Delivery outcome",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert!(
+        envelope["data"].get("planned_comment").is_none(),
+        "no write is planned, so no comment shape is reported: {envelope}"
+    );
+    // The outcome body itself is still validated, independently of the provider.
+    assert_eq!(preflight_verdict(&envelope, "outcome_body")["ok"], true);
+}
+
+#[test]
+fn observe_rejects_both_outcome_body_forms_at_once() {
+    let stub = StubEnv::new();
+    let findings = write_findings(&stub, "findings.json", VALID_FINDINGS);
+    let stub = stub.gh_stub("#!/bin/sh\nexit 99\n");
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "pr",
+            "review-loop",
+            "observe",
+            "7",
+            "--expected-head",
+            "provider-head",
+            "--findings-file",
+            &findings,
+            "--body",
+            "inline",
+            "--body-file",
+            "outcome.md",
+        ],
+    );
+
+    assert_eq!(out.code, 64, "stdout={} stderr={}", out.stdout, out.stderr);
+    assert!(
+        out.stderr.contains("--body-file"),
+        "stderr should name the conflicting flag: {}",
+        out.stderr
+    );
+}
+
+#[test]
+fn observe_help_documents_both_findings_file_shapes_and_the_combined_outcome() {
     let stub = StubEnv::new();
     let out = run_forge_cli(&stub, &["pr", "review-loop", "observe", "--help"]);
     assert_eq!(out.code, 0, "stderr={}", out.stderr);
@@ -278,6 +453,9 @@ fn observe_help_documents_both_findings_file_shapes() {
         "<category>:<component>:<invariant>",
         "disposition",
         "--dry-run",
+        "--body-file",
+        "forge-cli review ledger",
+        "outcome_posted",
     ] {
         assert!(
             out.stdout.contains(expected),


### PR DESCRIPTION
## Summary

Fixes #1417 — both stages.

`forge-cli` stored its append-only review ledger in PR issue comments whose body was
*only* an HTML comment marker. GitHub hides HTML comments when it renders Markdown, so
every ledger append showed up in the timeline as a blank comment authored by the
operator. An authenticated scan found 18 such comments across 8 PRs in one repository.

**Stage 1 — make every state comment identifiable.** A provider comment-body renderer,
separate from the canonical marker encoding, leads each comment with
`forge-cli review ledger · generation N · <payload-kind> · head <short-sha>` and then
the byte-identical marker. Presentation never enters a record digest, chain order, or
the parser, so historical bare-marker comments and new rendered comments validate as
one chain — no migration, and no existing comment is edited or deleted. The 64 KiB safe
limit now binds the **complete rendered body** (`review_state_comment_too_large`);
previously the marker alone could pass while the posted body overflowed.

**Stage 2 — one comment instead of two.** `pr review-loop observe --body/--body-file`
posts the human-readable delivery outcome in the same comment as the ledger record.
The outcome rides the append, so it inherits the append's idempotency. The capability is
complete and tested here, but **no workflow can call it yet** for an ordering reason
tracked in #1422 — see Follow-ups.

### Ledger invariants preserved

Append-only history, fork detection, retry deduplication, receipt-prewrite ordering,
pending-review recovery, and the merge convergence gate are unchanged. The receipt
prewrite stays its own comment because transaction recovery needs durable state before
the native-review mutation — it just carries the visible label now.

### Hardening after specialist review

Four specialist reviewers (concurrency/red-team, security, testing, API contract) found
real defects in the first commit. The second commit fixes them:

- **Label spoofing / hiding.** A Markdown HTML block opened in caller text runs until a
  line containing `-->`, so an outcome ending in an unterminated `<!--` swallowed the
  label, the rule *and* the marker — publishing a ledger record disguised as ordinary
  human prose, worse than the blank comment this work set out to fix. The label and
  marker are now rendered **first**, before any caller byte, and any HTML comment in an
  outcome body is refused (one rule closing both marker shadowing and label hiding).
- **`outcome_posted` false positive.** The chain deduplicates by *record*, and a record
  digest excludes presentation, so a digest-only read-back could be satisfied by a
  concurrent session's outcome-free comment while this session's own POST failed.
  `outcome_posted` is now set only after a post-write read-back confirms the outcome
  text is visible; otherwise `review_outcome_not_posted`.
- **Silent outcome loss.** An unchanged observation appends nothing, and previously
  discarded a supplied outcome with a success exit code. It now distinguishes "the
  earlier attempt already posted it" (`outcome_posted: true`, `appended: false`) from
  "this would be dropped", which fails closed. An identical retry still cannot
  duplicate the outcome, and can no longer lose it.
- **Dry-run faithfulness.** Every outcome-body rule moved ahead of the first provider
  call, so a dry run returns the verdict a live run would and a rejected body costs no
  round trip. The dry run now mirrors the live unextended-hard-stop short-circuit
  instead of advertising a provider write that provably never happens, and the
  `pr review --dry-run` receipt plan matches the live prewrite body again.

The documented record-vs-comment deduplication boundary, the reduced effective marker
budget, the shared portability guard's actual reach, and the single-use `--body-file -`
stdin caveat are all written down rather than implied.

### Contract

- New `data.outcome_posted` on `pr review-loop inspect` / `observe` / `extend`, and
  conditional `data.planned_comment` in `observe --dry-run`. Both are additive within
  `v1`, which `docs/specs/cli-output-contract-v1.md` explicitly permits.
- `--body` / `--body-file` follow the existing pair convention in `cli.rs`
  (`conflicts_with`, `-` for stdin).
- New error kinds `review_state_comment_invalid`, `review_state_comment_too_large`,
  `review_outcome_not_posted` — all `ForgeError::validation`, so DATA 65 like their
  siblings.
- `preflight_ok` semantics are unchanged for existing consumers: the conditional
  `state_comment_body` verdict only appears when a write is planned, so an
  already-current ledger still reports `preflight_ok: true`. Pinned by
  `an_already_current_ledger_still_reports_a_clean_combined_preflight`.

## Test plan

Regression coverage for every behaviour #1417 asks for, plus the review findings:

- visible rendering, and the receipt prewrite's label at its call site
- historical bare-marker vs rendered comments validating as one chain
- presentation never reaching a record digest
- complete-body size limit at the **exact** boundary (accept at the limit, reject one
  byte over)
- label suppression / HTML-comment rejection, and marker injection refused before the
  first provider call
- identical retry posting neither a ledger nor an outcome comment
- an unchanged observation refusing to drop a new outcome
- a durable record whose outcome is not visible failing instead of claiming delivery
- competing concurrent generations failing closed (asserted by message, not just kind)
- live `outcome_posted` true and false through the real append + read-back
- combined posting: exactly one comment mutation carrying label, marker and outcome
- dry run predicting the exact body size and writing nothing; failing outcome verdicts;
  no hard-stop receipt planned when one already exists

Commands:

```
cargo test -p nils-forge-cli                  # 836 lib + 462 integration, green
bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast   # green
bash scripts/ci/completion-asset-audit.sh --strict           # PASS
bash scripts/ci/completion-freshness-audit.sh --strict       # PASS
bash scripts/ci/completion-flag-parity-audit.sh --strict     # PASS
zsh -f tests/zsh/completion.test.zsh                         # OK
bash -n completions/bash/forge-cli && zsh -n completions/zsh/_forge-cli
```

`--local-fast` needs `AGENT_SESSION_BIN` unset locally because of #1420, an unrelated
pre-existing test-isolation bug in `crates/agent-hook/tests/activity_helper.rs`. That
suite is untouched by this PR and CI is unaffected.

## Follow-ups (not in this PR)

- **No consumer can use the combined operation yet — #1422.** The outcome rides a ledger
  *append*, but every delivery workflow produces its final outcome after its last
  append, and on a clean pass the closing `observe` is skipped entirely
  (`REVIEW_LEDGER_OPEN_COUNT -gt 0`). Running one more `observe` at the end to carry the
  outcome is blocked by this PR's own `review_outcome_not_posted` guard, which is
  correct — dropping the outcome silently would be worse. That is a design gap in what
  #1417 specified, so #1417's "update delivery workflow guidance" criterion cannot be
  met by a consumer-only edit. Filed as #1422 with the options and trade-offs.
  This does not hold up anything here: Stage 1 removes the blank comments on its own, and
  `--body`/`--body-file` is inert until a caller passes it.
- Consumer adoption is additionally release-gated whenever #1422 is settled: the three
  affected skills pin a minimum `forge-cli` and run the released binary from `PATH`.
- No cleanup of existing historical ledger comments, per #1417.
- `--body-file` inherits the shared `read_body_with_file_flag` primitive, so it has no
  credential scan, no regular-file check, and reports an absolute path in its read
  error. Same as every other `--body-file` in the crate; worth addressing once, for all
  of them, rather than only here.
