### PR TITLE
feat(agent-session): classify bootstrap and capacity attention

### DIFF
--- a/crates/agent-session/docs/runbooks/main-agent-orchestration.md
+++ b/crates/agent-session/docs/runbooks/main-agent-orchestration.md
@@ -417,7 +417,9 @@ envelopes. `idle_claim_revocation_required` and
 `provider_stop_canary_release_in_progress`,
 `provider_process_stopped_wrapper_live`, and generic
 `process_runtime_stopped_wrapper_live_contradiction` classifications use the
-v6 envelopes. Branch on `classification`, never on prose:
+v6 envelopes. `pre_bootstrap_attention_required` and
+`provider_capacity_attention_required` use v7 envelopes with a bounded
+`attention` projection. Branch on `classification`, never on prose:
 
 | Classification | Deterministic action |
 | --- | --- |
@@ -440,6 +442,8 @@ v6 envelopes. Branch on `classification`, never on prose:
 | `coordination_broker_stale` | Route to the exact worker's authenticated broker owner. Do not copy its capability or renew its claim as a substitute. |
 | `edit_authority_stale` | Preserve the exact worker and perform a bounded supervision recheck; route only durable broker-lost evidence to broker recovery. |
 | `claim_renewal_required` | Ask the exact worker to renew its own current claim and revision using its own capability file. |
+| `pre_bootstrap_attention_required` | Preserve the live starting worker and continue bounded bootstrap supervision. No claim exists to renew; do not send provider input or replace the worker. |
+| `provider_capacity_attention_required` | Preserve the exact worker and conversation, wait for capacity, and continue bounded supervision. Do not switch accounts, resend the prompt, or send raw terminal input. This requires exact structured `serverOverloaded` evidence, not rendered prose. |
 | `guidance_continuity_required` | Run revision-fenced `worker guidance-reconcile`; retain message identity and unread state. |
 | `orphan_guidance_quarantine_required` | Run revision-fenced `worker guidance-quarantine`; quarantine only exact-controller stale-incarnation records when no `previous_worker` exists. |
 | `account_handoff_capability_gap` | Preserve the worker. No public raw restart flag exists; retry only with a daemon-launched managed worker advertising `agent-session.codex-managed-account-handoff.v1`. |
@@ -449,8 +453,8 @@ v6 envelopes. Branch on `classification`, never on prose:
 | `safe_reassignment` | Start only a distinct assignment/session and clean worktree. Never reuse the old prompt. |
 
 `worker diagnose` returns the same evidence without the supervisor wrapper. It
