### PR TITLE
fix(agent-hook): classify Stop reentry state

### DIFF
--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -380,17 +380,34 @@ Degrading the conversation lane acquires no new authority: the prompt is admitte
 as text, every mutation stays gated, and the original prompt is neither lost nor
 executed more than once because the turn correlation digest bounds replay.
 
-The terminal lane has two degradations. A coordination transaction that cannot
-run at all returns `coordination-stop-reconciliation-required`, mirroring the
-existing `activity-stop-reconciliation-required` boundary — without it the first
-Stop delivery deadlocks before provider re-entry metadata can help. Separately,
-when the provider reports Stop re-entry and the aggregate still blocks, the
-decision becomes a warning with `stop-reentry-reconciliation-pending`: re-entry
-proves the previous block changed nothing the gate awaits, so blocking again only
-consumes the provider's consecutive-block budget. Neither degradation releases or
-alters claims, leases, operations, brokers, worktrees, or session state; every
-original reason is retained on the decision and the evidence is durable, so
-mutation stays gated until an external reconciliation runs.
+The terminal lane has two degradation boundaries. A coordination transaction
+that cannot run at all returns the compatibility classification
+`coordination-stop-reconciliation-required`, but its diagnostic makes no
+retained-state or gate claim and routes to read-only `agent-session broker
+status`; without a warning boundary the first Stop delivery deadlocks before
+provider re-entry metadata can help. Separately, when the provider reports Stop
+re-entry and the aggregate still blocks, the decision becomes a warning:
+re-entry proves the previous block changed nothing the gate awaits, so blocking
+again only consumes the provider's consecutive-block budget.
+
+Stop re-entry carries the typed coordination result into the terminal renderer;
+the runtime handler supplies `runtime-kit.session-coordination-result.v1` with
+one of `not-run`, `clean`, `pending`, or `unavailable`. Untyped provider payloads
+are treated as unavailable, never as broker-state proof. The renderer does not
+infer transaction state from generic provider actions or normalized reason
+strings:
+
+| Coordination result | Stable re-entry code | Disposition and recovery |
+| --- | --- | --- |
+| transaction explicitly reports a pending operation | `stop-reentry-reconciliation-pending` | `reconciliation-pending`; prescribe `agent-session broker reconcile` |
+| transaction reports clean | `stop-reentry-terminal-exit` | `terminal-exit`; no recovery mutation |
+| transaction did not run | `stop-reentry-terminal-exit` | `terminal-exit`; no coordination-state or gate claim |
+| transaction result unavailable | `stop-reentry-terminal-exit` | `terminal-exit`; read-only `agent-session broker status`, with no retained-state or gate claim |
+
+Every original reason is retained and no degradation releases or alters claims,
+leases, operations, brokers, worktrees, or session state. A gate assertion is
+made only for a reported pending operation in effective enforce mode; advisory,
+off, skipped, and unavailable outcomes do not manufacture one.
 
 ## Release compatibility
 

--- a/crates/agent-hook/src/degradation.rs
+++ b/crates/agent-hook/src/degradation.rs
@@ -15,10 +15,11 @@
 //! * [`Lane::Mutation`] — tool admission. Unchanged: a fault that cannot be
 //!   proven still fails closed.
 //! * [`Lane::Terminal`] — the Stop family. A fault, or provider re-entry
-//!   metadata, produces one deterministic terminal result with durable
-//!   reconciliation-pending evidence. Claims, leases, and operations are
-//!   retained, so mutation stays gated until an external reconciliation runs.
+//!   metadata, produces one deterministic terminal result. Recovery is named
+//!   only when the observed coordination outcome requires it; unrelated Stop
+//!   blocks do not manufacture claim, operation, or gating assertions.
 
+use nils_common::coordination_projection::CoordinationMode;
 use nils_common::observation::Severity;
 
 use crate::error::HookError;
@@ -41,8 +42,29 @@ pub(crate) const CONVERSATION_DEGRADED: &str = "coordination-degraded-read-only"
 pub(crate) const STOP_RECONCILIATION_REQUIRED: &str = "coordination-stop-reconciliation-required";
 /// Stable classification for a terminal exit forced by provider Stop re-entry.
 pub(crate) const STOP_REENTRY_PENDING: &str = "stop-reentry-reconciliation-pending";
+/// Stable classification for a terminal exit whose coordination outcome is clean.
+pub(crate) const STOP_REENTRY_TERMINAL: &str = "stop-reentry-terminal-exit";
 /// Stable disposition recorded for a retained-lease terminal exit.
 const RECONCILIATION_PENDING: &str = "reconciliation-pending";
