### PR TITLE
test(claude-cli): contain the detached refresh children

### DIFF
--- a/crates/claude-cli/tests/integration.rs
+++ b/crates/claude-cli/tests/integration.rs
@@ -33,6 +33,24 @@ fn stderr(output: &CmdOutput) -> String {
     output.stderr_text()
 }
 
+/// An endpoint nothing listens on, so a request that escapes a test's control
+/// fails immediately instead of reaching a real host.
+///
+/// `base_options` clears the `CLAUDE_PROMPT` prefix to isolate ambient config,
+/// which also clears `CLAUDE_PROMPT_SEGMENT_ENDPOINT` — and the production
+/// default is `https://api.anthropic.com/...`. A test therefore reached the real
+/// backend by *omission*, and the reach happened in the detached refresh child
+/// rather than in the command under test, so nothing in the test's own output
+/// showed it. Pinning it here makes the safe case the default; a test that wants
+/// a server sets its own endpoint afterwards and wins.
+const UNROUTABLE_ENDPOINT: &str = "http://127.0.0.1:9/usage";
+
+/// An executable that exits non-zero without writing anything, for a test that
+/// wants the spawn itself but nothing the child would do. `gemini-cli` uses the
+/// same value for the same purpose. This suite already assumes a POSIX shell
+/// for its other fixtures.
+const NO_OP_EXE: &str = "/usr/bin/false";
+
 fn base_options(cache_dir: &Path) -> CmdOptions {
     CmdOptions::default()
         .with_env_remove_prefix("CLAUDE_CLI_")
@@ -45,6 +63,7 @@ fn base_options(cache_dir: &Path) -> CmdOptions {
         )
         .with_env("CLAUDE_PROMPT_SEGMENT_CACHE_DIR", &path_str(cache_dir))
         .with_env("CLAUDE_PROMPT_SEGMENT_KEYCHAIN_DISABLED", "1")
+        .with_env("CLAUDE_PROMPT_SEGMENT_ENDPOINT", UNROUTABLE_ENDPOINT)
 }
 
 fn path_str(path: &Path) -> String {
@@ -990,10 +1009,38 @@ fn usage_auto_keeps_live_rate_limit_reason_when_expired_cache_is_omitted() {
     );
 }
 
+/// Pins the containment itself, because the failure it prevents is invisible:
+/// the reach happens in a detached child, so a test that lost its endpoint
+/// override would still pass while talking to the real backend.
+#[test]
+fn base_options_pins_an_unroutable_endpoint_for_every_suite_default() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let options = base_options(tmp.path());
+
+    assert!(
+        options
+            .envs
+            .iter()
+            .any(|(key, value)| key == "CLAUDE_PROMPT_SEGMENT_ENDPOINT"
+                && value == UNROUTABLE_ENDPOINT),
+        "base_options must pin an endpoint: it clears the CLAUDE_PROMPT prefix, and the \
+         production default is a real host, so omission means reaching it; envs={:?}",
+        options.envs
+    );
+}
+
 #[test]
 fn prompt_segment_missing_credentials_and_cache_is_quiet_success() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let output = run(&["prompt-segment"], &base_options(tmp.path()));
+    // Per-test enumeration (#1412) showed this test does reach
+    // `enqueue_background_refresh` despite having neither credentials nor a
+    // cache, and it was the one spawner in this suite with no containment. The
+    // detached child's first act is `create_dir_all` on the cache directory, so
+    // it could recreate this `tempdir` after teardown removed it. A no-op
+    // executable keeps the spawn under test while giving the child nothing to
+    // write.
+    let options = base_options(tmp.path()).with_env("CLAUDE_PROMPT_SEGMENT_EXE", NO_OP_EXE);
+    let output = run(&["prompt-segment"], &options);
     assert_exit(&output, 0);
     assert_eq!(stdout(&output), "");
     assert_eq!(stderr(&output), "");