-uses v3 for the same five additive classifications listed above and v2
-otherwise:
+uses the versioned envelopes described above for their additive
+classifications and v2 otherwise:
 
 ```bash
 main-agent worker diagnose ASSIGNMENT_ID --format json

--- a/crates/agent-session/docs/specs/main-agent-orchestration-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-orchestration-v1.md
@@ -390,6 +390,35 @@ evidence and a visible tmux wrapper; its reconciliation action is
 non-executable. Existing v2-v5 classifications retain their exact schema
 identifiers and projections.
 
+`pre_bootstrap_attention_required` and
+`provider_capacity_attention_required` use
+`main-agent.worker-diagnose-result.v7`,
+`main-agent.worker-supervise-result.v7`, and
+`main-agent.worker-recovery-action.v7`. The v7 diagnosis adds an `attention`
+projection with a bounded `kind`, evidence `source`, and explicit false
+`provider_input_authorized` and `account_change_authorized` fields. A live
+`starting` worker with no claim, no exhausted readiness receipt, no operation,
+no recovery reservation, and no blocker or terminal evidence is
+`pre_bootstrap_attention_required`; it MUST NOT be told to renew a claim that
+authenticated bootstrap has not created. An exact Codex app-server
+`codexErrorInfo: serverOverloaded` followed by the matching non-retrying failed
+turn is admitted only through the internal protocol-owned
+`agent-session.turn-event.v2` path. Generic activity ingestion continues to
+accept only v1 and its closed failure-reason union. Reduction persists the
+additive bounded `last_turn.provider_failure_kind: provider_capacity` marker,
+which classifies `provider_capacity_attention_required` only for a bound live
+worker in an eligible `starting`, `working`, or `blocked` assignment at that
+authoritative waiting boundary. A newer active turn or any later submitted,
+accepted, cancelled, or released assignment lifecycle retires the
+classification. Conflicting
+structured failure kinds for one turn fail closed unless the terminal
+completion embeds the resolving kind. Free-form error prose is not admitted.
+This state is distinct from quota or credit exhaustion: it MUST
+NOT arm usage auto-resume, authorize account handoff, resend the prompt, or
+send terminal input. Both v7 actions are Main-owned bounded supervision
+rechecks and are not automatic-retry-safe. Existing v2-v6 classifications
+retain their exact schema identifiers and projections.
+
 `worker stop-runtime` MUST authenticate the exact current Main controller and
 its active, unexpired claim; revalidate run ownership, assignment revision,
 primary manager, worker binding, and the final readiness receipt; and hold the
@@ -887,7 +916,9 @@ The full supervision classification set additionally includes
 `claim_renewal_required`, `guidance_continuity_required`,
 `orphan_guidance_quarantine_required`,
 `account_handoff_capability_gap`, `account_handoff_required`, and
-`stale_provider_activity`. Broker-heartbeat/edit-authority staleness is not
+`stale_provider_activity`. The additive v7 set also includes
+`pre_bootstrap_attention_required` and
+`provider_capacity_attention_required`. Broker-heartbeat/edit-authority staleness is not
 claim-expiry evidence: only `claim_renewal_required` directs the exact worker to
 renew its own claim. `coordination_broker_stale` routes to exact-incarnation
 broker-owner recovery; `edit_authority_stale` requests a bounded recheck while

--- a/crates/agent-session/src/activity.rs
+++ b/crates/agent-session/src/activity.rs
@@ -29,6 +29,7 @@ pub(crate) mod shadow;
 use provider::{normalize_provider_hook, normalize_provider_notification};
 
 pub(crate) const TURN_EVENT_VERSION: &str = "agent-session.turn-event.v1";
+const CODEX_PROTOCOL_TURN_EVENT_VERSION: &str = "agent-session.turn-event.v2";
 pub(crate) const TURN_STATE_VERSION: &str = "agent-session.turn-state.v1";
 const ACTIVITY_DOCUMENT_VERSION: &str = "agent-session.activity.v1";
 const ACTIVITY_FILE: &str = "activity.json";
@@ -164,6 +165,14 @@ pub(crate) struct LastTurn {
     pub(crate) outcome: String,
     #[serde(default, flatten)]
     extra: Map<String, Value>,
+}
+
+impl LastTurn {
+    pub(crate) fn provider_failure_kind(&self) -> Option<&str> {
+        self.extra
+            .get("provider_failure_kind")
+            .and_then(Value::as_str)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -423,6 +432,7 @@ pub(crate) struct ActivityResult {
     pub(crate) duplicate: bool,
 }
 
+#[cfg(test)]
 pub(crate) fn ingest_codex_app_server_failure(
     context: &CliContext,
     id: &str,
@@ -430,22 +440,46 @@ pub(crate) fn ingest_codex_app_server_failure(
     thread_id: &str,
     turn_id: &str,
 ) -> Result<ActivityResult, CliError> {
+    ingest_codex_app_server_failure_with_kind(
+        context,
+        id,
+        runtime_id,
+        thread_id,
+        turn_id,
+        crate::codex_app_server::StructuredFailureKind::UsageExhausted,
+    )
+}
+
+pub(crate) fn ingest_codex_app_server_failure_with_kind(
+    context: &CliContext,
+    id: &str,
+    runtime_id: &str,
+    thread_id: &str,
+    turn_id: &str,
+    failure_kind: crate::codex_app_server::StructuredFailureKind,
+) -> Result<ActivityResult, CliError> {
     let provider_session_id =
         projected_provider_identifier(runtime_id, AgentKind::Codex, "session", thread_id)?;
     let provider_turn_id =
         projected_provider_identifier(runtime_id, AgentKind::Codex, "turn", turn_id)?;
-    ingest_event_retry(
+    ingest_event_retry_with_admission(
         context,
         id,
         TurnEvent {
-            schema_version: TURN_EVENT_VERSION.to_string(),
+            schema_version: if failure_kind
+                == crate::codex_app_server::StructuredFailureKind::ProviderCapacity
+            {
+                CODEX_PROTOCOL_TURN_EVENT_VERSION.to_string()
+            } else {
+                TURN_EVENT_VERSION.to_string()
+            },
             event_id: format!("codex-app-server-failure:{provider_turn_id}"),
             runtime_id: runtime_id.to_string(),
             provider: AgentKind::Codex.as_str().to_string(),
             provider_session_id: Some(provider_session_id),
             provider_turn_id: Some(provider_turn_id),
             kind: TurnEventKind::TurnFailed,
-            failure_reason: Some("usage_exhausted".to_string()),
+            failure_reason: Some(failure_kind.activity_reason().to_string()),
             attention_id: None,
             attention_kind: None,
             attention_correlation_ambiguous: false,
@@ -456,6 +490,7 @@ pub(crate) fn ingest_codex_app_server_failure(
             source_kind: SourceKind::ProviderHook,
             provider_time: None,
         },
+        EventAdmission::CodexProtocol,
     )
 }
 
@@ -498,7 +533,7 @@ pub(crate) fn ingest_codex_app_server_attention(
         }
         None => (TurnEventKind::AttentionCleared, None, "resolved"),
     };
-    ingest_event_retry(
+    ingest_event_retry_with_admission(
         context,
         id,
         TurnEvent {
@@ -520,6 +555,7 @@ pub(crate) fn ingest_codex_app_server_attention(
             source_kind: SourceKind::ProviderHook,
             provider_time: None,
         },
+        EventAdmission::CodexProtocol,
     )
 }
 
@@ -2421,7 +2457,13 @@ pub(crate) fn ingest_event(
     id: &str,
     event: TurnEvent,
 ) -> Result<ActivityResult, CliError> {
-    ingest_event_with_lock(context, id, event, ActivityLockMode::Blocking)
+    ingest_event_with_lock(
+        context,
+        id,
+        event,
+        ActivityLockMode::Blocking,
+        EventAdmission::Generic,
+    )
 }
 
 fn ingest_event_nonblocking(
@@ -2429,7 +2471,13 @@ fn ingest_event_nonblocking(
     id: &str,
     event: TurnEvent,
 ) -> Result<ActivityResult, CliError> {
-    ingest_event_with_lock(context, id, event, ActivityLockMode::NonBlocking)
+    ingest_event_with_lock(
+        context,
+        id,
+        event,
+        ActivityLockMode::NonBlocking,
+        EventAdmission::Generic,
+    )
 }
 
 pub(crate) fn ingest_event_retry(
@@ -2442,6 +2490,28 @@ pub(crate) fn ingest_event_retry(
         id,
         event,
         ActivityLockMode::Timed(CODEX_COMPLETION_RETRY_TIMEOUT),
+        EventAdmission::Generic,
+    )
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EventAdmission {
+    Generic,
+    CodexProtocol,
+}
+
+fn ingest_event_retry_with_admission(
+    context: &CliContext,
+    id: &str,
+    event: TurnEvent,
+    admission: EventAdmission,
+) -> Result<ActivityResult, CliError> {
+    ingest_event_with_lock(
+        context,
+        id,
+        event,
+        ActivityLockMode::Timed(CODEX_COMPLETION_RETRY_TIMEOUT),
+        admission,
     )
 }
 
@@ -2450,8 +2520,9 @@ fn ingest_event_with_lock(
     id: &str,
     mut event: TurnEvent,
     lock_mode: ActivityLockMode,
+    admission: EventAdmission,
 ) -> Result<ActivityResult, CliError> {
-    validate_event(&event)?;
+    validate_event(&event, admission)?;
     let observed = load_session_record(context, id)?;
     let record_lock = match lock_mode {
         ActivityLockMode::Blocking => crate::acquire_session_record_lock(context, &observed.id)?,
@@ -2475,6 +2546,15 @@ fn ingest_event_with_lock(
             "activity-provider-mismatch",
             "activity event provider does not match the session provider",
             Some(json!({ "id": record.id, "provider": event.provider })),
+        ));
+    }
+    if admission == EventAdmission::CodexProtocol
+        && !crate::codex_app_server::runtime_is_supported(&record)
+    {
+        return Err(CliError::data(
+            "activity-provider-protocol-mismatch",
+            "provider-protocol activity requires the bound Codex app-server runtime",
+            Some(json!({ "id": record.id })),
         ));
     }
     let active_runtime = record.runtime.as_ref();
@@ -7246,7 +7326,7 @@ mod tests {
                 expected
             );
             for event in normalized {
-                validate_event(&event).expect("normalized fixture event");
+                validate_event(&event, EventAdmission::Generic).expect("normalized fixture event");
                 let serialized = serde_json::to_string(&event).expect("normalized event json");
                 assert!(!serialized.contains("codex-session"));
                 assert!(!serialized.contains("claude-session"));
@@ -8190,7 +8270,7 @@ mod tests {
         let events = include_str!("../tests/fixtures/activity/turn-events.jsonl");
         for line in events.lines() {
             let event: TurnEvent = serde_json::from_str(line).expect("turn event fixture");
-            validate_event(&event).expect("valid turn event fixture");
+            validate_event(&event, EventAdmission::Generic).expect("valid turn event fixture");
         }
         let states: Vec<TurnState> =
             serde_json::from_str(include_str!("../tests/fixtures/activity/turn-states.json"))
@@ -8227,10 +8307,32 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn provider_capacity_is_reserved_for_internal_protocol_v2_admission() {
+        let mut capacity = event(TurnEventKind::TurnFailed, "provider-capacity");
+        capacity.confidence = Confidence::Authoritative;
+        capacity.source_kind = SourceKind::ProviderHook;
+        capacity.failure_reason = Some("provider_capacity".to_string());
+
+        let v1_error = validate_event(&capacity, EventAdmission::Generic)
+            .expect_err("the closed public v1 failure union must reject provider capacity");
+        assert_eq!(v1_error.code(), "activity-failure-reason-invalid");
+
+        capacity.schema_version = CODEX_PROTOCOL_TURN_EVENT_VERSION.to_string();
+        let generic_v2_error = validate_event(&capacity, EventAdmission::Generic)
+            .expect_err("generic activity ingress must not impersonate provider protocol v2");
+        assert_eq!(generic_v2_error.code(), "unsupported-turn-event-version");
+        validate_event(&capacity, EventAdmission::CodexProtocol)
+            .expect("internal protocol admission accepts the exact v2 capacity reason");
+    }
 }
 
-fn validate_event(event: &TurnEvent) -> Result<(), CliError> {
-    if event.schema_version != TURN_EVENT_VERSION {
+fn validate_event(event: &TurnEvent, admission: EventAdmission) -> Result<(), CliError> {
+    let schema_supported = event.schema_version == TURN_EVENT_VERSION
+        || (admission == EventAdmission::CodexProtocol
+            && event.schema_version == CODEX_PROTOCOL_TURN_EVENT_VERSION);
+    if !schema_supported {
         return Err(CliError::data(
             "unsupported-turn-event-version",
             format!(
@@ -8298,26 +8400,30 @@ fn validate_event(event: &TurnEvent) -> Result<(), CliError> {
             None,
         ));
     }
-    if let Some(reason) = event.failure_reason.as_deref()
-        && (event.kind != TurnEventKind::TurnFailed
+    if let Some(reason) = event.failure_reason.as_deref() {
+        let reason_allowed = matches!(
+            reason,
+            "usage_exhausted"
+                | "authentication"
+                | "organization"
+                | "billing"
+                | "invalid_request"
+                | "service"
+                | "max_output_tokens"
+                | "unknown"
+        ) || (reason == "provider_capacity"
+            && admission == EventAdmission::CodexProtocol
+            && event.schema_version == CODEX_PROTOCOL_TURN_EVENT_VERSION);
+        if event.kind != TurnEventKind::TurnFailed
             || event.confidence != Confidence::Authoritative
-            || !matches!(
-                reason,
-                "usage_exhausted"
-                    | "authentication"
-                    | "organization"
-                    | "billing"
-                    | "invalid_request"
-                    | "service"
-                    | "max_output_tokens"
-                    | "unknown"
-            ))
-    {
-        return Err(CliError::data(
-            "activity-failure-reason-invalid",
-            "failure_reason requires an authoritative turn_failed event and an allowlisted value",
-            None,
-        ));
+            || !reason_allowed
+        {
+            return Err(CliError::data(
+                "activity-failure-reason-invalid",
+                "failure_reason requires an authoritative turn_failed event and an allowlisted value",
+                None,
+            ));
+        }
     }
     if let Some(provider_time) = event.provider_time.as_deref() {
         let parsed = provider_time.parse::<jiff::Timestamp>().map_err(|_| {
@@ -8553,7 +8659,16 @@ fn reduce(document: &mut ActivityDocument, event: &TurnEvent, at: &str) {
                     } else {
                         "completed".to_string()
                     },
-                    extra,
+                    extra: if event.failure_reason.as_deref() == Some("provider_capacity") {
+                        let mut extra = extra;
+                        extra.insert(
+                            "provider_failure_kind".to_string(),
+                            json!("provider_capacity"),
+                        );
+                        extra
+                    } else {
+                        extra
+                    },
                 });
                 document.pending_attention.clear();
                 document.overflow_attention = None;

--- a/crates/agent-session/src/codex_app_server.rs
+++ b/crates/agent-session/src/codex_app_server.rs
@@ -1,9 +1,10 @@
 //! Strict metadata-only projection of the Codex app-server v2 protocol.
 //!
 //! The interactive TUI's human-readable error text is intentionally ignored.
-//! Auto-resume is armed only when the live protocol reports both an exact
-//! `usageLimitExceeded` error and a matching terminal `failed` completion for
-//! the same bound thread and turn.
+//! Structured failures are admitted only when the live protocol reports an
+//! allowlisted `codexErrorInfo` and a matching terminal `failed` completion for
+//! the same bound thread and turn. Auto-resume remains exclusive to
+//! `usageLimitExceeded`; `serverOverloaded` is projected as provider capacity.
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::env;
@@ -1430,17 +1431,41 @@ pub(crate) fn cleanup_runtime_files(
     Ok(())
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StructuredFailureKind {
+    UsageExhausted,
+    ProviderCapacity,
+}
+
+impl StructuredFailureKind {
+    pub(crate) fn activity_reason(self) -> &'static str {
+        match self {
+            Self::UsageExhausted => "usage_exhausted",
+            Self::ProviderCapacity => "provider_capacity",
+        }
+    }
+
+    fn from_codex_error_info(value: &str) -> Option<Self> {
+        match value {
+            "usageLimitExceeded" => Some(Self::UsageExhausted),
+            "serverOverloaded" => Some(Self::ProviderCapacity),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct UsageFailure {
+pub(crate) struct StructuredFailure {
     pub(crate) thread_id: String,
     pub(crate) turn_id: String,
+    pub(crate) kind: StructuredFailureKind,
 }
 
 #[derive(Debug)]
 pub(crate) struct FailureReducer {
     thread_id: String,
-    exhausted_turns: BTreeSet<String>,
-    exhausted_order: VecDeque<String>,
+    pending_turns: BTreeMap<String, Option<StructuredFailureKind>>,
+    pending_order: VecDeque<String>,
     completed_turns: BTreeSet<String>,
     completed_order: VecDeque<String>,
 }
@@ -1449,35 +1474,36 @@ impl FailureReducer {
     pub(crate) fn new(thread_id: impl Into<String>) -> Self {
         Self {
             thread_id: thread_id.into(),
-            exhausted_turns: BTreeSet::new(),
-            exhausted_order: VecDeque::new(),
+            pending_turns: BTreeMap::new(),
+            pending_order: VecDeque::new(),
             completed_turns: BTreeSet::new(),
             completed_order: VecDeque::new(),
         }
     }
 
-    pub(crate) fn ingest(&mut self, message: &Value) -> Option<UsageFailure> {
+    pub(crate) fn ingest(&mut self, message: &Value) -> Option<StructuredFailure> {
         match message.get("method").and_then(Value::as_str) {
             Some("error") => {
                 let params = message.get("params")?;
                 if params.get("threadId").and_then(Value::as_str) != Some(self.thread_id.as_str())
                     || params.get("willRetry").and_then(Value::as_bool) != Some(false)
-                    || params
-                        .pointer("/error/codexErrorInfo")
-                        .and_then(Value::as_str)
-                        != Some("usageLimitExceeded")
                 {
                     return None;
                 }
+                let kind = params
+                    .pointer("/error/codexErrorInfo")
+                    .and_then(Value::as_str)
+                    .and_then(StructuredFailureKind::from_codex_error_info)?;
                 let turn_id = params
                     .get("turnId")
                     .and_then(Value::as_str)
                     .filter(|turn_id| protocol_id_is_valid(turn_id))?;
                 if !self.completed_turns.contains(turn_id) {
-                    insert_bounded_id(
-                        &mut self.exhausted_turns,
-                        &mut self.exhausted_order,
+                    insert_bounded_failure(
+                        &mut self.pending_turns,
+                        &mut self.pending_order,
                         turn_id,
+                        kind,
                     );
                 }
                 None
@@ -1493,28 +1519,67 @@ impl FailureReducer {
                     .pointer("/turn/id")
                     .and_then(Value::as_str)
                     .filter(|turn_id| protocol_id_is_valid(turn_id))?;
-                let embedded_usage_exhaustion = params
+                let embedded_kind = params
                     .pointer("/turn/error/codexErrorInfo")
                     .and_then(Value::as_str)
-                    == Some("usageLimitExceeded");
-                let matched_error = remove_bounded_id(
-                    &mut self.exhausted_turns,
-                    &mut self.exhausted_order,
+                    .and_then(StructuredFailureKind::from_codex_error_info);
+                let matched_kind = remove_bounded_failure(
+                    &mut self.pending_turns,
+                    &mut self.pending_order,
                     turn_id,
-                );
+                )
+                .flatten();
                 insert_bounded_id(
                     &mut self.completed_turns,
                     &mut self.completed_order,
                     turn_id,
                 );
-                (embedded_usage_exhaustion || matched_error).then(|| UsageFailure {
+                let kind = embedded_kind.or(matched_kind);
+                kind.map(|kind| StructuredFailure {
                     thread_id: self.thread_id.clone(),
                     turn_id: turn_id.to_string(),
+                    kind,
                 })
             }
             _ => None,
         }
     }
+}
+
+fn insert_bounded_failure(
+    pending: &mut BTreeMap<String, Option<StructuredFailureKind>>,
+    order: &mut VecDeque<String>,
+    id: &str,
+    kind: StructuredFailureKind,
+) {
+    if let Some(existing) = pending.get_mut(id) {
+        if existing.is_some_and(|existing| existing != kind) {
+            *existing = None;
+        }
+        return;
+    }
+    while pending.len() >= MAX_REDUCER_PENDING_TURNS {
+        let Some(oldest) = order.pop_front() else {
+            break;
+        };
+        pending.remove(&oldest);
+    }
+    pending.insert(id.to_string(), Some(kind));
+    order.push_back(id.to_string());
+}
+
+fn remove_bounded_failure(
+    pending: &mut BTreeMap<String, Option<StructuredFailureKind>>,
+    order: &mut VecDeque<String>,
+    id: &str,
+) -> Option<Option<StructuredFailureKind>> {
+    let removed = pending.remove(id);
+    if removed.is_some()
+        && let Some(index) = order.iter().position(|candidate| candidate == id)
+    {
+        order.remove(index);
+    }
+    removed
 }
 
 fn insert_bounded_id(set: &mut BTreeSet<String>, order: &mut VecDeque<String>, id: &str) {
@@ -1530,16 +1595,6 @@ fn insert_bounded_id(set: &mut BTreeSet<String>, order: &mut VecDeque<String>, i
     let owned = id.to_string();
     set.insert(owned.clone());
     order.push_back(owned);
-}
-
-fn remove_bounded_id(set: &mut BTreeSet<String>, order: &mut VecDeque<String>, id: &str) -> bool {
-    if !set.remove(id) {
-        return false;
-    }
-    if let Some(index) = order.iter().position(|item| item == id) {
-        order.remove(index);
-    }
-    true
 }
 
 pub(crate) fn initialize_request(id: u64) -> Value {
@@ -4100,12 +4155,13 @@ async fn process_live_message(
         .map(|runtime| runtime.launch_id.clone())
         .ok_or_else(|| "Codex runtime identity is missing".to_string())?;
     tokio::task::spawn_blocking(move || {
-        crate::activity::ingest_codex_app_server_failure(
+        crate::activity::ingest_codex_app_server_failure_with_kind(
             &context,
             &id,
             &runtime_id,
             &failure.thread_id,
             &failure.turn_id,
+            failure.kind,
         )
     })
     .await
@@ -5644,15 +5700,160 @@ printf '%s\n' '{"schema_version":"agent-session.codex-auth-broker.v1","account":
                 "method": "turn/completed",
                 "params": { "threadId": "thread-a", "turn": { "id": "turn-a", "status": "failed" } }
             })),
-            Some(UsageFailure {
+            Some(StructuredFailure {
                 thread_id: "thread-a".into(),
-                turn_id: "turn-a".into()
+                turn_id: "turn-a".into(),
+                kind: StructuredFailureKind::UsageExhausted,
             })
         );
         assert_eq!(
             reducer.ingest(&error),
             None,
             "a completed turn cannot be re-armed"
+        );
+    }
+
+    #[test]
+    fn reducer_admits_exact_server_overload_as_a_structured_capacity_failure() {
+        let mut reducer = FailureReducer::new("thread-a");
+        assert_eq!(
+            reducer.ingest(&json!({
+                "method": "error",
+                "params": {
+                    "threadId": "thread-a",
+                    "turnId": "turn-capacity",
+                    "willRetry": false,
+                    "error": {
+                        "message": "Selected model is at capacity",
+                        "codexErrorInfo": "serverOverloaded"
+                    }
+                }
+            })),
+            None
+        );
+        assert_eq!(
+            reducer.ingest(&json!({
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-a",
+                    "turn": { "id": "turn-capacity", "status": "failed" }
+                }
+            })),
+            Some(StructuredFailure {
+                thread_id: "thread-a".into(),
+                turn_id: "turn-capacity".into(),
+                kind: StructuredFailureKind::ProviderCapacity,
+            }),
+            "the exact structured serverOverloaded enum must survive the matched failed completion",
+        );
+    }
+
+    #[test]
+    fn structured_provider_capacity_is_projected_without_arming_usage_resume() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = CliContext {
+            state_dir: tmp.path().join("state"),
+            host: None,
+        };
+        let record = record_with_runtime("provider-capacity", &tmp.path().join("unused.sock"));
+        fs::create_dir_all(crate::session_dir(&context, &record.id)).unwrap();
+        crate::write_session_record(&context, &record).unwrap();
+        crate::activity::activate_runtime(&context, &record).unwrap();
+        crate::auto_resume::set_enabled(&context, &record.id, true, "2030-01-01T00:00:00Z")
+            .unwrap();
+
+        let result = crate::activity::ingest_codex_app_server_failure_with_kind(
+            &context,
+            &record.id,
+            &record.runtime.as_ref().unwrap().launch_id,
+            "thread-capacity",
+            "turn-capacity",
+            StructuredFailureKind::ProviderCapacity,
+        )
+        .unwrap();
+
+        assert_eq!(
+            result
+                .turn_state
+                .last_turn
+                .as_ref()
+                .and_then(crate::activity::LastTurn::provider_failure_kind),
+            Some("provider_capacity")
+        );
+        assert_eq!(
+            crate::auto_resume::view_for_record(&context, &record).state,
+            "enabled",
+            "provider capacity is not account usage exhaustion and must not arm auto-resume"
+        );
+    }
+
+    #[test]
+    fn reducer_fails_closed_for_conflicting_failure_kinds_on_one_turn() {
+        for kinds in [
+            ["usageLimitExceeded", "serverOverloaded"],
+            ["serverOverloaded", "usageLimitExceeded"],
+        ] {
+            let mut reducer = FailureReducer::new("thread-a");
+            for kind in kinds {
+                assert_eq!(
+                    reducer.ingest(&json!({
+                        "method": "error",
+                        "params": {
+                            "threadId": "thread-a",
+                            "turnId": "turn-conflict",
+                            "willRetry": false,
+                            "error": { "codexErrorInfo": kind }
+                        }
+                    })),
+                    None
+                );
+            }
+            assert_eq!(
+                reducer.ingest(&json!({
+                    "method": "turn/completed",
+                    "params": {
+                        "threadId": "thread-a",
+                        "turn": { "id": "turn-conflict", "status": "failed" }
+                    }
+                })),
+                None,
+                "conflicting structured evidence must never select the retry-authorizing usage branch"
+            );
+        }
+
+        let mut embedded = FailureReducer::new("thread-a");
+        for kind in ["usageLimitExceeded", "serverOverloaded"] {
+            assert_eq!(
+                embedded.ingest(&json!({
+                    "method": "error",
+                    "params": {
+                        "threadId": "thread-a",
+                        "turnId": "turn-embedded",
+                        "willRetry": false,
+                        "error": { "codexErrorInfo": kind }
+                    }
+                })),
+                None
+            );
+        }
+        assert_eq!(
+            embedded.ingest(&json!({
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-a",
+                    "turn": {
+                        "id": "turn-embedded",
+                        "status": "failed",
+                        "error": { "codexErrorInfo": "serverOverloaded" }
+                    }
+                }
+            })),
+            Some(StructuredFailure {
+                thread_id: "thread-a".into(),
+                turn_id: "turn-embedded".into(),
+                kind: StructuredFailureKind::ProviderCapacity,
+            }),
+            "the terminal completion's embedded structured kind resolves earlier conflicting frames"
         );
     }
 
@@ -5687,9 +5888,10 @@ printf '%s\n' '{"schema_version":"agent-session.codex-auth-broker.v1","account":
                     }
                 }
             })),
-            Some(UsageFailure {
+            Some(StructuredFailure {
                 thread_id: "thread-a".into(),
-                turn_id: "turn-b".into()
+                turn_id: "turn-b".into(),
+                kind: StructuredFailureKind::UsageExhausted,
             })
         );
     }
@@ -5721,7 +5923,7 @@ printf '%s\n' '{"schema_version":"agent-session.codex-auth-broker.v1","account":
                 None
             );
         }
-        assert_eq!(reducer.exhausted_turns.len(), MAX_REDUCER_PENDING_TURNS);
+        assert_eq!(reducer.pending_turns.len(), MAX_REDUCER_PENDING_TURNS);
         assert_eq!(reducer.completed_turns.len(), MAX_REDUCER_PENDING_TURNS);
         let oversized = "x".repeat(MAX_PROTOCOL_ID_BYTES + 1);
         assert_eq!(
@@ -5736,7 +5938,7 @@ printf '%s\n' '{"schema_version":"agent-session.codex-auth-broker.v1","account":
             })),
             None
         );
-        assert_eq!(reducer.exhausted_turns.len(), MAX_REDUCER_PENDING_TURNS);
+        assert_eq!(reducer.pending_turns.len(), MAX_REDUCER_PENDING_TURNS);
     }
 
     #[test]
@@ -7427,12 +7629,13 @@ printf '%s\n' '{"schema_version":"agent-session.codex-auth-broker.v1","account":
                 }
             }))
             .unwrap();
-        crate::activity::ingest_codex_app_server_failure(
+        crate::activity::ingest_codex_app_server_failure_with_kind(
             &context,
             &target.id,
             &target.runtime.as_ref().unwrap().launch_id,
             &failure.thread_id,
             &failure.turn_id,
+            failure.kind,
         )
         .unwrap();
 
@@ -8199,12 +8402,13 @@ printf '%s\n' "{\"schema_version\":\"agent-session.codex-auth-broker.v1\",\"acco
         .unwrap();
         record = crate::load_session_record(&context, &record.id).unwrap();
         crate::activity::activate_runtime(&context, &record).unwrap();
-        crate::activity::ingest_codex_app_server_failure(
+        crate::activity::ingest_codex_app_server_failure_with_kind(
             &context,
             &record.id,
             "runtime-failed-reconnect",
             "thread-failed",
             "turn-failed",
+            StructuredFailureKind::UsageExhausted,
         )
         .unwrap();
         bind_thread(&record, "raw-thread-failed").unwrap();
@@ -8446,12 +8650,13 @@ printf '%s\n' "{\"schema_version\":\"agent-session.codex-auth-broker.v1\",\"acco
         crate::activity::activate_runtime(&context, &record).unwrap();
         crate::auto_resume::set_enabled(&context, &record.id, true, "2030-01-01T00:00:00Z")
             .unwrap();
-        crate::activity::ingest_codex_app_server_failure(
+        crate::activity::ingest_codex_app_server_failure_with_kind(
             &context,
             &record.id,
             &record.runtime.as_ref().unwrap().launch_id,
             "thread-a",
             "failed-turn",
+            StructuredFailureKind::UsageExhausted,
         )
         .unwrap();
         assert_eq!(
@@ -9935,12 +10140,13 @@ printf '%s\n' "{\"schema_version\":\"agent-session.codex-auth-broker.v1\",\"acco
         crate::activity::activate_runtime(&context, &record).unwrap();
         crate::auto_resume::set_enabled(&context, &record.id, true, "2030-01-01T00:00:00Z")
             .unwrap();
-        crate::activity::ingest_codex_app_server_failure(
+        crate::activity::ingest_codex_app_server_failure_with_kind(
             &context,
             &record.id,
             &record.runtime.as_ref().unwrap().launch_id,
             "thread-a",
             "failed-turn",
+            StructuredFailureKind::UsageExhausted,
         )
         .unwrap();
         crate::auto_resume::tick_for_runtime(

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -8730,6 +8730,7 @@ fn run_worker_diagnose(context: &CliContext, args: WorkerDiagnoseArgs) -> Result
 fn run_worker_supervise(context: &CliContext, args: WorkerDiagnoseArgs) -> Result<Value, CliError> {
     let diagnosis = diagnose_worker(context, &args.assignment_id)?;
     let schema_version = match diagnosis["schema_version"].as_str() {
+        Some("main-agent.worker-diagnose-result.v7") => "main-agent.worker-supervise-result.v7",
         Some("main-agent.worker-diagnose-result.v6") => "main-agent.worker-supervise-result.v6",
         Some("main-agent.worker-diagnose-result.v5") => "main-agent.worker-supervise-result.v5",
         Some("main-agent.worker-diagnose-result.v4") => "main-agent.worker-supervise-result.v4",
@@ -8984,6 +8985,21 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
         || activity
             .and_then(|state| state.last_turn.as_ref())
             .is_some_and(|turn| bounded_quota_outcome(&turn.outcome));
+    let provider_capacity_evidence = matches!(
+        assignment.state.as_str(),
+        "starting" | "working" | "blocked"
+    ) && assignment.worker.is_some()
+        && worker_status == "running"
+        && activity.is_some_and(|state| {
+            state.phase == crate::activity::TurnPhase::Waiting
+                && state.current_turn.is_none()
+                && state.source.confidence == crate::activity::Confidence::Authoritative
+                && state.source.kind == crate::activity::SourceKind::ProviderHook
+                && state.last_turn.as_ref().is_some_and(|turn| {
+                    turn.outcome == "failed"
+                        && turn.provider_failure_kind() == Some("provider_capacity")
+                })
+        });
     // Guidance is projected from the same locked coordination snapshot when
     // that snapshot is usable. Any lock/schema failure is already represented
     // by coordination evidence, so it must not create a second, higher
@@ -9175,7 +9191,7 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
     };
     let claimed_runtime_stop_in_flight = claimed_runtime_stop_replay.is_some();
     let claim_revocation_in_flight = assignment.claim_revocation.is_some();
-    let readiness_stop_required = assignment.state == "starting"
+    let readiness_exhausted = assignment.state == "starting"
         && assignment.worker.as_ref().is_some_and(|worker| {
             has_exhausted_worker_start_readiness(
                 &registry,
@@ -9184,7 +9200,9 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
                 &assignment,
                 worker,
             )
-        })
+        });
+    let readiness_stop_required = assignment.state == "starting"
+        && readiness_exhausted
         && worker_status == "running"
         && !claim_active
         && active_operations == 0
@@ -9193,6 +9211,23 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
         && !account_handoff_in_flight
         && !runtime_stop_in_flight
         && !claim_revocation_in_flight;
+    let pre_bootstrap_attention_required =
+        worker_pre_bootstrap_attention_required(PreBootstrapEvidence {
+            assignment_state: &assignment.state,
+            worker_bound: assignment.worker.is_some(),
+            worker_status: &worker_status,
+            claim_active,
+            operations_quiescent: active_operations == 0 && uncertain_operations == 0,
+            readiness_exhausted,
+            recovery_in_flight: submit_recovery_in_flight(&assignment)
+                || account_handoff_in_flight
+                || runtime_stop_in_flight
+                || claim_revocation_in_flight,
+            blocker_or_terminal_evidence: preclaim_blocker
+                || provider_terminated
+                || terminal_recovery_reconciled
+                || startup_dialog,
+        });
     let idle_claim_revocation_required =
         matches!(assignment.state.as_str(), "working" | "accepted")
             && assignment.worker.is_some()
@@ -9267,6 +9302,8 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
         claim_revocation_in_flight,
         account_handoff_in_flight,
         readiness_stop_required,
+        pre_bootstrap_attention_required,
+        provider_capacity_attention_required: provider_capacity_evidence,
         idle_claim_revocation_required,
         coordination_broker_stale,
         edit_authority_stale,
@@ -9324,6 +9361,11 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
         })
     });
     let diagnosis_schema = if matches!(
+        classification,
+        "pre_bootstrap_attention_required" | "provider_capacity_attention_required"
+    ) {
+        "main-agent.worker-diagnose-result.v7"
+    } else if matches!(
         classification,
         "provider_stop_canary_release_in_progress"
             | "provider_process_stopped_wrapper_live"
@@ -9436,7 +9478,22 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
             }
         }
     });
-    if diagnosis_schema == "main-agent.worker-diagnose-result.v6" {
+    if diagnosis_schema == "main-agent.worker-diagnose-result.v7" {
+        diagnosis["attention"] = json!({
+            "kind": if classification == "provider_capacity_attention_required" {
+                "provider_capacity"
+            } else {
+                "pre_bootstrap"
+            },
+            "source": if classification == "provider_capacity_attention_required" {
+                "provider_protocol"
+            } else {
+                "coordination_state"
+            },
+            "provider_input_authorized": false,
+            "account_change_authorized": false
+        });
+    } else if diagnosis_schema == "main-agent.worker-diagnose-result.v6" {
         diagnosis["provider_stop_canary"] = json!({
             "authorized": provider_stop_canary_authorized,
             "provider_process_stopped": provider_process_stopped_wrapper_live,
@@ -9500,6 +9557,16 @@ fn worker_recovery_action(
         "argv": supervise
     });
     match classification {
+        "pre_bootstrap_attention_required" | "provider_capacity_attention_required" => {
+            action["schema_version"] = json!("main-agent.worker-recovery-action.v7");
+            action["kind"] = json!(
+                if classification == "provider_capacity_attention_required" {
+                    "bounded_provider_capacity_recheck"
+                } else {
+                    "bounded_bootstrap_attention_recheck"
+                }
+            );
+        }
         "provider_stop_canary_release_in_progress" => {
             action["schema_version"] = json!("main-agent.worker-recovery-action.v6");
             debug_assert!(provider_stop_canary_authorized);
@@ -9921,6 +9988,14 @@ struct WorkerDiagnosisFacts {
     /// proving bounded authenticated-checkpoint readiness exhausted. It has no
     /// worker claim or operation and no unknown recovery send in flight.
     readiness_stop_required: bool,
+    /// A live starting worker is still inside the authenticated bootstrap
+    /// window: it has no assignment claim yet, but no terminal or readiness
+    /// failure owns the lane. Claim renewal is impossible before bootstrap.
+    pre_bootstrap_attention_required: bool,
+    /// Exact provider-protocol evidence reports temporary model/service
+    /// capacity. This is distinct from account quota and never authorizes an
+    /// account switch or provider input.
+    provider_capacity_attention_required: bool,
     /// A live worker has authoritatively returned to an idle provider boundary
     /// while its exact assignment-derived claim and broker remain active, with
     /// no active or uncertain operation. Main can fence that authority without
@@ -10044,6 +10119,12 @@ fn classify_worker_diagnosis(facts: WorkerDiagnosisFacts) -> (&'static str, &'st
             "complete the exact reserved account handoff, or run the projected revision-fenced `main-agent worker account-handoff-cancel` action before any runtime stop or assignment transition",
             false,
         )
+    } else if facts.provider_capacity_attention_required {
+        (
+            "provider_capacity_attention_required",
+            "preserve the exact worker and provider conversation, wait for model/service capacity, and continue bounded supervision; do not switch accounts, resend the prompt, or send raw terminal input",
+            false,
+        )
     } else if facts.readiness_stop_required {
         (
             "readiness_stop_required",
@@ -10066,6 +10147,12 @@ fn classify_worker_diagnosis(facts: WorkerDiagnosisFacts) -> (&'static str, &'st
         (
             "edit_authority_stale",
             "preserve the exact worker and perform a bounded supervision recheck so the broker heartbeat sidecar can refresh; if durable broker-lost evidence appears, route to exact-session authenticated broker recovery rather than renewing the work-context claim",
+            false,
+        )
+    } else if facts.pre_bootstrap_attention_required {
+        (
+            "pre_bootstrap_attention_required",
+            "preserve the live starting worker and continue bounded authenticated-bootstrap supervision; no claim exists to renew, and no provider input or replacement is authorized",
             false,
         )
     } else if facts.claim_renewal_required {
@@ -10265,6 +10352,29 @@ fn worker_claim_renewal_required(
             || (!broker_authoritative
                 && claim_expires_in_seconds
                     .is_some_and(|remaining| remaining <= WORKER_CLAIM_RENEWAL_RISK_SECS)))
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PreBootstrapEvidence<'a> {
+    assignment_state: &'a str,
+    worker_bound: bool,
+    worker_status: &'a str,
+    claim_active: bool,
+    operations_quiescent: bool,
+    readiness_exhausted: bool,
+    recovery_in_flight: bool,
+    blocker_or_terminal_evidence: bool,
+}
+
+fn worker_pre_bootstrap_attention_required(evidence: PreBootstrapEvidence<'_>) -> bool {
+    evidence.assignment_state == "starting"
+        && evidence.worker_bound
+        && evidence.worker_status == "running"
+        && !evidence.claim_active
+        && evidence.operations_quiescent
+        && !evidence.readiness_exhausted
+        && !evidence.recovery_in_flight
+        && !evidence.blocker_or_terminal_evidence
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -30160,6 +30270,84 @@ mod tests {
         );
     }
 
+    #[test]
+    fn live_pre_bootstrap_worker_without_claim_requires_attention_before_renewal() {
+        let live_starting = PreBootstrapEvidence {
+            assignment_state: "starting",
+            worker_bound: true,
+            worker_status: "running",
+            claim_active: false,
+            operations_quiescent: true,
+            readiness_exhausted: false,
+            recovery_in_flight: false,
+            blocker_or_terminal_evidence: false,
+        };
+        assert!(worker_pre_bootstrap_attention_required(live_starting));
+        for (guard, evidence) in [
+            (
+                "assignment state",
+                PreBootstrapEvidence {
+                    assignment_state: "working",
+                    ..live_starting
+                },
+            ),
+            (
+                "worker binding",
+                PreBootstrapEvidence {
+                    worker_bound: false,
+                    ..live_starting
+                },
+            ),
+            (
+                "running runtime",
+                PreBootstrapEvidence {
+                    worker_status: "stopped",
+                    ..live_starting
+                },
+            ),
+            (
+                "absent claim",
+                PreBootstrapEvidence {
+                    claim_active: true,
+                    ..live_starting
+                },
+            ),
+            (
+                "quiescent operations",
+                PreBootstrapEvidence {
+                    operations_quiescent: false,
+                    ..live_starting
+                },
+            ),
+            (
+                "unexhausted readiness",
+                PreBootstrapEvidence {
+                    readiness_exhausted: true,
+                    ..live_starting
+                },
+            ),
+            (
+                "absent recovery owner",
+                PreBootstrapEvidence {
+                    recovery_in_flight: true,
+                    ..live_starting
+                },
+            ),
+            (
+                "absent blocker or terminal evidence",
+                PreBootstrapEvidence {
+                    blocker_or_terminal_evidence: true,
+                    ..live_starting
+                },
+            ),
+        ] {
+            assert!(
+                !worker_pre_bootstrap_attention_required(evidence),
+                "pre-bootstrap attention must require {guard}"
+            );
+        }
+    }
+
     /// Neutral supervision facts: every signal absent, so a single flipped
     /// field isolates exactly one classification.
     fn base_diagnosis_facts() -> WorkerDiagnosisFacts {
@@ -30173,6 +30361,8 @@ mod tests {
             claim_revocation_in_flight: false,
             account_handoff_in_flight: false,
             readiness_stop_required: false,
+            pre_bootstrap_attention_required: false,
+            provider_capacity_attention_required: false,
             idle_claim_revocation_required: false,
             coordination_broker_stale: false,
             edit_authority_stale: false,
@@ -31002,6 +31192,26 @@ mod tests {
         assert_eq!(classify_worker_diagnosis(base).0, "healthy_progress");
         assert_eq!(
             classify_worker_diagnosis(WorkerDiagnosisFacts {
+                pre_bootstrap_attention_required: true,
+                claim_renewal_required: true,
+                ..base
+            })
+            .0,
+            "pre_bootstrap_attention_required",
+            "a claim cannot be renewed before authenticated bootstrap creates it"
+        );
+        assert_eq!(
+            classify_worker_diagnosis(WorkerDiagnosisFacts {
+                provider_capacity_attention_required: true,
+                claim_renewal_required: true,
+                ..base
+            })
+            .0,
+            "provider_capacity_attention_required",
+            "exact provider capacity evidence must outrank generic claim renewal"
+        );
+        assert_eq!(
+            classify_worker_diagnosis(WorkerDiagnosisFacts {
                 evidence_unavailable: true,
                 ..base
             })
@@ -31019,6 +31229,7 @@ mod tests {
         assert_eq!(
             classify_worker_diagnosis(WorkerDiagnosisFacts {
                 readiness_stop_required: true,
+                pre_bootstrap_attention_required: true,
                 idle_claim_revocation_required: true,
                 claim_renewal_required: true,
                 ..base
@@ -31030,6 +31241,7 @@ mod tests {
         assert_eq!(
             classify_worker_diagnosis(WorkerDiagnosisFacts {
                 claim_revocation_in_flight: true,
+                pre_bootstrap_attention_required: true,
                 evidence_unavailable: true,
                 worker_unreachable: true,
                 post_claim_runtime_gone: true,
@@ -31167,6 +31379,7 @@ mod tests {
         assert_eq!(
             classify_worker_diagnosis(WorkerDiagnosisFacts {
                 active_or_uncertain_operation: true,
+                pre_bootstrap_attention_required: true,
                 startup_dialog: true,
                 preclaim_blocker: true,
                 ..base
@@ -31204,6 +31417,8 @@ mod tests {
             "evidence_unavailable",
             "worker_unreachable",
             "uncertain_mutation",
+            "pre_bootstrap_attention_required",
+            "provider_capacity_attention_required",
             "readiness_stop_required",
             "idle_claim_revocation_in_progress",
             "idle_claim_revocation_required",
@@ -31231,6 +31446,11 @@ mod tests {
                 None,
             );
             let expected_schema = if matches!(
+                classification,
+                "pre_bootstrap_attention_required" | "provider_capacity_attention_required"
+            ) {
+                "main-agent.worker-recovery-action.v7"
+            } else if matches!(
                 classification,
                 "idle_claim_revocation_required" | "idle_claim_revocation_in_progress"
             ) {

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -438,6 +438,26 @@ fn seed_activity_state(
     current_turn: serde_json::Value,
     last_turn: serde_json::Value,
 ) {
+    seed_activity_state_with_source(
+        state_dir,
+        id,
+        incarnation,
+        phase,
+        "runtime",
+        current_turn,
+        last_turn,
+    );
+}
+
+fn seed_activity_state_with_source(
+    state_dir: &Path,
+    id: &str,
+    incarnation: &str,
+    phase: &str,
+    source_kind: &str,
+    current_turn: serde_json::Value,
+    last_turn: serde_json::Value,
+) {
     let path = state_dir.join("sessions").join(id).join("activity.json");
     write_private_json(
         &path,
@@ -451,7 +471,7 @@ fn seed_activity_state(
                 "phase_changed_at": "2030-01-01T00:00:00Z",
                 "revision": 1,
                 "source": {
-                    "kind": "runtime",
+                    "kind": source_kind,
                     "provider": null,
                     "confidence": "authoritative"
                 },
@@ -27546,6 +27566,135 @@ fn main_agent_supervise_exposes_the_fail_closed_classification_matrix_without_mu
             .map(String::as_str)
             .collect::<BTreeSet<_>>(),
         expected_diagnose_keys
+    );
+
+    rewrite_orchestration_registry(&state_dir, |registry| {
+        registry["assignments"]["assignment-matrix"]["state"] = json!("starting");
+    });
+    rewrite_registry(&state_dir, |registry| {
+        let claim = registry["claims"]
+            .as_array_mut()
+            .expect("claims")
+            .iter_mut()
+            .find(|claim| claim["claim_id"] == "worker-matrix-claim")
+            .expect("worker matrix claim");
+        claim["state"] = json!("released");
+    });
+    let pre_bootstrap = supervise();
+    assert_eq!(
+        pre_bootstrap.code,
+        0,
+        "stderr={}",
+        pre_bootstrap.stderr_text()
+    );
+    assert_eq!(
+        data(&pre_bootstrap)["classification"],
+        "pre_bootstrap_attention_required"
+    );
+    assert_eq!(
+        data(&pre_bootstrap)["schema_version"],
+        "main-agent.worker-supervise-result.v7"
+    );
+    assert_eq!(
+        data(&pre_bootstrap)["last_proven_safe_state"]["attention"]["kind"],
+        "pre_bootstrap"
+    );
+    assert_eq!(
+        data(&pre_bootstrap)["recovery_action"]["kind"],
+        "bounded_bootstrap_attention_recheck"
+    );
+    assert_eq!(data(&pre_bootstrap)["automatic_retry_safe"], false);
+    rewrite_orchestration_registry(&state_dir, |registry| {
+        registry["assignments"]["assignment-matrix"]["state"] = json!("working");
+    });
+    rewrite_registry(&state_dir, |registry| {
+        let claim = registry["claims"]
+            .as_array_mut()
+            .expect("claims")
+            .iter_mut()
+            .find(|claim| claim["claim_id"] == "worker-matrix-claim")
+            .expect("worker matrix claim");
+        claim["state"] = json!("active");
+    });
+
+    seed_activity_state_with_source(
+        &state_dir,
+        "worker-matrix",
+        "worker-matrix-incarnation",
+        "waiting",
+        "provider_hook",
+        serde_json::Value::Null,
+        json!({
+            "provider_turn_id": "turn-provider-capacity",
+            "started_at": "2030-01-01T00:00:01Z",
+            "completed_at": "2030-01-01T00:00:02Z",
+            "outcome": "failed",
+            "provider_failure_kind": "provider_capacity"
+        }),
+    );
+    let provider_capacity = supervise();
+    assert_eq!(
+        data(&provider_capacity)["classification"],
+        "provider_capacity_attention_required"
+    );
+    assert_eq!(
+        data(&provider_capacity)["schema_version"],
+        "main-agent.worker-supervise-result.v7"
+    );
+    assert_eq!(
+        data(&provider_capacity)["last_proven_safe_state"]["attention"],
+        json!({
+            "kind": "provider_capacity",
+            "source": "provider_protocol",
+            "provider_input_authorized": false,
+            "account_change_authorized": false
+        })
+    );
+    assert_eq!(
+        data(&provider_capacity)["recovery_action"]["kind"],
+        "bounded_provider_capacity_recheck"
+    );
+    assert_eq!(data(&provider_capacity)["automatic_retry_safe"], false);
+    rewrite_orchestration_registry(&state_dir, |registry| {
+        registry["assignments"]["assignment-matrix"]["state"] = json!("submitted");
+    });
+    let submitted_after_capacity = supervise();
+    assert_eq!(
+        data(&submitted_after_capacity)["classification"],
+        "healthy_progress",
+        "submitted lifecycle state must retire provider-capacity attention"
+    );
+    assert!(
+        data(&submitted_after_capacity)["next_action"]
+            .as_str()
+            .is_some_and(|action| action.contains("validation evidence"))
+    );
+    rewrite_orchestration_registry(&state_dir, |registry| {
+        registry["assignments"]["assignment-matrix"]["state"] = json!("working");
+    });
+    seed_activity_state_with_source(
+        &state_dir,
+        "worker-matrix",
+        "worker-matrix-incarnation",
+        "working",
+        "provider_hook",
+        json!({
+            "provider_turn_id": "turn-after-provider-capacity",
+            "started_at": "2030-01-01T00:00:03Z"
+        }),
+        json!({
+            "provider_turn_id": "turn-provider-capacity",
+            "started_at": "2030-01-01T00:00:01Z",
+            "completed_at": "2030-01-01T00:00:02Z",
+            "outcome": "failed",
+            "provider_failure_kind": "provider_capacity"
+        }),
+    );
+    let resumed_after_capacity = supervise();
+    assert_eq!(
+        data(&resumed_after_capacity)["classification"],
+        "healthy_progress",
+        "a newer active provider turn must retire stale capacity attention"
     );
 
     let progress_file = worker_checkout.join("large-progress.bin");


### PR DESCRIPTION
## Summary

Add two additive Main-Agent attention classifications so a worker that is
merely waiting is never mistaken for one that needs a claim renewal, a resent
prompt, or an account handoff.

- `pre_bootstrap_attention_required` — a live `starting` worker with no claim,
  no exhausted readiness receipt, no operation, no recovery reservation, and no
  blocker or terminal evidence. Main preserves the worker and continues bounded
  bootstrap supervision; it must not tell the worker to renew a claim that
  authenticated bootstrap has not created.
- `provider_capacity_attention_required` — an exact Codex app-server
  `codexErrorInfo: serverOverloaded` followed by the matching non-retrying
  failed turn. Main preserves the exact worker and conversation and waits for
  capacity.

Both are carried by new v7 `worker-diagnose-result`, `worker-supervise-result`,
and `worker-recovery-action` envelopes whose bounded `attention` projection
records the evidence `source` and pins `provider_input_authorized` and
`account_change_authorized` to false.

## Changes

- Admit `serverOverloaded` only through the internal protocol-owned
  `agent-session.turn-event.v2` path; generic activity ingestion still accepts
  only v1 and its closed failure-reason union, and free-form error prose is
  never admitted.
- Persist a bounded `last_turn.provider_failure_kind: provider_capacity` marker
  and classify from it only for a bound live worker in an eligible `starting`,
  `working`, or `blocked` assignment at the authoritative waiting boundary.
- Retire the classification on a newer active turn or any later submitted,
  accepted, cancelled, or released assignment lifecycle.
- Fail closed when one turn carries conflicting structured failure kinds,
  unless the terminal completion embeds the resolving kind.
- Keep both v7 actions as Main-owned bounded supervision rechecks that are not
  automatic-retry-safe; existing v2-v6 classifications keep their exact schema
  identifiers and projections.
- Update `main-agent-orchestration-v1.md` and the matching runbook with the two
  classifications and their required operator response.

## Test-First Evidence

Genuine red evidence was captured before delivery, not waived.

With `crates/agent-session/src/{main_agent,activity,codex_app_server}.rs`
restored to `origin/main` and the delivered tests in place:

```
cargo nextest run --profile ci -p nils-agent-session \
  -E 'test(/main_agent_supervise_exposes_the_fail_closed_classification_matrix_without_mutation/)'
