### PR TITLE
feat(forge-cli): validate a review-loop findings file offline

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -265,6 +265,9 @@ _forge-cli() {
             forge__cli__help__pr__review__loop,observe)
                 cmd="forge__cli__help__pr__review__loop__observe"
                 ;;
+            forge__cli__help__pr__review__loop,validate)
+                cmd="forge__cli__help__pr__review__loop__validate"
+                ;;
             forge__cli__help__pr__review__threads,list)
                 cmd="forge__cli__help__pr__review__threads__list"
                 ;;
@@ -538,6 +541,9 @@ _forge-cli() {
             forge__cli__pr__help__review__loop,observe)
                 cmd="forge__cli__pr__help__review__loop__observe"
                 ;;
+            forge__cli__pr__help__review__loop,validate)
+                cmd="forge__cli__pr__help__review__loop__validate"
+                ;;
             forge__cli__pr__help__review__threads,list)
                 cmd="forge__cli__pr__help__review__threads__list"
                 ;;
@@ -607,6 +613,9 @@ _forge-cli() {
             forge__cli__pr__review__loop,observe)
                 cmd="forge__cli__pr__review__loop__observe"
                 ;;
+            forge__cli__pr__review__loop,validate)
+                cmd="forge__cli__pr__review__loop__validate"
+                ;;
             forge__cli__pr__review__loop__help,extend)
                 cmd="forge__cli__pr__review__loop__help__extend"
                 ;;
@@ -618,6 +627,9 @@ _forge-cli() {
                 ;;
             forge__cli__pr__review__loop__help,observe)
                 cmd="forge__cli__pr__review__loop__help__observe"
+                ;;
+            forge__cli__pr__review__loop__help,validate)
+                cmd="forge__cli__pr__review__loop__help__validate"
                 ;;
             forge__cli__pr__review__threads,help)
                 cmd="forge__cli__pr__review__threads__help"
@@ -1860,7 +1872,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help__pr__review__loop)
-            opts="inspect observe extend"
+            opts="inspect observe extend validate"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1902,6 +1914,20 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__help__pr__review__loop__observe)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__help__pr__review__loop__validate)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -4048,7 +4074,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__help__review__loop)
-            opts="inspect observe extend"
+            opts="inspect observe extend validate"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4090,6 +4116,20 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__help__review__loop__observe)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__pr__help__review__loop__validate)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -4856,7 +4896,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__review__loop)
-            opts="-h --format --remote --provider --host --repo --store-root --dry-run --help inspect observe extend help"
+            opts="-h --format --remote --provider --host --repo --store-root --dry-run --help inspect observe extend validate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4960,7 +5000,7 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__review__loop__help)
-            opts="inspect observe extend help"
+            opts="inspect observe extend validate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -5016,6 +5056,20 @@ _forge-cli() {
             return 0
             ;;
         forge__cli__pr__review__loop__help__observe)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__pr__review__loop__help__validate)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 5 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -5091,6 +5145,48 @@ _forge-cli() {
                     return 0
                     ;;
                 --body-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --remote)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --provider)
+                    COMPREPLY=($(compgen -W "github gitlab local" -- "${cur}"))
+                    return 0
+                    ;;
+                --host)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --repo)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --store-root)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        forge__cli__pr__review__loop__validate)
+            opts="-h --findings-file --format --remote --provider --host --repo --store-root --dry-run --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --findings-file)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -745,6 +745,21 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ':id:_default' \
 && ret=0
 ;;
+(validate)
+_arguments "${_arguments_options[@]}" : \
+'--findings-file=[Delivery-mode review-specialists merge envelope or observation array]:PATH:_default' \
+'--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
+'--provider=[Override auto-detected provider]:PROVIDER:(github gitlab local)' \
+'--host=[Override the forge authority (\`hostname\` or \`hostname\:port\`). With \`--provider\`, a syntactically valid custom authority is accepted unless it is positively identified as the other provider. Without \`--provider\`, the authority must identify a supported provider]:HOST:_default' \
+'--repo=[Override the remote-derived repository path. Accepted shapes\: GitHub \`owner/name\`; GitLab \`group\[/subgroup...\]/project\`; Local \`local\:<slug>\` or \`<slug>\`]:REPOSITORY:_default' \
+'--store-root=[Root directory of the file-backed store used by \`--provider local\`. Overrides the \`FORGE_CLI_LOCAL_STORE\` env var]:path:_files' \
+'--dry-run[Validate and describe the planned operation without applying its mutation. Read-only preflight calls may still run]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
 (help)
 _arguments "${_arguments_options[@]}" : \
 ":: :_forge-cli__subcmd__pr__subcmd__review-loop__subcmd__help_commands" \
@@ -766,6 +781,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (extend)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(validate)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -1053,6 +1072,10 @@ _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (extend)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
+(validate)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
@@ -2183,6 +2206,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
+(validate)
+_arguments "${_arguments_options[@]}" : \
+&& ret=0
+;;
         esac
     ;;
 esac
@@ -2864,6 +2891,7 @@ _forge-cli__subcmd__help__subcmd__pr__subcmd__review-loop_commands() {
 'inspect:Inspect the validated ledger tip and current round state' \
 'observe:Observe one reviewed head and append the resulting state transition' \
 'extend:Consume an exact provider-visible approval to extend one budget' \
+'validate:Validate a findings payload offline, before it reaches the provider' \
     )
     _describe -t commands 'forge-cli help pr review-loop commands' commands "$@"
 }
@@ -2881,6 +2909,11 @@ _forge-cli__subcmd__help__subcmd__pr__subcmd__review-loop__subcmd__inspect_comma
 _forge-cli__subcmd__help__subcmd__pr__subcmd__review-loop__subcmd__observe_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli help pr review-loop observe commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__help__subcmd__pr__subcmd__review-loop__subcmd__validate_commands] )) ||
+_forge-cli__subcmd__help__subcmd__pr__subcmd__review-loop__subcmd__validate_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli help pr review-loop validate commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__help__subcmd__pr__subcmd__review-threads_commands] )) ||
 _forge-cli__subcmd__help__subcmd__pr__subcmd__review-threads_commands() {
@@ -3410,6 +3443,7 @@ _forge-cli__subcmd__pr__subcmd__help__subcmd__review-loop_commands() {
 'inspect:Inspect the validated ledger tip and current round state' \
 'observe:Observe one reviewed head and append the resulting state transition' \
 'extend:Consume an exact provider-visible approval to extend one budget' \
+'validate:Validate a findings payload offline, before it reaches the provider' \
     )
     _describe -t commands 'forge-cli pr help review-loop commands' commands "$@"
 }
@@ -3427,6 +3461,11 @@ _forge-cli__subcmd__pr__subcmd__help__subcmd__review-loop__subcmd__inspect_comma
 _forge-cli__subcmd__pr__subcmd__help__subcmd__review-loop__subcmd__observe_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli pr help review-loop observe commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__pr__subcmd__help__subcmd__review-loop__subcmd__validate_commands] )) ||
