### PR TITLE
fix(release): record the ledger genesis before the release merge

### DIFF
--- a/.agents/skills/project-bump-version-tag-release/SKILL.md
+++ b/.agents/skills/project-bump-version-tag-release/SKILL.md
@@ -62,7 +62,10 @@ Inputs:
   - `NILS_CLI_CI_WAIT_SECONDS` (env var; direct-push only: max seconds to wait for the bump commit's
     `ci.yml`, default 1800)
   - `NILS_CLI_PR_WAIT` (env var; PR mode only: budget passed to `forge-cli pr deliver --timeout`,
-    default `30m`)
+    default `60m`. Keep it above the slowest lane a release PR can land on, not the
+    expected one: the reduced release-only lane needs the exact base `main` SHA to
+    already have one trusted successful full CI run, and a release cut soon after a
+    merge falls back to full PR CI where `test_macos` has measured 31m45s)
 - Optional (tap stage):
   - `--tap-repo <owner/repo>` (tap repo to wait on, default `sympoies/homebrew-tap`;
     env `NILS_CLI_HOMEBREW_TAP_REPO`)
@@ -86,9 +89,18 @@ Default delivery mode (PR-based):
 - Switches from `main` to a fresh `chore/release-X-Y-Z` branch before bumping any versions.
   (If the user is already on that branch, it is reused; any other starting branch is rejected
   so that `--direct-push` is an explicit opt-in.)
-- After commit, pushes the branch and invokes `forge-cli pr deliver --kind chore --method squash`,
-  which opens a draft PR, waits for required status checks to pass, promotes it to ready, and
-  squash-merges into `main` (deleting the source branch).
+- After commit, pushes the branch and invokes `forge-cli pr deliver --kind chore --method squash
+  --no-merge`, which opens a draft PR, waits for required status checks to pass, and promotes it
+  to ready.
+- Then records the review-loop ledger genesis for that PR and merges it as a separate step.
+  `forge-cli pr merge` fails closed with `review_state_conflict` when the ledger carries no
+  observation for the current head, and the chain refuses an append at a stale head, so the
+  genesis has to land between delivery and merge — a macro that merges in the same step leaves
+  nowhere to put it. A canonical release PR is a generated version-only diff, so the genesis is
+  the empty envelope `review-specialists bundle --mode delivery` produces; the schema rejects a
+  hand-rolled lookalike. The script then posts a `comments-only` delivery outcome recording that
+  the empty finding set is what the checks gated, rather than claiming a review that did not
+  happen, and merges with `--expected-head` bound to the observed head.
 - A canonical single-commit version-only release PR uses the reduced release-only CI lane only
   when protected base policy recognizes the change and the exact base `main` SHA has one trusted
   successful full CI run. Missing or ambiguous proof falls back to full PR CI; the required check

--- a/.agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh
+++ b/.agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh
@@ -505,6 +505,82 @@ tap_name_from_repo_slug() {
   echo "${owner}/${name}"
 }
 