```

failed (exit 100) with the exact defect this PR fixes — a live `starting` worker
holding no claim was classified `claim_renewal_required`, instructing renewal of
a claim that authenticated bootstrap never created:

```
Diff < left / right > :
<String("claim_renewal_required")
>"pre_bootstrap_attention_required"
```

At the delivered head the same command passes, together with the four new
reducer/classifier unit tests. A `test-first-evidence` record covering the
baseline, impact targets, the failing run, focused final validation, and the
delivered-head attestation verifies complete.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — pass:
  1141/1141 `nils-agent-session` tests, clippy and fmt clean, doc-tests clean.
- Focused red/green pair on
  `main_agent_supervise_exposes_the_fail_closed_classification_matrix_without_mutation`:
  fails against pre-fix production code, passes at the delivered head.
- Focused run of the five delivered cases — 6/6 pass:
  `provider_capacity_is_reserved_for_internal_protocol_v2_admission`,
  `reducer_admits_exact_server_overload_as_a_structured_capacity_failure`,
  `structured_provider_capacity_is_projected_without_arming_usage_resume`,
  `reducer_fails_closed_for_conflicting_failure_kinds_on_one_turn`,
  `live_pre_bootstrap_worker_without_claim_requires_attention_before_renewal`.

## Risk / Notes

- Additive only: existing v2-v6 classifications keep their schema identifiers
  and projections, so current consumers are unaffected until they opt into v7.
- `provider_capacity` admission is deliberately narrow. It requires exact
  structured evidence through the internal turn-event path; a provider that
  changes its error shape degrades to no classification rather than to a wrong
  one.
- This state is explicitly distinct from quota or credit exhaustion: it must not
  arm usage auto-resume or authorize account handoff. Both invariants are
  asserted by the delivered tests.
- The local full-package run reports two leaky cases
  (`serve::tests::timed_out_resize_releases_the_shared_lock`,
  `serve::tests::group_cleanup_success_replay_finishes_all_daemon_registry_evictions`)
  and one flaky retry-pass. Both leaky cases live in `serve.rs`, which this PR
  does not touch, and both are present on `main`; the flaky case was not
  isolated. All are pre-existing and out of scope here.
