### PR TITLE
test(nils-test-support): skip on an absent or stale sibling binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,9 @@ jobs:
       - name: Nils CLI checks (includes third-party-artifacts-audit, completion audits, docs-hygiene-audit, tempdir-leak-audit, test-stale-audit)
         env:
           NILS_CLI_TEST_RUNNER: nextest
+          # A skip here would mean a lane that builds every binary lost coverage
+          # silently; make it fatal instead. See `bin::sibling_or_skip`.
+          NILS_TEST_REQUIRE_SIBLING_BINS: "1"
         run: |
           if [ "${{ needs.changes.outputs.docs_only }}" = "true" ]; then
             bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only
@@ -316,6 +319,9 @@ jobs:
       - name: Nils CLI checks (includes third-party-artifacts-audit, completion audits, docs-hygiene-audit, tempdir-leak-audit, test-stale-audit)
         env:
           NILS_CLI_TEST_RUNNER: nextest
+          # A skip here would mean a lane that builds every binary lost coverage
+          # silently; make it fatal instead. See `bin::sibling_or_skip`.
+          NILS_TEST_REQUIRE_SIBLING_BINS: "1"
         run: |
           if [ "${{ needs.changes.outputs.docs_only }}" = "true" ]; then
             /opt/homebrew/bin/bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only
@@ -364,6 +370,9 @@ jobs:
       pull-requests: write
     env:
       COVERAGE_FAIL_UNDER_LINES: "85"
+      # A skip here would mean a lane that builds every binary lost coverage
+      # silently; make it fatal instead. See `bin::sibling_or_skip`.
+      NILS_TEST_REQUIRE_SIBLING_BINS: "1"
     steps:
       # Docs-only and proven release-only change sets skip coverage work at the
       # step level so the required `coverage` job still concludes `success`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -131,6 +131,13 @@ This runs changed-scope validation against `origin/main` by default:
 - the workspace lane runs its tests through `scripts/ci/tempdir-leak-probe.sh`,
   which fails on temp directories the suite leaves behind; see
   `docs/specs/test-temp-directory-policy.md`
+- a package-scoped lane does not build binaries another package owns, so tests
+  that need one — the `codex-cli`/`gemini-cli` parity oracles and the
+  `agent-hook` read-only producer cases — skip with a reason naming the build
+  command instead of failing. Build the sibling (for example
+  `cargo build -p nils-gemini-cli --bins`) to run them locally; the workspace
+  lane and CI always build every binary. See `bin::sibling_or_skip` in
+  `crates/nils-test-support`
 
 Override the base ref when needed:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -131,13 +131,15 @@ This runs changed-scope validation against `origin/main` by default:
 - the workspace lane runs its tests through `scripts/ci/tempdir-leak-probe.sh`,
   which fails on temp directories the suite leaves behind; see
   `docs/specs/test-temp-directory-policy.md`
-- a package-scoped lane does not build binaries another package owns, so tests
-  that need one — the `codex-cli`/`gemini-cli` parity oracles and the
-  `agent-hook` read-only producer cases — skip with a reason naming the build
-  command instead of failing. Build the sibling (for example
-  `cargo build -p nils-gemini-cli --bins`) to run them locally; the workspace
-  lane and CI always build every binary. See `bin::sibling_or_skip` in
-  `crates/nils-test-support`
+- a package-scoped lane does not build binaries another package owns, so a test
+  that needs one skips with a reason naming the build command; see
+  `bin::sibling_or_skip` in `crates/nils-test-support`. Build the sibling — for
+  example `cargo build -p nils-gemini-cli --bins` — to run those tests locally.
+  A *stale* sibling fails instead of skipping, because an artifact from an
+  earlier release is an operator error rather than a property of the run. The
+  workspace lane and CI build every default-feature binary, and CI additionally
+  sets `NILS_TEST_REQUIRE_SIBLING_BINS=1` so a skip there is a hard failure
+  rather than a silent loss of coverage
 
 Override the base ref when needed:
 

--- a/crates/agent-hook/tests/read_only_capability.rs
+++ b/crates/agent-hook/tests/read_only_capability.rs
@@ -10,12 +10,13 @@ use support::Fixture;
 /// The `agent-docs` binary these tests use as a trusted read-only producer.
 ///
 /// It belongs to another package, so a package-scoped run has no reason to have