+# Record the review-loop ledger genesis for a release PR, post its delivery
+# outcome, and print the head the observation was bound to.
+#
+# `forge-cli pr merge` fails closed with `review_state_conflict` when the ledger
+# carries no observation for the current head, and the chain refuses an append at
+# a stale head. So this has to run after the PR exists and before the merge --
+# a macro that opens, waits, and merges in one step leaves nowhere to put it,
+# which is why PR-mode releases could not complete on their own.
+#
+# A canonical release PR is a generated version-only diff, so the honest genesis
+# is the empty envelope `review-specialists bundle --mode delivery` produces. The
+# schema rejects a hand-rolled lookalike, which is why this calls the generator
+# instead of writing the payload here.
+record_release_review_genesis() {
+  local pr_number="$1"
+  local review_dir envelope pr_head
+
+  command -v review-specialists >/dev/null 2>&1 ||
+    die "review-specialists is required to record the release review-loop genesis"
+
+  review_dir="$(mktemp -d)"
+  : >"${review_dir}/findings.jsonl"
+  review-specialists bundle \
+    --input "${review_dir}/findings.jsonl" \
+    --out-dir "${review_dir}/bundle" \
+    --mode delivery >/dev/null ||
+    { rm -rf "$review_dir"; die "failed to generate the release review-loop genesis envelope"; }
+
+  envelope="${review_dir}/bundle/findings.merged.json"
+  [[ -s "$envelope" ]] ||
+    { rm -rf "$review_dir"; die "release review-loop genesis envelope was not generated"; }
+
+  pr_head="$(
+    forge-cli --format json pr view "$pr_number" | python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+data = payload.get("data") if payload.get("ok") is True else None
+head = data.get("head_sha") if isinstance(data, dict) else None
+if not isinstance(head, str) or not head:
+    raise SystemExit("pr view did not report a head sha")
+print(head)
+'
+  )" || { rm -rf "$review_dir"; die "could not read release PR #${pr_number} head"; }
+
+  # Validate before writing: a live observe appends durable, provider-visible
+  # state, so it is not a probe.
+  note "validating release review-loop genesis for #${pr_number} at ${pr_head}"
+  forge-cli --format json pr review-loop observe "$pr_number" \
+    --expected-head "$pr_head" --findings-file "$envelope" --dry-run |
+    python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+data = payload.get("data") if payload.get("ok") is True else None
+if not isinstance(data, dict) or data.get("preflight_ok") is not True:
+    raise SystemExit("release review-loop genesis preflight did not pass")
+' || { rm -rf "$review_dir"; die "release review-loop genesis preflight failed for #${pr_number}"; }
+
+  forge-cli --format json pr review-loop observe "$pr_number" \
+    --expected-head "$pr_head" --findings-file "$envelope" >/dev/null ||
+    { rm -rf "$review_dir"; die "failed to append the release review-loop genesis for #${pr_number}"; }
+  note "recorded release review-loop genesis for #${pr_number}"
+
+  forge-cli --format json pr review "$pr_number" \
+    --decision comments-only --lens quick \
+    --comment="Canonical release PR: a generated version-only change set. The required status checks gated this exact head, and the review-loop genesis records an empty finding set rather than asserting a review that did not happen." \
+    >/dev/null ||
+    { rm -rf "$review_dir"; die "failed to post the release delivery review outcome for #${pr_number}"; }
+
+  rm -rf "$review_dir"
+  printf '%s\n' "$pr_head"
+}
+
 # Read the version currently published in the tap's formula at its default
 # branch. This is the one fact in the release path that only the tap can
 # produce: it is independent of which event started the tap workflow, of how
@@ -1497,15 +1573,48 @@ if [[ "$pr_mode" -eq 1 ]]; then
     printf -- '- Tap stage updates homebrew formula\n'
   } >"$pr_body_file"
 
-  note "opening + waiting + merging release PR via forge-cli pr deliver"
-  forge-cli pr deliver \
-    --kind chore \
-    --title "chore(release): bump cli versions to ${version}" \
-    --body-file "$pr_body_file" \
-    --method squash \
-    --timeout "${NILS_CLI_PR_WAIT:-30m}" \
-    || { rm -f "$pr_body_file"; die "forge-cli pr deliver failed; release branch ${release_branch} left in place for recovery"; }
+  # Deliver up to readiness, then stop: the review-loop genesis has to be recorded
+  # between delivery and merge, so the merge is a separate step below.
+  #
+  # The wait budget must exceed the slowest CI lane this PR can land on, not the
+  # expected one. A release PR uses the reduced release-only lane only when the
+  # exact base `main` SHA already has one trusted successful full CI run; cut soon
+  # after a merge it cannot prove that and falls back to full PR CI, where
+  # `test_macos` has measured 31m45s.
+  note "opening + waiting for release PR via forge-cli pr deliver"
+  local_deliver_json="$(
+    forge-cli --format json pr deliver \
+      --kind chore \
+      --title "chore(release): bump cli versions to ${version}" \
+      --body-file "$pr_body_file" \
+      --method squash \
+      --no-merge \
+      --timeout "${NILS_CLI_PR_WAIT:-60m}"
+  )" || { rm -f "$pr_body_file"; die "forge-cli pr deliver failed; release branch ${release_branch} left in place for recovery"; }
   rm -f "$pr_body_file"
+
+  release_pr_number="$(python3 - "$local_deliver_json" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+data = payload.get("data") if payload.get("ok") is True else None
+pr = data.get("pr") if isinstance(data, dict) else None
+number = pr.get("number") if isinstance(pr, dict) else None
+if not isinstance(number, int) or number <= 0:
+    raise SystemExit("release delivery did not return one open PR number")
+print(number)
+PY
+  )" || die "release delivery did not return a trusted PR number; branch ${release_branch} left in place for recovery"
+
+  release_pr_head="$(record_release_review_genesis "$release_pr_number")" ||
+    die "could not record the release review-loop genesis; branch ${release_branch} left in place for recovery"
+
+  note "merging release PR #${release_pr_number} at ${release_pr_head}"
+  forge-cli pr merge "$release_pr_number" \
+    --method squash \
+    --expected-head "$release_pr_head" ||
+    die "release PR #${release_pr_number} merge failed; branch ${release_branch} left in place for recovery"
 
   note "resolving merged release bump on origin/main"
   git fetch origin --quiet

