### PR TITLE
fix(release): verify the tap formula instead of the dispatch ack

### DIFF
--- a/.agents/skills/project-bump-version-tag-release/SKILL.md
+++ b/.agents/skills/project-bump-version-tag-release/SKILL.md
@@ -79,6 +79,7 @@ Inputs:
   - `NILS_CLI_HOMEBREW_TAP_REPO` (env var; tap repo slug)
   - `NILS_CLI_RELEASE_WAIT_SECONDS` (env var; max seconds to wait for source `release.yml`, default 1200)
   - `NILS_CLI_TAP_WAIT_SECONDS` (env var; max seconds to wait for tap formula update, default 1200)
+  - `NILS_CLI_TAP_POLL_SECONDS` (env var; seconds between tap formula polls, default 15)
 
 Default delivery mode (PR-based):
 
@@ -96,8 +97,12 @@ Default delivery mode (PR-based):
   commit, and pushes the tag to trigger `release.yml`. The tag gate reuses the unique trusted
   merged PR's exact-SHA CI when available and otherwise falls back to polling checks on that SHA.
 - The tap stage waits for the source release workflow to finish, then waits for
-  the dispatched `sympoies/homebrew-tap` formula-update workflow to finish before
-  performing the local Homebrew install / upgrade check.
+  `sympoies/homebrew-tap` to publish the target version before performing the
+  local Homebrew install / upgrade check. The wait clears on the version read
+  from `Formula/<formula>.rb` at the tap's default branch — not on any tap run's
+  own conclusion, which is only evidence that a run happened and exists at all
+  only when the dispatch worked. Tap run telemetry is still polled, but solely
+  to report progress and to fail fast on a red run.
 
 Use `--direct-push` to opt out and reuse the legacy "commit + tag directly on the current
 branch" path. Use `--skip-push` to keep everything local without opening a PR (also implies

