### PR TITLE
chore(agent-docs): supersede bounded DSH context prototype

### DIFF
--- a/completions/bash/agent-docs
+++ b/completions/bash/agent-docs
@@ -70,6 +70,9 @@ _agent__docs() {
             agent__docs__session,activate)
                 cmd="agent__docs__session__activate"
                 ;;
+            agent__docs__session,context)
+                cmd="agent__docs__session__context"
+                ;;
             agent__docs__session,prepare)
                 cmd="agent__docs__session__prepare"
                 ;;
@@ -131,7 +134,7 @@ _agent__docs() {
                     return 0
                     ;;
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --docs-home)
@@ -415,7 +418,7 @@ _agent__docs() {
                     return 0
                     ;;
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --docs-home)
@@ -513,7 +516,7 @@ _agent__docs() {
             fi
             case "${prev}" in
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --format)
@@ -555,7 +558,7 @@ _agent__docs() {
                     return 0
                     ;;
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --docs-home)
@@ -631,7 +634,7 @@ _agent__docs() {
                     return 0
                     ;;
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --phase)
@@ -708,7 +711,7 @@ _agent__docs() {
             return 0
             ;;
         agent__docs__session)
-            opts="-h --docs-home --project-path --worktree-fallback --user-config --integration-fingerprint --help activate prepare status verify"
+            opts="-h --docs-home --project-path --worktree-fallback --user-config --integration-fingerprint --help activate prepare context status verify"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -749,7 +752,7 @@ _agent__docs() {
                     return 0
                     ;;
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --state-home)
@@ -791,6 +794,68 @@ _agent__docs() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        agent__docs__session__context)
+            opts="-h --session-id --product --state-home --format --intent --phase --request-id --max-bytes --docs-home --project-path --worktree-fallback --user-config --integration-fingerprint --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --session-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --product)
+                    COMPREPLY=($(compgen -W "dsh" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-home)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --intent)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --phase)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --request-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --max-bytes)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --docs-home)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --project-path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --worktree-fallback)
+                    COMPREPLY=($(compgen -W "auto local-only" -- "${cur}"))
+                    return 0
+                    ;;
+                --integration-fingerprint)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         agent__docs__session__prepare)
             opts="-h --session-id --product --state-home --format --intent --phase --docs-home --project-path --worktree-fallback --user-config --integration-fingerprint --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
@@ -803,7 +868,7 @@ _agent__docs() {
                     return 0
                     ;;
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --state-home)
@@ -857,7 +922,7 @@ _agent__docs() {
                     return 0
                     ;;
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --state-home)
@@ -903,7 +968,7 @@ _agent__docs() {
                     return 0
                     ;;
                 --product)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --state-home)