--- a/.agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh
+++ b/.agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh
@@ -551,11 +551,36 @@ print(head)
 '
   )" || { rm -rf "$review_dir"; die "could not read release PR #${pr_number} head"; }
 
+  # Append against the tip we actually observed. Every failure path in this
+  # script leaves the release branch in place for recovery, so a second run on a
+  # chain that already has a tip is a designed case: without this compare-and-swap
+  # a retry would write onto state it never read.
+  local state_tip
+  state_tip="$(
+    forge-cli --format json pr review-loop inspect "$pr_number" | python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+data = payload.get("data") if payload.get("ok") is True else None
+if not isinstance(data, dict):
+    raise SystemExit("review-loop inspect did not return a readable chain")
+print(data.get("state_tip_digest") or "")
+'
+  )" || { rm -rf "$review_dir"; die "could not inspect the review-loop chain for #${pr_number}"; }
+
+  local -a state_args=()
+  if [[ -n "$state_tip" ]]; then
+    state_args=(--expected-state "$state_tip")
+    note "review-loop chain for #${pr_number} already at ${state_tip}"
+  fi
+
   # Validate before writing: a live observe appends durable, provider-visible
   # state, so it is not a probe.
   note "validating release review-loop genesis for #${pr_number} at ${pr_head}"
   forge-cli --format json pr review-loop observe "$pr_number" \
-    --expected-head "$pr_head" --findings-file "$envelope" --dry-run |
+    --expected-head "$pr_head" "${state_args[@]}" \
+    --findings-file "$envelope" --dry-run |
     python3 -c '
 import json
 import sys
@@ -567,7 +592,8 @@ if not isinstance(data, dict) or data.get("preflight_ok") is not True:
 ' || { rm -rf "$review_dir"; die "release review-loop genesis preflight failed for #${pr_number}"; }
 
   forge-cli --format json pr review-loop observe "$pr_number" \
-    --expected-head "$pr_head" --findings-file "$envelope" >/dev/null ||
+    --expected-head "$pr_head" "${state_args[@]}" \
+    --findings-file "$envelope" >/dev/null ||
     { rm -rf "$review_dir"; die "failed to append the release review-loop genesis for #${pr_number}"; }
   note "recorded release review-loop genesis for #${pr_number}"
 

--- a/.agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh
+++ b/.agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh
@@ -1057,10 +1057,39 @@ PY
   assert_not_contains "$formula_path" 'v0.6.4/nils-cli-v0.6.4'
 }
 
