### PR TITLE
fix(forge-cli): stop an unchecked head satisfying the merge gate

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -3618,7 +3618,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__deliver)
-            opts="-h --kind --title --body --body-file --head --base --method --reviewer --label --label-catalog --strict-labels --test-first-evidence --timeout --no-merge --no-issue-closeout --allow-non-default-base --allow-unresolved-threads --allow-unresolved-threads-reason --review-convergence --allow-unchecked-tasks --allow-unchecked-tasks-reason --format --remote --provider --host --repo --store-root --dry-run --help"
+            opts="-h --kind --title --body --body-file --head --base --method --reviewer --label --label-catalog --strict-labels --test-first-evidence --timeout --no-merge --no-issue-closeout --allow-non-default-base --allow-unresolved-threads --allow-unresolved-threads-reason --review-convergence --allow-unchecked-tasks --allow-unchecked-tasks-reason --allow-no-checks --allow-no-checks-reason --format --remote --provider --host --repo --store-root --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -3681,6 +3681,10 @@ _forge-cli() {
                     return 0
                     ;;
                 --allow-unchecked-tasks-reason)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --allow-no-checks-reason)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -4284,7 +4288,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__merge)
-            opts="-h --expected-head --method --keep-branch --allow-non-default-base --allow-unresolved-threads --allow-unresolved-threads-reason --review-convergence --allow-unchecked-tasks --allow-unchecked-tasks-reason --format --remote --provider --host --repo --store-root --dry-run --help"
+            opts="-h --expected-head --method --keep-branch --allow-non-default-base --allow-unresolved-threads --allow-unresolved-threads-reason --review-convergence --allow-no-checks --allow-no-checks-reason --allow-unchecked-tasks --allow-unchecked-tasks-reason --format --remote --provider --host --repo --store-root --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4304,6 +4308,10 @@ _forge-cli() {
                     ;;
                 --review-convergence)
                     COMPREPLY=($(compgen -W "true false" -- "${cur}"))
+                    return 0
+                    ;;
+                --allow-no-checks-reason)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --allow-unchecked-tasks-reason)
@@ -5578,7 +5586,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__wait__checks)
-            opts="-h --timeout --interval --required-only --format --remote --provider --host --repo --store-root --dry-run --help"
+            opts="-h --timeout --interval --allow-no-checks --required-only --format --remote --provider --host --repo --store-root --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -802,6 +802,7 @@ _arguments "${_arguments_options[@]}" : \
 '--method=[Merge method override. When omitted, falls back to \`.forge-cli.toml \[merge\].method\` then the spec default \`squash\`]:METHOD:(squash merge rebase)' \
 '--allow-unresolved-threads-reason=[Required when \`--allow-unresolved-threads\` is set. Non-empty free-form text describing why the unresolved threads are safe to merge past; the reason is recorded in the merge envelope payload]:TEXT:_default' \
 '--review-convergence=[Override \`\[review_convergence\].require\`. Passing the flag without a value enables it; use \`--review-convergence=false\` to disable a repo or user-global opt-in for this invocation]::REVIEW_CONVERGENCE:(true false)' \
+'--allow-no-checks-reason=[Required when \`--allow-no-checks\` is set. Non-empty free-form text describing why merging an unchecked head is safe — normally that the repository configures no checks at all; the reason is recorded in the merge envelope payload]:TEXT:_default' \
 '--allow-unchecked-tasks-reason=[Required when \`--allow-unchecked-tasks\` is set. Non-empty free-form text describing why the unchecked items are safe to merge past; the reason is recorded in the merge envelope payload]:TEXT:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
