### PR TITLE
fix(agent-session): stabilize readiness recovery boundary fixtures

### DIFF
--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -7145,6 +7145,19 @@ fn worker_start_finalizer_lease_secs(progress: &Value) -> i64 {
     }
 }
 
+fn worker_submit_key_recovery_delay(timeout: Duration) -> Duration {
+    #[cfg(debug_assertions)]
+    if let Ok(value) = env::var("NILS_AGENT_SESSION_TEST_READINESS_RECOVERY_DELAY_MS")
+        && let Ok(value) = value.parse::<u64>()
+    {
+        let delay = Duration::from_millis(value);
+        if delay <= WORKER_SUBMIT_KEY_RECOVERY_DELAY && delay <= timeout {
+            return delay;
+        }
+    }
+    std::cmp::min(WORKER_SUBMIT_KEY_RECOVERY_DELAY, timeout / 2)
+}
+
 fn pause_readiness_recovery_for_test(stage: &str) -> Result<(), CliError> {
     #[cfg(debug_assertions)]
     if env::var("NILS_AGENT_SESSION_TEST_READINESS_RECOVERY_BARRIER_STAGE").as_deref() == Ok(stage)
@@ -7251,7 +7264,7 @@ fn await_worker_readiness(
         recovery_continuation,
     } = request;
     let started = Instant::now();
-    let recovery_after = std::cmp::min(WORKER_SUBMIT_KEY_RECOVERY_DELAY, timeout / 2);
+    let recovery_after = worker_submit_key_recovery_delay(timeout);
     let recovery_eligible = submit_key_recovery_eligible;
     let (mut recovery, mut recovery_stage) = match recovery_continuation.as_ref() {
         Some(value) => {

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -35389,11 +35389,10 @@ fn main_agent_worker_start_definitive_recovery_failure_converges_at_takeover_bou
 }
 
 fn exercise_definitive_recovery_failure_boundary(mode: &str) {
-    // Coverage instrumentation makes each same-release subprocess startup
-    // materially slower on macOS: a neighboring serialized fixture took more
-    // than 72 seconds in CI before this barrier. Keep synchronization waits
-    // generous without changing the four-second readiness deadline this
-    // fixture validates.
+    // These fixtures own the terminal boundary after a definitive recovery
+    // failure, not the production recovery delay. Start recovery immediately
+    // so macOS coverage overhead cannot consume half of the four-second
+    // readiness deadline before the fixture reaches its synchronization point.
     let synchronization_timeout = Duration::from_secs(120);
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");
@@ -35483,6 +35482,7 @@ fn exercise_definitive_recovery_failure_boundary(mode: &str) {
             "NILS_AGENT_SESSION_TEST_READINESS_FINALIZER_LEASE_SECS",
             "3",
         )
+        .env("NILS_AGENT_SESSION_TEST_READINESS_RECOVERY_DELAY_MS", "0")
         .env(
             "NILS_AGENT_SESSION_TEST_READINESS_RECOVERY_BARRIER_DIR",
             &recovery_barrier,
@@ -35501,14 +35501,12 @@ fn exercise_definitive_recovery_failure_boundary(mode: &str) {
     }
     let mut start = Some(command.spawn().expect("spawn worker start"));
 
-    let barrier_deadline = Instant::now() + synchronization_timeout;
-    while !recovery_barrier.join("ready").is_file() {
-        assert!(
-            Instant::now() < barrier_deadline,
-            "recovery barrier timed out for {mode}"
-        );
-        std::thread::sleep(Duration::from_millis(10));
-    }
+    wait_for_barrier_or_child_exit_with_timeout(
+        &recovery_barrier,
+        start.as_mut().expect("worker start"),
+        &format!("definitive recovery failure {mode}"),
+        synchronization_timeout,
+    );
     let receipt_key = format!("main-one:main-incarnation-one:{idempotency_key}");
     let original_deadline_at_epoch = orchestration_registry(&state_dir)["receipts"]
         [&receipt_key]["outcome"]["deadline_at_epoch"]
@@ -35539,6 +35537,10 @@ fn exercise_definitive_recovery_failure_boundary(mode: &str) {
     fs::write(recovery_barrier.join("release"), b"continue").expect("release recovery");
     let failure_deadline = Instant::now() + synchronization_timeout;
     loop {
+        panic_if_child_exited(
+            start.as_mut().expect("worker start"),
+            &format!("definitive recovery failure record {mode}"),
+        );
         let registry = orchestration_registry(&state_dir);
         let assignment = &registry["assignments"][&assignment_id];
         if assignment["submit_recovery"]["state"] == "failed" {
@@ -35578,6 +35580,10 @@ fn exercise_definitive_recovery_failure_boundary(mode: &str) {
     if mode == "final-checkpoint" {
         let final_deadline = Instant::now() + synchronization_timeout;
         while !final_barrier.join("ready").is_file() {
+            panic_if_child_exited(
+                start.as_mut().expect("worker start"),
+                "definitive recovery final receipt",
+            );
             assert!(
                 Instant::now() < final_deadline,
                 "final receipt barrier timed out"


### PR DESCRIPTION
## Summary

Stabilize the worker-start recovery terminal-boundary fixtures that blocked the 1.26.0 release coverage gate, without changing production recovery timing or the four-second readiness contract.

## Problem

- Expected: deadline, final-checkpoint, and takeover fixtures reach the recovery sending barrier and validate their terminal boundary.
- Actual: the default recovery delay consumed half of the four-second readiness budget; instrumentation variance could expire the deadline before the fixture reached its barrier.
- Impact: a release-only PR could fail the required coverage gate even though the same source commit had already passed.

## Reproduction

1. Run the full macOS coverage command from CI.
2. Observe one terminal-boundary fixture wait 120 seconds for a barrier it can no longer reach.
3. Observe nextest exhaust all three retries with exit status 100.

## Issues Found

- Release PR #1425: macOS LLVM coverage exhausted all three retries while waiting for the recovery sending barrier.

## Fix Approach

- Add a debug-only bounded recovery-delay override while retaining the production default.
- Set the terminal-boundary fixtures to recover immediately because they own convergence, not scheduling delay.
- Poll the child during synchronization so early exit or a true stall reports status and output instead of a generic timeout.

## Test-First Evidence

- Before fix: GitHub Actions coverage job 91663985088 failed all three retries of the deadline boundary fixture at the 120-second recovery barrier.
- Cross-check: the same source SHA previously failed two final-checkpoint retries before passing the third, proving the defect was fixture timing rather than one mode's state machine.
- Evidence is bound to baseline 4841afa8 and delivery head 363be101.

## Test plan

- PASS: focused three-case nextest regression.
- PASS: focused three-case LLVM coverage instrumentation.
- PASS: `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (1,136 tests, Clippy, formatting, doctests).
- PASS: repository pre-PR dispatcher with the same local-fast gate.

## Risk / Notes

- Production builds do not consult the test override because it is guarded by `debug_assertions`.
- Invalid or oversized override values fall back to the unchanged production delay.
- Required macOS coverage remains the final platform-specific acceptance gate.