+# Assert that one logged call happened before another. The review-loop ledger
+# rejects a `fixed` disposition at the head where a finding was first recorded and
+# refuses an append at a stale head, so genesis has to precede the merge rather
+# than merely coexist with it. Only ordering proves that.
+assert_precedes() {
+  local file="$1"
+  local earlier="$2"
+  local later="$3"
+  local earlier_line later_line
+  earlier_line="$(rg -n --fixed-strings -- "$earlier" "$file" | head -1 | cut -d: -f1)"
+  later_line="$(rg -n --fixed-strings -- "$later" "$file" | head -1 | cut -d: -f1)"
+  if [[ -z "$earlier_line" ]]; then
+    echo "error: expected '$earlier' in $file" >&2
+    sed -n '1,220p' "$file" >&2 || true
+    exit 1
+  fi
+  if [[ -z "$later_line" ]]; then
+    echo "error: expected '$later' in $file" >&2
+    sed -n '1,220p' "$file" >&2 || true
+    exit 1
+  fi
+  if ((earlier_line >= later_line)); then
+    echo "error: expected '$earlier' before '$later' in $file" >&2
+    sed -n '1,220p' "$file" >&2 || true
+    exit 1
+  fi
+}
+
 create_mock_forge_cli_deliver() {
-  # The mock simulates a successful PR deliver by fast-forwarding the bare
-  # remote's main to the freshly pushed release branch, then printing a final
-  # status line the way `forge-cli pr deliver` does.
+  # The mock walks the same sequence the release script drives: deliver the PR
+  # without merging, read its head, record the review-loop genesis, post the
+  # delivery outcome, then merge. `pr merge` is what fast-forwards the bare
+  # remote's main onto the pushed release branch.
   local bin_dir="$1"
   local bare_remote="$2"
   cat > "${bin_dir}/forge-cli" <<EOF
@@ -1068,37 +1097,110 @@ create_mock_forge_cli_deliver() {
 set -euo pipefail
 
 log_file="\${MOCK_LOG:?}"
-echo "forge-cli:\$*" >> "\$log_file"
-
-if [[ "\${1:-}" != "pr" || "\${2:-}" != "deliver" ]]; then
-  echo "unexpected forge-cli command: \$*" >&2
-  exit 1
-fi
-
-# Determine the branch that was just pushed by inspecting the bare remote.
-release_branch="\$(git -C "${bare_remote}" symbolic-ref --short HEAD 2>/dev/null || true)"
-# Find which branch ref was most recently advanced ahead of main.
-for ref in \$(git -C "${bare_remote}" for-each-ref --format='%(refname:short)' refs/heads); do
-  if [[ "\$ref" == "main" ]]; then
-    continue
-  fi
-  release_branch="\$ref"
-  break
+# Drop --format json so the logged shape stays stable for assertions.
+args=()
+for arg in "\$@"; do
+  [[ "\$arg" == "--format" || "\$arg" == "json" ]] && continue
+  args+=("\$arg")
 done
+echo "forge-cli:\${args[*]}" >> "\$log_file"
 
-if [[ -z "\$release_branch" ]]; then
-  echo "mock forge-cli: could not detect release branch on remote" >&2
-  exit 1
-fi
+detect_release_branch() {
+  local ref
+  for ref in \$(git -C "${bare_remote}" for-each-ref --format='%(refname:short)' refs/heads); do
+    [[ "\$ref" == "main" ]] && continue
+    printf '%s\n' "\$ref"
+    return 0
+  done
+  return 1
+}
 
-# Fast-forward main to the release branch on the bare remote (simulates squash-merge).
-release_sha="\$(git -C "${bare_remote}" rev-parse "refs/heads/\$release_branch")"
-git -C "${bare_remote}" update-ref refs/heads/main "\$release_sha"
-git -C "${bare_remote}" update-ref -d "refs/heads/\$release_branch"
+release_head() {
+  local branch
+  branch="\$(detect_release_branch)" || return 1
+  git -C "${bare_remote}" rev-parse "refs/heads/\$branch"
+}
 
-echo "merged #999 via squash → \$release_sha (branch deleted)"
+case "\${args[0]:-} \${args[1]:-} \${args[2]:-}" in
+  "pr deliver"*)
+    if [[ " \${args[*]} " != *" --no-merge "* ]]; then
+      echo "mock forge-cli: pr deliver must not merge; the ledger genesis has to be recorded first" >&2
+      exit 1
+    fi
+    printf '{"schema_version":"cli.forge-cli.pr.deliver.v1","ok":true,"data":{"pr":{"number":999,"url":"https://example.test/pr/999","merged":false}}}\n'
+    ;;
+  "pr view"*)
+    head="\$(release_head)" || { echo "mock forge-cli: no release branch on remote" >&2; exit 1; }
+    printf '{"schema_version":"cli.forge-cli.pr.view.v1","ok":true,"data":{"number":999,"head_sha":"%s","draft":false,"state":"open"}}\n' "\$head"
+    ;;
+  "pr review-loop inspect"*)
+    printf '{"schema_version":"cli.forge-cli.pr.review-loop.inspect.v1","ok":true,"data":{"number":999,"state_tip_digest":null,"appended":false}}\n'
+    ;;
+  "pr review-loop observe"*)
+    if [[ " \${args[*]} " == *" --dry-run "* ]]; then
+      printf '{"schema_version":"cli.forge-cli.pr.review-loop.observe.v1","ok":true,"data":{"preflight_ok":true,"would_append":true}}\n'
+    else
+      printf '{"schema_version":"cli.forge-cli.pr.review-loop.observe.v1","ok":true,"data":{"appended":true,"generation":0,"state_tip_digest":"sha256:mockdigest","state":{"round":0,"findings":{}}}}\n'
+    fi
+    ;;
+  "pr review"*)
+    printf '{"schema_version":"cli.forge-cli.pr.review.v1","ok":true,"data":{"number":999,"decision":"comments-only"}}\n'
+    ;;
+  "pr ready"*)
+    printf '{"schema_version":"cli.forge-cli.pr.ready.v1","ok":true,"data":{"number":999,"draft":false}}\n'
+    ;;
+  "pr merge"*)
+    branch="\$(detect_release_branch)" || { echo "mock forge-cli: no release branch on remote" >&2; exit 1; }
+    sha="\$(git -C "${bare_remote}" rev-parse "refs/heads/\$branch")"
+    git -C "${bare_remote}" update-ref refs/heads/main "\$sha"
+    git -C "${bare_remote}" update-ref -d "refs/heads/\$branch"
+    printf '{"schema_version":"cli.forge-cli.pr.merge.v1","ok":true,"data":{"number":999,"merge_sha":"%s","method":"squash","deleted_branch":true}}\n' "\$sha"
+    echo "merged #999 via squash → \$sha (branch deleted)" >&2
+    ;;
+  *)
+    echo "unexpected forge-cli command: \${args[*]}" >&2
+    exit 1
+    ;;
+esac
 EOF
   chmod +x "${bin_dir}/forge-cli"