--- a/crates/claude-cli/tests/integration.rs
+++ b/crates/claude-cli/tests/integration.rs
@@ -38,18 +38,72 @@ fn stderr(output: &CmdOutput) -> String {
 ///
 /// `base_options` clears the `CLAUDE_PROMPT` prefix to isolate ambient config,
 /// which also clears `CLAUDE_PROMPT_SEGMENT_ENDPOINT` — and the production
-/// default is `https://api.anthropic.com/...`. A test therefore reached the real
-/// backend by *omission*, and the reach happened in the detached refresh child
-/// rather than in the command under test, so nothing in the test's own output
-/// showed it. Pinning it here makes the safe case the default; a test that wants
-/// a server sets its own endpoint afterwards and wins.
+/// default is the real usage endpoint. This is **defence in depth, not a fix for
+/// an observed reach**: the same prefix removal also clears the token variables
+/// and `base_options` disables the keychain, so `refresh_blocking` returns at its
+/// token guard before it would fetch anything. What it buys is that the first
+/// token-bearing test added under this default cannot reach a real host by
+/// omission. A test that wants a server sets its own endpoint afterwards and
+/// wins, because removals are applied before values.
 const UNROUTABLE_ENDPOINT: &str = "http://127.0.0.1:9/usage";
 
-/// An executable that exits non-zero without writing anything, for a test that
-/// wants the spawn itself but nothing the child would do. `gemini-cli` uses the
-/// same value for the same purpose. This suite already assumes a POSIX shell
-/// for its other fixtures.
-const NO_OP_EXE: &str = "/usr/bin/false";
+/// Bound the fast-fail so it stays fast on a host that drops rather than refuses
+/// loopback traffic. `gemini-cli` pins its timeouts alongside its unroutable
+/// endpoint for the same reason.
+const FAST_FAIL_MAX_TIME_SECONDS: &str = "1";
+
+/// Keeps a plain `prompt-segment` run from launching a detached refresh child.
+///
+/// A run whose cache is expired calls `enqueue_background_refresh`, which spawns
+/// `prompt-segment --refresh` and returns without waiting. That child outlives the
+/// test, and its first act is `create_dir_all` on the cache directory, so it can
+/// recreate the fixture `TempDir` teardown has already removed — class 3 in
+/// `docs/specs/test-temp-directory-policy.md`.
+///
+/// A test whose subject is rendering rather than refreshing opts out through the
+/// production cooldown instead of racing the child or neutering it: a recent
+/// `usage.refresh.at` plus a long `CLAUDE_PROMPT_SEGMENT_REFRESH_MIN_SECONDS`
+/// makes `enqueue_background_refresh` return before it spawns anything. That is
+/// the approach the policy prefers, and unlike a no-op executable it is
+/// falsifiable — see [`RefreshCooldown::assert_held`].
+struct RefreshCooldown {
+    marker: PathBuf,
+    stamp: String,
+}
+
+impl RefreshCooldown {
+    /// Hold the cooldown for the `usage.json` cache in `cache_dir`.
+    fn hold(cache_dir: &Path) -> Self {
+        std::fs::create_dir_all(cache_dir).expect("cache dir");
+        let marker = cache_dir.join("usage.refresh.at");
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_secs().saturating_sub(5).max(1))
+            .expect("epoch")
+            .to_string();
+        std::fs::write(&marker, &stamp).expect("write refresh marker");
+
+        Self { marker, stamp }
+    }
+
+    /// The environment that makes the held marker actually gate the spawn.
+    fn env(&self) -> (&'static str, &'static str) {
+        ("CLAUDE_PROMPT_SEGMENT_REFRESH_MIN_SECONDS", "3600")
+    }
+
+    /// Fails when the run spawned a refresh child after all.
+    ///
+    /// `enqueue_background_refresh` rewrites the marker immediately before
+    /// spawning, so an unchanged marker is proof that it returned on the cooldown
+    /// and that no background writer can outlive this test.
+    fn assert_held(&self) {
+        assert_eq!(
+            std::fs::read_to_string(&self.marker).expect("read refresh marker"),
+            self.stamp,
+            "the run spawned a detached refresh child instead of honouring the cooldown"
+        );
+    }
+}
 
 fn base_options(cache_dir: &Path) -> CmdOptions {
     CmdOptions::default()
@@ -64,6 +118,10 @@ fn base_options(cache_dir: &Path) -> CmdOptions {
         .with_env("CLAUDE_PROMPT_SEGMENT_CACHE_DIR", &path_str(cache_dir))
         .with_env("CLAUDE_PROMPT_SEGMENT_KEYCHAIN_DISABLED", "1")
         .with_env("CLAUDE_PROMPT_SEGMENT_ENDPOINT", UNROUTABLE_ENDPOINT)
+        .with_env(
+            "CLAUDE_PROMPT_SEGMENT_MAX_TIME_SECONDS",
+            FAST_FAIL_MAX_TIME_SECONDS,
+        )
 }
 
 fn path_str(path: &Path) -> String {
@@ -788,10 +846,21 @@ fn prompt_segment_does_not_render_cache_older_than_max_stale_age() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let cache_file = write_cache(tmp.path(), &usage_json(25.0, 50.0));
     set_modified(&cache_file, SystemTime::now() - Duration::from_secs(601));
+    // The second uncontained spawner, which the first pass classified wrongly: a
+    // 601s-old cache is display-expired, so this run spawns a detached child that
+    // can recreate `tmp` after teardown. Its subject is max-stale rendering, so
+    // hold the cooldown.
+    //
+    // This one is the falsifiable case: disabling the gate makes the run spawn and
+    // `assert_held` fails with its own message, so the containment is demonstrated
+    // rather than assumed.
+    let cooldown = RefreshCooldown::hold(tmp.path());
 
     let output = run(
         &["prompt-segment", "--ttl", "1h", "--time-format", "%Y-%m-%d"],
-        &base_options(tmp.path()).with_env("NO_COLOR", "1"),
+        &base_options(tmp.path())
+            .with_env("NO_COLOR", "1")
+            .with_env(cooldown.env().0, cooldown.env().1),
     );
 
     assert_exit(&output, 0);
@@ -800,6 +869,7 @@ fn prompt_segment_does_not_render_cache_older_than_max_stale_age() {
         cache_file.is_file(),
         "max-stale handling must not delete cache"
     );
+    cooldown.assert_held();
 }
 
 #[test]
@@ -1009,22 +1079,45 @@ fn usage_auto_keeps_live_rate_limit_reason_when_expired_cache_is_omitted() {
     );
 }
 