--- a/completions/zsh/_agent-docs
+++ b/completions/zsh/_agent-docs
@@ -37,7 +37,7 @@ _agent-docs() {
 _arguments "${_arguments_options[@]}" : \
 '--target=[Audit scope target]:TARGET:(home project all)' \
 '--format=[Output format]:FORMAT:(text json)' \
-'--product=[Filter catalog documents by product]:PRODUCT:(codex claude hermes)' \
+'--product=[Filter catalog documents by product]:PRODUCT:(codex claude hermes dsh)' \
 '--docs-home=[Override the docs-home root (otherwise derived from the install symlink)]:PATH:_files' \
 '--project-path=[Override the project root path]:PATH:_files' \
 '--worktree-fallback=[Project worktree fallback mode]:MODE:(auto local-only)' \
@@ -52,7 +52,7 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '--intent=[Intent to resolve (for example project-dev)]:INTENT:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
-'--product=[Filter documents and validation by product]:PRODUCT:(codex claude hermes)' \
+'--product=[Filter documents and validation by product]:PRODUCT:(codex claude hermes dsh)' \
 '--phase=[Filter documents to a workflow phase (no-phase docs always apply)]:PHASE:_default' \
 '--docs-home=[Override the docs-home root (otherwise derived from the install symlink)]:PATH:_files' \
 '--project-path=[Override the project root path]:PATH:_files' \
@@ -84,7 +84,7 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '--intent=[Intent to explain; omit to list available intents]:INTENT:_default' \
 '--format=[Output format]:FORMAT:(text json)' \
-'--product=[Filter documents and validation by product]:PRODUCT:(codex claude hermes)' \
+'--product=[Filter documents and validation by product]:PRODUCT:(codex claude hermes dsh)' \
 '--docs-home=[Override the docs-home root (otherwise derived from the install symlink)]:PATH:_files' \
 '--project-path=[Override the project root path]:PATH:_files' \
 '--worktree-fallback=[Project worktree fallback mode]:MODE:(auto local-only)' \
@@ -97,7 +97,7 @@ _arguments "${_arguments_options[@]}" : \
 (list)
 _arguments "${_arguments_options[@]}" : \
 '--format=[Output format]:FORMAT:(text json)' \
-'--product=[Filter documents and validation by product]:PRODUCT:(codex claude hermes)' \
+'--product=[Filter documents and validation by product]:PRODUCT:(codex claude hermes dsh)' \
 '--docs-home=[Override the docs-home root (otherwise derived from the install symlink)]:PATH:_files' \
 '--project-path=[Override the project root path]:PATH:_files' \
 '--worktree-fallback=[Project worktree fallback mode]:MODE:(auto local-only)' \
@@ -235,7 +235,7 @@ _arguments "${_arguments_options[@]}" : \
         case $line[1] in
             (resolve)
 _arguments "${_arguments_options[@]}" : \
-'--product=[Product whose automatic integration decision is being resolved]:PRODUCT:(codex claude hermes)' \
+'--product=[Product whose automatic integration decision is being resolved]:PRODUCT:(codex claude hermes dsh)' \
 '--format=[Output format]:FORMAT:(text json)' \
 '--docs-home=[Override the docs-home root (otherwise derived from the install symlink)]:PATH:_files' \
 '--project-path=[Override the project root path]:PATH:_files' \
@@ -272,7 +272,7 @@ _arguments "${_arguments_options[@]}" : \
             (activate)
 _arguments "${_arguments_options[@]}" : \
 '--session-id=[]:ID:_default' \
-'--product=[]:PRODUCT:(codex claude hermes)' \
+'--product=[]:PRODUCT:(codex claude hermes dsh)' \
 '--state-home=[]:DIR:_files' \
 '--format=[]:FORMAT:(text json)' \
 '*--intent=[]:INTENT:_default' \
@@ -289,7 +289,7 @@ _arguments "${_arguments_options[@]}" : \
 (prepare)
 _arguments "${_arguments_options[@]}" : \
 '--session-id=[]:ID:_default' \
-'--product=[]:PRODUCT:(codex claude hermes)' \
+'--product=[]:PRODUCT:(codex claude hermes dsh)' \
 '--state-home=[]:DIR:_files' \
 '--format=[]:FORMAT:(text json)' \
 '*--intent=[]:INTENT:_default' \
@@ -303,10 +303,29 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
 ;;
+(context)
+_arguments "${_arguments_options[@]}" : \
+'--session-id=[]:ID:_default' \
+'--product=[]:PRODUCT:(dsh)' \
+'--state-home=[]:DIR:_files' \
+'--format=[]:FORMAT:(text json)' \
+'--intent=[]:INTENT:_default' \
+'--phase=[Scope preparation to a workflow phase (no-phase docs always apply)]:PHASE:_default' \
+'--request-id=[Bounded caller correlation id echoed by the context decision]:ID:_default' \
+'--max-bytes=[Maximum aggregate UTF-8 bytes of returned policy content (hard cap\: 65536)]:BYTES:_default' \
+'--docs-home=[Override the docs-home root (otherwise derived from the install symlink)]:PATH:_files' \
+'--project-path=[Override the project root path]:PATH:_files' \
+'--worktree-fallback=[Project worktree fallback mode]:MODE:(auto local-only)' \
+'--integration-fingerprint=[Require the current integration decision to match this fingerprint]:SHA256:_default' \
+'--user-config[Select the effective private user catalog for this operation]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
 (status)
 _arguments "${_arguments_options[@]}" : \
 '--session-id=[]:ID:_default' \
-'--product=[]:PRODUCT:(codex claude hermes)' \
+'--product=[]:PRODUCT:(codex claude hermes dsh)' \
 '--state-home=[]:DIR:_files' \
 '--format=[]:FORMAT:(text json)' \
 '--docs-home=[Override the docs-home root (otherwise derived from the install symlink)]:PATH:_files' \
@@ -321,7 +340,7 @@ _arguments "${_arguments_options[@]}" : \
 (verify)
 _arguments "${_arguments_options[@]}" : \
 '--session-id=[]:ID:_default' \
-'--product=[]:PRODUCT:(codex claude hermes)' \
+'--product=[]:PRODUCT:(codex claude hermes dsh)' \
 '--state-home=[]:DIR:_files' \
 '--format=[]:FORMAT:(text json)' \
 '*--require-intent=[]:INTENT:_default' \
@@ -479,6 +498,7 @@ _agent-docs__subcmd__session_commands() {
     local commands; commands=(
 'activate:Strictly preflight and atomically activate one or more declared intents' \
 'prepare:Atomically prepare one or more declared intents (activate + strict preflight) and report a stable JSON result usable by a runtime hook' \
+'context:Resolve and prepare exactly one DSH intent, returning only its bounded satisfied required document content as a replay-bound decision' \
 'status:Show active intents for the current session/project/product scope' \
 'verify:Re-resolve the catalog and verify required intents are active and fresh' \
     )
@@ -488,6 +508,11 @@ _agent-docs__subcmd__session_commands() {
 _agent-docs__subcmd__session__subcmd__activate_commands() {
     local commands; commands=()
     _describe -t commands 'agent-docs session activate commands' commands "$@"
+}
+(( $+functions[_agent-docs__subcmd__session__subcmd__context_commands] )) ||
+_agent-docs__subcmd__session__subcmd__context_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-docs session context commands' commands "$@"
 }
 (( $+functions[_agent-docs__subcmd__session__subcmd__prepare_commands] )) ||
 _agent-docs__subcmd__session__subcmd__prepare_commands() {

--- a/crates/agent-docs/README.md
+++ b/crates/agent-docs/README.md
@@ -38,7 +38,7 @@ design in `sympoies/agent-runtime-kit`
 | `remove` | Remove a `[[document]]` entry from the project catalog. |
 | `config enroll/exclude/show/list/remove` | Preview or apply exact user-local enrollment and exclusion rules. |
 | `integration resolve` | Resolve a typed integration action and content-bound fingerprint. |
-| `session activate/prepare/status/verify` | Persist and verify intent activation scoped to a session, repository, product, and integration decision. |
+| `session activate/prepare/context/status/verify` | Persist and verify intent activation; `context` returns a bounded DSH policy decision. |
 | `completion` | Generate shell completion scripts. |
 
 There is no top-level `resolve` command. The retired `baseline` / `scaffold-*` /
@@ -95,7 +95,7 @@ A catalog declares two array-of-tables sections:
 context  = "project-dev"            # free-form intent identifier
 scope    = "project"                # home | project | global
 path     = "DEVELOPMENT.md"         # relative to the scope root
-product  = "codex"                  # optional: codex | claude | hermes | a list
+product  = "codex"                  # optional: codex | claude | hermes | dsh | a list
 phase    = ["edit", "review"]       # optional: free-form phase name or a list
 required = true                     # default: false
 when     = "path-exists:Cargo.toml" # default: always (see grammar below)
@@ -139,8 +139,9 @@ document and validation entry whose `context` equals `X`.
 
 `product` is optional on both `[[document]]` and `[[validation]]`. It accepts a
 single product string or a non-empty list of product strings. Supported values
-are `codex`, `claude`, and `hermes`. Unscoped entries apply to every product; scoped
-entries are included only when the requested `--product` matches.
+are `codex`, `claude`, `hermes`, and `dsh`. Unscoped entries apply to every
+product; scoped entries are included only when the requested `--product`
+matches.
 
 ### Phases
 
@@ -160,8 +161,9 @@ phase filter and returns every document (today's behavior, byte-for-byte). A
 the no-phase set rather than erroring — so a phase with no dedicated documents
 still works. A malformed `--phase` value is a usage error (exit `64`).
 
-`--phase` is accepted by `preflight`, `session prepare`, and `session verify`
-(one phase per call, "the current phase"; `--intent` stays repeatable).
+`--phase` is accepted by `preflight`, `session prepare`, `session context`, and
+`session verify` (one phase per call, "the current phase"; `--intent` stays
+repeatable except for `session context`, which requires exactly one intent).
 
 ### `when` grammar
 
@@ -400,6 +402,12 @@ for the v2 product model; CLI JSON consumers should treat
 `agent-docs.preflight.v2` and `agent-docs.audit.v2` as the product-aware
 contract boundaries.
 
+`Product::Dsh` expands a previously closed public Rust enum. Existing Rust
+callers with exhaustive three-variant matches must add the DSH arm (or a
+wildcard) before upgrading. This source-breaking library change must ship at a
+workspace major-version boundary; it must not be published as a new 1.x
+`nils-agent-docs` release. The versioned CLI JSON contracts remain additive.
+
 Private catalog provenance is intentionally internal to the resolver and the
 new integration-decision response. It does not add a public `DocumentSource`
 variant or a required field to public `ScopeCatalog` literals, and it does not
@@ -435,6 +443,53 @@ agent-docs --user-config --integration-fingerprint "$FINGERPRINT" \
 Omit `--user-config` for the repository-catalog-only behavior. Products without
 hooks may still use these shared CLI records, but the record does not claim that
 product-native hooks invoked activation.
+
+### Bounded DSH context decision
+
+`session context` is the single-call policy loading boundary for DeepSeek
+Harness. It accepts the normal session scope, exactly one `--intent`, an
+optional caller-supplied `--phase`, and a caller-generated `--request-id`. It is
+valid only for `--product dsh`. While holding the same per-record lock, it
+strictly resolves the selected catalog, refreshes or creates the activation,
+and returns the current satisfied required documents. Repeating the call still
+returns those documents after compaction; only `decision.reason` changes from
+`prepared` to `already-current` when the fingerprint was already current.
+
+```bash
+agent-docs session context --session-id "$SESSION_ID" --product dsh \
+  --state-home "$STATE_HOME" --intent project-dev --phase edit \
+  --request-id "$REQUEST_ID" --max-bytes 20480 --format json
+```
+
+The success envelope uses `cli.agent-docs.session.context.v1` and its only data
+field is `decision`. That object uses `decision.context.v1` and contains the
+echoed request id, product, intent, optional phase, reason, `verified = true`,
+ordered `documents`, `document_count`, and `total_bytes`. Each document contains
+only `source`, `scope`, and `content`; the response never includes the catalog,
+optional documents, validation commands, document paths, record path, raw
+session id, or project path. This decision supplies context only and does not
+authorize a tool execution. The optional phase merely records the exact
+caller-supplied resolution scope; it is not decision authority.
+
+Request ids are 1–128 ASCII bytes: an alphanumeric first character followed by
+alphanumerics or `-_.:`. The content budget defaults to 20 KiB and has a 64 KiB
+hard cap; at most 128 currently required documents may be returned.
+`total_bytes` is the sum of returned UTF-8 document content bytes. Optional and
+condition-false documents are not opened. Every emitted document must use a
+relative traversal-free catalog path, resolve inside its declared scope (or a
+verified linked-worktree fallback), and be a regular non-symlink file. If the
+complete required set exceeds either budget, the command fails with
+`context-budget-exceeded`; it emits no partial policy and writes no activation
+for that request. An unsafe document fails with `context-document-unsafe` under
+the same atomic rule. Omitting `--phase` intentionally retains the existing
+full prepare semantics and includes required documents from every phase;
+callers that know the current workflow phase should pass it to select the
+no-phase plus matching phase documents. `session verify --product dsh` retains
+the normal `prepare-intent` / `session.prepare` remediation when the scoped
+intent has not been prepared. If an existing DSH context can no longer be
+resolved within the hard content or safety bounds, verification returns
+`context-policy-invalid` with `repair-catalog` / `audit` recovery instead of
+suggesting an unavailable budget argument.
 
 ### Phase-scoped preparation
 

--- a/crates/agent-docs/src/cli.rs
+++ b/crates/agent-docs/src/cli.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use crate::model::{AuditTarget, FallbackMode, OutputFormat, Product, Scope};
 
@@ -386,6 +386,9 @@ pub enum SessionCommand {
     /// Atomically prepare one or more declared intents (activate + strict
     /// preflight) and report a stable JSON result usable by a runtime hook.
     Prepare(SessionActivateArgs),
+    /// Resolve and prepare exactly one DSH intent, returning only its bounded
+    /// satisfied required document content as a replay-bound decision.
+    Context(SessionContextArgs),
     /// Show active intents for the current session/project/product scope.
     Status(SessionCommonArgs),
     /// Re-resolve the catalog and verify required intents are active and fresh.
@@ -416,6 +419,53 @@ pub struct SessionActivateArgs {
         help = "Scope preparation to a workflow phase (no-phase docs always apply)"
     )]
     pub phase: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct SessionContextArgs {
+    #[arg(long = "session-id", value_name = "ID")]
+    pub session_id: String,
+    #[arg(long, value_enum)]
+    pub product: ContextProduct,
+    #[arg(long = "state-home", value_name = "DIR")]
+    pub state_home: PathBuf,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+    #[arg(long, value_name = "INTENT", required = true)]
+    pub intent: String,
+    #[arg(
+        long,
+        value_name = "PHASE",
+        help = "Scope preparation to a workflow phase (no-phase docs always apply)"
+    )]
+    pub phase: Option<String>,
+    #[arg(
+        long = "request-id",
+        value_name = "ID",
+        help = "Bounded caller correlation id echoed by the context decision"
+    )]
+    pub request_id: String,
+    #[arg(
+        long = "max-bytes",
+        value_name = "BYTES",
+        default_value_t = 20 * 1024,
+        help = "Maximum aggregate UTF-8 bytes of returned policy content (hard cap: 65536)"
+    )]
+    pub max_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum ContextProduct {
+    Dsh,
+}
+
+impl ContextProduct {
+    pub const fn as_product(self) -> Product {
+        match self {
+            Self::Dsh => Product::Dsh,
+        }
+    }
 }
 
 #[derive(Debug, Args)]

--- a/crates/agent-docs/src/model.rs
+++ b/crates/agent-docs/src/model.rs
@@ -125,6 +125,7 @@ pub enum Product {
     Codex,
     Claude,
     Hermes,
+    Dsh,
 }
 
 impl Product {
@@ -133,11 +134,12 @@ impl Product {
             Self::Codex => "codex",
             Self::Claude => "claude",
             Self::Hermes => "hermes",
+            Self::Dsh => "dsh",
         }
     }
 
     pub const fn supported_values() -> &'static [&'static str] {
-        &["codex", "claude", "hermes"]
+        &["codex", "claude", "hermes", "dsh"]
     }
 
     pub fn from_config_value(value: &str) -> Option<Self> {
@@ -145,6 +147,7 @@ impl Product {
             "codex" => Some(Self::Codex),
             "claude" => Some(Self::Claude),
             "hermes" => Some(Self::Hermes),
+            "dsh" => Some(Self::Dsh),
             _ => None,
         }
     }