-/// built it. Worse than absence: an artifact from an earlier build reports an
-/// earlier release, which the producer identity check in
-/// `crates/agent-hook/src/read_only.rs` correctly rejects as
-/// `read-only-producer-mismatch` — turning a build-scope problem into what looks
-/// like a policy defect. Skip on either. See `sympoies/nils-cli#1413`.
-fn agent_docs_producer() -> Option<PathBuf> {
+/// built it and `None` means these assertions do not run. An artifact from an
+/// earlier release is worse than an absent one, because the producer identity
+/// check in `crates/agent-hook/src/read_only.rs` correctly rejects it as
+/// `read-only-producer-mismatch` and a build-scope problem then reads as a policy
+/// defect — so `bin::sibling_or_skip` fails on that rather than skipping.
+/// See `sympoies/nils-cli#1413`.
+fn agent_docs_producer_or_skip() -> Option<PathBuf> {
     let producer = nils_test_support::bin::sibling_or_skip("agent-docs", "nils-agent-docs")?;
 
     Some(
@@ -194,7 +195,7 @@ fn codex_and_claude_record_the_same_shadow_decision_for_equivalent_input() {
 
 #[test]
 fn enforce_accepts_a_valid_same_release_read_only_descriptor() {
-    let Some(producer) = agent_docs_producer() else {
+    let Some(producer) = agent_docs_producer_or_skip() else {
         return;
     };
     let policy = POLICY.replace("mode = \"shadow\"", "mode = \"enforce\"");
@@ -236,9 +237,57 @@ fn enforce_accepts_a_valid_same_release_read_only_descriptor() {
     assert!(output.stdout_json()["data"]["shadow"].is_null());
 }
 
+/// Assert one enforce-mode rejection and return nothing but the check.
+fn assert_enforce_blocks(fixture: &Fixture, command: &str, expected_code: &str) {
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "cwd": fixture.root,
+        "tool_input": {"command": command}
+    })
+    .to_string();
+    let output = fixture.run(
+        &["dispatch", "--product", "claude", "--format", "json"],
+        Some(&payload),
+    );
+
+    assert_eq!(
+        output.code,
+        1,
+        "command={command}; stderr={}",
+        output.stderr_text()
+    );
+    assert_eq!(output.stdout_json()["data"]["action"], "block");
+    assert_eq!(
+        output.stdout_json()["data"]["reasons"][0]["code"],
+        expected_code,
+        "command={command}"
+    );
+    assert!(output.stdout_json()["data"]["shadow"].is_null());
+}
+
+/// Deliberately takes no producer, so it cannot be gated on a sibling binary.
+///
+/// This is the only test asserting enforce-mode rejection of a command that is
+/// not a trusted producer at all — the other two owners of
+/// `read-only-command-unsupported` run in shadow mode and assert `allow`. It was
+/// previously the first case of a loop whose second case needed `agent-docs`, so
+/// gating that loop would have taken this invariant with it.
 #[test]
-fn enforce_rejects_unsupported_and_same_release_mutation_descriptors() {
-    let Some(producer) = agent_docs_producer() else {
+fn enforce_rejects_an_untrusted_producer_command() {
+    let policy = POLICY.replace("mode = \"shadow\"", "mode = \"enforce\"");
+    let fixture = Fixture::new(&policy);
+
+    assert_enforce_blocks(
+        &fixture,
+        "echo not-a-trusted-producer",
+        "read-only-command-unsupported",
+    );
+}
+
+#[test]
+fn enforce_rejects_a_same_release_mutation_descriptor() {
+    let Some(producer) = agent_docs_producer_or_skip() else {
         return;
     };
     let policy = POLICY.replace("mode = \"shadow\"", "mode = \"enforce\"");
@@ -249,44 +298,13 @@ fn enforce_rejects_unsupported_and_same_release_mutation_descriptors() {
         fixture.root.display(),
         fixture.root.display()
     );
-    for (command, expected_code) in [
-        (
-            "echo not-a-trusted-producer",
-            "read-only-command-unsupported",
-        ),
-        (mutation.as_str(), "read-only-effect-rejected"),
-    ] {
-        let payload = serde_json::json!({
-            "hook_event_name": "PreToolUse",
-            "tool_name": "Bash",
-            "cwd": fixture.root,
-            "tool_input": {"command": command}
-        })
-        .to_string();
-        let output = fixture.run(
-            &["dispatch", "--product", "claude", "--format", "json"],
-            Some(&payload),
-        );
 
-        assert_eq!(
-            output.code,
-            1,
-            "command={command}; stderr={}",
-            output.stderr_text()
-        );
-        assert_eq!(output.stdout_json()["data"]["action"], "block");
-        assert_eq!(
-            output.stdout_json()["data"]["reasons"][0]["code"],
-            expected_code,
-            "command={command}"
-        );
-        assert!(output.stdout_json()["data"]["shadow"].is_null());
-    }
+    assert_enforce_blocks(&fixture, &mutation, "read-only-effect-rejected");
 }
 
 #[test]
 fn enforce_valid_read_only_bypasses_only_the_declared_fallback_handler() {
-    let Some(producer) = agent_docs_producer() else {
+    let Some(producer) = agent_docs_producer_or_skip() else {
         return;
     };
     let policy = format!("{FALLBACK_POLICY}{UNRELATED_HANDLER_RULE}");

--- a/crates/agent-hook/tests/read_only_capability.rs
+++ b/crates/agent-hook/tests/read_only_capability.rs
@@ -2,9 +2,28 @@ mod support;
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
 
 use pretty_assertions::assert_eq;
 use support::Fixture;
+
+/// The `agent-docs` binary these tests use as a trusted read-only producer.
+///
+/// It belongs to another package, so a package-scoped run has no reason to have
+/// built it. Worse than absence: an artifact from an earlier build reports an
+/// earlier release, which the producer identity check in
+/// `crates/agent-hook/src/read_only.rs` correctly rejects as
+/// `read-only-producer-mismatch` — turning a build-scope problem into what looks
+/// like a policy defect. Skip on either. See `sympoies/nils-cli#1413`.
+fn agent_docs_producer() -> Option<PathBuf> {
+    let producer = nils_test_support::bin::sibling_or_skip("agent-docs", "nils-agent-docs")?;
+
+    Some(
+        producer
+            .canonicalize()
+            .expect("canonical agent-docs binary"),
+    )
+}
 
 const POLICY: &str = r#"schema_version = "agent-hook.policy.v1"
 bundle_id = "runtime-kit"
@@ -175,11 +194,11 @@ fn codex_and_claude_record_the_same_shadow_decision_for_equivalent_input() {
 
 #[test]
 fn enforce_accepts_a_valid_same_release_read_only_descriptor() {
+    let Some(producer) = agent_docs_producer() else {
+        return;
+    };
     let policy = POLICY.replace("mode = \"shadow\"", "mode = \"enforce\"");
     let fixture = Fixture::new(&policy);
-    let producer = nils_test_support::bin::resolve("agent-docs")
-        .canonicalize()
-        .expect("canonical agent-docs binary");
     let command = format!(
         "builtin command {} --docs-home {} --project-path {} preflight --intent project-dev --format json",
         producer.display(),
@@ -219,11 +238,11 @@ fn enforce_accepts_a_valid_same_release_read_only_descriptor() {
 
 #[test]
 fn enforce_rejects_unsupported_and_same_release_mutation_descriptors() {
+    let Some(producer) = agent_docs_producer() else {
+        return;
+    };
     let policy = POLICY.replace("mode = \"shadow\"", "mode = \"enforce\"");
     let fixture = Fixture::new(&policy);
-    let producer = nils_test_support::bin::resolve("agent-docs")
-        .canonicalize()
-        .expect("canonical agent-docs binary");
     let mutation = format!(
         "builtin command {} --docs-home {} --project-path {} init --force",
         producer.display(),
@@ -267,13 +286,13 @@ fn enforce_rejects_unsupported_and_same_release_mutation_descriptors() {
 
 #[test]
 fn enforce_valid_read_only_bypasses_only_the_declared_fallback_handler() {
+    let Some(producer) = agent_docs_producer() else {
+        return;
+    };
     let policy = format!("{FALLBACK_POLICY}{UNRELATED_HANDLER_RULE}");
     for product in ["codex", "claude"] {
         let fixture = Fixture::new(&policy);
         install_fallback_handler(&fixture);
-        let producer = nils_test_support::bin::resolve("agent-docs")
-            .canonicalize()
-            .expect("canonical agent-docs binary");
         let command = format!(
             "builtin command {} --docs-home {} --project-path {} preflight --intent project-dev --format json",
             producer.display(),

--- a/crates/codex-cli/tests/integration/parity_oracle.rs
+++ b/crates/codex-cli/tests/integration/parity_oracle.rs
@@ -8,12 +8,10 @@ fn codex_cli_bin() -> PathBuf {
     bin::resolve("codex-cli")
 }
 
-/// `gemini-cli` belongs to another package, so a package-scoped run has no reason
-/// to have built it, and an artifact left behind by an earlier build would
-/// compare this CLI against a different release. Either way the answer says
-/// nothing about parity, so skip with a reason instead of asserting.
-/// See `sympoies/nils-cli#1413`.
-fn gemini_cli_bin() -> Option<PathBuf> {
+/// `None` means this run cannot compare against `gemini-cli` at all, so the
+/// parity assertions below do not run. `bin::sibling_or_skip` owns why that
+/// happens and when it is legitimate.
+fn gemini_cli_bin_or_skip() -> Option<PathBuf> {
     bin::sibling_or_skip("gemini-cli", "nils-gemini-cli")
 }
 
@@ -57,7 +55,7 @@ fn extract_commands(help_text: &str) -> Vec<String> {
 
 #[test]
 fn parity_oracle_topology_matches_gemini() {
-    let Some(gemini_bin) = gemini_cli_bin() else {
+    let Some(gemini_bin) = gemini_cli_bin_or_skip() else {
         return;
     };
     let codex = run_codex(&["--help"]);
@@ -72,7 +70,7 @@ fn parity_oracle_topology_matches_gemini() {
 
 #[test]
 fn parity_oracle_format_flag_visibility_matches_gemini_for_auth_and_diag_help() {
-    let Some(gemini_bin) = gemini_cli_bin() else {
+    let Some(gemini_bin) = gemini_cli_bin_or_skip() else {
         return;
     };
     let codex_auth = run_codex(&["auth", "current", "--help"]);
@@ -102,7 +100,7 @@ fn parity_oracle_format_flag_visibility_matches_gemini_for_auth_and_diag_help() 
 
 #[test]
 fn parity_oracle_auth_json_schema_ids_are_provider_specific() {
-    let Some(gemini_bin) = gemini_cli_bin() else {
+    let Some(gemini_bin) = gemini_cli_bin_or_skip() else {
         return;
     };
     let codex = run_codex(&["auth", "current", "--json"]);

--- a/crates/codex-cli/tests/integration/parity_oracle.rs
+++ b/crates/codex-cli/tests/integration/parity_oracle.rs
@@ -2,14 +2,19 @@ use nils_test_support::bin;
 use nils_test_support::cmd::{self, CmdOutput};
 use pretty_assertions::assert_eq;
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn codex_cli_bin() -> PathBuf {
     bin::resolve("codex-cli")
 }
 
-fn gemini_cli_bin() -> PathBuf {
-    bin::resolve("gemini-cli")
+/// `gemini-cli` belongs to another package, so a package-scoped run has no reason
+/// to have built it, and an artifact left behind by an earlier build would
+/// compare this CLI against a different release. Either way the answer says
+/// nothing about parity, so skip with a reason instead of asserting.
+/// See `sympoies/nils-cli#1413`.
+fn gemini_cli_bin() -> Option<PathBuf> {
+    bin::sibling_or_skip("gemini-cli", "nils-gemini-cli")
 }
 
 fn run_codex(args: &[&str]) -> CmdOutput {
@@ -17,9 +22,8 @@ fn run_codex(args: &[&str]) -> CmdOutput {
     cmd::run(&bin, args, &[], None)
 }
 
-fn run_gemini(args: &[&str]) -> CmdOutput {
-    let bin = gemini_cli_bin();
-    cmd::run(&bin, args, &[], None)
+fn run_gemini(bin: &Path, args: &[&str]) -> CmdOutput {
+    cmd::run(bin, args, &[], None)
 }
 
 fn extract_commands(help_text: &str) -> Vec<String> {
@@ -53,8 +57,11 @@ fn extract_commands(help_text: &str) -> Vec<String> {
 
 #[test]
 fn parity_oracle_topology_matches_gemini() {
+    let Some(gemini_bin) = gemini_cli_bin() else {
+        return;
+    };
     let codex = run_codex(&["--help"]);
-    let gemini = run_gemini(&["--help"]);
+    let gemini = run_gemini(&gemini_bin, &["--help"]);
     assert_eq!(codex.code, 0, "stderr={}", codex.stderr_text());
     assert_eq!(gemini.code, 0, "stderr={}", gemini.stderr_text());
 
@@ -65,8 +72,11 @@ fn parity_oracle_topology_matches_gemini() {
 
 #[test]
 fn parity_oracle_format_flag_visibility_matches_gemini_for_auth_and_diag_help() {
+    let Some(gemini_bin) = gemini_cli_bin() else {
+        return;
+    };
     let codex_auth = run_codex(&["auth", "current", "--help"]);
-    let gemini_auth = run_gemini(&["auth", "current", "--help"]);
+    let gemini_auth = run_gemini(&gemini_bin, &["auth", "current", "--help"]);
     assert_eq!(codex_auth.code, 0);
     assert_eq!(gemini_auth.code, 0);
     let codex_auth_text = codex_auth.stdout_text();
@@ -77,7 +87,7 @@ fn parity_oracle_format_flag_visibility_matches_gemini_for_auth_and_diag_help() 
     assert!(!gemini_auth_text.contains("--json"));
 
     let codex_diag = run_codex(&["diag", "rate-limits", "--help"]);
-    let gemini_diag = run_gemini(&["diag", "rate-limits", "--help"]);
+    let gemini_diag = run_gemini(&gemini_bin, &["diag", "rate-limits", "--help"]);
     assert_eq!(codex_diag.code, 0);
     assert_eq!(gemini_diag.code, 0);
     let codex_diag_text = codex_diag.stdout_text();
@@ -92,8 +102,11 @@ fn parity_oracle_format_flag_visibility_matches_gemini_for_auth_and_diag_help() 
 
 #[test]
 fn parity_oracle_auth_json_schema_ids_are_provider_specific() {
+    let Some(gemini_bin) = gemini_cli_bin() else {
+        return;
+    };
     let codex = run_codex(&["auth", "current", "--json"]);
-    let gemini = run_gemini(&["auth", "current", "--json"]);
+    let gemini = run_gemini(&gemini_bin, &["auth", "current", "--json"]);
 
     let codex_json: Value = serde_json::from_str(&codex.stdout_text()).expect("codex auth json");
     let gemini_json: Value = serde_json::from_str(&gemini.stdout_text()).expect("gemini auth json");

--- a/crates/gemini-cli/tests/integration/parity_oracle.rs
+++ b/crates/gemini-cli/tests/integration/parity_oracle.rs
@@ -2,14 +2,19 @@ use nils_test_support::bin;
 use nils_test_support::cmd::{self, CmdOutput};
 use pretty_assertions::assert_eq;
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn gemini_cli_bin() -> PathBuf {
     bin::resolve("gemini-cli")
 }
 
-fn codex_cli_bin() -> PathBuf {
-    bin::resolve("codex-cli")
+/// `codex-cli` belongs to another package, so a package-scoped run has no reason
+/// to have built it, and an artifact left behind by an earlier build would
+/// compare this CLI against a different release. Either way the answer says
+/// nothing about parity, so skip with a reason instead of asserting.
+/// See `sympoies/nils-cli#1413`.
+fn codex_cli_bin() -> Option<PathBuf> {
+    bin::sibling_or_skip("codex-cli", "nils-codex-cli")
 }
 
 fn run_gemini(args: &[&str]) -> CmdOutput {
@@ -17,9 +22,8 @@ fn run_gemini(args: &[&str]) -> CmdOutput {
     cmd::run(&bin, args, &[], None)
 }
 
-fn run_codex(args: &[&str]) -> CmdOutput {
-    let bin = codex_cli_bin();
-    cmd::run(&bin, args, &[], None)
+fn run_codex(bin: &Path, args: &[&str]) -> CmdOutput {
+    cmd::run(bin, args, &[], None)
 }
 
 fn extract_commands(help_text: &str) -> Vec<String> {
@@ -53,8 +57,11 @@ fn extract_commands(help_text: &str) -> Vec<String> {
 
 #[test]
 fn parity_oracle_topology_matches_codex() {
+    let Some(codex_bin) = codex_cli_bin() else {
+        return;
+    };
     let gemini = run_gemini(&["--help"]);
-    let codex = run_codex(&["--help"]);
+    let codex = run_codex(&codex_bin, &["--help"]);
     assert_eq!(gemini.code, 0, "stderr={}", gemini.stderr_text());
     assert_eq!(codex.code, 0, "stderr={}", codex.stderr_text());
 
@@ -65,8 +72,11 @@ fn parity_oracle_topology_matches_codex() {
 
 #[test]
 fn parity_oracle_format_flag_visibility_matches_codex_for_auth_and_diag_help() {
+    let Some(codex_bin) = codex_cli_bin() else {
+        return;
+    };
     let gemini_auth = run_gemini(&["auth", "current", "--help"]);
-    let codex_auth = run_codex(&["auth", "current", "--help"]);
+    let codex_auth = run_codex(&codex_bin, &["auth", "current", "--help"]);
     assert_eq!(gemini_auth.code, 0);
     assert_eq!(codex_auth.code, 0);
     let gemini_auth_text = gemini_auth.stdout_text();
@@ -77,7 +87,7 @@ fn parity_oracle_format_flag_visibility_matches_codex_for_auth_and_diag_help() {
     assert!(!codex_auth_text.contains("--json"));
 
     let gemini_diag = run_gemini(&["diag", "rate-limits", "--help"]);
-    let codex_diag = run_codex(&["diag", "rate-limits", "--help"]);
+    let codex_diag = run_codex(&codex_bin, &["diag", "rate-limits", "--help"]);
     assert_eq!(gemini_diag.code, 0);
     assert_eq!(codex_diag.code, 0);
     let gemini_diag_text = gemini_diag.stdout_text();
@@ -92,8 +102,11 @@ fn parity_oracle_format_flag_visibility_matches_codex_for_auth_and_diag_help() {
 
 #[test]
 fn parity_oracle_auth_json_schema_ids_are_provider_specific() {
+    let Some(codex_bin) = codex_cli_bin() else {
+        return;
+    };
     let gemini = run_gemini(&["auth", "current", "--json"]);
-    let codex = run_codex(&["auth", "current", "--json"]);
+    let codex = run_codex(&codex_bin, &["auth", "current", "--json"]);
 
     let gemini_json: Value = serde_json::from_str(&gemini.stdout_text()).expect("gemini auth json");
     let codex_json: Value = serde_json::from_str(&codex.stdout_text()).expect("codex auth json");

--- a/crates/gemini-cli/tests/integration/parity_oracle.rs
+++ b/crates/gemini-cli/tests/integration/parity_oracle.rs
@@ -8,12 +8,10 @@ fn gemini_cli_bin() -> PathBuf {
     bin::resolve("gemini-cli")
 }
 
-/// `codex-cli` belongs to another package, so a package-scoped run has no reason
-/// to have built it, and an artifact left behind by an earlier build would
-/// compare this CLI against a different release. Either way the answer says
-/// nothing about parity, so skip with a reason instead of asserting.
-/// See `sympoies/nils-cli#1413`.
-fn codex_cli_bin() -> Option<PathBuf> {
+/// `None` means this run cannot compare against `codex-cli` at all, so the
+/// parity assertions below do not run. `bin::sibling_or_skip` owns why that
+/// happens and when it is legitimate.
+fn codex_cli_bin_or_skip() -> Option<PathBuf> {
     bin::sibling_or_skip("codex-cli", "nils-codex-cli")
 }
 
@@ -57,7 +55,7 @@ fn extract_commands(help_text: &str) -> Vec<String> {
 
 #[test]
 fn parity_oracle_topology_matches_codex() {
-    let Some(codex_bin) = codex_cli_bin() else {
+    let Some(codex_bin) = codex_cli_bin_or_skip() else {
         return;
     };
     let gemini = run_gemini(&["--help"]);
@@ -72,7 +70,7 @@ fn parity_oracle_topology_matches_codex() {
 
 #[test]
 fn parity_oracle_format_flag_visibility_matches_codex_for_auth_and_diag_help() {
-    let Some(codex_bin) = codex_cli_bin() else {
+    let Some(codex_bin) = codex_cli_bin_or_skip() else {
         return;
     };
     let gemini_auth = run_gemini(&["auth", "current", "--help"]);
@@ -102,7 +100,7 @@ fn parity_oracle_format_flag_visibility_matches_codex_for_auth_and_diag_help() {
 
 #[test]
 fn parity_oracle_auth_json_schema_ids_are_provider_specific() {
-    let Some(codex_bin) = codex_cli_bin() else {
+    let Some(codex_bin) = codex_cli_bin_or_skip() else {
         return;
     };
     let gemini = run_gemini(&["auth", "current", "--json"]);

--- a/crates/nils-test-support/README.md
+++ b/crates/nils-test-support/README.md
@@ -43,7 +43,13 @@ Stale-test cleanup sequencing is frozen in
     still reaches the child
   - `cmd::path_with_prepend_excluding_program`: construct a PATH that prepends stubs while filtering one real binary
 - Workspace binaries
-  - `bin`: `resolve` finds `CARGO_BIN_EXE_*` or falls back to `target/<profile>/<name>`
+  - `bin`: `resolve` finds `CARGO_BIN_EXE_*` or falls back to `target/<profile>/<name>`, panicking when neither
+    yields a path; `resolve_optional` returns `None` instead
+  - `bin::sibling_or_skip`: for a binary **another package** owns. Cargo sets `CARGO_BIN_EXE_*` only for the
+    package under test — a `dev-dependencies` entry neither exports it nor builds the dependency's binary — so a
+    package-scoped run may find nothing, or find an artifact from an earlier release. Both return `None` with a
+    stderr reason naming the build command, so the test skips instead of asserting against the wrong artifact.
+    `bin::sibling` exposes the same classification as a `Sibling` value
 - Git helpers
   - `git`: init temp repos (`InitRepoOptions`), run git commands, and commit files
 - Stubbing external tools

--- a/crates/nils-test-support/README.md
+++ b/crates/nils-test-support/README.md
@@ -47,9 +47,11 @@ Stale-test cleanup sequencing is frozen in
     yields a path; `resolve_optional` returns `None` instead
   - `bin::sibling_or_skip`: for a binary **another package** owns. Cargo sets `CARGO_BIN_EXE_*` only for the
     package under test — a `dev-dependencies` entry neither exports it nor builds the dependency's binary — so a
-    package-scoped run may find nothing, or find an artifact from an earlier release. Both return `None` with a
-    stderr reason naming the build command, so the test skips instead of asserting against the wrong artifact.
-    `bin::sibling` exposes the same classification as a `Sibling` value
+    package-scoped run may find nothing, or find an artifact from an earlier release. Returns `None` with a
+    stderr reason naming the build command when nothing was built, and **panics** when an artifact was selected
+    but does not belong to this build, since that is an operator error rather than a property of the run.
+    `NILS_TEST_REQUIRE_SIBLING_BINS=1` makes the absent case fatal too; CI sets it. The gate detects
+    cross-release artifacts only — a same-release artifact built from an older commit is accepted
 - Git helpers
   - `git`: init temp repos (`InitRepoOptions`), run git commands, and commit files
 - Stubbing external tools

--- a/crates/nils-test-support/src/bin.rs
+++ b/crates/nils-test-support/src/bin.rs
@@ -1,4 +1,12 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Release every crate in this workspace is bumped to.
+///
+/// `nils-test-support` is versioned in lockstep with the rest of the workspace,
+/// so its own package version is the release a workspace binary must report to
+/// belong to this build.
+pub const WORKSPACE_RELEASE: &str = env!("CARGO_PKG_VERSION");
 
 /// Resolve a workspace binary path for tests.
 ///
@@ -8,11 +16,23 @@ use std::path::PathBuf;
 ///
 /// When no env var is present, it falls back to `target/<profile>/<name>` based
 /// on the current test executable location.
+///
+/// Panics when neither source yields a path. Use [`sibling_or_skip`] for a
+/// binary another package owns, where absence is a property of the run rather
+/// than a defect.
 pub fn resolve(bin_name: &str) -> PathBuf {
-    let candidates = env_names(bin_name);
-    for candidate in candidates {
+    resolve_optional(bin_name).unwrap_or_else(|| panic!("{bin_name} binary path: NotPresent"))
+}
+
+/// Resolve a workspace binary path for tests, or `None` when nothing is there.
+///
+/// This reports presence only. A path it returns can still be an artifact from
+/// an earlier build, so prefer [`sibling`] when the binary belongs to another
+/// package.
+pub fn resolve_optional(bin_name: &str) -> Option<PathBuf> {
+    for candidate in env_names(bin_name) {
         if let Ok(bin) = std::env::var(&candidate) {
-            return PathBuf::from(bin);
+            return Some(PathBuf::from(bin));
         }
     }
 
@@ -20,11 +40,113 @@ pub fn resolve(bin_name: &str) -> PathBuf {
     let target_dir = exe.parent().and_then(|p| p.parent()).expect("target dir");
     let bin_file = format!("{bin_name}{}", std::env::consts::EXE_SUFFIX);
     let bin = target_dir.join(bin_file);
-    if bin.exists() {
-        return bin;
+    bin.exists().then_some(bin)
+}
+
+/// Whether a workspace binary another package owns can be used by this test run.
+///
+/// Cargo sets `CARGO_BIN_EXE_<name>` only for binaries of the package being
+/// tested. A `dev-dependencies` entry does not extend that: it neither exports
+/// the variable nor builds the dependency's binary. So a cross-crate sibling is
+/// resolved from `target/<profile>/<name>`, where a package-scoped run has no
+/// reason to have built it and an earlier build may have left an artifact from
+/// another release. See `sympoies/nils-cli#1413`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Sibling {
+    /// Present and reporting [`WORKSPACE_RELEASE`].
+    Ready(PathBuf),
+    /// Neither `CARGO_BIN_EXE_<name>` nor an artifact in the profile directory.
+    Absent,
+    /// An artifact exists but does not belong to this build: it reports another
+    /// release, or its `--version` could not be read at all.
+    ReleaseMismatch { reported: Option<String> },
+}
+
+impl Sibling {
+    /// The usable path, or `None` when this run cannot use the sibling.
+    pub fn ready(&self) -> Option<&Path> {
+        match self {
+            Self::Ready(path) => Some(path),
+            _ => None,
+        }
     }
 
-    panic!("{bin_name} binary path: NotPresent");
+    /// Why this run cannot use the sibling, naming the build command that fixes
+    /// it. `None` when the sibling is [`Sibling::Ready`].
+    ///
+    /// The message deliberately omits the artifact path: it is machine-local and
+    /// the build command is the actionable part.
+    pub fn skip_reason(&self, bin_name: &str, cargo_package: &str) -> Option<String> {
+        let build = format!("cargo build -p {cargo_package} --bins");
+        match self {
+            Self::Ready(_) => None,
+            Self::Absent => Some(format!(
+                "skipping: the `{bin_name}` binary is not built for this run. \
+                 A package-scoped run does not build a binary another package owns. \
+                 Run `{build}`, or any full-workspace build, first."
+            )),
+            Self::ReleaseMismatch {
+                reported: Some(reported),
+            } => Some(format!(
+                "skipping: the `{bin_name}` binary reports release {reported} but this \
+                 workspace builds {WORKSPACE_RELEASE}, so the artifact is from an earlier \
+                 build. Run `{build}` to refresh it."
+            )),
+            Self::ReleaseMismatch { reported: None } => Some(format!(
+                "skipping: the `{bin_name}` binary did not report a usable release from \
+                 `--version`. Run `{build}` to rebuild it."
+            )),
+        }
+    }
+}
+
+/// Classify a workspace binary another package owns.
+///
+/// The release is read from the artifact's own `--version` rather than inferred
+/// from its mtime, because a stale artifact is indistinguishable from a current
+/// one by timestamp alone once the sibling stops being rebuilt.
+pub fn sibling(bin_name: &str) -> Sibling {
+    let Some(path) = resolve_optional(bin_name) else {
+        return Sibling::Absent;
+    };
+
+    match reported_release(&path) {
+        Some(release) if release == WORKSPACE_RELEASE => Sibling::Ready(path),
+        reported => Sibling::ReleaseMismatch { reported },
+    }
+}
+
+/// Resolve a sibling binary, or explain on stderr why this test cannot run.
+///
+/// Returns `None` so the caller can return early instead of asserting against an
+/// absent or stale artifact. A full-workspace run always builds the sibling at
+/// the current release, so this never skips on CI; the reason is visible locally
+/// under `cargo nextest run --no-capture`.
+pub fn sibling_or_skip(bin_name: &str, cargo_package: &str) -> Option<PathBuf> {
+    let sibling = sibling(bin_name);
+    if let Some(reason) = sibling.skip_reason(bin_name, cargo_package) {
+        eprintln!("{reason}");
+        return None;
+    }
+
+    sibling.ready().map(Path::to_path_buf)
+}
+
+/// Read the release an artifact reports from its own `--version`.
+///
+/// Every user-facing CLI in this workspace exposes root `--version` and prints
+/// the package version as its second whitespace-separated token, so a failure to
+/// run or parse means the artifact is not usable rather than merely old.
+fn reported_release(path: &Path) -> Option<String> {
+    let output = Command::new(path).arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .nth(1)
+        .map(str::to_string)
 }
 
 fn env_names(bin_name: &str) -> Vec<String> {

--- a/crates/nils-test-support/src/bin.rs
+++ b/crates/nils-test-support/src/bin.rs
@@ -4,9 +4,18 @@ use std::process::Command;
 /// Release every crate in this workspace is bumped to.
 ///
 /// `nils-test-support` is versioned in lockstep with the rest of the workspace,
-/// so its own package version is the release a workspace binary must report to
-/// belong to this build.
-pub const WORKSPACE_RELEASE: &str = env!("CARGO_PKG_VERSION");
+/// which `scripts/ci/workspace-version-lockstep.sh --strict` enforces as a
+/// required check, so this crate's own package version is the release a
+/// workspace binary must report to belong to this build.
+const WORKSPACE_RELEASE: &str = env!("CARGO_PKG_VERSION");
+
+/// Set this to make an absent sibling fatal instead of a skip.
+///
+/// A skip reaches captured output, which both test runners discard for a passing
+/// test, so a lane that is supposed to build every binary would report
+/// green-but-empty if resolution ever regressed. CI sets this for the same reason
+/// `AGENT_SESSION_TEST_REQUIRE_CGROUP` exists.
+const REQUIRE_SIBLING_ENV: &str = "NILS_TEST_REQUIRE_SIBLING_BINS";
 
 /// Resolve a workspace binary path for tests.
 ///
@@ -24,15 +33,30 @@ pub fn resolve(bin_name: &str) -> PathBuf {
     resolve_optional(bin_name).unwrap_or_else(|| panic!("{bin_name} binary path: NotPresent"))
 }
 
-/// Resolve a workspace binary path for tests, or `None` when nothing is there.
+/// Resolve a workspace binary path for tests, or `None` when nothing selects one.
 ///
-/// This reports presence only. A path it returns can still be an artifact from
-/// an earlier build, so prefer [`sibling`] when the binary belongs to another
-/// package.
+/// This reports selection only. A path it returns can be an artifact from an
+/// earlier release, and an env-var value is returned verbatim without an
+/// existence check, so prefer [`sibling_or_skip`] when the binary belongs to
+/// another package.
 pub fn resolve_optional(bin_name: &str) -> Option<PathBuf> {
+    select(bin_name).map(|(path, _)| path)
+}
+
+/// What selected an artifact, so a reason can name the input to fix rather than a
+/// machine-local path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Origin {
+    /// A `CARGO_BIN_EXE_*` value, returned verbatim and never existence-checked.
+    CargoEnv(String),
+    /// An artifact found in `target/<profile>`, which was checked to exist.
+    ProfileDir,
+}
+
+fn select(bin_name: &str) -> Option<(PathBuf, Origin)> {
     for candidate in env_names(bin_name) {
         if let Ok(bin) = std::env::var(&candidate) {
-            return Some(PathBuf::from(bin));
+            return Some((PathBuf::from(bin), Origin::CargoEnv(candidate)));
         }
     }
 
@@ -40,7 +64,7 @@ pub fn resolve_optional(bin_name: &str) -> Option<PathBuf> {
     let target_dir = exe.parent().and_then(|p| p.parent()).expect("target dir");
     let bin_file = format!("{bin_name}{}", std::env::consts::EXE_SUFFIX);
     let bin = target_dir.join(bin_file);
-    bin.exists().then_some(bin)
+    bin.exists().then_some((bin, Origin::ProfileDir))
 }
 
 /// Whether a workspace binary another package owns can be used by this test run.
@@ -48,56 +72,86 @@ pub fn resolve_optional(bin_name: &str) -> Option<PathBuf> {
 /// Cargo sets `CARGO_BIN_EXE_<name>` only for binaries of the package being
 /// tested. A `dev-dependencies` entry does not extend that: it neither exports
 /// the variable nor builds the dependency's binary. So a cross-crate sibling is
-/// resolved from `target/<profile>/<name>`, where a package-scoped run has no
+/// selected from `target/<profile>/<name>`, where a package-scoped run has no
 /// reason to have built it and an earlier build may have left an artifact from
 /// another release. See `sympoies/nils-cli#1413`.
+///
+/// Exactly one of these outcomes is a property of the run; the rest are operator
+/// errors, which is why [`sibling_or_skip`] skips one and fails the others.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Sibling {
-    /// Present and reporting [`WORKSPACE_RELEASE`].
+enum Sibling {
+    /// Selected and reporting [`WORKSPACE_RELEASE`].
     Ready(PathBuf),
-    /// Neither `CARGO_BIN_EXE_<name>` nor an artifact in the profile directory.
+    /// Nothing selected an artifact: no `CARGO_BIN_EXE_<name>`, and nothing in
+    /// the profile directory. The only legitimate reason a run cannot use the
+    /// sibling.
     Absent,
-    /// An artifact exists but does not belong to this build: it reports another
-    /// release, or its `--version` could not be read at all.
-    ReleaseMismatch { reported: Option<String> },
+    /// An artifact was selected but reports a different release.
+    WrongRelease { reported: String, origin: Origin },
+    /// An artifact was selected but could not be identified at all: it did not
+    /// run, or its `--version` carried nothing parseable. A dangling
+    /// `CARGO_BIN_EXE_*` value lands here rather than in
+    /// [`Sibling::Absent`], because something did select it.
+    Unidentifiable { origin: Origin },
 }
 
 impl Sibling {
-    /// The usable path, or `None` when this run cannot use the sibling.
-    pub fn ready(&self) -> Option<&Path> {
-        match self {
-            Self::Ready(path) => Some(path),
-            _ => None,
-        }
-    }
-
-    /// Why this run cannot use the sibling, naming the build command that fixes
-    /// it. `None` when the sibling is [`Sibling::Ready`].
+    /// Why this run cannot use the sibling, and whether that is a legitimate
+    /// skip. `None` when the sibling is [`Sibling::Ready`].
     ///
-    /// The message deliberately omits the artifact path: it is machine-local and
-    /// the build command is the actionable part.
-    pub fn skip_reason(&self, bin_name: &str, cargo_package: &str) -> Option<String> {
+    /// The messages deliberately omit the artifact path: it is machine-local, and
+    /// the input to fix is the actionable part.
+    fn unusable(&self, bin_name: &str, cargo_package: &str) -> Option<Unusable> {
         let build = format!("cargo build -p {cargo_package} --bins");
         match self {
             Self::Ready(_) => None,
-            Self::Absent => Some(format!(
-                "skipping: the `{bin_name}` binary is not built for this run. \
-                 A package-scoped run does not build a binary another package owns. \
-                 Run `{build}`, or any full-workspace build, first."
-            )),
-            Self::ReleaseMismatch {
-                reported: Some(reported),
-            } => Some(format!(
-                "skipping: the `{bin_name}` binary reports release {reported} but this \
-                 workspace builds {WORKSPACE_RELEASE}, so the artifact is from an earlier \
-                 build. Run `{build}` to refresh it."
-            )),
-            Self::ReleaseMismatch { reported: None } => Some(format!(
-                "skipping: the `{bin_name}` binary did not report a usable release from \
-                 `--version`. Run `{build}` to rebuild it."
-            )),
+            Self::Absent => Some(Unusable {
+                skippable: true,
+                message: format!(
+                    "the `{bin_name}` binary is not built for this run. A package-scoped run \
+                     does not build a binary another package owns. Run `{build}`, or any \
+                     full-workspace build, first."
+                ),
+            }),
+            Self::WrongRelease { reported, origin } => Some(Unusable {
+                skippable: false,
+                message: format!(
+                    "the `{bin_name}` binary reports release {reported} but this workspace \
+                     builds {WORKSPACE_RELEASE}, so the artifact is from an earlier release. \
+                     {}",
+                    origin.remedy(&build)
+                ),
+            }),
+            Self::Unidentifiable { origin } => Some(Unusable {
+                skippable: false,
+                message: format!(
+                    "the `{bin_name}` binary did not answer `--version` with a release, so it \
+                     cannot be identified. {}",
+                    origin.remedy(&build)
+                ),
+            }),
         }
     }
+}
+
+impl Origin {
+    /// What to fix. A dangling or misdirected override is not repaired by any
+    /// rebuild, so naming the variable matters more than naming the path.
+    fn remedy(&self, build: &str) -> String {
+        match self {
+            Self::CargoEnv(variable) => format!(
+                "`{variable}` selected it, so that value is what needs fixing - rebuilding will \
+                 not change it."
+            ),
+            Self::ProfileDir => format!("Run `{build}` to refresh it."),
+        }
+    }
+}
+
+/// Why a run cannot use a sibling, and whether skipping is legitimate.
+struct Unusable {
+    message: String,
+    skippable: bool,
 }
 
 /// Classify a workspace binary another package owns.
@@ -105,38 +159,63 @@ impl Sibling {
 /// The release is read from the artifact's own `--version` rather than inferred
 /// from its mtime, because a stale artifact is indistinguishable from a current
 /// one by timestamp alone once the sibling stops being rebuilt.
-pub fn sibling(bin_name: &str) -> Sibling {
-    let Some(path) = resolve_optional(bin_name) else {
+///
+/// Two boundaries are worth knowing:
+///
+/// - The gate detects **cross-release** artifacts only. An artifact built from an
+///   older commit within the same release reports the same release and is
+///   [`Sibling::Ready`]; intra-release drift remains the caller's problem.
+/// - The probe runs the artifact and waits for it, so this is only for a binary
+///   whose root `--version` is answered before any real work. Every user-facing
+///   CLI in this workspace satisfies that because clap handles it during parse.
+fn sibling(bin_name: &str) -> Sibling {
+    let Some((path, origin)) = select(bin_name) else {
         return Sibling::Absent;
     };
 
     match reported_release(&path) {
         Some(release) if release == WORKSPACE_RELEASE => Sibling::Ready(path),
-        reported => Sibling::ReleaseMismatch { reported },
+        Some(reported) => Sibling::WrongRelease { reported, origin },
+        None => Sibling::Unidentifiable { origin },
     }
 }
 
 /// Resolve a sibling binary, or explain on stderr why this test cannot run.
 ///
-/// Returns `None` so the caller can return early instead of asserting against an
-/// absent or stale artifact. A full-workspace run always builds the sibling at
-/// the current release, so this never skips on CI; the reason is visible locally
-/// under `cargo nextest run --no-capture`.
+/// Returns `None` only when nothing selected an artifact — the package-scoped
+/// case, where skipping is honest. Panics when an artifact *was* selected but
+/// does not belong to this build: a stale `target/<profile>` artifact or a
+/// misdirected `CARGO_BIN_EXE_*` is an operator error, and skipping it would
+/// hide that the test never ran against the binary it names.
+///
+/// Set `NILS_TEST_REQUIRE_SIBLING_BINS=1` to make the absent case fatal too. CI
+/// sets it, so a lane that should have built every binary cannot report
+/// green-but-empty if resolution regresses.
 pub fn sibling_or_skip(bin_name: &str, cargo_package: &str) -> Option<PathBuf> {
-    let sibling = sibling(bin_name);
-    if let Some(reason) = sibling.skip_reason(bin_name, cargo_package) {
-        eprintln!("{reason}");
-        return None;
-    }
+    match sibling(bin_name) {
+        Sibling::Ready(path) => Some(path),
+        other => {
+            let unusable = other
+                .unusable(bin_name, cargo_package)
+                .expect("every non-Ready sibling has a reason");
+            if unusable.skippable && !require_sibling() {
+                eprintln!("skipping: {}", unusable.message);
+                return None;
+            }
 
-    sibling.ready().map(Path::to_path_buf)
+            panic!("{}", unusable.message);
+        }
+    }
+}
+
+fn require_sibling() -> bool {
+    std::env::var(REQUIRE_SIBLING_ENV).is_ok_and(|value| value == "1")
 }
 
 /// Read the release an artifact reports from its own `--version`.
 ///
 /// Every user-facing CLI in this workspace exposes root `--version` and prints
-/// the package version as its second whitespace-separated token, so a failure to
-/// run or parse means the artifact is not usable rather than merely old.
+/// the package version as its second whitespace-separated token.
 fn reported_release(path: &Path) -> Option<String> {
     let output = Command::new(path).arg("--version").output().ok()?;
     if !output.status.success() {
@@ -165,7 +244,35 @@ fn env_names(bin_name: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::env_names;
+    use super::{Origin, Sibling, WORKSPACE_RELEASE, env_names, resolve_optional, sibling};
+    use crate::{EnvGuard, GlobalStateLock, write_exe};
+    use tempfile::TempDir;
+
+    /// Guard both spellings Cargo could have exported for a hyphenated name, so
+    /// the absent cases cannot be satisfied by an inherited variable.
+    fn without_bin_exe_env(lock: &GlobalStateLock, bin_name: &str) -> Vec<EnvGuard> {
+        vec![
+            EnvGuard::remove(lock, &format!("CARGO_BIN_EXE_{bin_name}")),
+            EnvGuard::remove(
+                lock,
+                &format!("CARGO_BIN_EXE_{}", bin_name.replace('-', "_")),
+            ),
+        ]
+    }
+
+    /// Write a stub that answers `--version` the way a workspace CLI does.
+    #[cfg(unix)]
+    fn write_version_stub(
+        dir: &std::path::Path,
+        bin_name: &str,
+        release: &str,
+    ) -> std::path::PathBuf {
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' '{bin_name} {release} (v{release}, rustc 1.0.0 (0000000 1970-01-01))'\n"
+        );
+        write_exe(dir, bin_name, &script);
+        dir.join(bin_name)
+    }
 
     #[test]
     fn env_names_includes_variants() {
@@ -186,5 +293,192 @@ mod tests {
                 "CARGO_BIN_EXE_api-test".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn resolve_optional_reports_absence_instead_of_panicking() {
+        let lock = GlobalStateLock::new();
+        let _guards = without_bin_exe_env(&lock, "nts-absent-sibling");
+
+        assert_eq!(resolve_optional("nts-absent-sibling"), None);
+    }
+
+    #[test]
+    fn sibling_is_absent_when_nothing_selects_an_artifact() {
+        let lock = GlobalStateLock::new();
+        let _guards = without_bin_exe_env(&lock, "nts-absent-sibling");
+
+        assert_eq!(sibling("nts-absent-sibling"), Sibling::Absent);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sibling_is_ready_when_the_artifact_reports_this_workspace_release() {
+        let lock = GlobalStateLock::new();
+        let temp = TempDir::new().expect("tempdir");
+        let path = write_version_stub(temp.path(), "nts-current-sibling", WORKSPACE_RELEASE);
+        let _guard = EnvGuard::set(
+            &lock,
+            "CARGO_BIN_EXE_nts-current-sibling",
+            path.to_str().expect("path"),
+        );
+
+        assert_eq!(sibling("nts-current-sibling"), Sibling::Ready(path));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sibling_reports_the_wrong_release_for_an_artifact_from_an_earlier_one() {
+        let lock = GlobalStateLock::new();
+        let temp = TempDir::new().expect("tempdir");
+        let path = write_version_stub(temp.path(), "nts-stale-sibling", "1.0.0");
+        let _guard = EnvGuard::set(
+            &lock,
+            "CARGO_BIN_EXE_nts-stale-sibling",
+            path.to_str().expect("path"),
+        );
+
+        assert_eq!(
+            sibling("nts-stale-sibling"),
+            Sibling::WrongRelease {
+                reported: "1.0.0".to_string(),
+                origin: Origin::CargoEnv("CARGO_BIN_EXE_nts-stale-sibling".to_string()),
+            }
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sibling_is_unidentifiable_when_version_cannot_be_read() {
+        let lock = GlobalStateLock::new();
+        let temp = TempDir::new().expect("tempdir");
+        write_exe(temp.path(), "nts-broken-sibling", "#!/bin/sh\nexit 1\n");
+        let path = temp.path().join("nts-broken-sibling");
+        let _guard = EnvGuard::set(
+            &lock,
+            "CARGO_BIN_EXE_nts-broken-sibling",
+            path.to_str().expect("path"),
+        );
+
+        assert_eq!(
+            sibling("nts-broken-sibling"),
+            Sibling::Unidentifiable {
+                origin: Origin::CargoEnv("CARGO_BIN_EXE_nts-broken-sibling".to_string()),
+            }
+        );
+    }
+
+    /// A dangling override is selected by something, so it must not read as
+    /// "nothing was built" — the remedy is the variable, not a rebuild.
+    #[test]
+    fn a_dangling_override_is_unidentifiable_rather_than_absent() {
+        let lock = GlobalStateLock::new();
+        let temp = TempDir::new().expect("tempdir");
+        let missing = temp.path().join("nts-dangling-sibling");
+        let _guard = EnvGuard::set(
+            &lock,
+            "CARGO_BIN_EXE_nts-dangling-sibling",
+            missing.to_str().expect("path"),
+        );
+
+        let classified = sibling("nts-dangling-sibling");
+        assert_eq!(
+            classified,
+            Sibling::Unidentifiable {
+                origin: Origin::CargoEnv("CARGO_BIN_EXE_nts-dangling-sibling".to_string()),
+            }
+        );
+
+        let unusable = classified
+            .unusable("nts-dangling-sibling", "nils-nts")
+            .expect("a dangling override is unusable");
+        assert!(!unusable.skippable, "message={}", unusable.message);
+        assert!(
+            unusable
+                .message
+                .contains("CARGO_BIN_EXE_nts-dangling-sibling"),
+            "message={}",
+            unusable.message
+        );
+        assert!(
+            !unusable.message.contains("cargo build -p"),
+            "a rebuild cannot fix an override; message={}",
+            unusable.message
+        );
+    }
+
+    #[test]
+    fn only_an_absent_sibling_is_skippable() {
+        let absent = Sibling::Absent
+            .unusable("gemini-cli", "nils-gemini-cli")
+            .expect("an absent sibling is unusable");
+        assert!(absent.skippable);
+        assert!(
+            absent
+                .message
+                .contains("cargo build -p nils-gemini-cli --bins"),
+            "message={}",
+            absent.message
+        );
+
+        let stale = Sibling::WrongRelease {
+            reported: "1.25.13".to_string(),
+            origin: Origin::ProfileDir,
+        }
+        .unusable("agent-docs", "nils-agent-docs")
+        .expect("a stale sibling is unusable");
+        assert!(!stale.skippable, "message={}", stale.message);
+        assert!(
+            stale.message.contains("1.25.13"),
+            "message={}",
+            stale.message
+        );
+        assert!(
+            stale.message.contains(WORKSPACE_RELEASE),
+            "message={}",
+            stale.message
+        );
+        assert!(
+            stale
+                .message
+                .contains("cargo build -p nils-agent-docs --bins"),
+            "message={}",
+            stale.message
+        );
+    }
+
+    #[test]
+    fn a_ready_sibling_has_no_unusable_reason() {
+        let ready = Sibling::Ready(std::path::PathBuf::from("agent-docs"));
+
+        assert!(ready.unusable("agent-docs", "nils-agent-docs").is_none());
+    }
+
+    /// Pin the `--version` format against a real workspace artifact rather than
+    /// against a stub that writes the shape the parser expects.
+    ///
+    /// Vacuous where no sibling is built, which is the package-scoped case. It
+    /// carries its weight in the lanes that build every binary: if clap's
+    /// rendering or `nils_build_info::long_version` ever stopped putting the
+    /// release in the second token, every sibling would classify as
+    /// `Unidentifiable` and this fails instead of the parity and read-only
+    /// suites quietly losing their subject.
+    #[test]
+    fn a_real_workspace_artifact_is_never_unidentifiable() {
+        let lock = GlobalStateLock::new();
+        let _guards = without_bin_exe_env(&lock, "agent-docs");
+
+        match sibling("agent-docs") {
+            Sibling::Absent => {}
+            Sibling::Ready(_) => {}
+            Sibling::WrongRelease { reported, .. } => assert!(
+                reported.split('.').count() >= 2,
+                "a real artifact should report a release-shaped version, got {reported}"
+            ),
+            Sibling::Unidentifiable { origin } => panic!(
+                "a built agent-docs must answer --version with a release in its second token; \
+                 origin={origin:?}"
+            ),
+        }
     }
 }

--- a/crates/nils-test-support/tests/integration/bin_cmd.rs
+++ b/crates/nils-test-support/tests/integration/bin_cmd.rs
@@ -2,6 +2,29 @@ use nils_test_support::{EnvGuard, GlobalStateLock, bin, cmd, write_exe};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
+/// Guard both spellings Cargo could have exported for a hyphenated bin name, so
+/// the absent-sibling cases cannot be satisfied by an inherited variable.
+fn without_bin_exe_env(lock: &GlobalStateLock, bin_name: &str) -> Vec<EnvGuard> {
+    vec![
+        EnvGuard::remove(lock, &format!("CARGO_BIN_EXE_{bin_name}")),
+        EnvGuard::remove(
+            lock,
+            &format!("CARGO_BIN_EXE_{}", bin_name.replace('-', "_")),
+        ),
+    ]
+}
+
+/// Write a stub that answers `--version` the way a workspace CLI does, so the
+/// release comparison sees a realistic first line.
+#[cfg(unix)]
+fn write_version_stub(dir: &std::path::Path, bin_name: &str, release: &str) -> std::path::PathBuf {
+    let script = format!(
+        "#!/bin/sh\nprintf '%s\\n' '{bin_name} {release} (v{release}, rustc 1.0.0 (0000000 1970-01-01))'\n"
+    );
+    write_exe(dir, bin_name, &script);
+    dir.join(bin_name)
+}
+
 #[test]
 fn resolve_prefers_env_var_with_hyphen() {
     let lock = GlobalStateLock::new();
@@ -196,6 +219,126 @@ printf "%s" "${NTS_VALUE-unset}"
 
     assert_eq!(output.code, 0);
     assert_eq!(output.stdout_text(), "child");
+}
+
+#[test]
+fn resolve_optional_reports_absence_instead_of_panicking() {
+    let lock = GlobalStateLock::new();
+    let _guards = without_bin_exe_env(&lock, "nts-absent-sibling");
+
+    assert_eq!(bin::resolve_optional("nts-absent-sibling"), None);
+}
+
+#[test]
+fn sibling_is_absent_when_the_binary_was_never_built() {
+    let lock = GlobalStateLock::new();
+    let _guards = without_bin_exe_env(&lock, "nts-absent-sibling");
+
+    assert_eq!(bin::sibling("nts-absent-sibling"), bin::Sibling::Absent);
+}
+
+#[cfg(unix)]
+#[test]
+fn sibling_is_ready_when_the_artifact_reports_this_workspace_release() {
+    let lock = GlobalStateLock::new();
+    let temp = TempDir::new().expect("tempdir");
+    let path = write_version_stub(temp.path(), "nts-current-sibling", bin::WORKSPACE_RELEASE);
+    let _guard = EnvGuard::set(
+        &lock,
+        "CARGO_BIN_EXE_nts-current-sibling",
+        path.to_str().expect("path"),
+    );
+
+    assert_eq!(
+        bin::sibling("nts-current-sibling"),
+        bin::Sibling::Ready(path)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn sibling_reports_a_release_mismatch_for_an_artifact_from_an_earlier_build() {
+    let lock = GlobalStateLock::new();
+    let temp = TempDir::new().expect("tempdir");
+    let path = write_version_stub(temp.path(), "nts-stale-sibling", "1.0.0");
+    let _guard = EnvGuard::set(
+        &lock,
+        "CARGO_BIN_EXE_nts-stale-sibling",
+        path.to_str().expect("path"),
+    );
+
+    assert_eq!(
+        bin::sibling("nts-stale-sibling"),
+        bin::Sibling::ReleaseMismatch {
+            reported: Some("1.0.0".to_string())
+        }
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn sibling_reports_a_release_mismatch_when_version_cannot_be_read() {
+    let lock = GlobalStateLock::new();
+    let temp = TempDir::new().expect("tempdir");
+    write_exe(temp.path(), "nts-broken-sibling", "#!/bin/sh\nexit 1\n");
+    let path = temp.path().join("nts-broken-sibling");
+    let _guard = EnvGuard::set(
+        &lock,
+        "CARGO_BIN_EXE_nts-broken-sibling",
+        path.to_str().expect("path"),
+    );
+
+    assert_eq!(
+        bin::sibling("nts-broken-sibling"),
+        bin::Sibling::ReleaseMismatch { reported: None }
+    );
+}
+
+#[test]
+fn skip_reason_names_the_build_command_for_an_absent_sibling() {
+    let reason = bin::Sibling::Absent
+        .skip_reason("gemini-cli", "nils-gemini-cli")
+        .expect("an absent sibling has a skip reason");
+
+    assert!(reason.contains("gemini-cli"), "reason={reason}");
+    assert!(
+        reason.contains("cargo build -p nils-gemini-cli --bins"),
+        "reason={reason}"
+    );
+}
+
+#[test]
+fn skip_reason_names_both_releases_for_a_stale_sibling() {
+    let reason = bin::Sibling::ReleaseMismatch {
+        reported: Some("1.25.13".to_string()),
+    }
+    .skip_reason("agent-docs", "nils-agent-docs")
+    .expect("a stale sibling has a skip reason");
+
+    assert!(reason.contains("1.25.13"), "reason={reason}");
+    assert!(reason.contains(bin::WORKSPACE_RELEASE), "reason={reason}");
+    assert!(
+        reason.contains("cargo build -p nils-agent-docs --bins"),
+        "reason={reason}"
+    );
+}
+
+#[test]
+fn skip_reason_is_absent_for_a_ready_sibling() {
+    let ready = bin::Sibling::Ready(std::path::PathBuf::from("agent-docs"));
+
+    assert_eq!(ready.skip_reason("agent-docs", "nils-agent-docs"), None);
+}
+
+#[test]
+fn sibling_or_skip_yields_none_for_an_absent_sibling_without_panicking() {
+    let lock = GlobalStateLock::new();
+    let _guards = without_bin_exe_env(&lock, "nts-absent-sibling");
+
+    assert_eq!(
+        bin::sibling_or_skip("nts-absent-sibling", "nils-absent"),
+        None
+    );
 }
 
 #[cfg(unix)]

--- a/crates/nils-test-support/tests/integration/bin_cmd.rs
+++ b/crates/nils-test-support/tests/integration/bin_cmd.rs
@@ -2,29 +2,6 @@ use nils_test_support::{EnvGuard, GlobalStateLock, bin, cmd, write_exe};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
-/// Guard both spellings Cargo could have exported for a hyphenated bin name, so
-/// the absent-sibling cases cannot be satisfied by an inherited variable.
-fn without_bin_exe_env(lock: &GlobalStateLock, bin_name: &str) -> Vec<EnvGuard> {
-    vec![
-        EnvGuard::remove(lock, &format!("CARGO_BIN_EXE_{bin_name}")),
-        EnvGuard::remove(
-            lock,
-            &format!("CARGO_BIN_EXE_{}", bin_name.replace('-', "_")),
-        ),
-    ]
-}
-
-/// Write a stub that answers `--version` the way a workspace CLI does, so the
-/// release comparison sees a realistic first line.
-#[cfg(unix)]
-fn write_version_stub(dir: &std::path::Path, bin_name: &str, release: &str) -> std::path::PathBuf {
-    let script = format!(
-        "#!/bin/sh\nprintf '%s\\n' '{bin_name} {release} (v{release}, rustc 1.0.0 (0000000 1970-01-01))'\n"
-    );
-    write_exe(dir, bin_name, &script);
-    dir.join(bin_name)
-}
-
 #[test]
 fn resolve_prefers_env_var_with_hyphen() {
     let lock = GlobalStateLock::new();
@@ -221,119 +198,18 @@ printf "%s" "${NTS_VALUE-unset}"
     assert_eq!(output.stdout_text(), "child");
 }
 
-#[test]
-fn resolve_optional_reports_absence_instead_of_panicking() {
-    let lock = GlobalStateLock::new();
-    let _guards = without_bin_exe_env(&lock, "nts-absent-sibling");
-
-    assert_eq!(bin::resolve_optional("nts-absent-sibling"), None);
-}
-
-#[test]
-fn sibling_is_absent_when_the_binary_was_never_built() {
-    let lock = GlobalStateLock::new();
-    let _guards = without_bin_exe_env(&lock, "nts-absent-sibling");
-
-    assert_eq!(bin::sibling("nts-absent-sibling"), bin::Sibling::Absent);
-}
-
-#[cfg(unix)]
-#[test]
-fn sibling_is_ready_when_the_artifact_reports_this_workspace_release() {
-    let lock = GlobalStateLock::new();
-    let temp = TempDir::new().expect("tempdir");
-    let path = write_version_stub(temp.path(), "nts-current-sibling", bin::WORKSPACE_RELEASE);
-    let _guard = EnvGuard::set(
-        &lock,
-        "CARGO_BIN_EXE_nts-current-sibling",
-        path.to_str().expect("path"),
-    );
-
-    assert_eq!(
-        bin::sibling("nts-current-sibling"),
-        bin::Sibling::Ready(path)
-    );
-}
-
-#[cfg(unix)]
-#[test]
-fn sibling_reports_a_release_mismatch_for_an_artifact_from_an_earlier_build() {
-    let lock = GlobalStateLock::new();
-    let temp = TempDir::new().expect("tempdir");
-    let path = write_version_stub(temp.path(), "nts-stale-sibling", "1.0.0");
-    let _guard = EnvGuard::set(
-        &lock,
-        "CARGO_BIN_EXE_nts-stale-sibling",
-        path.to_str().expect("path"),
-    );
-
-    assert_eq!(
-        bin::sibling("nts-stale-sibling"),
-        bin::Sibling::ReleaseMismatch {
-            reported: Some("1.0.0".to_string())
-        }
-    );
-}
-
-#[cfg(unix)]
-#[test]
-fn sibling_reports_a_release_mismatch_when_version_cannot_be_read() {
-    let lock = GlobalStateLock::new();
-    let temp = TempDir::new().expect("tempdir");
-    write_exe(temp.path(), "nts-broken-sibling", "#!/bin/sh\nexit 1\n");
-    let path = temp.path().join("nts-broken-sibling");
-    let _guard = EnvGuard::set(
-        &lock,
-        "CARGO_BIN_EXE_nts-broken-sibling",
-        path.to_str().expect("path"),
-    );
-
-    assert_eq!(
-        bin::sibling("nts-broken-sibling"),
-        bin::Sibling::ReleaseMismatch { reported: None }
-    );
-}
-
-#[test]
-fn skip_reason_names_the_build_command_for_an_absent_sibling() {
-    let reason = bin::Sibling::Absent
-        .skip_reason("gemini-cli", "nils-gemini-cli")
-        .expect("an absent sibling has a skip reason");
-
-    assert!(reason.contains("gemini-cli"), "reason={reason}");
-    assert!(
-        reason.contains("cargo build -p nils-gemini-cli --bins"),
-        "reason={reason}"
-    );
-}
-
-#[test]
-fn skip_reason_names_both_releases_for_a_stale_sibling() {
-    let reason = bin::Sibling::ReleaseMismatch {
-        reported: Some("1.25.13".to_string()),
-    }
-    .skip_reason("agent-docs", "nils-agent-docs")
-    .expect("a stale sibling has a skip reason");
-
-    assert!(reason.contains("1.25.13"), "reason={reason}");
-    assert!(reason.contains(bin::WORKSPACE_RELEASE), "reason={reason}");
-    assert!(
-        reason.contains("cargo build -p nils-agent-docs --bins"),
-        "reason={reason}"
-    );
-}
-
-#[test]
-fn skip_reason_is_absent_for_a_ready_sibling() {
-    let ready = bin::Sibling::Ready(std::path::PathBuf::from("agent-docs"));
-
-    assert_eq!(ready.skip_reason("agent-docs", "nils-agent-docs"), None);
-}
-
+/// `sibling_or_skip` is the only cross-crate surface of the sibling contract, so
+/// it is the only part exercised from outside the crate. The classification it
+/// wraps is crate-private and unit-tested next to the code.
+///
+/// The require flag is dropped explicitly because CI sets it for the whole job,
+/// and this case is specifically about the behaviour when it is absent.
 #[test]
 fn sibling_or_skip_yields_none_for_an_absent_sibling_without_panicking() {
     let lock = GlobalStateLock::new();
-    let _guards = without_bin_exe_env(&lock, "nts-absent-sibling");
+    let _hyphen = EnvGuard::remove(&lock, "CARGO_BIN_EXE_nts-absent-sibling");
+    let _underscore = EnvGuard::remove(&lock, "CARGO_BIN_EXE_nts_absent_sibling");
+    let _require = EnvGuard::remove(&lock, "NILS_TEST_REQUIRE_SIBLING_BINS");
 
     assert_eq!(
         bin::sibling_or_skip("nts-absent-sibling", "nils-absent"),
@@ -341,197 +217,36 @@ fn sibling_or_skip_yields_none_for_an_absent_sibling_without_panicking() {
     );
 }
 
-#[cfg(unix)]
+/// The require flag exists so a lane that should have built every binary cannot
+/// report green-but-empty when resolution regresses.
 #[test]
-fn with_path_prepend_places_directory_before_existing_path() {
-    let temp = TempDir::new().expect("tempdir");
-    let first_dir = temp.path().join("first");
-    let second_dir = temp.path().join("second");
-    std::fs::create_dir_all(&first_dir).expect("create first dir");
-    std::fs::create_dir_all(&second_dir).expect("create second dir");
+#[should_panic(expected = "is not built for this run")]
+fn sibling_or_skip_panics_for_an_absent_sibling_when_the_require_flag_is_set() {
+    let lock = GlobalStateLock::new();
+    let _hyphen = EnvGuard::remove(&lock, "CARGO_BIN_EXE_nts-absent-sibling");
+    let _underscore = EnvGuard::remove(&lock, "CARGO_BIN_EXE_nts_absent_sibling");
+    let _require = EnvGuard::set(&lock, "NILS_TEST_REQUIRE_SIBLING_BINS", "1");
 
-    write_exe(
-        &first_dir,
-        "path-pick",
-        r#"#!/bin/sh
-printf "first"
-"#,
-    );
-    write_exe(
-        &second_dir,
-        "path-pick",
-        r#"#!/bin/sh
-printf "second"
-"#,
-    );
-    write_exe(
-        temp.path(),
-        "path-runner",
-        r#"#!/bin/sh
-path-pick
-"#,
-    );
-
-    let bin = temp.path().join("path-runner");
-    let base_path = second_dir.to_string_lossy().to_string();
-    let base_options = cmd::CmdOptions::new().with_env("PATH", &base_path);
-    let base = cmd::run_with(&bin, &[], &base_options);
-    assert_eq!(base.code, 0);
-    assert_eq!(base.stdout_text(), "second");
-
-    let prefixed_options = base_options.with_path_prepend(&first_dir);
-    let prefixed = cmd::run_with(&bin, &[], &prefixed_options);
-    assert_eq!(prefixed.code, 0);
-    assert_eq!(prefixed.stdout_text(), "first");
+    bin::sibling_or_skip("nts-absent-sibling", "nils-absent");
 }
 
+/// A selected-but-wrong artifact is an operator error, so it must fail rather
+/// than skip: skipping would leave the suite green while it never ran against
+/// the binary it names.
 #[cfg(unix)]
 #[test]
-fn path_with_prepend_excluding_program_filters_existing_program_and_prepends_stub_dir() {
+#[should_panic(expected = "from an earlier release")]
+fn sibling_or_skip_panics_for_a_stale_sibling_instead_of_skipping() {
     let lock = GlobalStateLock::new();
     let temp = TempDir::new().expect("tempdir");
-    let existing_program_dir = temp.path().join("existing");
-    let kept_dir = temp.path().join("kept");
-    let prepend_dir = temp.path().join("prepend");
-    std::fs::create_dir_all(&existing_program_dir).expect("create existing dir");
-    std::fs::create_dir_all(&kept_dir).expect("create kept dir");
-    std::fs::create_dir_all(&prepend_dir).expect("create prepend dir");
-    write_exe(
-        &existing_program_dir,
-        "path-filter-test",
-        "#!/bin/sh\nexit 0\n",
+    let script = "#!/bin/sh\nprintf '%s\\n' 'nts-stale-skip 1.0.0 (v1.0.0, rustc 1.0.0)'\n";
+    write_exe(temp.path(), "nts-stale-skip", script);
+    let path = temp.path().join("nts-stale-skip");
+    let _guard = EnvGuard::set(
+        &lock,
+        "CARGO_BIN_EXE_nts-stale-skip",
+        path.to_str().expect("path"),
     );
 
-    let base_path = std::env::join_paths([existing_program_dir.as_path(), kept_dir.as_path()])
-        .expect("join base path")
-        .to_string_lossy()
-        .to_string();
-    let _path = EnvGuard::set(&lock, "PATH", &base_path);
-
-    let filtered = cmd::path_with_prepend_excluding_program(&prepend_dir, "path-filter-test");
-    let split = std::env::split_paths(std::ffi::OsStr::new(&filtered)).collect::<Vec<_>>();
-
-    assert_eq!(split[0], prepend_dir);
-    assert!(
-        split
-            .iter()
-            .all(|dir| !dir.join("path-filter-test").is_file())
-    );
-    assert!(split.contains(&kept_dir));
-}
-
-#[cfg(unix)]
-#[test]
-fn run_in_dir_with_overrides_options_cwd() {
-    let temp = TempDir::new().expect("tempdir");
-    let dir_arg = temp.path().join("arg-dir");
-    let option_dir = temp.path().join("option-dir");
-    std::fs::create_dir_all(&dir_arg).expect("create arg dir");
-    std::fs::create_dir_all(&option_dir).expect("create option dir");
-
-    write_exe(
-        temp.path(),
-        "pwd-override-test",
-        r#"#!/bin/sh
-pwd
-"#,
-    );
-    let bin = temp.path().join("pwd-override-test");
-    let options = cmd::CmdOptions::new().with_cwd(&option_dir);
-
-    let output = cmd::run_in_dir_with(&dir_arg, &bin, &[], &options);
-    let stdout = output.stdout_text();
-    let stdout = stdout.trim_end();
-    let expected = std::fs::canonicalize(&dir_arg).expect("canonical");
-    let expected = expected.to_string_lossy();
-
-    assert_eq!(output.code, 0);
-    assert_eq!(stdout, expected);
-}
-
-/// A command under test is free to exit before draining its stdin. The harness
-/// must still report that command's own exit code and output instead of
-/// panicking on the broken pipe. See `sympoies/nils-cli#1420`.
-#[cfg(unix)]
-#[test]
-fn run_reports_the_exit_code_of_a_command_that_ignores_its_stdin() {
-    let temp = TempDir::new().expect("tempdir");
-    write_exe(
-        temp.path(),
-        "exit-before-reading",
-        "#!/bin/sh\nexec 0<&-\nprintf 'answered\\n'\nexit 3\n",
-    );
-    let bin = temp.path().join("exit-before-reading");
-    // A pipe holds 64 KiB, so a smaller payload would be buffered whole and the
-    // write would never see the closed read end.
-    let options = cmd::CmdOptions::new().with_stdin_bytes(&vec![b'x'; 128 * 1024]);
-
-    let output = cmd::run_with(&bin, &[], &options);
-
-    assert_eq!(output.code, 3);
-    assert_eq!(output.stdout_text().trim_end(), "answered");
-}
-
-/// A suite running inside a managed `agent-session` pane inherits every variable
-/// that pane pins. Those variables outrank `PATH` and the fixture layout, so a
-/// test controlling only part of a resolution input set silently measures the
-/// developer's runtime instead of its own. See `sympoies/nils-cli#1420`.
-#[cfg(unix)]
-#[test]
-fn without_ambient_managed_session_env_hides_every_inherited_override() {
-    let lock = GlobalStateLock::new();
-    let temp = TempDir::new().expect("tempdir");
-    let report = cmd::MANAGED_SESSION_ENV
-        .iter()
-        .map(|name| format!("printf '%s=%s\\n' {name} \"${{{name}-absent}}\"\n"))
-        .collect::<String>();
-    write_exe(
-        temp.path(),
-        "report-managed-env",
-        &format!("#!/bin/sh\n{report}"),
-    );
-    let bin = temp.path().join("report-managed-env");
-    let _guards: Vec<EnvGuard> = cmd::MANAGED_SESSION_ENV
-        .iter()
-        .map(|name| EnvGuard::set(&lock, name, "inherited-from-the-managed-pane"))
-        .collect();
-
-    let options = cmd::CmdOptions::new().without_ambient_managed_session_env();
-    let output = cmd::run_with(&bin, &[], &options);
-
-    assert_eq!(output.code, 0, "stderr={}", output.stderr_text());
-    let expected = cmd::MANAGED_SESSION_ENV
-        .iter()
-        .map(|name| format!("{name}=absent"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert_eq!(
-        output.stdout_text().trim_end(),
-        expected,
-        "no managed-session variable may reach a child that did not ask for it"
-    );
-}
-
-/// The removal must not take the variable away from a test that wants it, or
-/// every fixture legitimately pinning one would have to opt out by name.
-#[cfg(unix)]
-#[test]
-fn without_ambient_managed_session_env_still_lets_an_explicit_value_through() {
-    let lock = GlobalStateLock::new();
-    let temp = TempDir::new().expect("tempdir");
-    write_exe(
-        temp.path(),
-        "report-helper-override",
-        "#!/bin/sh\nprintf '%s\\n' \"${AGENT_SESSION_BIN-absent}\"\n",
-    );
-    let bin = temp.path().join("report-helper-override");
-    let _guard = EnvGuard::set(&lock, "AGENT_SESSION_BIN", "/inherited/agent-session");
-
-    let options = cmd::CmdOptions::new()
-        .without_ambient_managed_session_env()
-        .with_env("AGENT_SESSION_BIN", "/chosen/agent-session");
-    let output = cmd::run_with(&bin, &[], &options);
-
-    assert_eq!(output.code, 0, "stderr={}", output.stderr_text());
-    assert_eq!(output.stdout_text().trim_end(), "/chosen/agent-session");
+    bin::sibling_or_skip("nts-stale-skip", "nils-stale");
 }

--- a/docs/specs/codex-gemini-cli-parity-contract-v1.md
+++ b/docs/specs/codex-gemini-cli-parity-contract-v1.md
@@ -121,7 +121,13 @@ Per-crate integration tests are consolidated under a single `--test integration`
 
 ## Validation anchors
 
-- `cargo test -p nils-codex-cli --test integration -- parity_oracle`
-- `cargo test -p nils-gemini-cli --test integration -- parity_oracle`
+- `cargo build -p nils-gemini-cli --bins && cargo test -p nils-codex-cli --test integration -- parity_oracle`
+- `cargo build -p nils-codex-cli --bins && cargo test -p nils-gemini-cli --test integration -- parity_oracle`
 - `cargo test -p nils-codex-cli --test integration -- runtime_auth_contract runtime_error_contract runtime_exec_contract runtime_paths_config_contract`
 - `cargo test -p nils-gemini-cli --test integration -- runtime_auth_contract runtime_error_contract runtime_exec_contract runtime_paths_config_contract`
+
+Each parity oracle compares its own CLI against the *other* package's binary,
+which a package-scoped `cargo test` does not build. Without the paired build the
+suite skips and reports green with zero parity assertions, so the build is part
+of the anchor rather than an optimisation. See `bin::sibling_or_skip` in
+`crates/nils-test-support`.


### PR DESCRIPTION
## Summary

A test that needs a binary **another package** owns had no way to say so. Cargo
sets `CARGO_BIN_EXE_<name>` only for the package under test, so those tests fall
back to `target/<profile>/<name>` — where a package-scoped run has no reason to
have built anything, and an earlier build may have left an artifact from another
release.

`nils-test-support` now classifies such a sibling and the three cross-crate call
sites act on the classification instead of asserting against whatever they
found. Exactly one outcome is a property of the run and is skipped; the rest are
operator errors and fail.

Closes #1413.

## What each outcome does

| | before | after |
|---|---|---|
| nothing was built | `panic: gemini-cli binary path: NotPresent` across a large block of tests | skip with a reason naming `cargo build -p nils-gemini-cli --bins`; fatal when `NILS_TEST_REQUIRE_SIBLING_BINS=1` |
| an artifact reports another release | an assertion failure naming an unrelated policy rule | **fail** naming both releases and the build command |
| an artifact cannot be identified at all | same | **fail**; a misdirected `CARGO_BIN_EXE_*` names that variable rather than prescribing a rebuild |

The stale mode was found while verifying #1420 and is recorded on #1413. At
baseline `eef4c633`, `target/debug/agent-docs` was `1.25.13` while `agent-hook`
built at `1.26.0`, so
`read_only_capability::enforce_accepts_a_valid_same_release_read_only_descriptor`
failed as `read-only-producer-mismatch`: a correct release check
(`crates/agent-hook/src/read_only.rs`) reading as a policy defect.

## Cross-crate sites, all three wired

| consumer | sibling | package to build |
|---|---|---|
| `agent-hook` (3 tests) | `agent-docs` | `nils-agent-docs` |
| `codex-cli` parity oracle | `gemini-cli` | `nils-gemini-cli` |
| `gemini-cli` parity oracle | `codex-cli` | `nils-codex-cli` |

Every other `bin::resolve` call names a binary its own package owns, where Cargo
exports the path and none of these outcomes can occur. Re-checked against
`origin/main` at `e30a83a5`. The `gemini-cli` → `codex-cli` site was not
previously reported.

## Why not declare the dependency

The issue's option 3 was a `dev-dependencies` entry, so Cargo would build the
sibling and export `CARGO_BIN_EXE_*`, and asked to verify that before choosing
it. Verified in a throwaway workspace: with a dependency on a crate carrying
both a lib and a bin target, the consumer's integration test sees no
`CARGO_BIN_EXE_*` at all **and the sibling binary is never built**. It fails on
both counts. Artifact dependencies would cover this but are unstable.

## What review changed

Four specialist reviewers ran against the first cut and it needed real repair,
recorded as generation 0 of the review ledger with all 16 rows `open` before any
fix was pushed.

- **The first cut traded one silent failure for another.** It skipped on a stale
  artifact too, leaving the suite green while it never ran against the binary it
  names. Only absence is now skippable.
- **A uniquely-owned invariant was dropped.** The enforce-mode rejection of a
  command that is not a trusted producer needs no `agent-docs`, but it was the
  first case of a loop whose second case did, so gating the loop took it along.
  The other two owners of `read-only-command-unsupported` run in shadow mode and
  assert admission, so nothing else covered enforce-mode rejection. It is now its
  own test with no sibling dependency.
- **The parity contract's validation anchors were left vacuous.** `DEVELOPMENT.md`
  and the crate README were updated but
  `docs/specs/codex-gemini-cli-parity-contract-v1.md` still named package-scoped
  commands that would report green with zero parity assertions. The anchors now
  build the paired binary first.
- **"Never skips on CI" was a comment, not a gate.** A skip reaches captured
  output that both runners discard for a passing test.
  `NILS_TEST_REQUIRE_SIBLING_BINS=1` is now set in `test`, `test_macos` and
  `coverage`, mirroring `AGENT_SESSION_TEST_REQUIRE_CGROUP`, which exists for the
  same reason.
- **The published surface was speculative.** The classification had no
  cross-crate caller and its release comparison is meaningless outside this
  workspace, yet `nils-test-support` is published. It is now crate-private and
  unit-tested beside the code; only `resolve`, `resolve_optional` and
  `sibling_or_skip` are public.
- **Two claims overstated.** The message said "earlier build" for a release-string
  comparison that cannot see a same-release artifact from an older commit, and
  `DEVELOPMENT.md` said the lanes build *every* binary when the workspace test
  lane does not pass `--all-features`. Both now say what is true, and the
  intra-release boundary is stated rather than implied.

Two findings are accepted rather than fixed, with reasons in the delivery
outcome: the probe's unbounded child wait (the precondition is documented
instead; every workspace CLI answers `--version` during clap parse), and a
positive test for the profile-directory fallback branch (the require mode turns a
broken fallback into a CI failure rather than a silent universal skip).

I verified the three load-bearing review claims myself rather than taking them on
trust; one of my own earlier worries — that the release lockstep was unenforced —
turned out to be wrong, because `workspace-version-lockstep.sh --strict` is a
required check.

## Test plan

Baseline `eef4c633`, observed before any production edit:

- `-p nils-codex-cli` with `gemini-cli` absent → `340/470 tests run: 338 passed,
  2 failed`, plus `130/470 tests were not run due to test failure` (the issue
  reported 129)
- `-p nils-agent-hook` with `agent-docs` stale at `1.25.13` → `107/185 tests run:
  106 passed, 1 failed`, deterministic across all three nextest retries

After, each behaviour of the contract exercised directly:

- nothing built, no require flag → parity oracles `3 tests run: 3 passed`, run green
- nothing built, `NILS_TEST_REQUIRE_SIBLING_BINS=1` → `FAILED` with
  ``the `gemini-cli` binary is not built for this run … Run `cargo build -p nils-gemini-cli --bins` ``
- stale `agent-docs` → `FAILED` with ``reports release 1.25.13 but this workspace
  builds 1.26.0 … Run `cargo build -p nils-agent-docs --bins` ``, no silent skip
- siblings built → `read_only_capability` 12/12, both parity oracles 3/3, all
  **executing**, no skip line
- `-p nils-test-support` → 65/65, covering absent, ready, wrong release,
  unidentifiable, a dangling override, the require flag, and each message
- declared gate `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — the
  workspace lane, since `nils-test-support` is a shared crate

## Risk / Notes

- Test infrastructure only. No production crate behavior changes;
  `nils-test-support` is a dev-dependency everywhere it is used, which is why this
  is a `chore` PR rather than a bug PR — not to avoid the test-first gate, and the
  pre-fix evidence above is recorded either way.
- `resolve` keeps its panicking contract for callers that genuinely require a
  binary, and `resolve_optional` still returns an env-var value verbatim without
  an existence check, so neither changes behaviour for existing callers.
- The release comparison reads the artifact's own `--version` rather than its
  mtime, because once a sibling stops being rebuilt a stale artifact and a current
  one are indistinguishable by timestamp.
- `main` advanced by three commits (#1429, #1430, #1431) during this work. Their
  changed file sets are disjoint from this one and GitHub reports the PR
  `MERGEABLE`/`CLEAN`, but CI runs on the branch head rather than a merge with
  `main`, so it does not prove the combination.
- #1429's draft added a fourth cross-crate site and its risk note pointed here;
  the version that merged carries no `bin::resolve` call, so no fourth site
  exists.