+/// Stable disposition for a re-entry exit that prescribes no recovery mutation.
+const TERMINAL_EXIT: &str = "terminal-exit";
+
+/// Typed result of the coordination stage that preceded Stop re-entry.
+///
+/// Keep this separate from normalized decision reasons: those strings are a
+/// presentation contract and cannot distinguish a skipped transaction from a
+/// clean one or an unavailable result from a reported pending operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StopCoordinationOutcome {
+    /// No coordination transaction ran for this evaluation.
+    NotRun,
+    /// The transaction ran and did not report a pending operation.
+    Clean { mode: Option<CoordinationMode> },
+    /// The transaction ran and explicitly reported a pending operation.
+    Pending { mode: Option<CoordinationMode> },
+    /// The transaction was selected but its result could not be observed.
+    Unavailable { mode: Option<CoordinationMode> },
+}
 
 /// Which interaction lane a provider event belongs to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -220,15 +242,16 @@ pub(crate) fn terminal_exit_for_error(
             },
             DecisionReason {
                 rule_id: DEGRADATION_RULE_ID.to_string(),
-                code: STOP_REENTRY_PENDING.to_string(),
+                code: STOP_REENTRY_TERMINAL.to_string(),
                 disposition: "warn".to_string(),
             },
         ],
         context: Some(format!(
             "agent-hook terminal exit: this Stop hook already re-entered and the hook could not \
-             complete ({}), so the turn ends with reconciliation pending. The claim and any \
-             active operation are retained and mutation stays gated. Next: {}.",
-            error.code, RECOVERY_BROKER_RECONCILE
+             complete ({}), so the turn ends without repeating the block. Coordination state \
+             was not observed, so no retained claim, active operation, gate, or recovery \
+             mutation is inferred. Next: {}.",
+            error.code, RECOVERY_BROKER_STATUS
         )),
         replacement: None,
         shadow: Vec::new(),
@@ -237,11 +260,11 @@ pub(crate) fn terminal_exit_for_error(
         recovery_applied: false,
         provider_output: None,
     };
-    Record::new("stop", STOP_REENTRY_PENDING, Severity::Warn)
+    Record::new("stop", STOP_REENTRY_TERMINAL, Severity::Warn)
         .provider(request.product, &request.event)
-        .disposition(RECONCILIATION_PENDING)
+        .disposition(TERMINAL_EXIT)
         .correlate(request.product, raw)
-        .recovery(RECOVERY_BROKER_RECONCILE)
+        .recovery(RECOVERY_BROKER_STATUS)
         .emit();
     Some(decision)
 }