-/// Pins the containment itself, because the failure it prevents is invisible:
-/// the reach happens in a detached child, so a test that lost its endpoint
-/// override would still pass while talking to the real backend.
+/// Pins the containment defaults, asserting the **effective** value rather than
+/// mere presence.
+///
+/// `run_impl_os` replays `envs` in order through `Command::env`, whose map is
+/// last-write-wins per key, and applies `envs_os` after `envs`. So a later entry
+/// for the same key decides what the child sees. An `any()` assertion would stay
+/// green if a future edit appended a live endpoint after the pin — exactly the
+/// regression this guards. `with_path_prepend` in `nils-test-support` reads the
+/// effective value with `rev().find(..)` for the same reason.
 #[test]
-fn base_options_pins_an_unroutable_endpoint_for_every_suite_default() {
+fn base_options_pins_containment_defaults_as_the_effective_values() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let options = base_options(tmp.path());
 
-    assert!(
+    let effective = |key: &str| {
+        assert!(
+            !options.envs_os.iter().any(|(name, _)| name == key),
+            "{key} must not also be set through envs_os, which is applied last"
+        );
         options
             .envs
             .iter()
-            .any(|(key, value)| key == "CLAUDE_PROMPT_SEGMENT_ENDPOINT"
-                && value == UNROUTABLE_ENDPOINT),
-        "base_options must pin an endpoint: it clears the CLAUDE_PROMPT prefix, and the \
+            .rev()
+            .find(|(name, _)| name == key)
+            .map(|(_, value)| value.as_str())
+    };
+
+    assert_eq!(
+        effective("CLAUDE_PROMPT_SEGMENT_ENDPOINT"),
+        Some(UNROUTABLE_ENDPOINT),
+        "base_options must pin the endpoint: it clears the CLAUDE_PROMPT prefix, and the \
          production default is a real host, so omission means reaching it; envs={:?}",
+        options.envs
+    );
+    assert_eq!(
+        effective("CLAUDE_PROMPT_SEGMENT_MAX_TIME_SECONDS"),
+        Some(FAST_FAIL_MAX_TIME_SECONDS),
+        "the fast-fail must be bounded so the pinned endpoint fails fast on a host that \
+         drops rather than refuses loopback traffic; envs={:?}",
         options.envs
     );
 }
@@ -1032,18 +1125,26 @@ fn base_options_pins_an_unroutable_endpoint_for_every_suite_default() {
 #[test]
 fn prompt_segment_missing_credentials_and_cache_is_quiet_success() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    // Per-test enumeration (#1412) showed this test does reach
+    // Per-test enumeration (#1412) showed this test reaches
     // `enqueue_background_refresh` despite having neither credentials nor a
-    // cache, and it was the one spawner in this suite with no containment. The
-    // detached child's first act is `create_dir_all` on the cache directory, so
-    // it could recreate this `tempdir` after teardown removed it. A no-op
-    // executable keeps the spawn under test while giving the child nothing to
-    // write.
-    let options = base_options(tmp.path()).with_env("CLAUDE_PROMPT_SEGMENT_EXE", NO_OP_EXE);
+    // cache, with no containment at all. Its subject is the quiet-success
+    // rendering, not the refresh, so hold the cooldown.
+    //
+    // Measured: with the cooldown held this run enters `enqueue_background_refresh`
+    // and spawns nothing. Unlike the max-stale case below, disabling the gate does
+    // not make it spawn either — holding the cooldown also creates the cache
+    // directory, which changes the rest of the path — so `assert_held` here is a
+    // tripwire that cannot currently fire rather than a proof. Kept because it
+    // costs nothing and would catch the marker being rewritten if that changes.
+    let cooldown = RefreshCooldown::hold(tmp.path());
+    let options = base_options(tmp.path()).with_env(cooldown.env().0, cooldown.env().1);
+
     let output = run(&["prompt-segment"], &options);
+
     assert_exit(&output, 0);
     assert_eq!(stdout(&output), "");
     assert_eq!(stderr(&output), "");
+    cooldown.assert_held();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

#1412 asked for a per-test enumeration rather than inspection, because "appears
handled" is not evidence. Ran it, and it found what inspection could not — then
review found that my first pass had classified one of its own results wrongly and
overstated the defect. Both are corrected here.

Closes #1412.

## Method

The one #1410 proved: instrument the spawn point with a pid-keyed marker into a
fixed directory outside the repo, enumerate every test, run each **alone**, and
check whether a marker appeared. Instrumentation reverted before committing — the
diff contains none of it.

**311 gemini-cli tests + 113 claude-cli tests → 13 spawners.**

## gemini-cli: six spawners, all contained, no change needed

All six route through `set_fast_fail_refresh_env`, which pins
`GEMINI_PROMPT_SEGMENT_EXE=/usr/bin/false` **and** an unroutable
`CODE_ASSIST_ENDPOINT` **and** one-second timeouts. The issue's inspection was
correct here; it is now evidence.

## claude-cli: seven spawners, **two** uncontained

| test | first pass | actual |
|---|---|---|
| `prompt_segment_missing_credentials_and_cache_is_quiet_success` | uncontained | uncontained ✔ |
| `prompt_segment_does_not_render_cache_older_than_max_stale_age` | "contained" | **uncontained** |

The second was misclassified because the containment check read a fixed-size
window that overlapped the *following* test, which does hold all three forms of
containment. A 601s-old cache is display-expired, so that run spawns a detached
child whose first act is `create_dir_all` on the fixture directory — the class-3
resurrection in `docs/specs/test-temp-directory-policy.md`.

## Correction: the child never reached the real backend

The first pass claimed it did. It did not, and I verified this rather than taking
it on report: `base_options` disables the keychain and the same
`with_env_remove_prefix("CLAUDE_PROMPT")` that clears the endpoint also clears the
token variables, so `refresh_blocking` returns at its token guard **before**
`client::fetch_usage`. No HTTP request was ever issued.

So the accurate statement is:

- **proximate and provable**: an uncontained detached spawn that can recreate a
  torn-down `tempdir`;
- **latent**: the endpoint would have defaulted to the real host had a token been
  in scope.

That wrong framing mattered — by naming the endpoint rather than the spawn as the
defect, it is what let the second uncontained spawner go unnoticed.

## The fix: hold the cooldown, do not neuter the child

The temp-directory policy prefers not starting the child at all, and unlike a
no-op executable that is **falsifiable**. A recent `usage.refresh.at` plus a long
minimum interval makes `enqueue_background_refresh` return before spawning, and
because it rewrites that marker immediately before it spawns, an unchanged marker
proves no child was started.

Demonstrated rather than asserted:

- with the cooldown held, both runs **enter** `enqueue_background_refresh` and
  spawn **zero** children (verified by instrumenting the function entry and the
  spawn point separately)
- with the gate disabled, the max-stale run spawns and `assert_held` fails with
  its own message
- the same disabling does **not** make the missing-credentials run spawn, because
  holding the cooldown also creates the cache directory, which changes the rest of
  the path. That is recorded in the test rather than papered over: its tripwire
  cannot currently fire.

Also fixed from review: the pinning regression now asserts the **effective**
environment value (last-wins, and no `envs_os` shadow) rather than mere presence,
which is the regression it exists to catch; and the fast-fail is bounded so
containment stays fast on a host that drops rather than refuses loopback traffic.

## Test plan

- `-p nils-claude-cli` → **114/114**
- `bash scripts/ci/tempdir-leak-probe.sh --runs 3 -- --profile ci -p nils-claude-cli` → `ok — nothing left behind`
- `bash scripts/ci/tempdir-leak-probe.sh --runs 3 -- --profile ci -p nils-gemini-cli` → `311/311`, `ok`
- declared gate `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` → exit 0

The claude-cli suite is also faster, because children no longer wait out real
network timeouts.

## Deferred, with an owner

Three findings are `follow-up` on the ledger and filed as **#1438**: the loopback
pin is only unroutable without a proxy; the provider-binary variables are unpinned
the same way the endpoint was; and pinning the endpoint for every caller leaves the
production default with nothing asserting it. Each is the same omission shape on a
different variable, and none is triggerable by a current test.

## Independent confirmation of #1413

The gemini-cli probe first failed with `codex-cli binary path: NotPresent` — on
plain `main`, package-scoped, which is precisely #1413. After
`cargo build -p nils-codex-cli --bins` it was 311/311 and clean. #1433 covers it.

## Risk / Notes

- Test-only. The two `refresh.rs` spawners are untouched.
- Pinning an endpoint and a timeout in `base_options` changes what the *child*
  fails against for the ~56 tests that never set one. None asserts on that child,
  and the full suite passes.