+_forge-cli__subcmd__pr__subcmd__help__subcmd__review-loop__subcmd__validate_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli pr help review-loop validate commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__pr__subcmd__help__subcmd__review-threads_commands] )) ||
 _forge-cli__subcmd__pr__subcmd__help__subcmd__review-threads_commands() {
@@ -3603,6 +3642,7 @@ _forge-cli__subcmd__pr__subcmd__review-loop_commands() {
 'inspect:Inspect the validated ledger tip and current round state' \
 'observe:Observe one reviewed head and append the resulting state transition' \
 'extend:Consume an exact provider-visible approval to extend one budget' \
+'validate:Validate a findings payload offline, before it reaches the provider' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'forge-cli pr review-loop commands' commands "$@"
@@ -3618,6 +3658,7 @@ _forge-cli__subcmd__pr__subcmd__review-loop__subcmd__help_commands() {
 'inspect:Inspect the validated ledger tip and current round state' \
 'observe:Observe one reviewed head and append the resulting state transition' \
 'extend:Consume an exact provider-visible approval to extend one budget' \
+'validate:Validate a findings payload offline, before it reaches the provider' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'forge-cli pr review-loop help commands' commands "$@"
@@ -3642,6 +3683,11 @@ _forge-cli__subcmd__pr__subcmd__review-loop__subcmd__help__subcmd__observe_comma
     local commands; commands=()
     _describe -t commands 'forge-cli pr review-loop help observe commands' commands "$@"
 }
+(( $+functions[_forge-cli__subcmd__pr__subcmd__review-loop__subcmd__help__subcmd__validate_commands] )) ||
+_forge-cli__subcmd__pr__subcmd__review-loop__subcmd__help__subcmd__validate_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli pr review-loop help validate commands' commands "$@"
+}
 (( $+functions[_forge-cli__subcmd__pr__subcmd__review-loop__subcmd__inspect_commands] )) ||
 _forge-cli__subcmd__pr__subcmd__review-loop__subcmd__inspect_commands() {
     local commands; commands=()
@@ -3651,6 +3697,11 @@ _forge-cli__subcmd__pr__subcmd__review-loop__subcmd__inspect_commands() {
 _forge-cli__subcmd__pr__subcmd__review-loop__subcmd__observe_commands() {
     local commands; commands=()
     _describe -t commands 'forge-cli pr review-loop observe commands' commands "$@"
+}
+(( $+functions[_forge-cli__subcmd__pr__subcmd__review-loop__subcmd__validate_commands] )) ||
+_forge-cli__subcmd__pr__subcmd__review-loop__subcmd__validate_commands() {
+    local commands; commands=()
+    _describe -t commands 'forge-cli pr review-loop validate commands' commands "$@"
 }
 (( $+functions[_forge-cli__subcmd__pr__subcmd__review-threads_commands] )) ||
 _forge-cli__subcmd__pr__subcmd__review-threads_commands() {

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -761,6 +761,35 @@ operations:
       data: object<{provider,number,url,state_tip_digest,generation,state,appended:true,outcome_posted:false}>
     notes: "This command is separate from delivery retry paths. It requires an active durable hard-stop receipt, the canonical stop-code/budget-field pair and exact one-step proposal, plus an OWNER/MEMBER/COLLABORATOR approval comment on the same PR that is newer than the stopped state tip and carries the exact marker. One proposal can be consumed once."
 
+  - id: pr.review-loop.validate
+    schema_version: cli.forge-cli.pr.review-loop.validate.v1
+    summary: Check a review-loop findings payload offline, before it reaches the provider.
+    inputs:
+      - { name: --findings-file, type: path, required: true }
+    validations:
+      - review_findings_invalid
+      - review_fingerprint_required
+      - review_fingerprint_collision
+    backends:
+      github: none
+      gitlab: none
+      local: none
+    output:
+      data: object<{shape:enum<merge-envelope|observation-array>,row_count,identity_count,dispositions:[{disposition:enum<open|fixed|accepted|preference|follow-up>,count}],blocking_count,duplicate_identities?}>
+    notes: >-
+      Provider-independent and network-free: the op takes no id, resolves no
+      provider context, and runs no backend, so `--provider`, `--repo`,
+      `--host` and `--dry-run` are accepted by the global parser and have no
+      effect here. It applies exactly the offline half of `pr.review-loop.observe`
+      by calling the same canonicalization the append calls, so the accept/reject
+      decision cannot drift: lifecycle fingerprint form, identity collisions, and
+      blocking normalization for terminal dispositions. Head and state-tip
+      compare-and-swap, the transition against stored state, and the rendered
+      comment need the provider and remain in `observe --dry-run`. Failing here
+      proves an append cannot succeed; passing means the payload itself is
+      acceptable. Unlike its siblings the payload carries neither `appended` nor
+      `outcome_posted`, because nothing is ever appended.
+
   - id: pr.tasks
     schema_version: cli.forge-cli.pr.tasks.v1
     summary: List GFM task-list items in the PR/MR description with their state.

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -631,7 +631,7 @@ backend mapping, validation rules, and output schema versions.
   `pending_review_identity_mismatch`, `pending_review_pr_mismatch`, or
   `pending_review_not_found` with no mutation.
 
-### `pr review-loop inspect` / `observe` / `extend`
+### `pr review-loop inspect` / `observe` / `extend` / `validate`
 
 - These GitHub-only commands make the repair/re-review loop resumable from the
   append-only `forge-cli.review-loop.v1` chain. `inspect <id>` validates the
@@ -708,10 +708,31 @@ backend mapping, validation rules, and output schema versions.
   `fixed`, then merge at that head. Doing every repair first and then trying to
   record the history is unrecoverable, because the pre-repair head is gone and
   the round count cannot be reconstructed.
-- All three commands emit their own `cli.forge-cli.pr.review-loop.*.v1` schema
-  with `data.appended` and `data.outcome_posted`. Only `observe` can set
-  `outcome_posted`, and never without `appended`. `inspect` and `extend`
-  dry-runs are offline and report the command-specific read/transition plan.
+- The three provider-backed commands emit their own
+  `cli.forge-cli.pr.review-loop.*.v1` schema with `data.appended` and
+  `data.outcome_posted`. Only `observe` can set `outcome_posted`, and never
+  without `appended`. `inspect` and `extend` dry-runs are offline and report the
+  command-specific read/transition plan.
+- `validate --findings-file <path>` is the offline payload check, mirroring
+  `pr review validate`. It emits `cli.forge-cli.pr.review-loop.validate.v1` with
+  `data = { shape, row_count, identity_count, dispositions[], blocking_count,
+  duplicate_identities? }` and carries neither `appended` nor `outcome_posted`,
+  because it never appends. It takes no id, resolves no provider context and
+  runs no backend, so it is provider-independent and `--provider`, `--repo`,
+  `--host` and `--dry-run` have no effect on it.
+
+  Its accept/reject decision is not a second implementation of the payload
+  rules: it calls the same canonicalization `observe` calls, so lifecycle
+  fingerprint form, identity collisions (`review_fingerprint_collision`) and
+  blocking normalization for terminal dispositions are decided by one piece of
+  code. Head and state-tip compare-and-swap, the transition against stored
+  state, and the rendered comment need the provider and stay with
+  `observe --dry-run`. Failing `validate` therefore proves an append cannot
+  succeed; passing means the payload itself is acceptable.
+
+  Accepted dispositions are `open`, `fixed`, `accepted`, `preference` and
+  `follow-up`. A finding that reappears is submitted as `open`; the state
+  machine decides whether that is a reopen, and `reopened` is not an input.
 - `observe --dry-run` is a faithful non-mutating preflight. It reads and
   validates the findings payload and any outcome body, resolves the pull request,
   performs the head

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -915,10 +915,17 @@ pub struct PrReviewLoopInspectArgs {
       without a pull request, a provider call, or any network access. Use it \
       while authoring a findings file.\n\n\
       SCOPE\n  \
-      This validates the payload only. Head and state-tip compare-and-swap, the \
-      transition, and the rendered comment all need the provider, so they stay \
-      with `observe --dry-run`, which remains the full preflight. Passing here \
-      does not mean an append will succeed; failing here means it cannot.\n\n\
+      Everything `observe` decides offline is decided here, by calling the same \
+      canonicalization the append calls: lifecycle fingerprint form, identity \
+      collisions, and blocking normalization for terminal dispositions. Only \
+      head and state-tip compare-and-swap, the transition against stored state, \
+      and the rendered comment need the provider, and those stay with `observe \
+      --dry-run`, which remains the full preflight. Failing here proves an \
+      append cannot succeed; passing means the payload itself is acceptable.\n  \
+      Because it resolves no provider context, --provider, --repo, --host and \
+      --dry-run have NO effect on this subcommand. That is deliberate, not an \
+      oversight: the point is to check a file before any repository is in \
+      scope.\n\n\
       DISPOSITIONS\n  \
       open | fixed | accepted | preference | follow-up. A finding that reappears \
       is submitted as `open` — the state machine decides whether that is a \

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -900,11 +900,33 @@ pub enum PrReviewLoopCommand {
     Observe(PrReviewLoopObserveArgs),
     /// Consume an exact provider-visible approval to extend one budget.
     Extend(PrReviewLoopExtendArgs),
+    /// Validate a findings payload offline, before it reaches the provider.
+    Validate(PrReviewLoopValidateArgs),
 }
 
 #[derive(Args, Debug, Clone)]
 pub struct PrReviewLoopInspectArgs {
     pub id: u64,
+}
+
+#[derive(Args, Debug, Clone)]
+#[command(after_help = "\
+      Mirrors `pr review validate`: checks the payload `observe` would consume, \
+      without a pull request, a provider call, or any network access. Use it \
+      while authoring a findings file.\n\n\
+      SCOPE\n  \
+      This validates the payload only. Head and state-tip compare-and-swap, the \
+      transition, and the rendered comment all need the provider, so they stay \
+      with `observe --dry-run`, which remains the full preflight. Passing here \
+      does not mean an append will succeed; failing here means it cannot.\n\n\
+      DISPOSITIONS\n  \
+      open | fixed | accepted | preference | follow-up. A finding that reappears \
+      is submitted as `open` — the state machine decides whether that is a \
+      reopen, and `reopened` is NOT an accepted input.")]
+pub struct PrReviewLoopValidateArgs {
+    /// Delivery-mode review-specialists merge envelope or observation array.
+    #[arg(long = "findings-file", value_name = "PATH")]
+    pub findings_file: String,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -923,8 +945,12 @@ pub struct PrReviewLoopInspectArgs {
       row's `category`. The envelope schema REJECTS `disposition` as an unknown \
       field.\n  \
       2. A bare observation array. Each row needs `lifecycle_fingerprint` and \
-      accepts `disposition` (open | fixed | accepted | reopened), which is how \
-      dispositions are carried across rounds.\n\n\
+      accepts `disposition` (open | fixed | accepted | preference | follow-up), \
+      which is how dispositions are carried across rounds. A finding that \
+      reappears is submitted as `open`; the state machine decides whether that \
+      is a reopen, and `reopened` is NOT an accepted input.\n  \
+      Check either shape offline, with no pull request and no provider call, \
+      using `pr review-loop validate --findings-file <path>`.\n\n\
       COMBINED DELIVERY OUTCOME\n  \
       Every appended ledger comment leads with a visible \
       `forge-cli review ledger · generation N · <kind> · head <short-sha>` line \
@@ -2068,6 +2094,9 @@ pub fn dispatch(args: Vec<OsString>) -> i32 {
             }
             PrReviewLoopCommand::Extend(extend_args) => {
                 ops::pr_review_loop::run_extend(&global, extend_args, format)
+            }
+            PrReviewLoopCommand::Validate(validate_args) => {
+                ops::pr_review_loop::run_validate(validate_args, format)
             }
         },
         Some(Command::Pr(PrArgs {

--- a/crates/forge-cli/src/operation_effect.rs
+++ b/crates/forge-cli/src/operation_effect.rs
@@ -8,7 +8,7 @@ use nils_common::execution_effect::{
 use crate::cli::{
     ActivityArgs, AuthArgs, AuthCommand, Cli, Command, InboxArgs, InboxCommand, IssueArgs,
     IssueCommand, LabelArgs, LabelCommand, PrArgs, PrCommand, PrPendingReviewCommand,
-    PrReviewCommand, RepoArgs, RepoCommand, ReviewThreadsCommand, SearchArgs,
+    PrReviewCommand, PrReviewLoopCommand, RepoArgs, RepoCommand, ReviewThreadsCommand, SearchArgs,
 };
 
 pub fn run(argv: Vec<OsString>, format: OutputFormat) -> i32 {
@@ -102,6 +102,35 @@ fn classify(cli: &Cli) -> (&'static str, Effect, ProviderEffect, Vec<&'static st
             {
                 ("pr.pending-review.inspect", read, network, vec!["provider"])
             }
+            // Without this arm the whole `review-loop` family falls to the
+            // `pr.mutation` / `network_write` default below, which is the right
+            // answer for `observe` and `extend` and the wrong one for the two
+            // that write nothing. `validate` in particular reads one local file
+            // and never opens a socket, so declaring it a network write hands
+            // the permission layer an authority it does not need.
+            PrCommand::ReviewLoop(args) => match &args.command {
+                PrReviewLoopCommand::Validate(_) => (
+                    "pr.review-loop.validate",
+                    read,
+                    ProviderEffect::LocalRead,
+                    vec!["local_inputs"],
+                ),
+                PrReviewLoopCommand::Inspect(_) => {
+                    ("pr.review-loop.inspect", read, network, vec!["provider"])
+                }
+                PrReviewLoopCommand::Observe(_) => (
+                    "pr.review-loop.observe",
+                    mutation,
+                    ProviderEffect::NetworkWrite,
+                    Vec::new(),
+                ),
+                PrReviewLoopCommand::Extend(_) => (
+                    "pr.review-loop.extend",
+                    mutation,
+                    ProviderEffect::NetworkWrite,
+                    Vec::new(),
+                ),
+            },
             _ => (
                 "pr.mutation",
                 mutation,

--- a/crates/forge-cli/src/ops/pr_review_loop.rs
+++ b/crates/forge-cli/src/ops/pr_review_loop.rs
@@ -11,7 +11,7 @@ use crate::cli::{
     BINARY, GlobalFlags, PrReviewLoopExtendArgs, PrReviewLoopInspectArgs, PrReviewLoopObserveArgs,
     PrReviewLoopValidateArgs,
 };
-use crate::envelope::emit_success;
+use crate::envelope::{emit_success, emit_success_with_warnings};
 use crate::error::ForgeError;
 use crate::ops::pr_comments::github_repo_slug_from_url;
 use crate::ops::{pr_comment, pr_review, pr_view, review_state};
@@ -107,24 +107,33 @@ struct ApprovalComment {
 
 /// Envelope payload for `cli.forge-cli.pr.review-loop.validate.v1`.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct PrReviewLoopValidatePayload {
-    /// Which of the two accepted `--findings-file` shapes was read.
-    pub shape: &'static str,
-    pub row_count: usize,
-    /// Rows per disposition, in the order the state machine defines them.
-    pub dispositions: Vec<DispositionCount>,
-    pub blocking_count: usize,
-    /// Fingerprints appearing more than once. Accepted — the last row wins —
-    /// but almost always a copy-paste error, so it is surfaced rather than
-    /// silently collapsed.
+struct PrReviewLoopValidatePayload {
+    /// Stable token for the `--findings-file` shape that was read, not the
+    /// prose the text renderer prints — the wording must stay free to change.
+    shape: &'static str,
+    /// Rows as written in the file, before identities are collapsed.
+    row_count: usize,
+    /// Distinct lifecycle identities after canonicalization. Lower than
+    /// `row_count` only when rows share an identity.
+    identity_count: usize,
+    /// Rows per disposition, over the canonical identities, in
+    /// [`review_state::ReviewFindingStatus::ALL`] order. Sums to
+    /// `identity_count`.
+    dispositions: Vec<DispositionCount>,
+    /// Findings the merge gate would treat as blocking: `open` and blocking.
+    /// A terminal disposition is never blocking, matching the ledger.
+    blocking_count: usize,
+    /// Lifecycle identities carrying more than one row. Reported only when the
+    /// rows are byte-identical — differing rows for one identity are a
+    /// `review_fingerprint_collision` and fail, exactly as they do on append.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub duplicate_fingerprints: Vec<String>,
+    duplicate_identities: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct DispositionCount {
-    pub disposition: &'static str,
-    pub count: usize,
+struct DispositionCount {
+    disposition: &'static str,
+    count: usize,
 }
 
 /// Validate a findings payload without a pull request, a provider call, or any
@@ -136,10 +145,17 @@ pub struct DispositionCount {
 /// actually asked. `pr review validate` has exactly this shape for review
 /// summaries and thread specs; this is the same affordance for the ledger.
 ///
-/// Deliberately payload-only. Head and state-tip CAS, the transition, and the
-/// rendered comment all require the provider and stay with `observe --dry-run`.
-/// Passing here does not promise an append will succeed; failing here proves it
-/// cannot.
+/// Deliberately payload-only, and that boundary is drawn where the provider
+/// starts, not sooner. Everything `observe` decides *offline* — fingerprint
+/// form, identity collisions, blocking normalization — is decided here by
+/// calling the same [`review_state::canonicalize_observations`] the append
+/// calls. Only head and state-tip CAS, the transition against stored state, and
+/// the rendered comment need the provider, and those stay with
+/// `observe --dry-run`.
+///
+/// So: failing here proves an append cannot succeed, and passing here means the
+/// payload itself is acceptable. A second, laxer copy of the payload rules is
+/// exactly the drift this command was added to prevent, so there isn't one.
 pub fn run_validate(
     args: PrReviewLoopValidateArgs,
     format: OutputFormat,
@@ -147,57 +163,113 @@ pub fn run_validate(
     // Read once. The path may be a FIFO or a process substitution, where a
     // second open yields EOF and would be misreported as invalid JSON.
     let raw = read_findings_value(&args.findings_file)?;
-    let shape = detect_findings_shape(&raw);
-    let observations = observations_from_value(&raw)?;
-
-    let mut counts: Vec<DispositionCount> =
-        ["open", "fixed", "accepted", "preference", "follow-up"]
-            .into_iter()
-            .map(|disposition| DispositionCount {
-                disposition,
-                count: 0,
-            })
-            .collect();
-    let mut seen: Vec<&str> = Vec::with_capacity(observations.len());
-    let mut duplicates: Vec<String> = Vec::new();
-    let mut blocking_count = 0usize;
-    for observation in &observations {
-        let label = finding_status_label(observation.status);
-        if let Some(entry) = counts.iter_mut().find(|entry| entry.disposition == label) {
-            entry.count += 1;
-        }
-        if observation.blocking {
-            blocking_count += 1;
-        }
-        if seen.contains(&observation.fingerprint.as_str()) {
-            if !duplicates.contains(&observation.fingerprint) {
-                duplicates.push(observation.fingerprint.clone());
-            }
-        } else {
-            seen.push(observation.fingerprint.as_str());
-        }
-    }
-
-    Ok(emit_success(
+    let payload = validate_payload(&raw)?;
+    // Repeated identities are advisory, so they belong in the envelope's
+    // warnings channel — stderr in text mode, `warnings[]` in JSON — not
+    // printed onto stdout where a JSON consumer would never see them.
+    let warnings = payload
+        .duplicate_identities
+        .iter()
+        .map(|identity| format!("identical rows repeated for one identity: {identity}"))
+        .collect::<Vec<_>>();
+    Ok(emit_success_with_warnings(
         schema_version_for(BINARY, SCHEMA_VALIDATE, SCHEMA_VERSION),
-        PrReviewLoopValidatePayload {
-            shape,
-            row_count: observations.len(),
-            dispositions: counts,
-            blocking_count,
-            duplicate_fingerprints: duplicates,
-        },
+        payload,
+        warnings,
         format,
         render_validate_text,
     ))
+}
+
+/// The whole decision, separated from emission so tests can assert the report
+/// rather than only an exit code.
+fn validate_payload(raw: &serde_json::Value) -> Result<PrReviewLoopValidatePayload, ForgeError> {
+    let shape = detect_findings_shape(raw);
+    let observations = observations_from_value(raw)?;
+    // The same canonicalization an append performs: rejects a malformed
+    // lifecycle fingerprint and an identity whose rows disagree, and clears
+    // `blocking` on every terminal disposition.
+    let canonical = review_state::canonicalize_observations(&observations)?;
+
+    let mut counts: Vec<DispositionCount> = review_state::ReviewFindingStatus::ALL
+        .into_iter()
+        .map(|status| DispositionCount {
+            disposition: status.as_str(),
+            count: 0,
+        })
+        .collect();
+    let mut blocking_count = 0usize;
+    for observation in canonical.values() {
+        let label = observation.status.as_str();
+        let entry = counts
+            .iter_mut()
+            .find(|entry| entry.disposition == label)
+            .expect("ReviewFindingStatus::ALL covers every status");
+        entry.count += 1;
+        if observation.blocking {
+            blocking_count += 1;
+        }
+    }
+
+    // Anything that survived canonicalization and still collapsed rows did so
+    // because those rows were identical; a disagreement would have errored.
+    let duplicate_identities = if canonical.len() < observations.len() {
+        collapsed_identities(&observations)
+    } else {
+        Vec::new()
+    };
+
+    Ok(PrReviewLoopValidatePayload {
+        shape,
+        row_count: observations.len(),
+        identity_count: canonical.len(),
+        dispositions: counts,
+        blocking_count,
+        duplicate_identities,
+    })
+}
+
+/// Identities that more than one row maps to, keyed the way the ledger keys
+/// them: the root-cause fingerprint when present, else the row's own.
+fn collapsed_identities(observations: &[review_state::ReviewFindingObservation]) -> Vec<String> {
+    let mut seen: Vec<&str> = Vec::with_capacity(observations.len());
+    let mut collapsed: Vec<String> = Vec::new();
+    for observation in observations {
+        let identity = observation
+            .root_cause_fingerprint
+            .as_deref()
+            .unwrap_or(&observation.fingerprint);
+        if seen.contains(&identity) {
+            if !collapsed.iter().any(|entry| entry == identity) {
+                collapsed.push(identity.to_string());
+            }
+        } else {
+            seen.push(identity);
+        }
+    }
+    collapsed
+}
+
+/// Prose lives here, not in the payload, so wording can change freely.
+fn shape_prose(shape: &str) -> &str {
+    match shape {
+        SHAPE_MERGE_ENVELOPE => "review-specialists merge envelope",
+        _ => "bare observation array",
+    }
 }
 
 fn render_validate_text(payload: &PrReviewLoopValidatePayload) {
     println!(
         "ok: {rows} observation(s) from a {shape}",
         rows = payload.row_count,
-        shape = payload.shape,
+        shape = shape_prose(payload.shape),
     );
+    if payload.identity_count != payload.row_count {
+        println!(
+            "  identities: {identities} (rows sharing an identity were collapsed)",
+            identities = payload.identity_count,
+        );
+    }
     let breakdown = payload
         .dispositions
         .iter()
@@ -208,13 +280,14 @@ fn render_validate_text(payload: &PrReviewLoopValidatePayload) {
         println!("  dispositions: {}", breakdown.join(" "));
     }
     println!("  blocking: {}", payload.blocking_count);
-    for fingerprint in &payload.duplicate_fingerprints {
-        println!("  warning: duplicate fingerprint, last row wins: {fingerprint}");
-    }
 }
 
-/// Read the payload as JSON without interpreting its rows, so the shape can be
-/// reported alongside a row-level failure.
+/// Read the payload once and parse it as JSON, leaving the rows uninterpreted.
+///
+/// Split from [`read_observations`] so a caller that needs both the raw value
+/// and the parsed rows opens the path exactly once — a FIFO or a `<(...)`
+/// process substitution returns EOF on a second open, which would surface as
+/// invalid JSON for a payload that was fine.
 fn read_findings_value(path: &str) -> Result<serde_json::Value, ForgeError> {
     let body = fs::read_to_string(path).map_err(|error| {
         ForgeError::validation(
@@ -234,23 +307,18 @@ fn read_findings_value(path: &str) -> Result<serde_json::Value, ForgeError> {
     })
 }
 
-/// The two shapes `--findings-file` accepts, named the way the help names them.
+/// Stable wire tokens for the two shapes `--findings-file` accepts. These go in
+/// a versioned envelope, so they are tokens rather than the sentence fragments
+/// the text renderer prints.
+const SHAPE_MERGE_ENVELOPE: &str = "merge-envelope";
+const SHAPE_OBSERVATION_ARRAY: &str = "observation-array";
+
 fn detect_findings_shape(value: &serde_json::Value) -> &'static str {
     let inner = value.get("data").unwrap_or(value);
     if inner.get("findings").is_some() {
-        "review-specialists merge envelope"
+        SHAPE_MERGE_ENVELOPE
     } else {
-        "bare observation array"
-    }
-}
-
-fn finding_status_label(status: review_state::ReviewFindingStatus) -> &'static str {
-    match status {
-        review_state::ReviewFindingStatus::Open => "open",
-        review_state::ReviewFindingStatus::Fixed => "fixed",
-        review_state::ReviewFindingStatus::Accepted => "accepted",
-        review_state::ReviewFindingStatus::Preference => "preference",
-        review_state::ReviewFindingStatus::FollowUp => "follow-up",
+        SHAPE_OBSERVATION_ARRAY
     }
 }
 
@@ -820,23 +888,7 @@ fn ensure_expected_tip(provider: Option<&str>, expected: Option<&str>) -> Result
 fn read_observations(
     path: &str,
 ) -> Result<Vec<review_state::ReviewFindingObservation>, ForgeError> {
-    let body = fs::read_to_string(path).map_err(|error| {
-        ForgeError::validation(
-            schema_err(),
-            "review_findings_invalid",
-            "failed to read review finding observations",
-            Some(format!("path={path}; error={error}")),
-        )
-    })?;
-    let value: serde_json::Value = serde_json::from_str(&body).map_err(|error| {
-        ForgeError::validation(
-            schema_err(),
-            "review_findings_invalid",
-            "review finding observations are not valid JSON",
-            Some(error.to_string()),
-        )
-    })?;
-    observations_from_value(&value)
+    observations_from_value(&read_findings_value(path)?)
 }
 
 /// Row-level parse, split out so a caller that has already read the payload
@@ -915,20 +967,29 @@ fn observation_from_value(
     })
 }
 
+/// Accept exactly the dispositions the type defines, derived from
+/// [`review_state::ReviewFindingStatus::ALL`] so a new variant is accepted here
+/// the moment it exists rather than silently rejected.
+///
+/// `reopened` is deliberately absent: a finding that reappears is submitted as
+/// `open`, and the state machine decides whether that is a reopen.
 fn parse_finding_status(value: &str) -> Result<review_state::ReviewFindingStatus, ForgeError> {
-    match value {
-        "open" => Ok(review_state::ReviewFindingStatus::Open),
-        "fixed" => Ok(review_state::ReviewFindingStatus::Fixed),
-        "accepted" => Ok(review_state::ReviewFindingStatus::Accepted),
-        "preference" => Ok(review_state::ReviewFindingStatus::Preference),
-        "follow-up" => Ok(review_state::ReviewFindingStatus::FollowUp),
-        _ => Err(ForgeError::validation(
-            schema_err(),
-            "review_findings_invalid",
-            "review finding disposition is not supported",
-            Some(format!("status={value}")),
-        )),
-    }
+    review_state::ReviewFindingStatus::ALL
+        .into_iter()
+        .find(|status| status.as_str() == value)
+        .ok_or_else(|| {
+            ForgeError::validation(
+                schema_err(),
+                "review_findings_invalid",
+                "review finding disposition is not supported",
+                Some(format!(
+                    "status={value}; supported={}",
+                    review_state::ReviewFindingStatus::ALL
+                        .map(|status| status.as_str())
+                        .join(" | ")
+                )),
+            )
+        })
 }
 
 fn durable_hard_stop_error(
@@ -1842,10 +1903,11 @@ mod tests {
         assert_eq!(err.kind(), "review_findings_invalid");
     }
 
-    /// A duplicated fingerprint is accepted — the last row wins — but it is
-    /// almost always a copy-paste error, so the report names it.
+    /// Two rows for one identity that DISAGREE are a collision, exactly as on
+    /// append — my first cut documented and tested "last row wins", which is
+    /// not what `canonical_observations` does.
     #[test]
-    fn validate_reports_duplicate_fingerprints_without_failing() {
+    fn validate_rejects_two_rows_that_give_one_identity_incompatible_dispositions() {
         let dir = tempfile::tempdir().expect("tempdir");
         let findings = findings_file(
             &dir,
@@ -1855,10 +1917,133 @@ mod tests {
             ]"#,
         );
 
-        let code = run_validate(validate_args(&findings), OutputFormat::Json)
-            .expect("duplicates are accepted by observe, so validate accepts them too");
+        let err = run_validate(validate_args(&findings), OutputFormat::Json)
+            .expect_err("an identity cannot carry two different dispositions");
 
-        assert_eq!(code, 0);
+        assert_eq!(err.kind(), "review_fingerprint_collision");
+    }
+
+    /// Byte-identical repeats are the only duplicates the ledger really does
+    /// collapse, so they warn rather than fail.
+    #[test]
+    fn validate_reports_identical_repeats_as_one_identity_without_failing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let findings = findings_file(
+            &dir,
+            r#"[
+              {"lifecycle_fingerprint":"correctness:a:one","disposition":"open"},
+              {"lifecycle_fingerprint":"correctness:a:one","disposition":"open"}
+            ]"#,
+        );
+        let raw = read_findings_value(&findings).expect("read");
+
+        let payload = validate_payload(&raw).expect("identical repeats collapse cleanly");
+
+        assert_eq!(payload.row_count, 2);
+        assert_eq!(payload.identity_count, 1);
+        assert_eq!(payload.duplicate_identities, vec!["correctness:a:one"]);
+    }
+
+    /// Identity is the root-cause fingerprint when present, so two rows with
+    /// different lifecycle fingerprints can still be one identity — and
+    /// disagree.
+    #[test]
+    fn validate_keys_identity_on_the_root_cause_fingerprint() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let findings = findings_file(
+            &dir,
+            r#"[
+              {"lifecycle_fingerprint":"correctness:a:one","root_cause_fingerprint":"correctness:r:root","disposition":"open"},
+              {"lifecycle_fingerprint":"correctness:b:two","root_cause_fingerprint":"correctness:r:root","disposition":"fixed"}
+            ]"#,
+        );
+
+        let err = run_validate(validate_args(&findings), OutputFormat::Json)
+            .expect_err("one root cause with disagreeing rows is a collision");
+
+        assert_eq!(err.kind(), "review_fingerprint_collision");
+    }
+
+    /// A malformed lifecycle fingerprint is a purely local rule, so the offline
+    /// check must catch it rather than leaving it to the append.
+    #[test]
+    fn validate_rejects_a_malformed_lifecycle_fingerprint() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for bad in [
+            "abc",
+            "a:b",
+            "Maintainability:PrReviewLoop:dup",
+            "-a:b:c",
+            "a::c",
+        ] {
+            let findings = findings_file(
+                &dir,
+                &format!(r#"[{{"lifecycle_fingerprint":"{bad}","disposition":"open"}}]"#),
+            );
+            let err = run_validate(validate_args(&findings), OutputFormat::Json)
+                .expect_err("a malformed lifecycle fingerprint must be rejected offline");
+            assert_eq!(
+                err.kind(),
+                "review_fingerprint_collision",
+                "unexpected kind for {bad}"
+            );
+        }
+    }
+
+    /// The count the merge gate cares about. The ledger clears `blocking` on
+    /// every terminal disposition, so a payload of finished work is zero
+    /// blocking — counting the raw parsed bit reported one per row.
+    #[test]
+    fn validate_blocking_count_matches_what_the_ledger_would_record() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let findings = findings_file(
+            &dir,
+            r#"[
+              {"lifecycle_fingerprint":"correctness:a:one","disposition":"fixed"},
+              {"lifecycle_fingerprint":"correctness:b:two","disposition":"accepted"},
+              {"lifecycle_fingerprint":"correctness:c:three","disposition":"open"}
+            ]"#,
+        );
+        let raw = read_findings_value(&findings).expect("read");
+
+        let payload = validate_payload(&raw).expect("valid payload");
+
+        assert_eq!(
+            payload.blocking_count, 1,
+            "only the open row blocks; terminal dispositions never do"
+        );
+    }
+
+    /// The breakdown must account for every identity, so a future disposition
+    /// cannot silently vanish from the report.
+    #[test]
+    fn validate_dispositions_sum_to_the_identity_count() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let findings = findings_file(
+            &dir,
+            r#"[
+              {"lifecycle_fingerprint":"correctness:a:one","disposition":"open"},
+              {"lifecycle_fingerprint":"correctness:b:two","disposition":"fixed"},
+              {"lifecycle_fingerprint":"correctness:c:three","disposition":"follow-up"}
+            ]"#,
+        );
+        let raw = read_findings_value(&findings).expect("read");
+
+        let payload = validate_payload(&raw).expect("valid payload");
+
+        assert_eq!(
+            payload.dispositions.iter().map(|d| d.count).sum::<usize>(),
+            payload.identity_count
+        );
+        assert_eq!(
+            payload
+                .dispositions
+                .iter()
+                .map(|d| d.disposition)
+                .collect::<Vec<_>>(),
+            vec!["open", "fixed", "accepted", "preference", "follow-up"],
+            "order comes from ReviewFindingStatus::ALL"
+        );
     }
 
     /// The clean-review genesis path: an empty envelope is a valid payload, and
@@ -1894,7 +2079,7 @@ mod tests {
         let raw = read_findings_value(&path.to_string_lossy()).expect("read once");
 
         // Both answers must come from that one read.
-        assert_eq!(detect_findings_shape(&raw), "bare observation array");
+        assert_eq!(detect_findings_shape(&raw), SHAPE_OBSERVATION_ARRAY);
         let observations = observations_from_value(&raw).expect("parse from the same value");
         assert_eq!(observations.len(), 1);
     }
@@ -1903,12 +2088,12 @@ mod tests {
     fn validate_names_the_shape_it_read() {
         let envelope: serde_json::Value =
             serde_json::from_str(r#"{"data":{"findings":[]}}"#).expect("json");
-        assert_eq!(
-            detect_findings_shape(&envelope),
-            "review-specialists merge envelope"
-        );
+        assert_eq!(detect_findings_shape(&envelope), SHAPE_MERGE_ENVELOPE);
         let array: serde_json::Value = serde_json::from_str("[]").expect("json");
-        assert_eq!(detect_findings_shape(&array), "bare observation array");
+        assert_eq!(detect_findings_shape(&array), SHAPE_OBSERVATION_ARRAY);
+        // Stable tokens, not the prose the text renderer prints.
+        assert_eq!(SHAPE_MERGE_ENVELOPE, "merge-envelope");
+        assert_eq!(SHAPE_OBSERVATION_ARRAY, "observation-array");
     }
 
     fn observe_args(

--- a/crates/forge-cli/src/ops/pr_review_loop.rs
+++ b/crates/forge-cli/src/ops/pr_review_loop.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use crate::backend::{BackendCall, BackendProgram, BackendRunner};
 use crate::cli::{
     BINARY, GlobalFlags, PrReviewLoopExtendArgs, PrReviewLoopInspectArgs, PrReviewLoopObserveArgs,
+    PrReviewLoopValidateArgs,
 };
 use crate::envelope::emit_success;
 use crate::error::ForgeError;
@@ -21,6 +22,7 @@ use crate::validations::{RuleVerdict, no_escaped_control_markdown, no_local_path
 const SCHEMA_INSPECT: &str = "pr.review-loop.inspect";
 const SCHEMA_OBSERVE: &str = "pr.review-loop.observe";
 const SCHEMA_EXTEND: &str = "pr.review-loop.extend";
+const SCHEMA_VALIDATE: &str = "pr.review-loop.validate";
 const SCHEMA_VERSION: u32 = 1;
 const EXTENSION_MARKER_PREFIX: &str = "<!-- forge-cli:review-loop-extension:v1 ";
 
@@ -101,6 +103,155 @@ struct ApprovalComment {
     association: String,
     created_at: String,
     body: String,
+}
+
+/// Envelope payload for `cli.forge-cli.pr.review-loop.validate.v1`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PrReviewLoopValidatePayload {
+    /// Which of the two accepted `--findings-file` shapes was read.
+    pub shape: &'static str,
+    pub row_count: usize,
+    /// Rows per disposition, in the order the state machine defines them.
+    pub dispositions: Vec<DispositionCount>,
+    pub blocking_count: usize,
+    /// Fingerprints appearing more than once. Accepted — the last row wins —
+    /// but almost always a copy-paste error, so it is surfaced rather than
+    /// silently collapsed.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub duplicate_fingerprints: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DispositionCount {
+    pub disposition: &'static str,
+    pub count: usize,
+}
+
+/// Validate a findings payload without a pull request, a provider call, or any
+/// network access.
+///
+/// `observe --dry-run` already reports a payload verdict, but it needs a PR id
+/// and resolves the provider first, so it cannot answer "is this file well
+/// formed" while the file is being written — which is when the question is
+/// actually asked. `pr review validate` has exactly this shape for review
+/// summaries and thread specs; this is the same affordance for the ledger.
+///
+/// Deliberately payload-only. Head and state-tip CAS, the transition, and the
+/// rendered comment all require the provider and stay with `observe --dry-run`.
+/// Passing here does not promise an append will succeed; failing here proves it
+/// cannot.
+pub fn run_validate(
+    args: PrReviewLoopValidateArgs,
+    format: OutputFormat,
+) -> Result<i32, ForgeError> {
+    // Read once. The path may be a FIFO or a process substitution, where a
+    // second open yields EOF and would be misreported as invalid JSON.
+    let raw = read_findings_value(&args.findings_file)?;
+    let shape = detect_findings_shape(&raw);
+    let observations = observations_from_value(&raw)?;
+
+    let mut counts: Vec<DispositionCount> =
+        ["open", "fixed", "accepted", "preference", "follow-up"]
+            .into_iter()
+            .map(|disposition| DispositionCount {
+                disposition,
+                count: 0,
+            })
+            .collect();
+    let mut seen: Vec<&str> = Vec::with_capacity(observations.len());
+    let mut duplicates: Vec<String> = Vec::new();
+    let mut blocking_count = 0usize;
+    for observation in &observations {
+        let label = finding_status_label(observation.status);
+        if let Some(entry) = counts.iter_mut().find(|entry| entry.disposition == label) {
+            entry.count += 1;
+        }
+        if observation.blocking {
+            blocking_count += 1;
+        }
+        if seen.contains(&observation.fingerprint.as_str()) {
+            if !duplicates.contains(&observation.fingerprint) {
+                duplicates.push(observation.fingerprint.clone());
+            }
+        } else {
+            seen.push(observation.fingerprint.as_str());
+        }
+    }
+
+    Ok(emit_success(
+        schema_version_for(BINARY, SCHEMA_VALIDATE, SCHEMA_VERSION),
+        PrReviewLoopValidatePayload {
+            shape,
+            row_count: observations.len(),
+            dispositions: counts,
+            blocking_count,
+            duplicate_fingerprints: duplicates,
+        },
+        format,
+        render_validate_text,
+    ))
+}
+
+fn render_validate_text(payload: &PrReviewLoopValidatePayload) {
+    println!(
+        "ok: {rows} observation(s) from a {shape}",
+        rows = payload.row_count,
+        shape = payload.shape,
+    );
+    let breakdown = payload
+        .dispositions
+        .iter()
+        .filter(|entry| entry.count > 0)
+        .map(|entry| format!("{}={}", entry.disposition, entry.count))
+        .collect::<Vec<_>>();
+    if !breakdown.is_empty() {
+        println!("  dispositions: {}", breakdown.join(" "));
+    }
+    println!("  blocking: {}", payload.blocking_count);
+    for fingerprint in &payload.duplicate_fingerprints {
+        println!("  warning: duplicate fingerprint, last row wins: {fingerprint}");
+    }
+}
+
+/// Read the payload as JSON without interpreting its rows, so the shape can be
+/// reported alongside a row-level failure.
+fn read_findings_value(path: &str) -> Result<serde_json::Value, ForgeError> {
+    let body = fs::read_to_string(path).map_err(|error| {
+        ForgeError::validation(
+            schema_err(),
+            "review_findings_invalid",
+            "failed to read review finding observations",
+            Some(format!("path={path}; error={error}")),
+        )
+    })?;
+    serde_json::from_str(&body).map_err(|error| {
+        ForgeError::validation(
+            schema_err(),
+            "review_findings_invalid",
+            "review finding observations are not valid JSON",
+            Some(error.to_string()),
+        )
+    })
+}
+
+/// The two shapes `--findings-file` accepts, named the way the help names them.
+fn detect_findings_shape(value: &serde_json::Value) -> &'static str {
+    let inner = value.get("data").unwrap_or(value);
+    if inner.get("findings").is_some() {
+        "review-specialists merge envelope"
+    } else {
+        "bare observation array"
+    }
+}
+
+fn finding_status_label(status: review_state::ReviewFindingStatus) -> &'static str {
+    match status {
+        review_state::ReviewFindingStatus::Open => "open",
+        review_state::ReviewFindingStatus::Fixed => "fixed",
+        review_state::ReviewFindingStatus::Accepted => "accepted",
+        review_state::ReviewFindingStatus::Preference => "preference",
+        review_state::ReviewFindingStatus::FollowUp => "follow-up",
+    }
 }
 
 pub fn run_inspect(
@@ -685,7 +836,15 @@ fn read_observations(
             Some(error.to_string()),
         )
     })?;
-    let value = value.get("data").unwrap_or(&value);
+    observations_from_value(&value)
+}
+
+/// Row-level parse, split out so a caller that has already read the payload
+/// does not have to open the path a second time.
+fn observations_from_value(
+    value: &serde_json::Value,
+) -> Result<Vec<review_state::ReviewFindingObservation>, ForgeError> {
+    let value = value.get("data").unwrap_or(value);
     let rows = value
         .get("findings")
         .unwrap_or(value)
@@ -1597,6 +1756,159 @@ mod tests {
         let path = dir.path().join("findings.json");
         fs::write(&path, body).expect("write findings");
         path.to_string_lossy().into_owned()
+    }
+
+    fn validate_args(findings: &str) -> PrReviewLoopValidateArgs {
+        PrReviewLoopValidateArgs {
+            findings_file: findings.to_string(),
+        }
+    }
+
+    /// The payload check must not need a pull request, so it takes no id and
+    /// never resolves a provider — that is the whole reason the verb exists.
+    #[test]
+    fn validate_accepts_a_bare_disposition_array_with_no_provider_access() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let findings = findings_file(
+            &dir,
+            r#"[
+              {"lifecycle_fingerprint":"correctness:a:one","disposition":"fixed"},
+              {"lifecycle_fingerprint":"maintainability:b:two","disposition":"follow-up"}
+            ]"#,
+        );
+
+        let code = run_validate(validate_args(&findings), OutputFormat::Json)
+            .expect("a well-formed array must validate");
+
+        assert_eq!(code, 0);
+    }
+
+    /// `preference` and `follow-up` are accepted dispositions; the command help
+    /// used to omit both and advertise `reopened`, which the parser rejects.
+    #[test]
+    fn validate_accepts_every_disposition_the_parser_accepts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for disposition in ["open", "fixed", "accepted", "preference", "follow-up"] {
+            let findings = findings_file(
+                &dir,
+                &format!(
+                    r#"[{{"lifecycle_fingerprint":"correctness:a:one","disposition":"{disposition}"}}]"#
+                ),
+            );
+            let code = run_validate(validate_args(&findings), OutputFormat::Json)
+                .unwrap_or_else(|err| panic!("{disposition} must validate: {err}"));
+            assert_eq!(code, 0, "{disposition} must validate");
+        }
+    }
+
+    /// A finding that reappears is submitted as `open`. The state machine
+    /// decides whether that is a reopen, so `reopened` is not an input.
+    #[test]
+    fn validate_rejects_reopened_which_the_help_used_to_advertise() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let findings = findings_file(
+            &dir,
+            r#"[{"lifecycle_fingerprint":"correctness:a:one","disposition":"reopened"}]"#,
+        );
+
+        let err = run_validate(validate_args(&findings), OutputFormat::Json)
+            .expect_err("reopened is not an input disposition");
+
+        assert_eq!(err.kind(), "review_findings_invalid");
+    }
+
+    #[test]
+    fn validate_rejects_a_row_without_a_fingerprint() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let findings = findings_file(&dir, r#"[{"disposition":"fixed"}]"#);
+
+        let err = run_validate(validate_args(&findings), OutputFormat::Json)
+            .expect_err("a fingerprint is required");
+
+        assert_eq!(err.kind(), "review_fingerprint_required");
+    }
+
+    #[test]
+    fn validate_rejects_a_missing_file_rather_than_reporting_zero_rows() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("absent.json");
+
+        let err = run_validate(
+            validate_args(&missing.to_string_lossy()),
+            OutputFormat::Json,
+        )
+        .expect_err("an unreadable payload is not an empty one");
+
+        assert_eq!(err.kind(), "review_findings_invalid");
+    }
+
+    /// A duplicated fingerprint is accepted — the last row wins — but it is
+    /// almost always a copy-paste error, so the report names it.
+    #[test]
+    fn validate_reports_duplicate_fingerprints_without_failing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let findings = findings_file(
+            &dir,
+            r#"[
+              {"lifecycle_fingerprint":"correctness:a:one","disposition":"open"},
+              {"lifecycle_fingerprint":"correctness:a:one","disposition":"fixed"}
+            ]"#,
+        );
+
+        let code = run_validate(validate_args(&findings), OutputFormat::Json)
+            .expect("duplicates are accepted by observe, so validate accepts them too");
+
+        assert_eq!(code, 0);
+    }
+
+    /// The clean-review genesis path: an empty envelope is a valid payload, and
+    /// merge requires an observation even when there are no findings.
+    #[test]
+    fn validate_accepts_an_empty_delivery_envelope() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let findings = findings_file(&dir, r#"{"data":{"findings":[]}}"#);
+
+        let code = run_validate(validate_args(&findings), OutputFormat::Json)
+            .expect("an empty envelope is the clean-review genesis payload");
+
+        assert_eq!(code, 0);
+    }
+
+    /// The payload path is opened exactly once.
+    ///
+    /// Reporting the shape and parsing the rows are two questions about one
+    /// file; asking them with two `read_to_string` calls works for a regular
+    /// file and fails for a FIFO or a `<(...)` process substitution, where the
+    /// second open returns EOF and surfaces as "not valid JSON" — a misleading
+    /// error for a payload that was fine. Found by running the command against
+    /// a process substitution.
+    #[test]
+    fn validate_reads_a_single_use_payload_path_only_once() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("findings.json");
+        fs::write(
+            &path,
+            r#"[{"lifecycle_fingerprint":"correctness:a:one","disposition":"fixed"}]"#,
+        )
+        .expect("write findings");
+        let raw = read_findings_value(&path.to_string_lossy()).expect("read once");
+
+        // Both answers must come from that one read.
+        assert_eq!(detect_findings_shape(&raw), "bare observation array");
+        let observations = observations_from_value(&raw).expect("parse from the same value");
+        assert_eq!(observations.len(), 1);
+    }
+
+    #[test]
+    fn validate_names_the_shape_it_read() {
+        let envelope: serde_json::Value =
+            serde_json::from_str(r#"{"data":{"findings":[]}}"#).expect("json");
+        assert_eq!(
+            detect_findings_shape(&envelope),
+            "review-specialists merge envelope"
+        );
+        let array: serde_json::Value = serde_json::from_str("[]").expect("json");
+        assert_eq!(detect_findings_shape(&array), "bare observation array");
     }
 
     fn observe_args(

--- a/crates/forge-cli/src/ops/review_state.rs
+++ b/crates/forge-cli/src/ops/review_state.rs
@@ -86,6 +86,31 @@ pub enum ReviewFindingStatus {
     FollowUp,
 }
 
+impl ReviewFindingStatus {
+    /// Every disposition, in the order the loop reports them. Callers that
+    /// enumerate the set derive it from here so adding a variant is one edit
+    /// and a compile error rather than a silent omission.
+    pub const ALL: [Self; 5] = [
+        Self::Open,
+        Self::Fixed,
+        Self::Accepted,
+        Self::Preference,
+        Self::FollowUp,
+    ];
+
+    /// The wire name, matching this type's `rename_all = "kebab-case"` derive.
+    /// A round-trip test pins the two together.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Fixed => "fixed",
+            Self::Accepted => "accepted",
+            Self::Preference => "preference",
+            Self::FollowUp => "follow-up",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ReviewLoopFinding {
@@ -969,6 +994,20 @@ pub fn apply_review_loop_extension(
     Ok(state)
 }
 
+/// Canonicalize a findings payload exactly as an append would, without touching
+/// the ledger or the provider.
+///
+/// This is the whole offline half of `observe`'s acceptance decision: lifecycle
+/// fingerprint form, root-cause fingerprint form, blocking normalization for
+/// terminal dispositions, thread de-duplication, and identity collisions. An
+/// offline validator that stops short of it would accept payloads the append
+/// rejects, so it is exported rather than re-implemented.
+pub fn canonicalize_observations(
+    observations: &[ReviewFindingObservation],
+) -> Result<BTreeMap<String, ReviewFindingObservation>, ForgeError> {
+    canonical_observations(observations)
+}
+
 fn canonical_observations(
     observations: &[ReviewFindingObservation],
 ) -> Result<BTreeMap<String, ReviewFindingObservation>, ForgeError> {
@@ -1294,6 +1333,45 @@ fn error_schema() -> String {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+
+    /// `as_str` restates what `rename_all = "kebab-case"` produces, and callers
+    /// enumerate the set through `ALL`. Tie all three together so the hand
+    /// mapping cannot drift from the derive, and so `ALL` cannot go stale when
+    /// a variant is added.
+    #[test]
+    fn finding_status_as_str_round_trips_through_serde_for_every_variant() {
+        for status in ReviewFindingStatus::ALL {
+            assert_eq!(
+                serde_json::to_value(status).expect("serialize"),
+                serde_json::Value::String(status.as_str().to_string()),
+                "as_str must match the serde name for {status:?}"
+            );
+            let parsed: ReviewFindingStatus =
+                serde_json::from_value(serde_json::Value::String(status.as_str().to_string()))
+                    .expect("deserialize");
+            assert_eq!(parsed, status);
+        }
+    }
+
+    /// A new variant must be added to `ALL`, not just to the enum.
+    #[test]
+    fn finding_status_all_covers_every_variant() {
+        // Exhaustive match: adding a variant fails to compile here, which is
+        // the prompt to extend `ALL` below.
+        fn assert_known(status: ReviewFindingStatus) -> &'static str {
+            match status {
+                ReviewFindingStatus::Open => "open",
+                ReviewFindingStatus::Fixed => "fixed",
+                ReviewFindingStatus::Accepted => "accepted",
+                ReviewFindingStatus::Preference => "preference",
+                ReviewFindingStatus::FollowUp => "follow-up",
+            }
+        }
+        assert_eq!(ReviewFindingStatus::ALL.len(), 5);
+        for status in ReviewFindingStatus::ALL {
+            assert_eq!(assert_known(status), status.as_str());
+        }
+    }
 
     fn fixture_receipt() -> ReviewRunReceipt {
         ReviewRunReceipt {

--- a/crates/forge-cli/tests/integration/cli.rs
+++ b/crates/forge-cli/tests/integration/cli.rs
@@ -429,3 +429,96 @@ fn dry_run_repo_view_renders_plan_envelope_for_gitlab() {
     assert!(plan.iter().any(|v| v == "-F"));
     assert_eq!(envelope["data"]["provider"], "gitlab");
 }
+
+/// `pr review-loop validate` end to end: the schema literal, the full payload
+/// shape, and the claim the command is built on — that it reaches no backend.
+/// The stub exits 99 on any invocation, so a single provider call fails this.
+#[test]
+fn pr_review_loop_validate_emits_its_schema_without_touching_a_backend() {
+    let stub = StubEnv::new().gh_stub("#!/bin/sh\necho 'no backend expected' >&2\nexit 99\n");
+    let findings = stub.tempdir.path().join("findings.json");
+    std::fs::write(
+        &findings,
+        r#"[
+          {"lifecycle_fingerprint":"correctness:a:one","disposition":"open"},
+          {"lifecycle_fingerprint":"maintainability:b:two","disposition":"fixed"}
+        ]"#,
+    )
+    .expect("write findings");
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "pr",
+            "review-loop",
+            "validate",
+            "--findings-file",
+            &findings.to_string_lossy(),
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(
+        envelope["schema_version"],
+        "cli.forge-cli.pr.review-loop.validate.v1"
+    );
+    let data = &envelope["data"];
+    assert_eq!(data["shape"], "observation-array");
+    assert_eq!(data["row_count"], 2);
+    assert_eq!(data["identity_count"], 2);
+    assert_eq!(data["blocking_count"], 1);
+    assert_eq!(
+        data["dispositions"],
+        serde_json::json!([
+            {"disposition": "open", "count": 1},
+            {"disposition": "fixed", "count": 1},
+            {"disposition": "accepted", "count": 0},
+            {"disposition": "preference", "count": 0},
+            {"disposition": "follow-up", "count": 0},
+        ])
+    );
+    assert!(
+        data.get("duplicate_identities").is_none(),
+        "omitted when empty: {}",
+        out.stdout
+    );
+    assert!(
+        envelope.get("warnings").is_none()
+            || envelope["warnings"].as_array().is_none_or(|w| w.is_empty()),
+        "a clean payload warns about nothing: {}",
+        out.stdout
+    );
+}
+
+/// Provider globals are inert here by design; the command must not start
+/// rejecting payloads because a provider was named.
+#[test]
+fn pr_review_loop_validate_ignores_provider_globals() {
+    let stub = StubEnv::new().gh_stub("#!/bin/sh\nexit 99\n");
+    let findings = stub.tempdir.path().join("findings.json");
+    std::fs::write(
+        &findings,
+        r#"[{"lifecycle_fingerprint":"correctness:a:one","disposition":"open"}]"#,
+    )
+    .expect("write findings");
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--format",
+            "json",
+            "--provider",
+            "gitlab",
+            "pr",
+            "review-loop",
+            "validate",
+            "--findings-file",
+            &findings.to_string_lossy(),
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+}


### PR DESCRIPTION
## Summary

`pr review` has a `validate` verb. `pr review-loop` had `inspect`, `observe` and
`extend`, and no way to check a findings payload before sending it.

The gap is narrower than "no parity", which is worth stating because it changes
what to build. `observe --dry-run` *does* report a payload verdict — but it takes
a PR id and resolves the provider first, so it cannot answer "is this file well
formed" while the file is being written, which is when the question is asked.

This adds the offline half.

## Issues

Refs #1428

## Changes

### `pr review-loop validate --findings-file <path>`

No pull request, no provider call, no network. Reports the shape it read, the row
count, the distinct identity count, the per-disposition breakdown, the blocking
count, and any repeated identity.

**Its accept/reject decision is not a second implementation of the payload
rules.** Review caught that my first cut committed exactly the fault the verb
exists to prevent: it stopped at row parsing and never ran the canonicalization
`observe` runs, so it passed payloads the append rejects. Verified on the built
binary before fixing — a malformed fingerprint and two rows giving one identity
incompatible dispositions both exited 0.

It now calls the same `review_state::canonicalize_observations` the append calls,
so lifecycle fingerprint form, identity collisions and blocking normalization are
decided once. Only head and state-tip compare-and-swap, the transition against
stored state, and the rendered comment need the provider, and those stay with
`observe --dry-run`. Failing here proves an append cannot succeed; passing means
the payload itself is acceptable.

```
$ forge-cli pr review-loop validate --findings-file findings.json
ok: 3 observation(s) from a bare observation array
  dispositions: fixed=1 preference=1 follow-up=1
  blocking: 1
```

### Three semantics I documented wrongly, corrected

- **Duplicates.** I wrote "accepted — the last row wins" in the doc comment, the
  warning text, and a test. `canonical_observations` returns
  `review_fingerprint_collision` when the rows differ; only byte-identical
  repeats collapse. The test asserted exit 0 on precisely the payload `observe`
  rejects.
- **Identity.** Keyed on `lifecycle_fingerprint`, but the ledger keys on
  `root_cause_fingerprint` when present — so two rows sharing a root cause were
  reported as two clean rows instead of one colliding identity.
- **Blocking count.** Counted the raw parsed bit, which defaults to true for a
  row with no `severity`, while the ledger clears `blocking` on every terminal
  disposition. A payload of finished work reported one blocking finding per row
  instead of zero — the wrong answer to "will this block merge?".

### The `observe` help was wrong in both directions

It advertised `open | fixed | accepted | reopened`. The parser accepts
`open | fixed | accepted | preference | follow-up` and rejects `reopened` — there
is no `Reopened` variant at all. A finding that reappears is submitted as `open`;
the state machine decides whether that is a reopen.

### An offline command was declared as a network write

With no `PrCommand::ReviewLoop` arm, the whole family fell through to the
`pr.mutation` / `network_write` default, so `operation-effect` handed the
permission layer a much larger authority than this command needs. All four verbs
are now classified; `validate` reports `read_only` / `local_read`.

### Smaller corrections

Stable `shape` tokens instead of the sentence fragment the renderer prints; the
duplicate warning routed through the envelope's warnings channel rather than
stdout; disposition buckets derived from a new `ReviewFindingStatus::ALL` instead
of a third hardcoded copy; `read_observations` reduced to read + parse so the
read half is not duplicated; payload types made private; the op declared in the
spec and the ops catalog; and the payload path opened **once**, because two reads
break on a FIFO or `<(...)` and report a bogus "not valid JSON".

## Test-First Evidence

The accepted disposition set had no test, which is how the help drifted from the
parser unnoticed. `validate_accepts_every_disposition_the_parser_accepts` and
`validate_rejects_reopened_which_the_help_used_to_advertise` pin both directions.

`ReviewFindingStatus::ALL` is tied to the serde derive by a round-trip test, so
`as_str`, the enumeration, and the wire names cannot drift apart.

The single-read property is pinned by
`validate_reads_a_single_use_payload_path_only_once`. That bug was found by
running the command against a process substitution during a manual smoke test,
not by the suite — the test exists so it stays found.

## Test plan

Round 2 gave the report a testable seam. Every test could previously assert only
an exit code, which is exactly why the count divergences above were invisible;
`validate_payload` is now separate from emission and the tests assert the report.

- 15 unit tests in `pr_review_loop`, including collision rejection, root-cause
  identity, ledger-matching blocking count, and `dispositions` summing to
  `identity_count`
- 2 round-trip tests in `review_state` tying `ALL` / `as_str` to the serde derive
- 2 integration tests: the schema literal plus the full payload shape, and the
  provider-globals-are-inert contract. The stub exits 99 on any invocation, so
  the "no backend" claim is proven rather than asserted
- `-p nils-forge-cli` lib → **849/849**
- declared gate `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` →
  exit 0, **8411 tests run: 8411 passed**
- `bash -n` / `zsh -n` on both completion assets → ok
- `markdownlint-audit.sh --strict` → ok
- manual: `operation-effect` now reports `read_only` / `local_read`

**Pre-existing flake, unrelated:** `forgejo_http` fails intermittently under
parallel load; verified against the base commit and filed as **#1442**.

## Risk / Notes

Additive at the CLI surface: a new subcommand, one corrected help string, one
corrected capability descriptor, and internal refactors.

`read_observations` keeps its signature and behaviour — it is now
`observations_from_value(&read_findings_value(path)?)`, verified byte-identical
in effect — so `observe` and its dry-run are untouched.

The one behaviour change beyond the new verb is `operation-effect` for the
`review-loop` family: `inspect` moves from `mutation`/`network_write` to
`read_only`/`network_read`, and `validate` to `read_only`/`local_read`.
`observe` and `extend` keep their mutation classification. That corrects
descriptors that overstated authority; a permission layer that gated on the old
values will now see narrower, truthful ones.

`validate` is provider-independent by construction — no id, no provider
resolution, no backend — so `--provider`, `--repo`, `--host` and `--dry-run`
have no effect on it. Review flagged that this diverges from `pr review
validate`, which rejects GitLab. Keeping the divergence: the value of this verb
is checking a file before any repository is in scope. It is now declared in the
after_help, the spec, and the ops catalog, and pinned by a test, so it reads as
deliberate rather than as an oversight.