@@ -251,14 +274,16 @@ pub(crate) fn terminal_exit_for_error(
 ///
 /// Re-entry proves the previous Stop block did not change anything the gate is
 /// waiting on, so blocking again cannot converge — it only consumes the
-/// provider's consecutive-block budget until the turn is force-terminated. The
-/// exit is not a release: every original reason is retained on the decision, the
-/// evidence is durable, and no claim, lease, or operation is touched, so mutation
-/// stays gated until an external reconciliation runs.
+/// provider's consecutive-block budget until the turn is force-terminated.
+/// Every original reason is retained and no coordination state is changed. A
+/// broker reconciliation is prescribed only when the typed coordination result
+/// explicitly reports a pending operation; clean, skipped, and unavailable
+/// outcomes do not manufacture a retained-state or mutation-gate claim.
 pub(crate) fn apply_stop_reentry(
     request: &NormalizedRequest,
     raw: &[u8],
     mut decision: NormalizedDecision,
+    coordination: StopCoordinationOutcome,
 ) -> NormalizedDecision {
     if decision.action != DecisionAction::Block
         || lane(&request.event) != Lane::Terminal
@@ -269,27 +294,99 @@ pub(crate) fn apply_stop_reentry(
     decision.action = DecisionAction::Warn;
     // A block-shaped provider payload would re-render the block we just resolved.
     decision.provider_output = None;
+    let reconciliation_pending = matches!(coordination, StopCoordinationOutcome::Pending { .. });
+    let reentry_code = if reconciliation_pending {
+        STOP_REENTRY_PENDING
+    } else {
+        STOP_REENTRY_TERMINAL
+    };
     decision.reasons.push(DecisionReason {
         rule_id: DEGRADATION_RULE_ID.to_string(),
-        code: STOP_REENTRY_PENDING.to_string(),
+        code: reentry_code.to_string(),
         disposition: "warn".to_string(),
     });
-    let context = format!(
-        "agent-hook terminal exit: this Stop hook already re-entered, so the turn ends with \
-         reconciliation pending. The claim and any active operation are retained and mutation \
-         stays gated. Next: {RECOVERY_BROKER_RECONCILE}."
-    );
+    let context = if reconciliation_pending {
+        format!(
+            "agent-hook terminal exit: this Stop hook already re-entered, so the turn ends with \
+             reconciliation pending as reported by the coordination transaction. This exit \
+             does not change coordination state. {} Next: {RECOVERY_BROKER_RECONCILE}.",
+            coordination_context(coordination)
+        )
+    } else {
+        format!(
+            "agent-hook terminal exit: this Stop hook already re-entered, so the turn ends \
+             without repeating the block. No recovery mutation is prescribed. {} The original \
+             Stop reason remains visible for the next turn.",
+            coordination_context(coordination)
+        )
+    };
     decision.context = Some(match decision.context.take() {
         Some(existing) => format!("{existing}\n{context}"),
         None => context,
     });
-    Record::new("stop", STOP_REENTRY_PENDING, Severity::Warn)
+    let record = Record::new("stop", reentry_code, Severity::Warn)
         .provider(request.product, &request.event)
-        .disposition(RECONCILIATION_PENDING)
-        .correlate(request.product, raw)
-        .recovery(RECOVERY_BROKER_RECONCILE)
-        .emit();
+        .disposition(if reconciliation_pending {
+            RECONCILIATION_PENDING
+        } else {
+            TERMINAL_EXIT
+        })
+        .correlate(request.product, raw);
+    match coordination {
+        StopCoordinationOutcome::Pending { .. } => {
+            record.recovery(RECOVERY_BROKER_RECONCILE).emit();
+        }
+        StopCoordinationOutcome::Unavailable { .. } => {
+            record.recovery(RECOVERY_BROKER_STATUS).emit();
+        }
+        StopCoordinationOutcome::NotRun | StopCoordinationOutcome::Clean { .. } => {
+            record.emit();
+        }
+    }
     decision
+}
+
+fn coordination_context(outcome: StopCoordinationOutcome) -> &'static str {
+    match outcome {
+        StopCoordinationOutcome::NotRun => {
+            "No coordination transaction ran, so no coordination-state or gate claim is made."
+        }
+        StopCoordinationOutcome::Clean {
+            mode: Some(CoordinationMode::Advisory),
+        } => {
+            "The clean transaction ran in advisory mode and reported no pending operation; no mutation gate is claimed."
+        }
+        StopCoordinationOutcome::Clean {
+            mode: Some(CoordinationMode::Off),
+        } => {
+            "The clean transaction ran with coordination off and reported no pending operation; no mutation gate is claimed."
+        }
+        StopCoordinationOutcome::Clean {
+            mode: Some(CoordinationMode::Enforce),
+        } => "The clean enforce-mode transaction reported no pending operation.",
+        StopCoordinationOutcome::Clean { mode: None } => {
+            "The transaction reported no pending operation, but no effective coordination mode was observed; no gate claim is made."
+        }
+        StopCoordinationOutcome::Pending {
+            mode: Some(CoordinationMode::Enforce),
+        } => "Enforce-mode mutation remains gated by the reported pending transaction.",
+        StopCoordinationOutcome::Pending {
+            mode: Some(CoordinationMode::Advisory),
+        } => {
+            "The advisory transaction reported a pending operation, but this message does not claim an enforce-mode mutation gate."
+        }
+        StopCoordinationOutcome::Pending {
+            mode: Some(CoordinationMode::Off),
+        } => {
+            "The transaction reported a pending operation while coordination was off, but this message does not claim a mutation gate."
+        }
+        StopCoordinationOutcome::Pending { mode: None } => {
+            "The transaction reported a pending operation, but no effective coordination mode was observed; no gate claim is made."
+        }
+        StopCoordinationOutcome::Unavailable { .. } => {
+            "The coordination result was unavailable, so no retained-state or gate claim is made; inspect agent-session broker status read-only."
+        }
+    }
 }
 
 #[cfg(test)]
@@ -390,11 +487,23 @@ mod tests {
     fn stop_reentry_only_resolves_a_block_on_the_terminal_lane() {
         // Not re-entering: the authoritative block stands.
         assert_eq!(
-            apply_stop_reentry(&request("Stop", Some(false)), b"{}", blocked("Stop")).action,
+            apply_stop_reentry(
+                &request("Stop", Some(false)),
+                b"{}",
+                blocked("Stop"),
+                StopCoordinationOutcome::Pending { mode: None },
+            )
+            .action,
             DecisionAction::Block
         );
         assert_eq!(
-            apply_stop_reentry(&request("Stop", None), b"{}", blocked("Stop")).action,
+            apply_stop_reentry(
+                &request("Stop", None),
+                b"{}",
+                blocked("Stop"),
+                StopCoordinationOutcome::Pending { mode: None },
+            )
+            .action,
             DecisionAction::Block
         );
         // Re-entry metadata on another lane must not resolve its block.
@@ -402,7 +511,8 @@ mod tests {
             apply_stop_reentry(
                 &request("PreToolUse", Some(true)),
                 b"{}",
-                blocked("PreToolUse")
+                blocked("PreToolUse"),
+                StopCoordinationOutcome::Pending { mode: None },
             )
             .action,
             DecisionAction::Block
@@ -411,7 +521,14 @@ mod tests {
 
     #[test]
     fn a_reentered_stop_terminates_while_retaining_its_original_evidence() {
-        let resolved = apply_stop_reentry(&request("Stop", Some(true)), b"{}", blocked("Stop"));
+        let resolved = apply_stop_reentry(
+            &request("Stop", Some(true)),
+            b"{}",
+            blocked("Stop"),
+            StopCoordinationOutcome::Pending {
+                mode: Some(CoordinationMode::Enforce),
+            },
+        );
 
         assert_eq!(resolved.action, DecisionAction::Warn);
         assert_eq!(
@@ -428,11 +545,46 @@ mod tests {
             "a block-shaped provider payload must not re-render the resolved block"
         );
         let context = resolved.context.expect("terminal context");
-        assert!(context.contains("retained"), "context={context}");
+        assert!(
+            context.contains("reported by the coordination transaction"),
+            "context={context}"
+        );
+        assert!(!context.contains("claim and any active operation"));
+        assert!(!context.contains("mutation stays gated"));
         assert!(
             context.contains(RECOVERY_BROKER_RECONCILE),
             "context={context}"
         );
+    }
+
+    #[test]
+    fn a_clean_advisory_reentry_prescribes_no_recovery_or_gate() {
+        let mut decision = blocked("Stop");
+        decision.reasons[0].rule_id = "runtime.stop-prerequisite".to_string();
+        decision.reasons.push(DecisionReason {
+            rule_id: "runtime.stop-coordination".to_string(),
+            code: "coordination-admitted".to_string(),
+            disposition: "allow".to_string(),
+        });
+
+        let resolved = apply_stop_reentry(
+            &request("Stop", Some(true)),
+            b"{}",
+            decision,
+            StopCoordinationOutcome::Clean {
+                mode: Some(CoordinationMode::Advisory),
+            },
+        );
+
+        assert_eq!(resolved.action, DecisionAction::Warn);
+        assert_eq!(
+            resolved.reasons.last().map(|reason| reason.code.as_str()),
+            Some(STOP_REENTRY_TERMINAL)
+        );
+        let context = resolved.context.expect("terminal context");
+        assert!(context.contains("advisory mode"), "{context}");
+        assert!(context.contains("recovery mutation"), "{context}");
+        assert!(!context.contains(RECOVERY_BROKER_RECONCILE));
     }
 
     #[test]

--- a/crates/agent-hook/src/evaluator.rs
+++ b/crates/agent-hook/src/evaluator.rs
@@ -13,6 +13,7 @@ use serde_json::Value;
 use crate::contract::{
     effective_mode_for_product, matcher_expression_matches, runtime_handler_filename,
 };
+use crate::degradation::StopCoordinationOutcome;
 use crate::error::HookError;
 use crate::liveness;
 use crate::model::{
@@ -49,6 +50,20 @@ struct RuleOutcome {
     context: Option<String>,
     replacement: Option<Value>,
     provider_output: Option<Value>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CoordinationHandlerStatus {
+    NotRun,
+    Clean,
+    Pending,
+    Unavailable,
+}
+
+#[derive(Debug)]
+struct CoordinationHandlerOutcome {
+    outcome: RuleOutcome,
+    status: CoordinationHandlerStatus,
 }
 
 #[derive(Debug)]
@@ -626,10 +641,10 @@ pub(crate) fn terminal_activity_failure_decision(
 
 /// Degrade an unavailable coordination transaction on the terminal Stop lane.
 ///
-/// This is a liveness boundary, not a release: nothing about the claim, lease,
-/// operation, broker, worktree, or session state changes, so the retained
-/// uncertainty stays visible for typed external reconciliation after the provider
-/// runner exits.
+/// This is a liveness boundary, not a release. Because the transaction did not
+/// return an observed state, the diagnostic must not claim a retained operation
+/// or an effective mutation gate. It names the read-only status lane and leaves
+/// all coordination state untouched.
 fn terminal_coordination_failure_outcome(
     request: &NormalizedRequest,
     raw: &[u8],
@@ -643,18 +658,18 @@ fn terminal_coordination_failure_outcome(
         crate::observe::Severity::Warn,
     )
     .provider(request.product, &request.event)
-    .disposition("reconciliation-pending")
+    .disposition("warn")
     .correlate(request.product, raw)
-    .recovery(crate::observe::RECOVERY_BROKER_RECONCILE)
+    .recovery(crate::observe::RECOVERY_BROKER_STATUS)
     .emit();
     Some(RuleOutcome {
         action: DecisionAction::Warn,
         code: crate::degradation::STOP_RECONCILIATION_REQUIRED.to_string(),
         context: Some(format!(
             "agent-hook terminal degradation: the session coordination transaction is \
-             unavailable, so the turn may end with reconciliation pending. The claim and any \
-             active operation are retained and mutation stays gated. Next: {}.",
-            crate::observe::RECOVERY_BROKER_RECONCILE
+             unavailable, so the turn may end without inferring a retained claim, active \
+             operation, or mutation gate. Coordination state is unchanged. Next: {}.",
+            crate::observe::RECOVERY_BROKER_STATUS
         )),
         replacement: None,
         provider_output: None,
@@ -670,10 +685,20 @@ pub fn apply_session_coordination(
     execution: CoordinationExecution,
 ) -> Result<NormalizedDecision, HookError> {
     let Some(rule) = rule else {
-        return Ok(decision);
+        return Ok(crate::degradation::apply_stop_reentry(
+            request,
+            raw,
+            decision,
+            StopCoordinationOutcome::NotRun,
+        ));
     };
     if execution.unmanaged {
-        return Ok(decision);
+        return Ok(crate::degradation::apply_stop_reentry(
+            request,
+            raw,
+            decision,
+            StopCoordinationOutcome::NotRun,
+        ));
     }
     let typed_bootstrap_may_supersede_owner =
         exact_bootstrap_candidate_for_session_coordination(request, raw, true)
@@ -685,34 +710,61 @@ pub fn apply_session_coordination(
         )
         && !typed_bootstrap_may_supersede_owner
     {
-        return Ok(decision);
+        return Ok(crate::degradation::apply_stop_reentry(
+            request,
+            raw,
+            decision,
+            StopCoordinationOutcome::NotRun,
+        ));
     }
     let Capability::SessionCoordination { reason_code } = &rule.capability else {
         unreachable!("prepared coordination rule has the typed capability")
     };
-    let outcome = match run_session_coordination(request.product, raw) {
-        Ok(mut outcome) => {
-            if outcome.code == SESSION_COORDINATION_HANDLER {
-                outcome.code.clone_from(reason_code);
+    let (outcome, coordination_outcome) = match run_session_coordination(request.product, raw) {
+        Ok(mut handler) => {
+            if handler.outcome.code == SESSION_COORDINATION_HANDLER {
+                handler.outcome.code.clone_from(reason_code);
             }
-            outcome
+            let status = match handler.status {
+                CoordinationHandlerStatus::NotRun => StopCoordinationOutcome::NotRun,
+                CoordinationHandlerStatus::Clean => StopCoordinationOutcome::Clean {
+                    mode: execution.mode,
+                },
+                CoordinationHandlerStatus::Pending => StopCoordinationOutcome::Pending {
+                    mode: execution.mode,
+                },
+                CoordinationHandlerStatus::Unavailable => StopCoordinationOutcome::Unavailable {
+                    mode: execution.mode,
+                },
+            };
+            (handler.outcome, status)
         }
-        Err(error) if error.code == "capability-timeout" => coordination_timeout_outcome(
-            loaded,
-            request,
-            rule,
-            execution.mode,
-            execution.operation_effect,
-            raw,
+        Err(error) if error.code == "capability-timeout" => (
+            coordination_timeout_outcome(
+                loaded,
+                request,
+                rule,
+                execution.mode,
+                execution.operation_effect,
+                raw,
+            ),
+            StopCoordinationOutcome::Unavailable {
+                mode: execution.mode,
+            },
         ),
         // The activity capability already degrades a failed terminal observation
         // rather than denying provider termination. The coordination transaction
         // needed the same terminal boundary: without it the very first Stop
         // delivery deadlocks, before provider re-entry metadata can help.
-        Err(_) => match terminal_coordination_failure_outcome(request, raw) {
-            Some(outcome) => outcome,
-            None => failure_outcome(rule.failure_posture, &rule.id),
-        },
+        Err(_) => (
+            match terminal_coordination_failure_outcome(request, raw) {
+                Some(outcome) => outcome,
+                None => failure_outcome(rule.failure_posture, &rule.id),
+            },
+            StopCoordinationOutcome::Unavailable {
+                mode: execution.mode,
+            },
+        ),
     };
     if typed_bootstrap_may_supersede_owner
         && outcome.action == DecisionAction::Allow
@@ -721,7 +773,12 @@ pub fn apply_session_coordination(
         supersede_owner_active_foreign(loaded, &mut decision);
     }
     merge_coordination_outcome(&mut decision, &rule.id, outcome)?;
-    Ok(decision)
+    Ok(crate::degradation::apply_stop_reentry(
+        request,
+        raw,
+        decision,
+        coordination_outcome,
+    ))
 }
 
 fn owner_active_foreign_is_only_block(
@@ -1212,7 +1269,10 @@ fn run_runtime_handler(
     handler_outcome(handler_id, &output.stdout)
 }
 
-fn run_session_coordination(product: Product, raw: &[u8]) -> Result<RuleOutcome, HookError> {
+fn run_session_coordination(
+    product: Product,
+    raw: &[u8],
+) -> Result<CoordinationHandlerOutcome, HookError> {
     let path = runtime_hook_root(product)?.join(SESSION_COORDINATION_HANDLER);
     validate_handler(&path)?;
     let mut command = Command::new(&path);
@@ -1250,18 +1310,77 @@ struct TypedBootstrapAuthorization {
     authorization: String,
 }
 
-fn session_coordination_outcome(stdout: &[u8]) -> Result<RuleOutcome, HookError> {
+const SESSION_COORDINATION_RESULT_SCHEMA: &str = "runtime-kit.session-coordination-result.v1";
+
+#[derive(Clone, Copy, Debug, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum TypedCoordinationStatus {
+    NotRun,
+    Clean,
+    Pending,
+    Unavailable,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TypedSessionCoordinationResult {
+    schema_version: String,
+    status: TypedCoordinationStatus,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default, rename = "decision")]
+    _legacy_decision: Option<String>,
+    #[serde(default, rename = "reason")]
+    _legacy_reason: Option<String>,
+}
+
+fn session_coordination_outcome(stdout: &[u8]) -> Result<CoordinationHandlerOutcome, HookError> {
     if let Ok(value) = crate::strict_json::from_slice(stdout)
         && let Ok(authorization) = serde_json::from_value::<TypedBootstrapAuthorization>(value)
         && authorization.schema_version == TYPED_BOOTSTRAP_AUTHORIZATION_SCHEMA
         && authorization.authorization == TYPED_BOOTSTRAP_AUTHORIZATION_CODE
     {
-        return Ok(simple(
-            DecisionAction::Allow,
-            TYPED_BOOTSTRAP_AUTHORIZATION_CODE,
-        ));
+        return Ok(CoordinationHandlerOutcome {
+            outcome: simple(DecisionAction::Allow, TYPED_BOOTSTRAP_AUTHORIZATION_CODE),
+            status: CoordinationHandlerStatus::Clean,
+        });
     }
-    handler_outcome(SESSION_COORDINATION_HANDLER, stdout)
+    if let Ok(value) = crate::strict_json::from_slice(stdout)
+        && let Ok(result) = serde_json::from_value::<TypedSessionCoordinationResult>(value)
+        && result.schema_version == SESSION_COORDINATION_RESULT_SCHEMA
+    {
+        let (action, status) = match result.status {
+            TypedCoordinationStatus::NotRun => {
+                (DecisionAction::Allow, CoordinationHandlerStatus::NotRun)
+            }
+            TypedCoordinationStatus::Clean => {
+                (DecisionAction::Allow, CoordinationHandlerStatus::Clean)
+            }
+            TypedCoordinationStatus::Pending => {
+                (DecisionAction::Block, CoordinationHandlerStatus::Pending)
+            }
+            TypedCoordinationStatus::Unavailable => {
+                (DecisionAction::Warn, CoordinationHandlerStatus::Unavailable)
+            }
+        };
+        return Ok(CoordinationHandlerOutcome {
+            outcome: RuleOutcome {
+                action,
+                code: SESSION_COORDINATION_HANDLER.to_string(),
+                context: result.message,
+                replacement: None,
+                provider_output: None,
+            },
+            status,
+        });
+    }
+    Ok(CoordinationHandlerOutcome {
+        outcome: handler_outcome(SESSION_COORDINATION_HANDLER, stdout)?,
+        // Untyped provider payloads do not attest coordination state. They keep
+        // their ordinary admission action, but re-entry diagnostics must not
+        // reinterpret that action as clean or pending broker truth.
+        status: CoordinationHandlerStatus::Unavailable,
+    })
 }
 
 fn handler_outcome(handler_id: &str, stdout: &[u8]) -> Result<RuleOutcome, HookError> {

--- a/crates/agent-hook/src/lib.rs
+++ b/crates/agent-hook/src/lib.rs
@@ -397,7 +397,6 @@ fn run_dispatch(
                     );
                 }
             };
-            let decision = degradation::apply_stop_reentry(&request, &raw, decision);
             return complete_dispatch(args.format, started, &request, &decision);
         }
         Err(error) => {
@@ -486,7 +485,6 @@ fn run_dispatch(
             );
         }
     };
-    let decision = degradation::apply_stop_reentry(&request, &raw, decision);
     if args.trace
         && let Err(error) = trace::append(
             &layout.state_root,

--- a/crates/agent-hook/tests/degraded_liveness.rs
+++ b/crates/agent-hook/tests/degraded_liveness.rs
@@ -8,8 +8,8 @@
 //!    read-only lane while arbitrary mutation stays fail-closed.
 //! 2. `Stop` kept re-entering the same failing gate until the provider's
 //!    consecutive-block cap force-terminated the turn. Provider re-entry
-//!    metadata has to produce one deterministic terminal result that still
-//!    retains the claim/lease for external reconciliation.
+//!    metadata has to produce one deterministic terminal result without
+//!    inventing claim, lease, or gate state that coordination did not report.
 //! 3. A capability that exited before draining its stdin was scored as a failed
 //!    capability, so a `closed` plus `locked` rule denied at random depending on
 //!    machine load (`sympoies/nils-cli#1420`). Whether a child read its input is
@@ -68,6 +68,32 @@ override_class = "locked"
 capability = { id = "agent-session.coordination.v1", reason_code = "coordination-admitted" }
 "#;
 
+/// A non-coordination Stop gate paired with a clean coordination transaction.
+const CLEAN_STOP_REENTRY_POLICY: &str = r#"schema_version = "agent-hook.policy.v1"
+bundle_id = "runtime-kit"
+version = "2026.07.20.1"
+
+[[rules]]
+id = "runtime.stop-prerequisite"
+products = ["codex", "claude"]
+events = ["Stop"]
+priority = 10
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = { id = "decision.block.v1", reason_code = "validation-outstanding", message = "validation remains outstanding" }
+
+[[rules]]
+id = "runtime.stop-coordination"
+products = ["codex", "claude"]
+events = ["Stop"]
+priority = 20
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = { id = "agent-session.coordination.v1", reason_code = "coordination-admitted" }
+"#;
+
 fn break_coordination_registry(fixture: &Fixture) {
     let coordination = fixture.session_state.join("coordination");
     fs::create_dir_all(&coordination).expect("coordination directory");
@@ -83,6 +109,24 @@ fn managed_env<'a>() -> [(&'a str, &'a str); 2] {
         ("AGENT_SESSION_ID", "managed-session"),
         ("AGENT_SESSION_RUNTIME_ID", "managed-runtime"),
     ]
+}
+
+fn install_session_mode(fixture: &Fixture, mode: &str) {
+    let session = fixture.session_state.join("sessions/managed-session");
+    fs::create_dir_all(&session).expect("session directory");
+    let record = session.join("session.json");
+    fs::write(
+        &record,
+        serde_json::to_vec(&json!({
+            "schema_version": "agent-session.session.v1",
+            "id": "managed-session",
+            "coordination_mode": mode,
+            "runtime": {"launch_id": "managed-runtime"}
+        }))
+        .expect("session JSON"),
+    )
+    .expect("session record");
+    Fixture::set_private(&record);
 }
 
 fn reason_codes(decision: &Value) -> Vec<String> {
@@ -239,7 +283,8 @@ fn degraded_prompt_records_one_replayable_turn_boundary() {
 
 /// Stop re-entry is the loop. The provider tells us it is already inside a Stop
 /// hook; blocking again cannot change the outcome and only burns the provider's
-/// consecutive-block budget. The turn must end while the claim/lease stays held.
+/// consecutive-block budget. The turn must end while retaining only the state
+/// that the coordination transaction actually reported.
 #[test]
 fn stop_reentry_reaches_a_deterministic_terminal_result() {
     let fixture = Fixture::new(STOP_COORDINATION_POLICY);
@@ -251,7 +296,7 @@ fn stop_reentry_reaches_a_deterministic_terminal_result() {
         let handler = directory.join("session-coordination-guard.py");
         fs::write(
             &handler,
-            "#!/bin/sh\nset -eu\nprintf '%s\\n' '{\"decision\":\"block\",\"reason\":\"operation-uncertain\"}'\n",
+            "#!/bin/sh\nset -eu\nprintf '%s\\n' '{\"schema_version\":\"runtime-kit.session-coordination-result.v1\",\"status\":\"pending\",\"message\":\"operation-uncertain\",\"decision\":\"block\",\"reason\":\"operation-uncertain\"}'\n",
         )
         .expect("coordination handler");
         fs::set_permissions(&handler, fs::Permissions::from_mode(0o700)).expect("handler mode");
@@ -331,6 +376,133 @@ fn stop_reentry_reaches_a_deterministic_terminal_result() {
     }
 }
 
+#[test]
+fn clean_coordination_stop_reentry_does_not_prescribe_recovery() {
+    for (mode, expected_context) in [
+        ("advisory", "clean transaction ran in advisory mode"),
+        ("off", "clean transaction ran with coordination off"),
+        ("enforce", "clean enforce-mode transaction"),
+    ] {
+        let fixture = Fixture::new(CLEAN_STOP_REENTRY_POLICY);
+        install_session_mode(&fixture, mode);
+        let hooks = fixture.home.join(".claude/hooks");
+        fs::create_dir_all(&hooks).expect("claude hook directory");
+        let handler = hooks.join("session-coordination-guard.py");
+        fs::write(
+            &handler,
+            "#!/bin/sh\nset -eu\nprintf '%s\\n' '{\"schema_version\":\"runtime-kit.session-coordination-result.v1\",\"status\":\"clean\"}'\n",
+        )
+        .expect("coordination handler");
+        fs::set_permissions(&handler, fs::Permissions::from_mode(0o700)).expect("handler mode");
+        let envs = [
+            ("AGENT_SESSION_ID", "managed-session"),
+            ("AGENT_SESSION_RUNTIME_ID", "managed-runtime"),
+            ("AGENT_SESSION_COORDINATION_MODE", mode),
+        ];
+
+        let decision = fixture.run_with_env(
+            &["dispatch", "--product", "claude", "--format", "json"],
+            Some(r#"{"hook_event_name":"Stop","stop_hook_active":true}"#),
+            &envs,
+        );
+        assert_eq!(
+            decision.code,
+            0,
+            "mode={mode} stderr={}",
+            decision.stderr_text()
+        );
+        let decision = decision.stdout_json();
+        assert_eq!(decision["data"]["action"], "warn", "mode={mode} {decision}");
+        let codes = reason_codes(&decision);
+        assert!(
+            codes.contains(&"stop-reentry-terminal-exit".to_string()),
+            "mode={mode} clean coordination needs the terminal classification: {decision}"
+        );
+        assert!(
+            !codes.contains(&"stop-reentry-reconciliation-pending".to_string()),
+            "mode={mode} clean coordination must not claim reconciliation is pending: {decision}"
+        );
+        let context = decision["data"]["context"].as_str().unwrap_or_default();
+        assert!(context.contains(expected_context), "mode={mode} {context}");
+        assert!(
+            !context.contains("broker reconcile"),
+            "mode={mode} {context}"
+        );
+        assert!(
+            !context.contains("claim and any active operation"),
+            "mode={mode} {context}"
+        );
+        assert!(
+            !context.contains("mutation stays gated"),
+            "mode={mode} {context}"
+        );
+
+        let spool = fixture.session_state.join("observation/spool");
+        let mut body = String::new();
+        for entry in fs::read_dir(&spool).expect("spool entries") {
+            body.push_str(&fs::read_to_string(entry.expect("entry").path()).expect("segment"));
+        }
+        let terminal: Vec<Value> = body
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| serde_json::from_str::<Value>(line).expect("event JSON"))
+            .filter(|event| event["code"] == "stop-reentry-terminal-exit")
+            .collect();
+        assert_eq!(
+            terminal.len(),
+            1,
+            "mode={mode} terminal evidence: {terminal:?}"
+        );
+        assert_eq!(terminal[0]["severity"], "warn", "mode={mode}");
+        assert_eq!(terminal[0]["disposition"], "terminal-exit", "mode={mode}");
+        assert!(
+            terminal[0]["recovery_action"].is_null(),
+            "mode={mode} clean exit must not prescribe recovery: {}",
+            terminal[0]
+        );
+    }
+}
+
+#[test]
+fn untyped_coordination_output_does_not_claim_pending_broker_state() {
+    let fixture = Fixture::new(CLEAN_STOP_REENTRY_POLICY);
+    install_session_mode(&fixture, "enforce");
+    let hooks = fixture.home.join(".claude/hooks");
+    fs::create_dir_all(&hooks).expect("claude hook directory");
+    let handler = hooks.join("session-coordination-guard.py");
+    fs::write(
+        &handler,
+        "#!/bin/sh\nset -eu\nprintf '%s\\n' '{\"decision\":\"block\",\"reason\":\"arbitrary untyped block\"}'\n",
+    )
+    .expect("untyped coordination handler");
+    fs::set_permissions(&handler, fs::Permissions::from_mode(0o700)).expect("handler mode");
+    let envs = [
+        ("AGENT_SESSION_ID", "managed-session"),
+        ("AGENT_SESSION_RUNTIME_ID", "managed-runtime"),
+        ("AGENT_SESSION_COORDINATION_MODE", "enforce"),
+    ];
+
+    let decision = fixture.run_with_env(
+        &["dispatch", "--product", "claude", "--format", "json"],
+        Some(r#"{"hook_event_name":"Stop","stop_hook_active":true}"#),
+        &envs,
+    );
+    assert_eq!(decision.code, 0, "stderr={}", decision.stderr_text());
+    let decision = decision.stdout_json();
+    let codes = reason_codes(&decision);
+    assert!(
+        codes.contains(&"stop-reentry-terminal-exit".to_string()),
+        "{decision}"
+    );
+    assert!(
+        !codes.contains(&"stop-reentry-reconciliation-pending".to_string()),
+        "untyped provider output is not pending-state proof: {decision}"
+    );
+    let context = decision["data"]["context"].as_str().unwrap_or_default();
+    assert!(context.contains("broker status"), "{context}");
+    assert!(!context.contains("broker reconcile"), "{context}");
+}
+
 /// The liveness rule cannot depend on recognizing the fault. Once the provider
 /// reports Stop re-entry, a stage that fails outright must still terminate rather
 /// than render another denial the gate cannot converge on.
@@ -374,9 +546,12 @@ fn stop_reentry_terminates_even_for_an_unclassified_stage_failure() {
     assert_eq!(decision["data"]["action"], "warn", "{decision}");
     let codes = reason_codes(&decision);
     assert!(
-        codes.contains(&"stop-reentry-reconciliation-pending".to_string()),
+        codes.contains(&"stop-reentry-terminal-exit".to_string()),
         "{decision}"
     );
+    let context = decision["data"]["context"].as_str().unwrap_or_default();
+    assert!(context.contains("broker status"), "{context}");
+    assert!(!context.contains("broker reconcile"), "{context}");
     assert_eq!(
         codes.len(),
         2,
@@ -425,6 +600,16 @@ fn coordination_failure_on_stop_degrades_instead_of_deadlocking() {
             reason_codes(&decision)
                 .contains(&"coordination-stop-reconciliation-required".to_string()),
             "{product} missing the coordination Stop degradation: {decision}"
+        );
+        let context = decision["data"]["context"].as_str().unwrap_or_default();
+        assert!(context.contains("broker status"), "{product}: {context}");
+        assert!(
+            !context.contains("broker reconcile"),
+            "{product}: {context}"
+        );
+        assert!(
+            !context.contains("mutation stays gated"),
+            "{product}: {context}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Teach `agent-hook` Stop re-entry to consume the runtime kit's typed coordination result and distinguish clean, pending, unavailable, and not-run outcomes, so diagnostics and recovery advice reflect observed broker state.

## Problem

- Expected: reconciliation is prescribed only when the coordination broker reports an actual pending transaction.
- Actual: the degradation path inferred a retained claim, active operation, mutation gate, and reconcile action from any relevant Stop block.
- Impact: clean or unrelated Stop failures produced authoritative but false recovery instructions, obscuring the real cause and risking repeated no-op recovery attempts.

## Reproduction

1. Re-enter Stop with a clean coordination handler outcome.
2. Observe the baseline `stop-reentry-reconciliation-pending` diagnosis and broker reconcile action despite no pending transaction.
3. Repeat with an untyped unrelated block and observe the same manufactured broker-state claims.

## Issues Found

Refs sympoies/agent-runtime-kit#27

## Fix Approach

- Parse `runtime-kit.session-coordination-result.v1` independently from generic provider action fields.
- Carry typed `NotRun`, `Clean`, `Pending`, and `Unavailable` outcomes into degradation.
- Apply Stop re-entry reconciliation only for typed pending state; make clean/not-run terminal without recovery and unavailable explicit without inventing state.
- Preserve effective advisory/off/enforce mode in the user-facing diagnosis.

## Test-First Evidence

- Baseline regression: a clean broker outcome emitted reconciliation-pending, retained-operation, mutation-gated, and reconcile claims.
- Added clean, typed-pending, untyped, unavailable, and mode-aware unit/integration coverage.
- Durable evidence: `$HOME/.local/state/agent-runtime-kit/out/projects/sympoies__nils-cli/20260804-111911-issue-27-test-first` (verified complete).

## Test plan

- `cargo test -p nils-agent-hook --test degraded_liveness` — 9 passed.
- `bash .agents/scripts/pre-pr.sh` — formatting, Clippy, 190 nextest tests, and doc tests passed.

## Risk / Notes

- Medium compatibility risk at the hook protocol boundary. Untyped output degrades to unavailable instead of being treated as clean or pending, and the runtime producer keeps legacy block fields for genuine pending results during rollout.
