### PR TITLE
fix(agent-session): recover retained claims during retire replay

### DIFF
--- a/crates/agent-session/docs/runbooks/main-agent-orchestration.md
+++ b/crates/agent-session/docs/runbooks/main-agent-orchestration.md
@@ -1162,7 +1162,11 @@ with the matching primitive when intentionally changing the request.
 fails, retry the identical retire key with the original revision; its progress
 receipt replays release and resumes delete. Child stage keys are digest-backed
 and remain within the public idempotency-key bound even when the parent key is
-128 bytes.
+128 bytes. If the exact accepted-to-released progress retained only the
+assignment-derived worker claim, that same replay revokes the quiescent claim
+under the retire proof before deletion. Reconcile any active or uncertain
+operation first; a standalone released-state `worker revoke-claim` remains
+forbidden.
 
 ### 5. Review, accept, and release
 

--- a/crates/agent-session/docs/specs/main-agent-orchestration-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-orchestration-v1.md
@@ -1292,7 +1292,11 @@ only and MUST never be accepted automatically.
 Composite commands derive bounded, digest-backed child idempotency keys.
 `worker retire` stores top-level progress before release, after release, and
 after delete, so retrying the original key and revision resumes an accepted
-assignment whose release already committed.
+assignment whose release already committed. When that exact progress proves
+`accepted -> released` but the worker retained its assignment-derived claim,
+retire replay may internally revoke only that quiescent exact claim before
+resuming delete. A nonterminal operation still fences replay, and the public
+`worker revoke-claim` command does not gain general released-state authority.
 
 `closeout` is the run-wide terminal macro. Admission binds the exact active
 controller claim to authenticated provenance retained outside the v1 run

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -3246,7 +3246,7 @@ fn run_worker(context: &CliContext, args: WorkerArgs) -> Result<Value, CliError>
             run_worker_provider_stop_canary(context, args, true)
         }
         WorkerCommand::ReconcileStopped(args) => run_worker_reconcile_stopped(context, args),
-        WorkerCommand::RevokeClaim(args) => run_worker_revoke_claim(context, args),
+        WorkerCommand::RevokeClaim(args) => run_worker_revoke_claim(context, args, None),
         WorkerCommand::Cancel(args) => run_worker_cancel(context, args),
         WorkerCommand::Reassign(args) => run_worker_reassign(context, args),
     }
@@ -8584,6 +8584,7 @@ fn run_worker_retire(
                     "initial_revision": args.if_revision,
                     "initial_state": "accepted",
                     "release": release,
+                    "claim_revoke": Value::Null,
                     "delete": Value::Null
                 })
             } else {
@@ -8595,6 +8596,7 @@ fn run_worker_retire(
                     "initial_revision": assignment.revision,
                     "initial_state": assignment.state,
                     "release": Value::Null,
+                    "claim_revoke": Value::Null,
                     "delete": Value::Null
                 })
             };