--- a/.agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh
+++ b/.agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh
@@ -510,7 +510,16 @@ tap_name_from_repo_slug() {
 # produce: it is independent of which event started the tap workflow, of how
 # that run is named, and of whether the dispatch that was supposed to start it
 # did anything at all. Prints the bare version (e.g. 1.26.2); non-zero when the
-# formula cannot be read or carries no recognizable release URL.
+# formula cannot be read, carries no recognizable release URL, or is not
+# coherently at one version.
+#
+# Every platform URL must agree. The formula carries one per target (macOS and
+# Linux, arm64 and x86_64), and reading only the first would let a partially
+# updated formula satisfy the gate while brew on the remaining platforms still
+# resolves the old build. A mixed formula is reported as unpublished rather than
+# as whichever version happens to appear first: this gate exists so the release
+# stops assuming the tap produced a consistent artifact, and picking one of four
+# URLs would reimport a smaller form of that assumption.
 read_tap_formula_version() {
   local tap_repo="$1"
   local tap_formula="$2"
@@ -523,10 +532,12 @@ read_tap_formula_version() {
 import re
 import sys
 
-match = re.search(r"/releases/download/v([0-9]+\.[0-9]+\.[0-9]+)/", sys.argv[1])
-if not match:
+versions = set(
+    re.findall(r"/releases/download/v([0-9]+\.[0-9]+\.[0-9]+)/", sys.argv[1])
+)
+if len(versions) != 1:
     sys.exit(1)
-print(match.group(1))
+print(versions.pop())
 PY
 }
 

--- a/.agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh
+++ b/.agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh
@@ -505,39 +505,84 @@ tap_name_from_repo_slug() {
   echo "${owner}/${name}"
 }
 
+# Read the version currently published in the tap's formula at its default
+# branch. This is the one fact in the release path that only the tap can
+# produce: it is independent of which event started the tap workflow, of how
+# that run is named, and of whether the dispatch that was supposed to start it
+# did anything at all. Prints the bare version (e.g. 1.26.2); non-zero when the
+# formula cannot be read or carries no recognizable release URL.
+read_tap_formula_version() {
+  local tap_repo="$1"
+  local tap_formula="$2"
+  local formula_raw
+
+  formula_raw="$(gh api "repos/${tap_repo}/contents/Formula/${tap_formula}.rb" \
+    -H "Accept: application/vnd.github.raw" 2>/dev/null)" || return 1
+
+  python3 - "$formula_raw" <<'PY'
+import re
+import sys
+
+match = re.search(r"/releases/download/v([0-9]+\.[0-9]+\.[0-9]+)/", sys.argv[1])
+if not match:
+    sys.exit(1)
+print(match.group(1))
+PY
+}
+
+# Wait for the tap to actually publish <version>.
+#
+# The gate is the formula at tap main, never the tap run. A run is sender-side
+# evidence twice over: it only exists when the dispatch worked, and it is
+# matched by a human-facing `run-name` whose shape differs per trigger path
+# (`repository_dispatch` renders the v-prefixed tag, `workflow_dispatch` the
+# bare version). Run telemetry is still read, but only to report progress and to
+# fail fast on a red run — it can never stand in for the published artifact.
 wait_for_homebrew_tap_update() {
   local tap_repo="$1"
   local version="$2"
-  local tag="v${version}"
   local max_seconds="${3:-1200}"
+  local tap_formula="${4:-nils-cli}"
+  local tag="v${version}"
   local workflow="${NILS_CLI_TAP_UPDATE_WORKFLOW:-update-nils-cli-formula.yml}"
+  local poll_seconds="${NILS_CLI_TAP_POLL_SECONDS:-15}"
 
   command -v gh >/dev/null 2>&1 || die "gh is required to wait for ${tap_repo} formula update"
 
   local deadline=$((SECONDS + max_seconds))
   local run_id="" status="" conclusion="" url="" title=""
   local failed_run_seen="" failed_run_seen_count=0
+  local published=""
 
   while (( SECONDS < deadline )); do
+    # 1) Receiver-side gate: has the formula itself moved to the target version?
+    published="$(read_tap_formula_version "$tap_repo" "$tap_formula" || true)"
+    if [[ "$published" == "$version" ]]; then
+      note "${tap_repo} Formula/${tap_formula}.rb is published at ${version}"
+      return 0
+    fi
+
+    # 2) Run telemetry: progress reporting and fail-fast only. Matched on the
+    #    bare version so both trigger paths' run-name shapes are recognized.
     local runs_json
     runs_json="$(gh -R "$tap_repo" run list --workflow "$workflow" --limit 30 \
       --json databaseId,status,conclusion,url,displayTitle,event,createdAt 2>/dev/null)" \
-      || { sleep 10; continue; }
+      || { sleep "$poll_seconds"; continue; }
 
     local match
     match="$(
-      python3 - "$tag" "$runs_json" <<'PY'
+      python3 - "$version" "$runs_json" <<'PY'
 from __future__ import annotations
 
 import json
 import sys
 
-tag = sys.argv[1]
+version = sys.argv[1]
 runs = json.loads(sys.argv[2])
 matches = []
 for run in runs:
     title = run.get("displayTitle") or ""
-    if tag in title:
+    if version in title:
         matches.append(run)
 if matches:
     matches.sort(key=lambda run: (run.get("createdAt") or "", run.get("databaseId") or 0), reverse=True)
@@ -553,8 +598,8 @@ PY
     )"
 
     if [[ -z "$match" ]]; then
-      note "waiting for ${tap_repo} ${workflow} run for ${tag}"
-      sleep 15
+      note "waiting for ${tap_repo} to publish ${tap_formula} ${version} (no ${workflow} run for ${tag} yet; formula at ${published:-unknown})"
+      sleep "$poll_seconds"
       continue
     fi
 
@@ -564,12 +609,7 @@ PY
     url="$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['url'] or '')" "$match")"
     title="$(python3 -c "import json,sys;print(json.loads(sys.argv[1])['title'] or '')" "$match")"
 
-    if [[ "$status" == "completed" ]]; then
-      if [[ "$conclusion" == "success" ]]; then
-        note "${tap_repo} ${workflow} run ${run_id} completed: ${url}"
-        return 0
-      fi
-
+    if [[ "$status" == "completed" ]] && [[ "$conclusion" != "success" ]]; then
       local failed_key="${run_id}:${conclusion}"
       if [[ "$failed_run_seen" == "$failed_key" ]]; then
         failed_run_seen_count=$((failed_run_seen_count + 1))
@@ -579,21 +619,21 @@ PY
       fi
 
       if (( failed_run_seen_count >= 3 )); then
-        die "${tap_repo} ${workflow} run ${run_id} ended with conclusion='${conclusion}': ${url}"
+        die "${tap_repo} ${workflow} run ${run_id} ended with conclusion='${conclusion}' and Formula/${tap_formula}.rb is still at ${published:-unknown}: ${url}"
       fi
 
       warn "${tap_repo} ${workflow} latest matching run ${run_id} ended with conclusion='${conclusion}'; waiting for a retry run: ${url}"
-      sleep 20
+      sleep "$poll_seconds"
       continue
     fi
 
     failed_run_seen=""
     failed_run_seen_count=0
-    note "waiting for ${tap_repo} ${workflow} run ${run_id} (${status:-pending}, ${title}): ${url}"
-    sleep 20
+    note "waiting for ${tap_repo} ${workflow} run ${run_id} (${status:-pending}, ${title}) to publish ${version}; formula at ${published:-unknown}: ${url}"
+    sleep "$poll_seconds"
   done
 
-  die "timed out after ${max_seconds}s waiting for ${workflow} on ${tap_repo} for ${tag}"
+  die "timed out after ${max_seconds}s waiting for ${tap_repo} to publish ${tap_formula} ${version}; Formula/${tap_formula}.rb at ${tap_repo} default branch is still at ${published:-unknown}"
 }
 
 refresh_local_tap_dir_if_present() {
@@ -1145,7 +1185,7 @@ if [[ "$from_tap" -eq 1 ]]; then
 
   tap_repo_slug="$(resolve_tap_repo_slug "$tap_repo_arg")"
   if [[ "$skip_tap_wait" -eq 0 ]]; then
-    wait_for_homebrew_tap_update "$tap_repo_slug" "$version" "${NILS_CLI_TAP_WAIT_SECONDS:-1200}"
+    wait_for_homebrew_tap_update "$tap_repo_slug" "$version" "${NILS_CLI_TAP_WAIT_SECONDS:-1200}" "$tap_formula"
   else
     note "--skip-tap-wait set; not waiting for ${tap_repo_slug} formula update"
   fi
@@ -1557,7 +1597,7 @@ wait_for_release_run "$source_repo_slug" "release.yml" "$tag" "${NILS_CLI_RELEAS
 
 tap_repo_slug="$(resolve_tap_repo_slug "$tap_repo_arg")"
 if [[ "$skip_tap_wait" -eq 0 ]]; then
-  wait_for_homebrew_tap_update "$tap_repo_slug" "$version" "${NILS_CLI_TAP_WAIT_SECONDS:-1200}"
+  wait_for_homebrew_tap_update "$tap_repo_slug" "$version" "${NILS_CLI_TAP_WAIT_SECONDS:-1200}" "$tap_formula"
 else
   note "--skip-tap-wait set; not waiting for ${tap_repo_slug} formula update"
 fi

--- a/.agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh
+++ b/.agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh
@@ -251,6 +251,14 @@ EOF
 #                            `workflow_dispatch` renders the bare version.
 #   MOCK_TAP_FORMULA_VERSION version actually published in Formula/nils-cli.rb at
 #                            tap main — the only fact the tap alone can produce.
+#   MOCK_TAP_FORMULA_VERSION_LINUX
+#                            optional; version for the Linux URLs, so a formula
+#                            whose platform URLs disagree can be modelled.
+#                            Defaults to MOCK_TAP_FORMULA_VERSION.
+#   MOCK_TAP_FORMULA_UNREADABLE
+#                            when set, the formula read fails, as it would for a
+#                            bad repo slug, a renamed formula, or a token without
+#                            read access.
 create_mock_gh_tap_state() {
   local bin_dir="$1"
   cat > "${bin_dir}/gh" <<'EOF'
@@ -277,11 +285,28 @@ JSON
 fi
 
 if [[ "$*" == *"contents/Formula/"* ]]; then
+  if [[ -n "${MOCK_TAP_FORMULA_UNREADABLE:-}" ]]; then
+    echo "gh: Not Found (HTTP 404)" >&2
+    exit 1
+  fi
   version="${MOCK_TAP_FORMULA_VERSION:?}"
+  linux_version="${MOCK_TAP_FORMULA_VERSION_LINUX:-${version}}"
   cat <<RUBY
 class NilsCli < Formula
   on_macos do
-    url "https://github.com/test-org/test-repo/releases/download/v${version}/nils-cli-v${version}-aarch64-apple-darwin.tar.gz"
+    if Hardware::CPU.arm?
+      url "https://github.com/test-org/test-repo/releases/download/v${version}/nils-cli-v${version}-aarch64-apple-darwin.tar.gz"
+    else
+      url "https://github.com/test-org/test-repo/releases/download/v${version}/nils-cli-v${version}-x86_64-apple-darwin.tar.gz"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/test-org/test-repo/releases/download/v${linux_version}/nils-cli-v${linux_version}-aarch64-unknown-linux-gnu.tar.gz"
+    else
+      url "https://github.com/test-org/test-repo/releases/download/v${linux_version}/nils-cli-v${linux_version}-x86_64-unknown-linux-gnu.tar.gz"
+    end
   end
 end
 RUBY
@@ -835,6 +860,93 @@ test_from_tap_wait_fails_when_tap_formula_stale() {
   assert_contains "$stderr_file" '0.9.8'
 }
 
+# The formula carries one release URL per platform target. A partially updated
+# formula must not satisfy the gate on whichever URL happens to come first, or the
+# release completes while brew on the remaining platforms resolves the old build.
+test_from_tap_wait_rejects_mixed_version_tap_formula() {
+  local tmp repo bin_dir stderr_file rc
+  tmp="$(mktemp -d)"
+  repo="${tmp}/repo"
+  bin_dir="${tmp}/bin"
+  stderr_file="${tmp}/stderr.log"
+
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo" "v0.6.4"
+  create_mock_semantic_commit "$bin_dir"
+  create_mock_git_scope "$bin_dir"
+  create_mock_gh_tap_state "$bin_dir"
+  create_mock_cargo "$bin_dir"
+
+  git -C "$repo" remote add origin git@github.com:test-org/test-repo.git
+  git -C "$repo" tag -a v0.9.9 -m "v0.9.9"
+
+  set +e
+  (
+    cd "$repo"
+    env -u RUSTC_WRAPPER -u NILS_CLI_HOMEBREW_TAP_DIR \
+      PATH="${bin_dir}:$PATH" \
+      MOCK_TAP_RUN_TITLE="Update nils-cli v0.9.9" \
+      MOCK_TAP_FORMULA_VERSION="0.9.9" \
+      MOCK_TAP_FORMULA_VERSION_LINUX="0.9.8" \
+      NILS_CLI_TAP_WAIT_SECONDS=5 \
+      NILS_CLI_TAP_POLL_SECONDS=1 \
+      "$entrypoint" --version 0.9.9 --from-tap --tap-dir "${tmp}/tap" \
+      --skip-tap-tag --skip-dev-clean --skip-local-brew-upgrade \
+      >"${tmp}/stdout.log" 2>"${stderr_file}"
+  )
+  rc=$?
+  set -e
+
+  if [[ "$rc" -eq 0 ]]; then
+    fail "expected a formula whose platform URLs disagree to fail the release wait"
+  fi
+  # Reported as unpublished, not as the macOS URL's 0.9.9.
+  assert_contains "$stderr_file" 'still at unknown'
+}
+
+# A formula that cannot be read is a different failure from a tap that is merely
+# slow, and the timeout message is the only place an operator sees which one
+# happened.
+test_from_tap_wait_reports_unreadable_tap_formula() {
+  local tmp repo bin_dir stderr_file rc
+  tmp="$(mktemp -d)"
+  repo="${tmp}/repo"
+  bin_dir="${tmp}/bin"
+  stderr_file="${tmp}/stderr.log"
+
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo" "v0.6.4"
+  create_mock_semantic_commit "$bin_dir"
+  create_mock_git_scope "$bin_dir"
+  create_mock_gh_tap_state "$bin_dir"
+  create_mock_cargo "$bin_dir"
+
+  git -C "$repo" remote add origin git@github.com:test-org/test-repo.git
+  git -C "$repo" tag -a v0.9.9 -m "v0.9.9"
+
+  set +e
+  (
+    cd "$repo"
+    env -u RUSTC_WRAPPER -u NILS_CLI_HOMEBREW_TAP_DIR \
+      PATH="${bin_dir}:$PATH" \
+      MOCK_TAP_RUN_TITLE="Update nils-cli v0.9.9" \
+      MOCK_TAP_FORMULA_VERSION="0.9.9" \
+      MOCK_TAP_FORMULA_UNREADABLE=1 \
+      NILS_CLI_TAP_WAIT_SECONDS=5 \
+      NILS_CLI_TAP_POLL_SECONDS=1 \
+      "$entrypoint" --version 0.9.9 --from-tap --tap-dir "${tmp}/tap" \
+      --skip-tap-tag --skip-dev-clean --skip-local-brew-upgrade \
+      >"${tmp}/stdout.log" 2>"${stderr_file}"
+  )
+  rc=$?
+  set -e
+
+  if [[ "$rc" -eq 0 ]]; then
+    fail "expected an unreadable tap formula to fail the release wait"
+  fi
+  assert_contains "$stderr_file" 'still at unknown'
+}
+
 test_formula_inplace_editor_idempotent() {
   local tmp formula_path
   tmp="$(mktemp -d)"
@@ -1183,6 +1295,8 @@ run_all() {
     test_from_tap_upgrades_installed_local_brew_formula
     test_from_tap_wait_accepts_workflow_dispatch_run_title
     test_from_tap_wait_fails_when_tap_formula_stale
+    test_from_tap_wait_rejects_mixed_version_tap_formula
+    test_from_tap_wait_reports_unreadable_tap_formula
     test_formula_inplace_editor_idempotent
     test_pr_mode_default_opens_pr_and_tags_merge_commit
     test_pr_mode_from_linked_worktree_tags_without_checkout_main

--- a/.agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh
+++ b/.agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh
@@ -221,8 +221,76 @@ JSON
   exit 0
 fi
 
+if [[ "$*" == *"contents/Formula/"* ]]; then
+  cat <<'RUBY'
+class NilsCli < Formula
+  on_macos do
+    url "https://github.com/test-org/test-repo/releases/download/v0.9.9/nils-cli-v0.9.9-aarch64-apple-darwin.tar.gz"
+  end
+end
+RUBY
+  exit 0
+fi
+
 if [[ "$*" == *"run list"* ]]; then
   printf '[{"databaseId":1,"status":"completed","conclusion":"success","url":"https://example.test/run","displayTitle":"Update nils-cli formula to v0.9.9","event":"repository_dispatch","createdAt":"2026-07-08T00:00:00Z"}]\n'
+  exit 0
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 1
+EOF
+  chmod +x "${bin_dir}/gh"
+}
+
+# gh stub for the tap-wait gate with the two facts it must separate made
+# independently settable:
+#   MOCK_TAP_RUN_TITLE       displayTitle of the tap formula-update run, i.e. a
+#                            string the *sender* chose. Differs per trigger:
+#                            `repository_dispatch` renders the v-prefixed tag,
+#                            `workflow_dispatch` renders the bare version.
+#   MOCK_TAP_FORMULA_VERSION version actually published in Formula/nils-cli.rb at
+#                            tap main — the only fact the tap alone can produce.
+create_mock_gh_tap_state() {
+  local bin_dir="$1"
+  cat > "${bin_dir}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+
+if [[ "$*" == *"api repos/"*"/releases/tags/"* ]]; then
+  cat <<'JSON'
+{
+  "html_url": "https://github.com/test-org/test-repo/releases/tag/v0.9.9",
+  "assets": [
+    {"name": "nils-cli-v0.9.9-aarch64-apple-darwin.tar.gz"},
+    {"name": "nils-cli-v0.9.9-aarch64-apple-darwin.tar.gz.sha256"},
+    {"name": "nils-cli-v0.9.9-x86_64-apple-darwin.tar.gz"},
+    {"name": "nils-cli-v0.9.9-x86_64-apple-darwin.tar.gz.sha256"},
+    {"name": "nils-cli-v0.9.9-aarch64-unknown-linux-gnu.tar.gz"},
+    {"name": "nils-cli-v0.9.9-aarch64-unknown-linux-gnu.tar.gz.sha256"},
+    {"name": "nils-cli-v0.9.9-x86_64-unknown-linux-gnu.tar.gz"},
+    {"name": "nils-cli-v0.9.9-x86_64-unknown-linux-gnu.tar.gz.sha256"}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [[ "$*" == *"contents/Formula/"* ]]; then
+  version="${MOCK_TAP_FORMULA_VERSION:?}"
+  cat <<RUBY
+class NilsCli < Formula
+  on_macos do
+    url "https://github.com/test-org/test-repo/releases/download/v${version}/nils-cli-v${version}-aarch64-apple-darwin.tar.gz"
+  end
+end
+RUBY
+  exit 0
+fi
+
+if [[ "$*" == *"run list"* ]]; then
+  printf '[{"databaseId":7,"status":"completed","conclusion":"success","url":"https://example.test/run","displayTitle":"%s","event":"workflow_dispatch","createdAt":"2026-07-08T00:00:00Z"}]\n' \
+    "${MOCK_TAP_RUN_TITLE:?}"
   exit 0
 fi
 
@@ -670,18 +738,101 @@ EOF
   ) >"${tmp}/stdout.log" 2>"${stderr_file}"
 
   # The `--from-tap` path delegates the formula edit to the remote
-  # `update-nils-cli-formula.yml` workflow (it only *waits* for that run), so it
-  # must NOT edit the local formula — the seeded tap stays at v0.9.8. It asserts
-  # the release assets exist (REST), the tap-update run succeeded, and the local
-  # brew install was upgraded to the target version.
+  # `update-nils-cli-formula.yml` workflow (it only *waits* for it), so it must
+  # NOT edit the local formula — the seeded tap stays at v0.9.8. It asserts the
+  # release assets exist (REST), the tap published the target version, and the
+  # local brew install was upgraded to it. The wait clears on the published
+  # formula at tap main, not on the run's own conclusion.
   assert_contains "$stderr_file" 'GitHub Release assets are available'
-  assert_contains "$stderr_file" 'update-nils-cli-formula.yml run 1 completed'
+  assert_contains "$stderr_file" 'Formula/nils-cli.rb is published at 0.9.9'
   assert_not_contains "${tap}/Formula/nils-cli.rb" 'v0.9.9'
   assert_contains "$log_file" 'brew:list_formula nils-cli'
   assert_contains "$log_file" 'brew:update'
   assert_contains "$log_file" 'brew:upgrade nils-cli'
   assert_contains "$log_file" 'brew:list_versions nils-cli'
   assert_contains "$stderr_file" 'local Homebrew formula nils-cli is at 0.9.9'
+}
+
+# The tap workflow's run-name renders `client_payload.tag` (v-prefixed) on the
+# `repository_dispatch` path and `inputs.version` (bare) on the
+# `workflow_dispatch` path. A wait keyed on the v-prefixed tag can therefore
+# only ever recognise one of the two trigger paths. Regression for
+# sympoies/nils-cli#1447.
+test_from_tap_wait_accepts_workflow_dispatch_run_title() {
+  local tmp repo bin_dir stderr_file
+  tmp="$(mktemp -d)"
+  repo="${tmp}/repo"
+  bin_dir="${tmp}/bin"
+  stderr_file="${tmp}/stderr.log"
+
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo" "v0.6.4"
+  create_mock_semantic_commit "$bin_dir"
+  create_mock_git_scope "$bin_dir"
+  create_mock_gh_tap_state "$bin_dir"
+  create_mock_cargo "$bin_dir"
+
+  git -C "$repo" remote add origin git@github.com:test-org/test-repo.git
+  git -C "$repo" tag -a v0.9.9 -m "v0.9.9"
+
+  (
+    cd "$repo"
+    env -u RUSTC_WRAPPER -u NILS_CLI_HOMEBREW_TAP_DIR \
+      PATH="${bin_dir}:$PATH" \
+      MOCK_TAP_RUN_TITLE="Update nils-cli 0.9.9" \
+      MOCK_TAP_FORMULA_VERSION="0.9.9" \
+      NILS_CLI_TAP_WAIT_SECONDS=5 \
+      NILS_CLI_TAP_POLL_SECONDS=1 \
+      "$entrypoint" --version 0.9.9 --from-tap --tap-dir "${tmp}/tap" \
+      --skip-tap-tag --skip-dev-clean --skip-local-brew-upgrade
+  ) >"${tmp}/stdout.log" 2>"${stderr_file}"
+
+  assert_contains "$stderr_file" 'Formula/nils-cli.rb'
+  assert_contains "$stderr_file" '0.9.9'
+  assert_not_contains "$stderr_file" 'timed out'
+}
+
+# A tap run that exists and succeeded is still sender-side evidence: it does not
+# say the formula changed. The wait must gate on the published formula version,
+# so a green run over a stale formula fails instead of completing the release.
+# Regression for sympoies/nils-cli#1447.
+test_from_tap_wait_fails_when_tap_formula_stale() {
+  local tmp repo bin_dir stderr_file rc
+  tmp="$(mktemp -d)"
+  repo="${tmp}/repo"
+  bin_dir="${tmp}/bin"
+  stderr_file="${tmp}/stderr.log"
+
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo" "v0.6.4"
+  create_mock_semantic_commit "$bin_dir"
+  create_mock_git_scope "$bin_dir"
+  create_mock_gh_tap_state "$bin_dir"
+  create_mock_cargo "$bin_dir"
+
+  git -C "$repo" remote add origin git@github.com:test-org/test-repo.git
+  git -C "$repo" tag -a v0.9.9 -m "v0.9.9"
+
+  set +e
+  (
+    cd "$repo"
+    env -u RUSTC_WRAPPER -u NILS_CLI_HOMEBREW_TAP_DIR \
+      PATH="${bin_dir}:$PATH" \
+      MOCK_TAP_RUN_TITLE="Update nils-cli v0.9.9" \
+      MOCK_TAP_FORMULA_VERSION="0.9.8" \
+      NILS_CLI_TAP_WAIT_SECONDS=5 \
+      NILS_CLI_TAP_POLL_SECONDS=1 \
+      "$entrypoint" --version 0.9.9 --from-tap --tap-dir "${tmp}/tap" \
+      --skip-tap-tag --skip-dev-clean --skip-local-brew-upgrade \
+      >"${tmp}/stdout.log" 2>"${stderr_file}"
+  )
+  rc=$?
+  set -e
+
+  if [[ "$rc" -eq 0 ]]; then
+    fail "expected a stale tap formula to fail the release wait"
+  fi
+  assert_contains "$stderr_file" '0.9.8'
 }
 
 test_formula_inplace_editor_idempotent() {
@@ -1030,6 +1181,8 @@ run_all() {
     test_from_tap_with_skip_tap_is_mutually_exclusive
     test_from_tap_reports_rate_limit_instead_of_not_available
     test_from_tap_upgrades_installed_local_brew_formula
+    test_from_tap_wait_accepts_workflow_dispatch_run_title
+    test_from_tap_wait_fails_when_tap_formula_stale
     test_formula_inplace_editor_idempotent
     test_pr_mode_default_opens_pr_and_tags_merge_commit
     test_pr_mode_from_linked_worktree_tags_without_checkout_main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,3 +238,85 @@ jobs:
               return;
             }
             core.info(`Dispatched sympoies/homebrew-tap nils-cli formula update for ${tag}.`);
+
+            // The dispatches endpoint answers 204 whether or not any workflow
+            // starts, so the 204 above proves only that we sent something. A
+            // token GitHub resolves to an Actions identity, for one, is accepted
+            // here and creates no run at all. Confirm a run exists before this
+            // job — the last step of the release — reports success.
+            //
+            // The tap is public, so this job's own token can read its runs; fall
+            // back to the dispatch token if that read is ever refused.
+            const runsUrl =
+              "https://api.github.com/repos/sympoies/homebrew-tap/actions/workflows/" +
+              "update-nils-cli-formula.yml/runs?event=repository_dispatch&per_page=20";
+
+            const listRuns = async () => {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRuns({
+                  owner: "sympoies",
+                  repo: "homebrew-tap",
+                  workflow_id: "update-nils-cli-formula.yml",
+                  event: "repository_dispatch",
+                  per_page: 20,
+                });
+                return { runs: data.workflow_runs || [] };
+              } catch (defaultTokenError) {
+                const fallback = await fetch(runsUrl, {
+                  headers: {
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": `Bearer ${token}`,
+                    "X-GitHub-Api-Version": "2022-11-28",
+                  },
+                });
+                if (fallback.ok) {
+                  return { runs: (await fallback.json()).workflow_runs || [] };
+                }
+                return {
+                  error:
+                    `default token: ${defaultTokenError.status || defaultTokenError.message}; ` +
+                    `HOMEBREW_TAP_DISPATCH_TOKEN: HTTP ${fallback.status}`,
+                };
+              }
+            };
+
+            // Tolerate clock skew between this runner and the API.
+            const notBefore = Date.now() - 120_000;
+            const deadline = Date.now() + 180_000;
+            let created = null;
+            let readError = null;
+
+            while (Date.now() < deadline) {
+              const { runs, error } = await listRuns();
+              if (error) {
+                readError = error;
+                break;
+              }
+              created = runs.find((run) => Date.parse(run.created_at) >= notBefore);
+              if (created) break;
+              await new Promise((resolve) => setTimeout(resolve, 10_000));
+            }
+
+            if (readError) {
+              core.setFailed(
+                `Dispatched sympoies/homebrew-tap for ${tag} but could not read its workflow runs ` +
+                `(${readError}), so delivery is unproven. Grant the token read access to Actions on ` +
+                `the tap, or verify the formula update by hand before treating this release as done.`,
+              );
+              return;
+            }
+
+            if (!created) {
+              core.setFailed(
+                `Dispatched sympoies/homebrew-tap for ${tag} and got HTTP 204, but no ` +
+                `repository_dispatch run of update-nils-cli-formula.yml appeared within 180s. ` +
+                `The formula was NOT updated. HOMEBREW_TAP_DISPATCH_TOKEN is the thing to check ` +
+                `first: GitHub accepts the dispatch but starts no run when the token resolves to ` +
+                `an Actions identity. Recover with: gh workflow run update-nils-cli-formula.yml ` +
+                `--repo sympoies/homebrew-tap -f version=${version} -f source_repo=${sourceRepo} ` +
+                `-f expected_workflow_sha=<tap main sha>`,
+              );
+              return;
+            }
+
+            core.info(`Confirmed tap run ${created.id} for ${tag}: ${created.html_url}`);

--- a/scripts/ci/tests/release-workflow-contract.test.sh
+++ b/scripts/ci/tests/release-workflow-contract.test.sh
@@ -124,5 +124,16 @@ assert_contains .agents/skills/project-bump-version-tag-release/scripts/project-
   "reuses that exact-SHA PR CI" \
   "release helper help documents tag-gate CI reuse"
 
+# Both ends of the tap handoff must verify a receiver-side fact. The dispatches
+# endpoint answers 204 with no workflow listening, and a tap run's name is a
+# sender-chosen string whose shape differs per trigger path, so neither is proof
+# that the formula moved.
+assert_contains .github/workflows/release.yml \
+  "listWorkflowRuns" \
+  "release dispatch job confirms a tap run exists instead of trusting HTTP 204"
+assert_contains .agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh \
+  "read_tap_formula_version" \
+  "tap wait gates on the version published in the tap formula"
+
 echo
 echo "PASS: release-workflow-contract.test.sh"


### PR DESCRIPTION
## Summary

Both gaps reported in #1447 are the same defect at two layers: every verifier in
the homebrew-tap handoff was keyed to something the *sender* produced, so both
held in a world where the tap did nothing at all. `release.yml` treated HTTP 204
from `POST /repos/sympoies/homebrew-tap/dispatches` as proof of delivery, and the
release script's tap wait matched a v-prefixed tag against a `run-name` whose
shape the sender chooses. Neither read a fact only the tap can produce.

This moves the end-to-end gate to the artifact — the version published in
`Formula/<formula>.rb` at the tap's default branch — and makes the dispatch job
confirm a run exists before it reports success. The artifact gate is
trigger-agnostic and run-name-agnostic, and false in exactly one world: the
formula did not move.

## Problem

**Expected:** a release that does not update the Homebrew formula fails.

**Actual:** it reports success at both layers.

- `dispatch_homebrew_tap` checked only `response.ok`. The dispatches endpoint
  answers `204` whether or not any workflow is listening, so the job could not
  distinguish a delivered dispatch from an inert one.
- `wait_for_homebrew_tap_update` cleared on a run whose `displayTitle` contained
  `v<version>` and whose conclusion was `success`. The tap's `run-name` renders
  `client_payload.tag` (`v1.26.1`) on the `repository_dispatch` path and
  `inputs.version` (`1.26.1`) on the `workflow_dispatch` path, so the matcher
  recognized only the former — the path that had never produced a run — and was
  blind to the only path that had ever updated the formula.

**Impact:** the two defects hid each other. The dispatch silently did nothing,
and the wait that would have surfaced that could only recognize the run the
dispatch would have created. Nothing in the release went red when the formula
file at tap `main` did not change.

**Root cause (established, not inferred):** the tap side is correct. An
identical `repository_dispatch` — same `event_type`, same `client_payload`, same
endpoint — sent with a user PAT created a tap run in about 10 seconds and
completed all five jobs green. The tap's Actions policy is unrestricted
(`enabled: true`, `allowed_actions: all`) and both sides read `nils-cli-release`,
which rules out the other two candidates in #1447. The inert path is the sending
identity in `HOMEBREW_TAP_DISPATCH_TOKEN`; GitHub accepts a dispatch and starts
no run when the token resolves to an Actions identity. That secret is a
maintainer-side check and is not changed by this PR — which is the point of the
verification: the next release now fails loudly instead of reporting success.

## Reproduction

Both defects reproduce as unit-level regressions against the release skill's
mock-`gh` harness, and both failed before this change:

1. **Wait blind to the `workflow_dispatch` shape.** Drive `--from-tap` with a tap
   run titled `Update nils-cli 0.9.9` (the bare-version shape) while the tap
   formula is published at `0.9.9`. Before: the wait never matched and died with
   `timed out after 5s waiting for update-nils-cli-formula.yml`. After: it clears
   on the published formula.

2. **Green run over a stale formula.** Drive `--from-tap` with a matching,
   successful tap run while the formula at tap `main` is still at `0.9.8`.
   Before: the wait returned success and the release completed. After: it fails
   and names the stale version.

Field evidence from the original report, unchanged by this PR:

- `v1.26.1` logged `Dispatched sympoies/homebrew-tap ... for v1.26.1` with job
  conclusion `success`; the tap had no new run six minutes later.
- `Update nils-cli Formula` had two runs in its entire history at report time,
  both `workflow_dispatch`. There had never been a `repository_dispatch` run.

## Issues Found

Refs #1447

## Fix Approach

**Receiver-side gate (`project-bump-version-tag-release.sh`).** New
`read_tap_formula_version` reads `Formula/<formula>.rb` at the tap's default
branch and extracts the version from its release-download URL.
`wait_for_homebrew_tap_update` now clears only when that published version equals
the target. Run telemetry is still polled, but only to report progress and to
fail fast on a red run — it can no longer stand in for the artifact. The timeout
and red-run failures both name the version the formula is actually at, so a
failure says what is wrong rather than that something did not happen.

**Trigger-agnostic run matching.** Run telemetry is matched on the bare version,
which is a substring of both `Update nils-cli v1.2.3` and `Update nils-cli 1.2.3`,
so progress reporting works on either trigger path instead of only the one that
had never fired.

**Sender-side gate (`release.yml`).** After the `204`, the dispatch job polls the
tap for a `repository_dispatch` run of `update-nils-cli-formula.yml` created
within the dispatch window and fails if none appears in 180s. The read uses the
job's own token (the tap is public) and falls back to the dispatch token. The
failure text names `HOMEBREW_TAP_DISPATCH_TOKEN` as the first thing to check and
carries the manual `gh workflow run` recovery command, so the next occurrence is
diagnosable from the log alone.

**Testability.** `NILS_CLI_TAP_POLL_SECONDS` makes the wait's poll interval
settable so the regressions run in seconds.

Both gates are pinned in `scripts/ci/tests/release-workflow-contract.test.sh` so
a future edit cannot quietly return to sender-side evidence.

**Review round.** Pre-merge review found the artifact reader took only the first
of the formula's four platform release URLs, which let a partially updated formula
clear the gate on a coherent-looking prefix — a smaller form of the very
assumption this change removes. It now requires every occurrence to agree and
reports a mixed formula as unpublished. The unreadable-formula path, which already
failed closed, gained the test it was missing.

Not in scope: the `HOMEBREW_TAP_DISPATCH_TOKEN` secret itself (maintainer-side),
and #1446's release-PR ledger genesis gap.

## Test-First Evidence

Both reported defects had a regression written first and observed failing against
the unmodified implementation, each in the shape the report described:

```
FAIL test_from_tap_wait_accepts_workflow_dispatch_run_title
  error: timed out after 5s waiting for update-nils-cli-formula.yml on sympoies/homebrew-tap for v0.9.9
FAIL test_from_tap_wait_fails_when_tap_formula_stale
  error: expected a stale tap formula to fail the release wait
```

The other 14 tests passed unchanged at that point, so the two failures isolate the
two defects rather than a harness change.

Pre-merge review then found a third defect in the fix itself — the gate read only
the first of the formula's four platform release URLs — and one coverage gap. The
repair carries its own before-state evidence: with the script reverted to the
reviewed head and the new tests in place,

```
FAIL test_from_tap_wait_rejects_mixed_version_tap_formula
PASS test_from_tap_wait_reports_unreadable_tap_formula
```

That split is the honest classification and is why the two are recorded
differently: the mixed-version case was a real defect, while the unreadable-formula
case already behaved correctly and only lacked a test.

One pre-existing assertion was updated with the contract, not around it:
`test_from_tap_upgrades_installed_local_brew_formula` asserted the old sender-side
success line (`update-nils-cli-formula.yml run 1 completed`) and now asserts the
receiver-side one (`Formula/nils-cli.rb is published at 0.9.9`).

## Test plan

- `bash .agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh`
  — 18 tests: 17 pass, 1 skipped (`test_full_checks_...` requires rustc+cargo on
  PATH). Includes the two reported-defect regressions and the two added in the
  review round.
- `bash scripts/ci/tests/release-workflow-contract.test.sh` — passes, including
  the two new contract assertions.
- `bash .agents/scripts/pre-pr.sh` (the repo's `--local-fast` gate) — passes
  (`ok: local-fast workspace Rust gate passed`) against the delivered tree.
- `bash -n` on the modified release script and test harness — clean.
- `release.yml` parses as YAML with the same four jobs.
- Live check of the artifact reader against the real tap, outside the mocks: it
  returns `1.26.2` for `sympoies/homebrew-tap` (matching the shipped version, so
  the gate would clear) and returns non-zero for both a missing formula and an
  unreadable repo, so it fails closed rather than reporting an empty version as
  agreement.
- Root cause confirmed live rather than inferred: an identical
  `repository_dispatch` — same `event_type`, same `client_payload`, same endpoint —
  sent with a user PAT created tap run `30960781143` in about 10 seconds and
  completed all five of its jobs, skipping the commit, tag, and release steps
  because the formula was already at the dispatched version. Combined with the
  tap's unrestricted Actions policy (`enabled: true`, `allowed_actions: all`) and
  both sides reading `nils-cli-release`, that leaves the sending identity in
  `HOMEBREW_TAP_DISPATCH_TOKEN` as the only remaining variable.

Acceptance still owed after merge: cut a real release and confirm the tap stage
clears on the published formula. That exercises the `release.yml` half, which no
local harness can reach.

## Risk / Notes

- **The next release can now fail where it previously passed.** That is the
  intent, but it does mean a genuinely-inert dispatch will stop the release at the
  dispatch job instead of completing quietly. The failure text carries the manual
  `gh workflow run update-nils-cli-formula.yml` recovery command, and
  `--from-tap` still resumes the tap stage afterwards.
- **The dispatch job's verification needs to read the tap's Actions runs.** The
  tap is public, so the job's own token should suffice, with the dispatch token as
  a fallback. If both reads are refused, the job fails with the read error rather
  than silently skipping verification — loud, but it would block a release on a
  permissions problem. This half is only exercised by a real release.
- **The artifact gate clears immediately when the formula is already at the
  target version.** That makes re-running `--from-tap` idempotent, and it means a
  resume against an already-published version will not wait for the tap's tag and
  release steps. Those steps are themselves idempotent in the tap workflow.
- `--skip-tap-wait` still bypasses the gate entirely. It is an explicit opt-out
  and is logged, not silent.