+}
+
+create_mock_review_specialists() {
+  # `review-specialists bundle --mode delivery` generates the envelope the ledger
+  # requires. An empty input is the honest genesis for a generated version-only
+  # release diff, and the schema rejects a hand-rolled lookalike, which is why the
+  # script must call the real generator rather than writing the payload itself.
+  local bin_dir="$1"
+  cat > "${bin_dir}/review-specialists" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="${MOCK_LOG:?}"
+echo "review-specialists:$*" >> "$log_file"
+
+out_dir=""
+prev=""
+for arg in "$@"; do
+  [[ "$prev" == "--out-dir" ]] && out_dir="$arg"
+  prev="$arg"
+done
+
+if [[ "${1:-}" != "bundle" || -z "$out_dir" ]]; then
+  echo "unexpected review-specialists command: $*" >&2
+  exit 1
+fi
+if [[ " $* " != *" --mode delivery "* ]]; then
+  echo "review-specialists: the ledger genesis requires --mode delivery" >&2
+  exit 1
+fi
+
+mkdir -p "$out_dir"
+printf '{"schema":"review-specialists.merged.v2","counts":{"merged":0},"findings":[]}\n' \
+  >"${out_dir}/findings.merged.json"
+printf '{"schema_version":"cli.review-specialists.bundle.v1","ok":true,"data":{"counts":{"merged":0}}}\n'
+EOF
+  chmod +x "${bin_dir}/review-specialists"
 }
 
 test_pr_mode_default_opens_pr_and_tags_merge_commit() {
@@ -1121,6 +1223,7 @@ test_pr_mode_default_opens_pr_and_tags_merge_commit() {
   git -C "$repo" push -u origin main >/dev/null
 
   create_mock_forge_cli_deliver "$bin_dir" "$remote"
+  create_mock_review_specialists "$bin_dir"
 
   (
     cd "$repo"
@@ -1134,6 +1237,28 @@ test_pr_mode_default_opens_pr_and_tags_merge_commit() {
   assert_contains "$log_file" 'forge-cli:pr deliver --kind chore'
   assert_contains "$log_file" 'bump cli versions to 0.6.5'
   assert_contains "$log_file" '--method squash'
+
+  # The review-loop ledger genesis is what lets the merge gate pass. `pr merge`
+  # fails closed with `review_state_conflict` when no observation exists for the
+  # head, and an observation cannot be backfilled at a stale head, so the order
+  # matters as much as the presence.
+  assert_contains "$log_file" 'review-specialists:bundle'
+  assert_contains "$log_file" '--mode delivery'
+  assert_contains "$log_file" 'forge-cli:pr review-loop observe 999'
+  assert_precedes "$log_file" 'pr review-loop observe 999' 'pr merge 999'
+  # Genesis is validated before it is written: a live observe appends durable
+  # provider-visible state, so it is not a probe.
+  assert_precedes "$log_file" '--dry-run' 'pr merge 999'
+
+  # Delivery must stop before merging so the genesis can be recorded between the
+  # two, and the check wait must exceed the slowest CI lane a release PR can land
+  # on -- full PR CI has measured test_macos at 31m45s.
+  assert_contains "$log_file" '--no-merge'
+  local delivered_wait
+  delivered_wait="$(sed -n 's/.*--timeout \([0-9]\{1,\}\)m.*/\1/p' "$log_file" | head -1)"
+  [[ -n "$delivered_wait" ]] || fail "release delivery carried no --timeout budget"
+  ((delivered_wait >= 60)) ||
+    fail "release delivery wait budget ${delivered_wait}m is below the 60m full-CI lane worst case"
   # The release branch existed on the remote before merge and is gone now.
   if git -C "$remote" rev-parse --verify "refs/heads/chore/release-0-6-5" >/dev/null 2>&1; then
     fail "mock forge-cli left release branch behind on remote"
@@ -1179,6 +1304,7 @@ test_pr_mode_from_linked_worktree_tags_without_checkout_main() {
   git -C "$repo" push -u origin main >/dev/null
 
   create_mock_forge_cli_deliver "$bin_dir" "$remote"
+  create_mock_review_specialists "$bin_dir"
 
   # Dedicated release worktree on the release branch, while the primary checkout
   # ($repo) keeps `main` checked out. This is the shared-worktree-isolation

--- a/.agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh
+++ b/.agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh
@@ -1134,9 +1134,19 @@ case "\${args[0]:-} \${args[1]:-} \${args[2]:-}" in
     printf '{"schema_version":"cli.forge-cli.pr.view.v1","ok":true,"data":{"number":999,"head_sha":"%s","draft":false,"state":"open"}}\n' "\$head"
     ;;
   "pr review-loop inspect"*)
-    printf '{"schema_version":"cli.forge-cli.pr.review-loop.inspect.v1","ok":true,"data":{"number":999,"state_tip_digest":null,"appended":false}}\n'
+    # MOCK_LEDGER_TIP models a chain that already has state, which is what a
+    # resumed release meets. The observe call must then carry it as the CAS input.
+    if [[ -n "\${MOCK_LEDGER_TIP:-}" ]]; then
+      printf '{"schema_version":"cli.forge-cli.pr.review-loop.inspect.v1","ok":true,"data":{"number":999,"state_tip_digest":"%s","appended":true}}\n' "\${MOCK_LEDGER_TIP}"
+    else
+      printf '{"schema_version":"cli.forge-cli.pr.review-loop.inspect.v1","ok":true,"data":{"number":999,"state_tip_digest":null,"appended":false}}\n'
+    fi
     ;;
   "pr review-loop observe"*)
+    if [[ -n "\${MOCK_LEDGER_TIP:-}" && " \${args[*]} " != *" --expected-state \${MOCK_LEDGER_TIP} "* ]]; then
+      echo "mock forge-cli: observe must carry --expected-state \${MOCK_LEDGER_TIP} on a chain that already has a tip" >&2
+      exit 1
+    fi
     if [[ " \${args[*]} " == *" --dry-run "* ]]; then
       printf '{"schema_version":"cli.forge-cli.pr.review-loop.observe.v1","ok":true,"data":{"preflight_ok":true,"would_append":true}}\n'
     else
@@ -1283,6 +1293,49 @@ test_pr_mode_default_opens_pr_and_tags_merge_commit() {
   fi
 }
 
+# Every failure path leaves the release branch in place for recovery, so a second
+# run meets a chain that already has a tip. Appending without the observed tip
+# would write onto state the run never read, which is what the chain's
+# compare-and-swap exists to prevent. Regression for sympoies/nils-cli#1446.
+test_pr_mode_carries_the_observed_ledger_tip_on_a_resumed_chain() {
+  local tmp repo remote bin_dir log_file stderr_file
+  tmp="$(mktemp -d)"
+  repo="${tmp}/repo"
+  remote="${tmp}/repo.git"
+  bin_dir="${tmp}/bin"
+  log_file="${tmp}/mock.log"
+  stderr_file="${tmp}/stderr.log"
+
+  mkdir -p "$repo" "$bin_dir"
+  create_temp_repo "$repo" "v0.6.4"
+  create_mock_cargo "$bin_dir"
+  create_mock_semantic_commit "$bin_dir"
+  create_mock_git_scope "$bin_dir"
+
+  git init --bare "$remote" >/dev/null
+  git -C "$repo" remote add origin "$remote"
+  git -C "$repo" push -u origin main >/dev/null 2>&1
+
+  create_mock_forge_cli_deliver "$bin_dir" "$remote"
+  create_mock_review_specialists "$bin_dir"
+
+  (
+    cd "$repo"
+    env -u RUSTC_WRAPPER -u NILS_CLI_HOMEBREW_TAP_DIR \
+      PATH="${bin_dir}:$PATH" \
+      MOCK_LOG="$log_file" \
+      MOCK_LEDGER_TIP="sha256:resumedtip" \
+      "$entrypoint" --version v0.6.5 --skip-tap
+  ) >"${tmp}/stdout.log" 2>"${stderr_file}"
+
+  # The mock fails the observe outright when the tip is missing, so reaching a
+  # merge at all proves the CAS input was carried.
+  assert_contains "$log_file" '--expected-state sha256:resumedtip'
+  assert_precedes "$log_file" 'pr review-loop inspect 999' 'pr review-loop observe 999'
+  assert_contains "$log_file" 'forge-cli:pr merge 999'
+  assert_contains "$stderr_file" 'review-loop chain for #999 already at sha256:resumedtip'
+}
+
 test_pr_mode_from_linked_worktree_tags_without_checkout_main() {
   local tmp repo remote wt bin_dir log_file stderr_file
   tmp="$(mktemp -d)"
@@ -1425,6 +1478,7 @@ run_all() {
     test_from_tap_wait_reports_unreadable_tap_formula
     test_formula_inplace_editor_idempotent
     test_pr_mode_default_opens_pr_and_tags_merge_commit
+    test_pr_mode_carries_the_observed_ledger_tip_on_a_resumed_chain
     test_pr_mode_from_linked_worktree_tags_without_checkout_main
     test_pr_mode_rejects_non_chore_release_branch
   )

--- a/scripts/ci/tests/release-workflow-contract.test.sh
+++ b/scripts/ci/tests/release-workflow-contract.test.sh
@@ -135,5 +135,15 @@ assert_contains .agents/skills/project-bump-version-tag-release/scripts/project-
   "read_tap_formula_version" \
   "tap wait gates on the version published in the tap formula"
 
+# PR-mode delivery must leave a window between opening the PR and merging it: the
+# ledger merge gate needs an observation at the current head, and the chain
+# refuses an append at a stale head.
+assert_contains .agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh \
+  "record_release_review_genesis" \
+  "release PR delivery records the review-loop ledger genesis before merging"
+assert_contains .agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh \
+  "mode delivery" \
+  "release genesis envelope comes from the review-specialists delivery generator"
+
 echo
 echo "PASS: release-workflow-contract.test.sh"


### PR DESCRIPTION
## Summary

A PR-mode release could not complete on its own: the delivery macro merged in the
same step that opened the PR, so `forge-cli pr merge` reached its review-loop
ledger gate with no observation for the head and failed closed. There was nowhere
to record the genesis.

This splits delivery from merge and records the genesis in between.

Also raises the check-wait default from 30m to 60m — the same defect just fixed in
the private broker (serenvia/sympoies-infra#164) was still live in this script.

## Problem

**Expected:** `project-bump-version-tag-release.sh` in PR mode cuts a release
end to end.

**Actual:** it stops at the merge with

```
review_state_conflict: bounded review delivery requires an explicit genesis ledger observation
```

Two provider rules interact. An observation can only be appended at the *current*
head, so history cannot be backfilled; and `pr merge` fails closed unless the
ledger carries an observation for that head. The script called
`forge-cli pr deliver --kind chore --method squash`, which opens, waits, and
merges in one step — leaving no point at which a genesis could be recorded.

**Impact:** every PR-mode release needed the manual recovery sequence by hand, and
the script exited leaving a pushed branch and an open PR behind.

**Second, independent defect in the same call:** the check-wait budget was `30m`
while a release PR can land on full CI, where `test_macos` has measured 31m45s. A
release PR uses the reduced release-only lane only when the exact base `main` SHA
already has one trusted successful full CI run, and a release cut soon after a
merge cannot prove that because the base commit's own CI is still running. So the
budget was shorter than a lane the gate selects for itself.

## Reproduction

Reproduces in the skill's mock-driven harness. With the forge-cli mock taught to
refuse a merge inside `pr deliver` — which is what the provider effectively does
by failing the ledger gate — both PR-mode tests fail against the previous script:

```
error: expected pattern 'review-specialists:bundle' in /tmp/tmp.ZblPBxX37q/mock.log
FAIL test_pr_mode_default_opens_pr_and_tags_merge_commit

mock forge-cli: pr deliver must not merge; the ledger genesis has to be recorded first
error: forge-cli pr deliver failed; release branch chore/release-0-6-5 left in place for recovery
FAIL test_pr_mode_from_linked_worktree_tags_without_checkout_main
```

Field evidence: `v1.26.1` hit this while being cut, and the manual recovery
sequence in sympoies/nils-cli#1446 is what landed it.

## Issues Found

Refs sympoies/nils-cli#1446
Refs serenvia/sympoies-infra#164

## Fix Approach

**Split delivery from merge.** `pr deliver` now runs with `--no-merge`, and the
merge is a separate `pr merge` bound to `--expected-head`. The order is
load-bearing rather than stylistic: the chain refuses an append at a stale head,
so a genesis cannot be added after the merge.

**New `record_release_review_genesis`.** It generates the envelope with
`review-specialists bundle --mode delivery`, reads the PR head, validates the
observation with `--dry-run` before writing (a live `observe` appends durable
provider-visible state, so it is not a probe), appends it, and posts a
`comments-only` delivery outcome. The outcome says the empty finding set is what
the required checks gated, rather than claiming a review that did not happen.

The envelope comes from the generator, not from hand-written JSON: a canonical
release PR is a generated version-only diff, so an empty finding set is the honest
genesis, and the schema rejects a lookalike payload.

**Budget.** Default 30m → 60m, with the measurement and the invariant recorded at
the call site and in `SKILL.md`: keep it above the slowest lane, not the expected
one.

Not changed: the tap stage, the tagging path, and the recovery behavior that
leaves the release branch in place on failure.

**Review round.** Pre-merge review found the genesis appended with only
`--expected-head`, skipping the chain compare-and-swap. Every failure path here
leaves the release branch in place for recovery, so a second run meeting a chain
that already has a tip is a designed case, and without the CAS a retry writes onto
state it never read. It now inspects the chain and passes `--expected-state` when
the tip is non-null, covered by a regression that models a resumed chain.

## Test-First Evidence

The assertions were written first and observed failing against the unmodified
script, in the shape the report describes — see Reproduction above for the exact
output.

What the tests hold is the ordering, not just the presence: `assert_precedes`
requires the genesis observe to come before `pr merge`, and the `--dry-run`
preflight to come before the merge as well. Presence alone would pass even if the
genesis were appended after a merge, which the provider would reject.

The forge-cli mock was extended from accepting only `pr deliver` to walking the
real sequence (`pr deliver --no-merge`, `pr view`, `review-loop observe` dry-run
and live, `pr review`, `pr merge`), and it fails loudly if `pr deliver` is asked to
merge. That refusal is what makes the old behavior detectable at all.

The budget assertion pins the floor rather than a literal, so raising the budget
later stays green while dropping it below the full lane fails.

## Test plan

- `bash .agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh`
  — 18 tests: 17 pass, 1 skipped (`test_full_checks_...` needs rustc+cargo on
  PATH). Both PR-mode tests now exercise the full delivery sequence.
- `bash scripts/ci/tests/release-workflow-contract.test.sh` — passes, including
  two new assertions pinning the genesis step and the delivery-mode generator.
- `bash .agents/scripts/pre-pr.sh` — passes (`ok: local-fast workspace Rust gate
  passed`).
- `bash -n` on the modified script and harness — clean.

- 19 tests after the review round: 18 pass, 1 skipped. The added
  `test_pr_mode_carries_the_observed_ledger_tip_on_a_resumed_chain` fails against
  the reviewed head with `expected pattern '--expected-state sha256:resumedtip'`,
  and it was the only failure there, so it isolates the CAS gap.

## Risk / Notes

- PR-mode delivery now makes several provider calls where it previously made one.
  Each has an explicit failure message and leaves the release branch in place for
  recovery, matching the existing contract, but there are more places to stop.
- A live `review-loop observe` writes durable, provider-visible state. It is
  preceded by a `--dry-run` preflight that performs the same reads and validation,
  so a rejected genesis fails before anything is written.
- The whole sequence is verified against a mock, never against the real provider —
  a real end-to-end run would open and merge a release PR. The same sequence was
  executed by hand against the live provider during this work, which is where its
  shape came from. Recorded as an accepted gap in the test-first evidence.
- The canonical release path is the private broker, which fast-forwards and never
  reaches this gate. This fixes the manual fallback, so it is exercised only when
  someone cuts a release by hand.
