### PR TITLE
fix(agent-hook): judge a capability by its exit status, not its stdin

### DIFF
--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -328,6 +328,17 @@ limit. Identical replacements coalesce. Different replacements are an explicit
 posture is typed per rule (`open`, `warn`, or `closed`), while locked privacy,
 writer, transaction, and recovery rules must be `closed`.
 
+An executable capability is judged by its exit status and its output, never by
+how much of its stdin it chose to read. A capability that exits before draining
+the delivered payload closes the read end, and the runner's remaining write
+returns `EPIPE`; that is the child's decision and is not a capability failure.
+The runner returns promptly with the child's own result instead of blocking to
+the timeout, and a capability that stops reading and then fails still takes its
+rule's failure posture. Scoring the broken pipe as a failure made a `closed`
+plus `locked` rule deny at random, because whether the child won the race
+depended on machine load, and a `locked` rule offers no override to recover
+with.
+
 `agent-session.activity.v1` retains one terminal-only degradation boundary.
 Failure to record a `Stop` observation returns the stable warning
 `activity-stop-reconciliation-required` instead of denying provider

--- a/crates/agent-hook/src/evaluator.rs
+++ b/crates/agent-hook/src/evaluator.rs
@@ -1456,10 +1456,22 @@ fn run_bounded(
         .map_err(|_| HookError::runtime("capability-unavailable", "capability could not start"))?;
     let input = input.to_vec();
     let input_handle = child.stdin.take().map(|mut stdin| {
-        thread::spawn(move || {
-            stdin.write_all(&input).map_err(|_| {
-                HookError::runtime("capability-input-failed", "capability input failed")
-            })
+        thread::spawn(move || match stdin.write_all(&input) {
+            Ok(()) => Ok(()),
+            // A capability that exits before draining its stdin closes the read
+            // end, and the remaining write returns EPIPE. That is the child's
+            // decision and carries no verdict about the capability: its exit
+            // status and output do. Treating it as an input failure made a
+            // `failure_posture = "closed"` rule block at random whenever the
+            // child won the race, which for a `locked` rule is an unrecoverable
+            // prompt. Sequencing the write before the wait cannot fix it either,
+            // because a child is always free to exit early.
+            // See `sympoies/nils-cli#1420`.
+            Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+            Err(_) => Err(HookError::runtime(
+                "capability-input-failed",
+                "capability input failed",
+            )),
         })
     });
     let stdout_handle = child
@@ -1869,6 +1881,16 @@ mod tests {
         assert!(started.elapsed() < HANDLER_TIMEOUT);
     }
 
+    /// A child that exits without draining a 1 MiB payload leaves the runner
+    /// mid-write. The property this protects is that the runner returns promptly
+    /// rather than blocking to the timeout.
+    ///
+    /// It used to also require the broken pipe be reported as
+    /// `capability-input-failed`. That was the defect, not the contract: the
+    /// caller turns any capability error into `failure_outcome`, so a child which
+    /// merely stopped reading was scored as a failed capability and blocked a
+    /// `locked` rule at random. The child's exit status is the verdict.
+    /// See `sympoies/nils-cli#1420`.
     #[test]
     fn bounded_runner_handles_child_exit_before_stdin_is_consumed() {
         let mut command = Command::new("sh");
@@ -1879,17 +1901,40 @@ mod tests {
             .stderr(Stdio::piped());
 
         let started = Instant::now();
-        let error = run_bounded(
+        let output = run_bounded(
             command,
             &vec![b'x'; 1024 * 1024],
             HANDLER_TIMEOUT,
             MAX_HANDLER_OUTPUT,
             false,
         )
-        .expect_err("closed child stdin must be reported");
+        .expect("a child that stopped reading is not a failed child");
 
-        assert_eq!(error.code, "capability-input-failed");
+        assert!(output.status.success());
         assert!(started.elapsed() < HANDLER_TIMEOUT);
+    }
+
+    /// The tolerance covers the pipe, not the verdict.
+    #[test]
+    fn bounded_runner_still_reports_a_child_that_fails_before_reading_stdin() {
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", "exit 3"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let output = run_bounded(
+            command,
+            &vec![b'x'; 1024 * 1024],
+            HANDLER_TIMEOUT,
+            MAX_HANDLER_OUTPUT,
+            false,
+        )
+        .expect("the broken pipe must not mask the exit status");
+
+        assert!(!output.status.success());
+        assert_eq!(output.status.code(), Some(3));
     }
 
     #[test]

--- a/crates/agent-hook/tests/activity_helper.rs
+++ b/crates/agent-hook/tests/activity_helper.rs
@@ -17,7 +17,8 @@ mod support;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 
-use pretty_assertions::assert_eq;
+use nils_test_support::{EnvGuard, GlobalStateLock};
+use pretty_assertions::{assert_eq, assert_ne};
 use serde_json::Value;
 
 use support::Fixture;
@@ -293,4 +294,45 @@ fn doctor_fails_when_the_activity_helper_cannot_be_resolved() {
         healthy.stdout_text()
     );
     assert_eq!(healthy.stdout_json()["data"][0]["status"], "converged");
+}
+
+/// The suite itself runs inside a managed session, which pins `AGENT_SESSION_BIN`
+/// since `#1415`. Because that variable outranks `PATH`, every test above that
+/// makes the helper unresolvable by emptying `PATH` was measuring the inherited
+/// helper instead, so the local gate failed for changes that touch none of this.
+/// See `sympoies/nils-cli#1420`.
+#[test]
+fn an_inherited_helper_override_does_not_reach_the_process_under_test() {
+    let lock = GlobalStateLock::new();
+    let fixture = Fixture::new(ACTIVITY_POLICY);
+    // Ambient value that resolves, which is what a managed pane supplies.
+    let inherited = working_helper(&fixture).join("agent-session");
+    assert!(inherited.is_file(), "the inherited override must resolve");
+    let _guard = EnvGuard::set(
+        &lock,
+        "AGENT_SESSION_BIN",
+        inherited.to_str().expect("inherited path"),
+    );
+
+    converge_claude_ingress(&fixture);
+    let empty_dir = fixture.root.join("empty-bin");
+    fs::create_dir_all(&empty_dir).expect("empty directory");
+    let broken = fixture.run_with_env(
+        &["doctor", "--product", "claude", "--format", "json"],
+        None,
+        &[("PATH", empty_dir.to_str().expect("empty dir"))],
+    );
+
+    assert_ne!(
+        broken.code,
+        0,
+        "an inherited override must not resolve a helper this test removed: {}",
+        broken.stdout_text()
+    );
+    assert_eq!(
+        broken.stdout_json()["error"]["code"],
+        "activity-helper-unresolvable",
+        "{}",
+        broken.stdout_text()
+    );
 }

--- a/crates/agent-hook/tests/degraded_liveness.rs
+++ b/crates/agent-hook/tests/degraded_liveness.rs
@@ -1,7 +1,7 @@
 //! Regression coverage for the fail-closed liveness defect in
 //! `sympoies/nils-cli#1409`.
 //!
-//! Two confirmed deadlocks are reproduced here:
+//! Three confirmed defects are reproduced here:
 //!
 //! 1. A coordination subsystem failure blocked `UserPromptSubmit`, so the user
 //!    could not even ask what was wrong. Plain conversation has to survive in a
@@ -10,6 +10,10 @@
 //!    consecutive-block cap force-terminated the turn. Provider re-entry
 //!    metadata has to produce one deterministic terminal result that still
 //!    retains the claim/lease for external reconciliation.
+//! 3. A capability that exited before draining its stdin was scored as a failed
+//!    capability, so a `closed` plus `locked` rule denied at random depending on
+//!    machine load (`sympoies/nils-cli#1420`). Whether a child read its input is
+//!    not a verdict; its exit status is.
 
 mod support;
 
@@ -421,6 +425,112 @@ fn coordination_failure_on_stop_degrades_instead_of_deadlocking() {
             reason_codes(&decision)
                 .contains(&"coordination-stop-reconciliation-required".to_string()),
             "{product} missing the coordination Stop degradation: {decision}"
+        );
+    }
+}
+
+/// One enforced handler on `SessionStart`, fail-closed and locked, so a spurious
+/// failure has nowhere to go but a block the session cannot override.
+const HANDLER_POLICY: &str = r#"schema_version = "agent-hook.policy.v1"
+bundle_id = "runtime-kit"
+version = "2026.07.20.1"
+
+[[rules]]
+id = "runtime.session-start"
+products = ["codex", "claude"]
+events = ["SessionStart"]
+priority = 10
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = { id = "runtime-kit.handler.v1", handler_id = "session-start-healthcheck" }
+"#;
+
+/// Install a `SessionStart` handler and return a payload too large to fit in the
+/// pipe buffer, so the parent's write is still pending when the handler runs.
+fn stdin_closing_handler(fixture: &Fixture, body: &str) -> String {
+    for provider in [".codex/hooks", ".claude/hooks"] {
+        let hooks = fixture.home.join(provider);
+        fs::create_dir_all(&hooks).expect("hooks directory");
+        let handler = hooks.join("session-start-healthcheck.sh");
+        fs::write(&handler, body).expect("handler");
+        fs::set_permissions(&handler, fs::Permissions::from_mode(0o755)).expect("handler mode");
+    }
+    // A pipe holds 64 KiB by default, so a smaller payload would be buffered
+    // whole and the race would never be observable. 128 KiB stays well inside
+    // the 1 MiB provider input limit.
+    let padding = "p".repeat(128 * 1024);
+    format!(r#"{{"hook_event_name":"SessionStart","source":"startup","padding":"{padding}"}}"#)
+}
+
+/// A capability that exits without draining its stdin is not a failed
+/// capability. The remaining write returns `EPIPE`, and counting that as an
+/// input failure turned this fail-closed locked rule into a block the session
+/// could not override — at random, because whether the child won the race
+/// depended on machine load. Six tests in this crate flaked on it under
+/// parallel load, each recovering on retry, so the suite hid it.
+/// See `sympoies/nils-cli#1420`.
+#[test]
+fn a_capability_that_stops_reading_stdin_is_judged_by_its_exit_status() {
+    let fixture = Fixture::new(HANDLER_POLICY);
+    let payload = stdin_closing_handler(
+        &fixture,
+        // Close the read end, hold it closed while the parent is still writing,
+        // then answer. `sleep` is what makes the EPIPE deterministic rather than
+        // load-dependent; the defect it pins is the same one.
+        "#!/bin/sh\nexec 0<&-\nsleep 0.3\nprintf '{}\\n'\n",
+    );
+
+    for product in ["codex", "claude"] {
+        let started = fixture.run_with_env(
+            &["dispatch", "--product", product, "--format", "json"],
+            Some(&payload),
+            &managed_env(),
+        );
+        assert_eq!(
+            started.code,
+            0,
+            "{product} must not fail-close on a handler that closed its stdin: stdout={} stderr={}",
+            started.stdout_text(),
+            started.stderr_text()
+        );
+        let decision = started.stdout_json();
+        assert_eq!(
+            decision["data"]["action"], "allow",
+            "{product} must honour the handler's own verdict: {decision}"
+        );
+        assert!(
+            !reason_codes(&decision)
+                .iter()
+                .any(|code| code.ends_with("capability-failure-closed")),
+            "{product} recorded a capability failure for a handler that succeeded: {decision}"
+        );
+    }
+}
+
+/// The tolerance is scoped to the pipe, not to the verdict: a handler that stops
+/// reading and then fails must still fail-close, or the fix above would have
+/// turned every early-exiting failure into an allow.
+#[test]
+fn a_capability_that_stops_reading_stdin_and_then_fails_still_fails_closed() {
+    let fixture = Fixture::new(HANDLER_POLICY);
+    let payload = stdin_closing_handler(&fixture, "#!/bin/sh\nexec 0<&-\nsleep 0.3\nexit 3\n");
+
+    for product in ["codex", "claude"] {
+        let started = fixture.run_with_env(
+            &["dispatch", "--product", product, "--format", "json"],
+            Some(&payload),
+            &managed_env(),
+        );
+        let decision = started.stdout_json();
+        assert_eq!(
+            decision["data"]["action"], "block",
+            "{product} must still fail-close a handler that failed: {decision}"
+        );
+        assert!(
+            reason_codes(&decision)
+                .contains(&"runtime.session-start:capability-failure-closed".to_string()),
+            "{product} lost the fail-closed classification: {decision}"
         );
     }
 }

--- a/crates/agent-hook/tests/recovery.rs
+++ b/crates/agent-hook/tests/recovery.rs
@@ -3,7 +3,7 @@ mod support;
 use std::fs;
 use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -231,6 +231,33 @@ fn authorize_for_target(
             .expect("capability id")
             .to_string(),
     }
+}
+
+/// Mint a capability with a TTL short enough to expire during the test, then wait
+/// for it to expire.
+///
+/// The TTL bounds the challenge, and `authorize` runs in a second process, so
+/// minting has to finish inside the very window the test wants to outlive. Under
+/// full-workspace load two process spawns can exceed a one-second TTL, and
+/// `authorize` then rejects its own setup as expired — surfacing as exit 65 from
+/// `authorize` instead of the `capability-expired` this exists to assert.
+///
+/// Re-minting is the fix rather than a longer TTL, because the delay is unbounded:
+/// what is under test is that consume rejects an expired capability, not how fast
+/// the harness can mint one. Expiry stays real and is never simulated; there is
+/// deliberately no clock override on this path. See `sympoies/nils-cli#1420`.
+fn authorize_then_expire(fixture: &Fixture, name: &str, scope: &str) -> Authorized {
+    const TTL: Duration = Duration::from_secs(2);
+    for attempt in 0..5 {
+        let minted = Instant::now();
+        let authorized = authorize(fixture, &format!("{name}-{attempt}"), scope, "2", &[]);
+        let elapsed = minted.elapsed();
+        if elapsed < TTL {
+            thread::sleep(TTL - elapsed + Duration::from_millis(100));
+            return authorized;
+        }
+    }
+    panic!("minting a {TTL:?} capability never finished inside its own TTL in five attempts");
 }
 
 fn dispatch(
@@ -642,8 +669,7 @@ fn one_shot_rejects_binding_drift_revocation_expiry_key_rotation_and_unsafe_mode
         "capability-replay-or-revoked"
     );
 
-    let expired = authorize(&fixture, "expired", "one-shot", "1", &[]);
-    thread::sleep(Duration::from_millis(1_100));
+    let expired = authorize_then_expire(&fixture, "expired", "one-shot");
     let rejected = dispatch(&fixture, &expired, &[]);
     assert_eq!(rejected.code, 65);
     assert_eq!(

--- a/crates/agent-hook/tests/support/mod.rs
+++ b/crates/agent-hook/tests/support/mod.rs
@@ -81,8 +81,15 @@ impl Fixture {
         envs: &[(&str, &str)],
         removals: &[&str],
     ) -> CmdOutput {
+        // Helper resolution, coordination identity, and the state root are all
+        // env overrides that outrank what a test can set through `PATH` or the
+        // fixture layout, so every one of them has to be dropped unless this
+        // call asked for it. Removals are applied before values, so the
+        // `AGENT_SESSION_STATE_DIR` default below and any explicit `envs` entry
+        // still reach the child. See `sympoies/nils-cli#1420`.
         let options = CmdOptions::new()
             .with_cwd(&self.root)
+            .without_ambient_managed_session_env()
             .with_env_remove("CODEX_HOME")
             .with_env("HOME", self.home.to_str().expect("home UTF-8"))
             .with_env(

--- a/crates/nils-test-support/README.md
+++ b/crates/nils-test-support/README.md
@@ -37,6 +37,10 @@ Stale-test cleanup sequencing is frozen in
   - `cmd`: run binaries with captured output (`CmdOutput`) and flexible options (`CmdOptions`), including resolved workspace-binary helpers
     (`run_resolved*`)
   - `CmdOptions::with_env_remove_many`: remove multiple env vars in one call for deterministic harness setup
+  - `CmdOptions::without_ambient_managed_session_env`: drop the `cmd::MANAGED_SESSION_ENV` set a managed
+    `agent-session` pane pins, so a suite run inside one does not inherit overrides that outrank `PATH`
+    and the fixture layout. Removals are applied before values, so a later `with_env` for the same key
+    still reaches the child
   - `cmd::path_with_prepend_excluding_program`: construct a PATH that prepends stubs while filtering one real binary
 - Workspace binaries
   - `bin`: `resolve` finds `CARGO_BIN_EXE_*` or falls back to `target/<profile>/<name>`

--- a/crates/nils-test-support/src/cmd.rs
+++ b/crates/nils-test-support/src/cmd.rs
@@ -63,6 +63,33 @@ fn exit_status_from_code(code: i32) -> std::process::ExitStatus {
     std::process::ExitStatus::from_raw(raw)
 }
 
+/// Every variable a managed `agent-session` pane pins into the processes it
+/// launches, which a test therefore inherits when the suite itself runs inside
+/// one.
+///
+/// The list mirrors `session_environment_args` in `crates/agent-session/src/lib.rs`
+/// plus `AGENT_HOOK_BIN`, which `agent-session` consults when it invokes the hook.
+/// `CODEX_HOME` and `CLAUDE_CONFIG_DIR` are pinned by the same function but are
+/// omitted here: they are provider config roots that individual fixtures already
+/// own, so removing them centrally would change unrelated expectations.
+///
+/// These are overrides that outrank the inputs a test does control. A fixture
+/// that points `PATH` at an empty directory cannot express "nothing resolves"
+/// while an inherited `AGENT_SESSION_BIN` still names a real helper, so the
+/// assertion never reaches its subject and the suite is green on CI and red on a
+/// managed workstation. See `sympoies/nils-cli#1420`.
+pub const MANAGED_SESSION_ENV: [&str; 9] = [
+    "AGENT_SESSION_ID",
+    "AGENT_SESSION_RUNTIME_ID",
+    "AGENT_SESSION_STATE_DIR",
+    "AGENT_SESSION_COORDINATION_MODE",
+    "AGENT_SESSION_CAPABILITY_FILE",
+    "AGENT_SESSION_CHECKPOINT_FILE",
+    "AGENT_SESSION_ATTENTION_AUTHORITY",
+    "AGENT_SESSION_BIN",
+    "AGENT_HOOK_BIN",
+];
+
 #[derive(Debug, Clone)]
 pub struct CmdOptions {
     pub cwd: Option<PathBuf>,
@@ -113,6 +140,17 @@ impl CmdOptions {
             self = self.with_env_remove(key);
         }
         self
+    }
+
+    /// Drop every [`MANAGED_SESSION_ENV`] variable the caller inherited, so the
+    /// process under test sees only the managed-session inputs the test chose.
+    ///
+    /// This does not take anything away from a test that wants one of them:
+    /// `run_impl_os` applies removals before values, so a later `with_env` for
+    /// the same key still reaches the child. Callers that build a value
+    /// conditionally can therefore apply this first and decide afterwards.
+    pub fn without_ambient_managed_session_env(self) -> Self {
+        self.with_env_remove_many(&MANAGED_SESSION_ENV)
     }
 
     pub fn with_path_prepend(self, dir: &Path) -> Self {
@@ -302,7 +340,17 @@ fn run_impl_os(bin: &Path, args: &[&OsStr], options: &CmdOptions, dir: Option<&P
             cmd.stdin(Stdio::piped());
             let mut child = cmd.spawn().expect("spawn command");
             if let Some(mut writer) = child.stdin.take() {
-                writer.write_all(input).expect("write stdin");
+                match writer.write_all(input) {
+                    Ok(()) => {}
+                    // A command under test may exit before draining its stdin -
+                    // a usage error, an early `--help`, a filter that found what
+                    // it needed. Panicking here would report that as a harness
+                    // failure and lose the exit code and output the test is
+                    // actually asserting on. Same reasoning as the capability
+                    // runner in `agent-hook`; see `sympoies/nils-cli#1420`.
+                    Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+                    Err(error) => panic!("write stdin: {error}"),
+                }
             }
             child.wait_with_output().expect("wait command")
         }

--- a/crates/nils-test-support/tests/integration/bin_cmd.rs
+++ b/crates/nils-test-support/tests/integration/bin_cmd.rs
@@ -305,3 +305,90 @@ pwd
     assert_eq!(output.code, 0);
     assert_eq!(stdout, expected);
 }
+
+/// A command under test is free to exit before draining its stdin. The harness
+/// must still report that command's own exit code and output instead of
+/// panicking on the broken pipe. See `sympoies/nils-cli#1420`.
+#[cfg(unix)]
+#[test]
+fn run_reports_the_exit_code_of_a_command_that_ignores_its_stdin() {
+    let temp = TempDir::new().expect("tempdir");
+    write_exe(
+        temp.path(),
+        "exit-before-reading",
+        "#!/bin/sh\nexec 0<&-\nprintf 'answered\\n'\nexit 3\n",
+    );
+    let bin = temp.path().join("exit-before-reading");
+    // A pipe holds 64 KiB, so a smaller payload would be buffered whole and the
+    // write would never see the closed read end.
+    let options = cmd::CmdOptions::new().with_stdin_bytes(&vec![b'x'; 128 * 1024]);
+
+    let output = cmd::run_with(&bin, &[], &options);
+
+    assert_eq!(output.code, 3);
+    assert_eq!(output.stdout_text().trim_end(), "answered");
+}
+
+/// A suite running inside a managed `agent-session` pane inherits every variable
+/// that pane pins. Those variables outrank `PATH` and the fixture layout, so a
+/// test controlling only part of a resolution input set silently measures the
+/// developer's runtime instead of its own. See `sympoies/nils-cli#1420`.
+#[cfg(unix)]
+#[test]
+fn without_ambient_managed_session_env_hides_every_inherited_override() {
+    let lock = GlobalStateLock::new();
+    let temp = TempDir::new().expect("tempdir");
+    let report = cmd::MANAGED_SESSION_ENV
+        .iter()
+        .map(|name| format!("printf '%s=%s\\n' {name} \"${{{name}-absent}}\"\n"))
+        .collect::<String>();
+    write_exe(
+        temp.path(),
+        "report-managed-env",
+        &format!("#!/bin/sh\n{report}"),
+    );
+    let bin = temp.path().join("report-managed-env");
+    let _guards: Vec<EnvGuard> = cmd::MANAGED_SESSION_ENV
+        .iter()
+        .map(|name| EnvGuard::set(&lock, name, "inherited-from-the-managed-pane"))
+        .collect();
+
+    let options = cmd::CmdOptions::new().without_ambient_managed_session_env();
+    let output = cmd::run_with(&bin, &[], &options);
+
+    assert_eq!(output.code, 0, "stderr={}", output.stderr_text());
+    let expected = cmd::MANAGED_SESSION_ENV
+        .iter()
+        .map(|name| format!("{name}=absent"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert_eq!(
+        output.stdout_text().trim_end(),
+        expected,
+        "no managed-session variable may reach a child that did not ask for it"
+    );
+}
+
+/// The removal must not take the variable away from a test that wants it, or
+/// every fixture legitimately pinning one would have to opt out by name.
+#[cfg(unix)]
+#[test]
+fn without_ambient_managed_session_env_still_lets_an_explicit_value_through() {
+    let lock = GlobalStateLock::new();
+    let temp = TempDir::new().expect("tempdir");
+    write_exe(
+        temp.path(),
+        "report-helper-override",
+        "#!/bin/sh\nprintf '%s\\n' \"${AGENT_SESSION_BIN-absent}\"\n",
+    );
+    let bin = temp.path().join("report-helper-override");
+    let _guard = EnvGuard::set(&lock, "AGENT_SESSION_BIN", "/inherited/agent-session");
+
+    let options = cmd::CmdOptions::new()
+        .without_ambient_managed_session_env()
+        .with_env("AGENT_SESSION_BIN", "/chosen/agent-session");
+    let output = cmd::run_with(&bin, &[], &options);
+
+    assert_eq!(output.code, 0, "stderr={}", output.stderr_text());
+    assert_eq!(output.stdout_text().trim_end(), "/chosen/agent-session");
+}


### PR DESCRIPTION
## Summary

Make the `agent-hook` test harness own its complete resolution input set, and fix
the three defects that came out of validating it — one of them a production
fail-closed denial.

The reported defect is the harness one: a managed `agent-session` pane pins
`AGENT_SESSION_BIN`, that variable outranks `PATH`, and
`crates/agent-hook/tests/activity_helper.rs` did not neutralize it, so the local
gate failed for changes that touch nothing in `agent-hook`.

Rather than unset the one variable that happened to break, `nils-test-support` now
names the whole set a managed pane pins and drops it by default, because `#1415`
is evidence that the set grows. To establish that this was the only leak rather
than the first one found, the full workspace was run once against the untouched
baseline under that entire environment: 8336 tests, exactly one failure, the
reported one.

Validation then surfaced what the issue had filed as load flakiness. It is not
flakiness. Six `agent-hook` tests were failing on `capability-input-failed`: a
capability that exits before draining its stdin closes the read end, and the
runner's remaining write returns `EPIPE`, which was scored as a failed capability.
For a rule that is `failure_posture = "closed"` and `override_class = "locked"` —
which privacy, writer, transaction, and recovery rules must be — that is a denial
the session cannot override, arriving at random depending on machine load. Present
since `#1314`. A capability is now judged by its exit status and output, never by
how much of its stdin it chose to read.

Two smaller defects of the same shape are fixed with it: the shared test harness
panicked instead of reporting a command that exited before reading its stdin, and
one recovery test minted a capability with a TTL so short that its own two-process
setup could outlive it under load.

## Problem

`AGENT_SESSION_BIN` outranks `PATH` when `agent-hook` resolves the activity
helper. A test that makes the helper unresolvable by pointing `PATH` at an empty
directory therefore does not express "nothing resolves" — only "nothing resolves
*through `PATH`*", and the inherited override still wins.

Expected: `doctor_fails_when_the_activity_helper_cannot_be_resolved` empties
`PATH`, so `agent-hook doctor` reports `activity-helper-unresolvable` and exits
non-zero.

Actual: `doctor` resolves the developer's real helper through the inherited
variable, reports `status: "converged"`, and exits 0. The `assert_ne` at
`crates/agent-hook/tests/activity_helper.rs:269` fails.

Impact: `--local-fast` fails for changes that touch none of `agent-hook`, while
GitHub CI stays green because the runner sets no such variable. It was found while
validating an unrelated `forge-cli` change. Every local run inside a managed
`agent-session` pane hits it, because `#1415` began pinning the variable into new
panes.

The second defect is more serious and was not reported as a defect at all. The
issue lists two tests as intermittent under load and asks for them to be explained.
They are not load-sensitive tests; they are load-sensitive *product* behavior. Six
tests in the crate were failing on `capability-input-failed`:

Expected: an executable capability is judged by its exit status and output.

Actual: a capability that exited before draining its stdin closed the read end,
the runner's remaining write returned `EPIPE`, and that was mapped to
`capability-input-failed`, which the caller converts through `failure_outcome`
like any capability error.

Impact: on a rule that is `failure_posture = "closed"` and
`override_class = "locked"` — which privacy, writer, transaction, and recovery
rules are required to be — the session is denied, at random, with no override to
recover through. Whether the child won the race depended on machine load. Present
since `#1314`, and invisible because nextest retries turned every occurrence into
a pass.

## Reproduction

**Harness defect.** On the untouched baseline `31d2e98a`, with the variable a
managed pane pins:

```
$ AGENT_SESSION_BIN=<real helper> cargo nextest run --profile ci \
    -p nils-agent-hook --test activity_helper
TRY 3 FAIL doctor_fails_when_the_activity_helper_cannot_be_resolved
  {"ok":true,"data":[{... "status":"converged" ...}]}
Summary 5 tests run: 4 passed, 1 failed
```

Deterministic across all three retries; passes with the variable unset, which is
why GitHub CI never saw it.

**Only leak, not first leak.** The whole workspace was run once against
`31d2e98a` under every variable `session_environment_args` pins, each pointed away
from any fixture's own directories:

```
Starting 8336 tests across 163 binaries
Summary [304.633s] 8336 tests run: 8335 passed, 1 failed
```

Exactly one failure, the one above.

**`EPIPE` defect.** The issue's two "also observed" tests were reproduced, and the
set turned out to be six. Six consecutive `-p nils-agent-hook` runs, listing the
first-attempt failure of each:

| Run | First-attempt failures |
| --- | --- |
| 1 | `a_resolvable_helper_override_still_takes_effect`, `coordination_shadow_is_side_effect_free_and_handler_block_is_authoritative`, `stop_reentry_reaches_a_deterministic_terminal_result` |
| 2 | `an_empty_helper_override_resolves_through_path` |
| 3 | `a_resolvable_helper_override_still_takes_effect`, `a_stale_helper_override_falls_back_to_path_with_a_typed_classification` |
| 4 | `a_stale_helper_override_falls_back_to_path_with_a_typed_classification` |
| 5 | four of the above |
| 6 | `failed_stop_activity_does_not_override_authoritative_coordination_block` |

All six recovered on retry, so every run reported green. The reason codes named
only `capability-failure-closed`, which erases the cause, so the underlying error
was surfaced by a temporary `eprintln` at the one call site that discards it:

```
7 TEMPDEBUG capability error code=capability-input-failed msg=capability input failed
```

One cause for all six. After the fix, five consecutive runs of the same two
crates: `244 tests run: 244 passed`, zero retries, zero flaky.

The `capability-input-failed` mapping dates to #1314, confirmed with
`git log -L` on the block.

## Issues Found

Fixes #1420

| Issue | Relationship |
| --- | --- |
| #1420 | The reported harness defect, plus the two intermittent tests its "Also observed" section asked to explain. |
| #1409 | The `EPIPE` fix belongs to the same fail-closed liveness class: a locked, fail-closed rule denying for something that is not a failure, with no override to recover through. |
| #1415 | Pinning `AGENT_SESSION_BIN` into new panes is what made the harness gap visible. Not a regression in `#1415`; the pin is correct. |
| #1314 | Introduced the `capability-input-failed` mapping this corrects. |

## Fix Approach

**Harness hermeticity.** `nils-test-support` gains `cmd::MANAGED_SESSION_ENV` — the
nine variables `session_environment_args` pins into a managed pane, plus
`AGENT_HOOK_BIN` — and `CmdOptions::without_ambient_managed_session_env()`, which
drops all of them. The `agent-hook` fixture applies it. Removals are recorded
before values and `run_impl_os` applies them in that order, so the fixture's own
`AGENT_SESSION_STATE_DIR` default and every explicit `with_env` still reach the
child; the three tests that deliberately exercise the override keep doing so.

Naming the set rather than one variable is the point: `#1415` added
`AGENT_SESSION_BIN` to what a pane pins, and the next addition would recreate the
same silent failure. `CODEX_HOME` and `CLAUDE_CONFIG_DIR` are pinned by the same
function but deliberately excluded, because individual fixtures already own those
provider roots and removing them centrally would move unrelated expectations.

**Capability verdict (production).** In `run_bounded`, `ErrorKind::BrokenPipe` from
the stdin write is no longer an error. Sequencing the write before the wait would
not fix this, because a child is always free to exit early; the exit status is the
verdict. The tolerance is scoped to the pipe: a capability that stops reading and
then fails still takes its rule's failure posture, pinned from both the dispatch
and unit levels.

The pre-existing `bounded_runner_handles_child_exit_before_stdin_is_consumed`
asserted the old code. Its `elapsed() < HANDLER_TIMEOUT` assertion is the property
worth keeping — the runner must not block to the timeout — and it still holds; its
assertion that the broken pipe be reported as `capability-input-failed` was the
defect, and now checks the child's exit status.

The frozen `agent-hook-v1` contract records the rule under **Deterministic
evaluation**, because it changes when a fail-closed rule may deny.

**Harness robustness.** `cmd::run_impl_os` had the same defect in panic form:
`write_all(...).expect("write stdin")` turned any command that exited before
reading into a harness panic, discarding the exit code and output the test was
asserting on. It now tolerates the broken pipe the same way.

**Recovery TTL.** `one_shot_rejects_...expiry...` minted its expiring capability
with `--ttl-seconds 1`, but the TTL bounds the challenge and `authorize` runs in a
second process, so setup had to finish inside the same second the test wanted to
outlive. Under full-workspace load it did not, and `authorize` rejected its own
setup as expired. `authorize_then_expire` re-mints when setup loses the race, which
keeps expiry real — there is deliberately no clock override on this path — instead
of hiding it behind a longer sleep that would still be unbounded.

## Test-First Evidence

Both defects were reproduced before being fixed, each against a state with no fix
applied. Record: `test-first-evidence` bound to baseline `31d2e98a`.

**Harness defect.** On the untouched baseline, with the variable a managed pane
pins:

```
$ AGENT_SESSION_BIN=<real helper> cargo nextest run --profile ci \
    -p nils-agent-hook --test activity_helper
TRY 3 FAIL doctor_fails_when_the_activity_helper_cannot_be_resolved
  expected: activity-helper-unresolvable, non-zero exit
  observed: status "converged", exit 0
Summary 5 tests run: 4 passed, 1 failed
```

Deterministic across all three retries; passes with the variable unset.

**`EPIPE` defect.** New tests written first, then the fix reverted to confirm they
fail for the stated reason and not incidentally:

```
$ cargo nextest run --profile ci -p nils-agent-hook \
    --test degraded_liveness -E 'test(stdin)'
TRY 3 FAIL a_capability_that_stops_reading_stdin_is_judged_by_its_exit_status
  expected exit 0 (handler closed stdin, then exited 0)
  observed exit 1 (capability-failure-closed)
Summary 2 tests run: 1 passed, 1 failed
```

Deterministic across all three retries. The negative case
(`...and_then_fails_still_fails_closed`) passes with and without the fix, which is
what makes it a guard against over-correction rather than a restatement.

The 128 KiB payload is load-bearing: a pipe buffers 64 KiB, so a smaller payload
would be written whole before the child could close the read end and the race
would not be observable. `sleep 0.3` in the handler is what converts the original
load-dependent flake into a deterministic failure.

## Test plan

Every run below sets the full managed-pane environment, because a run without it
cannot observe the defect at all.

| Scope | Command | Result |
| --- | --- | --- |
| Baseline, whole workspace, no fix | `--workspace --no-fail-fast` at `31d2e98a` | 8336 run, 1 failed — the reported one, and only it |
| Reproduce, no fix | `-p nils-agent-hook --test activity_helper` at `31d2e98a` | 1 failed on all 3 retries |
| Reproduce `EPIPE`, fix reverted | `--test degraded_liveness -E 'test(stdin)'` | 1 failed on all 3 retries; the negative case passed |
| Flake rate, no fix | `-p nils-agent-hook` × 6 | 6 distinct tests failed a first attempt across the 6 runs |
| Flake rate, with fix | `-p nils-agent-hook -p nils-test-support` × 5 | 243 passed × 5, zero retries, zero flaky |
| Declared final gate | `scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` | **exit 0** — `8343 tests run: 8343 passed, 0 skipped`, zero first-attempt failures |

The final gate is the issue's own acceptance criterion: it passes inside a managed
`agent-session` environment with no manual `unset`. The same gate, on the same
machine, is what `#1420` was filed against.

Zero first-attempt failures is the load-bearing number, not just zero failures.
`--profile ci` retries three times, which is what let six real failures report as
green; the gate run before this change flaked at test 336 and again at 1363.

`cargo fmt --all -- --check` and the docs-hygiene checks are inside `--local-fast`
and passed as part of the exit 0.

Not run: `test_macos`, and `coverage`. Both are CI-owned for a normal PR and are
required checks on `main`.

## Risk / Notes

- The `EPIPE` change relaxes when a capability counts as failed, which is a
  security-relevant boundary and is called out for review. It does not widen what
  a capability may decide: a child that stops reading and then exits non-zero
  still fail-closes, and a child that exits 0 was always going to be honoured had
  it drained one more buffer. What it removes is a denial whose trigger was
  machine load. Both directions are pinned at the unit and dispatch levels.
- `MANAGED_SESSION_ENV` is a list that has to be maintained alongside
  `session_environment_args`. `without_ambient_managed_session_env_hides_every_inherited_override`
  iterates the const, so a dropped entry fails a test rather than silently
  reopening the hole, but an entry *added* to the pane and not to the list is not
  caught here. The remaining exposure is one crate's fixture, not the workspace.
- `CODEX_HOME` and `CLAUDE_CONFIG_DIR` are pinned by a managed pane and stay
  inherited by design, so a suite that resolves provider config through them
  keeps whatever behavior it has today.