--- a/crates/agent-docs/src/operation_effect.rs
+++ b/crates/agent-docs/src/operation_effect.rs
@@ -102,6 +102,12 @@ fn classify(command: &Command) -> (&'static str, Effect, ProviderEffect, Vec<&'s
                 ProviderEffect::None,
                 Vec::new(),
             ),
+            SessionCommand::Context(_) => (
+                "session.context",
+                mutation,
+                ProviderEffect::None,
+                Vec::new(),
+            ),
         },
         Command::Config(args) => match args.command {
             ConfigCommand::Show(_) => ("config.show", read, local, vec!["user_config"]),

--- a/crates/agent-docs/src/resolver.rs
+++ b/crates/agent-docs/src/resolver.rs
@@ -83,6 +83,54 @@ struct PrivateReadBudget {
     remaining_bytes: usize,
 }
 
+pub(crate) const MAX_CONTEXT_DOCUMENTS: usize = 128;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContextResolveError {
+    BudgetExceeded,
+    UnsafeDocument,
+}
+
+impl ContextResolveError {
+    pub(crate) const fn code(self) -> &'static str {
+        match self {
+            Self::BudgetExceeded => "context-budget-exceeded",
+            Self::UnsafeDocument => "context-document-unsafe",
+        }
+    }
+
+    pub(crate) const fn message(self) -> &'static str {
+        match self {
+            Self::BudgetExceeded => "required policy content exceeds the bounded context limits",
+            Self::UnsafeDocument => {
+                "a required policy document is outside its trusted scope or is not a regular file"
+            }
+        }
+    }
+}
+
+struct ContextReadBudget {
+    remaining_documents: usize,
+    remaining_bytes: usize,
+}
+
+impl ContextReadBudget {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            remaining_documents: MAX_CONTEXT_DOCUMENTS,
+            remaining_bytes: max_bytes,
+        }
+    }
+
+    fn claim_document(&mut self) -> Result<(), ContextResolveError> {
+        if self.remaining_documents == 0 {
+            return Err(ContextResolveError::BudgetExceeded);
+        }
+        self.remaining_documents -= 1;
+        Ok(())
+    }
+}
+
 impl PrivateReadBudget {
     fn new() -> Self {
         Self {
@@ -189,6 +237,51 @@ pub(crate) fn resolve_intent_with_effective_catalog_for_scope(
             private_allowed_roots: &effective.private_allowed_roots,
         },
     )
+}
+
+/// Resolve the content-bearing DSH context surface.
+///
+/// Unlike the general diagnostic resolver, this path never opens optional
+/// documents. Required documents are confined to their declared scope and are
+/// read through one aggregate byte/count budget before any activation can be
+/// persisted.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn resolve_context_with_effective_catalog_for_scope(
+    intent: &Context,
+    roots: &ResolvedRoots,
+    product: Product,
+    phase: Option<Phase>,
+    strict: bool,
+    fallback_mode: FallbackMode,
+    max_bytes: usize,
+    effective: &EffectiveCatalog,
+) -> Result<PreflightReport, ContextResolveError> {
+    let documents = resolve_context_documents(
+        roots,
+        product,
+        phase.as_ref(),
+        fallback_mode,
+        max_bytes,
+        &effective.catalog,
+        &mut |entry| entry.context == *intent,
+    )?;
+    let validation =
+        resolve_validation_contract_for_product(intent, roots, Some(product), &effective.catalog);
+    let summary = ResolveSummary::from_documents(&documents);
+
+    Ok(PreflightReport {
+        schema_version: PreflightReport::SCHEMA_VERSION,
+        intent: intent.clone(),
+        product: Some(product),
+        phase,
+        strict,
+        docs_home: roots.docs_home.clone(),
+        project_path: roots.project_path.clone(),
+        is_linked_worktree: roots.is_linked_worktree,
+        documents,
+        validation,
+        summary,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -363,6 +456,224 @@ fn resolve_documents(
     }
 
     documents
+}
+
+#[allow(clippy::too_many_arguments)]
+fn resolve_context_documents(
+    roots: &ResolvedRoots,
+    product: Product,
+    phase: Option<&Phase>,
+    fallback_mode: FallbackMode,
+    max_bytes: usize,
+    catalog: &LoadedCatalog,
+    accept: &mut dyn FnMut(&DocumentEntry) -> bool,
+) -> Result<Vec<ResolvedDocument>, ContextResolveError> {
+    let mut reader = read_context_document;
+    resolve_context_documents_with_reader(
+        roots,
+        product,
+        phase,
+        fallback_mode,
+        max_bytes,
+        catalog,
+        accept,
+        &mut reader,
+    )
+}
+
+type ContextDocumentReader<'a> = dyn FnMut(
+        &Path,
+        &Path,
+        Scope,
+        &ResolvedRoots,
+        FallbackMode,
+        &mut ContextReadBudget,
+    ) -> Result<Option<String>, ContextResolveError>
+    + 'a;
+
+#[allow(clippy::too_many_arguments)]
+fn resolve_context_documents_with_reader(
+    roots: &ResolvedRoots,
+    product: Product,
+    phase: Option<&Phase>,
+    fallback_mode: FallbackMode,
+    max_bytes: usize,
+    catalog: &LoadedCatalog,
+    accept: &mut dyn FnMut(&DocumentEntry) -> bool,
+    reader: &mut ContextDocumentReader<'_>,
+) -> Result<Vec<ResolvedDocument>, ContextResolveError> {
+    let mut effective_entries = Vec::new();
+    let mut index_by_path: HashMap<PathBuf, usize> = HashMap::new();
+    let home_project_scope_applies = home_project_scope_applies(roots);
+
+    for scope_catalog in catalog.in_load_order() {
+        for entry in &scope_catalog.documents {
+            if !accept(entry)
+                || !matches_product(&entry.products, Some(product))
+                || !matches_phase(&entry.phases, phase)
+            {
+                continue;
+            }
+            if scope_catalog.source_scope == Scope::Home
+                && entry.scope == Scope::Project
+                && !home_project_scope_applies
+            {
+                continue;
+            }
+
+            let path = resolve_entry_path(entry, roots, fallback_mode);
+            let candidate = (scope_catalog, entry, path.clone());
+            if let Some(existing) = index_by_path.get(&path).copied() {
+                effective_entries[existing] = candidate;
+            } else {
+                index_by_path.insert(path, effective_entries.len());
+                effective_entries.push(candidate);
+            }
+        }
+    }
+
+    let mut documents = Vec::with_capacity(effective_entries.len());
+    let mut budget = ContextReadBudget::new(max_bytes);
+    for (scope_catalog, entry, path) in effective_entries {
+        let when_satisfied = predicate::evaluate(&entry.when, &roots.project_path);
+        let required = entry.required && when_satisfied;
+        let raw = if required {
+            budget.claim_document()?;
+            reader(
+                &entry.path,
+                &path,
+                entry.scope,
+                roots,
+                fallback_mode,
+                &mut budget,
+            )?
+        } else {
+            None
+        };
+        let status = if raw.is_some() {
+            DocumentStatus::Present
+        } else {
+            DocumentStatus::Missing
+        };
+        let validation = raw
+            .as_deref()
+            .map(|raw| content::validate_content(raw, entry))
+            .unwrap_or_else(DocumentValidation::missing);
+        let resolved = ResolvedDocument {
+            context: entry.context.clone(),
+            scope: entry.scope,
+            path,
+            products: entry.products.clone(),
+            phases: entry.phases.clone(),
+            declared_required: entry.required,
+            required,
+            when: entry.when_raw.clone(),
+            when_satisfied,
+            status,
+            validation,
+            source: DocumentSource::from_scope(scope_catalog.source_scope),
+            why: describe_why(entry, scope_catalog, when_satisfied, false),
+            content: raw,
+        };
+        documents.push(resolved);
+    }
+
+    Ok(documents)
+}
+
+fn read_context_document(
+    declared_path: &Path,
+    resolved_path: &Path,
+    scope: Scope,
+    roots: &ResolvedRoots,
+    fallback_mode: FallbackMode,
+    budget: &mut ContextReadBudget,
+) -> Result<Option<String>, ContextResolveError> {
+    if declared_path.is_absolute()
+        || declared_path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return Err(ContextResolveError::UnsafeDocument);
+    }
+
+    let metadata = match fs::symlink_metadata(resolved_path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(ContextResolveError::UnsafeDocument),
+    };
+    if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+        return Err(ContextResolveError::UnsafeDocument);
+    }
+    if metadata.len() > budget.remaining_bytes as u64 {
+        return Err(ContextResolveError::BudgetExceeded);
+    }
+
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options
+        .open(resolved_path)
+        .map_err(|_| ContextResolveError::UnsafeDocument)?;
+    let opened_metadata = file
+        .metadata()
+        .map_err(|_| ContextResolveError::UnsafeDocument)?;
+    if !opened_metadata.is_file() {
+        return Err(ContextResolveError::UnsafeDocument);
+    }
+
+    let canonical_path =
+        fs::canonicalize(resolved_path).map_err(|_| ContextResolveError::UnsafeDocument)?;
+    let mut allowed_roots = vec![root_for_scope(scope, roots).to_path_buf()];
+    if scope == Scope::Project
+        && fallback_mode == FallbackMode::Auto
+        && let Some(primary) = roots.primary_worktree_fallback()
+    {
+        allowed_roots.push(primary.path.clone());
+    }
+    let contained = allowed_roots.iter().any(|root| {
+        fs::canonicalize(root)
+            .ok()
+            .is_some_and(|root| canonical_path.starts_with(root))
+    });
+    if !contained {
+        return Err(ContextResolveError::UnsafeDocument);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let canonical_metadata =
+            fs::metadata(&canonical_path).map_err(|_| ContextResolveError::UnsafeDocument)?;
+        if opened_metadata.dev() != canonical_metadata.dev()
+            || opened_metadata.ino() != canonical_metadata.ino()
+        {
+            return Err(ContextResolveError::UnsafeDocument);
+        }
+    }
+
+    let read_limit = budget.remaining_bytes;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.by_ref()
+        .take((read_limit as u64).saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| ContextResolveError::UnsafeDocument)?;
+    if bytes.len() > read_limit {
+        return Err(ContextResolveError::BudgetExceeded);
+    }
+    budget.remaining_bytes -= bytes.len();
+    String::from_utf8(bytes)
+        .map(Some)
+        .map_err(|_| ContextResolveError::UnsafeDocument)
 }
 
 fn resolve_entry(
@@ -953,6 +1264,139 @@ commands = ["cargo test"]
             .expect("optional document");
         assert_eq!(optional.status, DocumentStatus::Missing);
         assert_eq!(optional.content, None);
+    }
+
+    #[test]
+    fn context_resolution_never_opens_optional_documents() {
+        let catalog = r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "REQUIRED.md"
+product = "dsh"
+required = true
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "OPTIONAL.md"
+product = "dsh"
+required = false
+"#;
+        let fixture = fixture("", catalog);
+        let loaded = load_catalog_from_roots(&fixture.roots).expect("catalog");
+        let mut opened = Vec::new();
+        let documents = resolve_context_documents_with_reader(
+            &fixture.roots,
+            Product::Dsh,
+            None,
+            FallbackMode::Auto,
+            1024,
+            &loaded,
+            &mut |entry| entry.context == intent("project-dev"),
+            &mut |declared_path, _, _, _, _, budget| {
+                opened.push(declared_path.to_path_buf());
+                let content = "required policy\n".to_string();
+                budget.remaining_bytes -= content.len();
+                Ok(Some(content))
+            },
+        )
+        .expect("context resolution");
+
+        assert_eq!(opened, vec![PathBuf::from("REQUIRED.md")]);
+        assert_eq!(documents.len(), 2);
+        assert_eq!(documents[0].content.as_deref(), Some("required policy\n"));
+        assert_eq!(documents[1].content, None);
+    }
+
+    #[test]
+    fn context_resolution_budgets_only_the_winning_duplicate_entry() {
+        let home_catalog = r#"
+[[document]]
+context = "project-dev"
+scope = "home"
+path = "SHARED.md"
+product = "dsh"
+required = true
+"#;
+        let project_catalog = r#"
+[[document]]
+context = "project-dev"
+scope = "home"
+path = "SHARED.md"
+product = "dsh"
+required = true
+"#;
+        let fixture = fixture(home_catalog, project_catalog);
+        let loaded = load_catalog_from_roots(&fixture.roots).expect("catalog");
+        let mut opened = Vec::new();
+        let documents = resolve_context_documents_with_reader(
+            &fixture.roots,
+            Product::Dsh,
+            None,
+            FallbackMode::Auto,
+            8,
+            &loaded,
+            &mut |entry| entry.context == intent("project-dev"),
+            &mut |declared_path, _, _, _, _, budget| {
+                opened.push(declared_path.to_path_buf());
+                let content = "12345678".to_string();
+                if content.len() > budget.remaining_bytes {
+                    return Err(ContextResolveError::BudgetExceeded);
+                }
+                budget.remaining_bytes -= content.len();
+                Ok(Some(content))
+            },
+        )
+        .expect("only the effective entry consumes the byte budget");
+
+        assert_eq!(opened, vec![PathBuf::from("SHARED.md")]);
+        assert_eq!(documents.len(), 1);
+        assert_eq!(documents[0].source, DocumentSource::Project);
+        assert_eq!(documents[0].content.as_deref(), Some("12345678"));
+    }
+
+    #[test]
+    fn optional_project_override_prevents_opening_superseded_required_entry() {
+        let home_catalog = r#"
+[[document]]
+context = "project-dev"
+scope = "home"
+path = "SHARED.md"
+product = "dsh"
+required = true
+"#;
+        let project_catalog = r#"
+[[document]]
+context = "project-dev"
+scope = "home"
+path = "SHARED.md"
+product = "dsh"
+required = false
+"#;
+        let fixture = fixture(home_catalog, project_catalog);
+        let loaded = load_catalog_from_roots(&fixture.roots).expect("catalog");
+        let mut opened = Vec::new();
+        let documents = resolve_context_documents_with_reader(
+            &fixture.roots,
+            Product::Dsh,
+            None,
+            FallbackMode::Auto,
+            8,
+            &loaded,
+            &mut |entry| entry.context == intent("project-dev"),
+            &mut |declared_path, _, _, _, _, _| {
+                opened.push(declared_path.to_path_buf());
+                Ok(Some("unexpected".to_string()))
+            },
+        )
+        .expect("optional override");
+
+        assert!(opened.is_empty());
+        assert_eq!(documents.len(), 1);
+        assert_eq!(documents[0].source, DocumentSource::Project);
+        assert!(!documents[0].required);
+        assert_eq!(documents[0].content, None);
     }
 
     #[test]