@@ -8649,6 +8651,32 @@ fn run_worker_retire(
         revision = release["assignment"]["revision"]
             .as_u64()
             .ok_or_else(|| invalid_input("worker release result revision is invalid"))?;
+        let claim_revoke = if progress["claim_revoke"].is_null() {
+            recover_released_retire_claim(
+                context,
+                &record,
+                &incarnation,
+                &args,
+                &request_digest,
+                revision,
+            )?
+        } else {
+            Some(progress["claim_revoke"].clone())
+        };
+        if let Some(value) = claim_revoke {
+            revision = value["assignment"]["revision"].as_u64().ok_or_else(|| {
+                invalid_input("worker claim revocation result revision is invalid")
+            })?;
+            progress["claim_revoke"] = value;
+            persist_worker_retire_receipt(
+                context,
+                &record,
+                &incarnation,
+                &args.idempotency_key,
+                &request_digest,
+                progress.clone(),
+            )?;
+        }
     }
     let delete = if progress["delete"].is_null() {
         let value = run_worker_delete(
@@ -8700,6 +8728,81 @@ fn run_worker_retire(
         outcome.clone(),
     )?;
     Ok(outcome)
+}
+
+#[derive(Clone, Debug)]
+struct ReleasedRetireClaimRecovery {
+    retire_idempotency_key: String,
+    retire_request_digest: String,
+    release_revision: u64,
+}
+
+fn recover_released_retire_claim(
+    context: &CliContext,
+    main: &SessionRecord,
+    main_incarnation: &str,
+    args: &AssignmentMutationArgs,
+    retire_request_digest: &str,
+    release_revision: u64,
+) -> Result<Option<Value>, CliError> {
+    let registry = orchestration::load_registry_readonly(context)?;
+    let run = require_current_main(&registry, main, main_incarnation)?;
+    let assignment = registry
+        .assignments
+        .get(&args.assignment_id)
+        .filter(|assignment| assignment.run_id == run.run_id)
+        .ok_or_else(|| not_found("assignment-not-found", "assignment was not found"))?;
+    ensure_primary_manager(assignment, main, main_incarnation)?;
+    let worker = assignment.worker.as_ref().ok_or_else(|| {
+        CliError::data(
+            "worker-incarnation-changed",
+            "released retire progress has no bound worker claim to revoke",
+            None,
+        )
+    })?;
+    let revoke_key = compatible_child_idempotency_key(&args.idempotency_key, "revoke-claim");
+    let prior_revoke =
+        registry
+            .receipts
+            .contains_key(&receipt_key(&main.id, main_incarnation, &revoke_key));
+    if assignment.revision == release_revision {
+        let (active_claim, active_operation) =
+            crate::coordination::session_has_active_claim_or_operation(
+                context,
+                &worker.session_id,
+                &worker.session_incarnation,
+            )?;
+        if !active_claim || active_operation {
+            return Ok(None);
+        }
+    } else if !prior_revoke {
+        return Err(CliError::data(
+            "orchestration-revision-conflict",
+            "released assignment changed before retire claim recovery",
+            Some(json!({
+                "expected_revision": release_revision,
+                "actual_revision": assignment.revision
+            })),
+        ));
+    }
+    let proof = ReleasedRetireClaimRecovery {
+        retire_idempotency_key: args.idempotency_key.clone(),
+        retire_request_digest: retire_request_digest.to_string(),
+        release_revision,
+    };
+    run_worker_revoke_claim(
+        context,
+        WorkerRevokeClaimArgs {
+            assignment_id: args.assignment_id.clone(),
+            worker_incarnation: worker.session_incarnation.clone(),
+            if_revision: release_revision,
+            reason: "released retire replay retained the exact worker claim".to_string(),
+            idempotency_key: revoke_key,
+            format: OutputFormat::Json,
+        },
+        Some(&proof),
+    )
+    .map(Some)
 }
 
 fn persist_worker_retire_receipt(
@@ -12291,7 +12394,10 @@ fn parse_revoke_claim_progress(
     if progress.schema_version != REVOKE_CLAIM_PROGRESS_SCHEMA
         || progress.state != "in_progress"
         || progress.assignment_id != assignment_id
-        || !matches!(progress.assignment_state.as_str(), "working" | "accepted")
+        || !matches!(
+            progress.assignment_state.as_str(),
+            "working" | "accepted" | "released"
+        )
         || progress
             .assignment_revision
             .checked_add(1)
@@ -12621,6 +12727,7 @@ fn pause_revoke_claim_before_worker_lifecycle_for_test() -> Result<(), CliError>
 fn run_worker_revoke_claim(
     context: &CliContext,
     args: WorkerRevokeClaimArgs,
+    released_retire: Option<&ReleasedRetireClaimRecovery>,
 ) -> Result<Value, CliError> {
     validate_idempotency_key(&args.idempotency_key)?;
     orchestration::validate_summary("claim revocation reason", &args.reason)?;
@@ -12663,6 +12770,16 @@ fn run_worker_revoke_claim(
             .ok_or_else(|| not_found("assignment-not-found", "assignment was not found"))?
             .clone();
         ensure_primary_manager(&assignment, &main, &main_incarnation)?;
+        let released_retire_proven = assignment.state == "released"
+            && released_retire.is_some_and(|proof| {
+                released_retire_claim_recovery_matches(
+                    &registry,
+                    &main,
+                    &main_incarnation,
+                    &assignment,
+                    proof,
+                )
+            });
         let progress = if let Some(progress) = resumed {
             if assignment
                 .claim_revocation
@@ -12709,7 +12826,9 @@ fn run_worker_revoke_claim(
                 &assignment,
                 AssignmentMutationOwner::ClaimRevocation,
             )?;
-            if !matches!(assignment.state.as_str(), "working" | "accepted") {
+            if !matches!(assignment.state.as_str(), "working" | "accepted")
+                && !released_retire_proven
+            {
                 return Err(CliError::data(
                     "assignment-state-conflict",
                     "worker revoke-claim requires a working or accepted assignment",
@@ -13142,10 +13261,10 @@ fn run_worker_revoke_claim(
             "runtime_identity_digest": progress.runtime_identity_digest,
             "authority_fence": "exact-worker-session-quarantine"
         },
-        "next_action": if progress.assignment_state == "accepted" {
-            "retire this exact accepted assignment"
-        } else {
-            "retire this exact cancelled assignment or start a distinct replacement"
+        "next_action": match progress.assignment_state.as_str() {
+            "accepted" => "retire this exact accepted assignment",
+            "released" => "replay the exact in-progress retire request",
+            _ => "retire this exact cancelled assignment or start a distinct replacement",
         }
     });
     store_receipt(
@@ -13161,6 +13280,36 @@ fn run_worker_revoke_claim(
     drop(locked);
     drop(worker_lifecycle);
     Ok(outcome)
+}
+
+fn released_retire_claim_recovery_matches(
+    registry: &orchestration::Registry,
+    main: &SessionRecord,
+    main_incarnation: &str,
+    assignment: &AssignmentRecord,
+    proof: &ReleasedRetireClaimRecovery,
+) -> bool {
+    let Some(receipt) = registry.receipts.get(&receipt_key(
+        &main.id,
+        main_incarnation,
+        &proof.retire_idempotency_key,
+    )) else {
+        return false;
+    };
+    let outcome = &receipt.outcome;
+    receipt.principal_session_id == main.id
+        && receipt.principal_incarnation == main_incarnation
+        && receipt.operation == "worker-retire"
+        && receipt.request_digest == proof.retire_request_digest
+        && outcome["schema_version"] == "main-agent.worker-retire-progress.v1"
+        && outcome["state"] == "in_progress"
+        && outcome["assignment_id"] == assignment.assignment_id
+        && outcome["initial_state"] == "accepted"
+        && outcome["release"]["assignment"]["state"] == "released"
+        && outcome["release"]["assignment"]["revision"].as_u64() == Some(proof.release_revision)
+        && outcome["release"]["assignment"]["worker"]
+            == serde_json::to_value(&assignment.worker).unwrap_or(Value::Null)
+        && outcome["delete"].is_null()
 }
 
 fn clear_exact_terminal_provider_stop_canary_replay(

--- a/crates/agent-session/src/orchestration.rs
+++ b/crates/agent-session/src/orchestration.rs
@@ -1823,7 +1823,10 @@ impl Registry {
                     || reservation.run_id != assignment.run_id
                     || reservation.controller != assignment.primary_manager
                     || assignment.worker.as_ref() != Some(&reservation.worker)
-                    || !matches!(assignment.state.as_str(), "working" | "accepted")
+                    || !matches!(
+                        assignment.state.as_str(),
+                        "working" | "accepted" | "released"
+                    )
                     || !worker_claim_revocation_revision_is_valid(
                         reservation.reserved_revision,
                         reservation.adopted_revision,

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -36559,6 +36559,249 @@ fn main_agent_quick_idempotency_binds_the_canonical_readiness_wait() {
 }
 
 #[test]
+fn main_agent_retire_replays_released_worker_with_retained_claim() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let state_dir = tmp.path().join("state");
+    let state_arg = state_dir.to_string_lossy().into_owned();
+    let main_checkout = tmp.path().join("main-checkout");
+    let worker_checkout = tmp.path().join("worker-checkout");
+    fs::create_dir(&state_dir).expect("state");
+    for checkout in [&main_checkout, &worker_checkout] {
+        init_checkout(checkout, "https://example.invalid/example/repository.git");
+    }
+    seed_brokers_at(
+        &state_dir,
+        &[
+            (
+                "main-one",
+                "main-incarnation-one",
+                "main-private-capability-retire-replay-0001",
+                main_checkout.as_path(),
+                Some("enforce"),
+            ),
+            (
+                "worker-retire-claim",
+                "worker-retire-claim-incarnation",
+                "worker-private-capability-retire-replay-0001",
+                worker_checkout.as_path(),
+                Some("enforce"),
+            ),
+        ],
+    );
+    let main_capability = init_main_run(
+        tmp.path(),
+        &state_dir,
+        &main_checkout,
+        "main-one",
+        "run-one",
+    );
+    let packet = json!({
+        "schema_version": "main-agent.assignment-input.v1",
+        "assignment_id": "assignment-retire-claim",
+        "task_summary": "Retire a released worker with a retained claim",
+        "task": {},
+        "launch": {
+            "agent": "codex",
+            "cwd": worker_checkout,
+            "title": null,
+            "session_id": "worker-retire-claim",
+            "coordination_mode": "enforce",
+            "agent_args": []
+        },
+        "repository": "example/repository",
+        "worktree": worker_checkout,
+        "base_ref": "main",
+        "scopes": ["docs/retire-claim"],
+        "durable_refs": []
+    });
+    insert_orchestration_assignment(
+        &state_dir,
+        "assignment-retire-claim",
+        json!({
+            "schema_version": "agent-session.orchestration-assignment.v1",
+            "assignment_id": "assignment-retire-claim",
+            "run_id": "run-one",
+            "revision": 2,
+            "state": "starting",
+            "task_summary": "Retire a released worker with a retained claim",
+            "private_packet_digest": "replaced-by-fixture",
+            "primary_manager": {
+                "session_id": "main-one",
+                "session_incarnation": "main-incarnation-one",
+                "session_created_at": "2030-01-01T00:00:00Z"
+            },
+            "worker": {
+                "session_id": "worker-retire-claim",
+                "session_incarnation": "worker-retire-claim-incarnation",
+                "session_created_at": "2030-01-01T00:00:00Z"
+            },
+            "collaborators": [],
+            "borrowed_by": [],
+            "repository": "example/repository",
+            "worktree": worker_checkout,
+            "base_ref": "main",
+            "scopes": ["docs/retire-claim"],
+            "durable_refs": [],
+            "checkpoint": null,
+            "result_summary": null,
+            "blocker_summary": null,
+            "created_at": "2030-01-01T00:00:01Z",
+            "updated_at": "2030-01-01T00:00:02Z"
+        }),
+        &packet,
+    );
+    let worker_capability = capability(&state_dir, "worker-retire-claim");
+    let bootstrapped = run_main_agent(
+        &worker_checkout,
+        &[
+            "--state-dir",
+            &state_arg,
+            "bootstrap",
+            "--idempotency-key",
+            "retire-claim-bootstrap-0001",
+            "--format",
+            "json",
+        ],
+        &[("AGENT_SESSION_CAPABILITY_FILE", &worker_capability)],
+    );
+    assert_eq!(
+        bootstrapped.code,
+        0,
+        "outcome={}",
+        bootstrapped.stdout_text()
+    );
+    rewrite_orchestration_registry(&state_dir, |registry| {
+        let assignment = &mut registry["assignments"]["assignment-retire-claim"];
+        assignment["state"] = json!("accepted");
+        assignment["revision"] = json!(4);
+    });
+    seed_activity_state(
+        &state_dir,
+        "worker-retire-claim",
+        "worker-retire-claim-incarnation",
+        "waiting",
+        serde_json::Value::Null,
+        json!({
+            "provider_turn_id": "retire-claim-complete",
+            "started_at": "2030-01-01T00:00:01Z",
+            "completed_at": "2030-01-01T00:00:03Z",
+            "outcome": "completed"
+        }),
+    );
+    let runtime = seed_live_runtime_identity(
+        &state_dir,
+        "worker-retire-claim",
+        "worker-retire-claim-incarnation",
+        97,
+    );
+    seed_operation(
+        &state_dir,
+        "worker-retire-claim",
+        "worker-retire-claim-incarnation",
+        "retire-claim-active-operation",
+        "active",
+    );
+    let (tmux_bin, tmux_log) = fake_tmux(tmp.path());
+    let tmux_arg = tmux_bin.to_string_lossy().into_owned();
+    let tmux_log_arg = tmux_log.to_string_lossy().into_owned();
+    let runtime_pid = runtime.pid().to_string();
+    let state_runtime = state_dir.to_string_lossy().into_owned();
+    let envs = [
+        ("AGENT_SESSION_CAPABILITY_FILE", main_capability.as_str()),
+        ("AGENT_SESSION_TMUX_BIN", tmux_arg.as_str()),
+        ("AGENT_SESSION_FAKE_TMUX_LOG", tmux_log_arg.as_str()),
+        ("AGENT_SESSION_FAKE_TMUX_PANE_PID", runtime_pid.as_str()),
+        (
+            "AGENT_SESSION_FAKE_TMUX_PROCESS_GROUP_ID",
+            runtime_pid.as_str(),
+        ),
+        ("AGENT_SESSION_FAKE_TMUX_KEEP_PROCESS_GROUP", "1"),
+        ("AGENT_SESSION_FAKE_TMUX_SESSION_ID", "$97"),
+        ("AGENT_SESSION_FAKE_TMUX_PANE_ID", "%97"),
+        (
+            "AGENT_SESSION_FAKE_TMUX_AGENT_SESSION_ID",
+            "worker-retire-claim",
+        ),
+        ("AGENT_SESSION_FAKE_TMUX_STATE_DIR", state_runtime.as_str()),
+        (
+            "AGENT_SESSION_FAKE_TMUX_RUNTIME_ID",
+            "worker-retire-claim-incarnation",
+        ),
+    ];
+    let retire_args = [
+        "--state-dir",
+        state_arg.as_str(),
+        "worker",
+        "retire",
+        "assignment-retire-claim",
+        "--if-revision",
+        "4",
+        "--idempotency-key",
+        "retire-retained-claim-0001",
+        "--format",
+        "json",
+    ];
+    let fenced = run_main_agent(&main_checkout, &retire_args, &envs);
+    assert_eq!(fenced.code, 65, "outcome={}", fenced.stdout_text());
+    assert_eq!(
+        fenced.stdout_json()["error"]["code"],
+        "worker-not-quiescent"
+    );
+    assert_eq!(
+        orchestration_registry(&state_dir)["assignments"]["assignment-retire-claim"]["state"],
+        "released"
+    );
+
+    let arbitrary_revoke = run_main_agent(
+        &main_checkout,
+        &[
+            "--state-dir",
+            &state_arg,
+            "worker",
+            "revoke-claim",
+            "assignment-retire-claim",
+            "--worker-incarnation",
+            "worker-retire-claim-incarnation",
+            "--if-revision",
+            "5",
+            "--reason",
+            "arbitrary released claim revocation must remain forbidden",
+            "--idempotency-key",
+            "arbitrary-released-revoke-0001",
+            "--format",
+            "json",
+        ],
+        &envs,
+    );
+    assert_eq!(arbitrary_revoke.code, 65);
+    assert_eq!(
+        arbitrary_revoke.stdout_json()["error"]["code"],
+        "assignment-state-conflict"
+    );
+
+    rewrite_registry(&state_dir, |registry| {
+        registry["operations"]
+            .as_array_mut()
+            .expect("operations")
+            .retain(|operation| operation["lease_id"] != "retire-claim-active-operation");
+    });
+    let replayed = run_main_agent(&main_checkout, &retire_args, &envs);
+    assert_eq!(
+        replayed.code,
+        0,
+        "stdout={} stderr={}",
+        replayed.stdout_text(),
+        replayed.stderr_text()
+    );
+    assert_eq!(data(&replayed)["retired"], true);
+    assert_eq!(data(&replayed)["released"], true);
+    assert!(!state_dir.join("sessions/worker-retire-claim").exists());
+    let terminal_replay = run_main_agent(&main_checkout, &retire_args, &envs);
+    assert_eq!(terminal_replay.code, 0);
+    assert_eq!(data(&terminal_replay), data(&replayed));
+}
+
+#[test]
 fn main_agent_worker_retire_rejects_non_terminal_and_missing() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -36785,7 +36785,24 @@ fn main_agent_retire_replays_released_worker_with_retained_claim() {
             .expect("operations")
             .retain(|operation| operation["lease_id"] != "retire-claim-active-operation");
     });
-    let replayed = run_main_agent(&main_checkout, &retire_args, &envs);
+    // Claim recovery needs the worker runtime live, so the fixture keeps its
+    // process group alive until retire revokes the retained claim. Retire then
+    // tears the session down, and its termination probe can still observe the
+    // boundary as running: that is the documented retryable outcome carrying
+    // `action: retry-delete`. macOS reaches that path where Linux does not, so
+    // honor the retry instead of asserting one-shot success. Only this exact
+    // retryable reason is replayed; every other outcome falls straight through
+    // to the assertions below.
+    let mut replayed = run_main_agent(&main_checkout, &retire_args, &envs);
+    let retire_deadline = Instant::now() + Duration::from_secs(30);
+    while replayed.code != 0
+        && replayed.stdout_json()["error"]["code"] == "session-termination-failed"
+        && replayed.stdout_json()["error"]["details"]["reason"] == "process-still-running"
+        && Instant::now() < retire_deadline
+    {
+        std::thread::sleep(Duration::from_millis(100));
+        replayed = run_main_agent(&main_checkout, &retire_args, &envs);
+    }
     assert_eq!(
         replayed.code,
         0,


### PR DESCRIPTION
## Summary

Let Main-Agent retire replay finish when a released worker still holds the claim
its own assignment created, without widening released-state revocation authority.

Retire replay could stall: the exact accepted-to-released progress proved the
release had committed, but the worker had retained its assignment-derived claim,
and nothing was allowed to revoke it, so delete never resumed.

## Problem

**Expected** — retire replay for an assignment whose release already committed
proceeds to delete.

**Actual** — when the exact `accepted -> released` progress retained only the
assignment-derived worker claim, that quiescent claim blocked delete, and the
only surface that could clear it (`worker revoke-claim`) is forbidden in
released state. Replay had no way forward.

**Impact** — a retired assignment could stay undeleted, holding claim state that
no authorized path could release.

## Reproduction

1. Drive a Main-Agent worker assignment through `accepted -> released` so the
   release commits and the worker retains its assignment-derived claim.
2. Replay retire for that exact assignment.
3. Delete does not resume: the retained quiescent claim fences replay, and
   `worker revoke-claim` refuses because the worker is in released state.

Covered by
`crates/agent-session/tests/integration/coordination.rs::main_agent_retire_replays_released_worker_with_retained_claim`.

## Issues Found

No tracking issue was opened for this defect. It was found while triaging
abandoned worktrees, and the fix already existed on an unmerged branch; this PR
delivers it with its evidence rather than opening a tracker first.

- Retire replay could not finish for an assignment whose `accepted -> released`
  progress had committed while the worker retained its assignment-derived claim.

## Fix Approach

Bind the recovery to the exact retire proof instead of relaxing the command:

- When exact progress proves `accepted -> released` and the worker retained only
  its assignment-derived claim, retire replay internally revokes that one
  quiescent exact claim before resuming delete.
- A nonterminal operation still fences replay, so operation fencing is unchanged.
- The public `worker revoke-claim` command gains no general released-state
  authority; a standalone released-state revocation stays forbidden.
- `main-agent-orchestration-v1.md` and the runbook record the narrowed rule.

### Cross-platform retire termination

The first CI run failed on macOS (and in `coverage`, which also runs on the
macOS runner) while Linux passed. The cause is ordering, not this fix:

- claim recovery requires the worker runtime to still be **live** — the internal
  revocation is rejected with `worker-runtime-stopped` otherwise, which is why
  the fixture keeps the worker's process group alive;
- retire then tears the session down, and the termination probe can still see
  that boundary running. That is the documented retryable outcome carrying
  `retryable: true, action: retry-delete`.

macOS reaches that path where Linux's probe is lenient. The test now honors the
documented retry with a bounded replay instead of asserting one-shot success,
gated to the exact `session-termination-failed` / `process-still-running` reason
so every other outcome still fails immediately.

## Test-First Evidence

Genuine red evidence was captured before delivery, not waived.

With `crates/agent-session/src/{main_agent,orchestration}.rs` restored to
`origin/main` and the delivered test in place:

```
cargo nextest run --profile ci -p nils-agent-session \
  -E 'test(/main_agent_retire_replays_released_worker_with_retained_claim/)'
```

failed (exit 100) reproducing the exact defect — `worker-retire` refused with
`worker-not-quiescent`:

```
{"code":"worker-not-quiescent","message":"worker claim or mutation operation remains active",
 "details":{"active_claim":true,"active_operation":false,"assignment_id":"assignment-retire-claim"}}
```

The test asserts exit 0 but observed 65. At the delivered head the same command
passes. A `test-first-evidence` record covering the baseline, impact target, the
failing run, focused final validation, and the delivered-head attestation
verifies complete.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — pass:
  1137/1137 `nils-agent-session` tests, clippy and fmt clean, doc-tests clean.
- Focused red/green pair on
  `main_agent_retire_replays_released_worker_with_retained_claim`: fails with
  `worker-not-quiescent` against pre-fix production code restored to the
  branch's merge-base, passes at the delivered head.
- Re-verified the red run **after** adding the retryable-termination replay
  described below: pre-fix still fails fast with `worker-not-quiescent`, which is
  not in the replayed reason set, so the replay cannot mask the defect.

## Risk / Notes

- The new authority is internal to retire replay and scoped to one exact
  assignment-derived claim under a proven `accepted -> released` progress. It is
  not reachable from the public command surface.
- Operation fencing is retained: a nonterminal operation still blocks replay, so
  this cannot delete state while an operation is in flight.
- The forbidden standalone released-state `worker revoke-claim` path is asserted
  by the delivered test, so a future widening would fail the suite.
- The local full-package run reports two leaky cases
  (`serve::tests::timed_out_resize_releases_the_shared_lock`,
  `serve::tests::group_cleanup_success_replay_finishes_all_daemon_registry_evictions`).
  Both live in `serve.rs`, which this PR does not touch, and both are present on
  `main`. Pre-existing and out of scope here.
