### PR TITLE
feat(agent-hook): add strict DSH ingress

### DIFF
--- a/completions/bash/agent-hook
+++ b/completions/bash/agent-hook
@@ -168,7 +168,7 @@ _agent__hook() {
             fi
             case "${prev}" in
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude dsh hermes" -- "${cur}"))
                     return 0
                     ;;
                 --event)
@@ -246,7 +246,7 @@ _agent__hook() {
             fi
             case "${prev}" in
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude dsh hermes" -- "${cur}"))
                     return 0
                     ;;
                 --format)
@@ -500,7 +500,7 @@ _agent__hook() {
             fi
             case "${prev}" in
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude dsh hermes" -- "${cur}"))
                     return 0
                     ;;
                 --event)
@@ -617,7 +617,7 @@ _agent__hook() {
                     return 0
                     ;;
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude dsh hermes" -- "${cur}"))
                     return 0
                     ;;
                 --event)
@@ -810,7 +810,7 @@ _agent__hook() {
             fi
             case "${prev}" in
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude dsh hermes" -- "${cur}"))
                     return 0
                     ;;
                 --expected-plan-digest)

--- a/completions/zsh/_agent-hook
+++ b/completions/zsh/_agent-hook
@@ -33,7 +33,7 @@ _agent-hook() {
         case $line[1] in
             (dispatch)
 _arguments "${_arguments_options[@]}" : \
-'--product=[Provider whose bounded JSON request is read from stdin]:PRODUCT:(codex claude hermes)' \
+'--product=[Provider whose bounded JSON request is read from stdin]:PRODUCT:(codex claude dsh hermes)' \
 '--event=[Provider event when the request does not carry one]:EVENT:_default' \
 '--capability-file=[Private exact recovery capability file]:PATH:_files' \
 '--format=[Output contract. Provider is the hook-ingress default]:FORMAT:((provider\:"Provider-native output for hook ingress"
@@ -72,7 +72,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (doctor)
 _arguments "${_arguments_options[@]}" : \
-'(--all)--product=[Limit provider diagnostics]:PRODUCT:(codex claude hermes)' \
+'(--all)--product=[Limit provider diagnostics]:PRODUCT:(codex claude dsh hermes)' \
 '--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--config=[Override the strict user config path]:PATH:_files' \
@@ -85,7 +85,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (setup)
 _arguments "${_arguments_options[@]}" : \
-'--product=[Provider whose exact owned ingress is managed]:PRODUCT:(codex claude hermes)' \
+'--product=[Provider whose exact owned ingress is managed]:PRODUCT:(codex claude dsh hermes)' \
 '--expected-plan-digest=[Digest from the reviewed preview; required for drift, compatibility, or dual state]:SHA256:_default' \
 '--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
@@ -119,7 +119,7 @@ _arguments "${_arguments_options[@]}" : \
         case $line[1] in
             (challenge)
 _arguments "${_arguments_options[@]}" : \
-'--product=[]:PRODUCT:(codex claude hermes)' \
+'--product=[]:PRODUCT:(codex claude dsh hermes)' \
 '--event=[]:EVENT:_default' \
 '--target-digest=[]:TARGET_DIGEST:_default' \
 '--command-digest=[]:COMMAND_DIGEST:_default' \
@@ -154,7 +154,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 (consume)
 _arguments "${_arguments_options[@]}" : \
 '--capability-file=[Private authorized capability file to validate and consume]:PATH:_files' \
-'--product=[]:PRODUCT:(codex claude hermes)' \
+'--product=[]:PRODUCT:(codex claude dsh hermes)' \
 '--event=[]:EVENT:_default' \
 '--target-digest=[]:TARGET_DIGEST:_default' \
 '--command-digest=[]:COMMAND_DIGEST:_default' \

--- a/crates/agent-hook/README.md
+++ b/crates/agent-hook/README.md
@@ -1,9 +1,10 @@
 # agent-hook
 
 `agent-hook` is the shared policy control plane for Codex and Claude native
-hooks. Provider configuration contains only one dispatcher command per required
-event/matcher group; versioned policy, deterministic aggregation, diagnostics,
-and governed recovery live behind that ingress.
+hooks and the out-of-tree DeepSeek Harness (DSH) runtime bundle. Provider
+configuration contains only one dispatcher command per required event/matcher
+group; versioned policy, deterministic aggregation, diagnostics, and governed
+recovery live behind that ingress.
 
 ## Package and binary
 
@@ -42,6 +43,7 @@ agent-hook setup --product claude --remove --dry-run --format json
 agent-hook setup --product claude --remove \
   --expected-plan-digest sha256:<digest> --format json
 printf '%s' "$PROVIDER_HOOK_JSON" | agent-hook dispatch --product codex
+printf '%s' "$DSH_INGRESS_JSON" | agent-hook dispatch --product dsh --format json
 agent-hook completion zsh
 ```
 
@@ -50,9 +52,22 @@ is present. Setup preserves unrelated hooks and provider metadata, migrates
 recognized pre-dispatch `agent-session`/runtime-kit handlers, and removes only exact
 owned dispatcher entries. `--remove --dry-run` returns the
 `remove-dry-run` action without writes; its digest binds the remove operation
-and each provider file's exact before/after content or absence. Hermes policy
-can be validated and inspected, but native setup truthfully reports
-`unsupported` until Hermes exposes a compatible runner.
+and each provider file's exact before/after content or absence. DSH policy
+dispatch is enforceable, but setup truthfully reports `unsupported` because the
+external `dsh-runtime-kit` bundle owns the Cordis registration. Hermes policy
+can be validated and inspected, but native setup also reports `unsupported`
+until Hermes exposes a compatible runner.
+
+DSH doctor output names `dsh-runtime-kit` as `registration_owner` and reports
+`dispatch_supported: true` even though file-based setup remains unsupported.
+
+DSH sends strict `agent-hook.dsh-ingress.v1` JSON. The first supported native
+event is `tools/pre-execute`, normalized to canonical `PreToolUse`; the service
+JSON decision is mapped back to DSH's `tools/pre-execute` waterfall by the
+runtime bundle. DSH rules cannot select retired `runtime-kit.handler.v1` file
+handlers.
+DSH v1 policies accept only `decision.allow.v1` and `decision.block.v1` until
+native path binding and context-bearing decision semantics are implemented.
 
 Before `doctor` reports an enforceable provider as `converged`, it resolves
 every script-backed handler selected by that product's policy and applies the

--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -8,11 +8,13 @@ Ownership: crate-local canonical specification for `nils-agent-hook` and the
 ## Purpose and boundary
 
 `agent-hook` is the sole owner of nils-cli-managed Codex and Claude hook
-registrations. Provider-native hooks remain lifecycle ingress, but their owned
-commands contain only `agent-hook dispatch --product <provider>`; policy rules
-never live in provider configuration. The CLI does not manage unrelated hooks,
-execute config-defined programs, weaken lower-level transaction/privacy rules,
-or claim native enforcement for providers without a compatible runner.
+registrations and the policy engine behind the external DSH runtime bundle.
+Provider-native hooks remain lifecycle ingress, but their owned commands
+contain only `agent-hook dispatch --product <provider>`; policy rules never
+live in provider configuration. DSH is registered by `dsh-runtime-kit`, not by
+`agent-hook setup`. The CLI does not manage unrelated hooks, execute
+config-defined programs, weaken lower-level transaction/privacy rules, or claim
+native setup ownership for providers without a compatible runner.
 
 ## Files and limits
 
@@ -56,6 +58,10 @@ above.
   one public boolean fact. It is trusted in exactly one direction: `true` may end
   a turn that is already looping, and it can never grant authority, release a
   claim, or downgrade a proven owner.
+- `agent-hook.dsh-ingress.v1`: strict DSH-to-policy transport for one native
+  extension event. Version 1 carries exactly `event`, bounded `call_id`, an
+  absolute `cwd`, and a `tool` object with bounded `name` and object-valued
+  `arguments`. Unknown fields are rejected at the root and nested tool object.
 - `agent-hook.normalized-decision.v1`: aggregate action, ordered reason codes,
   optional bounded context or replacement, shadow observations, and config /
   policy digests.
@@ -67,7 +73,8 @@ above.
   permitted. Provider hook argv content is omitted.
 - `agent-hook.doctor.v1`: product status (missing, compatibility-only, `dual`,
   `drifted`, `converged`, `unsupported`, or `unrelated`), owned counts,
-  compatibility residue count, digests, policy availability, and recovery health.
+  compatibility residue count, digests, policy availability, recovery health,
+  registration owner, and whether direct dispatch is supported.
 - `agent-hook.inventory.v1`: ordered public rule metadata and effective mode;
   capability parameters and private paths are omitted.
 - `agent-hook.recovery-challenge.v1`: random challenge ID, exact product/event,
@@ -98,9 +105,10 @@ whose default is provider output so the documented ingress command is usable.
 
 ## Provider normalization and rendering
 
-Products are `codex`, `claude`, and `hermes`. Codex and Claude are enforceable;
-Hermes validates and evaluates shared policy but reports `unsupported` for
-native setup until a compatible runner exists.
+Products are `codex`, `claude`, `dsh`, and `hermes`. Codex, Claude, and DSH are
+enforceable. DSH setup reports `unsupported` because the out-of-tree runtime
+bundle owns registration. Hermes validates and evaluates shared policy but
+reports `unsupported` for native setup until a compatible runner exists.
 
 Supported canonical events are:
 
@@ -111,15 +119,20 @@ Supported canonical events are:
   `PostToolUse`, `PostToolUseFailure`, `PreCompact`, `Stop`, `StopFailure`,
   `Notification`, `SubagentStart`, `SubagentStop`, `Elicitation`, and
   `ElicitationResult`.
+- DSH: `PreToolUse`, normalized only from native `tools/pre-execute` ingress in
+  this version.
 
-The adapter accepts the event from `--event` or the provider's documented
-`hook_event_name`/`event` field and rejects a mismatch. Matcher values are
-normalized only from documented provider fields:
+The Codex/Claude/Hermes adapter accepts the event from `--event` or the
+provider's documented `hook_event_name`/`event` field and rejects a mismatch.
+The DSH adapter requires `agent-hook.dsh-ingress.v1`; an optional `--event`
+must equal its native event string before that string is mapped to the canonical
+policy event. Matcher values are normalized only from documented fields:
 
 | Provider events | Matcher input field |
 | --- | --- |
 | Codex/Claude `SessionStart` | `source` |
 | Codex/Claude `PermissionRequest`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure` | `tool_name` |
+| DSH `PreToolUse` | `tool.name` |
 | Codex/Claude `PreCompact`; Codex `PostCompact` | `trigger` |
 | Codex/Claude `SubagentStart`, `SubagentStop` | `agent_type` |
 | Claude `Notification` | `notification_type` |
@@ -155,6 +168,16 @@ normalized request, decision, trace, or recovery artifact.
 Owner-liveness evaluates every distinct target checkout plus the execution
 checkout and returns the strongest result; an active foreign owner therefore
 cannot be masked by a self-owned or unclaimed target.
+
+DSH v1 preserves the complete object-valued tool arguments for policy
+normalization, but it does not yet declare tool-specific mutation path mappings.
+Until those mappings are added, DSH `PreToolUse` binds target/effect context to
+the absolute session `cwd`; tool-name policy can still allow or block, but
+target-granular owner-liveness is not claimed. Policy validation therefore
+accepts only `decision.allow.v1` and `decision.block.v1` for DSH v1; context,
+warning, activity, coordination, read-only, owner-liveness, semantic-conflict,
+transform, and retired handler capabilities are rejected until their native
+semantics exist.
 
 Built-in semantic-conflict and owner-liveness admission applies only to a
 managed process. When `AGENT_SESSION_ID`, `AGENT_SESSION_RUNTIME_ID`,
@@ -193,19 +216,25 @@ safely produce no stdout, a concise stderr diagnostic, and exit `2` so the
 provider applies its native blocking fallback. Runtime or service-format
 failures use exit `1`; successful provider-native decisions use exit `0`.
 `dispatch --format json` returns the normalized decision envelope and does not
-return raw provider content.
+return raw provider content. DSH ingress requires this service JSON form; the
+runtime bundle maps `block` to a `tools/pre-execute` denial, delegates `allow`,
+and fails closed on every malformed, truncated, signaled, exit-mismatched,
+replayed, timed-out, oversized, or unsupported response.
 
 Policy validation also checks the complete provider/event/capability binding,
 not only each component in isolation. `decision.warn.v1` and
 `decision.context.v1` require an event with native model-context semantics;
 `decision.block.v1` requires native block, continuation, feedback, or decline
 semantics; and `decision.transform.v1` is limited to Codex `PreToolUse` plus
-Claude `PreToolUse`, `PermissionRequest`, and `PostToolUse`.
+Claude `PreToolUse`, `PermissionRequest`, and `PostToolUse`. DSH v1 does not
+transform arguments and accepts only native allow/block capabilities.
 `agent-session.owner-liveness.v1` and
 `agent-session.semantic-conflict.v1` require both context and block semantics
 because their result is data-dependent. Neutral `decision.allow.v1`, metadata
 side effects through `agent-session.activity.v1`, and trusted provider-native
-`runtime-kit.handler.v1` remain valid for every supported event. This preserves
+`runtime-kit.handler.v1` remain valid for supported Codex/Claude events. DSH
+rules reject retired file handlers so policy cannot fall back to the archived
+runtime-kit implementation. This preserves
 notification and failure logging without pretending that events such as
 Claude `Notification` or `StopFailure` can enforce a decision.
 `agent-session.coordination.v1` is limited to enforceable

--- a/crates/agent-hook/src/adapter.rs
+++ b/crates/agent-hook/src/adapter.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 
@@ -16,6 +16,7 @@ use crate::path_binding::{TargetBinding, resolve_target_bindings};
 use crate::strict_json;
 
 pub const MAX_PROVIDER_BYTES: usize = 1024 * 1024;
+const DSH_INGRESS_VERSION: &str = "agent-hook.dsh-ingress.v1";
 const MAX_PROVIDER_ID_CHARS: usize = 256;
 const MAX_MUTATION_TARGETS: usize = 256;
 const MAX_MUTATION_TARGET_BYTES: usize = 4096;
@@ -39,6 +40,23 @@ struct ActivityEvent {
     attention_kind: Option<&'static str>,
     confidence: &'static str,
     source_kind: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DshIngress {
+    schema_version: String,
+    event: String,
+    call_id: String,
+    cwd: PathBuf,
+    tool: DshToolCall,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DshToolCall {
+    name: String,
+    arguments: Value,
 }
 
 pub fn read_stdin() -> Result<Vec<u8>, HookError> {
@@ -70,6 +88,9 @@ pub fn normalize(
         ));
     }
     let raw = parse_provider_json(input)?;
+    if product == Product::Dsh {
+        return normalize_dsh(event_arg, input, raw);
+    }
     let object = raw.as_object().ok_or_else(|| {
         HookError::data(
             "provider-input-invalid",
@@ -150,6 +171,116 @@ pub fn normalize(
         // dispatcher replaces this with a #676 registry-derived projection.
         semantic_conflict: None,
         stop_reentry: stop_reentry(object),
+        target_paths,
+        execution_path,
+        binding_roots,
+    })
+}
+
+fn normalize_dsh(
+    event_arg: Option<&str>,
+    input: &[u8],
+    raw: Value,
+) -> Result<NormalizedRequest, HookError> {
+    let ingress: DshIngress = serde_json::from_value(raw).map_err(|_| {
+        HookError::data(
+            "dsh-ingress-invalid",
+            "DSH ingress must match the strict agent-hook.dsh-ingress.v1 object",
+        )
+    })?;
+    if ingress.schema_version != DSH_INGRESS_VERSION {
+        return Err(HookError::data(
+            "dsh-ingress-version-invalid",
+            "DSH ingress schema_version is unsupported",
+        ));
+    }
+    if let Some(argument) = event_arg
+        && argument != ingress.event
+    {
+        return Err(HookError::data(
+            "provider-event-mismatch",
+            "--event does not match the DSH ingress event",
+        ));
+    }
+    let event = match ingress.event.as_str() {
+        "tools/pre-execute" => "PreToolUse",
+        _ => {
+            return Err(HookError::data(
+                "provider-event-unsupported",
+                "DSH ingress event is not supported by agent-hook v1",
+            ));
+        }
+    };
+    if ingress.call_id.is_empty()
+        || ingress.call_id.chars().count() > MAX_PROVIDER_ID_CHARS
+        || ingress.tool.name.is_empty()
+        || ingress.tool.name.chars().count() > MAX_PROVIDER_ID_CHARS
+        || !ingress.cwd.is_absolute()
+        || !ingress.tool.arguments.is_object()
+    {
+        return Err(HookError::data(
+            "dsh-ingress-invalid",
+            "DSH ingress requires bounded call/tool identifiers, an absolute cwd, and object arguments",
+        ));
+    }
+
+    let mut canonical = Map::new();
+    canonical.insert(
+        "cwd".to_string(),
+        Value::String(ingress.cwd.to_string_lossy().into_owned()),
+    );
+    canonical.insert(
+        "tool_name".to_string(),
+        Value::String(ingress.tool.name.clone()),
+    );
+    canonical.insert("tool_input".to_string(), ingress.tool.arguments);
+
+    let matcher = Some(ingress.tool.name);
+    let (target_paths, execution_path) =
+        target_paths(Product::Dsh, &canonical, matcher.as_deref())?;
+    let target_count = target_paths.len();
+    let mut binding_paths = target_paths;
+    if let Some(execution_path) = execution_path.as_ref() {
+        binding_paths.push(execution_path.clone());
+    }
+    let mut resolved_bindings = resolve_target_bindings(&binding_paths)?;
+    let execution_binding = execution_path
+        .as_ref()
+        .and_then(|_| resolved_bindings.pop());
+    debug_assert_eq!(resolved_bindings.len(), target_count);
+    let mut target_bindings = resolved_bindings;
+    deduplicate_target_bindings(&mut target_bindings);
+    let target_material = target_set_binding_material(&target_bindings)?;
+    let mut binding_roots = target_bindings
+        .iter()
+        .map(|binding| binding.binding_root.clone())
+        .collect::<Vec<_>>();
+    if let Some(binding) = execution_binding {
+        binding_roots.push(binding.binding_root);
+    }
+    deduplicate_paths(&mut binding_roots);
+    let target_paths = target_bindings
+        .into_iter()
+        .map(|binding| binding.effective_path)
+        .collect();
+    let command_material = command_text(&canonical)
+        .unwrap_or("command-unavailable")
+        .as_bytes();
+    let snapshot_digest = digest(input);
+    let request_id = format!("request:{}", &snapshot_digest[7..39]);
+
+    Ok(NormalizedRequest {
+        schema_version: REQUEST_VERSION.to_string(),
+        request_id,
+        product: Product::Dsh,
+        event: event.to_string(),
+        matcher,
+        target_digest: digest(&target_material),
+        command_digest: digest(command_material),
+        snapshot_digest,
+        worktree_fingerprint: None,
+        semantic_conflict: None,
+        stop_reentry: None,
         target_paths,
         execution_path,
         binding_roots,

--- a/crates/agent-hook/src/adapter.rs
+++ b/crates/agent-hook/src/adapter.rs
@@ -126,55 +126,7 @@ pub fn normalize(
         .and_then(Value::as_str)
         .map(str::to_string)
         .filter(|value| value.len() <= 128);
-    let (target_paths, execution_path) = target_paths(product, object, matcher.as_deref())?;
-    let target_count = target_paths.len();
-    let mut binding_paths = target_paths;
-    if let Some(execution_path) = execution_path.as_ref() {
-        binding_paths.push(execution_path.clone());
-    }
-    let mut resolved_bindings = resolve_target_bindings(&binding_paths)?;
-    let execution_binding = execution_path
-        .as_ref()
-        .and_then(|_| resolved_bindings.pop());
-    debug_assert_eq!(resolved_bindings.len(), target_count);
-    let mut target_bindings = resolved_bindings;
-    deduplicate_target_bindings(&mut target_bindings);
-    let target_material = target_set_binding_material(&target_bindings)?;
-    let mut binding_roots = target_bindings
-        .iter()
-        .map(|binding| binding.binding_root.clone())
-        .collect::<Vec<_>>();
-    if let Some(binding) = execution_binding {
-        binding_roots.push(binding.binding_root);
-    }
-    deduplicate_paths(&mut binding_roots);
-    let target_paths = target_bindings
-        .into_iter()
-        .map(|binding| binding.effective_path)
-        .collect();
-    let command_material = command_text(object)
-        .unwrap_or("command-unavailable")
-        .as_bytes();
-    let snapshot_digest = digest(input);
-    let request_id = format!("request:{}", &snapshot_digest[7..39]);
-    Ok(NormalizedRequest {
-        schema_version: REQUEST_VERSION.to_string(),
-        request_id,
-        product,
-        event,
-        matcher,
-        target_digest: digest(&target_material),
-        command_digest: digest(command_material),
-        snapshot_digest,
-        worktree_fingerprint: None,
-        // Provider payload fields are untrusted and deliberately ignored. The
-        // dispatcher replaces this with a #676 registry-derived projection.
-        semantic_conflict: None,
-        stop_reentry: stop_reentry(object),
-        target_paths,
-        execution_path,
-        binding_roots,
-    })
+    finalize_normalized_request(product, event, matcher, input, object, stop_reentry(object))
 }
 
 fn normalize_dsh(
@@ -236,8 +188,25 @@ fn normalize_dsh(
     canonical.insert("tool_input".to_string(), ingress.tool.arguments);
 
     let matcher = Some(ingress.tool.name);
-    let (target_paths, execution_path) =
-        target_paths(Product::Dsh, &canonical, matcher.as_deref())?;
+    finalize_normalized_request(
+        Product::Dsh,
+        event.to_string(),
+        matcher,
+        input,
+        &canonical,
+        None,
+    )
+}
+
+fn finalize_normalized_request(
+    product: Product,
+    event: String,
+    matcher: Option<String>,
+    input: &[u8],
+    object: &Map<String, Value>,
+    stop_reentry: Option<bool>,
+) -> Result<NormalizedRequest, HookError> {
+    let (target_paths, execution_path) = target_paths(product, object, matcher.as_deref())?;
     let target_count = target_paths.len();
     let mut binding_paths = target_paths;
     if let Some(execution_path) = execution_path.as_ref() {
@@ -263,7 +232,7 @@ fn normalize_dsh(
         .into_iter()
         .map(|binding| binding.effective_path)
         .collect();
-    let command_material = command_text(&canonical)
+    let command_material = command_text(object)
         .unwrap_or("command-unavailable")
         .as_bytes();
     let snapshot_digest = digest(input);
@@ -272,15 +241,18 @@ fn normalize_dsh(
     Ok(NormalizedRequest {
         schema_version: REQUEST_VERSION.to_string(),
         request_id,
-        product: Product::Dsh,
-        event: event.to_string(),
+        product,
+        event,
         matcher,
         target_digest: digest(&target_material),
         command_digest: digest(command_material),
         snapshot_digest,
         worktree_fingerprint: None,
         semantic_conflict: None,
-        stop_reentry: None,
+        // Provider payload fields are untrusted and deliberately ignored. The
+        // dispatcher replaces semantic conflict state with a registry-derived
+        // projection. Only the separately validated Stop re-entry fact remains.
+        stop_reentry,
         target_paths,
         execution_path,
         binding_roots,
@@ -658,35 +630,39 @@ fn target_paths(
         .map(PathBuf::from)
         .filter(|path| path.is_absolute());
     let nested = object.get("tool_input").and_then(Value::as_object);
-    let mut targets = match matcher {
-        Some("Write" | "Edit" | "MultiEdit") => {
-            let input = mutation_input(nested)?;
-            let path = exactly_one_path(input, &["path", "file_path"])?;
-            vec![resolve_mutation_target(path, execution.as_deref())?]
+    let mut targets = if product == Product::Dsh {
+        execution.iter().cloned().collect()
+    } else {
+        match matcher {
+            Some("Write" | "Edit" | "MultiEdit") => {
+                let input = mutation_input(nested)?;
+                let path = exactly_one_path(input, &["path", "file_path"])?;
+                vec![resolve_mutation_target(path, execution.as_deref())?]
+            }
+            Some("NotebookEdit") => {
+                let input = mutation_input(nested)?;
+                let path = required_string(input.get("notebook_path"))?;
+                vec![resolve_mutation_target(path, execution.as_deref())?]
+            }
+            Some("apply_patch") if product == Product::Codex => {
+                let input = mutation_input(nested)?;
+                let patch = match input.get("command") {
+                    Some(Value::String(patch)) if !patch.is_empty() => patch.as_str(),
+                    _ => {
+                        return Err(untrusted_target(
+                            "Codex apply_patch mutation must contain a non-empty command string",
+                        ));
+                    }
+                };
+                parse_apply_patch_targets(patch, execution.as_deref())?
+            }
+            Some("apply_patch") => {
+                return Err(untrusted_target(
+                    "apply_patch mutation has no documented native mapping for this provider",
+                ));
+            }
+            _ => execution.iter().cloned().collect(),
         }
-        Some("NotebookEdit") => {
-            let input = mutation_input(nested)?;
-            let path = required_string(input.get("notebook_path"))?;
-            vec![resolve_mutation_target(path, execution.as_deref())?]
-        }
-        Some("apply_patch") if product == Product::Codex => {
-            let input = mutation_input(nested)?;
-            let patch = match input.get("command") {
-                Some(Value::String(patch)) if !patch.is_empty() => patch.as_str(),
-                _ => {
-                    return Err(untrusted_target(
-                        "Codex apply_patch mutation must contain a non-empty command string",
-                    ));
-                }
-            };
-            parse_apply_patch_targets(patch, execution.as_deref())?
-        }
-        Some("apply_patch") => {
-            return Err(untrusted_target(
-                "apply_patch mutation has no documented native mapping for this provider",
-            ));
-        }
-        _ => execution.iter().cloned().collect(),
     };
     deduplicate_targets(&mut targets);
     Ok((targets, execution))

--- a/crates/agent-hook/src/contract.rs
+++ b/crates/agent-hook/src/contract.rs
@@ -390,6 +390,23 @@ fn validate_capability_binding(
     event: &str,
     capability: &Capability,
 ) -> Result<(), HookError> {
+    if product == Product::Dsh && matches!(capability, Capability::RuntimeKitHandler { .. }) {
+        return Err(HookError::data(
+            "policy-capability-event-unsupported",
+            "DSH policy cannot invoke retired runtime-kit file handlers",
+        ));
+    }
+    if product == Product::Dsh
+        && !matches!(
+            capability,
+            Capability::Allow { .. } | Capability::Block { .. }
+        )
+    {
+        return Err(HookError::data(
+            "policy-capability-event-unsupported",
+            "DSH policy v1 supports only native allow and block decisions",
+        ));
+    }
     if matches!(capability, Capability::SessionCoordination { .. }) && !product.enforceable() {
         return Err(HookError::data(
             "policy-capability-event-unsupported",
@@ -447,6 +464,7 @@ fn supports_context(product: Product, event: &str) -> bool {
                 | "SubagentStop"
                 | "Stop"
         ),
+        Product::Dsh => false,
         Product::Hermes => false,
     }
 }
@@ -479,6 +497,7 @@ fn supports_block(product: Product, event: &str) -> bool {
                 | "Elicitation"
                 | "ElicitationResult"
         ),
+        Product::Dsh => event == "PreToolUse",
         Product::Hermes => false,
     }
 }
@@ -487,6 +506,7 @@ fn supports_transform(product: Product, event: &str) -> bool {
     match product {
         Product::Codex => event == "PreToolUse",
         Product::Claude => matches!(event, "PreToolUse" | "PermissionRequest" | "PostToolUse"),
+        Product::Dsh => false,
         Product::Hermes => false,
     }
 }
@@ -629,6 +649,7 @@ pub fn supported_event(product: Product, event: &str) -> bool {
                 | "Elicitation"
                 | "ElicitationResult"
         ),
+        Product::Dsh => event == "PreToolUse",
         Product::Hermes => matches!(
             event,
             "pre_llm_call" | "post_llm_call" | "pre_approval_request" | "post_approval_response"
@@ -640,7 +661,7 @@ pub fn matcher_input_field(product: Product, event: &str) -> Option<&'static str
     match (product, event) {
         (Product::Codex | Product::Claude, "SessionStart") => Some("source"),
         (
-            Product::Codex | Product::Claude,
+            Product::Codex | Product::Claude | Product::Dsh,
             "PermissionRequest" | "PreToolUse" | "PostToolUse" | "PostToolUseFailure",
         ) => Some("tool_name"),
         (Product::Codex | Product::Claude, "PreCompact") | (Product::Codex, "PostCompact") => {

--- a/crates/agent-hook/src/evaluator.rs
+++ b/crates/agent-hook/src/evaluator.rs
@@ -1450,6 +1450,7 @@ fn runtime_hook_root(product: Product) -> Result<PathBuf, HookError> {
             .unwrap_or_else(|| home.join(".codex"))
             .join("hooks"),
         Product::Claude => home.join(".claude/hooks"),
+        Product::Dsh => home.join(".dsh/hooks"),
         Product::Hermes => home.join(".hermes/hooks"),
     })
 }

--- a/crates/agent-hook/src/lib.rs
+++ b/crates/agent-hook/src/lib.rs
@@ -226,7 +226,12 @@ fn dispatch(layout: Layout, policy_override: Option<&std::path::Path>, command: 
             let products = if let Some(product) = args.product {
                 vec![product]
             } else if args.all {
-                vec![Product::Codex, Product::Claude, Product::Hermes]
+                vec![
+                    Product::Codex,
+                    Product::Claude,
+                    Product::Dsh,
+                    Product::Hermes,
+                ]
             } else {
                 vec![Product::Codex, Product::Claude]
             };

--- a/crates/agent-hook/src/model.rs
+++ b/crates/agent-hook/src/model.rs
@@ -15,6 +15,7 @@ pub const DECISION_VERSION: &str = "agent-hook.normalized-decision.v1";
 pub enum Product {
     Codex,
     Claude,
+    Dsh,
     Hermes,
 }
 
@@ -23,6 +24,7 @@ impl Product {
         match self {
             Self::Codex => "codex",
             Self::Claude => "claude",
+            Self::Dsh => "dsh",
             Self::Hermes => "hermes",
         }
     }

--- a/crates/agent-hook/src/setup.rs
+++ b/crates/agent-hook/src/setup.rs
@@ -110,6 +110,10 @@ pub struct DoctorResult {
     pub config_digest: String,
     pub policy_digest: String,
     pub recovery: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registration_owner: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispatch_supported: Option<bool>,
 }
 
 struct Plan {
@@ -141,8 +145,19 @@ pub fn run(
     action: SetupAction,
     expected_plan_digest: Option<&str>,
 ) -> Result<SetupResult, HookError> {
-    if !product.enforceable() {
+    if matches!(product, Product::Dsh | Product::Hermes) {
         let groups = policy_groups(loaded, product);
+        let (compatibility_owner, trust) = if product == Product::Dsh {
+            (
+                "dsh-runtime-kit",
+                "external dsh-runtime-kit bundle owns Cordis registration; no files changed",
+            )
+        } else {
+            (
+                "agent-hook",
+                "provider has no compatible native hook runner; no files changed",
+            )
+        };
         return Ok(SetupResult {
             schema_version: "agent-hook.setup-result.v1".to_string(),
             product: product.as_str().to_string(),
@@ -161,8 +176,8 @@ pub fn run(
             owned_groups: groups,
             legacy_residue_count: 0,
             unrelated_count: 0,
-            compatibility_owner: "agent-hook".to_string(),
-            trust: "provider has no compatible native hook runner; no files changed".to_string(),
+            compatibility_owner: compatibility_owner.to_string(),
+            trust: trust.to_string(),
         });
     }
     let plan = build_plan(loaded, product, action)?;
@@ -240,7 +255,8 @@ pub fn run(
 }
 
 pub fn doctor(loaded: &LoadedPolicy, product: Product) -> Result<DoctorResult, HookError> {
-    if !product.enforceable() {
+    if matches!(product, Product::Dsh | Product::Hermes) {
+        let dsh = product == Product::Dsh;
         return Ok(DoctorResult {
             schema_version: "agent-hook.doctor.v1".to_string(),
             product: product.as_str().to_string(),
@@ -252,7 +268,14 @@ pub fn doctor(loaded: &LoadedPolicy, product: Product) -> Result<DoctorResult, H
             unrelated_count: 0,
             config_digest: loaded.config_digest.clone(),
             policy_digest: loaded.policy_digest.clone(),
-            recovery: "available-for-shared-policy-only".to_string(),
+            recovery: if dsh {
+                "dispatch-supported-registration-owned-by-dsh-runtime-kit"
+            } else {
+                "available-for-shared-policy-only"
+            }
+            .to_string(),
+            registration_owner: dsh.then(|| "dsh-runtime-kit".to_string()),
+            dispatch_supported: dsh.then_some(true),
         });
     }
     let plan = build_plan(loaded, product, SetupAction::DryRun)?;
@@ -278,6 +301,8 @@ pub fn doctor(loaded: &LoadedPolicy, product: Product) -> Result<DoctorResult, H
         config_digest: loaded.config_digest.clone(),
         policy_digest: loaded.policy_digest.clone(),
         recovery: "challenge-authorize-consume".to_string(),
+        registration_owner: None,
+        dispatch_supported: None,
     })
 }
 
@@ -312,7 +337,7 @@ fn build_plan(
     match product {
         Product::Codex => build_codex_plan(loaded, product, action, path, original, groups),
         Product::Claude => build_json_plan(product, action, path, original, groups, loaded),
-        Product::Hermes => unreachable!("unsupported returned before plan"),
+        Product::Dsh | Product::Hermes => unreachable!("unsupported returned before plan"),
     }
 }
 
@@ -1734,7 +1759,7 @@ fn exact_runtime_handler_command(command: &str, product: Product, filename: &str
                 || command
                     == format!("AGENT_RUNTIME_PRODUCT=claude \"$HOME/.claude/hooks/{filename}\"")
         }
-        Product::Hermes => false,
+        Product::Dsh | Product::Hermes => false,
     }
 }
 
@@ -1750,6 +1775,7 @@ fn provider_path(product: Product) -> Result<PathBuf, HookError> {
             .unwrap_or_else(|| home.join(".codex"))
             .join("config.toml"),
         Product::Claude => home.join(".claude/settings.json"),
+        Product::Dsh => home.join(".dsh/cordis.patch.yml"),
         Product::Hermes => home.join(".hermes/config.yaml"),
     })
 }

--- a/crates/agent-hook/tests/api_contract.rs
+++ b/crates/agent-hook/tests/api_contract.rs
@@ -830,6 +830,7 @@ fn provider_event_capability_matrix_rejects_unenforceable_actions() {
                 "ElicitationResult",
             ][..],
         ),
+        ("dsh", &["PreToolUse"][..]),
     ];
     let capabilities = [
         (
@@ -915,6 +916,9 @@ capability = {capability_toml}
 }
 
 fn capability_is_compatible(product: &str, event: &str, capability: &str) -> bool {
+    if product == "dsh" {
+        return event == "PreToolUse" && matches!(capability, "allow" | "block");
+    }
     if matches!(capability, "allow" | "activity" | "runtime-handler") {
         return true;
     }

--- a/crates/agent-hook/tests/dsh_ingress.rs
+++ b/crates/agent-hook/tests/dsh_ingress.rs
@@ -1,0 +1,268 @@
+mod support;
+
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+use support::Fixture;
+
+const POLICY: &str = r#"schema_version = "agent-hook.policy.v1"
+bundle_id = "dsh-runtime-kit-test"
+version = "2026.08.18.1"
+
+[[rules]]
+id = "dsh.block-plus-one"
+products = ["dsh"]
+events = ["PreToolUse"]
+matcher = "runtime_kit_plus_one"
+priority = 10
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = { id = "decision.block.v1", reason_code = "plus-one-blocked", message = "fixture denial" }
+"#;
+
+fn request(fixture: &Fixture) -> String {
+    json!({
+        "schema_version": "agent-hook.dsh-ingress.v1",
+        "event": "tools/pre-execute",
+        "call_id": "dsh-call-1",
+        "cwd": fixture.root,
+        "tool": {
+            "name": "runtime_kit_plus_one",
+            "arguments": {"value": 41}
+        }
+    })
+    .to_string()
+}
+
+#[test]
+fn dsh_pre_execute_is_normalized_and_evaluated_by_the_shared_policy_engine() {
+    let fixture = Fixture::new(POLICY);
+    let output = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&request(&fixture)),
+    );
+
+    assert_eq!(output.code, 1, "stderr={}", output.stderr_text());
+    let envelope = output.stdout_json();
+    assert_eq!(envelope["schema_version"], "cli.agent-hook.dispatch.v1");
+    assert_eq!(envelope["ok"], true);
+    assert_eq!(envelope["data"]["product"], "dsh");
+    assert_eq!(envelope["data"]["event"], "PreToolUse");
+    assert_eq!(envelope["data"]["action"], "block");
+    assert_eq!(
+        envelope["data"]["reasons"],
+        json!([{
+            "rule_id": "dsh.block-plus-one",
+            "code": "plus-one-blocked",
+            "disposition": "block"
+        }])
+    );
+}
+
+#[test]
+fn dsh_ingress_rejects_unknown_versions_and_fields() {
+    let fixture = Fixture::new(POLICY);
+
+    let wrong_version =
+        request(&fixture).replace("agent-hook.dsh-ingress.v1", "agent-hook.dsh-ingress.v2");
+    let output = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&wrong_version),
+    );
+    assert_eq!(output.code, 65);
+    assert_eq!(
+        output.stdout_json()["error"]["code"],
+        "dsh-ingress-version-invalid"
+    );
+
+    let mut unknown_field: serde_json::Value =
+        serde_json::from_str(&request(&fixture)).expect("request JSON");
+    unknown_field["provider_extension"] = json!(true);
+    let output = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&unknown_field.to_string()),
+    );
+    assert_eq!(output.code, 65);
+    assert_eq!(output.stdout_json()["error"]["code"], "dsh-ingress-invalid");
+
+    let mut unknown_nested_field: serde_json::Value =
+        serde_json::from_str(&request(&fixture)).expect("request JSON");
+    unknown_nested_field["tool"]["provider_extension"] = json!(true);
+    let output = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&unknown_nested_field.to_string()),
+    );
+    assert_eq!(output.code, 65);
+    assert_eq!(output.stdout_json()["error"]["code"], "dsh-ingress-invalid");
+}
+
+#[test]
+fn dsh_ingress_enforces_field_boundaries_and_event_identity() {
+    let fixture = Fixture::new(POLICY);
+    let base: serde_json::Value = serde_json::from_str(&request(&fixture)).expect("request JSON");
+    let mut cases = Vec::new();
+
+    let mut unsupported_event = base.clone();
+    unsupported_event["event"] = json!("tools/post-execute");
+    cases.push((unsupported_event, "provider-event-unsupported"));
+
+    for call_id in [String::new(), "x".repeat(257)] {
+        let mut value = base.clone();
+        value["call_id"] = json!(call_id);
+        cases.push((value, "dsh-ingress-invalid"));
+    }
+    for tool_name in [String::new(), "x".repeat(257)] {
+        let mut value = base.clone();
+        value["tool"]["name"] = json!(tool_name);
+        cases.push((value, "dsh-ingress-invalid"));
+    }
+
+    let mut relative_cwd = base.clone();
+    relative_cwd["cwd"] = json!("relative/path");
+    cases.push((relative_cwd, "dsh-ingress-invalid"));
+    for arguments in [json!(null), json!([])] {
+        let mut value = base.clone();
+        value["tool"]["arguments"] = arguments;
+        cases.push((value, "dsh-ingress-invalid"));
+    }
+
+    for (value, error_code) in cases {
+        let output = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&value.to_string()),
+        );
+        assert_eq!(output.code, 65, "input={value}");
+        assert_eq!(output.stdout_json()["error"]["code"], error_code);
+    }
+
+    let mismatch = fixture.run(
+        &[
+            "dispatch",
+            "--product",
+            "dsh",
+            "--event",
+            "tools/post-execute",
+            "--format",
+            "json",
+        ],
+        Some(&request(&fixture)),
+    );
+    assert_eq!(mismatch.code, 65);
+    assert_eq!(
+        mismatch.stdout_json()["error"]["code"],
+        "provider-event-mismatch"
+    );
+
+    let mut boundary = base;
+    boundary["call_id"] = json!("c".repeat(256));
+    boundary["tool"]["name"] = json!("t".repeat(256));
+    let accepted = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&boundary.to_string()),
+    );
+    assert_eq!(accepted.code, 0, "stderr={}", accepted.stderr_text());
+}
+
+#[test]
+fn dsh_registration_is_bundle_owned_and_legacy_file_handlers_are_rejected() {
+    let fixture = Fixture::new(POLICY);
+    let setup = fixture.run(
+        &["setup", "--product", "dsh", "--dry-run", "--format", "json"],
+        None,
+    );
+    assert_eq!(setup.code, 0, "stderr={}", setup.stderr_text());
+    assert_eq!(setup.stdout_json()["data"]["status"], "unsupported");
+    assert_eq!(setup.stdout_json()["data"]["changed"], false);
+    assert_eq!(setup.stdout_json()["data"]["apply_allowed"], false);
+    assert_eq!(
+        setup.stdout_json()["data"]["compatibility_owner"],
+        "dsh-runtime-kit"
+    );
+
+    let doctor = fixture.run(&["doctor", "--product", "dsh", "--format", "json"], None);
+    assert_eq!(doctor.code, 0, "stderr={}", doctor.stderr_text());
+    assert_eq!(doctor.stdout_json()["data"][0]["dispatch_supported"], true);
+    assert_eq!(
+        doctor.stdout_json()["data"][0]["registration_owner"],
+        "dsh-runtime-kit"
+    );
+
+    let codex_doctor = fixture.run(&["doctor", "--product", "codex", "--format", "json"], None);
+    assert_eq!(
+        codex_doctor.code,
+        0,
+        "stderr={}",
+        codex_doctor.stderr_text()
+    );
+    assert!(
+        codex_doctor.stdout_json()["data"][0]["dispatch_supported"].is_null(),
+        "existing provider output must retain its v1 field set"
+    );
+    assert!(
+        codex_doctor.stdout_json()["data"][0]["registration_owner"].is_null(),
+        "existing provider output must retain its v1 field set"
+    );
+
+    let invalid_policy = POLICY.replace(
+        "capability = { id = \"decision.block.v1\", reason_code = \"plus-one-blocked\", message = \"fixture denial\" }",
+        "capability = { id = \"runtime-kit.handler.v1\", handler_id = \"pre-edit-intent-gate\" }",
+    );
+    let invalid = Fixture::new(&invalid_policy).run(&["validate", "--format", "json"], None);
+    assert_eq!(invalid.code, 65);
+    assert_eq!(
+        invalid.stdout_json()["error"]["code"],
+        "policy-capability-event-unsupported"
+    );
+}
+
+#[test]
+fn dsh_v1_rejects_capabilities_without_native_decision_or_target_semantics() {
+    let unsupported = [
+        "decision.warn.v1",
+        "decision.context.v1",
+        "agent-session.activity.v1",
+        "agent-session.owner-liveness.v1",
+        "agent-session.semantic-conflict.v1",
+        "execution.read-only.v1",
+        "agent-session.coordination.v1",
+    ];
+
+    for capability_id in unsupported {
+        let capability = match capability_id {
+            "decision.warn.v1" => {
+                r#"capability = { id = "decision.warn.v1", reason_code = "warn", message = "warn" }"#
+            }
+            "decision.context.v1" => {
+                r#"capability = { id = "decision.context.v1", reason_code = "context", text = "context" }"#
+            }
+            "agent-session.owner-liveness.v1" => {
+                r#"capability = { id = "agent-session.owner-liveness.v1", reason_code = "owner", legacy_ttl_seconds = 60 }"#
+            }
+            "agent-session.activity.v1" => {
+                r#"capability = { id = "agent-session.activity.v1", reason_code = "activity" }"#
+            }
+            "agent-session.semantic-conflict.v1" => {
+                r#"capability = { id = "agent-session.semantic-conflict.v1", reason_code = "conflict" }"#
+            }
+            "execution.read-only.v1" => {
+                r#"capability = { id = "execution.read-only.v1", reason_code = "read-only" }"#
+            }
+            "agent-session.coordination.v1" => {
+                r#"capability = { id = "agent-session.coordination.v1", reason_code = "coordination" }"#
+            }
+            _ => unreachable!(),
+        };
+        let policy = POLICY.replace(
+            "capability = { id = \"decision.block.v1\", reason_code = \"plus-one-blocked\", message = \"fixture denial\" }",
+            capability,
+        );
+        let output = Fixture::new(&policy).run(&["validate", "--format", "json"], None);
+        assert_eq!(output.code, 65, "capability={capability_id}");
+        assert_eq!(
+            output.stdout_json()["error"]["code"],
+            "policy-capability-event-unsupported",
+            "capability={capability_id}"
+        );
+    }
+}

--- a/crates/agent-hook/tests/dsh_ingress.rs
+++ b/crates/agent-hook/tests/dsh_ingress.rs
@@ -1,5 +1,7 @@
 mod support;
 
+use std::fs;
+
 use pretty_assertions::assert_eq;
 use serde_json::json;
 
@@ -162,11 +164,92 @@ fn dsh_ingress_enforces_field_boundaries_and_event_identity() {
         Some(&boundary.to_string()),
     );
     assert_eq!(accepted.code, 0, "stderr={}", accepted.stderr_text());
+    let envelope = accepted.stdout_json();
+    let request_id = envelope["data"]["request_id"].clone();
+    let config_digest = envelope["data"]["config_digest"].clone();
+    let policy_digest = envelope["data"]["policy_digest"].clone();
+    assert_eq!(
+        envelope,
+        json!({
+            "schema_version": "cli.agent-hook.dispatch.v1",
+            "ok": true,
+            "data": {
+                "schema_version": "agent-hook.normalized-decision.v1",
+                "request_id": request_id,
+                "product": "dsh",
+                "event": "PreToolUse",
+                "action": "allow",
+                "reasons": [],
+                "config_digest": config_digest,
+                "policy_digest": policy_digest,
+                "recovery_applied": false
+            }
+        })
+    );
+    assert!(
+        envelope["data"]["request_id"]
+            .as_str()
+            .is_some_and(|value| value.starts_with("request:"))
+    );
+    for field in ["config_digest", "policy_digest"] {
+        assert!(
+            envelope["data"][field]
+                .as_str()
+                .is_some_and(|value| value.starts_with("sha256:")),
+            "field={field}"
+        );
+    }
 }
 
 #[test]
-fn dsh_registration_is_bundle_owned_and_legacy_file_handlers_are_rejected() {
+fn dsh_tool_name_collisions_keep_dsh_cwd_only_target_semantics() {
     let fixture = Fixture::new(POLICY);
+
+    for tool_name in ["Write", "Edit", "MultiEdit", "NotebookEdit", "apply_patch"] {
+        let mut collision: serde_json::Value =
+            serde_json::from_str(&request(&fixture)).expect("request JSON");
+        collision["tool"]["name"] = json!(tool_name);
+        collision["tool"]["arguments"] = json!({});
+        let output = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&collision.to_string()),
+        );
+        assert_eq!(
+            output.code,
+            0,
+            "tool={tool_name} stdout={} stderr={}",
+            output.stdout_text(),
+            output.stderr_text()
+        );
+        assert_eq!(output.stdout_json()["data"]["action"], "allow");
+    }
+}
+
+#[test]
+#[rustfmt::skip]
+fn dsh_registration_is_bundle_owned_and_legacy_file_handlers_are_rejected() { // stale-audit: keep-contract
+    let fixture = Fixture::new(POLICY);
+    let dsh_config = fixture.home.join(".dsh/cordis.patch.yml");
+    for action in ["--apply", "--repair", "--remove"] {
+        let output = fixture.run(&["setup", "--product", "dsh", action, "--format", "json"], None);
+        assert_eq!(output.code, 0, "action={action} stderr={}", output.stderr_text());
+        assert_eq!(output.stdout_json()["data"]["status"], "unsupported", "action={action}");
+        assert_eq!(output.stdout_json()["data"]["changed"], false, "action={action}");
+        assert!(!dsh_config.exists(), "action={action} created an absent DSH config");
+    }
+
+    fs::create_dir_all(dsh_config.parent().expect("DSH config parent")).expect("DSH config dir");
+    let sentinel = b"foreign: cordis-registration\n";
+    fs::write(&dsh_config, sentinel).expect("DSH config sentinel");
+    Fixture::set_private(&dsh_config);
+    for action in ["--apply", "--repair", "--remove"] {
+        let output = fixture.run(&["setup", "--product", "dsh", action, "--format", "json"], None);
+        assert_eq!(output.code, 0, "action={action} stderr={}", output.stderr_text());
+        assert_eq!(output.stdout_json()["data"]["status"], "unsupported", "action={action}");
+        assert_eq!(output.stdout_json()["data"]["changed"], false, "action={action}");
+        assert_eq!(fs::read(&dsh_config).expect("DSH config sentinel retained"), sentinel, "action={action}");
+    }
+
     let setup = fixture.run(
         &["setup", "--product", "dsh", "--dry-run", "--format", "json"],
         None,
@@ -237,7 +320,7 @@ fn dsh_v1_rejects_capabilities_without_native_decision_or_target_semantics() {
                 r#"capability = { id = "decision.context.v1", reason_code = "context", text = "context" }"#
             }
             "agent-session.owner-liveness.v1" => {
-                r#"capability = { id = "agent-session.owner-liveness.v1", reason_code = "owner", legacy_ttl_seconds = 60 }"#
+                r#"capability = { id = "agent-session.owner-liveness.v1", reason_code = "owner", legacy_ttl_seconds = 60 }"# // stale-audit: keep-contract
             }
             "agent-session.activity.v1" => {
                 r#"capability = { id = "agent-session.activity.v1", reason_code = "activity" }"#

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -334,6 +334,8 @@ operations:
     #   pending_review_transaction_incomplete (DATA 65) — a receipt-bound pending review was created or updated but the next step was not confirmed. The draft and inline content are preserved; rerunning the identical command resumes it.
     #   pending_review_manifest_mismatch (DATA 65) — the pending body, inline-comment prefix, run marker, decision inputs, or immutable manifest differs. No mutation follows.
     #   pending_review_identity_mismatch (DATA 65) — the authenticated viewer does not own the receipt-bound pending review. No mutation follows.
+    #   pending_review_lease_busy (UNAVAILABLE 69) — another cooperating forge-cli process owns the provider/host/repository/PR/viewer pending-review mutation lease.
+    #   pending_review_lease_unsafe (DATA 65) — the private local lease directory or file does not satisfy ownership/type/mode invariants.
     #   review_state_conflict (DATA 65) — the append-only provider-visible receipt chain is malformed, forked, or binds one run id to different immutable inputs.
     # A non-404 guard failure (rate limit, 5xx, forbidden/SSO) surfaces as backend_error (RUNTIME 1),
     # not id_not_pull_request, since it may have hit a valid PR.
@@ -346,11 +348,12 @@ operations:
         - { program: gh, argv: [api, graphql, -f, "query=<pull request id lookup>", -f, "owner={owner}", -f, "name={repo}", -F, "number={id}"] } # with --thread-file: resolve the PR node id
         - { program: gh, argv: [api, graphql, -f, "query=<authenticated viewer plus paginated PR issue comments with author association>", -f, "owner={owner}", -f, "name={repo}", -F, "pr={id}", "-f after={cursor}?"] } # with --thread-file: retain the current viewer's and privileged collaborators' comments, then read and validate the forge-cli.review-loop.v1 append-only state chain
         - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body=<visible ledger metadata line plus immutable review-run receipt marker>", --jq, ".html_url"] } # append one provider-bounded receipt before native-review mutation, then verify from the prior cursor/tail; semantically identical append retries and reruns reuse it. The prewrite stays a distinct comment because recovery needs durable state before the mutation, so it carries no delivery outcome
-        - { program: gh, argv: [api, graphql, -f, "query=<complete submitted native reviews plus authenticated viewer>", -f, "owner={owner}", -f, "name={repo}", -F, "pr={id}", "-f after={cursor}?"] } # only when an exact receipt exists: idempotent success and lost-submit response detection require viewer author, expected head/state, untruncated marker, and complete receipt-bound thread manifest
+        - { program: gh, argv: [api, graphql, -f, "query=<complete submitted native reviews plus authenticated viewer>", -f, "owner={owner}", -f, "name={repo}", -F, "pr={id}", "-f after={cursor}?"] } # only when an exact receipt exists before mutation: idempotent success requires viewer author, expected head/state, untruncated marker, and complete receipt-bound thread manifest
         - { program: gh, argv: [api, graphql, -f, "query=<complete exact pending review and inline-comment manifest>", -f, "review={review_id}", "-f after={cursor}?"] } # exact receipt/body/head/commit/identity/manifest validation before any resumed mutation
         - { program: gh, argv: [api, graphql, -f, "query=<addPullRequestReview>", -f, "pullRequestId={pull_request_id}", -f, "commitOID={expected_head}", -f, "body={summary plus review-run marker}"] } # create only when no viewer-owned draft exists
         - { program: gh, argv: [api, graphql, -f, "query=<addPullRequestReviewThread>", -f, "reviewId={review_id}", -f, "path={path}", -f, "body={finding marker plus semantic body}", -F, "line={line}", -f, "side={LEFT|RIGHT}", -f, "subjectType={LINE|FILE}"] } # add only the missing ordered manifest suffix; never delete completed inline content
-        - { program: gh, argv: [api, graphql, -f, "query=<submitPullRequestReview>", -f, "reviewId={review_id}", -f, "event={EVENT}", -f, "body={summary plus review-run marker}"] } # submit only after a final exact complete snapshot; failures trigger submitted-review read-back, not deletion
+        - { program: gh, argv: [api, graphql, -f, "query=<submitPullRequestReview>", -f, "reviewId={review_id}", -f, "event={EVENT}", -f, "body={summary plus review-run marker}"] } # create/thread/submit mutations run under the private provider/host/repository/PR/viewer cross-process lease; submit only after a final exact complete snapshot
+        - { program: gh, argv: [api, graphql, -f, "query=<complete exact submitted review and inline-comment manifest>", -f, "review={review_id}", "-f after={cursor}?"] } # mandatory immediate reconciliation after submit, including lost mutation responses; success requires the exact submitted state and receipt-bound manifest
         - { program: gh, argv: [api, "repos/{repo}/issues/{issue}/comments", --method, POST, --raw-field, "body=<generated mirror>", --jq, ".html_url"] } # only with --mirror-issue
       gitlab:
         # One `glab mr note create --help` probe selects the form (covers every glab version class):
@@ -549,7 +552,7 @@ operations:
         number: integer
         url: string
         snapshot: object<{number,pr_url,head_sha,review_id,review_url,author,commit_sha?,body,semantic_body,viewer_did_author,viewer_can_delete,review_run_id?,provenance,inline_comments:list<{id,url,author,body,semantic_body,created_at,path,line?,original_line?,diff_side?,start_line?,original_start_line?,start_diff_side?,subject_type,body_digest,review_run_id?}>,snapshot_digest}>
-    notes: "The read is complete and fail-closed: every inline-comment page repeats the same review, PR, head, commit, author, body, and viewer-capability identity. The snapshot and digest preserve diff_side and start_diff_side as well as line/range anchors. Owned versioned markers are removed only from semantic_body; raw provider content remains visible in the snapshot. provenance is receipt-bound or unmarked, while mixed or digest-mismatched markers return pending_review_manifest_mismatch."
+    notes: "The read is complete and fail-closed: every inline-comment page repeats the same review, PR, head, commit, author, body, viewer-capability identity, and stable totalCount. totalCount above 1,000 is rejected before another page, and the decoded retained snapshot is capped at 4 MiB. The snapshot and digest preserve diff_side and start_diff_side as well as line/range anchors. Owned versioned markers are removed only from semantic_body; raw provider content remains visible in the snapshot. provenance is receipt-bound or unmarked, while mixed or digest-mismatched markers return pending_review_manifest_mismatch."
 
   - id: pr.pending-review.resume-submit
     schema_version: cli.forge-cli.pr.pending-review.resume-submit.v1
@@ -569,6 +572,9 @@ operations:
       - pending_review_commit_mismatch
       - pending_review_manifest_mismatch
       - pending_review_identity_mismatch
+      - pending_review_lease_busy
+      - pending_review_lease_unsafe
+      - pending_review_reconciliation_failed
     backends:
       github:
         - { program: gh, argv: [pr, view, "{id}", --json, "number,url,state,isDraft,baseRefName,headRefName,headRefOid,title,body"] }
@@ -578,8 +584,8 @@ operations:
       gitlab: unsupported
       local: unsupported
     output:
-      data: object<{provider,number,url,review_id,review_url,head_sha,commit_sha,snapshot_digest,review_run_id,submitted}>
-    notes: "The exact receipt-bound pending snapshot is submitted once, after recomputing the immutable review_run_id and comparing summary digest plus every path/line/side/range/subject/body manifest field. If submission already completed, a complete submitted-review read-back authored by the authenticated viewer with the same review_run_id, review id, current head, commit, decision state, and complete receipt-bound thread manifest returns idempotent success without another mutation."
+      data: object<{provider,number,url,review_id,review_url,head_sha,commit_sha,snapshot_digest?,snapshot_provenance,review_run_id,submitted}>
+    notes: "The exact receipt-bound pending snapshot is submitted once under a private provider/host/repository/PR/viewer cross-process lease, then its complete submitted manifest is immediately reconciled. FILE receipt anchors accept provider-null side/range fields; LINE and range anchors remain exact. A live reconciled submit reports snapshot_provenance=pending-cas+submitted-reconciled. If submission already completed, a complete submitted-review read-back authored by the authenticated viewer with the same review_run_id, review id, current head, commit, decision state, and complete receipt-bound thread manifest returns idempotent success without another mutation, with snapshot_digest=null and snapshot_provenance=pending-snapshot-unverified because the former pending digest cannot be proven. GitHub provides no submission CAS, so the lease excludes cooperating forge-cli processes but cannot exclude a same-identity non-cooperating provider client between final read and mutation."
 
   - id: pr.pending-review.submit
     schema_version: cli.forge-cli.pr.pending-review.submit.v1
@@ -599,6 +605,9 @@ operations:
       - pending_review_commit_mismatch
       - pending_review_manifest_mismatch
       - pending_review_identity_mismatch
+      - pending_review_lease_busy
+      - pending_review_lease_unsafe
+      - pending_review_reconciliation_failed
     backends:
       github:
         - { program: gh, argv: [pr, view, "{id}", --json, "number,url,state,isDraft,baseRefName,headRefName,headRefOid,title,body"] }
@@ -607,8 +616,8 @@ operations:
       gitlab: unsupported
       local: unsupported
     output:
-      data: object<{provider,number,url,review_id,review_url,head_sha,commit_sha,snapshot_digest,review_run_id?,submitted}>
-    notes: "Only provenance=unmarked is eligible. The exact snapshot digest, head, commit, viewer identity, body, and every inline comment are re-read before submission; inline content is preserved."
+      data: object<{provider,number,url,review_id,review_url,head_sha,commit_sha,snapshot_digest?,snapshot_provenance,review_run_id?,submitted}>
+    notes: "Only provenance=unmarked is eligible. The exact snapshot digest, head, commit, viewer identity, body, and every inline comment are re-read under the cross-process lease before submission; inline content is preserved, and the complete submitted manifest is reconciled before success."
 
   - id: pr.pending-review.discard
     schema_version: cli.forge-cli.pr.pending-review.discard.v1
@@ -629,6 +638,9 @@ operations:
       - pending_review_manifest_mismatch
       - pending_review_identity_mismatch
       - pending_review_inline_discard_approval_required
+      - pending_review_lease_busy
+      - pending_review_lease_unsafe
+      - pending_review_reconciliation_failed
     backends:
       github:
         - { program: gh, argv: [pr, view, "{id}", --json, "number,url,state,isDraft,baseRefName,headRefName,headRefOid,title,body"] }
@@ -638,7 +650,7 @@ operations:
       local: unsupported
     output:
       data: object<{provider,number,url,review_id,review_url,head_sha,commit_sha,snapshot_digest,inline_comment_count,discarded}>
-    notes: "Deletion is never automatic. --confirm-inline-content-loss is additionally mandatory when the complete snapshot contains one or more inline comments."
+    notes: "Deletion is never automatic. --confirm-inline-content-loss is additionally mandatory when the complete snapshot contains one or more inline comments. Mutation runs under the cross-process lease and provider absence is reconciled before success."
 
   - id: pr.pending-review.delete
     schema_version: cli.forge-cli.pr.pending-review.delete.v1
@@ -664,6 +676,9 @@ operations:
       - pending_review_body_too_large
       - pending_review_pr_mismatch
       - pending_review_inline_comments_present
+      - pending_review_lease_busy
+      - pending_review_lease_unsafe
+      - pending_review_reconciliation_failed
     backends:
       github:
         - { program: gh, argv: [pr, view, "{id}", --json, "number,url,state,isDraft,baseRefName,headRefName,headRefOid,title,body"] }
@@ -683,7 +698,7 @@ operations:
         review_url: string
         author: string
         deleted: boolean
-    notes: "destructive recovery requires an explicit --confirm-abandoned acknowledgement plus exact expected PR head, review commit, and review body. Expected and provider bodies are limited to 64 KiB; file and stdin inputs use bounded reads. The live command reads and validates a complete paginated pending-only membership snapshot while retaining only the target body, then re-fetches the exact target node immediately before mutation and revalidates PR membership, PENDING state, head, commit, normalized body, viewerDidAuthor, and viewerCanDelete. Inline draft comments fail with pending_review_inline_comments_present and require manual provider recovery. Body values and body-file paths are never emitted; dry-run validates a named body file and includes the exact-target plan. Only the revalidated node id is passed to deletePullRequestReview. GitHub exposes no content CAS for that mutation, so a small final-read-to-delete race remains despite the explicit confirmation and guards."
+    notes: "destructive recovery requires an explicit --confirm-abandoned acknowledgement plus exact expected PR head, review commit, and review body. Expected and provider bodies are limited to 64 KiB; file and stdin inputs use bounded reads. The live command reads and validates a complete paginated pending-only membership snapshot while retaining only the target body, then takes the private provider/host/repository/PR/viewer lease, re-fetches the exact target node immediately before mutation, and revalidates PR membership, PENDING state, head, commit, normalized body, viewerDidAuthor, and viewerCanDelete. Inline draft comments fail with pending_review_inline_comments_present and require manual provider recovery. Body values and body-file paths are never emitted; dry-run validates a named body file and includes the exact-target plan. Only the revalidated node id is passed to deletePullRequestReview, and provider absence is reconciled before success. GitHub exposes no content CAS for that mutation, so the lease excludes cooperating forge-cli processes but not a same-identity non-cooperating provider client in the irreducible final-read-to-delete interval."
 
   - id: pr.review-loop.inspect
     schema_version: cli.forge-cli.pr.review-loop.inspect.v1

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -555,7 +555,7 @@ operations:
     notes: "The read is complete and fail-closed: every inline-comment page repeats the same review, PR, head, commit, author, body, viewer-capability identity, and stable totalCount. totalCount above 1,000 is rejected before another page, and the decoded retained snapshot is capped at 4 MiB. The snapshot and digest preserve diff_side and start_diff_side as well as line/range anchors. Owned versioned markers are removed only from semantic_body; raw provider content remains visible in the snapshot. provenance is receipt-bound or unmarked, while mixed or digest-mismatched markers return pending_review_manifest_mismatch."
 
   - id: pr.pending-review.resume-submit
-    schema_version: cli.forge-cli.pr.pending-review.resume-submit.v1
+    schema_version: cli.forge-cli.pr.pending-review.resume-submit.v2
     summary: Submit one exact receipt-bound pending review after final compare-and-swap validation.
     inputs:
       - { name: <id>, type: integer, required: true }
@@ -585,7 +585,7 @@ operations:
       local: unsupported
     output:
       data: object<{provider,number,url,review_id,review_url,head_sha,commit_sha,snapshot_digest?,snapshot_provenance,review_run_id,submitted}>
-    notes: "The exact receipt-bound pending snapshot is submitted once under a private provider/host/repository/PR/viewer cross-process lease, then its complete submitted manifest is immediately reconciled. FILE receipt anchors accept provider-null side/range fields; LINE and range anchors remain exact. A live reconciled submit reports snapshot_provenance=pending-cas+submitted-reconciled. If submission already completed, a complete submitted-review read-back authored by the authenticated viewer with the same review_run_id, review id, current head, commit, decision state, and complete receipt-bound thread manifest returns idempotent success without another mutation, with snapshot_digest=null and snapshot_provenance=pending-snapshot-unverified because the former pending digest cannot be proven. GitHub provides no submission CAS, so the lease excludes cooperating forge-cli processes but cannot exclude a same-identity non-cooperating provider client between final read and mutation."
+    notes: "Version 2 makes snapshot_digest nullable and adds snapshot_provenance so idempotent recovery never misrepresents an unprovable former pending digest. The exact receipt-bound pending snapshot is submitted once under a private provider/host/repository/PR/viewer cross-process lease, then its complete submitted manifest is immediately reconciled. FILE receipt anchors accept provider-null side/range fields; LINE and range anchors remain exact. A live reconciled submit reports snapshot_provenance=pending-cas+submitted-reconciled. If submission already completed, a complete submitted-review read-back authored by the authenticated viewer with the same review_run_id, review id, current head, commit, decision state, and complete receipt-bound thread manifest returns idempotent success without another mutation, with snapshot_digest=null and snapshot_provenance=pending-snapshot-unverified because the former pending digest cannot be proven. GitHub provides no submission CAS, so the lease excludes cooperating forge-cli processes but cannot exclude a same-identity non-cooperating provider client between final read and mutation."
 
   - id: pr.pending-review.submit
     schema_version: cli.forge-cli.pr.pending-review.submit.v1
@@ -616,8 +616,8 @@ operations:
       gitlab: unsupported
       local: unsupported
     output:
-      data: object<{provider,number,url,review_id,review_url,head_sha,commit_sha,snapshot_digest?,snapshot_provenance,review_run_id?,submitted}>
-    notes: "Only provenance=unmarked is eligible. The exact snapshot digest, head, commit, viewer identity, body, and every inline comment are re-read under the cross-process lease before submission; inline content is preserved, and the complete submitted manifest is reconciled before success."
+      data: object<{provider,number,url,review_id,review_url,head_sha,commit_sha,snapshot_digest,snapshot_provenance,review_run_id?,submitted}>
+    notes: "The released v1 snapshot_digest remains a required string. Only provenance=unmarked is eligible. The exact snapshot digest, head, commit, viewer identity, body, and every inline comment are re-read under the cross-process lease before submission; inline content is preserved, and the complete submitted manifest is reconciled before success."
 
   - id: pr.pending-review.discard
     schema_version: cli.forge-cli.pr.pending-review.discard.v1

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -612,7 +612,9 @@ backend mapping, validation rules, and output schema versions.
 - `pr pending-review resume-submit <id> --review <PRR_...> --review-run-id
   <digest> --expected-head <sha> --expected-commit <sha> --expected-snapshot
   <digest> --decision <decision>` emits
-  `cli.forge-cli.pr.pending-review.resume-submit.v1`. It submits only an exact
+  `cli.forge-cli.pr.pending-review.resume-submit.v2`. Version 2 makes
+  `snapshot_digest` nullable and adds `snapshot_provenance` so idempotent
+  recovery never claims a pending snapshot it cannot prove. It submits only an exact
   viewer-owned receipt-bound snapshot after recomputing the run id and matching
   the summary plus every immutable inline-manifest field. If that review was
   already submitted, the command reads submitted reviews and threads, verifies
@@ -628,8 +630,9 @@ backend mapping, validation rules, and output schema versions.
 - `pr pending-review submit <id> --review <PRR_...> --expected-head <sha>
   --expected-commit <sha> --expected-snapshot <digest> --decision <decision>
   --confirm-unmarked-submit` emits `cli.forge-cli.pr.pending-review.submit.v1`.
-  It accepts only `unmarked` provenance and preserves the exact body and
-  all inline comments while submitting. It never auto-adopts a unmarked draft.
+  Its released v1 `snapshot_digest` remains a required string. It accepts only
+  `unmarked` provenance and preserves the exact body and all inline comments
+  while submitting. It never auto-adopts a unmarked draft.
 - `pr pending-review discard <id> --review <PRR_...> --expected-head <sha>
   --expected-commit <sha> --expected-snapshot <digest> --confirm-discard`
   emits `cli.forge-cli.pr.pending-review.discard.v1`. It is destructive and

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -602,10 +602,12 @@ backend mapping, validation rules, and output schema versions.
   PR/head/review identity, author, commit, raw and semantic body,
   `viewerDidAuthor`, `viewerCanDelete`, provenance, every inline comment with
   normalized body digest plus `diffSide`/`startDiffSide` and line/range anchors,
-  and `snapshot_digest`. Every page must
-  repeat identical review metadata; partial data, cursor loops, count mismatch,
-  or head drift returns `review_snapshot_incomplete` instead of a partial
-  snapshot. Provenance is `receipt-bound` or `unmarked`; mixed, missing,
+  and `snapshot_digest`. Every page must repeat identical review metadata and a
+  stable `totalCount`; partial data, cursor loops, count mismatch, head drift,
+  an aggregate above 1,000 comments, or a decoded retained snapshot above 4 MiB
+  returns `review_snapshot_incomplete` instead of a partial snapshot. An
+  excessive `totalCount` is rejected before another page. Provenance is
+  `receipt-bound` or `unmarked`; mixed, missing,
   or digest-mismatched owned markers return `pending_review_manifest_mismatch`.
 - `pr pending-review resume-submit <id> --review <PRR_...> --review-run-id
   <digest> --expected-head <sha> --expected-commit <sha> --expected-snapshot
@@ -616,7 +618,13 @@ backend mapping, validation rules, and output schema versions.
   already submitted, the command reads submitted reviews and threads, verifies
   the authenticated author, same run id, review id, head, commit, decision
   state, and complete receipt-bound manifest, and returns the same successful
-  envelope without another mutation.
+  envelope without another mutation. Because a submitted review cannot prove
+  the caller's former pending-snapshot digest, that idempotent envelope reports
+  `snapshot_digest: null` with `snapshot_provenance:
+  pending-snapshot-unverified`; a live submit reports its guarded digest with
+  `snapshot_provenance: pending-cas+submitted-reconciled`. Provider-null
+  side/range values on a `FILE` comment are normalized away when matching a
+  receipt; `LINE` and range anchors remain exact.
 - `pr pending-review submit <id> --review <PRR_...> --expected-head <sha>
   --expected-commit <sha> --expected-snapshot <digest> --decision <decision>
   --confirm-unmarked-submit` emits `cli.forge-cli.pr.pending-review.submit.v1`.
@@ -630,8 +638,16 @@ backend mapping, validation rules, and output schema versions.
   invokes discard or delete.
 - Live inspect data is required for these four commands, so their current v1
   dry-run form fails with `pending_review_snapshot_required`. All mutating forms
-  perform the exact head/commit/snapshot and viewer-identity checks before the
-  mutation. Mismatches return `pending_review_head_changed`,
+  perform the exact head/commit/snapshot and viewer-identity checks under a
+  private cross-process forge-cli lease keyed by provider, host, repository,
+  PR, and authenticated viewer. Submission and deletion are immediately read
+  back and succeed only when the exact submitted manifest or absence is
+  reconciled; otherwise they return `pending_review_reconciliation_failed`.
+  A busy or unsafe lease returns `pending_review_lease_busy` or
+  `pending_review_lease_unsafe`. GitHub exposes no compare-and-swap token on
+  review submission, so the lease closes races among cooperating forge-cli
+  processes but cannot exclude a same-identity non-cooperating API client in
+  the irreducible interval between the final read and mutation. Mismatches return `pending_review_head_changed`,
   `pending_review_commit_mismatch`, `pending_review_manifest_mismatch`,
   `pending_review_identity_mismatch`, `pending_review_pr_mismatch`, or
   `pending_review_not_found` with no mutation.
@@ -783,19 +799,22 @@ backend mapping, validation rules, and output schema versions.
   `pending_review_not_deletable`; content drift returns the corresponding
   `pending_review_*_mismatch`. Submitted-review parsing is independent and
   cannot block this recovery path.
-- After the membership checks, the command reads the exact review node again
-  immediately before deletion. It revalidates PR membership, head, commit,
+- After the membership checks, the command takes the private cross-process
+  viewer/repository/PR lease and reads the exact review node again immediately
+  before deletion. It revalidates PR membership, head, commit,
   body, ownership, and delete capability. `pending_review_pr_mismatch` rejects
   a moved or inconsistent target. Reviews with inline draft comments return
   `pending_review_inline_comments_present` and require manual provider recovery;
   this primitive deletes only confirmed abandoned body-only drafts.
-- Only the revalidated node id is passed to `deletePullRequestReview`, and the
-  returned id must match. The success payload is
+- Only the revalidated node id is passed to `deletePullRequestReview`, the
+  returned id must match, and an exact-node read must reconcile provider absence
+  before success. The success payload is
   `data = { provider, number, url, head_sha, commit_sha, review_id, review_url,
   author, deleted }`. GitHub does not expose content compare-and-swap on this
-  deletion mutation, so a small residual race remains between the exact final
-  read and delete; explicit abandonment confirmation, immutable content guards,
-  and the inline-comment refusal bound that risk, but cannot remove it.
+  deletion mutation. The lease excludes cooperating forge-cli processes, while
+  explicit abandonment confirmation, immutable content guards, reconciliation,
+  and the inline-comment refusal bound the irreducible same-identity
+  non-cooperating-client window between the exact final read and delete.
 - `--dry-run` is offline. It validates a named `--expected-body-file`, renders
   the PR guard, complete snapshot, exact-target read, and delete plans, and
   never emits the expected body or its file path.
@@ -864,12 +883,15 @@ backend mapping, validation rules, and output schema versions.
   whose semantic `(path, body)` already has a live non-resolved/non-outdated
   thread, computes a deterministic `review_run_id`, and appends an immutable
   `forge-cli.review-loop.v1` receipt before native-review mutation. It then
-  selects only an exact viewer-owned receipt-bound pending review, or creates a
+  takes the same private provider/host/repository/PR/viewer cross-process lease
+  used by pending-review recovery and selects only an exact viewer-owned
+  receipt-bound pending review, or creates a
   new review bound to `--expected-head` through `commitOID`. The review body and
   every finding carry owned run/digest markers. An exact pending manifest must
   be an ordered prefix of the receipt manifest; the command adds only the
   missing suffix and performs a final complete snapshot before
-  `submitPullRequestReview`.
+  `submitPullRequestReview`. Success requires an immediate exact-node read-back
+  whose submitted state and complete receipt-bound manifest reconcile.
 
   Every interrupted stage is resumable: a lost create response, any lost inline
   comment response, a pre-submit failure, and a lost submit response preserve
@@ -1345,69 +1367,72 @@ backend implementations cannot diverge.
 
 Violations map to `DATA 65` with one of these `data.error.kind` values:
 
-| `error.kind`                               | Triggered by rule    |
-| ------------------------------------------ | -------------------- |
-| `branch_name_invalid`                      | 1                    |
-| `branch_kind_mismatch`                     | 1                    |
-| `body_missing_summary`                     | 2                    |
-| `body_missing_test_plan`                   | 2                    |
-| `title_too_long`                           | 3                    |
-| `dirty_worktree`                           | 4                    |
-| `head_not_pushed`                          | 5                    |
-| `default_branch_protected`                 | 6                    |
-| `push_destination_missing`                 | 6                    |
-| `push_destination_ambiguous`               | 6                    |
-| `push_destination_credentials_unsupported` | 6                    |
-| `push_destination_rewrite_ambiguous`       | 6                    |
-| `provider_mismatch`                        | 6                    |
-| `provider_unsupported`                     | 6 (`USAGE 64`)       |
-| `repository_mismatch`                      | 6                    |
-| `detached_head`                            | 6                    |
-| `default_branch_checkout`                  | 6                    |
-| `head_not_checked_out`                     | 6                    |
-| `expected_base_mismatch`                   | 6                    |
-| `expected_base_missing`                    | 6                    |
-| `expected_base_not_ancestor`               | 6                    |
-| `direct_commit_count_invalid`              | 6                    |
-| `commit_signature_unverified`              | 6                    |
-| `reason_file_unreadable`                   | 6                    |
-| `reason_invalid`                           | 6                    |
-| `object_id_invalid`                        | 6                    |
-| `remote_default_lookup_failed`             | 6 (`UNAVAILABLE 69`) |
-| `remote_default_branch_missing`            | 6                    |
-| `git_timeout`                              | 6 (`UNAVAILABLE 69`) |
-| `git_output_limit`                         | 6 (`UNAVAILABLE 69`) |
-| `backend_timeout`                          | 6 (`UNAVAILABLE 69`) |
-| `backend_output_limit`                     | 6 (`UNAVAILABLE 69`) |
-| `default_push_rejected`                    | 6 (`RUNTIME 1`)      |
-| `default_push_verification_failed`         | 6 (`RUNTIME 1`)      |
-| `software_error`                           | 6 (`SOFTWARE 70`)    |
-| `draft_merge_refused`                      | 7                    |
-| `checks_pending`                           | 8                    |
-| `checks_failed`                            | 8 (`RUNTIME 1`)      |
-| `checks_not_registered`                    | 8                    |
-| `merge_method_unsupported`                 | 9                    |
-| `keep_branch_conflict`                     | 10                   |
-| `local_path_present`                       | 11                   |
-| `agent_attribution_present`                | 17                   |
-| `review_changes_requested`                 | 12                   |
-| `review_convergence_head_missing`          | 12                   |
-| `review_convergence_head_changed`          | 12                   |
-| `review_convergence_activity_changed`      | 12                   |
-| `review_snapshot_incomplete`               | 12, 16               |
-| `invalid_review_convergence_config`        | 12                   |
-| `unresolved_review_threads`                | 13                   |
-| `unchecked_task_items`                     | 14                   |
-| `review_thread_pr_mismatch`                | 15                   |
-| `pending_review_not_found`                 | 16                   |
-| `pending_review_author_mismatch`           | 16                   |
-| `pending_review_not_deletable`             | 16                   |
-| `pending_review_head_mismatch`             | 16                   |
-| `pending_review_commit_mismatch`           | 16                   |
-| `pending_review_body_mismatch`             | 16                   |
-| `pending_review_body_too_large`            | 16                   |
-| `pending_review_pr_mismatch`               | 16                   |
-| `pending_review_inline_comments_present`   | 16                   |
+| `error.kind`                               | Triggered by rule     |
+| ------------------------------------------ | --------------------- |
+| `branch_name_invalid`                      | 1                     |
+| `branch_kind_mismatch`                     | 1                     |
+| `body_missing_summary`                     | 2                     |
+| `body_missing_test_plan`                   | 2                     |
+| `title_too_long`                           | 3                     |
+| `dirty_worktree`                           | 4                     |
+| `head_not_pushed`                          | 5                     |
+| `default_branch_protected`                 | 6                     |
+| `push_destination_missing`                 | 6                     |
+| `push_destination_ambiguous`               | 6                     |
+| `push_destination_credentials_unsupported` | 6                     |
+| `push_destination_rewrite_ambiguous`       | 6                     |
+| `provider_mismatch`                        | 6                     |
+| `provider_unsupported`                     | 6 (`USAGE 64`)        |
+| `repository_mismatch`                      | 6                     |
+| `detached_head`                            | 6                     |
+| `default_branch_checkout`                  | 6                     |
+| `head_not_checked_out`                     | 6                     |
+| `expected_base_mismatch`                   | 6                     |
+| `expected_base_missing`                    | 6                     |
+| `expected_base_not_ancestor`               | 6                     |
+| `direct_commit_count_invalid`              | 6                     |
+| `commit_signature_unverified`              | 6                     |
+| `reason_file_unreadable`                   | 6                     |
+| `reason_invalid`                           | 6                     |
+| `object_id_invalid`                        | 6                     |
+| `remote_default_lookup_failed`             | 6 (`UNAVAILABLE 69`)  |
+| `remote_default_branch_missing`            | 6                     |
+| `git_timeout`                              | 6 (`UNAVAILABLE 69`)  |
+| `git_output_limit`                         | 6 (`UNAVAILABLE 69`)  |
+| `backend_timeout`                          | 6 (`UNAVAILABLE 69`)  |
+| `backend_output_limit`                     | 6 (`UNAVAILABLE 69`)  |
+| `default_push_rejected`                    | 6 (`RUNTIME 1`)       |
+| `default_push_verification_failed`         | 6 (`RUNTIME 1`)       |
+| `software_error`                           | 6 (`SOFTWARE 70`)     |
+| `draft_merge_refused`                      | 7                     |
+| `checks_pending`                           | 8                     |
+| `checks_failed`                            | 8 (`RUNTIME 1`)       |
+| `checks_not_registered`                    | 8                     |
+| `merge_method_unsupported`                 | 9                     |
+| `keep_branch_conflict`                     | 10                    |
+| `local_path_present`                       | 11                    |
+| `agent_attribution_present`                | 17                    |
+| `review_changes_requested`                 | 12                    |
+| `review_convergence_head_missing`          | 12                    |
+| `review_convergence_head_changed`          | 12                    |
+| `review_convergence_activity_changed`      | 12                    |
+| `review_snapshot_incomplete`               | 12, 16                |
+| `invalid_review_convergence_config`        | 12                    |
+| `unresolved_review_threads`                | 13                    |
+| `unchecked_task_items`                     | 14                    |
+| `review_thread_pr_mismatch`                | 15                    |
+| `pending_review_not_found`                 | 16                    |
+| `pending_review_author_mismatch`           | 16                    |
+| `pending_review_not_deletable`             | 16                    |
+| `pending_review_head_mismatch`             | 16                    |
+| `pending_review_commit_mismatch`           | 16                    |
+| `pending_review_body_mismatch`             | 16                    |
+| `pending_review_body_too_large`            | 16                    |
+| `pending_review_pr_mismatch`               | 16                    |
+| `pending_review_inline_comments_present`   | 16                    |
+| `pending_review_lease_busy`                | 16 (`UNAVAILABLE 69`) |
+| `pending_review_lease_unsafe`              | 16                    |
+| `pending_review_reconciliation_failed`     | 16                    |
 
 ## Activity output contract
 

--- a/crates/forge-cli/src/ops/pr_pending_review.rs
+++ b/crates/forge-cli/src/ops/pr_pending_review.rs
@@ -1,10 +1,16 @@
 //! Authenticated recovery for provider-valid pending GitHub reviews.
 
-use std::fs;
+use std::env;
+use std::fmt::Write as _;
+use std::fs::{self, File, OpenOptions};
 use std::io::Read;
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
 
 use nils_common::cli_contract::{OutputFormat, schema_version_for};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 use crate::backend::{BackendRunner, BackendSuccess};
 use crate::cli::{
@@ -38,7 +44,8 @@ pub struct PrPendingReviewSubmitPayload {
     pub review_url: String,
     pub head_sha: String,
     pub commit_sha: String,
-    pub snapshot_digest: String,
+    pub snapshot_digest: Option<String>,
+    pub snapshot_provenance: &'static str,
     pub review_run_id: Option<String>,
     pub submitted: bool,
 }
@@ -157,6 +164,9 @@ pub fn run_resume_submit_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             format,
         );
     };
+    ensure_pending_author(&snapshot)?;
+    let _lease = acquire_pending_review_lease(&ctx, &view, &snapshot.author)?;
+    let snapshot = reload_pending_snapshot(runner, &ctx, &view, &args.review)?;
     validate_snapshot_cas(
         &snapshot,
         &args.expected_head,
@@ -215,6 +225,9 @@ pub fn run_submit_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 ) -> Result<i32, ForgeError> {
     let (ctx, view, snapshot) =
         load_pending_snapshot(runner, global, args.id, &args.review, &remote_url_lookup)?;
+    ensure_pending_author(&snapshot)?;
+    let _lease = acquire_pending_review_lease(&ctx, &view, &snapshot.author)?;
+    let snapshot = reload_pending_snapshot(runner, &ctx, &view, &args.review)?;
     validate_snapshot_cas(
         &snapshot,
         &args.expected_head,
@@ -258,6 +271,9 @@ pub fn run_discard_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
 ) -> Result<i32, ForgeError> {
     let (ctx, view, snapshot) =
         load_pending_snapshot(runner, global, args.id, &args.review, &remote_url_lookup)?;
+    ensure_pending_author(&snapshot)?;
+    let _lease = acquire_pending_review_lease(&ctx, &view, &snapshot.author)?;
+    let snapshot = reload_pending_snapshot(runner, &ctx, &view, &args.review)?;
     validate_snapshot_cas(
         &snapshot,
         &args.expected_head,
@@ -284,21 +300,11 @@ pub fn run_discard_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             )),
         ));
     }
-    let output = runner.run(&pr_review::build_github_delete_pending_review_call(
+    let mutation = runner.run(&pr_review::build_github_delete_pending_review_call(
         &ctx,
         &snapshot.review_id,
-    ))?;
-    let (deleted_id, deleted_url) = parse_deleted_review(&output)?;
-    if deleted_id != snapshot.review_id {
-        return Err(ForgeError::software(
-            schema_err(),
-            "GitHub returned a different review after pending-review discard",
-            Some(format!(
-                "expected_review_id={}; provider_review_id={deleted_id}",
-                snapshot.review_id
-            )),
-        ));
-    }
+    ));
+    let deleted_url = reconcile_deleted_snapshot(runner, &ctx, &snapshot, mutation)?;
     let commit_sha = snapshot.commit_sha.clone().expect("CAS checked commit");
     let inline_comment_count = snapshot.inline_comments.len();
     Ok(emit_success(
@@ -403,22 +409,40 @@ pub fn run_delete_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         ));
     }
 
-    let pending = &target.review;
-    let deleted_output = runner.run(&pr_review::build_github_delete_pending_review_call(
-        &ctx,
-        &pending.id,
-    ))?;
-    let (deleted_id, deleted_url) = parse_deleted_review(&deleted_output)?;
-    if deleted_id != pending.id {
-        return Err(ForgeError::software(
+    let _lease = acquire_pending_review_lease(&ctx, &view, &target.review.author)?;
+    let target = pr_reviews::compute_pending_target(runner, &ctx, &args.review)?
+        .ok_or_else(|| pending_not_found(args.id, &args.review))?;
+    if target.number != view.number || target.pr_url != view.url || target.review.id != args.review
+    {
+        return Err(ForgeError::validation(
             schema_err(),
-            "GitHub returned a different review after pending-review deletion",
+            "pending_review_pr_mismatch",
+            "the pending review target no longer belongs to the named pull request",
             Some(format!(
-                "expected_review_id={}; provider_review_id={deleted_id}",
-                pending.id
+                "expected_pr={}; provider_pr={}; review_id={}",
+                view.number, target.number, args.review
             )),
         ));
     }
+    validate_pending_guard(&target.review, &target.head_sha, &args, &expected_body)?;
+    if target.inline_comment_count != 0 {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "pending_review_inline_comments_present",
+            "pending reviews with inline draft comments require manual recovery",
+            Some(format!(
+                "review_id={}; inline_comment_count={}",
+                target.review.id, target.inline_comment_count
+            )),
+        ));
+    }
+
+    let pending = &target.review;
+    let mutation = runner.run(&pr_review::build_github_delete_pending_review_call(
+        &ctx,
+        &pending.id,
+    ));
+    let deleted_url = reconcile_deleted_target(runner, &ctx, &target, mutation)?;
 
     let payload = PrPendingReviewDeletePayload {
         provider: ctx.provider.as_str(),
@@ -516,10 +540,27 @@ fn emit_already_submitted<R: BackendRunner>(
     review_run_id: &str,
     expected_head: &str,
     expected_commit: &str,
-    expected_snapshot: &str,
+    _expected_snapshot: &str,
     decision: PrReviewDecision,
     format: OutputFormat,
 ) -> Result<i32, ForgeError> {
+    let initial_reviews = pr_reviews::compute_for_pr(runner, ctx, view.number, &view.url)?;
+    if initial_reviews.viewer_login.is_empty() {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "pending_review_identity_mismatch",
+            "the authenticated GitHub viewer identity is unavailable",
+            Some(format!("review_id={review_id}")),
+        ));
+    }
+    let _lease = acquire_pending_review_lease(ctx, &view, &initial_reviews.viewer_login)?;
+    if pr_reviews::compute_pending_snapshot(runner, ctx, review_id)?.is_some() {
+        return Err(expected_mismatch(
+            "pending_review_manifest_mismatch",
+            "the pending review changed while entering submitted-review recovery",
+            format!("review_id={review_id}"),
+        ));
+    }
     let reviews = pr_reviews::compute_for_pr(runner, ctx, view.number, &view.url)?;
     if reviews.head_sha != expected_head {
         return Err(expected_mismatch(
@@ -617,7 +658,8 @@ fn emit_already_submitted<R: BackendRunner>(
         review_url: submitted.url.clone(),
         head_sha: reviews.head_sha,
         commit_sha: submitted.commit_sha.clone(),
-        snapshot_digest: expected_snapshot.to_string(),
+        snapshot_digest: None,
+        snapshot_provenance: "pending-snapshot-unverified",
         review_run_id: Some(review_run_id.to_string()),
         submitted: true,
     };
@@ -738,14 +780,23 @@ fn validate_snapshot_against_receipt(
         .zip(&receipt.inline_manifest)
         .enumerate()
     {
-        let matches = expected.index == index
-            && comment.review_run_id.as_deref() == Some(receipt.review_run_id.as_str())
-            && comment.path == expected.path
+        let file_anchor_matches = comment.subject_type == "FILE"
+            && expected.subject_type == "FILE"
+            && comment.line.is_none()
+            && comment.diff_side.is_none()
+            && comment.start_line.is_none()
+            && comment.start_diff_side.is_none();
+        let line_anchor_matches = comment.subject_type != "FILE"
+            && expected.subject_type != "FILE"
             && comment.line == expected.line
             && comment.diff_side.as_deref() == Some(expected.side.as_str())
             && comment.start_line == expected.start_line
-            && comment.start_diff_side == expected.start_side
+            && comment.start_diff_side == expected.start_side;
+        let matches = expected.index == index
+            && comment.review_run_id.as_deref() == Some(receipt.review_run_id.as_str())
+            && comment.path == expected.path
             && comment.subject_type == expected.subject_type
+            && (file_anchor_matches || line_anchor_matches)
             && comment.body_digest == expected.body_digest;
         if !matches {
             return Err(expected_mismatch(
@@ -820,14 +871,41 @@ fn submit_snapshot<R: BackendRunner>(
             )),
         ));
     }
-    let output = runner.run(&pr_review::build_github_submit_review_call(
+    let mutation = runner.run(&pr_review::build_github_submit_review_call(
         ctx,
         &snapshot.review_id,
         decision.to_github_event(),
         Some(snapshot.body.as_str()),
-    ))?;
-    let review_url = pr_review::parse_submitted_review_url(&output)
-        .unwrap_or_else(|| snapshot.review_url.clone());
+    ));
+    let expected_state = match decision {
+        PrReviewDecision::CommentsOnly => "COMMENTED",
+        PrReviewDecision::Approve => "APPROVED",
+        PrReviewDecision::RequestChanges => "CHANGES_REQUESTED",
+    };
+    let submitted = pr_reviews::compute_submitted_review_snapshot(
+        runner,
+        ctx,
+        &snapshot.review_id,
+        expected_state,
+    )?
+    .ok_or_else(|| reconciliation_failed(&snapshot.review_id, mutation.as_ref().err()))?;
+    validate_submitted_reconciliation(&snapshot, &submitted)?;
+    if let Ok(output) = mutation.as_ref()
+        && let Some(returned_url) = pr_review::parse_submitted_review_url(output)
+        && returned_url != submitted.review_url
+    {
+        return Err(reconciliation_failed(
+            &snapshot.review_id,
+            Some(&ForgeError::software(
+                schema_err(),
+                "GitHub returned a different submitted review URL",
+                Some(format!(
+                    "mutation_url={returned_url}; reconciled_url={}",
+                    submitted.review_url
+                )),
+            )),
+        ));
+    }
     let commit_sha = snapshot.commit_sha.clone().expect("CAS checked commit");
     Ok(emit_success(
         schema_version_for(BINARY, schema, 1),
@@ -836,10 +914,11 @@ fn submit_snapshot<R: BackendRunner>(
             number: view.number,
             url: view.url,
             review_id: snapshot.review_id,
-            review_url,
+            review_url: submitted.review_url,
             head_sha: snapshot.head_sha,
             commit_sha,
-            snapshot_digest: snapshot.snapshot_digest,
+            snapshot_digest: Some(snapshot.snapshot_digest),
+            snapshot_provenance: "pending-cas+submitted-reconciled",
             review_run_id: snapshot.review_run_id,
             submitted: true,
         },
@@ -853,6 +932,276 @@ fn submit_snapshot<R: BackendRunner>(
             );
         },
     ))
+}
+
+fn ensure_pending_author(snapshot: &pr_reviews::PendingReviewSnapshot) -> Result<(), ForgeError> {
+    if snapshot.viewer_did_author {
+        return Ok(());
+    }
+    Err(ForgeError::validation(
+        schema_err(),
+        "pending_review_identity_mismatch",
+        "the invoking GitHub identity is not the pending review author",
+        Some(format!(
+            "review_id={}; review_author={}",
+            snapshot.review_id, snapshot.author
+        )),
+    ))
+}
+
+fn reload_pending_snapshot<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    view: &pr_view::PrViewPayload,
+    review_id: &str,
+) -> Result<pr_reviews::PendingReviewSnapshot, ForgeError> {
+    let snapshot = pr_reviews::compute_pending_snapshot(runner, ctx, review_id)?
+        .ok_or_else(|| pending_not_found(view.number, review_id))?;
+    if snapshot.number != view.number
+        || snapshot.pr_url != view.url
+        || snapshot.review_id != review_id
+    {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "pending_review_pr_mismatch",
+            "the pending review target does not belong to the named pull request",
+            Some(format!(
+                "expected_pr={}; provider_pr={}; review_id={review_id}",
+                view.number, snapshot.number
+            )),
+        ));
+    }
+    ensure_pending_author(&snapshot)?;
+    Ok(snapshot)
+}
+
+fn validate_submitted_reconciliation(
+    pending: &pr_reviews::PendingReviewSnapshot,
+    submitted: &pr_reviews::PendingReviewSnapshot,
+) -> Result<(), ForgeError> {
+    let matches = submitted.number == pending.number
+        && submitted.pr_url == pending.pr_url
+        && submitted.head_sha == pending.head_sha
+        && submitted.review_id == pending.review_id
+        && submitted.review_url == pending.review_url
+        && submitted.author == pending.author
+        && submitted.commit_sha == pending.commit_sha
+        && submitted.body == pending.body
+        && submitted.semantic_body == pending.semantic_body
+        && submitted.viewer_did_author
+        && submitted.review_run_id == pending.review_run_id
+        && submitted.provenance == pending.provenance
+        && submitted.inline_comments == pending.inline_comments;
+    if matches {
+        return Ok(());
+    }
+    Err(reconciliation_failed(&pending.review_id, None))
+}
+
+fn reconciliation_failed(review_id: &str, mutation_error: Option<&ForgeError>) -> ForgeError {
+    ForgeError::validation(
+        schema_err(),
+        "pending_review_reconciliation_failed",
+        "the pending-review mutation could not be reconciled to the exact provider state",
+        Some(match mutation_error {
+            Some(error) => format!("review_id={review_id}; mutation_error={error}"),
+            None => format!("review_id={review_id}"),
+        }),
+    )
+}
+
+fn reconcile_deleted_snapshot<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    snapshot: &pr_reviews::PendingReviewSnapshot,
+    mutation: Result<BackendSuccess, ForgeError>,
+) -> Result<String, ForgeError> {
+    let remaining = pr_reviews::compute_pending_snapshot(runner, ctx, &snapshot.review_id)?;
+    let deleted_url = reconciled_deleted_url(mutation, &snapshot.review_id, &snapshot.review_url)?;
+    if remaining.is_some() {
+        return Err(reconciliation_failed(&snapshot.review_id, None));
+    }
+    Ok(deleted_url)
+}
+
+fn reconcile_deleted_target<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    target: &pr_reviews::PendingReviewTarget,
+    mutation: Result<BackendSuccess, ForgeError>,
+) -> Result<String, ForgeError> {
+    let remaining = pr_reviews::compute_pending_target(runner, ctx, &target.review.id)?;
+    let deleted_url = reconciled_deleted_url(mutation, &target.review.id, &target.review.url)?;
+    if remaining.is_some() {
+        return Err(reconciliation_failed(&target.review.id, None));
+    }
+    Ok(deleted_url)
+}
+
+fn reconciled_deleted_url(
+    mutation: Result<BackendSuccess, ForgeError>,
+    expected_id: &str,
+    fallback_url: &str,
+) -> Result<String, ForgeError> {
+    let Ok(output) = mutation else {
+        return Ok(fallback_url.to_string());
+    };
+    let (deleted_id, deleted_url) = parse_deleted_review(&output)?;
+    if deleted_id != expected_id {
+        return Err(ForgeError::software(
+            schema_err(),
+            "GitHub returned a different review after pending-review deletion",
+            Some(format!(
+                "expected_review_id={expected_id}; provider_review_id={deleted_id}"
+            )),
+        ));
+    }
+    Ok(deleted_url)
+}
+
+pub(crate) struct PendingReviewLease(File);
+
+impl Drop for PendingReviewLease {
+    fn drop(&mut self) {
+        unlock_file(self.0.as_raw_fd());
+    }
+}
+
+fn acquire_pending_review_lease(
+    ctx: &ProviderContext,
+    view: &pr_view::PrViewPayload,
+    viewer: &str,
+) -> Result<PendingReviewLease, ForgeError> {
+    acquire_pending_review_lease_for(ctx, &view.url, view.number, viewer)
+}
+
+pub(crate) fn acquire_pending_review_lease_for(
+    ctx: &ProviderContext,
+    pr_url: &str,
+    number: u64,
+    viewer: &str,
+) -> Result<PendingReviewLease, ForgeError> {
+    if viewer.is_empty() {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "pending_review_identity_mismatch",
+            "the authenticated GitHub viewer identity is unavailable",
+            Some(format!("pr={number}")),
+        ));
+    }
+    let repository = crate::ops::pr_comments::github_repo_slug_from_url(pr_url)
+        .or_else(|| ctx.repo.clone())
+        .ok_or_else(|| {
+            ForgeError::validation(
+                schema_err(),
+                "repo_required",
+                "pending-review recovery requires a repository slug",
+                None,
+            )
+        })?;
+    let state_root = pending_review_state_root()?;
+    let lease_dir = state_root.join("forge-cli").join("pending-review-leases");
+    let key = format!(
+        "{}\n{}\n{}\n{}\n{}",
+        ctx.provider.as_str(),
+        ctx.host.to_ascii_lowercase(),
+        repository.to_ascii_lowercase(),
+        number,
+        viewer.to_ascii_lowercase()
+    );
+    acquire_pending_review_lease_at(&lease_dir, &key)
+}
+
+fn pending_review_state_root() -> Result<PathBuf, ForgeError> {
+    let path = env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".local/state")))
+        .ok_or_else(|| lease_unsafe("neither XDG_STATE_HOME nor HOME is available"))?;
+    if !path.is_absolute() {
+        return Err(lease_unsafe("pending-review state root is not absolute"));
+    }
+    Ok(path)
+}
+
+fn acquire_pending_review_lease_at(
+    lease_dir: &Path,
+    key: &str,
+) -> Result<PendingReviewLease, ForgeError> {
+    if !lease_dir.exists() {
+        fs::create_dir_all(lease_dir)
+            .map_err(|error| lease_unsafe(&format!("failed to create lease directory: {error}")))?;
+        fs::set_permissions(lease_dir, fs::Permissions::from_mode(0o700))
+            .map_err(|error| lease_unsafe(&format!("failed to secure lease directory: {error}")))?;
+    }
+    let directory = fs::symlink_metadata(lease_dir)
+        .map_err(|error| lease_unsafe(&format!("failed to inspect lease directory: {error}")))?;
+    if !directory.file_type().is_dir()
+        || directory.uid() != effective_uid()
+        || directory.mode() & 0o077 != 0
+    {
+        return Err(lease_unsafe(
+            "pending-review lease directory is not a private viewer-owned directory",
+        ));
+    }
+
+    let digest = Sha256::digest(key.as_bytes());
+    let mut digest_hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut digest_hex, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    let lock_path = lease_dir.join(format!("{digest_hex}.lock"));
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .create(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    let file = options
+        .open(&lock_path)
+        .map_err(|error| lease_unsafe(&format!("failed to open lease file: {error}")))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| lease_unsafe(&format!("failed to inspect lease file: {error}")))?;
+    if !metadata.file_type().is_file()
+        || metadata.uid() != effective_uid()
+        || metadata.mode() & 0o077 != 0
+    {
+        return Err(lease_unsafe(
+            "pending-review lease file is not a private viewer-owned regular file",
+        ));
+    }
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        let error = std::io::Error::last_os_error();
+        let raw = error.raw_os_error();
+        if raw == Some(libc::EWOULDBLOCK) || raw == Some(libc::EAGAIN) {
+            return Err(ForgeError::unavailable(
+                schema_err(),
+                "pending_review_lease_busy",
+                "another trusted forge-cli process is mutating this viewer's pending review",
+                None,
+            ));
+        }
+        return Err(lease_unsafe(&format!("failed to acquire lease: {error}")));
+    }
+    Ok(PendingReviewLease(file))
+}
+
+fn lease_unsafe(detail: &str) -> ForgeError {
+    ForgeError::validation(
+        schema_err(),
+        "pending_review_lease_unsafe",
+        "the pending-review mutation lease cannot be used safely",
+        Some(detail.to_string()),
+    )
+}
+
+fn effective_uid() -> u32 {
+    unsafe { libc::geteuid() }
+}
+
+fn unlock_file(fd: RawFd) {
+    let _ = unsafe { libc::flock(fd, libc::LOCK_UN) };
 }
 
 fn validate_pending_guard(
@@ -1128,4 +1477,45 @@ fn render_text(payload: &PrPendingReviewDeletePayload) {
         number = payload.number,
         url = payload.review_url,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::symlink;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn pending_review_lease_excludes_a_concurrent_holder() {
+        let temp = TempDir::new().expect("tempdir");
+        let lease_dir = temp.path().join("leases");
+        let first = acquire_pending_review_lease_at(&lease_dir, "github/repo/7/viewer")
+            .expect("first lease");
+        let error = match acquire_pending_review_lease_at(&lease_dir, "github/repo/7/viewer") {
+            Err(error) => error,
+            Ok(_) => panic!("concurrent holder must be rejected"),
+        };
+        assert_eq!(error.kind(), "pending_review_lease_busy");
+        drop(first);
+        acquire_pending_review_lease_at(&lease_dir, "github/repo/7/viewer")
+            .expect("lease is available after release");
+    }
+
+    #[test]
+    fn pending_review_lease_rejects_a_symlinked_directory() {
+        let temp = TempDir::new().expect("tempdir");
+        let target = temp.path().join("target");
+        fs::create_dir(&target).expect("target dir");
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o700)).expect("private target");
+        let lease_dir = temp.path().join("leases");
+        symlink(&target, &lease_dir).expect("symlink lease dir");
+
+        let error = match acquire_pending_review_lease_at(&lease_dir, "github/repo/7/viewer") {
+            Err(error) => error,
+            Ok(_) => panic!("symlinked lease directory must be rejected"),
+        };
+        assert_eq!(error.kind(), "pending_review_lease_unsafe");
+    }
 }

--- a/crates/forge-cli/src/ops/pr_pending_review.rs
+++ b/crates/forge-cli/src/ops/pr_pending_review.rs
@@ -44,10 +44,31 @@ pub struct PrPendingReviewSubmitPayload {
     pub review_url: String,
     pub head_sha: String,
     pub commit_sha: String,
-    pub snapshot_digest: Option<String>,
+    pub snapshot_digest: String,
     pub snapshot_provenance: &'static str,
     pub review_run_id: Option<String>,
     pub submitted: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PrPendingReviewResumeSubmitPayload {
+    pub provider: &'static str,
+    pub number: u64,
+    pub url: String,
+    pub review_id: String,
+    pub review_url: String,
+    pub head_sha: String,
+    pub commit_sha: String,
+    pub snapshot_digest: Option<String>,
+    pub snapshot_provenance: &'static str,
+    pub review_run_id: String,
+    pub submitted: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubmitContract {
+    DirectV1,
+    ResumeV2,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -202,7 +223,7 @@ pub fn run_resume_submit_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         view,
         snapshot,
         args.decision,
-        "pr.pending-review.resume-submit",
+        SubmitContract::ResumeV2,
         format,
     )
 }
@@ -248,7 +269,7 @@ pub fn run_submit_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         view,
         snapshot,
         args.decision,
-        "pr.pending-review.submit",
+        SubmitContract::DirectV1,
         format,
     )
 }
@@ -650,7 +671,7 @@ fn emit_already_submitted<R: BackendRunner>(
         ));
     }
     validate_snapshot_against_receipt(&submitted_snapshot, &receipt)?;
-    let payload = PrPendingReviewSubmitPayload {
+    let payload = PrPendingReviewResumeSubmitPayload {
         provider: ctx.provider.as_str(),
         number: view.number,
         url: view.url,
@@ -660,11 +681,11 @@ fn emit_already_submitted<R: BackendRunner>(
         commit_sha: submitted.commit_sha.clone(),
         snapshot_digest: None,
         snapshot_provenance: "pending-snapshot-unverified",
-        review_run_id: Some(review_run_id.to_string()),
+        review_run_id: review_run_id.to_string(),
         submitted: true,
     };
     Ok(emit_success(
-        schema_version_for(BINARY, "pr.pending-review.resume-submit", 1),
+        schema_version_for(BINARY, "pr.pending-review.resume-submit", 2),
         payload,
         format,
         |payload| {
@@ -857,7 +878,7 @@ fn submit_snapshot<R: BackendRunner>(
     view: pr_view::PrViewPayload,
     snapshot: pr_reviews::PendingReviewSnapshot,
     decision: PrReviewDecision,
-    schema: &str,
+    contract: SubmitContract,
     format: OutputFormat,
 ) -> Result<i32, ForgeError> {
     if !snapshot.viewer_did_author {
@@ -907,31 +928,66 @@ fn submit_snapshot<R: BackendRunner>(
         ));
     }
     let commit_sha = snapshot.commit_sha.clone().expect("CAS checked commit");
-    Ok(emit_success(
-        schema_version_for(BINARY, schema, 1),
-        PrPendingReviewSubmitPayload {
-            provider: ctx.provider.as_str(),
-            number: view.number,
-            url: view.url,
-            review_id: snapshot.review_id,
-            review_url: submitted.review_url,
-            head_sha: snapshot.head_sha,
-            commit_sha,
-            snapshot_digest: Some(snapshot.snapshot_digest),
-            snapshot_provenance: "pending-cas+submitted-reconciled",
-            review_run_id: snapshot.review_run_id,
-            submitted: true,
-        },
-        format,
-        |payload| {
-            println!(
-                "submitted pending review {review} on #{number}\n  {url}",
-                review = payload.review_id,
-                number = payload.number,
-                url = payload.review_url
-            );
-        },
-    ))
+    let provider = ctx.provider.as_str();
+    let number = view.number;
+    let url = view.url;
+    let review_id = snapshot.review_id;
+    let review_url = submitted.review_url;
+    let head_sha = snapshot.head_sha;
+    let snapshot_digest = snapshot.snapshot_digest;
+    let review_run_id = snapshot.review_run_id;
+    Ok(match contract {
+        SubmitContract::DirectV1 => emit_success(
+            schema_version_for(BINARY, "pr.pending-review.submit", 1),
+            PrPendingReviewSubmitPayload {
+                provider,
+                number,
+                url,
+                review_id,
+                review_url,
+                head_sha,
+                commit_sha,
+                snapshot_digest,
+                snapshot_provenance: "pending-cas+submitted-reconciled",
+                review_run_id,
+                submitted: true,
+            },
+            format,
+            |payload| {
+                println!(
+                    "submitted pending review {review} on #{number}\n  {url}",
+                    review = payload.review_id,
+                    number = payload.number,
+                    url = payload.review_url
+                );
+            },
+        ),
+        SubmitContract::ResumeV2 => emit_success(
+            schema_version_for(BINARY, "pr.pending-review.resume-submit", 2),
+            PrPendingReviewResumeSubmitPayload {
+                provider,
+                number,
+                url,
+                review_id,
+                review_url,
+                head_sha,
+                commit_sha,
+                snapshot_digest: Some(snapshot_digest),
+                snapshot_provenance: "pending-cas+submitted-reconciled",
+                review_run_id: review_run_id.expect("receipt-bound recovery checked review run"),
+                submitted: true,
+            },
+            format,
+            |payload| {
+                println!(
+                    "submitted pending review {review} on #{number}\n  {url}",
+                    review = payload.review_id,
+                    number = payload.number,
+                    url = payload.review_url
+                );
+            },
+        ),
+    })
 }
 
 fn ensure_pending_author(snapshot: &pr_reviews::PendingReviewSnapshot) -> Result<(), ForgeError> {

--- a/crates/forge-cli/src/ops/pr_review.rs
+++ b/crates/forge-cli/src/ops/pr_review.rs
@@ -1452,6 +1452,12 @@ fn submit_github_review_with_threads<R: BackendRunner>(
             skipped,
         });
     }
+    let _pending_review_lease = super::pr_pending_review::acquire_pending_review_lease_for(
+        ctx,
+        &target.url,
+        number,
+        &state.viewer_login,
+    )?;
 
     let marked_body = marked_review_body(&summary, &review_run_id);
     let marked_specs = to_post
@@ -1610,34 +1616,70 @@ fn submit_github_review_with_threads<R: BackendRunner>(
         ));
     }
 
-    let submit_output = match runner.run(&build_github_submit_review_call(
+    let submit_result = runner.run(&build_github_submit_review_call(
         ctx,
         &pending.review_id,
         decision.to_github_event(),
         Some(&marked_body),
-    )) {
-        Ok(output) => output,
-        Err(err) => {
-            let err = map_github_native_review_submit_error(decision, err);
-            if let Some(review_url) =
-                find_submitted_review_run(runner, ctx, number, &target.url, &receipt)?
-            {
-                return Ok(GithubReviewSubmission {
-                    review_url: Some(review_url),
-                    submitted: true,
-                    created: review_threads,
-                    skipped,
-                });
-            }
-            return Err(pending_transaction_incomplete(
-                &review_run_id,
-                Some(&pending.review_id),
-                "pending review submit result is unknown; content was preserved",
-                Some(err),
-            ));
-        }
+    ));
+    let expected_state = match decision {
+        PrReviewDecision::CommentsOnly => "COMMENTED",
+        PrReviewDecision::Approve => "APPROVED",
+        PrReviewDecision::RequestChanges => "CHANGES_REQUESTED",
     };
-    let review_url = parse_submitted_review_url(&submit_output).unwrap_or(pending.url);
+    let submitted_snapshot = pr_reviews::compute_submitted_review_snapshot(
+        runner,
+        ctx,
+        &pending.review_id,
+        expected_state,
+    )
+    .map_err(|error| {
+        pending_transaction_incomplete(
+            &review_run_id,
+            Some(&pending.review_id),
+            "submitted review read-back failed",
+            Some(error),
+        )
+    })?;
+    let Some(submitted_snapshot) = submitted_snapshot else {
+        let cause = submit_result
+            .err()
+            .map(|error| map_github_native_review_submit_error(decision, error));
+        return Err(pending_transaction_incomplete(
+            &review_run_id,
+            Some(&pending.review_id),
+            "pending review submission could not be reconciled",
+            cause,
+        ));
+    };
+    validate_receipt_bound_snapshot(
+        &submitted_snapshot,
+        number,
+        expected_head,
+        &summary,
+        &review_run_id,
+        &manifest,
+    )?;
+    if submitted_snapshot.inline_comments.len() != manifest.len() {
+        return Err(pending_transaction_incomplete(
+            &review_run_id,
+            Some(&pending.review_id),
+            "submitted review manifest is not complete",
+            None,
+        ));
+    }
+    if let Ok(output) = submit_result.as_ref()
+        && let Some(review_url) = parse_submitted_review_url(output)
+        && review_url != submitted_snapshot.review_url
+    {
+        return Err(pending_transaction_incomplete(
+            &review_run_id,
+            Some(&pending.review_id),
+            "submitted review URL differs from the reconciled provider node",
+            None,
+        ));
+    }
+    let review_url = submitted_snapshot.review_url;
     Ok(GithubReviewSubmission {
         review_url: Some(review_url),
         submitted: true,
@@ -1749,13 +1791,22 @@ fn validate_receipt_bound_snapshot(
         ));
     }
     for (comment, expected) in snapshot.inline_comments.iter().zip(manifest) {
+        let file_anchor_matches = comment.subject_type == "FILE"
+            && expected.subject_type == "FILE"
+            && comment.line.is_none()
+            && comment.diff_side.is_none()
+            && comment.start_line.is_none()
+            && comment.start_diff_side.is_none();
+        let line_anchor_matches = comment.subject_type != "FILE"
+            && expected.subject_type != "FILE"
+            && comment.line == expected.line
+            && comment.diff_side.as_deref() == Some(expected.side.as_str())
+            && comment.start_line == expected.start_line
+            && comment.start_diff_side == expected.start_side;
         if comment.review_run_id.as_deref() != Some(review_run_id)
             || comment.path != expected.path
-            || comment.line != expected.line
-            || comment.diff_side.as_deref() != Some(expected.side.as_str())
-            || comment.start_line != expected.start_line
-            || comment.start_diff_side != expected.start_side
             || comment.subject_type != expected.subject_type
+            || !(file_anchor_matches || line_anchor_matches)
             || comment.body_digest != expected.body_digest
         {
             return Err(ForgeError::validation(

--- a/crates/forge-cli/src/ops/pr_reviews.rs
+++ b/crates/forge-cli/src/ops/pr_reviews.rs
@@ -1821,6 +1821,95 @@ mod tests {
     }
 
     #[test]
+    fn pending_snapshot_rejects_cross_page_total_count_drift() {
+        let first = pending_snapshot_page(PendingSnapshotPageSpec {
+            head: "head-7",
+            id: "PRRC_1",
+            path: "src/one.rs",
+            line: 1,
+            diff_side: "RIGHT",
+            start_line: None,
+            start_diff_side: None,
+            has_next_page: true,
+            end_cursor: Some("cursor-1"),
+        });
+        let mut second = pending_snapshot_page(PendingSnapshotPageSpec {
+            head: "head-7",
+            id: "PRRC_2",
+            path: "src/two.rs",
+            line: 2,
+            diff_side: "RIGHT",
+            start_line: None,
+            start_diff_side: None,
+            has_next_page: false,
+            end_cursor: None,
+        });
+        let mut value: serde_json::Value =
+            serde_json::from_str(&second.stdout).expect("snapshot fixture");
+        value["data"]["node"]["comments"]["totalCount"] = 3.into();
+        second.stdout = value.to_string();
+        let runner = ScriptedRunner::new(vec![first, second]);
+
+        let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect_err("totalCount drift across pages must fail closed");
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert_eq!(runner.calls.borrow().len(), 2);
+    }
+
+    #[test]
+    fn pending_snapshot_rejects_more_than_one_thousand_accumulated_nodes() {
+        let page = |id: &'static str, node_count: usize, has_next_page, end_cursor| {
+            let mut output = pending_snapshot_page(PendingSnapshotPageSpec {
+                head: "head-7",
+                id,
+                path: "src/many.rs",
+                line: 1,
+                diff_side: "RIGHT",
+                start_line: None,
+                start_diff_side: None,
+                has_next_page,
+                end_cursor,
+            });
+            let mut value: serde_json::Value =
+                serde_json::from_str(&output.stdout).expect("snapshot fixture");
+            let node = value["data"]["node"]["comments"]["nodes"][0].clone();
+            value["data"]["node"]["comments"]["totalCount"] = MAX_PENDING_REVIEW_COMMENTS.into();
+            value["data"]["node"]["comments"]["nodes"] = vec![node; node_count].into();
+            output.stdout = value.to_string();
+            output
+        };
+        let runner = ScriptedRunner::new(vec![
+            page("PRRC_1", 501, true, Some("cursor-1")),
+            page("PRRC_2", 500, false, None),
+        ]);
+
+        let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect_err("accumulated nodes above the safety limit must fail closed");
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert_eq!(runner.calls.borrow().len(), 2);
+    }
+
+    #[test]
+    fn pending_snapshot_rejects_terminal_actual_count_mismatch() {
+        let runner = ScriptedRunner::new(vec![pending_snapshot_page(PendingSnapshotPageSpec {
+            head: "head-7",
+            id: "PRRC_only",
+            path: "src/one.rs",
+            line: 1,
+            diff_side: "RIGHT",
+            start_line: None,
+            start_diff_side: None,
+            has_next_page: false,
+            end_cursor: None,
+        })]);
+
+        let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect_err("terminal observed node count must match totalCount");
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert_eq!(runner.calls.borrow().len(), 1);
+    }
+
+    #[test]
     fn pending_snapshot_rejects_multi_page_retained_byte_exhaustion() {
         let oversized_body = "x".repeat(MAX_PENDING_REVIEW_SNAPSHOT_BYTES / 3 + 1);
         let page = |id: &'static str, has_next_page, end_cursor| {

--- a/crates/forge-cli/src/ops/pr_reviews.rs
+++ b/crates/forge-cli/src/ops/pr_reviews.rs
@@ -965,14 +965,12 @@ fn parse_github_pending_review_snapshot_page(
                 "/diffSide",
                 line.or(original_line),
                 &subject_type,
-                None,
             )?;
             let start_diff_side = normalized_comment_side(
                 comment,
                 "/startDiffSide",
                 start_line.or(original_start_line),
                 &subject_type,
-                diff_side.as_deref(),
             )?;
             Ok(PendingReviewInlineComment {
                 id: required_string(comment, "/id", "review.comment.id")?,
@@ -1046,7 +1044,6 @@ fn normalized_comment_side(
     direct_pointer: &str,
     anchor_line: Option<u32>,
     subject_type: &str,
-    preferred_side: Option<&str>,
 ) -> Result<Option<String>, ForgeError> {
     if let Some(side) = optional_string(comment, direct_pointer) {
         return Ok(Some(side));
@@ -1055,30 +1052,22 @@ fn normalized_comment_side(
         return Ok(None);
     }
     let diff_hunk = required_string(comment, "/diffHunk", "review.comment.diffHunk")?;
-    let side = infer_side_from_diff_hunk(
-        &diff_hunk,
-        anchor_line.expect("checked above"),
-        preferred_side,
-    )
-    .ok_or_else(|| {
-        snapshot_incomplete(
-            "pending review comment diff side cannot be derived from its diff hunk",
-            optional_string(comment, "/id").map(|id| {
-                format!(
-                    "comment_id={id}; anchor_line={}",
-                    anchor_line.expect("checked above")
-                )
-            }),
-        )
-    })?;
+    let side = infer_side_from_diff_hunk(&diff_hunk, anchor_line.expect("checked above"))
+        .ok_or_else(|| {
+            snapshot_incomplete(
+                "pending review comment diff side cannot be derived from its diff hunk",
+                optional_string(comment, "/id").map(|id| {
+                    format!(
+                        "comment_id={id}; anchor_line={}",
+                        anchor_line.expect("checked above")
+                    )
+                }),
+            )
+        })?;
     Ok(Some(side.to_string()))
 }
 
-fn infer_side_from_diff_hunk(
-    diff_hunk: &str,
-    anchor_line: u32,
-    preferred_side: Option<&str>,
-) -> Option<&'static str> {
+fn infer_side_from_diff_hunk(diff_hunk: &str, anchor_line: u32) -> Option<&'static str> {
     let mut old_line = None;
     let mut new_line = None;
     let mut candidates = Vec::new();
@@ -1118,15 +1107,11 @@ fn infer_side_from_diff_hunk(
         }
     }
 
-    preferred_side
-        .and_then(|preferred| {
-            candidates
-                .iter()
-                .rev()
-                .find(|side| **side == preferred)
-                .copied()
-        })
-        .or_else(|| candidates.last().copied())
+    let side = candidates.first().copied()?;
+    candidates
+        .iter()
+        .all(|candidate| *candidate == side)
+        .then_some(side)
 }
 
 fn parse_diff_hunk_starts(header: &str) -> Option<(u32, u32)> {
@@ -1599,14 +1584,14 @@ mod tests {
                 head: "head-7",
                 id: "PRRC_right",
                 path: "src/new.rs",
-                line: 8,
+                line: 9,
                 diff_side: "RIGHT",
                 start_line: Some(7),
                 start_diff_side: Some("RIGHT"),
                 has_next_page: false,
                 end_cursor: None,
             },
-            "@@ -7,2 +7,2 @@\n context\n-old value\n+new value",
+            "@@ -7,0 +7,3 @@\n+first\n+middle\n+last",
         );
         let page = parse_github_pending_review_snapshot_page(&right_range, "PENDING")
             .expect("supported GraphQL fields parse")
@@ -1641,6 +1626,50 @@ mod tests {
             page.snapshot.inline_comments[0].diff_side.as_deref(),
             Some("LEFT")
         );
+
+        let mut direct_side = pending_snapshot_page(PendingSnapshotPageSpec {
+            head: "head-7",
+            id: "PRRC_direct",
+            path: "src/replaced.rs",
+            line: 8,
+            diff_side: "LEFT",
+            start_line: None,
+            start_diff_side: None,
+            has_next_page: false,
+            end_cursor: None,
+        });
+        let mut value: serde_json::Value =
+            serde_json::from_str(&direct_side.stdout).expect("snapshot fixture");
+        value["data"]["node"]["comments"]["nodes"][0]["diffHunk"] =
+            "@@ -8,1 +8,1 @@\n-old value\n+new value".into();
+        direct_side.stdout = value.to_string();
+        let page = parse_github_pending_review_snapshot_page(&direct_side, "PENDING")
+            .expect("direct provider discriminator parses")
+            .expect("pending snapshot");
+        assert_eq!(
+            page.snapshot.inline_comments[0].diff_side.as_deref(),
+            Some("LEFT")
+        );
+
+        let ambiguous = snapshot_without_side_fields(
+            PendingSnapshotPageSpec {
+                head: "head-7",
+                id: "PRRC_ambiguous",
+                path: "src/replaced.rs",
+                line: 8,
+                diff_side: "RIGHT",
+                start_line: None,
+                start_diff_side: None,
+                has_next_page: false,
+                end_cursor: None,
+            },
+            "@@ -8,1 +8,1 @@\n-old value\n+new value",
+        );
+        let error = match parse_github_pending_review_snapshot_page(&ambiguous, "PENDING") {
+            Err(error) => error,
+            Ok(_) => panic!("same-number replacement without a side discriminator is ambiguous"),
+        };
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_reviews.rs
+++ b/crates/forge-cli/src/ops/pr_reviews.rs
@@ -22,6 +22,8 @@ pub const SCHEMA_VERSION: u32 = 1;
 const MAX_SUMMARY_BYTES: usize = 4096;
 const MAX_REVIEW_PAGES: usize = 100;
 pub(crate) const MAX_PENDING_REVIEW_BODY_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_PENDING_REVIEW_COMMENTS: u64 = 1_000;
+pub(crate) const MAX_PENDING_REVIEW_SNAPSHOT_BYTES: usize = 4 * 1024 * 1024;
 
 const GITHUB_REVIEWS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $after: String) { viewer { login } repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviews(first: 100, after: $after) { nodes { id databaseId url author { login } state commit { oid } submittedAt body viewerDidAuthor } pageInfo { hasNextPage endCursor } } } } }";
 const GITHUB_PENDING_REVIEWS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $after: String) { repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviews(first: 100, after: $after, states: [PENDING]) { nodes { id url author { login } state commit { oid } body viewerDidAuthor viewerCanDelete } pageInfo { hasNextPage endCursor } } } } }";
@@ -395,6 +397,26 @@ fn compute_review_snapshot_for_state<R: BackendRunner>(
                 ))
             };
         };
+        if page.total_count > MAX_PENDING_REVIEW_COMMENTS {
+            return Err(snapshot_incomplete(
+                "pending review inline-comment count exceeds the recovery safety limit",
+                Some(format!(
+                    "review_id={review_id}; total_count={}; max_comments={MAX_PENDING_REVIEW_COMMENTS}",
+                    page.total_count
+                )),
+            ));
+        }
+        if let Some(total) = expected_total
+            && page.total_count != total
+        {
+            return Err(snapshot_incomplete(
+                "pending review inline-comment count changed while paginating",
+                Some(format!(
+                    "review_id={review_id}; expected_total={total}; observed_total={}",
+                    page.total_count
+                )),
+            ));
+        }
         if let Some(existing) = snapshot.as_mut() {
             validate_snapshot_page_identity(existing, &page.snapshot)?;
             existing
@@ -403,6 +425,33 @@ fn compute_review_snapshot_for_state<R: BackendRunner>(
         } else {
             expected_total = Some(page.total_count);
             snapshot = Some(page.snapshot);
+        }
+        let retained = snapshot.as_ref().expect("page created a snapshot");
+        if retained.inline_comments.len() as u64 > MAX_PENDING_REVIEW_COMMENTS {
+            return Err(snapshot_incomplete(
+                "pending review retained inline-comment count exceeds the recovery safety limit",
+                Some(format!(
+                    "review_id={review_id}; observed_comments={}; max_comments={MAX_PENDING_REVIEW_COMMENTS}",
+                    retained.inline_comments.len()
+                )),
+            ));
+        }
+        let retained_bytes = serde_json::to_vec(retained)
+            .map_err(|error| {
+                ForgeError::software(
+                    schema_err(),
+                    "failed to size pending-review snapshot",
+                    Some(error.to_string()),
+                )
+            })?
+            .len();
+        if retained_bytes > MAX_PENDING_REVIEW_SNAPSHOT_BYTES {
+            return Err(snapshot_incomplete(
+                "pending review decoded snapshot exceeds the recovery safety limit",
+                Some(format!(
+                    "review_id={review_id}; retained_bytes={retained_bytes}; max_bytes={MAX_PENDING_REVIEW_SNAPSHOT_BYTES}"
+                )),
+            ));
         }
         if !page.has_next_page {
             let mut snapshot = snapshot.expect("page created a snapshot");
@@ -1744,6 +1793,63 @@ mod tests {
         let error = compute_pending_snapshot(&drifted, &github_ctx(), "PRR_pending")
             .expect_err("metadata drift between pages must fail closed");
         assert_eq!(error.kind(), "review_snapshot_incomplete");
+    }
+
+    #[test]
+    fn pending_snapshot_rejects_excessive_total_count_before_following_pages() {
+        let mut first = pending_snapshot_page(PendingSnapshotPageSpec {
+            head: "head-7",
+            id: "PRRC_1",
+            path: "src/one.rs",
+            line: 1,
+            diff_side: "RIGHT",
+            start_line: None,
+            start_diff_side: None,
+            has_next_page: true,
+            end_cursor: Some("cursor-1"),
+        });
+        let mut value: serde_json::Value =
+            serde_json::from_str(&first.stdout).expect("snapshot fixture");
+        value["data"]["node"]["comments"]["totalCount"] = (MAX_PENDING_REVIEW_COMMENTS + 1).into();
+        first.stdout = value.to_string();
+        let runner = ScriptedRunner::new(vec![first]);
+
+        let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect_err("oversized aggregate count must fail before another page");
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert_eq!(runner.calls.borrow().len(), 1);
+    }
+
+    #[test]
+    fn pending_snapshot_rejects_multi_page_retained_byte_exhaustion() {
+        let oversized_body = "x".repeat(MAX_PENDING_REVIEW_SNAPSHOT_BYTES / 3 + 1);
+        let page = |id: &'static str, has_next_page, end_cursor| {
+            let mut output = pending_snapshot_page(PendingSnapshotPageSpec {
+                head: "head-7",
+                id,
+                path: "src/large.rs",
+                line: 1,
+                diff_side: "RIGHT",
+                start_line: None,
+                start_diff_side: None,
+                has_next_page,
+                end_cursor,
+            });
+            let mut value: serde_json::Value =
+                serde_json::from_str(&output.stdout).expect("snapshot fixture");
+            value["data"]["node"]["comments"]["nodes"][0]["body"] = oversized_body.clone().into();
+            output.stdout = value.to_string();
+            output
+        };
+        let runner = ScriptedRunner::new(vec![
+            page("PRRC_1", true, Some("cursor-1")),
+            page("PRRC_2", false, None),
+        ]);
+
+        let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect_err("decoded retained aggregate bytes must be bounded");
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert_eq!(runner.calls.borrow().len(), 2);
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_reviews.rs
+++ b/crates/forge-cli/src/ops/pr_reviews.rs
@@ -26,7 +26,7 @@ pub(crate) const MAX_PENDING_REVIEW_BODY_BYTES: usize = 64 * 1024;
 const GITHUB_REVIEWS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $after: String) { viewer { login } repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviews(first: 100, after: $after) { nodes { id databaseId url author { login } state commit { oid } submittedAt body viewerDidAuthor } pageInfo { hasNextPage endCursor } } } } }";
 const GITHUB_PENDING_REVIEWS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $after: String) { repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviews(first: 100, after: $after, states: [PENDING]) { nodes { id url author { login } state commit { oid } body viewerDidAuthor viewerCanDelete } pageInfo { hasNextPage endCursor } } } } }";
 const GITHUB_PENDING_REVIEW_TARGET_QUERY: &str = "query($review: ID!) { node(id: $review) { ... on PullRequestReview { id url author { login } state commit { oid } body viewerDidAuthor viewerCanDelete comments(first: 1) { totalCount } pullRequest { number url headRefOid } } } }";
-const GITHUB_PENDING_REVIEW_SNAPSHOT_QUERY: &str = "query($review: ID!, $after: String) { node(id: $review) { ... on PullRequestReview { id url author { login } state commit { oid } body viewerDidAuthor viewerCanDelete comments(first: 100, after: $after) { totalCount nodes { id url author { login } body createdAt path line originalLine diffSide startLine originalStartLine startDiffSide subjectType } pageInfo { hasNextPage endCursor } } pullRequest { number url headRefOid } } } }";
+const GITHUB_PENDING_REVIEW_SNAPSHOT_QUERY: &str = "query($review: ID!, $after: String) { node(id: $review) { ... on PullRequestReview { id url author { login } state commit { oid } body viewerDidAuthor viewerCanDelete comments(first: 100, after: $after) { totalCount nodes { id url author { login } body createdAt path diffHunk line originalLine startLine originalStartLine subjectType } pageInfo { hasNextPage endCursor } } pullRequest { number url headRefOid } } } }";
 
 struct ReviewPage {
     viewer_login: String,
@@ -955,6 +955,25 @@ fn parse_github_pending_review_snapshot_page(
             let semantic_body = review_state::strip_owned_markers(&body);
             let body_digest = review_state::sha256_digest(semantic_body.as_bytes());
             let line = optional_u32(comment, "/line");
+            let original_line = optional_u32(comment, "/originalLine");
+            let start_line = optional_u32(comment, "/startLine");
+            let original_start_line = optional_u32(comment, "/originalStartLine");
+            let subject_type = optional_string(comment, "/subjectType")
+                .unwrap_or_else(|| if line.is_some() { "LINE" } else { "FILE" }.to_string());
+            let diff_side = normalized_comment_side(
+                comment,
+                "/diffSide",
+                line.or(original_line),
+                &subject_type,
+                None,
+            )?;
+            let start_diff_side = normalized_comment_side(
+                comment,
+                "/startDiffSide",
+                start_line.or(original_start_line),
+                &subject_type,
+                diff_side.as_deref(),
+            )?;
             Ok(PendingReviewInlineComment {
                 id: required_string(comment, "/id", "review.comment.id")?,
                 url: required_string(comment, "/url", "review.comment.url")?,
@@ -966,13 +985,12 @@ fn parse_github_pending_review_snapshot_page(
                 created_at: required_string(comment, "/createdAt", "review.comment.createdAt")?,
                 path: optional_string(comment, "/path").unwrap_or_default(),
                 line,
-                original_line: optional_u32(comment, "/originalLine"),
-                diff_side: optional_string(comment, "/diffSide"),
-                start_line: optional_u32(comment, "/startLine"),
-                original_start_line: optional_u32(comment, "/originalStartLine"),
-                start_diff_side: optional_string(comment, "/startDiffSide"),
-                subject_type: optional_string(comment, "/subjectType")
-                    .unwrap_or_else(|| if line.is_some() { "LINE" } else { "FILE" }.to_string()),
+                original_line,
+                diff_side,
+                start_line,
+                original_start_line,
+                start_diff_side,
+                subject_type,
                 body_digest,
             })
         })
@@ -1021,6 +1039,104 @@ fn parse_github_pending_review_snapshot_page(
             snapshot_digest: String::new(),
         },
     }))
+}
+
+fn normalized_comment_side(
+    comment: &serde_json::Value,
+    direct_pointer: &str,
+    anchor_line: Option<u32>,
+    subject_type: &str,
+    preferred_side: Option<&str>,
+) -> Result<Option<String>, ForgeError> {
+    if let Some(side) = optional_string(comment, direct_pointer) {
+        return Ok(Some(side));
+    }
+    if subject_type == "FILE" || anchor_line.is_none() {
+        return Ok(None);
+    }
+    let diff_hunk = required_string(comment, "/diffHunk", "review.comment.diffHunk")?;
+    let side = infer_side_from_diff_hunk(
+        &diff_hunk,
+        anchor_line.expect("checked above"),
+        preferred_side,
+    )
+    .ok_or_else(|| {
+        snapshot_incomplete(
+            "pending review comment diff side cannot be derived from its diff hunk",
+            optional_string(comment, "/id").map(|id| {
+                format!(
+                    "comment_id={id}; anchor_line={}",
+                    anchor_line.expect("checked above")
+                )
+            }),
+        )
+    })?;
+    Ok(Some(side.to_string()))
+}
+
+fn infer_side_from_diff_hunk(
+    diff_hunk: &str,
+    anchor_line: u32,
+    preferred_side: Option<&str>,
+) -> Option<&'static str> {
+    let mut old_line = None;
+    let mut new_line = None;
+    let mut candidates = Vec::new();
+
+    for row in diff_hunk.lines() {
+        if row.starts_with("@@") {
+            let (old_start, new_start) = parse_diff_hunk_starts(row)?;
+            old_line = Some(old_start);
+            new_line = Some(new_start);
+            continue;
+        }
+        let (Some(old), Some(new)) = (old_line.as_mut(), new_line.as_mut()) else {
+            continue;
+        };
+        match row.as_bytes().first().copied() {
+            Some(b'+') => {
+                if *new == anchor_line {
+                    candidates.push("RIGHT");
+                }
+                *new = new.saturating_add(1);
+            }
+            Some(b'-') => {
+                if *old == anchor_line {
+                    candidates.push("LEFT");
+                }
+                *old = old.saturating_add(1);
+            }
+            Some(b' ') => {
+                if *new == anchor_line {
+                    // GitHub normalizes unchanged context anchors to RIGHT.
+                    candidates.push("RIGHT");
+                }
+                *old = old.saturating_add(1);
+                *new = new.saturating_add(1);
+            }
+            _ => {}
+        }
+    }
+
+    preferred_side
+        .and_then(|preferred| {
+            candidates
+                .iter()
+                .rev()
+                .find(|side| **side == preferred)
+                .copied()
+        })
+        .or_else(|| candidates.last().copied())
+}
+
+fn parse_diff_hunk_starts(header: &str) -> Option<(u32, u32)> {
+    let body = header.strip_prefix("@@ -")?;
+    let (old_span, rest) = body.split_once(" +")?;
+    let (new_span, _) = rest.split_once(" @@")?;
+    Some((
+        old_span.split(',').next()?.parse().ok()?,
+        new_span.split(',').next()?.parse().ok()?,
+    ))
 }
 
 fn validate_snapshot_page_identity(
@@ -1456,8 +1572,75 @@ mod tests {
             build_github_pending_review_target_page_call(&github_ctx(), "PRR_pending", None)
                 .plan_argv()
                 .join(" ");
-        assert!(pending.contains("diffSide"), "{pending}");
-        assert!(pending.contains("startDiffSide"), "{pending}");
+        assert!(pending.contains("diffHunk"), "{pending}");
+        assert!(!pending.contains(" diffSide"), "{pending}");
+        assert!(!pending.contains(" startDiffSide"), "{pending}");
+    }
+
+    #[test]
+    fn pending_snapshot_derives_normalized_sides_from_supported_comment_fields() {
+        let snapshot_without_side_fields = |spec: PendingSnapshotPageSpec<'_>, diff_hunk: &str| {
+            let mut output = pending_snapshot_page(spec);
+            let mut value: serde_json::Value =
+                serde_json::from_str(&output.stdout).expect("snapshot fixture");
+            let comment = value
+                .pointer_mut("/data/node/comments/nodes/0")
+                .and_then(serde_json::Value::as_object_mut)
+                .expect("comment object");
+            comment.remove("diffSide");
+            comment.remove("startDiffSide");
+            comment.insert("diffHunk".into(), diff_hunk.into());
+            output.stdout = value.to_string();
+            output
+        };
+
+        let right_range = snapshot_without_side_fields(
+            PendingSnapshotPageSpec {
+                head: "head-7",
+                id: "PRRC_right",
+                path: "src/new.rs",
+                line: 8,
+                diff_side: "RIGHT",
+                start_line: Some(7),
+                start_diff_side: Some("RIGHT"),
+                has_next_page: false,
+                end_cursor: None,
+            },
+            "@@ -7,2 +7,2 @@\n context\n-old value\n+new value",
+        );
+        let page = parse_github_pending_review_snapshot_page(&right_range, "PENDING")
+            .expect("supported GraphQL fields parse")
+            .expect("pending snapshot");
+        assert_eq!(
+            page.snapshot.inline_comments[0].diff_side.as_deref(),
+            Some("RIGHT")
+        );
+        assert_eq!(
+            page.snapshot.inline_comments[0].start_diff_side.as_deref(),
+            Some("RIGHT")
+        );
+
+        let left_line = snapshot_without_side_fields(
+            PendingSnapshotPageSpec {
+                head: "head-7",
+                id: "PRRC_left",
+                path: "src/old.rs",
+                line: 8,
+                diff_side: "LEFT",
+                start_line: None,
+                start_diff_side: None,
+                has_next_page: false,
+                end_cursor: None,
+            },
+            "@@ -8,1 +8,0 @@\n-old value",
+        );
+        let page = parse_github_pending_review_snapshot_page(&left_line, "PENDING")
+            .expect("supported GraphQL fields parse")
+            .expect("pending snapshot");
+        assert_eq!(
+            page.snapshot.inline_comments[0].diff_side.as_deref(),
+            Some("LEFT")
+        );
     }
 
     #[test]

--- a/crates/forge-cli/tests/integration/pr_pending_review.rs
+++ b/crates/forge-cli/tests/integration/pr_pending_review.rs
@@ -162,6 +162,7 @@ fn pending_recovery_snapshot(marked: bool, inline_count: usize, viewer_owned: bo
     };
     let comments = (0..inline_count)
         .map(|index| {
+            let line = index + 1;
             let semantic = if marked {
                 "first".to_string()
             } else {
@@ -181,12 +182,11 @@ fn pending_recovery_snapshot(marked: bool, inline_count: usize, viewer_owned: bo
                 "body": body,
                 "createdAt": format!("2026-07-20T12:00:{index:02}Z"),
                 "path": format!("src/file-{index}.rs"),
-                "line": index + 1,
-                "originalLine": index + 1,
-                "diffSide": "RIGHT",
+                "diffHunk": format!("@@ -{line},0 +{line},1 @@\n+added line"),
+                "line": line,
+                "originalLine": line,
                 "startLine": null,
                 "originalStartLine": null,
-                "startDiffSide": null,
                 "subjectType": "LINE"
             })
         })
@@ -395,7 +395,7 @@ case "$1 $2" in
     printf '%s\n' '{{"number":42,"url":"https://github.com/acme/widgets/pull/42","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"feat/reviews","headRefOid":"head-new","title":"feat: reviews","body":""}}'
     ;;
   "api graphql")
-    printf '%s\n' '{{"data":{{"node":{{"id":"PRR_pending","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102","author":{{"login":"review-bot"}},"state":"PENDING","commit":{{"oid":"head-new"}},"body":"Summary\n<!-- forge-cli:review-run:v1 run=run-123 -->","viewerDidAuthor":true,"viewerCanDelete":true,"comments":{{"totalCount":1,"nodes":[{{"id":"PRRC_1","url":"https://github.com/acme/widgets/pull/42#discussion_r1","author":{{"login":"review-bot"}},"body":"first\n<!-- forge-cli:review-finding:v1 run=run-123 digest=sha256:a7937b64b8caa58f03721bb6bacf5c78cb235febe0e70b1b84cd99541461a08e -->","createdAt":"2026-07-20T12:00:00Z","path":"src/lib.rs","diffHunk":"@@ -10,1 +10,1 @@\n-old\n+new","line":10,"originalLine":10,"startLine":null,"originalStartLine":null,"subjectType":"LINE"}}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}},"pullRequest":{{"number":42,"url":"https://github.com/acme/widgets/pull/42","headRefOid":"head-new"}}}}}}}}'
+    printf '%s\n' '{{"data":{{"node":{{"id":"PRR_pending","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102","author":{{"login":"review-bot"}},"state":"PENDING","commit":{{"oid":"head-new"}},"body":"Summary\n<!-- forge-cli:review-run:v1 run=run-123 -->","viewerDidAuthor":true,"viewerCanDelete":true,"comments":{{"totalCount":1,"nodes":[{{"id":"PRRC_1","url":"https://github.com/acme/widgets/pull/42#discussion_r1","author":{{"login":"review-bot"}},"body":"first\n<!-- forge-cli:review-finding:v1 run=run-123 digest=sha256:a7937b64b8caa58f03721bb6bacf5c78cb235febe0e70b1b84cd99541461a08e -->","createdAt":"2026-07-20T12:00:00Z","path":"src/lib.rs","diffHunk":"@@ -10,0 +10,1 @@\n+new","line":10,"originalLine":10,"startLine":null,"originalStartLine":null,"subjectType":"LINE"}}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}},"pullRequest":{{"number":42,"url":"https://github.com/acme/widgets/pull/42","headRefOid":"head-new"}}}}}}}}'
     ;;
   *)
     echo "unexpected gh args: $*" >&2

--- a/crates/forge-cli/tests/integration/pr_pending_review.rs
+++ b/crates/forge-cli/tests/integration/pr_pending_review.rs
@@ -1,6 +1,9 @@
 //! Recovery tests for an authenticated actor's provider-valid pending review.
 
 use std::fs;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 use forge_cli::ops::review_state::{
     ReviewCommentManifestItem, ReviewRunReceipt, ReviewStatePayload, ReviewStateRecord,
@@ -8,7 +11,9 @@ use forge_cli::ops::review_state::{
 };
 use pretty_assertions::assert_eq;
 
-use super::support::{CmdOutput, StubEnv, parse_envelope, run_forge_cli, run_forge_cli_with_stdin};
+use super::support::{
+    CmdOutput, StubEnv, forge_cli_bin, parse_envelope, run_forge_cli, run_forge_cli_with_stdin,
+};
 
 const INCOMPLETE_RECEIPT_RUN_ID: &str =
     "sha256:3de5f335496edb76e29ba96b787fbc9dc18d081f45a285b0e2ae877443f49405";
@@ -220,6 +225,13 @@ fn pending_recovery_snapshot(marked: bool, inline_count: usize, viewer_owned: bo
 
 fn pending_recovery_script(capture: &str, snapshot: &str, marker: &str) -> String {
     let state_marker = serde_json::to_string(marker).expect("serialize review-state marker");
+    let mut submitted: serde_json::Value =
+        serde_json::from_str(snapshot).expect("pending snapshot fixture");
+    submitted["data"]["node"]["state"] = "COMMENTED".into();
+    submitted["data"]["node"]["viewerCanDelete"] = false.into();
+    let submitted = submitted.to_string();
+    let submitted_flag = format!("{capture}.submitted");
+    let deleted_flag = format!("{capture}.deleted");
     r#"#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "@CAPTURE@"
@@ -233,13 +245,21 @@ case "$1 $2" in
         printf '%s\n' '{"data":{"viewer":{"login":"review-bot"},"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"review-bot"},"body":@STATE_MARKER@}],"pageInfo":{"hasNextPage":false,"endCursor":"state-tip"}}}}}}'
         ;;
       *"submitPullRequestReview(input:"*)
+        : > "@SUBMITTED_FLAG@"
         printf '%s\n' '{"data":{"submitPullRequestReview":{"pullRequestReview":{"url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102"}}}}'
         ;;
       *"deletePullRequestReview(input:"*)
+        : > "@DELETED_FLAG@"
         printf '%s\n' '{"data":{"deletePullRequestReview":{"pullRequestReview":{"id":"PRR_pending","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102"}}}}'
         ;;
       *"comments(first: 100"*)
-        printf '%s\n' '@SNAPSHOT@'
+        if [ -e "@DELETED_FLAG@" ]; then
+          printf '%s\n' '{"data":{"node":null}}'
+        elif [ -e "@SUBMITTED_FLAG@" ]; then
+          printf '%s\n' '@SUBMITTED_SNAPSHOT@'
+        else
+          printf '%s\n' '@SNAPSHOT@'
+        fi
         ;;
       *)
         echo "unexpected graphql args: $*" >&2
@@ -255,6 +275,9 @@ esac
 "#
     .replace("@CAPTURE@", capture)
     .replace("@SNAPSHOT@", snapshot)
+    .replace("@SUBMITTED_SNAPSHOT@", &submitted)
+    .replace("@SUBMITTED_FLAG@", &submitted_flag)
+    .replace("@DELETED_FLAG@", &deleted_flag)
     .replace("@STATE_MARKER@", &state_marker)
 }
 
@@ -606,9 +629,337 @@ fn pr_pending_review_resume_submit_accepts_an_exact_receipt_manifest() {
     let envelope = parse_envelope(&output.stdout);
     assert_eq!(envelope["data"]["submitted"], true);
     assert_eq!(envelope["data"]["review_run_id"], review_run_id);
+    assert_eq!(
+        envelope["data"]["snapshot_provenance"],
+        "pending-cas+submitted-reconciled"
+    );
     let calls = fs::read_to_string(capture).expect("read calls");
     assert_eq!(calls.matches("submitPullRequestReview(input:").count(), 1);
     assert!(!calls.contains("deletePullRequestReview(input:"), "{calls}");
+}
+
+#[test]
+fn pr_pending_review_submit_fails_when_provider_state_cannot_be_reconciled() {
+    let stub = StubEnv::new();
+    let capture = stub.tempdir.path().join("unreconciled-submit-calls.log");
+    let manifest = vec![ReviewCommentManifestItem {
+        index: 0,
+        path: "src/file-0.rs".to_string(),
+        line: Some(1),
+        side: "RIGHT".to_string(),
+        start_line: None,
+        start_side: None,
+        subject_type: "LINE".to_string(),
+        body_digest: sha256_digest(b"first"),
+    }];
+    let (review_run_id, marker) = receipt_marker("Summary", manifest);
+    let snapshot =
+        pending_recovery_snapshot(true, 1, true).replace(INCOMPLETE_RECEIPT_RUN_ID, &review_run_id);
+    let script = pending_recovery_script(&capture.to_string_lossy(), &snapshot, &marker).replace(
+        &format!(": > \"{}.submitted\"", capture.to_string_lossy()),
+        ":",
+    );
+    let stub = stub.gh_stub(&script);
+    let inspect = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "inspect",
+            "42",
+            "--review",
+            "PRR_pending",
+        ],
+    );
+    let digest = parse_envelope(&inspect.stdout)["data"]["snapshot"]["snapshot_digest"]
+        .as_str()
+        .expect("snapshot digest")
+        .to_string();
+
+    let output = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "resume-submit",
+            "42",
+            "--review",
+            "PRR_pending",
+            "--review-run-id",
+            &review_run_id,
+            "--expected-head",
+            "head-new",
+            "--expected-commit",
+            "head-new",
+            "--expected-snapshot",
+            &digest,
+            "--decision",
+            "comments-only",
+        ],
+    );
+
+    assert_eq!(
+        output.code, 65,
+        "stdout={}\nstderr={}",
+        output.stdout, output.stderr
+    );
+    assert_eq!(
+        parse_envelope(&output.stdout)["error"]["code"],
+        "pending_review_reconciliation_failed"
+    );
+    let calls = fs::read_to_string(capture).expect("read calls");
+    assert_eq!(calls.matches("submitPullRequestReview(input:").count(), 1);
+}
+
+#[test]
+fn pr_pending_review_cross_process_lease_excludes_a_second_mutation() {
+    let stub = StubEnv::new();
+    let capture = stub.tempdir.path().join("concurrent-submit-calls.log");
+    let started = stub.tempdir.path().join("submit-started.flag");
+    let release = stub.tempdir.path().join("submit-release.flag");
+    let manifest = vec![ReviewCommentManifestItem {
+        index: 0,
+        path: "src/file-0.rs".to_string(),
+        line: Some(1),
+        side: "RIGHT".to_string(),
+        start_line: None,
+        start_side: None,
+        subject_type: "LINE".to_string(),
+        body_digest: sha256_digest(b"first"),
+    }];
+    let (review_run_id, marker) = receipt_marker("Summary", manifest);
+    let snapshot =
+        pending_recovery_snapshot(true, 1, true).replace(INCOMPLETE_RECEIPT_RUN_ID, &review_run_id);
+    let submitted_flag = format!("{}.submitted", capture.to_string_lossy());
+    let transition = format!(
+        ": > {started:?}\n        while [ ! -e {release:?} ]; do sleep 0.01; done\n        : > \"{submitted_flag}\""
+    );
+    let script = pending_recovery_script(&capture.to_string_lossy(), &snapshot, &marker)
+        .replace(&format!(": > \"{submitted_flag}\""), &transition);
+    let stub = stub.gh_stub(&script);
+    let inspect = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "inspect",
+            "42",
+            "--review",
+            "PRR_pending",
+        ],
+    );
+    let digest = parse_envelope(&inspect.stdout)["data"]["snapshot"]["snapshot_digest"]
+        .as_str()
+        .expect("snapshot digest")
+        .to_string();
+    let args = [
+        "--provider",
+        "github",
+        "--repo",
+        "acme/widgets",
+        "--format",
+        "json",
+        "pr",
+        "pending-review",
+        "resume-submit",
+        "42",
+        "--review",
+        "PRR_pending",
+        "--review-run-id",
+        &review_run_id,
+        "--expected-head",
+        "head-new",
+        "--expected-commit",
+        "head-new",
+        "--expected-snapshot",
+        &digest,
+        "--decision",
+        "comments-only",
+    ];
+    let mut first = Command::new(forge_cli_bin());
+    first
+        .args(args)
+        .env("XDG_CONFIG_HOME", stub.tempdir.path().join("xdg-config"))
+        .env("XDG_STATE_HOME", stub.tempdir.path().join("xdg-state"))
+        .env("FORGE_CLI_RATE_LIMIT_GATE", "off")
+        .current_dir(stub.tempdir.path());
+    for (key, value) in &stub.envs {
+        first.env(key, value);
+    }
+    let first = first.spawn().expect("spawn first submit");
+    for _ in 0..500 {
+        if started.exists() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(started.exists(), "first submit did not reach the mutation");
+
+    let second = run_forge_cli(&stub, &args);
+    assert_eq!(second.code, 69, "{}", second.stdout);
+    assert_eq!(
+        parse_envelope(&second.stdout)["error"]["code"],
+        "pending_review_lease_busy"
+    );
+    let calls = fs::read_to_string(&capture).expect("read calls");
+    assert_eq!(calls.matches("submitPullRequestReview(input:").count(), 1);
+
+    fs::write(&release, "release\n").expect("release first submit");
+    let output = first.wait_with_output().expect("wait for first submit");
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn pr_pending_review_resume_submit_accepts_provider_null_file_anchors() {
+    let stub = StubEnv::new();
+    let capture = stub
+        .tempdir
+        .path()
+        .join("file-anchor-resume-submit-calls.log");
+    let bodies = [
+        "first file finding",
+        "second file finding",
+        "third file finding",
+    ];
+    let manifest = bodies
+        .iter()
+        .enumerate()
+        .map(|(index, body)| ReviewCommentManifestItem {
+            index,
+            path: format!("src/file-{index}.rs"),
+            line: None,
+            side: "RIGHT".to_string(),
+            start_line: None,
+            start_side: None,
+            subject_type: "FILE".to_string(),
+            body_digest: sha256_digest(body.as_bytes()),
+        })
+        .collect::<Vec<_>>();
+    let (review_run_id, marker) = receipt_marker("Summary", manifest);
+    let comments = bodies
+        .iter()
+        .enumerate()
+        .map(|(index, body)| serde_json::json!({
+            "id": format!("PRRC_{index}"),
+            "url": format!("https://github.com/acme/widgets/pull/42#discussion_file_{index}"),
+            "author": {"login": "review-bot"},
+            "body": format!("{body}\n<!-- forge-cli:review-finding:v1 run={review_run_id} digest={} -->", sha256_digest(body.as_bytes())),
+            "createdAt": format!("2026-07-20T12:00:{index:02}Z"),
+            "path": format!("src/file-{index}.rs"),
+            "diffHunk": "",
+            "line": null,
+            "originalLine": null,
+            "startLine": null,
+            "originalStartLine": null,
+            "subjectType": "FILE"
+        }))
+        .collect::<Vec<_>>();
+    let snapshot = serde_json::json!({
+        "data": {"node": {
+            "id": "PRR_pending",
+            "url": "https://github.com/acme/widgets/pull/42#pullrequestreview-102",
+            "author": {"login": "review-bot"},
+            "state": "PENDING",
+            "commit": {"oid": "head-new"},
+            "body": format!("Summary\n<!-- forge-cli:review-run:v1 run={review_run_id} -->"),
+            "viewerDidAuthor": true,
+            "viewerCanDelete": true,
+            "comments": {
+                "totalCount": 3,
+                "nodes": comments,
+                "pageInfo": {"hasNextPage": false, "endCursor": null}
+            },
+            "pullRequest": {
+                "number": 42,
+                "url": "https://github.com/acme/widgets/pull/42",
+                "headRefOid": "head-new"
+            }
+        }}
+    })
+    .to_string();
+    let script = pending_recovery_script(&capture.to_string_lossy(), &snapshot, &marker);
+    let stub = stub.gh_stub(&script);
+
+    let inspect = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "inspect",
+            "42",
+            "--review",
+            "PRR_pending",
+        ],
+    );
+    assert_eq!(inspect.code, 0, "{}", inspect.stdout);
+    let digest = parse_envelope(&inspect.stdout)["data"]["snapshot"]["snapshot_digest"]
+        .as_str()
+        .expect("snapshot digest")
+        .to_string();
+    let output = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "resume-submit",
+            "42",
+            "--review",
+            "PRR_pending",
+            "--review-run-id",
+            &review_run_id,
+            "--expected-head",
+            "head-new",
+            "--expected-commit",
+            "head-new",
+            "--expected-snapshot",
+            &digest,
+            "--decision",
+            "comments-only",
+        ],
+    );
+
+    assert_eq!(
+        output.code, 0,
+        "stdout={}\nstderr={}",
+        output.stdout, output.stderr
+    );
+    let calls = fs::read_to_string(capture).expect("read calls");
+    assert_eq!(calls.matches("submitPullRequestReview(input:").count(), 1);
 }
 
 #[test]
@@ -804,6 +1155,11 @@ esac
     );
     assert_eq!(envelope["data"]["review_id"], "PRR_pending");
     assert_eq!(envelope["data"]["review_run_id"], review_run_id);
+    assert_eq!(envelope["data"]["snapshot_digest"], serde_json::Value::Null);
+    assert_eq!(
+        envelope["data"]["snapshot_provenance"],
+        "pending-snapshot-unverified"
+    );
     assert_eq!(envelope["data"]["submitted"], true);
     let calls = fs::read_to_string(capture).expect("read calls");
     assert!(!calls.contains("submitPullRequestReview(input:"), "{calls}");
@@ -1176,6 +1532,7 @@ fn pr_pending_review_discard_requires_distinct_inline_content_approval() {
 fn pr_pending_review_delete_verifies_and_deletes_the_exact_pending_node() {
     let stub = StubEnv::new();
     let capture = stub.tempdir.path().join("gh-calls.log");
+    let deleted = stub.tempdir.path().join("deleted.flag");
     let script = format!(
         r#"#!/bin/sh
 set -eu
@@ -1187,10 +1544,15 @@ case "$1 $2" in
   "api graphql")
     case "$*" in
       *"deletePullRequestReview(input:"*)
+        : > {deleted:?}
         printf '%s\n' '{{"data":{{"deletePullRequestReview":{{"pullRequestReview":{{"id":"PRR_pending","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102"}}}}}}}}'
         ;;
       *"comments(first: 1)"*)
-        printf '%s\n' '{{"data":{{"node":{{"id":"PRR_pending","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102","author":{{"login":"example-review-bot[bot]"}},"state":"PENDING","commit":{{"oid":"head-new"}},"body":"Pending review summary","viewerDidAuthor":true,"viewerCanDelete":true,"comments":{{"totalCount":0}},"pullRequest":{{"number":42,"url":"https://github.com/acme/widgets/pull/42","headRefOid":"head-new"}}}}}}}}'
+        if [ -e {deleted:?} ]; then
+          printf '%s\n' '{{"data":{{"node":null}}}}'
+        else
+          printf '%s\n' '{{"data":{{"node":{{"id":"PRR_pending","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102","author":{{"login":"example-review-bot[bot]"}},"state":"PENDING","commit":{{"oid":"head-new"}},"body":"Pending review summary","viewerDidAuthor":true,"viewerCanDelete":true,"comments":{{"totalCount":0}},"pullRequest":{{"number":42,"url":"https://github.com/acme/widgets/pull/42","headRefOid":"head-new"}}}}}}}}'
+        fi
         ;;
       *)
         printf '%s\n' '{{"data":{{"repository":{{"pullRequest":{{"headRefOid":"head-new","reviews":{{"nodes":[{{"id":"PRR_pending","databaseId":102,"url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102","author":{{"login":"example-review-bot[bot]"}},"state":"PENDING","commit":{{"oid":"head-new"}},"viewerDidAuthor":true,"viewerCanDelete":true,"body":"Pending review summary"}}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}}}}}}}}}}'
@@ -2091,6 +2453,7 @@ esac
 fn pr_pending_review_delete_finds_the_exact_node_on_a_later_page() {
     let stub = StubEnv::new();
     let capture = stub.tempdir.path().join("gh-calls.log");
+    let deleted = stub.tempdir.path().join("deleted.flag");
     let script = format!(
         r#"#!/bin/sh
 set -eu
@@ -2102,10 +2465,15 @@ case "$1 $2" in
   "api graphql")
     case "$*" in
       *"deletePullRequestReview(input:"*)
+        : > {deleted:?}
         printf '%s\n' '{{"data":{{"deletePullRequestReview":{{"pullRequestReview":{{"id":"PRR_page_2","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-202"}}}}}}}}'
         ;;
       *"comments(first: 1)"*)
-        printf '%s\n' '{{"data":{{"node":{{"id":"PRR_page_2","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-202","author":{{"login":"example-review-bot[bot]"}},"state":"PENDING","commit":{{"oid":"head-new"}},"body":"target","viewerDidAuthor":true,"viewerCanDelete":true,"comments":{{"totalCount":0}},"pullRequest":{{"number":42,"url":"https://github.com/acme/widgets/pull/42","headRefOid":"head-new"}}}}}}}}'
+        if [ -e {deleted:?} ]; then
+          printf '%s\n' '{{"data":{{"node":null}}}}'
+        else
+          printf '%s\n' '{{"data":{{"node":{{"id":"PRR_page_2","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-202","author":{{"login":"example-review-bot[bot]"}},"state":"PENDING","commit":{{"oid":"head-new"}},"body":"target","viewerDidAuthor":true,"viewerCanDelete":true,"comments":{{"totalCount":0}},"pullRequest":{{"number":42,"url":"https://github.com/acme/widgets/pull/42","headRefOid":"head-new"}}}}}}}}'
+        fi
         ;;
       *"after=cursor-1"*)
         printf '%s\n' '{{"data":{{"repository":{{"pullRequest":{{"headRefOid":"head-new","reviews":{{"nodes":[{{"id":"PRR_page_2","databaseId":202,"url":"https://github.com/acme/widgets/pull/42#pullrequestreview-202","author":{{"login":"example-review-bot[bot]"}},"state":"PENDING","commit":{{"oid":"head-new"}},"viewerDidAuthor":true,"viewerCanDelete":true,"body":"target"}}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}}}}}}}}}}'

--- a/crates/forge-cli/tests/integration/pr_pending_review.rs
+++ b/crates/forge-cli/tests/integration/pr_pending_review.rs
@@ -395,7 +395,7 @@ case "$1 $2" in
     printf '%s\n' '{{"number":42,"url":"https://github.com/acme/widgets/pull/42","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"feat/reviews","headRefOid":"head-new","title":"feat: reviews","body":""}}'
     ;;
   "api graphql")
-    printf '%s\n' '{{"data":{{"node":{{"id":"PRR_pending","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102","author":{{"login":"review-bot"}},"state":"PENDING","commit":{{"oid":"head-new"}},"body":"Summary\n<!-- forge-cli:review-run:v1 run=run-123 -->","viewerDidAuthor":true,"viewerCanDelete":true,"comments":{{"totalCount":1,"nodes":[{{"id":"PRRC_1","url":"https://github.com/acme/widgets/pull/42#discussion_r1","author":{{"login":"review-bot"}},"body":"first\n<!-- forge-cli:review-finding:v1 run=run-123 digest=sha256:a7937b64b8caa58f03721bb6bacf5c78cb235febe0e70b1b84cd99541461a08e -->","createdAt":"2026-07-20T12:00:00Z","path":"src/lib.rs","line":10}}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}},"pullRequest":{{"number":42,"url":"https://github.com/acme/widgets/pull/42","headRefOid":"head-new"}}}}}}}}'
+    printf '%s\n' '{{"data":{{"node":{{"id":"PRR_pending","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102","author":{{"login":"review-bot"}},"state":"PENDING","commit":{{"oid":"head-new"}},"body":"Summary\n<!-- forge-cli:review-run:v1 run=run-123 -->","viewerDidAuthor":true,"viewerCanDelete":true,"comments":{{"totalCount":1,"nodes":[{{"id":"PRRC_1","url":"https://github.com/acme/widgets/pull/42#discussion_r1","author":{{"login":"review-bot"}},"body":"first\n<!-- forge-cli:review-finding:v1 run=run-123 digest=sha256:a7937b64b8caa58f03721bb6bacf5c78cb235febe0e70b1b84cd99541461a08e -->","createdAt":"2026-07-20T12:00:00Z","path":"src/lib.rs","diffHunk":"@@ -10,1 +10,1 @@\n-old\n+new","line":10,"originalLine":10,"startLine":null,"originalStartLine":null,"subjectType":"LINE"}}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}},"pullRequest":{{"number":42,"url":"https://github.com/acme/widgets/pull/42","headRefOid":"head-new"}}}}}}}}'
     ;;
   *)
     echo "unexpected gh args: $*" >&2
@@ -439,6 +439,10 @@ esac
             .expect("inline comment manifest")
             .len(),
         1
+    );
+    assert_eq!(
+        env["data"]["snapshot"]["inline_comments"][0]["diff_side"],
+        "RIGHT"
     );
     assert!(
         env["data"]["snapshot"]["snapshot_digest"]

--- a/crates/forge-cli/tests/integration/pr_pending_review.rs
+++ b/crates/forge-cli/tests/integration/pr_pending_review.rs
@@ -1,7 +1,8 @@
 //! Recovery tests for an authenticated actor's provider-valid pending review.
 
 use std::fs;
-use std::process::Command;
+use std::path::PathBuf;
+use std::process::{Child, Command, ExitStatus};
 use std::thread;
 use std::time::Duration;
 
@@ -17,6 +18,42 @@ use super::support::{
 
 const INCOMPLETE_RECEIPT_RUN_ID: &str =
     "sha256:3de5f335496edb76e29ba96b787fbc9dc18d081f45a285b0e2ae877443f49405";
+
+struct LeaseTestChild {
+    child: Option<Child>,
+    release: PathBuf,
+}
+
+impl LeaseTestChild {
+    fn new(child: Child, release: PathBuf) -> Self {
+        Self {
+            child: Some(child),
+            release,
+        }
+    }
+
+    fn release_and_wait(mut self) -> ExitStatus {
+        fs::write(&self.release, "release\n").expect("release first submit");
+        let status = self
+            .child
+            .as_mut()
+            .expect("lease child")
+            .wait()
+            .expect("wait for first submit");
+        self.child.take();
+        status
+    }
+}
+
+impl Drop for LeaseTestChild {
+    fn drop(&mut self) {
+        let _ = fs::write(&self.release, "release\n");
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
 
 fn incomplete_receipt_marker() -> String {
     let receipt = ReviewRunReceipt {
@@ -111,6 +148,28 @@ fn pr_pending_review_catalog_uses_provider_native_viewer_guards() {
     }
     assert!(catalog.contains("schema: forge-cli.review-loop.v1"));
     assert!(catalog.contains("privacy_forbidden:"));
+    let resume_submit = catalog
+        .split_once("  - id: pr.pending-review.resume-submit\n")
+        .expect("resume-submit operation")
+        .1
+        .split_once("  - id: pr.pending-review.submit\n")
+        .expect("submit follows resume-submit")
+        .0;
+    assert!(
+        resume_submit.contains("schema_version: cli.forge-cli.pr.pending-review.resume-submit.v2")
+    );
+    assert!(resume_submit.contains("snapshot_digest?"));
+    assert!(resume_submit.contains("snapshot_provenance"));
+    let direct_submit = catalog
+        .split_once("  - id: pr.pending-review.submit\n")
+        .expect("direct-submit operation")
+        .1
+        .split_once("  - id: pr.pending-review.discard\n")
+        .expect("discard follows direct-submit")
+        .0;
+    assert!(direct_submit.contains("schema_version: cli.forge-cli.pr.pending-review.submit.v1"));
+    assert!(direct_submit.contains("commit_sha,snapshot_digest,snapshot_provenance"));
+    assert!(!direct_submit.contains("snapshot_digest?"));
     let operation = catalog
         .split_once("  - id: pr.pending-review.delete\n")
         .expect("pending-review operation")
@@ -627,6 +686,10 @@ fn pr_pending_review_resume_submit_accepts_an_exact_receipt_manifest() {
 
     assert_eq!(output.code, 0, "{}", output.stdout);
     let envelope = parse_envelope(&output.stdout);
+    assert_eq!(
+        envelope["schema_version"],
+        "cli.forge-cli.pr.pending-review.resume-submit.v2"
+    );
     assert_eq!(envelope["data"]["submitted"], true);
     assert_eq!(envelope["data"]["review_run_id"], review_run_id);
     assert_eq!(
@@ -636,6 +699,84 @@ fn pr_pending_review_resume_submit_accepts_an_exact_receipt_manifest() {
     let calls = fs::read_to_string(capture).expect("read calls");
     assert_eq!(calls.matches("submitPullRequestReview(input:").count(), 1);
     assert!(!calls.contains("deletePullRequestReview(input:"), "{calls}");
+}
+
+#[test]
+fn pr_pending_review_direct_submit_v1_remains_deserializable_with_a_required_digest() {
+    #[derive(serde::Deserialize)]
+    struct PriorV1Envelope {
+        schema_version: String,
+        data: PriorV1SubmitPayload,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct PriorV1SubmitPayload {
+        snapshot_digest: String,
+    }
+
+    let stub = StubEnv::new();
+    let capture = stub.tempdir.path().join("direct-submit-v1-calls.log");
+    let snapshot = pending_recovery_snapshot(false, 1, true);
+    let script = pending_recovery_script(&capture.to_string_lossy(), &snapshot, "unused");
+    let stub = stub.gh_stub(&script);
+    let inspect = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "inspect",
+            "42",
+            "--review",
+            "PRR_pending",
+        ],
+    );
+    assert_eq!(inspect.code, 0, "{}", inspect.stdout);
+    let digest = parse_envelope(&inspect.stdout)["data"]["snapshot"]["snapshot_digest"]
+        .as_str()
+        .expect("snapshot digest")
+        .to_string();
+
+    let output = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "submit",
+            "42",
+            "--review",
+            "PRR_pending",
+            "--expected-head",
+            "head-new",
+            "--expected-commit",
+            "head-new",
+            "--expected-snapshot",
+            &digest,
+            "--decision",
+            "comments-only",
+            "--confirm-unmarked-submit",
+        ],
+    );
+
+    assert_eq!(output.code, 0, "{}", output.stdout);
+    let prior: PriorV1Envelope =
+        serde_json::from_str(&output.stdout).expect("prior v1 consumer shape");
+    assert_eq!(
+        prior.schema_version,
+        "cli.forge-cli.pr.pending-review.submit.v1"
+    );
+    assert_eq!(prior.data.snapshot_digest, digest);
 }
 
 #[test]
@@ -804,7 +945,7 @@ fn pr_pending_review_cross_process_lease_excludes_a_second_mutation() {
     for (key, value) in &stub.envs {
         first.env(key, value);
     }
-    let first = first.spawn().expect("spawn first submit");
+    let first = LeaseTestChild::new(first.spawn().expect("spawn first submit"), release.clone());
     for _ in 0..500 {
         if started.exists() {
             break;
@@ -822,14 +963,8 @@ fn pr_pending_review_cross_process_lease_excludes_a_second_mutation() {
     let calls = fs::read_to_string(&capture).expect("read calls");
     assert_eq!(calls.matches("submitPullRequestReview(input:").count(), 1);
 
-    fs::write(&release, "release\n").expect("release first submit");
-    let output = first.wait_with_output().expect("wait for first submit");
-    assert!(
-        output.status.success(),
-        "stdout={}\nstderr={}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let status = first.release_and_wait();
+    assert!(status.success(), "first submit exited with {status}");
 }
 
 #[test]
@@ -1151,7 +1286,7 @@ esac
     let envelope = parse_envelope(&output.stdout);
     assert_eq!(
         envelope["schema_version"],
-        "cli.forge-cli.pr.pending-review.resume-submit.v1"
+        "cli.forge-cli.pr.pending-review.resume-submit.v2"
     );
     assert_eq!(envelope["data"]["review_id"], "PRR_pending");
     assert_eq!(envelope["data"]["review_run_id"], review_run_id);

--- a/crates/forge-cli/tests/integration/pr_review.rs
+++ b/crates/forge-cli/tests/integration/pr_review.rs
@@ -963,9 +963,15 @@ case "$*" in
     fi
     ;;
   *"query(\$review: ID!"*)
-    if [ ! -f "$pending_body" ] || [ -f "$submitted" ]; then
+    if [ ! -f "$pending_body" ]; then
       printf '%s\n' '{"data":{"node":null}}'
       exit 0
+    fi
+    state=PENDING
+    can_delete=true
+    if [ -f "$submitted" ]; then
+      state=COMMENTED
+      can_delete=false
     fi
     body=$(json_escape "$pending_body")
     comments=''
@@ -991,7 +997,7 @@ case "$*" in
       fi
       total=2
     fi
-    printf '{"data":{"node":{"id":"PRR_kwDOpending","url":"https://github.com/acme/widgets/pull/44#pullrequestreview-9900","author":{"login":"review-bot"},"state":"PENDING","commit":{"oid":"head-44"},"body":"%s","viewerDidAuthor":true,"viewerCanDelete":true,"comments":{"totalCount":%s,"nodes":[%s],"pageInfo":{"hasNextPage":false,"endCursor":null}},"pullRequest":{"number":44,"url":"https://github.com/acme/widgets/pull/44","headRefOid":"head-44"}}}}\n' "$body" "$total" "$comments"
+    printf '{"data":{"node":{"id":"PRR_kwDOpending","url":"https://github.com/acme/widgets/pull/44#pullrequestreview-9900","author":{"login":"review-bot"},"state":"%s","commit":{"oid":"head-44"},"body":"%s","viewerDidAuthor":true,"viewerCanDelete":%s,"comments":{"totalCount":%s,"nodes":[%s],"pageInfo":{"hasNextPage":false,"endCursor":null}},"pullRequest":{"number":44,"url":"https://github.com/acme/widgets/pull/44","headRefOid":"head-44"}}}}\n' "$state" "$body" "$can_delete" "$total" "$comments"
     ;;
   *"query(\$owner: String!, \$name: String!, \$number: Int!"*)
     printf '%s\n' '{"data":{"repository":{"pullRequest":{"id":"PR_kwDOabc","url":"https://github.com/acme/widgets/pull/44"}}}}'
@@ -1473,8 +1479,8 @@ fn pr_review_transaction_recovers_a_lost_submit_response() {
     let calls = fs::read_to_string(capture).expect("read captured calls");
     assert_eq!(calls.matches("submitPullRequestReview(input:").count(), 1);
     assert!(
-        calls.matches("reviews(first: 100").count() >= 2,
-        "the lost response must be reconciled through submitted-review read-back: {calls}"
+        calls.matches("query($review: ID!").count() >= 2,
+        "the lost response must be reconciled through exact submitted-node read-back: {calls}"
     );
 }
 

--- a/crates/forge-cli/tests/integration/support.rs
+++ b/crates/forge-cli/tests/integration/support.rs
@@ -141,6 +141,7 @@ pub fn run_forge_cli_in(stub: &StubEnv, args: &[&str], cwd: Option<&Path>) -> Cm
     // tests and flip outcomes. Point it at an empty per-run dir; individual
     // stubs may still override it via `.env("XDG_CONFIG_HOME", …)`.
     cmd.env("XDG_CONFIG_HOME", stub.tempdir.path().join("xdg-config"));
+    cmd.env("XDG_STATE_HOME", stub.tempdir.path().join("xdg-state"));
     // Disable the GraphQL rate-limit gate by default so existing stubs, which
     // branch on an exact `gh` argv sequence, do not see the extra
     // `gh api rate_limit` preflight probe the gate inserts. Gate-specific tests
@@ -167,6 +168,7 @@ pub fn run_forge_cli_with_stdin(stub: &StubEnv, args: &[&str], stdin: &str) -> C
         cmd.env_remove(key);
     }
     cmd.env("XDG_CONFIG_HOME", stub.tempdir.path().join("xdg-config"));
+    cmd.env("XDG_STATE_HOME", stub.tempdir.path().join("xdg-state"));
     // See `run_forge_cli_in`: keep the rate-limit gate off by default here too.
     cmd.env("FORGE_CLI_RATE_LIMIT_GATE", "off");
     for (k, v) in &stub.envs {


### PR DESCRIPTION
## Summary

- Add strict `agent-hook.dsh-ingress.v1` pre-tool request normalization and native allow/block decisions through the shared policy engine.
- Keep DSH registration owned by public `dsh-runtime-kit` while preserving existing Codex, Claude, and Hermes doctor/output compatibility.
- Restore github.com pending-review recovery using provider-supported comment fields, fail-closed side derivation, aggregate count/byte ceilings, a private cross-process mutation lease, and exact provider read-back reconciliation.
- Preserve direct `pending-review submit.v1` compatibility and expose honest nullable digest provenance through `resume-submit.v2`.

Cross-repo dispatch: https://github.com/sympoies/dsh-runtime-kit/issues/1

## Test plan

- `cargo test -p nils-agent-hook`
- `cargo test -p nils-agent-hook --test api_contract`
- `cargo test -p nils-forge-cli -- --test-threads=1` — 876 unit + 486 integration passed
- Pending-review focused integration — 40/40 passed
- Pagination/security focused unit tests — 5/5 passed
- Strict downstream `nils-agent-session` doctor consumer tests
- `cargo clippy -p nils-agent-hook -p nils-forge-cli --all-targets --all-features -- -D warnings`
- Completion, fixture, contract, docs, formatting, and no-run workspace gates
- Live github.com inspect/resume-submit recovery: https://github.com/sympoies/dsh-runtime-kit/pull/2#pullrequestreview-4955409568

The full local-fast execution is host-limited only at 12 unchanged Bubblewrap-backed `agent_run_inspect` tests because this machine cannot configure loopback networking (`RTM_NEWADDR: Operation not permitted`). All prerequisite gates pass; the exact-head GitHub Linux, macOS, coverage, cargo-deny, and CodeQL jobs provide the clean-host validation.
