### PR TITLE
feat(agent-memory): align recall and persona contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,6 +2067,7 @@ dependencies = [
  "nils-common",
  "nils-test-support",
  "pretty_assertions",
+ "serde",
  "serde_json",
  "tempfile",
 ]

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `a492bbfdc2631bd3efa5c0e92f636d8f3e28634638a1237482fa20760ae2902d`
+- Cargo.lock SHA256: `561dd7d1087fdd4a2eadc3013c60218ef66db6d2eb3e7c8bd69b7500e02b11c8`
 - Third-party crates (`source != null`): 487
 - Workspace crates (`source == null`, excluded below): 46
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `a492bbfdc2631bd3efa5c0e92f636d8f3e28634638a1237482fa20760ae2902d`
+- Cargo.lock SHA256: `561dd7d1087fdd4a2eadc3013c60218ef66db6d2eb3e7c8bd69b7500e02b11c8`
 - Third-party crates (`source != null`): 487
 
 ## Notice Extraction Policy

--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -323,7 +323,9 @@ rule_id asc)`. A duplicate rule ID is invalid. Decision precedence is
 `block > transform-conflict > transform > warn/context > allow`.
 
 Multiple context values concatenate in rule order with a 16 KiB aggregate
-limit. Identical replacements coalesce. Different replacements are an explicit
+limit. Provider-native rendering uses that complete aggregate even when the
+first context rule supplied an otherwise reusable native envelope. Identical
+replacements coalesce. Different replacements are an explicit
 `transform-conflict` block; transforms never compose implicitly. Failure
 posture is typed per rule (`open`, `warn`, or `closed`), while locked privacy,
 writer, transaction, and recovery rules must be `closed`.

--- a/crates/agent-hook/src/adapter.rs
+++ b/crates/agent-hook/src/adapter.rs
@@ -157,8 +157,8 @@ pub fn normalize(
 }
 
 pub fn render_provider(decision: &NormalizedDecision) -> Result<String, HookError> {
-    if let Some(output) = decision.provider_output.as_ref() {
-        return serde_json::to_string(output).map_err(|_| {
+    if let Some(output) = provider_output_with_aggregate_context(decision) {
+        return serde_json::to_string(&output).map_err(|_| {
             HookError::runtime(
                 "provider-output-render-failed",
                 "provider output could not be rendered",
@@ -201,6 +201,45 @@ pub fn render_provider(decision: &NormalizedDecision) -> Result<String, HookErro
             "provider output could not be rendered",
         )
     })
+}
+
+fn provider_output_with_aggregate_context(decision: &NormalizedDecision) -> Option<Value> {
+    let mut output = decision.provider_output.clone()?;
+    let context = decision.context.as_deref()?;
+    if !matches!(
+        decision.action,
+        DecisionAction::Context | DecisionAction::Warn
+    ) {
+        return Some(output);
+    }
+
+    let Some(root) = output.as_object_mut() else {
+        return Some(json!({
+            "hookSpecificOutput": {
+                "hookEventName": decision.event,
+                "additionalContext": context,
+            }
+        }));
+    };
+    if let Some(hook_output) = root
+        .get_mut("hookSpecificOutput")
+        .and_then(Value::as_object_mut)
+    {
+        hook_output.insert("additionalContext".to_string(), json!(context));
+        hook_output
+            .entry("hookEventName".to_string())
+            .or_insert_with(|| json!(decision.event));
+    } else if root.contains_key("additionalContext") {
+        root.insert("additionalContext".to_string(), json!(context));
+    } else {
+        return Some(json!({
+            "hookSpecificOutput": {
+                "hookEventName": decision.event,
+                "additionalContext": context,
+            }
+        }));
+    }
+    Some(output)
 }
 
 pub fn render_provider_error(
@@ -809,4 +848,50 @@ fn parse_provider_json(input: &[u8]) -> Result<Value, HookError> {
             )
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{DecisionReason, ShadowObservation};
+
+    #[test]
+    fn provider_render_uses_the_full_aggregated_context() {
+        for product in [Product::Codex, Product::Claude] {
+            let decision = NormalizedDecision {
+                schema_version: "agent-hook.decision.v1".to_string(),
+                request_id: "request:test".to_string(),
+                product,
+                event: "UserPromptSubmit".to_string(),
+                action: DecisionAction::Context,
+                reasons: vec![DecisionReason {
+                    rule_id: "fixture.context".to_string(),
+                    code: "fixture-context".to_string(),
+                    disposition: "context".to_string(),
+                }],
+                context: Some("first context\nsecond context".to_string()),
+                replacement: None,
+                shadow: Vec::<ShadowObservation>::new(),
+                config_digest: "sha256:config".to_string(),
+                policy_digest: "sha256:policy".to_string(),
+                recovery_applied: false,
+                provider_output: Some(json!({
+                    "hookSpecificOutput": {
+                        "hookEventName": "UserPromptSubmit",
+                        "additionalContext": "first context",
+                    },
+                    "suppressOutput": true,
+                })),
+            };
+
+            let rendered: Value =
+                serde_json::from_str(&render_provider(&decision).expect("provider output"))
+                    .expect("provider JSON");
+            assert_eq!(
+                rendered["hookSpecificOutput"]["additionalContext"],
+                "first context\nsecond context"
+            );
+            assert_eq!(rendered["suppressOutput"], true);
+        }
+    }
 }

--- a/crates/agent-hook/src/adapter.rs
+++ b/crates/agent-hook/src/adapter.rs
@@ -205,13 +205,15 @@ pub fn render_provider(decision: &NormalizedDecision) -> Result<String, HookErro
 
 fn provider_output_with_aggregate_context(decision: &NormalizedDecision) -> Option<Value> {
     let mut output = decision.provider_output.clone()?;
-    let context = decision.context.as_deref()?;
     if !matches!(
         decision.action,
         DecisionAction::Context | DecisionAction::Warn
     ) {
         return Some(output);
     }
+    let Some(context) = decision.context.as_deref() else {
+        return Some(output);
+    };
 
     let Some(root) = output.as_object_mut() else {
         return Some(json!({
@@ -892,6 +894,44 @@ mod tests {
                 "first context\nsecond context"
             );
             assert_eq!(rendered["suppressOutput"], true);
+        }
+    }
+
+    #[test]
+    fn provider_render_preserves_native_envelopes_without_aggregate_context() {
+        for product in [Product::Codex, Product::Claude] {
+            for action in [
+                DecisionAction::Allow,
+                DecisionAction::Block,
+                DecisionAction::Transform,
+            ] {
+                let provider_output = json!({
+                    "decision": "provider-native",
+                    "reason": "preserve me",
+                    "suppressOutput": true,
+                    "providerExtension": {"product": product.as_str()},
+                });
+                let decision = NormalizedDecision {
+                    schema_version: "agent-hook.decision.v1".to_string(),
+                    request_id: "request:provider-preservation".to_string(),
+                    product,
+                    event: "PreToolUse".to_string(),
+                    action,
+                    reasons: Vec::new(),
+                    context: None,
+                    replacement: None,
+                    shadow: Vec::<ShadowObservation>::new(),
+                    config_digest: "sha256:config".to_string(),
+                    policy_digest: "sha256:policy".to_string(),
+                    recovery_applied: false,
+                    provider_output: Some(provider_output.clone()),
+                };
+
+                let rendered: Value =
+                    serde_json::from_str(&render_provider(&decision).expect("provider output"))
+                        .expect("provider JSON");
+                assert_eq!(rendered, provider_output);
+            }
         }
     }
 }

--- a/crates/agent-hook/src/adapter.rs
+++ b/crates/agent-hook/src/adapter.rs
@@ -223,6 +223,7 @@ fn provider_output_with_aggregate_context(decision: &NormalizedDecision) -> Opti
             }
         }));
     };
+    let has_top_level_context = root.contains_key("additionalContext");
     if let Some(hook_output) = root
         .get_mut("hookSpecificOutput")
         .and_then(Value::as_object_mut)
@@ -231,7 +232,10 @@ fn provider_output_with_aggregate_context(decision: &NormalizedDecision) -> Opti
         hook_output
             .entry("hookEventName".to_string())
             .or_insert_with(|| json!(decision.event));
-    } else if root.contains_key("additionalContext") {
+        if has_top_level_context {
+            root.insert("additionalContext".to_string(), json!(context));
+        }
+    } else if has_top_level_context {
         root.insert("additionalContext".to_string(), json!(context));
     } else {
         return Some(json!({
@@ -932,6 +936,46 @@ mod tests {
                         .expect("provider JSON");
                 assert_eq!(rendered, provider_output);
             }
+        }
+    }
+
+    #[test]
+    fn provider_render_synchronizes_mixed_accepted_context_locations() {
+        for product in [Product::Codex, Product::Claude] {
+            let decision = NormalizedDecision {
+                schema_version: "agent-hook.decision.v1".to_string(),
+                request_id: "request:mixed-context".to_string(),
+                product,
+                event: "UserPromptSubmit".to_string(),
+                action: DecisionAction::Context,
+                reasons: Vec::new(),
+                context: Some("first context\nsecond context".to_string()),
+                replacement: None,
+                shadow: Vec::<ShadowObservation>::new(),
+                config_digest: "sha256:config".to_string(),
+                policy_digest: "sha256:policy".to_string(),
+                recovery_applied: false,
+                provider_output: Some(json!({
+                    "additionalContext": "first context",
+                    "hookSpecificOutput": {
+                        "hookEventName": "UserPromptSubmit",
+                    },
+                    "suppressOutput": true,
+                })),
+            };
+
+            let rendered: Value =
+                serde_json::from_str(&render_provider(&decision).expect("provider output"))
+                    .expect("provider JSON");
+            assert_eq!(
+                rendered["hookSpecificOutput"]["additionalContext"],
+                "first context\nsecond context"
+            );
+            assert_eq!(
+                rendered["additionalContext"],
+                "first context\nsecond context"
+            );
+            assert_eq!(rendered["suppressOutput"], true);
         }
     }
 }

--- a/crates/agent-memory/Cargo.toml
+++ b/crates/agent-memory/Cargo.toml
@@ -20,6 +20,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 nils-build-info = { version = "1.26.3", path = "../nils-build-info" }
 nils-common = { version = "1.26.3", path = "../nils-common", package = "nils-common" }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/agent-memory/README.md
+++ b/crates/agent-memory/README.md
@@ -43,7 +43,7 @@ agent-memory add [SCOPE] --name <slug> --type <t> --description <text> \
 agent-memory list [SCOPE] [--type <t>] [--format text|json]
 agent-memory search <term> [SCOPE] [--all] [--format text|json]
 agent-memory recall startup [--max-bytes <bytes>] [--format text|json]
-agent-memory recall on-demand <term> [--format text|json]
+agent-memory recall on-demand <term> [--agent <id>] [--format text|json]
 agent-memory recall candidates [producer] [--format text|json]
 agent-memory candidate add <producer> --name <slug> \
   [--title <text>] [--hook <text>] [--body <text>|-] \
@@ -110,14 +110,17 @@ matches and `1` when there are none.
 ## Recall profiles
 
 `recall startup` reads only `profiles/startup/MEMORY.md`, treats the payload as
-untrusted memory data, and fails closed when the file exceeds 3,072 bytes by
-default. `--max-bytes` can set a stricter or explicitly configured boundary.
+untrusted memory data, and rejects a file that exceeds the deployed 768-byte
+transport budget by default. `--max-bytes` can set an explicitly configured
+boundary.
 It never falls back to `global/MEMORY.md`.
 
-`recall on-demand <term>` searches curated `global/*.md` notes only and does
-not emit the full global index. `recall candidates [producer]` lists opaque
-proposal files under producer-isolated candidate roots and labels the result
-untrusted.
+`recall on-demand <term>` searches curated `global/*.md` notes and does not emit
+the full global index. `--agent <id>` additionally includes only the exact
+registered `agents/<id>/*.md` scope; candidate, archive, profile, and persona
+content remain excluded. Omitting `--agent` preserves the global-only contract.
+`recall candidates [producer]` lists opaque proposal files under
+producer-isolated candidate roots and labels the result untrusted.
 
 ## Candidate lifecycle
 
@@ -125,6 +128,14 @@ untrusted.
 proposal file, and updates its candidate index. Candidate bodies do not need
 canonical frontmatter because provider-native memory may use its own format.
 Candidate roots, indexes, source files, and body-file inputs reject symlinks.
+Candidate listing uses an optional recognizable frontmatter description, then
+the first body line, for its bounded preview; otherwise it preserves the opaque
+first-non-empty-line fallback.
+
+`init-persona` writes the isolated auto-memory path to
+`personas/<id>/.claude/settings.local.json`. Persona launchers must pass that
+file explicitly with `claude --settings`; the filename alone is not a promise
+that Claude will honor user-scope-only settings keys.
 
 `candidate promote` is non-mutating unless `--apply` is present. The preview
 validates the producer, source, destination, canonical type, and both indexes,

--- a/crates/agent-memory/README.md
+++ b/crates/agent-memory/README.md
@@ -120,8 +120,8 @@ the full global index. `--agent <id>` additionally includes only the exact
 registered `agents/<id>/*.md` scope; candidate, archive, profile, and persona
 content remain excluded. Omitting `--agent` preserves the global-only contract.
 This manual query returns the complete curated match set; automatic provider
-injection uses only the separately bounded startup profile. Text results stream
-as they are found, while JSON avoids a duplicate in-memory value tree.
+injection uses only the separately bounded startup profile. The implementation
+does not retain a second text hit collection or duplicate the JSON value tree.
 `recall candidates [producer]` lists opaque proposal files under
 producer-isolated candidate roots and labels the result untrusted.
 

--- a/crates/agent-memory/README.md
+++ b/crates/agent-memory/README.md
@@ -119,6 +119,9 @@ It never falls back to `global/MEMORY.md`.
 the full global index. `--agent <id>` additionally includes only the exact
 registered `agents/<id>/*.md` scope; candidate, archive, profile, and persona
 content remain excluded. Omitting `--agent` preserves the global-only contract.
+This manual query returns the complete curated match set; automatic provider
+injection uses only the separately bounded startup profile. Text results stream
+as they are found, while JSON avoids a duplicate in-memory value tree.
 `recall candidates [producer]` lists opaque proposal files under
 producer-isolated candidate roots and labels the result untrusted.
 

--- a/crates/agent-memory/docs/README.md
+++ b/crates/agent-memory/docs/README.md
@@ -37,15 +37,16 @@ Beyond the original shell contract, the Rust CLI adds:
   the default text output is unchanged.
 - `search <term> [SCOPE] [--all]` — case-insensitive substring search over note
   frontmatter and bodies, returning `scope/file:line: text`.
-- `recall startup|on-demand|candidates` — exposes bounded startup routing,
-  curated term recall, and explicitly untrusted proposal listing as separate
-  profiles.
+- `recall startup|on-demand|candidates` — exposes 768-byte bounded startup
+  routing, curated global term recall with an optional exact `--agent` scope,
+  and explicitly untrusted proposal listing as separate profiles.
 - `candidate add|list|promote` — isolates proposal writers by producer and
   provides an explicit dry-run/apply promotion transaction into curated
   `global/` memory. Promotion requires explicit session provenance, preserves
   supported global-directory symlinks, removes exact native-index filename
   references, and reports incomplete rollback without deleting recovery
-  backups.
+  backups. Listing prefers an optional frontmatter description or body preview
+  while retaining opaque fallback behavior.
 - `archive list|search` — explicitly queries historical superseded notes that
   are structurally excluded from active recall, search, checks, and completion.
 - `archive retire <slug> ... [--apply]` — dry-run-first, rollback-safe movement

--- a/crates/agent-memory/src/candidate.rs
+++ b/crates/agent-memory/src/candidate.rs
@@ -133,14 +133,15 @@ pub(crate) fn print_list(
             let contents = fs::read_to_string(&path).map_err(|err| {
                 CliError::runtime(format!("failed to read {}: {err}", display_path(&path)))
             })?;
-            let preview = contents
-                .lines()
-                .map(str::trim)
-                .find(|line| !line.is_empty())
-                .unwrap_or("")
-                .chars()
-                .take(160)
-                .collect();
+            let preview_source = frontmatter::candidate_preview(&contents).unwrap_or_else(|| {
+                contents
+                    .lines()
+                    .map(str::trim)
+                    .find(|line| !line.is_empty())
+                    .unwrap_or("")
+                    .to_string()
+            });
+            let preview = preview_source.chars().take(160).collect();
             let mtime = metadata
                 .modified()
                 .ok()

--- a/crates/agent-memory/src/candidate.rs
+++ b/crates/agent-memory/src/candidate.rs
@@ -139,7 +139,6 @@ pub(crate) fn print_list(
                     .map(str::trim)
                     .find(|line| !line.is_empty())
                     .unwrap_or("")
-                    .to_string()
             });
             let preview = preview_source.chars().take(160).collect();
             let mtime = metadata

--- a/crates/agent-memory/src/cli.rs
+++ b/crates/agent-memory/src/cli.rs
@@ -183,7 +183,7 @@ pub struct RecallArgs {
 pub enum RecallCommand {
     /// Print the bounded profiles/startup index.
     Startup(RecallStartupArgs),
-    /// Search curated global notes only.
+    /// Search curated global notes, optionally including one agent scope.
     OnDemand(RecallOnDemandArgs),
     /// List untrusted candidate notes, optionally for one producer.
     Candidates(RecallCandidatesArgs),
@@ -192,7 +192,7 @@ pub enum RecallCommand {
 #[derive(Debug, Args)]
 pub struct RecallStartupArgs {
     /// Maximum allowed startup index size.
-    #[arg(long, value_name = "BYTES", default_value_t = 3072)]
+    #[arg(long, value_name = "BYTES", default_value_t = 768)]
     pub max_bytes: usize,
     /// Output format.
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
@@ -207,6 +207,9 @@ pub struct RecallOnDemandArgs {
     /// Term to find in curated global note content.
     #[arg(value_name = "TERM")]
     pub term: String,
+    /// Also search one exact registered non-Claude agent scope.
+    #[arg(long, value_name = "ID")]
+    pub agent: Option<String>,
     /// Output format.
     #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
     pub format: OutputFormat,

--- a/crates/agent-memory/src/frontmatter.rs
+++ b/crates/agent-memory/src/frontmatter.rs
@@ -38,6 +38,28 @@ pub(crate) fn body_after_frontmatter(contents: &str) -> &str {
     strip_optional_separator(&contents[end..])
 }
 
+/// Return a useful preview for a candidate with recognizable optional
+/// frontmatter.
+///
+/// Candidate files remain opaque input: a leading thematic `---` block is not
+/// treated as metadata unless it carries `name` or `description`. When a
+/// description is present it is the best bounded summary; otherwise the first
+/// non-empty body line is used.
+pub(crate) fn candidate_preview(contents: &str) -> Option<String> {
+    let (frontmatter, end) = parse_leading_block(contents)?;
+    if frontmatter.name.is_none() && frontmatter.description.is_none() {
+        return None;
+    }
+    if let Some(description) = frontmatter.description {
+        return Some(description);
+    }
+    strip_optional_separator(&contents[end..])
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
+}
+
 /// Report whether a note starts with two consecutive recognizable blocks.
 pub(crate) fn has_duplicate_frontmatter(contents: &str) -> bool {
     let Some((_, end)) = parse_leading_block(contents) else {

--- a/crates/agent-memory/src/frontmatter.rs
+++ b/crates/agent-memory/src/frontmatter.rs
@@ -45,19 +45,39 @@ pub(crate) fn body_after_frontmatter(contents: &str) -> &str {
 /// treated as metadata unless it carries `name` or `description`. When a
 /// description is present it is the best bounded summary; otherwise the first
 /// non-empty body line is used.
-pub(crate) fn candidate_preview(contents: &str) -> Option<String> {
-    let (frontmatter, end) = parse_leading_block(contents)?;
-    if frontmatter.name.is_none() && frontmatter.description.is_none() {
+pub(crate) fn candidate_preview(contents: &str) -> Option<&str> {
+    let end = frontmatter_end(contents)?;
+    let mut lines = contents[..end].lines();
+    lines.next();
+    let mut has_name = false;
+    let mut description = None;
+    for line in lines {
+        if is_frontmatter_fence(line) {
+            break;
+        }
+        if line.starts_with(char::is_whitespace) {
+            continue;
+        }
+        let Some((key, value)) = line.trim().split_once(':') else {
+            continue;
+        };
+        let value = strip_quotes(value.trim());
+        match key.trim() {
+            "name" => has_name = !value.is_empty(),
+            "description" if !value.is_empty() => description = Some(value),
+            _ => {}
+        }
+    }
+    if !has_name && description.is_none() {
         return None;
     }
-    if let Some(description) = frontmatter.description {
+    if let Some(description) = description {
         return Some(description);
     }
     strip_optional_separator(&contents[end..])
         .lines()
         .map(str::trim)
         .find(|line| !line.is_empty())
-        .map(str::to_string)
 }
 
 /// Report whether a note starts with two consecutive recognizable blocks.

--- a/crates/agent-memory/src/lib.rs
+++ b/crates/agent-memory/src/lib.rs
@@ -119,6 +119,15 @@ fn print_help() -> Result<i32, CliError> {
 struct CliError {
     message: String,
     exit_code: i32,
+    code: Option<&'static str>,
+    details: Option<CliErrorDetails>,
+}
+
+#[derive(Debug)]
+struct CliErrorDetails {
+    retryable: bool,
+    next_action: &'static str,
+    recovery_command: &'static str,
 }
 
 impl CliError {
@@ -126,6 +135,27 @@ impl CliError {
         Self {
             message: message.into(),
             exit_code: EXIT_RUNTIME,
+            code: None,
+            details: None,
+        }
+    }
+
+    fn runtime_typed(
+        code: &'static str,
+        message: impl Into<String>,
+        retryable: bool,
+        next_action: &'static str,
+        recovery_command: &'static str,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            exit_code: EXIT_RUNTIME,
+            code: Some(code),
+            details: Some(CliErrorDetails {
+                retryable,
+                next_action,
+                recovery_command,
+            }),
         }
     }
 
@@ -133,6 +163,8 @@ impl CliError {
         Self {
             message: message.into(),
             exit_code: EXIT_USAGE,
+            code: None,
+            details: None,
         }
     }
 }
@@ -650,8 +682,9 @@ Claude Code session scoped to "{id}" persona. Loads on top of the base
 
 ## Memory
 
-- Auto-memory store: `./memory/` (this persona's isolated scope, wired via
-  `.claude/settings.local.json`).
+- Auto-memory store: `./memory/` (this persona's isolated scope; its
+  `.claude/settings.local.json` is passed explicitly with `claude --settings`
+  by the persona launcher).
 - Cross-persona facts (shell, git identity, host) belong in global memory,
   not here.
 "#

--- a/crates/agent-memory/src/recall.rs
+++ b/crates/agent-memory/src/recall.rs
@@ -10,7 +10,7 @@ use nils_common::fs::display_path;
 use crate::cli::{
     RecallArgs, RecallCandidatesArgs, RecallCommand, RecallOnDemandArgs, RecallStartupArgs,
 };
-use crate::{CliError, EXIT_OK, EXIT_RUNTIME, EXIT_USAGE, Layout, markdown_files};
+use crate::{CliError, EXIT_OK, EXIT_RUNTIME, EXIT_USAGE, Layout, markdown_files, validate_id};
 
 pub(crate) fn run(layout: &Layout, args: &RecallArgs) -> Result<i32, CliError> {
     let (json, schema_command) = match &args.command {
@@ -94,6 +94,7 @@ fn startup(layout: &Layout, args: &RecallStartupArgs) -> Result<i32, CliError> {
 }
 
 struct RecallHit {
+    scope: String,
     file: String,
     line: usize,
     text: String,
@@ -110,28 +111,49 @@ fn on_demand(layout: &Layout, args: &RecallOnDemandArgs) -> Result<i32, CliError
             display_path(&global)
         )));
     }
+    let mut scopes = vec![("global".to_string(), global)];
+    if let Some(agent) = args.agent.as_deref() {
+        validate_id(agent)?;
+        let agent_dir = layout.agents_dir().join(agent);
+        let available = fs::symlink_metadata(&agent_dir)
+            .is_ok_and(|metadata| !metadata.file_type().is_symlink() && metadata.is_dir());
+        if !available {
+            return Err(CliError::runtime_typed(
+                "agent-scope-not-found",
+                format!("agent scope is not available: {agent}"),
+                false,
+                "select an existing agent scope or initialize one",
+                "agent-memory agents",
+            ));
+        }
+        scopes.push((format!("agents/{agent}"), agent_dir));
+    }
+
     let needle = args.term.to_lowercase();
     let mut hits = Vec::new();
-    for file in markdown_files(&global)? {
-        let Some(name) = file
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-        else {
-            continue;
-        };
-        if name == "MEMORY.md" {
-            continue;
-        }
-        let contents = fs::read_to_string(&file).map_err(|err| {
-            CliError::runtime(format!("failed to read {}: {err}", display_path(&file)))
-        })?;
-        for (index, line) in contents.lines().enumerate() {
-            if line.to_lowercase().contains(&needle) {
-                hits.push(RecallHit {
-                    file: name.clone(),
-                    line: index + 1,
-                    text: line.trim().to_string(),
-                });
+    for (scope, directory) in scopes {
+        for file in markdown_files(&directory)? {
+            let Some(name) = file
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+            else {
+                continue;
+            };
+            if name == "MEMORY.md" {
+                continue;
+            }
+            let contents = fs::read_to_string(&file).map_err(|err| {
+                CliError::runtime(format!("failed to read {}: {err}", display_path(&file)))
+            })?;
+            for (index, line) in contents.lines().enumerate() {
+                if line.to_lowercase().contains(&needle) {
+                    hits.push(RecallHit {
+                        scope: scope.clone(),
+                        file: name.clone(),
+                        line: index + 1,
+                        text: line.trim().to_string(),
+                    });
+                }
             }
         }
     }
@@ -142,14 +164,14 @@ fn on_demand(layout: &Layout, args: &RecallOnDemandArgs) -> Result<i32, CliError
             .iter()
             .map(|hit| {
                 json!({
-                    "scope": "global",
+                    "scope": hit.scope,
                     "file": hit.file,
                     "line": hit.line,
                     "text": hit.text,
                 })
             })
             .collect();
-        let doc = json!({
+        let mut doc = json!({
             "schema_version": schema_version_for("agent-memory", "recall-on-demand", 1),
             "ok": !hits.is_empty(),
             "profile": "on-demand",
@@ -159,13 +181,16 @@ fn on_demand(layout: &Layout, args: &RecallOnDemandArgs) -> Result<i32, CliError
             "count": hits.len(),
             "hits": records,
         });
+        if let Some(agent) = args.agent.as_deref() {
+            doc["agent"] = json!(agent);
+        }
         println!(
             "{}",
             serde_json::to_string(&doc).expect("on-demand recall should serialize")
         );
     } else {
         for hit in &hits {
-            println!("global/{}:{}: {}", hit.file, hit.line, hit.text);
+            println!("{}/{}:{}: {}", hit.scope, hit.file, hit.line, hit.text);
         }
     }
     Ok(if hits.is_empty() {
@@ -189,18 +214,28 @@ fn output_format(format: OutputFormat, json: bool) -> OutputFormat {
 }
 
 fn print_json_error(schema_command: &str, err: &CliError) {
-    let code = if err.exit_code == EXIT_USAGE {
+    let default_code = if err.exit_code == EXIT_USAGE {
         "usage-error"
     } else {
         "runtime-error"
     };
+    let mut error = json!({
+        "code": err.code.unwrap_or(default_code),
+        "message": err.message,
+    });
+    if let Some(details) = &err.details {
+        error["details"] = json!({
+            "retryable": details.retryable,
+            "next_action": details.next_action,
+            "recovery": {
+                "command": details.recovery_command,
+            },
+        });
+    }
     let doc = json!({
         "schema_version": schema_version_for("agent-memory", schema_command, 1),
         "ok": false,
-        "error": {
-            "code": code,
-            "message": err.message,
-        },
+        "error": error,
     });
     println!(
         "{}",

--- a/crates/agent-memory/src/recall.rs
+++ b/crates/agent-memory/src/recall.rs
@@ -1,7 +1,9 @@
 //! Bounded startup, curated on-demand, and untrusted candidate recall.
 
 use std::fs;
+use std::io::{self, Write};
 
+use serde::Serialize;
 use serde_json::json;
 
 use nils_common::cli_contract::{OutputFormat, schema_version_for};
@@ -93,11 +95,26 @@ fn startup(layout: &Layout, args: &RecallStartupArgs) -> Result<i32, CliError> {
     Ok(EXIT_OK)
 }
 
+#[derive(Serialize)]
 struct RecallHit {
     scope: String,
     file: String,
     line: usize,
     text: String,
+}
+
+#[derive(Serialize)]
+struct RecallOnDemandResponse<'a> {
+    schema_version: String,
+    ok: bool,
+    profile: &'static str,
+    trust: &'static str,
+    curation: &'static str,
+    term: &'a str,
+    count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent: Option<&'a str>,
+    hits: &'a [RecallHit],
 }
 
 fn on_demand(layout: &Layout, args: &RecallOnDemandArgs) -> Result<i32, CliError> {
@@ -114,13 +131,18 @@ fn on_demand(layout: &Layout, args: &RecallOnDemandArgs) -> Result<i32, CliError
     let mut scopes = vec![("global".to_string(), global)];
     if let Some(agent) = args.agent.as_deref() {
         validate_id(agent)?;
-        let agent_dir = layout.agents_dir().join(agent);
+        let agents_dir = layout.agents_dir();
+        validate_agents_root_metadata(agent, fs::symlink_metadata(&agents_dir))?;
+        let agent_dir = agents_dir.join(agent);
         validate_agent_scope_metadata(agent, fs::symlink_metadata(&agent_dir))?;
         scopes.push((format!("agents/{agent}"), agent_dir));
     }
 
+    let format = output_format(args.format, args.json);
+    let json_output = format.is_json();
     let needle = args.term.to_lowercase();
     let mut hits = Vec::new();
+    let mut hit_count = 0;
     for (scope, directory) in scopes {
         for file in markdown_files(&directory)? {
             let Some(name) = file
@@ -136,58 +158,77 @@ fn on_demand(layout: &Layout, args: &RecallOnDemandArgs) -> Result<i32, CliError
                 CliError::runtime(format!("failed to read {}: {err}", display_path(&file)))
             })?;
             for (index, line) in contents.lines().enumerate() {
-                if line.to_lowercase().contains(&needle) {
-                    hits.push(RecallHit {
-                        scope: scope.clone(),
-                        file: name.clone(),
-                        line: index + 1,
-                        text: line.trim().to_string(),
-                    });
+                if contains_case_insensitive(line, &args.term, &needle) {
+                    hit_count += 1;
+                    if json_output {
+                        hits.push(RecallHit {
+                            scope: scope.clone(),
+                            file: name.clone(),
+                            line: index + 1,
+                            text: line.trim().to_string(),
+                        });
+                    } else {
+                        println!("{scope}/{name}:{}: {}", index + 1, line.trim());
+                    }
                 }
             }
         }
     }
 
-    let format = output_format(args.format, args.json);
-    if format.is_json() {
-        let records: Vec<_> = hits
-            .iter()
-            .map(|hit| {
-                json!({
-                    "scope": hit.scope,
-                    "file": hit.file,
-                    "line": hit.line,
-                    "text": hit.text,
-                })
-            })
-            .collect();
-        let mut doc = json!({
-            "schema_version": schema_version_for("agent-memory", "recall-on-demand", 1),
-            "ok": !hits.is_empty(),
-            "profile": "on-demand",
-            "trust": "untrusted-memory-data",
-            "curation": "curated",
-            "term": args.term,
-            "count": hits.len(),
-            "hits": records,
-        });
-        if let Some(agent) = args.agent.as_deref() {
-            doc["agent"] = json!(agent);
-        }
-        println!(
-            "{}",
-            serde_json::to_string(&doc).expect("on-demand recall should serialize")
-        );
-    } else {
-        for hit in &hits {
-            println!("{}/{}:{}: {}", hit.scope, hit.file, hit.line, hit.text);
-        }
+    if json_output {
+        let doc = RecallOnDemandResponse {
+            schema_version: schema_version_for("agent-memory", "recall-on-demand", 1),
+            ok: hit_count != 0,
+            profile: "on-demand",
+            trust: "untrusted-memory-data",
+            curation: "curated",
+            term: args.term.as_str(),
+            count: hit_count,
+            agent: args.agent.as_deref(),
+            hits: &hits,
+        };
+        let mut output = io::stdout().lock();
+        serde_json::to_writer(&mut output, &doc)
+            .map_err(|err| CliError::runtime(format!("failed to write recall JSON: {err}")))?;
+        output
+            .write_all(b"\n")
+            .map_err(|err| CliError::runtime(format!("failed to write recall JSON: {err}")))?;
     }
-    Ok(if hits.is_empty() {
+    Ok(if hit_count == 0 {
         EXIT_RUNTIME
     } else {
         EXIT_OK
     })
+}
+
+fn contains_case_insensitive(haystack: &str, needle: &str, lowercase_needle: &str) -> bool {
+    if haystack.is_ascii() && needle.is_ascii() {
+        return haystack
+            .as_bytes()
+            .windows(needle.len())
+            .any(|window| window.eq_ignore_ascii_case(needle.as_bytes()));
+    }
+    haystack.to_lowercase().contains(lowercase_needle)
+}
+
+fn validate_agents_root_metadata(
+    agent: &str,
+    metadata: std::io::Result<fs::Metadata>,
+) -> Result<(), CliError> {
+    match metadata {
+        Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_dir() => Ok(()),
+        Ok(_) => Err(CliError::runtime_typed(
+            "agent-scope-untrusted",
+            "agent scope root must be a non-symlink directory",
+            false,
+            "repair the agent memory layout before agent-scoped recall",
+            "agent-memory doctor",
+        )),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Err(agent_scope_not_found(agent)),
+        Err(err) => Err(CliError::runtime(format!(
+            "failed to inspect agent scope root: {err}"
+        ))),
+    }
 }
 
 fn validate_agent_scope_metadata(
@@ -197,22 +238,10 @@ fn validate_agent_scope_metadata(
     match metadata {
         Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_dir() => {}
         Ok(_) => {
-            return Err(CliError::runtime_typed(
-                "agent-scope-not-found",
-                format!("agent scope is not available: {agent}"),
-                false,
-                "select an existing agent scope or initialize one",
-                "agent-memory agents",
-            ));
+            return Err(agent_scope_not_found(agent));
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            return Err(CliError::runtime_typed(
-                "agent-scope-not-found",
-                format!("agent scope is not available: {agent}"),
-                false,
-                "select an existing agent scope or initialize one",
-                "agent-memory agents",
-            ));
+            return Err(agent_scope_not_found(agent));
         }
         Err(err) => {
             return Err(CliError::runtime(format!(
@@ -221,6 +250,16 @@ fn validate_agent_scope_metadata(
         }
     }
     Ok(())
+}
+
+fn agent_scope_not_found(agent: &str) -> CliError {
+    CliError::runtime_typed(
+        "agent-scope-not-found",
+        format!("agent scope is not available: {agent}"),
+        false,
+        "select an existing agent scope or initialize one",
+        "agent-memory agents",
+    )
 }
 
 fn candidates(layout: &Layout, args: &RecallCandidatesArgs) -> Result<i32, CliError> {

--- a/crates/agent-memory/src/recall.rs
+++ b/crates/agent-memory/src/recall.rs
@@ -158,7 +158,7 @@ fn on_demand(layout: &Layout, args: &RecallOnDemandArgs) -> Result<i32, CliError
                 CliError::runtime(format!("failed to read {}: {err}", display_path(&file)))
             })?;
             for (index, line) in contents.lines().enumerate() {
-                if contains_case_insensitive(line, &args.term, &needle) {
+                if contains_case_insensitive(line, &needle) {
                     hit_count += 1;
                     if json_output {
                         hits.push(RecallHit {
@@ -201,13 +201,11 @@ fn on_demand(layout: &Layout, args: &RecallOnDemandArgs) -> Result<i32, CliError
     })
 }
 
-fn contains_case_insensitive(haystack: &str, needle: &str, lowercase_needle: &str) -> bool {
-    if haystack.is_ascii() && needle.is_ascii() {
-        return haystack
-            .as_bytes()
-            .windows(needle.len())
-            .any(|window| window.eq_ignore_ascii_case(needle.as_bytes()));
-    }
+fn contains_case_insensitive(haystack: &str, lowercase_needle: &str) -> bool {
+    // `str::contains` keeps the substring search algorithm out of the
+    // quadratic `windows(...).eq_ignore_ascii_case(...)` worst case. Recall
+    // processes one line at a time, so the temporary lowercase buffer stays
+    // bounded by the current line rather than the complete result set.
     haystack.to_lowercase().contains(lowercase_needle)
 }
 

--- a/crates/agent-memory/src/recall.rs
+++ b/crates/agent-memory/src/recall.rs
@@ -115,17 +115,7 @@ fn on_demand(layout: &Layout, args: &RecallOnDemandArgs) -> Result<i32, CliError
     if let Some(agent) = args.agent.as_deref() {
         validate_id(agent)?;
         let agent_dir = layout.agents_dir().join(agent);
-        let available = fs::symlink_metadata(&agent_dir)
-            .is_ok_and(|metadata| !metadata.file_type().is_symlink() && metadata.is_dir());
-        if !available {
-            return Err(CliError::runtime_typed(
-                "agent-scope-not-found",
-                format!("agent scope is not available: {agent}"),
-                false,
-                "select an existing agent scope or initialize one",
-                "agent-memory agents",
-            ));
-        }
+        validate_agent_scope_metadata(agent, fs::symlink_metadata(&agent_dir))?;
         scopes.push((format!("agents/{agent}"), agent_dir));
     }
 
@@ -200,6 +190,39 @@ fn on_demand(layout: &Layout, args: &RecallOnDemandArgs) -> Result<i32, CliError
     })
 }
 
+fn validate_agent_scope_metadata(
+    agent: &str,
+    metadata: std::io::Result<fs::Metadata>,
+) -> Result<(), CliError> {
+    match metadata {
+        Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_dir() => {}
+        Ok(_) => {
+            return Err(CliError::runtime_typed(
+                "agent-scope-not-found",
+                format!("agent scope is not available: {agent}"),
+                false,
+                "select an existing agent scope or initialize one",
+                "agent-memory agents",
+            ));
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(CliError::runtime_typed(
+                "agent-scope-not-found",
+                format!("agent scope is not available: {agent}"),
+                false,
+                "select an existing agent scope or initialize one",
+                "agent-memory agents",
+            ));
+        }
+        Err(err) => {
+            return Err(CliError::runtime(format!(
+                "failed to inspect agent scope {agent}: {err}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn candidates(layout: &Layout, args: &RecallCandidatesArgs) -> Result<i32, CliError> {
     crate::candidate::print_list(
         layout,
@@ -241,4 +264,33 @@ fn print_json_error(schema_command: &str, err: &CliError) {
         "{}",
         serde_json::to_string(&doc).expect("recall error should serialize")
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_scope_not_found_remains_typed_and_non_retryable() {
+        let err = validate_agent_scope_metadata(
+            "codex",
+            Err(std::io::Error::from(std::io::ErrorKind::NotFound)),
+        )
+        .expect_err("missing agent scope");
+
+        assert_eq!(err.code, Some("agent-scope-not-found"));
+        assert!(!err.details.expect("typed details").retryable);
+    }
+
+    #[test]
+    fn agent_scope_operational_error_is_not_misreported_as_missing() {
+        let err = validate_agent_scope_metadata(
+            "codex",
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+        )
+        .expect_err("agent scope inspection failure");
+
+        assert_eq!(err.code, None);
+        assert!(err.message.contains("failed to inspect agent scope codex"));
+    }
 }

--- a/crates/agent-memory/src/recall.rs
+++ b/crates/agent-memory/src/recall.rs
@@ -235,6 +235,15 @@ fn validate_agent_scope_metadata(
 ) -> Result<(), CliError> {
     match metadata {
         Ok(metadata) if !metadata.file_type().is_symlink() && metadata.is_dir() => {}
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(CliError::runtime_typed(
+                "agent-scope-untrusted",
+                format!("agent scope must be a non-symlink directory: {agent}"),
+                false,
+                "repair the agent memory layout before agent-scoped recall",
+                "agent-memory doctor",
+            ));
+        }
         Ok(_) => {
             return Err(agent_scope_not_found(agent));
         }

--- a/crates/agent-memory/tests/integration/cli.rs
+++ b/crates/agent-memory/tests/integration/cli.rs
@@ -806,6 +806,16 @@ fn recall_startup_defaults_to_deployed_768_byte_budget() {
     seed_recall_layout(tmp.path());
     fs::write(
         tmp.path().join("profiles/startup/MEMORY.md"),
+        "x".repeat(768),
+    )
+    .expect("boundary startup profile");
+
+    let boundary = run(tmp.path(), &["recall", "startup"]);
+    assert_eq!(boundary.code, 0, "stderr={}", boundary.stderr_text());
+    assert_eq!(boundary.stdout_text().len(), 768);
+
+    fs::write(
+        tmp.path().join("profiles/startup/MEMORY.md"),
         "x".repeat(769),
     )
     .expect("oversized startup profile");
@@ -853,6 +863,37 @@ fn recall_on_demand_searches_curated_global_only() {
     let no_candidate = run(tmp.path(), &["recall", "on-demand", "candidate_only_token"]);
     assert_eq!(no_candidate.code, 1);
     assert!(no_candidate.stdout_text().is_empty());
+
+    let json_hit = run(
+        tmp.path(),
+        &["recall", "on-demand", "route body", "--format", "json"],
+    );
+    assert_eq!(json_hit.code, 0, "stderr={}", json_hit.stderr_text());
+    let hit_doc: serde_json::Value =
+        serde_json::from_str(json_hit.stdout_text().trim()).expect("recall hit json");
+    assert_eq!(
+        hit_doc["schema_version"],
+        "cli.agent-memory.recall-on-demand.v1"
+    );
+    assert!(hit_doc.get("agent").is_none());
+    assert_eq!(hit_doc["count"], 1);
+    assert_eq!(hit_doc["hits"][0]["scope"], "global");
+
+    let json_miss = run(
+        tmp.path(),
+        &["recall", "on-demand", "absent_token", "--format", "json"],
+    );
+    assert_eq!(json_miss.code, 1);
+    let miss_doc: serde_json::Value =
+        serde_json::from_str(json_miss.stdout_text().trim()).expect("recall miss json");
+    assert_eq!(
+        miss_doc["schema_version"],
+        "cli.agent-memory.recall-on-demand.v1"
+    );
+    assert_eq!(miss_doc["ok"], false);
+    assert_eq!(miss_doc["count"], 0);
+    assert_eq!(miss_doc["hits"], serde_json::json!([]));
+    assert!(miss_doc.get("agent").is_none());
 }
 
 #[test]
@@ -868,10 +909,33 @@ fn recall_on_demand_can_include_one_exact_agent_scope() {
             "codex-routing",
             "reference",
             "Codex-only routing",
-            "codex_agent_only_token",
+            "shared_agent_scope_token codex_agent_only_token",
         ),
     )
     .expect("codex note");
+    fs::write(
+        tmp.path().join("global/shared.md"),
+        note_with(
+            "global-shared",
+            "reference",
+            "Global shared routing",
+            "shared_agent_scope_token",
+        ),
+    )
+    .expect("global shared note");
+    let hermes = tmp.path().join("agents/hermes");
+    fs::create_dir_all(&hermes).expect("hermes agent scope");
+    fs::write(hermes.join("MEMORY.md"), "# Hermes memory\n").expect("hermes index");
+    fs::write(
+        hermes.join("routing.md"),
+        note_with(
+            "hermes-routing",
+            "reference",
+            "Hermes-only routing",
+            "shared_agent_scope_token",
+        ),
+    )
+    .expect("hermes note");
     fs::write(
         tmp.path().join("candidates/codex/not-curated.md"),
         "codex_agent_only_token candidate",
@@ -908,6 +972,31 @@ fn recall_on_demand_can_include_one_exact_agent_scope() {
         "{}",
         selected.stdout_text()
     );
+
+    let additive = run(
+        tmp.path(),
+        &[
+            "recall",
+            "on-demand",
+            "shared_agent_scope_token",
+            "--agent",
+            "codex",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(additive.code, 0, "stderr={}", additive.stderr_text());
+    let doc: serde_json::Value =
+        serde_json::from_str(additive.stdout_text().trim()).expect("additive recall json");
+    assert_eq!(doc["count"], 2);
+    let scopes: Vec<_> = doc["hits"]
+        .as_array()
+        .expect("recall hits")
+        .iter()
+        .map(|hit| hit["scope"].as_str().expect("hit scope"))
+        .collect();
+    assert_eq!(scopes, vec!["global", "agents/codex"]);
+    assert!(!additive.stdout_text().contains("agents/hermes"));
 }
 
 #[test]

--- a/crates/agent-memory/tests/integration/cli.rs
+++ b/crates/agent-memory/tests/integration/cli.rs
@@ -1100,7 +1100,11 @@ fn recall_on_demand_rejects_symlinked_agent_leaf_without_candidate_content() {
     assert_eq!(out.code, 1);
     let doc: serde_json::Value =
         serde_json::from_str(out.stdout_text().trim()).expect("typed recall error");
-    assert_eq!(doc["error"]["code"], "agent-scope-not-found");
+    assert_eq!(doc["error"]["code"], "agent-scope-untrusted");
+    assert_eq!(
+        doc["error"]["details"]["recovery"]["command"],
+        "agent-memory doctor"
+    );
     assert!(!out.stdout_text().contains("leaf_candidate_injection_token"));
 }
 

--- a/crates/agent-memory/tests/integration/cli.rs
+++ b/crates/agent-memory/tests/integration/cli.rs
@@ -1068,6 +1068,42 @@ fn recall_on_demand_rejects_symlinked_agents_root_without_candidate_content() {
     assert!(!out.stdout_text().contains("candidate_injection_token"));
 }
 
+#[cfg(unix)]
+#[test]
+fn recall_on_demand_rejects_symlinked_agent_leaf_without_candidate_content() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_recall_layout(tmp.path());
+    fs::write(
+        tmp.path().join("candidates/codex/injected.md"),
+        "leaf_candidate_injection_token",
+    )
+    .expect("candidate payload");
+    fs::create_dir_all(tmp.path().join("agents")).expect("agents root");
+    std::os::unix::fs::symlink(
+        tmp.path().join("candidates/codex"),
+        tmp.path().join("agents/codex"),
+    )
+    .expect("agent scope symlink");
+
+    let out = run(
+        tmp.path(),
+        &[
+            "recall",
+            "on-demand",
+            "leaf_candidate_injection_token",
+            "--agent",
+            "codex",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(out.code, 1);
+    let doc: serde_json::Value =
+        serde_json::from_str(out.stdout_text().trim()).expect("typed recall error");
+    assert_eq!(doc["error"]["code"], "agent-scope-not-found");
+    assert!(!out.stdout_text().contains("leaf_candidate_injection_token"));
+}
+
 #[test]
 fn candidate_list_prefers_frontmatter_description_for_preview() {
     let tmp = tempfile::TempDir::new().expect("tempdir");

--- a/crates/agent-memory/tests/integration/cli.rs
+++ b/crates/agent-memory/tests/integration/cli.rs
@@ -800,6 +800,25 @@ fn recall_startup_is_bounded_and_has_json_contract() {
     assert!(too_small.stderr_text().contains("exceeds 8 bytes"));
 }
 
+#[test]
+fn recall_startup_defaults_to_deployed_768_byte_budget() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_recall_layout(tmp.path());
+    fs::write(
+        tmp.path().join("profiles/startup/MEMORY.md"),
+        "x".repeat(769),
+    )
+    .expect("oversized startup profile");
+
+    let out = run(tmp.path(), &["recall", "startup"]);
+    assert_eq!(out.code, 1);
+    assert!(
+        out.stderr_text().contains("exceeds 768 bytes"),
+        "stderr={}",
+        out.stderr_text()
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn recall_startup_rejects_symlink_profile_directory() {
@@ -834,6 +853,138 @@ fn recall_on_demand_searches_curated_global_only() {
     let no_candidate = run(tmp.path(), &["recall", "on-demand", "candidate_only_token"]);
     assert_eq!(no_candidate.code, 1);
     assert!(no_candidate.stdout_text().is_empty());
+}
+
+#[test]
+fn recall_on_demand_can_include_one_exact_agent_scope() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_recall_layout(tmp.path());
+    let codex = tmp.path().join("agents/codex");
+    fs::create_dir_all(&codex).expect("codex agent scope");
+    fs::write(codex.join("MEMORY.md"), "# Codex memory\n").expect("codex index");
+    fs::write(
+        codex.join("routing.md"),
+        note_with(
+            "codex-routing",
+            "reference",
+            "Codex-only routing",
+            "codex_agent_only_token",
+        ),
+    )
+    .expect("codex note");
+    fs::write(
+        tmp.path().join("candidates/codex/not-curated.md"),
+        "codex_agent_only_token candidate",
+    )
+    .expect("candidate");
+
+    let global_only = run(
+        tmp.path(),
+        &["recall", "on-demand", "codex_agent_only_token"],
+    );
+    assert_eq!(global_only.code, 1);
+
+    let selected = run(
+        tmp.path(),
+        &[
+            "recall",
+            "on-demand",
+            "codex_agent_only_token",
+            "--agent",
+            "codex",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(selected.code, 0, "stderr={}", selected.stderr_text());
+    let doc: serde_json::Value =
+        serde_json::from_str(selected.stdout_text().trim()).expect("recall json");
+    assert_eq!(doc["count"], 1);
+    assert_eq!(doc["agent"], "codex");
+    assert_eq!(doc["hits"][0]["scope"], "agents/codex");
+    assert_eq!(doc["hits"][0]["file"], "routing.md");
+    assert!(
+        !selected.stdout_text().contains("not-curated.md"),
+        "{}",
+        selected.stdout_text()
+    );
+}
+
+#[test]
+fn recall_on_demand_reports_typed_missing_agent_error() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_recall_layout(tmp.path());
+
+    let out = run(
+        tmp.path(),
+        &[
+            "recall",
+            "on-demand",
+            "anything",
+            "--agent",
+            "missing",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(out.code, 1);
+    let doc: serde_json::Value =
+        serde_json::from_str(out.stdout_text().trim()).expect("typed recall error");
+    assert_eq!(doc["error"]["code"], "agent-scope-not-found");
+    assert_eq!(doc["error"]["details"]["retryable"], false);
+    assert_eq!(
+        doc["error"]["details"]["next_action"],
+        "select an existing agent scope or initialize one"
+    );
+    assert_eq!(
+        doc["error"]["details"]["recovery"]["command"],
+        "agent-memory agents"
+    );
+    assert!(
+        !out.stdout_text()
+            .contains(&tmp.path().display().to_string())
+    );
+}
+
+#[test]
+fn candidate_list_prefers_frontmatter_description_for_preview() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_recall_layout(tmp.path());
+    fs::write(
+        tmp.path().join("candidates/claude/frontmatter.md"),
+        "---\nname: frontmatter\ndescription: \"Diagnose shared startup memory\"\nmetadata:\n  type: project\n---\n\nDetailed candidate body.\n",
+    )
+    .expect("frontmatter candidate");
+    fs::write(
+        tmp.path().join("candidates/claude/body-fallback.md"),
+        "---\nname: body-fallback\n---\n\nPreview the first body line.\n",
+    )
+    .expect("body fallback candidate");
+    fs::write(
+        tmp.path().join("candidates/claude/opaque.md"),
+        "---\nThematic separator content.\n---\n",
+    )
+    .expect("opaque candidate");
+
+    let out = run(
+        tmp.path(),
+        &["candidate", "list", "claude", "--format", "json"],
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr_text());
+    let doc: serde_json::Value =
+        serde_json::from_str(out.stdout_text().trim()).expect("candidate list json");
+    let candidates = doc["candidates"].as_array().expect("candidate rows");
+    let preview = |file: &str| {
+        candidates
+            .iter()
+            .find(|candidate| candidate["file"] == file)
+            .expect("candidate row")["preview"]
+            .as_str()
+            .expect("preview")
+    };
+    assert_eq!(preview("frontmatter.md"), "Diagnose shared startup memory");
+    assert_eq!(preview("body-fallback.md"), "Preview the first body line.");
+    assert_eq!(preview("opaque.md"), "---");
 }
 
 #[test]

--- a/crates/agent-memory/tests/integration/cli.rs
+++ b/crates/agent-memory/tests/integration/cli.rs
@@ -1035,6 +1035,39 @@ fn recall_on_demand_reports_typed_missing_agent_error() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn recall_on_demand_rejects_symlinked_agents_root_without_candidate_content() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_recall_layout(tmp.path());
+    fs::write(
+        tmp.path().join("candidates/codex/injected.md"),
+        "candidate_injection_token",
+    )
+    .expect("candidate payload");
+    fs::remove_dir_all(tmp.path().join("agents")).expect("remove agents root");
+    std::os::unix::fs::symlink(tmp.path().join("candidates"), tmp.path().join("agents"))
+        .expect("agents symlink");
+
+    let out = run(
+        tmp.path(),
+        &[
+            "recall",
+            "on-demand",
+            "candidate_injection_token",
+            "--agent",
+            "codex",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(out.code, 1);
+    let doc: serde_json::Value =
+        serde_json::from_str(out.stdout_text().trim()).expect("typed recall error");
+    assert_eq!(doc["error"]["code"], "agent-scope-untrusted");
+    assert!(!out.stdout_text().contains("candidate_injection_token"));
+}
+
 #[test]
 fn candidate_list_prefers_frontmatter_description_for_preview() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -1054,6 +1087,15 @@ fn candidate_list_prefers_frontmatter_description_for_preview() {
         "---\nThematic separator content.\n---\n",
     )
     .expect("opaque candidate");
+    fs::write(
+        tmp.path()
+            .join("candidates/claude/oversized-description.md"),
+        format!(
+            "---\nname: oversized-description\ndescription: \"{}\"\n---\n",
+            "x".repeat(1024 * 1024)
+        ),
+    )
+    .expect("oversized description candidate");
 
     let out = run(
         tmp.path(),
@@ -1074,6 +1116,7 @@ fn candidate_list_prefers_frontmatter_description_for_preview() {
     assert_eq!(preview("frontmatter.md"), "Diagnose shared startup memory");
     assert_eq!(preview("body-fallback.md"), "Preview the first body line.");
     assert_eq!(preview("opaque.md"), "---");
+    assert_eq!(preview("oversized-description.md").chars().count(), 160);
 }
 
 #[test]

--- a/crates/agent-memory/tests/integration/coverage.rs
+++ b/crates/agent-memory/tests/integration/coverage.rs
@@ -186,6 +186,13 @@ fn init_persona_renders_tilde_settings_when_store_lives_under_home() {
         settings.contains("\"~/.config/agent-memory/personas/work/memory\""),
         "settings should use a HOME-relative path; got: {settings}"
     );
+
+    let instructions =
+        fs::read_to_string(amh.join("personas/work/CLAUDE.md")).expect("persona instructions");
+    assert!(
+        instructions.contains("passed explicitly with `claude --settings`"),
+        "persona scaffold must explain the explicit settings contract; got: {instructions}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add frontmatter-aware candidate previews without weakening opaque fallback behavior
- add exact `--agent <id>` recall scope while preserving global-only compatibility
- align persona scaffold guidance and the 768-byte startup default with the runtime contract
- preserve the full aggregated context when `agent-hook` renders a provider-native envelope

Refs serenvia/agent-memory#19

## Test plan

- `cargo test -p nils-agent-memory`
- `cargo test -p nils-agent-hook`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- test-first evidence verified for the delivered head