@@ -813,6 +814,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--keep-branch[Skip the post-merge branch deletion (\`--delete-branch\` on gh, \`--remove-source-branch\` on glab). Mutually exclusive with the implicit-true default; flagging both is \`keep_branch_conflict\`]' \
 '--allow-non-default-base[Allow merges where the PR'\''s base is not the repo'\''s default branch. Without this flag, mismatched bases trigger \`default_branch_protected\`]' \
 '--allow-unresolved-threads[Merge despite unresolved review threads. Without this flag, any non-outdated unresolved thread (bot or human) triggers \`unresolved_review_threads\`. Requires \`--allow-unresolved-threads-reason\`]' \
+'--allow-no-checks[Merge a head for which no required checks are registered. Without this flag an empty required-check snapshot triggers \`checks_not_registered\`, because "all required checks passed" is vacuously true over an empty set and so proves nothing about the head. Requires \`--allow-no-checks-reason\`]' \
 '--allow-unchecked-tasks[Merge despite unchecked task-list items in the PR/MR description. Without this flag, any unchecked \`- \[ \]\` item triggers \`unchecked_task_items\`. Requires \`--allow-unchecked-tasks-reason\`]' \
 '--dry-run[Validate and describe the planned operation without applying its mutation. Read-only preflight calls may still run]' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -863,6 +865,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--host=[Override the forge authority (\`hostname\` or \`hostname\:port\`). With \`--provider\`, a syntactically valid custom authority is accepted unless it is positively identified as the other provider. Without \`--provider\`, the authority must identify a supported provider]:HOST:_default' \
 '--repo=[Override the remote-derived repository path. Accepted shapes\: GitHub \`owner/name\`; GitLab \`group\[/subgroup...\]/project\`; Local \`local\:<slug>\` or \`<slug>\`]:REPOSITORY:_default' \
 '--store-root=[Root directory of the file-backed store used by \`--provider local\`. Overrides the \`FORGE_CLI_LOCAL_STORE\` env var]:path:_files' \
+'--allow-no-checks[Treat a head with no registered checks as complete instead of waiting out the timeout. Without it, an empty check set is not terminal and the wait expires as \`checks_not_registered\`]' \
 '--dry-run[Validate and describe the planned operation without applying its mutation. Read-only preflight calls may still run]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -886,6 +889,7 @@ _arguments "${_arguments_options[@]}" : \
 '--allow-unresolved-threads-reason=[Required when \`--allow-unresolved-threads\` is set. Non-empty free-form text describing why the unresolved threads are safe to merge past; the reason is recorded in the merge-step payload]:TEXT:_default' \
 '--review-convergence=[Override \`\[review_convergence\].require\` for the merge phase. Passing the flag without a value enables it; \`--review-convergence=false\` disables a configured opt-in for this invocation]::REVIEW_CONVERGENCE:(true false)' \
 '--allow-unchecked-tasks-reason=[Required when \`--allow-unchecked-tasks\` is set. Non-empty free-form text describing why the unchecked items are safe to merge past; the reason is recorded in the merge-step payload]:TEXT:_default' \
+'--allow-no-checks-reason=[Required when \`--allow-no-checks\` is set. Non-empty free-form text describing why delivering an unchecked head is safe; the reason is recorded in the merge-step payload]:TEXT:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
@@ -899,6 +903,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--allow-non-default-base[Allow merges where the PR'\''s base is not the repo'\''s default branch]' \
 '--allow-unresolved-threads[Merge despite unresolved review threads. Without this flag, any non-outdated unresolved thread (bot or human) triggers \`unresolved_review_threads\` at the merge step. Requires \`--allow-unresolved-threads-reason\`]' \
 '--allow-unchecked-tasks[Merge despite unchecked task-list items in the PR/MR description. Without this flag, any unchecked \`- \[ \]\` item triggers \`unchecked_task_items\` at the merge step. Requires \`--allow-unchecked-tasks-reason\`]' \
+'--allow-no-checks[Deliver a head for which no checks are registered. Without this flag, delivery waits out its \`--timeout\` for checks to appear and then fails with \`checks_not_registered\` rather than treating an empty check set as a pass. Requires \`--allow-no-checks-reason\`]' \
 '--dry-run[Validate and describe the planned operation without applying its mutation. Read-only preflight calls may still run]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \

--- a/crates/forge-cli/docs/README.md
+++ b/crates/forge-cli/docs/README.md
@@ -9,6 +9,13 @@ Crate-local documentation for the `forge-cli` binary.
 - [`specs/forge-cli-ops-v1.yaml`](specs/forge-cli-ops-v1.yaml) —
   machine-readable op catalog.
 
+## Runbooks
+
+- [`runbooks/pr-head-repair-loop.md`](runbooks/pr-head-repair-loop.md) —
+  keeping one PR and one review timeline across a CI repair loop: amend,
+  force-with-lease, re-bind evidence, re-deliver, and the check-registration
+  window after a new head.
+
 Workspace-level docs that govern this crate (the envelope contract, the
 crate docs placement policy, and the dispatch plan) live under the
 repository root `docs/` tree; consult that tree from the workspace

--- a/crates/forge-cli/docs/runbooks/pr-head-repair-loop.md
+++ b/crates/forge-cli/docs/runbooks/pr-head-repair-loop.md
@@ -1,0 +1,93 @@
+# Repairing a PR after its head changes
+
+How to keep one pull request — and one review timeline — across a CI repair
+loop, instead of closing it and opening a replacement.
+
+This is the workflow #1398 was filed about. The capability already existed; what
+was missing was this page.
+
+## The property that makes it feel impossible
+
+Delivery evidence is bound to an exact commit, tree digest, and delivery
+attempt. That is deliberate: evidence that survived an amend would no longer
+describe the code being merged. So after `git commit --amend` and a
+`--force-with-lease` push, the evidence bound to the old head is stale, and
+`pr deliver` refuses it with `test_first_evidence_subject_mismatch` or
+`test_first_evidence_provider_head_mismatch`.
+
+The reflex is to close the PR and open a new one. That is not necessary, and it
+throws away the review timeline, the review-loop ledger, and every thread.
+
+## The loop
+
+The baseline is **never** replaced. `bind-delivery` appends a new attestation
+for the new head; the old attempt stays auditable.
+
+```bash
+# 1. repair, amend, and re-sign
+git commit --amend        # via semantic-commit in this repo
+git-cli push --force-with-lease
+
+# 2. re-bind evidence to the new head and re-verify
+test-first-evidence record-final --out "$EVIDENCE_DIR" \
+  --command 'bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast' \
+  --status pass --scope focused
+test-first-evidence bind-delivery --out "$EVIDENCE_DIR" --project-path .
+test-first-evidence verify --out "$EVIDENCE_DIR" --project-path . --format json
+
+# 3. re-deliver against the SAME pr — deliver adopts it, it does not recreate
+forge-cli pr deliver --kind feature --title "$TITLE" --body-file "$PR_BODY" \
+  --base main --test-first-evidence "$EVIDENCE_DIR" --no-merge
+```
+
+`pr deliver` looks up the open PR on the head branch and **adopts** it, recording
+an `adopt` step instead of a `create` step. The PR number, author, labels, draft
+state, and review timeline are untouched.
+
+## Ordering rules that cannot be repaired after the fact
+
+**Record the review-loop observation before you push the repair.** An
+observation can only be appended at the current provider head, so history cannot
+be backfilled; and a `fixed` disposition requires a *repaired* head, so a finding
+cannot be declared fixed at the head where it was first recorded. Together these
+force: observe findings as `open` at the reviewed head → repair → push → observe
+them as `fixed` at the new head. Doing every repair first and then trying to
+write the history is unrecoverable — the pre-repair head is gone.
+
+**Pin the head at merge.** Pass `--expected-head <sha>` so the merge is a
+compare-and-swap against the head you verified. Without it a concurrent push can
+land between your last check and the merge.
+
+## Checks after a force-with-lease
+
+A new head starts with no checks registered. The provider needs time to register
+them, and during that window `gh pr checks --required` reports "no required
+checks reported".
+
+`pr wait-checks` and `pr merge` treat that empty snapshot as **not yet checked**
+rather than as a pass: the wait polls through the window, and both fail closed
+with `checks_not_registered` if nothing ever appears. This is lock-down rule 8 —
+see the spec's "Absence is not success". Before that rule existed, a re-delivery
+inside the registration window could report green having run no CI at all.
+
+If the repository genuinely configures no checks, say so explicitly:
+
+```bash
+forge-cli pr merge "$PR" --method squash --expected-head "$SHA" \
+  --allow-no-checks --allow-no-checks-reason 'this repository configures no CI'
+```
+
+The reason is recorded in the merge envelope as `no_checks_override_reason`, and
+it is the only durable record that a merge happened without CI evidence.
+
+## Reducing the number of iterations
+
+Broad CI repair is slow when each run reports only the next failure. Use
+`cargo nextest --no-fail-fast` so one run reports every remaining failure. That
+does not replace anything above; it just makes the loop converge in fewer trips.
+
+## Links
+
+- [`../specs/forge-cli-spec-v1.md`](../specs/forge-cli-spec-v1.md) — lock-down
+  rules, including rule 8 and the `checks_not_registered` mapping.
+- Back to crate docs: [`../README.md`](../README.md)

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -68,9 +68,10 @@ validations_catalog:
     error_kind: draft_merge_refused
     exit: DATA
   required_checks_green:
-    rule: "every required check is success at merge time"
+    rule: "every required check is success at merge time, and at least one check was reported"
     error_kind: checks_pending     # exit DATA when pending
     failed_error_kind: checks_failed  # exit RUNTIME when failed
+    absent_error_kind: checks_not_registered  # exit DATA when no required checks AND no visible rows; bypass with --allow-no-checks (+ --allow-no-checks-reason)
   merge_method_supported:
     rule: "method in {squash, merge, rebase} and backend supports it"
     error_kind: merge_method_unsupported
@@ -792,6 +793,8 @@ operations:
       - { name: --review-convergence,        type: optional<bool>,               default: resolved-config }
       - { name: --allow-unchecked-tasks,    type: bool,                          default: false }
       - { name: --allow-unchecked-tasks-reason, type: string,                    default: null }
+      - { name: --allow-no-checks,          type: bool,                          default: false } # requires --allow-no-checks-reason
+      - { name: --allow-no-checks-reason,   type: string,                        default: null }
     validations:
       - worktree_clean
       - test_first_evidence_provider_head_mismatch # when --expected-head is supplied, the first provider snapshot must still match it before merge mutation
@@ -816,6 +819,7 @@ operations:
         deleted_branch: bool
         unchecked_tasks_override_reason?: string # present only when --allow-unchecked-tasks bypass was used
         unresolved_threads_override_reason?: string # present only when --allow-unresolved-threads bypass was used
+        no_checks_override_reason?: string # present only when --allow-no-checks bypass was used; the only durable record that a merge happened with no CI evidence
         stale_thread_dispositions?: 'list<{ thread_id: string, author: string, path: string, summary: string, disposition: "stale", rationale: string }>' # outdated unresolved threads dispositioned stale at rule 13; omitted when none
         review_convergence: optional<{required, head_sha, observed_reviews, stale_reviews, semantic_activity, semantic_digest, unresolved_threads, changes_requested_by, missing_reviewers, latest_activity_at?, quiet_until?, quiet_period_ms, timeout_ms, waited_ms, bots}>
         review_loop: optional<{state_tip_digest,head_sha,round,no_progress_rounds,open_blocking_findings}>
@@ -863,14 +867,25 @@ operations:
       - { name: --timeout,       type: duration,          default: 30m }
       - { name: --interval,      type: duration,          default: 20s }
       - { name: --required-only, type: bool,              default: true }
+      - { name: --allow-no-checks, type: bool,            default: false } # reason-free by design: this op is non-mutating and records no durable decision, so there is no payload field to carry a reason. The mutating siblings (pr.merge, pr.deliver) do require one.
     validations: []
     behaviour: |
-      Polls pr.checks until every required check is terminal. Emits
-      a single envelope at the end. Maps results to exit code:
+      Polls pr.checks until every required check is terminal. An empty gating
+      set is NOT terminal (lock-down rule 8): the poll continues through the
+      provider's check-registration window instead of reading "nothing is
+      failing" as "everything passed". --allow-no-checks makes it terminal for
+      a project that configures none. Emits a single envelope at the end.
+      Maps results to exit code:
         all success         -> SUCCESS 0
         any failure         -> RUNTIME 1, error.kind=checks_failed
         cancelled/timed_out -> RUNTIME 1, error.kind=checks_failed
-        deadline reached    -> UNAVAILABLE 69, error.kind=checks_timeout
+        deadline reached,
+          checks were seen  -> UNAVAILABLE 69, error.kind=checks_timeout
+        deadline reached,
+          none ever seen    -> DATA 65, error.kind=checks_not_registered
+      On the checks_not_registered emission the envelope carries ok=false while
+      data.state is still "success" (the snapshot is reported verbatim), so
+      consumers must gate on ok / error.kind, not on data.state.
     backends: inherits-from-pr.checks
     output: inherits-from-pr.checks
 
@@ -1253,6 +1268,8 @@ macros:
       - { name: --review-convergence,        type: optional<bool>,              default: resolved-config }
       - { name: --allow-unchecked-tasks,    type: bool,                         default: false }
       - { name: --allow-unchecked-tasks-reason, type: string,                   default: null }
+      - { name: --allow-no-checks,          type: bool,                         default: false } # requires --allow-no-checks-reason
+      - { name: --allow-no-checks-reason,   type: string,                       default: null }
       - { name: --test-first-evidence,      type: path,                         required: false } # forwarded to create and enforced on the adopt path when [test_first].require resolves true
     sequence:
       # Before dry-run/live branching and before provider access, validate
@@ -1272,7 +1289,11 @@ macros:
       # GitHub delivery starts required-only. When that snapshot reports zero
       # required checks but retains visible rows, the macro re-gates those rows
       # as all-checks and polls only if pending, using the same timeout budget.
-      # An empty visible set succeeds immediately; GitLab semantics are unchanged.
+      # A fully empty check set no longer succeeds: wait_checks treats it as
+      # non-terminal and, once the budget expires, fails DATA 65 with
+      # checks_not_registered (lock-down rule 8). This applies on GitLab too,
+      # where an MR with no pipeline reports the same empty snapshot.
+      # --allow-no-checks (+ reason) is the declared opt-out.
       - { step: wait_checks,        op: pr.wait-checks }
       - { step: ready,              op: pr.ready,  skip_when: "--no-merge" }
       - { step: merge,              op: pr.merge,  skip_when: "--no-merge" }

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -475,11 +475,17 @@ backend mapping, validation rules, and output schema versions.
   without project context fall back to the version-pinned
   `glab ci status -b <branch>` text parser.
 - Terminal states map to envelope `ok`:
-  - all required `success` → `ok = true`.
+  - all required `success`, with at least one check reported → `ok = true`.
   - any required `failure`/`cancelled`/`timed_out` → `ok = false`,
     exit `RUNTIME 1`, `error.kind = "checks_failed"`.
-  - timeout reached → `ok = false`, exit `UNAVAILABLE 69`,
-    `error.kind = "checks_timeout"`.
+  - timeout reached with checks still running → `ok = false`, exit
+    `UNAVAILABLE 69`, `error.kind = "checks_timeout"`.
+  - timeout reached having never seen a required check or a visible row →
+    `ok = false`, exit `DATA 65`, `error.kind = "checks_not_registered"`.
+    An empty snapshot is **not** terminal (rule 8): the poll continues
+    through the provider's check-registration window rather than reading
+    "nothing is failing" as "everything passed". `--allow-no-checks` makes
+    the empty set terminal for a repository that configures none.
 - Output schema: `cli.forge-cli.pr.checks.v1`,
   `data = { state, required_count, success_count, failed:[…], pending:[…], checks:[…], duration_ms, warnings? }`.
 
@@ -1163,6 +1169,23 @@ backend implementations cannot diverge.
    `pr wait-checks` was called earlier in the macro. This is the
    TTL-zero re-check that addresses the
    `github-pr-required-check-gating` operation record.
+
+   **Absence is not success.** "All required checks passed" is vacuously
+   true over an empty set, so a snapshot reporting no required checks
+   *and* no visible check rows means nothing ran — not that everything
+   passed. `pr merge` fails closed with `checks_not_registered`
+   (`DATA 65`) and `pr wait-checks` treats the empty set as non-terminal,
+   polling out its budget before reporting the same kind. Both accept
+   `--allow-no-checks` (with a recorded `--allow-no-checks-reason`) for a
+   repository that genuinely configures none.
+
+   The predicate deliberately requires *both* halves. A repository can run
+   CI without branch protection, producing zero required checks alongside
+   visible rows; those are re-gated against the visible set rather than
+   refused. What is refused is the case with nothing to re-gate, which is
+   also what the provider reports during the check-registration window
+   after a force-with-lease — the window in which delivery previously
+   reported success against an unchecked head.
 9. **Merge method.** Default `squash`. Repo override allowed via
    `.forge-cli.toml` `[merge] method = "squash" | "merge" | "rebase"`.
    Per-invocation `--method` overrides the repo override; both are
@@ -1318,6 +1341,7 @@ Violations map to `DATA 65` with one of these `data.error.kind` values:
 | `draft_merge_refused`                      | 7                    |
 | `checks_pending`                           | 8                    |
 | `checks_failed`                            | 8 (`RUNTIME 1`)      |
+| `checks_not_registered`                    | 8                    |
 | `merge_method_unsupported`                 | 9                    |
 | `keep_branch_conflict`                     | 10                   |
 | `local_path_present`                       | 11                   |

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -982,8 +982,13 @@ backend mapping, validation rules, and output schema versions.
 - Preconditions enforced before invoking the backend:
   - PR exists and is not draft (call `pr ready` first if needed);
   - working tree clean;
-  - required checks all green (re-checked even if `pr wait-checks`
-    succeeded earlier — TTL-zero gate);
+  - required checks all green **and at least one check reported**
+    (re-checked even if `pr wait-checks` succeeded earlier — TTL-zero
+    gate). A head with no required checks and no visible rows is refused
+    with `checks_not_registered`; `--allow-no-checks` with a non-empty
+    `--allow-no-checks-reason` bypasses it and records the reason in
+    `data.no_checks_override_reason`. `pr deliver` accepts the same pair
+    and forwards it to its wait-checks and merge steps;
   - target branch is the repo default branch OR explicitly approved
     via `--allow-non-default-base`;
   - when resolved review convergence is enabled, no current-head native
@@ -1035,8 +1040,10 @@ backend mapping, validation rules, and output schema versions.
 - Output schema: `cli.forge-cli.pr.merge.v1`,
   `data = { number, url, merge_sha, method, deleted_branch,
   unchecked_tasks_override_reason?, unresolved_threads_override_reason?,
+  no_checks_override_reason?,
   stale_thread_dispositions?, review_convergence?, review_loop? }`.
-  `unchecked_tasks_override_reason` / `unresolved_threads_override_reason` are
+  `unchecked_tasks_override_reason` / `unresolved_threads_override_reason` /
+  `no_checks_override_reason` are
   present only when the matching bypass was used; `stale_thread_dispositions`
   lists the outdated threads dispositioned `stale` at rule 13 (omitted when
   none). The additive convergence snapshot contains
@@ -1181,11 +1188,27 @@ backend implementations cannot diverge.
 
    The predicate deliberately requires *both* halves. A repository can run
    CI without branch protection, producing zero required checks alongside
-   visible rows; those are re-gated against the visible set rather than
-   refused. What is refused is the case with nothing to re-gate, which is
-   also what the provider reports during the check-registration window
-   after a force-with-lease — the window in which delivery previously
-   reported success against an unchecked head.
+   visible rows; refusing those would block every such repository. What is
+   refused is the case with nothing to fall back to, which is also what the
+   provider reports during the check-registration window after a
+   force-with-lease — the window in which delivery previously reported
+   success against an unchecked head.
+
+   Be precise about what happens to the zero-required-with-visible-rows
+   case, because the two commands differ. `pr deliver` re-gates those rows
+   against the full visible set — but only on GitHub
+   (`should_gate_visible_checks`). Standalone `pr merge` does **not**
+   re-gate them on any provider: its snapshot is taken with
+   `required_only`, so a non-required failing row is not in `failed` and
+   the gate accepts the head. That gap predates this rule and is not
+   closed by it.
+
+   The rule is provider-neutral, and on GitLab that is a behaviour change
+   worth stating: an MR whose head has no pipeline — no `.gitlab-ci.yml`,
+   excluded by `workflow:rules`, or pipelines disabled on a fork — reports
+   the same empty snapshot and is now refused rather than merged. That is
+   the intended reading of "absence is not success", and
+   `--allow-no-checks` is the declared way to say a project has no CI.
 9. **Merge method.** Default `squash`. Repo override allowed via
    `.forge-cli.toml` `[merge] method = "squash" | "merge" | "rebase"`.
    Per-invocation `--method` overrides the repo override; both are
@@ -1519,14 +1542,14 @@ without exception:
 `nils_common::cli_contract::exit`. Discriminators go in
 `data.error.kind`, not in numeric exit codes.
 
-| Constant      | Value | `forge-cli` triggers                                                                                                                                                                |
-| ------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SUCCESS`     | `0`   | Op completed; required state achieved.                                                                                                                                              |
-| `RUNTIME`     | `1`   | Remote semantic failure: required checks failed, merge conflict, draft already ready.                                                                                               |
-| `USAGE`       | `64`  | Bad CLI syntax, unknown subcommand, unsupported provider.                                                                                                                           |
-| `DATA`        | `65`  | Lock-down policy violation (any rule above); body parse failure; invalid VPN config.                                                                                                |
-| `UNAVAILABLE` | `69`  | `gh`/`glab` missing, auth required, remote 5xx/network error, wait-checks or review-convergence timeout, GitLab VPN probe failure, backend timeout or backend output-limit failure. |
-| `SOFTWARE`    | `70`  | Internal invariant violation (backend JSON did not match expected shape).                                                                                                           |
+| Constant      | Value | `forge-cli` triggers                                                                                                                                                                                                                                                                                         |
+| ------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SUCCESS`     | `0`   | Op completed; required state achieved.                                                                                                                                                                                                                                                                       |
+| `RUNTIME`     | `1`   | Remote semantic failure: required checks failed, merge conflict, draft already ready.                                                                                                                                                                                                                        |
+| `USAGE`       | `64`  | Bad CLI syntax, unknown subcommand, unsupported provider.                                                                                                                                                                                                                                                    |
+| `DATA`        | `65`  | Lock-down policy violation (any rule above); body parse failure; invalid VPN config.                                                                                                                                                                                                                         |
+| `UNAVAILABLE` | `69`  | `gh`/`glab` missing, auth required, remote 5xx/network error, wait-checks expiry when checks were seen but did not finish (an expiry with none ever reported is `DATA 65` / `checks_not_registered`), review-convergence timeout, GitLab VPN probe failure, backend timeout or backend output-limit failure. |
+| `SOFTWARE`    | `70`  | Internal invariant violation (backend JSON did not match expected shape).                                                                                                                                                                                                                                    |
 
 Callers (agent-runtime-kit skills, CI scripts) MUST branch on `error.kind`
 when finer granularity is needed. Numeric exit codes alone are

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -850,6 +850,28 @@ pub struct PrMergeArgs {
         default_missing_value = "true"
     )]
     pub review_convergence: Option<bool>,
+    /// Merge a head for which no required checks are registered. Without this
+    /// flag an empty required-check snapshot triggers `checks_not_registered`,
+    /// because "all required checks passed" is vacuously true over an empty set
+    /// and so proves nothing about the head. Requires
+    /// `--allow-no-checks-reason`.
+    #[arg(
+        long = "allow-no-checks",
+        action = ArgAction::SetTrue,
+        requires = "allow_no_checks_reason"
+    )]
+    pub allow_no_checks: bool,
+    /// Required when `--allow-no-checks` is set. Non-empty free-form text
+    /// describing why merging an unchecked head is safe — normally that the
+    /// repository configures no checks at all; the reason is recorded in the
+    /// merge envelope payload.
+    #[arg(
+        long = "allow-no-checks-reason",
+        value_name = "TEXT",
+        requires = "allow_no_checks",
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
+    pub allow_no_checks_reason: Option<String>,
     /// Merge despite unchecked task-list items in the PR/MR description.
     /// Without this flag, any unchecked `- [ ]` item triggers
     /// `unchecked_task_items`. Requires `--allow-unchecked-tasks-reason`.
@@ -1170,6 +1192,11 @@ pub struct PrWaitChecksArgs {
     /// Pause between polls (default `20s`).
     #[arg(long, value_parser = parse_duration, default_value = "20s")]
     pub interval: Duration,
+    /// Treat a head with no registered checks as complete instead of waiting
+    /// out the timeout. Without it, an empty check set is not terminal and the
+    /// wait expires as `checks_not_registered`.
+    #[arg(long = "allow-no-checks", action = ArgAction::SetTrue)]
+    pub allow_no_checks: bool,
     /// Restrict the gating decision to required checks (default `true`).
     #[arg(
         long = "required-only",
@@ -1481,6 +1508,26 @@ pub struct PrDeliverArgs {
         value_parser = clap::builder::NonEmptyStringValueParser::new()
     )]
     pub allow_unchecked_tasks_reason: Option<String>,
+    /// Deliver a head for which no checks are registered. Without this flag,
+    /// delivery waits out its `--timeout` for checks to appear and then fails
+    /// with `checks_not_registered` rather than treating an empty check set as
+    /// a pass. Requires `--allow-no-checks-reason`.
+    #[arg(
+        long = "allow-no-checks",
+        action = ArgAction::SetTrue,
+        requires = "allow_no_checks_reason"
+    )]
+    pub allow_no_checks: bool,
+    /// Required when `--allow-no-checks` is set. Non-empty free-form text
+    /// describing why delivering an unchecked head is safe; the reason is
+    /// recorded in the merge-step payload.
+    #[arg(
+        long = "allow-no-checks-reason",
+        value_name = "TEXT",
+        requires = "allow_no_checks",
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
+    pub allow_no_checks_reason: Option<String>,
 }
 
 /// `issue` subtree.

--- a/crates/forge-cli/src/macros/pr_deliver.rs
+++ b/crates/forge-cli/src/macros/pr_deliver.rs
@@ -361,6 +361,7 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
         timeout: args.timeout,
         interval: std::time::Duration::from_secs(20),
         required_only: true,
+        allow_no_checks: args.allow_no_checks,
     };
     let wait_outcome = match pr_wait_checks::compute(runner, clock, global, ctx, &wait_args) {
         Ok(WaitOutcome::Success(snapshot))
@@ -370,8 +371,12 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
             // checks. Delivery must still converge those visible checks before
             // it can ready or merge the PR. Keep the explicit wait-checks atom's
             // required-only semantics unchanged and apply this fallback only to
-            // the delivery macro. A genuinely empty check set still completes
-            // from the required-only snapshot above without a second poll.
+            // the delivery macro.
+            //
+            // A *fully* empty check set no longer arrives here as a success:
+            // `poll_until_terminal_or_timeout` treats an empty gating set as
+            // non-terminal and expires it as `NotRegistered`, so the case this
+            // branch used to hand through silently is now gated upstream.
             let visible_snapshot =
                 pr_checks::aggregate(ctx, snapshot.checks.clone(), false, snapshot.duration_ms);
             if visible_snapshot.pending.is_empty() {
@@ -415,6 +420,29 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
                 schema_version_for(BINARY, "pr.checks", 1),
                 "checks_failed",
                 "delivery checks did not reach success",
+                None,
+            );
+            steps.push(Step {
+                step: "wait_checks",
+                ok: false,
+                schema_version: schema_version_for(BINARY, "pr.checks", 1),
+                payload: to_value(&snapshot),
+            });
+            return Ok(emit_chain_failure(
+                steps,
+                args,
+                ctx,
+                Some((pr_number, pr_url)),
+                &err,
+                format,
+            ));
+        }
+        Ok(WaitOutcome::NotRegistered(snapshot)) => {
+            let err = ForgeError::validation(
+                schema_version_for(BINARY, "pr.checks", 1),
+                "checks_not_registered",
+                "no checks registered for the delivered head within the timeout; \
+                 pass --allow-no-checks if this repository genuinely configures none",
                 None,
             );
             steps.push(Step {
@@ -598,6 +626,8 @@ fn build_merge_args(
         review_convergence: args.review_convergence,
         allow_unchecked_tasks: args.allow_unchecked_tasks,
         allow_unchecked_tasks_reason: args.allow_unchecked_tasks_reason.clone(),
+        allow_no_checks: args.allow_no_checks,
+        allow_no_checks_reason: args.allow_no_checks_reason.clone(),
     }
 }
 
@@ -618,6 +648,9 @@ fn add_duration_prefix(outcome: WaitOutcome, prefix: std::time::Duration) -> Wai
             WaitOutcome::Success(with_total_duration(snapshot, prefix))
         }
         WaitOutcome::Failed(snapshot) => WaitOutcome::Failed(with_total_duration(snapshot, prefix)),
+        WaitOutcome::NotRegistered(snapshot) => {
+            WaitOutcome::NotRegistered(with_total_duration(snapshot, prefix))
+        }
         WaitOutcome::TimedOut(snapshot) => {
             WaitOutcome::TimedOut(with_total_duration(snapshot, prefix))
         }
@@ -1181,6 +1214,8 @@ mod tests {
             review_convergence: None,
             allow_unchecked_tasks: false,
             allow_unchecked_tasks_reason: None,
+            allow_no_checks: false,
+            allow_no_checks_reason: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_checks_gitlab.rs
+++ b/crates/forge-cli/src/ops/pr_checks_gitlab.rs
@@ -41,10 +41,15 @@ pub fn build_version_call() -> BackendCall {
 /// `mr view`), then parses `glab ci status` text.
 ///
 /// `glab` exits non-zero when there is no pipeline at all (vs. an empty
-/// pipeline). We surface that case as an empty-success payload to match the
-/// "empty pipeline" semantic the rest of the gate already expects — a repo
-/// without `.gitlab-ci.yml` should not look like a backend failure to the
-/// merge gate.
+/// pipeline). We surface that case as an empty-success payload rather than a
+/// backend error: a repo without `.gitlab-ci.yml` is not a broken provider
+/// call, and this read surface is right to report "nothing is failing".
+///
+/// That is a *reporting* answer, not a gating one. Since lock-down rule 8, the
+/// merge gate treats the same empty snapshot as "nothing proves this head was
+/// checked" and refuses it with `checks_not_registered`, so an MR with no
+/// pipeline needs an explicit `--allow-no-checks` to merge. Do not restore the
+/// old reading that empty-success here means the gate will pass.
 pub fn snapshot<R: BackendRunner>(
     runner: &R,
     ctx: &ProviderContext,

--- a/crates/forge-cli/src/ops/pr_merge.rs
+++ b/crates/forge-cli/src/ops/pr_merge.rs
@@ -9,6 +9,7 @@
 //! | 6 — default_branch_protected        | PR base ≠ repo default branch, `--allow-non-default-base=0` | `default_branch_protected`| DATA 65    |
 //! | 7 — draft_merge_refused             | `pr view` returns `draft=true`                              | `draft_merge_refused`     | DATA 65    |
 //! | 8 — required_checks_green (TTL=0)   | fresh `pr.checks --required-only` not all green             | `checks_pending`/`failed` | DATA / RT  |
+//! | 8 — checks_registered (TTL=0)       | no required checks *and* no visible rows, `--allow-no-checks=0` | `checks_not_registered` | DATA 65 |
 //! | 9 — merge_method_supported          | resolved method not in `repo.view.merge_methods_allowed`    | `merge_method_unsupported`| DATA 65    |
 //! | 10 — keep_branch_conflict           | `--keep-branch` set while `[merge].delete_branch=true`      | `keep_branch_conflict`    | DATA 65    |
 //! | 12 — review_convergence             | enabled native-review policy has not converged              | review-specific kind       | DATA / UNAV |
@@ -40,7 +41,7 @@ use crate::ops::pr_tasks;
 use crate::ops::pr_view;
 use crate::ops::pr_wait_checks::{Clock, SystemClock};
 use crate::ops::repo_view::{self, RepoViewPayload};
-use crate::ops::required_check_gate::ensure_required_checks_green;
+use crate::ops::required_check_gate::{CheckPresence, ensure_required_checks_green};
 use crate::ops::review_convergence::{self, ReviewConvergenceSnapshot};
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
@@ -68,6 +69,11 @@ pub struct PrMergePayload {
     /// gate (rule 13) was explicitly bypassed; absent otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unresolved_threads_override_reason: Option<String>,
+    /// Recorded `--allow-no-checks-reason` when the head merged with no
+    /// required checks registered (rule 8); absent otherwise. This is the only
+    /// durable record that a merge happened without CI evidence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_checks_override_reason: Option<String>,
     /// Outdated unresolved review threads mechanically dispositioned `stale`
     /// at rule 13 (the anchored diff hunk changed) so they no longer block;
     /// recorded for auditability. Empty/absent when none were dispositioned.
@@ -361,8 +367,15 @@ fn run_lockdown_chain<R: BackendRunner, C: Clock>(
     // Rule 9 — method must be in the repo's allowed list.
     enforce_method_supported(settings.method, &repo)?;
 
-    // Rule 8 — TTL-zero required-check re-check.
-    ensure_required_checks_green(runner, global, ctx, &args.id.to_string())?;
+    // Rule 8 — TTL-zero required-check re-check. An empty gating set fails
+    // closed here: absence of checks is not evidence the head passed any.
+    ensure_required_checks_green(
+        runner,
+        global,
+        ctx,
+        &args.id.to_string(),
+        CheckPresence::from_allow_no_checks(args.allow_no_checks),
+    )?;
 
     // Durable review-loop gate. Existing ledgers are never bypassed by the
     // independent quiet-convergence flag. Enforced convergence additionally
@@ -496,6 +509,11 @@ fn run_lockdown_chain<R: BackendRunner, C: Clock>(
         },
         unresolved_threads_override_reason: if args.allow_unresolved_threads {
             args.allow_unresolved_threads_reason.clone()
+        } else {
+            None
+        },
+        no_checks_override_reason: if args.allow_no_checks {
+            args.allow_no_checks_reason.clone()
         } else {
             None
         },

--- a/crates/forge-cli/src/ops/pr_wait_checks.rs
+++ b/crates/forge-cli/src/ops/pr_wait_checks.rs
@@ -171,9 +171,19 @@ fn poll_until_terminal_or_timeout<R: BackendRunner, C: Clock>(
     let start = clock.now();
     let deadline = start + timeout;
 
+    // "Never registered" is a property of the whole run, not of the last read.
+    // `pr_checks` normalizes a transient "no checks reported" into an empty
+    // successful snapshot, so classifying from the final poll alone would turn a
+    // run that had been watching real pending checks into `checks_not_registered`
+    // — flipping a retryable UNAVAILABLE 69 into a fatal DATA 65 on exactly the
+    // slow-registration case this exists for.
+    let mut ever_saw_a_check = false;
+
     loop {
         let snapshot = pr_checks::snapshot(runner, global, ctx, snapshot_args)?;
         let snapshot = with_duration(snapshot, ms_between(start, clock.now()));
+        ever_saw_a_check =
+            ever_saw_a_check || !crate::ops::required_check_gate::nothing_was_checked(&snapshot);
         if is_terminal(&snapshot, presence) {
             if snapshot.state == "success" {
                 return Ok(WaitOutcome::Success(snapshot));
@@ -184,8 +194,8 @@ fn poll_until_terminal_or_timeout<R: BackendRunner, C: Clock>(
         if now >= deadline {
             let expired = with_duration(snapshot, ms_between(start, now));
             // Report *why* the budget expired. Nothing ever registered is a
-            // different problem from checks that ran long.
-            if crate::ops::required_check_gate::nothing_was_checked(&expired) {
+            // different problem, with a different fix, from checks that ran long.
+            if !ever_saw_a_check {
                 return Ok(WaitOutcome::NotRegistered(expired));
             }
             return Ok(WaitOutcome::TimedOut(expired));
@@ -455,6 +465,15 @@ mod tests {
         };
         let snapshot = pr_checks::snapshot(&runner, &global, &ctx, &snapshot_args).unwrap();
         assert_eq!(snapshot.state, "success");
+        // Without this the test passes on a single-output stub, where the
+        // `--required` list comes back empty, `build` is never marked required,
+        // and "terminal success" is true only over an empty gating set. Assert
+        // the gating set is real so the doubled fixture is load-bearing.
+        assert_eq!(
+            snapshot.required_count, 1,
+            "the fixture must produce a real gating set, not a vacuous one"
+        );
+        assert_eq!(snapshot.success_count, 1);
         let snapshot = with_duration(snapshot, ms_between(clock.now(), clock.now()));
         assert!(is_terminal(&snapshot, CheckPresence::Required));
     }
@@ -556,6 +575,52 @@ mod tests {
         assert!(
             matches!(outcome, WaitOutcome::NotRegistered(_)),
             "an always-empty snapshot must expire as not-registered"
+        );
+    }
+
+    /// "Never registered" is a property of the run, not of the last poll.
+    ///
+    /// `pr_checks` normalizes a transient "no checks reported" into an empty
+    /// successful snapshot, so a run that watched real pending checks and then
+    /// hit one empty read at the deadline must still expire as `checks_timeout`
+    /// (UNAVAILABLE 69, retryable) — not as `checks_not_registered` (DATA 65,
+    /// fatal). Classifying from the final snapshot alone flips exactly the
+    /// slow-registration case this feature exists for onto the wrong side of
+    /// the retry boundary.
+    #[test]
+    fn a_transient_empty_read_at_the_deadline_is_still_a_timeout() {
+        const ONE_REQUIRED_PENDING: &str =
+            r#"[{"name":"build","bucket":"pending","isRequired":true}]"#;
+        let runner = StubRunner {
+            outputs: RefCell::new(vec![
+                // poll 1: a real pending required check
+                ONE_REQUIRED_PENDING.into(),
+                ONE_REQUIRED_PENDING.into(),
+                // poll 2, at the deadline: a transient empty read
+                "[]".into(),
+                "[]".into(),
+            ]),
+        };
+        let clock = StepClock::new();
+        let ctx = make_ctx(Provider::GitHub);
+        let global = make_global();
+        let args = PrWaitChecksArgs {
+            timeout: Duration::from_millis(2),
+            interval: Duration::from_millis(2),
+            ..make_args("1")
+        };
+        let snapshot_args = PrChecksArgs {
+            id: args.id.clone(),
+            required_only: args.required_only,
+        };
+
+        let outcome =
+            poll_until_terminal_or_timeout(&runner, &clock, &global, &ctx, &args, &snapshot_args)
+                .expect("poll must not error");
+
+        assert!(
+            matches!(outcome, WaitOutcome::TimedOut(_)),
+            "a run that saw checks must expire as a timeout, not as not-registered"
         );
     }
 

--- a/crates/forge-cli/src/ops/pr_wait_checks.rs
+++ b/crates/forge-cli/src/ops/pr_wait_checks.rs
@@ -8,7 +8,17 @@
 //! - all required `success` → `SUCCESS 0`
 //! - any required `failure` / `cancelled` / `timed_out` → `RUNTIME 1`,
 //!   `error.kind = "checks_failed"`
-//! - deadline reached → `UNAVAILABLE 69`, `error.kind = "checks_timeout"`
+//! - deadline reached with checks still running → `UNAVAILABLE 69`,
+//!   `error.kind = "checks_timeout"`
+//! - deadline reached with nothing ever reported → `DATA 65`,
+//!   `error.kind = "checks_not_registered"`
+//!
+//! The last case is why an empty snapshot is not terminal. "All required checks
+//! passed" is vacuously true over an empty set, so treating it as terminal
+//! reported success for a head no CI had touched — which is exactly what the
+//! provider returns during its check-registration window after a push or
+//! force-with-lease. Polling through that window is the point of this atom.
+//! `--allow-no-checks` opts a genuinely check-free repository out.
 //!
 //! Polling uses `std::thread::sleep`; the implementation owns the clock
 //! through the [`Clock`] trait so tests can drive deterministic snapshot
@@ -24,6 +34,7 @@ use crate::cli::{BINARY, GlobalFlags, PrChecksArgs, PrWaitChecksArgs};
 use crate::envelope::emit_success;
 use crate::error::ForgeError;
 use crate::ops::pr_checks::{self, PrChecksPayload, SCHEMA, SCHEMA_VERSION};
+use crate::ops::required_check_gate::CheckPresence;
 use crate::provider::{ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
 
@@ -104,6 +115,14 @@ pub fn run_with<R: BackendRunner, C: Clock, F: Fn(&str) -> Option<String>>(
             format,
         )),
         WaitOutcome::TimedOut(snapshot) => Ok(emit_timeout(snapshot, format)),
+        WaitOutcome::NotRegistered(snapshot) => Ok(emit_failure(
+            snapshot,
+            "checks_not_registered",
+            "no checks registered for this head within the timeout; \
+             pass --allow-no-checks if this repository genuinely configures none",
+            nils_common::cli_contract::exit::DATA,
+            format,
+        )),
     }
 }
 
@@ -113,6 +132,11 @@ pub enum WaitOutcome {
     Success(PrChecksPayload),
     Failed(PrChecksPayload),
     TimedOut(PrChecksPayload),
+    /// The budget expired with the gating set still empty — no check ever
+    /// registered for this head. Distinct from [`WaitOutcome::TimedOut`],
+    /// where checks existed but had not finished: the two have different
+    /// causes and different fixes, so they must not share an error kind.
+    NotRegistered(PrChecksPayload),
 }
 
 /// Macro-facing entry point: poll until terminal or timeout and return the
@@ -143,13 +167,14 @@ fn poll_until_terminal_or_timeout<R: BackendRunner, C: Clock>(
 ) -> Result<WaitOutcome, ForgeError> {
     let timeout = args.timeout;
     let interval = args.interval;
+    let presence = CheckPresence::from_allow_no_checks(args.allow_no_checks);
     let start = clock.now();
     let deadline = start + timeout;
 
     loop {
         let snapshot = pr_checks::snapshot(runner, global, ctx, snapshot_args)?;
         let snapshot = with_duration(snapshot, ms_between(start, clock.now()));
-        if is_terminal(&snapshot) {
+        if is_terminal(&snapshot, presence) {
             if snapshot.state == "success" {
                 return Ok(WaitOutcome::Success(snapshot));
             }
@@ -157,8 +182,13 @@ fn poll_until_terminal_or_timeout<R: BackendRunner, C: Clock>(
         }
         let now = clock.now();
         if now >= deadline {
-            let timed_out = with_duration(snapshot, ms_between(start, now));
-            return Ok(WaitOutcome::TimedOut(timed_out));
+            let expired = with_duration(snapshot, ms_between(start, now));
+            // Report *why* the budget expired. Nothing ever registered is a
+            // different problem from checks that ran long.
+            if crate::ops::required_check_gate::nothing_was_checked(&expired) {
+                return Ok(WaitOutcome::NotRegistered(expired));
+            }
+            return Ok(WaitOutcome::TimedOut(expired));
         }
         let remaining = deadline.saturating_duration_since(now);
         let sleep_for = std::cmp::min(interval, remaining);
@@ -178,8 +208,22 @@ fn with_duration(mut snapshot: PrChecksPayload, duration_ms: u64) -> PrChecksPay
     snapshot
 }
 
-fn is_terminal(snapshot: &PrChecksPayload) -> bool {
-    // Terminal iff no entries are pending in the gating set.
+/// Terminal iff nothing in the gating set is still pending **and** the gating
+/// set exists at all.
+///
+/// An empty set is not a terminal pass. `gh pr checks --required` reports "no
+/// required checks reported" during the provider's check-registration window
+/// after a push or force-with-lease, which [`pr_checks`] normalizes to an empty
+/// successful snapshot; polling through that window is the entire point of this
+/// atom, so it keeps waiting instead of declaring the head green. A repository
+/// that configures no checks passes [`CheckPresence::Optional`] so the loop
+/// still terminates immediately.
+fn is_terminal(snapshot: &PrChecksPayload, presence: CheckPresence) -> bool {
+    if presence == CheckPresence::Required
+        && crate::ops::required_check_gate::nothing_was_checked(snapshot)
+    {
+        return false;
+    }
     snapshot.pending.is_empty()
 }
 
@@ -335,6 +379,7 @@ mod tests {
             timeout: Duration::from_secs(5),
             interval: Duration::from_millis(1),
             required_only: true,
+            allow_no_checks: false,
         }
     }
 
@@ -381,12 +426,21 @@ mod tests {
         }
     }
 
+    /// A required-only snapshot costs *two* backend calls — the general check
+    /// list and the `--required` list that names which of them gate — so a stub
+    /// must answer both. Queueing one output leaves the required list empty,
+    /// which used to read as a vacuous "success" and is now correctly rejected
+    /// as an unregistered head.
+    const ONE_REQUIRED_PASS: &str =
+        r#"[{"name":"build","bucket":"pass","conclusion":"success","isRequired":true}]"#;
+
     #[test]
     fn succeeds_when_first_snapshot_is_terminal_success() {
         let runner = StubRunner {
             outputs: RefCell::new(vec![
-                r#"[{"name":"build","bucket":"pass","conclusion":"success","isRequired":true}]"#
-                    .into(),
+                ONE_REQUIRED_PASS.into(),
+                // the `--required` list, naming `build` as gating
+                ONE_REQUIRED_PASS.into(),
             ]),
         };
         let clock = StepClock::new();
@@ -402,16 +456,21 @@ mod tests {
         let snapshot = pr_checks::snapshot(&runner, &global, &ctx, &snapshot_args).unwrap();
         assert_eq!(snapshot.state, "success");
         let snapshot = with_duration(snapshot, ms_between(clock.now(), clock.now()));
-        assert!(is_terminal(&snapshot));
+        assert!(is_terminal(&snapshot, CheckPresence::Required));
     }
 
     #[test]
     fn pending_then_success_succeeds_on_second_poll() {
+        const ONE_REQUIRED_PENDING: &str =
+            r#"[{"name":"build","bucket":"pending","isRequired":true}]"#;
         let runner = StubRunner {
             outputs: RefCell::new(vec![
-                r#"[{"name":"build","bucket":"pending","isRequired":true}]"#.into(),
-                r#"[{"name":"build","bucket":"pass","conclusion":"success","isRequired":true}]"#
-                    .into(),
+                // poll 1: general list, then the `--required` list
+                ONE_REQUIRED_PENDING.into(),
+                ONE_REQUIRED_PENDING.into(),
+                // poll 2: the same check, now passing
+                ONE_REQUIRED_PASS.into(),
+                ONE_REQUIRED_PASS.into(),
             ]),
         };
         let ctx = make_ctx(Provider::GitHub);
@@ -422,10 +481,113 @@ mod tests {
         };
         let s1 = pr_checks::snapshot(&runner, &global, &ctx, &args).unwrap();
         assert_eq!(s1.state, "pending");
-        assert!(!is_terminal(&s1));
+        assert!(!is_terminal(&s1, CheckPresence::Required));
         let s2 = pr_checks::snapshot(&runner, &global, &ctx, &args).unwrap();
         assert_eq!(s2.state, "success");
-        assert!(is_terminal(&s2));
+        assert!(is_terminal(&s2, CheckPresence::Required));
+    }
+
+    /// An empty gating set is the provider saying "I have not registered any
+    /// checks for this head yet", which is the opposite of "they all passed".
+    /// Treating it as terminal is what let delivery report success against a
+    /// head no CI had touched.
+    #[test]
+    fn an_empty_gating_set_is_not_terminal() {
+        let runner = StubRunner {
+            outputs: RefCell::new(vec!["[]".into()]),
+        };
+        let ctx = make_ctx(Provider::GitHub);
+        let global = make_global();
+        let args = PrChecksArgs {
+            id: "1".into(),
+            required_only: true,
+        };
+        let snapshot = pr_checks::snapshot(&runner, &global, &ctx, &args).unwrap();
+        // The read surface still reports "nothing is failing" — that stays true.
+        assert_eq!(snapshot.state, "success");
+        assert_eq!(snapshot.required_count, 0);
+        // The wait loop must not accept it as a terminal pass.
+        assert!(
+            !is_terminal(&snapshot, CheckPresence::Required),
+            "an unregistered head must keep the poll loop running"
+        );
+    }
+
+    /// A repository that genuinely has no checks must still terminate, or
+    /// `pr wait-checks` would hang for its whole timeout on every invocation.
+    #[test]
+    fn an_empty_gating_set_is_terminal_when_no_checks_are_allowed() {
+        let runner = StubRunner {
+            outputs: RefCell::new(vec!["[]".into()]),
+        };
+        let ctx = make_ctx(Provider::GitHub);
+        let global = make_global();
+        let args = PrChecksArgs {
+            id: "1".into(),
+            required_only: true,
+        };
+        let snapshot = pr_checks::snapshot(&runner, &global, &ctx, &args).unwrap();
+        assert!(is_terminal(&snapshot, CheckPresence::Optional));
+    }
+
+    /// Checks that never register must expire as `checks_not_registered`, not
+    /// as `checks_timeout`: the two need different fixes, and "waited and
+    /// nothing ever appeared" is the actionable one.
+    #[test]
+    fn checks_that_never_register_time_out_as_not_registered() {
+        let runner = StubRunner {
+            outputs: RefCell::new(vec!["[]".into(), "[]".into(), "[]".into()]),
+        };
+        let clock = StepClock::new();
+        let ctx = make_ctx(Provider::GitHub);
+        let global = make_global();
+        let args = PrWaitChecksArgs {
+            timeout: Duration::from_millis(3),
+            interval: Duration::from_millis(1),
+            ..make_args("1")
+        };
+        let snapshot_args = PrChecksArgs {
+            id: args.id.clone(),
+            required_only: args.required_only,
+        };
+        let outcome =
+            poll_until_terminal_or_timeout(&runner, &clock, &global, &ctx, &args, &snapshot_args)
+                .expect("poll must not error");
+        assert!(
+            matches!(outcome, WaitOutcome::NotRegistered(_)),
+            "an always-empty snapshot must expire as not-registered"
+        );
+    }
+
+    /// The registration window is the real scenario: nothing at first, then the
+    /// provider registers the checks and they pass.
+    #[test]
+    fn checks_registering_late_still_succeed() {
+        let runner = StubRunner {
+            outputs: RefCell::new(vec![
+                // poll 1: the registration window — nothing reported yet
+                "[]".into(),
+                "[]".into(),
+                // poll 2: the checks have registered and passed
+                ONE_REQUIRED_PASS.into(),
+                ONE_REQUIRED_PASS.into(),
+            ]),
+        };
+        let clock = StepClock::new();
+        let ctx = make_ctx(Provider::GitHub);
+        let global = make_global();
+        let args = make_args("1");
+        let snapshot_args = PrChecksArgs {
+            id: args.id.clone(),
+            required_only: args.required_only,
+        };
+        let outcome =
+            poll_until_terminal_or_timeout(&runner, &clock, &global, &ctx, &args, &snapshot_args)
+                .expect("poll must not error");
+        match outcome {
+            WaitOutcome::Success(snapshot) => assert_eq!(snapshot.required_count, 1),
+            _ => panic!("late registration must still reach success"),
+        }
     }
 
     #[test]
@@ -454,7 +616,7 @@ mod tests {
             duration_ms: Some(123),
             warnings: Vec::new(),
         };
-        assert!(is_terminal(&snapshot));
+        assert!(is_terminal(&snapshot, CheckPresence::Required));
         let code = emit_failure(
             snapshot,
             "checks_failed",

--- a/crates/forge-cli/src/ops/required_check_gate.rs
+++ b/crates/forge-cli/src/ops/required_check_gate.rs
@@ -116,7 +116,7 @@ pub fn ensure_required_checks_green<R: BackendRunner>(
 /// refusing them here would block every such repository. What must not pass is
 /// the case with no gating set *and* no rows to fall back to: then nothing ran,
 /// and nothing can be re-gated.
-pub fn nothing_was_checked(snapshot: &PrChecksPayload) -> bool {
+pub(crate) fn nothing_was_checked(snapshot: &PrChecksPayload) -> bool {
     snapshot.required_count == 0 && snapshot.checks.is_empty()
 }
 
@@ -351,6 +351,34 @@ mod tests {
         let result = classify(snap, CheckPresence::Required)
             .expect("visible checks mean the head was checked");
         assert_eq!(result.checks.len(), 2);
+    }
+
+    /// Pins a gap this rule does **not** close, so nobody reads the rule as
+    /// wider than it is.
+    ///
+    /// With `required_only`, a non-required row is not in `failed`, so a head
+    /// whose only visible check FAILED still reaches `Ok` here. `pr deliver`
+    /// catches it by re-gating the visible set — on GitHub only — but
+    /// standalone `pr merge` does not, on any provider. That predates this
+    /// change and is out of its scope; the test exists so the behaviour is
+    /// owned and a future fix has something to flip.
+    #[test]
+    fn a_failing_visible_row_with_no_required_checks_still_passes_the_gate() {
+        let mut snap = pass_snapshot();
+        snap.required_count = 0;
+        snap.success_count = 0;
+        for check in &mut snap.checks {
+            check.required = false;
+        }
+        snap.checks[0].state = "failure";
+
+        let result = classify(snap, CheckPresence::Required)
+            .expect("documented current behaviour, not an endorsement");
+        assert_eq!(result.checks[0].state, "failure");
+        assert!(
+            result.failed.is_empty(),
+            "a non-required failure never enters the gating set"
+        );
     }
 
     /// A repository that genuinely configures no checks must still be able to

--- a/crates/forge-cli/src/ops/required_check_gate.rs
+++ b/crates/forge-cli/src/ops/required_check_gate.rs
@@ -11,15 +11,40 @@
 //!
 //! Error surface:
 //!
-//! | Outcome           | Variant                                 | Exit         |
-//! | ----------------- | --------------------------------------- | ------------ |
-//! | All required pass | `Ok(PrChecksPayload)`                   | n/a          |
-//! | Any required fail | `Err(checks_failed)` → RuntimeFailure   | RUNTIME 1    |
-//! | Else any pending  | `Err(checks_pending)` → Validation      | DATA 65      |
+//! | Outcome            | Variant                                       | Exit      |
+//! | ------------------ | --------------------------------------------- | --------- |
+//! | All required pass  | `Ok(PrChecksPayload)`                         | n/a       |
+//! | Any required fail  | `Err(checks_failed)` → RuntimeFailure         | RUNTIME 1 |
+//! | Else any pending   | `Err(checks_pending)` → Validation            | DATA 65   |
+//! | Else nothing ran   | `Err(checks_not_registered)` → Validation     | DATA 65   |
 //!
 //! Failure dominates pending — if both are present the gate reports
 //! `checks_failed` because the spec terminal-state mapping puts failure ahead
 //! of pending.
+//!
+//! # Absence is not success
+//!
+//! "All required checks passed" is vacuously true over an empty set, so a
+//! snapshot with nothing failing, nothing pending, **and nothing passing** used
+//! to reach `Ok`. That let a PR satisfy the gate having run no CI at all, which
+//! is not hypothetical: `gh pr checks --required` exits non-zero with "no
+//! required checks reported" during the provider's check-registration window
+//! after a force-with-lease, and [`pr_checks`] deliberately normalizes that into
+//! an empty successful snapshot so the read surface can report "nothing is
+//! failing" without erroring.
+//!
+//! Reporting and gating want opposite defaults there. The read surface is right
+//! to say "no checks are failing"; the gate must not accept that as proof the
+//! head was checked, because the gate exists to establish exactly that. So the
+//! empty gating set fails closed here as `checks_not_registered`, while
+//! [`pr_checks`] keeps reporting it as `success` — and a repository that
+//! genuinely configures no checks opts out per invocation with
+//! `--allow-no-checks`.
+//!
+//! The neighbouring REST fallback already reached this conclusion: when
+//! requiredness is unknown and the row set is empty it *synthesizes a pending
+//! row* rather than returning an empty pass. This is the same rule applied to
+//! the path that reports emptiness honestly.
 
 use crate::backend::BackendRunner;
 use crate::cli::{BINARY, GlobalFlags, PrChecksArgs};
@@ -36,6 +61,30 @@ fn schema() -> String {
     schema_version_for(BINARY, pr_checks::SCHEMA, pr_checks::SCHEMA_VERSION)
 }
 
+/// Whether the caller requires the head to have been checked at all.
+///
+/// Deliberately not a bare `bool`: at the call site `CheckPresence::Optional`
+/// says which authority is being granted, where `true` would not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckPresence {
+    /// The gating set must be non-empty — absence of checks blocks the merge.
+    Required,
+    /// The repository genuinely configures no checks; an empty gating set is
+    /// acceptable. Failing and pending checks are still reported.
+    Optional,
+}
+
+impl CheckPresence {
+    /// Map the `--allow-no-checks` flag onto the presence requirement.
+    pub fn from_allow_no_checks(allow_no_checks: bool) -> Self {
+        if allow_no_checks {
+            Self::Optional
+        } else {
+            Self::Required
+        }
+    }
+}
+
 /// Fetch the current required-check snapshot and assert all required checks
 /// are passing.
 ///
@@ -48,16 +97,33 @@ pub fn ensure_required_checks_green<R: BackendRunner>(
     global: &GlobalFlags,
     ctx: &ProviderContext,
     pr_id: &str,
+    presence: CheckPresence,
 ) -> Result<PrChecksPayload, ForgeError> {
     let args = PrChecksArgs {
         id: pr_id.to_string(),
         required_only: true,
     };
     let snapshot = pr_checks::snapshot(runner, global, ctx, &args)?;
-    classify(snapshot)
+    classify(snapshot, presence)
 }
 
-fn classify(snapshot: PrChecksPayload) -> Result<PrChecksPayload, ForgeError> {
+/// True when the provider reported nothing at all for this head.
+///
+/// The predicate is deliberately narrower than "no *required* checks". A
+/// repository can run CI without branch protection, so a snapshot with visible
+/// rows but nothing marked required means the head *was* checked — `pr deliver`
+/// re-gates those visible rows through `should_gate_visible_checks`, and
+/// refusing them here would block every such repository. What must not pass is
+/// the case with no gating set *and* no rows to fall back to: then nothing ran,
+/// and nothing can be re-gated.
+pub fn nothing_was_checked(snapshot: &PrChecksPayload) -> bool {
+    snapshot.required_count == 0 && snapshot.checks.is_empty()
+}
+
+fn classify(
+    snapshot: PrChecksPayload,
+    presence: CheckPresence,
+) -> Result<PrChecksPayload, ForgeError> {
     if !snapshot.failed.is_empty() {
         let names = snapshot
             .failed
@@ -91,6 +157,18 @@ fn classify(snapshot: PrChecksPayload) -> Result<PrChecksPayload, ForgeError> {
                 snapshot.pending.len(),
                 names
             ),
+            None,
+        ));
+    }
+    // Checked last, so a snapshot that also carries a failure or a pending row
+    // still reports the more actionable of the two first.
+    if presence == CheckPresence::Required && nothing_was_checked(&snapshot) {
+        return Err(ForgeError::validation(
+            schema(),
+            "checks_not_registered",
+            "no required checks are registered for this head, so nothing proves it was checked; \
+             wait for the provider to register them, or pass --allow-no-checks if this repository \
+             genuinely configures none",
             None,
         ));
     }
@@ -139,6 +217,22 @@ mod tests {
         }
     }
 
+    /// What `gh pr checks --required` yields when the provider reports "no
+    /// required checks reported": a successful, entirely empty snapshot.
+    fn empty_snapshot() -> PrChecksPayload {
+        PrChecksPayload {
+            provider: "github",
+            state: "success",
+            required_count: 0,
+            success_count: 0,
+            failed: vec![],
+            pending: vec![],
+            checks: vec![],
+            duration_ms: None,
+            warnings: Vec::new(),
+        }
+    }
+
     fn with_failure(name: &str) -> PrChecksPayload {
         let mut snap = pass_snapshot();
         snap.state = "failure";
@@ -165,21 +259,23 @@ mod tests {
     #[test]
     fn all_green_returns_payload_untouched() {
         let snap = pass_snapshot();
-        let result = classify(snap.clone()).expect("must pass");
+        let result = classify(snap.clone(), CheckPresence::Required).expect("must pass");
         assert_eq!(result.state, "success");
         assert_eq!(result.success_count, 2);
     }
 
     #[test]
     fn pending_only_yields_checks_pending_validation_with_data_65() {
-        let err = classify(with_pending("integration")).expect_err("must fail with pending");
+        let err = classify(with_pending("integration"), CheckPresence::Required)
+            .expect_err("must fail with pending");
         assert_eq!(err.kind(), "checks_pending");
         assert_eq!(err.exit_code(), exit::DATA);
     }
 
     #[test]
     fn failure_yields_checks_failed_runtime_with_exit_1() {
-        let err = classify(with_failure("test")).expect_err("must fail with failure");
+        let err = classify(with_failure("test"), CheckPresence::Required)
+            .expect_err("must fail with failure");
         assert_eq!(err.kind(), "checks_failed");
         assert_eq!(err.exit_code(), exit::RUNTIME);
     }
@@ -193,7 +289,7 @@ mod tests {
             name: "integration".into(),
             url: None,
         });
-        let err = classify(snap).expect_err("must fail with failure");
+        let err = classify(snap, CheckPresence::Required).expect_err("must fail with failure");
         assert_eq!(err.kind(), "checks_failed");
     }
 
@@ -215,11 +311,88 @@ mod tests {
             });
             s
         };
-        let err = classify(snap).expect_err("must fail");
+        let err = classify(snap, CheckPresence::Required).expect_err("must fail");
         let rendered = format!("{err}");
         assert!(rendered.contains("test"), "got {rendered}");
         assert!(rendered.contains("lint"), "got {rendered}");
         assert!(rendered.starts_with("2 required check(s) failed"));
+    }
+
+    /// The gate's whole purpose is proving the head was checked, and an empty
+    /// snapshot proves the opposite. "All required checks passed" is vacuously
+    /// true over an empty set, which is how a PR reached a green gate having
+    /// run no CI at all — the provider's check-registration window after a
+    /// force-with-lease is exactly when that happens.
+    #[test]
+    fn an_empty_snapshot_cannot_satisfy_the_gate() {
+        let err = classify(empty_snapshot(), CheckPresence::Required)
+            .expect_err("an unchecked head must not satisfy the gate");
+        assert_eq!(err.kind(), "checks_not_registered");
+        assert_eq!(err.exit_code(), exit::DATA);
+    }
+
+    /// CI without branch protection is not an unchecked head.
+    ///
+    /// A repository can run checks while marking none of them required, which
+    /// yields `required_count == 0` alongside visible passing rows. `pr deliver`
+    /// re-gates exactly those rows, so refusing here would block every such
+    /// repository — a far bigger blast radius than the defect being fixed. The
+    /// refusal is scoped to "no gating set *and* nothing to fall back to".
+    #[test]
+    fn visible_checks_with_no_required_ones_are_not_an_unchecked_head() {
+        let mut snap = pass_snapshot();
+        // The rows stay visible; branch protection just does not gate on them.
+        snap.required_count = 0;
+        snap.success_count = 0;
+        for check in &mut snap.checks {
+            check.required = false;
+        }
+
+        let result = classify(snap, CheckPresence::Required)
+            .expect("visible checks mean the head was checked");
+        assert_eq!(result.checks.len(), 2);
+    }
+
+    /// A repository that genuinely configures no checks must still be able to
+    /// merge, so the refusal is opt-out-able — explicitly, per invocation.
+    #[test]
+    fn an_empty_snapshot_passes_when_the_caller_allows_no_checks() {
+        let snap = classify(empty_snapshot(), CheckPresence::Optional)
+            .expect("an explicit allowance must let an unchecked head through");
+        assert_eq!(snap.required_count, 0);
+    }
+
+    /// The allowance is scoped to absence only. It must not become a blanket
+    /// "ignore the checks" switch, because that is a far larger authority than
+    /// "this repo has no checks".
+    #[test]
+    fn allowing_no_checks_still_reports_a_failing_check() {
+        let err = classify(with_failure("test"), CheckPresence::Optional)
+            .expect_err("an allowance for absence must not excuse a failure");
+        assert_eq!(err.kind(), "checks_failed");
+    }
+
+    #[test]
+    fn allowing_no_checks_still_reports_a_pending_check() {
+        let err = classify(with_pending("integration"), CheckPresence::Optional)
+            .expect_err("an allowance for absence must not excuse a pending check");
+        assert_eq!(err.kind(), "checks_pending");
+    }
+
+    /// The message has to say what to do about it: a caller who hits this needs
+    /// to know both that nothing ran and which flag states otherwise.
+    #[test]
+    fn not_registered_message_names_the_head_state_and_the_opt_out() {
+        let err = classify(empty_snapshot(), CheckPresence::Required).expect_err("must fail");
+        let rendered = format!("{err}");
+        assert!(
+            rendered.contains("no required checks"),
+            "must say nothing was registered: {rendered}"
+        );
+        assert!(
+            rendered.contains("--allow-no-checks"),
+            "must name the opt-out: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/forge-cli/tests/integration/exit_codes_full.rs
+++ b/crates/forge-cli/tests/integration/exit_codes_full.rs
@@ -84,6 +84,7 @@ const LOCKDOWN_DATA_KINDS: &[&str] = &[
     "default_branch_protected",
     "draft_merge_refused",
     "checks_pending",
+    "checks_not_registered",
     "merge_method_unsupported",
     "keep_branch_conflict",
     "local_path_present",

--- a/crates/forge-cli/tests/integration/pr_deliver_chain.rs
+++ b/crates/forge-cli/tests/integration/pr_deliver_chain.rs
@@ -489,6 +489,46 @@ fn run_zero_required_delivery(
     (stub, output)
 }
 
+/// Same delivery, declaring up front that this repository configures no checks.
+fn run_zero_required_delivery_allowing_no_checks(
+    stub: StubEnv,
+    repo_path: &Path,
+    all_checks: &str,
+    timeout: &str,
+) -> (StubEnv, CmdOutput) {
+    let gh_path = write_zero_required_checks_stub(&stub, all_checks);
+    let stub = stub.env("FORGE_CLI_GH_BIN", gh_path.to_string_lossy());
+    let output = run_in_repo(
+        &stub,
+        repo_path,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "deliver",
+            "--kind",
+            "feature",
+            "--title",
+            "feat: wait for visible checks",
+            "--body",
+            "## Summary\n\nWait for visible checks.\n\n## Test plan\n\nVerified.\n",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--timeout",
+            timeout,
+            "--allow-no-checks",
+            "--allow-no-checks-reason",
+            "this fixture repository configures no checks at all",
+            "--no-merge",
+        ],
+    );
+    (stub, output)
+}
+
 fn assert_no_all_check_call_after_required(calls: &str) {
     let required_index = calls
         .lines()
@@ -1261,15 +1301,41 @@ fn pr_deliver_zero_required_failed_visible_check_blocks_merge() {
     );
 }
 
+/// Contract change: this used to complete immediately with exit 0.
+///
+/// Zero required checks *and* zero visible rows means the provider reported
+/// nothing at all for this head, which is indistinguishable from a repository
+/// that configures no checks — and identical to the check-registration window
+/// after a force-with-lease, where delivery previously reported success against
+/// a head no CI had touched. The default now waits out the budget and fails
+/// closed; a repository that genuinely has no checks says so explicitly.
 #[test]
-fn pr_deliver_zero_required_and_zero_visible_checks_complete_immediately() {
+fn pr_deliver_zero_required_and_zero_visible_checks_are_refused() {
+    let tempdir = make_git_repo();
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let (_stub, out) =
+        run_zero_required_delivery(stub, &repo_path, FIXTURE_EMPTY_CHECKS_JSON, "0s", true);
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["error"]["code"], "checks_not_registered");
+}
+
+#[test]
+fn pr_deliver_zero_required_and_zero_visible_checks_complete_when_explicitly_allowed() {
     let tempdir = make_git_repo();
     let repo_path = tempdir.path().join("repo");
 
     let stub = StubEnv::new();
     let checks_calls = stub.tempdir.path().join("checks-calls");
-    let (_stub, out) =
-        run_zero_required_delivery(stub, &repo_path, FIXTURE_EMPTY_CHECKS_JSON, "5s", true);
+    let (_stub, out) = run_zero_required_delivery_allowing_no_checks(
+        stub,
+        &repo_path,
+        FIXTURE_EMPTY_CHECKS_JSON,
+        "5s",
+    );
 
     assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
     let calls = fs::read_to_string(checks_calls).expect("checks call log");
@@ -1587,6 +1653,8 @@ fn local_deliver_args(evidence: &Path) -> PrDeliverArgs {
         review_convergence: None,
         allow_unchecked_tasks: false,
         allow_unchecked_tasks_reason: None,
+        allow_no_checks: false,
+        allow_no_checks_reason: None,
     }
 }
 

--- a/crates/forge-cli/tests/integration/pr_merge.rs
+++ b/crates/forge-cli/tests/integration/pr_merge.rs
@@ -202,7 +202,7 @@ case "$1 $2" in
   "repo view")
     printf '%s\n' '{{"name":"widgets","owner":{{"login":"acme"}},"url":"https://github.com/acme/widgets","defaultBranchRef":{{"name":"main"}},"mergeCommitAllowed":true,"squashMergeAllowed":true,"rebaseMergeAllowed":true}}'
     ;;
-  "pr checks") printf '%s\n' '[]' ;;
+  "pr checks") printf '%s\n' '[{{"name":"ci","bucket":"pass","state":"COMPLETED","isRequired":true}}]' ;;
   "api graphql")
     case "$*" in
       *"authorAssociation body createdAt"*) printf '%s\n' '{{"data":{{"viewer":{{"login":"maintainer"}},"repository":{{"pullRequest":{{"comments":{{"nodes":[{state_nodes}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}}}}}}}}}}' ;;

--- a/crates/forge-cli/tests/integration/pr_merge.rs
+++ b/crates/forge-cli/tests/integration/pr_merge.rs
@@ -150,12 +150,38 @@ fn review_loop_marker(with_open_finding: bool) -> String {
     .expect("review-loop marker")
 }
 
+/// One passing required check: enough for rule 8 to pass on its own merits, so
+/// tests aimed at the other gates are not silently riding on an empty snapshot.
+const ONE_REQUIRED_PASS_CHECKS: &str =
+    r#"[{"name":"ci","bucket":"pass","state":"COMPLETED","isRequired":true}]"#;
+
+/// What the provider reports for a head with no checks at all.
+const NO_CHECKS: &str = "[]";
+
 fn github_merge_stub_with_ledger(
     stub: &StubEnv,
     review_nodes: &str,
     thread_nodes: &str,
     reject_reviews: bool,
     ledger_marker: Option<String>,
+) -> String {
+    github_merge_stub_with_checks(
+        stub,
+        review_nodes,
+        thread_nodes,
+        reject_reviews,
+        ledger_marker,
+        ONE_REQUIRED_PASS_CHECKS,
+    )
+}
+
+fn github_merge_stub_with_checks(
+    stub: &StubEnv,
+    review_nodes: &str,
+    thread_nodes: &str,
+    reject_reviews: bool,
+    ledger_marker: Option<String>,
+    checks_json: &str,
 ) -> String {
     let merged = stub.tempdir.path().join("github-merged");
     let review_calls = stub.tempdir.path().join("review-calls");
@@ -202,7 +228,7 @@ case "$1 $2" in
   "repo view")
     printf '%s\n' '{{"name":"widgets","owner":{{"login":"acme"}},"url":"https://github.com/acme/widgets","defaultBranchRef":{{"name":"main"}},"mergeCommitAllowed":true,"squashMergeAllowed":true,"rebaseMergeAllowed":true}}'
     ;;
-  "pr checks") printf '%s\n' '[{{"name":"ci","bucket":"pass","state":"COMPLETED","isRequired":true}}]' ;;
+  "pr checks") printf '%s\n' '{checks_json}' ;;
   "api graphql")
     case "$*" in
       *"authorAssociation body createdAt"*) printf '%s\n' '{{"data":{{"viewer":{{"login":"maintainer"}},"repository":{{"pullRequest":{{"comments":{{"nodes":[{state_nodes}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}}}}}}}}}}' ;;
@@ -219,6 +245,7 @@ esac
         thread_nodes = thread_nodes,
         state_nodes = state_nodes,
         merged = merged.display(),
+        checks_json = checks_json,
     )
 }
 
@@ -1613,4 +1640,228 @@ fn pr_merge_gitlab_allow_unchecked_tasks_bypasses_gate_and_records_reason() {
         "e2e deferred to follow-up #814"
     );
     assert!(args_log.exists(), "bypassed merge must reach the backend");
+}
+
+/// Rule 8's absence half, end to end: the provider reports no checks for the
+/// head, and the merge is refused rather than passing on a vacuous "all
+/// required checks are green".
+#[test]
+fn pr_merge_github_refuses_a_head_with_no_checks_at_all() {
+    let tempdir = make_github_repo(None);
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let merged = stub.tempdir.path().join("github-merged");
+    let body = github_merge_stub_with_checks(&stub, "", "", true, None, NO_CHECKS);
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "7",
+        ],
+        Some(&repo_path),
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["error"]["code"], "checks_not_registered");
+    assert!(
+        !merged.exists(),
+        "an unchecked head must never reach the provider merge"
+    );
+}
+
+/// The declared opt-out, and the only durable record that a merge happened
+/// without CI evidence.
+#[test]
+fn pr_merge_github_allow_no_checks_bypasses_rule_eight_and_records_the_reason() {
+    let tempdir = make_github_repo(None);
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let merged = stub.tempdir.path().join("github-merged");
+    let body = github_merge_stub_with_checks(&stub, "", "", true, None, NO_CHECKS);
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "7",
+            "--review-convergence=false",
+            "--allow-no-checks",
+            "--allow-no-checks-reason",
+            "this repository configures no CI",
+        ],
+        Some(&repo_path),
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(
+        env["data"]["no_checks_override_reason"],
+        "this repository configures no CI"
+    );
+    assert!(merged.exists(), "the bypassed merge must reach the backend");
+}
+
+/// The field is absent — not null, not empty — when the bypass was not used,
+/// so its presence is itself the audit signal.
+#[test]
+fn pr_merge_omits_the_no_checks_reason_when_the_bypass_was_not_used() {
+    let tempdir = make_github_repo(None);
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let body = github_merge_stub(&stub, "", "", true);
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "7",
+        ],
+        Some(&repo_path),
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert!(
+        env["data"].get("no_checks_override_reason").is_none(),
+        "an ordinary merge must not carry an override record: {}",
+        out.stdout
+    );
+}
+
+/// `--allow-no-checks` cannot be used without stating why, matching the two
+/// sibling bypasses.
+#[test]
+fn pr_merge_allow_no_checks_requires_a_reason() {
+    let tempdir = make_github_repo(None);
+    let repo_path = tempdir.path().join("repo");
+    let stub = StubEnv::new().gh_stub(FORBIDDEN_STUB);
+
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "7",
+            "--allow-no-checks",
+        ],
+        Some(&repo_path),
+    );
+
+    assert_eq!(out.code, 64, "stdout={}\nstderr={}", out.stdout, out.stderr);
+}
+
+/// Rule 8 is provider-neutral, and on GitLab that is a behaviour change worth
+/// pinning: an MR whose head has no pipeline — no `.gitlab-ci.yml`, excluded by
+/// `workflow:rules`, or pipelines disabled on a fork — reports the same empty
+/// snapshot as an unregistered GitHub head, and is refused for the same reason.
+/// The deliver-side visible-row fallback is GitHub-only, so there is no
+/// mitigation here; `--allow-no-checks` is the declared way through.
+#[test]
+fn pr_merge_gitlab_refuses_an_mr_whose_head_has_no_pipeline() {
+    let tempdir = make_gitlab_repo();
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let sentinel = stub.tempdir.path().join("merged");
+    let body = gitlab_merge_api_stub_full(&stub, "[]", "null").replace(
+        r#""head_pipeline": { "id": 99, "status": "success", "web_url": "https://gitlab.example.com/group/project/-/pipelines/99" }"#,
+        r#""head_pipeline": null"#,
+    );
+    let stub = stub.glab_stub(&body);
+
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "gitlab",
+            "--host",
+            "gitlab.example.com",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "7",
+            "--review-convergence=false",
+        ],
+        Some(&repo_path),
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["error"]["code"], "checks_not_registered");
+    assert!(!sentinel.exists(), "the merge must not reach the backend");
+}
+
+/// …and the opt-out works there too, which is what makes the refusal
+/// acceptable for projects that genuinely have no CI.
+#[test]
+fn pr_merge_gitlab_allow_no_checks_merges_an_mr_with_no_pipeline() {
+    let tempdir = make_gitlab_repo();
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let sentinel = stub.tempdir.path().join("merged");
+    let body = gitlab_merge_api_stub_full(&stub, "[]", "null").replace(
+        r#""head_pipeline": { "id": 99, "status": "success", "web_url": "https://gitlab.example.com/group/project/-/pipelines/99" }"#,
+        r#""head_pipeline": null"#,
+    );
+    let stub = stub.glab_stub(&body);
+
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "gitlab",
+            "--host",
+            "gitlab.example.com",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "7",
+            "--review-convergence=false",
+            "--allow-no-checks",
+            "--allow-no-checks-reason",
+            "this project has no .gitlab-ci.yml",
+        ],
+        Some(&repo_path),
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(
+        env["data"]["no_checks_override_reason"],
+        "this project has no .gitlab-ci.yml"
+    );
+    assert!(
+        sentinel.exists(),
+        "the bypassed merge must reach the backend"
+    );
 }

--- a/crates/forge-cli/tests/integration/pr_wait_checks.rs
+++ b/crates/forge-cli/tests/integration/pr_wait_checks.rs
@@ -279,3 +279,75 @@ exit 99
     assert_eq!(env["data"]["state"], "success");
     assert_eq!(env["data"]["required_count"], 1);
 }
+
+const EMPTY_SNAP: &str = "[]";
+
+/// The emitter arm for a head that never registers a check: DATA 65 and its own
+/// kind, not the UNAVAILABLE 69 a genuine timeout gets. The two need different
+/// fixes, so automation must be able to tell them apart.
+#[test]
+fn pr_wait_checks_expires_as_not_registered_when_nothing_is_ever_reported() {
+    let mut stub = StubEnv::new();
+    gh_sequence_stub(&stub, &[EMPTY_SNAP]);
+    let gh_path = stub.tempdir.path().join("gh");
+    stub = stub.env("FORGE_CLI_GH_BIN", gh_path.to_string_lossy());
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "wait-checks",
+            "1",
+            "--interval",
+            "10ms",
+            "--timeout",
+            "30ms",
+        ],
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["error"]["code"], "checks_not_registered");
+    // The snapshot is reported verbatim, so `data.state` is still "success"
+    // while `ok` is false. Consumers must gate on ok / error.kind — this
+    // asserts the combination so any future normalization is deliberate.
+    assert_eq!(env["ok"], false);
+    assert_eq!(env["data"]["state"], "success");
+    assert_eq!(env["data"]["required_count"], 0);
+}
+
+/// The reason-free opt-out on this non-mutating op: a project that configures
+/// no checks terminates immediately instead of burning the whole budget.
+#[test]
+fn pr_wait_checks_allow_no_checks_completes_immediately() {
+    let mut stub = StubEnv::new();
+    gh_sequence_stub(&stub, &[EMPTY_SNAP]);
+    let gh_path = stub.tempdir.path().join("gh");
+    stub = stub.env("FORGE_CLI_GH_BIN", gh_path.to_string_lossy());
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "wait-checks",
+            "1",
+            "--interval",
+            "10ms",
+            "--timeout",
+            "30s",
+            "--allow-no-checks",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["data"]["required_count"], 0);
+}

--- a/crates/forge-cli/tests/integration/required_check_gate.rs
+++ b/crates/forge-cli/tests/integration/required_check_gate.rs
@@ -12,7 +12,7 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use forge_cli::backend::ProcessRunner;
 use forge_cli::cli::GlobalFlags;
-use forge_cli::ops::required_check_gate::ensure_required_checks_green;
+use forge_cli::ops::required_check_gate::{CheckPresence, ensure_required_checks_green};
 use forge_cli::provider::{DetectionSource, Provider, ProviderContext};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
@@ -56,6 +56,11 @@ fn run_globals() -> GlobalFlags {
     }
 }
 
+/// What `gh pr checks --required` prints when the provider has registered no
+/// required contexts for the head: a non-zero exit with this on stderr, which
+/// `pr_checks` normalizes into an empty successful snapshot.
+const NO_REQUIRED_CHECKS_STDERR: &str = "no required checks reported on the 'feat/example' branch";
+
 const SUCCESS_JSON: &str = r#"[{"name":"build","bucket":"pass","state":"COMPLETED","link":"https://ci/1"},{"name":"test","bucket":"pass","state":"COMPLETED","link":"https://ci/2"}]"#;
 const PENDING_JSON: &str = r#"[{"name":"build","bucket":"pass","state":"COMPLETED","link":"https://ci/1"},{"name":"test","bucket":"pending","state":"IN_PROGRESS","link":"https://ci/2"}]"#;
 const FAILURE_JSON: &str = r#"[{"name":"build","bucket":"pass","state":"COMPLETED","link":"https://ci/1"},{"name":"test","bucket":"fail","state":"COMPLETED","link":"https://ci/2"}]"#;
@@ -80,7 +85,7 @@ fn all_required_green_returns_payload_with_runtime_runner() {
     let runner = ProcessRunner;
     let globals = run_globals();
     let ctx = github_ctx();
-    let snap = ensure_required_checks_green(&runner, &globals, &ctx, "42")
+    let snap = ensure_required_checks_green(&runner, &globals, &ctx, "42", CheckPresence::Required)
         .expect("required checks must be green");
 
     assert_eq!(snap.state, "success");
@@ -103,8 +108,14 @@ fn pending_required_check_exits_data_with_kind_checks_pending() {
     }
 
     let runner = ProcessRunner;
-    let err = ensure_required_checks_green(&runner, &run_globals(), &github_ctx(), "42")
-        .expect_err("must surface pending");
+    let err = ensure_required_checks_green(
+        &runner,
+        &run_globals(),
+        &github_ctx(),
+        "42",
+        CheckPresence::Required,
+    )
+    .expect_err("must surface pending");
     assert_eq!(err.kind(), "checks_pending");
     assert_eq!(err.exit_code(), 65);
 }
@@ -124,8 +135,14 @@ fn failing_required_check_exits_runtime_with_kind_checks_failed() {
     }
 
     let runner = ProcessRunner;
-    let err = ensure_required_checks_green(&runner, &run_globals(), &github_ctx(), "42")
-        .expect_err("must surface failure");
+    let err = ensure_required_checks_green(
+        &runner,
+        &run_globals(),
+        &github_ctx(),
+        "42",
+        CheckPresence::Required,
+    )
+    .expect_err("must surface failure");
     assert_eq!(err.kind(), "checks_failed");
     assert_eq!(err.exit_code(), 1);
 }
@@ -151,8 +168,10 @@ fn helper_refetches_every_call_no_caching_across_atoms() {
     let runner = ProcessRunner;
     let globals = run_globals();
     let ctx = github_ctx();
-    ensure_required_checks_green(&runner, &globals, &ctx, "42").expect("call 1 must pass");
-    ensure_required_checks_green(&runner, &globals, &ctx, "42").expect("call 2 must pass");
+    ensure_required_checks_green(&runner, &globals, &ctx, "42", CheckPresence::Required)
+        .expect("call 1 must pass");
+    ensure_required_checks_green(&runner, &globals, &ctx, "42", CheckPresence::Required)
+        .expect("call 2 must pass");
 
     let final_count: u32 = fs::read_to_string(&counter)
         .unwrap()
@@ -160,4 +179,63 @@ fn helper_refetches_every_call_no_caching_across_atoms() {
         .parse()
         .unwrap();
     assert_eq!(final_count, 2, "gh must be re-invoked on every gate call");
+}
+
+/// End-to-end proof of the false green this gate used to allow: `gh` reports
+/// that the head has no required checks, `pr_checks` normalizes that into an
+/// empty successful snapshot, and the gate used to return `Ok` — so a merge
+/// could proceed against a head no CI had run on.
+#[test]
+fn a_head_with_no_registered_required_checks_is_refused() {
+    let tmp = TempDir::new().unwrap();
+    write_stub(
+        &tmp,
+        &format!(
+            "#!/bin/sh\ncase \"$1 $2\" in\n  \"pr checks\")\n    echo \"{NO_REQUIRED_CHECKS_STDERR}\" >&2; exit 1;;\n  *)\n    echo \"stub: unexpected gh args: $*\" >&2; exit 99;;\nesac\n"
+        ),
+    );
+    let _guard = lock_env();
+    unsafe {
+        std::env::set_var("FORGE_CLI_GH_BIN", tmp.path().join("gh"));
+    }
+
+    let runner = ProcessRunner;
+    let err = ensure_required_checks_green(
+        &runner,
+        &run_globals(),
+        &github_ctx(),
+        "42",
+        CheckPresence::Required,
+    )
+    .expect_err("an unchecked head must not satisfy the gate");
+    assert_eq!(err.kind(), "checks_not_registered");
+    assert_eq!(err.exit_code(), 65);
+}
+
+/// The same provider response, with the repository declaring it genuinely has
+/// no checks. The refusal is an opt-out, not a wall.
+#[test]
+fn a_head_with_no_registered_required_checks_passes_when_explicitly_allowed() {
+    let tmp = TempDir::new().unwrap();
+    write_stub(
+        &tmp,
+        &format!(
+            "#!/bin/sh\ncase \"$1 $2\" in\n  \"pr checks\")\n    echo \"{NO_REQUIRED_CHECKS_STDERR}\" >&2; exit 1;;\n  *)\n    echo \"stub: unexpected gh args: $*\" >&2; exit 99;;\nesac\n"
+        ),
+    );
+    let _guard = lock_env();
+    unsafe {
+        std::env::set_var("FORGE_CLI_GH_BIN", tmp.path().join("gh"));
+    }
+
+    let runner = ProcessRunner;
+    let snap = ensure_required_checks_green(
+        &runner,
+        &run_globals(),
+        &github_ctx(),
+        "42",
+        CheckPresence::Optional,
+    )
+    .expect("an explicit allowance must let an unchecked head through");
+    assert_eq!(snap.required_count, 0);
 }


### PR DESCRIPTION
## Summary

The required-check gate never consulted whether anything *passed*.
`required_check_gate::classify` returned `Err` for a failing check and for a
pending one, then fell through to `Ok`:

```rust
if !snapshot.failed.is_empty()  { return Err(checks_failed)  }
if !snapshot.pending.is_empty() { return Err(checks_pending) }
Ok(snapshot)
```

"All required checks passed" is vacuously true over an empty set, so a snapshot
with nothing failing, nothing pending, **and nothing at all** satisfied lock-down
rule 8. A PR could clear the check gate having run no CI.

`pr wait-checks` had the same hole from the other side: `is_terminal` was
`pending.is_empty()`, so an empty snapshot was terminal *and* `state == "success"`
— it returned success immediately.

## Problem

The required-check gate never consulted whether anything *passed*.
`required_check_gate::classify` returned `Err` for a failing check and for a
pending one, then fell through to `Ok`:

```rust
if !snapshot.failed.is_empty()  { return Err(checks_failed)  }
if !snapshot.pending.is_empty() { return Err(checks_pending) }
Ok(snapshot)
```

"All required checks passed" is vacuously true over an empty set, so a snapshot
with nothing failing, nothing pending, **and nothing at all** satisfied lock-down
rule 8. A PR could clear the check gate having run no CI.

`pr wait-checks` had the same hole from the other side: `is_terminal` was
`pending.is_empty()`, so an empty snapshot was terminal *and* `state == "success"`
— it returned success immediately.

## Reproduction

Not hypothetical — this issue's own follow-up recorded it. After a
force-with-lease the provider needs time to register checks, and in that window
`gh pr checks --required` exits non-zero with `no required checks reported`.
`pr_checks::run_github_checks_call` normalizes that to `stdout: "[]"`, which
aggregates to `required_count: 0, success_count: 0, failed: [], pending: []` —
a *successful* empty snapshot.

Three tests encoded the behaviour, which is how it survived:

- `aggregate_empty_checks_is_success`
- `parse_github_snapshot_empty_array_is_success`
- `pr_deliver_zero_required_and_zero_visible_checks_complete_immediately`

The codebase already disagreed with itself. The REST fallback
(`aggregate_github_unknown_requiredness`) **synthesizes a pending row** when the
required-only row set is empty, precisely so an empty set cannot pass. The
primary path — the one that reports emptiness honestly — fell straight through.

## Issues Found

Refs #1398

## Fix Approach

Refuse an unprovable head in both places that decide, and make the escape hatch
explicit.

- **`pr merge`** fails closed with `checks_not_registered` (`DATA 65`).
- **`pr wait-checks`** stops treating an empty gating set as terminal, so it
  polls through the registration window and reports `checks_not_registered` on
  expiry rather than `checks_timeout`. A head that never registered a check needs
  a different fix from one whose checks ran long, so they do not share a kind.
- **`--allow-no-checks`** requires `--allow-no-checks-reason`, matching how
  `--allow-unresolved-threads` and `--allow-unchecked-tasks` already work. The
  reason lands in the merge envelope as `no_checks_override_reason` — the only
  durable record that a merge happened without CI evidence.

### The predicate is narrower than "no required checks", deliberately

My first cut refused on `required_count == 0` alone and **broke eighteen tests**.
That is not a test problem — a repository can run CI without branch protection,
which yields zero *required* checks alongside visible rows, and `pr deliver`
already re-gates exactly those through `should_gate_visible_checks`. Refusing
them would have blocked every such repository.

The predicate is now `required_count == 0 && checks.is_empty()`: no gating set
**and** nothing to fall back to. `visible_checks_with_no_required_ones_are_not_an_unchecked_head`
pins the case I nearly broke.

### Two existing tests were themselves vacuous

A required-only snapshot costs *two* backend calls — the general list and the
`--required` list. `pr_wait_checks`'s stub queued one output, so the second
returned empty, the check was never marked required, and both
`succeeds_when_first_snapshot_is_terminal_success` and
`pending_then_success_succeeds_on_second_poll` asserted success over an empty
gating set while claiming to cover the passing path. They now answer both calls.

The same shape hid in `github_merge_stub`, which returned `[]` for `pr checks`;
seventeen `pr_merge` tests were clearing rule 8 vacuously while testing other
gates. The stub now reports a genuinely green required check.

## Test-First Evidence

The failing tests were written before the production change, and their binding
to it was demonstrated rather than asserted: neutralizing `nothing_was_checked`
to `false` fails exactly the three new zero-check tests and nothing else.

- `an_empty_snapshot_cannot_satisfy_the_gate` — expected
  `checks_not_registered`, observed `Ok(snapshot)`
- `not_registered_message_names_the_head_state_and_the_opt_out`
- `a_head_with_no_registered_required_checks_is_refused` — end-to-end through a
  `gh` stub that reports "no required checks reported"

Restoring the predicate returns 12/12 unit and 6/6 integration.

## Test plan

Test-first: the new tests were written before the production change, and their
binding to it was **demonstrated** rather than assumed. Neutralizing
`nothing_was_checked` to `false` fails exactly three tests and no others;
restoring it returns them to green.

**Round 2 added the coverage review found missing** — the bypass had none at all:

- `pr merge` GitHub: refusal, bypass + `no_checks_override_reason`, field absent
  when unused, and `--allow-no-checks` without a reason is a usage error
- `pr merge` GitLab: no-pipeline refusal and no-pipeline bypass
- `pr wait-checks`: `checks_not_registered` at DATA 65 (asserting the
  `ok:false` / `state:"success"` combination explicitly), and `--allow-no-checks`
- expiry classification: a run that saw pending checks and then hits one empty
  read at the deadline stays `checks_timeout`, not `checks_not_registered`
- `checks_not_registered` added to the lock-down exit matrix the file declares
  it must mirror

Totals:

- `-p nils-forge-cli` lib → **852/852**
- declared gate `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` →
  exit 0, **8416 tests run: 8416 passed**
- `bash -n completions/bash/forge-cli`, `zsh -n completions/zsh/_forge-cli` → ok
- `markdownlint-audit.sh --strict` → ok
- test-first evidence `verify` → ok

**Pre-existing flake, not from this change:** `forgejo_http` fails
intermittently under parallel load, a different test each run. Verified against
the parent commit `d87f283a`, which fails the same way in 3 of 4 runs. Filed as
**#1442**; nextest retries and reports it clean.

## Risk / Notes

**This is a contract change, not only a bug fix**, and review widened my
understanding of how far it reaches.

`pr_deliver_zero_required_and_zero_visible_checks_complete_immediately` asserted
the old behaviour by name; it is now `..._are_refused`, with
`..._complete_when_explicitly_allowed` covering the declared-no-checks path.

**Who is affected**

- Any repository whose PRs report **no checks at all**: those merges now need
  `--allow-no-checks --allow-no-checks-reason '...'`.
- **GitLab MRs with no pipeline** — no `.gitlab-ci.yml`, excluded by
  `workflow:rules`, or pipelines disabled on a fork. Review caught that my first
  pass neither noticed nor tested this. The rule is kept, because "absence is not
  success" is not a GitHub-specific claim, but it is now stated in the spec and
  covered by a refusal test and a bypass test. The deliver-side visible-row
  fallback is GitHub-only, so GitLab has no implicit mitigation.
- **Not** affected: repositories running CI without branch protection. That case
  is explicitly preserved and tested.

**A gap this does not close.** With `required_only`, a non-required failing row
never enters `failed`, so standalone `pr merge` still accepts a head whose only
visible check failed. `pr deliver` catches it by re-gating the visible set, on
GitHub only. That predates this change; rule 8's prose used to imply otherwise
and has been corrected, and the behaviour is pinned by a test that documents it
rather than endorsing it.

Also lands #1398's item 8:
`crates/forge-cli/docs/runbooks/pr-head-repair-loop.md` documents the amend →
force-with-lease → `bind-delivery` → re-deliver loop, the review-loop ordering
rules that cannot be repaired after the fact, and the registration window.
Items 1–7 of the proposed contract already existed.