--- a/crates/agent-docs/src/session.rs
+++ b/crates/agent-docs/src/session.rs
@@ -11,7 +11,8 @@ use sha2::{Digest, Sha256};
 use nils_common::cli_contract::{Envelope, EnvelopeError};
 
 use crate::cli::{
-    SessionActivateArgs, SessionArgs, SessionCommand, SessionCommonArgs, SessionVerifyArgs,
+    SessionActivateArgs, SessionArgs, SessionCommand, SessionCommonArgs, SessionContextArgs,
+    SessionVerifyArgs,
 };
 use crate::config::load_catalog_from_roots;
 use crate::env::{PathOverrides, ResolvedRoots, resolve_roots};
@@ -36,6 +37,10 @@ const MAX_AVAILABLE_INTENTS: usize = 32;
 const MAX_RECOVERY_INTENTS: usize = 16;
 const MAX_RECOVERY_IDENTIFIER_BYTES: usize = 128;
 const BOUNDED_RETRY_ATTEMPTS: u8 = 3;
+const MAX_CONTEXT_REQUEST_ID_BYTES: usize = 128;
+const MAX_CONTEXT_BYTES: usize = 64 * 1024;
+const CONTEXT_DECISION_SCHEMA: &str = "decision.context.v1";
+const CONTEXT_FINGERPRINT_PREFIX: &str = "dsh-context-v1:";
 
 #[derive(Debug, Serialize, Deserialize)]
 struct SessionRecord {
@@ -82,6 +87,33 @@ struct SessionData {
     /// Stable reason code for a `prepare` result (`prepared` / `already-current`).
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ContextData {
+    decision: ContextDecision,
+}
+
+#[derive(Debug, Serialize)]
+struct ContextDecision {
+    schema_version: &'static str,
+    request_id: String,
+    product: Product,
+    intent: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    phase: Option<String>,
+    reason: &'static str,
+    verified: bool,
+    documents: Vec<ContextDocument>,
+    document_count: usize,
+    total_bytes: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ContextDocument {
+    source: &'static str,
+    scope: &'static str,
+    content: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -316,6 +348,13 @@ pub fn run(
             use_user_config,
             expected_integration_fingerprint.as_deref(),
         ),
+        SessionCommand::Context(args) => context(
+            args,
+            overrides,
+            fallback,
+            use_user_config,
+            expected_integration_fingerprint.as_deref(),
+        ),
         SessionCommand::Status(args) => status(
             args,
             overrides,
@@ -331,6 +370,159 @@ pub fn run(
             expected_integration_fingerprint.as_deref(),
         ),
     }
+}
+
+/// Resolve one DSH intent, validate the complete response budget, and only
+/// then persist its activation while the same per-scope record lock is held.
+/// The success DTO deliberately excludes catalog metadata, filesystem paths,
+/// validation commands, session state paths, and the raw session identifier.
+fn context(
+    args: SessionContextArgs,
+    overrides: PathOverrides,
+    fallback: FallbackMode,
+    use_user_config: bool,
+    expected_integration_fingerprint: Option<&str>,
+) -> i32 {
+    let common = SessionCommonArgs {
+        session_id: args.session_id.clone(),
+        product: args.product.as_product(),
+        state_home: args.state_home.clone(),
+        format: args.format,
+    };
+    let common = &common;
+    let result = (|| -> Result<ContextData, SessionFailure> {
+        validate_common(common)?;
+        validate_context_args(&args)?;
+        let phase = parse_phase_arg(args.phase.as_deref())?;
+        let roots = resolve_session_roots(&overrides)?;
+        let path = record_path(common, &roots.project_path)?;
+        let _lock = RecordLock::acquire(&path)?;
+        let existing = if path.exists() {
+            match decode_record(&path)? {
+                DecodedRecord::Current(record) => {
+                    validate_record_context(common, &roots.project_path, &record)?;
+                    Some(*record)
+                }
+                DecodedRecord::LegacyV1 => None,
+            }
+        } else {
+            None
+        };
+        let (catalog, integration_fingerprint) = load_session_catalog(
+            &roots,
+            common.product,
+            fallback,
+            use_user_config,
+            expected_integration_fingerprint,
+        )?;
+        let available = resolver::declared_intents(&roots, fallback, &catalog.catalog);
+        let intent = Context::parse(&args.intent).map_err(|err| {
+            SessionFailure::data("invalid-intent", err).with_available_intents(&available)
+        })?;
+        if !available.iter().any(|item| item == intent.as_str()) {
+            return Err(SessionFailure::data(
+                "undeclared-intent",
+                format!("intent `{intent}` is not declared"),
+            )
+            .with_available_intents(&available));
+        }
+        let report = resolver::resolve_context_with_effective_catalog_for_scope(
+            &intent,
+            &roots,
+            common.product,
+            phase.clone(),
+            true,
+            fallback,
+            args.max_bytes,
+            &catalog,
+        )
+        .map_err(context_resolve_failure)?;
+        if report.has_unsatisfied_required() {
+            return Err(SessionFailure::data(
+                unsatisfied_code(phase.as_ref()),
+                format!("strict preflight failed for `{intent}`"),
+            )
+            .with_preflight_context(&intent, phase.as_ref(), &report));
+        }
+
+        let mut total_bytes = 0usize;
+        let mut documents = Vec::with_capacity(report.summary.satisfied_required);
+        for document in report
+            .documents
+            .iter()
+            .filter(|document| document.required && document.satisfied())
+        {
+            let content = document.content.clone().ok_or_else(|| {
+                SessionFailure::runtime(
+                    "context-content-missing",
+                    "a satisfied required document omitted its content",
+                )
+            })?;
+            total_bytes = total_bytes.checked_add(content.len()).ok_or_else(|| {
+                SessionFailure::data(
+                    "context-budget-exceeded",
+                    "required policy content exceeds the requested response budget",
+                )
+            })?;
+            if total_bytes > args.max_bytes {
+                return Err(SessionFailure::data(
+                    "context-budget-exceeded",
+                    "required policy content exceeds the requested response budget",
+                ));
+            }
+            documents.push(ContextDocument {
+                source: document.source.as_str(),
+                scope: document.scope.as_str(),
+                content,
+            });
+        }
+
+        let had_existing = existing.is_some();
+        let mut record = existing.unwrap_or_else(|| {
+            new_record(common, &roots.project_path, integration_fingerprint.clone())
+        });
+        let mut changed = !had_existing;
+        if record.integration_fingerprint != integration_fingerprint {
+            record.active_intents.clear();
+            record.active_phase_intents.clear();
+            record.integration_fingerprint = integration_fingerprint.clone();
+            changed = true;
+        }
+        changed |= store_activation(
+            &mut record,
+            &intent,
+            phase.as_ref(),
+            context_fingerprint(
+                &report,
+                &catalog,
+                fallback,
+                integration_fingerprint.as_deref(),
+            )?,
+        );
+        let reason = if changed {
+            record.activated_at = jiff::Timestamp::now().to_string();
+            write_record(&path, &record)?;
+            "prepared"
+        } else {
+            "already-current"
+        };
+        let document_count = documents.len();
+        Ok(ContextData {
+            decision: ContextDecision {
+                schema_version: CONTEXT_DECISION_SCHEMA,
+                request_id: args.request_id.clone(),
+                product: common.product,
+                intent: intent.to_string(),
+                phase: phase.as_ref().map(ToString::to_string),
+                reason,
+                verified: true,
+                documents,
+                document_count,
+                total_bytes,
+            },
+        })
+    })();
+    render_context(common.format, result)
 }
 
 fn activate(
@@ -799,6 +991,25 @@ fn activation_matches(
     catalog: &integration::EffectiveCatalog,
     integration_fingerprint: Option<&str>,
 ) -> Result<bool, SessionFailure> {
+    if stored.starts_with(CONTEXT_FINGERPRINT_PREFIX) {
+        if product != Product::Dsh {
+            return Ok(false);
+        }
+        let report = resolver::resolve_context_with_effective_catalog_for_scope(
+            intent,
+            roots,
+            product,
+            phase.cloned(),
+            true,
+            fallback,
+            MAX_CONTEXT_BYTES,
+            catalog,
+        )
+        .map_err(verification_context_failure)?;
+        return Ok(!report.has_unsatisfied_required()
+            && stored
+                == context_fingerprint(&report, catalog, fallback, integration_fingerprint)?);
+    }
     let report = resolver::resolve_intent_with_effective_catalog_for_scope(
         intent,
         roots,
@@ -811,6 +1022,17 @@ fn activation_matches(
     );
     Ok(!report.has_unsatisfied_required()
         && stored == fingerprint(&report, catalog, fallback, integration_fingerprint)?)
+}
+
+fn context_resolve_failure(error: resolver::ContextResolveError) -> SessionFailure {
+    SessionFailure::data(error.code(), error.message())
+}
+
+fn verification_context_failure(_error: resolver::ContextResolveError) -> SessionFailure {
+    SessionFailure::data(
+        "context-policy-invalid",
+        "the prepared DSH context can no longer be resolved within its safety limits",
+    )
 }
 
 fn parse_phase_arg(raw: Option<&str>) -> Result<Option<Phase>, SessionFailure> {
@@ -885,6 +1107,29 @@ fn validate_common(common: &SessionCommonArgs) -> Result<(), SessionFailure> {
         return Err(SessionFailure::data(
             "invalid-state-home",
             "--state-home must be absolute",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_context_args(args: &SessionContextArgs) -> Result<(), SessionFailure> {
+    let request_id = args.request_id.as_bytes();
+    let valid_request_id = !request_id.is_empty()
+        && request_id.len() <= MAX_CONTEXT_REQUEST_ID_BYTES
+        && request_id[0].is_ascii_alphanumeric()
+        && request_id
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':'));
+    if !valid_request_id {
+        return Err(SessionFailure::data(
+            "invalid-request-id",
+            "--request-id must be a bounded argv-safe identifier",
+        ));
+    }
+    if args.max_bytes == 0 || args.max_bytes > MAX_CONTEXT_BYTES {
+        return Err(SessionFailure::data(
+            "invalid-max-bytes",
+            "--max-bytes must be between 1 and 65536",
         ));
     }
     Ok(())
@@ -1035,6 +1280,18 @@ fn fingerprint(
     let bytes = serde_json::to_vec(&input)
         .map_err(|err| SessionFailure::runtime("fingerprint-failed", err.to_string()))?;
     Ok(digest(&bytes))
+}
+
+fn context_fingerprint(
+    report: &PreflightReport,
+    catalog: &integration::EffectiveCatalog,
+    fallback: FallbackMode,
+    integration_fingerprint: Option<&str>,
+) -> Result<String, SessionFailure> {
+    Ok(format!(
+        "{CONTEXT_FINGERPRINT_PREFIX}{}",
+        fingerprint(report, catalog, fallback, integration_fingerprint)?
+    ))
 }
 
 fn product_names(products: &[Product]) -> Vec<&'static str> {
@@ -1192,6 +1449,58 @@ fn render(format: OutputFormat, command: &str, result: Result<SessionData, Sessi
     }
 }
 
+fn render_context(format: OutputFormat, result: Result<ContextData, SessionFailure>) -> i32 {
+    const SCHEMA: &str = "cli.agent-docs.session.context.v1";
+    match result {
+        Ok(data) => {
+            if format == OutputFormat::Json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "schema_version": SCHEMA,
+                        "ok": true,
+                        "data": data,
+                    }))
+                    .expect("session context output serializes")
+                );
+            } else {
+                println!(
+                    "agent-docs session context: product={} intent={} documents={} bytes={} verified={}",
+                    data.decision.product,
+                    data.decision.intent,
+                    data.decision.document_count,
+                    data.decision.total_bytes,
+                    data.decision.verified
+                );
+            }
+            EXIT_OK
+        }
+        Err(failure) => {
+            if format == OutputFormat::Json {
+                let details = serde_json::to_value(&failure.details)
+                    .expect("session failure details serialize");
+                let mut error =
+                    EnvelopeError::new(failure.code, &failure.message).with_details(details);
+                if let Some(hint) = &failure.hint {
+                    error = error.with_hint(hint);
+                }
+                let envelope: Envelope<ContextData> = Envelope::failure(SCHEMA, error);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&envelope).expect("session error serializes")
+                );
+            } else {
+                eprintln!(
+                    "agent-docs session context: {}; next action: {}",
+                    failure.message,
+                    failure.details.next_action.as_str()
+                );
+            }
+            failure.exit_code
+        }
+    }
+}
+
 struct SessionFailure {
     code: &'static str,
     message: String,
@@ -1284,6 +1593,10 @@ fn failure_details(code: &str) -> Box<SessionFailureDetails> {
         | "invalid-state-home"
         | "invalid-intent"
         | "invalid-phase"
+        | "invalid-product"
+        | "invalid-request-id"
+        | "invalid-max-bytes"
+        | "context-budget-exceeded"
         | "root-resolution-failed" => (
             false,
             NextAction::FixArguments,
@@ -1331,7 +1644,8 @@ fn failure_details(code: &str) -> Box<SessionFailureDetails> {
         ),
         "catalog-load-failed"
         | "integration-catalog-not-selected"
-        | "integration-resolution-failed" => (
+        | "integration-resolution-failed"
+        | "context-policy-invalid" => (
             false,
             NextAction::RepairCatalog,
             recovery_command(RecoveryCommand::Audit, catalog_reuse_scope()),
@@ -1346,6 +1660,7 @@ fn failure_details(code: &str) -> Box<SessionFailureDetails> {
         ),
         "fingerprint-producer-missing"
         | "fingerprint-failed"
+        | "context-content-missing"
         | "record-render-failed"
         | "record-path-not-portable"
         | "lock-owner-render-failed"
@@ -1381,6 +1696,14 @@ fn failure_message(code: &str) -> &'static str {
         "invalid-state-home" => "the session state location is invalid",
         "invalid-intent" => "the intent identifier is invalid",
         "invalid-phase" => "the phase identifier is invalid",
+        "invalid-product" => "the selected product is not supported for session context",
+        "invalid-request-id" => "the context request identifier is invalid",
+        "invalid-max-bytes" => "the context response budget is invalid",
+        "context-budget-exceeded" => "required policy content exceeds the response budget",
+        "context-policy-invalid" => {
+            "the prepared DSH context no longer satisfies the bounded policy contract"
+        }
+        "context-content-missing" => "required policy content was unavailable after validation",
         "undeclared-intent" => "the requested intent is not declared for this project",
         "preflight-unsatisfied" => "required policy documents are not satisfied",
         "phase-unsatisfied" => "required policy documents are not satisfied for this phase",

--- a/crates/agent-docs/tests/integration.rs
+++ b/crates/agent-docs/tests/integration.rs
@@ -18,6 +18,8 @@ mod content_validation;
 mod control_plane;
 #[path = "integration/docs_home.rs"]
 mod docs_home;
+#[path = "integration/dsh_context.rs"]
+mod dsh_context;
 #[path = "integration/exit_codes.rs"]
 mod exit_codes;
 #[path = "integration/explain_list_remove.rs"]

--- a/crates/agent-docs/tests/integration/command_surface.rs
+++ b/crates/agent-docs/tests/integration/command_surface.rs
@@ -97,7 +97,7 @@ fn private_config_surface_is_structured() {
         (["integration", "--help"].as_slice(), ["resolve"].as_slice()),
         (
             ["integration", "resolve", "--help"].as_slice(),
-            ["--product", "codex", "claude", "hermes", "--format"].as_slice(),
+            ["--product", "codex", "claude", "hermes", "dsh", "--format"].as_slice(),
         ),
     ] {
         let out = run_cli(args, &options);

--- a/crates/agent-docs/tests/integration/completion_outside_repo.rs
+++ b/crates/agent-docs/tests/integration/completion_outside_repo.rs
@@ -13,7 +13,11 @@ fn completion_export_succeeds_outside_git_repo() {
         "missing zsh completion header: {stdout}"
     );
     assert!(
-        stdout.contains("--product") && stdout.contains("codex claude"),
+        stdout.contains("--product")
+            && stdout.contains("codex claude hermes dsh")
+            && stdout.contains("context")
+            && stdout.contains("--request-id")
+            && stdout.contains("--max-bytes"),
         "missing product completion choices: {stdout}"
     );
 }
@@ -27,7 +31,11 @@ fn bash_completion_exports_product_choices_outside_git_repo() {
     assert_eq!(output.code, 0, "expected exit code 0, got: {output:?}");
     let stdout = output.stdout_text();
     assert!(
-        stdout.contains("--product") && stdout.contains("codex claude"),
+        stdout.contains("--product")
+            && stdout.contains("codex claude hermes dsh")
+            && stdout.contains("context")
+            && stdout.contains("--request-id")
+            && stdout.contains("--max-bytes"),
         "missing product completion choices: {stdout}"
     );
 }

--- a/crates/agent-docs/tests/integration/dsh_context.rs
+++ b/crates/agent-docs/tests/integration/dsh_context.rs
@@ -1,0 +1,802 @@
+use std::collections::BTreeSet;
+use std::fs;
+
+use pretty_assertions::assert_eq;
+
+use super::common::TestEnv;
+
+fn context_args<'a>(state: &'a str, request_id: &'a str) -> Vec<&'a str> {
+    vec![
+        "session",
+        "context",
+        "--session-id",
+        "dsh-session-private-sentinel",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--intent",
+        "project-dev",
+        "--request-id",
+        request_id,
+        "--format",
+        "json",
+    ]
+}
+
+#[test]
+fn dsh_context_returns_only_satisfied_required_document_content() {
+    let env = TestEnv::new();
+    env.write_home_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "home"
+path = "HOME_POLICY.md"
+product = "dsh"
+required = true
+"#,
+    )
+    .write_home_doc("HOME_POLICY.md", "home policy\n")
+    .write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "PROJECT_POLICY.md"
+product = "dsh"
+required = true
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "OPTIONAL_PRIVATE_SENTINEL.md"
+product = "dsh"
+required = false
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "CODEX_ONLY_SENTINEL.md"
+product = "codex"
+required = true
+
+[[validation]]
+context = "project-dev"
+product = "dsh"
+commands = ["VALIDATION_COMMAND_PRIVATE_SENTINEL"]
+"#,
+    )
+    .write_project_doc("PROJECT_POLICY.md", "project policy\n")
+    .write_project_doc(
+        "OPTIONAL_PRIVATE_SENTINEL.md",
+        "optional content private sentinel\n",
+    )
+    .write_project_doc("CODEX_ONLY_SENTINEL.md", "codex-only private sentinel\n");
+    let state_home = env.project_path("ABSOLUTE_STATE_HOME_SENTINEL");
+    let state = state_home.to_str().unwrap();
+
+    let first = env.run(&context_args(state, "request-0001"));
+    assert_eq!(first.code, 0, "stderr={}", first.stderr);
+    let json = first.json();
+    assert_eq!(json["schema_version"], "cli.agent-docs.session.context.v1");
+    assert_eq!(json["ok"], true);
+    assert_eq!(
+        json.as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["data", "ok", "schema_version"])
+    );
+    assert_eq!(
+        json["data"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["decision"])
+    );
+    let decision = &json["data"]["decision"];
+    assert_eq!(decision["schema_version"], "decision.context.v1");
+    assert_eq!(decision["request_id"], "request-0001");
+    assert_eq!(decision["product"], "dsh");
+    assert_eq!(decision["intent"], "project-dev");
+    assert_eq!(decision["reason"], "prepared");
+    assert_eq!(decision["verified"], true);
+    assert_eq!(decision["document_count"], 2);
+    assert_eq!(decision["total_bytes"], 27);
+    assert_eq!(
+        decision
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([
+            "document_count",
+            "documents",
+            "intent",
+            "product",
+            "reason",
+            "request_id",
+            "schema_version",
+            "total_bytes",
+            "verified",
+        ])
+    );
+    assert_eq!(
+        decision["documents"],
+        serde_json::json!([
+            {"source": "home", "scope": "home", "content": "home policy\n"},
+            {"source": "project", "scope": "project", "content": "project policy\n"}
+        ])
+    );
+    for private in [
+        "dsh-session-private-sentinel",
+        "ABSOLUTE_STATE_HOME_SENTINEL",
+        env.project.to_str().unwrap(),
+        "HOME_POLICY.md",
+        "PROJECT_POLICY.md",
+        "OPTIONAL_PRIVATE_SENTINEL",
+        "optional content private sentinel",
+        "CODEX_ONLY_SENTINEL",
+        "codex-only private sentinel",
+        "VALIDATION_COMMAND_PRIVATE_SENTINEL",
+    ] {
+        assert!(!first.stdout.contains(private), "leaked {private:?}");
+    }
+
+    let second = env.run(&context_args(state, "request-0002"));
+    assert_eq!(second.code, 0, "stderr={}", second.stderr);
+    let second_json = second.json();
+    let second_decision = &second_json["data"]["decision"];
+    assert_eq!(second_decision["reason"], "already-current");
+    assert_eq!(second_decision["request_id"], "request-0002");
+    for field in [
+        "schema_version",
+        "product",
+        "intent",
+        "verified",
+        "documents",
+        "document_count",
+        "total_bytes",
+    ] {
+        assert_eq!(
+            second_decision[field], decision[field],
+            "already-current changed policy field {field}"
+        );
+    }
+}
+
+#[test]
+fn dsh_context_budget_failure_does_not_activate_or_emit_partial_policy() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+required = true
+"#,
+    )
+    .write_project_doc("POLICY.md", "POLICY_CONTENT_MUST_NOT_BE_PARTIAL\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+    let mut args = context_args(state, "request-budget");
+    args.splice(args.len() - 2..args.len() - 2, ["--max-bytes", "4"]);
+
+    let output = env.run(&args);
+    assert_eq!(output.code, 65, "stderr={}", output.stderr);
+    assert_eq!(
+        output.json()["schema_version"],
+        "cli.agent-docs.session.context.v1"
+    );
+    assert_eq!(output.json()["error"]["code"], "context-budget-exceeded");
+    assert!(!output.stdout.contains("POLICY_CONTENT_MUST_NOT_BE_PARTIAL"));
+
+    let verify = env.run(&[
+        "session",
+        "verify",
+        "--session-id",
+        "dsh-session-private-sentinel",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--require-intent",
+        "project-dev",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(verify.code, 65, "stderr={}", verify.stderr);
+    assert_eq!(verify.json()["error"]["code"], "missing-activation");
+    assert_eq!(
+        verify.json()["error"]["details"]["next_action"],
+        "prepare-intent"
+    );
+    assert_eq!(
+        verify.json()["error"]["details"]["recovery"]["command"],
+        "session.prepare"
+    );
+
+    let prepared = env.run(&context_args(state, "request-prepared"));
+    assert_eq!(prepared.code, 0, "stderr={}", prepared.stderr);
+    let status = env.run(&[
+        "session",
+        "status",
+        "--session-id",
+        "dsh-session-private-sentinel",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--format",
+        "json",
+    ]);
+    assert_eq!(status.code, 0, "stderr={}", status.stderr);
+    let record_file = status.json()["data"]["record_file"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let record_path = state_home.join(record_file);
+    let before = fs::read(&record_path).unwrap();
+
+    let mut failed_refresh = context_args(state, "request-budget-existing");
+    failed_refresh.splice(
+        failed_refresh.len() - 2..failed_refresh.len() - 2,
+        ["--max-bytes", "4"],
+    );
+    let failed_refresh = env.run(&failed_refresh);
+    assert_eq!(failed_refresh.code, 65, "stderr={}", failed_refresh.stderr);
+    assert_eq!(
+        failed_refresh.json()["error"]["code"],
+        "context-budget-exceeded"
+    );
+    assert_eq!(fs::read(&record_path).unwrap(), before);
+
+    let verify_preserved = env.run(&[
+        "session",
+        "verify",
+        "--session-id",
+        "dsh-session-private-sentinel",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--require-intent",
+        "project-dev",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(
+        verify_preserved.code, 0,
+        "stderr={}",
+        verify_preserved.stderr
+    );
+    assert_eq!(verify_preserved.json()["data"]["verified"], true);
+}
+
+#[test]
+fn dsh_context_validates_request_id_budget_and_exactly_one_intent() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+required = true
+"#,
+    )
+    .write_project_doc("POLICY.md", "policy\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+
+    for request_id in ["", "unsafe request", "../unsafe", &"x".repeat(129)] {
+        let output = env.run(&context_args(state, request_id));
+        assert_eq!(output.code, 65, "request_id={request_id:?}");
+        assert_eq!(output.json()["error"]["code"], "invalid-request-id");
+    }
+
+    let mut too_large = context_args(state, "request-hard-cap");
+    too_large.splice(
+        too_large.len() - 2..too_large.len() - 2,
+        ["--max-bytes", "65537"],
+    );
+    let output = env.run(&too_large);
+    assert_eq!(output.code, 65);
+    assert_eq!(output.json()["error"]["code"], "invalid-max-bytes");
+
+    let duplicated = env.run(&[
+        "session",
+        "context",
+        "--session-id",
+        "session",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--intent",
+        "project-dev",
+        "--intent",
+        "task-tools",
+        "--request-id",
+        "request-duplicate-intent",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(duplicated.code, 64, "stdout={}", duplicated.stdout);
+    assert_eq!(duplicated.json()["error"]["code"], "parse-error");
+
+    let mut wrong_product = context_args(state, "request-wrong-product");
+    let product = wrong_product
+        .iter_mut()
+        .find(|value| **value == "dsh")
+        .unwrap();
+    *product = "codex";
+    let wrong_product = env.run(&wrong_product);
+    assert_eq!(wrong_product.code, 64, "stdout={}", wrong_product.stdout);
+    assert_eq!(wrong_product.json()["error"]["code"], "parse-error");
+}
+
+#[test]
+fn dsh_context_phase_and_session_scope_remain_isolated() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "COMMON.md"
+product = "dsh"
+required = true
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "EDIT.md"
+product = "dsh"
+phase = "edit"
+required = true
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "DELIVERY.md"
+product = "dsh"
+phase = "delivery"
+required = true
+
+[[document]]
+context = "task-tools"
+scope = "project"
+path = "TOOLS.md"
+product = "dsh"
+required = true
+"#,
+    )
+    .write_project_doc("COMMON.md", "common\n")
+    .write_project_doc("EDIT.md", "edit\n")
+    .write_project_doc("TOOLS.md", "tools\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+    let mut args = context_args(state, "request-phase");
+    args.splice(args.len() - 2..args.len() - 2, ["--phase", "edit"]);
+    let output = env.run(&args);
+    assert_eq!(output.code, 0, "stderr={}", output.stderr);
+    let decision = &output.json()["data"]["decision"];
+    assert_eq!(decision["phase"], "edit");
+    assert_eq!(decision["document_count"], 2);
+    assert!(!output.stdout.contains("DELIVERY.md"));
+
+    let same_phase = env.run(&[
+        "session",
+        "verify",
+        "--session-id",
+        "dsh-session-private-sentinel",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--require-intent",
+        "project-dev",
+        "--phase",
+        "edit",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(same_phase.code, 0, "stderr={}", same_phase.stderr);
+    assert_eq!(same_phase.json()["data"]["verified"], true);
+
+    let other_phase = env.run(&[
+        "session",
+        "verify",
+        "--session-id",
+        "dsh-session-private-sentinel",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--require-intent",
+        "project-dev",
+        "--phase",
+        "delivery",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(other_phase.code, 65, "stdout={}", other_phase.stdout);
+    assert_eq!(other_phase.json()["error"]["code"], "missing-intent");
+
+    for (session, intent, expected_code) in [
+        ("other-session", "project-dev", "missing-activation"),
+        (
+            "dsh-session-private-sentinel",
+            "task-tools",
+            "missing-intent",
+        ),
+    ] {
+        let verify = env.run(&[
+            "session",
+            "verify",
+            "--session-id",
+            session,
+            "--product",
+            "dsh",
+            "--state-home",
+            state,
+            "--require-intent",
+            intent,
+            "--phase",
+            "edit",
+            "--format",
+            "json",
+        ]);
+        assert_eq!(verify.code, 65, "stdout={}", verify.stdout);
+        assert_eq!(verify.json()["error"]["code"], expected_code);
+    }
+}
+
+#[test]
+fn dsh_context_default_budget_is_full_without_phase_and_selective_with_phase() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "COMMON.md"
+product = "dsh"
+required = true
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "EDIT.md"
+product = "dsh"
+phase = "edit"
+required = true
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "DELIVERY.md"
+product = "dsh"
+phase = "delivery"
+required = true
+"#,
+    )
+    .write_project_doc("COMMON.md", &"c".repeat(8 * 1024))
+    .write_project_doc("EDIT.md", &"e".repeat(8 * 1024))
+    .write_project_doc("DELIVERY.md", &"d".repeat(8 * 1024));
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+
+    let full = env.run(&context_args(state, "request-full-budget"));
+    assert_eq!(full.code, 65, "stdout={}", full.stdout);
+    assert_eq!(full.json()["error"]["code"], "context-budget-exceeded");
+
+    let mut edit_args = context_args(state, "request-edit-budget");
+    edit_args.splice(
+        edit_args.len() - 2..edit_args.len() - 2,
+        ["--phase", "edit"],
+    );
+    let edit = env.run(&edit_args);
+    assert_eq!(edit.code, 0, "stderr={}", edit.stderr);
+    let decision = &edit.json()["data"]["decision"];
+    assert_eq!(decision["phase"], "edit");
+    assert_eq!(decision["document_count"], 2);
+    assert_eq!(decision["total_bytes"], 16 * 1024);
+    assert_eq!(decision["reason"], "prepared");
+}
+
+#[test]
+fn dsh_context_rejects_catalog_paths_outside_their_declared_scope() {
+    for path_kind in ["absolute", "parent"] {
+        let env = TestEnv::new();
+        let secret = env.home_path("OUTSIDE_SCOPE_SECRET.md");
+        fs::write(&secret, "OUTSIDE_SCOPE_SECRET_SENTINEL\n").unwrap();
+        let declared_path = match path_kind {
+            "absolute" => secret.display().to_string(),
+            "parent" => "../docs-home/OUTSIDE_SCOPE_SECRET.md".to_string(),
+            _ => unreachable!(),
+        };
+        env.write_project_catalog(&format!(
+            r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = {declared_path:?}
+product = "dsh"
+required = true
+"#
+        ));
+        let state_home = env.project_path("state");
+        let output = env.run(&context_args(
+            state_home.to_str().unwrap(),
+            &format!("request-outside-{path_kind}"),
+        ));
+        assert_eq!(output.code, 65, "stdout={}", output.stdout);
+        assert_eq!(output.json()["error"]["code"], "context-document-unsafe");
+        assert!(!output.stdout.contains("OUTSIDE_SCOPE_SECRET_SENTINEL"));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn dsh_context_rejects_a_required_document_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+required = true
+"#,
+    );
+    let secret = env.home_path("SYMLINK_SECRET.md");
+    fs::write(&secret, "SYMLINK_SECRET_SENTINEL\n").unwrap();
+    symlink(secret, env.project_path("POLICY.md")).unwrap();
+    let state_home = env.project_path("state");
+    let output = env.run(&context_args(
+        state_home.to_str().unwrap(),
+        "request-symlink",
+    ));
+    assert_eq!(output.code, 65, "stdout={}", output.stdout);
+    assert_eq!(output.json()["error"]["code"], "context-document-unsafe");
+    assert!(!output.stdout.contains("SYMLINK_SECRET_SENTINEL"));
+}
+
+#[test]
+fn dsh_context_skips_optional_content_before_reading_and_enforces_required_limits() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+required = true
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "OPTIONAL_HUGE.md"
+product = "dsh"
+required = false
+"#,
+    )
+    .write_project_doc("POLICY.md", "bounded policy\n")
+    .write_project_doc("OPTIONAL_HUGE.md", &"o".repeat(1024 * 1024));
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+    let output = env.run(&context_args(state, "request-optional-huge"));
+    assert_eq!(output.code, 0, "stdout={}", output.stdout);
+    assert_eq!(output.json()["data"]["decision"]["document_count"], 1);
+    assert_eq!(output.json()["data"]["decision"]["total_bytes"], 15);
+
+    env.write_project_doc("POLICY.md", &"r".repeat(64 * 1024));
+    let mut at_limit = context_args(state, "request-required-at-limit");
+    at_limit.splice(
+        at_limit.len() - 2..at_limit.len() - 2,
+        ["--max-bytes", "65536"],
+    );
+    let at_limit = env.run(&at_limit);
+    assert_eq!(at_limit.code, 0, "stdout={}", at_limit.stdout);
+    assert_eq!(at_limit.json()["data"]["decision"]["total_bytes"], 65536);
+
+    env.write_project_doc("POLICY.md", &"r".repeat(64 * 1024 + 1));
+    let mut over_limit = context_args(state, "request-required-over-limit");
+    over_limit.splice(
+        over_limit.len() - 2..over_limit.len() - 2,
+        ["--max-bytes", "65536"],
+    );
+    let required = env.run(&over_limit);
+    assert_eq!(required.code, 65, "stdout={}", required.stdout);
+    assert_eq!(required.json()["error"]["code"], "context-budget-exceeded");
+}
+
+#[test]
+fn dsh_context_caps_the_number_of_required_documents() {
+    let env = TestEnv::new();
+    let mut catalog = String::new();
+    for index in 0..128 {
+        catalog.push_str(&format!(
+            r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY_{index}.md"
+product = "dsh"
+required = true
+"#
+        ));
+        env.write_project_doc(&format!("POLICY_{index}.md"), "x");
+    }
+    env.write_project_catalog(&catalog);
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+    let at_limit = env.run(&context_args(state, "request-document-count-limit"));
+    assert_eq!(at_limit.code, 0, "stdout={}", at_limit.stdout);
+    assert_eq!(at_limit.json()["data"]["decision"]["document_count"], 128);
+    assert_eq!(at_limit.json()["data"]["decision"]["total_bytes"], 128);
+
+    catalog.push_str(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY_128.md"
+product = "dsh"
+required = true
+"#,
+    );
+    env.write_project_doc("POLICY_128.md", "x");
+    env.write_project_catalog(&catalog);
+    let output = env.run(&context_args(state, "request-document-count"));
+    assert_eq!(output.code, 65, "stdout={}", output.stdout);
+    assert_eq!(output.json()["error"]["code"], "context-budget-exceeded");
+}
+
+#[test]
+fn dsh_verify_reports_policy_repair_when_context_exceeds_the_hard_limit() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+required = true
+"#,
+    )
+    .write_project_doc("POLICY.md", "small policy\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+
+    let prepared = env.run(&context_args(state, "request-before-growth"));
+    assert_eq!(prepared.code, 0, "stderr={}", prepared.stderr);
+
+    env.write_project_doc("POLICY.md", &"x".repeat(64 * 1024 + 1));
+    let verify = env.run(&[
+        "session",
+        "verify",
+        "--session-id",
+        "dsh-session-private-sentinel",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--require-intent",
+        "project-dev",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(verify.code, 65, "stdout={}", verify.stdout);
+    let error = &verify.json()["error"];
+    assert_eq!(error["code"], "context-policy-invalid");
+    assert_eq!(error["details"]["next_action"], "repair-catalog");
+    assert_eq!(error["details"]["recovery"]["command"], "audit");
+}
+
+#[test]
+fn standard_session_prepare_and_verify_accept_the_dsh_product() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+required = true
+"#,
+    )
+    .write_project_doc("POLICY.md", "policy\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+    let prepare = env.run(&[
+        "session",
+        "prepare",
+        "--session-id",
+        "standard-dsh-session",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--intent",
+        "project-dev",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(prepare.code, 0, "stderr={}", prepare.stderr);
+    assert_eq!(prepare.json()["data"]["product"], "dsh");
+
+    let verify = env.run(&[
+        "session",
+        "verify",
+        "--session-id",
+        "standard-dsh-session",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--require-intent",
+        "project-dev",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(verify.code, 0, "stderr={}", verify.stderr);
+    assert_eq!(verify.json()["data"]["verified"], true);
+}
+
+#[test]
+fn dsh_catalog_filter_and_integration_resolve_are_supported() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "DSH.md"
+product = "dsh"
+required = true
+
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "CODEX.md"
+product = "codex"
+required = true
+"#,
+    )
+    .write_project_doc("DSH.md", "dsh policy\n")
+    .write_project_doc("CODEX.md", "codex policy\n");
+
+    let list = env.run(&["list", "--product", "dsh", "--format", "json"]);
+    assert_eq!(list.code, 0, "stderr={}", list.stderr);
+    assert_eq!(list.json()["documents"].as_array().unwrap().len(), 1);
+    assert_eq!(list.json()["documents"][0]["products"][0], "dsh");
+
+    let integration = env.run(&[
+        "integration",
+        "resolve",
+        "--product",
+        "dsh",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(integration.code, 0, "stderr={}", integration.stderr);
+    assert_eq!(integration.json()["data"]["product"], "dsh");
+    assert_eq!(integration.json()["data"]["action"], "integrate");
+}

--- a/crates/agent-docs/tests/integration/help_snapshot.rs
+++ b/crates/agent-docs/tests/integration/help_snapshot.rs
@@ -32,3 +32,23 @@ fn help_snapshot_root_help() {
         ],
     ));
 }
+
+#[test]
+fn help_snapshot_dsh_context_help() {
+    assert_help_contains(HelpCase {
+        bin: "agent-docs",
+        args: &["session", "context", "--help"],
+        expected: &[
+            "Usage:",
+            "--session-id",
+            "--product",
+            "dsh",
+            "--state-home",
+            "--intent",
+            "--phase",
+            "--request-id",
+            "--max-bytes",
+            "--format",
+        ],
+    });
+}

--- a/crates/agent-docs/tests/integration/operation_effect.rs
+++ b/crates/agent-docs/tests/integration/operation_effect.rs
@@ -83,6 +83,38 @@ fn session_prepare_is_never_described_as_read_only() {
 }
 
 #[test]
+fn session_context_is_never_described_as_read_only() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let output = run_cli(
+        &[
+            "operation-effect",
+            "--format",
+            "json",
+            "--",
+            "session",
+            "context",
+            "--session-id",
+            "session-1",
+            "--product",
+            "dsh",
+            "--state-home",
+            temp.path().to_str().expect("temp UTF-8"),
+            "--intent",
+            "project-dev",
+            "--request-id",
+            "request-1",
+            "--format",
+            "json",
+        ],
+        &cmd::CmdOptions::default().with_cwd(temp.path()),
+    );
+
+    assert_eq!(output.code, 0, "stderr={}", output.stderr);
+    assert_eq!(output.json()["data"]["operation"], "session.context");
+    assert_ne!(output.json()["data"]["effect"], "read_only");
+}
+
+#[test]
 fn unknown_inner_flags_produce_no_descriptor() {
     let output = run_cli(
         &[

--- a/crates/agent-docs/tests/integration/user_config.rs
+++ b/crates/agent-docs/tests/integration/user_config.rs
@@ -1568,6 +1568,70 @@ required = false
 }
 
 #[test]
+fn dsh_context_uses_the_bound_private_user_catalog() {
+    let env = UserConfigEnv::new();
+    env.write_private_catalog();
+    let enroll = env.run(&[
+        "config",
+        "enroll",
+        "--catalog",
+        env.private_catalog.to_str().expect("utf-8 catalog"),
+        "--apply",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(enroll.code, 0, "stderr={}", enroll.stderr);
+    let resolved = env.run(&[
+        "integration",
+        "resolve",
+        "--product",
+        "dsh",
+        "--format",
+        "json",
+    ]);
+    assert_resolve_action(&resolved, "integrate", "user-enrollment");
+    let fingerprint = resolved.json()["data"]["decision_fingerprint"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let state_home = env.home.join("dsh-state");
+    let output = env.run(&[
+        "session",
+        "context",
+        "--session-id",
+        "private-dsh-session",
+        "--product",
+        "dsh",
+        "--state-home",
+        state_home.to_str().expect("utf-8 state home"),
+        "--intent",
+        "project-dev",
+        "--request-id",
+        "private-request-1",
+        "--user-config",
+        "--integration-fingerprint",
+        &fingerprint,
+        "--format",
+        "json",
+    ]);
+    assert_eq!(output.code, 0, "stderr={}", output.stderr);
+    assert_eq!(output.json()["data"]["decision"]["product"], "dsh");
+    assert_eq!(
+        output.json()["data"]["decision"]["documents"],
+        serde_json::json!([{
+            "source": "project",
+            "scope": "project",
+            "content": "# Private policy\n"
+        }])
+    );
+    assert!(
+        !output
+            .stdout
+            .contains(env.private_catalog.to_str().unwrap())
+    );
+}
+
+#[test]
 fn unsupported_user_config_schema_falls_back_without_granting_policy() {
     let env = UserConfigEnv::new();
     env.write_user_config("schema_version = 2\n");


### PR DESCRIPTION
## Summary

This prototype is superseded by #1468, which contains the complete native DSH runtime integration and the current validation evidence.

The final design does not add DSH to the closed public `agent_docs::model::Product` enum. DSH uses an isolated internal catalog projection while the public Rust boundary remains Codex, Claude, and Hermes, so this work does not require a nils 2.0 release.

Tracking issue: https://github.com/sympoies/dsh-runtime-kit/issues/1

Do not merge this PR.

## Test plan

- No further validation applies to this superseded prototype; current test-first and full-gate evidence is recorded on #1468.
